### PR TITLE
feat: Sidebar submenuitem start and end components

### DIFF
--- a/.changeset/poor-peaches-taste.md
+++ b/.changeset/poor-peaches-taste.md
@@ -2,4 +2,4 @@
 '@backstage/core-components': minor
 ---
 
-Adds the ability to add a start and end component to sidebar submenu items (which are not dropdowns)
+Adds the ability to add a start and end component to sidebar submenu items

--- a/.changeset/poor-peaches-taste.md
+++ b/.changeset/poor-peaches-taste.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': minor
+---
+
+Adds the ability to add a start and end component to sidebar submenu items (which are not dropdowns)

--- a/.github/vale/config/vocabularies/Backstage/accept.txt
+++ b/.github/vale/config/vocabularies/Backstage/accept.txt
@@ -468,6 +468,7 @@ subfolders
 subheader
 subheaders
 subkey
+submenu
 subpage
 subpath
 subpaths

--- a/packages/core-components/report.api.md
+++ b/packages/core-components/report.api.md
@@ -1218,6 +1218,8 @@ export type SidebarSubmenuItemProps = {
   dropdownItems?: SidebarSubmenuItemDropdownItem[];
   exact?: boolean;
   initialShowDropdown?: boolean;
+  startComponent?: React.ReactNode;
+  endComponent?: React.ReactNode;
 };
 
 // @public

--- a/packages/core-components/src/layout/Sidebar/Bar.test.tsx
+++ b/packages/core-components/src/layout/Sidebar/Bar.test.tsx
@@ -144,8 +144,12 @@ describe('Sidebar', () => {
 
     it('Submenu item with start and end components should render them', async () => {
       await userEvent.hover(screen.getByTestId('item-with-submenu'));
-      expect(screen.getByTestId('my-start-component')).toBeInTheDocument();
-      expect(screen.getByTestId('my-end-component')).toBeInTheDocument();
+      const startEle = screen.getByTestId('my-start-component');
+      const endEle = screen.getByTestId('my-end-component');
+      expect(startEle).toBeInTheDocument();
+      expect(endEle).toBeInTheDocument();
+      expect(startEle.textContent).toEqual('[START]');
+      expect(endEle.textContent).toEqual('[END]');
     });
   });
 });

--- a/packages/core-components/src/layout/Sidebar/Bar.test.tsx
+++ b/packages/core-components/src/layout/Sidebar/Bar.test.tsx
@@ -65,6 +65,13 @@ async function renderScalableSidebar() {
                 },
               ]}
             />
+            <SidebarSubmenuItem
+              title="Start and End Components"
+              startComponent={
+                <div data-testid="my-start-component">[START]</div>
+              }
+              endComponent={<div data-testid="my-end-component">[END]</div>}
+            />
           </SidebarSubmenu>
         </SidebarItem>
         <SidebarItem icon={CreateComponentIcon} to="create" text="Create..." />
@@ -132,6 +139,12 @@ describe('Sidebar', () => {
         'href',
         'https://backstage.io/',
       );
+    });
+
+    it('Submenu item with start and end components should render them', async () => {
+      await userEvent.hover(screen.getByTestId('item-with-submenu'));
+      expect(screen.getByTestId('my-start-component')).toBeInTheDocument();
+      expect(screen.getByTestId('my-end-component')).toBeInTheDocument();
     });
   });
 });

--- a/packages/core-components/src/layout/Sidebar/Bar.test.tsx
+++ b/packages/core-components/src/layout/Sidebar/Bar.test.tsx
@@ -67,6 +67,7 @@ async function renderScalableSidebar() {
             />
             <SidebarSubmenuItem
               title="Start and End Components"
+              to="#"
               startComponent={
                 <div data-testid="my-start-component">[START]</div>
               }

--- a/packages/core-components/src/layout/Sidebar/Sidebar.stories.tsx
+++ b/packages/core-components/src/layout/Sidebar/Sidebar.stories.tsx
@@ -97,6 +97,12 @@ export const SampleScalableSidebar = () => (
                 },
               ]}
             />
+            <SidebarSubmenuItem
+              title="Start and End Components"
+              to="#"
+              startComponent={<div>⭐</div>}
+              endComponent={<div>🔥</div>}
+            />
           </SidebarSubmenu>
         </SidebarItem>
         <SidebarItem icon={HomeOutlinedIcon} to="#" text="Plugins" />

--- a/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
@@ -137,6 +137,8 @@ export type SidebarSubmenuItemDropdownItem = {
  * to: Path to navigate to when item is clicked
  * icon: Icon displayed on the left of text content
  * dropdownItems: Optional array of dropdown items displayed when submenu item is clicked.
+ * startComponent: Optional custom component to add to the beginning of the menu item (non-dropdown items only)
+ * endComponent: Optional custom component to add to the end of the menu item (non-dropdown items only)
  *
  * @public
  */
@@ -148,6 +150,8 @@ export type SidebarSubmenuItemProps = {
   dropdownItems?: SidebarSubmenuItemDropdownItem[];
   exact?: boolean;
   initialShowDropdown?: boolean;
+  startComponent?: React.ReactNode;
+  endComponent?: React.ReactNode;
 };
 
 /**
@@ -156,7 +160,16 @@ export type SidebarSubmenuItemProps = {
  * @public
  */
 export const SidebarSubmenuItem = (props: SidebarSubmenuItemProps) => {
-  const { title, subtitle, to, icon: Icon, dropdownItems, exact } = props;
+  const {
+    title,
+    subtitle,
+    to,
+    icon: Icon,
+    dropdownItems,
+    exact,
+    startComponent,
+    endComponent,
+  } = props;
   const classes = useStyles();
   const { setIsHoveredOn } = useContext(SidebarItemWithSubmenuContext);
   const closeSubmenu = () => {
@@ -257,6 +270,7 @@ export const SidebarSubmenuItem = (props: SidebarSubmenuItemProps) => {
           onClick={closeSubmenu}
           onTouchStart={e => e.stopPropagation()}
         >
+          {startComponent}
           {Icon && <Icon fontSize="small" />}
           <Typography
             variant="subtitle1"
@@ -275,6 +289,7 @@ export const SidebarSubmenuItem = (props: SidebarSubmenuItemProps) => {
               </Typography>
             )}
           </Typography>
+          {endComponent}
         </Link>
       </Tooltip>
     </Box>

--- a/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
@@ -137,8 +137,8 @@ export type SidebarSubmenuItemDropdownItem = {
  * to: Path to navigate to when item is clicked
  * icon: Icon displayed on the left of text content
  * dropdownItems: Optional array of dropdown items displayed when submenu item is clicked.
- * startComponent: Optional custom component to add to the beginning of the menu item (non-dropdown items only)
- * endComponent: Optional custom component to add to the end of the menu item (non-dropdown items only)
+ * startComponent: Optional custom component to add to the beginning of the menu item
+ * endComponent: Optional custom component to add to the end of the menu item
  *
  * @public
  */
@@ -204,6 +204,7 @@ export const SidebarSubmenuItem = (props: SidebarSubmenuItemProps) => {
               isActive ? classes.selected : undefined,
             )}
           >
+            {startComponent}
             {Icon && <Icon fontSize="small" />}
             <Typography
               variant="subtitle1"
@@ -222,6 +223,7 @@ export const SidebarSubmenuItem = (props: SidebarSubmenuItemProps) => {
                 </Typography>
               )}
             </Typography>
+            {endComponent}
             {showDropDown ? (
               <ArrowDropUpIcon className={classes.dropdownArrow} />
             ) : (

--- a/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
@@ -137,8 +137,8 @@ export type SidebarSubmenuItemDropdownItem = {
  * to: Path to navigate to when item is clicked
  * icon: Icon displayed on the left of text content
  * dropdownItems: Optional array of dropdown items displayed when submenu item is clicked.
- * startComponent: Optional custom component to add to the beginning of the menu item
- * endComponent: Optional custom component to add to the end of the menu item
+ * startComponent: Optional custom component to add to the beginning of the menu item. NOTE: As this can be rendered inside a button or link element, please use non-interactive components or handle events appropriately!
+ * endComponent: Optional custom component to add to the end of the menu item. NOTE: As this can be rendered inside a button or link element, please use non-interactive components or handle events appropriately!
  *
  * @public
  */


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds `startComponent` and `endComponent` optional props to `SidebarSubmenuItem` component, which allows some simple customization of the submenu items.

Use cases:
 - Adding a type tag before the item
 - Adding "NEW" indicators on items
 - Adding favorite toggle controls

A basic example where `starredEntities` are listed in a submenu:

<img width="736" height="489" alt="image" src="https://github.com/user-attachments/assets/1a75fd70-c527-4a10-8edb-f9d457d1997e" />

```jsx
const FavoritesMenu = () => {
  const { starredEntities } = useStarredEntities()

  return (
    <>
      {Array.from(starredEntities).map((entityRef) => {
        const kind = entityRef.split(':')[0]
        const namespace = entityRef.split(':')[1].split('/')[0]
        const name = entityRef.split(':')[1].split('/')[1]
        const link = `catalog/${namespace}/${kind}/${name}`
        return (
          <SidebarSubmenuItem to={link} title={name} 
            startComponent={<Chip label={kind} style={{ margin: 0 }} />} 
            endComponent={<Chip label='NEW' size='small' style={{ margin: 0, backgroundColor: 'blue', color: 'white' }} />} 
          />
        )
      })}
    </>
  )
}

...


        <SidebarItem icon={MenuBookIcon} text="Favorites">
          <SidebarSubmenu title="Favorites">
            <FavoritesMenu />
          </SidebarSubmenu>
        </SidebarItem>
```

An example from our actual submenu where we use the `startComponent` to inject the "star toggle" and an entity type pill in "recent" and "favorites" submenu lists:

<img width="626" height="927" alt="image" src="https://github.com/user-attachments/assets/83cbf196-cd8f-4158-b063-5333690e99d0" />



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
