### PR TITLE
bui(docs-ui): Add discord link to backstage ui docs header

### DIFF
--- a/docs-ui/src/components/Toolbar/Toolbar.tsx
+++ b/docs-ui/src/components/Toolbar/Toolbar.tsx
@@ -96,6 +96,7 @@ export const Toolbar = ({ version }: ToolbarProps) => {
         <a
           href="https://www.npmjs.com/package/@backstage/ui"
           target="_blank"
+          rel="noopener noreferrer"
           className={styles.bubble}
           data-hide-tablet
         >
@@ -104,16 +105,20 @@ export const Toolbar = ({ version }: ToolbarProps) => {
         <a
           href="https://github.com/backstage/backstage/tree/master/packages/ui"
           target="_blank"
+          rel="noopener noreferrer"
           className={styles.bubble}
           data-hide-tablet
+          aria-label="View source on GitHub"
         >
           <RiGithubLine size={16} />
         </a>
         <a
           href="https://discord.gg/backstage-687207715902193673"
           target="_blank"
+          rel="noopener noreferrer"
           className={styles.bubble}
           data-hide-tablet
+          aria-label="Join Backstage on Discord"
         >
           <RiDiscordLine size={16} />
         </a>


### PR DESCRIPTION
## Add Discord link to docs-ui header

<img width="1887" height="541" alt="image" src="https://github.com/user-attachments/assets/66992cac-985a-4b58-9708-3408685984b2" />


Added a Discord icon link next to the GitHub icon in the toolbar header, providing quick access to the Backstage community Discord server.

### Changes
- Added Discord icon (`RiDiscordLine`) to the Toolbar component
- Positioned the Discord link immediately after the GitHub link
- Applied consistent styling with other toolbar icons
- Link points to: https://discord.gg/backstage-687207715902193673

### Files Modified
- `docs-ui/src/components/Toolbar/Toolbar.tsx`