### PR TITLE
fix(catalog-backend-module-gitlab): correct GitLab API parameter from 'topics' to 'topic'

### DIFF
--- a/.changeset/fix-gitlab-topic-filter.md
+++ b/.changeset/fix-gitlab-topic-filter.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-gitlab': patch
+---
+
+Fixed GitLab project topic filtering by using correct API parameter 'topic' instead of 'topics'

--- a/plugins/catalog-backend-module-gitlab/src/lib/client.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/client.ts
@@ -41,7 +41,7 @@ interface ListProjectOptions extends CommonListOptions {
   archived?: boolean;
   group?: string;
   membership?: boolean;
-  topics?: string;
+  topic?: string;
   last_activity_after?: string;
 }
 

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.test.ts
@@ -827,3 +827,67 @@ describe('GitlabDiscoveryEntityProvider - simple parameter', () => {
     });
   });
 });
+
+describe('GitlabDiscoveryEntityProvider - topic parameter', () => {
+  it('should pass topic (singular) when topics (plural) is configured', async () => {
+    const config = new ConfigReader({
+      integrations: {
+        gitlab: [
+          {
+            host: 'example.com',
+            apiBaseUrl: 'https://example.com/api/v4',
+            token: 'test-token',
+          },
+        ],
+      },
+      catalog: {
+        providers: {
+          gitlab: {
+            'test-id': {
+              host: 'example.com',
+              group: 'test-group',
+              topics: ['topic1', 'topic2'],
+            },
+          },
+        },
+      },
+    });
+
+    const schedule = new PersistingTaskRunner();
+    const entityProviderConnection: EntityProviderConnection = {
+      applyMutation: jest.fn(),
+      refresh: jest.fn(),
+    };
+
+    const provider = GitlabDiscoveryEntityProvider.fromConfig(config, {
+      logger,
+      schedule,
+    })[0];
+
+    // Mock the GitLabClient listProjects method to verify parameters
+    const mockListProjects = jest.fn().mockResolvedValue({
+      items: [],
+      nextPage: undefined,
+    });
+
+    (provider as any).gitLabClient.listProjects = mockListProjects;
+
+    await provider.connect(entityProviderConnection);
+    await provider.refresh(logger);
+
+    expect(mockListProjects).toHaveBeenCalledWith({
+      group: 'test-group',
+      page: undefined,
+      per_page: 50,
+      archived: false,
+      topic: 'topic1,topic2', // Correct singular 'topic' parameter
+      simple: true,
+    });
+    // Verify the old incorrect 'topics' key is NOT present
+    expect(mockListProjects).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        topics: expect.anything(),
+      }),
+    );
+  });
+});

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts
@@ -383,7 +383,7 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
         per_page: 50,
         ...(!this.config.includeArchivedRepos && { archived: false }),
         ...(this.config.membership && { membership: true }),
-        ...(this.config.topics && { topics: this.config.topics }),
+        ...(this.config.topics && { topic: this.config.topics }),
         // Only use simple=true when we don't need to skip forked repos.
         // The simple=true parameter reduces response size by returning fewer fields,
         // but it excludes the 'forked_from_project' field which is required for fork detection.


### PR DESCRIPTION
## Summary
Fixes #33110

The `GitlabDiscoveryEntityProvider` passes the query parameter `topics` (plural) to the GitLab Projects API when filtering projects by topic. However, the GitLab API expects the parameter name `topic` (singular), causing the filter to be ignored.

## Changes
- **GitlabDiscoveryEntityProvider.ts**
  - Updated the API query parameter from `topics` to `topic` when calling `listProjects`.

- **client.ts**
  - Updated the `ListProjectOptions` interface to use `topic` instead of `topics` to match the GitLab API parameter.

## Root Cause
The original implementation introduced topic filtering but used `topics` (plural) as the query parameter name.

The GitLab API endpoint `GET /projects` expects `topic` (singular), so the filtering was not applied.

## Notes
This is a **non-breaking change**.

The internal configuration (`topics` in `app-config.yaml`) remains unchanged. Only the outbound API request parameter has been corrected.

---

## Checklist
- [ ] A changeset describing the change and affected packages
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes) — N/A
- [x] All commits include a `Signed-off-by` line