### PR TITLE
Fix(home): fix editable and draggable state of widgets in edit mode.

### DIFF
--- a/.changeset/blue-lies-try.md
+++ b/.changeset/blue-lies-try.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home': patch
+---
+
+Fixed the editable and draggable state of widgets in edit mode

--- a/.github/vale/config/vocabularies/Backstage/accept.txt
+++ b/.github/vale/config/vocabularies/Backstage/accept.txt
@@ -132,6 +132,7 @@ Docusaurus
 Dominik
 DOMPurify
 don'ts
+draggable
 dynatrace
 dyno
 ecco

--- a/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.tsx
+++ b/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.tsx
@@ -303,8 +303,8 @@ export const CustomHomepageGrid = (props: CustomHomepageGridProps) => {
     setEditMode(isEditMode);
 
     const updatedWidgets = widgets.map(widget => {
-      const isDraggable = isEditMode ? widget.movable : false;
-      const isResizable = isEditMode ? widget.resizable : false;
+      const isDraggable = Boolean(isEditMode && widget.movable);
+      const isResizable = Boolean(isEditMode && widget.resizable);
 
       return {
         ...widget,

--- a/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.tsx
+++ b/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.tsx
@@ -299,19 +299,27 @@ export const CustomHomepageGrid = (props: CustomHomepageGridProps) => {
     setWidgets(widgets.filter(w => w.deletable === false));
   };
 
-  const changeEditMode = (mode: boolean) => {
-    setEditMode(mode);
+  const changeEditMode = (isEditMode: boolean) => {
+    setEditMode(isEditMode);
 
-    if (!mode) {
-      const newWidgets = widgets.map(w => {
-        const resizable = w.resizable === false ? false : mode;
-        const movable = w.movable === false ? false : mode;
-        return {
-          ...w,
-          layout: { ...w.layout, isDraggable: movable, isResizable: resizable },
-        };
-      });
-      storeWidgets(newWidgets);
+    const updatedWidgets = widgets.map(widget => {
+      const isDraggable = isEditMode ? widget.movable : false;
+      const isResizable = isEditMode ? widget.resizable : false;
+
+      return {
+        ...widget,
+        layout: {
+          ...widget.layout,
+          isDraggable,
+          isResizable,
+        },
+      };
+    });
+
+    if (isEditMode) {
+      setWidgets(updatedWidgets);
+    } else {
+      storeWidgets(updatedWidgets);
     }
   };
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Currently widget on the customizable homepage do not get the correct editable and draggable state when the homepage is in edit mode. Because of this no widget can be moved or resized.

This issue can be experienced in the demo app: https://demo.backstage.io/home with the `customizable-home-page-preview` feature flag enabled. When entering edit mode none of the widgets can be resized or moved.

This change allows the widget to correctly use the configuration to let the user drag or resize widgets when edit mode is enabled.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
