### PR TITLE
fix(mcp-actions-backend): use external URLs in OAuth protected resource endpoint

### DIFF
--- a/.changeset/fix-mcp-oauth-external-urls.md
+++ b/.changeset/fix-mcp-oauth-external-urls.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-mcp-actions-backend': patch
+---
+
+Fixed OAuth protected resource endpoint to use external URLs instead of internal URLs, ensuring MCP clients receive publicly accessible URLs for the authorization server and resource endpoints.

--- a/plugins/mcp-actions-backend/src/plugin.ts
+++ b/plugins/mcp-actions-backend/src/plugin.ts
@@ -114,8 +114,8 @@ export const mcpPlugin = createBackendPlugin({
             '/.well-known/oauth-protected-resource',
             async (_, res) => {
               const [authBaseUrl, mcpBaseUrl] = await Promise.all([
-                discovery.getBaseUrl('auth'),
-                discovery.getBaseUrl('mcp-actions'),
+                discovery.getExternalBaseUrl('auth'),
+                discovery.getExternalBaseUrl('mcp-actions'),
               ]);
               res.json({
                 resource: mcpBaseUrl,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The oauth-protected-resource well-known endpoint returns URLs directly to external MCP clients, so it must use getExternalBaseUrl() to provide publicly accessible URLs rather than internal/local ones.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
