### PR TITLE
Remove deprecated `defaultPath` migration helper from `PageBlueprint`

### DIFF
--- a/.changeset/remove-page-blueprint-defaultpath.md
+++ b/.changeset/remove-page-blueprint-defaultpath.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+Removed the deprecated `defaultPath` migration helper from `PageBlueprint` params.

--- a/packages/app-example-plugin/report.api.md
+++ b/packages/app-example-plugin/report.api.md
@@ -87,7 +87,6 @@ const examplePlugin: OverridableFrontendPlugin<
         >;
       };
       params: {
-        defaultPath?: [Error: `Use the 'path' param instead`];
         path: string;
         title?: string;
         icon?: IconElement;

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -1722,7 +1722,6 @@ export interface OverridableFrontendPlugin<
 export const PageBlueprint: ExtensionBlueprint_2<{
   kind: 'page';
   params: {
-    defaultPath?: [Error: `Use the 'path' param instead`];
     path: string;
     title?: string;
     icon?: IconElement;

--- a/packages/frontend-plugin-api/src/blueprints/PageBlueprint.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/PageBlueprint.tsx
@@ -59,10 +59,6 @@ export const PageBlueprint = createExtensionBlueprint({
   },
   *factory(
     params: {
-      /**
-       * @deprecated Use the `path` param instead.
-       */
-      defaultPath?: [Error: `Use the 'path' param instead`];
       path: string;
       title?: string;
       icon?: IconElement;

--- a/plugins/api-docs/report-alpha.api.md
+++ b/plugins/api-docs/report-alpha.api.md
@@ -563,7 +563,6 @@ const _default: OverridableFrontendPlugin<
       kind: 'page';
       name: undefined;
       params: {
-        defaultPath?: [Error: `Use the 'path' param instead`];
         path: string;
         title?: string;
         icon?: IconElement;

--- a/plugins/app-visualizer/report.api.md
+++ b/plugins/app-visualizer/report.api.md
@@ -109,7 +109,6 @@ const visualizerPlugin: OverridableFrontendPlugin<
         >;
       };
       params: {
-        defaultPath?: [Error: `Use the 'path' param instead`];
         path: string;
         title?: string;
         icon?: IconElement;

--- a/plugins/auth/report.api.md
+++ b/plugins/auth/report.api.md
@@ -88,7 +88,6 @@ const _default: OverridableFrontendPlugin<
         >;
       };
       params: {
-        defaultPath?: [Error: `Use the 'path' param instead`];
         path: string;
         title?: string;
         icon?: IconElement;

--- a/plugins/catalog-graph/report-alpha.api.md
+++ b/plugins/catalog-graph/report-alpha.api.md
@@ -238,7 +238,6 @@ const _default: OverridableFrontendPlugin<
       kind: 'page';
       name: undefined;
       params: {
-        defaultPath?: [Error: `Use the 'path' param instead`];
         path: string;
         title?: string;
         icon?: IconElement;

--- a/plugins/catalog-import/report-alpha.api.md
+++ b/plugins/catalog-import/report-alpha.api.md
@@ -181,7 +181,6 @@ const _default: OverridableFrontendPlugin<
         >;
       };
       params: {
-        defaultPath?: [Error: `Use the 'path' param instead`];
         path: string;
         title?: string;
         icon?: IconElement;

--- a/plugins/catalog-unprocessed-entities/report-alpha.api.md
+++ b/plugins/catalog-unprocessed-entities/report-alpha.api.md
@@ -130,7 +130,6 @@ const _default: OverridableFrontendPlugin<
         >;
       };
       params: {
-        defaultPath?: [Error: `Use the 'path' param instead`];
         path: string;
         title?: string;
         icon?: IconElement;

--- a/plugins/catalog/report-alpha.api.md
+++ b/plugins/catalog/report-alpha.api.md
@@ -1082,7 +1082,6 @@ const _default: OverridableFrontendPlugin<
       kind: 'page';
       name: undefined;
       params: {
-        defaultPath?: [Error: `Use the 'path' param instead`];
         path: string;
         title?: string;
         icon?: IconElement;
@@ -1270,7 +1269,6 @@ const _default: OverridableFrontendPlugin<
       kind: 'page';
       name: 'entity';
       params: {
-        defaultPath?: [Error: `Use the 'path' param instead`];
         path: string;
         title?: string;
         icon?: IconElement;

--- a/plugins/devtools/report-alpha.api.md
+++ b/plugins/devtools/report-alpha.api.md
@@ -146,7 +146,6 @@ const _default: OverridableFrontendPlugin<
       kind: 'page';
       name: undefined;
       params: {
-        defaultPath?: [Error: `Use the 'path' param instead`];
         path: string;
         title?: string;
         icon?: IconElement;

--- a/plugins/home/report-alpha.api.md
+++ b/plugins/home/report-alpha.api.md
@@ -194,7 +194,6 @@ const _default: OverridableFrontendPlugin<
       kind: 'page';
       name: undefined;
       params: {
-        defaultPath?: [Error: `Use the 'path' param instead`];
         path: string;
         title?: string;
         icon?: IconElement;

--- a/plugins/kubernetes/report-alpha.api.md
+++ b/plugins/kubernetes/report-alpha.api.md
@@ -228,7 +228,6 @@ const _default: OverridableFrontendPlugin<
         >;
       };
       params: {
-        defaultPath?: [Error: `Use the 'path' param instead`];
         path: string;
         title?: string;
         icon?: IconElement;

--- a/plugins/mui-to-bui/report.api.md
+++ b/plugins/mui-to-bui/report.api.md
@@ -102,7 +102,6 @@ const _default: OverridableFrontendPlugin<
         >;
       };
       params: {
-        defaultPath?: [Error: `Use the 'path' param instead`];
         path: string;
         title?: string;
         icon?: IconElement;

--- a/plugins/notifications/report-alpha.api.md
+++ b/plugins/notifications/report-alpha.api.md
@@ -108,7 +108,6 @@ const _default: OverridableFrontendPlugin<
         >;
       };
       params: {
-        defaultPath?: [Error: `Use the 'path' param instead`];
         path: string;
         title?: string;
         icon?: IconElement;

--- a/plugins/scaffolder/report-alpha.api.md
+++ b/plugins/scaffolder/report-alpha.api.md
@@ -274,7 +274,6 @@ const _default: OverridableFrontendPlugin<
       kind: 'page';
       name: undefined;
       params: {
-        defaultPath?: [Error: `Use the 'path' param instead`];
         path: string;
         title?: string;
         icon?: IconElement;

--- a/plugins/search/report-alpha.api.md
+++ b/plugins/search/report-alpha.api.md
@@ -181,7 +181,6 @@ const _default: OverridableFrontendPlugin<
       kind: 'page';
       name: undefined;
       params: {
-        defaultPath?: [Error: `Use the 'path' param instead`];
         path: string;
         title?: string;
         icon?: IconElement;
@@ -351,7 +350,6 @@ export const searchPage: OverridableExtensionDefinition<{
   kind: 'page';
   name: undefined;
   params: {
-    defaultPath?: [Error: `Use the 'path' param instead`];
     path: string;
     title?: string;
     icon?: IconElement;

--- a/plugins/techdocs/report-alpha.api.md
+++ b/plugins/techdocs/report-alpha.api.md
@@ -348,7 +348,6 @@ const _default: OverridableFrontendPlugin<
         >;
       };
       params: {
-        defaultPath?: [Error: `Use the 'path' param instead`];
         path: string;
         title?: string;
         icon?: IconElement;
@@ -441,7 +440,6 @@ const _default: OverridableFrontendPlugin<
       kind: 'page';
       name: 'reader';
       params: {
-        defaultPath?: [Error: `Use the 'path' param instead`];
         path: string;
         title?: string;
         icon?: IconElement;

--- a/plugins/user-settings/report-alpha.api.md
+++ b/plugins/user-settings/report-alpha.api.md
@@ -120,7 +120,6 @@ const _default: OverridableFrontendPlugin<
       kind: 'page';
       name: undefined;
       params: {
-        defaultPath?: [Error: `Use the 'path' param instead`];
         path: string;
         title?: string;
         icon?: IconElement;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Remove the `defaultPath` migration artifact from `PageBlueprint` in `@backstage/frontend-plugin-api`. This property was typed as `[Error: "Use the 'path' param instead"]` — a compile-time helper that guided users during the migration from `defaultPath` to `path`. The migration period is over, so this cleans it up from the public API surface.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))