### PR TITLE
Fix JSX type reference inconsistency in DialogApiDialog

### DIFF
--- a/.changeset/fix-dialog-api-jsx-type.md
+++ b/.changeset/fix-dialog-api-jsx-type.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+Fixed inconsistent `JSX.Element` type reference in the `DialogApiDialog.update` method signature.

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -866,7 +866,7 @@ export interface DialogApiDialog<TResult = void> {
   result(): Promise<TResult>;
   update(
     elementOrComponent:
-      | React.JSX.Element
+      | JSX.Element
       | ((props: { dialog: DialogApiDialog<TResult> }) => JSX.Element),
   ): void;
 }

--- a/packages/frontend-plugin-api/src/apis/definitions/DialogApi.ts
+++ b/packages/frontend-plugin-api/src/apis/definitions/DialogApi.ts
@@ -42,7 +42,7 @@ export interface DialogApiDialog<TResult = void> {
    */
   update(
     elementOrComponent:
-      | React.JSX.Element
+      | JSX.Element
       | ((props: { dialog: DialogApiDialog<TResult> }) => JSX.Element),
   ): void;
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `update` method in the `DialogApiDialog` interface used `React.JSX.Element` for the first union member and plain `JSX.Element` for the second member of the same parameter. These resolve to the same type but the inconsistency within a single method signature is confusing. This aligns both to use `JSX.Element` to match the rest of the file.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))