### PR TITLE
Deprecate NavItemBlueprint in @backstage/frontend-plugin-api

### DIFF
--- a/.changeset/deprecate-nav-item-blueprint.md
+++ b/.changeset/deprecate-nav-item-blueprint.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+Deprecated `NavItemBlueprint`. Nav items are now automatically inferred from `PageBlueprint` extensions based on their `title` and `icon` params.

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -1470,7 +1470,7 @@ export const microsoftAuthApiRef: ApiRef<
     SessionApi
 >;
 
-// @public
+// @public @deprecated
 export const NavItemBlueprint: ExtensionBlueprint_2<{
   kind: 'nav-item';
   params: {

--- a/packages/frontend-plugin-api/src/blueprints/NavItemBlueprint.ts
+++ b/packages/frontend-plugin-api/src/blueprints/NavItemBlueprint.ts
@@ -29,6 +29,10 @@ const targetDataRef = createExtensionDataRef<{
  * Creates extensions that make up the items of the nav bar.
  *
  * @public
+ * @deprecated Nav items are now automatically inferred from `PageBlueprint`
+ * extensions based on their `title` and `icon` params. You can remove your
+ * `NavItemBlueprint` usage and instead pass `title` and `icon` directly to
+ * the `PageBlueprint`.
  */
 export const NavItemBlueprint = createExtensionBlueprint({
   kind: 'nav-item',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Marks `NavItemBlueprint` as deprecated in `@backstage/frontend-plugin-api`. Nav items are now automatically inferred from `PageBlueprint` extensions based on their `title` and `icon` params, making explicit `NavItemBlueprint` usage redundant.

The `@deprecated` JSDoc tag includes a migration pointer guiding users to pass `title` and `icon` directly to `PageBlueprint` instead.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))