### PR TITLE
Add incremental entity provider for Microsoft Graph org ingestion

### DIFF
--- a/plugins/catalog-backend-module-msgraph/package.json
+++ b/plugins/catalog-backend-module-msgraph/package.json
@@ -55,6 +55,7 @@
     "@backstage/backend-plugin-api": "workspace:^",
     "@backstage/catalog-model": "workspace:^",
     "@backstage/config": "workspace:^",
+    "@backstage/plugin-catalog-backend-module-incremental-ingestion": "workspace:^",
     "@backstage/plugin-catalog-common": "workspace:^",
     "@backstage/plugin-catalog-node": "workspace:^",
     "@microsoft/microsoft-graph-types": "^2.6.0",

--- a/plugins/catalog-backend-module-msgraph/src/module/catalogModuleMicrosoftGraphOrgIncrementalEntityProvider.ts
+++ b/plugins/catalog-backend-module-msgraph/src/module/catalogModuleMicrosoftGraphOrgIncrementalEntityProvider.ts
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  coreServices,
+  createBackendModule,
+  createExtensionPoint,
+} from '@backstage/backend-plugin-api';
+import { incrementalIngestionProvidersExtensionPoint } from '@backstage/plugin-catalog-backend-module-incremental-ingestion';
+import {
+  GroupTransformer,
+  OrganizationTransformer,
+  ProviderConfigTransformer,
+  UserTransformer,
+} from '../microsoftGraph/types';
+import { readProviderConfigs } from '../microsoftGraph/config';
+import { MicrosoftGraphOrgIncrementalEntityProvider } from '../processors/MicrosoftGraphOrgIncrementalEntityProvider';
+
+/**
+ * Interface for {@link microsoftGraphOrgIncrementalEntityProviderTransformExtensionPoint}.
+ *
+ * @public
+ */
+export interface MicrosoftGraphOrgIncrementalEntityProviderTransformsExtensionPoint {
+  /**
+   * Set the function that transforms a user entry in msgraph to an entity.
+   * Optionally, you can pass separate transformers per provider ID.
+   */
+  setUserTransformer(
+    transformer: UserTransformer | Record<string, UserTransformer>,
+  ): void;
+
+  /**
+   * Set the function that transforms a group entry in msgraph to an entity.
+   * Optionally, you can pass separate transformers per provider ID.
+   */
+  setGroupTransformer(
+    transformer: GroupTransformer | Record<string, GroupTransformer>,
+  ): void;
+
+  /**
+   * Set the function that transforms an organization entry in msgraph to an entity.
+   * Optionally, you can pass separate transformers per provider ID.
+   */
+  setOrganizationTransformer(
+    transformer:
+      | OrganizationTransformer
+      | Record<string, OrganizationTransformer>,
+  ): void;
+
+  /**
+   * Set the function that transforms provider config dynamically.
+   * Optionally, you can pass separate transformers per provider ID.
+   */
+  setProviderConfigTransformer(
+    transformer:
+      | ProviderConfigTransformer
+      | Record<string, ProviderConfigTransformer>,
+  ): void;
+}
+
+/**
+ * Extension point used to customize the transforms used by the incremental module.
+ *
+ * @public
+ */
+export const microsoftGraphOrgIncrementalEntityProviderTransformExtensionPoint =
+  createExtensionPoint<MicrosoftGraphOrgIncrementalEntityProviderTransformsExtensionPoint>(
+    {
+      id: 'catalog.microsoftGraphOrgIncrementalEntityProvider.transforms',
+    },
+  );
+
+/**
+ * Registers the MicrosoftGraphOrgIncrementalEntityProvider with the
+ * incremental ingestion extension point.
+ *
+ * @remarks
+ *
+ * This module requires the
+ * `@backstage/plugin-catalog-backend-module-incremental-ingestion` module
+ * to also be installed in the backend.
+ *
+ * @public
+ */
+export const catalogModuleMicrosoftGraphOrgIncrementalEntityProvider =
+  createBackendModule({
+    pluginId: 'catalog',
+    moduleId: 'microsoftGraphOrgIncrementalEntityProvider',
+    register(env) {
+      let userTransformer:
+        | UserTransformer
+        | Record<string, UserTransformer>
+        | undefined;
+      let groupTransformer:
+        | GroupTransformer
+        | Record<string, GroupTransformer>
+        | undefined;
+      let organizationTransformer:
+        | OrganizationTransformer
+        | Record<string, OrganizationTransformer>
+        | undefined;
+      let providerConfigTransformer:
+        | ProviderConfigTransformer
+        | Record<string, ProviderConfigTransformer>
+        | undefined;
+
+      env.registerExtensionPoint(
+        microsoftGraphOrgIncrementalEntityProviderTransformExtensionPoint,
+        {
+          setUserTransformer(transformer) {
+            if (userTransformer) {
+              throw new Error('User transformer may only be set once');
+            }
+            userTransformer = transformer;
+          },
+          setGroupTransformer(transformer) {
+            if (groupTransformer) {
+              throw new Error('Group transformer may only be set once');
+            }
+            groupTransformer = transformer;
+          },
+          setOrganizationTransformer(transformer) {
+            if (organizationTransformer) {
+              throw new Error('Organization transformer may only be set once');
+            }
+            organizationTransformer = transformer;
+          },
+          setProviderConfigTransformer(transformer) {
+            if (providerConfigTransformer) {
+              throw new Error('Provider transformer may only be set once');
+            }
+            providerConfigTransformer = transformer;
+          },
+        },
+      );
+
+      env.registerInit({
+        deps: {
+          incrementalBuilder: incrementalIngestionProvidersExtensionPoint,
+          config: coreServices.rootConfig,
+          logger: coreServices.logger,
+        },
+        async init({ incrementalBuilder, config, logger }) {
+          function getTransformer<T extends Function>(
+            id: string,
+            transformers?: T | Record<string, T>,
+          ): T | undefined {
+            if (['undefined', 'function'].includes(typeof transformers)) {
+              return transformers as T;
+            }
+            return (transformers as Record<string, T>)[id];
+          }
+
+          const providerConfigs = readProviderConfigs(config);
+
+          for (const providerConfig of providerConfigs) {
+            const provider = new MicrosoftGraphOrgIncrementalEntityProvider({
+              id: providerConfig.id,
+              provider: providerConfig,
+              logger,
+              userTransformer: getTransformer(
+                providerConfig.id,
+                userTransformer,
+              ),
+              groupTransformer: getTransformer(
+                providerConfig.id,
+                groupTransformer,
+              ),
+              organizationTransformer: getTransformer(
+                providerConfig.id,
+                organizationTransformer,
+              ),
+              providerConfigTransformer: getTransformer(
+                providerConfig.id,
+                providerConfigTransformer,
+              ),
+            });
+
+            incrementalBuilder.addProvider({
+              provider,
+              options: {
+                burstInterval: { seconds: 3 },
+                burstLength: { minutes: 5 },
+                restLength: { hours: 1 },
+              },
+            });
+          }
+        },
+      });
+    },
+  });

--- a/plugins/catalog-backend-module-msgraph/src/module/index.ts
+++ b/plugins/catalog-backend-module-msgraph/src/module/index.ts
@@ -19,3 +19,8 @@ export {
   microsoftGraphOrgEntityProviderTransformExtensionPoint,
   type MicrosoftGraphOrgEntityProviderTransformsExtensionPoint,
 } from './catalogModuleMicrosoftGraphOrgEntityProvider';
+export {
+  catalogModuleMicrosoftGraphOrgIncrementalEntityProvider,
+  microsoftGraphOrgIncrementalEntityProviderTransformExtensionPoint,
+  type MicrosoftGraphOrgIncrementalEntityProviderTransformsExtensionPoint,
+} from './catalogModuleMicrosoftGraphOrgIncrementalEntityProvider';

--- a/plugins/catalog-backend-module-msgraph/src/processors/MicrosoftGraphOrgIncrementalEntityProvider.ts
+++ b/plugins/catalog-backend-module-msgraph/src/processors/MicrosoftGraphOrgIncrementalEntityProvider.ts
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity } from '@backstage/catalog-model';
+import { LoggerService } from '@backstage/backend-plugin-api';
+import type {
+  IncrementalEntityProvider,
+  EntityIteratorResult,
+} from '@backstage/plugin-catalog-backend-module-incremental-ingestion';
+import type { DeferredEntity } from '@backstage/plugin-catalog-node';
+import {
+  GroupTransformer,
+  MicrosoftGraphClient,
+  MicrosoftGraphProviderConfig,
+  OrganizationTransformer,
+  ProviderConfigTransformer,
+  readMicrosoftGraphOrg,
+  UserTransformer,
+} from '../microsoftGraph';
+import { withLocations } from './MicrosoftGraphOrgEntityProvider';
+
+const BATCH_SIZE = 100;
+
+/**
+ * Options for {@link MicrosoftGraphOrgIncrementalEntityProvider}.
+ *
+ * @public
+ */
+export interface MicrosoftGraphOrgIncrementalEntityProviderOptions {
+  id: string;
+  provider: MicrosoftGraphProviderConfig;
+  logger: LoggerService;
+  userTransformer?: UserTransformer;
+  groupTransformer?: GroupTransformer;
+  organizationTransformer?: OrganizationTransformer;
+  providerConfigTransformer?: ProviderConfigTransformer;
+}
+
+/**
+ * Cursor representing the current offset into the pre-loaded entity array.
+ */
+type MicrosoftGraphOrgCursor = number;
+
+/**
+ * Context provided during a burst, containing the full set of entities
+ * read from Microsoft Graph.
+ */
+type MicrosoftGraphOrgContext = {
+  entities: DeferredEntity[];
+};
+
+/**
+ * Reads user and group entries out of Microsoft Graph, and provides them as
+ * User and Group entities for the catalog via incremental ingestion.
+ *
+ * Unlike {@link MicrosoftGraphOrgEntityProvider} which performs full mutations,
+ * this provider yields entities in small batches. This lets the catalog process
+ * and persist them incrementally, giving better resilience for very large
+ * organizations and automatic handling of removed entities.
+ *
+ * @public
+ */
+export class MicrosoftGraphOrgIncrementalEntityProvider
+  implements
+    IncrementalEntityProvider<
+      MicrosoftGraphOrgCursor,
+      MicrosoftGraphOrgContext
+    >
+{
+  private cachedEntities?: DeferredEntity[];
+
+  constructor(
+    private readonly options: MicrosoftGraphOrgIncrementalEntityProviderOptions,
+  ) {}
+
+  getProviderName(): string {
+    return `MicrosoftGraphOrgIncrementalEntityProvider:${this.options.id}`;
+  }
+
+  /**
+   * Reads the full Microsoft Graph organization and provides the resulting
+   * entities to the burst callback. Entities are cached across bursts within
+   * the same ingestion cycle to avoid redundant API calls.
+   */
+  async around(
+    burst: (context: MicrosoftGraphOrgContext) => Promise<void>,
+  ): Promise<void> {
+    if (!this.cachedEntities) {
+      this.cachedEntities = await this.readAllEntities();
+    }
+
+    await burst({ entities: this.cachedEntities });
+  }
+
+  async next(
+    context: MicrosoftGraphOrgContext,
+    cursor?: MicrosoftGraphOrgCursor,
+  ): Promise<EntityIteratorResult<MicrosoftGraphOrgCursor>> {
+    const offset = cursor ?? 0;
+    const batch = context.entities.slice(offset, offset + BATCH_SIZE);
+    const nextOffset = offset + batch.length;
+
+    if (nextOffset >= context.entities.length) {
+      this.cachedEntities = undefined;
+      return { done: true, entities: batch, cursor: nextOffset };
+    }
+
+    return { done: false, entities: batch, cursor: nextOffset };
+  }
+
+  private async readAllEntities(): Promise<DeferredEntity[]> {
+    const provider = this.options.providerConfigTransformer
+      ? await this.options.providerConfigTransformer(this.options.provider)
+      : this.options.provider;
+
+    const client = MicrosoftGraphClient.create(this.options.provider);
+    const startTime = Date.now();
+
+    const { users, groups } = await readMicrosoftGraphOrg(
+      client,
+      provider.tenantId,
+      {
+        userExpand: provider.userExpand,
+        userFilter: provider.userFilter,
+        userSelect: provider.userSelect,
+        userPath: provider.userPath,
+        loadUserPhotos: provider.loadUserPhotos,
+        userGroupMemberFilter: provider.userGroupMemberFilter,
+        userGroupMemberSearch: provider.userGroupMemberSearch,
+        userGroupMemberPath: provider.userGroupMemberPath,
+        groupExpand: provider.groupExpand,
+        groupFilter: provider.groupFilter,
+        groupSearch: provider.groupSearch,
+        groupSelect: provider.groupSelect,
+        groupPath: provider.groupPath,
+        groupIncludeSubGroups: provider.groupIncludeSubGroups,
+        queryMode: provider.queryMode,
+        groupTransformer: this.options.groupTransformer,
+        userTransformer: this.options.userTransformer,
+        organizationTransformer: this.options.organizationTransformer,
+        logger: this.options.logger,
+      },
+    );
+
+    const readDuration = ((Date.now() - startTime) / 1000).toFixed(1);
+    this.options.logger.info(
+      `Read ${users.length} users and ${groups.length} groups from Microsoft Graph in ${readDuration} seconds`,
+    );
+
+    return [...users, ...groups].map(entity => ({
+      entity: withLocations(this.options.id, entity) as Entity,
+      locationKey: `msgraph-org-provider:${this.options.id}`,
+    }));
+  }
+}

--- a/plugins/catalog-backend-module-msgraph/src/processors/index.ts
+++ b/plugins/catalog-backend-module-msgraph/src/processors/index.ts
@@ -19,4 +19,6 @@ export type {
   MicrosoftGraphOrgEntityProviderOptions,
   MicrosoftGraphOrgEntityProviderLegacyOptions,
 } from './MicrosoftGraphOrgEntityProvider';
+export { MicrosoftGraphOrgIncrementalEntityProvider } from './MicrosoftGraphOrgIncrementalEntityProvider';
+export type { MicrosoftGraphOrgIncrementalEntityProviderOptions } from './MicrosoftGraphOrgIncrementalEntityProvider';
 export { MicrosoftGraphOrgReaderProcessor } from './MicrosoftGraphOrgReaderProcessor';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5137,7 +5137,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage/plugin-catalog-backend-module-incremental-ingestion@workspace:plugins/catalog-backend-module-incremental-ingestion":
+"@backstage/plugin-catalog-backend-module-incremental-ingestion@workspace:^, @backstage/plugin-catalog-backend-module-incremental-ingestion@workspace:plugins/catalog-backend-module-incremental-ingestion":
   version: 0.0.0-use.local
   resolution: "@backstage/plugin-catalog-backend-module-incremental-ingestion@workspace:plugins/catalog-backend-module-incremental-ingestion"
   dependencies:
@@ -5205,6 +5205,7 @@ __metadata:
     "@backstage/catalog-model": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/config": "workspace:^"
+    "@backstage/plugin-catalog-backend-module-incremental-ingestion": "workspace:^"
     "@backstage/plugin-catalog-common": "workspace:^"
     "@backstage/plugin-catalog-node": "workspace:^"
     "@microsoft/microsoft-graph-types": "npm:^2.6.0"


### PR DESCRIPTION
## Summary

- Adds `MicrosoftGraphOrgIncrementalEntityProvider`, an implementation of the `IncrementalEntityProvider` interface that reads users and groups from Microsoft Graph and yields them in small batches (100 at a time) rather than performing a single full mutation. This provides better resilience for very large organizations and automatic handling of removed entities.
- Adds a corresponding backend module (`catalogModuleMicrosoftGraphOrgIncrementalEntityProvider`) that reads the same `catalog.providers.microsoftGraphOrg` config and registers providers with the incremental ingestion extension point. Includes its own transform extension point for customizing user/group/organization transformers.
- Entities are cached across bursts within an ingestion cycle to avoid redundant Microsoft Graph API calls; the cache is cleared when the cycle completes so the next cycle gets fresh data.

### Usage

```ts
// packages/backend/src/index.ts
backend.add(import('@backstage/plugin-catalog-backend-module-incremental-ingestion'));

import { catalogModuleMicrosoftGraphOrgIncrementalEntityProvider } from '@backstage/plugin-catalog-backend-module-msgraph';
backend.add(catalogModuleMicrosoftGraphOrgIncrementalEntityProvider);
```

## Test plan

- [ ] Verify TypeScript compilation passes (confirmed: only pre-existing error in catalog-model, no errors from new code)
- [ ] Verify lint hooks pass (confirmed: commit succeeded through pre-commit hooks)
- [ ] Manual testing with a Microsoft Graph tenant
- [ ] Add unit tests for the incremental provider

Made with [Cursor](https://cursor.com)