### PR TITLE
ci: dedupe yarn.lock in Dependabot PR workflow

### DIFF
--- a/.github/workflows/sync_dependabot-changesets.yml
+++ b/.github/workflows/sync_dependabot-changesets.yml
@@ -21,15 +21,27 @@ jobs:
           fetch-depth: 2
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}
+      - name: Verify Dependabot branch
+        id: verify
+        run: |
+          if git branch --show-current | grep -q '^dependabot/'; then
+            echo "is_dependabot=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Not a dependabot branch, skipping"
+            echo "is_dependabot=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Configure Git
+        if: steps.verify.outputs.is_dependabot == 'true'
         run: |
           git config --global user.email noreply@backstage.io
           git config --global user.name 'Github changeset workflow'
       - name: Setup Node
+        if: steps.verify.outputs.is_dependabot == 'true'
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: 22.x
       - name: Dedupe lockfiles
+        if: steps.verify.outputs.is_dependabot == 'true'
         id: dedupe
         run: |
           corepack enable
@@ -48,6 +60,7 @@ jobs:
 
           echo "changed=$changed" >> "$GITHUB_OUTPUT"
       - name: Generate changeset
+        if: steps.verify.outputs.is_dependabot == 'true'
         id: changeset
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
@@ -71,12 +84,6 @@ jobs:
               const message = commitMessage.replace(/([bB])ump ([\S]+)/, '$1ump `$2`').trim();
               const body = `---\n${pkgs}\n---\n\n${message}\n`;
               await fs.writeFile(fileName, body);
-            }
-
-            const branch = await exec.getExecOutput('git branch --show-current');
-            if (!branch.stdout.startsWith('dependabot/')) {
-              console.log('Not a dependabot branch, skipping');
-              return;
             }
 
             const diffOutput = await exec.getExecOutput('git diff --name-only HEAD~1');
@@ -104,7 +111,7 @@ jobs:
             await exec.exec('git', ['add', fileName]);
             core.setOutput('changed', 'true');
       - name: Commit and push
-        if: steps.dedupe.outputs.changed == 'true' || steps.changeset.outputs.changed == 'true'
+        if: steps.verify.outputs.is_dependabot == 'true' && (steps.dedupe.outputs.changed == 'true' || steps.changeset.outputs.changed == 'true')
         run: |
           git commit -C HEAD --amend --no-edit
           git push --force


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When Dependabot creates PRs, it doesn't dedupe the yarn.lock file. This adds a `yarn dedupe` step to the existing Dependabot changeset sync workflow so that the lockfile is deduped before the commit is amended and force-pushed.

The new steps (Setup Node + Dedupe lockfile) run between "Configure Git" and "Generate changeset", and the deduped lockfile changes are picked up by the existing amend + force-push at the end.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

🤖 Generated with [Claude Code](https://claude.com/claude-code)