### PR TITLE
skip verify on the dependabot pr fixup

### DIFF
--- a/.github/workflows/sync_dependabot-changesets.yml
+++ b/.github/workflows/sync_dependabot-changesets.yml
@@ -113,5 +113,5 @@ jobs:
       - name: Commit and push
         if: steps.verify.outputs.is_dependabot == 'true' && (steps.dedupe.outputs.changed == 'true' || steps.changeset.outputs.changed == 'true')
         run: |
-          git commit -C HEAD --amend --no-edit
+          git commit -C HEAD --amend --no-edit --no-verify
           git push --force


### PR DESCRIPTION
Otherwise all the precommit hooks complain if there wasn't a full yarn install available.