### PR TITLE
Add RuleHub Policy Catalog plugin to the Backstage plugin directory

### DIFF
--- a/microsite/data/plugins/rulehub-policy-catalog.yaml
+++ b/microsite/data/plugins/rulehub-policy-catalog.yaml
@@ -1,0 +1,10 @@
+title: RuleHub Policy Catalog
+author: Rulehub
+authorUrl: https://github.com/rulehub
+category: Security
+description: Backstage frontend plugin that displays a policy/compliance catalog from a static JSON index.
+documentation: https://github.com/rulehub/rulehub-backstage-plugin#readme
+iconUrl: https://github.com/rulehub.png
+npmPackageName: '@rulehub/rulehub-backstage-plugin'
+addedDate: '2026-03-06'
+status: active


### PR DESCRIPTION
## What this adds

This PR adds RuleHub Policy Catalog to the Backstage plugin directory.

- Plugin repo: https://github.com/rulehub/rulehub-backstage-plugin
- npm package: https://www.npmjs.com/package/@rulehub/rulehub-backstage-plugin

## Notes

- The package is publicly available on npm.
- The plugin is a frontend Backstage plugin that displays a policy/compliance catalog from a static JSON index.