### PR TITLE
Remove inputs from upgrade-helper workflow dispatch

### DIFF
--- a/.github/workflows/sync_release-manifest.yml
+++ b/.github/workflows/sync_release-manifest.yml
@@ -81,9 +81,5 @@ jobs:
               owner: 'backstage',
               repo: 'upgrade-helper-diff',
               workflow_id: 'release.yml',
-              ref: 'master',
-              inputs: {
-                version: require('./packages/create-app/package.json').version,
-                releaseVersion: require('./package.json').version
-              },
+              ref: 'master'
             });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Inputs aren't needed anymore: https://github.com/backstage/upgrade-helper-diff/pull/11

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
