### PR TITLE
Rename PageTab to PageLayoutTab in @backstage/frontend-plugin-api

### DIFF
--- a/.changeset/rename-page-tab-to-page-layout-tab.md
+++ b/.changeset/rename-page-tab-to-page-layout-tab.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+Renamed the `PageTab` type to `PageLayoutTab`. The old `PageTab` name is now a deprecated type alias.

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -1802,13 +1802,13 @@ export interface PageLayoutProps {
   // (undocumented)
   noHeader?: boolean;
   // (undocumented)
-  tabs?: PageTab[];
+  tabs?: PageLayoutTab[];
   // (undocumented)
   title?: string;
 }
 
 // @public
-export interface PageTab {
+export interface PageLayoutTab {
   // (undocumented)
   href: string;
   // (undocumented)
@@ -1818,6 +1818,9 @@ export interface PageTab {
   // (undocumented)
   label: string;
 }
+
+// @public @deprecated (undocumented)
+export type PageTab = PageLayoutTab;
 
 // @public
 export type PendingOAuthRequest = {

--- a/packages/frontend-plugin-api/src/blueprints/PageBlueprint.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/PageBlueprint.tsx
@@ -23,7 +23,7 @@ import {
   createExtensionBlueprint,
   createExtensionInput,
 } from '../wiring';
-import { ExtensionBoundary, PageLayout, PageTab } from '../components';
+import { ExtensionBoundary, PageLayout, PageLayoutTab } from '../components';
 import { useApi } from '../apis/system';
 import { pluginHeaderActionsApiRef } from '../apis/definitions/PluginHeaderActionsApi';
 
@@ -97,7 +97,7 @@ export const PageBlueprint = createExtensionBlueprint({
       yield coreExtensionData.reactElement(<PageContent />);
     } else if (inputs.pages.length > 0) {
       // Parent page with sub-pages - render header with tabs
-      const tabs: PageTab[] = inputs.pages.map(page => {
+      const tabs: PageLayoutTab[] = inputs.pages.map(page => {
         const path = page.get(coreExtensionData.routePath);
         const tabTitle = page.get(coreExtensionData.title);
         const tabIcon = page.get(coreExtensionData.icon);

--- a/packages/frontend-plugin-api/src/components/PageLayout.tsx
+++ b/packages/frontend-plugin-api/src/components/PageLayout.tsx
@@ -22,12 +22,18 @@ import { createSwappableComponent } from './createSwappableComponent';
  * Tab configuration for page navigation
  * @public
  */
-export interface PageTab {
+export interface PageLayoutTab {
   id: string;
   label: string;
   icon?: IconElement;
   href: string;
 }
+
+/**
+ * @deprecated Use {@link PageLayoutTab} instead
+ * @public
+ */
+export type PageTab = PageLayoutTab;
 
 /**
  * Props for the PageLayout component
@@ -38,7 +44,7 @@ export interface PageLayoutProps {
   icon?: IconElement;
   noHeader?: boolean;
   headerActions?: Array<JSX.Element | null>;
-  tabs?: PageTab[];
+  tabs?: PageLayoutTab[];
   children?: ReactNode;
 }
 

--- a/packages/frontend-plugin-api/src/components/index.ts
+++ b/packages/frontend-plugin-api/src/components/index.ts
@@ -25,4 +25,9 @@ export {
 } from './createSwappableComponent';
 export { useAppNode } from './AppNodeProvider';
 export * from './DefaultSwappableComponents';
-export { PageLayout, type PageLayoutProps, type PageTab } from './PageLayout';
+export {
+  PageLayout,
+  type PageLayoutProps,
+  type PageLayoutTab,
+  type PageTab,
+} from './PageLayout';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Renames the `PageTab` type to `PageLayoutTab` in `@backstage/frontend-plugin-api` for consistency with the `PageLayout` component it belongs to. The old `PageTab` name is kept as a deprecated type alias for backwards compatibility.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))