### PR TITLE
chore (microsite): fix graphiql logo url

### DIFF
--- a/microsite/data/plugins/graphiql.yaml
+++ b/microsite/data/plugins/graphiql.yaml
@@ -5,7 +5,7 @@ authorUrl: https://github.com/spotify
 category: Debugging
 description: Integrates GraphiQL as a tool to browse GraphQL API endpoints inside Backstage.
 documentation: https://github.com/backstage/community-plugins/tree/main/workspaces/graphiql/plugins/graphiql
-iconUrl: https://upload.wikimedia.org/wikipedia/commons/thumb/1/17/GraphQL_Logo.svg/1024px-GraphQL_Logo.svg.png
+iconUrl: https://upload.wikimedia.org/wikipedia/commons/1/17/GraphQL_Logo.svg
 npmPackageName: '@backstage-community/plugin-graphiql'
 addedDate: '2020-11-03'
 status: active


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixed up logo url to graphiql icon in the microsite: 

from 
<img width="332" height="350" alt="Screenshot 2026-03-08 at 7 41 30 PM" src="https://github.com/user-attachments/assets/8da1ea94-a7bf-4c0f-9f3b-2463c8af70be" />
to:
<img width="324" height="343" alt="Screenshot 2026-03-08 at 7 41 18 PM" src="https://github.com/user-attachments/assets/caea0015-2fed-4ffe-9ae9-696dd5a7066a" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
