### PR TITLE
`feat(catalog-model)`: Implement `type: mcp-server` with `kind: API`

### DIFF
--- a/.changeset/mcp-server-api-docs-fix.md
+++ b/.changeset/mcp-server-api-docs-fix.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': patch
+---
+
+Handle optional `definition` field on API entities following the addition of the `mcp-server` API type. The definition card now renders an empty state instead of nothing when no definition is present.

--- a/.changeset/mcp-server-api-entity.md
+++ b/.changeset/mcp-server-api-entity.md
@@ -1,0 +1,9 @@
+---
+'@backstage/catalog-model': major
+---
+
+Added `backstage.io/v1alpha2` API entity schema with support for MCP server entities. MCP server entities on v1alpha2 use a structured `remotes` array instead of a `definition` string.
+
+`ApiEntity` is now a union of `ApiEntityV1alpha1 | ApiEntityV1alpha2`. Consumers should narrow on `apiVersion` before accessing version-specific fields like `spec.definition` or `spec.remotes`.
+
+New exports: `ApiEntityV1alpha2`, `ApiEntityV1alpha2Spec`, `apiEntityV1alpha2Validator`.

--- a/.changeset/mcp-server-catalog-backend.md
+++ b/.changeset/mcp-server-catalog-backend.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Register `apiEntityV1alpha2Validator` in `BuiltinKindsEntityProcessor` to support API entities using `backstage.io/v1alpha2`.

--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -817,10 +817,10 @@ Template, but there will always be one ultimate owner.
 
 Describes the following entity kind:
 
-| Field        | Value                   |
-| ------------ | ----------------------- |
-| `apiVersion` | `backstage.io/v1alpha1` |
-| `kind`       | `API`                   |
+| Field        | Value                                              |
+| ------------ | -------------------------------------------------- |
+| `apiVersion` | `backstage.io/v1alpha1` or `backstage.io/v1alpha2` |
+| `kind`       | `API`                                              |
 
 An API describes an interface that can be exposed by a component. The API can be
 defined in different formats, like [OpenAPI](https://swagger.io/specification/),
@@ -857,12 +857,33 @@ spec:
     ...
 ```
 
+API entities using `backstage.io/v1alpha2` support structured spec fields that
+vary by type. For example, MCP server entities use a `remotes` array instead of
+a `definition` string:
+
+```yaml
+apiVersion: backstage.io/v1alpha2
+kind: API
+metadata:
+  name: my-mcp-server
+  description: An MCP server
+spec:
+  type: mcp-server
+  lifecycle: production
+  owner: platform-team
+  remotes:
+    - type: streamable-http
+      url: https://example.com/api/mcp
+```
+
 In addition to the [common envelope metadata](#common-to-all-kinds-the-metadata)
 shape, this kind has the following structure.
 
 ### `apiVersion` and `kind` [required]
 
-Exactly equal to `backstage.io/v1alpha1` and `API`, respectively.
+The `kind` must be `API`. The `apiVersion` is either `backstage.io/v1alpha1` or
+`backstage.io/v1alpha2`. The available `spec` fields depend on the
+`apiVersion`.
 
 ### `spec.type` [required]
 
@@ -887,6 +908,9 @@ The current set of well-known and common values for this field is:
 - `grpc` - An API definition based on
   [Protocol Buffers](https://developers.google.com/protocol-buffers) to use with
   [gRPC](https://grpc.io/).
+- `mcp-server` - An [MCP](https://modelcontextprotocol.io/) server endpoint.
+  Only available on `backstage.io/v1alpha2`. Uses `spec.remotes` instead of
+  `spec.definition`.
 
 ### `spec.lifecycle` [required]
 
@@ -932,10 +956,17 @@ API belongs to, e.g. `artist-engagement-portal`. This field is optional.
 | --------------------------------------- | ------------------------------------------ | ----------------------------------------------------------------------------- |
 | [`System`](#kind-system) (default)      | Same as this entity, typically `default`   | [`partOf`, and reverse `hasPart`](well-known-relations.md#partof-and-haspart) |
 
-### `spec.definition` [required]
+### `spec.definition` [required on v1alpha1, conditional on v1alpha2]
 
-The definition of the API, based on the format defined by `spec.type`. This
-field is required.
+The definition of the API, based on the format defined by `spec.type`. Required
+on `backstage.io/v1alpha1` for all types. On `backstage.io/v1alpha2`, required
+for all types except `mcp-server`.
+
+### `spec.remotes` [v1alpha2 mcp-server only]
+
+An array of remote endpoints for MCP server entities. Each entry has a `type`
+string and a `url` string. At least one entry is required. Only available on
+`backstage.io/v1alpha2` entities with `spec.type: mcp-server`.
 
 ## Kind: Group
 

--- a/docs/features/software-catalog/extending-the-model.md
+++ b/docs/features/software-catalog/extending-the-model.md
@@ -28,6 +28,47 @@ Backstage comes with a number of catalog concepts out of the box:
 
 We'll list different possibilities for extending this below.
 
+## Working with Entity Types in TypeScript
+
+The `@backstage/catalog-model` package exports TypeScript types for each
+built-in entity kind. Each kind's type is a union of all known `apiVersion`
+variants for that kind. For example, `ApiEntity` is a union of
+`ApiEntityV1alpha1` and `ApiEntityV1alpha2`.
+
+Because `spec` fields can vary between versions, you should narrow on
+`apiVersion` before accessing version-specific fields:
+
+```ts
+import { ApiEntity } from '@backstage/catalog-model';
+
+function processApi(entity: ApiEntity) {
+  // Fields common to all versions are always available
+  entity.spec.type;
+  entity.spec.lifecycle;
+  entity.spec.owner;
+
+  // Version-specific fields require narrowing first
+  if (entity.apiVersion === 'backstage.io/v1alpha1') {
+    entity.spec.definition; // string — always present on v1alpha1
+  }
+
+  if (entity.apiVersion === 'backstage.io/v1alpha2') {
+    if (entity.spec.type === 'mcp-server') {
+      entity.spec.remotes; // MCP servers have remotes, not definition
+    } else {
+      entity.spec.definition; // other v1alpha2 types have definition
+    }
+  }
+}
+```
+
+The versioned types are also exported individually, e.g. `ApiEntityV1alpha1`
+and `ApiEntityV1alpha2`, for cases where you already know the exact version.
+
+This pattern applies to all entity kind types. When a kind introduces a new
+`apiVersion`, its type alias is updated to include the new version as part of
+the union.
+
 ## Adding a New `apiVersion` of an Existing Kind
 
 Example intents:

--- a/packages/catalog-model/report.api.md
+++ b/packages/catalog-model/report.api.md
@@ -33,7 +33,10 @@ export const ANNOTATION_SOURCE_LOCATION = 'backstage.io/source-location';
 export const ANNOTATION_VIEW_URL = 'backstage.io/view-url';
 
 // @public
-interface ApiEntityV1alpha1 extends Entity {
+export type ApiEntity = ApiEntityV1alpha1 | ApiEntityV1alpha2;
+
+// @public
+export interface ApiEntityV1alpha1 extends Entity {
   // (undocumented)
   apiVersion: 'backstage.io/v1alpha1' | 'backstage.io/v1beta1';
   // (undocumented)
@@ -47,11 +50,40 @@ interface ApiEntityV1alpha1 extends Entity {
     system?: string;
   };
 }
-export { ApiEntityV1alpha1 as ApiEntity };
-export { ApiEntityV1alpha1 };
 
 // @public
 export const apiEntityV1alpha1Validator: KindValidator;
+
+// @public
+export interface ApiEntityV1alpha2 extends Entity {
+  // (undocumented)
+  apiVersion: 'backstage.io/v1alpha2';
+  // (undocumented)
+  kind: 'API';
+  // (undocumented)
+  spec: {
+    lifecycle: string;
+    owner: string;
+    system?: string;
+  } & ApiEntityV1alpha2Spec;
+}
+
+// @public
+export type ApiEntityV1alpha2Spec =
+  | {
+      type: 'mcp-server';
+      remotes: {
+        type: string;
+        url: string;
+      }[];
+    }
+  | {
+      type: string;
+      definition: string;
+    };
+
+// @public
+export const apiEntityV1alpha2Validator: KindValidator;
 
 // @public
 export class CommonValidatorFunctions {
@@ -255,7 +287,7 @@ export { GroupEntityV1alpha1 };
 export const groupEntityV1alpha1Validator: KindValidator;
 
 // @public (undocumented)
-export function isApiEntity(entity: Entity): entity is ApiEntityV1alpha1;
+export function isApiEntity(entity: Entity): entity is ApiEntity;
 
 // @public (undocumented)
 export function isComponentEntity(

--- a/packages/catalog-model/src/kinds/ApiEntityV1alpha1.test.ts
+++ b/packages/catalog-model/src/kinds/ApiEntityV1alpha1.test.ts
@@ -180,4 +180,9 @@ components:
     (entity as any).annotations = 'Test';
     await expect(validator.check(entity)).rejects.toThrow(/annotations/);
   });
+
+  it('ignores v1alpha2 apiVersion', async () => {
+    (entity as any).apiVersion = 'backstage.io/v1alpha2';
+    await expect(validator.check(entity)).resolves.toBe(false);
+  });
 });

--- a/packages/catalog-model/src/kinds/ApiEntityV1alpha2.test.ts
+++ b/packages/catalog-model/src/kinds/ApiEntityV1alpha2.test.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ApiEntityV1alpha2,
+  apiEntityV1alpha2Validator as validator,
+} from './ApiEntityV1alpha2';
+
+describe('ApiV1alpha2Validator', () => {
+  describe('standard API types', () => {
+    let entity: ApiEntityV1alpha2;
+
+    beforeEach(() => {
+      entity = {
+        apiVersion: 'backstage.io/v1alpha2',
+        kind: 'API',
+        metadata: {
+          name: 'test',
+        },
+        spec: {
+          type: 'openapi',
+          lifecycle: 'production',
+          owner: 'me',
+          definition: 'openapi: "3.0.0"\ninfo:\n  title: Test',
+          system: 'system',
+        },
+      };
+    });
+
+    it('accepts valid data', async () => {
+      await expect(validator.check(entity)).resolves.toBe(true);
+    });
+
+    it('ignores v1alpha1 apiVersion', async () => {
+      (entity as any).apiVersion = 'backstage.io/v1alpha1';
+      await expect(validator.check(entity)).resolves.toBe(false);
+    });
+
+    it('ignores v1beta1 apiVersion', async () => {
+      (entity as any).apiVersion = 'backstage.io/v1beta1';
+      await expect(validator.check(entity)).resolves.toBe(false);
+    });
+
+    it('ignores unknown kind', async () => {
+      (entity as any).kind = 'Wizard';
+      await expect(validator.check(entity)).resolves.toBe(false);
+    });
+
+    it('rejects missing type', async () => {
+      delete (entity as any).spec.type;
+      await expect(validator.check(entity)).rejects.toThrow(/type/);
+    });
+
+    it('rejects empty type', async () => {
+      (entity as any).spec.type = '';
+      await expect(validator.check(entity)).rejects.toThrow(/type/);
+    });
+
+    it('rejects missing lifecycle', async () => {
+      delete (entity as any).spec.lifecycle;
+      await expect(validator.check(entity)).rejects.toThrow(/lifecycle/);
+    });
+
+    it('rejects missing owner', async () => {
+      delete (entity as any).spec.owner;
+      await expect(validator.check(entity)).rejects.toThrow(/owner/);
+    });
+
+    it('rejects missing definition for non-mcp-server types', async () => {
+      delete (entity as any).spec.definition;
+      await expect(validator.check(entity)).rejects.toThrow(/definition/);
+    });
+
+    it('rejects empty definition', async () => {
+      (entity as any).spec.definition = '';
+      await expect(validator.check(entity)).rejects.toThrow(/definition/);
+    });
+
+    it('accepts missing system', async () => {
+      delete (entity as any).spec.system;
+      await expect(validator.check(entity)).resolves.toBe(true);
+    });
+  });
+
+  describe('mcp-server type', () => {
+    let entity: ApiEntityV1alpha2;
+
+    beforeEach(() => {
+      entity = {
+        apiVersion: 'backstage.io/v1alpha2',
+        kind: 'API',
+        metadata: {
+          name: 'test-mcp',
+        },
+        spec: {
+          type: 'mcp-server',
+          lifecycle: 'experimental',
+          owner: 'me',
+          remotes: [
+            {
+              type: 'streamable-http',
+              url: 'http://localhost:7007/api/mcp',
+            },
+          ],
+        },
+      };
+    });
+
+    it('accepts valid mcp-server entity', async () => {
+      await expect(validator.check(entity)).resolves.toBe(true);
+    });
+
+    it('accepts mcp-server entity with multiple remotes', async () => {
+      (entity as any).spec.remotes = [
+        { type: 'streamable-http', url: 'http://localhost:7007/api/mcp' },
+        { type: 'sse', url: 'http://localhost:7007/api/mcp-sse' },
+      ];
+      await expect(validator.check(entity)).resolves.toBe(true);
+    });
+
+    it('does not require definition for mcp-server type', async () => {
+      expect((entity.spec as any).definition).toBeUndefined();
+      await expect(validator.check(entity)).resolves.toBe(true);
+    });
+
+    it('rejects mcp-server entity without remotes', async () => {
+      delete (entity as any).spec.remotes;
+      await expect(validator.check(entity)).rejects.toThrow(/remotes/);
+    });
+
+    it('rejects mcp-server entity with empty remotes array', async () => {
+      (entity as any).spec.remotes = [];
+      await expect(validator.check(entity)).rejects.toThrow(/remotes/);
+    });
+
+    it('rejects mcp-server remote missing type', async () => {
+      (entity as any).spec.remotes = [{ url: 'http://localhost' }];
+      await expect(validator.check(entity)).rejects.toThrow(/type/);
+    });
+
+    it('rejects mcp-server remote missing url', async () => {
+      (entity as any).spec.remotes = [{ type: 'streamable-http' }];
+      await expect(validator.check(entity)).rejects.toThrow(/url/);
+    });
+
+    it('rejects mcp-server remote with empty type', async () => {
+      (entity as any).spec.remotes = [{ type: '', url: 'http://localhost' }];
+      await expect(validator.check(entity)).rejects.toThrow(/type/);
+    });
+
+    it('rejects mcp-server remote with empty url', async () => {
+      (entity as any).spec.remotes = [{ type: 'streamable-http', url: '' }];
+      await expect(validator.check(entity)).rejects.toThrow(/url/);
+    });
+  });
+});

--- a/packages/catalog-model/src/kinds/ApiEntityV1alpha2.ts
+++ b/packages/catalog-model/src/kinds/ApiEntityV1alpha2.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Entity } from '../entity/Entity';
+import schema from '../schema/kinds/API.v1alpha2.schema.json';
+import { ajvCompiledJsonSchemaValidator } from './util';
+
+/**
+ * The specification fields that vary based on the API type.
+ *
+ * @public
+ */
+export type ApiEntityV1alpha2Spec =
+  | {
+      type: 'mcp-server';
+      remotes: { type: string; url: string }[];
+    }
+  | { type: string; definition: string };
+
+/**
+ * Backstage API kind Entity using the v1alpha2 schema.
+ *
+ * @remarks
+ *
+ * This version supports structured spec fields that vary by API type.
+ * MCP server entities use a remotes array instead of a definition string.
+ * The JSON schema enforces which fields are required based on spec.type.
+ *
+ * See {@link https://backstage.io/docs/features/software-catalog/system-model}
+ *
+ * @public
+ */
+export interface ApiEntityV1alpha2 extends Entity {
+  apiVersion: 'backstage.io/v1alpha2';
+  kind: 'API';
+  spec: {
+    lifecycle: string;
+    owner: string;
+    system?: string;
+  } & ApiEntityV1alpha2Spec;
+}
+
+/**
+ * {@link KindValidator} for {@link ApiEntityV1alpha2}.
+ *
+ * @public
+ */
+export const apiEntityV1alpha2Validator =
+  ajvCompiledJsonSchemaValidator(schema);

--- a/packages/catalog-model/src/kinds/index.ts
+++ b/packages/catalog-model/src/kinds/index.ts
@@ -14,11 +14,29 @@
  * limitations under the License.
  */
 
+import type { ApiEntityV1alpha1 } from './ApiEntityV1alpha1';
+import type { ApiEntityV1alpha2 } from './ApiEntityV1alpha2';
+
+/**
+ * Union of all known API entity versions.
+ *
+ * @remarks
+ *
+ * Consumers should narrow on `apiVersion` before accessing version-specific
+ * fields like `spec.definition` or `spec.remotes`. This pattern applies to
+ * all catalog entity types, not just API entities.
+ *
+ * @public
+ */
+export type ApiEntity = ApiEntityV1alpha1 | ApiEntityV1alpha2;
+
 export { apiEntityV1alpha1Validator } from './ApiEntityV1alpha1';
+export type { ApiEntityV1alpha1 } from './ApiEntityV1alpha1';
+export { apiEntityV1alpha2Validator } from './ApiEntityV1alpha2';
 export type {
-  ApiEntityV1alpha1 as ApiEntity,
-  ApiEntityV1alpha1,
-} from './ApiEntityV1alpha1';
+  ApiEntityV1alpha2,
+  ApiEntityV1alpha2Spec,
+} from './ApiEntityV1alpha2';
 export { componentEntityV1alpha1Validator } from './ComponentEntityV1alpha1';
 export type {
   ComponentEntityV1alpha1 as ComponentEntity,

--- a/packages/catalog-model/src/schema/kinds/API.v1alpha2.schema.json
+++ b/packages/catalog-model/src/schema/kinds/API.v1alpha2.schema.json
@@ -1,0 +1,143 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "ApiV1alpha2",
+  "description": "An API describes an interface that can be exposed by a component. The API can be defined in different formats, like OpenAPI, AsyncAPI, GraphQL, gRPC, or other formats. MCP server entities use a structured remotes array instead of a definition string.",
+  "examples": [
+    {
+      "apiVersion": "backstage.io/v1alpha2",
+      "kind": "API",
+      "metadata": {
+        "name": "artist-api",
+        "description": "Retrieve artist details",
+        "labels": {
+          "product_name": "Random value Generator"
+        },
+        "annotations": {
+          "docs": "https://github.com/..../tree/develop/doc"
+        }
+      },
+      "spec": {
+        "type": "openapi",
+        "lifecycle": "production",
+        "owner": "artist-relations-team",
+        "system": "artist-engagement-portal",
+        "definition": "openapi: \"3.0.0\"\ninfo:..."
+      }
+    },
+    {
+      "apiVersion": "backstage.io/v1alpha2",
+      "kind": "API",
+      "metadata": {
+        "name": "backstage-mcp-actions",
+        "description": "Exposes tools related to the Backstage Ecosystem such as the Software Catalog"
+      },
+      "spec": {
+        "type": "mcp-server",
+        "lifecycle": "experimental",
+        "owner": "backstage",
+        "remotes": [
+          {
+            "type": "streamable-http",
+            "url": "http://internal.backstage.company:7007/api/mcp-actions/v1"
+          }
+        ]
+      }
+    }
+  ],
+  "allOf": [
+    {
+      "$ref": "Entity"
+    },
+    {
+      "type": "object",
+      "required": ["spec"],
+      "properties": {
+        "apiVersion": {
+          "enum": ["backstage.io/v1alpha2"]
+        },
+        "kind": {
+          "enum": ["API"]
+        },
+        "spec": {
+          "type": "object",
+          "required": ["type", "lifecycle", "owner"],
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "The type of the API definition.",
+              "examples": [
+                "openapi",
+                "asyncapi",
+                "graphql",
+                "grpc",
+                "trpc",
+                "mcp-server"
+              ],
+              "minLength": 1
+            },
+            "lifecycle": {
+              "type": "string",
+              "description": "The lifecycle state of the API.",
+              "examples": ["experimental", "production", "deprecated"],
+              "minLength": 1
+            },
+            "owner": {
+              "type": "string",
+              "description": "An entity reference to the owner of the API.",
+              "examples": ["artist-relations-team", "user:john.johnson"],
+              "minLength": 1
+            },
+            "system": {
+              "type": "string",
+              "description": "An entity reference to the system that the API belongs to.",
+              "minLength": 1
+            }
+          },
+          "if": {
+            "required": ["type"],
+            "properties": {
+              "type": { "const": "mcp-server" }
+            }
+          },
+          "then": {
+            "required": ["remotes"],
+            "properties": {
+              "remotes": {
+                "type": "array",
+                "description": "The list of remote endpoints for the MCP server.",
+                "items": {
+                  "type": "object",
+                  "required": ["type", "url"],
+                  "properties": {
+                    "type": {
+                      "type": "string",
+                      "description": "The transport type of the MCP server remote.",
+                      "examples": ["streamable-http", "sse"],
+                      "minLength": 1
+                    },
+                    "url": {
+                      "type": "string",
+                      "description": "The URL of the MCP server remote endpoint.",
+                      "minLength": 1
+                    }
+                  }
+                },
+                "minItems": 1
+              }
+            }
+          },
+          "else": {
+            "required": ["definition"],
+            "properties": {
+              "definition": {
+                "type": "string",
+                "description": "The definition of the API, based on the format defined by the type.",
+                "minLength": 1
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/plugins/api-docs/report-alpha.api.md
+++ b/plugins/api-docs/report-alpha.api.md
@@ -32,6 +32,7 @@ export const apiDocsTranslationRef: TranslationRef<
   {
     readonly 'apiDefinitionCard.error.title': 'Could not fetch the API';
     readonly 'apiDefinitionCard.rawButtonTitle': 'Raw';
+    readonly 'apiDefinitionCard.noDefinition.title': 'No API definition available for this entity.';
     readonly 'apiDefinitionDialog.closeButtonTitle': 'Close';
     readonly 'apiDefinitionDialog.tabsAriaLabel': 'API definition options';
     readonly 'apiDefinitionDialog.rawButtonTitle': 'Raw';

--- a/plugins/api-docs/src/components/ApiDefinitionCard/ApiDefinitionCard.test.tsx
+++ b/plugins/api-docs/src/components/ApiDefinitionCard/ApiDefinitionCard.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ApiEntity } from '@backstage/catalog-model';
+import { ApiEntity, ApiEntityV1alpha2 } from '@backstage/catalog-model';
 import { EntityProvider } from '@backstage/plugin-catalog-react';
 import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
 import { waitFor } from '@testing-library/react';
@@ -130,5 +130,34 @@ paths:
         (_text, element) => element?.textContent === 'Custom Definition',
       ).length,
     ).toBeGreaterThan(0);
+  });
+
+  it('renders empty state for API entities without a definition', async () => {
+    const apiEntity: ApiEntityV1alpha2 = {
+      apiVersion: 'backstage.io/v1alpha2',
+      kind: 'API',
+      metadata: {
+        name: 'my-mcp-server',
+      },
+      spec: {
+        type: 'mcp-server',
+        lifecycle: '...',
+        owner: '...',
+        remotes: [
+          { type: 'streamable-http', url: 'http://localhost:7007/api/mcp' },
+        ],
+      },
+    };
+
+    const { getByText } = await renderInTestApp(
+      <Wrapper>
+        <EntityProvider entity={apiEntity}>
+          <ApiDefinitionCard />
+        </EntityProvider>
+      </Wrapper>,
+    );
+
+    expect(getByText(/my-mcp-server/i)).toBeInTheDocument();
+    expect(getByText(/No API definition available/i)).toBeInTheDocument();
   });
 });

--- a/plugins/api-docs/src/components/ApiDefinitionCard/ApiDefinitionCard.tsx
+++ b/plugins/api-docs/src/components/ApiDefinitionCard/ApiDefinitionCard.tsx
@@ -14,15 +14,29 @@
  * limitations under the License.
  */
 
-import { ApiEntity } from '@backstage/catalog-model';
+import { ApiEntity, ApiEntityV1alpha1 } from '@backstage/catalog-model';
 import { useEntity } from '@backstage/plugin-catalog-react';
 import { CardTab, TabbedCard } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
 import { useTranslationRef } from '@backstage/frontend-plugin-api';
 import Alert from '@material-ui/lab/Alert';
+import Typography from '@material-ui/core/Typography';
 import { apiDocsConfigRef } from '../../config';
 import { apiDocsTranslationRef } from '../../translation';
 import { PlainApiDefinitionWidget } from '../PlainApiDefinitionWidget';
+
+function ApiDefinitionCardEmpty(props: { title: string; message: string }) {
+  return (
+    <TabbedCard
+      title={props.title}
+      children={[
+        <CardTab label="Definition" key="empty">
+          <Typography variant="body2">{props.message}</Typography>
+        </CardTab>,
+      ]}
+    />
+  );
+}
 
 /** @public */
 export const ApiDefinitionCard = () => {
@@ -35,19 +49,33 @@ export const ApiDefinitionCard = () => {
     return <Alert severity="error">{t('apiDefinitionCard.error.title')}</Alert>;
   }
 
-  const definitionWidget = getApiDefinitionWidget(entity);
   const entityTitle = entity.metadata.title ?? entity.metadata.name;
+
+  if (
+    entity.apiVersion === 'backstage.io/v1alpha2' &&
+    entity.spec.type === 'mcp-server'
+  ) {
+    return (
+      <ApiDefinitionCardEmpty
+        title={entityTitle}
+        message={t('apiDefinitionCard.noDefinition.title')}
+      />
+    );
+  }
+
+  const apiEntity = entity as ApiEntityV1alpha1;
+  const definitionWidget = getApiDefinitionWidget(apiEntity);
 
   if (definitionWidget) {
     return (
       <TabbedCard title={entityTitle}>
         <CardTab label={definitionWidget.title} key="widget">
-          {definitionWidget.component(entity.spec.definition)}
+          {definitionWidget.component(apiEntity.spec.definition)}
         </CardTab>
         <CardTab label={t('apiDefinitionCard.rawButtonTitle')} key="raw">
           <PlainApiDefinitionWidget
-            definition={entity.spec.definition}
-            language={definitionWidget.rawLanguage || entity.spec.type}
+            definition={apiEntity.spec.definition}
+            language={definitionWidget.rawLanguage || apiEntity.spec.type}
           />
         </CardTab>
       </TabbedCard>
@@ -59,10 +87,10 @@ export const ApiDefinitionCard = () => {
       title={entityTitle}
       children={[
         // Has to be an array, otherwise typescript doesn't like that this has only a single child
-        <CardTab label={entity.spec.type} key="raw">
+        <CardTab label={apiEntity.spec.type} key="raw">
           <PlainApiDefinitionWidget
-            definition={entity.spec.definition}
-            language={entity.spec.type}
+            definition={apiEntity.spec.definition}
+            language={apiEntity.spec.type}
           />
         </CardTab>,
       ]}

--- a/plugins/api-docs/src/components/ApiDefinitionDialog/ApiDefinitionDialog.test.tsx
+++ b/plugins/api-docs/src/components/ApiDefinitionDialog/ApiDefinitionDialog.test.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ApiEntityV1alpha1, ApiEntityV1alpha2 } from '@backstage/catalog-model';
+import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
+import { ApiDocsConfig, apiDocsConfigRef } from '../../config';
+import { ApiDefinitionDialog } from './ApiDefinitionDialog';
+
+describe('<ApiDefinitionDialog />', () => {
+  const apiDocsConfig: jest.Mocked<ApiDocsConfig> = {
+    getApiDefinitionWidget: jest.fn(),
+  } as any;
+
+  afterEach(() => jest.resetAllMocks());
+
+  it('renders empty state for v1alpha2 mcp-server entities', async () => {
+    const entity: ApiEntityV1alpha2 = {
+      apiVersion: 'backstage.io/v1alpha2',
+      kind: 'API',
+      metadata: {
+        name: 'my-mcp-server',
+        title: 'My MCP Server',
+      },
+      spec: {
+        type: 'mcp-server',
+        lifecycle: 'production',
+        owner: 'team-a',
+        remotes: [
+          { type: 'streamable-http', url: 'http://localhost:7007/api/mcp' },
+        ],
+      },
+    };
+
+    const { getByText } = await renderInTestApp(
+      <TestApiProvider apis={[[apiDocsConfigRef, apiDocsConfig]]}>
+        <ApiDefinitionDialog entity={entity} open onClose={() => {}} />
+      </TestApiProvider>,
+    );
+
+    expect(getByText(/My MCP Server/i)).toBeInTheDocument();
+    expect(getByText(/No API definition available/i)).toBeInTheDocument();
+  });
+
+  it('renders definition widget for v1alpha1 entities', async () => {
+    const entity: ApiEntityV1alpha1 = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'API',
+      metadata: {
+        name: 'my-api',
+        title: 'My API',
+      },
+      spec: {
+        type: 'openapi',
+        lifecycle: 'production',
+        owner: 'team-a',
+        definition: 'openapi: "3.0.0"',
+      },
+    };
+
+    apiDocsConfig.getApiDefinitionWidget.mockReturnValue({
+      type: 'openapi',
+      title: 'OpenAPI',
+      rawLanguage: 'yaml',
+      component: definition => <div>Rendered: {definition}</div>,
+    });
+
+    const { getByText } = await renderInTestApp(
+      <TestApiProvider apis={[[apiDocsConfigRef, apiDocsConfig]]}>
+        <ApiDefinitionDialog entity={entity} open onClose={() => {}} />
+      </TestApiProvider>,
+    );
+
+    expect(getByText(/My API/i)).toBeInTheDocument();
+    expect(getByText(/Rendered: openapi: "3.0.0"/)).toBeInTheDocument();
+  });
+});

--- a/plugins/api-docs/src/components/ApiDefinitionDialog/ApiDefinitionDialog.tsx
+++ b/plugins/api-docs/src/components/ApiDefinitionDialog/ApiDefinitionDialog.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ApiEntity } from '@backstage/catalog-model';
+import { ApiEntity, ApiEntityV1alpha1 } from '@backstage/catalog-model';
 import { useApi } from '@backstage/core-plugin-api';
 import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
@@ -117,7 +117,46 @@ export function ApiDefinitionDialog(props: {
   }, [open]);
 
   const config = useApi(apiDocsConfigRef);
-  const definitionWidget = config.getApiDefinitionWidget(entity);
+
+  if (
+    entity.apiVersion === 'backstage.io/v1alpha2' &&
+    entity.spec.type === 'mcp-server'
+  ) {
+    return (
+      <Dialog
+        fullWidth
+        maxWidth="xl"
+        open={open}
+        onClose={onClose}
+        aria-labelledby="api-definition-dialog-title"
+        PaperProps={{ className: classes.fullHeightDialog }}
+      >
+        <DialogTitle id="api-definition-dialog-title" disableTypography>
+          <Typography className={classes.type}>
+            API - {entity.spec.type}
+          </Typography>
+          <Typography className={classes.title} variant="h1">
+            {entity.metadata.title ?? entity.metadata.name}
+          </Typography>
+        </DialogTitle>
+        <DialogContent dividers>
+          <Box p={3}>
+            <Typography variant="body2">
+              {t('apiDefinitionCard.noDefinition.title')}
+            </Typography>
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose} color="primary">
+            {t('apiDefinitionDialog.closeButtonTitle')}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    );
+  }
+
+  const apiEntity = entity as ApiEntityV1alpha1;
+  const definitionWidget = config.getApiDefinitionWidget(apiEntity);
 
   let tabIndex = 0;
   let tabPanelIndex = 0;
@@ -160,13 +199,13 @@ export function ApiDefinitionDialog(props: {
 
         {definitionWidget ? (
           <TabPanel value={activeTab} index={tabPanelIndex++}>
-            {definitionWidget.component(entity.spec.definition)}
+            {definitionWidget.component(apiEntity.spec.definition)}
           </TabPanel>
         ) : null}
         <TabPanel value={activeTab} index={tabPanelIndex++}>
           <PlainApiDefinitionWidget
-            definition={entity.spec.definition}
-            language={definitionWidget?.rawLanguage ?? entity.spec.type}
+            definition={apiEntity.spec.definition}
+            language={definitionWidget?.rawLanguage ?? apiEntity.spec.type}
           />
         </TabPanel>
       </DialogContent>

--- a/plugins/api-docs/src/translation.ts
+++ b/plugins/api-docs/src/translation.ts
@@ -26,6 +26,9 @@ export const apiDocsTranslationRef = createTranslationRef({
       error: {
         title: 'Could not fetch the API',
       },
+      noDefinition: {
+        title: 'No API definition available for this entity.',
+      },
       rawButtonTitle: 'Raw',
     },
     apiDefinitionDialog: {

--- a/plugins/catalog-backend/src/processors/BuiltinKindsEntityProcessor.ts
+++ b/plugins/catalog-backend/src/processors/BuiltinKindsEntityProcessor.ts
@@ -17,6 +17,7 @@
 import {
   ApiEntity,
   apiEntityV1alpha1Validator,
+  apiEntityV1alpha2Validator,
   ComponentEntity,
   componentEntityV1alpha1Validator,
   DomainEntity,
@@ -60,6 +61,7 @@ import { get, set } from 'lodash';
 export class BuiltinKindsEntityProcessor implements CatalogProcessor {
   private readonly validators = [
     apiEntityV1alpha1Validator,
+    apiEntityV1alpha2Validator,
     componentEntityV1alpha1Validator,
     resourceEntityV1alpha1Validator,
     groupEntityV1alpha1Validator,


### PR DESCRIPTION
Implementation of #32062.

Not sure of the best way to ship this, so this is a first pass. It's a bit of a breaking change to `kind: API`. Wondering if there's a better way or if we just handle it like this?