### PR TITLE
bump a timeout somewhat

### DIFF
--- a/plugins/api-docs/src/setupTests.ts
+++ b/plugins/api-docs/src/setupTests.ts
@@ -24,4 +24,5 @@ Object.defineProperty(global, 'TextDecoder', {
   value: require('node:util').TextDecoder,
 });
 
+// Use a 15s timeout to accommodate the slowest API docs rendering tests under concurrency.
 jest.setTimeout(15_000);


### PR DESCRIPTION
Tests in this package flake sometimes because, together with all the concurrency, rendering of these views can get a little slow sometimes and hits jest limits