### PR TITLE
plugin-scaffolder-node: Add function to gitHelpers to stage files for removal

### DIFF
--- a/.changeset/cruel-cities-jump.md
+++ b/.changeset/cruel-cities-jump.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-node': patch
+---
+
+Added `removeFiles` helper function for staging file removals in Git.

--- a/plugins/scaffolder-node/report.api.md
+++ b/plugins/scaffolder-node/report.api.md
@@ -318,6 +318,21 @@ export const parseRepoUrl: (
   project?: string;
 };
 
+// @public (undocumented)
+export function removeFiles(options: {
+  dir: string;
+  filepath: string;
+  auth:
+    | {
+        username: string;
+        password: string;
+      }
+    | {
+        token: string;
+      };
+  logger?: LoggerService | undefined;
+}): Promise<void>;
+
 // @public
 export interface ScaffolderActionsExtensionPoint {
   // (undocumented)

--- a/plugins/scaffolder-node/src/actions/gitHelpers.test.ts
+++ b/plugins/scaffolder-node/src/actions/gitHelpers.test.ts
@@ -17,6 +17,7 @@
 import { Git } from '../scm';
 import {
   addFiles,
+  removeFiles,
   cloneRepo,
   commitAndPushBranch,
   commitAndPushRepo,
@@ -31,6 +32,7 @@ jest.mock('../scm', () => ({
     fromAuth: jest.fn().mockReturnValue({
       init: jest.fn(),
       add: jest.fn(),
+      remove: jest.fn(),
       checkout: jest.fn(),
       branch: jest.fn(),
       commit: jest
@@ -523,6 +525,47 @@ describe('addFiles', () => {
 
     expect(mockedGit.add).toHaveBeenCalledWith({
       filepath: '.',
+      dir: '/tmp/repo/dir/',
+    });
+  });
+});
+
+describe('removeFiles', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('with minimal parameters', () => {
+    beforeEach(async () => {
+      await removeFiles({
+        dir: '/tmp/repo/dir/',
+        filepath: 'file-to-remove.txt',
+        auth: {
+          username: 'test-user',
+          password: 'test-password',
+        },
+      });
+    });
+
+    it('removes the file', () => {
+      expect(mockedGit.remove).toHaveBeenCalledWith({
+        filepath: 'file-to-remove.txt',
+        dir: '/tmp/repo/dir/',
+      });
+    });
+  });
+
+  it('with token', async () => {
+    await removeFiles({
+      dir: '/tmp/repo/dir/',
+      filepath: 'file-to-remove.txt',
+      auth: {
+        token: 'test-token',
+      },
+    });
+
+    expect(mockedGit.remove).toHaveBeenCalledWith({
+      filepath: 'file-to-remove.txt',
       dir: '/tmp/repo/dir/',
     });
   });

--- a/plugins/scaffolder-node/src/actions/gitHelpers.ts
+++ b/plugins/scaffolder-node/src/actions/gitHelpers.ts
@@ -207,6 +207,27 @@ export async function addFiles(options: {
 /**
  * @public
  */
+export async function removeFiles(options: {
+  dir: string;
+  filepath: string;
+  // For use cases where token has to be used with Basic Auth
+  // it has to be provided as password together with a username
+  // which may be a fixed value defined by the provider.
+  auth: { username: string; password: string } | { token: string };
+  logger?: LoggerService | undefined;
+}): Promise<void> {
+  const { dir, filepath, auth, logger } = options;
+  const git = Git.fromAuth({
+    ...auth,
+    logger,
+  });
+
+  await git.remove({ dir, filepath });
+}
+
+/**
+ * @public
+ */
 export async function commitAndPushBranch(options: {
   dir: string;
   // For use cases where token has to be used with Basic Auth

--- a/plugins/scaffolder-node/src/actions/index.ts
+++ b/plugins/scaffolder-node/src/actions/index.ts
@@ -30,6 +30,7 @@ export {
   commitAndPushRepo,
   commitAndPushBranch,
   addFiles,
+  removeFiles,
   createBranch,
   cloneRepo,
 } from './gitHelpers';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

To fix https://github.com/backstage/community-plugins/issues/7898 the ability to stage files for removal is required. This PR adds this functionality.

See https://github.com/backstage/community-plugins/pull/7900 for a bit of context. As rightfully pointed out there, the removal functionality should be added here so that it can be used by the Azure DevOps actions.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
