### PR TITLE
catalog-backend: fix catalog multi-ancestry

### DIFF
--- a/.changeset/fix-catalog-multi-ancestry.md
+++ b/.changeset/fix-catalog-multi-ancestry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Fixed a bug where multiple locations pointing to the same entity file would result in only the last processed location being recorded as the entity's ancestor. When multiple parents with null location keys reference the same child entity, all of them are now correctly preserved as ancestors. A parent only takes exclusive ownership (removing other references) when it explicitly claims an entity by transitioning its location key from null to a specific key.

--- a/plugins/catalog-backend/src/database/DefaultProcessingDatabase.test.ts
+++ b/plugins/catalog-backend/src/database/DefaultProcessingDatabase.test.ts
@@ -465,7 +465,7 @@ describe.each(databases.eachSupportedId())(
         });
       });
 
-      it('preserves multi-ancestry when multiple null-key parents emit the same child entity, %p', async () => {
+      it('preserves multi-ancestry when multiple null-key parents emit the same child entity', async () => {
         const { knex, db } = await createDatabase();
 
         const locationAId = 'locationAId';

--- a/plugins/catalog-backend/src/database/DefaultProcessingDatabase.test.ts
+++ b/plugins/catalog-backend/src/database/DefaultProcessingDatabase.test.ts
@@ -465,13 +465,11 @@ describe.each(databases.eachSupportedId())(
         });
       });
 
-      it.each(databases.eachSupportedId())(
-      'preserves multi-ancestry when multiple null-key parents emit the same child entity, %p',
-      async databaseId => {
-        const { knex, db } = await createDatabase(databaseId);
+      it('preserves multi-ancestry when multiple null-key parents emit the same child entity, %p', async () => {
+        const { knex, db } = await createDatabase();
 
-        const locationAId = uuid.v4();
-        const locationBId = uuid.v4();
+        const locationAId = 'locationAId';
+        const locationBId = 'locationBId';
         const processedEntityA: Entity = {
           apiVersion: '1',
           kind: 'Location',
@@ -543,16 +541,13 @@ describe.each(databases.eachSupportedId())(
           'location:default/location-a',
           'location:default/location-b',
         ]);
-      },
-    );
+      });
 
-    it.each(databases.eachSupportedId())(
-      'steals references when a keyed location claims an entity previously owned with null key, %p',
-      async databaseId => {
-        const { knex, db } = await createDatabase(databaseId);
+      it('steals references when a keyed location claims an entity previously owned with null key, %p', async () => {
+        const { knex, db } = await createDatabase();
 
-        const nullKeyLocationId = uuid.v4();
-        const keyedLocationId = uuid.v4();
+        const nullKeyLocationId = 'nullKeyLocationId';
+        const keyedLocationId = 'keyedLocationId';
         const processedEntityNullKey: Entity = {
           apiVersion: '1',
           kind: 'Location',
@@ -620,10 +615,9 @@ describe.each(databases.eachSupportedId())(
         ).select();
         const ancestorRefs = refs.map(r => r.source_entity_ref).filter(Boolean);
         expect(ancestorRefs).toEqual(['location:default/keyed-location']);
-      },
-    );
+      });
 
-    it('stores the refresh keys for the entity where key length is 255 chars or less', async () => {
+      it('stores the refresh keys for the entity where key length is 255 chars or less', async () => {
         const mockLogger = {
           debug: jest.fn(),
           error: jest.fn(),

--- a/plugins/catalog-backend/src/database/DefaultProcessingDatabase.test.ts
+++ b/plugins/catalog-backend/src/database/DefaultProcessingDatabase.test.ts
@@ -465,7 +465,165 @@ describe.each(databases.eachSupportedId())(
         });
       });
 
-      it('stores the refresh keys for the entity where key length is 255 chars or less', async () => {
+      it.each(databases.eachSupportedId())(
+      'preserves multi-ancestry when multiple null-key parents emit the same child entity, %p',
+      async databaseId => {
+        const { knex, db } = await createDatabase(databaseId);
+
+        const locationAId = uuid.v4();
+        const locationBId = uuid.v4();
+        const processedEntityA: Entity = {
+          apiVersion: '1',
+          kind: 'Location',
+          metadata: { name: 'location-a' },
+        };
+        const processedEntityB: Entity = {
+          apiVersion: '1',
+          kind: 'Location',
+          metadata: { name: 'location-b' },
+        };
+        await insertRefreshStateRow(knex, {
+          entity_id: locationAId,
+          entity_ref: stringifyEntityRef(processedEntityA),
+          unprocessed_entity: '{}',
+          processed_entity: '{}',
+          errors: '[]',
+          next_update_at: '2021-04-01 13:37:00',
+          last_discovery_at: '2021-04-01 13:37:00',
+        });
+        await insertRefreshStateRow(knex, {
+          entity_id: locationBId,
+          entity_ref: stringifyEntityRef(processedEntityB),
+          unprocessed_entity: '{}',
+          processed_entity: '{}',
+          errors: '[]',
+          next_update_at: '2021-04-01 13:37:00',
+          last_discovery_at: '2021-04-01 13:37:00',
+        });
+
+        const sharedChild: Entity = {
+          apiVersion: '1',
+          kind: 'Component',
+          metadata: { name: 'shared' },
+        };
+
+        // Location A (no location key) emits the shared child
+        await db.transaction(tx =>
+          db.updateProcessedEntity(tx, {
+            id: locationAId,
+            processedEntity: processedEntityA,
+            resultHash: '',
+            relations: [],
+            deferredEntities: [{ entity: sharedChild }],
+            refreshKeys: [],
+          }),
+        );
+
+        // Location B (no location key) also emits the same shared child
+        await db.transaction(tx =>
+          db.updateProcessedEntity(tx, {
+            id: locationBId,
+            processedEntity: processedEntityB,
+            resultHash: '',
+            relations: [],
+            deferredEntities: [{ entity: sharedChild }],
+            refreshKeys: [],
+          }),
+        );
+
+        // Both location A and location B should remain as ancestors of the shared child
+        const refs = await knex<DbRefreshStateReferencesRow>(
+          'refresh_state_references',
+        ).select();
+        const ancestorRefs = refs
+          .map(r => r.source_entity_ref)
+          .filter(Boolean)
+          .sort();
+        expect(ancestorRefs).toEqual([
+          'location:default/location-a',
+          'location:default/location-b',
+        ]);
+      },
+    );
+
+    it.each(databases.eachSupportedId())(
+      'steals references when a keyed location claims an entity previously owned with null key, %p',
+      async databaseId => {
+        const { knex, db } = await createDatabase(databaseId);
+
+        const nullKeyLocationId = uuid.v4();
+        const keyedLocationId = uuid.v4();
+        const processedEntityNullKey: Entity = {
+          apiVersion: '1',
+          kind: 'Location',
+          metadata: { name: 'null-key-location' },
+        };
+        const processedEntityKeyed: Entity = {
+          apiVersion: '1',
+          kind: 'Location',
+          metadata: { name: 'keyed-location' },
+        };
+        await insertRefreshStateRow(knex, {
+          entity_id: nullKeyLocationId,
+          entity_ref: stringifyEntityRef(processedEntityNullKey),
+          unprocessed_entity: '{}',
+          processed_entity: '{}',
+          errors: '[]',
+          next_update_at: '2021-04-01 13:37:00',
+          last_discovery_at: '2021-04-01 13:37:00',
+        });
+        await insertRefreshStateRow(knex, {
+          entity_id: keyedLocationId,
+          entity_ref: stringifyEntityRef(processedEntityKeyed),
+          unprocessed_entity: '{}',
+          processed_entity: '{}',
+          errors: '[]',
+          next_update_at: '2021-04-01 13:37:00',
+          last_discovery_at: '2021-04-01 13:37:00',
+        });
+
+        const sharedChild: Entity = {
+          apiVersion: '1',
+          kind: 'Component',
+          metadata: { name: 'shared' },
+        };
+
+        // Null-key location emits the child (weak/null ownership)
+        await db.transaction(tx =>
+          db.updateProcessedEntity(tx, {
+            id: nullKeyLocationId,
+            processedEntity: processedEntityNullKey,
+            resultHash: '',
+            relations: [],
+            deferredEntities: [{ entity: sharedChild }],
+            refreshKeys: [],
+          }),
+        );
+
+        // Keyed location claims the same child (strong ownership, steals from null-key location)
+        await db.transaction(tx =>
+          db.updateProcessedEntity(tx, {
+            id: keyedLocationId,
+            processedEntity: processedEntityKeyed,
+            resultHash: '',
+            relations: [],
+            deferredEntities: [
+              { entity: sharedChild, locationKey: 'specific-key' },
+            ],
+            refreshKeys: [],
+          }),
+        );
+
+        // Only the keyed location should remain as ancestor (it stole from null-key location)
+        const refs = await knex<DbRefreshStateReferencesRow>(
+          'refresh_state_references',
+        ).select();
+        const ancestorRefs = refs.map(r => r.source_entity_ref).filter(Boolean);
+        expect(ancestorRefs).toEqual(['location:default/keyed-location']);
+      },
+    );
+
+    it('stores the refresh keys for the entity where key length is 255 chars or less', async () => {
         const mockLogger = {
           debug: jest.fn(),
           error: jest.fn(),

--- a/plugins/catalog-backend/src/database/DefaultProcessingDatabase.ts
+++ b/plugins/catalog-backend/src/database/DefaultProcessingDatabase.ts
@@ -320,6 +320,10 @@ export class DefaultProcessingDatabase implements ProcessingDatabase {
 
     // Keeps track of the entities that we end up inserting to update refresh_state_references afterwards
     const stateReferences = new Array<string>();
+    // Tracks entities that are transitioning from null to non-null location key.
+    // These are entities being "claimed" by a specific location for the first time,
+    // so we need to remove any existing weak (null-key) references from other parents.
+    const stealableReferences = new Array<string>();
 
     // Upsert all of the unprocessed entities into the refresh_state table, by
     // their entity ref.
@@ -327,14 +331,18 @@ export class DefaultProcessingDatabase implements ProcessingDatabase {
       const entityRef = stringifyEntityRef(entity);
       const hash = generateStableHash(entity);
 
-      const updated = await updateUnprocessedEntity({
-        tx,
-        entity,
-        hash,
-        locationKey,
-      });
+      const { updated, claimedFromNullLocationKey } =
+        await updateUnprocessedEntity({
+          tx,
+          entity,
+          hash,
+          locationKey,
+        });
       if (updated) {
         stateReferences.push(entityRef);
+        if (claimedFromNullLocationKey) {
+          stealableReferences.push(entityRef);
+        }
         continue;
       }
 
@@ -378,13 +386,21 @@ export class DefaultProcessingDatabase implements ProcessingDatabase {
       }
     }
 
-    // Lastly, replace refresh state references for the originating entity and any successfully added entities
-    await tx<DbRefreshStateReferencesRow>('refresh_state_references')
+    // Replace refresh state references for the originating entity and any
+    // successfully added entities that are transitioning ownership.
+    const deletionQuery = tx<DbRefreshStateReferencesRow>(
+      'refresh_state_references',
+    )
       // Remove all existing references from the originating entity
-      .where({ source_entity_ref: options.sourceEntityRef })
-      // And remove any existing references to entities that we're inserting new references for
-      .orWhereIn('target_entity_ref', stateReferences)
-      .delete();
+      .where({ source_entity_ref: options.sourceEntityRef });
+    if (stealableReferences.length > 0) {
+      // Also remove references to entities that are being claimed from null
+      // location key (weak ownership) by a specific location key (strong
+      // ownership). This ensures that previously weak references from other
+      // parents are replaced when a location takes ownership of an entity.
+      deletionQuery.orWhereIn('target_entity_ref', stealableReferences);
+    }
+    await deletionQuery.delete();
     await tx.batchInsert(
       'refresh_state_references',
       stateReferences.map(entityRef => ({

--- a/plugins/catalog-backend/src/database/DefaultProcessingDatabase.ts
+++ b/plugins/catalog-backend/src/database/DefaultProcessingDatabase.ts
@@ -388,19 +388,19 @@ export class DefaultProcessingDatabase implements ProcessingDatabase {
 
     // Replace refresh state references for the originating entity and any
     // successfully added entities that are transitioning ownership.
-    const deletionQuery = tx<DbRefreshStateReferencesRow>(
-      'refresh_state_references',
-    )
+    await tx<DbRefreshStateReferencesRow>('refresh_state_references')
       // Remove all existing references from the originating entity
-      .where({ source_entity_ref: options.sourceEntityRef });
-    if (stealableReferences.length > 0) {
-      // Also remove references to entities that are being claimed from null
-      // location key (weak ownership) by a specific location key (strong
-      // ownership). This ensures that previously weak references from other
-      // parents are replaced when a location takes ownership of an entity.
-      deletionQuery.orWhereIn('target_entity_ref', stealableReferences);
-    }
-    await deletionQuery.delete();
+      .where({ source_entity_ref: options.sourceEntityRef })
+      .modify(qb => {
+        if (stealableReferences.length > 0) {
+          // Also remove references to entities that are being claimed from null
+          // location key (weak ownership) by a specific location key (strong
+          // ownership). This ensures that previously weak references from other
+          // parents are replaced when a location takes ownership of an entity.
+          qb.orWhereIn('target_entity_ref', stealableReferences);
+        }
+      })
+      .delete();
     await tx.batchInsert(
       'refresh_state_references',
       stateReferences.map(entityRef => ({

--- a/plugins/catalog-backend/src/database/DefaultProviderDatabase.test.ts
+++ b/plugins/catalog-backend/src/database/DefaultProviderDatabase.test.ts
@@ -1014,6 +1014,147 @@ describe.each(databases.eachSupportedId())(
       });
     });
 
+    it.each(databases.eachSupportedId())(
+      'should delete all references when taking over an entity from null location key, but preserve references for entities with strong ownership, %p',
+      async databaseId => {
+        const fakeLogger = mockServices.logger.mock();
+        const { knex, db } = await createDatabase(databaseId, fakeLogger);
+
+        const weakEntity: Entity = {
+          apiVersion: '1',
+          kind: 'Component',
+          metadata: { namespace: 'default', name: 'weak-entity' },
+        };
+        const strongEntity: Entity = {
+          apiVersion: '1',
+          kind: 'Component',
+          metadata: { namespace: 'default', name: 'strong-entity' },
+        };
+
+        // Provider A owns weak-entity with null location key (weak ownership)
+        await insertRefreshStateRow(knex, {
+          entity_id: uuid.v4(),
+          entity_ref: stringifyEntityRef(weakEntity),
+          unprocessed_entity: JSON.stringify(weakEntity),
+          errors: '[]',
+          next_update_at: '2021-04-01 13:37:00',
+          last_discovery_at: '2021-04-01 13:37:00',
+        });
+        await insertRefRow(knex, {
+          source_key: 'provider-a',
+          target_entity_ref: stringifyEntityRef(weakEntity),
+        });
+
+        // Provider A owns strong-entity with a non-null location key (strong ownership)
+        await insertRefreshStateRow(knex, {
+          entity_id: uuid.v4(),
+          entity_ref: stringifyEntityRef(strongEntity),
+          unprocessed_entity: JSON.stringify(strongEntity),
+          errors: '[]',
+          next_update_at: '2021-04-01 13:37:00',
+          last_discovery_at: '2021-04-01 13:37:00',
+          location_key: 'provider-a-key',
+        });
+        await insertRefRow(knex, {
+          source_key: 'provider-a',
+          target_entity_ref: stringifyEntityRef(strongEntity),
+        });
+
+        // Provider B claims both entities with strong location keys
+        await db.transaction(async tx => {
+          await db.replaceUnprocessedEntities(tx, {
+            type: 'delta',
+            sourceKey: 'provider-b',
+            removed: [],
+            added: [
+              {
+                entity: {
+                  ...weakEntity,
+                  spec: { marker: 'taken-over' },
+                },
+                locationKey: 'provider-b-key',
+              },
+              {
+                entity: {
+                  ...strongEntity,
+                  spec: { marker: 'attempted-takeover' },
+                },
+                locationKey: 'provider-b-key',
+              },
+            ],
+          });
+        });
+
+        // weak-entity should have been taken over by provider B
+        const refreshState = await knex<DbRefreshStateRow>('refresh_state')
+          .select()
+          .orderBy('entity_ref');
+        expect(refreshState).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              entity_ref: stringifyEntityRef(weakEntity),
+              location_key: 'provider-b-key',
+              unprocessed_entity: expect.stringContaining('taken-over'),
+            }),
+          ]),
+        );
+
+        // strong-entity should NOT have been taken over - still has provider A's key
+        expect(refreshState).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              entity_ref: stringifyEntityRef(strongEntity),
+              location_key: 'provider-a-key',
+              unprocessed_entity: JSON.stringify(strongEntity),
+            }),
+          ]),
+        );
+
+        // Check references: weak-entity's old reference from provider-a should be
+        // deleted (because claimedFromNullLocationKey=true deletes ALL refs), and
+        // a new reference from provider-b should exist
+        const refs = await knex<DbRefreshStateReferencesRow>(
+          'refresh_state_references',
+        )
+          .select()
+          .orderBy(['target_entity_ref', 'source_key']);
+
+        expect(refs).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              source_key: 'provider-b',
+              target_entity_ref: stringifyEntityRef(weakEntity),
+            }),
+          ]),
+        );
+
+        // There should be NO leftover reference from provider-a to weak-entity
+        expect(
+          refs.some(
+            r =>
+              r.source_key === 'provider-a' &&
+              r.target_entity_ref === stringifyEntityRef(weakEntity),
+          ),
+        ).toBe(false);
+
+        // strong-entity's reference from provider-a should still be intact
+        expect(refs).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              source_key: 'provider-a',
+              target_entity_ref: stringifyEntityRef(strongEntity),
+            }),
+          ]),
+        );
+
+        // A conflict warning should have been logged for the strong entity
+        expect(fakeLogger.warn).toHaveBeenCalledWith(
+          expect.stringContaining(stringifyEntityRef(strongEntity)),
+        );
+      },
+    );
+  });
+
     describe('listReferenceSourceKeys', () => {
       it('returns the source_keys from "refresh_state_references"', async () => {
         const { knex, db } = await createDatabase();

--- a/plugins/catalog-backend/src/database/DefaultProviderDatabase.test.ts
+++ b/plugins/catalog-backend/src/database/DefaultProviderDatabase.test.ts
@@ -1014,146 +1014,142 @@ describe.each(databases.eachSupportedId())(
       });
     });
 
-    it.each(databases.eachSupportedId())(
-      'should delete all references when taking over an entity from null location key, but preserve references for entities with strong ownership, %p',
-      async databaseId => {
-        const fakeLogger = mockServices.logger.mock();
-        const { knex, db } = await createDatabase(databaseId, fakeLogger);
+    it('should delete all references when taking over an entity from null location key, but preserve references for entities with strong ownership, %p', async () => {
+      const fakeLogger = mockServices.logger.mock();
+      const { knex, db } = await createDatabase(fakeLogger);
 
-        const weakEntity: Entity = {
-          apiVersion: '1',
-          kind: 'Component',
-          metadata: { namespace: 'default', name: 'weak-entity' },
-        };
-        const strongEntity: Entity = {
-          apiVersion: '1',
-          kind: 'Component',
-          metadata: { namespace: 'default', name: 'strong-entity' },
-        };
+      const weakEntity: Entity = {
+        apiVersion: '1',
+        kind: 'Component',
+        metadata: { namespace: 'default', name: 'weak-entity' },
+      };
+      const strongEntity: Entity = {
+        apiVersion: '1',
+        kind: 'Component',
+        metadata: { namespace: 'default', name: 'strong-entity' },
+      };
 
-        // Provider A owns weak-entity with null location key (weak ownership)
-        await insertRefreshStateRow(knex, {
-          entity_id: uuid.v4(),
-          entity_ref: stringifyEntityRef(weakEntity),
-          unprocessed_entity: JSON.stringify(weakEntity),
-          errors: '[]',
-          next_update_at: '2021-04-01 13:37:00',
-          last_discovery_at: '2021-04-01 13:37:00',
-        });
-        await insertRefRow(knex, {
-          source_key: 'provider-a',
-          target_entity_ref: stringifyEntityRef(weakEntity),
-        });
+      // Provider A owns weak-entity with null location key (weak ownership)
+      await insertRefreshStateRow(knex, {
+        entity_id: 'id1',
+        entity_ref: stringifyEntityRef(weakEntity),
+        unprocessed_entity: JSON.stringify(weakEntity),
+        errors: '[]',
+        next_update_at: '2021-04-01 13:37:00',
+        last_discovery_at: '2021-04-01 13:37:00',
+      });
+      await insertRefRow(knex, {
+        source_key: 'provider-a',
+        target_entity_ref: stringifyEntityRef(weakEntity),
+      });
 
-        // Provider A owns strong-entity with a non-null location key (strong ownership)
-        await insertRefreshStateRow(knex, {
-          entity_id: uuid.v4(),
-          entity_ref: stringifyEntityRef(strongEntity),
-          unprocessed_entity: JSON.stringify(strongEntity),
-          errors: '[]',
-          next_update_at: '2021-04-01 13:37:00',
-          last_discovery_at: '2021-04-01 13:37:00',
-          location_key: 'provider-a-key',
-        });
-        await insertRefRow(knex, {
-          source_key: 'provider-a',
-          target_entity_ref: stringifyEntityRef(strongEntity),
-        });
+      // Provider A owns strong-entity with a non-null location key (strong ownership)
+      await insertRefreshStateRow(knex, {
+        entity_id: 'id2',
+        entity_ref: stringifyEntityRef(strongEntity),
+        unprocessed_entity: JSON.stringify(strongEntity),
+        errors: '[]',
+        next_update_at: '2021-04-01 13:37:00',
+        last_discovery_at: '2021-04-01 13:37:00',
+        location_key: 'provider-a-key',
+      });
+      await insertRefRow(knex, {
+        source_key: 'provider-a',
+        target_entity_ref: stringifyEntityRef(strongEntity),
+      });
 
-        // Provider B claims both entities with strong location keys
-        await db.transaction(async tx => {
-          await db.replaceUnprocessedEntities(tx, {
-            type: 'delta',
-            sourceKey: 'provider-b',
-            removed: [],
-            added: [
-              {
-                entity: {
-                  ...weakEntity,
-                  spec: { marker: 'taken-over' },
-                },
-                locationKey: 'provider-b-key',
+      // Provider B claims both entities with strong location keys
+      await db.transaction(async tx => {
+        await db.replaceUnprocessedEntities(tx, {
+          type: 'delta',
+          sourceKey: 'provider-b',
+          removed: [],
+          added: [
+            {
+              entity: {
+                ...weakEntity,
+                spec: { marker: 'taken-over' },
               },
-              {
-                entity: {
-                  ...strongEntity,
-                  spec: { marker: 'attempted-takeover' },
-                },
-                locationKey: 'provider-b-key',
+              locationKey: 'provider-b-key',
+            },
+            {
+              entity: {
+                ...strongEntity,
+                spec: { marker: 'attempted-takeover' },
               },
-            ],
-          });
+              locationKey: 'provider-b-key',
+            },
+          ],
         });
+      });
 
-        // weak-entity should have been taken over by provider B
-        const refreshState = await knex<DbRefreshStateRow>('refresh_state')
-          .select()
-          .orderBy('entity_ref');
-        expect(refreshState).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({
-              entity_ref: stringifyEntityRef(weakEntity),
-              location_key: 'provider-b-key',
-              unprocessed_entity: expect.stringContaining('taken-over'),
-            }),
-          ]),
-        );
+      // weak-entity should have been taken over by provider B
+      const refreshState = await knex<DbRefreshStateRow>('refresh_state')
+        .select()
+        .orderBy('entity_ref');
+      expect(refreshState).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            entity_ref: stringifyEntityRef(weakEntity),
+            location_key: 'provider-b-key',
+            unprocessed_entity: expect.stringContaining('taken-over'),
+          }),
+        ]),
+      );
 
-        // strong-entity should NOT have been taken over - still has provider A's key
-        expect(refreshState).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({
-              entity_ref: stringifyEntityRef(strongEntity),
-              location_key: 'provider-a-key',
-              unprocessed_entity: JSON.stringify(strongEntity),
-            }),
-          ]),
-        );
+      // strong-entity should NOT have been taken over - still has provider A's key
+      expect(refreshState).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            entity_ref: stringifyEntityRef(strongEntity),
+            location_key: 'provider-a-key',
+            unprocessed_entity: JSON.stringify(strongEntity),
+          }),
+        ]),
+      );
 
-        // Check references: weak-entity's old reference from provider-a should be
-        // deleted (because claimedFromNullLocationKey=true deletes ALL refs), and
-        // a new reference from provider-b should exist
-        const refs = await knex<DbRefreshStateReferencesRow>(
-          'refresh_state_references',
-        )
-          .select()
-          .orderBy(['target_entity_ref', 'source_key']);
+      // Check references: weak-entity's old reference from provider-a should be
+      // deleted (because claimedFromNullLocationKey=true deletes ALL refs), and
+      // a new reference from provider-b should exist
+      const refs = await knex<DbRefreshStateReferencesRow>(
+        'refresh_state_references',
+      )
+        .select()
+        .orderBy(['target_entity_ref', 'source_key']);
 
-        expect(refs).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({
-              source_key: 'provider-b',
-              target_entity_ref: stringifyEntityRef(weakEntity),
-            }),
-          ]),
-        );
+      expect(refs).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            source_key: 'provider-b',
+            target_entity_ref: stringifyEntityRef(weakEntity),
+          }),
+        ]),
+      );
 
-        // There should be NO leftover reference from provider-a to weak-entity
-        expect(
-          refs.some(
-            r =>
-              r.source_key === 'provider-a' &&
-              r.target_entity_ref === stringifyEntityRef(weakEntity),
-          ),
-        ).toBe(false);
+      // There should be NO leftover reference from provider-a to weak-entity
+      expect(
+        refs.some(
+          r =>
+            r.source_key === 'provider-a' &&
+            r.target_entity_ref === stringifyEntityRef(weakEntity),
+        ),
+      ).toBe(false);
 
-        // strong-entity's reference from provider-a should still be intact
-        expect(refs).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({
-              source_key: 'provider-a',
-              target_entity_ref: stringifyEntityRef(strongEntity),
-            }),
-          ]),
-        );
+      // strong-entity's reference from provider-a should still be intact
+      expect(refs).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            source_key: 'provider-a',
+            target_entity_ref: stringifyEntityRef(strongEntity),
+          }),
+        ]),
+      );
 
-        // A conflict warning should have been logged for the strong entity
-        expect(fakeLogger.warn).toHaveBeenCalledWith(
-          expect.stringContaining(stringifyEntityRef(strongEntity)),
-        );
-      },
-    );
-  });
+      // A conflict warning should have been logged for the strong entity
+      expect(fakeLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(stringifyEntityRef(strongEntity)),
+      );
+    });
 
     describe('listReferenceSourceKeys', () => {
       it('returns the source_keys from "refresh_state_references"', async () => {

--- a/plugins/catalog-backend/src/database/DefaultProviderDatabase.test.ts
+++ b/plugins/catalog-backend/src/database/DefaultProviderDatabase.test.ts
@@ -1014,7 +1014,7 @@ describe.each(databases.eachSupportedId())(
       });
     });
 
-    it('should delete all references when taking over an entity from null location key, but preserve references for entities with strong ownership, %p', async () => {
+    it('should delete all references when taking over an entity from null location key, but preserve references for entities with strong ownership', async () => {
       const fakeLogger = mockServices.logger.mock();
       const { knex, db } = await createDatabase(fakeLogger);
 

--- a/plugins/catalog-backend/src/database/DefaultProviderDatabase.ts
+++ b/plugins/catalog-backend/src/database/DefaultProviderDatabase.ts
@@ -178,9 +178,9 @@ export class DefaultProviderDatabase implements ProviderDatabase {
           if (ok) {
             await tx<DbRefreshStateReferencesRow>('refresh_state_references')
               .where('target_entity_ref', entityRef)
-              .andWhere(inner => {
+              .modify(qb => {
                 if (!claimedFromNullLocationKey) {
-                  inner.where({ source_key: options.sourceKey });
+                  qb.andWhere({ source_key: options.sourceKey });
                 }
               })
               .delete();

--- a/plugins/catalog-backend/src/database/DefaultProviderDatabase.ts
+++ b/plugins/catalog-backend/src/database/DefaultProviderDatabase.ts
@@ -165,24 +165,11 @@ export class DefaultProviderDatabase implements ProviderDatabase {
               locationKey,
             });
 
-          let ok = updated;
-          if (!ok) {
-            ok = await insertUnprocessedEntity({
-              tx,
-              entity,
-              hash,
-              locationKey,
-              logger: this.options.logger,
-            });
-          }
-          if (ok) {
+          if (updated && claimedFromNullLocationKey) {
+            // Entity was claimed from weak (null-key) ownership to strong
+            // ownership - delete all old references and insert the new one
             await tx<DbRefreshStateReferencesRow>('refresh_state_references')
               .where('target_entity_ref', entityRef)
-              .modify(qb => {
-                if (!claimedFromNullLocationKey) {
-                  qb.andWhere({ source_key: options.sourceKey });
-                }
-              })
               .delete();
 
             await tx<DbRefreshStateReferencesRow>(
@@ -191,7 +178,37 @@ export class DefaultProviderDatabase implements ProviderDatabase {
               source_key: options.sourceKey,
               target_entity_ref: entityRef,
             });
+          } else if (updated) {
+            // Normal update - ensure this provider's reference exists
+            await tx<DbRefreshStateReferencesRow>('refresh_state_references')
+              .where('target_entity_ref', entityRef)
+              .andWhere({ source_key: options.sourceKey })
+              .delete();
+
+            await tx<DbRefreshStateReferencesRow>(
+              'refresh_state_references',
+            ).insert({
+              source_key: options.sourceKey,
+              target_entity_ref: entityRef,
+            });
+          } else if (
+            await insertUnprocessedEntity({
+              tx,
+              entity,
+              hash,
+              locationKey,
+              logger: this.options.logger,
+            })
+          ) {
+            // New entity inserted - add the reference
+            await tx<DbRefreshStateReferencesRow>(
+              'refresh_state_references',
+            ).insert({
+              source_key: options.sourceKey,
+              target_entity_ref: entityRef,
+            });
           } else {
+            // Neither update nor insert succeeded - conflict
             await tx<DbRefreshStateReferencesRow>('refresh_state_references')
               .where('target_entity_ref', entityRef)
               .andWhere({ source_key: options.sourceKey })

--- a/plugins/catalog-backend/src/database/DefaultProviderDatabase.ts
+++ b/plugins/catalog-backend/src/database/DefaultProviderDatabase.ts
@@ -157,12 +157,15 @@ export class DefaultProviderDatabase implements ProviderDatabase {
         const entityRef = stringifyEntityRef(entity);
 
         try {
-          let ok = await updateUnprocessedEntity({
-            tx,
-            entity,
-            hash,
-            locationKey,
-          });
+          const { updated, claimedFromNullLocationKey } =
+            await updateUnprocessedEntity({
+              tx,
+              entity,
+              hash,
+              locationKey,
+            });
+
+          let ok = updated;
           if (!ok) {
             ok = await insertUnprocessedEntity({
               tx,
@@ -175,6 +178,11 @@ export class DefaultProviderDatabase implements ProviderDatabase {
           if (ok) {
             await tx<DbRefreshStateReferencesRow>('refresh_state_references')
               .where('target_entity_ref', entityRef)
+              .andWhere(inner => {
+                if (!claimedFromNullLocationKey) {
+                  inner.where({ source_key: options.sourceKey });
+                }
+              })
               .delete();
 
             await tx<DbRefreshStateReferencesRow>(

--- a/plugins/catalog-backend/src/database/operations/refreshState/updateUnprocessedEntity.test.ts
+++ b/plugins/catalog-backend/src/database/operations/refreshState/updateUnprocessedEntity.test.ts
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestDatabaseId, TestDatabases } from '@backstage/backend-test-utils';
+import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
+import * as uuid from 'uuid';
+import { applyDatabaseMigrations } from '../../migrations';
+import { DbRefreshStateRow } from '../../tables';
+import { updateUnprocessedEntity } from './updateUnprocessedEntity';
+
+jest.setTimeout(60_000);
+
+describe('updateUnprocessedEntity', () => {
+  const databases = TestDatabases.create();
+
+  async function createDatabase(databaseId: TestDatabaseId) {
+    const knex = await databases.init(databaseId);
+    await applyDatabaseMigrations(knex);
+    return knex;
+  }
+
+  async function insertRefreshStateRow(
+    db: Awaited<ReturnType<typeof createDatabase>>,
+    row: DbRefreshStateRow,
+  ) {
+    await db<DbRefreshStateRow>('refresh_state').insert(row);
+  }
+
+  async function getRefreshStateRow(
+    db: Awaited<ReturnType<typeof createDatabase>>,
+    entityRef: string,
+  ) {
+    return db<DbRefreshStateRow>('refresh_state')
+      .where({ entity_ref: entityRef })
+      .first();
+  }
+
+  function normalizeTimestamp(value: string | Date | undefined): number {
+    if (!value) {
+      throw new Error('Expected timestamp value');
+    }
+
+    return typeof value === 'string'
+      ? new Date(value).getTime()
+      : value.getTime();
+  }
+
+  it.each(databases.eachSupportedId())(
+    'updates an existing weakly owned row when no location key is provided, %p',
+    async databaseId => {
+      const knex = await createDatabase(databaseId);
+      const entityBefore: Entity = {
+        apiVersion: '1',
+        kind: 'Component',
+        metadata: { namespace: 'default', name: 'weak-entity' },
+      };
+      const entityAfter: Entity = {
+        ...entityBefore,
+        spec: { owner: 'team-a' },
+      };
+      const entityRef = stringifyEntityRef(entityBefore);
+      const originalTimestamp = '2021-04-01 13:37:00';
+
+      await insertRefreshStateRow(knex, {
+        entity_id: uuid.v4(),
+        entity_ref: entityRef,
+        unprocessed_entity: JSON.stringify(entityBefore),
+        unprocessed_hash: 'old-hash',
+        errors: '[]',
+        next_update_at: originalTimestamp,
+        last_discovery_at: originalTimestamp,
+      });
+
+      await expect(
+        updateUnprocessedEntity({
+          tx: knex,
+          entity: entityAfter,
+          hash: 'new-hash',
+        }),
+      ).resolves.toEqual({
+        updated: true,
+        claimedFromNullLocationKey: false,
+      });
+
+      await expect(getRefreshStateRow(knex, entityRef)).resolves.toEqual(
+        expect.objectContaining({
+          entity_ref: entityRef,
+          unprocessed_entity: JSON.stringify(entityAfter),
+          unprocessed_hash: 'new-hash',
+          location_key: null,
+        }),
+      );
+
+      const row = await getRefreshStateRow(knex, entityRef);
+      expect(normalizeTimestamp(row?.next_update_at)).toBeGreaterThan(
+        normalizeTimestamp(originalTimestamp),
+      );
+      expect(normalizeTimestamp(row?.last_discovery_at)).toBeGreaterThan(
+        normalizeTimestamp(originalTimestamp),
+      );
+    },
+  );
+
+  it.each(databases.eachSupportedId())(
+    'updates an existing row with the same location key, %p',
+    async databaseId => {
+      const knex = await createDatabase(databaseId);
+      const entityBefore: Entity = {
+        apiVersion: '1',
+        kind: 'Component',
+        metadata: { namespace: 'default', name: 'same-key-entity' },
+      };
+      const entityAfter: Entity = {
+        ...entityBefore,
+        spec: { owner: 'team-b' },
+      };
+      const entityRef = stringifyEntityRef(entityBefore);
+
+      await insertRefreshStateRow(knex, {
+        entity_id: uuid.v4(),
+        entity_ref: entityRef,
+        unprocessed_entity: JSON.stringify(entityBefore),
+        unprocessed_hash: 'old-hash',
+        errors: '[]',
+        next_update_at: '2021-04-01 13:37:00',
+        last_discovery_at: '2021-04-01 13:37:00',
+        location_key: 'provider-key',
+      });
+
+      await expect(
+        updateUnprocessedEntity({
+          tx: knex,
+          entity: entityAfter,
+          hash: 'new-hash',
+          locationKey: 'provider-key',
+        }),
+      ).resolves.toEqual({
+        updated: true,
+        claimedFromNullLocationKey: false,
+      });
+
+      await expect(getRefreshStateRow(knex, entityRef)).resolves.toEqual(
+        expect.objectContaining({
+          entity_ref: entityRef,
+          unprocessed_entity: JSON.stringify(entityAfter),
+          unprocessed_hash: 'new-hash',
+          location_key: 'provider-key',
+        }),
+      );
+    },
+  );
+
+  it.each(databases.eachSupportedId())(
+    'claims a weakly owned row when a location key is provided, %p',
+    async databaseId => {
+      const knex = await createDatabase(databaseId);
+      const entityBefore: Entity = {
+        apiVersion: '1',
+        kind: 'Component',
+        metadata: { namespace: 'default', name: 'claimed-entity' },
+      };
+      const entityAfter: Entity = {
+        ...entityBefore,
+        spec: { owner: 'team-c' },
+      };
+      const entityRef = stringifyEntityRef(entityBefore);
+
+      await insertRefreshStateRow(knex, {
+        entity_id: uuid.v4(),
+        entity_ref: entityRef,
+        unprocessed_entity: JSON.stringify(entityBefore),
+        unprocessed_hash: 'old-hash',
+        errors: '[]',
+        next_update_at: '2021-04-01 13:37:00',
+        last_discovery_at: '2021-04-01 13:37:00',
+      });
+
+      await expect(
+        updateUnprocessedEntity({
+          tx: knex,
+          entity: entityAfter,
+          hash: 'new-hash',
+          locationKey: 'provider-key',
+        }),
+      ).resolves.toEqual({
+        updated: true,
+        claimedFromNullLocationKey: true,
+      });
+
+      await expect(getRefreshStateRow(knex, entityRef)).resolves.toEqual(
+        expect.objectContaining({
+          entity_ref: entityRef,
+          unprocessed_entity: JSON.stringify(entityAfter),
+          unprocessed_hash: 'new-hash',
+          location_key: 'provider-key',
+        }),
+      );
+    },
+  );
+
+  it.each(databases.eachSupportedId())(
+    'refuses to update rows owned by a different location key, %p',
+    async databaseId => {
+      const knex = await createDatabase(databaseId);
+      const entityBefore: Entity = {
+        apiVersion: '1',
+        kind: 'Component',
+        metadata: { namespace: 'default', name: 'conflicting-entity' },
+      };
+      const entityAfter: Entity = {
+        ...entityBefore,
+        spec: { owner: 'team-d' },
+      };
+      const entityRef = stringifyEntityRef(entityBefore);
+
+      await insertRefreshStateRow(knex, {
+        entity_id: uuid.v4(),
+        entity_ref: entityRef,
+        unprocessed_entity: JSON.stringify(entityBefore),
+        unprocessed_hash: 'old-hash',
+        errors: '[]',
+        next_update_at: '2021-04-01 13:37:00',
+        last_discovery_at: '2021-04-01 13:37:00',
+        location_key: 'other-provider-key',
+      });
+
+      await expect(
+        updateUnprocessedEntity({
+          tx: knex,
+          entity: entityAfter,
+          hash: 'new-hash',
+          locationKey: 'provider-key',
+        }),
+      ).resolves.toEqual({
+        updated: false,
+        claimedFromNullLocationKey: false,
+      });
+
+      await expect(getRefreshStateRow(knex, entityRef)).resolves.toEqual(
+        expect.objectContaining({
+          entity_ref: entityRef,
+          unprocessed_entity: JSON.stringify(entityBefore),
+          unprocessed_hash: 'old-hash',
+          location_key: 'other-provider-key',
+        }),
+      );
+    },
+  );
+
+  it.each(databases.eachSupportedId())(
+    'does not let a weak update replace a strongly owned row, %p',
+    async databaseId => {
+      const knex = await createDatabase(databaseId);
+      const entityBefore: Entity = {
+        apiVersion: '1',
+        kind: 'Component',
+        metadata: { namespace: 'default', name: 'strongly-owned-entity' },
+      };
+      const entityAfter: Entity = {
+        ...entityBefore,
+        spec: { owner: 'team-e' },
+      };
+      const entityRef = stringifyEntityRef(entityBefore);
+
+      await insertRefreshStateRow(knex, {
+        entity_id: uuid.v4(),
+        entity_ref: entityRef,
+        unprocessed_entity: JSON.stringify(entityBefore),
+        unprocessed_hash: 'old-hash',
+        errors: '[]',
+        next_update_at: '2021-04-01 13:37:00',
+        last_discovery_at: '2021-04-01 13:37:00',
+        location_key: 'provider-key',
+      });
+
+      await expect(
+        updateUnprocessedEntity({
+          tx: knex,
+          entity: entityAfter,
+          hash: 'new-hash',
+        }),
+      ).resolves.toEqual({
+        updated: false,
+        claimedFromNullLocationKey: false,
+      });
+
+      await expect(getRefreshStateRow(knex, entityRef)).resolves.toEqual(
+        expect.objectContaining({
+          entity_ref: entityRef,
+          unprocessed_entity: JSON.stringify(entityBefore),
+          unprocessed_hash: 'old-hash',
+          location_key: 'provider-key',
+        }),
+      );
+    },
+  );
+});

--- a/plugins/catalog-backend/src/database/operations/refreshState/updateUnprocessedEntity.test.ts
+++ b/plugins/catalog-backend/src/database/operations/refreshState/updateUnprocessedEntity.test.ts
@@ -16,7 +16,6 @@
 
 import { TestDatabaseId, TestDatabases } from '@backstage/backend-test-utils';
 import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
-import * as uuid from 'uuid';
 import { applyDatabaseMigrations } from '../../migrations';
 import { DbRefreshStateRow } from '../../tables';
 import { updateUnprocessedEntity } from './updateUnprocessedEntity';
@@ -75,7 +74,7 @@ describe('updateUnprocessedEntity', () => {
       const originalTimestamp = '2021-04-01 13:37:00';
 
       await insertRefreshStateRow(knex, {
-        entity_id: uuid.v4(),
+        entity_id: 'id1',
         entity_ref: entityRef,
         unprocessed_entity: JSON.stringify(entityBefore),
         unprocessed_hash: 'old-hash',
@@ -130,7 +129,7 @@ describe('updateUnprocessedEntity', () => {
       const entityRef = stringifyEntityRef(entityBefore);
 
       await insertRefreshStateRow(knex, {
-        entity_id: uuid.v4(),
+        entity_id: 'id2',
         entity_ref: entityRef,
         unprocessed_entity: JSON.stringify(entityBefore),
         unprocessed_hash: 'old-hash',
@@ -179,7 +178,7 @@ describe('updateUnprocessedEntity', () => {
       const entityRef = stringifyEntityRef(entityBefore);
 
       await insertRefreshStateRow(knex, {
-        entity_id: uuid.v4(),
+        entity_id: 'id3',
         entity_ref: entityRef,
         unprocessed_entity: JSON.stringify(entityBefore),
         unprocessed_hash: 'old-hash',
@@ -227,7 +226,7 @@ describe('updateUnprocessedEntity', () => {
       const entityRef = stringifyEntityRef(entityBefore);
 
       await insertRefreshStateRow(knex, {
-        entity_id: uuid.v4(),
+        entity_id: 'id4',
         entity_ref: entityRef,
         unprocessed_entity: JSON.stringify(entityBefore),
         unprocessed_hash: 'old-hash',
@@ -276,7 +275,7 @@ describe('updateUnprocessedEntity', () => {
       const entityRef = stringifyEntityRef(entityBefore);
 
       await insertRefreshStateRow(knex, {
-        entity_id: uuid.v4(),
+        entity_id: 'id5',
         entity_ref: entityRef,
         unprocessed_entity: JSON.stringify(entityBefore),
         unprocessed_hash: 'old-hash',

--- a/plugins/catalog-backend/src/database/operations/refreshState/updateUnprocessedEntity.ts
+++ b/plugins/catalog-backend/src/database/operations/refreshState/updateUnprocessedEntity.ts
@@ -19,8 +19,12 @@ import { Knex } from 'knex';
 import { DbRefreshStateRow } from '../../tables';
 
 /**
- * Attempts to update an existing refresh state row, returning true if it was
- * updated and false if there was no entity with a matching ref and location key.
+ * Attempts to update an existing refresh state row, returning an object with:
+ * - `updated`: true if the row was updated, false if there was no entity with
+ *   a matching ref and location key.
+ * - `claimedFromNullLocationKey`: true if the update transitioned the entity's location_key
+ *   from null to a non-null value (i.e., the entity was claimed by a specific
+ *   location for the first time).
  *
  * Updating the entity will also cause it to be scheduled for immediate processing.
  */
@@ -29,11 +33,25 @@ export async function updateUnprocessedEntity(options: {
   entity: Entity;
   hash: string;
   locationKey?: string;
-}): Promise<boolean> {
+}): Promise<{ updated: boolean; claimedFromNullLocationKey: boolean }> {
   const { tx, entity, hash, locationKey } = options;
 
   const entityRef = stringifyEntityRef(entity);
   const serializedEntity = JSON.stringify(entity);
+
+  // When claiming an entity with a non-null location key, check whether it
+  // currently has a null location key. If so, the update will transition it
+  // from weak (null) to strong (keyed) ownership, and we'll need to steal
+  // references from other parents that only had weak ownership.
+  let claimedFromNullLocationKey = false;
+  if (locationKey) {
+    const existingNullKeyRow = await tx<DbRefreshStateRow>('refresh_state')
+      .where({ entity_ref: entityRef })
+      .whereNull('location_key')
+      .select('entity_id')
+      .first();
+    claimedFromNullLocationKey = existingNullKeyRow !== undefined;
+  }
 
   const refreshResult = await tx<DbRefreshStateRow>('refresh_state')
     .update({
@@ -56,5 +74,5 @@ export async function updateUnprocessedEntity(options: {
         .orWhereNull('location_key');
     });
 
-  return refreshResult === 1;
+  return { updated: refreshResult === 1, claimedFromNullLocationKey };
 }

--- a/plugins/catalog-backend/src/database/operations/refreshState/updateUnprocessedEntity.ts
+++ b/plugins/catalog-backend/src/database/operations/refreshState/updateUnprocessedEntity.ts
@@ -39,40 +39,61 @@ export async function updateUnprocessedEntity(options: {
   const entityRef = stringifyEntityRef(entity);
   const serializedEntity = JSON.stringify(entity);
 
-  // When claiming an entity with a non-null location key, check whether it
-  // currently has a null location key. If so, the update will transition it
-  // from weak (null) to strong (keyed) ownership, and we'll need to steal
-  // references from other parents that only had weak ownership.
-  let claimedFromNullLocationKey = false;
-  if (locationKey) {
-    const existingNullKeyRow = await tx<DbRefreshStateRow>('refresh_state')
-      .where({ entity_ref: entityRef })
-      .whereNull('location_key')
-      .select('entity_id')
-      .first();
-    claimedFromNullLocationKey = existingNullKeyRow !== undefined;
-  }
-
-  const refreshResult = await tx<DbRefreshStateRow>('refresh_state')
-    .update({
-      unprocessed_entity: serializedEntity,
-      unprocessed_hash: hash,
-      location_key: locationKey,
-      last_discovery_at: tx.fn.now(),
-      // We only get to this point if a processed entity actually had any changes, or
-      // if an entity provider requested this mutation, meaning that we can safely
-      // bump the deferred entities to the front of the queue for immediate processing.
-      next_update_at: tx.fn.now(),
-    })
-    .where('entity_ref', entityRef)
-    .andWhere(inner => {
-      if (!locationKey) {
-        return inner.whereNull('location_key');
+  return tx.transaction(
+    async subTx => {
+      // When claiming an entity with a non-null location key, check whether it
+      // currently has a null location key. If so, the update will transition it
+      // from weak (null) to strong (keyed) ownership, and we'll need to steal
+      // references from other parents that only had weak ownership.
+      let claimedFromNullLocationKey = false;
+      if (locationKey) {
+        const existingNullKeyRow = await subTx<DbRefreshStateRow>(
+          'refresh_state',
+        )
+          .where({ entity_ref: entityRef })
+          .whereNull('location_key')
+          .select('entity_id')
+          .modify(qb => {
+            if (
+              ['mysql', 'mysql2', 'pg'].includes(subTx.client.config.client)
+            ) {
+              // In MySQL and Postgres, we can use "SELECT ... FOR UPDATE" to lock the selected row until the end of the transaction.
+              qb.forUpdate();
+            }
+          })
+          .first();
+        claimedFromNullLocationKey = existingNullKeyRow !== undefined;
       }
-      return inner
-        .where('location_key', locationKey)
-        .orWhereNull('location_key');
-    });
 
-  return { updated: refreshResult === 1, claimedFromNullLocationKey };
+      const refreshResult = await subTx<DbRefreshStateRow>('refresh_state')
+        .update({
+          unprocessed_entity: serializedEntity,
+          unprocessed_hash: hash,
+          location_key: locationKey,
+          last_discovery_at: subTx.fn.now(),
+          // We only get to this point if a processed entity actually had any changes, or
+          // if an entity provider requested this mutation, meaning that we can safely
+          // bump the deferred entities to the front of the queue for immediate processing.
+          next_update_at: subTx.fn.now(),
+        })
+        .where('entity_ref', entityRef)
+        .andWhere(inner => {
+          if (!locationKey) {
+            return inner.whereNull('location_key');
+          }
+          return inner
+            .where('location_key', locationKey)
+            .orWhereNull('location_key');
+        });
+
+      return { updated: refreshResult === 1, claimedFromNullLocationKey };
+    },
+    // We need to use REPEATABLE READ here to ensure that if we read a null location key,
+    // it won't be changed by another transaction until we commit.
+    // This allows us to correctly determine whether we're claiming an
+    // entity from null ownership or not, and steal references if so.
+    //
+    // sqlite3 only supports serializable transactions, and will ignore the isolation level param.
+    { isolationLevel: 'repeatable read' },
+  );
 }

--- a/plugins/catalog-backend/src/tests/integration.test.ts
+++ b/plugins/catalog-backend/src/tests/integration.test.ts
@@ -1091,6 +1091,155 @@ describe('Catalog Backend Integration', () => {
     });
   });
 
+  it('should take over weak-ownership entity while preserving strong-ownership entity from same provider', async () => {
+    const firstProvider = new TestProvider('first');
+    const secondProvider = new TestProvider('second');
+
+    const harness = await TestHarness.create({
+      db: await databases.init('SQLITE_3'),
+      additionalProviders: [firstProvider, secondProvider],
+    });
+
+    const baseAnnotations = {
+      'backstage.io/managed-by-location': 'url:.',
+      'backstage.io/managed-by-origin-location': 'url:.',
+    };
+
+    // First provider emits two entities:
+    //  - weak-entity with no location key (weak ownership)
+    //  - strong-entity with a location key (strong ownership)
+    await firstProvider.getConnection().applyMutation({
+      type: 'full',
+      entities: [
+        {
+          entity: {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Component',
+            metadata: {
+              name: 'weak-entity',
+              annotations: baseAnnotations,
+            },
+            spec: { type: 'service', owner: 'first-provider' },
+          },
+        },
+        {
+          locationKey: 'first-provider-key',
+          entity: {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Component',
+            metadata: {
+              name: 'strong-entity',
+              annotations: baseAnnotations,
+            },
+            spec: { type: 'service', owner: 'first-provider' },
+          },
+        },
+      ],
+    });
+
+    await expect(harness.process()).resolves.toEqual({});
+
+    await expect(harness.getRefreshStateReferences()).resolves.toEqual(
+      expect.arrayContaining([
+        {
+          sourceKey: 'first',
+          targetEntityRef: 'component:default/weak-entity',
+        },
+        {
+          sourceKey: 'first',
+          targetEntityRef: 'component:default/strong-entity',
+        },
+      ]),
+    );
+
+    // Second provider claims both entities with a location key (strong ownership).
+    // weak-entity should be taken over, strong-entity should NOT.
+    await secondProvider.getConnection().applyMutation({
+      type: 'full',
+      entities: [
+        {
+          locationKey: 'second-provider-key',
+          entity: {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Component',
+            metadata: {
+              name: 'weak-entity',
+              annotations: baseAnnotations,
+            },
+            spec: { type: 'service', owner: 'second-provider' },
+          },
+        },
+        {
+          locationKey: 'second-provider-key',
+          entity: {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Component',
+            metadata: {
+              name: 'strong-entity',
+              annotations: baseAnnotations,
+            },
+            spec: { type: 'service', owner: 'second-provider' },
+          },
+        },
+      ],
+    });
+
+    await expect(harness.process()).resolves.toEqual({});
+
+    // weak-entity should now be owned by the second provider
+    await expect(harness.getOutputEntities()).resolves.toEqual(
+      expect.objectContaining({
+        'component:default/weak-entity': expect.objectContaining({
+          spec: { type: 'service', owner: 'second-provider' },
+        }),
+      }),
+    );
+
+    // strong-entity should still be owned by the first provider
+    await expect(harness.getOutputEntities()).resolves.toEqual(
+      expect.objectContaining({
+        'component:default/strong-entity': expect.objectContaining({
+          spec: { type: 'service', owner: 'first-provider' },
+        }),
+      }),
+    );
+
+    // Verify references:
+    // - weak-entity: old reference from 'first' should be gone, new one from 'second'
+    // - strong-entity: reference from 'first' should still exist
+    const refs = await harness.getRefreshStateReferences();
+
+    expect(refs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sourceKey: 'second',
+          targetEntityRef: 'component:default/weak-entity',
+        }),
+        expect.objectContaining({
+          sourceKey: 'first',
+          targetEntityRef: 'component:default/strong-entity',
+        }),
+      ]),
+    );
+
+    expect(
+      refs.some(
+        r =>
+          r.sourceKey === 'first' &&
+          r.targetEntityRef === 'component:default/weak-entity',
+      ),
+    ).toBe(false);
+
+    // Verify refresh_state: strong-entity should retain the first provider's location key
+    const refreshState = await harness.getRefreshState();
+    expect(refreshState['component:default/weak-entity']).toEqual(
+      expect.objectContaining({ locationKey: 'second-provider-key' }),
+    );
+    expect(refreshState['component:default/strong-entity']).toEqual(
+      expect.objectContaining({ locationKey: 'first-provider-key' }),
+    );
+  });
+
   function withOutputFields(entity: Entity) {
     return {
       ...entity,


### PR DESCRIPTION
This pull request fixes a bug in the catalog backend where multiple locations pointing to the same entity file could incorrectly result in only the last processed location being recorded as the entity's ancestor. Now, when multiple parents with null location keys reference the same child entity, all are preserved as ancestors, and exclusive ownership is only taken when a specific location key is set. The changes include updates to both the processing and provider database logic, as well as new tests to verify the correct ancestry behavior.

fixes https://github.com/backstage/backstage/issues/31315


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
