### PR TITLE
AGENTS.md: fix duplicate /packages/app entry in Key Directories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,9 @@ Backstage is an open platform for building developer portals. This is a TypeScri
 
 - `/packages`: Core framework packages (prefixed `@backstage/`)
 - `/plugins`: Plugin packages (prefixed `@backstage/plugin-*`)
-- `/packages/app` and `/packages/backend`: Example app for local development
 - `/packages/app`: Main example app using the new frontend system
 - `/packages/app-legacy`: Example app using the old frontend system
+- `/packages/backend`: Example backend for local development
 - `/docs`: Documentation files
 
 Packages prefixed with `core-` (e.g., `@backstage/core-plugin-api`) are part of the old frontend system. Packages prefixed with `frontend-` (e.g., `@backstage/frontend-plugin-api`) are part of the new frontend system (NFS). Packages prefixed with `backend-` (e.g., `@backstage/backend-plugin-api`) are part of the backend system.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes a duplicate `/packages/app` entry in the Key Directories section of `AGENTS.md`. The combined line for `/packages/app` and `/packages/backend` is removed, and `/packages/backend` is listed as its own entry instead.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))