### PR TITLE
fix(catalog): preserve provider references during slow-path upserts

### DIFF
--- a/.changeset/catalog-provider-upsert-reference-guard.md
+++ b/.changeset/catalog-provider-upsert-reference-guard.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Fixed provider slow-path upserts to preserve refresh state references owned by other source keys when an existing entity is updated.

--- a/plugins/catalog-backend/src/database/DefaultProviderDatabase.test.ts
+++ b/plugins/catalog-backend/src/database/DefaultProviderDatabase.test.ts
@@ -742,6 +742,62 @@ describe('DefaultProviderDatabase', () => {
     );
 
     it.each(databases.eachSupportedId())(
+      'preserves unrelated source references during slow-path upserts, %p',
+      async databaseId => {
+        const fakeLogger = mockServices.logger.mock();
+        const { knex, db } = await createDatabase(databaseId, fakeLogger);
+
+        await createLocations(knex, ['component:default/a']);
+
+        await insertRefRow(knex, {
+          source_key: 'other-provider',
+          target_entity_ref: 'component:default/a',
+        });
+
+        await db.transaction(async tx => {
+          await db.replaceUnprocessedEntities(tx, {
+            type: 'full',
+            sourceKey: 'my-provider',
+            items: [
+              {
+                entity: {
+                  apiVersion: '1',
+                  kind: 'Component',
+                  metadata: { name: 'a' },
+                  spec: { marker: 'WILL_CHANGE' },
+                } as Entity,
+                locationKey: 'file:///tmp/a',
+              },
+            ],
+          });
+        });
+
+        expect(fakeLogger.debug).toHaveBeenCalledWith(
+          expect.stringMatching(
+            /Fast insert path failed, falling back to slow path/,
+          ),
+        );
+
+        const references = await knex<DbRefreshStateReferencesRow>(
+          'refresh_state_references',
+        )
+          .select(['source_key', 'target_entity_ref'])
+          .orderBy('source_key');
+
+        expect(references).toEqual([
+          {
+            source_key: 'my-provider',
+            target_entity_ref: 'component:default/a',
+          },
+          {
+            source_key: 'other-provider',
+            target_entity_ref: 'component:default/a',
+          },
+        ]);
+      },
+    );
+
+    it.each(databases.eachSupportedId())(
       'should gracefully handle accidental duplicate refresh state references when deletion happens during a full sync, %p',
       async databaseId => {
         const fakeLogger = mockServices.logger.mock();

--- a/plugins/catalog-backend/src/database/DefaultProviderDatabase.ts
+++ b/plugins/catalog-backend/src/database/DefaultProviderDatabase.ts
@@ -167,6 +167,7 @@ export class DefaultProviderDatabase implements ProviderDatabase {
           if (ok) {
             await tx<DbRefreshStateReferencesRow>('refresh_state_references')
               .where('target_entity_ref', entityRef)
+              .andWhere({ source_key: options.sourceKey })
               .delete();
 
             await tx<DbRefreshStateReferencesRow>(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

this fixes issue  in the provider upsert flow where updating one source could delete other sources references for the same entity.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
