### PR TITLE
chore(ci): auto-approve yarn.lock-only dependabot PRs

### DIFF
--- a/.github/workflows/sync_dependabot-changesets.yml
+++ b/.github/workflows/sync_dependabot-changesets.yml
@@ -15,6 +15,29 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Approve yarn.lock-only PRs
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          github-token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}
+          script: |
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+
+            if (files.some(file => !file.filename.endsWith("yarn.lock"))) {
+              console.log("Skipping approval since some files are not yarn.lock");
+              return;
+            }
+
+            await github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              event: "APPROVE",
+            });
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds the same auto-approval step to the dependabot changeset workflow that the renovate workflow already has. When a dependabot PR only touches `yarn.lock` files, it gets auto-approved so it can merge without manual review.

#### :heavy_check_mark: Checklist

- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

🤖 Generated with [Claude Code](https://claude.com/claude-code)