### PR TITLE
docs: fix typos and grammar errors across documentation

### DIFF
--- a/docs/api/deprecations.md
+++ b/docs/api/deprecations.md
@@ -83,7 +83,7 @@ migrate to your own custom API.
 
 First, you'll need to define a new Utility API reference. If you're only using
 the API for sign-in, you can put the definition in `packages/app/src/apis.ts`.
-However, if you need to access your auth API inside plugins you you'll need to
+However, if you need to access your auth API inside plugins you'll need to
 export it from a common package. If you don't already have one, we recommend
 creating `@internal/apis` and from there exporting the API reference.
 

--- a/docs/integrations/azure-blobStorage/discovery.md
+++ b/docs/integrations/azure-blobStorage/discovery.md
@@ -61,7 +61,7 @@ the Azure catalog plugin:
 yarn --cwd packages/backend add @backstage/plugin-catalog-backend-module-azure
 ```
 
-Then updated your backend by adding the following line:
+Then update your backend by adding the following line:
 
 ```ts title="packages/backend/src/index.ts"
 backend.add(import('@backstage/plugin-catalog-backend'));

--- a/docs/integrations/azure/discovery.md
+++ b/docs/integrations/azure/discovery.md
@@ -97,7 +97,7 @@ the Azure catalog plugin:
 yarn --cwd packages/backend add @backstage/plugin-catalog-backend-module-azure
 ```
 
-Then updated your backend by adding the following line:
+Then update your backend by adding the following line:
 
 ```ts title="packages/backend/src/index.ts"
 backend.add(import('@backstage/plugin-catalog-backend'));

--- a/docs/integrations/azure/org.md
+++ b/docs/integrations/azure/org.md
@@ -41,7 +41,7 @@ catalog:
 For large organizations, this plugin can take a long time, so be careful setting low frequency / timeouts and importing a large amount of users / groups for the first try.
 :::
 
-Finally, updated your backend by adding the following line:
+Finally, update your backend by adding the following line:
 
 ```ts title="packages/backend/src/index.ts"
 backend.add(import('@backstage/plugin-catalog-backend'));

--- a/docs/integrations/ldap/org.md
+++ b/docs/integrations/ldap/org.md
@@ -40,7 +40,7 @@ catalog:
           timeout: PT15M
 ```
 
-Finally, updated your backend by adding the following line:
+Finally, update your backend by adding the following line:
 
 ```ts title="packages/backend/src/index.ts"
 backend.add(import('@backstage/plugin-catalog-backend'));

--- a/docs/overview/threat-model.md
+++ b/docs/overview/threat-model.md
@@ -30,7 +30,7 @@ This section assumes that you are using the
 
 Backstage is primarily designed to be deployed in a protected environment rather than being exposed to the public internet. From a confidentiality and integrity perspective, Backstage is designed to protect against unauthorized access to data and to ensure that data is not tampered with. However, Backstage does not provide more than rudimentary protection against denial of service attacks, and it is the responsibility of the operator to ensure that the Backstage deployment is protected against such attacks. A common and recommended way to protect a Backstage deployment from unauthorized access is to deploy it behind an authenticating proxy such as AWS’s ALB, GCP’s IAP, or Cloudflare Access.
 
-Users that are signed-in in to Backstage generally have full access to all information and actions. If more fine-grained control is required, the [permissions system](../permissions/overview.md) should be enabled and configured to restrict access as necessary.
+Users that are signed in to Backstage generally have full access to all information and actions. If more fine-grained control is required, the [permissions system](../permissions/overview.md) should be enabled and configured to restrict access as necessary.
 
 An operator is responsible for protecting the integrity of configuration files as it may otherwise be possible to introduce vulnerable configurations, as well as the confidentiality of configured secrets related to Backstage as these typically include authentication details to third party systems.
 


### PR DESCRIPTION
Fixed typos and grammar errors across 5 documentation files:

- **docs/api/deprecations.md** — Removed repeated word: "you you'll" → "you'll"
- **docs/overview/threat-model.md** — Fixed repeated word: "signed-in in to" → "signed in to"
- **docs/integrations/azure/org.md** — Fixed tense: "Finally, updated your" → "Finally, update your"
- **docs/integrations/azure/discovery.md** — Fixed tense: "Then updated your" → "Then update your"
- **docs/integrations/azure-blobStorage/discovery.md** — Fixed tense: "Then updated your" → "Then update your"
- **docs/integrations/ldap/org.md** — Fixed tense: "Finally, updated your" → "Finally, update your"

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
