### PR TITLE
docs: enrich kubernetes plugin READMEs

### DIFF
--- a/.changeset/enrich-readme-kubernetes-common.md
+++ b/.changeset/enrich-readme-kubernetes-common.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-common': patch
+---
+
+Enriched the README with documentation covering entity annotations, permissions, types/interfaces, and utility functions.

--- a/.changeset/enrich-readme-kubernetes-node.md
+++ b/.changeset/enrich-readme-kubernetes-node.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-node': patch
+---
+
+Enriched the README with documentation covering extension points, key interfaces, and a usage example for custom auth strategies.

--- a/.changeset/enrich-readme-kubernetes-react.md
+++ b/.changeset/enrich-readme-kubernetes-react.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-react': patch
+---
+
+Enriched the README with documentation covering API references, hooks, components, contexts, cluster link formatters, and auth providers.

--- a/plugins/kubernetes-common/README.md
+++ b/plugins/kubernetes-common/README.md
@@ -1,3 +1,60 @@
 # @backstage/plugin-kubernetes-common
 
-Common types and functionalities for kubernetes, to be shared between kubernetes and kubernetes-backend.
+Shared types, constants, and utilities for the Backstage Kubernetes plugin ecosystem. This package is used by both the frontend (`@backstage/plugin-kubernetes-react`) and backend (`@backstage/plugin-kubernetes-backend`) packages, providing a consistent set of interfaces for Kubernetes resource fetching, error detection, and cluster management.
+
+## Installation
+
+```bash
+# From your Backstage root directory
+yarn --cwd packages/app add @backstage/plugin-kubernetes-common
+```
+
+> **Note:** You typically don't install this package directly — it is pulled in as a dependency of `@backstage/plugin-kubernetes-react` or `@backstage/plugin-kubernetes-backend`.
+
+## What's Included
+
+### Entity Annotations
+
+Constants for entity annotations used to configure Kubernetes integration:
+
+| Annotation                                       | Description                                        |
+| ------------------------------------------------ | -------------------------------------------------- |
+| `backstage.io/kubernetes-id`                     | Associates an entity with Kubernetes resources     |
+| `backstage.io/kubernetes-label-selector`         | Uses a label selector to find Kubernetes resources |
+| `kubernetes.io/api-server`                       | Specifies the Kubernetes API server URL            |
+| `kubernetes.io/api-server-certificate-authority` | CA data for the API server                         |
+| `kubernetes.io/auth-provider`                    | Authentication provider to use                     |
+| `kubernetes.io/oidc-token-provider`              | OIDC token provider name                           |
+| `kubernetes.io/skip-metrics-lookup`              | Skips pod metrics lookup                           |
+| `kubernetes.io/skip-tls-verify`                  | Skips TLS verification                             |
+| `kubernetes.io/dashboard-url`                    | URL to the Kubernetes dashboard                    |
+| `kubernetes.io/dashboard-app`                    | Dashboard application type                         |
+| `kubernetes.io/dashboard-parameters`             | Additional dashboard parameters                    |
+
+### Permissions
+
+Permission resources for Backstage's permission framework:
+
+- `kubernetesProxyPermission` — Controls access to the Kubernetes proxy endpoint
+- `kubernetesResourcesReadPermission` — Controls access to `/resources` and `/services/:serviceId` endpoints
+- `kubernetesClustersReadPermission` — Controls access to the `/clusters` endpoint
+
+### Types and Interfaces
+
+Key types used across the Kubernetes plugin ecosystem:
+
+- **Request/Response** — `KubernetesRequestBody`, `ObjectsByEntityResponse`, `ClusterObjects`, `FetchResponse`
+- **Cluster** — `ClusterAttributes`, including dashboard configuration
+- **Resources** — Typed fetch responses for pods, deployments, services, configmaps, secrets, jobs, cronjobs, ingresses, statefulsets, daemonsets, persistent volumes, and custom resources
+- **Metrics** — `ClientPodStatus`, `ClientContainerStatus`, `ClientCurrentResourceUsage`
+- **Errors** — `KubernetesFetchError`, `DetectedError`, `ProposedFix` (with `LogSolution`, `DocsSolution`, and `EventsSolution` variants)
+
+### Utility Functions
+
+- `groupResponses(fetchResponse)` — Groups raw fetch responses by resource type into a `GroupedResponses` object
+- `detectErrors(objects)` — Analyzes Kubernetes objects and returns detected errors grouped by cluster
+
+## Links
+
+- [Kubernetes feature documentation](https://backstage.io/docs/features/kubernetes/)
+- [Backstage homepage](https://backstage.io)

--- a/plugins/kubernetes-node/README.md
+++ b/plugins/kubernetes-node/README.md
@@ -1,5 +1,90 @@
 # @backstage/plugin-kubernetes-node
 
-Welcome to the Node.js library package for the kubernetes plugin!
+Node.js library for the Backstage Kubernetes plugin. This package provides backend interfaces and extension points for cluster management, authentication, resource fetching, and service location — allowing backend modules to extend or customize Kubernetes plugin behavior.
 
-_This plugin was created through the Backstage CLI_
+## Installation
+
+```bash
+# From your Backstage root directory
+yarn --cwd packages/backend add @backstage/plugin-kubernetes-node
+```
+
+> **Note:** This package is primarily used by backend modules that extend the Kubernetes plugin. Most adopters won't need to install it directly.
+
+## Extension Points
+
+The package exposes several extension points that backend modules can use to customize the Kubernetes plugin:
+
+| Extension Point                           | Description                                                          |
+| ----------------------------------------- | -------------------------------------------------------------------- |
+| `kubernetesObjectsProviderExtensionPoint` | Register a custom objects provider for fetching Kubernetes resources |
+| `kubernetesClusterSupplierExtensionPoint` | Register a custom cluster supplier for cluster discovery             |
+| `kubernetesAuthStrategyExtensionPoint`    | Register a custom authentication strategy                            |
+| `kubernetesFetcherExtensionPoint`         | Register a custom resource fetcher                                   |
+| `kubernetesServiceLocatorExtensionPoint`  | Register a custom service locator                                    |
+| `kubernetesRouterExtensionPoint`          | Register a custom Express router                                     |
+
+### Example: Custom Auth Strategy
+
+```ts
+import { createBackendModule } from '@backstage/backend-plugin-api';
+import {
+  kubernetesAuthStrategyExtensionPoint,
+  AuthenticationStrategy,
+} from '@backstage/plugin-kubernetes-node';
+
+const myAuthStrategy: AuthenticationStrategy = {
+  async getCredential(clusterDetails, authConfig) {
+    return { type: 'bearer token', token: 'my-token' };
+  },
+  validateCluster(authMetadata) {
+    return [];
+  },
+  presentAuthMetadata(authMetadata) {
+    return authMetadata;
+  },
+};
+
+export default createBackendModule({
+  pluginId: 'kubernetes',
+  moduleId: 'my-auth-strategy',
+  register(reg) {
+    reg.registerInit({
+      deps: {
+        authStrategy: kubernetesAuthStrategyExtensionPoint,
+      },
+      async init({ authStrategy }) {
+        authStrategy.addAuthStrategy('my-provider', myAuthStrategy);
+      },
+    });
+  },
+});
+```
+
+## Key Interfaces
+
+### Cluster Management
+
+- `ClusterDetails` — Full cluster configuration including URL, auth metadata, TLS settings, dashboard config, and custom resources
+- `KubernetesClustersSupplier` — Provides the list of available clusters via `getClusters()`
+
+### Authentication
+
+- `KubernetesCredential` — Represents a credential (bearer token, x509 certificate, or anonymous)
+- `AuthenticationStrategy` — Defines how to obtain credentials for a given cluster
+- `PinnipedHelper` — Helper class for Pinniped-based authentication flows
+
+### Resource Fetching
+
+- `KubernetesFetcher` — Fetches Kubernetes objects and pod metrics from clusters
+- `KubernetesObjectsProvider` — Higher-level provider that fetches objects by entity
+- `ObjectFetchParams` — Parameters for fetch operations including cluster details, credentials, and label selectors
+
+### Service Location
+
+- `KubernetesServiceLocator` — Resolves which clusters serve a given Backstage entity
+
+## Links
+
+- [Kubernetes feature documentation](https://backstage.io/docs/features/kubernetes/)
+- [Backstage homepage](https://backstage.io)

--- a/plugins/kubernetes-react/README.md
+++ b/plugins/kubernetes-react/README.md
@@ -1,5 +1,106 @@
 # @backstage/plugin-kubernetes-react
 
-Welcome to the web library package for the kubernetes-react plugin!
+React components, hooks, and API clients for the Backstage Kubernetes plugin. This package provides the frontend building blocks for displaying Kubernetes resources, pod logs, metrics, error diagnostics, and cluster links within Backstage entity pages.
 
-_This plugin was created through the Backstage CLI_
+## Installation
+
+```bash
+# From your Backstage root directory
+yarn --cwd packages/app add @backstage/plugin-kubernetes-react
+```
+
+## API References
+
+The package provides several API refs for interacting with Kubernetes data:
+
+| API Ref                                | Description                                            |
+| -------------------------------------- | ------------------------------------------------------ |
+| `kubernetesApiRef`                     | Fetch Kubernetes objects, clusters, and proxy requests |
+| `kubernetesProxyApiRef`                | Fetch pod logs, delete pods, and get events            |
+| `kubernetesClusterLinkFormatterApiRef` | Format links to external Kubernetes dashboards         |
+| `kubernetesAuthProvidersApiRef`        | Manage authentication for Kubernetes requests          |
+
+## Hooks
+
+| Hook                                                | Description                                            |
+| --------------------------------------------------- | ------------------------------------------------------ |
+| `useKubernetesObjects(entity, intervalMs?)`         | Fetch all Kubernetes objects associated with an entity |
+| `useCustomResources(entity, matchers, intervalMs?)` | Fetch custom resources for an entity                   |
+| `usePodMetrics(clusterName, matcher)`               | Get pod metric data for a specific pod                 |
+| `usePodLogs(input)`                                 | Fetch logs for a pod container                         |
+| `useEvents(input)`                                  | Fetch events for a Kubernetes resource                 |
+| `useMatchingErrors(matcher)`                        | Get detected errors matching a resource                |
+
+## Components
+
+### Resource Display
+
+- `PodsTable` — Table display of pods with optional extra columns (`READY`, `RESOURCE`)
+- `ContainerCard` — Shows container details including status and resource metrics
+- `ResourceUtilization` — Displays CPU/memory utilization bars
+- `ManifestYaml` — Renders raw YAML for any Kubernetes object
+
+### Resource Accordions
+
+- `CronJobsAccordions` — Expandable list of CronJobs
+- `JobsAccordions` — Expandable list of Jobs
+- `IngressesAccordions` — Expandable list of Ingresses
+- `ServicesAccordions` — Expandable list of Services
+- `CustomResources` — Expandable list of custom resources
+
+### Drawers and Dialogs
+
+- `KubernetesDrawer` — Slide-out drawer for any Kubernetes object
+- `KubernetesStructuredMetadataTableDrawer` — Drawer with a structured metadata table
+- `PodDrawer` — Drawer showing pod details and errors
+- `HorizontalPodAutoscalerDrawer` — Drawer for HPA details
+- `PodLogsDialog` — Dialog for viewing pod container logs
+- `PodExecTerminal` — Embedded terminal for exec into a pod container
+- `PodExecTerminalDialog` — Dialog wrapping the pod exec terminal
+- `FixDialog` — Dialog suggesting fixes for detected errors
+
+### Error Handling
+
+- `ErrorPanel` — Shows an error message for the Kubernetes plugin
+- `LinkErrorPanel` — Error panel with cluster link
+- `ErrorReporting` — Summarizes detected errors across clusters
+- `ErrorList` — Lists pods with their associated errors
+
+### Events
+
+- `Events` — Fetches and displays events for a given resource
+- `EventsContent` — Renders a list of events (with optional warning-only filter)
+
+### Cluster
+
+- `Cluster` — Component for displaying cluster overview and resources
+
+## Contexts
+
+The package provides React contexts for passing Kubernetes data through component trees:
+
+- `ClusterContext` — Current cluster attributes
+- `GroupedResponsesContext` — Grouped Kubernetes responses (pods, deployments, services, etc.)
+- `DetectedErrorsContext` — Detected errors for the current scope
+- `PodMetricsContext` — Pod metrics data by cluster
+- `PodNamesWithErrorsContext` — Set of pod names with detected errors
+
+## Cluster Link Formatting
+
+Built-in classes for generating dashboard links:
+
+`StandardClusterLinksFormatter`, `GkeClusterLinksFormatter`, `AksClusterLinksFormatter`, `EksClusterLinksFormatter`, `OpenshiftClusterLinksFormatter`, `RancherClusterLinksFormatter`, `HeadlampClusterLinksFormatter`
+
+## Auth Providers
+
+Built-in authentication providers:
+
+- `GoogleKubernetesAuthProvider` — Google/GKE authentication
+- `AksKubernetesAuthProvider` — Azure AKS authentication
+- `OidcKubernetesAuthProvider` — OIDC-based authentication
+- `ServerSideKubernetesAuthProvider` — Server-side (service account) authentication
+
+## Links
+
+- [Kubernetes feature documentation](https://backstage.io/docs/features/kubernetes/)
+- [Backstage homepage](https://backstage.io)


### PR DESCRIPTION
### Enrich READMEs for Kubernetes plugin packages

The three Kubernetes library packages (`kubernetes-common`, `kubernetes-node`, `kubernetes-react`) had minimal boilerplate READMEs (2–3 lines each). This PR replaces them with comprehensive documentation derived from each package's API reports and source code.

#### Changes

**`@backstage/plugin-kubernetes-common`**

- Added documentation for all entity annotations (`backstage.io/kubernetes-id`, `kubernetes.io/api-server`, etc.)
- Documented permission resources (`kubernetesProxyPermission`, `kubernetesResourcesReadPermission`, `kubernetesClustersReadPermission`)
- Listed key types and interfaces (request/response, cluster, resources, metrics, errors)
- Documented utility functions (`groupResponses`, `detectErrors`)

**`@backstage/plugin-kubernetes-node`**

- Documented all 6 extension points (`kubernetesObjectsProviderExtensionPoint`, `kubernetesClusterSupplierExtensionPoint`, `kubernetesAuthStrategyExtensionPoint`, `kubernetesFetcherExtensionPoint`, `kubernetesServiceLocatorExtensionPoint`, `kubernetesRouterExtensionPoint`)
- Added a code example for registering a custom auth strategy via `createBackendModule`
- Documented key interfaces for cluster management, authentication, resource fetching, and service location

**`@backstage/plugin-kubernetes-react`**

- Documented 4 API references (`kubernetesApiRef`, `kubernetesProxyApiRef`, `kubernetesClusterLinkFormatterApiRef`, `kubernetesAuthProvidersApiRef`)
- Listed all 7 hooks with descriptions (`useKubernetesObjects`, `useCustomResources`, `usePodMetrics`, etc.)
- Added a usage example for `useKubernetesObjects`
- Cataloged all exported components organized by category (resource display, accordions, drawers/dialogs, error handling, events, cluster)
- Documented React contexts, cluster link formatters, and auth providers

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
