### PR TITLE
Add tooltips to GitHub and Discord navbar icons

### DIFF
--- a/microsite/docusaurus.config.ts
+++ b/microsite/docusaurus.config.ts
@@ -432,12 +432,14 @@ const config: Config = {
           position: 'right',
           className: 'header-github-link',
           'aria-label': 'GitHub repository',
+          title: 'GitHub repository',
         },
         {
           href: 'https://discord.gg/backstage-687207715902193673',
           position: 'right',
           className: 'header-discord-link',
           'aria-label': 'Discord community',
+          title: 'Discord community',
         },
         ...(useVersionedDocs
           ? [


### PR DESCRIPTION
- Added `title` attributes to the GitHub and Discord icon links in the navbar to display tooltips on hover
  - **GitHub icon:** shows "GitHub repository"  
  - **Discord icon:** shows "Discord community"  
- This update improves consistency with other navbar items (such as the theme toggle) and enhances overall UX by making icon‑only links more discoverable.


<img width="1903" height="107" alt="image" src="https://github.com/user-attachments/assets/4e6aa2bb-b429-4d10-a2a9-53e5495af913" />
<img width="1899" height="89" alt="image" src="https://github.com/user-attachments/assets/50f5d1fb-fc6f-4a98-bbb8-fee2e047c1f4" />
