### PR TITLE
docs(scheduler): add REST API URL examples

### DIFF
--- a/docs/backend-system/core-services/scheduler.md
+++ b/docs/backend-system/core-services/scheduler.md
@@ -45,7 +45,21 @@ The scheduler exposes a REST API on top of each plugin's base URL, that lets you
 
 ### `GET <pluginBaseURL>/.backstage/scheduler/v1/tasks`
 
-Lists all tasks that the given plugin registered at startup, and their current states. The response shape is as follows:
+Lists all tasks that the given plugin registered at startup, and their current states.
+
+For example, to list all scheduled tasks for the Catalog plugin:
+
+```sh
+curl 'https://<instance-name>/api/catalog/.backstage/scheduler/v1/tasks'
+```
+
+You can try this out on the Backstage demo instance:
+
+```sh
+curl 'https://demo.backstage.io/api/catalog/.backstage/scheduler/v1/tasks'
+```
+
+The response shape is as follows:
 
 ```json
 {
@@ -117,6 +131,18 @@ The `workerState` shape is as follows:
 
 Schedules the given task ID for immediate execution, instead of waiting for its
 next scheduled time slot to arrive.
+
+For example, to trigger a specific Catalog task:
+
+```bash
+curl -X POST "https://<instance-name>/api/catalog/.backstage/scheduler/v1/tasks/InternalOpenApiDocumentationProvider:refresh/trigger"
+```
+
+A working example would be:
+
+```bash
+curl -X POST "https://demo.backstage.io/api/catalog/.backstage/scheduler/v1/tasks/InternalOpenApiDocumentationProvider:refresh/trigger"
+```
 
 Note that there can still be an additional small delay before a worker discovers
 that the task is due and actually picks it up. This typically takes less than a


### PR DESCRIPTION
Adds concrete URL examples to the Scheduler REST API documentation, making it clearer what a "plugin base URL" looks like in practice.

The docs currently say _"The scheduler exposes a REST API on top of each plugin's base URL"_ but don't show what a full URL looks like. This can be confusing for users unfamiliar with the Backstage URL structure.

### Changes

- Added a full URL example under `GET <pluginBaseURL>/.backstage/scheduler/v1/tasks` using the Catalog plugin
- Added a full URL example under `POST <pluginBaseURL>/.backstage/scheduler/v1/tasks/<taskId>/trigger` using a Catalog task

Fixes #31540

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
