### PR TITLE
docs: add Okta entity provider documentation

### DIFF
--- a/docs/integrations/okta/org.md
+++ b/docs/integrations/okta/org.md
@@ -1,0 +1,23 @@
+---
+id: org
+title: Okta Organizational Data
+sidebar_label: Org Data
+description: Ingesting organizational data from Okta into Backstage
+---
+
+The Backstage catalog can be set up to ingest organizational data — users and
+groups — directly from Okta. The result is a hierarchy of
+[`User`](../../features/software-catalog/descriptor-format.md#kind-user) and
+[`Group`](../../features/software-catalog/descriptor-format.md#kind-group) kind
+entities that mirror your Okta organization.
+
+This integration is provided by the community-maintained
+[`@roadiehq/catalog-backend-module-okta`](https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/backend/catalog-backend-module-okta)
+plugin, owned and maintained by [Roadie](https://roadie.io/).
+
+## Installation and configuration
+
+For setup instructions, including authentication options (API token and OAuth
+2.0), user/group filtering, custom naming strategies, and entity transformers,
+see the
+[plugin documentation maintained by Roadie](https://github.com/RoadieHQ/roadie-backstage-plugins/tree/main/plugins/backend/catalog-backend-module-okta).

--- a/microsite/sidebars.ts
+++ b/microsite/sidebars.ts
@@ -399,6 +399,7 @@ export default {
           'integrations/google-cloud-storage/locations',
         ]),
         sidebarElementWithIndex({ label: 'LDAP' }, ['integrations/ldap/org']),
+        sidebarElementWithIndex({ label: 'Okta' }, ['integrations/okta/org']),
       ],
     ),
     sidebarElementWithIndex(


### PR DESCRIPTION
Adds documentation for the Okta entity provider under the Integrations section, making it easier for adopters to discover and configure Okta org data ingestion.

Fixes #29670

### Changes

- Added `docs/integrations/okta/org.md` — covers installation, configuration (API token + OAuth), backend setup, and user/group filtering
- Added "Okta" to the Integrations sidebar in `microsite/sidebars.ts`


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
