### PR TITLE
docs: fix broken link in gerrit catalog module README.

### DIFF
--- a/plugins/catalog-backend-module-gerrit/README.md
+++ b/plugins/catalog-backend-module-gerrit/README.md
@@ -4,5 +4,5 @@ This is an extension module to the plugin-catalog-backend plugin, providing exte
 
 ## Getting started
 
-See [Backstage documentation](https://backstage.io/docs/integrations/gerrit/discovery.md)
+See [Backstage documentation](https://backstage.io/docs/integrations/gerrit/discovery)
 for details on how to install and configure the plugin.


### PR DESCRIPTION
## Fix broken documentation link in Gerrit catalog module README

### What
Remove erroneous `.md` extension from the Backstage documentation URL in `plugins/catalog-backend-module-gitea/README.md`.

### Why
The link `https://backstage.io/docs/integrations/gerrit/discovery.md`. The correct URL is `https://backstage.io/docs/integrations/gerrit/discovery`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
