### PR TITLE
docs: fix malformed HTML href in documentation landing page

### DIFF
--- a/docs/landing-page/doc-landing-page.md
+++ b/docs/landing-page/doc-landing-page.md
@@ -115,7 +115,7 @@ description: Documentation landing page.
       <ul>
         <li><a href='https://backstage.io/docs/contribute/'>Contributor's Guide</a></li>
         <li><a href='https://backstage.io/docs/contribute/getting-involved'>Getting Involved</a></li>
-        <li><a href=https://backstage.io/docs/contribute/project-structure'>Backstage Project Structure</a></li>
+        <li><a href='https://backstage.io/docs/contribute/project-structure'>Backstage Project Structure</a></li>
       </ul>
     </td>
   </tr>


### PR DESCRIPTION
## Fix malformed HTML href in documentation landing page

### What
Add missing opening quote in an `<a>` tag in `docs/landing-page/doc-landing-page.md`.

**Before:**
```<a href=https://backstage.io/docs/contribute/project-structure'>```

**After**
```<a href='https://backstage.io/docs/contribute/project-structure'>```

Why
The missing opening `'` on the href attribute makes the HTML invalid. This causes the trailing `'` to be included as part of the URL, which can result in a 404 when users click the "Backstage Project Structure" link on the documentation landing page.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
