### PR TITLE
`feat(mcp-actions-backend)`: add audit logging for MCP server operations

### DIFF
--- a/.changeset/mcp-audit-logging.md
+++ b/.changeset/mcp-audit-logging.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-mcp-actions-backend': patch
+---
+
+Added audit logging for MCP server operations using the Backstage Auditor Service. The plugin now emits `connection`, `tool-discovery`, and `tool-execution` audit events, allowing adopters to monitor and audit MCP server activity.

--- a/plugins/mcp-actions-backend/src/plugin.ts
+++ b/plugins/mcp-actions-backend/src/plugin.ts
@@ -50,6 +50,7 @@ export const mcpPlugin = createBackendPlugin({
         config: coreServices.rootConfig,
         metrics: metricsServiceRef,
         tracing: tracingServiceRef,
+        auditor: coreServices.auditor,
       },
       async init({
         actions,
@@ -61,6 +62,7 @@ export const mcpPlugin = createBackendPlugin({
         config,
         metrics,
         tracing,
+        auditor,
       }) {
         const serverConfigs = parseServerConfigs(config);
         const namespacedToolNames = config.getOptionalBoolean(
@@ -74,6 +76,7 @@ export const mcpPlugin = createBackendPlugin({
           actions,
           metrics,
           logger,
+          auditor,
           namespacedToolNames,
           tracingService: tracing,
           captureToolPayloads,
@@ -90,6 +93,7 @@ export const mcpPlugin = createBackendPlugin({
               logger,
               metrics,
               tracing,
+              auditor,
               serverConfig,
             });
 
@@ -109,6 +113,7 @@ export const mcpPlugin = createBackendPlugin({
             logger,
             metrics,
             tracing,
+            auditor,
             serverConfig,
           });
 

--- a/plugins/mcp-actions-backend/src/routers/createStreamableRouter.ts
+++ b/plugins/mcp-actions-backend/src/routers/createStreamableRouter.ts
@@ -25,7 +25,6 @@ import {
 } from '@backstage/backend-plugin-api/alpha';
 import {
   AuditorService,
-  AuditorServiceEvent,
   HttpAuthService,
   LoggerService,
 } from '@backstage/backend-plugin-api';
@@ -71,7 +70,7 @@ export const createStreamableRouter = ({
       'network.protocol.name': 'http',
     };
 
-    let connectionEvent: AuditorServiceEvent;
+    let connectionEvent;
     try {
       connectionEvent = await auditor.createEvent({
         eventId: 'connection',
@@ -79,7 +78,7 @@ export const createStreamableRouter = ({
         meta: { transport: 'streamable', actionType: 'established' },
       });
     } catch {
-      // Make audit logging best-effort: fall back to a no-op event if auditing is unavailable.
+      // best-effort
       connectionEvent = { success: async () => {}, fail: async () => {} };
     }
 
@@ -106,9 +105,13 @@ export const createStreamableRouter = ({
         transport.handleRequest(req, res, req.body),
       );
 
-      await connectionEvent.success().catch(() => {});
+      try {
+        await connectionEvent.success();
+      } catch {
+        // best-effort
+      }
 
-      res.on('close', () => {
+      res.on('close', async () => {
         transport.close();
         server.close();
 
@@ -116,14 +119,16 @@ export const createStreamableRouter = ({
 
         sessionDuration.record(durationSeconds, baseAttributes);
 
-        auditor
-          .createEvent({
+        try {
+          const e = await auditor.createEvent({
             eventId: 'connection',
             request: req,
             meta: { transport: 'streamable', actionType: 'closed' },
-          })
-          .then(e => e.success())
-          .catch(() => {});
+          });
+          await e.success();
+        } catch {
+          // best-effort
+        }
       });
     } catch (error) {
       const err = toError(error);
@@ -149,11 +154,13 @@ export const createStreamableRouter = ({
         'error.type': errorType,
       });
 
-      await connectionEvent
-        .fail({
+      try {
+        await connectionEvent.fail({
           error: error instanceof Error ? error : new Error(String(error)),
-        })
-        .catch(() => {});
+        });
+      } catch {
+        // best-effort
+      }
     }
   });
 

--- a/plugins/mcp-actions-backend/src/routers/createStreamableRouter.ts
+++ b/plugins/mcp-actions-backend/src/routers/createStreamableRouter.ts
@@ -19,12 +19,16 @@ import { performance } from 'node:perf_hooks';
 import { McpService } from '../services/McpService';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/sdk/types.js';
-import { HttpAuthService, LoggerService } from '@backstage/backend-plugin-api';
 import { toError } from '@backstage/errors';
 import {
-  MetricsService,
   TracingService,
 } from '@backstage/backend-plugin-api/alpha';
+import {
+  HttpAuthService,
+  LoggerService,
+  AuditorService,
+} from '@backstage/backend-plugin-api';
+import { MetricsService } from '@backstage/backend-plugin-api/alpha';
 import { bucketBoundaries, McpServerSessionAttributes } from '../metrics';
 import { McpServerConfig } from '../config';
 
@@ -34,6 +38,7 @@ export const createStreamableRouter = ({
   logger,
   metrics,
   tracing,
+  auditor,
   serverConfig,
 }: {
   mcpService: McpService;
@@ -41,6 +46,7 @@ export const createStreamableRouter = ({
   httpAuth: HttpAuthService;
   metrics: MetricsService;
   tracing: TracingService;
+  auditor: AuditorService;
   serverConfig?: McpServerConfig;
 }): Router => {
   const router = PromiseRouter();
@@ -64,10 +70,18 @@ export const createStreamableRouter = ({
       'network.protocol.name': 'http',
     };
 
+    const connectionEvent = await auditor.createEvent({
+      eventId: 'connection',
+      severityLevel: 'medium',
+      request: req,
+      meta: { transport: 'streamable', actionType: 'established' },
+    });
+
     try {
       const server = mcpService.getServer({
         credentials: await httpAuth.credentials(req),
         serverConfig,
+        req,
       });
 
       const transport = new StreamableHTTPServerTransport({
@@ -81,6 +95,7 @@ export const createStreamableRouter = ({
         tracing.context.active(),
         req.headers,
       );
+      await connectionEvent.success();
       await tracing.context.with(ctx, () =>
         transport.handleRequest(req, res, req.body),
       );
@@ -92,6 +107,14 @@ export const createStreamableRouter = ({
         const durationSeconds = (performance.now() - sessionStart) / 1000;
 
         sessionDuration.record(durationSeconds, baseAttributes);
+
+        auditor
+          .createEvent({
+            eventId: 'connection',
+            request: req,
+            meta: { transport: 'streamable', actionType: 'closed' },
+          })
+          .then(e => e.success());
       });
     } catch (error) {
       const err = toError(error);
@@ -116,6 +139,8 @@ export const createStreamableRouter = ({
         ...baseAttributes,
         'error.type': errorType,
       });
+
+      await connectionEvent.fail({ error: error as Error });
     }
   });
 

--- a/plugins/mcp-actions-backend/src/routers/createStreamableRouter.ts
+++ b/plugins/mcp-actions-backend/src/routers/createStreamableRouter.ts
@@ -90,7 +90,6 @@ export const createStreamableRouter = ({
       });
 
       await server.connect(transport);
-      await connectionEvent.success();
 
       const ctx = tracing.propagation.extract(
         tracing.context.active(),
@@ -99,6 +98,7 @@ export const createStreamableRouter = ({
       await tracing.context.with(ctx, () =>
         transport.handleRequest(req, res, req.body),
       );
+      await connectionEvent.success();
 
       res.on('close', () => {
         transport.close();
@@ -141,7 +141,11 @@ export const createStreamableRouter = ({
         'error.type': errorType,
       });
 
-      await connectionEvent.fail({ error: error as Error });
+      await connectionEvent
+        .fail({
+          error: error instanceof Error ? error : new Error(String(error)),
+        })
+        .catch(() => {});
     }
   });
 

--- a/plugins/mcp-actions-backend/src/routers/createStreamableRouter.ts
+++ b/plugins/mcp-actions-backend/src/routers/createStreamableRouter.ts
@@ -72,7 +72,6 @@ export const createStreamableRouter = ({
 
     const connectionEvent = await auditor.createEvent({
       eventId: 'connection',
-      severityLevel: 'medium',
       request: req,
       meta: { transport: 'streamable', actionType: 'established' },
     });
@@ -114,7 +113,8 @@ export const createStreamableRouter = ({
             request: req,
             meta: { transport: 'streamable', actionType: 'closed' },
           })
-          .then(e => e.success());
+          .then(e => e.success())
+          .catch(() => {});
       });
     } catch (error) {
       const err = toError(error);

--- a/plugins/mcp-actions-backend/src/routers/createStreamableRouter.ts
+++ b/plugins/mcp-actions-backend/src/routers/createStreamableRouter.ts
@@ -25,6 +25,7 @@ import {
 } from '@backstage/backend-plugin-api/alpha';
 import {
   AuditorService,
+  AuditorServiceEvent,
   HttpAuthService,
   LoggerService,
 } from '@backstage/backend-plugin-api';
@@ -70,7 +71,7 @@ export const createStreamableRouter = ({
       'network.protocol.name': 'http',
     };
 
-    let connectionEvent;
+    let connectionEvent: AuditorServiceEvent;
     try {
       connectionEvent = await auditor.createEvent({
         eventId: 'connection',

--- a/plugins/mcp-actions-backend/src/routers/createStreamableRouter.ts
+++ b/plugins/mcp-actions-backend/src/routers/createStreamableRouter.ts
@@ -90,6 +90,8 @@ export const createStreamableRouter = ({
       });
 
       await server.connect(transport);
+      await connectionEvent.success();
+
       const ctx = tracing.propagation.extract(
         tracing.context.active(),
         req.headers,
@@ -97,7 +99,6 @@ export const createStreamableRouter = ({
       await tracing.context.with(ctx, () =>
         transport.handleRequest(req, res, req.body),
       );
-      await connectionEvent.success();
 
       res.on('close', () => {
         transport.close();

--- a/plugins/mcp-actions-backend/src/routers/createStreamableRouter.ts
+++ b/plugins/mcp-actions-backend/src/routers/createStreamableRouter.ts
@@ -105,7 +105,8 @@ export const createStreamableRouter = ({
       await tracing.context.with(ctx, () =>
         transport.handleRequest(req, res, req.body),
       );
-      await connectionEvent.success();
+
+      await connectionEvent.success().catch(() => {});
 
       res.on('close', () => {
         transport.close();

--- a/plugins/mcp-actions-backend/src/routers/createStreamableRouter.ts
+++ b/plugins/mcp-actions-backend/src/routers/createStreamableRouter.ts
@@ -94,10 +94,10 @@ export const createStreamableRouter = ({
         tracing.context.active(),
         req.headers,
       );
-      await connectionEvent.success();
       await tracing.context.with(ctx, () =>
         transport.handleRequest(req, res, req.body),
       );
+      await connectionEvent.success();
 
       res.on('close', () => {
         transport.close();

--- a/plugins/mcp-actions-backend/src/routers/createStreamableRouter.ts
+++ b/plugins/mcp-actions-backend/src/routers/createStreamableRouter.ts
@@ -23,7 +23,6 @@ import { toError } from '@backstage/errors';
 import { TracingService } from '@backstage/backend-plugin-api/alpha';
 import {
   AuditorService,
-  AuditorServiceEvent,
   HttpAuthService,
   LoggerService,
 } from '@backstage/backend-plugin-api';
@@ -69,17 +68,11 @@ export const createStreamableRouter = ({
       'network.protocol.name': 'http',
     };
 
-    let connectionEvent: AuditorServiceEvent;
-    try {
-      connectionEvent = await auditor.createEvent({
-        eventId: 'connection',
-        request: req,
-        meta: { transport: 'streamable', actionType: 'established' },
-      });
-    } catch {
-      // best-effort
-      connectionEvent = { success: async () => {}, fail: async () => {} };
-    }
+    const connectionEvent = await auditor.createEvent({
+      eventId: 'connection',
+      request: req,
+      meta: { transport: 'streamable', actionType: 'established' },
+    });
 
     try {
       const server = mcpService.getServer({
@@ -104,11 +97,7 @@ export const createStreamableRouter = ({
         transport.handleRequest(req, res, req.body),
       );
 
-      try {
-        await connectionEvent.success();
-      } catch {
-        // best-effort
-      }
+      await connectionEvent.success();
 
       res.on('close', async () => {
         transport.close();
@@ -118,16 +107,12 @@ export const createStreamableRouter = ({
 
         sessionDuration.record(durationSeconds, baseAttributes);
 
-        try {
-          const e = await auditor.createEvent({
-            eventId: 'connection',
-            request: req,
-            meta: { transport: 'streamable', actionType: 'closed' },
-          });
-          await e.success();
-        } catch {
-          // best-effort
-        }
+        const e = await auditor.createEvent({
+          eventId: 'connection',
+          request: req,
+          meta: { transport: 'streamable', actionType: 'closed' },
+        });
+        await e.success();
       });
     } catch (error) {
       const err = toError(error);
@@ -153,13 +138,7 @@ export const createStreamableRouter = ({
         'error.type': errorType,
       });
 
-      try {
-        await connectionEvent.fail({
-          error: error instanceof Error ? error : new Error(String(error)),
-        });
-      } catch {
-        // best-effort
-      }
+      await connectionEvent.fail({ error: toError(error) });
     }
   });
 

--- a/plugins/mcp-actions-backend/src/routers/createStreamableRouter.ts
+++ b/plugins/mcp-actions-backend/src/routers/createStreamableRouter.ts
@@ -20,9 +20,7 @@ import { McpService } from '../services/McpService';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { LATEST_PROTOCOL_VERSION } from '@modelcontextprotocol/sdk/types.js';
 import { toError } from '@backstage/errors';
-import {
-  TracingService,
-} from '@backstage/backend-plugin-api/alpha';
+import { TracingService } from '@backstage/backend-plugin-api/alpha';
 import {
   AuditorService,
   AuditorServiceEvent,

--- a/plugins/mcp-actions-backend/src/routers/createStreamableRouter.ts
+++ b/plugins/mcp-actions-backend/src/routers/createStreamableRouter.ts
@@ -24,9 +24,10 @@ import {
   TracingService,
 } from '@backstage/backend-plugin-api/alpha';
 import {
+  AuditorService,
+  AuditorServiceEvent,
   HttpAuthService,
   LoggerService,
-  AuditorService,
 } from '@backstage/backend-plugin-api';
 import { MetricsService } from '@backstage/backend-plugin-api/alpha';
 import { bucketBoundaries, McpServerSessionAttributes } from '../metrics';
@@ -70,11 +71,17 @@ export const createStreamableRouter = ({
       'network.protocol.name': 'http',
     };
 
-    const connectionEvent = await auditor.createEvent({
-      eventId: 'connection',
-      request: req,
-      meta: { transport: 'streamable', actionType: 'established' },
-    });
+    let connectionEvent: AuditorServiceEvent;
+    try {
+      connectionEvent = await auditor.createEvent({
+        eventId: 'connection',
+        request: req,
+        meta: { transport: 'streamable', actionType: 'established' },
+      });
+    } catch {
+      // Make audit logging best-effort: fall back to a no-op event if auditing is unavailable.
+      connectionEvent = { success: async () => {}, fail: async () => {} };
+    }
 
     try {
       const server = mcpService.getServer({

--- a/plugins/mcp-actions-backend/src/services/McpService.test.ts
+++ b/plugins/mcp-actions-backend/src/services/McpService.test.ts
@@ -351,7 +351,7 @@ describe('McpService', () => {
     expect(toolExecutionCall![0]).toMatchObject({
       eventId: 'tool-execution',
       severityLevel: 'medium',
-      meta: { toolName: 'test:mock-action' },
+      meta: { toolName: 'test.mock-action' },
     });
     const toolExecutionEvent = await mockAuditor.createEvent.mock.results.find(
       (_: unknown, i: number) =>
@@ -872,6 +872,7 @@ describe('McpService', () => {
         actions: actionsRegistryServiceMock(),
         metrics: metricsServiceMock.mock(),
         tracingService: tracingServiceMock.mock(),
+        auditor: mockServices.auditor.mock(),
       });
 
       const server = mcpService.getServer({
@@ -896,6 +897,7 @@ describe('McpService', () => {
         actions: actionsRegistryServiceMock(),
         metrics: metricsServiceMock.mock(),
         tracingService: tracingServiceMock.mock(),
+        auditor: mockServices.auditor.mock(),
       });
 
       const server = mcpService.getServer({
@@ -926,6 +928,7 @@ describe('McpService', () => {
         actions: actionsRegistryServiceMock(),
         metrics: metricsServiceMock.mock(),
         tracingService: tracingServiceMock.mock(),
+        auditor: mockServices.auditor.mock(),
       });
 
       const server = mcpService.getServer({

--- a/plugins/mcp-actions-backend/src/services/McpService.test.ts
+++ b/plugins/mcp-actions-backend/src/services/McpService.test.ts
@@ -229,6 +229,7 @@ describe('McpService', () => {
       actions: fakeActions,
       metrics: metricsServiceMock.mock(),
       tracingService: tracingServiceMock.mock(),
+      auditor: mockServices.auditor.mock(),
       logger,
     });
 

--- a/plugins/mcp-actions-backend/src/services/McpService.test.ts
+++ b/plugins/mcp-actions-backend/src/services/McpService.test.ts
@@ -47,11 +47,12 @@ describe('McpService', () => {
     });
 
     const mockMetrics = metricsServiceMock.mock();
+    const mockAuditor = mockServices.auditor.mock();
     const mcpService = await McpService.create({
       actions: mockActionsRegistry,
       metrics: mockMetrics,
       tracingService: tracingServiceMock.mock(),
-      auditor: mockServices.auditor.mock(),
+      auditor: mockAuditor,
     });
 
     const server = mcpService.getServer({
@@ -112,6 +113,13 @@ describe('McpService', () => {
       }),
     );
     expect(histogram.record.mock.calls[0][1]).not.toHaveProperty('error.type');
+
+    expect(mockAuditor.createEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ eventId: 'tool-discovery' }),
+    );
+    const auditorEvent = await mockAuditor.createEvent.mock.results[0]?.value;
+    expect(auditorEvent.success).toHaveBeenCalled();
+    expect(auditorEvent.fail).not.toHaveBeenCalled();
   });
 
   it('should record metrics with error.type when tools/list fails', async () => {
@@ -121,11 +129,12 @@ describe('McpService', () => {
       .mockRejectedValue(new Error('List failed'));
 
     const mockMetrics = metricsServiceMock.mock();
+    const mockAuditor = mockServices.auditor.mock();
     const mcpService = await McpService.create({
       actions: mockActionsRegistry,
       metrics: mockMetrics,
       tracingService: tracingServiceMock.mock(),
-      auditor: mockServices.auditor.mock(),
+      auditor: mockAuditor,
     });
 
     const server = mcpService.getServer({
@@ -158,6 +167,13 @@ describe('McpService', () => {
         'error.type': 'Error',
       }),
     );
+
+    expect(mockAuditor.createEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ eventId: 'tool-discovery' }),
+    );
+    const auditorEvent = await mockAuditor.createEvent.mock.results[0]?.value;
+    expect(auditorEvent.fail).toHaveBeenCalled();
+    expect(auditorEvent.success).not.toHaveBeenCalled();
   });
 
   it('should skip actions with invalid input schemas instead of failing the whole list', async () => {
@@ -266,11 +282,12 @@ describe('McpService', () => {
     });
 
     const mockMetrics = metricsServiceMock.mock();
+    const mockAuditor = mockServices.auditor.mock();
     const mcpService = await McpService.create({
       actions: mockActionsRegistry,
       metrics: mockMetrics,
       tracingService: tracingServiceMock.mock(),
-      auditor: mockServices.auditor.mock(),
+      auditor: mockAuditor,
     });
 
     const server = mcpService.getServer({
@@ -325,6 +342,24 @@ describe('McpService', () => {
       }),
     );
     expect(histogram.record.mock.calls[0][1]).not.toHaveProperty('error.type');
+
+    // tool-discovery (tools/list during connect) + tool-execution
+    const toolExecutionCall = mockAuditor.createEvent.mock.calls.find(
+      ([args]: [{ eventId: string }]) => args.eventId === 'tool-execution',
+    );
+    expect(toolExecutionCall).toBeDefined();
+    expect(toolExecutionCall![0]).toMatchObject({
+      eventId: 'tool-execution',
+      severityLevel: 'medium',
+      meta: { toolName: 'test:mock-action' },
+    });
+    const toolExecutionEvent = await mockAuditor.createEvent.mock.results.find(
+      (_: unknown, i: number) =>
+        mockAuditor.createEvent.mock.calls[i]?.[0]?.eventId ===
+        'tool-execution',
+    )?.value;
+    expect(toolExecutionEvent?.success).toHaveBeenCalled();
+    expect(toolExecutionEvent?.fail).not.toHaveBeenCalled();
   });
 
   it('should return an error when the action is not found', async () => {
@@ -399,11 +434,12 @@ describe('McpService', () => {
     });
 
     const mockMetrics = metricsServiceMock.mock();
+    const mockAuditor = mockServices.auditor.mock();
     const mcpService = await McpService.create({
       actions: mockActionsRegistry,
       metrics: mockMetrics,
       tracingService: tracingServiceMock.mock(),
-      auditor: mockServices.auditor.mock(),
+      auditor: mockAuditor,
     });
 
     const server = mcpService.getServer({
@@ -444,6 +480,18 @@ describe('McpService', () => {
         'error.type': 'CustomError',
       }),
     );
+
+    const toolExecutionCall = mockAuditor.createEvent.mock.calls.find(
+      ([args]: [{ eventId: string }]) => args.eventId === 'tool-execution',
+    );
+    expect(toolExecutionCall).toBeDefined();
+    const toolExecutionEvent = await mockAuditor.createEvent.mock.results.find(
+      (_: unknown, i: number) =>
+        mockAuditor.createEvent.mock.calls[i]?.[0]?.eventId ===
+        'tool-execution',
+    )?.value;
+    expect(toolExecutionEvent?.fail).toHaveBeenCalled();
+    expect(toolExecutionEvent?.success).not.toHaveBeenCalled();
   });
 
   it('should forward the original InputError when an action throws one', async () => {

--- a/plugins/mcp-actions-backend/src/services/McpService.test.ts
+++ b/plugins/mcp-actions-backend/src/services/McpService.test.ts
@@ -51,6 +51,7 @@ describe('McpService', () => {
       actions: mockActionsRegistry,
       metrics: mockMetrics,
       tracingService: tracingServiceMock.mock(),
+      auditor: mockServices.auditor.mock(),
     });
 
     const server = mcpService.getServer({
@@ -124,6 +125,7 @@ describe('McpService', () => {
       actions: mockActionsRegistry,
       metrics: mockMetrics,
       tracingService: tracingServiceMock.mock(),
+      auditor: mockServices.auditor.mock(),
     });
 
     const server = mcpService.getServer({
@@ -268,6 +270,7 @@ describe('McpService', () => {
       actions: mockActionsRegistry,
       metrics: mockMetrics,
       tracingService: tracingServiceMock.mock(),
+      auditor: mockServices.auditor.mock(),
     });
 
     const server = mcpService.getServer({
@@ -330,6 +333,7 @@ describe('McpService', () => {
       actions: actionsRegistryServiceMock(),
       metrics: mockMetrics,
       tracingService: tracingServiceMock.mock(),
+      auditor: mockServices.auditor.mock(),
     });
 
     const server = mcpService.getServer({
@@ -399,6 +403,7 @@ describe('McpService', () => {
       actions: mockActionsRegistry,
       metrics: mockMetrics,
       tracingService: tracingServiceMock.mock(),
+      auditor: mockServices.auditor.mock(),
     });
 
     const server = mcpService.getServer({
@@ -460,6 +465,7 @@ describe('McpService', () => {
       actions: mockActionsRegistry,
       metrics: metricsServiceMock.mock(),
       tracingService: tracingServiceMock.mock(),
+      auditor: mockServices.auditor.mock(),
     });
 
     const server = mcpService.getServer({
@@ -517,6 +523,7 @@ describe('McpService', () => {
       actions: mockActionsRegistry,
       metrics: metricsServiceMock.mock(),
       tracingService: tracingServiceMock.mock(),
+      auditor: mockServices.auditor.mock(),
     });
 
     const server = mcpService.getServer({
@@ -605,6 +612,7 @@ describe('McpService', () => {
         actions: fakeActionsService,
         metrics: metricsServiceMock.mock(),
         tracingService: tracingServiceMock.mock(),
+        auditor: mockServices.auditor.mock(),
       });
 
       const serverConfig: McpServerConfig = {
@@ -639,6 +647,7 @@ describe('McpService', () => {
         actions: fakeActionsService,
         metrics: metricsServiceMock.mock(),
         tracingService: tracingServiceMock.mock(),
+        auditor: mockServices.auditor.mock(),
       });
 
       const serverConfig: McpServerConfig = {
@@ -681,6 +690,7 @@ describe('McpService', () => {
         actions: fakeActionsService,
         metrics: metricsServiceMock.mock(),
         tracingService: tracingServiceMock.mock(),
+        auditor: mockServices.auditor.mock(),
       });
 
       const serverConfig: McpServerConfig = {
@@ -720,6 +730,7 @@ describe('McpService', () => {
         actions: fakeActionsService,
         metrics: metricsServiceMock.mock(),
         tracingService: tracingServiceMock.mock(),
+        auditor: mockServices.auditor.mock(),
       });
 
       const serverConfig: McpServerConfig = {
@@ -759,6 +770,7 @@ describe('McpService', () => {
         actions: fakeActionsService,
         metrics: metricsServiceMock.mock(),
         tracingService: tracingServiceMock.mock(),
+        auditor: mockServices.auditor.mock(),
       });
 
       const serverConfig: McpServerConfig = {
@@ -909,6 +921,7 @@ describe('McpService', () => {
         actions: mockActionsRegistry,
         metrics: metricsServiceMock.mock(),
         tracingService: tracingServiceMock.mock(),
+        auditor: mockServices.auditor.mock(),
       });
 
       const server = mcpService.getServer({
@@ -948,6 +961,7 @@ describe('McpService', () => {
         actions: mockActionsRegistry,
         metrics: metricsServiceMock.mock(),
         tracingService: tracingServiceMock.mock(),
+        auditor: mockServices.auditor.mock(),
         namespacedToolNames: false,
       });
 
@@ -988,6 +1002,7 @@ describe('McpService', () => {
         actions: mockActionsRegistry,
         metrics: metricsServiceMock.mock(),
         tracingService: tracingServiceMock.mock(),
+        auditor: mockServices.auditor.mock(),
       });
 
       const server = mcpService.getServer({

--- a/plugins/mcp-actions-backend/src/services/McpService.test.ts
+++ b/plugins/mcp-actions-backend/src/services/McpService.test.ts
@@ -1104,6 +1104,7 @@ describe('McpService', () => {
         actions: mockActionsRegistry,
         metrics: metricsServiceMock.mock(),
         tracingService: opts.tracing,
+        auditor: mockServices.auditor.mock(),
         captureToolPayloads: opts.captureToolPayloads,
       });
 
@@ -1278,6 +1279,7 @@ describe('McpService', () => {
         actions: mockActionsRegistry,
         metrics: metricsServiceMock.mock(),
         tracingService: tracing,
+        auditor: mockServices.auditor.mock(),
         captureToolPayloads: true,
       });
 

--- a/plugins/mcp-actions-backend/src/services/McpService.ts
+++ b/plugins/mcp-actions-backend/src/services/McpService.ts
@@ -169,10 +169,19 @@ export class McpService {
       const startTime = performance.now();
       let errorType: string | undefined;
 
-      const auditorEvent = await this.auditor.createEvent({
-        eventId: 'tool-discovery',
-        ...(req && { request: req }),
-      });
+      let auditorEvent: any;
+      try {
+        auditorEvent = await this.auditor.createEvent({
+          eventId: 'tool-discovery',
+          ...(req && { request: req }),
+        });
+      } catch {
+        // Make audit logging best-effort: fall back to a no-op event if auditing is unavailable.
+        auditorEvent = {
+          success: async () => {},
+          fail: async () => {},
+        };
+      }
 
       try {
         const { actions: allActions } = await this.actions.list({

--- a/plugins/mcp-actions-backend/src/services/McpService.ts
+++ b/plugins/mcp-actions-backend/src/services/McpService.ts
@@ -17,7 +17,6 @@ import {
   BackstageCredentials,
   LoggerService,
   AuditorService,
-  AuditorServiceEvent,
 } from '@backstage/backend-plugin-api';
 import type { Request } from 'express';
 import { Server as McpServer } from '@modelcontextprotocol/sdk/server/index.js';
@@ -170,19 +169,10 @@ export class McpService {
       const startTime = performance.now();
       let errorType: string | undefined;
 
-      let auditorEvent: AuditorServiceEvent;
-      try {
-        auditorEvent = await this.auditor.createEvent({
-          eventId: 'tool-discovery',
-          ...(req && { request: req }),
-        });
-      } catch {
-        // Make audit logging best-effort: fall back to a no-op event if auditing is unavailable.
-        auditorEvent = {
-          success: async () => {},
-          fail: async () => {},
-        };
-      }
+      const auditorEvent = await this.auditor.createEvent({
+        eventId: 'tool-discovery',
+        ...(req && { request: req }),
+      });
 
       try {
         const { actions: allActions } = await this.actions.list({
@@ -232,13 +222,9 @@ export class McpService {
         return { tools };
       } catch (err) {
         errorType = err instanceof Error ? err.name : 'Error';
-        try {
-          await auditorEvent.fail({
-            error: err instanceof Error ? err : new Error(String(err)),
-          });
-        } catch {
-          // best-effort
-        }
+        await auditorEvent.fail({
+          error: err instanceof Error ? err : new Error(String(err)),
+        });
         throw err;
       } finally {
         const durationSeconds = (performance.now() - startTime) / 1000;
@@ -255,21 +241,12 @@ export class McpService {
       let errorType: string | undefined;
       let isError = false;
 
-      let auditorEvent: AuditorServiceEvent;
-      try {
-        auditorEvent = await this.auditor.createEvent({
-          eventId: 'tool-execution',
-          severityLevel: 'medium',
-          ...(req && { request: req }),
-          meta: { toolName: params.name },
-        });
-      } catch {
-        // Make audit logging best-effort: fall back to a no-op event if auditing is unavailable.
-        auditorEvent = {
-          success: async () => {},
-          fail: async () => {},
-        };
-      }
+      const auditorEvent = await this.auditor.createEvent({
+        eventId: 'tool-execution',
+        severityLevel: 'medium',
+        ...(req && { request: req }),
+        meta: { toolName: params.name },
+      });
 
       try {
         return await this.tracingService.startActiveSpan(
@@ -357,12 +334,10 @@ export class McpService {
         );
       } catch (err) {
         errorType = err instanceof Error ? err.name : 'Error';
-        try {
+        if (!isError) {
           await auditorEvent.fail({
             error: err instanceof Error ? err : new Error(String(err)),
           });
-        } catch {
-          // best-effort
         }
         throw err;
       } finally {

--- a/plugins/mcp-actions-backend/src/services/McpService.ts
+++ b/plugins/mcp-actions-backend/src/services/McpService.ts
@@ -16,7 +16,9 @@
 import {
   BackstageCredentials,
   LoggerService,
+  AuditorService,
 } from '@backstage/backend-plugin-api';
+import type { Request } from 'express';
 import { Server as McpServer } from '@modelcontextprotocol/sdk/server/index.js';
 import {
   ListToolsRequestSchema,
@@ -82,6 +84,7 @@ function baggageAttributes(
 export class McpService {
   private readonly actions: ActionsService;
   private readonly logger: LoggerService | undefined;
+  private readonly auditor: AuditorService;
   private readonly namespacedToolNames: boolean;
   private readonly tracingService: TracingService;
   private readonly captureToolPayloads: boolean;
@@ -93,11 +96,13 @@ export class McpService {
     metrics: MetricsService,
     tracingService: TracingService,
     logger: LoggerService | undefined,
+    auditor: AuditorService,
     namespacedToolNames?: boolean,
     captureToolPayloads?: boolean,
   ) {
     this.actions = actions;
     this.logger = logger;
+    this.auditor = auditor;
     this.namespacedToolNames = namespacedToolNames ?? true;
     this.tracingService = tracingService;
     this.captureToolPayloads = captureToolPayloads ?? false;
@@ -117,6 +122,7 @@ export class McpService {
     metrics,
     tracingService,
     logger,
+    auditor,
     namespacedToolNames,
     captureToolPayloads,
   }: {
@@ -124,6 +130,7 @@ export class McpService {
     metrics: MetricsService;
     tracingService: TracingService;
     logger?: LoggerService;
+    auditor: AuditorService;
     namespacedToolNames?: boolean;
     captureToolPayloads?: boolean;
   }) {
@@ -132,6 +139,7 @@ export class McpService {
       metrics,
       tracingService,
       logger,
+      auditor,
       namespacedToolNames,
       captureToolPayloads,
     );
@@ -140,9 +148,11 @@ export class McpService {
   getServer({
     credentials,
     serverConfig,
+    req,
   }: {
     credentials: BackstageCredentials;
     serverConfig?: McpServerConfig;
+    req?: Request;
   }) {
     const server = new McpServer(
       {
@@ -158,6 +168,11 @@ export class McpService {
     server.setRequestHandler(ListToolsRequestSchema, async () => {
       const startTime = performance.now();
       let errorType: string | undefined;
+
+      const auditorEvent = await this.auditor.createEvent({
+        eventId: 'tool-discovery',
+        ...(req && { request: req }),
+      });
 
       try {
         const { actions: allActions } = await this.actions.list({
@@ -199,9 +214,11 @@ export class McpService {
           tools.push(parsed.data);
         }
 
+        await auditorEvent.success({ meta: { toolCount: actions.length } });
         return { tools };
       } catch (err) {
         errorType = err instanceof Error ? err.name : 'Error';
+        await auditorEvent.fail({ error: err as Error });
         throw err;
       } finally {
         const durationSeconds = (performance.now() - startTime) / 1000;
@@ -217,6 +234,13 @@ export class McpService {
       const startTime = performance.now();
       let errorType: string | undefined;
       let isError = false;
+
+      const auditorEvent = await this.auditor.createEvent({
+        eventId: 'tool-execution',
+        severityLevel: 'medium',
+        ...(req && { request: req }),
+        meta: { toolName: params.name },
+      });
 
       try {
         return await this.tracingService.startActiveSpan(
@@ -284,15 +308,20 @@ export class McpService {
             });
 
             isError = !!(result as { isError?: boolean })?.isError;
+
             if (isError) {
               span.setAttribute('error.type', 'tool_error');
               span.setStatus({ code: 'error', message: 'tool_error' });
             }
+
+            await auditorEvent.success();
+
             return result;
           },
         );
       } catch (err) {
         errorType = err instanceof Error ? err.name : 'Error';
+        await auditorEvent.fail({ error: err as Error });
         throw err;
       } finally {
         const durationSeconds = (performance.now() - startTime) / 1000;

--- a/plugins/mcp-actions-backend/src/services/McpService.ts
+++ b/plugins/mcp-actions-backend/src/services/McpService.ts
@@ -224,13 +224,21 @@ export class McpService {
           tools.push(parsed.data);
         }
 
-        await auditorEvent.success({ meta: { toolCount: actions.length } });
+        try {
+          await auditorEvent.success({ meta: { toolCount: actions.length } });
+        } catch {
+          // best-effort
+        }
         return { tools };
       } catch (err) {
         errorType = err instanceof Error ? err.name : 'Error';
-        await auditorEvent.fail({
-          error: err instanceof Error ? err : new Error(String(err)),
-        });
+        try {
+          await auditorEvent.fail({
+            error: err instanceof Error ? err : new Error(String(err)),
+          });
+        } catch {
+          // best-effort
+        }
         throw err;
       } finally {
         const durationSeconds = (performance.now() - startTime) / 1000;

--- a/plugins/mcp-actions-backend/src/services/McpService.ts
+++ b/plugins/mcp-actions-backend/src/services/McpService.ts
@@ -17,6 +17,7 @@ import {
   BackstageCredentials,
   LoggerService,
   AuditorService,
+  AuditorServiceEvent,
 } from '@backstage/backend-plugin-api';
 import type { Request } from 'express';
 import { Server as McpServer } from '@modelcontextprotocol/sdk/server/index.js';
@@ -169,7 +170,7 @@ export class McpService {
       const startTime = performance.now();
       let errorType: string | undefined;
 
-      let auditorEvent: any;
+      let auditorEvent: AuditorServiceEvent;
       try {
         auditorEvent = await this.auditor.createEvent({
           eventId: 'tool-discovery',
@@ -227,7 +228,9 @@ export class McpService {
         return { tools };
       } catch (err) {
         errorType = err instanceof Error ? err.name : 'Error';
-        await auditorEvent.fail({ error: err as Error });
+        await auditorEvent.fail({
+          error: err instanceof Error ? err : new Error(String(err)),
+        });
         throw err;
       } finally {
         const durationSeconds = (performance.now() - startTime) / 1000;
@@ -244,12 +247,21 @@ export class McpService {
       let errorType: string | undefined;
       let isError = false;
 
-      const auditorEvent = await this.auditor.createEvent({
-        eventId: 'tool-execution',
-        severityLevel: 'medium',
-        ...(req && { request: req }),
-        meta: { toolName: params.name },
-      });
+      let auditorEvent: AuditorServiceEvent;
+      try {
+        auditorEvent = await this.auditor.createEvent({
+          eventId: 'tool-execution',
+          severityLevel: 'medium',
+          ...(req && { request: req }),
+          meta: { toolName: params.name },
+        });
+      } catch {
+        // Make audit logging best-effort: fall back to a no-op event if auditing is unavailable.
+        auditorEvent = {
+          success: async () => {},
+          fail: async () => {},
+        };
+      }
 
       try {
         return await this.tracingService.startActiveSpan(
@@ -337,7 +349,13 @@ export class McpService {
         );
       } catch (err) {
         errorType = err instanceof Error ? err.name : 'Error';
-        await auditorEvent.fail({ error: err as Error });
+        try {
+          await auditorEvent.fail({
+            error: err instanceof Error ? err : new Error(String(err)),
+          });
+        } catch {
+          // best-effort
+        }
         throw err;
       } finally {
         const durationSeconds = (performance.now() - startTime) / 1000;

--- a/plugins/mcp-actions-backend/src/services/McpService.ts
+++ b/plugins/mcp-actions-backend/src/services/McpService.ts
@@ -35,7 +35,7 @@ import {
   TracingService,
 } from '@backstage/backend-plugin-api/alpha';
 import { version } from '@backstage/plugin-mcp-actions-backend/package.json';
-import { NotFoundError } from '@backstage/errors';
+import { NotFoundError, toError } from '@backstage/errors';
 import { performance } from 'node:perf_hooks';
 
 import { handleErrors } from './handleErrors';
@@ -220,7 +220,7 @@ export class McpService {
       } catch (err) {
         errorType = err instanceof Error ? err.name : 'Error';
         await auditorEvent.fail({
-          error: err instanceof Error ? err : new Error(String(err)),
+          error: toError(err),
         });
         throw err;
       } finally {
@@ -333,7 +333,7 @@ export class McpService {
         errorType = err instanceof Error ? err.name : 'Error';
         if (!isError) {
           await auditorEvent.fail({
-            error: err instanceof Error ? err : new Error(String(err)),
+            error: toError(err),
           });
         }
         throw err;

--- a/plugins/mcp-actions-backend/src/services/McpService.ts
+++ b/plugins/mcp-actions-backend/src/services/McpService.ts
@@ -214,11 +214,8 @@ export class McpService {
           tools.push(parsed.data);
         }
 
-        try {
-          await auditorEvent.success({ meta: { toolCount: actions.length } });
-        } catch {
-          // best-effort
-        }
+        await auditorEvent.success({ meta: { toolCount: tools.length } });
+
         return { tools };
       } catch (err) {
         errorType = err instanceof Error ? err.name : 'Error';

--- a/plugins/mcp-actions-backend/src/services/McpService.ts
+++ b/plugins/mcp-actions-backend/src/services/McpService.ts
@@ -312,6 +312,13 @@ export class McpService {
             if (isError) {
               span.setAttribute('error.type', 'tool_error');
               span.setStatus({ code: 'error', message: 'tool_error' });
+              const errorDescription =
+                (result as { errorDescription?: string })?.errorDescription ??
+                `Tool "${params.name}" reported isError=true`;
+
+              await auditorEvent.fail({
+                error: new Error(errorDescription),
+              });
             }
 
             await auditorEvent.success();

--- a/plugins/mcp-actions-backend/src/services/McpService.ts
+++ b/plugins/mcp-actions-backend/src/services/McpService.ts
@@ -325,9 +325,9 @@ export class McpService {
               await auditorEvent.fail({
                 error: new Error(errorDescription),
               });
+            } else {
+              await auditorEvent.success();
             }
-
-            await auditorEvent.success();
 
             return result;
           },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR enhances the `mcp-actions-backend` plugin with audit logging via the Backstage Auditor Service, giving operators visibility into MCP server operations. Connections, tool discovery, and tool execution are now tracked across both `SSE` and `streamable HTTP` transports.

We have now three new event IDs:
- `connection`: when a transport session is established or closed.
- `tool-discovery`: when a client lists available tools
- `tool-execution`: when a tool is invoked

`connection` and `tool-discovery` are using the `low` (default) severity while the `tool-execution` uses `medium`.

The approach in the PR tries to follow what exists already in `catalog-backend` and `scaffolder-backend`, where a single event per operation with `.success()` / `.fail()` captures the outcome, and meta fields are used for differentiation of events. For more info you can check the discussions in the related issue: https://github.com/backstage/backstage/issues/32104

**Note:** This PR was developed with AI assistance (Cursor). However, the implementation, design decisions, etc. were reviewed and verified by the author.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
