### PR TITLE
docs: add missing reference link definitions in component design guidelines

### DIFF
--- a/docs/dls/component-design-guidelines.md
+++ b/docs/dls/component-design-guidelines.md
@@ -104,3 +104,5 @@ accessibility.
 [8]: https://v4.mui.com/customization/palette/#default-values
 [9]: https://v4.mui.com/customization/typography/
 [10]: https://backstage.io/docs/conf/user-interface
+[11]: https://v4.mui.com/customization/components/
+[12]: https://v4.mui.com/customization/default-theme/


### PR DESCRIPTION
This PR adds the missing reference link definitions `[11]` and `[12]` in the Component Design Guidelines documentation.

### The Problem

In `docs/dls/component-design-guidelines.md`, two reference-style links are used in the text but were never defined at the bottom of the file:

- **Line 50**: `[Override the Component Styles][11]` — reference `[11]` is undefined
- **Line 76**: `[Default Theme Explorer][12]` — reference `[12]` is undefined

This causes both links to render as plain text instead of clickable links on the docs site, making them useless for readers.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
