### PR TITLE
Fix Card onPress event

### DIFF
--- a/.changeset/tidy-friends-act.md
+++ b/.changeset/tidy-friends-act.md
@@ -1,0 +1,7 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed `Card` interactive cards not firing the `onPress` handler when clicking the card surface.
+
+**Affected components**: Card

--- a/packages/ui/src/components/Card/Card.tsx
+++ b/packages/ui/src/components/Card/Card.tsx
@@ -77,7 +77,7 @@ export const Card = forwardRef<HTMLDivElement, CardProps>((props, ref) => {
 
       triggerRef.current.dispatchEvent(
         new MouseEvent('click', {
-          bubbles: false,
+          bubbles: true,
           cancelable: true,
           ctrlKey: e.ctrlKey,
           metaKey: e.metaKey,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix `onPress` not firing on interactive `Card` components.

The `Card` component supports an `onPress` prop that makes the entire card surface act as a button. Clicking the card delegates the interaction to a hidden `<button>` element by dispatching a synthetic `MouseEvent`. The event was dispatched with `bubbles: false`, which prevented it from reaching React's root-level event delegation listener (React 17+), so the `onPress` handler was never invoked.

The fix is to dispatch the event with `bubbles: true`. The existing guard — which checks whether the click target is already the trigger button itself — prevents any re-entry loop when the bubbling event reaches the card's own `onClick` handler.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

