### PR TITLE
Fix: replace removed --bui-bg-tint tokens in Table component (fixes #33292)

### DIFF
--- a/.changeset/fix-table-bui-bg-tint-tokens.md
+++ b/.changeset/fix-table-bui-bg-tint-tokens.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed Table component to use current `--bui-bg-neutral-1` tokens instead of the removed `--bui-bg-tint` tokens, restoring row hover, selected, pressed, and disabled background colors.

--- a/packages/ui/src/components/Table/Table.module.css
+++ b/packages/ui/src/components/Table/Table.module.css
@@ -93,15 +93,15 @@
     cursor: default;
 
     &:hover {
-      background-color: var(--bui-bg-tint-hover);
+      background-color: var(--bui-bg-neutral-1-hover);
     }
 
     &[data-selected] {
-      background-color: var(--bui-bg-tint-pressed);
+      background-color: var(--bui-bg-neutral-1-pressed);
     }
 
     &[data-pressed] {
-      background-color: var(--bui-bg-tint-pressed);
+      background-color: var(--bui-bg-neutral-1-pressed);
     }
 
     &[data-href],
@@ -111,7 +111,7 @@
     }
 
     &[data-disabled] {
-      background-color: var(--bui-bg-tint-disabled);
+      background-color: var(--bui-bg-neutral-1-disabled);
       cursor: not-allowed;
     }
   }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #33292.

The `Table` component's `TableRow` states (hover, selected/pressed, disabled) were using `--bui-bg-tint-hover`, `--bui-bg-tint-pressed`, and `--bui-bg-tint-disabled` CSS tokens. These tokens were removed from the design system on 2026-01-30 in favour of the `--bui-bg-neutral-*` family, but `Table.module.css` was missed during the migration. As a result, hovering table rows produces no visual feedback.

---

## Root Cause

In `packages/ui/src/components/Table/Table.module.css` (lines 96, 100, 104, 114), `TableRow` state styles referenced `--bui-bg-tint-hover`, `--bui-bg-tint-pressed`, and `--bui-bg-tint-disabled`. The CHANGELOG (`packages/ui/CHANGELOG.md`) documents the removal and the replacement mapping:

- `--bui-bg-tint-hover` → `--bui-bg-neutral-on-surface-0-hover` (later renamed `--bui-bg-neutral-1-hover`)
- `--bui-bg-tint-pressed` → `--bui-bg-neutral-on-surface-0-pressed` (later renamed `--bui-bg-neutral-1-pressed`)
- `--bui-bg-tint-disabled` → `--bui-bg-neutral-on-surface-0-disabled` (later renamed `--bui-bg-neutral-1-disabled`)

## Solution

Replace all four occurrences in `Table.module.css` with the current `--bui-bg-neutral-1-*` tokens, matching the pattern used by other interactive components (Button, ButtonLink, ButtonIcon, Accordion, etc.).

## Testing

This is a CSS-only change. Visual verification:
1. Visit https://backstage.io/storybook/?path=/story/backstage-ui-table-dev--basic-local-data
2. Hover a table row — background should now change
3. Select a row — selected state background should be visible

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message.