### PR TITLE
frontend-plugin-api: reduce top-level API surface clutter

### DIFF
--- a/.changeset/mdowryepwlkfidia.md
+++ b/.changeset/mdowryepwlkfidia.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': minor
+---
+
+Removed the `ResolvedExtensionInput` and `ExtensionDataRefToValue` helper types from the public API surface to reduce top-level API clutter. These types were internal plumbing that are not needed by plugin authors. If you were relying on `ResolvedExtensionInput`, use the `ResolvedExtensionInputs` type instead, which maps a full set of inputs. If you were using `ExtensionDataRefToValue`, replace it with `ExtensionDataValue` combined with inferred types from your `ExtensionDataRef`.

--- a/packages/frontend-app-api/src/tree/instantiateAppNodeTree.test.ts
+++ b/packages/frontend-app-api/src/tree/instantiateAppNodeTree.test.ts
@@ -17,11 +17,10 @@
 import {
   AppNode,
   Extension,
+  ExtensionDataContainer,
   ExtensionDataRef,
   ExtensionDefinition,
-  ExtensionInput,
   PortableSchema,
-  ResolvedExtensionInput,
   createExtension,
   createExtensionBlueprint,
   createExtensionDataRef,
@@ -146,8 +145,8 @@ function mirrorInputs(ctx: {
   inputs: {
     [name in string]:
       | undefined
-      | ResolvedExtensionInput<ExtensionInput>
-      | Array<ResolvedExtensionInput<ExtensionInput>>;
+      | ({ node: AppNode } & ExtensionDataContainer<ExtensionDataRef>)
+      | Array<{ node: AppNode } & ExtensionDataContainer<ExtensionDataRef>>;
   };
 }) {
   return [

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -1157,12 +1157,6 @@ export type ExtensionDataRef<
 };
 
 // @public (undocumented)
-export type ExtensionDataRefToValue<TDataRef extends ExtensionDataRef> =
-  TDataRef extends ExtensionDataRef<infer IData, infer IId, any>
-    ? ExtensionDataValue<IData, IId>
-    : never;
-
-// @public (undocumented)
 export type ExtensionDataValue<TData, TId extends string> = {
   readonly $$type: '@backstage/ExtensionDataValue';
   readonly id: TId;
@@ -1906,14 +1900,6 @@ export const Progress: {
 
 // @public (undocumented)
 export type ProgressProps = {};
-
-// @public
-export type ResolvedExtensionInput<TExtensionInput extends ExtensionInput> =
-  TExtensionInput['extensionData'] extends Array<ExtensionDataRef>
-    ? {
-        node: AppNode;
-      } & ExtensionDataContainer<TExtensionInput['extensionData'][number]>
-    : never;
 
 // @public
 export type ResolvedExtensionInputs<

--- a/packages/frontend-plugin-api/src/wiring/createExtension.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtension.ts
@@ -43,11 +43,8 @@ import { FrontendModule } from './createFrontendModule';
  */
 export const ctxParamsSymbol = Symbol('params');
 
-/**
- * Convert a single extension input into a matching resolved input.
- * @public
- */
-export type ResolvedExtensionInput<TExtensionInput extends ExtensionInput> =
+/** @ignore */
+type ResolvedExtensionInput<TExtensionInput extends ExtensionInput> =
   TExtensionInput['extensionData'] extends Array<ExtensionDataRef>
     ? {
         node: AppNode;

--- a/packages/frontend-plugin-api/src/wiring/createExtensionDataRef.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionDataRef.ts
@@ -33,7 +33,7 @@ export type ExtensionDataRef<
   readonly config: TConfig;
 };
 
-/** @public */
+/** @ignore */
 export type ExtensionDataRefToValue<TDataRef extends ExtensionDataRef> =
   TDataRef extends ExtensionDataRef<infer IData, infer IId, any>
     ? ExtensionDataValue<IData, IId>

--- a/packages/frontend-plugin-api/src/wiring/index.ts
+++ b/packages/frontend-plugin-api/src/wiring/index.ts
@@ -22,7 +22,6 @@ export {
   type ExtensionDefinitionParameters,
   type CreateExtensionOptions,
   type OverridableExtensionDefinition,
-  type ResolvedExtensionInput,
   type ResolvedExtensionInputs,
 } from './createExtension';
 export {
@@ -32,7 +31,6 @@ export {
 export {
   createExtensionDataRef,
   type ExtensionDataRef,
-  type ExtensionDataRefToValue,
   type ExtensionDataValue,
   type ConfigurableExtensionDataRef,
 } from './createExtensionDataRef';

--- a/packages/frontend-plugin-api/src/wiring/resolveInputOverrides.ts
+++ b/packages/frontend-plugin-api/src/wiring/resolveInputOverrides.ts
@@ -16,7 +16,6 @@
 
 import { AppNode } from '../apis';
 import { Expand } from '@backstage/types';
-import { ResolvedExtensionInput } from './createExtension';
 import { createExtensionDataContainer } from '@internal/frontend';
 import {
   ExtensionDataRefToValue,
@@ -124,7 +123,7 @@ export function resolveInputOverrides(
           );
         }
         newInputs[name] = Object.assign(providedContainer, {
-          node: (originalInput as ResolvedExtensionInput<any>).node,
+          node: (originalInput as { node: AppNode }).node,
         }) as any;
       }
     } else {
@@ -158,7 +157,7 @@ export function resolveInputOverrides(
               declaredInput.extensionData,
             );
             return Object.assign(providedContainer, {
-              node: (originalInput[i] as ResolvedExtensionInput<any>).node,
+              node: (originalInput[i] as { node: AppNode }).node,
             }) as any;
           });
         } else if (withNodesCount === providedData.length) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This removes `ResolvedExtensionInput` and `ExtensionDataRefToValue` from the public API surface of `@backstage/frontend-plugin-api` to reduce top-level API clutter.

These types were internal plumbing that plugin authors don't need to import directly:

- **`ResolvedExtensionInput`** was a helper for `ResolvedExtensionInputs` — it's now a file-local type that still powers the same functionality, it just doesn't show up in autocomplete or documentation anymore.
- **`ExtensionDataRefToValue`** had zero external consumers and was only used internally by `@ignore`-tagged types.

Draft for now while awaiting feedback on whether this is a good direction. There are more types that could potentially be hidden from the surface (e.g. `ExtensionBlueprintParameters`, `ExtensionDefinitionParameters`, `CreateExtensionOptions`, `CreateExtensionBlueprintOptions`), but those are referenced by other packages' public APIs or appear in function signatures, so they can't easily be removed without broader changes.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))