### PR TITLE
frontend-plugin-api: convert ApiRef to opaque type with chained creation

### DIFF
--- a/.changeset/opaque-api-ref-type.md
+++ b/.changeset/opaque-api-ref-type.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': minor
+---
+
+**BREAKING**: The `ApiRef` type is now an opaque type with a `$$type` discriminator field, matching the pattern used by `ExtensionDataRef`. The `createApiRef` function now also supports a chained creation form: `createApiRef<MyApi>().with({ id: 'my-api' })`. The previous shorthand form `createApiRef<MyApi>({ id: 'my-api' })` is still supported.

--- a/packages/frontend-app-api/src/wiring/createSpecializedApp.test.tsx
+++ b/packages/frontend-app-api/src/wiring/createSpecializedApp.test.tsx
@@ -166,10 +166,9 @@ describe('createSpecializedApp', () => {
           "factories": Map {
             "core.featureflags" => {
               "factory": {
-                "api": ApiRefImpl {
-                  "config": {
-                    "id": "core.featureflags",
-                  },
+                "api": {
+                  "$$type": "@backstage/ApiRef",
+                  "id": "core.featureflags",
                 },
                 "deps": {},
                 "factory": [Function],
@@ -178,10 +177,9 @@ describe('createSpecializedApp', () => {
             },
             "core.app-tree" => {
               "factory": {
-                "api": ApiRefImpl {
-                  "config": {
-                    "id": "core.app-tree",
-                  },
+                "api": {
+                  "$$type": "@backstage/ApiRef",
+                  "id": "core.app-tree",
                 },
                 "deps": {},
                 "factory": [Function],
@@ -190,10 +188,9 @@ describe('createSpecializedApp', () => {
             },
             "core.config" => {
               "factory": {
-                "api": ApiRefImpl {
-                  "config": {
-                    "id": "core.config",
-                  },
+                "api": {
+                  "$$type": "@backstage/ApiRef",
+                  "id": "core.config",
                 },
                 "deps": {},
                 "factory": [Function],
@@ -202,10 +199,9 @@ describe('createSpecializedApp', () => {
             },
             "core.route-resolution" => {
               "factory": {
-                "api": ApiRefImpl {
-                  "config": {
-                    "id": "core.route-resolution",
-                  },
+                "api": {
+                  "$$type": "@backstage/ApiRef",
+                  "id": "core.route-resolution",
                 },
                 "deps": {},
                 "factory": [Function],
@@ -214,10 +210,9 @@ describe('createSpecializedApp', () => {
             },
             "core.identity" => {
               "factory": {
-                "api": ApiRefImpl {
-                  "config": {
-                    "id": "core.identity",
-                  },
+                "api": {
+                  "$$type": "@backstage/ApiRef",
+                  "id": "core.identity",
                 },
                 "deps": {},
                 "factory": [Function],

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -31,7 +31,7 @@ export type AlertApi = {
 };
 
 // @public
-export const alertApiRef: ApiRef<AlertApi>;
+export const alertApiRef: ApiRef_2<AlertApi>;
 
 // @public
 export type AlertMessage = {
@@ -46,7 +46,7 @@ export type AnalyticsApi = {
 };
 
 // @public
-export const analyticsApiRef: ApiRef<AnalyticsApi>;
+export const analyticsApiRef: ApiRef_2<AnalyticsApi>;
 
 // @public
 export const AnalyticsContext: (options: {
@@ -188,8 +188,9 @@ export type ApiHolder = {
 
 // @public
 export type ApiRef<T> = {
-  id: string;
-  T: T;
+  readonly $$type: '@backstage/ApiRef';
+  readonly id: string;
+  readonly T: T;
 };
 
 // @public
@@ -212,7 +213,7 @@ export type AppLanguageApi = {
 };
 
 // @public (undocumented)
-export const appLanguageApiRef: ApiRef<AppLanguageApi>;
+export const appLanguageApiRef: ApiRef_2<AppLanguageApi>;
 
 // @public
 export interface AppNode {
@@ -285,7 +286,7 @@ export type AppThemeApi = {
 };
 
 // @public
-export const appThemeApiRef: ApiRef<AppThemeApi>;
+export const appThemeApiRef: ApiRef_2<AppThemeApi>;
 
 // @public
 export interface AppTree {
@@ -308,7 +309,7 @@ export interface AppTreeApi {
 export const appTreeApiRef: ApiRef_2<AppTreeApi>;
 
 // @public
-export const atlassianAuthApiRef: ApiRef<
+export const atlassianAuthApiRef: ApiRef_2<
   OAuthApi & ProfileInfoApi & BackstageIdentityApi & SessionApi
 >;
 
@@ -348,12 +349,12 @@ export type BackstageUserIdentity = {
 };
 
 // @public
-export const bitbucketAuthApiRef: ApiRef<
+export const bitbucketAuthApiRef: ApiRef_2<
   OAuthApi & ProfileInfoApi & BackstageIdentityApi & SessionApi
 >;
 
 // @public
-export const bitbucketServerAuthApiRef: ApiRef<
+export const bitbucketServerAuthApiRef: ApiRef_2<
   OAuthApi & ProfileInfoApi & BackstageIdentityApi & SessionApi
 >;
 
@@ -361,7 +362,7 @@ export const bitbucketServerAuthApiRef: ApiRef<
 export type ConfigApi = Config;
 
 // @public
-export const configApiRef: ApiRef<ConfigApi>;
+export const configApiRef: ApiRef_2<Config>;
 
 // @public (undocumented)
 export interface ConfigurableExtensionDataRef<
@@ -417,6 +418,11 @@ export function createApiFactory<Api, Impl extends Api>(
 
 // @public
 export function createApiRef<T>(config: ApiRefConfig): ApiRef<T>;
+
+// @public (undocumented)
+export function createApiRef<T>(): {
+  with(config: ApiRefConfig): ApiRef<T>;
+};
 
 // @public
 export function createExtension<
@@ -877,7 +883,7 @@ export type DiscoveryApi = {
 };
 
 // @public
-export const discoveryApiRef: ApiRef<DiscoveryApi>;
+export const discoveryApiRef: ApiRef_2<DiscoveryApi>;
 
 // @public
 export type ErrorApi = {
@@ -901,7 +907,7 @@ export type ErrorApiErrorContext = {
 };
 
 // @public
-export const errorApiRef: ApiRef<ErrorApi>;
+export const errorApiRef: ApiRef_2<ErrorApi>;
 
 // @public (undocumented)
 export const ErrorDisplay: {
@@ -1291,7 +1297,7 @@ export interface FeatureFlagsApi {
 }
 
 // @public
-export const featureFlagsApiRef: ApiRef<FeatureFlagsApi>;
+export const featureFlagsApiRef: ApiRef_2<FeatureFlagsApi>;
 
 // @public
 export type FeatureFlagsSaveOptions = {
@@ -1323,7 +1329,7 @@ export type FetchApi = {
 };
 
 // @public
-export const fetchApiRef: ApiRef<FetchApi>;
+export const fetchApiRef: ApiRef_2<FetchApi>;
 
 // @public (undocumented)
 export type FrontendFeature =
@@ -1396,12 +1402,12 @@ export type FrontendPluginInfoOptions = {
 };
 
 // @public
-export const githubAuthApiRef: ApiRef<
+export const githubAuthApiRef: ApiRef_2<
   OAuthApi & ProfileInfoApi & BackstageIdentityApi & SessionApi
 >;
 
 // @public
-export const gitlabAuthApiRef: ApiRef<
+export const gitlabAuthApiRef: ApiRef_2<
   OAuthApi &
     OpenIdConnectApi &
     ProfileInfoApi &
@@ -1410,7 +1416,7 @@ export const gitlabAuthApiRef: ApiRef<
 >;
 
 // @public
-export const googleAuthApiRef: ApiRef<
+export const googleAuthApiRef: ApiRef_2<
   OAuthApi &
     OpenIdConnectApi &
     ProfileInfoApi &
@@ -1449,10 +1455,10 @@ export type IdentityApi = {
 };
 
 // @public
-export const identityApiRef: ApiRef<IdentityApi>;
+export const identityApiRef: ApiRef_2<IdentityApi>;
 
 // @public
-export const microsoftAuthApiRef: ApiRef<
+export const microsoftAuthApiRef: ApiRef_2<
   OAuthApi &
     OpenIdConnectApi &
     ProfileInfoApi &
@@ -1521,7 +1527,7 @@ export type OAuthRequestApi = {
 };
 
 // @public
-export const oauthRequestApiRef: ApiRef<OAuthRequestApi>;
+export const oauthRequestApiRef: ApiRef_2<OAuthRequestApi>;
 
 // @public
 export type OAuthRequester<TAuthResponse> = (
@@ -1538,7 +1544,7 @@ export type OAuthRequesterOptions<TOAuthResponse> = {
 export type OAuthScope = string | string[];
 
 // @public
-export const oktaAuthApiRef: ApiRef<
+export const oktaAuthApiRef: ApiRef_2<
   OAuthApi &
     OpenIdConnectApi &
     ProfileInfoApi &
@@ -1547,7 +1553,7 @@ export const oktaAuthApiRef: ApiRef<
 >;
 
 // @public
-export const oneloginAuthApiRef: ApiRef<
+export const oneloginAuthApiRef: ApiRef_2<
   OAuthApi &
     OpenIdConnectApi &
     ProfileInfoApi &
@@ -1561,7 +1567,7 @@ export type OpenIdConnectApi = {
 };
 
 // @public
-export const openshiftAuthApiRef: ApiRef<
+export const openshiftAuthApiRef: ApiRef_2<
   OAuthApi & ProfileInfoApi & BackstageIdentityApi & SessionApi
 >;
 
@@ -1996,7 +2002,7 @@ export interface StorageApi {
 }
 
 // @public
-export const storageApiRef: ApiRef<StorageApi>;
+export const storageApiRef: ApiRef_2<StorageApi>;
 
 // @public
 export type StorageValueSnapshot<TValue extends JsonValue> =
@@ -2107,7 +2113,7 @@ export type TranslationApi = {
 };
 
 // @public (undocumented)
-export const translationApiRef: ApiRef<TranslationApi>;
+export const translationApiRef: ApiRef_2<TranslationApi>;
 
 // @public (undocumented)
 export type TranslationFunction<
@@ -2297,7 +2303,7 @@ export const useTranslationRef: <TMessages extends { [key in string]: string }>(
 };
 
 // @public
-export const vmwareCloudAuthApiRef: ApiRef<
+export const vmwareCloudAuthApiRef: ApiRef_2<
   OAuthApi &
     OpenIdConnectApi &
     ProfileInfoApi &

--- a/packages/frontend-plugin-api/src/apis/definitions/AlertApi.ts
+++ b/packages/frontend-plugin-api/src/apis/definitions/AlertApi.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { createApiRef, ApiRef } from '../system';
+import { createApiRef } from '../system';
 import { Observable } from '@backstage/types';
 
 /**
@@ -51,6 +51,6 @@ export type AlertApi = {
  *
  * @public
  */
-export const alertApiRef: ApiRef<AlertApi> = createApiRef({
+export const alertApiRef = createApiRef<AlertApi>().with({
   id: 'core.alert',
 });

--- a/packages/frontend-plugin-api/src/apis/definitions/AnalyticsApi.ts
+++ b/packages/frontend-plugin-api/src/apis/definitions/AnalyticsApi.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ApiRef, createApiRef } from '../system';
+import { createApiRef } from '../system';
 import { AnalyticsContextValue } from '../../analytics/types';
 
 /**
@@ -151,6 +151,6 @@ export type AnalyticsApi = {
  *
  * @public
  */
-export const analyticsApiRef: ApiRef<AnalyticsApi> = createApiRef({
+export const analyticsApiRef = createApiRef<AnalyticsApi>().with({
   id: 'core.analytics',
 });

--- a/packages/frontend-plugin-api/src/apis/definitions/AppLanguageApi.ts
+++ b/packages/frontend-plugin-api/src/apis/definitions/AppLanguageApi.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ApiRef, createApiRef } from '../system';
+import { createApiRef } from '../system';
 import { Observable } from '@backstage/types';
 
 /** @public */
@@ -31,6 +31,6 @@ export type AppLanguageApi = {
 /**
  * @public
  */
-export const appLanguageApiRef: ApiRef<AppLanguageApi> = createApiRef({
+export const appLanguageApiRef = createApiRef<AppLanguageApi>().with({
   id: 'core.applanguage',
 });

--- a/packages/frontend-plugin-api/src/apis/definitions/AppThemeApi.ts
+++ b/packages/frontend-plugin-api/src/apis/definitions/AppThemeApi.ts
@@ -15,7 +15,7 @@
  */
 
 import { ReactNode } from 'react';
-import { ApiRef, createApiRef } from '../system';
+import { createApiRef } from '../system';
 import { Observable } from '@backstage/types';
 
 /**
@@ -82,6 +82,6 @@ export type AppThemeApi = {
  *
  * @public
  */
-export const appThemeApiRef: ApiRef<AppThemeApi> = createApiRef({
+export const appThemeApiRef = createApiRef<AppThemeApi>().with({
   id: 'core.apptheme',
 });

--- a/packages/frontend-plugin-api/src/apis/definitions/AppTreeApi.ts
+++ b/packages/frontend-plugin-api/src/apis/definitions/AppTreeApi.ts
@@ -117,4 +117,6 @@ export interface AppTreeApi {
  *
  * @public
  */
-export const appTreeApiRef = createApiRef<AppTreeApi>({ id: 'core.app-tree' });
+export const appTreeApiRef = createApiRef<AppTreeApi>().with({
+  id: 'core.app-tree',
+});

--- a/packages/frontend-plugin-api/src/apis/definitions/ConfigApi.ts
+++ b/packages/frontend-plugin-api/src/apis/definitions/ConfigApi.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ApiRef, createApiRef } from '../system';
+import { createApiRef } from '../system';
 import type { Config } from '@backstage/config';
 
 /**
@@ -29,6 +29,6 @@ export type ConfigApi = Config;
  *
  * @public
  */
-export const configApiRef: ApiRef<ConfigApi> = createApiRef({
+export const configApiRef = createApiRef<ConfigApi>().with({
   id: 'core.config',
 });

--- a/packages/frontend-plugin-api/src/apis/definitions/DialogApi.ts
+++ b/packages/frontend-plugin-api/src/apis/definitions/DialogApi.ts
@@ -173,6 +173,6 @@ export interface DialogApi {
  *
  * @public
  */
-export const dialogApiRef = createApiRef<DialogApi>({
+export const dialogApiRef = createApiRef<DialogApi>().with({
   id: 'core.dialog',
 });

--- a/packages/frontend-plugin-api/src/apis/definitions/DiscoveryApi.ts
+++ b/packages/frontend-plugin-api/src/apis/definitions/DiscoveryApi.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ApiRef, createApiRef } from '../system';
+import { createApiRef } from '../system';
 
 /**
  * The discovery API is used to provide a mechanism for plugins to
@@ -50,6 +50,6 @@ export type DiscoveryApi = {
  *
  * @public
  */
-export const discoveryApiRef: ApiRef<DiscoveryApi> = createApiRef({
+export const discoveryApiRef = createApiRef<DiscoveryApi>().with({
   id: 'core.discovery',
 });

--- a/packages/frontend-plugin-api/src/apis/definitions/ErrorApi.ts
+++ b/packages/frontend-plugin-api/src/apis/definitions/ErrorApi.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ApiRef, createApiRef } from '../system';
+import { createApiRef } from '../system';
 import { Observable } from '@backstage/types';
 
 /**
@@ -86,6 +86,6 @@ export type ErrorApi = {
  *
  * @public
  */
-export const errorApiRef: ApiRef<ErrorApi> = createApiRef({
+export const errorApiRef = createApiRef<ErrorApi>().with({
   id: 'core.error',
 });

--- a/packages/frontend-plugin-api/src/apis/definitions/FeatureFlagsApi.ts
+++ b/packages/frontend-plugin-api/src/apis/definitions/FeatureFlagsApi.ts
@@ -16,7 +16,7 @@
 /* We want to maintain the same information as an enum, so we disable the redeclaration warning */
 /* eslint-disable @typescript-eslint/no-redeclare */
 
-import { ApiRef, createApiRef } from '../system';
+import { createApiRef } from '../system';
 
 /**
  * Feature flag descriptor.
@@ -121,6 +121,6 @@ export interface FeatureFlagsApi {
  *
  * @public
  */
-export const featureFlagsApiRef: ApiRef<FeatureFlagsApi> = createApiRef({
+export const featureFlagsApiRef = createApiRef<FeatureFlagsApi>().with({
   id: 'core.featureflags',
 });

--- a/packages/frontend-plugin-api/src/apis/definitions/FetchApi.ts
+++ b/packages/frontend-plugin-api/src/apis/definitions/FetchApi.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ApiRef, createApiRef } from '../system';
+import { createApiRef } from '../system';
 
 /**
  * A wrapper for the fetch API, that has additional behaviors such as the
@@ -46,6 +46,6 @@ export type FetchApi = {
  *
  * @public
  */
-export const fetchApiRef: ApiRef<FetchApi> = createApiRef({
+export const fetchApiRef = createApiRef<FetchApi>().with({
   id: 'core.fetch',
 });

--- a/packages/frontend-plugin-api/src/apis/definitions/IconsApi.ts
+++ b/packages/frontend-plugin-api/src/apis/definitions/IconsApi.ts
@@ -41,6 +41,6 @@ export interface IconsApi {
  *
  * @public
  */
-export const iconsApiRef = createApiRef<IconsApi>({
+export const iconsApiRef = createApiRef<IconsApi>().with({
   id: 'core.icons',
 });

--- a/packages/frontend-plugin-api/src/apis/definitions/IdentityApi.ts
+++ b/packages/frontend-plugin-api/src/apis/definitions/IdentityApi.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ApiRef, createApiRef } from '../system';
+import { createApiRef } from '../system';
 import { BackstageUserIdentity, ProfileInfo } from './auth';
 
 /**
@@ -51,6 +51,6 @@ export type IdentityApi = {
  *
  * @public
  */
-export const identityApiRef: ApiRef<IdentityApi> = createApiRef({
+export const identityApiRef = createApiRef<IdentityApi>().with({
   id: 'core.identity',
 });

--- a/packages/frontend-plugin-api/src/apis/definitions/OAuthRequestApi.ts
+++ b/packages/frontend-plugin-api/src/apis/definitions/OAuthRequestApi.ts
@@ -15,7 +15,7 @@
  */
 
 import { Observable } from '@backstage/types';
-import { ApiRef, createApiRef } from '../system';
+import { createApiRef } from '../system';
 import { AuthProviderInfo } from './auth';
 
 /**
@@ -126,6 +126,6 @@ export type OAuthRequestApi = {
  *
  * @public
  */
-export const oauthRequestApiRef: ApiRef<OAuthRequestApi> = createApiRef({
+export const oauthRequestApiRef = createApiRef<OAuthRequestApi>().with({
   id: 'core.oauthrequest',
 });

--- a/packages/frontend-plugin-api/src/apis/definitions/PluginHeaderActionsApi.ts
+++ b/packages/frontend-plugin-api/src/apis/definitions/PluginHeaderActionsApi.ts
@@ -40,6 +40,7 @@ export type PluginHeaderActionsApi = {
  *
  * @public
  */
-export const pluginHeaderActionsApiRef = createApiRef<PluginHeaderActionsApi>({
-  id: 'core.plugin-header-actions',
-});
+export const pluginHeaderActionsApiRef =
+  createApiRef<PluginHeaderActionsApi>().with({
+    id: 'core.plugin-header-actions',
+  });

--- a/packages/frontend-plugin-api/src/apis/definitions/PluginWrapperApi.ts
+++ b/packages/frontend-plugin-api/src/apis/definitions/PluginWrapperApi.ts
@@ -45,6 +45,6 @@ export type PluginWrapperApi = {
  *
  * @alpha
  */
-export const pluginWrapperApiRef = createApiRef<PluginWrapperApi>({
+export const pluginWrapperApiRef = createApiRef<PluginWrapperApi>().with({
   id: 'core.plugin-wrapper.alpha',
 });

--- a/packages/frontend-plugin-api/src/apis/definitions/RouteResolutionApi.ts
+++ b/packages/frontend-plugin-api/src/apis/definitions/RouteResolutionApi.ts
@@ -65,6 +65,6 @@ export interface RouteResolutionApi {
  *
  * @public
  */
-export const routeResolutionApiRef = createApiRef<RouteResolutionApi>({
+export const routeResolutionApiRef = createApiRef<RouteResolutionApi>().with({
   id: 'core.route-resolution',
 });

--- a/packages/frontend-plugin-api/src/apis/definitions/StorageApi.ts
+++ b/packages/frontend-plugin-api/src/apis/definitions/StorageApi.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ApiRef, createApiRef } from '../system';
+import { createApiRef } from '../system';
 import { JsonValue, Observable } from '@backstage/types';
 
 /**
@@ -105,6 +105,6 @@ export interface StorageApi {
  *
  * @public
  */
-export const storageApiRef: ApiRef<StorageApi> = createApiRef({
+export const storageApiRef = createApiRef<StorageApi>().with({
   id: 'core.storage',
 });

--- a/packages/frontend-plugin-api/src/apis/definitions/SwappableComponentsApi.ts
+++ b/packages/frontend-plugin-api/src/apis/definitions/SwappableComponentsApi.ts
@@ -36,6 +36,7 @@ export interface SwappableComponentsApi {
  *
  * @public
  */
-export const swappableComponentsApiRef = createApiRef<SwappableComponentsApi>({
-  id: 'core.swappable-components',
-});
+export const swappableComponentsApiRef =
+  createApiRef<SwappableComponentsApi>().with({
+    id: 'core.swappable-components',
+  });

--- a/packages/frontend-plugin-api/src/apis/definitions/TranslationApi.ts
+++ b/packages/frontend-plugin-api/src/apis/definitions/TranslationApi.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ApiRef, createApiRef } from '../system';
+import { createApiRef } from '../system';
 import { Expand, ExpandRecursive, Observable } from '@backstage/types';
 import { TranslationRef } from '../../translation';
 import { JSX } from 'react';
@@ -358,6 +358,6 @@ export type TranslationApi = {
 /**
  * @public
  */
-export const translationApiRef: ApiRef<TranslationApi> = createApiRef({
+export const translationApiRef = createApiRef<TranslationApi>().with({
   id: 'core.translation',
 });

--- a/packages/frontend-plugin-api/src/apis/definitions/auth.ts
+++ b/packages/frontend-plugin-api/src/apis/definitions/auth.ts
@@ -16,7 +16,7 @@
 /* We want to maintain the same information as an enum, so we disable the redeclaration warning */
 /* eslint-disable @typescript-eslint/no-redeclare */
 
-import { ApiRef, createApiRef } from '../system';
+import { createApiRef } from '../system';
 import { IconComponent } from '../../icons/types';
 import { Observable } from '@backstage/types';
 
@@ -328,15 +328,13 @@ export type SessionApi = {
  * Note that the ID token payload is only guaranteed to contain the user's numerical Google ID,
  * email and expiration information. Do not rely on any other fields, as they might not be present.
  */
-export const googleAuthApiRef: ApiRef<
+export const googleAuthApiRef = createApiRef<
   OAuthApi &
     OpenIdConnectApi &
     ProfileInfoApi &
     BackstageIdentityApi &
     SessionApi
-> = createApiRef({
-  id: 'core.auth.google',
-});
+>().with({ id: 'core.auth.google' });
 
 /**
  * Provides authentication towards GitHub APIs.
@@ -347,11 +345,9 @@ export const googleAuthApiRef: ApiRef<
  * See {@link https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/}
  * for a full list of supported scopes.
  */
-export const githubAuthApiRef: ApiRef<
+export const githubAuthApiRef = createApiRef<
   OAuthApi & ProfileInfoApi & BackstageIdentityApi & SessionApi
-> = createApiRef({
-  id: 'core.auth.github',
-});
+>().with({ id: 'core.auth.github' });
 
 /**
  * Provides authentication towards Okta APIs.
@@ -362,15 +358,13 @@ export const githubAuthApiRef: ApiRef<
  * See {@link https://developer.okta.com/docs/guides/implement-oauth-for-okta/scopes/}
  * for a full list of supported scopes.
  */
-export const oktaAuthApiRef: ApiRef<
+export const oktaAuthApiRef = createApiRef<
   OAuthApi &
     OpenIdConnectApi &
     ProfileInfoApi &
     BackstageIdentityApi &
     SessionApi
-> = createApiRef({
-  id: 'core.auth.okta',
-});
+>().with({ id: 'core.auth.okta' });
 
 /**
  * Provides authentication towards GitLab APIs.
@@ -381,15 +375,13 @@ export const oktaAuthApiRef: ApiRef<
  * See {@link https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#limiting-scopes-of-a-personal-access-token}
  * for a full list of supported scopes.
  */
-export const gitlabAuthApiRef: ApiRef<
+export const gitlabAuthApiRef = createApiRef<
   OAuthApi &
     OpenIdConnectApi &
     ProfileInfoApi &
     BackstageIdentityApi &
     SessionApi
-> = createApiRef({
-  id: 'core.auth.gitlab',
-});
+>().with({ id: 'core.auth.gitlab' });
 
 /**
  * Provides authentication towards Microsoft APIs and identities.
@@ -401,30 +393,26 @@ export const gitlabAuthApiRef: ApiRef<
  * - {@link https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-permissions-and-consent}
  * - {@link https://docs.microsoft.com/en-us/graph/permissions-reference}
  */
-export const microsoftAuthApiRef: ApiRef<
+export const microsoftAuthApiRef = createApiRef<
   OAuthApi &
     OpenIdConnectApi &
     ProfileInfoApi &
     BackstageIdentityApi &
     SessionApi
-> = createApiRef({
-  id: 'core.auth.microsoft',
-});
+>().with({ id: 'core.auth.microsoft' });
 
 /**
  * Provides authentication towards OneLogin APIs.
  *
  * @public
  */
-export const oneloginAuthApiRef: ApiRef<
+export const oneloginAuthApiRef = createApiRef<
   OAuthApi &
     OpenIdConnectApi &
     ProfileInfoApi &
     BackstageIdentityApi &
     SessionApi
-> = createApiRef({
-  id: 'core.auth.onelogin',
-});
+>().with({ id: 'core.auth.onelogin' });
 
 /**
  * Provides authentication towards Bitbucket APIs.
@@ -435,11 +423,9 @@ export const oneloginAuthApiRef: ApiRef<
  * See {@link https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-bitbucket-cloud/}
  * for a full list of supported scopes.
  */
-export const bitbucketAuthApiRef: ApiRef<
+export const bitbucketAuthApiRef = createApiRef<
   OAuthApi & ProfileInfoApi & BackstageIdentityApi & SessionApi
-> = createApiRef({
-  id: 'core.auth.bitbucket',
-});
+>().with({ id: 'core.auth.bitbucket' });
 
 /**
  * Provides authentication towards Bitbucket Server APIs.
@@ -450,11 +436,9 @@ export const bitbucketAuthApiRef: ApiRef<
  * See {@link https://confluence.atlassian.com/bitbucketserver/bitbucket-oauth-2-0-provider-api-1108483661.html#BitbucketOAuth2.0providerAPI-scopes}
  * for a full list of supported scopes.
  */
-export const bitbucketServerAuthApiRef: ApiRef<
+export const bitbucketServerAuthApiRef = createApiRef<
   OAuthApi & ProfileInfoApi & BackstageIdentityApi & SessionApi
-> = createApiRef({
-  id: 'core.auth.bitbucket-server',
-});
+>().with({ id: 'core.auth.bitbucket-server' });
 
 /**
  * Provides authentication towards Atlassian APIs.
@@ -465,11 +449,9 @@ export const bitbucketServerAuthApiRef: ApiRef<
  * See {@link https://developer.atlassian.com/cloud/jira/platform/scopes-for-connect-and-oauth-2-3LO-apps/}
  * for a full list of supported scopes.
  */
-export const atlassianAuthApiRef: ApiRef<
+export const atlassianAuthApiRef = createApiRef<
   OAuthApi & ProfileInfoApi & BackstageIdentityApi & SessionApi
-> = createApiRef({
-  id: 'core.auth.atlassian',
-});
+>().with({ id: 'core.auth.atlassian' });
 
 /**
  * Provides authentication towards VMware Cloud APIs and identities.
@@ -480,15 +462,13 @@ export const atlassianAuthApiRef: ApiRef<
  * For more info about VMware Cloud identity and access management:
  * - {@link https://docs.vmware.com/en/VMware-Cloud-services/services/Using-VMware-Cloud-Services/GUID-53D39337-D93A-4B84-BD18-DDF43C21479A.html}
  */
-export const vmwareCloudAuthApiRef: ApiRef<
+export const vmwareCloudAuthApiRef = createApiRef<
   OAuthApi &
     OpenIdConnectApi &
     ProfileInfoApi &
     BackstageIdentityApi &
     SessionApi
-> = createApiRef({
-  id: 'core.auth.vmware-cloud',
-});
+>().with({ id: 'core.auth.vmware-cloud' });
 
 /**
  * Provides authentication towards OpenShift APIs and identities.
@@ -501,8 +481,6 @@ export const vmwareCloudAuthApiRef: ApiRef<
  * {@link https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html-single/authentication_and_authorization/index#tokens-scoping-about_configuring-internal-oauth}
  * for available scopes.
  */
-export const openshiftAuthApiRef: ApiRef<
+export const openshiftAuthApiRef = createApiRef<
   OAuthApi & ProfileInfoApi & BackstageIdentityApi & SessionApi
-> = createApiRef({
-  id: 'core.auth.openshift',
-});
+>().with({ id: 'core.auth.openshift' });

--- a/packages/frontend-plugin-api/src/apis/system/ApiRef.test.ts
+++ b/packages/frontend-plugin-api/src/apis/system/ApiRef.test.ts
@@ -17,8 +17,17 @@
 import { createApiRef } from './ApiRef';
 
 describe('ApiRef', () => {
-  it('should be created', () => {
+  it('should be created with shorthand', () => {
     const ref = createApiRef({ id: 'abc' });
+    expect(ref.$$type).toBe('@backstage/ApiRef');
+    expect(ref.id).toBe('abc');
+    expect(String(ref)).toBe('apiRef{abc}');
+    expect(() => ref.T).toThrow('tried to read ApiRef.T of apiRef{abc}');
+  });
+
+  it('should be created with chained form', () => {
+    const ref = createApiRef<{ method(): void }>().with({ id: 'abc' });
+    expect(ref.$$type).toBe('@backstage/ApiRef');
     expect(ref.id).toBe('abc');
     expect(String(ref)).toBe('apiRef{abc}');
     expect(() => ref.T).toThrow('tried to read ApiRef.T of apiRef{abc}');
@@ -43,6 +52,30 @@ describe('ApiRef', () => {
       '_',
     ]) {
       expect(() => createApiRef({ id }).id).toThrow(
+        `API id must only contain period separated lowercase alphanum tokens with dashes, got '${id}'`,
+      );
+    }
+  });
+
+  it('should reject invalid ids in chained form', () => {
+    for (const id of ['a', 'abc', 'ab-c', 'a.b.c', 'a-b.c', 'abc.a-b-c.abc3']) {
+      expect(createApiRef().with({ id }).id).toBe(id);
+    }
+
+    for (const id of [
+      '123',
+      'ab-3',
+      'ab_c',
+      '.',
+      '2ac',
+      'ab.3a',
+      '.abc',
+      'abc.',
+      'ab..s',
+      '',
+      '_',
+    ]) {
+      expect(() => createApiRef().with({ id }).id).toThrow(
         `API id must only contain period separated lowercase alphanum tokens with dashes, got '${id}'`,
       );
     }

--- a/packages/frontend-plugin-api/src/apis/system/ApiRef.ts
+++ b/packages/frontend-plugin-api/src/apis/system/ApiRef.ts
@@ -25,48 +25,75 @@ export type ApiRefConfig = {
   id: string;
 };
 
-class ApiRefImpl<T> implements ApiRef<T> {
-  constructor(private readonly config: ApiRefConfig) {
-    const valid = config.id
-      .split('.')
-      .flatMap(part => part.split('-'))
-      .every(part => part.match(/^[a-z][a-z0-9]*$/));
-    if (!valid) {
-      throw new Error(
-        `API id must only contain period separated lowercase alphanum tokens with dashes, got '${config.id}'`,
-      );
-    }
-  }
-
-  get id(): string {
-    return this.config.id;
-  }
-
-  // Utility for getting type of an api, using `typeof apiRef.T`
-  get T(): T {
-    throw new Error(`tried to read ApiRef.T of ${this}`);
-  }
-
-  toString() {
-    return `apiRef{${this.config.id}}`;
+function validateApiRefId(id: string): void {
+  const valid = id
+    .split('.')
+    .flatMap(part => part.split('-'))
+    .every(part => part.match(/^[a-z][a-z0-9]*$/));
+  if (!valid) {
+    throw new Error(
+      `API id must only contain period separated lowercase alphanum tokens with dashes, got '${id}'`,
+    );
   }
 }
 
+function createApiRefInternal<T>(id: string): ApiRef<T> {
+  validateApiRefId(id);
+  return Object.create(
+    { toString: () => `apiRef{${id}}` },
+    {
+      $$type: { value: '@backstage/ApiRef', enumerable: true },
+      id: { value: id, enumerable: true },
+      T: {
+        get(): T {
+          throw new Error(`tried to read ApiRef.T of apiRef{${id}}`);
+        },
+      },
+    },
+  );
+}
+
 /**
- * Creates a reference to an API. The provided `id` is a stable identifier for
- * the API implementation.
+ * Creates a reference to an API.
  *
  * @remarks
  *
- * The frontend system infers the owning plugin for an API from the `id`. The
+ * The recommended way to create an API reference is the chained form:
+ *
+ * ```ts
+ * const myApiRef = createApiRef<MyApi>().with({ id: 'plugin.my-plugin.my-api' });
+ * ```
+ *
+ * A shorthand form is also available for convenience:
+ *
+ * ```ts
+ * const myApiRef = createApiRef<MyApi>({ id: 'plugin.my-plugin.my-api' });
+ * ```
+ *
+ * The provided `id` is a stable identifier for the API implementation. The
+ * frontend system infers the owning plugin for an API from the `id`. The
  * recommended pattern is `plugin.<plugin-id>.*` (for example,
  * `plugin.catalog.entity-presentation`). This ensures that other plugins can't
  * mistakenly override your API implementation.
  *
  * @param config - The descriptor of the API to reference.
- * @returns An API reference.
+ * @returns An API reference, or a builder with a `.with()` method if called without arguments.
  * @public
  */
-export function createApiRef<T>(config: ApiRefConfig): ApiRef<T> {
-  return new ApiRefImpl<T>(config);
+export function createApiRef<T>(config: ApiRefConfig): ApiRef<T>;
+/** @public */
+export function createApiRef<T>(): {
+  with(config: ApiRefConfig): ApiRef<T>;
+};
+export function createApiRef<T>(
+  config?: ApiRefConfig,
+): ApiRef<T> | { with(config: ApiRefConfig): ApiRef<T> } {
+  if (config) {
+    return createApiRefInternal<T>(config.id);
+  }
+  return {
+    with(c: ApiRefConfig): ApiRef<T> {
+      return createApiRefInternal<T>(c.id);
+    },
+  };
 }

--- a/packages/frontend-plugin-api/src/apis/system/types.ts
+++ b/packages/frontend-plugin-api/src/apis/system/types.ts
@@ -20,8 +20,9 @@
  * @public
  */
 export type ApiRef<T> = {
-  id: string;
-  T: T;
+  readonly $$type: '@backstage/ApiRef';
+  readonly id: string;
+  readonly T: T;
 };
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This converts the `ApiRef` type to an opaque type with a `$$type` discriminator field, matching the pattern already used by `ExtensionDataRef`. The `createApiRef` function now also supports a chained creation form similar to `createExtensionDataRef`:

```ts
const myApiRef = createApiRef<MyApi>().with({ id: 'plugin.my-plugin.my-api' });
```

The previous shorthand form is still supported for backward compatibility:

```ts
const myApiRef = createApiRef<MyApi>({ id: 'plugin.my-plugin.my-api' });
```

All core API definitions in the new frontend system have been updated to use the chained form. Old-system API refs created via `core-plugin-api` remain fully compatible with the new system since they use the same underlying `createApiRef` function.

The `FeatureFlagConfig` type already has an optional `description` field that is wired through to `featureFlagApi.registerFlag()` in both plugins and modules, so no additional changes were needed there.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))