### PR TITLE
fix(plugin-techdocs-node): Move docs directory validation to after copying README.md

### DIFF
--- a/.changeset/tough-pots-dream.md
+++ b/.changeset/tough-pots-dream.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-node': patch
+---
+
+Fixed bug causing --legacyCopyReadmeMdToIndexMd option to fail if docs directory is not present

--- a/.changeset/tough-pots-dream.md
+++ b/.changeset/tough-pots-dream.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-techdocs-node': patch
 ---
 
-Fixed bug causing --legacyCopyReadmeMdToIndexMd option to fail if docs directory is not present
+Fixed bug causing `--legacyCopyReadmeMdToIndexMd` option to fail if docs directory is not present

--- a/packages/techdocs-cli/cli-e2e-tests/techdocs-cli.test.ts
+++ b/packages/techdocs-cli/cli-e2e-tests/techdocs-cli.test.ts
@@ -60,6 +60,7 @@ jest.setTimeout(timeout * 2);
 
 describe('end-to-end', () => {
   const cwd = path.resolve(__dirname, '../src/example-docs');
+  const legacyCwd = path.resolve(__dirname, '../src/legacy-docs');
   const entryPoint = path.resolve(__dirname, '../bin/techdocs-cli');
 
   afterEach(async () => {
@@ -102,6 +103,19 @@ describe('end-to-end', () => {
       timeout,
       env,
     });
+    expect(proc.stdout).toContain('Successfully generated docs');
+    expect(proc.exit).toEqual(0);
+  });
+
+  it('can generate with --legacyCopyReadmeMdToIndexMd option', async () => {
+    const proc = await executeCommand(
+      entryPoint,
+      ['generate', '--no-docker', '--legacyCopyReadmeMdToIndexMd'],
+      {
+        legacyCwd,
+        timeout,
+      },
+    );
     expect(proc.stdout).toContain('Successfully generated docs');
     expect(proc.exit).toEqual(0);
   });

--- a/packages/techdocs-cli/cli-e2e-tests/techdocs-cli.test.ts
+++ b/packages/techdocs-cli/cli-e2e-tests/techdocs-cli.test.ts
@@ -112,8 +112,8 @@ describe('end-to-end', () => {
       entryPoint,
       ['generate', '--no-docker', '--legacyCopyReadmeMdToIndexMd'],
       {
-        legacyCwd,
-        timeout,
+        cwd: legacyCwd,
+        timeout: timeout,
       },
     );
     expect(proc.stdout).toContain('Successfully generated docs');

--- a/packages/techdocs-cli/src/legacy-docs/README.md
+++ b/packages/techdocs-cli/src/legacy-docs/README.md
@@ -1,1 +1,1 @@
-Very simple file to test that `--legacyCopyReadmeMdToIndexMd` option work
+Very simple file to test that `--legacyCopyReadmeMdToIndexMd` option works

--- a/packages/techdocs-cli/src/legacy-docs/README.md
+++ b/packages/techdocs-cli/src/legacy-docs/README.md
@@ -1,0 +1,1 @@
+Very simple file to test that `--legacyCopyReadmeMdToIndexMd` option work

--- a/plugins/techdocs-node/src/stages/generate/helpers.test.ts
+++ b/plugins/techdocs-node/src/stages/generate/helpers.test.ts
@@ -584,6 +584,43 @@ describe('helpers', () => {
         ).rejects.toThrow(/not allowed to refer to a location outside/i);
       },
     );
+
+    it.each(['README.md', 'readme.md'])(
+      'should write %s to a symlink docs directory if docs/index.md does not exist',
+      async fileName => {
+        mockDir.setContent({
+          'target/docs': {},
+          docs: ctx => ctx.symlink('./target/docs'),
+          [fileName]: `${fileName} content`,
+        });
+
+        await patchIndexPreBuild({
+          inputDir: mockDir.path,
+          logger: mockLogger,
+        });
+
+        await expect(
+          fs.readFile(mockDir.resolve('docs/index.md'), 'utf-8'),
+        ).resolves.toEqual(`${fileName} content`);
+      },
+    );
+
+    it.each(['README.md', 'readme.md'])(
+      'should reject writing %s if targe symlink points outside of the current directory',
+      async fileName => {
+        const anotherMockDir = createMockDirectory();
+
+        mockDir.setContent({
+          docs: ctx => ctx.symlink(anotherMockDir.path),
+          'information.md': 'information.md content',
+          [fileName]: `${fileName} content`,
+        });
+
+        await expect(
+          patchIndexPreBuild({ inputDir: mockDir.path, logger: mockLogger }),
+        ).rejects.toThrow(/not allowed to refer to a location outside/i);
+      },
+    );
   });
 
   describe('addBuildTimestampMetadata', () => {

--- a/plugins/techdocs-node/src/stages/generate/helpers.test.ts
+++ b/plugins/techdocs-node/src/stages/generate/helpers.test.ts
@@ -581,11 +581,13 @@ describe('helpers', () => {
 
         await expect(
           patchIndexPreBuild({ inputDir: mockDir.path, logger: mockLogger }),
-        ).rejects.toThrow(/not allowed to refer to a location outside/i);
+        ).rejects.toThrow(
+          /Source path .* is not allowed to refer to a location outside/i,
+        );
       },
     );
 
-    it.each(['README.md', 'readme.md'])(
+    it.each(['README.md', 'readme.md', 'docs/README.md', 'docs/readme.md'])(
       'should write %s to a symlink docs directory if docs/index.md does not exist',
       async fileName => {
         mockDir.setContent({
@@ -600,25 +602,58 @@ describe('helpers', () => {
         });
 
         await expect(
-          fs.readFile(mockDir.resolve('docs/index.md'), 'utf-8'),
+          fs.readFile(mockDir.resolve('target/docs/index.md'), 'utf-8'),
         ).resolves.toEqual(`${fileName} content`);
       },
     );
 
     it.each(['README.md', 'readme.md'])(
-      'should reject writing %s if targe symlink points outside of the current directory',
+      'should reject creating docs dir if target symlink points to non-existing directory outside of the current directory',
       async fileName => {
         const anotherMockDir = createMockDirectory();
 
         mockDir.setContent({
-          docs: ctx => ctx.symlink(anotherMockDir.path),
+          docs: ctx => ctx.symlink(anotherMockDir.resolve('docs')),
           'information.md': 'information.md content',
           [fileName]: `${fileName} content`,
         });
 
         await expect(
           patchIndexPreBuild({ inputDir: mockDir.path, logger: mockLogger }),
-        ).rejects.toThrow(/not allowed to refer to a location outside/i);
+        ).rejects.toThrow(
+          /Target path .* is not allowed to refer to a location outside/i,
+        );
+
+        await expect(fs.exists(anotherMockDir.resolve('docs'))).resolves.toBe(
+          false,
+        );
+      },
+    );
+
+    it.each(['README.md', 'readme.md'])(
+      'should reject creating docs dir if target symlink points to existing directory outside of the current directory',
+      async fileName => {
+        const anotherMockDir = createMockDirectory();
+
+        mockDir.setContent({
+          docs: ctx => ctx.symlink(anotherMockDir.resolve('docs')),
+          'information.md': 'information.md content',
+          [fileName]: `${fileName} content`,
+        });
+
+        anotherMockDir.setContent({
+          docs: {},
+        });
+
+        await expect(
+          patchIndexPreBuild({ inputDir: mockDir.path, logger: mockLogger }),
+        ).rejects.toThrow(
+          /Target path .* is not allowed to refer to a location outside/i,
+        );
+
+        await expect(
+          fs.exists(anotherMockDir.resolve('docs/index.md')),
+        ).resolves.toBe(false);
       },
     );
   });

--- a/plugins/techdocs-node/src/stages/generate/helpers.test.ts
+++ b/plugins/techdocs-node/src/stages/generate/helpers.test.ts
@@ -543,6 +543,48 @@ describe('helpers', () => {
         ],
       ]);
     });
+
+    it('should use a symlink to README.md if docs/index.md does not exist', async () => {
+      mockDir.setContent({
+        'information.md': 'information.md content',
+        'README.md': ctx => ctx.symlink('./information.md'),
+      });
+
+      await patchIndexPreBuild({ inputDir: mockDir.path, logger: mockLogger });
+
+      await expect(
+        fs.readFile(mockDir.resolve('docs/index.md'), 'utf-8'),
+      ).resolves.toEqual('information.md content');
+      expect(warn.mock.calls).toEqual([
+        [`${path.normalize('docs/index.md')} not found.`],
+        [`${path.normalize('docs/README.md')} not found.`],
+        [`${path.normalize('docs/readme.md')} not found.`],
+      ]);
+    });
+
+    it('should reject a symlink pointing outside of the current directory', async () => {
+      const anotherMockDir = createMockDirectory();
+
+      mockDir.setContent({
+        'information.md': 'information.md content',
+        'README.md': ctx => ctx.symlink(anotherMockDir.resolve('tmp/secret')),
+      });
+
+      anotherMockDir.setContent({
+        tmp: {
+          secret: 'password',
+        },
+      });
+
+      await expect(
+        patchIndexPreBuild({ inputDir: mockDir.path, logger: mockLogger }),
+      ).rejects.toThrow(/not allowed to refer to a location outside/i);
+      expect(warn.mock.calls).toEqual([
+        [`${path.normalize('docs/index.md')} not found.`],
+        [`${path.normalize('docs/README.md')} not found.`],
+        [`${path.normalize('docs/readme.md')} not found.`],
+      ]);
+    });
   });
 
   describe('addBuildTimestampMetadata', () => {

--- a/plugins/techdocs-node/src/stages/generate/helpers.test.ts
+++ b/plugins/techdocs-node/src/stages/generate/helpers.test.ts
@@ -544,47 +544,47 @@ describe('helpers', () => {
       ]);
     });
 
-    it('should use a symlink to README.md if docs/index.md does not exist', async () => {
-      mockDir.setContent({
-        'information.md': 'information.md content',
-        'README.md': ctx => ctx.symlink('./information.md'),
-      });
+    it.each(['README.md', 'readme.md', 'docs/README.md', 'docs/readme.md'])(
+      'should use a symlink to %s if docs/index.md does not exist',
+      async fileName => {
+        console.log(`Testing with symlink to ${fileName}`);
+        mockDir.setContent({
+          'information.md': 'information.md content',
+          [fileName]: ctx => ctx.symlink(mockDir.resolve('information.md')),
+        });
 
-      await patchIndexPreBuild({ inputDir: mockDir.path, logger: mockLogger });
+        await patchIndexPreBuild({
+          inputDir: mockDir.path,
+          logger: mockLogger,
+        });
 
-      await expect(
-        fs.readFile(mockDir.resolve('docs/index.md'), 'utf-8'),
-      ).resolves.toEqual('information.md content');
-      expect(warn.mock.calls).toEqual([
-        [`${path.normalize('docs/index.md')} not found.`],
-        [`${path.normalize('docs/README.md')} not found.`],
-        [`${path.normalize('docs/readme.md')} not found.`],
-      ]);
-    });
+        await expect(
+          fs.readFile(mockDir.resolve('docs/index.md'), 'utf-8'),
+        ).resolves.toEqual('information.md content');
+      },
+    );
 
-    it('should reject a symlink pointing outside of the current directory', async () => {
-      const anotherMockDir = createMockDirectory();
+    it.each(['README.md', 'readme.md', 'docs/README.md', 'docs/readme.md'])(
+      'should reject a symlink from %s to outside of the current directory',
+      async fileName => {
+        const anotherMockDir = createMockDirectory();
 
-      mockDir.setContent({
-        'information.md': 'information.md content',
-        'README.md': ctx => ctx.symlink(anotherMockDir.resolve('tmp/secret')),
-      });
+        mockDir.setContent({
+          'information.md': 'information.md content',
+          [fileName]: ctx => ctx.symlink(anotherMockDir.resolve('tmp/secret')),
+        });
 
-      anotherMockDir.setContent({
-        tmp: {
-          secret: 'password',
-        },
-      });
+        anotherMockDir.setContent({
+          tmp: {
+            secret: 'password',
+          },
+        });
 
-      await expect(
-        patchIndexPreBuild({ inputDir: mockDir.path, logger: mockLogger }),
-      ).rejects.toThrow(/not allowed to refer to a location outside/i);
-      expect(warn.mock.calls).toEqual([
-        [`${path.normalize('docs/index.md')} not found.`],
-        [`${path.normalize('docs/README.md')} not found.`],
-        [`${path.normalize('docs/readme.md')} not found.`],
-      ]);
-    });
+        await expect(
+          patchIndexPreBuild({ inputDir: mockDir.path, logger: mockLogger }),
+        ).rejects.toThrow(/not allowed to refer to a location outside/i);
+      },
+    );
   });
 
   describe('addBuildTimestampMetadata', () => {

--- a/plugins/techdocs-node/src/stages/generate/helpers.test.ts
+++ b/plugins/techdocs-node/src/stages/generate/helpers.test.ts
@@ -547,7 +547,6 @@ describe('helpers', () => {
     it.each(['README.md', 'readme.md', 'docs/README.md', 'docs/readme.md'])(
       'should use a symlink to %s if docs/index.md does not exist',
       async fileName => {
-        console.log(`Testing with symlink to ${fileName}`);
         mockDir.setContent({
           'information.md': 'information.md content',
           [fileName]: ctx => ctx.symlink(mockDir.resolve('information.md')),

--- a/plugins/techdocs-node/src/stages/generate/helpers.ts
+++ b/plugins/techdocs-node/src/stages/generate/helpers.ts
@@ -397,11 +397,16 @@ export const patchIndexPreBuild = async ({
     path.join(inputDir, 'readme.md'),
   ];
 
+  if (!isChildPath(inputDir, docsPath)) {
+    throw new NotAllowedError(
+      `Target path ${docsPath} is not allowed to refer to a location outside ${inputDir}`,
+    );
+  }
   await fs.ensureDir(docsPath);
   for (const filePath of fallbacks) {
     if (!isChildPath(inputDir, filePath)) {
       throw new NotAllowedError(
-        `Path ${filePath} is not allowed to refer to a location outside ${inputDir}`,
+        `Source path ${filePath} is not allowed to refer to a location outside ${inputDir}`,
       );
     }
     try {

--- a/plugins/techdocs-node/src/stages/generate/helpers.ts
+++ b/plugins/techdocs-node/src/stages/generate/helpers.ts
@@ -399,6 +399,11 @@ export const patchIndexPreBuild = async ({
 
   await fs.ensureDir(docsPath);
   for (const filePath of fallbacks) {
+    if (!isChildPath(inputDir, filePath)) {
+      throw new NotAllowedError(
+        `Path ${filePath} is not allowed to refer to a location outside ${inputDir}`,
+      );
+    }
     try {
       await fs.copyFile(filePath, indexMdPath);
       return;

--- a/plugins/techdocs-node/src/stages/generate/techdocs.ts
+++ b/plugins/techdocs-node/src/stages/generate/techdocs.ts
@@ -121,11 +121,6 @@ export class TechdocsGenerator implements GeneratorBase {
       this.options.dangerouslyAllowAdditionalKeys,
     );
 
-    // Validate that no symlinks in the docs directory point outside the input directory
-    // This prevents path traversal attacks where malicious symlinks could leak host files
-    const resolvedDocsDir = path.join(inputDir, docsDir ?? 'docs');
-    await validateDocsDirectory(resolvedDocsDir, inputDir);
-
     if (parsedLocationAnnotation) {
       await patchMkdocsYmlPreBuild(
         mkdocsYmlPath,
@@ -138,6 +133,12 @@ export class TechdocsGenerator implements GeneratorBase {
     if (this.options.legacyCopyReadmeMdToIndexMd) {
       await patchIndexPreBuild({ inputDir, logger: childLogger, docsDir });
     }
+
+    // Validate that no symlinks in the docs directory point outside the input directory
+    // This prevents path traversal attacks where malicious symlinks could leak host files
+    const resolvedDocsDir = path.join(inputDir, docsDir ?? 'docs');
+
+    await validateDocsDirectory(resolvedDocsDir, inputDir);
 
     // patch the list of mkdocs plugins
     const defaultPlugins = this.options.defaultPlugins ?? [];


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This MR fixes https://github.com/backstage/backstage/issues/32714 and also prevents a security issue when `README.md` is actually a symbolic link pointing outside of the input directory.

CC: @benjdlambert @mrackoa

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
