### PR TITLE
GitLab Discovery Provider: Add glob support for entityFilename (including .yaml/.yml)

### DIFF
--- a/.changeset/gitlab-discovery-entity-provider-glob-pattern.md
+++ b/.changeset/gitlab-discovery-entity-provider-glob-pattern.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-gitlab': patch
+---
+
+Added glob pattern support for `catalog.providers.gitlab.<id>.entityFilename` in `GitlabDiscoveryEntityProvider`, including push event handling for matching added, removed, and modified files. This includes patterns such as `**/catalog-info.y?(a)ml` to discover both `.yaml` and `.yml` catalog files.

--- a/docs/integrations/gitlab/discovery.md
+++ b/docs/integrations/gitlab/discovery.md
@@ -90,8 +90,20 @@ catalog:
 
 - **Glob patterns and `useSearch` are incompatible**: When `useSearch: true` is enabled, the provider uses GitLab's search API which does not support glob patterns. If you need glob pattern support (e.g., `**/catalog-info.y?(a)ml`), you must set `useSearch: false`. Attempting to use both will result in an error.
 
-- **Performance considerations**: Glob patterns require scanning repository trees recursively, which can be significantly more resource-intensive than exact filename matching or search API usage, especially for large monorepos or instances with many projects.
+- **Performance considerations**: Glob patterns significantly change the API call pattern and resource usage:
 
+  - **Exact filename** (e.g., `catalog-info.yaml`): `O(projects)` - Makes one HEAD request per project to check file existence
+  - **Glob patterns** (e.g., `**/catalog-info.y?(a)ml`): `O(projects × files)` - Requires recursive tree scanning of entire repository structure
+
+For large installations (100+ projects with 1000+ files each), this can mean the difference between hundreds and tens of thousands of API calls per refresh.
+
+**Recommendations:**
+
+- Use exact filenames (`catalog-info.yaml`) for most cases
+- GitLab Premium/Ultimate users should consider setting `useSearch: true` with exact filenames over glob patterns, to avoid performance degradation
+- Use glob patterns only when necessary for monorepo discovery or matching multiple file extensions
+- Consider [GitLab REST API rate limits](https://docs.gitlab.com/ee/api/rest/index.html#rate-limits) which may be hit with extensive tree scanning
+- Schedule glob-based refreshes during off-peak hours to avoid impacting other GitLab operations
 :::
 
 ## Alternative processor

--- a/docs/integrations/gitlab/discovery.md
+++ b/docs/integrations/gitlab/discovery.md
@@ -104,7 +104,7 @@ For large installations (100+ projects with 1000+ files each), this can mean the
 - Use glob patterns only when necessary for monorepo discovery or matching multiple file extensions
 - Consider [GitLab REST API rate limits](https://docs.gitlab.com/ee/api/rest/index.html#rate-limits) which may be hit with extensive tree scanning
 - Schedule glob-based refreshes during off-peak hours to avoid impacting other GitLab operations
-:::
+  :::
 
 ## Alternative processor
 

--- a/docs/integrations/gitlab/discovery.md
+++ b/docs/integrations/gitlab/discovery.md
@@ -76,7 +76,7 @@ catalog:
           - '^somegroup$'
           - 'anothergroup'
         entityFilename: catalog-info.yaml # Optional. Defaults to `catalog-info.yaml`. Supports glob patterns like `**/catalog-info.yaml` and `**/catalog-info.y?(a)ml` (to match both `.yaml` and `.yml`)
-        useSearch: false # Optional. Whether to use the GitLab group search API to find files. Requires Gitlab 'Premium' or 'Ultimate' licenses.  Defaults to `false`
+        useSearch: false # Optional. Whether to use the GitLab group search API to find files. Requires Gitlab 'Premium' or 'Ultimate' licenses. Defaults to `false`. **Note: Cannot be used with glob patterns in entityFilename**
         projectPattern: '[\s\S]*' # Optional. Filters found projects based on provided pattern. Defaults to `[\s\S]*`, which means to not filter anything
         excludeRepos: [] # Optional. A list of project paths that should be excluded from discovery, e.g. group/subgroup/repo. Should not start or end with a slash.
         schedule: # Same options as in SchedulerServiceTaskScheduleDefinition. Optional for the Legacy Backend System
@@ -85,6 +85,14 @@ catalog:
           # supports ISO duration, "human duration" as used in code
           timeout: { minutes: 3 }
 ```
+
+:::caution Important Limitations
+
+- **Glob patterns and `useSearch` are incompatible**: When `useSearch: true` is enabled, the provider uses GitLab's search API which does not support glob patterns. If you need glob pattern support (e.g., `**/catalog-info.y?(a)ml`), you must set `useSearch: false`. Attempting to use both will result in an error.
+
+- **Performance considerations**: Glob patterns require scanning repository trees recursively, which can be significantly more resource-intensive than exact filename matching or search API usage, especially for large monorepos or instances with many projects.
+
+:::
 
 ## Alternative processor
 

--- a/docs/integrations/gitlab/discovery.md
+++ b/docs/integrations/gitlab/discovery.md
@@ -75,7 +75,7 @@ catalog:
         groupPattern: # Optional. Filters for groups based on a list of RegEx. Default, no filters.
           - '^somegroup$'
           - 'anothergroup'
-        entityFilename: catalog-info.yaml # Optional. Defaults to `catalog-info.yaml`
+        entityFilename: catalog-info.yaml # Optional. Defaults to `catalog-info.yaml`. Supports glob patterns like `**/catalog-info.yaml` and `**/catalog-info.y?(a)ml` (to match both `.yaml` and `.yml`)
         useSearch: false # Optional. Whether to use the GitLab group search API to find files. Requires Gitlab 'Premium' or 'Ultimate' licenses.  Defaults to `false`
         projectPattern: '[\s\S]*' # Optional. Filters found projects based on provided pattern. Defaults to `[\s\S]*`, which means to not filter anything
         excludeRepos: [] # Optional. A list of project paths that should be excluded from discovery, e.g. group/subgroup/repo. Should not start or end with a slash.

--- a/plugins/catalog-backend-module-gitlab/package.json
+++ b/plugins/catalog-backend-module-gitlab/package.json
@@ -62,8 +62,7 @@
     "@backstage/plugin-events-node": "workspace:^",
     "@gitbeaker/rest": "^40.0.3",
     "lodash": "^4.17.21",
-    "node-fetch": "^2.7.0",
-    "minimatch": "^10.2.1",
+    "minimatch": "^10.2.1"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "workspace:^",

--- a/plugins/catalog-backend-module-gitlab/package.json
+++ b/plugins/catalog-backend-module-gitlab/package.json
@@ -61,7 +61,9 @@
     "@backstage/plugin-catalog-node": "workspace:^",
     "@backstage/plugin-events-node": "workspace:^",
     "@gitbeaker/rest": "^40.0.3",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "node-fetch": "^2.7.0",
+    "minimatch": "^10.2.1",
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "workspace:^",

--- a/plugins/catalog-backend-module-gitlab/src/__testUtils__/handlers.ts
+++ b/plugins/catalog-backend-module-gitlab/src/__testUtils__/handlers.ts
@@ -304,20 +304,56 @@ const httpProjectFindByIdDynamic = all_projects_response.map(project => {
  * See https://docs.gitlab.com/api/repository_files/#get-file-from-repository
  */
 const httpProjectCatalogDynamic = all_projects_response.flatMap(project => {
-  return rest.head(
-    `${apiBaseUrl}/projects/${project.id.toString()}/repository/files/catalog-info.yaml`,
-    (req, res, ctx) => {
-      const branch = req.url.searchParams.get('ref');
-      if (
-        branch === project.default_branch ||
-        branch === 'main' ||
-        branch === 'develop'
-      ) {
-        return res(ctx.status(200));
-      }
-      return res(ctx.status(404, 'Not Found'));
-    },
-  );
+  return [
+    rest.head(
+      `${apiBaseUrl}/projects/${project.id.toString()}/repository/files/catalog-info.yaml`,
+      (req, res, ctx) => {
+        const branch = req.url.searchParams.get('ref');
+        if (
+          branch === project.default_branch ||
+          branch === 'main' ||
+          branch === 'develop'
+        ) {
+          return res(ctx.status(200));
+        }
+        return res(ctx.status(404, 'Not Found'));
+      },
+    ),
+    rest.get(
+      `${apiBaseUrl}/projects/${project.id.toString()}/repository/tree`,
+      (_, res, ctx) => {
+        return res(
+          ctx.set('x-next-page', ''),
+          ctx.json([
+            {
+              id: `root-${project.id}`,
+              name: 'catalog-info.yaml',
+              type: 'blob',
+              path: 'catalog-info.yaml',
+            },
+            {
+              id: `nested-${project.id}`,
+              name: 'catalog-info.yaml',
+              type: 'blob',
+              path: 'service/catalog-info.yaml',
+            },
+            {
+              id: `nested-yml-${project.id}`,
+              name: 'catalog-info.yml',
+              type: 'blob',
+              path: 'apps/catalog-info.yml',
+            },
+            {
+              id: `docs-${project.id}`,
+              name: 'README.md',
+              type: 'blob',
+              path: 'docs/README.md',
+            },
+          ]),
+        );
+      },
+    ),
+  ];
 });
 
 /**

--- a/plugins/catalog-backend-module-gitlab/src/__testUtils__/mocks.ts
+++ b/plugins/catalog-backend-module-gitlab/src/__testUtils__/mocks.ts
@@ -242,6 +242,63 @@ export const config_single_integration: MockObject = {
   },
 };
 
+export const config_single_integration_wildcard_entity_filename: MockObject = {
+  integrations: {
+    gitlab: [
+      {
+        host: 'example.com',
+        apiBaseUrl: 'https://example.com/api/v4',
+        token: '1234',
+      },
+    ],
+  },
+  catalog: {
+    providers: {
+      gitlab: {
+        'test-id': {
+          host: 'example.com',
+          group: 'group1',
+          entityFilename: '**/catalog-info.yaml',
+          skipForkedRepos: false,
+          schedule: {
+            frequency: 'PT30M',
+            timeout: 'PT3M',
+          },
+        },
+      },
+    },
+  },
+};
+
+export const config_single_integration_wildcard_entity_filename_yaml_and_yml: MockObject =
+  {
+    integrations: {
+      gitlab: [
+        {
+          host: 'example.com',
+          apiBaseUrl: 'https://example.com/api/v4',
+          token: '1234',
+        },
+      ],
+    },
+    catalog: {
+      providers: {
+        gitlab: {
+          'test-id': {
+            host: 'example.com',
+            group: 'group1',
+            entityFilename: '**/catalog-info.y?(a)ml',
+            skipForkedRepos: false,
+            schedule: {
+              frequency: 'PT30M',
+              timeout: 'PT3M',
+            },
+          },
+        },
+      },
+    },
+  };
+
 export const config_single_integration_specific_branch: MockObject = {
   integrations: {
     gitlab: [

--- a/plugins/catalog-backend-module-gitlab/src/lib/client.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/client.ts
@@ -26,6 +26,7 @@ import {
   GitLabGroup,
   GitLabGroupMembersResponse,
   GitLabProject,
+  GitLabRepositoryTreeItem,
   GitLabUser,
   PagedResponse,
 } from './types';
@@ -48,6 +49,12 @@ interface ListProjectOptions extends CommonListOptions {
 interface ListFilesOptions extends CommonListOptions {
   group?: string;
   search?: string;
+}
+
+interface ListProjectTreeOptions extends CommonListOptions {
+  ref?: string;
+  recursive?: boolean;
+  path?: string;
 }
 
 interface UserListOptions extends CommonListOptions {
@@ -212,6 +219,21 @@ export class GitLabClient {
     return {
       items: [],
     };
+  }
+
+  async listProjectTree(
+    projectIdentifier: string | number,
+    options?: ListProjectTreeOptions,
+  ): Promise<PagedResponse<GitLabRepositoryTreeItem>> {
+    const encodedProjectId =
+      typeof projectIdentifier === 'string'
+        ? encodeURIComponent(projectIdentifier)
+        : projectIdentifier;
+
+    return this.pagedRequest(
+      `/projects/${encodedProjectId}/repository/tree`,
+      options,
+    );
   }
 
   // https://docs.gitlab.com/ee/api/groups.html#list-group-details

--- a/plugins/catalog-backend-module-gitlab/src/lib/index.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/index.ts
@@ -21,6 +21,7 @@ export type {
   GitLabGroup,
   GitLabGroupSamlIdentity,
   GitLabProject,
+  GitLabRepositoryTreeItem,
   GitLabUser,
   GitlabGroupDescription,
   GitlabProviderConfig,

--- a/plugins/catalog-backend-module-gitlab/src/lib/types.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/types.ts
@@ -110,6 +110,14 @@ export type GitLabFile = {
   project_id: number;
 };
 
+export type GitLabRepositoryTreeItem = {
+  id: string;
+  name: string;
+  type: 'blob' | 'tree';
+  path: string;
+  mode?: string;
+};
+
 export type GitLabGroupMembersResponse = {
   errors: { message: string }[];
   data: {

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.test.ts
@@ -217,6 +217,70 @@ describe('GitlabDiscoveryEntityProvider - refresh', () => {
     });
   });
 
+  it('should discover all wildcard matches in a project tree', async () => {
+    const config = new ConfigReader(
+      mock.config_single_integration_wildcard_entity_filename,
+    );
+    const schedule = new PersistingTaskRunner();
+    const entityProviderConnection: EntityProviderConnection = {
+      applyMutation: jest.fn(),
+      refresh: jest.fn(),
+    };
+    const provider = GitlabDiscoveryEntityProvider.fromConfig(config, {
+      logger,
+      schedule,
+    })[0];
+
+    await provider.connect(entityProviderConnection);
+    await provider.refresh(logger);
+
+    const mutationCalls = (entityProviderConnection.applyMutation as jest.Mock)
+      .mock.calls;
+    const lastCall = mutationCalls[mutationCalls.length - 1][0];
+    const targets = lastCall.entities.map(
+      (entity: any) => entity.entity.spec.target,
+    );
+
+    expect(targets).toContain(
+      'https://example.com/group1/test-repo1/-/blob/main/catalog-info.yaml',
+    );
+    expect(targets).toContain(
+      'https://example.com/group1/test-repo1/-/blob/main/service/catalog-info.yaml',
+    );
+  });
+
+  it('should discover both yaml and yml catalog files with a glob pattern', async () => {
+    const config = new ConfigReader(
+      mock.config_single_integration_wildcard_entity_filename_yaml_and_yml,
+    );
+    const schedule = new PersistingTaskRunner();
+    const entityProviderConnection: EntityProviderConnection = {
+      applyMutation: jest.fn(),
+      refresh: jest.fn(),
+    };
+    const provider = GitlabDiscoveryEntityProvider.fromConfig(config, {
+      logger,
+      schedule,
+    })[0];
+
+    await provider.connect(entityProviderConnection);
+    await provider.refresh(logger);
+
+    const mutationCalls = (entityProviderConnection.applyMutation as jest.Mock)
+      .mock.calls;
+    const lastCall = mutationCalls[mutationCalls.length - 1][0];
+    const targets = lastCall.entities.map(
+      (entity: any) => entity.entity.spec.target,
+    );
+
+    expect(targets).toContain(
+      'https://example.com/group1/test-repo1/-/blob/main/service/catalog-info.yaml',
+    );
+    expect(targets).toContain(
+      'https://example.com/group1/test-repo1/-/blob/main/apps/catalog-info.yml',
+    );
+  });
+
   it('should filter fork projects', async () => {
     const config = new ConfigReader(mock.config_single_integration_skip_forks);
     const schedule = new PersistingTaskRunner();
@@ -596,6 +660,41 @@ describe('GitlabDiscoveryEntityProvider - events', () => {
       ],
     });
     expect(entityProviderConnection.applyMutation).toHaveBeenCalledTimes(0);
+  });
+
+  it('should match wildcard entity filenames on push events', async () => {
+    const config = new ConfigReader(
+      mock.config_single_integration_wildcard_entity_filename,
+    );
+    const schedule = new PersistingTaskRunner();
+    const events = DefaultEventsService.create({ logger });
+    const entityProviderConnection: EntityProviderConnection = {
+      applyMutation: jest.fn(),
+      refresh: jest.fn(),
+    };
+    const provider = GitlabDiscoveryEntityProvider.fromConfig(config, {
+      logger,
+      schedule,
+      events,
+    })[0];
+
+    await provider.connect(entityProviderConnection);
+    await events.publish(mock.push_add_event);
+
+    expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith({
+      type: 'delta',
+      added: expect.arrayContaining([
+        expect.objectContaining({
+          entity: expect.objectContaining({
+            spec: expect.objectContaining({
+              target:
+                'https://example.com/group1/test-repo1/-/blob/main/cool-folder-1/cool-folder-2/catalog-info.yaml',
+            }),
+          }),
+        }),
+      ]),
+      removed: [],
+    });
   });
 
   it('should ignore projects when none of the groups regex patterns match', async () => {

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.test.ts
@@ -281,6 +281,52 @@ describe('GitlabDiscoveryEntityProvider - refresh', () => {
     );
   });
 
+  it('should continue discovery when one project tree scan fails', async () => {
+    const config = new ConfigReader(
+      mock.config_single_integration_wildcard_entity_filename,
+    );
+    const schedule = new PersistingTaskRunner();
+    const entityProviderConnection: EntityProviderConnection = {
+      applyMutation: jest.fn(),
+      refresh: jest.fn(),
+    };
+    const provider = GitlabDiscoveryEntityProvider.fromConfig(config, {
+      logger,
+      schedule,
+    })[0];
+
+    const originalListProjectTree = (provider as any).gitLabClient
+      .listProjectTree;
+    (provider as any).gitLabClient.listProjectTree = jest
+      .fn()
+      .mockImplementation(async (projectId: number, options: unknown) => {
+        if (projectId === 1) {
+          throw new TypeError('fetch failed');
+        }
+
+        return originalListProjectTree.call(
+          (provider as any).gitLabClient,
+          projectId,
+          options,
+        );
+      });
+
+    await provider.connect(entityProviderConnection);
+    await expect(provider.refresh(logger)).resolves.toBeUndefined();
+
+    const mutationCalls = (entityProviderConnection.applyMutation as jest.Mock)
+      .mock.calls;
+    const lastCall = mutationCalls[mutationCalls.length - 1][0];
+    const targets = lastCall.entities.map(
+      (entity: any) => entity.entity.spec.target,
+    );
+
+    expect(targets.length).toBeGreaterThan(0);
+    expect(
+      targets.some((target: string) => target.includes('/test-repo1/')),
+    ).toBe(false);
+  });
+
   it('should filter fork projects', async () => {
     const config = new ConfigReader(mock.config_single_integration_skip_forks);
     const schedule = new PersistingTaskRunner();

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.test.ts
@@ -560,25 +560,13 @@ describe('GitlabDiscoveryEntityProvider - refresh', () => {
   });
 
   it('should throw error when useSearch is combined with glob patterns', async () => {
-    const config = new ConfigReader({
-      integrations: mock.integrations,
-      catalog: {
-        providers: {
-          gitlab: {
-            testProvider: {
-              host: 'gitlab.com',
-              entityFilename: '**/catalog-info.y?(a)ml', // glob pattern
-              useSearch: true, // This combination should error
-            },
-          },
-        },
-      },
-    });
+    const config = new ConfigReader(mock.config_no_org_integration);
 
     const schedule = new PersistingTaskRunner();
     const testLogger = mockServices.logger.mock();
     const entityProviderConnection: EntityProviderConnection = {
       applyMutation: jest.fn(),
+      refresh: jest.fn(),
     };
 
     const provider = GitlabDiscoveryEntityProvider.fromConfig(config, {

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.test.ts
@@ -560,7 +560,28 @@ describe('GitlabDiscoveryEntityProvider - refresh', () => {
   });
 
   it('should throw error when useSearch is combined with glob patterns', async () => {
-    const config = new ConfigReader(mock.config_no_org_integration);
+    const config = new ConfigReader({
+      integrations: {
+        gitlab: [
+          {
+            host: 'gitlab.com',
+            apiBaseUrl: 'https://gitlab.com/api/v4',
+            token: 'token',
+          },
+        ],
+      },
+      catalog: {
+        providers: {
+          gitlab: {
+            testProvider: {
+              host: 'gitlab.com',
+              entityFilename: '**/catalog-info.y?(a)ml', // glob pattern
+              useSearch: true, // This combination should error
+            },
+          },
+        },
+      },
+    });
 
     const schedule = new PersistingTaskRunner();
     const testLogger = mockServices.logger.mock();

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.test.ts
@@ -558,6 +558,40 @@ describe('GitlabDiscoveryEntityProvider - refresh', () => {
       ),
     });
   });
+
+  it('should throw error when useSearch is combined with glob patterns', async () => {
+    const config = new ConfigReader({
+      integrations: mock.integrations,
+      catalog: {
+        providers: {
+          gitlab: {
+            testProvider: {
+              host: 'gitlab.com',
+              entityFilename: '**/catalog-info.y?(a)ml', // glob pattern
+              useSearch: true, // This combination should error
+            },
+          },
+        },
+      },
+    });
+
+    const schedule = new PersistingTaskRunner();
+    const testLogger = mockServices.logger.mock();
+    const entityProviderConnection: EntityProviderConnection = {
+      applyMutation: jest.fn(),
+    };
+
+    const provider = GitlabDiscoveryEntityProvider.fromConfig(config, {
+      logger: testLogger,
+      schedule,
+    })[0];
+
+    await provider.connect(entityProviderConnection);
+
+    await expect(provider.refresh(testLogger)).rejects.toThrow(
+      'useSearch=true does not support glob patterns in entityFilename',
+    );
+  });
 });
 describe('GitlabDiscoveryEntityProvider - events', () => {
   it('should ignore push event if project is forked', async () => {

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts
@@ -753,6 +753,13 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
       return this.catalogFileMatcher.match(filePath);
     }
 
-    return path.basename(filePath) === this.config.catalogFile;
+    const configuredCatalogFile = this.config.catalogFile;
+    const hasPathSeparator =
+      configuredCatalogFile.includes('/') ||
+      configuredCatalogFile.includes('\\');
+    if (hasPathSeparator) {
+      return filePath === configuredCatalogFile;
+    }
+    return path.basename(filePath) === configuredCatalogFile;
   }
 }

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts
@@ -414,10 +414,19 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
     for await (const project of projects) {
       res.scanned++;
 
-      const matchingFiles = await this.getProjectCatalogFiles(
-        project,
-        this.gitLabClient,
-      );
+      let matchingFiles: string[] = [];
+
+      try {
+        matchingFiles = await this.getProjectCatalogFiles(
+          project,
+          this.gitLabClient,
+        );
+      } catch (error) {
+        this.logger.warn(
+          `Skipping project ${project.path_with_namespace} due to error while scanning catalog files: ${error}`,
+        );
+        continue;
+      }
 
       for (const catalogFile of matchingFiles) {
         res.matches.push({ project, catalogFile });
@@ -704,20 +713,32 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
     }
 
     const matchingFiles: string[] = [];
-    const projectFiles = paginated<GitLabRepositoryTreeItem>(
-      options => client.listProjectTree(project.id, options),
-      {
-        page: 1,
-        per_page: 100,
-        ref: project_branch,
-        recursive: true,
-      },
-    );
+    try {
+      const projectFiles = paginated<GitLabRepositoryTreeItem>(
+        options => client.listProjectTree(project.id, options),
+        {
+          page: 1,
+          per_page: 100,
+          ref: project_branch,
+          recursive: true,
+        },
+      );
 
-    for await (const file of projectFiles) {
-      if (file.type === 'blob' && this.catalogFileMatcher.match(file.path)) {
-        matchingFiles.push(file.path);
+      for await (const file of projectFiles) {
+        if (file.type === 'blob' && this.catalogFileMatcher.match(file.path)) {
+          matchingFiles.push(file.path);
+        }
       }
+    } catch (error) {
+      const message = String(error);
+      if (message.includes('Expected 200 but got 404')) {
+        this.logger.debug(
+          `Skipping project ${project.path_with_namespace} while scanning repository tree at ref '${project_branch}' due to 404 response.`,
+        );
+        return [];
+      }
+
+      throw error;
     }
 
     return matchingFiles;

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts
@@ -218,20 +218,22 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
       );
     }
 
+    // Validate that useSearch and glob patterns are not used together
+    if (this.config.useSearch && this.catalogFileMatcher.hasMagic()) {
+      throw new Error(
+        `useSearch=true does not support glob patterns in entityFilename. ` +
+          `Either set useSearch=false or use an exact filename without glob patterns. ` +
+          `Current entityFilename: '${this.config.catalogFile}'`,
+      );
+    }
+
     this.logger.info(
       `Refreshing Gitlab entity discovery using ${
         this.config.useSearch ? 'search' : 'discovery'
       } mode`,
     );
 
-    const shouldUseSearch =
-      this.config.useSearch && !this.catalogFileMatcher.hasMagic();
-
-    if (this.config.useSearch && this.catalogFileMatcher.hasMagic()) {
-      this.logger.warn(
-        `useSearch=true does not support glob patterns in entityFilename, falling back to discovery mode for '${this.config.catalogFile}'.`,
-      );
-    }
+    const shouldUseSearch = this.config.useSearch;
 
     const locations = shouldUseSearch
       ? await this.searchEntities()

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts
@@ -500,21 +500,9 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
     }
 
     // Get array of added, removed or modified files from the push event
-    const added = this.getFilesMatchingConfig(
-      event,
-      'added',
-      this.catalogFileMatcher,
-    );
-    const removed = this.getFilesMatchingConfig(
-      event,
-      'removed',
-      this.catalogFileMatcher,
-    );
-    const modified = this.getFilesMatchingConfig(
-      event,
-      'modified',
-      this.catalogFileMatcher,
-    );
+    const added = this.getFilesMatchingConfig(event, 'added');
+    const removed = this.getFilesMatchingConfig(event, 'removed');
+    const modified = this.getFilesMatchingConfig(event, 'modified');
 
     // Modified files will be scheduled to a refresh
     const addedEntities = this.createLocationSpecCommittedFiles(
@@ -576,7 +564,6 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
   private getFilesMatchingConfig(
     event: WebhookPushEventSchema,
     action: 'added' | 'removed' | 'modified',
-    catalogFileMatcher: Minimatch,
   ): string[] {
     if (!event.commits) {
       return [];
@@ -588,7 +575,7 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
 
     if (matchingFiles.length === 0) {
       this.logger.debug(
-        `No files matching '${catalogFileMatcher.pattern}' found in the commits.`,
+        `No files matching '${this.catalogFileMatcher.pattern}' found in the commits.`,
       );
     }
 

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts
@@ -425,7 +425,8 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
         );
       } catch (error) {
         this.logger.warn(
-          `Skipping project ${project.path_with_namespace} due to error while scanning catalog files: ${error}`,
+          `Skipping project ${project.path_with_namespace} due to error while scanning catalog files`,
+          error,
         );
         continue;
       }

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts
@@ -369,10 +369,10 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
   }
 
   /**
-   * Deduplicate a list of projects based on their id.
+   * Deduplicate a list of catalog locations based on their target.
    *
-   * @param projects - a list of projects to be deduplicated
-   * @returns a list of projects with unique id
+   * @param locations - a list of locations to be deduplicated
+   * @returns a list of locations with unique targets
    */
   private deduplicateLocations(locations: LocationSpec[]): LocationSpec[] {
     const uniqueLocations = new Map<string, LocationSpec>();
@@ -554,12 +554,14 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
   }
 
   /**
-   * Gets files matching the specified commit action and catalog file name.
+   * Gets files matching the specified commit action using the instance's catalog file matcher.
+   *
+   * For glob patterns: matches full file paths against the pattern.
+   * For exact filenames: matches basenames against the configured filename.
    *
    * @param event - The push event payload.
    * @param action - The action type ('added', 'removed', or 'modified').
-   * @param catalogFile - The catalog file name.
-   * @returns An array of file paths.
+   * @returns An array of file paths that match the configured catalog file pattern.
    */
   private getFilesMatchingConfig(
     event: WebhookPushEventSchema,

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts
@@ -35,18 +35,24 @@ import {
   GitLabClient,
   GitLabGroup,
   GitLabProject,
+  GitLabRepositoryTreeItem,
   GitlabProviderConfig,
   paginated,
   readGitlabConfigs,
 } from '../lib';
-
+import { Minimatch } from 'minimatch';
 import * as path from 'node:path';
 
 const TOPIC_REPO_PUSH = 'gitlab.push';
 
 type Result = {
   scanned: number;
-  matches: GitLabProject[];
+  matches: MatchedProjectFile[];
+};
+
+type MatchedProjectFile = {
+  project: GitLabProject;
+  catalogFile: string;
 };
 
 /**
@@ -66,6 +72,7 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
   private connection?: EntityProviderConnection;
   private readonly events?: EventsService;
   private readonly gitLabClient: GitLabClient;
+  private readonly catalogFileMatcher: Minimatch;
 
   static fromConfig(
     config: Config,
@@ -137,6 +144,9 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
     this.gitLabClient = new GitLabClient({
       integration: this.integration,
       logger: this.logger,
+    });
+    this.catalogFileMatcher = new Minimatch(this.config.catalogFile, {
+      dot: true,
     });
   }
 
@@ -214,7 +224,16 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
       } mode`,
     );
 
-    const locations = this.config.useSearch
+    const shouldUseSearch =
+      this.config.useSearch && !this.catalogFileMatcher.hasMagic();
+
+    if (this.config.useSearch && this.catalogFileMatcher.hasMagic()) {
+      this.logger.warn(
+        `useSearch=true does not support glob patterns in entityFilename, falling back to discovery mode for '${this.config.catalogFile}'.`,
+      );
+    }
+
+    const locations = shouldUseSearch
       ? await this.searchEntities()
       : await this.getEntities();
 
@@ -336,8 +355,8 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
       res = await this.getProjectsToProcess(this.config.group);
     }
 
-    const locations = this.deduplicateProjects(res.matches).map(p =>
-      this.createLocationSpec(p),
+    const locations = this.deduplicateLocations(
+      res.matches.map(match => this.createLocationSpec(match)),
     );
 
     this.logger.info(
@@ -353,14 +372,14 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
    * @param projects - a list of projects to be deduplicated
    * @returns a list of projects with unique id
    */
-  private deduplicateProjects(projects: GitLabProject[]): GitLabProject[] {
-    const uniqueProjects = new Map<number, GitLabProject>();
+  private deduplicateLocations(locations: LocationSpec[]): LocationSpec[] {
+    const uniqueLocations = new Map<string, LocationSpec>();
 
-    for (const project of projects) {
-      uniqueProjects.set(project.id, project);
+    for (const location of locations) {
+      uniqueLocations.set(location.target, location);
     }
 
-    return Array.from(uniqueProjects.values());
+    return Array.from(uniqueLocations.values());
   }
 
   /**
@@ -395,8 +414,13 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
     for await (const project of projects) {
       res.scanned++;
 
-      if (await this.shouldProcessProject(project, this.gitLabClient)) {
-        res.matches.push(project);
+      const matchingFiles = await this.getProjectCatalogFiles(
+        project,
+        this.gitLabClient,
+      );
+
+      for (const catalogFile of matchingFiles) {
+        res.matches.push({ project, catalogFile });
       }
     }
 
@@ -415,7 +439,8 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
     };
   }
 
-  private createLocationSpec(project: GitLabProject): LocationSpec {
+  private createLocationSpec(projectMatch: MatchedProjectFile): LocationSpec {
+    const { project, catalogFile } = projectMatch;
     const project_branch =
       this.config.branch ??
       project.default_branch ??
@@ -424,7 +449,7 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
     return this.createLocationSpecFromParams(
       project.web_url,
       project_branch,
-      this.config.catalogFile,
+      catalogFile,
     );
   }
 
@@ -453,7 +478,12 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
       return;
     }
 
-    if (!(await this.shouldProcessProject(project, this.gitLabClient))) {
+    const projectCatalogFiles = await this.getProjectCatalogFiles(
+      project,
+      this.gitLabClient,
+    );
+
+    if (projectCatalogFiles.length === 0) {
       this.logger.debug(`Skipping event ${event.project.path_with_namespace}`);
       return;
     }
@@ -462,17 +492,17 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
     const added = this.getFilesMatchingConfig(
       event,
       'added',
-      this.config.catalogFile,
+      this.catalogFileMatcher,
     );
     const removed = this.getFilesMatchingConfig(
       event,
       'removed',
-      this.config.catalogFile,
+      this.catalogFileMatcher,
     );
     const modified = this.getFilesMatchingConfig(
       event,
       'modified',
-      this.config.catalogFile,
+      this.catalogFileMatcher,
     );
 
     // Modified files will be scheduled to a refresh
@@ -535,21 +565,19 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
   private getFilesMatchingConfig(
     event: WebhookPushEventSchema,
     action: 'added' | 'removed' | 'modified',
-    catalogFile: string,
+    catalogFileMatcher: Minimatch,
   ): string[] {
     if (!event.commits) {
       return [];
     }
 
     const matchingFiles = event.commits.flatMap((element: any) =>
-      element[action].filter(
-        (file: string) => path.basename(file) === catalogFile,
-      ),
+      element[action].filter((file: string) => this.filePathMatches(file)),
     );
 
     if (matchingFiles.length === 0) {
       this.logger.debug(
-        `No files matching '${catalogFile}' found in the commits.`,
+        `No files matching '${catalogFileMatcher.pattern}' found in the commits.`,
       );
     }
 
@@ -573,9 +601,7 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
       this.config.fallbackBranch;
 
     // Filter added files that match the catalog file pattern
-    const matchingFiles = addedFiles.filter(
-      file => path.basename(file) === this.config.catalogFile,
-    );
+    const matchingFiles = addedFiles.filter(file => this.filePathMatches(file));
 
     // Create a location spec for each matching file
     const locationSpecs: LocationSpec[] = matchingFiles.map(file => ({
@@ -654,12 +680,12 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
     return true;
   }
 
-  private async shouldProcessProject(
+  private async getProjectCatalogFiles(
     project: GitLabProject,
     client: GitLabClient,
-  ): Promise<boolean> {
+  ): Promise<string[]> {
     if (!this.isProjectCompliant(project)) {
-      return false;
+      return [];
     }
 
     const project_branch =
@@ -667,13 +693,34 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
       project.default_branch ??
       this.config.fallbackBranch;
 
-    const hasFile = await client.hasFile(
-      project.id,
-      project_branch,
-      this.config.catalogFile,
+    if (!this.catalogFileMatcher.hasMagic()) {
+      const hasFile = await client.hasFile(
+        project.id,
+        project_branch,
+        this.config.catalogFile,
+      );
+
+      return hasFile ? [this.config.catalogFile] : [];
+    }
+
+    const matchingFiles: string[] = [];
+    const projectFiles = paginated<GitLabRepositoryTreeItem>(
+      options => client.listProjectTree(project.id, options),
+      {
+        page: 1,
+        per_page: 100,
+        ref: project_branch,
+        recursive: true,
+      },
     );
 
-    return hasFile;
+    for await (const file of projectFiles) {
+      if (file.type === 'blob' && this.catalogFileMatcher.match(file.path)) {
+        matchingFiles.push(file.path);
+      }
+    }
+
+    return matchingFiles;
   }
 
   private isGroupCompliant(name: string | undefined) {
@@ -686,5 +733,13 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
     }
 
     return false;
+  }
+
+  private filePathMatches(filePath: string): boolean {
+    if (this.catalogFileMatcher.hasMagic()) {
+      return this.catalogFileMatcher.match(filePath);
+    }
+
+    return path.basename(filePath) === this.config.catalogFile;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4581,6 +4581,7 @@ __metadata:
     "@gitbeaker/rest": "npm:^40.0.3"
     "@types/lodash": "npm:^4.14.151"
     lodash: "npm:^4.17.21"
+    minimatch: "npm:^10.2.1"
     msw: "npm:^1.0.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds glob pattern support to `GitlabDiscoveryEntityProvider` so catalog files can be discovered at nested paths, not only at a fixed root path.

### What changed

- Added glob matching for `catalog.providers.gitlab.<id>.entityFilename` in `GitlabDiscoveryEntityProvider`.
- For wildcard patterns, the provider now lists each project’s repository tree and emits concrete location targets for matched files.
- Kept existing exact-file behavior for non-glob patterns (HEAD existence checks).
- Updated push event handling so wildcard patterns match full file paths from commits, while exact `entityFilename` keeps prior basename matching behavior.
- Added glob pattern support with explicit error handling when `useSearch` is combined with glob patterns. The provider now throws a clear error instead of silently falling back, preventing confusing behavior changes for users.
- Added GitLab client support for repository tree listing and the related exported type.

### Why

This enables common monorepo use cases such as:

- entityFilename: `**/catalog-info.yaml`
- entityFilename: `**/catalog-info.y?(a)ml` (matches both .yaml and .yml)

It addresses long-standing wildcard discovery requests for GitLab:

### Additional Improvements

Based on review feedback, the implementation includes several enhancements beyond the core glob pattern feature:

**Code Quality:**
- Removed dead `catalogFileMatcher` parameter from `getFilesMatchingConfig()`
- Fixed outdated JSDoc comments to match actual implementation
- Improved error logging to preserve stack traces for better debugging
- Fixed `filePathMatches()` to properly handle exact paths with separators (e.g. `service/catalog-info.yaml`)

**Testing:**
- Added regression coverage for glob discovery, push event matching, and the `useSearch` incompatibility
- Added coverage ensuring pushes to unrelated branches do not trigger project lookups or repository tree scans

**Performance:**
- Skip project lookups and repository tree scans for pushes to branches that are not configured for discovery

**Documentation:**
- Documented the incompatibility between glob patterns and `useSearch`
- Documented performance considerations and how glob patterns interact with push events
- Updated the configuration schema for `entityFilename` and `useSearch`
- Fixed JSDoc to accurately reflect method signatures

**Behaviour Changes:**
- Changed from silent fallback to explicit error when `useSearch=true` with glob patterns
- This prevents confusing behavior changes for Premium/Ultimate users

- Issue: #31167
- Earlier related discussion/need: #27233
- Prior abandoned implementation attempt: #29569

This approach avoids requiring users to manually enumerate catalog file paths for nested repository structures and provides concrete matched locations for ingestion.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

