### PR TITLE
Fix Table loading skeleton not showing for complete mode with getData

### DIFF
--- a/.changeset/fix-table-complete-mode-loading.md
+++ b/.changeset/fix-table-complete-mode-loading.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed a bug in the `useTable` hook where the loading skeleton was never shown for `complete` mode when using `getData`. The initial data state was an empty array instead of `undefined`, causing the `Table` component to skip the loading state.

--- a/packages/ui/src/components/Table/hooks/useCompletePagination.ts
+++ b/packages/ui/src/components/Table/hooks/useCompletePagination.ts
@@ -43,7 +43,7 @@ export function useCompletePagination<T extends TableItem, TFilter>(
   const getData = useStableCallback(getDataProp);
   const { sort, filter, search } = query;
 
-  const [items, setItems] = useState<T[]>([]);
+  const [items, setItems] = useState<T[] | undefined>(undefined);
   const [isLoading, setIsLoading] = useState(!data);
   const [error, setError] = useState<Error | undefined>(undefined);
   const [loadCount, setLoadCount] = useState(0);
@@ -95,6 +95,9 @@ export function useCompletePagination<T extends TableItem, TFilter>(
 
   // Process data client-side (filter, search, sort)
   const processedData = useMemo(() => {
+    if (!resolvedItems) {
+      return undefined;
+    }
     let result = [...resolvedItems];
     if (filter !== undefined && filterFn) {
       result = filterFn(result, filter);
@@ -108,11 +111,11 @@ export function useCompletePagination<T extends TableItem, TFilter>(
     return result;
   }, [resolvedItems, sort, filter, search, filterFn, searchFn, sortFn]);
 
-  const totalCount = processedData.length;
+  const totalCount = processedData?.length ?? 0;
 
   // Paginate the processed data
   const paginatedData = useMemo(
-    () => processedData.slice(offset, offset + pageSize),
+    () => processedData?.slice(offset, offset + pageSize),
     [processedData, offset, pageSize],
   );
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixed a bug where the `Table` component's loading skeleton was never displayed when using `useTable` in `complete` mode with `getData`.

### Root cause

In `useCompletePagination`, the `items` state was initialized as `[]` (empty array) instead of `undefined`. This meant that during the initial async data fetch, the `data` prop flowing into the `Table` component was `[]` — a truthy value. The loading check in `Table.tsx` (`loading && !data`) therefore always evaluated to `false`, and the skeleton was never rendered.

The `offset` and `cursor` pagination modes correctly used `undefined` as the initial data state via `usePageCache`, so this bug only affected `complete` mode.

### Fix

Initialize `items` state as `undefined` instead of `[]`, and propagate `undefined` through the processing pipeline until data has actually been loaded. This aligns `complete` mode with the behavior of `offset` and `cursor` modes.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))