### PR TITLE
Match cluster by name regardless of namespace in CatalogRelationServiceLocator

### DIFF
--- a/plugins/kubernetes-backend/src/service-locator/CatalogRelationServiceLocator.test.ts
+++ b/plugins/kubernetes-backend/src/service-locator/CatalogRelationServiceLocator.test.ts
@@ -142,6 +142,39 @@ describe('CatalogRelationServiceLocator', () => {
     });
   });
 
+  it('should return cluster when cluster entity namespace differs from component namespace', async () => {
+    const testEntity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      relations: [
+        {
+          type: 'dependsOn',
+          targetRef: 'resource:cluster1/cluster1', // cluster lives in its own namespace
+        },
+        { type: 'ownedBy', targetRef: 'group:default/group1' },
+      ],
+      metadata: {
+        namespace: 'my-service', // component is in a different namespace
+        name: 'testEntity',
+      },
+    };
+
+    const result = await serviceLocator.getClustersByEntity(
+      testEntity,
+      {} as ServiceLocatorRequestContext,
+    );
+
+    expect(result).toEqual({
+      clusters: [
+        {
+          name: 'cluster1',
+          url: 'http://localhost:8080',
+          authMetadata: {},
+        },
+      ],
+    });
+  });
+
   it('should return an empty array when entity does not have dependsOn relation with resource target', async () => {
     const testEntity = {
       apiVersion: 'backstage.io/v1alpha1',

--- a/plugins/kubernetes-backend/src/service-locator/CatalogRelationServiceLocator.ts
+++ b/plugins/kubernetes-backend/src/service-locator/CatalogRelationServiceLocator.ts
@@ -61,8 +61,8 @@ export class CatalogRelationServiceLocator implements KubernetesServiceLocator {
     return entity.relations!.some(
       rel =>
         rel.type === 'dependsOn' &&
-        rel.targetRef ===
-          `resource:${entity.metadata.namespace ?? 'default'}/${cluster.name}`,
+        rel.targetRef.startsWith('resource:') &&
+        rel.targetRef.endsWith(`/${cluster.name}`),
     );
   }
 }


### PR DESCRIPTION
Do not require the `component` entity and cluster `resource` entity to share a namespace for the `catalogRelation` `serviceLocatorMethod`.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
