### PR TITLE
feat: allow notification description rendering to be overriden

### DIFF
--- a/.changeset/fuzzy-coats-lie.md
+++ b/.changeset/fuzzy-coats-lie.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications': minor
+---
+
+Added a new optional prop to the notifications page, allowing developers to override the component used to render notification descriptions within the notifications table.

--- a/.changeset/fuzzy-coats-lie.md
+++ b/.changeset/fuzzy-coats-lie.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-notifications': minor
+'@backstage/plugin-notifications': patch
 ---
 
 Added a new optional prop to the notifications page, allowing developers to override the component used to render notification descriptions within the notifications table.

--- a/plugins/notifications/report.api.md
+++ b/plugins/notifications/report.api.md
@@ -5,6 +5,7 @@
 ```ts
 import { ApiRef } from '@backstage/frontend-plugin-api';
 import { BackstagePlugin } from '@backstage/core-plugin-api';
+import type { ComponentType } from 'react';
 import { DiscoveryApi } from '@backstage/core-plugin-api';
 import { FetchApi } from '@backstage/core-plugin-api';
 import { IconComponent } from '@backstage/core-plugin-api';
@@ -132,6 +133,9 @@ export type NotificationsPageProps = {
   tooltip?: string;
   type?: string;
   typeLink?: string;
+  NotificationDescriptionComponent?: ComponentType<{
+    description: string;
+  }>;
 };
 
 // @public (undocumented)
@@ -186,6 +190,9 @@ export type NotificationsTableProps = Pick<
   onUpdate: () => void;
   setContainsText: (search: string) => void;
   pageSize: number;
+  NotificationDescriptionComponent?: ComponentType<{
+    description: string;
+  }>;
 };
 
 // @public (undocumented)

--- a/plugins/notifications/src/components/NotificationsPage/NotificationsPage.tsx
+++ b/plugins/notifications/src/components/NotificationsPage/NotificationsPage.tsx
@@ -15,6 +15,7 @@
  */
 
 import { useEffect, useMemo, useState } from 'react';
+import type { ComponentType } from 'react';
 import throttle from 'lodash/throttle';
 import {
   Content,
@@ -63,6 +64,11 @@ export type NotificationsPageProps = {
   tooltip?: string;
   type?: string;
   typeLink?: string;
+  /**
+   * Optional custom component used to render the notification description cell.
+   * When provided, receives an object with a `description` string property.
+   */
+  NotificationDescriptionComponent?: ComponentType<{ description: string }>;
 };
 
 function NotificationsPageContent(
@@ -78,6 +84,7 @@ function NotificationsPageContent(
     typeLink,
     markAsReadOnLinkOpen,
     headerVariant,
+    NotificationDescriptionComponent,
   } = props;
 
   const [refresh, setRefresh] = useState(false);
@@ -222,6 +229,9 @@ function NotificationsPageContent(
             page={pageNumber}
             pageSize={pageSize}
             totalCount={totalCount}
+            NotificationDescriptionComponent={
+              NotificationDescriptionComponent
+            }
           />
         </Grid.Item>
       </Grid.Root>

--- a/plugins/notifications/src/components/NotificationsPage/NotificationsPage.tsx
+++ b/plugins/notifications/src/components/NotificationsPage/NotificationsPage.tsx
@@ -229,9 +229,7 @@ function NotificationsPageContent(
             page={pageNumber}
             pageSize={pageSize}
             totalCount={totalCount}
-            NotificationDescriptionComponent={
-              NotificationDescriptionComponent
-            }
+            NotificationDescriptionComponent={NotificationDescriptionComponent}
           />
         </Grid.Item>
       </Grid.Root>

--- a/plugins/notifications/src/components/NotificationsTable/NotificationsTable.tsx
+++ b/plugins/notifications/src/components/NotificationsTable/NotificationsTable.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { ComponentType } from 'react';
 import throttle from 'lodash/throttle';
 // @ts-ignore
 import RelativeTime from 'react-relative-time';
@@ -62,6 +63,11 @@ export type NotificationsTableProps = Pick<
   onUpdate: () => void;
   setContainsText: (search: string) => void;
   pageSize: number;
+  /**
+   * Optional custom component used to render the notification description cell.
+   * When provided, receives an object with a `description` string property.
+   */
+  NotificationDescriptionComponent?: ComponentType<{ description: string }>;
 };
 
 /** @public */
@@ -78,6 +84,7 @@ export const NotificationsTable = ({
   page,
   pageSize,
   totalCount,
+  NotificationDescriptionComponent = NotificationDescription,
 }: NotificationsTableProps) => {
   const { t } = useTranslationRef(notificationsTranslationRef);
   const notificationsApi = useApi(notificationsApiRef);
@@ -221,7 +228,7 @@ export const NotificationsTable = ({
                   )}
                 </Text>
                 {notification.payload.description ? (
-                  <NotificationDescription
+                  <NotificationDescriptionComponent
                     description={notification.payload.description}
                   />
                 ) : null}
@@ -290,6 +297,7 @@ export const NotificationsTable = ({
     onMarkAllRead,
     onNotificationsSelectChange,
     markAsReadOnLinkOpen,
+    NotificationDescriptionComponent,
   ]);
 
   return (


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added a new optional prop to the notifications page, allowing developers to override the component used to render notification descriptions within the notifictions table.

Closes https://github.com/backstage/backstage/issues/33271

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
