### PR TITLE
feat(catalog-graph): use Catalog Presentation API instead of humanizeEntityRef

### DIFF
--- a/plugins/catalog-graph/src/alpha.test.tsx
+++ b/plugins/catalog-graph/src/alpha.test.tsx
@@ -21,20 +21,9 @@ import {
   createTestEntityPage,
   catalogApiMock,
 } from '@backstage/plugin-catalog-react/testUtils';
-import {
-  defaultEntityPresentation,
-  entityPresentationApiRef,
-} from '@backstage/plugin-catalog-react';
 import catalogGraphPlugin from './alpha';
 import { catalogGraphRouteRef } from './routes';
 import { catalogGraphApiRef, DefaultCatalogGraphApi } from './api';
-
-const mockEntityPresentationApi = {
-  forEntity(entityOrRef: Parameters<typeof defaultEntityPresentation>[0]) {
-    const snapshot = defaultEntityPresentation(entityOrRef);
-    return { snapshot, promise: Promise.resolve(snapshot) };
-  },
-};
 
 const CatalogGraphEntityCard = catalogGraphPlugin.getExtension(
   'entity-card:catalog-graph/relations',
@@ -70,7 +59,6 @@ describe('catalog-graph alpha plugin', () => {
         apis: [
           catalogApiMock({ entities: [entity] }),
           [catalogGraphApiRef, new DefaultCatalogGraphApi()],
-          [entityPresentationApiRef, mockEntityPresentationApi],
         ],
       });
 
@@ -108,7 +96,6 @@ describe('catalog-graph alpha plugin', () => {
         apis: [
           catalogApiMock({ entities: [entity] }),
           [catalogGraphApiRef, new DefaultCatalogGraphApi()],
-          [entityPresentationApiRef, mockEntityPresentationApi],
         ],
       });
 
@@ -145,7 +132,6 @@ describe('catalog-graph alpha plugin', () => {
         apis: [
           catalogApiMock({ entities: [entity] }),
           [catalogGraphApiRef, new DefaultCatalogGraphApi()],
-          [entityPresentationApiRef, mockEntityPresentationApi],
         ],
       });
 

--- a/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.test.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.test.tsx
@@ -20,7 +20,6 @@ import { analyticsApiRef } from '@backstage/core-plugin-api';
 import {
   catalogApiRef,
   EntityProvider,
-  entityPresentationApiRef,
   entityRouteRef,
 } from '@backstage/plugin-catalog-react';
 import { catalogApiMock } from '@backstage/plugin-catalog-react/testUtils';
@@ -37,14 +36,6 @@ import { CatalogGraphCard } from './CatalogGraphCard';
 import Button from '@material-ui/core/Button';
 import { translationApiRef } from '@backstage/core-plugin-api/alpha';
 import { catalogGraphApiRef, DefaultCatalogGraphApi } from '../../api';
-import { defaultEntityPresentation } from '@backstage/plugin-catalog-react';
-
-const mockEntityPresentationApi = {
-  forEntity(entityOrRef: Parameters<typeof defaultEntityPresentation>[0]) {
-    const snapshot = defaultEntityPresentation(entityOrRef);
-    return { snapshot, promise: Promise.resolve(snapshot) };
-  },
-};
 
 describe('<CatalogGraphCard/>', () => {
   let entity: Entity;
@@ -67,7 +58,6 @@ describe('<CatalogGraphCard/>', () => {
       [catalogApiRef, catalog],
       [translationApiRef, mockApis.translation()],
       [catalogGraphApiRef, new DefaultCatalogGraphApi()],
-      [entityPresentationApiRef, mockEntityPresentationApi],
     );
 
     wrapper = (

--- a/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.tsx
@@ -19,10 +19,10 @@ import {
   parseEntityRef,
   stringifyEntityRef,
 } from '@backstage/catalog-model';
-import { useAnalytics, useRouteRef, useApi } from '@backstage/core-plugin-api';
+import { useAnalytics, useRouteRef } from '@backstage/core-plugin-api';
 import {
   EntityInfoCard,
-  entityPresentationApiRef,
+  entityPresentationSnapshot,
   useEntity,
   entityRouteRef,
 } from '@backstage/plugin-catalog-react';
@@ -89,7 +89,6 @@ export const CatalogGraphCard = (
   const navigate = useNavigate();
   const classes = useStyles({ height });
   const analytics = useAnalytics();
-  const entityPresentationApi = useApi(entityPresentationApiRef);
 
   const defaultOnNodeClick = useCallback(
     (node: EntityNode, _: MouseEvent<unknown>) => {
@@ -101,12 +100,12 @@ export const CatalogGraphCard = (
       });
       analytics.captureEvent(
         'click',
-        entityPresentationApi.forEntity(node.entity).snapshot.primaryTitle,
+        entityPresentationSnapshot(node.entity).primaryTitle,
         { attributes: { to: path } },
       );
       navigate(path);
     },
-    [catalogEntityRoute, navigate, analytics, entityPresentationApi],
+    [catalogEntityRoute, navigate, analytics],
   );
 
   const catalogGraphParams = qs.stringify(

--- a/plugins/catalog-graph/src/components/CatalogGraphPage/CatalogGraphPage.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphPage/CatalogGraphPage.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { parseEntityRef, stringifyEntityRef } from '@backstage/catalog-model';
+import { parseEntityRef } from '@backstage/catalog-model';
 import {
   Content,
   ContentHeader,
@@ -22,9 +22,9 @@ import {
   Page,
   SupportButton,
 } from '@backstage/core-components';
-import { useAnalytics, useRouteRef, useApi } from '@backstage/core-plugin-api';
+import { useAnalytics, useRouteRef } from '@backstage/core-plugin-api';
 import {
-  entityPresentationApiRef,
+  entityPresentationSnapshot,
   entityRouteRef,
 } from '@backstage/plugin-catalog-react';
 import Grid from '@material-ui/core/Grid';
@@ -157,12 +157,10 @@ export const CatalogGraphPage = (
     toggleShowFilters,
   } = useCatalogGraphPage({ initialState });
   const analytics = useAnalytics();
-  const entityPresentationApi = useApi(entityPresentationApiRef);
   const onNodeClick = useCallback(
     (node: EntityNode, event: MouseEvent<unknown>) => {
       const nodeEntityName = parseEntityRef(node.id);
-      const nodeTitle = entityPresentationApi.forEntity(node.entity).snapshot
-        .primaryTitle;
+      const nodeTitle = entityPresentationSnapshot(node.entity).primaryTitle;
 
       if (event.shiftKey) {
         const path = catalogEntityRoute({
@@ -180,13 +178,7 @@ export const CatalogGraphPage = (
         setRootEntityNames([nodeEntityName]);
       }
     },
-    [
-      catalogEntityRoute,
-      navigate,
-      setRootEntityNames,
-      analytics,
-      entityPresentationApi,
-    ],
+    [catalogEntityRoute, navigate, setRootEntityNames, analytics],
   );
 
   return (
@@ -194,11 +186,7 @@ export const CatalogGraphPage = (
       <Header
         title={t('catalogGraphPage.title')}
         subtitle={rootEntityNames
-          .map(
-            e =>
-              entityPresentationApi.forEntity(stringifyEntityRef(e)).snapshot
-                .primaryTitle,
-          )
+          .map(e => entityPresentationSnapshot(e).primaryTitle)
           .join(', ')}
       />
       <Content stretch className={classes.content}>


### PR DESCRIPTION
Replaced `humanizeEntityRef` with the Catalog Presentation API (`entityPresentationApiRef`) in `CatalogGraphCard` and `CatalogGraphPage` components, contributing to #20955.

The entity graph components were still using the deprecated `humanizeEntityRef` function to generate display names for analytics events and the page subtitle. This PR switches them to use `entityPresentationApiRef.forEntity().snapshot.primaryTitle`, which respects custom entity presentation implementations and provides richer display names (e.g. using `metadata.title` or `spec.profile.displayName` when available).

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))