### PR TITLE
Fix Table complete mode loading state for data prop variant

### DIFF
--- a/packages/ui/src/components/Table/hooks/useCompletePagination.ts
+++ b/packages/ui/src/components/Table/hooks/useCompletePagination.ts
@@ -37,6 +37,7 @@ export function useCompletePagination<T extends TableItem, TFilter>(
     filterFn,
     searchFn,
   } = options;
+  const hasGetData = 'getData' in options;
   const { initialOffset = 0 } = paginationOptions;
   const defaultPageSize = getEffectivePageSize(paginationOptions);
 
@@ -54,6 +55,11 @@ export function useCompletePagination<T extends TableItem, TFilter>(
   // Load data on mount and when loadCount changes (reload trigger)
   useEffect(() => {
     if (data) {
+      setIsLoading(false);
+      return;
+    }
+
+    if (!hasGetData) {
       return;
     }
 
@@ -64,9 +70,9 @@ export function useCompletePagination<T extends TableItem, TFilter>(
     (async () => {
       try {
         const result = getData();
-        const data = result instanceof Promise ? await result : result;
+        const resolvedData = result instanceof Promise ? await result : result;
         if (!cancelled) {
-          setItems(data);
+          setItems(resolvedData);
           setIsLoading(false);
         }
       } catch (err) {
@@ -80,7 +86,7 @@ export function useCompletePagination<T extends TableItem, TFilter>(
     return () => {
       cancelled = true;
     };
-  }, [data, getData, loadCount]);
+  }, [data, getData, hasGetData, loadCount]);
 
   // Reset offset when query changes (query object is memoized)
   const prevQueryRef = useRef(query);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Follow-up to #33378. Fixes the loading state in `useCompletePagination` for the `data` prop variant of `complete` mode.

### Problem

When using `useTable` in `complete` mode with the `data` prop (e.g., `data` starts as `undefined` while loading), the effect was calling the default `getData = () => []` — which immediately returned an empty array and cleared `isLoading` before the consumer's actual data arrived. This prevented the loading skeleton from showing.

Additionally, when `data` transitioned from `undefined` to a defined array, `isLoading` was never cleared (as identified in [this review comment](https://github.com/backstage/backstage/pull/33378#discussion_r2942067870)).

### Fix

- Detect whether `getData` was explicitly provided via `'getData' in options`
- Only run the async loading logic when `getData` is present
- Clear `isLoading` when `data` transitions from `undefined` to defined

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))