### PR TITLE
fix(core-components): resolve DOM nesting warning in OAuthRequestDialog

### DIFF
--- a/.changeset/lazy-jars-shake.md
+++ b/.changeset/lazy-jars-shake.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Resolved DOM nesting warning in OAuthRequestDialog by rendering secondary text as block-level spans.

--- a/packages/core-components/src/components/OAuthRequestDialog/LoginRequestListItem.tsx
+++ b/packages/core-components/src/components/OAuthRequestDialog/LoginRequestListItem.tsx
@@ -95,13 +95,14 @@ const LoginRequestListItem = ({ request, busy, setBusy }: RowProps) => {
                   <Typography
                     variant="subtitle2"
                     component="span"
+                    display="block"
                     color="textSecondary"
                   >
                     {message}
                   </Typography>
                 )}
                 {error && (
-                  <Typography component="span" color="error">
+                  <Typography component="span" display="block" color="error">
                     {error}
                   </Typography>
                 )}


### PR DESCRIPTION
This PR resolves a DOM nesting warning in the OAuthRequestDialog where a heading <h6> (from Typography subtitle2) was being rendered inside a paragraph <p> (from ListItemText secondary).

Changes:

Added component="span" to Typography components in LoginRequestListItem to ensure valid HTML nesting.

Fixes #33179