### PR TITLE
fix(core-components): resolve active state routing bug in SidebarItem

### DIFF
--- a/.changeset/metal-teams-push.md
+++ b/.changeset/metal-teams-push.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+This PR resolves an issue where multiple sidebar items were incorrectly highlighted when navigating to nested routes (e.g., /test and /test/again both appearing active).

--- a/packages/core-components/src/layout/Sidebar/Items.test.tsx
+++ b/packages/core-components/src/layout/Sidebar/Items.test.tsx
@@ -19,13 +19,17 @@ import {
   TestApiProvider,
   renderInTestApp,
 } from '@backstage/test-utils';
-import { createEvent, fireEvent, screen } from '@testing-library/react';
+import {
+  createEvent,
+  fireEvent,
+  screen,
+  renderHook,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import HomeIcon from '@material-ui/icons/Home';
 import CreateComponentIcon from '@material-ui/icons/AddCircleOutline';
 import { Sidebar } from './Bar';
 import { SidebarItem, SidebarSearchField, SidebarExpandButton } from './Items';
-import { renderHook } from '@testing-library/react';
 import { makeStyles } from '@material-ui/core/styles';
 import { analyticsApiRef } from '@backstage/core-plugin-api';
 

--- a/packages/core-components/src/layout/Sidebar/Items.test.tsx
+++ b/packages/core-components/src/layout/Sidebar/Items.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2026 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -128,6 +128,23 @@ describe('Items', () => {
         await screen.findByRole('link', { name: /explore/i }),
       );
       expect(analyticsApiMock.captureEvent).not.toHaveBeenCalled();
+    });
+
+    it('should only highlight the exact matching nested route', async () => {
+      await renderInTestApp(
+        <Sidebar>
+          <SidebarItem to="/test" icon={HomeIcon} text="ParentRoute" />
+          <SidebarItem to="/test/again" icon={HomeIcon} text="ChildRoute" />
+        </Sidebar>,
+        { routeEntries: ['/test/again'] },
+      );
+
+      const parentLink = screen.getByRole('link', { name: /parentroute/i });
+      const childLink = screen.getByRole('link', { name: /childroute/i });
+
+      expect(childLink).toHaveAttribute('aria-current', 'page');
+
+      expect(parentLink).not.toHaveAttribute('aria-current');
     });
   });
 

--- a/packages/core-components/src/layout/Sidebar/Items.tsx
+++ b/packages/core-components/src/layout/Sidebar/Items.tsx
@@ -438,12 +438,17 @@ const SidebarItemBase = forwardRef<
     );
   }
 
+  if (!props.to) {
+    throw new Error('SidebarItem: "to" is required when rendering as a link');
+  }
+
   return (
     <NavLink
       {...childProps}
-      to={props.to ? props.to : ''}
+      to={props.to}
       ref={ref}
       aria-label={text ? text : props.to}
+      end={(props as NavLinkProps).end ?? true}
       {...navLinkProps}
       className={({ isActive }) =>
         classnames(

--- a/packages/core-components/src/layout/Sidebar/Items.tsx
+++ b/packages/core-components/src/layout/Sidebar/Items.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2026 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,6 @@ import type { Location } from 'history';
 import {
   ComponentProps,
   ComponentType,
-  CSSProperties,
   forwardRef,
   KeyboardEventHandler,
   ReactNode,
@@ -54,7 +53,7 @@ import {
 } from 'react';
 
 import {
-  Link,
+  NavLink,
   NavLinkProps,
   resolvePath,
   useLocation,
@@ -324,61 +323,6 @@ function isButtonItem(
 
 const sidebarSubmenuType = createElement(SidebarSubmenu).type;
 
-// TODO(Rugvip): Remove this once NavLink is updated in react-router-dom.
-//               This is needed because react-router doesn't handle the path comparison
-//               properly yet, matching for example /foobar with /foo.
-export const WorkaroundNavLink = forwardRef<
-  HTMLAnchorElement,
-  NavLinkProps & {
-    children?: ReactNode;
-    activeStyle?: CSSProperties;
-    activeClassName?: string;
-  }
->(function WorkaroundNavLinkWithRef(
-  {
-    to,
-    end,
-    style,
-    className,
-    activeStyle,
-    caseSensitive,
-    activeClassName = 'active',
-    'aria-current': ariaCurrentProp = 'page',
-    ...rest
-  },
-  ref,
-) {
-  let { pathname: locationPathname } = useLocation();
-  let { pathname: toPathname } = useResolvedPath(to);
-
-  if (!caseSensitive) {
-    locationPathname = locationPathname.toLocaleLowerCase('en-US');
-    toPathname = toPathname.toLocaleLowerCase('en-US');
-  }
-
-  let isActive = locationPathname === toPathname;
-  if (!isActive && !end) {
-    // This is the behavior that is different from the original NavLink
-    isActive = locationPathname.startsWith(`${toPathname}/`);
-  }
-
-  const ariaCurrent = isActive ? ariaCurrentProp : undefined;
-
-  return (
-    <Link
-      {...rest}
-      to={to}
-      ref={ref}
-      aria-current={ariaCurrent}
-      style={{ ...style, ...(isActive ? activeStyle : undefined) }}
-      className={classnames([
-        typeof className !== 'function' ? className : undefined,
-        isActive ? activeClassName : undefined,
-      ])}
-    />
-  );
-});
-
 /**
  * Common component used by SidebarItem & SidebarItemWithSubmenu
  */
@@ -495,17 +439,22 @@ const SidebarItemBase = forwardRef<
   }
 
   return (
-    <WorkaroundNavLink
+    <NavLink
       {...childProps}
-      activeClassName={classes.selected}
       to={props.to ? props.to : ''}
       ref={ref}
       aria-label={text ? text : props.to}
       {...navLinkProps}
+      className={({ isActive }) =>
+        classnames(
+          childProps.className,
+          isActive ? classes.selected : undefined,
+        )
+      }
       onClick={handleClick}
     >
       {content}
-    </WorkaroundNavLink>
+    </NavLink>
   );
 });
 


### PR DESCRIPTION
 Pull Request Description
 Problem
Currently, the Backstage sidebar incorrectly highlights multiple items when a user navigates to a nested route where one path is a prefix of another (e.g., /catalog and /catalog/default/...). This happens because of a legacy matching logic that uses .startsWith(), causing both parent and child routes to appear "active" simultaneously.

Solution
Since Backstage has migrated to React Router v6, the previous WorkaroundNavLink is no longer necessary. This PR:

Removes the custom WorkaroundNavLink and its manual path-matching logic.

Refactors SidebarItemBase to use the native NavLink from react-router-dom.

Leverages React Router v6's built-in isActive state for class application.

Enables the end prop support, allowing the sidebar to correctly distinguish between exact and partial matches.

How to verify
Add two sidebar items in Root.tsx: one for /test and one for /test/again.

Navigate to /test/again.

Observed Result: Only the "Test Again" item is highlighted (Previously, both would be highlighted).

Checklist
[x] I have followed the [Contributing Guidelines](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md).

[x] I have ran yarn lint and yarn tsc and they pass.

[x] I have added a changeset using yarn changeset.

Fixes: #33302 