### PR TITLE
cli-node: rename `description` to `name` in `CliCommand`

### DIFF
--- a/.changeset/rename-cli-command-description-to-name.md
+++ b/.changeset/rename-cli-command-description-to-name.md
@@ -1,0 +1,6 @@
+---
+'@backstage/cli-node': minor
+'@backstage/cli': patch
+---
+
+**BREAKING**: Renamed the `description` field to `name` in the `CliCommand` interface.

--- a/packages/cli-module-actions/src/index.ts
+++ b/packages/cli-module-actions/src/index.ts
@@ -22,27 +22,27 @@ export default createCliModule({
   init: async reg => {
     reg.addCommand({
       path: ['actions', 'list'],
-      description: 'List available actions from configured plugin sources',
+      name: 'List available actions from configured plugin sources',
       execute: { loader: () => import('./commands/list') },
     });
     reg.addCommand({
       path: ['actions', 'execute'],
-      description: 'Execute an action',
+      name: 'Execute an action',
       execute: { loader: () => import('./commands/execute') },
     });
     reg.addCommand({
       path: ['actions', 'sources', 'add'],
-      description: 'Add a plugin source for action discovery',
+      name: 'Add a plugin source for action discovery',
       execute: { loader: () => import('./commands/sourcesAdd') },
     });
     reg.addCommand({
       path: ['actions', 'sources', 'list'],
-      description: 'List configured plugin sources',
+      name: 'List configured plugin sources',
       execute: { loader: () => import('./commands/sourcesList') },
     });
     reg.addCommand({
       path: ['actions', 'sources', 'remove'],
-      description: 'Remove a plugin source',
+      name: 'Remove a plugin source',
       execute: { loader: () => import('./commands/sourcesRemove') },
     });
   },

--- a/packages/cli-module-auth/src/index.ts
+++ b/packages/cli-module-auth/src/index.ts
@@ -22,32 +22,32 @@ export default createCliModule({
   init: async reg => {
     reg.addCommand({
       path: ['auth', 'login'],
-      description: 'Log in the CLI to a Backstage instance',
+      name: 'Log in the CLI to a Backstage instance',
       execute: { loader: () => import('./commands/login') },
     });
     reg.addCommand({
       path: ['auth', 'logout'],
-      description: 'Log out the CLI and clear stored credentials',
+      name: 'Log out the CLI and clear stored credentials',
       execute: { loader: () => import('./commands/logout') },
     });
     reg.addCommand({
       path: ['auth', 'show'],
-      description: 'Show details of an authenticated instance',
+      name: 'Show details of an authenticated instance',
       execute: { loader: () => import('./commands/show') },
     });
     reg.addCommand({
       path: ['auth', 'list'],
-      description: 'List authenticated instances',
+      name: 'List authenticated instances',
       execute: { loader: () => import('./commands/list') },
     });
     reg.addCommand({
       path: ['auth', 'print-token'],
-      description: 'Print an access token to stdout (auto-refresh if needed)',
+      name: 'Print an access token to stdout (auto-refresh if needed)',
       execute: { loader: () => import('./commands/printToken') },
     });
     reg.addCommand({
       path: ['auth', 'select'],
-      description: 'Select the default instance',
+      name: 'Select the default instance',
       execute: { loader: () => import('./commands/select') },
     });
   },

--- a/packages/cli-module-build/src/index.ts
+++ b/packages/cli-module-build/src/index.ts
@@ -22,20 +22,19 @@ export default createCliModule({
   init: async reg => {
     reg.addCommand({
       path: ['package', 'build'],
-      description: 'Build a package for production deployment or publishing',
+      name: 'Build a package for production deployment or publishing',
       execute: { loader: () => import('./commands/package/build') },
     });
 
     reg.addCommand({
       path: ['repo', 'build'],
-      description:
-        'Build packages in the project, excluding bundled app and backend packages.',
+      name: 'Build packages in the project, excluding bundled app and backend packages.',
       execute: { loader: () => import('./commands/repo/build') },
     });
 
     reg.addCommand({
       path: ['package', 'bundle'],
-      description:
+      name:
         'Bundle a plugin for dynamic loading. Creates a self-contained plugin ' +
         'package that can be deployed and loaded dynamically by a Backstage application. ' +
         'Supports both backend and frontend plugins. Experimental.',
@@ -45,19 +44,19 @@ export default createCliModule({
 
     reg.addCommand({
       path: ['package', 'start'],
-      description: 'Start a package for local development',
+      name: 'Start a package for local development',
       execute: { loader: () => import('./commands/package/start') },
     });
 
     reg.addCommand({
       path: ['repo', 'start'],
-      description: 'Starts packages in the repo for local development',
+      name: 'Starts packages in the repo for local development',
       execute: { loader: () => import('./commands/repo/start') },
     });
 
     reg.addCommand({
       path: ['package', 'clean'],
-      description: 'Delete cache directories',
+      name: 'Delete cache directories',
       execute: {
         loader: () => import('./commands/package/clean'),
       },
@@ -65,7 +64,7 @@ export default createCliModule({
 
     reg.addCommand({
       path: ['package', 'prepack'],
-      description: 'Prepares a package for packaging before publishing',
+      name: 'Prepares a package for packaging before publishing',
       execute: {
         loader: () => import('./commands/package/prepack'),
       },
@@ -73,7 +72,7 @@ export default createCliModule({
 
     reg.addCommand({
       path: ['package', 'postpack'],
-      description: 'Restores the changes made by the prepack command',
+      name: 'Restores the changes made by the prepack command',
       execute: {
         loader: () => import('./commands/package/postpack'),
       },
@@ -81,7 +80,7 @@ export default createCliModule({
 
     reg.addCommand({
       path: ['repo', 'clean'],
-      description: 'Delete cache and output directories',
+      name: 'Delete cache and output directories',
       execute: {
         loader: () => import('./commands/repo/clean'),
       },
@@ -89,8 +88,7 @@ export default createCliModule({
 
     reg.addCommand({
       path: ['build-workspace'],
-      description:
-        'Builds a temporary dist workspace from the provided packages',
+      name: 'Builds a temporary dist workspace from the provided packages',
       execute: { loader: () => import('./commands/buildWorkspace') },
     });
   },

--- a/packages/cli-module-config/src/index.ts
+++ b/packages/cli-module-config/src/index.ts
@@ -21,33 +21,32 @@ export default createCliModule({
   init: async reg => {
     reg.addCommand({
       path: ['config:docs'],
-      description: 'Browse the configuration reference documentation',
+      name: 'Browse the configuration reference documentation',
       execute: { loader: () => import('./commands/docs') },
     });
     reg.addCommand({
       path: ['config', 'docs'],
-      description: 'Browse the configuration reference documentation',
+      name: 'Browse the configuration reference documentation',
       execute: { loader: () => import('./commands/docs') },
     });
     reg.addCommand({
       path: ['config:print'],
-      description: 'Print the app configuration for the current package',
+      name: 'Print the app configuration for the current package',
       execute: { loader: () => import('./commands/print') },
     });
     reg.addCommand({
       path: ['config:check'],
-      description:
-        'Validate that the given configuration loads and matches schema',
+      name: 'Validate that the given configuration loads and matches schema',
       execute: { loader: () => import('./commands/validate') },
     });
     reg.addCommand({
       path: ['config:schema'],
-      description: 'Print the JSON schema for the given configuration',
+      name: 'Print the JSON schema for the given configuration',
       execute: { loader: () => import('./commands/schema') },
     });
     reg.addCommand({
       path: ['config', 'schema'],
-      description: 'Print the JSON schema for the given configuration',
+      name: 'Print the JSON schema for the given configuration',
       execute: { loader: () => import('./commands/schema') },
     });
   },

--- a/packages/cli-module-github/src/index.ts
+++ b/packages/cli-module-github/src/index.ts
@@ -21,7 +21,7 @@ export default createCliModule({
   init: async reg => {
     reg.addCommand({
       path: ['create-github-app'],
-      description: 'Create new GitHub App in your organization.',
+      name: 'Create new GitHub App in your organization.',
       execute: { loader: () => import('./commands/create-github-app') },
     });
   },

--- a/packages/cli-module-info/src/index.ts
+++ b/packages/cli-module-info/src/index.ts
@@ -21,7 +21,7 @@ export default createCliModule({
   init: async reg => {
     reg.addCommand({
       path: ['info'],
-      description: 'Show helpful information for debugging and reporting bugs',
+      name: 'Show helpful information for debugging and reporting bugs',
       execute: { loader: () => import('./commands/info') },
     });
   },

--- a/packages/cli-module-lint/src/index.ts
+++ b/packages/cli-module-lint/src/index.ts
@@ -21,13 +21,13 @@ export default createCliModule({
   init: async reg => {
     reg.addCommand({
       path: ['package', 'lint'],
-      description: 'Lint a package',
+      name: 'Lint a package',
       execute: { loader: () => import('./commands/package/lint') },
     });
 
     reg.addCommand({
       path: ['repo', 'lint'],
-      description: 'Lint a repository',
+      name: 'Lint a repository',
       execute: { loader: () => import('./commands/repo/lint') },
     });
   },

--- a/packages/cli-module-maintenance/src/index.ts
+++ b/packages/cli-module-maintenance/src/index.ts
@@ -21,13 +21,13 @@ export default createCliModule({
   init: async reg => {
     reg.addCommand({
       path: ['repo', 'fix'],
-      description: 'Automatically fix packages in the project',
+      name: 'Automatically fix packages in the project',
       execute: { loader: () => import('./commands/repo/fix') },
     });
 
     reg.addCommand({
       path: ['repo', 'list-deprecations'],
-      description: 'List deprecations',
+      name: 'List deprecations',
       execute: { loader: () => import('./commands/repo/list-deprecations') },
     });
   },

--- a/packages/cli-module-migrate/src/index.ts
+++ b/packages/cli-module-migrate/src/index.ts
@@ -21,20 +21,19 @@ export default createCliModule({
   init: async reg => {
     reg.addCommand({
       path: ['versions:migrate'],
-      description:
-        'Migrate any plugins that have been moved to the @backstage-community namespace automatically',
+      name: 'Migrate any plugins that have been moved to the @backstage-community namespace automatically',
       execute: { loader: () => import('./commands/versions/migrate') },
     });
 
     reg.addCommand({
       path: ['versions:bump'],
-      description: 'Bump Backstage packages to the latest versions',
+      name: 'Bump Backstage packages to the latest versions',
       execute: { loader: () => import('./commands/versions/bump') },
     });
 
     reg.addCommand({
       path: ['migrate', 'package-roles'],
-      description: `Add package role field to packages that don't have it`,
+      name: `Add package role field to packages that don't have it`,
       execute: {
         loader: () => import('./commands/packageRole'),
       },
@@ -42,7 +41,7 @@ export default createCliModule({
 
     reg.addCommand({
       path: ['migrate', 'package-scripts'],
-      description: 'Set package scripts according to each package role',
+      name: 'Set package scripts according to each package role',
       execute: {
         loader: () => import('./commands/packageScripts'),
       },
@@ -50,7 +49,7 @@ export default createCliModule({
 
     reg.addCommand({
       path: ['migrate', 'package-exports'],
-      description: 'Synchronize package subpath export definitions',
+      name: 'Synchronize package subpath export definitions',
       execute: {
         loader: () => import('./commands/packageExports'),
       },
@@ -58,8 +57,7 @@ export default createCliModule({
 
     reg.addCommand({
       path: ['migrate', 'package-lint-configs'],
-      description:
-        'Migrates all packages to use @backstage/cli/config/eslint-factory',
+      name: 'Migrates all packages to use @backstage/cli/config/eslint-factory',
       execute: {
         loader: () => import('./commands/packageLintConfigs'),
       },
@@ -67,8 +65,7 @@ export default createCliModule({
 
     reg.addCommand({
       path: ['migrate', 'react-router-deps'],
-      description:
-        'Migrates the react-router dependencies for all packages to be peer dependencies',
+      name: 'Migrates the react-router dependencies for all packages to be peer dependencies',
       execute: {
         loader: () => import('./commands/reactRouterDeps'),
       },

--- a/packages/cli-module-new/src/index.ts
+++ b/packages/cli-module-new/src/index.ts
@@ -22,14 +22,13 @@ export default createCliModule({
   init: async reg => {
     reg.addCommand({
       path: ['new'],
-      description:
-        'Open up an interactive guide to creating new things in your app',
+      name: 'Open up an interactive guide to creating new things in your app',
       execute: { loader: () => import('./commands/new') },
     });
 
     reg.addCommand({
       path: ['create'],
-      description: 'Create a new Backstage app',
+      name: 'Create a new Backstage app',
       deprecated: true,
       execute: async () => {
         throw new NotImplementedError(
@@ -39,7 +38,7 @@ export default createCliModule({
     });
     reg.addCommand({
       path: ['create-plugin'],
-      description: 'Create a new Backstage plugin',
+      name: 'Create a new Backstage plugin',
       deprecated: true,
       execute: async () => {
         throw new NotImplementedError(

--- a/packages/cli-module-test-jest/src/index.ts
+++ b/packages/cli-module-test-jest/src/index.ts
@@ -21,15 +21,13 @@ export default createCliModule({
   init: async reg => {
     reg.addCommand({
       path: ['repo', 'test'],
-      description:
-        'Run tests, forwarding args to Jest, defaulting to watch mode',
+      name: 'Run tests, forwarding args to Jest, defaulting to watch mode',
       execute: { loader: () => import('./commands/repo/test') },
     });
 
     reg.addCommand({
       path: ['package', 'test'],
-      description:
-        'Run tests, forwarding args to Jest, defaulting to watch mode',
+      name: 'Run tests, forwarding args to Jest, defaulting to watch mode',
       execute: { loader: () => import('./commands/package/test') },
     });
   },

--- a/packages/cli-module-translations/src/index.ts
+++ b/packages/cli-module-translations/src/index.ts
@@ -21,15 +21,13 @@ export default createCliModule({
   init: async reg => {
     reg.addCommand({
       path: ['translations', 'export'],
-      description:
-        'Export translation messages from an app and all of its frontend plugins to JSON files',
+      name: 'Export translation messages from an app and all of its frontend plugins to JSON files',
       execute: { loader: () => import('./commands/export') },
     });
 
     reg.addCommand({
       path: ['translations', 'import'],
-      description:
-        'Generate translation resource wiring from translated JSON files',
+      name: 'Generate translation resource wiring from translated JSON files',
       execute: { loader: () => import('./commands/import') },
     });
   },

--- a/packages/cli-node/report.api.md
+++ b/packages/cli-node/report.api.md
@@ -104,7 +104,6 @@ export interface CliAuthCreateOptions {
 // @public
 export interface CliCommand {
   deprecated?: boolean;
-  description: string;
   execute:
     | ((context: CliCommandContext) => Promise<void>)
     | {
@@ -113,6 +112,7 @@ export interface CliCommand {
         }>;
       };
   experimental?: boolean;
+  name: string;
   path: string[];
 }
 

--- a/packages/cli-node/src/cli-module/createCliModule.ts
+++ b/packages/cli-node/src/cli-module/createCliModule.ts
@@ -34,7 +34,7 @@ import { CliCommand, CliModule } from './types';
  *   init: async reg => {
  *     reg.addCommand({
  *       path: ['repo', 'test'],
- *       description: 'Run tests across the repository',
+ *       name: 'Run tests across the repository',
  *       execute: { loader: () => import('./commands/test') },
  *     });
  *   },

--- a/packages/cli-node/src/cli-module/runCliModule.ts
+++ b/packages/cli-node/src/cli-module/runCliModule.ts
@@ -101,7 +101,7 @@ function registerCommands(
           hidden:
             !!internal.command.deprecated || !!internal.command.experimental,
         })
-        .description(internal.command.description)
+        .description(internal.command.name)
         .helpOption(false)
         .allowUnknownOption(true)
         .allowExcessArguments(true)

--- a/packages/cli-node/src/cli-module/types.ts
+++ b/packages/cli-node/src/cli-module/types.ts
@@ -68,9 +68,9 @@ export interface CliCommand {
    */
   path: string[];
   /**
-   * A short description of the command, displayed in help output.
+   * A short name for the command, displayed in help output.
    */
-  description: string;
+  name: string;
   /**
    * If `true`, the command is deprecated and will be hidden from help output
    * but can still be invoked.

--- a/packages/cli/src/wiring/CliInitializer.test.ts
+++ b/packages/cli/src/wiring/CliInitializer.test.ts
@@ -51,7 +51,7 @@ describe('CliInitializer', () => {
         init: async reg =>
           reg.addCommand({
             path: ['test'],
-            description: 'test',
+            name: 'test',
             execute: ({ args }) => {
               expect(args).toEqual([]);
               return Promise.resolve();
@@ -73,7 +73,7 @@ describe('CliInitializer', () => {
         init: async reg =>
           reg.addCommand({
             path: ['test'],
-            description: 'test',
+            name: 'test',
             execute: ({ args }) => {
               expect(args).toEqual(['[positional]', '<arg>']);
               return Promise.resolve();
@@ -95,7 +95,7 @@ describe('CliInitializer', () => {
         init: async reg =>
           reg.addCommand({
             path: ['test'],
-            description: 'test',
+            name: 'test',
             execute: {
               loader: async () => ({
                 default: async ({ args }) => {
@@ -120,12 +120,12 @@ describe('CliInitializer', () => {
         init: async reg => {
           reg.addCommand({
             path: ['visible'],
-            description: 'A visible command',
+            name: 'A visible command',
             execute: () => Promise.resolve(),
           });
           reg.addCommand({
             path: ['secret'],
-            description: 'An experimental command',
+            name: 'An experimental command',
             experimental: true,
             execute: ({ args }) => {
               expect(args).toEqual([]);
@@ -147,12 +147,12 @@ describe('CliInitializer', () => {
         init: async reg => {
           reg.addCommand({
             path: ['visible'],
-            description: 'A visible command',
+            name: 'A visible command',
             execute: () => Promise.resolve(),
           });
           reg.addCommand({
             path: ['secret'],
-            description: 'An experimental command',
+            name: 'An experimental command',
             experimental: true,
             execute: () => Promise.resolve(),
           });
@@ -175,18 +175,18 @@ describe('CliInitializer', () => {
         init: async reg => {
           reg.addCommand({
             path: ['visible'],
-            description: 'A visible command',
+            name: 'A visible command',
             execute: () => Promise.resolve(),
           });
           reg.addCommand({
             path: ['group', 'alpha'],
-            description: 'First experimental command',
+            name: 'First experimental command',
             experimental: true,
             execute: () => Promise.resolve(),
           });
           reg.addCommand({
             path: ['group', 'beta'],
-            description: 'Second experimental command',
+            name: 'Second experimental command',
             experimental: true,
             execute: () => Promise.resolve(),
           });
@@ -210,12 +210,12 @@ describe('CliInitializer', () => {
         init: async reg => {
           reg.addCommand({
             path: ['group', 'alpha'],
-            description: 'A visible nested command',
+            name: 'A visible nested command',
             execute: () => Promise.resolve(),
           });
           reg.addCommand({
             path: ['group', 'beta'],
-            description: 'An experimental nested command',
+            name: 'An experimental nested command',
             experimental: true,
             execute: () => Promise.resolve(),
           });
@@ -246,7 +246,7 @@ describe('CliInitializer', () => {
         init: async reg =>
           reg.addCommand({
             path: ['test', 'nested', 'command'],
-            description: 'test',
+            name: 'test',
             execute: ({ args }) => {
               expect(args).toEqual(['[positional]', '<arg>']);
               return Promise.resolve();
@@ -268,7 +268,7 @@ describe('CliInitializer', () => {
       init: async reg =>
         reg.addCommand({
           path: ['test'],
-          description: 'individual test',
+          name: 'individual test',
           execute: ({ args }) => {
             expect(args).toEqual([]);
             return Promise.resolve();
@@ -281,7 +281,7 @@ describe('CliInitializer', () => {
       init: async reg =>
         reg.addCommand({
           path: ['test'],
-          description: 'array test (should be skipped)',
+          name: 'array test (should be skipped)',
           execute: () => Promise.resolve(),
         }),
     });
@@ -291,7 +291,7 @@ describe('CliInitializer', () => {
       init: async reg =>
         reg.addCommand({
           path: ['other'],
-          description: 'other command',
+          name: 'other command',
           execute: () => Promise.resolve(),
         }),
     });
@@ -320,7 +320,7 @@ describe('CliInitializer', () => {
         init: async reg =>
           reg.addCommand({
             path: ['conflicting'],
-            description: 'from module A',
+            name: 'from module A',
             execute: () => Promise.resolve(),
           }),
       }),
@@ -332,7 +332,7 @@ describe('CliInitializer', () => {
         init: async reg =>
           reg.addCommand({
             path: ['conflicting'],
-            description: 'from module B',
+            name: 'from module B',
             execute: () => Promise.resolve(),
           }),
       }),
@@ -351,7 +351,7 @@ describe('CliInitializer', () => {
       init: async reg =>
         reg.addCommand({
           path: ['shared'],
-          description: 'from array A',
+          name: 'from array A',
           execute: () => Promise.resolve(),
         }),
     });
@@ -361,7 +361,7 @@ describe('CliInitializer', () => {
       init: async reg =>
         reg.addCommand({
           path: ['shared'],
-          description: 'from array B',
+          name: 'from array B',
           execute: () => Promise.resolve(),
         }),
     });

--- a/packages/cli/src/wiring/CliInitializer.ts
+++ b/packages/cli/src/wiring/CliInitializer.ts
@@ -150,7 +150,7 @@ export class CliInitializer {
             hidden:
               !!internal.command.deprecated || !!internal.command.experimental,
           })
-          .description(internal.command.description)
+          .description(internal.command.name)
           .helpOption(false)
           .allowUnknownOption(true)
           .allowExcessArguments(true)


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This renames the `description` field to `name` in the `CliCommand` interface from `@backstage/cli-node`. The field was always used as a short name for the command rather than a description, so this makes the naming more accurate.

Replaces #33408

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))