### PR TITLE
Add DORA Metrics plugin metadata

### DIFF
--- a/microsite/data/plugins/c2l2c-dora-metrics.yaml
+++ b/microsite/data/plugins/c2l2c-dora-metrics.yaml
@@ -1,0 +1,11 @@
+---
+title: DORA Metrics
+author: C2L2C
+authorUrl: https://github.com/C2L2C
+category: Monitoring
+description: Per-entity DORA metrics for catalog services. Computes Deployment Frequency, Lead Time, CFR & MTTR from GitHub PRs — multi-environment, trend history, no extra backend.
+documentation: https://github.com/C2L2C/backstage-plugin-dora-metrics#readme
+iconUrl: https://raw.githubusercontent.com/tailwindlabs/heroicons/master/src/24/outline/chart-bar.svg
+npmPackageName: '@c2l2c/backstage-plugin-dora-metrics'
+addedDate: '2026-03-18'
+status: active


### PR DESCRIPTION
Added metadata for the `@c2l2c/backstage-plugin-dora-metrics` plugin — a frontend plugin that
  displays DORA metrics (Deployment Frequency, Lead Time, Change Failure Rate, MTTR) for Backstage   
  catalog entities using the GitHub API.
                                                                                                     
  - Published on npm: https://www.npmjs.com/package/@c2l2c/backstage-plugin-dora-metrics             
  - Source: https://github.com/C2L2C/backstage-plugin-dora-metrics
                                                                                                     
  ## Hey, I just made a Pull Request!                                                                
   
  Adding a new plugin entry to the marketplace directory for a DORA metrics plugin that surfaces     
  GitHub PR data as DORA metrics on catalog entity pages. Supports multiple environments, trend
  history charts, and elite/high/medium/low ratings per DORA research benchmarks.                    
                                                                
  #### :heavy_check_mark: Checklist                                                                  
   
  - [ ] A changeset describing the change and affected packages. ([more                              
  info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
    - _Not applicable — this is a plugin directory metadata addition only, no Backstage package      
  changes._                                                                                          
  - [x] Added or updated documentation
    - _README at https://github.com/C2L2C/backstage-plugin-dora-metrics#readme_                      
  - [x] Tests for new functionality and regression tests for bug fixes                               
    - _29 unit tests in the plugin repo covering all metric calculations and rating logic._
  - [x] Screenshots attached (for UI changes)                                                        
  - [x] All your commits have a `Signed-off-by` line in the message.    