### PR TITLE
chore: exclude stories from tsc type checking

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "plugins/*/dev",
     "plugins/*/migrations"
   ],
+  "exclude": ["**/*.stories.ts", "**/*.stories.tsx"],
   "compilerOptions": {
     "outDir": "dist-types",
     "rootDir": ".",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Storybook CSF4 type inference generates massive `.d.ts` files for stories — for example `Card.stories.d.ts` grew to 1.4MB by aggressively inlining all React HTML/ARIA prop types. This happened after the storybook upgrade from `10.3.0-alpha.1` to `10.3.0-alpha.14`.

The 123 stories files across `packages/` and `plugins/` are never imported by production code, but their `.d.ts` output was consuming significant resources during `yarn tsc`:

| Metric | Before | After | Saved |
|---|---|---|---|
| Emit time | ~36.8s | ~18.4s | **-50%** |
| Memory | ~5,641 MB | ~5,499 MB | **-142 MB** |
| Total time | ~109s | ~97s | **-12s** |
| dist-types stories size | 6.5 MB | 0 | **-6.5 MB** |

This may also help downstream adopters who were reporting OOM during `tsc` after upgrading to the latest Backstage release.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))