### PR TITLE
create-app: use nav system for settings sidebar item

### DIFF
--- a/.changeset/fix-sidebar-settings-nav.md
+++ b/.changeset/fix-sidebar-settings-nav.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Fixed the `create-app` template sidebar to render the user settings nav item via the nav system instead of a hardcoded `SidebarSettings` component.

--- a/packages/create-app/templates/next-app/packages/app/src/modules/nav/Sidebar.tsx
+++ b/packages/create-app/templates/next-app/packages/app/src/modules/nav/Sidebar.tsx
@@ -12,10 +12,7 @@ import { SidebarLogo } from './SidebarLogo';
 import MenuIcon from '@material-ui/icons/Menu';
 import SearchIcon from '@material-ui/icons/Search';
 import { SidebarSearchModal } from '@backstage/plugin-search';
-import {
-  UserSettingsSignInAvatar,
-  Settings as SidebarSettings,
-} from '@backstage/plugin-user-settings';
+import { UserSettingsSignInAvatar } from '@backstage/plugin-user-settings';
 import { NotificationsSidebarItem } from '@backstage/plugin-notifications';
 
 export const SidebarContent = NavContentBlueprint.make({
@@ -50,7 +47,7 @@ export const SidebarContent = NavContentBlueprint.make({
             icon={<UserSettingsSignInAvatar />}
             to="/settings"
           >
-            <SidebarSettings />
+            {nav.take('page:user-settings')}
           </SidebarGroup>
         </Sidebar>,
       );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes the `create-app` template sidebar to use `nav.take('page:user-settings')` instead of a hardcoded `<SidebarSettings />` component inside the Settings `SidebarGroup`. This way the user-settings nav item is rendered via the nav system, consistent with how other nav items are handled.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))