### PR TITLE
docs: add corporate proxy tutorial to sidebar navigation

### DIFF
--- a/microsite/sidebars.ts
+++ b/microsite/sidebars.ts
@@ -652,6 +652,7 @@ export default {
             'tutorials/manual-knex-rollback',
             'tutorials/switching-sqlite-postgres',
             'tutorials/using-backstage-proxy-within-plugin',
+            'tutorials/corporate-proxy',
             'tutorials/enable-public-entry',
             'tutorials/setup-opentelemetry',
             'tutorials/integrating-event-driven-updates-with-entity-providers',


### PR DESCRIPTION
The corporate proxy tutorial added in #33006 is not visible in the docs sidebar. Add it to the Technical tutorials section so that it is discoverable at https://backstage.io/docs/tutorials/corporate-proxy.