### PR TITLE
BUI: Add usedebounce hook to docs-ui

### DIFF
--- a/docs-ui/src/app/hooks/use-debounce/components.tsx
+++ b/docs-ui/src/app/hooks/use-debounce/components.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+export function useDebounce<T>(value: T, delay: number = 500): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}
+
+export function UseDebounceExample() {
+  const [inputValue, setInputValue] = useState('');
+  const debouncedValue = useDebounce(inputValue, 500);
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <label className="block text-sm font-medium mb-2">
+          Type something:
+        </label>
+        <input
+          type="text"
+          value={inputValue}
+          onChange={e => setInputValue(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          placeholder="Start typing..."
+        />
+      </div>
+      <div className="p-4 bg-gray-50 rounded-md">
+        <p className="text-sm text-gray-600">
+          <strong>Input Value:</strong> {inputValue || '(empty)'}
+        </p>
+        <p className="text-sm text-gray-600">
+          <strong>Debounced Value:</strong> {debouncedValue || '(empty)'}
+        </p>
+        <p className="text-xs text-gray-500 mt-2">
+          The debounced value updates 500ms after you stop typing.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/docs-ui/src/app/hooks/use-debounce/page.mdx
+++ b/docs-ui/src/app/hooks/use-debounce/page.mdx
@@ -1,0 +1,43 @@
+import { ChangelogComponent } from '@/components/ChangelogComponent';
+import { PageTitle } from '@/components/PageTitle';
+import { PropsTable } from '@/components/PropsTable';
+import { Snippet } from '@/components/Snippet';
+import { useDebounceParamDefs, useDebounceReturnDefs } from './props-definition';
+import { useDebounceExampleSnippet } from './snippets';
+import { UseDebounceExample } from './components';
+
+<PageTitle
+  title="useDebounce"
+  description="A custom hook to debounce values and delay updates until after a specified delay."
+/>
+
+## Usage
+
+The `useDebounce` hook delays updating a value until after a specified delay has elapsed since the last change. This is particularly useful for optimizing expensive operations like API calls, search queries, or validation that shouldn't trigger on every keystroke.
+
+This is a custom implementation demonstrating how to create a debounce hook. In production Backstage code, consider using `react-use/esm/useDebounce` instead.
+
+<Snippet
+  align="center"
+  py={4}
+  height={200}
+  preview={<UseDebounceExample />}
+  code={useDebounceExampleSnippet}
+/>
+
+## Common Use Cases
+
+- **Search Input**: Debounce search queries to reduce API calls while typing
+- **Form Validation**: Delay validation until user stops typing
+- **Window Resize**: Debounce resize handlers to improve performance
+- **Auto-save**: Delay save operations until user has stopped making changes
+
+## Parameters
+
+<PropsTable data={useDebounceParamDefs} isHook />
+
+## Return Value
+
+<PropsTable data={useDebounceReturnDefs} isHook />
+
+<ChangelogComponent hook="use-debounce" />

--- a/docs-ui/src/app/hooks/use-debounce/props-definition.ts
+++ b/docs-ui/src/app/hooks/use-debounce/props-definition.ts
@@ -1,0 +1,22 @@
+import { type PropDef } from '@/utils/propDefs';
+
+export const useDebounceParamDefs: Record<string, PropDef> = {
+  value: {
+    type: 'string',
+    description: 'The value to debounce. Can be any type',
+  },
+  delay: {
+    type: 'number',
+    description:
+      'The delay in milliseconds to wait before updating the debounced value',
+    default: '500',
+  },
+};
+
+export const useDebounceReturnDefs: Record<string, PropDef> = {
+  debouncedValue: {
+    type: 'string',
+    description:
+      'The debounced value that updates after the specified delay has passed since the last change',
+  },
+};

--- a/docs-ui/src/app/hooks/use-debounce/snippets.ts
+++ b/docs-ui/src/app/hooks/use-debounce/snippets.ts
@@ -1,0 +1,40 @@
+export const useDebounceExampleSnippet = `import { useState } from 'react';
+
+function useDebounce<T>(value: T, delay: number = 500): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}
+
+function SearchComponent() {
+  const [searchTerm, setSearchTerm] = useState('');
+  const debouncedSearchTerm = useDebounce(searchTerm, 500);
+
+  // Use debouncedSearchTerm for API calls
+  // It will only update 500ms after the user stops typing
+  useEffect(() => {
+    if (debouncedSearchTerm) {
+      // Make API call with debouncedSearchTerm
+      fetchSearchResults(debouncedSearchTerm);
+    }
+  }, [debouncedSearchTerm]);
+
+  return (
+    <input
+      type="text"
+      value={searchTerm}
+      onChange={e => setSearchTerm(e.target.value)}
+      placeholder="Search..."
+    />
+  );
+}`;

--- a/docs-ui/src/utils/data.ts
+++ b/docs-ui/src/utils/data.ts
@@ -152,4 +152,8 @@ export const hooks: Page[] = [
     title: 'useBreakpoint',
     slug: 'use-breakpoint',
   },
+  {
+    title: 'useDebounce',
+    slug: 'use-debounce',
+  },
 ];


### PR DESCRIPTION
## What Was Added

- New `useDebounce` hook documentation
- Registered hook in navigation

<img width="1903" height="864" alt="image" src="https://github.com/user-attachments/assets/bfb9f8c8-ad05-4e1c-9dc9-3ca4b381c972" />


## Why
Without debouncing, every keystroke in an input field triggers immediate actions, which can cause:
- **Performance Issues**: Hundreds of API calls while typing a search query
- **Rate Limiting**: Hitting API rate limits unnecessarily
- **Poor UX**: Flickering results and loading states on every character
- **Server Load**: Unnecessary backend processing for incomplete input

### Use Cases
- **Search bars**: Wait until user stops typing before querying the API
- **Autocomplete**: Fetch suggestions only after user pauses
- **Form validation**: Validate fields after user finishes input, not on every keystroke
- **Filter controls**: Apply filters after user completes their selection
- **Auto-save**: Save draft only after user stops editing

### Why Document It
Debouncing is a fundamental pattern for responsive UIs, and documenting it helps Backstage developers:
- Learn best practices for handling user input
- Understand when and how to optimize performance
- See a consistent implementation pattern across the project