### PR TITLE
fix: adapt test types for @types/supertest v7

### DIFF
--- a/packages/backend-defaults/src/entrypoints/rootHttpRouter/rootHttpRouterServiceFactory.test.ts
+++ b/packages/backend-defaults/src/entrypoints/rootHttpRouter/rootHttpRouterServiceFactory.test.ts
@@ -260,11 +260,11 @@ describe('rootHttpRouterServiceFactory', () => {
       status: 'ok',
     });
 
-    await request(app)
+    await request(app!)
       .get('/.backstage/health/v1/liveness')
       .expect(200, { status: 'ok' });
 
-    await request(app).get('/.backstage/health/v1/readiness').expect(200, {
+    await request(app!).get('/.backstage/health/v1/readiness').expect(200, {
       status: 'ok',
     });
 
@@ -279,12 +279,12 @@ describe('rootHttpRouterServiceFactory', () => {
       status: 'ok',
     });
 
-    await request(app)
+    await request(app!)
       .get('/.backstage/health/v1/liveness')
       .expect(200, { status: 'ok' });
 
     // Immediately start failing the readiness health check
-    await request(app).get('/.backstage/health/v1/readiness').expect(503, {
+    await request(app!).get('/.backstage/health/v1/readiness').expect(503, {
       message: 'Backend is shutting down',
       status: 'error',
     });
@@ -296,22 +296,22 @@ describe('rootHttpRouterServiceFactory', () => {
       status: 'ok',
     });
 
-    await request(app)
+    await request(app!)
       .get('/.backstage/health/v1/liveness')
       .expect(200, { status: 'ok' });
 
-    await request(app).get('/.backstage/health/v1/readiness').expect(503, {
+    await request(app!).get('/.backstage/health/v1/readiness').expect(503, {
       message: 'Backend is shutting down',
       status: 'error',
     });
 
     jest.advanceTimersByTime(1);
 
-    await request(app)
+    await request(app!)
       .get('/.backstage/health/v1/liveness')
       .expect(200, { status: 'ok' });
 
-    await request(app).get('/.backstage/health/v1/readiness').expect(503, {
+    await request(app!).get('/.backstage/health/v1/readiness').expect(503, {
       message: 'Backend is shutting down',
       status: 'error',
     });

--- a/plugins/auth-backend-module-atlassian-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-atlassian-provider/src/module.test.ts
@@ -59,7 +59,7 @@ describe('authModuleAtlassianProvider', () => {
     });
     expect(nonceCookie).toBeDefined();
 
-    const startUrl = new URL(res.get('location'));
+    const startUrl = new URL(res.get('location')!);
     expect(startUrl.origin).toBe('https://auth.atlassian.com');
     expect(startUrl.pathname).toBe('/authorize');
     expect(Object.fromEntries(startUrl.searchParams)).toEqual({
@@ -74,7 +74,7 @@ describe('authModuleAtlassianProvider', () => {
 
     expect(decodeOAuthState(startUrl.searchParams.get('state')!)).toEqual({
       env: 'development',
-      nonce: decodeURIComponent(nonceCookie.value),
+      nonce: decodeURIComponent(nonceCookie!.value),
     });
   });
 
@@ -118,7 +118,7 @@ describe('authModuleAtlassianProvider', () => {
     });
     expect(nonceCookie).toBeDefined();
 
-    const startUrl = new URL(res.get('location'));
+    const startUrl = new URL(res.get('location')!);
     expect(startUrl.origin).toBe('https://auth.atlassian.com');
     expect(startUrl.pathname).toBe('/authorize');
     expect(Object.fromEntries(startUrl.searchParams)).toEqual({
@@ -134,7 +134,7 @@ describe('authModuleAtlassianProvider', () => {
 
     expect(decodeOAuthState(startUrl.searchParams.get('state')!)).toEqual({
       env: 'development',
-      nonce: decodeURIComponent(nonceCookie.value),
+      nonce: decodeURIComponent(nonceCookie!.value),
     });
   });
 

--- a/plugins/auth-backend-module-auth0-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-auth0-provider/src/module.test.ts
@@ -66,7 +66,7 @@ describe('authModuleAuth0Provider', () => {
     });
     expect(nonceCookie).toBeDefined();
 
-    const startUrl = new URL(res.get('location'));
+    const startUrl = new URL(res.get('location')!);
     expect(startUrl.origin).toBe('https://domain');
     expect(startUrl.pathname).toBe('/authorize');
     expect(Object.fromEntries(startUrl.searchParams)).toEqual({
@@ -84,7 +84,7 @@ describe('authModuleAuth0Provider', () => {
 
     expect(decodeOAuthState(startUrl.searchParams.get('state')!)).toEqual({
       env: 'development',
-      nonce: decodeURIComponent(nonceCookie.value),
+      nonce: decodeURIComponent(nonceCookie!.value),
     });
   });
 
@@ -126,7 +126,7 @@ describe('authModuleAuth0Provider', () => {
       '/api/auth/auth0/start?env=development&organization=foo-organization&invitation=foo-invitation',
     );
 
-    const startUrl = new URL(res.get('location'));
+    const startUrl = new URL(res.get('location')!);
     expect(startUrl.origin).toBe('https://domain');
     expect(startUrl.pathname).toBe('/authorize');
     expect(Object.fromEntries(startUrl.searchParams)).toEqual(

--- a/plugins/auth-backend-module-bitbucket-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-bitbucket-provider/src/module.test.ts
@@ -59,7 +59,7 @@ describe('authModuleBitbucketProvider', () => {
     });
     expect(nonceCookie).toBeDefined();
 
-    const startUrl = new URL(res.get('location'));
+    const startUrl = new URL(res.get('location')!);
     expect(startUrl.origin).toBe('https://bitbucket.org');
     expect(startUrl.pathname).toBe('/site/oauth2/authorize');
     expect(Object.fromEntries(startUrl.searchParams)).toEqual({
@@ -72,7 +72,7 @@ describe('authModuleBitbucketProvider', () => {
 
     expect(decodeOAuthState(startUrl.searchParams.get('state')!)).toEqual({
       env: 'development',
-      nonce: decodeURIComponent(nonceCookie.value),
+      nonce: decodeURIComponent(nonceCookie!.value),
       scope: 'account',
     });
   });

--- a/plugins/auth-backend-module-bitbucket-server-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-bitbucket-server-provider/src/module.test.ts
@@ -63,7 +63,7 @@ describe('authModuleBitbucketServerProvider', () => {
     });
     expect(nonceCookie).toBeDefined();
 
-    const startUrl = new URL(res.get('location'));
+    const startUrl = new URL(res.get('location')!);
     expect(startUrl.origin).toBe('https://bitbucket.org');
     expect(startUrl.pathname).toBe('/rest/oauth2/latest/authorize');
     expect(Object.fromEntries(startUrl.searchParams)).toEqual({
@@ -75,7 +75,7 @@ describe('authModuleBitbucketServerProvider', () => {
 
     expect(decodeOAuthState(startUrl.searchParams.get('state')!)).toEqual({
       env: 'development',
-      nonce: decodeURIComponent(nonceCookie.value),
+      nonce: decodeURIComponent(nonceCookie!.value),
     });
   });
 });

--- a/plugins/auth-backend-module-github-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-github-provider/src/module.test.ts
@@ -59,7 +59,7 @@ describe('authModuleGithubProvider', () => {
     });
     expect(nonceCookie).toBeDefined();
 
-    const startUrl = new URL(res.get('location'));
+    const startUrl = new URL(res.get('location')!);
     expect(startUrl.origin).toBe('https://github.com');
     expect(startUrl.pathname).toBe('/login/oauth/authorize');
     expect(Object.fromEntries(startUrl.searchParams)).toEqual({
@@ -72,7 +72,7 @@ describe('authModuleGithubProvider', () => {
 
     expect(decodeOAuthState(startUrl.searchParams.get('state')!)).toEqual({
       env: 'development',
-      nonce: decodeURIComponent(nonceCookie.value),
+      nonce: decodeURIComponent(nonceCookie!.value),
       scope: 'read:user',
     });
   });

--- a/plugins/auth-backend-module-gitlab-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-gitlab-provider/src/module.test.ts
@@ -59,7 +59,7 @@ describe('authModuleGitlabProvider', () => {
     });
     expect(nonceCookie).toBeDefined();
 
-    const startUrl = new URL(res.get('location'));
+    const startUrl = new URL(res.get('location')!);
     expect(startUrl.origin).toBe('https://gitlab.com');
     expect(startUrl.pathname).toBe('/oauth/authorize');
     expect(Object.fromEntries(startUrl.searchParams)).toEqual({
@@ -72,7 +72,7 @@ describe('authModuleGitlabProvider', () => {
 
     expect(decodeOAuthState(startUrl.searchParams.get('state')!)).toEqual({
       env: 'development',
-      nonce: decodeURIComponent(nonceCookie.value),
+      nonce: decodeURIComponent(nonceCookie!.value),
     });
   });
 });

--- a/plugins/auth-backend-module-google-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-google-provider/src/module.test.ts
@@ -59,7 +59,7 @@ describe('authModuleGoogleProvider', () => {
     });
     expect(nonceCookie).toBeDefined();
 
-    const startUrl = new URL(res.get('location'));
+    const startUrl = new URL(res.get('location')!);
     expect(startUrl.origin).toBe('https://accounts.google.com');
     expect(startUrl.pathname).toBe('/o/oauth2/v2/auth');
     expect(Object.fromEntries(startUrl.searchParams)).toEqual({
@@ -76,7 +76,7 @@ describe('authModuleGoogleProvider', () => {
 
     expect(decodeOAuthState(startUrl.searchParams.get('state')!)).toEqual({
       env: 'development',
-      nonce: decodeURIComponent(nonceCookie.value),
+      nonce: decodeURIComponent(nonceCookie!.value),
     });
   });
 });

--- a/plugins/auth-backend-module-microsoft-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-microsoft-provider/src/module.test.ts
@@ -62,7 +62,7 @@ describe('authModuleMicrosoftProvider', () => {
     });
     expect(nonceCookie).toBeDefined();
 
-    const startUrl = new URL(res.get('location'));
+    const startUrl = new URL(res.get('location')!);
     expect(startUrl.origin).toBe('https://login.microsoftonline.com');
     expect(startUrl.pathname).toBe('/my-tenant-id/oauth2/v2.0/authorize');
     expect(Object.fromEntries(startUrl.searchParams)).toEqual({
@@ -75,7 +75,7 @@ describe('authModuleMicrosoftProvider', () => {
 
     expect(decodeOAuthState(startUrl.searchParams.get('state')!)).toEqual({
       env: 'development',
-      nonce: decodeURIComponent(nonceCookie.value),
+      nonce: decodeURIComponent(nonceCookie!.value),
     });
   });
 
@@ -121,7 +121,7 @@ describe('authModuleMicrosoftProvider', () => {
     });
     expect(nonceCookie).toBeDefined();
 
-    const startUrl = new URL(res.get('location'));
+    const startUrl = new URL(res.get('location')!);
     expect(startUrl.origin).toBe('https://login.microsoftonline.com');
     expect(startUrl.pathname).toBe('/another-tenant-id/oauth2/v2.0/authorize');
     expect(Object.fromEntries(startUrl.searchParams)).toEqual({
@@ -135,7 +135,7 @@ describe('authModuleMicrosoftProvider', () => {
 
     expect(decodeOAuthState(startUrl.searchParams.get('state')!)).toEqual({
       env: 'development',
-      nonce: decodeURIComponent(nonceCookie.value),
+      nonce: decodeURIComponent(nonceCookie!.value),
     });
   });
 
@@ -182,7 +182,7 @@ describe('authModuleMicrosoftProvider', () => {
     });
     expect(nonceCookie).toBeDefined();
 
-    const startUrl = new URL(res.get('location'));
+    const startUrl = new URL(res.get('location')!);
     expect(startUrl.origin).toBe('https://login.microsoftonline.com');
     expect(startUrl.pathname).toBe('/another-tenant-id/oauth2/v2.0/authorize');
     expect(Object.fromEntries(startUrl.searchParams)).toEqual({
@@ -195,7 +195,7 @@ describe('authModuleMicrosoftProvider', () => {
 
     expect(decodeOAuthState(startUrl.searchParams.get('state')!)).toEqual({
       env: 'development',
-      nonce: decodeURIComponent(nonceCookie.value),
+      nonce: decodeURIComponent(nonceCookie!.value),
     });
   });
 });

--- a/plugins/auth-backend-module-oauth2-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-oauth2-provider/src/module.test.ts
@@ -61,7 +61,7 @@ describe('authModuleOauth2Provider', () => {
     });
     expect(nonceCookie).toBeDefined();
 
-    const startUrl = new URL(res.get('location'));
+    const startUrl = new URL(res.get('location')!);
     expect(startUrl.origin).toBe('https://oauth2.com');
     expect(startUrl.pathname).toBe('/authorize');
     expect(Object.fromEntries(startUrl.searchParams)).toEqual({
@@ -73,7 +73,7 @@ describe('authModuleOauth2Provider', () => {
 
     expect(decodeOAuthState(startUrl.searchParams.get('state')!)).toEqual({
       env: 'development',
-      nonce: decodeURIComponent(nonceCookie.value),
+      nonce: decodeURIComponent(nonceCookie!.value),
     });
   });
 });

--- a/plugins/auth-backend-module-oidc-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-oidc-provider/src/module.test.ts
@@ -192,7 +192,7 @@ describe('authModuleOidcProvider', () => {
     });
     expect(nonceCookie).toBeDefined();
 
-    const startUrl = new URL(startResponse.get('location'));
+    const startUrl = new URL(startResponse.get('location')!);
     expect(startUrl.origin).toBe('https://oidc.test');
     expect(startUrl.pathname).toBe('/oauth2/authorize');
     const expected = Object.fromEntries(startUrl.searchParams);
@@ -211,7 +211,7 @@ describe('authModuleOidcProvider', () => {
 
     expect(decodeOAuthState(startUrl.searchParams.get('state')!)).toEqual({
       env: 'development',
-      nonce: decodeURIComponent(nonceCookie.value),
+      nonce: decodeURIComponent(nonceCookie!.value),
       scope: 'openid profile email',
     });
   });
@@ -222,10 +222,10 @@ describe('authModuleOidcProvider', () => {
       `${appUrl}/api/auth/oidc/start?env=development`,
     );
     const authorizationResponse = await agent.get(
-      startResponse.header.location,
+      startResponse.header.location!,
     );
     const handlerResponse = await agent.get(
-      authorizationResponse.header.location,
+      authorizationResponse.header.location!,
     );
 
     expect(handlerResponse.text).toContain(

--- a/plugins/auth-backend-module-okta-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-okta-provider/src/module.test.ts
@@ -60,7 +60,7 @@ describe('authModuleOktaProvider', () => {
     });
     expect(nonceCookie).toBeDefined();
 
-    const startUrl = new URL(res.get('location'));
+    const startUrl = new URL(res.get('location')!);
     expect(startUrl.origin).toBe('https://okta.com');
     expect(startUrl.pathname).toBe('/oauth2/v1/authorize');
     expect(Object.fromEntries(startUrl.searchParams)).toEqual({
@@ -73,7 +73,7 @@ describe('authModuleOktaProvider', () => {
 
     expect(decodeOAuthState(startUrl.searchParams.get('state')!)).toEqual({
       env: 'development',
-      nonce: decodeURIComponent(nonceCookie.value),
+      nonce: decodeURIComponent(nonceCookie!.value),
     });
   });
 

--- a/plugins/auth-backend-module-onelogin-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-onelogin-provider/src/module.test.ts
@@ -60,7 +60,7 @@ describe('authModuleOneLoginProvider', () => {
     });
     expect(nonceCookie).toBeDefined();
 
-    const startUrl = new URL(res.get('location'));
+    const startUrl = new URL(res.get('location')!);
     expect(startUrl.origin).toBe('https://my-company.onelogin.com');
     expect(startUrl.pathname).toBe('/oidc/2/auth');
     expect(Object.fromEntries(startUrl.searchParams)).toEqual({
@@ -73,7 +73,7 @@ describe('authModuleOneLoginProvider', () => {
 
     expect(decodeOAuthState(startUrl.searchParams.get('state')!)).toEqual({
       env: 'development',
-      nonce: decodeURIComponent(nonceCookie.value),
+      nonce: decodeURIComponent(nonceCookie!.value),
     });
   });
 });

--- a/plugins/auth-backend-module-vmware-cloud-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-vmware-cloud-provider/src/module.test.ts
@@ -65,7 +65,7 @@ describe('authModuleVmwareCloudProvider', () => {
     });
     expect(nonceCookie).toBeDefined();
 
-    const startUrl = new URL(res.get('location'));
+    const startUrl = new URL(res.get('location')!);
     expect(startUrl.origin).toBe('https://console.cloud.vmware.com');
     expect(startUrl.pathname).toBe('/csp/gateway/discovery');
     expect(Object.fromEntries(startUrl.searchParams)).toEqual({
@@ -82,7 +82,7 @@ describe('authModuleVmwareCloudProvider', () => {
     expect(decodeOAuthState(startUrl.searchParams.get('state')!)).toEqual({
       env: 'development',
       handle: expect.any(String),
-      nonce: decodeURIComponent(nonceCookie.value),
+      nonce: decodeURIComponent(nonceCookie!.value),
     });
 
     backend.stop();

--- a/plugins/auth-node/src/oauth/createOAuthRouteHandlers.test.ts
+++ b/plugins/auth-node/src/oauth/createOAuthRouteHandlers.test.ts
@@ -16,7 +16,7 @@
 
 import { ConfigReader } from '@backstage/config';
 import express from 'express';
-import request, { SuperAgentTest } from 'supertest';
+import request from 'supertest';
 import cookieParser from 'cookie-parser';
 import PromiseRouter from 'express-promise-router';
 import {
@@ -97,7 +97,7 @@ function wrapInApp(handlers: AuthProviderRouteHandlers) {
   return app;
 }
 
-function getNonceCookie(test: SuperAgentTest) {
+function getNonceCookie(test: request.Agent) {
   return test.jar.getCookie('my-provider-nonce', {
     domain: '127.0.0.1',
     path: '/my-provider/handler',
@@ -106,7 +106,7 @@ function getNonceCookie(test: SuperAgentTest) {
   });
 }
 
-function getRefreshTokenCookie(test: SuperAgentTest, chunkNumber?: number) {
+function getRefreshTokenCookie(test: request.Agent, chunkNumber?: number) {
   if (chunkNumber !== undefined) {
     return test.jar.getCookie(`my-provider-refresh-token-${chunkNumber}`, {
       domain: '127.0.0.1',
@@ -147,7 +147,7 @@ function confirmRefreshTokenCookieDeletion(
   );
 }
 
-function getGrantedScopesCookie(test: SuperAgentTest) {
+function getGrantedScopesCookie(test: request.Agent) {
   return test.jar.getCookie('my-provider-granted-scope', {
     domain: '127.0.0.1',
     path: '/my-provider',
@@ -202,7 +202,7 @@ describe('createOAuthRouteHandlers', () => {
         '/my-provider/start?env=development&scope=my-scope',
       );
 
-      const { value: nonce } = getNonceCookie(agent);
+      const { value: nonce } = getNonceCookie(agent)!;
 
       expect(res.text).toBe('');
       expect(res.status).toBe(302);
@@ -316,7 +316,7 @@ describe('createOAuthRouteHandlers', () => {
         },
       });
 
-      expect(getRefreshTokenCookie(agent).value).toBe('refresh-token');
+      expect(getRefreshTokenCookie(agent)!.value).toBe('refresh-token');
       expect(getGrantedScopesCookie(agent)).toBeUndefined();
     });
 
@@ -365,10 +365,10 @@ describe('createOAuthRouteHandlers', () => {
         },
       });
 
-      expect(getRefreshTokenCookie(agent, 0).value).toBe(
+      expect(getRefreshTokenCookie(agent, 0)!.value).toBe(
         extractTokenStringSlice(fiveKilobyteRefreshToken, 0),
       );
-      expect(getRefreshTokenCookie(agent, 1).value).toBe(
+      expect(getRefreshTokenCookie(agent, 1)!.value).toBe(
         extractTokenStringSlice(fiveKilobyteRefreshToken, 1),
       );
       expect(getGrantedScopesCookie(agent)).toBeUndefined();
@@ -465,10 +465,10 @@ describe('createOAuthRouteHandlers', () => {
         },
       });
 
-      expect(getRefreshTokenCookie(agent, 0).value).toBe(
+      expect(getRefreshTokenCookie(agent, 0)!.value).toBe(
         extractTokenStringSlice(fiveKilobyteRefreshToken, 0),
       );
-      expect(getRefreshTokenCookie(agent, 1).value).toBe(
+      expect(getRefreshTokenCookie(agent, 1)!.value).toBe(
         extractTokenStringSlice(fiveKilobyteRefreshToken, 1),
       );
       // verify that the old chunked cookie 2 is cleaned up
@@ -531,7 +531,7 @@ describe('createOAuthRouteHandlers', () => {
         confirmRefreshTokenCookieDeletion(res, { domain: '127.0.0.1' }),
       ).toBe(true);
 
-      expect(getRefreshTokenCookie(agent).value).toBe('refresh-token');
+      expect(getRefreshTokenCookie(agent)!.value).toBe('refresh-token');
     });
 
     it('should clean up old chunked cookies with domain attribute during migration', async () => {
@@ -593,10 +593,10 @@ describe('createOAuthRouteHandlers', () => {
         }),
       ).toBe(true);
 
-      expect(getRefreshTokenCookie(agent, 0).value).toBe(
+      expect(getRefreshTokenCookie(agent, 0)!.value).toBe(
         extractTokenStringSlice(fiveKilobyteRefreshToken, 0),
       );
-      expect(getRefreshTokenCookie(agent, 1).value).toBe(
+      expect(getRefreshTokenCookie(agent, 1)!.value).toBe(
         extractTokenStringSlice(fiveKilobyteRefreshToken, 1),
       );
     });
@@ -656,7 +656,7 @@ describe('createOAuthRouteHandlers', () => {
         }),
       ).toBe(true);
 
-      expect(getRefreshTokenCookie(agent).value).toBe('refresh-token');
+      expect(getRefreshTokenCookie(agent)!.value).toBe('refresh-token');
       expect(getRefreshTokenCookie(agent, 0)).toBeUndefined();
       expect(getRefreshTokenCookie(agent, 1)).toBeUndefined();
     });
@@ -717,8 +717,8 @@ describe('createOAuthRouteHandlers', () => {
         },
       });
 
-      expect(getRefreshTokenCookie(agent).value).toBe('refresh-token');
-      expect(getGrantedScopesCookie(agent).value).toBe(
+      expect(getRefreshTokenCookie(agent)!.value).toBe('refresh-token');
+      expect(getGrantedScopesCookie(agent)!.value).toBe(
         'my-scope%20my-other-scope',
       );
     });
@@ -762,8 +762,8 @@ describe('createOAuthRouteHandlers', () => {
       expect(res.status).toBe(302);
       expect(res.get('Location')).toBe('https://127.0.0.1:3000/redirect');
 
-      expect(getRefreshTokenCookie(agent).value).toBe('refresh-token');
-      expect(getGrantedScopesCookie(agent).value).toBe(
+      expect(getRefreshTokenCookie(agent)!.value).toBe('refresh-token');
+      expect(getGrantedScopesCookie(agent)!.value).toBe(
         'my-scope%20my-other-scope',
       );
     });
@@ -1070,7 +1070,7 @@ describe('createOAuthRouteHandlers', () => {
           token: mockBackstageToken,
         },
       });
-      expect(getRefreshTokenCookie(agent).value).toBe('new-refresh-token');
+      expect(getRefreshTokenCookie(agent)!.value).toBe('new-refresh-token');
     });
 
     it('should forward errors', async () => {
@@ -1171,7 +1171,7 @@ describe('createOAuthRouteHandlers', () => {
 
       expect(res.status).toBe(200);
       const expectedExpirationDate = Date.now() + 7 * 24 * 60 * 60 * 1000;
-      const cookie = getRefreshTokenCookie(agent);
+      const cookie = getRefreshTokenCookie(agent)!;
       expect(cookie.expiration_date).toBeGreaterThanOrEqual(
         expectedExpirationDate - 1000,
       );
@@ -1202,7 +1202,7 @@ describe('createOAuthRouteHandlers', () => {
 
       expect(res.status).toBe(200);
       const expectedExpirationDate = Date.now() + 1000 * 24 * 60 * 60 * 1000;
-      const cookie = getRefreshTokenCookie(agent);
+      const cookie = getRefreshTokenCookie(agent)!;
       expect(cookie.expiration_date).toBeGreaterThanOrEqual(
         expectedExpirationDate - 5000,
       );
@@ -1224,7 +1224,7 @@ describe('createOAuthRouteHandlers', () => {
         '/my-provider',
       );
 
-      expect(getRefreshTokenCookie(agent).value).toBe('my-refresh-token');
+      expect(getRefreshTokenCookie(agent)!.value).toBe('my-refresh-token');
 
       const res = await agent
         .post('/my-provider/logout')

--- a/plugins/scaffolder-backend/src/service/router.test.ts
+++ b/plugins/scaffolder-backend/src/service/router.test.ts
@@ -1342,7 +1342,7 @@ describe('scaffolder router', () => {
       let headers: Record<string, string> = {};
       const responseDataFn = jest.fn();
 
-      const req = request(router)
+      const req = request(router as any)
         .get('/v2/tasks/a-random-id/eventstream')
         .set('accept', 'text/event-stream')
         .parse((res, _) => {
@@ -1424,7 +1424,7 @@ data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{
       let statusCode: number | undefined = undefined;
       let headers: Record<string, string> = {};
 
-      const req = request(router)
+      const req = request(router as any)
         .get('/v2/tasks/a-random-id/eventstream')
         .query({ after: 10 })
         .set('accept', 'text/event-stream')
@@ -1677,7 +1677,7 @@ data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{
       const mockToken = mockCredentials.user.token();
       const mockTemplate = generateMockTemplate();
 
-      const response = await request(unwrappedRouter)
+      const response = await request(unwrappedRouter as any)
         .post('/v2/dry-run')
         .set('Authorization', `Bearer ${mockToken}`)
         .send({

--- a/plugins/techdocs-node/src/stages/publish/googleStorage.test.ts
+++ b/plugins/techdocs-node/src/stages/publish/googleStorage.test.ts
@@ -491,7 +491,7 @@ describe('GoogleGCSPublish', () => {
     const entityTripletPath = `${entity.metadata.namespace}/${entity.kind}/${entity.metadata.name}`;
     // const entityTripletPath =
 
-    let app: Express.Application;
+    let app: any;
 
     beforeEach(async () => {
       const publisher = createPublisherFromConfig();


### PR DESCRIPTION
## Summary

Fixes the type errors introduced by bumping `@types/supertest` from v2 to v7 in #33248.

The v7 types are stricter than v2 in several ways:

- **`app` parameter typed as `App` instead of `any`** -- `supertest(app)` no longer accepts `undefined`, Express `Router`, or Express `Application` directly. Fixed with `!` assertions and `as any` casts in test code.
- **`SuperAgentTest` type changed** -- replaced with `request.Agent` which properly extends `superagent.agent` and has `.jar` for cookie access.
- **Response headers can be `undefined`** -- `res.get('location')` now returns `string | undefined`. Added `!` assertions.
- **Cookie lookups return `Cookie | undefined`** -- `getCookie()` results need `!` when accessing `.value`.

### Files changed (17 test files)

- `packages/backend-defaults` -- rootHttpRouterServiceFactory.test.ts
- `plugins/auth-node` -- createOAuthRouteHandlers.test.ts
- `plugins/scaffolder-backend` -- router.test.ts
- `plugins/techdocs-node` -- googleStorage.test.ts
- 12 auth provider module tests (atlassian, auth0, bitbucket, bitbucket-server, github, gitlab, google, microsoft, oauth2, oidc, okta, onelogin, vmware-cloud)

## Test plan

- [x] `yarn tsc` passes (no supertest-related errors)
- [x] `createOAuthRouteHandlers.test.ts` -- 31/31 tests pass
- [x] `rootHttpRouterServiceFactory.test.ts` -- 7/7 tests pass
- [x] `googleStorage.test.ts` -- 27/27 tests pass


Made with [Cursor](https://cursor.com)