### PR TITLE
docs: correct syntax for configuring RUM instrumentation

### DIFF
--- a/docs/integrations/datadog-rum/installation.md
+++ b/docs/integrations/datadog-rum/installation.md
@@ -62,9 +62,9 @@ In case after a proper configuration, the events still are not being captured: C
       service: 'backstage',
       env: '<%= config.getString("app.datadogRum.env") %>',
       sampleRate:
-        '<%= config.getOptionalNumber("app.datadogRum.sessionSampleRate") || 100 %>',
+        <%= config.getOptionalNumber("app.datadogRum.sessionSampleRate") || 100 %>,
       sessionReplaySampleRate:
-        '<%= config.getOptionalNumber("app.datadogRum.sessionReplaySampleRate") || 0 %>',
+        <%= config.getOptionalNumber("app.datadogRum.sessionReplaySampleRate") || 0 %>,
       trackInteractions: true,
     });
   });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

As noted by @danherd [here](https://github.com/backstage/backstage/pull/25411#pullrequestreview-2278615828), the documented script to enable publishing Datadog RUM events contains a syntactical error which will cause the RUM instrumentation to fail to load.

The single quotes around the config interpolation in the script for values expecting Numbers must be removed, as this causes the value to be a string. Otherwise, the browser console will throw an error like the following:
`Datadog Browser SDK: Session Replay Sample Rate should be a number between 0 and 100`
(Original issue [here](https://github.com/backstage/backstage/issues/25190))

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
