### PR TITLE
fix(auth): improve SignInResolverFactory Zod schema usage

### DIFF
--- a/.changeset/auth-resolver-use-zod-defaults.md
+++ b/.changeset/auth-resolver-use-zod-defaults.md
@@ -1,0 +1,20 @@
+---
+'@backstage/plugin-auth-backend-module-atlassian-provider': patch
+'@backstage/plugin-auth-backend-module-aws-alb-provider': patch
+'@backstage/plugin-auth-backend-module-azure-easyauth-provider': patch
+'@backstage/plugin-auth-backend-module-bitbucket-provider': patch
+'@backstage/plugin-auth-backend-module-bitbucket-server-provider': patch
+'@backstage/plugin-auth-backend-module-cloudflare-access-provider': patch
+'@backstage/plugin-auth-backend-module-gcp-iap-provider': patch
+'@backstage/plugin-auth-backend-module-github-provider': patch
+'@backstage/plugin-auth-backend-module-gitlab-provider': patch
+'@backstage/plugin-auth-backend-module-google-provider': patch
+'@backstage/plugin-auth-backend-module-microsoft-provider': patch
+'@backstage/plugin-auth-backend-module-oauth2-provider': patch
+'@backstage/plugin-auth-backend-module-oauth2-proxy-provider': patch
+'@backstage/plugin-auth-backend-module-okta-provider': patch
+'@backstage/plugin-auth-backend-module-onelogin-provider': patch
+'@backstage/plugin-auth-backend-module-openshift-provider': patch
+---
+
+Migrated Zod usage from v3 to v4 and updated sign-in resolver option schemas to use Zod `.prefault()` instead of `.optional()` with JavaScript-level parameter defaults, aligning with the updated `SignInResolverFactoryOptions` interface in `@backstage/plugin-auth-node`.

--- a/.changeset/simplify-sign-in-resolver-factory-types.md
+++ b/.changeset/simplify-sign-in-resolver-factory-types.md
@@ -1,0 +1,32 @@
+---
+'@backstage/plugin-auth-node': minor
+---
+
+**BREAKING**: Simplified `SignInResolverFactoryOptions` generic type parameters. Instead of `<TAuthResult, TOptionsOutput, TOptionsInput>`, the interface now uses `<TAuthResult, TSchema extends z.ZodType>`, following the Zod recommendation for writing generic functions. This fixes "Type instantiation is excessively deep and possibly infinite" errors that occurred when users had a different Zod version from Backstage core.
+
+The `SignInResolverFactory` call signature now accepts `unknown` options, since the input is always validated by Zod at runtime. The default type parameters have been changed from `any` to `unknown`.
+
+Migrated internal Zod usage from v3 to v4, replaced `zod-to-json-schema` with the built-in `z.toJSONSchema`, and replaced `zod-validation-error` with the built-in `z.prettifyError`.
+
+Implemented the missing `allowedDomains` enforcement in `emailMatchingUserEntityProfileEmail`. The option was introduced in #28967 but was never wired up. It is now enforced the same way as in `emailLocalPartMatchingUserEntityName`.
+
+If you have custom sign-in resolver factories, update them to use `.prefault()` on the Zod schema instead of `.optional()` with JavaScript-level parameter defaults:
+
+```diff
+  createSignInResolverFactory({
+    optionsSchema: z
+      .object({
+-       dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().optional(),
++       dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().prefault(false),
+      })
+-     .optional(),
+-   create(options = {}) {
++     .prefault({}),
++   create({ dangerouslyAllowSignInWithoutUserInCatalog }) {
+      return async (info, ctx) => {
+-       if (options?.dangerouslyAllowSignInWithoutUserInCatalog) { ... }
++       if (dangerouslyAllowSignInWithoutUserInCatalog) { ... }
+      };
+    },
+  });
+```

--- a/plugins/auth-backend-module-atlassian-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-atlassian-provider/src/resolvers.ts
@@ -20,7 +20,7 @@ import {
   PassportProfile,
   SignInInfo,
 } from '@backstage/plugin-auth-node';
-import { z } from 'zod/v3';
+import * as z from 'zod/v4';
 
 /**
  * Available sign-in resolvers for the Atlassian auth provider.
@@ -34,10 +34,10 @@ export namespace atlassianSignInResolvers {
   export const usernameMatchingUserEntityName = createSignInResolverFactory({
     optionsSchema: z
       .object({
-        dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().optional(),
+        dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().prefault(false),
       })
-      .optional(),
-    create(options = {}) {
+      .prefault({}),
+    create({ dangerouslyAllowSignInWithoutUserInCatalog }) {
       return async (
         info: SignInInfo<OAuthAuthenticatorResult<PassportProfile>>,
         ctx,
@@ -53,7 +53,7 @@ export namespace atlassianSignInResolvers {
           { entityRef: { name: id } },
           {
             dangerousEntityRefFallback:
-              options?.dangerouslyAllowSignInWithoutUserInCatalog
+              dangerouslyAllowSignInWithoutUserInCatalog
                 ? { entityRef: { name: id } }
                 : undefined,
           },

--- a/plugins/auth-backend-module-aws-alb-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-aws-alb-provider/src/resolvers.ts
@@ -19,7 +19,7 @@ import {
   SignInInfo,
 } from '@backstage/plugin-auth-node';
 import { AwsAlbResult } from './types';
-import { z } from 'zod/v3';
+import * as z from 'zod/v4';
 
 /**
  * Available sign-in resolvers for the AWS ALB auth provider.
@@ -31,10 +31,12 @@ export namespace awsAlbSignInResolvers {
     createSignInResolverFactory({
       optionsSchema: z
         .object({
-          dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().optional(),
+          dangerouslyAllowSignInWithoutUserInCatalog: z
+            .boolean()
+            .prefault(false),
         })
-        .optional(),
-      create(options = {}) {
+        .prefault({}),
+      create({ dangerouslyAllowSignInWithoutUserInCatalog }) {
         return async (info: SignInInfo<AwsAlbResult>, ctx) => {
           if (!info.result.fullProfile.emails) {
             throw new Error(
@@ -51,7 +53,7 @@ export namespace awsAlbSignInResolvers {
             },
             {
               dangerousEntityRefFallback:
-                options?.dangerouslyAllowSignInWithoutUserInCatalog
+                dangerouslyAllowSignInWithoutUserInCatalog
                   ? {
                       entityRef: {
                         name: info.result.fullProfile.emails[0].value,

--- a/plugins/auth-backend-module-azure-easyauth-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-azure-easyauth-provider/src/resolvers.ts
@@ -19,17 +19,17 @@ import {
   SignInInfo,
 } from '@backstage/plugin-auth-node';
 import { AzureEasyAuthResult } from './types';
-import { z } from 'zod/v3';
+import * as z from 'zod/v4';
 
 /** @public */
 export namespace azureEasyAuthSignInResolvers {
   export const idMatchingUserEntityAnnotation = createSignInResolverFactory({
     optionsSchema: z
       .object({
-        dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().optional(),
+        dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().prefault(false),
       })
-      .optional(),
-    create(options = {}) {
+      .prefault({}),
+    create({ dangerouslyAllowSignInWithoutUserInCatalog }) {
       return async (info: SignInInfo<AzureEasyAuthResult>, ctx) => {
         const {
           fullProfile: { id },
@@ -46,7 +46,7 @@ export namespace azureEasyAuthSignInResolvers {
           },
           {
             dangerousEntityRefFallback:
-              options?.dangerouslyAllowSignInWithoutUserInCatalog
+              dangerouslyAllowSignInWithoutUserInCatalog
                 ? { entityRef: { name: id } }
                 : undefined,
           },

--- a/plugins/auth-backend-module-bitbucket-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-bitbucket-provider/src/resolvers.ts
@@ -20,7 +20,7 @@ import {
   PassportProfile,
   SignInInfo,
 } from '@backstage/plugin-auth-node';
-import { z } from 'zod/v3';
+import * as z from 'zod/v4';
 
 /**
  * Available sign-in resolvers for the Bitbucket auth provider.
@@ -35,10 +35,12 @@ export namespace bitbucketSignInResolvers {
     {
       optionsSchema: z
         .object({
-          dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().optional(),
+          dangerouslyAllowSignInWithoutUserInCatalog: z
+            .boolean()
+            .prefault(false),
         })
-        .optional(),
-      create(options = {}) {
+        .prefault({}),
+      create({ dangerouslyAllowSignInWithoutUserInCatalog }) {
         return async (
           info: SignInInfo<OAuthAuthenticatorResult<PassportProfile>>,
           ctx,
@@ -58,7 +60,7 @@ export namespace bitbucketSignInResolvers {
             },
             {
               dangerousEntityRefFallback:
-                options?.dangerouslyAllowSignInWithoutUserInCatalog
+                dangerouslyAllowSignInWithoutUserInCatalog
                   ? { entityRef: { name: id } }
                   : undefined,
             },
@@ -75,10 +77,12 @@ export namespace bitbucketSignInResolvers {
     createSignInResolverFactory({
       optionsSchema: z
         .object({
-          dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().optional(),
+          dangerouslyAllowSignInWithoutUserInCatalog: z
+            .boolean()
+            .prefault(false),
         })
-        .optional(),
-      create(options = {}) {
+        .prefault({}),
+      create({ dangerouslyAllowSignInWithoutUserInCatalog }) {
         return async (
           info: SignInInfo<OAuthAuthenticatorResult<PassportProfile>>,
           ctx,
@@ -100,7 +104,7 @@ export namespace bitbucketSignInResolvers {
             },
             {
               dangerousEntityRefFallback:
-                options?.dangerouslyAllowSignInWithoutUserInCatalog
+                dangerouslyAllowSignInWithoutUserInCatalog
                   ? { entityRef: { name: username } }
                   : undefined,
             },

--- a/plugins/auth-backend-module-bitbucket-server-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-bitbucket-server-provider/src/resolvers.ts
@@ -19,7 +19,7 @@ import {
   PassportProfile,
   SignInInfo,
 } from '@backstage/plugin-auth-node';
-import { z } from 'zod/v3';
+import * as z from 'zod/v4';
 
 /**
  * Available sign-in resolvers for the Bitbucket Server auth provider.
@@ -34,10 +34,12 @@ export namespace bitbucketServerSignInResolvers {
     createSignInResolverFactory({
       optionsSchema: z
         .object({
-          dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().optional(),
+          dangerouslyAllowSignInWithoutUserInCatalog: z
+            .boolean()
+            .prefault(false),
         })
-        .optional(),
-      create(options = {}) {
+        .prefault({}),
+      create({ dangerouslyAllowSignInWithoutUserInCatalog }) {
         return async (
           info: SignInInfo<OAuthAuthenticatorResult<PassportProfile>>,
           ctx,
@@ -58,7 +60,7 @@ export namespace bitbucketServerSignInResolvers {
             },
             {
               dangerousEntityRefFallback:
-                options?.dangerouslyAllowSignInWithoutUserInCatalog
+                dangerouslyAllowSignInWithoutUserInCatalog
                   ? { entityRef: { name: profile.email } }
                   : undefined,
             },

--- a/plugins/auth-backend-module-cloudflare-access-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-cloudflare-access-provider/src/resolvers.ts
@@ -19,7 +19,7 @@ import {
   SignInInfo,
 } from '@backstage/plugin-auth-node';
 import { CloudflareAccessResult } from './types';
-import { z } from 'zod/v3';
+import * as z from 'zod/v4';
 
 /**
  * Available sign-in resolvers for the Cloudflare Access auth provider.
@@ -34,10 +34,12 @@ export namespace cloudflareAccessSignInResolvers {
     createSignInResolverFactory({
       optionsSchema: z
         .object({
-          dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().optional(),
+          dangerouslyAllowSignInWithoutUserInCatalog: z
+            .boolean()
+            .prefault(false),
         })
-        .optional(),
-      create(options = {}) {
+        .prefault({}),
+      create({ dangerouslyAllowSignInWithoutUserInCatalog }) {
         return async (info: SignInInfo<CloudflareAccessResult>, ctx) => {
           const { profile } = info;
 
@@ -55,7 +57,7 @@ export namespace cloudflareAccessSignInResolvers {
             },
             {
               dangerousEntityRefFallback:
-                options?.dangerouslyAllowSignInWithoutUserInCatalog
+                dangerouslyAllowSignInWithoutUserInCatalog
                   ? { entityRef: { name: profile.email } }
                   : undefined,
             },

--- a/plugins/auth-backend-module-gcp-iap-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-gcp-iap-provider/src/resolvers.ts
@@ -19,7 +19,7 @@ import {
   SignInInfo,
 } from '@backstage/plugin-auth-node';
 import { GcpIapResult } from './types';
-import { z } from 'zod/v3';
+import * as z from 'zod/v4';
 
 /**
  * Available sign-in resolvers for the Google auth provider.
@@ -33,10 +33,10 @@ export namespace gcpIapSignInResolvers {
   export const emailMatchingUserEntityAnnotation = createSignInResolverFactory({
     optionsSchema: z
       .object({
-        dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().optional(),
+        dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().prefault(false),
       })
-      .optional(),
-    create(options = {}) {
+      .prefault({}),
+    create({ dangerouslyAllowSignInWithoutUserInCatalog }) {
       return async (info: SignInInfo<GcpIapResult>, ctx) => {
         const email = info.result.iapToken.email;
 
@@ -52,7 +52,7 @@ export namespace gcpIapSignInResolvers {
           },
           {
             dangerousEntityRefFallback:
-              options?.dangerouslyAllowSignInWithoutUserInCatalog
+              dangerouslyAllowSignInWithoutUserInCatalog
                 ? { entityRef: { name: email } }
                 : undefined,
           },
@@ -67,10 +67,10 @@ export namespace gcpIapSignInResolvers {
   export const idMatchingUserEntityAnnotation = createSignInResolverFactory({
     optionsSchema: z
       .object({
-        dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().optional(),
+        dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().prefault(false),
       })
-      .optional(),
-    create(options = {}) {
+      .prefault({}),
+    create({ dangerouslyAllowSignInWithoutUserInCatalog }) {
       return async (info: SignInInfo<GcpIapResult>, ctx) => {
         const userId = info.result.iapToken.sub.split(':')[1];
 
@@ -82,7 +82,7 @@ export namespace gcpIapSignInResolvers {
           },
           {
             dangerousEntityRefFallback:
-              options?.dangerouslyAllowSignInWithoutUserInCatalog
+              dangerouslyAllowSignInWithoutUserInCatalog
                 ? { entityRef: { name: userId } }
                 : undefined,
           },

--- a/plugins/auth-backend-module-github-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-github-provider/src/resolvers.ts
@@ -19,7 +19,7 @@ import {
   OAuthAuthenticatorResult,
   SignInInfo,
 } from '@backstage/plugin-auth-node';
-import { z } from 'zod/v3';
+import * as z from 'zod/v4';
 
 import { GithubProfile } from './authenticator';
 
@@ -35,10 +35,10 @@ export namespace githubSignInResolvers {
   export const usernameMatchingUserEntityName = createSignInResolverFactory({
     optionsSchema: z
       .object({
-        dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().optional(),
+        dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().prefault(false),
       })
-      .optional(),
-    create(options = {}) {
+      .prefault({}),
+    create({ dangerouslyAllowSignInWithoutUserInCatalog }) {
       return async (
         info: SignInInfo<OAuthAuthenticatorResult<GithubProfile>>,
         ctx,
@@ -56,7 +56,7 @@ export namespace githubSignInResolvers {
           },
           {
             dangerousEntityRefFallback:
-              options?.dangerouslyAllowSignInWithoutUserInCatalog
+              dangerouslyAllowSignInWithoutUserInCatalog
                 ? { entityRef: { name: userId } }
                 : undefined,
           },
@@ -72,10 +72,12 @@ export namespace githubSignInResolvers {
     {
       optionsSchema: z
         .object({
-          dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().optional(),
+          dangerouslyAllowSignInWithoutUserInCatalog: z
+            .boolean()
+            .prefault(false),
         })
-        .optional(),
-      create(options = {}) {
+        .prefault({}),
+      create({ dangerouslyAllowSignInWithoutUserInCatalog }) {
         return async (
           info: SignInInfo<OAuthAuthenticatorResult<GithubProfile>>,
           ctx,
@@ -95,7 +97,7 @@ export namespace githubSignInResolvers {
             },
             {
               dangerousEntityRefFallback:
-                options?.dangerouslyAllowSignInWithoutUserInCatalog
+                dangerouslyAllowSignInWithoutUserInCatalog
                   ? { entityRef: { name: userId } }
                   : undefined,
             },

--- a/plugins/auth-backend-module-gitlab-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-gitlab-provider/src/resolvers.ts
@@ -19,7 +19,7 @@ import {
   OAuthAuthenticatorResult,
   SignInInfo,
 } from '@backstage/plugin-auth-node';
-import { z } from 'zod/v3';
+import * as z from 'zod/v4';
 
 import { GitlabProfile } from './authenticator';
 
@@ -35,10 +35,10 @@ export namespace gitlabSignInResolvers {
   export const usernameMatchingUserEntityName = createSignInResolverFactory({
     optionsSchema: z
       .object({
-        dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().optional(),
+        dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().prefault(false),
       })
-      .optional(),
-    create(options = {}) {
+      .prefault({}),
+    create({ dangerouslyAllowSignInWithoutUserInCatalog }) {
       return async (
         info: SignInInfo<OAuthAuthenticatorResult<GitlabProfile>>,
         ctx,
@@ -56,7 +56,7 @@ export namespace gitlabSignInResolvers {
           },
           {
             dangerousEntityRefFallback:
-              options?.dangerouslyAllowSignInWithoutUserInCatalog
+              dangerouslyAllowSignInWithoutUserInCatalog
                 ? { entityRef: { name: id } }
                 : undefined,
           },
@@ -72,10 +72,12 @@ export namespace gitlabSignInResolvers {
     {
       optionsSchema: z
         .object({
-          dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().optional(),
+          dangerouslyAllowSignInWithoutUserInCatalog: z
+            .boolean()
+            .prefault(false),
         })
-        .optional(),
-      create(options = {}) {
+        .prefault({}),
+      create({ dangerouslyAllowSignInWithoutUserInCatalog }) {
         return async (
           info: SignInInfo<OAuthAuthenticatorResult<GitlabProfile>>,
           ctx,
@@ -102,7 +104,7 @@ export namespace gitlabSignInResolvers {
             },
             {
               dangerousEntityRefFallback:
-                options?.dangerouslyAllowSignInWithoutUserInCatalog
+                dangerouslyAllowSignInWithoutUserInCatalog
                   ? { entityRef: { name: userId } }
                   : undefined,
             },

--- a/plugins/auth-backend-module-google-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-google-provider/src/resolvers.ts
@@ -20,7 +20,7 @@ import {
   PassportProfile,
   SignInInfo,
 } from '@backstage/plugin-auth-node';
-import { z } from 'zod/v3';
+import * as z from 'zod/v4';
 
 /**
  * Available sign-in resolvers for the Google auth provider.
@@ -34,10 +34,10 @@ export namespace googleSignInResolvers {
   export const emailMatchingUserEntityAnnotation = createSignInResolverFactory({
     optionsSchema: z
       .object({
-        dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().optional(),
+        dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().prefault(false),
       })
-      .optional(),
-    create(options = {}) {
+      .prefault({}),
+    create({ dangerouslyAllowSignInWithoutUserInCatalog }) {
       return async (
         info: SignInInfo<OAuthAuthenticatorResult<PassportProfile>>,
         ctx,
@@ -56,7 +56,7 @@ export namespace googleSignInResolvers {
           },
           {
             dangerousEntityRefFallback:
-              options?.dangerouslyAllowSignInWithoutUserInCatalog
+              dangerouslyAllowSignInWithoutUserInCatalog
                 ? { entityRef: { name: profile.email } }
                 : undefined,
           },

--- a/plugins/auth-backend-module-microsoft-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-microsoft-provider/src/resolvers.ts
@@ -20,7 +20,7 @@ import {
   PassportProfile,
   SignInInfo,
 } from '@backstage/plugin-auth-node';
-import { z } from 'zod/v3';
+import * as z from 'zod/v4';
 
 /**
  * Available sign-in resolvers for the Microsoft auth provider.
@@ -34,10 +34,10 @@ export namespace microsoftSignInResolvers {
   export const emailMatchingUserEntityAnnotation = createSignInResolverFactory({
     optionsSchema: z
       .object({
-        dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().optional(),
+        dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().prefault(false),
       })
-      .optional(),
-    create(options = {}) {
+      .prefault({}),
+    create({ dangerouslyAllowSignInWithoutUserInCatalog }) {
       return async (
         info: SignInInfo<OAuthAuthenticatorResult<PassportProfile>>,
         ctx,
@@ -56,7 +56,7 @@ export namespace microsoftSignInResolvers {
           },
           {
             dangerousEntityRefFallback:
-              options?.dangerouslyAllowSignInWithoutUserInCatalog
+              dangerouslyAllowSignInWithoutUserInCatalog
                 ? { entityRef: { name: profile.email } }
                 : undefined,
           },
@@ -71,10 +71,12 @@ export namespace microsoftSignInResolvers {
     {
       optionsSchema: z
         .object({
-          dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().optional(),
+          dangerouslyAllowSignInWithoutUserInCatalog: z
+            .boolean()
+            .prefault(false),
         })
-        .optional(),
-      create(options = {}) {
+        .prefault({}),
+      create({ dangerouslyAllowSignInWithoutUserInCatalog }) {
         return async (
           info: SignInInfo<OAuthAuthenticatorResult<PassportProfile>>,
           ctx,
@@ -95,7 +97,7 @@ export namespace microsoftSignInResolvers {
             },
             {
               dangerousEntityRefFallback:
-                options?.dangerouslyAllowSignInWithoutUserInCatalog
+                dangerouslyAllowSignInWithoutUserInCatalog
                   ? { entityRef: { name: id } }
                   : undefined,
             },

--- a/plugins/auth-backend-module-oauth2-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-oauth2-provider/src/resolvers.ts
@@ -20,7 +20,7 @@ import {
   PassportProfile,
   SignInInfo,
 } from '@backstage/plugin-auth-node';
-import { z } from 'zod/v3';
+import * as z from 'zod/v4';
 
 /**
  * Available sign-in resolvers for the oauth2 auth provider.
@@ -34,10 +34,10 @@ export namespace oauth2SignInResolvers {
   export const usernameMatchingUserEntityName = createSignInResolverFactory({
     optionsSchema: z
       .object({
-        dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().optional(),
+        dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().prefault(false),
       })
-      .optional(),
-    create(options = {}) {
+      .prefault({}),
+    create({ dangerouslyAllowSignInWithoutUserInCatalog }) {
       return async (
         info: SignInInfo<OAuthAuthenticatorResult<PassportProfile>>,
         ctx,
@@ -55,7 +55,7 @@ export namespace oauth2SignInResolvers {
           },
           {
             dangerousEntityRefFallback:
-              options?.dangerouslyAllowSignInWithoutUserInCatalog
+              dangerouslyAllowSignInWithoutUserInCatalog
                 ? { entityRef: { name: id } }
                 : undefined,
           },

--- a/plugins/auth-backend-module-oauth2-proxy-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-oauth2-proxy-provider/src/resolvers.ts
@@ -19,7 +19,7 @@ import {
   SignInInfo,
 } from '@backstage/plugin-auth-node';
 import { OAuth2ProxyResult } from './types';
-import { z } from 'zod/v3';
+import * as z from 'zod/v4';
 
 /**
  * @public
@@ -29,10 +29,12 @@ export namespace oauth2ProxySignInResolvers {
     createSignInResolverFactory({
       optionsSchema: z
         .object({
-          dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().optional(),
+          dangerouslyAllowSignInWithoutUserInCatalog: z
+            .boolean()
+            .prefault(false),
         })
-        .optional(),
-      create(options = {}) {
+        .prefault({}),
+      create({ dangerouslyAllowSignInWithoutUserInCatalog }) {
         return async (info: SignInInfo<OAuth2ProxyResult>, ctx) => {
           const name = info.result.getHeader('x-forwarded-user');
           if (!name) {
@@ -45,7 +47,7 @@ export namespace oauth2ProxySignInResolvers {
             },
             {
               dangerousEntityRefFallback:
-                options?.dangerouslyAllowSignInWithoutUserInCatalog
+                dangerouslyAllowSignInWithoutUserInCatalog
                   ? { entityRef: { name } }
                   : undefined,
             },

--- a/plugins/auth-backend-module-okta-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-okta-provider/src/resolvers.ts
@@ -20,7 +20,7 @@ import {
   PassportProfile,
   SignInInfo,
 } from '@backstage/plugin-auth-node';
-import { z } from 'zod/v3';
+import * as z from 'zod/v4';
 
 /**
  * Available sign-in resolvers for the Okta auth provider.
@@ -35,10 +35,10 @@ export namespace oktaSignInResolvers {
   export const emailMatchingUserEntityAnnotation = createSignInResolverFactory({
     optionsSchema: z
       .object({
-        dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().optional(),
+        dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().prefault(false),
       })
-      .optional(),
-    create(options = {}) {
+      .prefault({}),
+    create({ dangerouslyAllowSignInWithoutUserInCatalog }) {
       return async (
         info: SignInInfo<OAuthAuthenticatorResult<PassportProfile>>,
         ctx,
@@ -57,7 +57,7 @@ export namespace oktaSignInResolvers {
           },
           {
             dangerousEntityRefFallback:
-              options?.dangerouslyAllowSignInWithoutUserInCatalog
+              dangerouslyAllowSignInWithoutUserInCatalog
                 ? { entityRef: { name: profile.email } }
                 : undefined,
           },

--- a/plugins/auth-backend-module-onelogin-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-onelogin-provider/src/resolvers.ts
@@ -20,7 +20,7 @@ import {
   PassportProfile,
   SignInInfo,
 } from '@backstage/plugin-auth-node';
-import { z } from 'zod/v3';
+import * as z from 'zod/v4';
 
 /**
  * Available sign-in resolvers for the OneLogin auth provider.
@@ -34,10 +34,10 @@ export namespace oneLoginSignInResolvers {
   export const usernameMatchingUserEntityName = createSignInResolverFactory({
     optionsSchema: z
       .object({
-        dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().optional(),
+        dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().prefault(false),
       })
-      .optional(),
-    create(options = {}) {
+      .prefault({}),
+    create({ dangerouslyAllowSignInWithoutUserInCatalog }) {
       return async (
         info: SignInInfo<OAuthAuthenticatorResult<PassportProfile>>,
         ctx,
@@ -55,7 +55,7 @@ export namespace oneLoginSignInResolvers {
           },
           {
             dangerousEntityRefFallback:
-              options?.dangerouslyAllowSignInWithoutUserInCatalog
+              dangerouslyAllowSignInWithoutUserInCatalog
                 ? { entityRef: { name: id } }
                 : undefined,
           },

--- a/plugins/auth-backend-module-openshift-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-openshift-provider/src/authenticator.ts
@@ -22,7 +22,7 @@ import {
 } from '@backstage/plugin-auth-node';
 import { createHash } from 'node:crypto';
 import OAuth2Strategy from 'passport-oauth2';
-import { z } from 'zod/v3';
+import * as z from 'zod/v4';
 
 /** @public */
 export interface OpenShiftAuthenticatorContext {

--- a/plugins/auth-backend-module-openshift-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-openshift-provider/src/resolvers.ts
@@ -25,16 +25,16 @@ import {
   DEFAULT_NAMESPACE,
   stringifyEntityRef,
 } from '@backstage/catalog-model';
-import { z } from 'zod/v3';
+import * as z from 'zod/v4';
 
 export namespace openshiftSignInResolvers {
   export const displayNameMatchingUserEntityName = createSignInResolverFactory({
     optionsSchema: z
       .object({
-        dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().optional(),
+        dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().prefault(false),
       })
-      .optional(),
-    create(options = {}) {
+      .prefault({}),
+    create({ dangerouslyAllowSignInWithoutUserInCatalog }) {
       return async (
         info: SignInInfo<OAuthAuthenticatorResult<PassportProfile>>,
         ctx,
@@ -57,7 +57,7 @@ export namespace openshiftSignInResolvers {
           { entityRef: userRef },
           {
             dangerousEntityRefFallback:
-              options?.dangerouslyAllowSignInWithoutUserInCatalog
+              dangerouslyAllowSignInWithoutUserInCatalog
                 ? { entityRef: { name: displayName } }
                 : undefined,
           },

--- a/plugins/auth-node/package.json
+++ b/plugins/auth-node/package.json
@@ -50,9 +50,7 @@
     "jose": "^5.0.0",
     "lodash": "^4.17.21",
     "passport": "^0.7.0",
-    "zod": "^3.25.76 || ^4.0.0",
-    "zod-to-json-schema": "^3.25.1",
-    "zod-validation-error": "^4.0.2"
+    "zod": "^3.25.76 || ^4.0.0"
   },
   "devDependencies": {
     "@backstage/backend-defaults": "workspace:^",

--- a/plugins/auth-node/report.api.md
+++ b/plugins/auth-node/report.api.md
@@ -16,8 +16,7 @@ import { Profile } from 'passport';
 import { Request as Request_2 } from 'express';
 import { Response as Response_2 } from 'express';
 import { Strategy } from 'passport';
-import type { ZodSchema } from 'zod/v3';
-import type { ZodTypeDef } from 'zod/v3';
+import * as z from 'zod/v4';
 
 // @public (undocumented)
 export interface AuthOwnershipResolutionExtensionPoint {
@@ -196,9 +195,10 @@ export function createOAuthProviderFactory<TProfile>(options: {
   stateTransform?: OAuthStateTransform;
   profileTransform?: ProfileTransform<OAuthAuthenticatorResult<TProfile>>;
   signInResolver?: SignInResolver<OAuthAuthenticatorResult<TProfile>>;
-  signInResolverFactories?: {
-    [name in string]: SignInResolverFactory;
-  };
+  signInResolverFactories?: Record<
+    string,
+    SignInResolverFactory<OAuthAuthenticatorResult<TProfile>>
+  >;
 }): AuthProviderFactory;
 
 // @public (undocumented)
@@ -216,7 +216,7 @@ export function createProxyAuthProviderFactory<TResult>(options: {
   authenticator: ProxyAuthenticator<unknown, TResult, unknown>;
   profileTransform?: ProfileTransform<TResult>;
   signInResolver?: SignInResolver<TResult>;
-  signInResolverFactories?: Record<string, SignInResolverFactory>;
+  signInResolverFactories?: Record<string, SignInResolverFactory<TResult>>;
 }): AuthProviderFactory;
 
 // @public (undocumented)
@@ -227,15 +227,10 @@ export function createProxyAuthRouteHandlers<TResult>(
 // @public (undocumented)
 export function createSignInResolverFactory<
   TAuthResult,
-  TOptionsOutput,
-  TOptionsInput,
+  TSchema extends z.ZodType = z.ZodUndefined,
 >(
-  options: SignInResolverFactoryOptions<
-    TAuthResult,
-    TOptionsOutput,
-    TOptionsInput
-  >,
-): SignInResolverFactory<TAuthResult, TOptionsInput>;
+  input: SignInResolverFactoryOptions<TAuthResult, TSchema>,
+): SignInResolverFactory<TAuthResult, z.input<TSchema>>;
 
 // @public (undocumented)
 export function decodeOAuthState(encodedState: string): OAuthState;
@@ -637,9 +632,7 @@ export interface ReadDeclarativeSignInResolverOptions<TAuthResult> {
   // (undocumented)
   config: Config;
   // (undocumented)
-  signInResolverFactories: {
-    [name in string]: SignInResolverFactory<TAuthResult, unknown>;
-  };
+  signInResolverFactories: Record<string, SignInResolverFactory<TAuthResult>>;
 }
 
 // @public (undocumented)
@@ -662,13 +655,12 @@ export type SignInResolver<TAuthResult> = (
 ) => Promise<BackstageSignInResult>;
 
 // @public (undocumented)
-export interface SignInResolverFactory<TAuthResult = any, TOptions = any> {
+export interface SignInResolverFactory<
+  TAuthResult = unknown,
+  _TOptions = unknown,
+> {
   // (undocumented)
-  (
-    ...options: undefined extends TOptions
-      ? [options?: TOptions]
-      : [options: TOptions]
-  ): SignInResolver<TAuthResult>;
+  (options?: unknown): SignInResolver<TAuthResult>;
   // (undocumented)
   optionsJsonSchema?: JsonObject;
 }
@@ -676,13 +668,12 @@ export interface SignInResolverFactory<TAuthResult = any, TOptions = any> {
 // @public (undocumented)
 export interface SignInResolverFactoryOptions<
   TAuthResult,
-  TOptionsOutput,
-  TOptionsInput,
+  TSchema extends z.ZodType = z.ZodUndefined,
 > {
   // (undocumented)
-  create(options: TOptionsOutput): SignInResolver<TAuthResult>;
+  create: (options: z.output<TSchema>) => SignInResolver<TAuthResult>;
   // (undocumented)
-  optionsSchema?: ZodSchema<TOptionsOutput, ZodTypeDef, TOptionsInput>;
+  optionsSchema?: TSchema;
 }
 
 // @public

--- a/plugins/auth-node/src/oauth/createOAuthProviderFactory.ts
+++ b/plugins/auth-node/src/oauth/createOAuthProviderFactory.ts
@@ -33,9 +33,10 @@ export function createOAuthProviderFactory<TProfile>(options: {
   stateTransform?: OAuthStateTransform;
   profileTransform?: ProfileTransform<OAuthAuthenticatorResult<TProfile>>;
   signInResolver?: SignInResolver<OAuthAuthenticatorResult<TProfile>>;
-  signInResolverFactories?: {
-    [name in string]: SignInResolverFactory;
-  };
+  signInResolverFactories?: Record<
+    string,
+    SignInResolverFactory<OAuthAuthenticatorResult<TProfile>>
+  >;
 }): AuthProviderFactory {
   return ctx => {
     return OAuthEnvironmentHandler.mapConfig(ctx.config, envConfig => {

--- a/plugins/auth-node/src/proxy/createProxyAuthProviderFactory.ts
+++ b/plugins/auth-node/src/proxy/createProxyAuthProviderFactory.ts
@@ -31,7 +31,7 @@ export function createProxyAuthProviderFactory<TResult>(options: {
   authenticator: ProxyAuthenticator<unknown, TResult, unknown>;
   profileTransform?: ProfileTransform<TResult>;
   signInResolver?: SignInResolver<TResult>;
-  signInResolverFactories?: Record<string, SignInResolverFactory>;
+  signInResolverFactories?: Record<string, SignInResolverFactory<TResult>>;
 }): AuthProviderFactory {
   return ctx => {
     const signInResolver =

--- a/plugins/auth-node/src/sign-in/commonSignInResolvers.ts
+++ b/plugins/auth-node/src/sign-in/commonSignInResolvers.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from 'zod/v3';
+import * as z from 'zod/v4';
 import { createSignInResolverFactory } from './createSignInResolverFactory';
 import { NotAllowedError } from '@backstage/errors';
 
@@ -38,16 +38,27 @@ export namespace commonSignInResolvers {
       optionsSchema: z
         .object({
           allowedDomains: z.array(z.string()).optional(),
-          dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().optional(),
+          dangerouslyAllowSignInWithoutUserInCatalog: z
+            .boolean()
+            .prefault(false),
         })
-        .optional(),
-      create(options = {}) {
+        .prefault({}),
+      create({ allowedDomains, dangerouslyAllowSignInWithoutUserInCatalog }) {
         return async (info, ctx) => {
           const { profile } = info;
 
           if (!profile.email) {
             throw new Error(
               'Login failed, user profile does not contain an email',
+            );
+          }
+
+          const [localPart] = profile.email.split('@');
+          const emailDomain = profile.email.slice(localPart.length + 1);
+
+          if (allowedDomains && !allowedDomains.includes(emailDomain)) {
+            throw new NotAllowedError(
+              'Sign-in user email is not from an allowed domain',
             );
           }
 
@@ -73,7 +84,7 @@ export namespace commonSignInResolvers {
                   },
                   {
                     dangerousEntityRefFallback:
-                      options?.dangerouslyAllowSignInWithoutUserInCatalog
+                      dangerouslyAllowSignInWithoutUserInCatalog
                         ? { entityRef: { name: noPlusEmail } }
                         : undefined,
                   },
@@ -96,11 +107,12 @@ export namespace commonSignInResolvers {
       optionsSchema: z
         .object({
           allowedDomains: z.array(z.string()).optional(),
-          dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().optional(),
+          dangerouslyAllowSignInWithoutUserInCatalog: z
+            .boolean()
+            .prefault(false),
         })
-        .optional(),
-      create(options = {}) {
-        const { allowedDomains } = options;
+        .prefault({}),
+      create({ allowedDomains, dangerouslyAllowSignInWithoutUserInCatalog }) {
         return async (info, ctx) => {
           const { profile } = info;
 
@@ -121,7 +133,7 @@ export namespace commonSignInResolvers {
             { entityRef: { name: localPart } },
             {
               dangerousEntityRefFallback:
-                options?.dangerouslyAllowSignInWithoutUserInCatalog
+                dangerouslyAllowSignInWithoutUserInCatalog
                   ? { entityRef: { name: localPart } }
                   : undefined,
             },

--- a/plugins/auth-node/src/sign-in/createSignInResolverFactory.ts
+++ b/plugins/auth-node/src/sign-in/createSignInResolverFactory.ts
@@ -14,70 +14,51 @@
  * limitations under the License.
  */
 
-import type { ZodSchema, ZodTypeDef } from 'zod/v3';
+import * as z from 'zod/v4';
 import { SignInResolver } from '../types';
-import zodToJsonSchema from 'zod-to-json-schema';
 import { JsonObject } from '@backstage/types';
-import { fromError } from 'zod-validation-error/v3';
 import { InputError } from '@backstage/errors';
 
 /** @public */
-export interface SignInResolverFactory<TAuthResult = any, TOptions = any> {
-  (
-    ...options: undefined extends TOptions
-      ? [options?: TOptions]
-      : [options: TOptions]
-  ): SignInResolver<TAuthResult>;
+export interface SignInResolverFactory<
+  TAuthResult = unknown,
+  _TOptions = unknown,
+> {
+  (options?: unknown): SignInResolver<TAuthResult>;
   optionsJsonSchema?: JsonObject;
 }
 
 /** @public */
 export interface SignInResolverFactoryOptions<
   TAuthResult,
-  TOptionsOutput,
-  TOptionsInput,
+  TSchema extends z.ZodType = z.ZodUndefined,
 > {
-  optionsSchema?: ZodSchema<TOptionsOutput, ZodTypeDef, TOptionsInput>;
-  create(options: TOptionsOutput): SignInResolver<TAuthResult>;
+  optionsSchema?: TSchema;
+  create: (options: z.output<TSchema>) => SignInResolver<TAuthResult>;
 }
 
 /** @public */
 export function createSignInResolverFactory<
   TAuthResult,
-  TOptionsOutput,
-  TOptionsInput,
->(
-  options: SignInResolverFactoryOptions<
-    TAuthResult,
-    TOptionsOutput,
-    TOptionsInput
-  >,
-): SignInResolverFactory<TAuthResult, TOptionsInput> {
-  const { optionsSchema } = options;
-  if (!optionsSchema) {
-    return (resolverOptions?: TOptionsInput) => {
-      if (resolverOptions) {
-        throw new InputError('sign-in resolver does not accept options');
-      }
-      return options.create(undefined as TOptionsOutput);
-    };
-  }
-  const factory = (
-    ...[resolverOptions]: undefined extends TOptionsInput
-      ? [options?: TOptionsInput]
-      : [options: TOptionsInput]
-  ) => {
-    let parsedOptions;
-    try {
-      parsedOptions = optionsSchema.parse(resolverOptions);
-    } catch (error) {
+  TSchema extends z.ZodType = z.ZodUndefined,
+>({
+  optionsSchema,
+  create,
+}: SignInResolverFactoryOptions<TAuthResult, TSchema>): SignInResolverFactory<
+  TAuthResult,
+  z.input<TSchema>
+> {
+  const schema = (optionsSchema ?? z.undefined()) as TSchema;
+
+  const factory = (resolverOptions?: unknown) => {
+    const result = schema.safeParse(resolverOptions);
+    if (!result.success) {
       throw new InputError(
-        `Invalid sign-in resolver options, ${fromError(error)}`,
+        `Invalid sign-in resolver options:\n${z.prettifyError(result.error)}`,
       );
     }
-    return options.create(parsedOptions);
+    return create(result.data);
   };
-
-  factory.optionsJsonSchema = zodToJsonSchema(optionsSchema) as JsonObject;
+  factory.optionsJsonSchema = z.toJSONSchema(schema) as JsonObject;
   return factory;
 }

--- a/plugins/auth-node/src/sign-in/readDeclarativeSignInResolver.ts
+++ b/plugins/auth-node/src/sign-in/readDeclarativeSignInResolver.ts
@@ -22,9 +22,7 @@ import { SignInResolverFactory } from './createSignInResolverFactory';
 /** @public */
 export interface ReadDeclarativeSignInResolverOptions<TAuthResult> {
   config: Config;
-  signInResolverFactories: {
-    [name in string]: SignInResolverFactory<TAuthResult, unknown>;
-  };
+  signInResolverFactories: Record<string, SignInResolverFactory<TAuthResult>>;
 }
 
 /** @public */

--- a/yarn.lock
+++ b/yarn.lock
@@ -4635,8 +4635,6 @@ __metadata:
     supertest: "npm:^7.0.0"
     uuid: "npm:^11.0.0"
     zod: "npm:^3.25.76 || ^4.0.0"
-    zod-to-json-schema: "npm:^3.25.1"
-    zod-validation-error: "npm:^4.0.2"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Context

Contributes to #30607

When the Zod version in a user's project does not align with the one in Backstage core, it can result in "Type instantiation is excessively deep and possibly infinite" errors, `yarn lint:all` running out of memory, and similar issues. This can break Backstage apps due to Backstage upgrades.

The root cause: `SignInResolverFactory` previously used `TOptionsInput` and `TOptionsOutput` as generic type parameters, constructing `ZodSchema<TOptionsOutput, ZodTypeDef, TOptionsInput>` from them. `ZodSchema` resolves to `z.ZodType` where `Input` defaults to `Output`, tangling the derivation of `TOptionsInput` and `TOptionsOutput` together as basis types. TypeScript struggles to resolve this in our current usage.

The fix follows the Zod recommendation for writing generic functions:
- https://v3.zod.dev/?id=writing-generic-functions
- https://zod.dev/library-authors?id=how-to-accept-user-defined-schemas

Instead of deriving the schema type from input/output types via the general `ZodSchema`, use the schema itself (`TSchema extends z.ZodType` for v4) as the generic basis and derive input/output types via `z.input<TSchema>` and `z.output<TSchema>`. While Zod v4 has improved the generics (https://zod.dev/v4/changelog?id=updates-generics), it is still cleaner and more natural to have the schema itself as the sole basis.

Additionally, the resolver option schemas across all auth providers were using `.optional()` with JavaScript-level parameter defaults (`create(options = {})`). This reduces the impact of runtime validation, since `create` never receives well-defined, complete objects. This is replaced with `.default()` and `.prefault()` (Zod v4's pre-parse default).

## Changes

- Migrate `auth-node` and all `auth-backend-module-*` packages from `zod/v3` to `zod/v4`
- Replace `zod-to-json-schema` dependency with the built-in `z.toJSONSchema` in `zod/v4`
- Replace `zod-validation-error` dependency with the built-in `z.prettifyError`
- Use `.safeParse` instead of `.parse` so that the error is well-typed
- Refactor `SignInResolverFactoryOptions` and `createSignInResolverFactory` to use `TSchema extends z.ZodType` as the generic basis instead of `TOptionsInput`/`TOptionsOutput`
- Change `SignInResolverFactory` call signature to accept `unknown` options, since input is always validated by Zod at runtime; default type parameters changed from `any` to `unknown`
- Default to `z.undefined()` when no `optionsSchema` is provided, removing the separate `!optionsSchema` code path
- Update all 16 auth-backend-module resolver files to use `.prefault()` instead of `.optional()` with parameter defaults, letting Zod handle default values at the schema level
- Implement the missing `allowedDomains` enforcement in `emailMatchingUserEntityProfileEmail`
  - The option was introduced in #28967 but was never wired up, which is considered a bug, as users would pass in allowed domains without getting the intended restriction behaviour
  - This is valuable for larger organisations that work with external vendors and want to restrict sign-in to specific email domains

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
