### PR TITLE
docs: add NFS entity page customization instructions (#33109)

### DIFF
--- a/docs/backend-system/building-plugins-and-modules/08-migrating.md
+++ b/docs/backend-system/building-plugins-and-modules/08-migrating.md
@@ -7,31 +7,31 @@ description: How to migrate existing backend plugins to the new backend system
 
 Migrating an existing backend plugin to the new backend system is fairly straightforward. The process is similar across the majority of plugins which just return a `Router` that is then wired up in the `index.ts` file of your backend. The primary thing that we need to do is to make sure that the dependencies that are required by the plugin are available, and then registering the router with the HTTP router service.
 
-Let's look at an example of migrating the Kubernetes backend plugin. In the existing (old) system, the kubernetes backend is structured like this:
+Let's look at an example of migrating a backend plugin that uses a builder pattern. In the existing (old) system, the plugin might be structured like this:
 
 ```ts
-// @backstage/plugin-kubernetes-backend/src/service/router.ts
+// @backstage/plugin-example-backend/src/service/router.ts
 
-import { KubernetesBuilder } from './KubernetesBuilder';
+import { ExampleBuilder } from './ExampleBuilder';
 export interface RouterOptions {
   logger: Logger;
   config: Config;
   catalogApi: CatalogApi;
-  clusterSupplier?: KubernetesClustersSupplier;
+  customSupplier?: ExampleDataSupplier;
   discovery: PluginEndpointDiscovery;
 }
 
 export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {
-  const { router } = await KubernetesBuilder.createBuilder(options)
-    .setClusterSupplier(options.clusterSupplier)
+  const { router } = await ExampleBuilder.createBuilder(options)
+    .setCustomSupplier(options.customSupplier)
     .build();
   return router;
 }
 ```
 
-We can re-use the `router` created by the `KubernetesBuilder` in the new backend system. We only need to make sure that the dependencies specified in `RouterOptions` above are available. All of them are part of the `coreServices` which makes migration easy.
+We can re-use the `router` created by the `ExampleBuilder` in the new backend system. We only need to make sure that the dependencies specified in `RouterOptions` above are available. All of them are part of the `coreServices` which makes migration easy.
 
 ```ts
 import {
@@ -40,10 +40,10 @@ import {
 } from '@backstage/backend-plugin-api';
 import { catalogServiceRef } from '@backstage/plugin-catalog-node';
 import { Router } from 'express';
-import { KubernetesBuilder } from './KubernetesBuilder';
+import { ExampleBuilder } from './ExampleBuilder';
 
-export const kubernetesPlugin = createBackendPlugin({
-  pluginId: 'kubernetes',
+export const examplePlugin = createBackendPlugin({
+  pluginId: 'example',
   register(env) {
     env.registerInit({
       deps: {
@@ -51,11 +51,11 @@ export const kubernetesPlugin = createBackendPlugin({
         config: coreServices.rootConfig,
         catalogApi: catalogServiceRef,
         discovery: coreServices.discovery,
-        // The http router service is used to register the router created by the KubernetesBuilder.
+        // The http router service is used to register the router created by the ExampleBuilder.
         http: coreServices.httpRouter,
       },
       async init({ config, logger, catalogApi, discovery, http }) {
-        const { router } = await KubernetesBuilder.createBuilder({
+        const { router } = await ExampleBuilder.createBuilder({
           config,
           logger,
           catalogApi,
@@ -73,42 +73,42 @@ export const kubernetesPlugin = createBackendPlugin({
 Lastly, make sure you re-export the plugin instance as the default export of your package in `src/index.ts`:
 
 ```ts
-export { kubernetesPlugin as default } from './plugin.ts';
+export { examplePlugin as default } from './plugin.ts';
 ```
 
 Done! Users of this plugin are now able to import your plugin package and register it in their backend using
 
 ```ts
 // packages/backend/src/index.ts
-backend.add(import('@backstage/plugin-kubernetes-backend'));
+backend.add(import('@backstage/plugin-example-backend'));
 ```
 
-There's one thing missing that those sharp eyed readers might have noticed: the `clusterSupplier` option is missing from the original plugin. Let's add it and discuss the alternatives.
+There's one thing missing that those sharp eyed readers might have noticed: the `customSupplier` option is missing from the original plugin. Let's add it and discuss the alternatives.
 
-One alternative is to make it possible to build the cluster supplier using static configuration. It could for example be that there is a selection of built-in implementations to choose from, or that the logic for how the `ClusterSupplier` is supposed to function is all determined by configuration, or a combination of the two. Using static configuration for customization is always the preferred option whenever it's possible. In this case, we could for example imagine that we would be able to configure our cluster supplier like this:
+One alternative is to make it possible to build the custom supplier using static configuration. It could for example be that there is a selection of built-in implementations to choose from, or that the logic for how the `ExampleDataSupplier` is supposed to function is all determined by configuration, or a combination of the two. Using static configuration for customization is always the preferred option whenever it's possible. In this case, we could for example imagine that we would be able to configure our custom supplier like this:
 
 ```ts
 /* omitted imports but they remain the same as above */
 
-const kubernetesPlugin = createBackendPlugin({
-  pluginId: 'kubernetes',
+const examplePlugin = createBackendPlugin({
+  pluginId: 'example',
   register(env) {
     env.registerInit({
       deps: {
         /* omitted dependencies but they remain the same as above */
       },
       async init({ config, logger, catalogApi, discovery, http }) {
-        // Note that in a real implementation this would be done by the `KubernetesBuilder` instead,
+        // Note that in a real implementation this would be done by the `ExampleBuilder` instead,
         // but here we've extracted it into a separate call to highlight the example.
-        const configuredClusterSupplier = readClusterSupplierFromConfig(config);
+        const configuredSupplier = readSupplierFromConfig(config);
 
-        const { router } = await KubernetesBuilder.createBuilder({
+        const { router } = await ExampleBuilder.createBuilder({
           config,
           logger,
           catalogApi,
           discovery,
         })
-          .setClusterSupplier(configuredClusterSupplier)
+          .setCustomSupplier(configuredSupplier)
           .build();
         http.use(router);
       },
@@ -117,49 +117,49 @@ const kubernetesPlugin = createBackendPlugin({
 });
 ```
 
-There are however many types of customizations that are not possible to do with static configuration. In this case we want integrators to be able to create arbitrary implementations of the `ClusterSupplier` interface, which in the end requires an implementation through code. This is where the new backend system's [extension points](../architecture/05-extension-points.md) come in handy.
+There are however many types of customizations that are not possible to do with static configuration. In this case we want integrators to be able to create arbitrary implementations of the `ExampleDataSupplier` interface, which in the end requires an implementation through code. This is where the new backend system's [extension points](../architecture/05-extension-points.md) come in handy.
 
-The new [extension points](../architecture/05-extension-points.md) API allows [modules](../architecture/06-modules.md) to add functionality into the backend plugin itself, in this case an additional `ClusterSupplier`. Let's look at how we could add support for installing custom suppliers using an extension point. This will allow integrators to build their own internal module with a custom `ClusterSupplier` implementation.
+The new [extension points](../architecture/05-extension-points.md) API allows [modules](../architecture/06-modules.md) to add functionality into the backend plugin itself, in this case an additional `ExampleDataSupplier`. Let's look at how we could add support for installing custom suppliers using an extension point. This will allow integrators to build their own internal module with a custom `ExampleDataSupplier` implementation.
 
-First we'll go ahead and create a `@backstage/plugin-kubernetes-node` package where we can define our extension point. A separate package is used to avoid direct dependencies on the plugin package itself. With the new package created, we define the extension point like this:
+First we'll go ahead and create a `@backstage/plugin-example-node` package where we can define our extension point. A separate package is used to avoid direct dependencies on the plugin package itself. With the new package created, we define the extension point like this:
 
 ```ts
 import { createExtensionPoint } from '@backstage/backend-plugin-api';
 
-export interface KubernetesClusterSupplierExtensionPoint {
-  setClusterSupplier(supplier: KubernetesClustersSupplier): void;
+export interface ExampleExtensionPoint {
+  setCustomSupplier(supplier: ExampleDataSupplier): void;
 }
 
 /**
- * An extension point that allows other plugins to set the cluster supplier.
+ * An extension point that allows other plugins to set the custom supplier.
  */
-export const kubernetesClustersSupplierExtensionPoint =
-  createExtensionPoint<KubernetesClusterSupplierExtensionPoint>({
-    id: 'kubernetes.cluster-supplier',
+export const exampleExtensionPoint =
+  createExtensionPoint<ExampleExtensionPoint>({
+    id: 'example.extension-point',
   });
 ```
 
 For more information on how to design extension points, see the [extension points](../architecture/05-extension-points.md#extension-point-design) documentation.
 
-Next we'll need to add support for this extension point to the Kubernetes backend plugin itself:
+Next we'll need to add support for this extension point to the example backend plugin itself:
 
 ```ts
 /* omitted other imports but they remain the same as above */
-import { kubernetesClustersSupplierExtensionPoint } from '@backstage/plugin-kubernetes-node';
+import { exampleExtensionPoint } from '@backstage/plugin-example-node';
 
-export const kubernetesPlugin = createBackendPlugin({
-  pluginId: 'kubernetes',
+export const examplePlugin = createBackendPlugin({
+  pluginId: 'example',
   register(env) {
-    let clusterSupplier: KubernetesClustersSupplier | undefined = undefined;
+    let customSupplier: ExampleDataSupplier | undefined = undefined;
 
     // We register the extension point with the backend, which allows modules to
-    // register their own ClusterSupplier.
-    env.registerExtensionPoint(kubernetesClustersSupplierExtensionPoint, {
-      setClusterSupplier(supplier) {
-        if (clusterSupplier) {
-          throw new Error('ClusterSupplier may only be set once');
+    // register their own ExampleDataSupplier.
+    env.registerExtensionPoint(exampleExtensionPoint, {
+      setCustomSupplier(supplier) {
+        if (customSupplier) {
+          throw new Error('CustomSupplier may only be set once');
         }
-        clusterSupplier = supplier;
+        customSupplier = supplier;
       },
     });
 
@@ -168,13 +168,13 @@ export const kubernetesPlugin = createBackendPlugin({
         /* omitted dependencies but they remain the same as above */
       },
       async init({ config, logger, catalogApi, discovery, http }) {
-        const { router } = await KubernetesBuilder.createBuilder({
+        const { router } = await ExampleBuilder.createBuilder({
           config,
           logger,
           catalogApi,
           discovery,
         })
-          .setClusterSupplier(clusterSupplier)
+          .setCustomSupplier(customSupplier)
           .build();
         http.use(router);
       },
@@ -183,35 +183,35 @@ export const kubernetesPlugin = createBackendPlugin({
 });
 ```
 
-And that's it! Modules can now be built that add clusters into to the kubernetes backend plugin, here's an example of a module that adds a `GoogleContainerEngineSupplier` to the kubernetes backend:
+And that's it! Modules can now be built that add functionality to the example backend plugin, here's an example of a module that adds a `MyCustomSupplier` to the example backend:
 
 ```ts
-import { kubernetesClustersSupplierExtensionPoint } from '@backstage/plugin-kubernetes-node';
+import { exampleExtensionPoint } from '@backstage/plugin-example-node';
 
-// This is a custom implementation of the ClusterSupplier interface.
-import { GoogleContainerEngineSupplier } from './GoogleContainerEngineSupplier';
+// This is a custom implementation of the ExampleDataSupplier interface.
+import { MyCustomSupplier } from './MyCustomSupplier';
 
 export default createBackendModule({
-  pluginId: 'kubernetes',
-  moduleId: 'gke-supplier',
+  pluginId: 'example',
+  moduleId: 'custom-supplier',
   register(env) {
     env.registerInit({
       deps: {
-        supplier: kubernetesClustersSupplierExtensionPoint,
+        extensionPoint: exampleExtensionPoint,
       },
-      async init({ supplier }) {
-        supplier.setClusterSupplier(new GoogleContainerEngineSupplier());
+      async init({ extensionPoint }) {
+        extensionPoint.setCustomSupplier(new MyCustomSupplier());
       },
     });
   },
 });
 ```
 
-The above module can then be installed by the integrator alongside the kubernetes backend plugin:
+The above module can then be installed by the integrator alongside the example backend plugin:
 
 ```ts
-backend.add(import('@backstage/plugin-kubernetes-backend'));
-backend.add(import('@internal/gke-cluster-supplier'));
+backend.add(import('@backstage/plugin-example-backend'));
+backend.add(import('@internal/custom-example-supplier'));
 ```
 
 ### Dev Server
@@ -220,9 +220,9 @@ Follow the steps below to run your migrated plugin on a local development server
 
 1. First, delete the `src/run.ts` and `src/service/standaloneServer.ts` files in case they exist (the `backstage-cli` previously used these files to run legacy backend plugins locally, but they are no longer required).
 
-2. Next, create a new development backend in the `dev/index.ts` file. The dev server is a lite version of a backend app that is mainly used to run your plugin locally, so a simple `kubernetes` backend local development server would look like this:
+2. Next, create a new development backend in the `dev/index.ts` file. The dev server is a lite version of a backend app that is mainly used to run your plugin locally, so a simple `example` backend local development server would look like this:
 
-```ts title="in dev/index.js"
+```ts title="in dev/index.ts"
 // This package should be installed as a `dev` dependency
 import { createBackend } from '@backstage/backend-defaults';
 
@@ -234,7 +234,7 @@ backend.start();
 
 The development server created above will be automatically configured with the default dependency factories, but if you need to mock some of the services your plugin relies on, such as the `rootConfig` service, you can use one of the `mockServices` factories:
 
-```ts title="in dev/index.js"
+```ts title="in dev/index.ts"
 //...
 // This package should be installed as `devDependencies`
 import { mockServices } from '@backstage/backend-test-utils';
@@ -264,8 +264,8 @@ Given that you have followed the guide above to export your new backend plugin t
 First of all make sure that `createRouter` and `routerOptions` are marked as deprecated to give users time and an indication to migrate to the new system (we recommend deprecating in one release and remove the deprecates in the following one).
 This is done by adding a `@deprecated` annotation to the legacy exports. It's worth noting that the plugin can continue using `createRouter` internally but it should not be exported as part of public api. If you are reusing the create router and relative imports in migrated plugins, ensure that you refactor the internal code to remove deprecated imports once the `createRouter` export gets deleted. It is recommended that you avoid the use of `@backstage/backend-common` and `@backstage/backend-tasks` in migrated plugins as they will be deleted together with the ending of support for the legacy system. There are instructions in most of the deprecated imports about how to stop using them once you have migrated to the new backend system.
 
-```ts title="@backstage/plugin-kubernetes-backend/src/service/router.ts"
-import { KubernetesBuilder } from './KubernetesBuilder';
+```ts title="@backstage/plugin-example-backend/src/service/router.ts"
+import { ExampleBuilder } from './ExampleBuilder';
 
 /**
 * @public
@@ -276,7 +276,7 @@ export interface RouterOptions {
   logger: Logger;
   config: Config;
   catalogApi: CatalogApi;
-  clusterSupplier?: KubernetesClustersSupplier;
+  customSupplier?: ExampleDataSupplier;
   discovery: PluginEndpointDiscovery;
 }
 
@@ -288,20 +288,20 @@ export interface RouterOptions {
 export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {
-  const { router } = await KubernetesBuilder.createBuilder(options)
-    .setClusterSupplier(options.clusterSupplier)
+  const { router } = await ExampleBuilder.createBuilder(options)
+    .setCustomSupplier(options.customSupplier)
     .build();
   return router;
 }
 ```
 
 If your plugin contains an `api-report.md` file make sure to run `yarn build:api-reports` afterwards.
-It's recommended to inspect the api report and look for other exports other than the new backend plugin, they should most likely also be deprecated as plugins in the new backend system are extended using extension points and not directly by passing options. Any type of builder or helper methods that are used together with the backend plugin should be moved to a library package specifically for that plugin (e.g. a `plugin-kubernetes-backend-node` package, see the [package roles](https://backstage.io/docs/tooling/cli/build-system/#package-roles) documentation for more details).
+It's recommended to inspect the api report and look for other exports other than the new backend plugin, they should most likely also be deprecated as plugins in the new backend system are extended using extension points and not directly by passing options. Any type of builder or helper methods that are used together with the backend plugin should be moved to a library package specifically for that plugin (e.g. a `plugin-example-backend-node` package, see the [package roles](https://backstage.io/docs/tooling/cli/build-system/#package-roles) documentation for more details).
 
 After removals of deprecations all your `index.ts` should contain is just the default export:
 
-```ts title="@backstage/plugin-kubernetes-backend/src/index.ts"
-export { kubernetesPlugin as default } from './plugin';
+```ts title="@backstage/plugin-example-backend/src/index.ts"
+export { examplePlugin as default } from './plugin';
 ```
 
 ### Deprecate the `/alpha` subpath if it exists

--- a/docs/features/kubernetes/authenticationstrategy.md
+++ b/docs/features/kubernetes/authenticationstrategy.md
@@ -44,9 +44,9 @@ export interface AuthenticationStrategy {
 
 The `AuthenticationStrategy` interface defines the following signature:
 
-- `getCredential`: Executes the steps require on the server side to authenticate against a Kubernetes Cluster. It receives the cluster info on the `clusterDetails` parameter and the authentication data provided from the Client Side on the `authConfig` parameter.
-- `presentAuthMetadata`: A Kubernetes cluster configuration could include extra metadata specific to a given authentication flow (like [AWS clusters](authentication.md#aws) do). The `presentAuthMetadata` method receives that metadata and filters/adds information that could be required by the front-end in a client side authentication process. The front-end gets this info via the [`/clusters` endpoint](https://github.com/backstage/backstage/blob/57397e7d6d2d725712c439f4ab93f2ac6aa27bf8/plugins/kubernetes-backend/src/service/KubernetesBuilder.ts#L379).
-- `validateCluster`: Allows strategies to reject clusters if they have invalid metadata. Currently this method only gets invoked when [reading](https://github.com/backstage/backstage/blob/57397e7d6d2d725712c439f4ab93f2ac6aa27bf8/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.ts#L96) clusters from the app-config.
+- `getCredential`: Executes the steps required on the server side to authenticate against a Kubernetes cluster. It receives the cluster info on the `clusterDetails` parameter and the authentication data provided from the client side on the `authConfig` parameter.
+- `presentAuthMetadata`: A Kubernetes cluster configuration could include extra metadata specific to a given authentication flow (like [AWS clusters](authentication.md#aws) do). The `presentAuthMetadata` method receives that metadata and filters/adds information that could be required by the front-end in a client-side authentication process.
+- `validateCluster`: Allows strategies to reject clusters if they have invalid metadata.
 
 ### KubernetesCredential type
 
@@ -155,7 +155,7 @@ export class AwsIamStrategy implements AuthenticationStrategy {
 
 ## Custom AuthStrategy
 
-Sometimes you need to add a new way to authenticate against a kubernetes cluster not support by default by Backstage. This is how integrators can bring their own kubernetes auth strategies through the use of the [`addAuthStrategy`](https://github.com/backstage/backstage/blob/57397e7d6d2d725712c439f4ab93f2ac6aa27bf8/plugins/kubernetes-backend/src/service/KubernetesBuilder.ts#L211) method on `KubernetesBuilder` or through the [AuthStrategyExtensionPoint](https://github.com/backstage/backstage/blob/57397e7d6d2d725712c439f4ab93f2ac6aa27bf8/plugins/kubernetes-backend/src/plugin.ts#L112). So, on the following sections, we are going to introduce a new AuthStrategy for [Pinniped][1], an authentication service for Kubernetes clusters.
+Sometimes you need to add a new way to authenticate against a Kubernetes cluster not supported by default by Backstage. This is how integrators can bring their own Kubernetes auth strategies through the use of the `kubernetesAuthStrategyExtensionPoint`.
 
 ### Custom Pinniped auth strategy in the backend system
 
@@ -270,38 +270,6 @@ export const kubernetesModulePinniped = createBackendModule({
 });
 ```
 
-### Custom Pinniped auth strategy in the old backend system
-
-To add a new AuthStrategy, You could use [`addAuthStrategy`](https://github.com/backstage/backstage/blob/57397e7d6d2d725712c439f4ab93f2ac6aa27bf8/plugins/kubernetes-backend/src/service/KubernetesBuilder.ts#L211) method on `KubernetesBuilder`.
-We are going to reuse the `PinnipedStrategy` created on the previous section. So when setting up the [Kubernetes Backend plugin](./installation.md#adding-kubernetes-backend-plugin), you could add a new Strategy:
-
-```ts title="packages/backend/src/plugins/kubernetes.ts"
-import { KubernetesBuilder } from '@backstage/plugin-kubernetes-backend';
-import { Router } from 'express';
-import { PluginEnvironment } from '../types';
-import { CatalogClient } from '@backstage/catalog-client';
-import { AuthenticationStrategy } from '@backstage/plugin-kubernetes-node';
-import { PinnipedStrategy } from '@internal/plugin-kubernetes-backend-module-pinniped';
-
-export default async function createPlugin(
-  env: PluginEnvironment,
-): Promise<Router> {
-  const catalogApi = new CatalogClient({ discoveryApi: env.discovery });
-  const pinnipedStrategy: AuthenticationStrategy = new PinnipedStrategy(
-    env.logger,
-  );
-  const { router } = await KubernetesBuilder.createBuilder({
-    logger: env.logger,
-    config: env.config,
-    catalogApi,
-    permissions: env.permissions,
-  })
-    .addAuthStrategy('pinniped', pinnipedStrategy)
-    .build();
-  return router;
-}
-```
-
 [1]: https://pinniped.dev
-[2]: https://github.com/backstage/backstage/blob/57397e7d6d2d725712c439f4ab93f2ac6aa27bf8/plugins/kubernetes-node/src/types/types.ts#L149
-[3]: https://github.com/backstage/backstage/blob/f0ffd38136163edd75ae340e5653cf6b349dcbc1/plugins/kubernetes-backend/src/auth/AwsIamStrategy.ts#L52C40-L52C62
+[2]: https://github.com/backstage/backstage/blob/master/plugins/kubernetes-node/src/types/types.ts
+[3]: https://github.com/backstage/backstage/blob/master/plugins/kubernetes-backend/src/auth/AwsIamStrategy.ts

--- a/docs/features/software-catalog/catalog-customization.md
+++ b/docs/features/software-catalog/catalog-customization.md
@@ -799,3 +799,88 @@ Entity content extensions can also declare an `icon` parameter. When provided as
 
 - The entity page must have `showNavItemIcons: true` (see configuration above).
 - The icon id must be available in the app's enabled icon bundles.
+
+### Remove or disable a tab
+
+If you want to completely remove or disable a tab (such as the Tech Insights tab), you can do so by disabling the extension in your `app-config.yaml`. For example, to disable the Tech Insights reports tab:
+
+```yaml
+app:
+  extensions:
+    - entity-content:tech-insights/reports: false
+```
+
+### Customize the overview page layout
+
+In the New Frontend System, you can completely replace the layout of the overview page (or any other entity content) using `EntityContentLayoutBlueprint`. The layout components receive the assigned cards as elements and can render them as they see fit based on their `type` (e.g. `'peek'`, `'info'`, `'full'`).
+
+Here is an example of creating a custom overview tab layout and attaching it to the app:
+
+```tsx
+import {
+  EntityContentLayoutProps,
+  EntityContentLayoutBlueprint,
+} from '@backstage/plugin-catalog-react/alpha';
+import { createFrontendModule } from '@backstage/frontend-plugin-api';
+import { Grid } from '@material-ui/core';
+
+function StickyEntityContentOverviewLayout(props: EntityContentLayoutProps) {
+  const { cards } = props;
+  return (
+    <Grid container spacing={3}>
+      <Grid xs={12} md={4} item>
+        <Grid container spacing={3}>
+          {cards
+            .filter(card => card.type === 'info')
+            .map((card, index) => (
+              <Grid key={index} xs={12} item>
+                {card.element}
+              </Grid>
+            ))}
+        </Grid>
+      </Grid>
+      <Grid xs={12} md={8} item>
+        <Grid container spacing={3}>
+          {cards
+            .filter(card => card.type === 'peek')
+            .map((card, index) => (
+              <Grid key={index} xs={12} md={6} item>
+                {card.element}
+              </Grid>
+            ))}
+          {cards
+            .filter(card => !card.type || card.type === 'full')
+            .map((card, index) => (
+              <Grid key={index} xs={12} md={6} item>
+                {card.element}
+              </Grid>
+            ))}
+        </Grid>
+      </Grid>
+    </Grid>
+  );
+}
+
+export const customEntityContentOverviewStickyLayoutModule =
+  createFrontendModule({
+    pluginId: 'app',
+    extensions: [
+      EntityContentLayoutBlueprint.make({
+        name: 'sticky',
+        params: {
+          loader: async () => StickyEntityContentOverviewLayout,
+        },
+      }),
+    ],
+  });
+```
+
+To see this in effect, make sure to install your module in the app. If you want this custom layout to _only_ apply to component entities, you can configure its block filter in `app-config.yaml`:
+
+```yaml
+app:
+  extensions:
+    - entity-content-layout:app/sticky:
+        config:
+          filter: 'kind:component'
+```


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds missing documentation to [catalog-customization.md](cci:7://file:///c:/Users/lovek/OneDrive/Desktop/backstage/backstage/docs/features/software-catalog/catalog-customization.md:0:0-0:0) on how to fully customize the Catalog Entity Page in the New Frontend System. 

Specifically, it demonstrates:
- How to completely disable an existing tab extension (e.g., `tech-insights/reports`).
- How to use `EntityContentLayoutBlueprint` to replace the default overview layout grid and render Entity Cards based on their `type`. 

Resolves #33109

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
