### PR TITLE
core-compat-api: hide page header for compat-wrapped legacy pages

### DIFF
--- a/.changeset/hide-compat-wrapper-headers.md
+++ b/.changeset/hide-compat-wrapper-headers.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-compat-api': patch
+---
+
+Hide the default page header for pages created through the compatibility wrappers, since legacy plugins already render their own headers.

--- a/packages/core-compat-api/src/collectLegacyRoutes.tsx
+++ b/packages/core-compat-api/src/collectLegacyRoutes.tsx
@@ -236,6 +236,7 @@ export function collectLegacyRoutes(
           // todo(blam): why do we not use the inputs here?
           return originalFactory({
             path: normalizeRoutePath(path),
+            noHeader: true,
             routeRef: routeRef ? convertLegacyRouteRef(routeRef) : undefined,
             loader: async () =>
               compatWrapper(

--- a/packages/core-compat-api/src/convertLegacyPageExtension.tsx
+++ b/packages/core-compat-api/src/convertLegacyPageExtension.tsx
@@ -60,6 +60,7 @@ export function convertLegacyPageExtension(
     name: overrides?.name ?? kebabName,
     params: {
       path: overrides?.path ?? `/${kebabName}`,
+      noHeader: true,
       routeRef: mountPoint && convertLegacyRouteRef(mountPoint),
       loader: async () => compatWrapper(element),
     },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes duplicate page headers showing up for legacy plugins that are rendered through the compatibility wrappers (`convertLegacyPageExtension` and `collectLegacyRoutes`). Legacy plugins already render their own `Header` / `PageWithHeader`, so the `PageLayout` header added by `PageBlueprint` was redundant. The fix passes `noHeader: true` in both compat conversion paths.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))