### PR TITLE
docs(techdocs): fix incorrect S3 IAM permission name in using-cloud-s…

### DIFF
--- a/docs/features/techdocs/using-cloud-storage.md
+++ b/docs/features/techdocs/using-cloud-storage.md
@@ -207,7 +207,7 @@ If you need to migrate documentation objects from an older-style path
 format including case-sensitive entity metadata, you will need to add some
 additional permissions to be able to perform the migration, including:
 
-- `s3:PutBucketAcl` (for copying files,
+- `s3:PutObjectAcl` (for copying files,
   [more info here](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectAcl.html))
 - `s3:DeleteObject` and `s3:DeleteObjectVersion` (for deleting migrated files,
   [more info here](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html))


### PR DESCRIPTION
…torage docs

Replaces `s3:PutBucketAcl` with the correct `s3:PutObjectAcl` in the migration note under "Configuring AWS S3 Bucket with TechDocs". The bucket-level ACL action was a typo — the linked AWS API docs and the example JSON policy in the same section already referenced PutObjectAcl correctly. Fixes #32925.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
