### PR TITLE
fix(home): update widget layout properties when entering edit mode

### DIFF
--- a/.changeset/fix-home-widget-resize-edit-mode.md
+++ b/.changeset/fix-home-widget-resize-edit-mode.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home': patch
+---
+
+Fixed a bug where existing homepage widgets could not be resized or moved after re-entering edit mode on a previously saved layout. The `changeEditMode` function now updates `isResizable` and `isDraggable` on all widget layouts when entering edit mode, not only when exiting it.

--- a/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.test.tsx
+++ b/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.test.tsx
@@ -166,4 +166,52 @@ describe('CustomHomepageGrid', () => {
       expect.objectContaining({ presence: 'absent', value: undefined }),
     );
   });
+
+  it('should allow resizing widgets when re-entering edit mode after save', async () => {
+    const resizableConfig: ComponentProps<typeof CustomHomepageGrid>['config'] =
+      defaultConfig!.map(c => ({ ...c, resizable: true }));
+    const mockStorage = mockApis.storage();
+
+    const { unmount } = await renderInTestApp(
+      <TestApiProvider apis={[[storageApiRef, mockStorage]]}>
+        <CustomHomepageGrid config={resizableConfig}>
+          <ComponentA />
+          <ComponentB />
+          <ComponentC />
+        </CustomHomepageGrid>
+      </TestApiProvider>,
+    );
+
+    // Enter edit mode and save to persist the layout
+    await userEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    // Verify layout was persisted
+    const snapshot = mockStorage
+      .forBucket('home.customHomepage')
+      .snapshot('home');
+    expect(snapshot.presence).toBe('present');
+
+    // Unmount and re-render to simulate a page reload with persisted layout
+    unmount();
+    await renderInTestApp(
+      <TestApiProvider apis={[[storageApiRef, mockStorage]]}>
+        <CustomHomepageGrid config={resizableConfig}>
+          <ComponentA />
+          <ComponentB />
+          <ComponentC />
+        </CustomHomepageGrid>
+      </TestApiProvider>,
+    );
+
+    expect(screen.getByText('A')).toBeInTheDocument();
+
+    // Re-enter edit mode — widgets should be resizable
+    await userEvent.click(screen.getByRole('button', { name: 'Edit' }));
+
+    // react-grid-layout renders span elements with class "react-resizable-handle"
+    // for each resizable grid item when isResizable is true
+    const resizeHandles = document.querySelectorAll('.react-resizable-handle');
+    expect(resizeHandles.length).toBeGreaterThan(0);
+  });
 });

--- a/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.tsx
+++ b/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.tsx
@@ -302,16 +302,19 @@ export const CustomHomepageGrid = (props: CustomHomepageGridProps) => {
   const changeEditMode = (mode: boolean) => {
     setEditMode(mode);
 
+    const newWidgets = widgets.map(w => {
+      const resizable = w.resizable === false ? false : mode;
+      const movable = w.movable === false ? false : mode;
+      return {
+        ...w,
+        layout: { ...w.layout, isDraggable: movable, isResizable: resizable },
+      };
+    });
+
     if (!mode) {
-      const newWidgets = widgets.map(w => {
-        const resizable = w.resizable === false ? false : mode;
-        const movable = w.movable === false ? false : mode;
-        return {
-          ...w,
-          layout: { ...w.layout, isDraggable: movable, isResizable: resizable },
-        };
-      });
       storeWidgets(newWidgets);
+    } else {
+      setWidgets(newWidgets);
     }
   };
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Bug

`CustomHomepageGrid`'s `changeEditMode` function does not update `isResizable` and `isDraggable` on existing widget layouts when entering edit mode. It only calls `setEditMode(true)` without touching the layout objects.

This means that after a user saves their homepage layout and later re-enters edit mode, all existing widgets have `isResizable: false` / `isDraggable: false` persisted in their layouts and cannot be resized or moved. Only newly added widgets (via `handleAdd`) correctly receive `isResizable: editMode`.

### Fix

Move the widget layout property update outside the `if (!mode)` guard in `changeEditMode` so it runs for both entering and exiting edit mode:

- **Entering edit mode** (`mode = true`): Sets `isResizable` / `isDraggable` to `true` on all widgets (respecting `w.resizable === false`) and calls `setWidgets(newWidgets)` to update the React state.
- **Exiting edit mode** (`mode = false`): Sets them to `false` and calls `storeWidgets(newWidgets)` to persist, same as before.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

---
<sub>This fix was identified and verified in production. The changes and the PR were generated with assistance from OpenCode.</sub>