### PR TITLE
fix(mcp-actions): use external base urls to generate oauth document

### DIFF
--- a/.changeset/rare-seas-act.md
+++ b/.changeset/rare-seas-act.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-mcp-actions-backend': patch
+---
+
+Uses external base urls in oauth-protected-resource document

--- a/plugins/mcp-actions-backend/src/plugin.test.ts
+++ b/plugins/mcp-actions-backend/src/plugin.test.ts
@@ -307,10 +307,15 @@ describe('Mcp Backend', () => {
     });
 
     it('should expose oauth-protected-resource when DCR is enabled', async () => {
+      const discoveryMock = mockServices.discovery.mock();
+      discoveryMock.getExternalBaseUrl.mockImplementation(
+        async pluginId => `http://localhost:7777/api/${pluginId}`,
+      );
       const { server } = await startTestBackend({
         features: [
           mcpPlugin,
           mockPluginWithActions,
+          discoveryMock.factory,
           mockServices.rootConfig.factory({
             data: {
               backend: {
@@ -332,16 +337,25 @@ describe('Mcp Backend', () => {
         '/.well-known/oauth-protected-resource',
       );
       expect(response.status).toBe(200);
-      expect(response.body.resource).toMatch(/\/api\/mcp-actions$/);
+      expect(response.body.resource).toEqual(
+        'http://localhost:7777/api/mcp-actions',
+      );
       expect(response.body.authorization_servers).toHaveLength(1);
-      expect(response.body.authorization_servers[0]).toMatch(/\/api\/auth$/);
+      expect(response.body.authorization_servers[0]).toEqual(
+        'http://localhost:7777/api/auth',
+      );
     });
 
     it('should expose oauth-protected-resource when CIMD is enabled', async () => {
+      const discoveryMock = mockServices.discovery.mock();
+      discoveryMock.getExternalBaseUrl.mockImplementation(
+        async pluginId => `http://localhost:7777/api/${pluginId}`,
+      );
       const { server } = await startTestBackend({
         features: [
           mcpPlugin,
           mockPluginWithActions,
+          discoveryMock.factory,
           mockServices.rootConfig.factory({
             data: {
               backend: {
@@ -363,9 +377,13 @@ describe('Mcp Backend', () => {
         '/.well-known/oauth-protected-resource',
       );
       expect(response.status).toBe(200);
-      expect(response.body.resource).toMatch(/\/api\/mcp-actions$/);
+      expect(response.body.resource).toEqual(
+        'http://localhost:7777/api/mcp-actions',
+      );
       expect(response.body.authorization_servers).toHaveLength(1);
-      expect(response.body.authorization_servers[0]).toMatch(/\/api\/auth$/);
+      expect(response.body.authorization_servers[0]).toEqual(
+        'http://localhost:7777/api/auth',
+      );
     });
   });
 });

--- a/plugins/mcp-actions-backend/src/plugin.ts
+++ b/plugins/mcp-actions-backend/src/plugin.ts
@@ -144,8 +144,8 @@ export const mcpPlugin = createBackendPlugin({
             '/.well-known/oauth-protected-resource',
             async (_, res) => {
               const [authBaseUrl, mcpBaseUrl] = await Promise.all([
-                discovery.getBaseUrl('auth'),
-                discovery.getBaseUrl('mcp-actions'),
+                discovery.getExternalBaseUrl('auth'),
+                discovery.getExternalBaseUrl('mcp-actions'),
               ]);
               res.json({
                 resource: mcpBaseUrl,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

We are unable to connect the GitHub Copilot CLI to our Backstage MCP server when we have differing external and internal base urls for plugins. Copilot CLI is trying to discover authorization server metadata from the internal base URL. This uses the external base urls for both plugins to generate the oauth-protected-resource metadata document.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
