### PR TITLE
Add AWS plugins to plugin directory (ECR, Config, GenAI, Security Hub)

### DIFF
--- a/microsite/data/plugins/aws-amazon-ecr.yaml
+++ b/microsite/data/plugins/aws-amazon-ecr.yaml
@@ -1,0 +1,11 @@
+---
+title: Amazon Elastic Container Registry
+author: Amazon Web Services
+authorUrl: https://aws.amazon.com/
+category: Infrastructure
+description: View Amazon ECR repositories and container image scan findings for your components in Backstage.
+documentation: https://github.com/awslabs/backstage-plugins-for-aws/tree/main/plugins/ecr#readme
+iconUrl: https://raw.githubusercontent.com/awslabs/backstage-plugins-for-aws/main/docs/images/logos/ecr.png
+npmPackageName: '@aws/amazon-ecr-plugin-for-backstage'
+addedDate: '2026-03-26'
+status: active

--- a/microsite/data/plugins/aws-config.yaml
+++ b/microsite/data/plugins/aws-config.yaml
@@ -1,0 +1,11 @@
+---
+title: AWS Config
+author: Amazon Web Services
+authorUrl: https://aws.amazon.com/
+category: Infrastructure
+description: Ingest AWS resources from AWS Config into the Backstage catalog using incremental ingestion.
+documentation: https://github.com/awslabs/backstage-plugins-for-aws/tree/main/plugins/core/catalog-config#readme
+iconUrl: https://raw.githubusercontent.com/awslabs/backstage-plugins-for-aws/main/docs/images/logos/config.png
+npmPackageName: '@aws/aws-config-catalog-module-for-backstage'
+addedDate: '2026-03-26'
+status: active

--- a/microsite/data/plugins/aws-genai.yaml
+++ b/microsite/data/plugins/aws-genai.yaml
@@ -1,0 +1,11 @@
+---
+title: Generative AI
+author: Amazon Web Services
+authorUrl: https://aws.amazon.com/
+category: Machine Learning
+description: Build generative AI assistants in Backstage that leverage the plugin ecosystem with tool use and LLM integration.
+documentation: https://github.com/awslabs/backstage-plugins-for-aws/tree/main/plugins/genai#readme
+iconUrl: https://raw.githubusercontent.com/awslabs/backstage-plugins-for-aws/main/docs/images/logos/bedrock.png
+npmPackageName: '@aws/genai-plugin-for-backstage'
+addedDate: '2026-03-26'
+status: active

--- a/microsite/data/plugins/aws-securityhub.yaml
+++ b/microsite/data/plugins/aws-securityhub.yaml
@@ -1,0 +1,11 @@
+---
+title: AWS Security Hub
+author: Amazon Web Services
+authorUrl: https://aws.amazon.com/
+category: Security
+description: View and manage AWS Security Hub findings for your resources with severity filtering and AI remediation.
+documentation: https://github.com/awslabs/backstage-plugins-for-aws/tree/main/plugins/securityhub#readme
+iconUrl: https://raw.githubusercontent.com/awslabs/backstage-plugins-for-aws/main/docs/images/logos/securityhub.png
+npmPackageName: '@aws/aws-securityhub-plugin-for-backstage'
+addedDate: '2026-03-26'
+status: active


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds 4 AWS plugins from [awslabs/backstage-plugins-for-aws](https://github.com/
awslabs/backstage-plugins-for-aws) to the Backstage plugin directory. Some plugins from this
repository are already listed (ECS, CodeBuild, CodePipeline); this adds the remaining ones:

| Plugin | Category | NPM Package |
|--------|----------|-------------|
| Amazon Elastic Container Registry | Infrastructure | @aws/amazon-ecr-plugin-for-backstage|
| AWS Config | Infrastructure | @aws/aws-config-catalog-module-for-backstage |
| Generative AI | Machine Learning | @aws/genai-plugin-for-backstage |
| AWS Security Hub | Security | @aws/aws-securityhub-plugin-for-backstage |

All packages are published on npm. Icon URLs and documentation links have been verified.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://
github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] ~Tests for new functionality and regression tests for bug fixes~ (not applicable —
data-only change)
- [ ] ~Screenshots attached (for UI changes)~ (not applicable — no UI changes)
- [x] All your commits have a Signed-off-by line in the message. ([more info](https://
github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
