### PR TITLE
fix(eslint-plugin): fix TypeScript 6.0 type errors in `no-mixed-plugin-imports`

### DIFF
--- a/.changeset/ts6-eslint-plugin.md
+++ b/.changeset/ts6-eslint-plugin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/eslint-plugin': patch
+---
+
+Fixed `no-mixed-plugin-imports` rule to return `null` from non-fixable suggestion handlers and added an explicit `SuggestionReportDescriptor[]` type annotation, matching the stricter type checking in TypeScript 6.0.

--- a/packages/eslint-plugin/rules/no-mixed-plugin-imports.js
+++ b/packages/eslint-plugin/rules/no-mixed-plugin-imports.js
@@ -173,6 +173,7 @@ module.exports = {
             !ignoreTargetPackages.includes(targetName),
         )
       ) {
+        /** @type {import('eslint').Rule.SuggestionReportDescriptor[]} */
         const suggest = [];
 
         if (
@@ -187,9 +188,9 @@ module.exports = {
               sourcePackage: sourceName,
               sourceRole: sourceRole,
             },
-            /** @param {import('eslint').Rule.RuleFixer} _fixer */
-            fix(_fixer) {
+            fix() {
               // Not a fixable case, just give a suggestion to change plugin id
+              return null;
             },
           });
           suggest.push({
@@ -197,7 +198,6 @@ module.exports = {
             data: {
               targetPackage: targetName,
             },
-            /** @param {import('eslint').Rule.RuleFixer} fixer */
             fix(fixer) {
               const source = context.sourceCode;
               const nodeSource = source.getText(imp.node);
@@ -210,7 +210,6 @@ module.exports = {
             data: {
               targetPackage: targetName,
             },
-            /** @param {import('eslint').Rule.RuleFixer} fixer */
             fix(fixer) {
               const source = context.sourceCode;
               const nodeSource = source.getText(imp.node);
@@ -228,7 +227,6 @@ module.exports = {
             data: {
               targetPackage: targetName,
             },
-            /** @param {import('eslint').Rule.RuleFixer} fixer */
             fix(fixer) {
               const source = context.sourceCode;
               const nodeSource = source.getText(imp.node);
@@ -241,7 +239,6 @@ module.exports = {
             data: {
               targetPackage: targetName,
             },
-            /** @param {import('eslint').Rule.RuleFixer} fixer */
             fix(fixer) {
               const source = context.sourceCode;
               const nodeSource = source.getText(imp.node);
@@ -252,9 +249,9 @@ module.exports = {
         } else {
           suggest.push({
             messageId: 'removeImport',
-            /** @param {import('eslint').Rule.RuleFixer} _fixer */
-            fix(_fixer) {
-              // Not a fixable case, just give a suggestion to remove the import
+            fix() {
+              // Not a fixable case, just give a suggestion to change plugin id
+              return null;
             },
           });
         }


### PR DESCRIPTION
TypeScript 6.0 no longer applies bivariant checking to method-shorthand functions that don't reference `this`. This causes the `fix` callbacks in suggestion descriptors to fail type checking when they return `void` instead of a valid `Fix | null` value.

- Return `null` from non-fixable suggestion `fix` handlers
- Add explicit `SuggestionReportDescriptor[]` type annotation to `suggest`
- Remove redundant `@param` JSDoc annotations now covered by the array type

This PR is part of a series of PRs I will be making to introduce TypeScript 6 support.