### PR TITLE
exclude some dirs in microsite to speed things up

### DIFF
--- a/microsite/tsconfig.json
+++ b/microsite/tsconfig.json
@@ -9,5 +9,6 @@
       "@docusaurus/theme-classic",
       "@types/webpack-env"
     ]
-  }
+  },
+  "exclude": ["node_modules", "build", ".docusaurus", "static", "blog"]
 }


### PR DESCRIPTION
Cursor kept telling me to do this.

The `blog` entry is arguable; if we had mdx in there that had actual code in it then that would need type checks, but we don't it seems.