### PR TITLE
Add excludeGroups option for the GitLab provider

### DIFF
--- a/.changeset/gitlab-exclude-groups.md
+++ b/.changeset/gitlab-exclude-groups.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-gitlab': patch
+---
+
+Added `excludeGroups` configuration option to the GitLab discovery provider. This allows excluding entire groups and their subgroups from catalog discovery. All projects under the excluded groups will be skipped during discovery. This option works alongside the existing `excludeRepos` option.

--- a/docs/integrations/gitlab/discovery.md
+++ b/docs/integrations/gitlab/discovery.md
@@ -251,7 +251,7 @@ catalog:
         useSearch: false # Optional. Whether to use the GitLab group search API to find files. Requires Gitlab 'Premium' or 'Ultimate' licenses.  Defaults to `false`
         projectPattern: '[\s\S]*' # Optional. Filters found projects based on provided pattern. Defaults to `[\s\S]*`, which means to not filter anything
         excludeRepos: [] # Optional. A list of project paths that should be excluded from discovery, e.g. group/subgroup/repo. Should not start or end with a slash.
-        excludeGroups: [] # Optional. A list of group paths to exclude from discovery. All projects under the excluded groups and their subgroups will be skipped, e.g. group/subgroup. Should not start or end with a slash.
+        excludeGroups: [] # Optional. A list of group paths to exclude from discovery. Matching groups will be skipped during both project and organization discovery (including membership ingestion), and all projects under the excluded groups and their subgroups will also be skipped, e.g. group/subgroup. Should not start or end with a slash.
         schedule: # Same options as in SchedulerServiceTaskScheduleDefinition. Optional for the Legacy Backend System
           # supports cron, ISO duration, "human duration" as used in code
           frequency: { minutes: 30 }

--- a/docs/integrations/gitlab/discovery.md
+++ b/docs/integrations/gitlab/discovery.md
@@ -251,6 +251,7 @@ catalog:
         useSearch: false # Optional. Whether to use the GitLab group search API to find files. Requires Gitlab 'Premium' or 'Ultimate' licenses.  Defaults to `false`
         projectPattern: '[\s\S]*' # Optional. Filters found projects based on provided pattern. Defaults to `[\s\S]*`, which means to not filter anything
         excludeRepos: [] # Optional. A list of project paths that should be excluded from discovery, e.g. group/subgroup/repo. Should not start or end with a slash.
+        excludeGroups: [] # Optional. A list of group paths to exclude from discovery. All projects under the excluded groups and their subgroups will be skipped, e.g. group/subgroup. Should not start or end with a slash.
         schedule: # Same options as in SchedulerServiceTaskScheduleDefinition. Optional for the Legacy Backend System
           # supports cron, ISO duration, "human duration" as used in code
           frequency: { minutes: 30 }

--- a/plugins/catalog-backend-module-gitlab/config.d.ts
+++ b/plugins/catalog-backend-module-gitlab/config.d.ts
@@ -107,6 +107,12 @@ export interface Config {
            */
           excludeRepos?: string[];
           /**
+           * (Optional) A list of strings containing the paths of the groups to exclude from discovery.
+           * All projects under the excluded groups and their subgroups will be skipped.
+           * Should be in the format group/subgroup, with no leading or trailing slashes.
+           */
+          excludeGroups?: string[];
+          /**
            * If true, users without a seat will be included in the catalog.
            * Group/Application Access Tokens are still filtered out but you might find service accounts or other users without a seat.
            * Defaults to `false`

--- a/plugins/catalog-backend-module-gitlab/report.api.md
+++ b/plugins/catalog-backend-module-gitlab/report.api.md
@@ -120,6 +120,7 @@ export type GitlabProviderConfig = {
   skipForkedRepos?: boolean;
   includeArchivedRepos?: boolean;
   excludeRepos?: string[];
+  excludeGroups?: string[];
   includeUsersWithoutSeat?: boolean;
   membership?: boolean;
   topics?: string;

--- a/plugins/catalog-backend-module-gitlab/src/__testUtils__/mocks.ts
+++ b/plugins/catalog-backend-module-gitlab/src/__testUtils__/mocks.ts
@@ -605,6 +605,30 @@ export const config_userPattern_integration: MockObject = {
   },
 };
 
+export const config_org_excludeGroups_integration: MockObject = {
+  integrations: {
+    gitlab: [
+      {
+        host: 'example.com',
+        apiBaseUrl: 'https://example.com/api/v4',
+        token: '1234',
+      },
+    ],
+  },
+  catalog: {
+    providers: {
+      gitlab: {
+        'test-id': {
+          host: 'example.com',
+          groupPattern: '^group.*',
+          orgEnabled: true,
+          excludeGroups: ['group1/subgroup1'],
+        },
+      },
+    },
+  },
+};
+
 export const config_org_integration_saas: MockObject = {
   integrations: {
     gitlab: [
@@ -2500,6 +2524,135 @@ export const expected_full_org_scan_entities: MockObject[] = [
         children: [],
         profile: {
           displayName: 'subgroup1',
+        },
+        type: 'team',
+      },
+    },
+    locationKey: 'GitlabOrgDiscoveryEntityProvider:test-id',
+  },
+];
+
+export const expected_org_excludeGroups_entities: MockObject[] = [
+  {
+    entity: {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'User',
+      metadata: {
+        annotations: {
+          'backstage.io/managed-by-location': 'url:https://example.com/JohnDoe',
+          'backstage.io/managed-by-origin-location':
+            'url:https://example.com/JohnDoe',
+          'example.com/user-login': 'https://gitlab.example/john_doe',
+          'example.com/user-id': '1',
+        },
+        name: 'JohnDoe',
+      },
+      spec: {
+        memberOf: ['group1'],
+        profile: {
+          displayName: 'John Doe',
+          email: 'john.doe@company.com',
+          picture: 'https://secure.gravatar.com/',
+        },
+      },
+    },
+    locationKey: 'GitlabOrgDiscoveryEntityProvider:test-id',
+  },
+  {
+    entity: {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'User',
+      metadata: {
+        annotations: {
+          'backstage.io/managed-by-location': 'url:https://example.com/JaneDoe',
+          'backstage.io/managed-by-origin-location':
+            'url:https://example.com/JaneDoe',
+          'example.com/user-login': 'https://gitlab.example/jane_doe',
+          'example.com/user-id': '2',
+        },
+        name: 'JaneDoe',
+      },
+      spec: {
+        memberOf: [],
+        profile: {
+          displayName: 'Jane Doe',
+          email: 'jane.doe@company.com',
+          picture: 'https://secure.gravatar.com/',
+        },
+      },
+    },
+    locationKey: 'GitlabOrgDiscoveryEntityProvider:test-id',
+  },
+  {
+    entity: {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'User',
+      metadata: {
+        annotations: {
+          'backstage.io/managed-by-location':
+            'url:https://example.com/MarySmith',
+          'backstage.io/managed-by-origin-location':
+            'url:https://example.com/MarySmith',
+          'example.com/user-login': 'https://gitlab.example/mary_smith',
+          'example.com/user-id': '3',
+        },
+        name: 'MarySmith',
+      },
+      spec: {
+        memberOf: [],
+        profile: {
+          displayName: 'Mary Smith',
+          email: 'mary.smith@company.com',
+          picture: 'https://secure.gravatar.com/',
+        },
+      },
+    },
+    locationKey: 'GitlabOrgDiscoveryEntityProvider:test-id',
+  },
+  {
+    entity: {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'User',
+      metadata: {
+        annotations: {
+          'backstage.io/managed-by-location':
+            'url:https://example.com/MarioMario',
+          'backstage.io/managed-by-origin-location':
+            'url:https://example.com/MarioMario',
+          'example.com/user-login': 'https://gitlab.example/mario_mario',
+          'example.com/user-id': '5',
+        },
+        name: 'MarioMario',
+      },
+      spec: {
+        memberOf: [],
+        profile: {
+          displayName: 'Mario Mario',
+          email: 'mario.mario-company.com',
+          picture: 'https://secure.gravatar.com/',
+        },
+      },
+    },
+    locationKey: 'GitlabOrgDiscoveryEntityProvider:test-id',
+  },
+  {
+    entity: {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Group',
+      metadata: {
+        annotations: {
+          'backstage.io/managed-by-location': 'url:https://example.com/group1',
+          'backstage.io/managed-by-origin-location':
+            'url:https://example.com/group1',
+          'example.com/team-path': 'group1',
+        },
+        description: 'description1',
+        name: 'group1',
+      },
+      spec: {
+        children: [],
+        profile: {
+          displayName: 'group1',
         },
         type: 'team',
       },

--- a/plugins/catalog-backend-module-gitlab/src/__testUtils__/mocks.ts
+++ b/plugins/catalog-backend-module-gitlab/src/__testUtils__/mocks.ts
@@ -406,6 +406,33 @@ export const config_single_integration_exclude_repos: MockObject = {
   },
 };
 
+export const config_single_integration_exclude_groups: MockObject = {
+  integrations: {
+    gitlab: [
+      {
+        host: 'example.com',
+        apiBaseUrl: 'https://example.com/api/v4',
+        token: '1234',
+      },
+    ],
+  },
+  catalog: {
+    providers: {
+      gitlab: {
+        'test-id': {
+          host: 'example.com',
+          group: 'group1',
+          excludeGroups: ['group1/subgroup1'],
+          schedule: {
+            frequency: 'PT30M',
+            timeout: 'PT3M',
+          },
+        },
+      },
+    },
+  },
+};
+
 export const config_no_schedule: MockObject = {
   integrations: {
     gitlab: [

--- a/plugins/catalog-backend-module-gitlab/src/__testUtils__/mocks.ts
+++ b/plugins/catalog-backend-module-gitlab/src/__testUtils__/mocks.ts
@@ -1124,6 +1124,18 @@ export const all_projects_response: GitLabProject[] = [
     web_url: 'https://example.com/group1/subgroup1/test-repo9',
     path_with_namespace: 'group1/subgroup1/test-repo9',
   },
+  // project in a nested sub-subgroup (descendant of group1/subgroup1)
+  {
+    id: 10,
+    description: 'Project Ten Description',
+    name: 'test-repo10',
+    default_branch: 'main',
+    path: 'test-repo10',
+    archived: false,
+    last_activity_at: new Date().toString(),
+    web_url: 'https://example.com/group1/subgroup1/nested/test-repo10',
+    path_with_namespace: 'group1/subgroup1/nested/test-repo10',
+  },
 ];
 
 export const all_users_response: GitLabUser[] = [

--- a/plugins/catalog-backend-module-gitlab/src/lib/types.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/types.ts
@@ -278,8 +278,10 @@ export type GitlabProviderConfig = {
   /**
    * List of groups to exclude from discovery, should be the full path to the group, e.g. `group/subgroup`
    * All projects under the excluded groups and their subgroups will be skipped by the GitlabDiscoveryEntityProvider.
-   * When organization discovery is enabled (GitlabOrgDiscoveryEntityProvider), the corresponding groups and their users
-   * will also be skipped. Paths should not start or end with a slash.
+   * When organization discovery is enabled (GitlabOrgDiscoveryEntityProvider), the corresponding groups and their group
+   * membership relations will also be skipped. Users that only belong to excluded groups may still be discovered (for
+   * example when listing all instance users), but will be emitted without memberships for those excluded groups. Paths
+   * should not start or end with a slash.
    */
   excludeGroups?: string[];
 

--- a/plugins/catalog-backend-module-gitlab/src/lib/types.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/types.ts
@@ -276,6 +276,13 @@ export type GitlabProviderConfig = {
   excludeRepos?: string[];
 
   /**
+   * List of groups to exclude from discovery, should be the full path to the group, e.g. `group/subgroup`
+   * All projects under the excluded groups and their subgroups will be skipped.
+   * Paths should not start or end with a slash.
+   */
+  excludeGroups?: string[];
+
+  /**
    * If true, users without a seat will be included in the catalog.
    * Group/Application Access Tokens are still filtered out but you might find service accounts or other users without a seat.
    * Defaults to `false`

--- a/plugins/catalog-backend-module-gitlab/src/lib/types.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/types.ts
@@ -277,8 +277,9 @@ export type GitlabProviderConfig = {
 
   /**
    * List of groups to exclude from discovery, should be the full path to the group, e.g. `group/subgroup`
-   * All projects under the excluded groups and their subgroups will be skipped.
-   * Paths should not start or end with a slash.
+   * All projects under the excluded groups and their subgroups will be skipped by the GitlabDiscoveryEntityProvider.
+   * When organization discovery is enabled (GitlabOrgDiscoveryEntityProvider), the corresponding groups and their users
+   * will also be skipped. Paths should not start or end with a slash.
    */
   excludeGroups?: string[];
 

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.test.ts
@@ -308,6 +308,38 @@ describe('GitlabDiscoveryEntityProvider - refresh', () => {
     });
   });
 
+  it('should filter repositories belonging to excluded groups', async () => {
+    const config = new ConfigReader(
+      mock.config_single_integration_exclude_groups,
+    );
+    const schedule = new PersistingTaskRunner();
+    const entityProviderConnection: EntityProviderConnection = {
+      applyMutation: jest.fn(),
+      refresh: jest.fn(),
+    };
+    const provider = GitlabDiscoveryEntityProvider.fromConfig(config, {
+      logger,
+      schedule,
+    })[0];
+
+    await provider.connect(entityProviderConnection);
+
+    await provider.refresh(logger);
+
+    expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith({
+      type: 'full',
+      entities: mock.expected_location_entities_default_branch.filter(
+        entity =>
+          !entity.entity.metadata.annotations[
+            'backstage.io/managed-by-location'
+          ].includes('subgroup1') &&
+          !entity.entity.metadata.annotations[
+            'backstage.io/managed-by-location'
+          ].includes('awesome'),
+      ),
+    });
+  });
+
   // branch and fallback branch are undefined in the config
   it('should ingest catalog from project default branch only', async () => {
     const config = new ConfigReader(mock.config_single_integration);

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.test.ts
@@ -276,7 +276,7 @@ describe('GitlabDiscoveryEntityProvider - refresh', () => {
     });
   });
 
-  it('should filter repositories that are excluded', async () => {
+  it('should filter repositories that are in excluded groups', async () => {
     const config = new ConfigReader(
       mock.config_single_integration_exclude_repos,
     );
@@ -300,10 +300,10 @@ describe('GitlabDiscoveryEntityProvider - refresh', () => {
         entity =>
           !entity.entity.metadata.annotations[
             'backstage.io/managed-by-location'
-          ].includes('test-repo1') &&
+          ].includes('/group1/test-repo1') &&
           !entity.entity.metadata.annotations[
             'backstage.io/managed-by-location'
-          ].includes('awesome'),
+          ].includes('awesome-group'),
       ),
     });
   });
@@ -332,10 +332,10 @@ describe('GitlabDiscoveryEntityProvider - refresh', () => {
         entity =>
           !entity.entity.metadata.annotations[
             'backstage.io/managed-by-location'
-          ].includes('subgroup1') &&
+          ].includes('/group1/subgroup1/') &&
           !entity.entity.metadata.annotations[
             'backstage.io/managed-by-location'
-          ].includes('awesome'),
+          ].includes('awesome-group'),
       ),
     });
   });

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts
@@ -651,6 +651,19 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
       return false;
     }
 
+    if (
+      this.config.excludeGroups?.some(
+        group =>
+          project.path_with_namespace === group ||
+          project.path_with_namespace?.startsWith(`${group}/`),
+      )
+    ) {
+      this.logger.debug(
+        `Skipping project ${project.path_with_namespace} as it belongs to an excluded group.`,
+      );
+      return false;
+    }
+
     return true;
   }
 

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts
@@ -652,10 +652,8 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
     }
 
     if (
-      this.config.excludeGroups?.some(
-        group =>
-          project.path_with_namespace === group ||
-          project.path_with_namespace?.startsWith(`${group}/`),
+      this.config.excludeGroups?.some(excludedGroup =>
+        project.path_with_namespace?.startsWith(`${excludedGroup}/`),
       )
     ) {
       this.logger.debug(

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.test.ts
@@ -829,3 +829,46 @@ describe('GitlabOrgDiscoveryEntityProvider with events support', () => {
     });
   });
 });
+
+describe('GitlabOrgDiscoveryEntityProvider - excludeGroups', () => {
+  it('should exclude groups and their subgroups from org discovery', async () => {
+    const config = new ConfigReader(mock.config_org_excludeGroups_integration);
+    const schedule = new PersistingTaskRunner();
+    const entityProviderConnection: EntityProviderConnection = {
+      applyMutation: jest.fn(),
+      refresh: jest.fn(),
+    };
+    const provider = GitlabOrgDiscoveryEntityProvider.fromConfig(config, {
+      logger,
+      schedule,
+    })[0];
+    expect(provider.getProviderName()).toEqual(
+      'GitlabOrgDiscoveryEntityProvider:test-id',
+    );
+
+    await provider.connect(entityProviderConnection);
+
+    const taskDef = schedule.getTasks()[0];
+    expect(taskDef.id).toEqual(
+      'GitlabOrgDiscoveryEntityProvider:test-id:refresh',
+    );
+    await (taskDef.fn as () => Promise<void>)();
+
+    expect(entityProviderConnection.applyMutation).toHaveBeenCalledTimes(1);
+    expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith({
+      type: 'full',
+      entities: mock.expected_org_excludeGroups_entities,
+    });
+    // Verify the excluded subgroup entity is not present
+    const mutationCall = (entityProviderConnection.applyMutation as jest.Mock)
+      .mock.calls[0][0];
+    const groupEntities = mutationCall.entities.filter(
+      (e: any) => e.entity.kind === 'Group',
+    );
+    expect(
+      groupEntities.some(
+        (e: any) => e.entity.metadata.name === 'group1-subgroup1',
+      ),
+    ).toBe(false);
+  });
+});

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabOrgDiscoveryEntityProvider.ts
@@ -801,6 +801,16 @@ export class GitlabOrgDiscoveryEntityProvider implements EntityProvider {
   }
 
   private shouldProcessGroup(group: GitLabGroup): boolean {
+    if (
+      this.config.excludeGroups?.some(
+        excludedGroup =>
+          group.full_path === excludedGroup ||
+          group.full_path.startsWith(`${excludedGroup}/`),
+      )
+    ) {
+      return false;
+    }
+
     return (
       this.groupPatterns.some(pattern => pattern.test(group.full_path)) &&
       (!this.config.group ||

--- a/plugins/catalog-backend-module-gitlab/src/providers/config.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/config.test.ts
@@ -63,6 +63,7 @@ describe('config', () => {
         skipForkedRepos: false,
         includeArchivedRepos: false,
         excludeRepos: [],
+        excludeGroups: [],
         restrictUsersToGroup: false,
         includeUsersWithoutSeat: false,
         membership: undefined,
@@ -110,6 +111,7 @@ describe('config', () => {
         skipForkedRepos: false,
         includeArchivedRepos: false,
         excludeRepos: [],
+        excludeGroups: [],
         restrictUsersToGroup: false,
         includeUsersWithoutSeat: true,
         membership: undefined,
@@ -156,6 +158,7 @@ describe('config', () => {
         schedule: undefined,
         restrictUsersToGroup: false,
         excludeRepos: [],
+        excludeGroups: [],
         skipForkedRepos: true,
         includeArchivedRepos: false,
         includeUsersWithoutSeat: false,
@@ -203,6 +206,7 @@ describe('config', () => {
         schedule: undefined,
         restrictUsersToGroup: false,
         excludeRepos: [],
+        excludeGroups: [],
         skipForkedRepos: false,
         includeArchivedRepos: true,
         includeUsersWithoutSeat: false,
@@ -253,6 +257,7 @@ describe('config', () => {
         skipForkedRepos: false,
         includeArchivedRepos: false,
         excludeRepos: ['foo/bar', 'quz/qux'],
+        excludeGroups: [],
         includeUsersWithoutSeat: false,
         membership: undefined,
         topics: undefined,
@@ -301,6 +306,7 @@ describe('config', () => {
         includeArchivedRepos: false,
         restrictUsersToGroup: false,
         excludeRepos: [],
+        excludeGroups: [],
         includeUsersWithoutSeat: false,
         membership: undefined,
         topics: undefined,
@@ -392,6 +398,7 @@ describe('config', () => {
         schedule: undefined,
         restrictUsersToGroup: false,
         excludeRepos: [],
+        excludeGroups: [],
         skipForkedRepos: false,
         includeUsersWithoutSeat: false,
         includeArchivedRepos: false,
@@ -439,6 +446,7 @@ describe('config', () => {
         schedule: undefined,
         restrictUsersToGroup: false,
         excludeRepos: [],
+        excludeGroups: [],
         skipForkedRepos: false,
         includeUsersWithoutSeat: false,
         includeArchivedRepos: false,
@@ -486,11 +494,61 @@ describe('config', () => {
         schedule: undefined,
         restrictUsersToGroup: false,
         excludeRepos: [],
+        excludeGroups: [],
         skipForkedRepos: false,
         includeUsersWithoutSeat: false,
         includeArchivedRepos: false,
         membership: undefined,
         topics: 'topic1',
+        useSearch: false,
+      }),
+    );
+  });
+
+  it('valid config with excludeGroups', () => {
+    const config = new ConfigReader({
+      catalog: {
+        providers: {
+          gitlab: {
+            test: {
+              group: 'group',
+              host: 'host',
+              branch: 'not-master',
+              fallbackBranch: 'main',
+              entityFilename: 'custom-file.yaml',
+              skipForkedRepos: false,
+              excludeGroups: ['group/personal-dev', 'group/experiments'],
+            },
+          },
+        },
+      },
+    });
+
+    const result = readGitlabConfigs(config);
+    expect(result).toHaveLength(1);
+    result.forEach(r =>
+      expect(r).toStrictEqual({
+        id: 'test',
+        group: 'group',
+        branch: 'not-master',
+        fallbackBranch: 'main',
+        host: 'host',
+        catalogFile: 'custom-file.yaml',
+        projectPattern: /[\s\S]*/,
+        groupPattern: /[\s\S]*/,
+        userPattern: /[\s\S]*/,
+        orgEnabled: false,
+        allowInherited: false,
+        relations: [],
+        schedule: undefined,
+        restrictUsersToGroup: false,
+        skipForkedRepos: false,
+        includeArchivedRepos: false,
+        excludeRepos: [],
+        excludeGroups: ['group/personal-dev', 'group/experiments'],
+        includeUsersWithoutSeat: false,
+        membership: undefined,
+        topics: undefined,
         useSearch: false,
       }),
     );
@@ -533,6 +591,7 @@ describe('config', () => {
         schedule: undefined,
         restrictUsersToGroup: false,
         excludeRepos: [],
+        excludeGroups: [],
         skipForkedRepos: false,
         includeUsersWithoutSeat: false,
         includeArchivedRepos: false,

--- a/plugins/catalog-backend-module-gitlab/src/providers/config.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/config.ts
@@ -67,6 +67,8 @@ function readGitlabConfig(id: string, config: Config): GitlabProviderConfig {
     config.getOptionalBoolean('includeArchivedRepos') ?? false;
   const excludeRepos: string[] =
     config.getOptionalStringArray('excludeRepos') ?? [];
+  const excludeGroups: string[] =
+    config.getOptionalStringArray('excludeGroups') ?? [];
 
   const schedule = config.has('schedule')
     ? readSchedulerServiceTaskScheduleDefinitionFromConfig(
@@ -102,6 +104,7 @@ function readGitlabConfig(id: string, config: Config): GitlabProviderConfig {
     skipForkedRepos,
     includeArchivedRepos,
     excludeRepos,
+    excludeGroups,
     restrictUsersToGroup,
     includeUsersWithoutSeat,
     membership,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Implemented a filter for GitLab group that also includes its sub groups.
The feature has been discussed before : https://github.com/backstage/backstage/issues/29958

We have the need to exclude some test groups from production. Our technical user has access to the whole GitLab instance. Therefore an exclude option is needed. Excluding all repositories of a group with the `excludeRepos` option is not manageable. New repos could be added at any time.

This additional configuration will be possible:

```yaml
catalog:
  providers:
    gitlab:
      default:
        excludeGroups:
          - backstage/test-repos
```

Implementation was done following the PR adding the [excludeRepos option](https://github.com/backstage/backstage/pull/25796/changes) 

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
