### PR TITLE
fix(catalog-react): fix component list truncation in EntityRelationCard due to incorrect pageSize

### DIFF
--- a/.changeset/tall-insects-mix.md
+++ b/.changeset/tall-insects-mix.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Fix component list truncation in EntityRelationCard by setting a large default pageSize

--- a/.changeset/tall-insects-mix.md
+++ b/.changeset/tall-insects-mix.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-react': patch
 ---
 
-Fix component list truncation in EntityRelationCard by setting a large default pageSize
+Fix component list truncation in EntityRelationCard by setting a large default `pageSize`

--- a/plugins/catalog-react/src/components/EntityDataTable/EntityDataTable.tsx
+++ b/plugins/catalog-react/src/components/EntityDataTable/EntityDataTable.tsx
@@ -61,7 +61,12 @@ export function EntityDataTable(props: EntityDataTableProps) {
     mode: 'complete',
     data: tableData,
     sortFn,
-    paginationOptions: { pageSize: tableData.length || 1 },
+    // FIX: Using Number.MAX_SAFE_INTEGER prevents the table pageSize from
+    // locking to 1 during the initial render when tableData is empty.
+    paginationOptions: {
+      pageSize:
+        tableData.length > 0 ? tableData.length : Number.MAX_SAFE_INTEGER,
+    },
   });
 
   return (

--- a/plugins/catalog-react/src/components/EntityDataTable/EntityDataTable.tsx
+++ b/plugins/catalog-react/src/components/EntityDataTable/EntityDataTable.tsx
@@ -64,8 +64,7 @@ export function EntityDataTable(props: EntityDataTableProps) {
     // FIX: Using Number.MAX_SAFE_INTEGER prevents the table pageSize from
     // locking to 1 during the initial render when tableData is empty.
     paginationOptions: {
-      pageSize:
-        tableData.length > 0 ? tableData.length : Number.MAX_SAFE_INTEGER,
+      pageSize: Number.MAX_SAFE_INTEGER,
     },
   });
 

--- a/plugins/catalog-react/src/components/EntityDataTable/EntityDataTable.tsx
+++ b/plugins/catalog-react/src/components/EntityDataTable/EntityDataTable.tsx
@@ -61,8 +61,7 @@ export function EntityDataTable(props: EntityDataTableProps) {
     mode: 'complete',
     data: tableData,
     sortFn,
-    // FIX: Using Number.MAX_SAFE_INTEGER prevents the table pageSize from
-    // locking to 1 during the initial render when tableData is empty.
+
     paginationOptions: {
       pageSize: Number.MAX_SAFE_INTEGER,
     },


### PR DESCRIPTION
## Description

This PR fixes an issue where the `EntityRelationCard` (specifically the "Has components" card) only displayed a single component initially, even if multiple components were associated with the system. 

### Root Cause
The issue originated in `EntityDataTable.tsx`. During the initial component mount, the data fetch is still in progress, meaning the `tableData` array is empty. 
The pagination hook was previously configured as:
`paginationOptions: { pageSize: tableData.length || 1 }`

Because `tableData.length` evaluated to `0`, the OR `||` operator forced the `pageSize` to fall back to `1`. The `useTable` hook then locked onto this internal state. Once the API call finished and hydrated the data array with multiple items, the table was restricted to rendering only the first row due to the locked `pageSize` of `1`.

### The Fix
Updated the fallback logic in `paginationOptions` to use `Number.MAX_SAFE_INTEGER` when the array is empty:
`paginationOptions: { pageSize: tableData.length > 0 ? tableData.length : Number.MAX_SAFE_INTEGER }`

This prevents the initial render from truncating the UI and allows the table to display all dynamically loaded rows correctly since `pagination={{ type: 'none' }}` is being used.

## Resolves
Fixes #33583

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)