### PR TITLE
feat(scaffolder-backend-module-gitlab): add allowEmpty option to gitlab:repo:push action

### DIFF
--- a/.changeset/deep-kings-strive.md
+++ b/.changeset/deep-kings-strive.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gitlab': patch
+---
+
+Added `allowEmpty` input option to the `gitlab:repo:push` action, allowing empty commits. Required from GitLab 18.8 or later.

--- a/plugins/scaffolder-backend-module-gitlab/report.api.md
+++ b/plugins/scaffolder-backend-module-gitlab/report.api.md
@@ -69,7 +69,7 @@ export const createGitlabIssueAction: (options: {
     discussionToResolve?: string | undefined;
     epicId?: number | undefined;
     labels?: string | undefined;
-    issueType?: 'issue' | 'incident' | 'test_case' | 'task' | undefined;
+    issueType?: 'issue' | 'task' | 'incident' | 'test_case' | undefined;
     mergeRequestToResolveDiscussionsOf?: number | undefined;
     milestoneId?: number | undefined;
     weight?: number | undefined;
@@ -274,7 +274,7 @@ export const createPublishGitlabMergeRequestAction: (options: {
     sourcePath?: string | undefined;
     targetPath?: string | undefined;
     token?: string | undefined;
-    commitAction?: 'auto' | 'update' | 'skip' | 'create' | 'delete' | undefined;
+    commitAction?: 'auto' | 'update' | 'create' | 'delete' | 'skip' | undefined;
     projectid?: string | undefined;
     removeSourceBranch?: boolean | undefined;
     assignee?: string | undefined;
@@ -325,7 +325,7 @@ export const editGitlabIssueAction: (options: {
     discussionLocked?: boolean | undefined;
     dueDate?: string | undefined;
     epicId?: number | undefined;
-    issueType?: 'issue' | 'incident' | 'test_case' | 'task' | undefined;
+    issueType?: 'issue' | 'task' | 'incident' | 'test_case' | undefined;
     labels?: string | undefined;
     milestoneId?: number | undefined;
     removeLabels?: string | undefined;

--- a/plugins/scaffolder-backend-module-gitlab/report.api.md
+++ b/plugins/scaffolder-backend-module-gitlab/report.api.md
@@ -69,7 +69,7 @@ export const createGitlabIssueAction: (options: {
     discussionToResolve?: string | undefined;
     epicId?: number | undefined;
     labels?: string | undefined;
-    issueType?: 'issue' | 'task' | 'incident' | 'test_case' | undefined;
+    issueType?: 'issue' | 'incident' | 'test_case' | 'task' | undefined;
     mergeRequestToResolveDiscussionsOf?: number | undefined;
     milestoneId?: number | undefined;
     weight?: number | undefined;
@@ -155,6 +155,7 @@ export const createGitlabRepoPushAction: (options: {
     targetPath?: string | undefined;
     token?: string | undefined;
     commitAction?: 'auto' | 'update' | 'create' | 'delete' | undefined;
+    allowEmpty?: boolean | undefined;
   },
   {
     projectid: string;
@@ -211,7 +212,7 @@ export function createPublishGitlabAction(options: {
           visibility?: 'internal' | 'private' | 'public' | undefined;
           path?: string | undefined;
           description?: string | undefined;
-          merge_method?: 'merge' | 'rebase_merge' | 'ff' | undefined;
+          merge_method?: 'merge' | 'ff' | 'rebase_merge' | undefined;
           topics?: string[] | undefined;
           auto_devops_enabled?: boolean | undefined;
           only_allow_merge_if_pipeline_succeeds?: boolean | undefined;
@@ -273,7 +274,7 @@ export const createPublishGitlabMergeRequestAction: (options: {
     sourcePath?: string | undefined;
     targetPath?: string | undefined;
     token?: string | undefined;
-    commitAction?: 'auto' | 'update' | 'create' | 'delete' | 'skip' | undefined;
+    commitAction?: 'auto' | 'update' | 'skip' | 'create' | 'delete' | undefined;
     projectid?: string | undefined;
     removeSourceBranch?: boolean | undefined;
     assignee?: string | undefined;
@@ -324,7 +325,7 @@ export const editGitlabIssueAction: (options: {
     discussionLocked?: boolean | undefined;
     dueDate?: string | undefined;
     epicId?: number | undefined;
-    issueType?: 'issue' | 'task' | 'incident' | 'test_case' | undefined;
+    issueType?: 'issue' | 'incident' | 'test_case' | 'task' | undefined;
     labels?: string | undefined;
     milestoneId?: number | undefined;
     removeLabels?: string | undefined;

--- a/plugins/scaffolder-backend-module-gitlab/report.api.md
+++ b/plugins/scaffolder-backend-module-gitlab/report.api.md
@@ -212,7 +212,7 @@ export function createPublishGitlabAction(options: {
           visibility?: 'internal' | 'private' | 'public' | undefined;
           path?: string | undefined;
           description?: string | undefined;
-          merge_method?: 'merge' | 'ff' | 'rebase_merge' | undefined;
+          merge_method?: 'merge' | 'rebase_merge' | 'ff' | undefined;
           topics?: string[] | undefined;
           auto_devops_enabled?: boolean | undefined;
           only_allow_merge_if_pipeline_succeeds?: boolean | undefined;

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.examples.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.examples.test.ts
@@ -181,4 +181,25 @@ describe('gitlab:repo:push', () => {
       );
     });
   });
+
+  describe('Push an empty commit to gitlab repository', () => {
+    it(`Should ${examples[3].description}`, async () => {
+      const input = yaml.parse(examples[3].example).steps[0].input;
+      mockDir.setContent({ [workspacePath]: {} });
+      const ctx = createMockActionContext({ input, workspacePath });
+      await instance.handler(ctx);
+
+      expect(mockGitlabClient.Commits.create).toHaveBeenCalledWith(
+        'owner/repo',
+        'feature-branch',
+        'Initial Commit',
+        [],
+        { allowEmpty: true },
+      );
+      expect(ctx.output).toHaveBeenCalledWith(
+        'commitHash',
+        'f8a2c9bd4e2915b0792b43235c779e82ddad54af',
+      );
+    });
+  });
 });

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.examples.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.examples.ts
@@ -73,4 +73,23 @@ export const examples: TemplateExample[] = [
       ],
     }),
   },
+  {
+    description:
+      'Push an empty commit to gitlab repository (from GitLab 18.8+ on)',
+    example: yaml.stringify({
+      steps: [
+        {
+          id: 'pushChanges',
+          action: 'gitlab:repo:push',
+          name: 'Push empty commit to gitlab repository',
+          input: {
+            repoUrl: 'gitlab.com?repo=repo&owner=owner',
+            commitMessage: 'Initial Commit',
+            branchName: 'feature-branch',
+            allowEmpty: true,
+          },
+        },
+      ],
+    }),
+  },
 ];

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.test.ts
@@ -57,6 +57,11 @@ describe('createGitLabCommit', () => {
 
   beforeEach(() => {
     mockDir.clear();
+    jest.clearAllMocks();
+
+    mockGitlabClient.Commits.create.mockResolvedValue({
+      id: 'bb6bce457ed069a38ef8d16ef38602972c7735c5',
+    });
 
     const config = new ConfigReader({
       integrations: {
@@ -107,7 +112,6 @@ describe('createGitLabCommit', () => {
             execute_filemode: false,
           },
         ],
-        undefined,
       );
       expect(ctx.output).toHaveBeenCalledWith(
         'commitHash',
@@ -147,7 +151,6 @@ describe('createGitLabCommit', () => {
             execute_filemode: false,
           },
         ],
-        undefined,
       );
       expect(ctx.output).toHaveBeenCalledWith(
         'commitHash',
@@ -185,7 +188,6 @@ describe('createGitLabCommit', () => {
             execute_filemode: false,
           },
         ],
-        undefined,
       );
       expect(ctx.output).toHaveBeenCalledWith(
         'commitHash',
@@ -223,7 +225,6 @@ describe('createGitLabCommit', () => {
             execute_filemode: false,
           },
         ],
-        undefined,
       );
       expect(ctx.output).toHaveBeenCalledWith(
         'commitHash',
@@ -267,7 +268,6 @@ describe('createGitLabCommit', () => {
             execute_filemode: false,
           },
         ],
-        undefined,
       );
       expect(ctx.output).toHaveBeenCalledWith(
         'commitHash',
@@ -310,7 +310,6 @@ describe('createGitLabCommit', () => {
             execute_filemode: false,
           },
         ],
-        undefined,
       );
       expect(ctx.output).toHaveBeenCalledWith(
         'commitHash',
@@ -375,7 +374,6 @@ describe('createGitLabCommit', () => {
             execute_filemode: false,
           },
         ],
-        undefined,
       );
       expect(ctx.output).toHaveBeenCalledWith(
         'commitHash',
@@ -451,6 +449,97 @@ describe('createGitLabCommit', () => {
 
       await expect(instance.handler(ctx)).rejects.toThrow(
         "Committing the changes to some-branch failed. Please verify that all files you're trying to modify exist in the repository. Error: Commit failed",
+      );
+    });
+  });
+
+  describe('allowEmpty parameter', () => {
+    it('passes allowEmpty: true to Commits.create when specified', async () => {
+      const input = {
+        repoUrl: 'gitlab.com?repo=repo&owner=owner',
+        commitMessage: 'Empty commit',
+        branchName: 'some-branch',
+        allowEmpty: true,
+      };
+      mockDir.setContent({
+        [workspacePath]: {},
+      });
+
+      const ctx = createMockActionContext({ input, workspacePath });
+      await instance.handler(ctx);
+
+      expect(mockGitlabClient.Commits.create).toHaveBeenCalledWith(
+        'owner/repo',
+        'some-branch',
+        'Empty commit',
+        [],
+        { allowEmpty: true },
+      );
+    });
+
+    it('does not pass 5th argument when allowEmpty is not specified', async () => {
+      const input = {
+        repoUrl: 'gitlab.com?repo=repo&owner=owner',
+        commitMessage: 'Normal commit',
+        branchName: 'some-branch',
+      };
+      mockDir.setContent({
+        [workspacePath]: {
+          'foo.txt': 'content',
+        },
+      });
+
+      const ctx = createMockActionContext({ input, workspacePath });
+      await instance.handler(ctx);
+
+      expect(mockGitlabClient.Commits.create).toHaveBeenCalledWith(
+        'owner/repo',
+        'some-branch',
+        'Normal commit',
+        [
+          {
+            action: 'create',
+            filePath: 'foo.txt',
+            content: 'Y29udGVudA==',
+            encoding: 'base64',
+            execute_filemode: false,
+          },
+        ],
+      );
+      // Verify only 4 arguments were passed (no 5th)
+      expect(mockGitlabClient.Commits.create.mock.calls[0]).toHaveLength(4);
+    });
+
+    it('passes allowEmpty: false to Commits.create when explicitly set', async () => {
+      const input = {
+        repoUrl: 'gitlab.com?repo=repo&owner=owner',
+        commitMessage: 'Commit with files',
+        branchName: 'some-branch',
+        allowEmpty: false,
+      };
+      mockDir.setContent({
+        [workspacePath]: {
+          'foo.txt': 'content',
+        },
+      });
+
+      const ctx = createMockActionContext({ input, workspacePath });
+      await instance.handler(ctx);
+
+      expect(mockGitlabClient.Commits.create).toHaveBeenCalledWith(
+        'owner/repo',
+        'some-branch',
+        'Commit with files',
+        [
+          {
+            action: 'create',
+            filePath: 'foo.txt',
+            content: 'Y29udGVudA==',
+            encoding: 'base64',
+            execute_filemode: false,
+          },
+        ],
+        { allowEmpty: false },
       );
     });
   });

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.test.ts
@@ -107,6 +107,7 @@ describe('createGitLabCommit', () => {
             execute_filemode: false,
           },
         ],
+        undefined,
       );
       expect(ctx.output).toHaveBeenCalledWith(
         'commitHash',
@@ -146,6 +147,7 @@ describe('createGitLabCommit', () => {
             execute_filemode: false,
           },
         ],
+        undefined,
       );
       expect(ctx.output).toHaveBeenCalledWith(
         'commitHash',
@@ -183,6 +185,7 @@ describe('createGitLabCommit', () => {
             execute_filemode: false,
           },
         ],
+        undefined,
       );
       expect(ctx.output).toHaveBeenCalledWith(
         'commitHash',
@@ -220,6 +223,7 @@ describe('createGitLabCommit', () => {
             execute_filemode: false,
           },
         ],
+        undefined,
       );
       expect(ctx.output).toHaveBeenCalledWith(
         'commitHash',
@@ -263,6 +267,7 @@ describe('createGitLabCommit', () => {
             execute_filemode: false,
           },
         ],
+        undefined,
       );
       expect(ctx.output).toHaveBeenCalledWith(
         'commitHash',
@@ -305,6 +310,7 @@ describe('createGitLabCommit', () => {
             execute_filemode: false,
           },
         ],
+        undefined,
       );
       expect(ctx.output).toHaveBeenCalledWith(
         'commitHash',
@@ -369,6 +375,7 @@ describe('createGitLabCommit', () => {
             execute_filemode: false,
           },
         ],
+        undefined,
       );
       expect(ctx.output).toHaveBeenCalledWith(
         'commitHash',

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.ts
@@ -224,7 +224,7 @@ export const createGitlabRepoPushAction = (options: {
               branchName,
               ctx.input.commitMessage,
               actions,
-              ...(allowEmpty !== undefined ? [{ allowEmpty } as object] : []),
+              allowEmpty !== undefined ? ({ allowEmpty } as any) : undefined,
             );
             return commit.id;
           },

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.ts
@@ -83,6 +83,12 @@ export const createGitlabRepoPushAction = (options: {
                 'The action to be used for git commit. Defaults to create, but can be set to update or delete',
             })
             .optional(),
+        allowEmpty: z =>
+          z
+            .boolean({
+              description: 'Allow an empty commit to be created.',
+            })
+            .optional(),
       },
       output: {
         projectid: z =>
@@ -107,6 +113,7 @@ export const createGitlabRepoPushAction = (options: {
         sourcePath,
         token,
         commitAction,
+        allowEmpty,
       } = ctx.input;
 
       const { owner, repo, project } = parseRepoUrl(repoUrl, integrations);
@@ -217,6 +224,7 @@ export const createGitlabRepoPushAction = (options: {
               branchName,
               ctx.input.commitMessage,
               actions,
+              ...(allowEmpty !== undefined ? [{ allowEmpty } as object] : []),
             );
             return commit.id;
           },

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.ts
@@ -219,13 +219,21 @@ export const createGitlabRepoPushAction = (options: {
         const commitId = await ctx.checkpoint({
           key: `commit.create.${repoID}.${branchName}`,
           fn: async () => {
-            const commit = await api.Commits.create(
-              repoID,
-              branchName,
-              ctx.input.commitMessage,
-              actions,
-              allowEmpty !== undefined ? ({ allowEmpty } as any) : undefined,
-            );
+            const commit =
+              allowEmpty !== undefined
+                ? await api.Commits.create(
+                    repoID,
+                    branchName,
+                    ctx.input.commitMessage,
+                    actions,
+                    { allowEmpty } as any,
+                  )
+                : await api.Commits.create(
+                    repoID,
+                    branchName,
+                    ctx.input.commitMessage,
+                    actions,
+                  );
             return commit.id;
           },
         });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

GitLab version 18.8 has introduced the attribute `allow_empty` to the commit API create endpoint. 
Without it, `gitlab:repo:push` now fails when pushing an empty commit on GitLab 18.8+.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
