### PR TITLE
feat(frontend-plugin-api): add titleRouteRef to createFrontendPlugin

### DIFF
--- a/.changeset/silly-hounds-shine.md
+++ b/.changeset/silly-hounds-shine.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+Added `titleRouteRef` option to `createFrontendPlugin`. When set, page headers render the plugin title as a link to this route. Falls back to the `root` route if not provided.

--- a/packages/core-compat-api/src/convertLegacyPlugin.test.tsx
+++ b/packages/core-compat-api/src/convertLegacyPlugin.test.tsx
@@ -48,6 +48,7 @@ describe('convertLegacyPlugin', () => {
         "pluginId": "test",
         "routes": {},
         "title": undefined,
+        "titleRouteRef": undefined,
         "toString": [Function],
         "version": "v1",
         "withOverrides": [Function],

--- a/packages/frontend-plugin-api/report-alpha.api.md
+++ b/packages/frontend-plugin-api/report-alpha.api.md
@@ -444,6 +444,7 @@ export interface FrontendPlugin<
   // (undocumented)
   readonly routes: TRoutes;
   readonly title?: string;
+  readonly titleRouteRef?: RouteRef<undefined>;
 }
 
 // @public

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -811,6 +811,7 @@ export interface CreateFrontendPluginOptions<
   // (undocumented)
   routes?: TRoutes;
   title?: string;
+  titleRouteRef?: RouteRef<undefined>;
 }
 
 // @public
@@ -1457,6 +1458,7 @@ export interface FrontendPlugin<
   // (undocumented)
   readonly routes: TRoutes;
   readonly title?: string;
+  readonly titleRouteRef?: RouteRef<undefined>;
 }
 
 // @public

--- a/packages/frontend-plugin-api/src/blueprints/PageBlueprint.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/PageBlueprint.tsx
@@ -96,7 +96,9 @@ export const PageBlueprint = createExtensionBlueprint({
       title ?? node.spec.plugin.title ?? node.spec.plugin.pluginId;
     const resolvedIcon = icon ?? node.spec.plugin.icon;
     const titleRouteRef =
-      (node.spec.plugin.routes as { root?: RouteRef }).root ?? params.routeRef;
+      node.spec.plugin.titleRouteRef ??
+      (node.spec.plugin.routes as { root?: RouteRef }).root ??
+      params.routeRef;
 
     yield coreExtensionData.routePath(config.path ?? params.path);
     if (params.loader) {

--- a/packages/frontend-plugin-api/src/wiring/createFrontendPlugin.test.ts
+++ b/packages/frontend-plugin-api/src/wiring/createFrontendPlugin.test.ts
@@ -19,6 +19,7 @@ import { createElement } from 'react';
 import { createApp } from '../../../frontend-defaults/src/createApp';
 import { screen } from '@testing-library/react';
 import { FrontendPlugin, createFrontendPlugin } from './createFrontendPlugin';
+import { createRouteRef } from '../routing';
 import { JsonObject } from '@backstage/types';
 import { createExtension } from './createExtension';
 import { createExtensionDataRef } from './createExtensionDataRef';
@@ -140,6 +141,16 @@ describe('createFrontendPlugin', () => {
 
     expect(plugin).toBeDefined();
     expect(String(plugin)).toBe('Plugin{id=test}');
+  });
+
+  it('should expose titleRouteRef on the created plugin', () => {
+    const titleRouteRef = createRouteRef();
+    const plugin = createFrontendPlugin({
+      pluginId: 'test',
+      titleRouteRef,
+    });
+
+    expect(plugin.titleRouteRef).toBe(titleRouteRef);
   });
 
   it('should warn about invalid plugin IDs', () => {

--- a/packages/frontend-plugin-api/src/wiring/createFrontendPlugin.ts
+++ b/packages/frontend-plugin-api/src/wiring/createFrontendPlugin.ts
@@ -167,6 +167,13 @@ export interface FrontendPlugin<
    * The display icon of the plugin, used in page headers and navigation.
    */
   readonly icon?: IconElement;
+  /**
+   * A route ref used to resolve the title link in the plugin header.
+   * When set, page headers will render the plugin title as a link to this route.
+   * Falls back to the `root` route if not provided, then to the page's own route ref.
+   * Must be a param-less route ref, as no params are supplied when resolving it.
+   */
+  readonly titleRouteRef?: RouteRef<undefined>;
   readonly routes: TRoutes;
   readonly externalRoutes: TExternalRoutes;
 
@@ -197,6 +204,13 @@ export interface CreateFrontendPluginOptions<
    * The display icon of the plugin, used in page headers and navigation.
    */
   icon?: IconElement;
+  /**
+   * A route ref used to resolve the title link in the plugin header.
+   * When set, page headers will render the plugin title as a link to this route.
+   * Falls back to the `root` route if not provided, then to the page's own route ref.
+   * Must be a param-less route ref, as no params are supplied when resolving it.
+   */
+  titleRouteRef?: RouteRef<undefined>;
   routes?: TRoutes;
   externalRoutes?: TExternalRoutes;
   extensions?: TExtensions;
@@ -308,6 +322,7 @@ export function createFrontendPlugin<
     id: pluginId,
     title: options.title,
     icon: options.icon,
+    titleRouteRef: options.titleRouteRef,
     routes: options.routes ?? ({} as TRoutes),
     externalRoutes: options.externalRoutes ?? ({} as TExternalRoutes),
     featureFlags: options.featureFlags ?? [],


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds a `titleRouteRef` option to `createFrontendPlugin` that controls the plugin header title link. When set, all pages in the plugin render the title as a link to this route.

Resolution order in `PageBlueprint`: `plugin.titleRouteRef` → `plugin.routes.root` → page's own `routeRef`.

This is needed for plugins like catalog where the root route key isn't named `root`, causing the PluginHeader title to not be a link on sub-pages.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.