### PR TITLE
fix(docs-ui): remove duplicate component registry entries

### DIFF
--- a/docs-ui/src/utils/data.ts
+++ b/docs-ui/src/utils/data.ts
@@ -110,14 +110,6 @@ export const components: Page[] = [
     slug: 'slider',
   },
   {
-    title: 'Select',
-    slug: 'select',
-  },
-  {
-    title: 'Skeleton',
-    slug: 'skeleton',
-  },
-  {
     title: 'Switch',
     slug: 'switch',
   },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Remove duplicate Select and Skeleton entries in the docs-ui component registry, fixing the React warning: "Encountered two children with the same key".

<img width="262" height="187" alt="image" src="https://github.com/user-attachments/assets/e2921bf8-3d84-4818-8d4e-9ec53014c606" />


#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.