### PR TITLE
[DevTools] Migrate ExternalDependenciesContent to Backstage UI

### DIFF
--- a/.changeset/migrate-devtools-external-deps-bui.md
+++ b/.changeset/migrate-devtools-external-deps-bui.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-devtools': patch
+---
+
+Migrated the `ExternalDependenciesContent` component to use BUI components. The table now uses BUI `Table` instead of the `Table` from `@backstage/core-components`, and layout elements use BUI `Box`, `Card`, `Flex`, and `Text` instead of Material UI equivalents. Status icons from `@backstage/core-components` are preserved.

--- a/plugins/devtools/src/components/Content/ExternalDependenciesContent/ExternalDependenciesContent.tsx
+++ b/plugins/devtools/src/components/Content/ExternalDependenciesContent/ExternalDependenciesContent.tsx
@@ -70,6 +70,7 @@ const columns: ColumnConfig<ExternalDependencyRow>[] = [
   {
     id: 'name',
     label: 'Name',
+    isRowHeader: true,
     cell: item => <CellText title={item.name} />,
   },
   {
@@ -102,9 +103,9 @@ export const ExternalDependenciesContent = () => {
 
   const data = useMemo(
     () =>
-      externalDependencies?.map(dep => ({
+      externalDependencies?.map((dep, index) => ({
         ...dep,
-        id: `${dep.name}-${dep.type}-${dep.target}`,
+        id: `${dep.name}-${dep.type}-${dep.target}-${index}`,
       })),
     [externalDependencies],
   );
@@ -112,7 +113,7 @@ export const ExternalDependenciesContent = () => {
   if (loading) {
     return <Progress />;
   } else if (error) {
-    return <Alert status="danger" icon title={error.message} />;
+    return <Alert status="danger" icon title={error.message} role="alert" />;
   }
 
   if (!data || data.length === 0) {

--- a/plugins/devtools/src/components/Content/ExternalDependenciesContent/ExternalDependenciesContent.tsx
+++ b/plugins/devtools/src/components/Content/ExternalDependenciesContent/ExternalDependenciesContent.tsx
@@ -34,7 +34,10 @@ import {
   useTable,
   type ColumnConfig,
 } from '@backstage/ui';
-import { ExternalDependency } from '@backstage/plugin-devtools-common';
+import {
+  ExternalDependency,
+  ExternalDependencyStatus,
+} from '@backstage/plugin-devtools-common';
 import { useExternalDependencies } from '../../../hooks';
 
 type ExternalDependencyRow = ExternalDependency & { id: string };
@@ -44,13 +47,13 @@ export const getExternalDependencyStatus = (
   result: Partial<ExternalDependency> | undefined,
 ) => {
   switch (result?.status) {
-    case 'Healthy':
+    case ExternalDependencyStatus.healthy:
       return (
         <Text as="span" color="success">
           <StatusOK /> {result.status}
         </Text>
       );
-    case 'Unhealthy':
+    case ExternalDependencyStatus.unhealthy:
       return (
         <Text as="span" color="danger">
           <StatusError /> {result.status}

--- a/plugins/devtools/src/components/Content/ExternalDependenciesContent/ExternalDependenciesContent.tsx
+++ b/plugins/devtools/src/components/Content/ExternalDependenciesContent/ExternalDependenciesContent.tsx
@@ -14,122 +14,135 @@
  * limitations under the License.
  */
 
+import { useMemo } from 'react';
 import {
   Progress,
   StatusError,
   StatusOK,
   StatusWarning,
-  Table,
-  TableColumn,
 } from '@backstage/core-components';
+import {
+  Alert,
+  Box,
+  Card,
+  CardBody,
+  Cell,
+  CellText,
+  Flex,
+  Table,
+  Text,
+  useTable,
+  type ColumnConfig,
+} from '@backstage/ui';
 import { ExternalDependency } from '@backstage/plugin-devtools-common';
-import Box from '@material-ui/core/Box';
-import Grid from '@material-ui/core/Grid';
-import Paper from '@material-ui/core/Paper';
-import Typography from '@material-ui/core/Typography';
-import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
-import Alert from '@material-ui/lab/Alert';
 import { useExternalDependencies } from '../../../hooks';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    paperStyle: {
-      padding: theme.spacing(2),
-    },
-  }),
-);
+type ExternalDependencyRow = ExternalDependency & { id: string };
 
+/** @public */
 export const getExternalDependencyStatus = (
   result: Partial<ExternalDependency> | undefined,
 ) => {
   switch (result?.status) {
     case 'Healthy':
       return (
-        <Typography component="span">
+        <Text as="span" color="success">
           <StatusOK /> {result.status}
-        </Typography>
+        </Text>
       );
     case 'Unhealthy':
       return (
-        <Typography component="span">
-          <StatusError /> {`${result.status}`}
-        </Typography>
+        <Text as="span" color="danger">
+          <StatusError /> {result.status}
+        </Text>
       );
     case undefined:
     default:
       return (
-        <Typography component="span">
+        <Text as="span" color="warning">
           <StatusWarning /> Unknown
-        </Typography>
+        </Text>
       );
   }
 };
 
-const columns: TableColumn[] = [
+const columns: ColumnConfig<ExternalDependencyRow>[] = [
   {
-    title: 'Name',
-    width: 'auto',
-    field: 'name',
+    id: 'name',
+    label: 'Name',
+    cell: item => <CellText title={item.name} />,
   },
   {
-    title: 'Target',
-    width: 'auto',
-    field: 'target',
+    id: 'target',
+    label: 'Target',
+    cell: item => <CellText title={item.target} />,
   },
   {
-    title: 'Type',
-    width: 'auto',
-    field: 'type',
+    id: 'type',
+    label: 'Type',
+    cell: item => <CellText title={item.type} />,
   },
   {
-    title: 'Status',
-    width: 'auto',
-    render: (row: Partial<ExternalDependency>) => (
-      <Grid container direction="column">
-        <Grid item>
-          <Typography variant="button">
-            {getExternalDependencyStatus(row)}
-          </Typography>
-        </Grid>
-        <Grid item>{row.error && <Typography>{row.error}</Typography>}</Grid>
-      </Grid>
+    id: 'status',
+    label: 'Status',
+    cell: item => (
+      <Cell>
+        <Flex direction="column" gap="1">
+          {getExternalDependencyStatus(item)}
+          {item.error && <Text>{item.error}</Text>}
+        </Flex>
+      </Cell>
     ),
   },
 ];
 
 /** @public */
 export const ExternalDependenciesContent = () => {
-  const classes = useStyles();
   const { externalDependencies, loading, error } = useExternalDependencies();
+
+  const data = useMemo(
+    () =>
+      externalDependencies?.map(dep => ({
+        ...dep,
+        id: `${dep.name}-${dep.type}-${dep.target}`,
+      })),
+    [externalDependencies],
+  );
 
   if (loading) {
     return <Progress />;
   } else if (error) {
-    return <Alert severity="error">{error.message}</Alert>;
+    return <Alert status="danger" icon title={error.message} />;
   }
 
-  if (!externalDependencies || externalDependencies.length === 0) {
+  if (!data || data.length === 0) {
     return (
-      <Box>
-        <Paper className={classes.paperStyle}>
-          <Typography>No external dependencies found</Typography>
-        </Paper>
+      <Box p="2">
+        <Card>
+          <CardBody>
+            <Text>No external dependencies found</Text>
+          </CardBody>
+        </Card>
       </Box>
     );
   }
 
-  return (
-    <Table
-      title="Status"
-      options={{
-        paging: true,
-        pageSize: 20,
-        pageSizeOptions: [20, 50, 100],
-        loadingType: 'linear',
-        showEmptyDataSourceMessage: !loading,
-      }}
-      columns={columns}
-      data={externalDependencies || []}
-    />
-  );
+  return <ExternalDependenciesTable data={data} />;
 };
+
+function ExternalDependenciesTable({
+  data,
+}: {
+  data: ExternalDependencyRow[];
+}) {
+  const { tableProps } = useTable({
+    mode: 'complete',
+    data,
+    paginationOptions: {
+      pageSize: 20,
+      pageSizeOptions: [20, 50, 100],
+    },
+  });
+
+  return <Table columnConfig={columns} {...tableProps} />;
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Following the Contribfest session at KubeCon/CloudNativeCon yesterday, i finalized the PR.

Closes #32746

This PR is largely AI generated, but i made sure that i understood and tested everything myself. 

It swaps out MUI components and the `Table` from `@backstage/core-components` with their BUI equivalents in `ExternalDependenciesContent`:
- `Box`, `Grid`, `Paper`, `Typography`, `Alert` (MUI) -> `Box`, `Flex`, `Card`, `Text`, `Alert` (BUI)
- `Table` / `TableColumn` (core-components) -> `Table` / `useTable` / `ColumnConfig` (BUI)                                                                                             - Removed `makeStyles` / `createStyles`. Using BUI utility props instead

`StatusOK`, `StatusError`, `StatusWarning` and `Progress` from `@backstage/core-components` are kept as BUI has no equivalent.   

#### :heavy_check_mark: Checklist

### Screenshots
| Empty state | With data |
|---|---|
| <img width="1499" height="852" alt="image" src="https://github.com/user-attachments/assets/2a486ce1-f83f-45ec-a96e-d6cd538e0d25" /> | <img width="1501" height="853" alt="image" src="https://github.com/user-attachments/assets/6424b533-47f1-4691-8c97-124cbeafa4f9" /> |

### Testing
The `ExternalDependenciesContent` component is not included in the app ran with `yarn start` by default. To test it visually, I temporarily added a `SubPageBlueprint` in `alpha/plugin.tsx`:
```tsx
/** @alpha */
export const devToolsExternalDependenciesPage = SubPageBlueprint.make({
  name: 'external-dependencies',
  params: {
    path: 'external-dependencies',
    title: 'External Dependencies',
    loader: () =>
      import('../components/Content').then(m => (
        <Content>
          <m.ExternalDependenciesContent />
        </Content>
      )),
  },
});
```

Test cases : 
- **Empty state** : ran `yarn start` with no `devTools.externalDependencies.endpoints` in `app-config.yaml`
- **With data** : added test endpoints to `app-config.yaml` (two healthy, one unhealthy) and verified the table renders with correct status icons and error messages

Additional tests : 
- **Type checking** :`yarn tsc` passes
- **API reports** :`yarn build:api-reports plugins/devtools` produces no changes      

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
