### PR TITLE
chore: add PR #33552 to patch release

### DIFF
--- a/.patches/pr-33552.txt
+++ b/.patches/pr-33552.txt
@@ -1,0 +1,1 @@
+Add showPaginationLabel prop to TablePagination


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds PR #33552 (`showPaginationLabel` prop) to the patch release as a dependency for PR #33614 (relation card fix). Without it, #33614 fails to cherry-pick onto `patch/v1.49.0` due to context mismatch in `PaginationOptions`.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.