### PR TITLE
fix: scaffolder entity picker null handling

### DIFF
--- a/.changeset/fix-entity-picker-null-catalog-filter.md
+++ b/.changeset/fix-entity-picker-null-catalog-filter.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Fixed a crash in `EntityPicker` and `MultiEntityPicker` where a `null` value in a `catalogFilter` property (e.g. from malformed YAML templates) would cause a `TypeError: Cannot read properties of null (reading 'exists')`. Invalid filter values are now defensively ignored. Also consolidated duplicated catalog filter conversion logic into a shared utility.

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 import {
-  type EntityFilterQuery,
-  CATALOG_FILTER_EXISTS,
-} from '@backstage/catalog-client';
-import {
   Entity,
   parseEntityRef,
   stringifyEntityRef,
@@ -36,13 +32,9 @@ import Autocomplete, {
 } from '@material-ui/lab/Autocomplete';
 import { useCallback, useEffect } from 'react';
 import useAsync from 'react-use/esm/useAsync';
-import {
-  EntityPickerFilterQueryValue,
-  EntityPickerProps,
-  EntityPickerUiOptions,
-  EntityPickerFilterQuery,
-} from './schema';
+import { EntityPickerProps } from './schema';
 import { VirtualizedListbox } from '../VirtualizedListbox';
+import { buildCatalogFilter } from './utils';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { scaffolderTranslationRef } from '../../../translation';
 import { ScaffolderField } from '@backstage/plugin-scaffolder-react/alpha';
@@ -70,7 +62,11 @@ export const EntityPicker = (props: EntityPickerProps) => {
     idSchema,
     errors,
   } = props;
-  const catalogFilter = buildCatalogFilter(uiSchema);
+  const allowedKinds = uiSchema['ui:options']?.allowedKinds;
+  const catalogFilter = buildCatalogFilter(
+    uiSchema['ui:options']?.catalogFilter ||
+      (allowedKinds && { kind: allowedKinds }),
+  );
   const defaultKind = uiSchema['ui:options']?.defaultKind;
   const defaultNamespace =
     uiSchema['ui:options']?.defaultNamespace || undefined;
@@ -234,71 +230,3 @@ export const EntityPicker = (props: EntityPickerProps) => {
     </ScaffolderField>
   );
 };
-
-/**
- * Converts a especial `{exists: true}` value to the `CATALOG_FILTER_EXISTS` symbol.
- *
- * @param value - The value to convert.
- * @returns The converted value.
- */
-function convertOpsValues(
-  value: Exclude<EntityPickerFilterQueryValue, Array<any>>,
-): string | symbol {
-  if (typeof value === 'object' && value.exists) {
-    return CATALOG_FILTER_EXISTS;
-  }
-  return value?.toString();
-}
-
-/**
- * Converts schema filters to entity filter query, replacing `{exists:true}` values
- * with the constant `CATALOG_FILTER_EXISTS`.
- *
- * @param schemaFilters - An object containing schema filters with keys as filter names
- * and values as filter values.
- * @returns An object with the same keys as the input object, but with `{exists:true}` values
- * transformed to `CATALOG_FILTER_EXISTS` symbol.
- */
-function convertSchemaFiltersToQuery(
-  schemaFilters: EntityPickerFilterQuery,
-): Exclude<EntityFilterQuery, Array<any>> {
-  const query: EntityFilterQuery = {};
-
-  for (const [key, value] of Object.entries(schemaFilters)) {
-    if (Array.isArray(value)) {
-      query[key] = value;
-    } else {
-      query[key] = convertOpsValues(value);
-    }
-  }
-
-  return query;
-}
-
-/**
- * Builds an `EntityFilterQuery` based on the `uiSchema` passed in.
- * If `catalogFilter` is specified in the `uiSchema`, it is converted to a `EntityFilterQuery`.
- * If `allowedKinds` is specified in the `uiSchema` will support the legacy `allowedKinds` option.
- *
- * @param uiSchema The `uiSchema` of an `EntityPicker` component.
- * @returns An `EntityFilterQuery` based on the `uiSchema`, or `undefined` if `catalogFilter` is not specified in the `uiSchema`.
- */
-function buildCatalogFilter(
-  uiSchema: EntityPickerProps['uiSchema'],
-): EntityFilterQuery | undefined {
-  const allowedKinds = uiSchema['ui:options']?.allowedKinds;
-
-  const catalogFilter: EntityPickerUiOptions['catalogFilter'] | undefined =
-    uiSchema['ui:options']?.catalogFilter ||
-    (allowedKinds && { kind: allowedKinds });
-
-  if (!catalogFilter) {
-    return undefined;
-  }
-
-  if (Array.isArray(catalogFilter)) {
-    return catalogFilter.map(convertSchemaFiltersToQuery);
-  }
-
-  return convertSchemaFiltersToQuery(catalogFilter);
-}

--- a/plugins/scaffolder/src/components/fields/EntityPicker/utils.test.ts
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/utils.test.ts
@@ -59,7 +59,7 @@ describe('buildCatalogFilter', () => {
     ).toEqual({ kind: 'Component' });
   });
 
-  it('does not crash when a filter value is null', () => {
+  it('ignores invalid null filter values from malformed templates', () => {
     expect(
       buildCatalogFilter({
         kind: 'User',

--- a/plugins/scaffolder/src/components/fields/EntityPicker/utils.test.ts
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/utils.test.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CATALOG_FILTER_EXISTS } from '@backstage/catalog-client';
+import { buildCatalogFilter } from './utils';
+
+describe('buildCatalogFilter', () => {
+  it('returns undefined for undefined input', () => {
+    expect(buildCatalogFilter(undefined)).toBeUndefined();
+  });
+
+  it('converts a simple filter object', () => {
+    expect(buildCatalogFilter({ kind: 'Component' })).toEqual({
+      kind: 'Component',
+    });
+  });
+
+  it('converts an array of filter objects', () => {
+    expect(
+      buildCatalogFilter([{ kind: 'Component' }, { kind: 'API' }]),
+    ).toEqual([{ kind: 'Component' }, { kind: 'API' }]);
+  });
+
+  it('converts { exists: true } to CATALOG_FILTER_EXISTS', () => {
+    expect(
+      buildCatalogFilter({ 'metadata.annotations.foo': { exists: true } }),
+    ).toEqual({
+      'metadata.annotations.foo': CATALOG_FILTER_EXISTS,
+    });
+  });
+
+  it('omits keys with { exists: false }', () => {
+    expect(
+      buildCatalogFilter({
+        kind: 'Component',
+        'metadata.annotations.foo': { exists: false },
+      }),
+    ).toEqual({ kind: 'Component' });
+  });
+
+  it('omits keys with empty object values', () => {
+    expect(
+      buildCatalogFilter({
+        kind: 'Component',
+        'metadata.annotations.foo': {} as any,
+      }),
+    ).toEqual({ kind: 'Component' });
+  });
+
+  it('does not crash when a filter value is null', () => {
+    expect(
+      buildCatalogFilter({
+        kind: 'User',
+        properties: null as any,
+      }),
+    ).toEqual({ kind: 'User' });
+  });
+
+  it('preserves array filter values', () => {
+    expect(buildCatalogFilter({ kind: ['Component', 'API'] })).toEqual({
+      kind: ['Component', 'API'],
+    });
+  });
+});

--- a/plugins/scaffolder/src/components/fields/EntityPicker/utils.ts
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/utils.ts
@@ -48,6 +48,21 @@ function convertSchemaFiltersToQuery(
   return query;
 }
 
+/**
+ * Builds an {@link EntityFilterQuery} from a `catalogFilter` value provided
+ * via `ui:options` in a scaffolder field schema.
+ *
+ * Filter values are converted as follows:
+ * - `string` values are passed through as-is.
+ * - `string[]` values are passed through as-is (multi-value match).
+ * - `{ exists: true }` is replaced with the `CATALOG_FILTER_EXISTS` symbol.
+ * - `{ exists: false }`, `{}`, and `null` values are silently omitted from
+ *   the resulting query (they carry no meaningful filter semantics and would
+ *   otherwise produce invalid filter entries).
+ *
+ * Accepts a single filter object, an array of filter objects (OR semantics),
+ * or `undefined`. Returns `undefined` when the input is falsy.
+ */
 export function buildCatalogFilter(
   catalogFilter:
     | Record<string, FilterQueryValue>

--- a/plugins/scaffolder/src/components/fields/EntityPicker/utils.ts
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/utils.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  type EntityFilterQuery,
+  CATALOG_FILTER_EXISTS,
+} from '@backstage/catalog-client';
+
+type FilterQueryValue = string | { exists?: boolean } | string[];
+
+function convertOpsValues(
+  value: Exclude<FilterQueryValue, Array<any>>,
+): string | symbol {
+  if (value !== null && typeof value === 'object' && value.exists) {
+    return CATALOG_FILTER_EXISTS;
+  }
+  return value?.toString();
+}
+
+function convertSchemaFiltersToQuery(
+  schemaFilters: Record<string, FilterQueryValue>,
+): Exclude<EntityFilterQuery, Array<any>> {
+  const query: EntityFilterQuery = {};
+
+  for (const [key, value] of Object.entries(schemaFilters)) {
+    if (Array.isArray(value)) {
+      query[key] = value;
+    } else {
+      query[key] = convertOpsValues(value);
+    }
+  }
+
+  return query;
+}
+
+export function buildCatalogFilter(
+  catalogFilter:
+    | Record<string, FilterQueryValue>
+    | Record<string, FilterQueryValue>[]
+    | undefined,
+): EntityFilterQuery | undefined {
+  if (!catalogFilter) {
+    return undefined;
+  }
+
+  if (Array.isArray(catalogFilter)) {
+    return catalogFilter.map(convertSchemaFiltersToQuery);
+  }
+
+  return convertSchemaFiltersToQuery(catalogFilter);
+}

--- a/plugins/scaffolder/src/components/fields/EntityPicker/utils.ts
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/utils.ts
@@ -56,9 +56,11 @@ function convertSchemaFiltersToQuery(
  * - `string` values are passed through as-is.
  * - `string[]` values are passed through as-is (multi-value match).
  * - `{ exists: true }` is replaced with the `CATALOG_FILTER_EXISTS` symbol.
- * - `{ exists: false }`, `{}`, and `null` values are silently omitted from
- *   the resulting query (they carry no meaningful filter semantics and would
- *   otherwise produce invalid filter entries).
+ * - `{ exists: false }` and `{}` are omitted from the resulting query since
+ *   they carry no meaningful filter semantics.
+ *
+ * Invalid values such as `null` (which can arise from malformed YAML
+ * templates) are defensively ignored rather than causing a runtime crash.
  *
  * Accepts a single filter object, an array of filter objects (OR semantics),
  * or `undefined`. Returns `undefined` when the input is falsy.

--- a/plugins/scaffolder/src/components/fields/EntityPicker/utils.ts
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/utils.ts
@@ -22,9 +22,9 @@ type FilterQueryValue = string | { exists?: boolean } | string[];
 
 function convertOpsValues(
   value: Exclude<FilterQueryValue, Array<any>>,
-): string | symbol {
-  if (value !== null && typeof value === 'object' && value.exists) {
-    return CATALOG_FILTER_EXISTS;
+): string | symbol | undefined {
+  if (value !== null && typeof value === 'object') {
+    return value.exists ? CATALOG_FILTER_EXISTS : undefined;
   }
   return value?.toString();
 }
@@ -38,7 +38,10 @@ function convertSchemaFiltersToQuery(
     if (Array.isArray(value)) {
       query[key] = value;
     } else {
-      query[key] = convertOpsValues(value);
+      const converted = convertOpsValues(value);
+      if (converted !== undefined) {
+        query[key] = converted;
+      }
     }
   }
 

--- a/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/MultiEntityPicker/MultiEntityPicker.tsx
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 import {
-  type EntityFilterQuery,
-  CATALOG_FILTER_EXISTS,
-} from '@backstage/catalog-client';
-import {
   Entity,
   parseEntityRef,
   stringifyEntityRef,
@@ -37,12 +33,8 @@ import Autocomplete, {
 import { useCallback, useEffect, useState } from 'react';
 import useAsync from 'react-use/esm/useAsync';
 import { FieldValidation } from '@rjsf/utils';
-import {
-  MultiEntityPickerFilterQueryValue,
-  MultiEntityPickerProps,
-  MultiEntityPickerUiOptions,
-  MultiEntityPickerFilterQuery,
-} from './schema';
+import { MultiEntityPickerProps } from './schema';
+import { buildCatalogFilter } from '../EntityPicker/utils';
 import { VirtualizedListbox } from '../VirtualizedListbox';
 import { ScaffolderField } from '@backstage/plugin-scaffolder-react/alpha';
 import { useTranslationRef } from '@backstage/frontend-plugin-api';
@@ -76,7 +68,9 @@ export const MultiEntityPicker = (props: MultiEntityPickerProps) => {
     errors,
   } = props;
 
-  const catalogFilter = buildCatalogFilter(uiSchema);
+  const catalogFilter = buildCatalogFilter(
+    uiSchema['ui:options']?.catalogFilter,
+  );
   const defaultKind = uiSchema['ui:options']?.defaultKind;
   const defaultNamespace =
     uiSchema['ui:options']?.defaultNamespace || undefined;
@@ -238,67 +232,3 @@ export const validateMultiEntityPickerValidation = (
     }
   });
 };
-
-/**
- * Converts a special `{exists: true}` value to the `CATALOG_FILTER_EXISTS` symbol.
- *
- * @param value - The value to convert.
- * @returns The converted value.
- */
-function convertOpsValues(
-  value: Exclude<MultiEntityPickerFilterQueryValue, Array<any>>,
-): string | symbol {
-  if (typeof value === 'object' && value.exists) {
-    return CATALOG_FILTER_EXISTS;
-  }
-  return value?.toString();
-}
-
-/**
- * Converts schema filters to entity filter query, replacing `{exists:true}` values
- * with the constant `CATALOG_FILTER_EXISTS`.
- *
- * @param schemaFilters - An object containing schema filters with keys as filter names
- * and values as filter values.
- * @returns An object with the same keys as the input object, but with `{exists:true}` values
- * transformed to `CATALOG_FILTER_EXISTS` symbol.
- */
-function convertSchemaFiltersToQuery(
-  schemaFilters: MultiEntityPickerFilterQuery,
-): Exclude<EntityFilterQuery, Array<any>> {
-  const query: EntityFilterQuery = {};
-
-  for (const [key, value] of Object.entries(schemaFilters)) {
-    if (Array.isArray(value)) {
-      query[key] = value;
-    } else {
-      query[key] = convertOpsValues(value);
-    }
-  }
-
-  return query;
-}
-
-/**
- * Builds an `EntityFilterQuery` based on the `uiSchema` passed in.
- * If `catalogFilter` is specified in the `uiSchema`, it is converted to a `EntityFilterQuery`.
- *
- * @param uiSchema The `uiSchema` of an `EntityPicker` component.
- * @returns An `EntityFilterQuery` based on the `uiSchema`, or `undefined` if `catalogFilter` is not specified in the `uiSchema`.
- */
-function buildCatalogFilter(
-  uiSchema: MultiEntityPickerProps['uiSchema'],
-): EntityFilterQuery | undefined {
-  const catalogFilter: MultiEntityPickerUiOptions['catalogFilter'] | undefined =
-    uiSchema['ui:options']?.catalogFilter;
-
-  if (!catalogFilter) {
-    return undefined;
-  }
-
-  if (Array.isArray(catalogFilter)) {
-    return catalogFilter.map(convertSchemaFiltersToQuery);
-  }
-
-  return convertSchemaFiltersToQuery(catalogFilter);
-}


### PR DESCRIPTION
Ideally, we'd consolidate the entity pickers into a shared directory - but didn't want to mess with so many imports for a simple bug fix.

## Hey, I just made a Pull Request!
Improved null check if block and consolidated Entity/MultiEntity duplicate logic.

#### :heavy_check_mark: Checklist

- [✔️] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [✔️ ] Added or updated documentation
- [✔️ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [✔️] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
