### PR TITLE
Simplify createRouteRef type signature

### DIFF
--- a/.changeset/simplify-compat-route-ref.md
+++ b/.changeset/simplify-compat-route-ref.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-compat-api': patch
+---
+
+Removed unnecessary type argument from internal `createRouteRef` call.

--- a/.changeset/simplify-route-ref-types.md
+++ b/.changeset/simplify-route-ref-types.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': minor
+---
+
+Simplified the type signature of `createRouteRef` by replacing the dual `TParams`/`TParamKeys` type parameters with a single `TParamKey` parameter. This is a breaking change for callers that explicitly provided type arguments, but most usage that relies on inference is unaffected.

--- a/packages/core-compat-api/src/convertLegacyRouteRef.ts
+++ b/packages/core-compat-api/src/convertLegacyRouteRef.ts
@@ -220,7 +220,7 @@ function convertOldToNew(
     const legacyRef = ref as LegacyRouteRef;
     const legacyRefStr = String(legacyRef);
     const newRef = OpaqueRouteRef.toInternal(
-      createRouteRef<{ [key in string]: string }>({
+      createRouteRef({
         params: legacyRef.params as string[],
       }),
     );

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -814,25 +814,14 @@ export interface CreateFrontendPluginOptions<
 }
 
 // @public
-export function createRouteRef<
-  TParams extends
-    | {
-        [param in TParamKeys]: string;
-      }
-    | undefined = undefined,
-  TParamKeys extends string = string,
->(config?: {
-  readonly params?: string extends TParamKeys
-    ? (keyof TParams)[]
-    : TParamKeys[];
+export function createRouteRef<TParamKey extends string = never>(config?: {
+  readonly params?: TParamKey[];
   aliasFor?: string;
 }): RouteRef<
-  keyof TParams extends never
+  [TParamKey] extends [never]
     ? undefined
-    : string extends TParamKeys
-    ? TParams
     : {
-        [param in TParamKeys]: string;
+        [param in TParamKey]: string;
       }
 >;
 

--- a/packages/frontend-plugin-api/src/routing/RouteRef.ts
+++ b/packages/frontend-plugin-api/src/routing/RouteRef.ts
@@ -41,23 +41,16 @@ export interface RouteRef<
  * @public
  */
 export function createRouteRef<
-  // Params is the type that we care about and the one to be embedded in the route ref.
-  // For example, given the params ['name', 'kind'], Params will be {name: string, kind: string}
-  TParams extends { [param in TParamKeys]: string } | undefined = undefined,
-  TParamKeys extends string = string,
+  // ParamKey is narrowed to the literal union of param name strings.
+  // Defaulting to never means we get undefined params when the array is empty or omitted.
+  TParamKey extends string = never,
 >(config?: {
   /** A list of parameter names that the path that this route ref is bound to must contain */
-  readonly params?: string extends TParamKeys
-    ? (keyof TParams)[]
-    : TParamKeys[];
+  readonly params?: TParamKey[];
 
   aliasFor?: string;
 }): RouteRef<
-  keyof TParams extends never
-    ? undefined
-    : string extends TParamKeys
-    ? TParams
-    : { [param in TParamKeys]: string }
+  [TParamKey] extends [never] ? undefined : { [param in TParamKey]: string }
 > {
   const params = (config?.params ?? []) as string[];
   const creationSite = describeParentCallSite();
@@ -65,7 +58,7 @@ export function createRouteRef<
   let id: string | undefined = undefined;
 
   return OpaqueRouteRef.createInstance('v1', {
-    T: undefined as unknown as TParams,
+    T: undefined as any,
     getParams() {
       return params;
     },


### PR DESCRIPTION
## Summary

- Replaced the dual `TParams`/`TParamKeys` type parameters in `createRouteRef` with a single `TParamKey` parameter, removing unnecessary complexity while preserving runtime behavior and type inference for most callers.
- Removed the now-unnecessary explicit type argument from the internal `createRouteRef` call in `@backstage/core-compat-api`.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

🤖 Generated with [Claude Code](https://claude.com/claude-code)