### PR TITLE
Remove unused jest-when dependency from scaffolder-backend-module-rails

### DIFF
--- a/.changeset/remove-jest-when-dep.md
+++ b/.changeset/remove-jest-when-dep.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-rails': patch
+---
+
+Removed unused `jest-when` dev dependency.

--- a/plugins/scaffolder-backend-module-rails/knip-report.md
+++ b/plugins/scaffolder-backend-module-rails/knip-report.md
@@ -1,8 +1,3 @@
 # Knip report
 
-## Unused devDependencies (1)
-
-| Name      | Location     | Severity |
-| :-------- | :----------- | :------- |
-| jest-when | plugins/scaffolder-backend-module-rails/package.json | error    |
-
+No issues found.

--- a/plugins/scaffolder-backend-module-rails/package.json
+++ b/plugins/scaffolder-backend-module-rails/package.json
@@ -59,7 +59,6 @@
     "@backstage/plugin-scaffolder-node-test-utils": "workspace:^",
     "@types/command-exists": "^1.2.0",
     "@types/fs-extra": "^11.0.0",
-    "@types/node": "^22.13.14",
-    "jest-when": "^3.1.0"
+    "@types/node": "^22.13.14"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6755,7 +6755,6 @@ __metadata:
     "@types/node": "npm:^22.13.14"
     command-exists: "npm:^1.2.9"
     fs-extra: "npm:^11.0.0"
-    jest-when: "npm:^3.1.0"
     yaml: "npm:^2.0.0"
   languageName: unknown
   linkType: soft
@@ -35661,15 +35660,6 @@ __metadata:
     jest-diff: "npm:^29.2.0"
     mock-socket: "npm:^9.3.0"
   checksum: 10/99585445503ef5ab391052243643dc1afa1abf9dfa65a39f4bd55b9b0918cc6c486847c9d059fdefb337370eb06fef269c1ca0e76fd755abcfd3e73bf4c2bd87
-  languageName: node
-  linkType: hard
-
-"jest-when@npm:^3.1.0":
-  version: 3.7.0
-  resolution: "jest-when@npm:3.7.0"
-  peerDependencies:
-    jest: ">= 25"
-  checksum: 10/b5b88d077ed467aab220c71c885dbc5f448604f06e68f761ce9f479c99bb74e0dbf553d1cc980751d88401b034a578e1c44eec5e4095743b7586f02bb7c6313d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Removed the unused `jest-when` dev dependency from `@backstage/plugin-scaffolder-backend-module-rails`. It was listed in `package.json` but not imported anywhere in the plugin's source or test files (also flagged by knip).

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))