### PR TITLE
fix(auth-node): omit granted-scope cookie from new OAuth authorization request

### DIFF
--- a/.changeset/oauth-scope-cookie-authorize.md
+++ b/.changeset/oauth-scope-cookie-authorize.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-node': patch
+---
+
+Fixed OAuth authorization requests incorrectly including previously granted scopes from the `<provider>-granted-scope` cookie, which could cause sign-in to fail when provider configuration changes or the identity provider no longer allows those scopes. New authorization requests now only include configured and explicitly requested scopes; persisted scopes are still used when refreshing tokens.

--- a/plugins/auth-node/src/oauth/CookieScopeManager.test.ts
+++ b/plugins/auth-node/src/oauth/CookieScopeManager.test.ts
@@ -142,15 +142,15 @@ describe('CookieScopeManager', () => {
     });
 
     await expect(manager.start(makeReq())).resolves.toEqual({
-      scope: 'g',
+      scope: '',
       scopeState: {
-        scope: 'g',
+        scope: '',
       },
     });
     await expect(manager.start(makeReq('x'))).resolves.toEqual({
-      scope: 'x g',
+      scope: 'x',
       scopeState: {
-        scope: 'x g',
+        scope: 'x',
       },
     });
 
@@ -159,13 +159,13 @@ describe('CookieScopeManager', () => {
       manager.handleCallback(makeReq(), {
         // The state is prioritized even if scope is present in the result
         result: { session: { scope: 'x,y' } } as OAuthAuthenticatorResult<any>,
-        state: { scope: 'x g' } as OAuthState,
+        state: { scope: 'x' } as OAuthState,
         origin: 'https://other.example.com',
       }),
-    ).resolves.toEqual('x g');
+    ).resolves.toEqual('x');
     expect(setGrantedScopes).toHaveBeenCalledWith(
       expect.anything(),
-      'x g',
+      'x',
       'https://other.example.com',
     );
     setGrantedScopes.mockClear();
@@ -265,15 +265,15 @@ describe('CookieScopeManager', () => {
     });
 
     await expect(manager.start(makeReq())).resolves.toEqual({
-      scope: 'granted-g required-a additional-b',
+      scope: 'required-a additional-b',
       scopeState: {
-        scope: 'granted-g required-a additional-b',
+        scope: 'required-a additional-b',
       },
     });
     await expect(manager.start(makeReq('x'))).resolves.toEqual({
-      scope: 'requested-x granted-g required-a additional-b',
+      scope: 'requested-x required-a additional-b',
       scopeState: {
-        scope: 'requested-x granted-g required-a additional-b',
+        scope: 'requested-x required-a additional-b',
       },
     });
 

--- a/plugins/auth-node/src/oauth/CookieScopeManager.ts
+++ b/plugins/auth-node/src/oauth/CookieScopeManager.ts
@@ -99,9 +99,7 @@ export class CookieScopeManager {
     req: express.Request,
   ): Promise<{ scopeState?: Partial<OAuthState>; scope: string }> {
     const requestScope = splitScope(req.query.scope?.toString());
-    const grantedScope = splitScope(this.cookieManager?.getGrantedScopes(req));
-
-    const scope = this.scopeTransform(requestScope, grantedScope);
+    const scope = this.scopeTransform(requestScope, []);
 
     if (this.cookieManager) {
       // If scopes are persisted then we pass them through the state so that we

--- a/plugins/auth-node/src/oauth/createOAuthRouteHandlers.test.ts
+++ b/plugins/auth-node/src/oauth/createOAuthRouteHandlers.test.ts
@@ -222,6 +222,51 @@ describe('createOAuthRouteHandlers', () => {
       );
     });
 
+    it('should not merge stale granted-scope cookie into authorization request', async () => {
+      const agent = request.agent(
+        wrapInApp(
+          createOAuthRouteHandlers({
+            ...baseConfig,
+            authenticator: {
+              ...mockAuthenticator,
+              shouldPersistScopes: true,
+            },
+          }),
+        ),
+      );
+
+      agent.jar.setCookie(
+        'my-provider-granted-scope=stale-scope',
+        '127.0.0.1',
+        '/my-provider',
+      );
+
+      mockAuthenticator.start.mockResolvedValue({
+        url: 'https://example.com/redirect',
+      });
+
+      const res = await agent.get('/my-provider/start').query({
+        env: 'development',
+        scope: 'my-scope',
+      });
+
+      const { value: nonce } = getNonceCookie(agent);
+
+      expect(res.status).toBe(302);
+      expect(mockAuthenticator.start).toHaveBeenCalledWith(
+        {
+          req: expect.anything(),
+          scope: 'my-scope',
+          state: encodeOAuthState({
+            nonce: decodeURIComponent(nonce),
+            env: 'development',
+            scope: 'my-scope',
+          }),
+        },
+        { ctx: 'authenticator' },
+      );
+    });
+
     it('should start with additional parameters, transform state, and persist scopes', async () => {
       const agent = request.agent(
         wrapInApp(

--- a/plugins/auth-node/src/oauth/types.ts
+++ b/plugins/auth-node/src/oauth/types.ts
@@ -36,7 +36,10 @@ export interface OAuthAuthenticatorScopeOptions {
   transform?: (options: {
     /** Scopes requested by the client */
     requested: Iterable<string>;
-    /** Scopes which have already been granted */
+    /**
+     * Scopes persisted from a prior session (cookie). Empty when building a
+     * new authorization request; populated when refreshing tokens.
+     */
     granted: Iterable<string>;
     /** Scopes that are required for the authenticator to function */
     required: Iterable<string>;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #33099

For OAuth providers that persist scopes, Backstage was reusing previously granted scopes from a session cookie when building new authorization requests. That could send stale scopes to the identity provider after a change to configuration, OAuth client, or which scopes are valid. Authorization can then fail or be denied when the request still includes scopes that are no longer valid for the user or client (even though current configuration only needs a new valid set (see #33099)).

This change no longer applies that persisted scope when starting a new authorization, only what the app is configured to need now (and what the client explicitly requests) is used. Refreshing tokens still uses persisted scope information as it did before.

### Why the old behavior existed

In #24743, scope handling was unified so required, additional, requested, and persisted (granted) scopes are merged in one place. That fixed refresh flows and inconsistent behaviour between refresh and full auth, and aligned merging of client- and server-defined scope (see the PR description in there).

I think that persisting granted scopes in a cookie was meant to support refresh when an IdP does not return or normalizes `scope`, and to keep one consistent merge model.

### How that led to this issue

I think that applying the same merge on every new `/authorize` means the cookie can outlive a config or client change. The next login then asks the IdP for scopes that are no longer valid for this app or user (e.g. renamed scope, different OAuth client, revoked access), as described in #33099.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
