### PR TITLE
catalog-backend: add covering indices on search table

### DIFF
--- a/.changeset/catalog-search-covering-indices.md
+++ b/.changeset/catalog-search-covering-indices.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Added covering database indices on the `search` table for improved entity filter query performance. The new `(entity_id, key, value)` and `(key, value, entity_id)` indices enable index-only scans, eliminating heap fetches during filter queries on large catalogs.

--- a/plugins/catalog-backend/migrations/20260311000000_search_covering_indices.js
+++ b/plugins/catalog-backend/migrations/20260311000000_search_covering_indices.js
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-check
+
+/**
+ * Adds covering indices to the search table that include entity_id, enabling
+ * index-only scans for the EXISTS subqueries used in entity filtering.
+ *
+ * - (entity_id, key, value): Optimal for correlated EXISTS subqueries where
+ *   the outer query provides entity_id and the inner query filters by key/value.
+ * - (key, value, entity_id): Replaces the old (key, value) index; enables
+ *   index-only scans when scanning by key+value and returning entity_id.
+ *
+ * @param { import("knex").Knex } knex
+ */
+exports.up = async function up(knex) {
+  if (knex.client.config.client === 'pg') {
+    // Covering index for EXISTS correlated subqueries (probe by entity_id)
+    await knex.raw(
+      'CREATE INDEX CONCURRENTLY IF NOT EXISTS search_entity_key_value_idx ON search (entity_id, key, value)',
+    );
+    // Covering replacement for the old (key, value) index
+    await knex.raw(
+      'CREATE INDEX CONCURRENTLY IF NOT EXISTS search_key_value_entity_idx ON search (key, value, entity_id)',
+    );
+    // Drop the old non-covering index, now superseded
+    await knex.raw('DROP INDEX CONCURRENTLY IF EXISTS search_key_value_idx');
+  } else {
+    // The search_key_value_idx only existed on pg, so no need to drop it here
+    await knex.schema.alterTable('search', table => {
+      table.index(['entity_id', 'key', 'value'], 'search_entity_key_value_idx');
+      table.index(['key', 'value', 'entity_id'], 'search_key_value_entity_idx');
+    });
+  }
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ */
+exports.down = async function down(knex) {
+  if (knex.client.config.client === 'pg') {
+    // Restore the original index
+    await knex.raw(
+      'CREATE INDEX CONCURRENTLY IF NOT EXISTS search_key_value_idx ON search (key, value)',
+    );
+    // Drop the new indices
+    await knex.raw(
+      'DROP INDEX CONCURRENTLY IF EXISTS search_key_value_entity_idx',
+    );
+    await knex.raw(
+      'DROP INDEX CONCURRENTLY IF EXISTS search_entity_key_value_idx',
+    );
+  } else {
+    await knex.schema.alterTable('search', table => {
+      table.index(['key', 'value'], 'search_key_value_idx');
+      table.dropIndex([], 'search_key_value_entity_idx');
+      table.dropIndex([], 'search_entity_key_value_idx');
+    });
+  }
+};
+
+exports.config = {
+  transaction: false,
+};

--- a/plugins/catalog-backend/report.sql.md
+++ b/plugins/catalog-backend/report.sql.md
@@ -129,8 +129,9 @@
 ### Indices
 
 - `search_entity_id_idx` (`entity_id`)
+- `search_entity_key_value_idx` (`entity_id`, `key`, `value`)
 - `search_key_original_value_idx` (`key`, `original_value`)
-- `search_key_value_idx` (`key`, `value`)
+- `search_key_value_entity_idx` (`key`, `value`, `entity_id`)
 
 ## Table `stitch_queue`
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

**Stacks on top of #33290** (the EXISTS query optimization). Merge that first.

Adds covering database indices on the `search` table to further improve entity filter query performance:

- `(entity_id, key, value)` — optimal for correlated EXISTS subqueries where the outer query provides `entity_id`
- `(key, value, entity_id)` — replaces the old `(key, value)` index with a covering version that enables index-only scans

**Measured impact** on a catalog with 500k entities and 12M search rows: the old `(key, value)` index required ~41,700 heap fetches per filter condition on top of ~230 index reads. The covering index eliminates all heap fetches.

The migration uses `CREATE INDEX CONCURRENTLY` on PostgreSQL to avoid locking the table during index creation. For SQLite it uses standard `CREATE INDEX`.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))