### PR TITLE
docs: migrate plugin development pages to new frontend system

### DIFF
--- a/docs/plugins/composability--old.md
+++ b/docs/plugins/composability--old.md
@@ -1,0 +1,556 @@
+---
+id: composability--old
+title: Composability System (Old Frontend System)
+description: Documentation for the Backstage plugin composability APIs.
+---
+
+::::info
+This documentation is for Backstage apps that still use the old frontend
+system. If your app uses the new frontend system, read the
+[current guide](./composability.md) instead.
+::::
+
+## Summary
+
+This page describes the composability system that helps bring together content
+from a multitude of plugins into one Backstage application.
+
+The core principle of the composability system is that plugins should have clear
+boundaries and connections. It should isolate crashes within a plugin, but allow
+navigation between them. It should allow for plugins to be loaded only when
+needed, and enable plugins to provide extension points for other plugins to
+build upon. The composability system is also built with an app-first mindset,
+prioritizing simplicity and clarity in the app over that in the plugins and core
+APIs.
+
+The composability system isn't a single API surface. It is a collection of
+patterns, primitives, and APIs. At the core is the concept of **extensions**,
+which are exported by plugins for use in the app. There is also a primitive
+called component data, which helps keep the structure of the app more
+declarative. There are also `RouteRef`s that help route between pages in a
+flexible way, which is especially important when bringing together different
+open source plugins.
+
+## Concepts
+
+This section is a brief look into all the concepts that help support the
+composability system.
+
+### Component Data
+
+Component data is a composability primitive that is introduced as a way to
+provide a new data dimension for React components. Data is attached to React
+components using a key, and is then readable from any JSX elements created with
+those components, using the same key, as illustrated by the following example:
+
+```tsx
+const MyComponent = () => <h1>This is my component</h1>;
+attachComponentData(MyComponent, 'my.data', 5);
+
+const element = <MyComponent />;
+const myData = getComponentData(element, 'my.data');
+// myData === 5
+```
+
+The purpose of component data is to provide a method for embedding data that can
+be inspected before rendering elements. Element inspection is a pattern that is
+quite common among React libraries, and used for example by `react-router` and
+`material-ui` to discover properties of the child elements before rendering.
+Although in those libraries only the element type and props are typically
+inspected, while our component data adds more structured access and simplifies
+evolution by allowing for multiple different versions of a piece of data to be
+used and interpreted at once.
+
+One of the use-cases for component data is to support route and plugin discovery
+through elements in the app. Through this we allow for the React element tree in
+the app to be the source of truth, both for which plugins are used, as well as
+all top-level plugin routes in the app. The use of component data is not limited
+to these use-cases though, as it can be used as a primitive to create new
+abstractions as well.
+
+### Extensions
+
+Extensions are what plugins export for use in an app. Most typically they are
+React components, but in practice they can be any kind of JavaScript value. They
+are created using `create*Extension` functions, and wrapped with
+`plugin.provide()` in order to create the actual exported extension.
+
+The extension type is a simple one:
+
+```ts
+export type Extension<T> = {
+  expose(plugin: BackstagePlugin): T;
+};
+```
+
+The power of extensions comes from the ability of various actors to hook into
+their usage. The creation and plugin wrapping is controlled by whoever owns the
+creation function, the Backstage core is able to hook into the process of
+exposing the extension outside the plugin, and in the end the app controls the
+usage of the extension.
+
+The Backstage core API currently provides two different types of extension
+creators, `createComponentExtension`, and `createRoutableExtension`. Component
+extensions are plain React component with no particular requirements, for
+example a card for an entity overview page. The component will be exported more
+or less as is, but is wrapped to provide things like an error boundary, lazy
+loading, and a plugin context.
+
+Routable extensions build on top of component extensions and are used for any
+component that should be rendered at a specific route path, such as top-level
+pages or entity page tab content. When creating a routable extension you need to
+supply a `RouteRef` as `mountPoint`. The mount point will be the handle of the
+component for the outside world, and is used by other components and plugins
+that wish to link to the routable component.
+
+As of now there are only two extension creation functions in the core library,
+but more may be added in the future. There are also some plugins that provide
+ways to extend functionality through their own extensions, like
+`createScaffolderFieldExtension` from `@backstage/plugin-scaffolder`. Extensions
+are also not tied to React, and can both be used to model generic JavaScript
+concepts, as well as potentially bridge to rendering libraries and web
+frameworks other than React.
+
+### Extensions from a Plugin's Point of View
+
+Extensions are one of the primary methods to traverse the plugin boundary, and
+the way that plugins provide concrete content for use within an app. They
+replace existing component export concepts such as `Router` or `*Card`s for
+display on entity overview pages.
+
+It is recommended to create the exported extensions either in the top-level
+`plugin.ts` file, or in a dedicated `extensions.ts` (or `.tsx`) file. That file
+should not contain the bulk of the implementation though, and in fact, if the
+extension is a React component it is recommended to lazy-load the actual
+component. Component extensions support lazy loading out of the box using the
+`lazy` component declaration, for example:
+
+```ts
+export const EntityFooCard = plugin.provide(
+  createComponentExtension({
+    component: {
+      lazy: () => import('./components/FooCard').then(m => m.FooCard),
+    },
+  }),
+);
+```
+
+Routable extensions even enforce lazy loading, as it is the only way to provide
+a component:
+
+```ts
+export const FooPage = plugin.provide(
+  createRoutableExtension({
+    name: 'FooPage',
+    component: () => import('./components/FooPage').then(m => m.FooPage),
+    mountPoint: fooPageRouteRef,
+  }),
+);
+```
+
+### Using Extensions in an App
+
+Right now all extensions are modelled as React components. The usage of these
+extension is like regular usage of any React components, with one important
+difference. Extensions must all be part of a single React element tree spanning
+from the root `AppProvider`.
+
+For example, the following app code does **NOT** work:
+
+```tsx
+const AppRoutes = () => (
+  <Routes>
+    <Route path="/foo" element={<FooPage />} />
+    <Route path="/bar" element={<BarPage />} />
+  </Routes>
+);
+
+const App = () => (
+  <AppProvider>
+    <AppRouter>
+      <Root>
+        <AppRoutes />
+      </Root>
+    </AppRouter>
+  </AppProvider>
+);
+```
+
+But in this case it is simple to fix! Simply be sure to not create any
+intermediate components in the app, for example like this:
+
+```tsx
+const appRoutes = (
+  <Routes>
+    <Route path="/foo" element={<FooPage />} />
+    <Route path="/bar" element={<BarPage />} />
+  </Routes>
+);
+
+const App = () => (
+  <AppProvider>
+    <AppRouter>
+      <Root>{appRoutes}</Root>
+    </AppRouter>
+  </AppProvider>
+);
+```
+
+### Naming Patterns
+
+There are a couple of naming patterns to adhere to as you build plugins, which
+helps clarify the intent and usage of the exports.
+
+| Description           | Pattern          | Examples                                             |
+| --------------------- | ---------------- | ---------------------------------------------------- |
+| Top-level Pages       | `*Page`          | `CatalogIndexPage`, `SettingsPage`, `LighthousePage` |
+| Entity Tab Content    | `Entity*Content` | `EntityJenkinsContent`, `EntityKubernetesContent`    |
+| Entity Overview Card  | `Entity*Card`    | `EntitySentryCard`, `EntityPagerDutyCard`            |
+| Entity Conditional    | `is*Available`   | `isPagerDutyAvailable`, `isJenkinsAvailable`         |
+| Plugin Instance       | `*Plugin`        | `jenkinsPlugin`, `catalogPlugin`                     |
+| Utility API Reference | `*ApiRef`        | `configApiRef`, `catalogApiRef`                      |
+
+### Routing System
+
+The routing system of Backstage relies heavily on the composability system. It
+uses `RouteRef`s to represent routing targets in the app, which at runtime will
+be bound to a concrete `path`, but provides a level of indirection to help mix
+together different plugins that otherwise wouldn't know how to route to each
+other.
+
+The concrete `path` for each `RouteRef` is discovered based on the element tree
+in the app. Let's consider the following example:
+
+```tsx
+const appRoutes = (
+  <Routes>
+    <Route path="/foo" element={<FooPage />} />
+    <Route path="/bar" element={<BarPage />} />
+  </Routes>
+);
+```
+
+We'll assume that `FooPage` and `BarPage` are routable extensions, exported by
+the `fooPlugin` and `barPlugin` respectively. Since the `FooPage` is a routable
+extension it has a `RouteRef` assigned as its mount point, which we'll refer to
+as `fooPageRouteRef`.
+
+Given the above example, the `fooPageRouteRef` will be associated with the
+`'/foo'` route. If we want to route to the `FooPage`, we can use the
+`useRouteRef` hook to create a concrete link to the page. The `useRouteRef` hook
+takes a single `RouteRef` as its only parameter, and returns a function that is
+called to create the URL. For example like this:
+
+```tsx
+const MyComponent = () => {
+  const fooRoute = useRouteRef(fooPageRouteRef);
+  return <a href={fooRoute()}>Link to Foo</a>;
+};
+```
+
+Now let's assume that we want to link from the `BarPage` to the `FooPage`. We
+don't want to reference the `fooPageRouteRef` directly from our `barPlugin`,
+since that would create an unnecessary dependency on the `fooPlugin`. It would
+also provided little flexibility in allowing the app to tie plugins together,
+with the links instead being dictated by the plugins themselves. To solve this,
+we use `ExternalRouteRef`s. Much like regular route references, they can be
+passed to `useRouteRef` to create concrete URLs, but they can not be used as
+mount points in routable component and instead have to be associated with a
+target route using route bindings in the app.
+
+We create a new `ExternalRouteRef` inside the `barPlugin`, using a neutral name
+that describes its role in the plugin rather than a specific plugin page that it
+might be linking to, allowing the app to decide the final target. If the
+`BarPage` for example wants to link to an external page in the header, it might
+declare an `ExternalRouteRef` similar to this:
+
+```ts
+const headerLinkRouteRef = createExternalRouteRef({ id: 'header-link' });
+```
+
+### Binding External Routes in the App
+
+The association of external routes is controlled by the app. Each
+`ExternalRouteRef` of a plugin should be bound to an actual `RouteRef`, usually
+from another plugin. The binding process happens once at app startup, and is
+then used through the lifetime of the app to help resolve concrete route paths.
+
+Using the above example of the `BarPage` linking to the `FooPage`, we might do
+something like this in the app:
+
+```ts
+createApp({
+  bindRoutes({ bind }) {
+    bind(barPlugin.externalRoutes, {
+      headerLink: fooPlugin.routes.root,
+    });
+  },
+});
+```
+
+Given the above binding, using `useRouteRef(headerLinkRouteRef)` within the
+`barPlugin` will let us create a link to whatever path the `FooPage` is mounted
+at.
+
+Note that we are not importing and using the `RouteRef`s directly in the app,
+and instead rely on the plugin instance to access routes of the plugins. This is
+a new convention that was introduced to provide better namespacing and
+discoverability of routes, as well as reduce the number of separate exports from
+each plugin package. The route references would be supplied to `createPlugin`
+like this:
+
+```ts
+// In foo-plugin
+export const fooPlugin = createPlugin({
+  routes: {
+    root: fooPageRouteRef,
+  },
+  ...
+})
+
+// In bar-plugin
+export const barPlugin = createPlugin({
+  externalRoutes: {
+    headerLink: headerLinkRouteRef,
+  },
+  ...
+})
+```
+
+Also note that you almost always want to create the route references themselves
+in a different file than the one that creates the plugin instance, for example a
+top-level `routes.ts`. This is to avoid circular imports when you use the route
+references from other parts of the same plugin.
+
+Another thing to note is that this indirection in the routing is particularly
+useful for open source plugins that need to leave flexibility in how they are
+integrated. For plugins that you build internally for your own Backstage
+application, you can choose to go the route of direct imports or even use
+concrete routes directly. Although there can be some benefits to using the full
+routing system even in internal plugins. It can help you structure your routes,
+and as you will see further down it also helps you manage route parameters.
+
+You can also use static configuration to bind routes, removing the need to make
+changes to the app code. It does however mean that you won't get type safety
+when binding routes and compile-time validation of the bindings. Static
+configuration of route bindings is done under the `app.routes.bindings` key in
+`app-config.yaml`. It works the same way as [route bindings in the new frontend system](../frontend-system/architecture/36-routes.md#binding-external-route-references),
+for example:
+
+```yaml
+app:
+  routes:
+    bindings:
+      bar.headerLink: foo.root
+```
+
+### Default Targets for External Route References
+
+Following the `1.28` release of Backstage you can now define default targets for
+external route references. They work the same way as [default targets in the new frontend system](../frontend-system/architecture/36-routes.md#default-targets-for-external-route-references),
+for example:
+
+```ts
+export const createComponentExternalRouteRef = createExternalRouteRef({
+  // highlight-next-line
+  defaultTarget: 'scaffolder.createComponent',
+});
+```
+
+### Optional External Routes
+
+When creating an `ExternalRouteRef` it is possible to mark it as optional:
+
+```ts
+const headerLinkRouteRef = createExternalRouteRef({
+  id: 'header-link',
+  optional: true,
+});
+```
+
+An external route that is marked as optional is not required to be bound in the
+app, allowing it to be used as a switch for whether a particular link should be
+displayed or action should be taken.
+
+When calling `useRouteRef` with an optional external route, its return signature
+is changed to `RouteFunc | undefined`, allowing for logic like this:
+
+```tsx
+const MyComponent = () => {
+  const headerLink = useRouteRef(headerLinkRouteRef);
+
+  return (
+    <header>
+      My Header
+      {headerLink && <a href={headerLink()}>External Link</a>}
+    </header>
+  );
+};
+```
+
+### Parameterized Routes
+
+A feature of `RouteRef`s is the possibility of adding named and typed
+parameters. Parameters are declared at creation, and will enforce presence of
+the parameters in the path in the app, and require them as a parameter when
+using `useRouteRef`.
+
+The following is an example of creation and usage of a parameterized route:
+
+```tsx
+// Creation of a parameterized route
+const myRouteRef = createRouteRef({
+  id: 'myroute',
+  params: ['name']
+})
+
+// In the app, where MyPage is a routable extension with myRouteRef set as mountPoint
+<Route path='/my-page/:name' element={<MyPage />}/>
+
+// Usage within a component
+const myRoute = useRouteRef(myRouteRef)
+return (
+  <div>
+    <a href={myRoute({name: 'a'})}>A</a>
+    <a href={myRoute({name: 'b'})}>B</a>
+  </div>
+)
+```
+
+It is currently not possible to have parameterized `ExternalRouteRef`s, or to
+bind an external route to a parameterized route, although this may be added in
+the future if needed.
+
+### Subroutes
+
+The last kind of route refs that can be created are `SubRouteRef`s, which can be
+used to create a route ref with a fixed path relative to an absolute `RouteRef`.
+They are useful if you have a page that internally is mounted at a sub route of
+a routable extension component, and you want other plugins to be able to route
+to that page.
+
+For example:
+
+```tsx
+// routes.ts
+const rootRouteRef = createRouteRef({ id: 'root' });
+const detailsRouteRef = createSubRouteRef({
+  id: 'root-sub',
+  parent: rootRouteRef,
+  path: '/details',
+});
+
+// plugin.ts
+export const myPlugin = createPlugin({
+  routes: {
+    root: rootRouteRef,
+    details: detailsRouteRef,
+  },
+});
+
+export const MyPage = myPlugin.provide(
+  createRoutableExtension({
+    name: 'MyPage',
+    component: () => import('./components/MyPage').then(m => m.MyPage),
+    mountPoint: rootRouteRef,
+  }),
+);
+
+// components/MyPage.tsx
+const MyPage = () => (
+  <Routes>
+    {/* myPlugin.routes.root will take the user to this page */}
+    <Route path="/" element={<IndexPage />} />
+
+    {/* myPlugin.routes.details will take the user to this page */}
+    <Route path="/details" element={<DetailsPage />} />
+  </Routes>
+);
+```
+
+### Catalog Components
+
+To help structure the catalog entity pages in your app and choose what content
+to render in different scenarios, the `@backstage/catalog` plugin provides an
+`EntitySwitch` component. It works by selecting at most one element to render
+using a list of `EntitySwitch.Case` children.
+
+For example, if you want all entities of kind `"Template"` to be rendered with a
+`MyTemplate` component, and all other entities to be rendered with a `MyOther`
+component, you would do the following:
+
+```tsx
+<EntitySwitch>
+  <EntitySwitch.Case if={isKind('template')}>
+    <MyTemplate />
+  </EntitySwitch.Case>
+
+  <EntitySwitch.Case>
+    <MyOther />
+  </EntitySwitch.Case>
+</EntitySwitch>
+
+// Shorter form if desired:
+<EntitySwitch>
+  <EntitySwitch.Case if={isKind('template')} children={<MyTemplate />}/>
+  <EntitySwitch.Case children={<MyOther />}/>
+</EntitySwitch>
+```
+
+The `EntitySwitch` component will render the children of the first
+`EntitySwitch.Case` that returns `true` when the selected entity is passed to
+the function of the `if` prop. If none of the cases match, no children will be
+rendered, and if a case doesn't specify an `if` filter function, it will always
+match. The `if` property is simply a function of the type
+`(entity: Entity) => boolean`, for example, `isKind` can be implemented like
+this:
+
+```ts
+function isKind(kind: string) {
+  return (entity: Entity) => entity.kind.toLowerCase() === kind.toLowerCase();
+}
+```
+
+The `@backstage/catalog` plugin provides a couple of built-in conditions,
+`isKind`, `isComponentType`, `isResourceType`, `isEntityWith`, and `isNamespace`.
+
+In addition to the `EntitySwitch` component, the catalog plugin also exports a
+new `EntityLayout` component. It is a tweaked version and replacement for the
+`EntityPageLayout` component, and is introduced more in depth in the app
+migration section below.
+
+**NOTE**: The rest of this documentation covers how to migrate older
+applications to the new composability system described above.
+
+## Porting Existing Plugins
+
+There are a couple of high-level steps to porting an existing plugin to the new
+composability system:
+
+- Remove usage of `router.addRoute` or `router.registerRoute` within
+  `createPlugin`, and export the page components as routable extensions instead.
+- Switch any `Router` export to instead be a routable extension.
+- Change any plain component exports, such as catalog overview cards, to be
+  component extensions.
+- Stop exporting `RouteRef`s and instead pass them to `createPlugin`.
+- Stop accepting `RouteRef`s as props or importing them from other plugins,
+  instead create an `ExternalRouteRef` as a replacement, and pass it to
+  `createPlugin.`
+- Rename any other exported symbols according to the naming pattern table below.
+
+Note that removing the existing exports and configuration is a breaking change
+in any plugin. If backwards compatibility is needed the existing code be
+deprecated while making the new additions, to then be removed at a later point.
+
+### Naming Patterns
+
+Many export naming patterns have been changed to avoid import aliases and to
+clarify intent. Refer to the following table to formulate the new name:
+
+| Description          | Existing Pattern             | New Pattern       | Examples                                             |
+| -------------------- | ---------------------------- | ----------------- | ---------------------------------------------------- |
+| Top-level Pages      | `Router`                     | `\*Page`          | `CatalogIndexPage`, `SettingsPage`, `LighthousePage` |
+| Entity Tab Content   | `Router`                     | `Entity\*Content` | `EntityJenkinsContent`, `EntityKubernetesContent`    |
+| Entity Overview Card | `\*Card`                     | `Entity\*Card`    | `EntitySentryCard`, `EntityPagerDutyCard`            |
+| Entity Conditional   | `isPluginApplicableToEntity` | `is\*Available`   | `isPagerDutyAvailable`, `isJenkinsAvailable`         |
+| Plugin Instance      | `plugin`                     | `\*Plugin`        | `jenkinsPlugin`, `catalogPlugin`                     |

--- a/docs/plugins/composability.md
+++ b/docs/plugins/composability.md
@@ -1,205 +1,181 @@
 ---
 id: composability
 title: Composability System
-description: Documentation for the Backstage plugin composability APIs.
+description: Documentation for the Backstage plugin composability system.
 ---
 
-:::caution Legacy Documentation
-
-This page describes the composability system for the **old frontend system**, including `createRoutableExtension`, `createComponentExtension`, `RouteRef`, `ExternalRouteRef`, and component data. For the new frontend system, see [Extensions](../frontend-system/architecture/20-extensions.md), [Extension Blueprints](../frontend-system/architecture/23-extension-blueprints.md), and [Routes](../frontend-system/architecture/36-routes.md).
-
-:::
+::::info
+This documentation is written for the new frontend system, which is the default
+in new Backstage apps. If your Backstage app still uses the old frontend system,
+read the [old frontend system version of this guide](./composability--old.md)
+instead.
+::::
 
 ## Summary
 
-This page describes the composability system that helps bring together content
-from a multitude of plugins into one Backstage application.
+This page describes the composability system that brings together content from a
+multitude of plugins into one Backstage application.
 
 The core principle of the composability system is that plugins should have clear
 boundaries and connections. It should isolate crashes within a plugin, but allow
 navigation between them. It should allow for plugins to be loaded only when
-needed, and enable plugins to provide extension points for other plugins to
-build upon. The composability system is also built with an app-first mindset,
-prioritizing simplicity and clarity in the app over that in the plugins and core
-APIs.
-
-The composability system isn't a single API surface. It is a collection of
-patterns, primitives, and APIs. At the core is the concept of **extensions**,
-which are exported by plugins for use in the app. There is also a primitive
-called component data, which helps keep the structure of the app more
-declarative. There are also `RouteRef`s that help route between pages in a
-flexible way, which is especially important when bringing together different
-open source plugins.
+needed, and enable plugins to provide extension points for other plugins to build
+upon.
 
 ## Concepts
 
-This section is a brief look into all the concepts that help support the
-composability system.
-
-### Component Data
-
-Component data is a composability primitive that is introduced as a way to
-provide a new data dimension for React components. Data is attached to React
-components using a key, and is then readable from any JSX elements created with
-those components, using the same key, as illustrated by the following example:
-
-```tsx
-const MyComponent = () => <h1>This is my component</h1>;
-attachComponentData(MyComponent, 'my.data', 5);
-
-const element = <MyComponent />;
-const myData = getComponentData(element, 'my.data');
-// myData === 5
-```
-
-The purpose of component data is to provide a method for embedding data that can
-be inspected before rendering elements. Element inspection is a pattern that is
-quite common among React libraries, and used for example by `react-router` and
-`material-ui` to discover properties of the child elements before rendering.
-Although in those libraries only the element type and props are typically
-inspected, while our component data adds more structured access and simplifies
-evolution by allowing for multiple different versions of a piece of data to be
-used and interpreted at once.
-
-One of the use-cases for component data is to support route and plugin discovery
-through elements in the app. Through this we allow for the React element tree in
-the app to be the source of truth, both for which plugins are used, as well as
-all top-level plugin routes in the app. The use of component data is not limited
-to these use-cases though, as it can be used as a primitive to create new
-abstractions as well.
+The new frontend system is built on an extension-based architecture where
+plugins contribute functionality through _extensions_. Extensions are assembled
+into a tree that makes up the application, with each extension declaring its
+inputs, outputs, and attachment point. This architecture replaces the old
+patterns of component data, `createRoutableExtension`, and
+`createComponentExtension`.
 
 ### Extensions
 
-Extensions are what plugins export for use in an app. Most typically they are
-React components, but in practice they can be any kind of JavaScript value. They
-are created using `create*Extension` functions, and wrapped with
-`plugin.provide()` in order to create the actual exported extension.
+Extensions are the primary building blocks of the new frontend system. Every
+piece of functionality that a plugin provides — pages, cards, API
+implementations, navigation items — is modeled as an extension.
 
-The extension type is a simple one:
+Extensions are created using
+[extension blueprints](../frontend-system/architecture/23-extension-blueprints.md),
+which are pre-defined templates for common extension types. For example,
+`PageBlueprint` creates page extensions, `EntityCardBlueprint` creates entity
+cards, and `ApiBlueprint` creates utility API extensions.
 
-```ts
-export type Extension<T> = {
-  expose(plugin: BackstagePlugin): T;
-};
+```tsx title="src/plugin.ts"
+import {
+  createFrontendPlugin,
+  PageBlueprint,
+} from '@backstage/frontend-plugin-api';
+
+const examplePage = PageBlueprint.make({
+  params: {
+    path: '/example',
+    loader: () =>
+      import('./components/ExamplePage').then(m => <m.ExamplePage />),
+  },
+});
+
+export const examplePlugin = createFrontendPlugin({
+  pluginId: 'example',
+  extensions: [examplePage],
+});
 ```
 
-The power of extensions comes from the ability of various actors to hook into
-their usage. The creation and plugin wrapping is controlled by whoever owns the
-creation function, the Backstage core is able to hook into the process of
-exposing the extension outside the plugin, and in the end the app controls the
-usage of the extension.
+Extensions are not exported individually from the plugin package. Instead, they
+are provided through the plugin instance, and the app discovers them
+automatically when the plugin is installed.
 
-The Backstage core API currently provides two different types of extension
-creators, `createComponentExtension`, and `createRoutableExtension`. Component
-extensions are plain React component with no particular requirements, for
-example a card for an entity overview page. The component will be exported more
-or less as is, but is wrapped to provide things like an error boundary, lazy
-loading, and a plugin context.
+For full details on creating extensions, see
+[Extensions](../frontend-system/architecture/20-extensions.md).
 
-Routable extensions build on top of component extensions and are used for any
-component that should be rendered at a specific route path, such as top-level
-pages or entity page tab content. When creating a routable extension you need to
-supply a `RouteRef` as `mountPoint`. The mount point will be the handle of the
-component for the outside world, and is used by other components and plugins
-that wish to link to the routable component.
+### Extension Blueprints
 
-As of now there are only two extension creation functions in the core library,
-but more may be added in the future. There are also some plugins that provide
-ways to extend functionality through their own extensions, like
-`createScaffolderFieldExtension` from `@backstage/plugin-scaffolder`. Extensions
-are also not tied to React, and can both be used to model generic JavaScript
-concepts, as well as potentially bridge to rendering libraries and web
-frameworks other than React.
+Blueprints simplify creating extensions by providing a high-level API tailored
+to a specific use case. Rather than working with the low-level `createExtension`
+API directly, you use a blueprint's `make` method and pass in the parameters
+relevant to that type of extension.
 
-### Extensions from a Plugin's Point of View
+Common blueprints include:
 
-Extensions are one of the primary methods to traverse the plugin boundary, and
-the way that plugins provide concrete content for use within an app. They
-replace existing component export concepts such as `Router` or `*Card`s for
-display on entity overview pages.
+| Blueprint                | Purpose                      | Package                                 |
+| ------------------------ | ---------------------------- | --------------------------------------- |
+| `PageBlueprint`          | Top-level pages              | `@backstage/frontend-plugin-api`        |
+| `SubPageBlueprint`       | Tabbed content within a page | `@backstage/frontend-plugin-api`        |
+| `ApiBlueprint`           | Utility API implementations  | `@backstage/frontend-plugin-api`        |
+| `EntityContentBlueprint` | Entity page tabs             | `@backstage/plugin-catalog-react/alpha` |
+| `EntityCardBlueprint`    | Entity overview cards        | `@backstage/plugin-catalog-react/alpha` |
 
-It is recommended to create the exported extensions either in the top-level
-`plugin.ts` file, or in a dedicated `extensions.ts` (or `.tsx`) file. That file
-should not contain the bulk of the implementation though, and in fact, if the
-extension is a React component it is recommended to lazy-load the actual
-component. Component extensions support lazy loading out of the box using the
-`lazy` component declaration, for example:
+For the full list, see
+[Common Extension Blueprints](../frontend-system/building-plugins/03-common-extension-blueprints.md).
 
-```ts
-export const EntityFooCard = plugin.provide(
-  createComponentExtension({
-    component: {
-      lazy: () => import('./components/FooCard').then(m => m.FooCard),
-    },
-  }),
-);
+### Extension Tree
+
+The app is organized as a tree of extensions. Each extension declares an
+_attachment point_ — the parent extension and input it attaches to. This tree
+structure determines how extensions are rendered and how data flows through the
+application.
+
+Extensions communicate with their parent through _inputs_ and _outputs_. A
+parent extension declares what inputs it accepts, and child extensions provide
+matching outputs. This makes the system fully declarative and allows the app to
+validate the extension tree at startup.
+
+### Configuration and Overrides
+
+App integrators control which extensions are active, their ordering, and
+configuration through `app-config.yaml`:
+
+```yaml title="app-config.yaml"
+app:
+  extensions:
+    - page:example:
+        config:
+          path: /my-custom-path
+    - entity-content:my-plugin:
+        config:
+          filter: kind:component
 ```
 
-Routable extensions even enforce lazy loading, as it is the only way to provide
-a component:
+Extensions can be enabled, disabled, reordered, or reconfigured without changing
+any code. This is a key improvement over the old system where such changes
+required modifying the app's source code.
 
-```ts
-export const FooPage = plugin.provide(
-  createRoutableExtension({
-    name: 'FooPage',
-    component: () => import('./components/FooPage').then(m => m.FooPage),
-    mountPoint: fooPageRouteRef,
-  }),
-);
+### Routing System
+
+The routing system uses `RouteRef`s to represent navigation targets. At runtime,
+route references are bound to concrete paths, allowing plugins to link to each
+other without direct dependencies.
+
+There are three types of route references:
+
+- **Route references** — regular routes created with `createRouteRef` and
+  associated with page extensions.
+- **Sub-route references** — routes relative to a parent route, created with
+  `createSubRouteRef`.
+- **External route references** — routes to pages in other plugins, created with
+  `createExternalRouteRef` and bound by the app integrator.
+
+External routes are bound through app configuration:
+
+```yaml title="app-config.yaml"
+app:
+  routes:
+    bindings:
+      example.createComponent: scaffolder.index
 ```
 
-### Using Extensions in an App
+Or through code in `createApp`:
 
-Right now all extensions are modelled as React components. The usage of these
-extension is like regular usage of any React components, with one important
-difference. Extensions must all be part of a single React element tree spanning
-from the root `AppProvider`.
+```tsx title="packages/app/src/App.tsx"
+import { createApp } from '@backstage/frontend-defaults';
+import example from '@backstage/plugin-example';
+import scaffolder from '@backstage/plugin-scaffolder';
 
-For example, the following app code does **NOT** work:
+const app = createApp({
+  bindRoutes({ bind }) {
+    bind(example.externalRoutes, {
+      createComponent: scaffolder.routes.index,
+    });
+  },
+});
+```
+
+External route references can also declare default targets to reduce
+configuration burden:
 
 ```tsx
-const AppRoutes = () => (
-  <Routes>
-    <Route path="/foo" element={<FooPage />} />
-    <Route path="/bar" element={<BarPage />} />
-  </Routes>
-);
-
-const App = () => (
-  <AppProvider>
-    <AppRouter>
-      <Root>
-        <AppRoutes />
-      </Root>
-    </AppRouter>
-  </AppProvider>
-);
+export const createComponentRouteRef = createExternalRouteRef({
+  defaultTarget: 'scaffolder.createComponent',
+});
 ```
 
-But in this case it is simple to fix! Simply be sure to not create any
-intermediate components in the app, for example like this:
-
-```tsx
-const appRoutes = (
-  <Routes>
-    <Route path="/foo" element={<FooPage />} />
-    <Route path="/bar" element={<BarPage />} />
-  </Routes>
-);
-
-const App = () => (
-  <AppProvider>
-    <AppRouter>
-      <Root>{appRoutes}</Root>
-    </AppRouter>
-  </AppProvider>
-);
-```
+For a comprehensive guide, see [Routes](../frontend-system/architecture/36-routes.md).
 
 ### Naming Patterns
 
-There are a couple of naming patterns to adhere to as you build plugins, which
-helps clarify the intent and usage of the exports.
+The following naming patterns help clarify the intent of plugin exports:
 
 | Description           | Pattern          | Examples                                             |
 | --------------------- | ---------------- | ---------------------------------------------------- |
@@ -209,348 +185,3 @@ helps clarify the intent and usage of the exports.
 | Entity Conditional    | `is*Available`   | `isPagerDutyAvailable`, `isJenkinsAvailable`         |
 | Plugin Instance       | `*Plugin`        | `jenkinsPlugin`, `catalogPlugin`                     |
 | Utility API Reference | `*ApiRef`        | `configApiRef`, `catalogApiRef`                      |
-
-### Routing System
-
-The routing system of Backstage relies heavily on the composability system. It
-uses `RouteRef`s to represent routing targets in the app, which at runtime will
-be bound to a concrete `path`, but provides a level of indirection to help mix
-together different plugins that otherwise wouldn't know how to route to each
-other.
-
-The concrete `path` for each `RouteRef` is discovered based on the element tree
-in the app. Let's consider the following example:
-
-```tsx
-const appRoutes = (
-  <Routes>
-    <Route path="/foo" element={<FooPage />} />
-    <Route path="/bar" element={<BarPage />} />
-  </Routes>
-);
-```
-
-We'll assume that `FooPage` and `BarPage` are routable extensions, exported by
-the `fooPlugin` and `barPlugin` respectively. Since the `FooPage` is a routable
-extension it has a `RouteRef` assigned as its mount point, which we'll refer to
-as `fooPageRouteRef`.
-
-Given the above example, the `fooPageRouteRef` will be associated with the
-`'/foo'` route. If we want to route to the `FooPage`, we can use the
-`useRouteRef` hook to create a concrete link to the page. The `useRouteRef` hook
-takes a single `RouteRef` as its only parameter, and returns a function that is
-called to create the URL. For example like this:
-
-```tsx
-const MyComponent = () => {
-  const fooRoute = useRouteRef(fooPageRouteRef);
-  return <a href={fooRoute()}>Link to Foo</a>;
-};
-```
-
-Now let's assume that we want to link from the `BarPage` to the `FooPage`. We
-don't want to reference the `fooPageRouteRef` directly from our `barPlugin`,
-since that would create an unnecessary dependency on the `fooPlugin`. It would
-also provided little flexibility in allowing the app to tie plugins together,
-with the links instead being dictated by the plugins themselves. To solve this,
-we use `ExternalRouteRef`s. Much like regular route references, they can be
-passed to `useRouteRef` to create concrete URLs, but they can not be used as
-mount points in routable component and instead have to be associated with a
-target route using route bindings in the app.
-
-We create a new `ExternalRouteRef` inside the `barPlugin`, using a neutral name
-that describes its role in the plugin rather than a specific plugin page that it
-might be linking to, allowing the app to decide the final target. If the
-`BarPage` for example wants to link to an external page in the header, it might
-declare an `ExternalRouteRef` similar to this:
-
-```ts
-const headerLinkRouteRef = createExternalRouteRef({ id: 'header-link' });
-```
-
-### Binding External Routes in the App
-
-The association of external routes is controlled by the app. Each
-`ExternalRouteRef` of a plugin should be bound to an actual `RouteRef`, usually
-from another plugin. The binding process happens once at app startup, and is
-then used through the lifetime of the app to help resolve concrete route paths.
-
-Using the above example of the `BarPage` linking to the `FooPage`, we might do
-something like this in the app:
-
-```ts
-createApp({
-  bindRoutes({ bind }) {
-    bind(barPlugin.externalRoutes, {
-      headerLink: fooPlugin.routes.root,
-    });
-  },
-});
-```
-
-Given the above binding, using `useRouteRef(headerLinkRouteRef)` within the
-`barPlugin` will let us create a link to whatever path the `FooPage` is mounted
-at.
-
-Note that we are not importing and using the `RouteRef`s directly in the app,
-and instead rely on the plugin instance to access routes of the plugins. This is
-a new convention that was introduced to provide better namespacing and
-discoverability of routes, as well as reduce the number of separate exports from
-each plugin package. The route references would be supplied to `createPlugin`
-like this:
-
-```ts
-// In foo-plugin
-export const fooPlugin = createPlugin({
-  routes: {
-    root: fooPageRouteRef,
-  },
-  ...
-})
-
-// In bar-plugin
-export const barPlugin = createPlugin({
-  externalRoutes: {
-    headerLink: headerLinkRouteRef,
-  },
-  ...
-})
-```
-
-Also note that you almost always want to create the route references themselves
-in a different file than the one that creates the plugin instance, for example a
-top-level `routes.ts`. This is to avoid circular imports when you use the route
-references from other parts of the same plugin.
-
-Another thing to note is that this indirection in the routing is particularly
-useful for open source plugins that need to leave flexibility in how they are
-integrated. For plugins that you build internally for your own Backstage
-application, you can choose to go the route of direct imports or even use
-concrete routes directly. Although there can be some benefits to using the full
-routing system even in internal plugins. It can help you structure your routes,
-and as you will see further down it also helps you manage route parameters.
-
-You can also use static configuration to bind routes, removing the need to make
-changes to the app code. It does however mean that you won't get type safety
-when binding routes and compile-time validation of the bindings. Static
-configuration of route bindings is done under the `app.routes.bindings` key in
-`app-config.yaml`. It works the same way as [route bindings in the new frontend system](../frontend-system/architecture/36-routes.md#binding-external-route-references),
-for example:
-
-```yaml
-app:
-  routes:
-    bindings:
-      bar.headerLink: foo.root
-```
-
-### Default Targets for External Route References
-
-Following the `1.28` release of Backstage you can now define default targets for
-external route references. They work the same way as [default targets in the new frontend system](../frontend-system/architecture/36-routes.md#default-targets-for-external-route-references),
-for example:
-
-```ts
-export const createComponentExternalRouteRef = createExternalRouteRef({
-  // highlight-next-line
-  defaultTarget: 'scaffolder.createComponent',
-});
-```
-
-### Optional External Routes
-
-When creating an `ExternalRouteRef` it is possible to mark it as optional:
-
-```ts
-const headerLinkRouteRef = createExternalRouteRef({
-  id: 'header-link',
-  optional: true,
-});
-```
-
-An external route that is marked as optional is not required to be bound in the
-app, allowing it to be used as a switch for whether a particular link should be
-displayed or action should be taken.
-
-When calling `useRouteRef` with an optional external route, its return signature
-is changed to `RouteFunc | undefined`, allowing for logic like this:
-
-```tsx
-const MyComponent = () => {
-  const headerLink = useRouteRef(headerLinkRouteRef);
-
-  return (
-    <header>
-      My Header
-      {headerLink && <a href={headerLink()}>External Link</a>}
-    </header>
-  );
-};
-```
-
-### Parameterized Routes
-
-A feature of `RouteRef`s is the possibility of adding named and typed
-parameters. Parameters are declared at creation, and will enforce presence of
-the parameters in the path in the app, and require them as a parameter when
-using `useRouteRef`.
-
-The following is an example of creation and usage of a parameterized route:
-
-```tsx
-// Creation of a parameterized route
-const myRouteRef = createRouteRef({
-  id: 'myroute',
-  params: ['name']
-})
-
-// In the app, where MyPage is a routable extension with myRouteRef set as mountPoint
-<Route path='/my-page/:name' element={<MyPage />}/>
-
-// Usage within a component
-const myRoute = useRouteRef(myRouteRef)
-return (
-  <div>
-    <a href={myRoute({name: 'a'})}>A</a>
-    <a href={myRoute({name: 'b'})}>B</a>
-  </div>
-)
-```
-
-It is currently not possible to have parameterized `ExternalRouteRef`s, or to
-bind an external route to a parameterized route, although this may be added in
-the future if needed.
-
-### Subroutes
-
-The last kind of route refs that can be created are `SubRouteRef`s, which can be
-used to create a route ref with a fixed path relative to an absolute `RouteRef`.
-They are useful if you have a page that internally is mounted at a sub route of
-a routable extension component, and you want other plugins to be able to route
-to that page.
-
-For example:
-
-```tsx
-// routes.ts
-const rootRouteRef = createRouteRef({ id: 'root' });
-const detailsRouteRef = createSubRouteRef({
-  id: 'root-sub',
-  parent: rootRouteRef,
-  path: '/details',
-});
-
-// plugin.ts
-export const myPlugin = createPlugin({
-  routes: {
-    root: rootRouteRef,
-    details: detailsRouteRef,
-  },
-});
-
-export const MyPage = myPlugin.provide(
-  createRoutableExtension({
-    name: 'MyPage',
-    component: () => import('./components/MyPage').then(m => m.MyPage),
-    mountPoint: rootRouteRef,
-  }),
-);
-
-// components/MyPage.tsx
-const MyPage = () => (
-  <Routes>
-    {/* myPlugin.routes.root will take the user to this page */}
-    <Route path="/" element={<IndexPage />} />
-
-    {/* myPlugin.routes.details will take the user to this page */}
-    <Route path="/details" element={<DetailsPage />} />
-  </Routes>
-);
-```
-
-### Catalog Components
-
-To help structure the catalog entity pages in your app and choose what content
-to render in different scenarios, the `@backstage/catalog` plugin provides an
-`EntitySwitch` component. It works by selecting at most one element to render
-using a list of `EntitySwitch.Case` children.
-
-For example, if you want all entities of kind `"Template"` to be rendered with a
-`MyTemplate` component, and all other entities to be rendered with a `MyOther`
-component, you would do the following:
-
-```tsx
-<EntitySwitch>
-  <EntitySwitch.Case if={isKind('template')}>
-    <MyTemplate />
-  </EntitySwitch.Case>
-
-  <EntitySwitch.Case>
-    <MyOther />
-  </EntitySwitch.Case>
-</EntitySwitch>
-
-// Shorter form if desired:
-<EntitySwitch>
-  <EntitySwitch.Case if={isKind('template')} children={<MyTemplate />}/>
-  <EntitySwitch.Case children={<MyOther />}/>
-</EntitySwitch>
-```
-
-The `EntitySwitch` component will render the children of the first
-`EntitySwitch.Case` that returns `true` when the selected entity is passed to
-the function of the `if` prop. If none of the cases match, no children will be
-rendered, and if a case doesn't specify an `if` filter function, it will always
-match. The `if` property is simply a function of the type
-`(entity: Entity) => boolean`, for example, `isKind` can be implemented like
-this:
-
-```ts
-function isKind(kind: string) {
-  return (entity: Entity) => entity.kind.toLowerCase() === kind.toLowerCase();
-}
-```
-
-The `@backstage/catalog` plugin provides a couple of built-in conditions,
-`isKind`, `isComponentType`, `isResourceType`, `isEntityWith`, and `isNamespace`.
-
-In addition to the `EntitySwitch` component, the catalog plugin also exports a
-new `EntityLayout` component. It is a tweaked version and replacement for the
-`EntityPageLayout` component, and is introduced more in depth in the app
-migration section below.
-
-**NOTE**: The rest of this documentation covers how to migrate older
-applications to the new composability system described above.
-
-## Porting Existing Plugins
-
-There are a couple of high-level steps to porting an existing plugin to the new
-composability system:
-
-- Remove usage of `router.addRoute` or `router.registerRoute` within
-  `createPlugin`, and export the page components as routable extensions instead.
-- Switch any `Router` export to instead be a routable extension.
-- Change any plain component exports, such as catalog overview cards, to be
-  component extensions.
-- Stop exporting `RouteRef`s and instead pass them to `createPlugin`.
-- Stop accepting `RouteRef`s as props or importing them from other plugins,
-  instead create an `ExternalRouteRef` as a replacement, and pass it to
-  `createPlugin.`
-- Rename any other exported symbols according to the naming pattern table below.
-
-Note that removing the existing exports and configuration is a breaking change
-in any plugin. If backwards compatibility is needed the existing code be
-deprecated while making the new additions, to then be removed at a later point.
-
-### Naming Patterns
-
-Many export naming patterns have been changed to avoid import aliases and to
-clarify intent. Refer to the following table to formulate the new name:
-
-| Description          | Existing Pattern             | New Pattern       | Examples                                             |
-| -------------------- | ---------------------------- | ----------------- | ---------------------------------------------------- |
-| Top-level Pages      | `Router`                     | `\*Page`          | `CatalogIndexPage`, `SettingsPage`, `LighthousePage` |
-| Entity Tab Content   | `Router`                     | `Entity\*Content` | `EntityJenkinsContent`, `EntityKubernetesContent`    |
-| Entity Overview Card | `\*Card`                     | `Entity\*Card`    | `EntitySentryCard`, `EntityPagerDutyCard`            |
-| Entity Conditional   | `isPluginApplicableToEntity` | `is\*Available`   | `isPagerDutyAvailable`, `isJenkinsAvailable`         |
-| Plugin Instance      | `plugin`                     | `\*Plugin`        | `jenkinsPlugin`, `catalogPlugin`                     |

--- a/docs/plugins/feature-flags--old.md
+++ b/docs/plugins/feature-flags--old.md
@@ -1,0 +1,96 @@
+---
+id: feature-flags--old
+title: Feature Flags (Old Frontend System)
+description: Details the process of defining setting and reading a feature flag.
+---
+
+::::info
+This documentation is for Backstage apps that still use the old frontend
+system. If your app uses the new frontend system, read the
+[current guide](./feature-flags.md) instead.
+::::
+
+Backstage offers the ability to define feature flags inside a plugin or during application creation. This allows you to restrict parts of your plugin to those individual users who have toggled the feature flag to on.
+
+This page describes the process of defining, setting and reading a feature flag. If you are looking for using feature flags specifically with software templates please see [Writing Templates](https://backstage.io/docs/features/software-templates/writing-templates#remove-sections-or-fields-based-on-feature-flags).
+
+## Defining a Feature Flag
+
+### In a plugin
+
+Defining a feature flag in a plugin is done by passing the name of the feature flag into the `featureFlags` array:
+
+```ts title="src/plugin.ts"
+import { createPlugin } from '@backstage/core-plugin-api';
+
+export const examplePlugin = createPlugin({
+  // ...
+  featureFlags: [
+    {
+      name: 'show-example-feature',
+      description: 'Enables the new beta dashboard view',
+    },
+  ],
+  // ...
+});
+```
+
+Note that the `description` property is optional. If not provided, the default "Registered in {pluginId} plugin" message is shown.
+
+### In the application
+
+Defining a feature flag in the application is done by adding feature flags in `featureFlags` array in the
+`createApp()` function call:
+
+```ts title="packages/app/src/App.tsx"
+import { createApp } from '@backstage/app-defaults';
+
+const app = createApp({
+  // ...
+  featureFlags: [
+    {
+      // pluginId is required for feature flags used in plugins.
+      // pluginId can be left blank for a feature flag used in the application and not in plugins.
+      pluginId: '',
+      name: 'tech-radar',
+      description: 'Enables the tech radar plugin',
+    },
+  ],
+  // ...
+});
+```
+
+## Enabling Feature Flags
+
+Feature flags are defaulted to off and can be updated by individual users in the backstage interface. These are set by navigating to the page under `Settings` > `Feature Flags`.
+
+The user's selection is saved in the user's browser local storage. Once a feature flag is toggled it may be required for a user to refresh the page to see the change.
+
+## FeatureFlagged Component
+
+The easiest way to control content based on the state of a feature flag is to use the [FeatureFlagged](https://backstage.io/api/stable/functions/_backstage_core-app-api.FeatureFlagged.html) component.
+
+```ts
+import { FeatureFlagged } from '@backstage/core-app-api';
+
+...
+
+<FeatureFlagged with="show-example-feature">
+  <NewFeatureComponent />
+</FeatureFlagged>
+
+<FeatureFlagged without="show-example-feature">
+  <PreviousFeatureComponent />
+</FeatureFlagged>
+```
+
+## Evaluating Feature Flag State
+
+It is also possible to query a feature flag using the [FeatureFlags Api](https://backstage.io/api/stable/interfaces/_backstage_core-plugin-api.index.FeatureFlagsApi.html).
+
+```ts
+import { useApi, featureFlagsApiRef } from '@backstage/core-plugin-api';
+
+const featureFlagsApi = useApi(featureFlagsApiRef);
+const isOn = featureFlagsApi.isActive('show-example-feature');
+```

--- a/docs/plugins/feature-flags.md
+++ b/docs/plugins/feature-flags.md
@@ -4,54 +4,61 @@ title: Feature Flags
 description: Details the process of defining setting and reading a feature flag.
 ---
 
-:::caution Legacy Documentation
+::::info
+This documentation is written for the new frontend system, which is the default
+in new Backstage apps. If your Backstage app still uses the old frontend system,
+read the [old frontend system version of this guide](./feature-flags--old.md)
+instead.
+::::
 
-This page describes feature flags using the **old frontend system** APIs (`createPlugin` from `@backstage/core-plugin-api` and `createApp` from `@backstage/app-defaults`). For the new frontend system version, see [Feature Flags](../frontend-system/building-plugins/09-feature-flags.md). The `FeatureFlagged` component and `featureFlagsApiRef` work the same way in both systems.
+Backstage offers the ability to define feature flags inside a plugin or during
+application creation. This allows you to restrict parts of your plugin to those
+individual users who have toggled the feature flag to on.
 
-:::
-
-Backstage offers the ability to define feature flags inside a plugin or during application creation. This allows you to restrict parts of your plugin to those individual users who have toggled the feature flag to on.
-
-This page describes the process of defining, setting and reading a feature flag. If you are looking for using feature flags specifically with software templates please see [Writing Templates](https://backstage.io/docs/features/software-templates/writing-templates#remove-sections-or-fields-based-on-feature-flags).
+This page describes the process of defining, setting and reading a feature flag.
+If you are looking for using feature flags specifically with software templates
+please see
+[Writing Templates](https://backstage.io/docs/features/software-templates/writing-templates#remove-sections-or-fields-based-on-feature-flags).
 
 ## Defining a Feature Flag
 
 ### In a plugin
 
-Defining a feature flag in a plugin is done by passing the name of the feature flag into the `featureFlags` array:
+Feature flags are declared via the `featureFlags` option in
+`createFrontendPlugin`:
 
 ```ts title="src/plugin.ts"
-import { createPlugin } from '@backstage/core-plugin-api';
+import { createFrontendPlugin } from '@backstage/frontend-plugin-api';
 
-export const examplePlugin = createPlugin({
-  // ...
+export const examplePlugin = createFrontendPlugin({
+  pluginId: 'example',
   featureFlags: [
     {
       name: 'show-example-feature',
       description: 'Enables the new beta dashboard view',
     },
   ],
-  // ...
+  extensions: [
+    // ...
+  ],
 });
 ```
 
-Note that the `description` property is optional. If not provided, the default "Registered in {pluginId} plugin" message is shown.
+Note that the `description` property is optional. If not provided, the default
+"Registered in {pluginId} plugin" message is shown.
 
 ### In the application
 
-Defining a feature flag in the application is done by adding feature flags in `featureFlags` array in the
-`createApp()` function call:
+Defining a feature flag in the application is done by adding feature flags in
+the `featureFlags` array in the `createApp()` function call:
 
 ```ts title="packages/app/src/App.tsx"
-import { createApp } from '@backstage/app-defaults';
+import { createApp } from '@backstage/frontend-defaults';
 
 const app = createApp({
   // ...
   featureFlags: [
     {
-      // pluginId is required for feature flags used in plugins.
-      // pluginId can be left blank for a feature flag used in the application and not in plugins.
-      pluginId: '',
       name: 'tech-radar',
       description: 'Enables the tech radar plugin',
     },
@@ -62,35 +69,54 @@ const app = createApp({
 
 ## Enabling Feature Flags
 
-Feature flags are defaulted to off and can be updated by individual users in the backstage interface. These are set by navigating to the page under `Settings` > `Feature Flags`.
+Feature flags are defaulted to off and can be updated by individual users in the
+backstage interface. These are set by navigating to the page under **Settings** >
+**Feature Flags**.
 
-The user's selection is saved in the user's browser local storage. Once a feature flag is toggled it may be required for a user to refresh the page to see the change.
-
-## FeatureFlagged Component
-
-The easiest way to control content based on the state of a feature flag is to use the [FeatureFlagged](https://backstage.io/api/stable/functions/_backstage_core-app-api.FeatureFlagged.html) component.
-
-```ts
-import { FeatureFlagged } from '@backstage/core-app-api';
-
-...
-
-<FeatureFlagged with="show-example-feature">
-  <NewFeatureComponent />
-</FeatureFlagged>
-
-<FeatureFlagged without="show-example-feature">
-  <PreviousFeatureComponent />
-</FeatureFlagged>
-```
+The user's selection is saved in the user's browser local storage. Once a
+feature flag is toggled it may be required for a user to refresh the page to see
+the change.
 
 ## Evaluating Feature Flag State
 
-It is also possible to query a feature flag using the [FeatureFlags Api](https://backstage.io/api/stable/interfaces/_backstage_core-plugin-api.index.FeatureFlagsApi.html).
+You can query a feature flag using the
+[FeatureFlagsApi](https://backstage.io/api/stable/interfaces/_backstage_frontend-plugin-api.index.FeatureFlagsApi.html):
 
-```ts
-import { useApi, featureFlagsApiRef } from '@backstage/core-plugin-api';
+```tsx
+import { useApi, featureFlagsApiRef } from '@backstage/frontend-plugin-api';
 
-const featureFlagsApi = useApi(featureFlagsApiRef);
-const isOn = featureFlagsApi.isActive('show-example-feature');
+function MyComponent() {
+  const featureFlagsApi = useApi(featureFlagsApiRef);
+
+  if (featureFlagsApi.isActive('show-example-feature')) {
+    return <NewFeatureComponent />;
+  }
+  return <PreviousFeatureComponent />;
+}
 ```
+
+## Conditionally Enabling Extensions
+
+The new frontend system also allows you to conditionally enable entire
+extensions based on feature flags, without needing to check the flag at runtime
+in your component code:
+
+```tsx
+import { PageBlueprint } from '@backstage/frontend-plugin-api';
+
+const experimentalPage = PageBlueprint.make({
+  params: {
+    path: '/experimental',
+    loader: () =>
+      import('./ExperimentalPage').then(m => <m.ExperimentalPage />),
+  },
+  if: { featureFlags: { $contains: 'experimental-features' } },
+});
+```
+
+When using the `if` option, the extension is only installed if the specified
+feature flag is active. This is evaluated when the app extension tree is
+assembled, so changes to the flag require a page reload to take effect.
+
+For more details, see
+[Feature Flags](../frontend-system/building-plugins/09-feature-flags.md).

--- a/docs/plugins/integrating-plugin-into-software-catalog--old.md
+++ b/docs/plugins/integrating-plugin-into-software-catalog--old.md
@@ -1,0 +1,123 @@
+---
+id: integrating-plugin-into-software-catalog--old
+title: Integrate into the Software Catalog (Old Frontend System)
+description: How to integrate a plugin into software catalog
+---
+
+::::info
+This documentation is for Backstage apps that still use the old frontend
+system. If your app uses the new frontend system, read the
+[current guide](./integrating-plugin-into-software-catalog.md) instead.
+::::
+
+## Steps
+
+1. [Create a plugin](#create-a-plugin)
+1. [Reading entities from within your plugin](#reading-entities-from-within-your-plugin)
+1. [Import your plugin and embed in the entities page](#import-your-plugin-and-embed-in-the-entities-page)
+
+### Create a plugin
+
+Follow the [same process](create-a-plugin.md) as for standalone plugin. You
+should have a separate package in a folder, which represents your plugin.
+
+Example:
+
+```
+$ yarn new
+# Select `frontend-plugin`
+> ? Enter an ID for the plugin [required] my-plugin
+> ? Enter the owner(s) of the plugin. If specified, this will be added to CODEOWNERS for the plugin path. [optional]
+
+Creating the plugin...
+```
+
+### Reading entities from within your plugin
+
+You can access the currently selected entity using the backstage api
+[`useEntity`](https://backstage.io/api/stable/functions/_backstage_plugin-catalog-react.index.useEntity.html). For example,
+
+```tsx
+import { useEntity } from '@backstage/plugin-catalog-react';
+
+export const MyPluginEntityContent = () => {
+  const entity = useEntity();
+
+  // Do something with the entity data...
+};
+```
+
+Internally `useEntity` makes use of
+[react `Contexts`](https://18.react.dev/learn/passing-data-deeply-with-context). The entity context is
+provided by the entity page into which your plugin will be embedded.
+
+### Import your plugin and embed in the entities page
+
+To begin, you will need to import your plugin in the entities page. Located at
+`packages/app/src/components/Catalog/EntityPage.tsx` from the root package of
+your backstage app.
+
+```tsx
+import { MyPluginEntityContent } from '@backstage/plugin-my-plugin';
+```
+
+To add your component to the Entity view, you will need to modify the
+`packages/app/src/components/Catalog/EntityPage.tsx`. Depending on the needs of
+your plugin, you may only care about certain kinds of
+[entities](https://backstage.io/docs/features/software-catalog/descriptor-format),
+each of which has its own
+element for rendering. This
+functionality is handled by the `EntitySwitch` component:
+
+```tsx
+export const entityPage = (
+  <EntitySwitch>
+    <EntitySwitch.Case if={isKind('component')} children={componentPage} />
+    <EntitySwitch.Case if={isKind('api')} children={apiPage} />
+    <EntitySwitch.Case if={isKind('group')} children={groupPage} />
+    <EntitySwitch.Case if={isKind('user')} children={userPage} />
+    <EntitySwitch.Case if={isKind('system')} children={systemPage} />
+    <EntitySwitch.Case if={isKind('domain')} children={domainPage} />
+
+    <EntitySwitch.Case>{defaultEntityPage}</EntitySwitch.Case>
+  </EntitySwitch>
+);
+```
+
+At this point, you will need to modify the specific page where you want your
+component to appear. If you are extending the Software Catalog model you will
+need to add a new case to the `EntitySwitch`. For adding a plugin to an existing
+component type, you modify the existing page. For example, if you want to add
+your plugin to the `systemPage`, you can add a new tab by adding an
+`EntityLayout.Route` such as below:
+
+```tsx
+const systemPage = (
+  <EntityLayout>
+    <EntityLayout.Route path="/" title="Overview">
+      <Grid container spacing={3} alignItems="stretch">
+        <Grid item md={6}>
+          <EntityAboutCard />
+        </Grid>
+        <Grid item md={6}>
+          <EntityHasComponentsCard variant="gridItem" />
+        </Grid>
+        <Grid item md={6}>
+          <EntityHasApisCard variant="gridItem" />
+        </Grid>
+        <Grid item md={6}>
+          <EntityHasResourcesCard variant="gridItem" />
+        </Grid>
+      </Grid>
+    </EntityLayout.Route>
+    <EntityLayout.Route path="/diagram" title="Diagram">
+      <EntityCatalogGraphCard variant="gridItem" height={400} />
+    </EntityLayout.Route>
+
+    {/* Adding a new tab to the system view */}
+    <EntityLayout.Route path="/your-custom-route" title="CustomTitle">
+      <MyPluginEntityContent />
+    </EntityLayout.Route>
+  </EntityLayout>
+);
+```

--- a/docs/plugins/integrating-plugin-into-software-catalog.md
+++ b/docs/plugins/integrating-plugin-into-software-catalog.md
@@ -4,27 +4,29 @@ title: Integrate into the Software Catalog
 description: How to integrate a plugin into software catalog
 ---
 
-:::caution Legacy Documentation
+::::info
+This documentation is written for the new frontend system, which is the default
+in new Backstage apps. If your Backstage app still uses the old frontend system,
+read the [old frontend system version of this guide](./integrating-plugin-into-software-catalog--old.md)
+instead.
+::::
 
-This page describes integrating plugins into the Software Catalog using the **old frontend system** patterns (`EntitySwitch`, `EntityLayout`, `EntityLayout.Route`). For the new frontend system, entity page integrations are done using `EntityCardBlueprint` and `EntityContentBlueprint` — see [Common Extension Blueprints](../frontend-system/building-plugins/03-common-extension-blueprints.md).
-
-:::
-
-> This is an advanced use case and currently is an experimental feature. Expect
-> API to change over time
+The Software Catalog in Backstage provides entity pages that can be extended
+with content from plugins. In the new frontend system, plugins contribute to
+entity pages through extensions created with blueprints from
+`@backstage/plugin-catalog-react/alpha`.
 
 ## Steps
 
 1. [Create a plugin](#create-a-plugin)
-1. [Reading entities from within your plugin](#reading-entities-from-within-your-plugin)
-1. [Import your plugin and embed in the entities page](#import-your-plugin-and-embed-in-the-entities-page)
+2. [Reading entities from within your plugin](#reading-entities-from-within-your-plugin)
+3. [Add entity content or cards via extensions](#add-entity-content-or-cards-via-extensions)
+4. [Configuring where extensions appear](#configuring-where-extensions-appear)
 
 ### Create a plugin
 
-Follow the [same process](create-a-plugin.md) as for standalone plugin. You
-should have a separate package in a folder, which represents your plugin.
-
-Example:
+Follow the [same process](create-a-plugin.md) as for any plugin. You should
+have a separate package in a folder that represents your plugin.
 
 ```
 $ yarn new
@@ -37,90 +39,107 @@ Creating the plugin...
 
 ### Reading entities from within your plugin
 
-You can access the currently selected entity using the backstage api
-[`useEntity`](https://backstage.io/api/stable/functions/_backstage_plugin-catalog-react.index.useEntity.html). For example,
+You can access the currently selected entity using
+[`useEntity`](https://backstage.io/api/stable/functions/_backstage_plugin-catalog-react.index.useEntity.html)
+from `@backstage/plugin-catalog-react`:
 
 ```tsx
 import { useEntity } from '@backstage/plugin-catalog-react';
 
 export const MyPluginEntityContent = () => {
   const entity = useEntity();
-
   // Do something with the entity data...
 };
 ```
 
-Internally `useEntity` makes use of
-[react `Contexts`](https://18.react.dev/learn/passing-data-deeply-with-context). The entity context is
-provided by the entity page into which your plugin will be embedded.
+The entity context is provided by the catalog entity page, into which your
+plugin's extensions are embedded.
 
-### Import your plugin and embed in the entities page
+### Add entity content or cards via extensions
 
-To begin, you will need to import your plugin in the entities page. Located at
-`packages/app/src/components/Catalog/EntityPage.tsx` from the root package of
-your backstage app.
+In the new frontend system, you don't manually wire your component into an
+`EntityPage.tsx` file. Instead, you create extensions using blueprints that the
+catalog plugin automatically discovers and renders.
 
-```tsx
-import { MyPluginEntityContent } from '@backstage/plugin-my-plugin';
+#### Entity content (tab pages)
+
+Use `EntityContentBlueprint` to create a new tab on entity pages:
+
+```tsx title="src/plugin.ts"
+import { createFrontendPlugin } from '@backstage/frontend-plugin-api';
+import { EntityContentBlueprint } from '@backstage/plugin-catalog-react/alpha';
+
+const myPluginEntityContent = EntityContentBlueprint.make({
+  params: {
+    path: 'my-plugin',
+    title: 'My Plugin',
+    loader: () =>
+      import('./components/MyPluginEntityContent').then(m => (
+        <m.MyPluginEntityContent />
+      )),
+  },
+});
+
+export const myPlugin = createFrontendPlugin({
+  pluginId: 'my-plugin',
+  extensions: [myPluginEntityContent],
+});
 ```
 
-To add your component to the Entity view, you will need to modify the
-`packages/app/src/components/Catalog/EntityPage.tsx`. Depending on the needs of
-your plugin, you may only care about certain kinds of
-[entities](https://backstage.io/docs/features/software-catalog/descriptor-format),
-each of which has its own
-element for rendering. This
-functionality is handled by the `EntitySwitch` component:
+The `path` determines the URL segment under the entity page, and the `title` is
+shown as the tab label.
 
-```tsx
-export const entityPage = (
-  <EntitySwitch>
-    <EntitySwitch.Case if={isKind('component')} children={componentPage} />
-    <EntitySwitch.Case if={isKind('api')} children={apiPage} />
-    <EntitySwitch.Case if={isKind('group')} children={groupPage} />
-    <EntitySwitch.Case if={isKind('user')} children={userPage} />
-    <EntitySwitch.Case if={isKind('system')} children={systemPage} />
-    <EntitySwitch.Case if={isKind('domain')} children={domainPage} />
+#### Entity cards (overview cards)
 
-    <EntitySwitch.Case>{defaultEntityPage}</EntitySwitch.Case>
-  </EntitySwitch>
-);
+Use `EntityCardBlueprint` to create a card that can appear on entity overview
+pages:
+
+```tsx title="src/plugin.ts"
+import { EntityCardBlueprint } from '@backstage/plugin-catalog-react/alpha';
+
+const myPluginEntityCard = EntityCardBlueprint.make({
+  params: {
+    loader: () =>
+      import('./components/MyPluginCard').then(m => <m.MyPluginCard />),
+  },
+});
 ```
 
-At this point, you will need to modify the specific page where you want your
-component to appear. If you are extending the Software Catalog model you will
-need to add a new case to the `EntitySwitch`. For adding a plugin to an existing
-component type, you modify the existing page. For example, if you want to add
-your plugin to the `systemPage`, you can add a new tab by adding an
-`EntityLayout.Route` such as below:
+Add the card extension to your plugin's `extensions` array alongside any other
+extensions.
+
+### Configuring where extensions appear
+
+By default, entity content and cards are available on all entity pages. App
+integrators can control where extensions appear and their ordering through
+`app-config.yaml`.
+
+For example, to enable a content tab only for components:
+
+```yaml title="app-config.yaml"
+app:
+  extensions:
+    - entity-content:my-plugin:
+        config:
+          filter: kind:component
+```
+
+Entity content also supports an optional `group` parameter to associate the tab
+with a tab group on the entity page:
 
 ```tsx
-const systemPage = (
-  <EntityLayout>
-    <EntityLayout.Route path="/" title="Overview">
-      <Grid container spacing={3} alignItems="stretch">
-        <Grid item md={6}>
-          <EntityAboutCard />
-        </Grid>
-        <Grid item md={6}>
-          <EntityHasComponentsCard variant="gridItem" />
-        </Grid>
-        <Grid item md={6}>
-          <EntityHasApisCard variant="gridItem" />
-        </Grid>
-        <Grid item md={6}>
-          <EntityHasResourcesCard variant="gridItem" />
-        </Grid>
-      </Grid>
-    </EntityLayout.Route>
-    <EntityLayout.Route path="/diagram" title="Diagram">
-      <EntityCatalogGraphCard variant="gridItem" height={400} />
-    </EntityLayout.Route>
-
-    {/* Adding a new tab to the system view */}
-    <EntityLayout.Route path="/your-custom-route" title="CustomTitle">
-      <MyPluginEntityContent />
-    </EntityLayout.Route>
-  </EntityLayout>
-);
+const myPluginEntityContent = EntityContentBlueprint.make({
+  params: {
+    path: 'my-plugin',
+    title: 'My Plugin',
+    group: 'quality',
+    loader: () =>
+      import('./components/MyPluginEntityContent').then(m => (
+        <m.MyPluginEntityContent />
+      )),
+  },
+});
 ```
+
+For a full list of available blueprints and configuration options, see
+[Common Extension Blueprints](../frontend-system/building-plugins/03-common-extension-blueprints.md).

--- a/docs/plugins/plugin-development--old.md
+++ b/docs/plugins/plugin-development--old.md
@@ -1,0 +1,89 @@
+---
+id: plugin-development--old
+title: Plugin Development (Old Frontend System)
+description: Documentation on Plugin Development
+---
+
+::::info
+This documentation is for Backstage apps that still use the old frontend
+system. If your app uses the new frontend system, read the
+[current guide](./plugin-development.md) instead.
+::::
+
+Backstage plugins provide features to a Backstage App.
+
+Each plugin is treated as a self-contained web app and can include almost any
+type of content. Plugins all use a common set of platform APIs and reusable UI
+components. Plugins can fetch data from external sources using the regular
+browser APIs or by depending on external modules to do the work.
+
+## Developing guidelines
+
+- Consider writing plugins in `TypeScript`.
+- Plan the directory structure of your plugin so that it becomes easy to manage.
+- Prefer using the [Backstage components](https://backstage.io/storybook),
+  otherwise go with [Material UI](https://material-ui.com/).
+- Check out the shared Backstage APIs before building a new one.
+
+## Plugin concepts / API
+
+### Routing
+
+Each plugin can export routable extensions, which are then imported into the app
+and mounted at a path.
+
+First you will need a `RouteRef` instance to serve as the mount point of your
+extensions. This can be used within your own plugin to create a link to the
+extension page using `useRouteRef`, as well as for other plugins to link to your
+extension.
+
+It is best to place these in a separate top-level `src/routes.ts` file, in order
+to avoid import cycles, for example like this:
+
+```tsx
+/* src/routes.ts */
+import { createRouteRef } from '@backstage/core-plugin-api';
+
+// Note: This route ref is for internal use only, don't export it from the plugin
+export const rootRouteRef = createRouteRef({
+  id: 'Example Page',
+});
+```
+
+Now that we have a `RouteRef`, we import it into `src/plugin.ts`, create our
+plugin instance with `createPlugin`, as well as create and wrap our routable
+extension using `createRoutableExtension` from `@backstage/core-plugin-api`:
+
+```tsx
+/* src/plugin.ts */
+import { createPlugin, createRouteRef } from '@backstage/core-plugin-api';
+import ExampleComponent from './components/ExampleComponent';
+
+// Create a plugin instance and export this from your plugin package
+export const examplePlugin = createPlugin({
+  id: 'example',
+  routes: {
+    root: rootRouteRef, // This is where the route ref should be exported for usage in the app
+  },
+});
+
+// This creates a routable extension, which are typically full pages of content.
+// Each extension should also be exported from your plugin package.
+export const ExamplePage = examplePlugin.provide(
+  createRoutableExtension({
+    name: 'ExamplePage',
+    // The component needs to be lazy-loaded. It's what will actually be rendered in the end.
+    component: () =>
+      import('./components/ExampleComponent').then(m => m.ExampleComponent),
+    // This binds the extension to this route ref, which allows for routing within and across plugin extensions
+    mountPoint: rootRouteRef,
+  }),
+);
+```
+
+This extension can then be imported and used in the app as follow, typically
+placed within the top-level `<FlatRoutes>`:
+
+```tsx
+<Route path="/any-path" element={<ExamplePage />} />
+```

--- a/docs/plugins/plugin-development.md
+++ b/docs/plugins/plugin-development.md
@@ -4,11 +4,12 @@ title: Plugin Development
 description: Documentation on Plugin Development
 ---
 
-:::caution Legacy Documentation
-
-This page covers plugin development patterns for the **old frontend system**, including `createPlugin`, `createRoutableExtension`, and `RouteRef` from `@backstage/core-plugin-api`. For the new frontend system equivalents, see [Building Frontend Plugins](../frontend-system/building-plugins/01-index.md) and [Routes](../frontend-system/architecture/36-routes.md).
-
-:::
+::::info
+This documentation is written for the new frontend system, which is the default
+in new Backstage apps. If your Backstage app still uses the old frontend system,
+read the [old frontend system version of this guide](./plugin-development--old.md)
+instead.
+::::
 
 Backstage plugins provide features to a Backstage App.
 
@@ -25,65 +26,194 @@ browser APIs or by depending on external modules to do the work.
   otherwise go with [Material UI](https://material-ui.com/).
 - Check out the shared Backstage APIs before building a new one.
 
-## Plugin concepts / API
+## Creating a new plugin
 
-### Routing
+To create a frontend plugin, run `yarn new`, select `plugin`, and fill out the
+prompts. This will create a new package at `plugins/<pluginId>`.
 
-Each plugin can export routable extensions, which are then imported into the app
-and mounted at a path.
+## The plugin instance
 
-First you will need a `RouteRef` instance to serve as the mount point of your
-extensions. This can be used within your own plugin to create a link to the
-extension page using `useRouteRef`, as well as for other plugins to link to your
-extension.
+The starting point of a frontend plugin is the `createFrontendPlugin` function
+from `@backstage/frontend-plugin-api`. It accepts a single options object and
+returns a plugin instance that should be the default export of your package.
 
-It is best to place these in a separate top-level `src/routes.ts` file, in order
-to avoid import cycles, for example like this:
+```tsx title="src/plugin.ts"
+import { createFrontendPlugin } from '@backstage/frontend-plugin-api';
 
-```tsx
-/* src/routes.ts */
-import { createRouteRef } from '@backstage/core-plugin-api';
-
-// Note: This route ref is for internal use only, don't export it from the plugin
-export const rootRouteRef = createRouteRef({
-  id: 'Example Page',
+export const examplePlugin = createFrontendPlugin({
+  pluginId: 'example',
+  extensions: [],
 });
 ```
 
-Now that we have a `RouteRef`, we import it into `src/plugin.ts`, create our
-plugin instance with `createPlugin`, as well as create and wrap our routable
-extension using `createRoutableExtension` from `@backstage/core-plugin-api`:
+```tsx title="src/index.ts"
+export { examplePlugin as default } from './plugin';
+```
 
-```tsx
-/* src/plugin.ts */
-import { createPlugin, createRouteRef } from '@backstage/core-plugin-api';
-import ExampleComponent from './components/ExampleComponent';
+Exporting the plugin as the default export allows it to be automatically
+discovered and installed in a Backstage app without any code changes in the app
+itself.
 
-// Create a plugin instance and export this from your plugin package
-export const examplePlugin = createPlugin({
-  id: 'example',
-  routes: {
-    root: rootRouteRef, // This is where the route ref should be exported for usage in the app
+The plugin ID should be a lowercase dash-separated string, and the plugin
+instance variable should be the camel case version of the ID with a `Plugin`
+suffix. For more details, see
+[naming patterns](../frontend-system/architecture/50-naming-patterns.md).
+
+## Adding a page extension
+
+To add functionality you provide the plugin with one or more
+[extensions](../frontend-system/architecture/20-extensions.md). Let's add a page
+to our plugin along with a navigation item.
+
+Extensions are created using
+[extension blueprints](../frontend-system/architecture/23-extension-blueprints.md).
+For a page we use `PageBlueprint` from `@backstage/frontend-plugin-api`. We also
+need a [route reference](../frontend-system/architecture/36-routes.md#creating-a-route-reference)
+so that other parts of the app can link to our page.
+
+```tsx title="src/routes.ts"
+import { createRouteRef } from '@backstage/frontend-plugin-api';
+
+export const rootRouteRef = createRouteRef();
+```
+
+```tsx title="src/plugin.ts"
+import {
+  createFrontendPlugin,
+  PageBlueprint,
+} from '@backstage/frontend-plugin-api';
+import { rootRouteRef } from './routes';
+
+const examplePage = PageBlueprint.make({
+  params: {
+    routeRef: rootRouteRef,
+    path: '/example',
+    loader: () =>
+      import('./components/ExamplePage').then(m => <m.ExamplePage />),
   },
 });
 
-// This creates a routable extension, which are typically full pages of content.
-// Each extension should also be exported from your plugin package.
-export const ExamplePage = examplePlugin.provide(
-  createRoutableExtension({
-    name: 'ExamplePage',
-    // The component needs to be lazy-loaded. It's what will actually be rendered in the end.
-    component: () =>
-      import('./components/ExampleComponent').then(m => m.ExampleComponent),
-    // This binds the extension to this route ref, which allows for routing within and across plugin extensions
-    mountPoint: rootRouteRef,
-  }),
-);
+export const examplePlugin = createFrontendPlugin({
+  pluginId: 'example',
+  extensions: [examplePage],
+  routes: {
+    root: rootRouteRef,
+  },
+});
 ```
 
-This extension can then be imported and used in the app as follow, typically
-placed within the top-level `<FlatRoutes>`:
+The page will automatically be available at `/example` and a navigation item
+will appear in the sidebar using the plugin's `title` and `icon` properties.
+
+The `ExamplePage` component referenced in the `loader` is a regular React
+component where you implement the actual page content.
+
+## Running a dev server
+
+Each frontend plugin package has a `dev/` folder used as the entry point when
+you run `yarn start`. The `@backstage/frontend-dev-utils` package provides a
+`createDevApp` helper:
+
+```tsx title="dev/index.ts"
+import { createDevApp } from '@backstage/frontend-dev-utils';
+import myPlugin from '../src';
+
+createDevApp({ features: [myPlugin] });
+```
+
+This creates and renders a minimal Backstage app with only your plugin
+installed. Run `yarn start` in the plugin directory to launch the dev server
+with hot reloading.
+
+## Routing
+
+The new frontend system uses route references to provide a level of indirection
+for navigation between plugins. A route reference is an opaque value that
+represents a route target, which gets bound to a concrete path at runtime.
+
+### Route references
+
+Route references are created with `createRouteRef` from
+`@backstage/frontend-plugin-api` and are typically placed in a dedicated
+`src/routes.ts` file to avoid circular imports:
+
+```tsx title="src/routes.ts"
+import { createRouteRef } from '@backstage/frontend-plugin-api';
+
+export const rootRouteRef = createRouteRef();
+```
+
+Use `useRouteRef` to create concrete URLs from a route reference:
 
 ```tsx
-<Route path="/any-path" element={<ExamplePage />} />
+import { useRouteRef } from '@backstage/frontend-plugin-api';
+import { rootRouteRef } from '../routes';
+
+function MyComponent() {
+  const getPath = useRouteRef(rootRouteRef);
+  return <a href={getPath?.()}>Go to example</a>;
+}
 ```
+
+### External route references
+
+To link to pages provided by other plugins without creating a direct dependency,
+use external route references. These are bound to concrete routes by the app
+integrator through configuration or code.
+
+```tsx title="src/routes.ts"
+import { createExternalRouteRef } from '@backstage/frontend-plugin-api';
+
+export const createComponentRouteRef = createExternalRouteRef();
+```
+
+Provide the external route through your plugin so that app integrators can bind
+it:
+
+```tsx title="src/plugin.ts"
+export const examplePlugin = createFrontendPlugin({
+  pluginId: 'example',
+  extensions: [examplePage],
+  routes: {
+    root: rootRouteRef,
+  },
+  externalRoutes: {
+    createComponent: createComponentRouteRef,
+  },
+});
+```
+
+App integrators bind external routes in `app-config.yaml`:
+
+```yaml title="app-config.yaml"
+app:
+  routes:
+    bindings:
+      example.createComponent: scaffolder.index
+```
+
+You can also provide a sensible default target to reduce configuration needed by
+app integrators:
+
+```tsx
+export const createComponentRouteRef = createExternalRouteRef({
+  defaultTarget: 'scaffolder.createComponent',
+});
+```
+
+For a comprehensive guide to the routing system, see
+[Routes](../frontend-system/architecture/36-routes.md).
+
+## Naming patterns
+
+The following naming patterns help clarify the intent and usage of plugin
+exports:
+
+| Description           | Pattern          | Examples                                             |
+| --------------------- | ---------------- | ---------------------------------------------------- |
+| Top-level Pages       | `*Page`          | `CatalogIndexPage`, `SettingsPage`, `LighthousePage` |
+| Entity Tab Content    | `Entity*Content` | `EntityJenkinsContent`, `EntityKubernetesContent`    |
+| Entity Overview Card  | `Entity*Card`    | `EntitySentryCard`, `EntityPagerDutyCard`            |
+| Entity Conditional    | `is*Available`   | `isPagerDutyAvailable`, `isJenkinsAvailable`         |
+| Plugin Instance       | `*Plugin`        | `jenkinsPlugin`, `catalogPlugin`                     |
+| Utility API Reference | `*ApiRef`        | `configApiRef`, `catalogApiRef`                      |


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This rewrites four plugin development documentation pages to use the new frontend system as the primary content. Each page now documents extensions, blueprints, and declarative configuration as the default approach, with the old frontend system content moved to `--old` suffixed files following the established pattern (same as `homepage.md` / `homepage--old.md`).

Pages migrated:
- `plugin-development.md` — new system plugin creation with `createFrontendPlugin`, `PageBlueprint`, route refs
- `integrating-plugin-into-software-catalog.md` — entity page integration with `EntityContentBlueprint` and `EntityCardBlueprint`
- `composability.md` — new extension-based composability model with blueprints and app configuration
- `feature-flags.md` — feature flags via `createFrontendPlugin` from `@backstage/frontend-plugin-api` and `createApp` from `@backstage/frontend-defaults`, plus conditional extension enabling with `if`

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))