### PR TITLE
Fix flaky api-docs alpha test

### DIFF
--- a/plugins/api-docs/src/alpha.test.tsx
+++ b/plugins/api-docs/src/alpha.test.tsx
@@ -55,7 +55,9 @@ describe('api-docs plugin entity extensions', () => {
         ],
       });
 
-      expect(await screen.findByText('My API')).toBeInTheDocument();
+      expect(
+        await screen.findByText('My API', {}, { timeout: 10000 }),
+      ).toBeInTheDocument();
     });
 
     it('should not render for non-API entities', async () => {
@@ -111,7 +113,9 @@ describe('api-docs plugin entity extensions', () => {
         ],
       });
 
-      expect(await screen.findByText('pet-api')).toBeInTheDocument();
+      expect(
+        await screen.findByText('pet-api', {}, { timeout: 10000 }),
+      ).toBeInTheDocument();
     });
   });
 
@@ -140,7 +144,9 @@ describe('api-docs plugin entity extensions', () => {
         ],
       });
 
-      expect(await screen.findByText('Content API')).toBeInTheDocument();
+      expect(
+        await screen.findByText('Content API', {}, { timeout: 10000 }),
+      ).toBeInTheDocument();
     });
 
     it('should not render for non-API entities', async () => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `api-docs` alpha test (`plugins/api-docs/src/alpha.test.tsx`) is flaky in CI — the `findByText` assertions for lazy-loaded extension components time out under load because they use the default 1000ms RTL timeout. Increased to 10000ms to give the `React.lazy()` dynamic imports time to resolve, matching the existing pattern in `createDevApp.test.tsx`.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

🤖 Generated with [Claude Code](https://claude.com/claude-code)