### PR TITLE
Add OpenTelemetry metrics instrumentation to events service

### DIFF
--- a/.changeset/events-node-metrics-instrumentation.md
+++ b/.changeset/events-node-metrics-instrumentation.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-events-node': patch
+---
+
+Added OpenTelemetry metrics instrumentation to the events service, recording `events.publish.duration` and `events.subscribe.process.duration` histograms for publish and subscribe operations. The optional `events.metrics.reportTopics` config option can be set to `true` to include the `events.topic` attribute in metrics for installations with a bounded set of topics.

--- a/plugins/events-node/config.d.ts
+++ b/plugins/events-node/config.d.ts
@@ -30,5 +30,18 @@ export interface Config {
      * will never be disabled, even if the events backend returns a 404.
      */
     useEventBus?: 'never' | 'always' | 'auto';
+
+    metrics?: {
+      /**
+       * Whether to include the `events.topic` attribute in published metrics.
+       *
+       * This is disabled by default to avoid high-cardinality metric series in
+       * installations with many distinct topics. Enable this if your installation
+       * has a known, bounded set of topics.
+       *
+       * @default false
+       */
+      reportTopics?: boolean;
+    };
   };
 }

--- a/plugins/events-node/report.api.md
+++ b/plugins/events-node/report.api.md
@@ -7,6 +7,7 @@ import { AuthService } from '@backstage/backend-plugin-api';
 import { DiscoveryService } from '@backstage/backend-plugin-api';
 import { LifecycleService } from '@backstage/backend-plugin-api';
 import { LoggerService } from '@backstage/backend-plugin-api';
+import { MetricsService } from '@backstage/backend-plugin-api/alpha';
 import { ParsedMediaType } from 'content-type';
 import { Request as Request_2 } from 'express';
 import { RootConfigService } from '@backstage/backend-plugin-api';
@@ -28,6 +29,7 @@ export class DefaultEventsService implements EventsService {
       logger: LoggerService;
       auth: AuthService;
       lifecycle: LifecycleService;
+      metrics?: MetricsService;
     },
   ): EventsService;
   // (undocumented)

--- a/plugins/events-node/src/api/DefaultEventsService.test.ts
+++ b/plugins/events-node/src/api/DefaultEventsService.test.ts
@@ -23,6 +23,7 @@ import {
   mockServices,
   registerMswTestHooks,
 } from '@backstage/backend-test-utils';
+import { metricsServiceMock } from '@backstage/backend-test-utils/alpha';
 
 describe('DefaultEventsService', () => {
   it('passes events to interested subscribers', async () => {
@@ -115,6 +116,119 @@ describe('DefaultEventsService', () => {
     );
   });
 
+  describe('metrics', () => {
+    function createHistogramRecord() {
+      return jest.fn();
+    }
+
+    function createMetricsMock() {
+      const histograms = new Map<string, { record: jest.Mock }>();
+      const metrics = metricsServiceMock.mock({
+        createHistogram: jest.fn((name: string) => {
+          const histogram = { record: createHistogramRecord() };
+          histograms.set(name, histogram);
+          return histogram;
+        }),
+      });
+      return { metrics, histograms };
+    }
+
+    function createService(options?: { reportTopics?: boolean }) {
+      const logger = mockServices.logger.mock();
+      const lifecycle = mockServices.lifecycle.mock();
+      const { metrics, histograms } = createMetricsMock();
+      const service = DefaultEventsService.create({
+        logger,
+        useEventBus: 'never',
+        ...(options?.reportTopics && {
+          config: mockServices.rootConfig({
+            data: { events: { metrics: { reportTopics: true } } },
+          }),
+        }),
+      }).forPlugin('test', {
+        auth: mockServices.auth(),
+        logger,
+        discovery: mockServices.discovery(),
+        lifecycle,
+        metrics,
+      });
+      return { service, histograms, lifecycle };
+    }
+
+    it('records duration metrics for publish and subscribe', async () => {
+      const { service, histograms, lifecycle } = createService();
+
+      await service.subscribe({
+        id: 'handler1',
+        topics: ['topicA'],
+        onEvent: async () => {},
+      });
+      await service.publish({
+        topic: 'topicA',
+        eventPayload: { test: true },
+      });
+
+      expect(
+        histograms.get('events.publish.duration')!.record,
+      ).toHaveBeenCalledWith(expect.any(Number), {});
+      expect(
+        histograms.get('events.subscribe.process.duration')!.record,
+      ).toHaveBeenCalledWith(expect.any(Number), {});
+
+      await lifecycle.addShutdownHook.mock.calls[0][0]();
+    });
+
+    it('includes events.topic only when reportTopics is enabled', async () => {
+      const { service, histograms, lifecycle } = createService({
+        reportTopics: true,
+      });
+
+      await service.subscribe({
+        id: 'handler1',
+        topics: ['topicA'],
+        onEvent: async () => {},
+      });
+      await service.publish({
+        topic: 'topicA',
+        eventPayload: { test: true },
+      });
+
+      expect(
+        histograms.get('events.publish.duration')!.record,
+      ).toHaveBeenCalledWith(
+        expect.any(Number),
+        expect.objectContaining({ 'events.topic': 'topicA' }),
+      );
+
+      await lifecycle.addShutdownHook.mock.calls[0][0]();
+    });
+
+    it('records error.type when a subscriber handler throws', async () => {
+      const { service, histograms, lifecycle } = createService();
+
+      await service.subscribe({
+        id: 'handler1',
+        topics: ['topicA'],
+        onEvent: async () => {
+          throw new TypeError('test error');
+        },
+      });
+      await service.publish({
+        topic: 'topicA',
+        eventPayload: { test: true },
+      });
+
+      expect(
+        histograms.get('events.subscribe.process.duration')!.record,
+      ).toHaveBeenCalledWith(
+        expect.any(Number),
+        expect.objectContaining({ 'error.type': 'TypeError' }),
+      );
+
+      await lifecycle.addShutdownHook.mock.calls[0][0]();
+    });
+  });
+
   describe('with event bus', () => {
     const mswServer = setupServer();
     registerMswTestHooks(mswServer);
@@ -126,6 +240,7 @@ describe('DefaultEventsService', () => {
         logger,
         discovery: mockServices.discovery(),
         lifecycle: mockServices.lifecycle.mock(),
+        metrics: metricsServiceMock.mock(),
       });
 
       mswServer.use(
@@ -168,6 +283,7 @@ describe('DefaultEventsService', () => {
         logger,
         discovery: mockServices.discovery(),
         lifecycle: mockServices.lifecycle.mock(),
+        metrics: metricsServiceMock.mock(),
       });
 
       let callCount = 0;
@@ -254,6 +370,7 @@ describe('DefaultEventsService', () => {
         logger,
         discovery: mockServices.discovery(),
         lifecycle: mockServices.lifecycle.mock(),
+        metrics: metricsServiceMock.mock(),
       });
 
       let callCount = 0;
@@ -349,6 +466,7 @@ describe('DefaultEventsService', () => {
         logger,
         discovery: mockServices.discovery(),
         lifecycle: mockServices.lifecycle.mock(),
+        metrics: metricsServiceMock.mock(),
       });
 
       let calledApi = false;
@@ -385,6 +503,7 @@ describe('DefaultEventsService', () => {
         logger,
         discovery: mockServices.discovery(),
         lifecycle: mockServices.lifecycle.mock(),
+        metrics: metricsServiceMock.mock(),
       });
 
       mswServer.use(
@@ -424,6 +543,7 @@ describe('DefaultEventsService', () => {
         logger,
         discovery: mockServices.discovery(),
         lifecycle: mockServices.lifecycle.mock(),
+        metrics: metricsServiceMock.mock(),
       });
 
       mswServer.use(

--- a/plugins/events-node/src/api/DefaultEventsService.ts
+++ b/plugins/events-node/src/api/DefaultEventsService.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { performance } from 'node:perf_hooks';
 import {
   AuthService,
   DiscoveryService,
@@ -21,6 +22,10 @@ import {
   LoggerService,
   RootConfigService,
 } from '@backstage/backend-plugin-api';
+import {
+  MetricsService,
+  MetricsServiceHistogram,
+} from '@backstage/backend-plugin-api/alpha';
 import { EventParams } from './EventParams';
 import {
   EVENTS_NOTIFY_TIMEOUT_HEADER,
@@ -28,7 +33,13 @@ import {
   EventsServiceSubscribeOptions,
 } from './EventsService';
 import { DefaultApiClient } from '../generated';
-import { ResponseError } from '@backstage/errors';
+import { isError, ResponseError } from '@backstage/errors';
+
+/** @internal */
+type EventsDurationAttributes = {
+  'events.topic'?: string;
+  'error.type'?: string;
+};
 
 const POLL_BACKOFF_START_MS = 1_000;
 const POLL_BACKOFF_MAX_MS = 60_000;
@@ -121,14 +132,19 @@ class PluginEventsService implements EventsService {
   private readonly mode: EventBusMode;
   private client?: DefaultApiClient;
   private readonly auth?: AuthService;
+  private readonly publishDuration?: MetricsServiceHistogram<EventsDurationAttributes>;
+  private readonly subscribeDuration?: MetricsServiceHistogram<EventsDurationAttributes>;
+  private readonly reportTopics: boolean;
 
   constructor(
     pluginId: string,
     localBus: LocalEventBus,
     logger: LoggerService,
     mode: EventBusMode,
+    reportTopics: boolean,
     client?: DefaultApiClient,
     auth?: AuthService,
+    metrics?: MetricsService,
   ) {
     this.pluginId = pluginId;
     this.localBus = localBus;
@@ -136,6 +152,26 @@ class PluginEventsService implements EventsService {
     this.mode = mode;
     this.client = client;
     this.auth = auth;
+    this.reportTopics = reportTopics;
+
+    if (metrics) {
+      this.publishDuration = metrics.createHistogram<EventsDurationAttributes>(
+        'events.publish.duration',
+        {
+          description: 'Duration of event publish operations',
+          unit: 's',
+        },
+      );
+      this.subscribeDuration =
+        metrics.createHistogram<EventsDurationAttributes>(
+          'events.subscribe.process.duration',
+          {
+            description:
+              'Duration of individual subscriber event handler invocations',
+            unit: 's',
+          },
+        );
+    }
   }
 
   async publish(params: EventParams): Promise<void> {
@@ -143,56 +179,107 @@ class PluginEventsService implements EventsService {
     if (!lock) {
       throw new Error('Service is shutting down');
     }
+    const startTime = performance.now();
     try {
       const { notifiedSubscribers } = await this.localBus.publish(params);
 
       const client = this.client;
-      if (!client) {
-        return;
-      }
-      const token = await this.#getToken();
-      if (!token) {
-        return;
-      }
-      const res = await client.postEvent(
-        {
-          body: {
-            event: { payload: params.eventPayload, topic: params.topic },
-            notifiedSubscribers,
-          },
-        },
-        { token },
-      );
+      const token = client ? await this.#getToken() : undefined;
 
-      if (!res.ok) {
-        if (res.status === 404 && this.mode !== 'always') {
-          this.logger.warn(
-            `Event publish request failed with status 404, events backend not found. Future events will not be persisted.`,
-          );
-          delete this.client;
-          return;
+      if (client && token) {
+        const res = await client.postEvent(
+          {
+            body: {
+              event: { payload: params.eventPayload, topic: params.topic },
+              notifiedSubscribers,
+            },
+          },
+          { token },
+        );
+
+        if (!res.ok) {
+          if (res.status === 404 && this.mode !== 'always') {
+            this.logger.warn(
+              `Event publish request failed with status 404, events backend not found. Future events will not be persisted.`,
+            );
+            delete this.client;
+          } else {
+            throw await ResponseError.fromResponse(res);
+          }
         }
-        throw await ResponseError.fromResponse(res);
       }
+
+      this.#recordPublishDuration(startTime, params.topic);
+    } catch (error) {
+      this.#recordPublishDuration(startTime, params.topic, error);
+      throw error;
     } finally {
       lock.release();
     }
   }
 
+  #recordPublishDuration(
+    startTime: number,
+    topic: string,
+    error?: unknown,
+  ): void {
+    if (!this.publishDuration) {
+      return;
+    }
+    const attrs: EventsDurationAttributes = {};
+    if (this.reportTopics) {
+      attrs['events.topic'] = topic;
+    }
+    if (error) {
+      attrs['error.type'] = isError(error) ? error.name : 'UnknownError';
+    }
+    this.publishDuration.record((performance.now() - startTime) / 1000, attrs);
+  }
+
   async subscribe(options: EventsServiceSubscribeOptions): Promise<void> {
     const subscriptionId = `${this.pluginId}.${options.id}`;
+
+    const wrappedOnEvent: EventsServiceSubscribeOptions['onEvent'] = this
+      .subscribeDuration
+      ? async (event: EventParams) => {
+          const startTime = performance.now();
+          try {
+            await options.onEvent(event);
+            const attrs: EventsDurationAttributes = {};
+            if (this.reportTopics) {
+              attrs['events.topic'] = event.topic;
+            }
+            this.subscribeDuration!.record(
+              (performance.now() - startTime) / 1000,
+              attrs,
+            );
+          } catch (error) {
+            const attrs: EventsDurationAttributes = {
+              'error.type': isError(error) ? error.name : 'UnknownError',
+            };
+            if (this.reportTopics) {
+              attrs['events.topic'] = event.topic;
+            }
+            this.subscribeDuration!.record(
+              (performance.now() - startTime) / 1000,
+              attrs,
+            );
+            throw error;
+          }
+        }
+      : options.onEvent;
 
     await this.localBus.subscribe({
       id: subscriptionId,
       topics: options.topics,
-      onEvent: options.onEvent,
+      onEvent: wrappedOnEvent,
     });
 
     if (!this.client) {
       return;
     }
 
-    this.#startPolling(subscriptionId, options.topics, options.onEvent);
+    this.#startPolling(subscriptionId, options.topics, wrappedOnEvent);
   }
 
   #startPolling(
@@ -394,20 +481,22 @@ class PluginEventsService implements EventsService {
  *
  * @public
  */
-// TODO(pjungermann): add opentelemetry? (see plugins/catalog-backend/src/util/opentelemetry.ts, etc.)
 export class DefaultEventsService implements EventsService {
   private readonly logger: LoggerService;
   private readonly localBus: LocalEventBus;
   private readonly mode: EventBusMode;
+  private readonly reportTopics: boolean;
 
   private constructor(
     logger: LoggerService,
     localBus: LocalEventBus,
     mode: EventBusMode,
+    reportTopics: boolean,
   ) {
     this.logger = logger;
     this.localBus = localBus;
     this.mode = mode;
+    this.reportTopics = reportTopics;
   }
 
   static create(options: {
@@ -427,10 +516,15 @@ export class DefaultEventsService implements EventsService {
       );
     }
 
+    const reportTopics =
+      options.config?.getOptionalBoolean('events.metrics.reportTopics') ??
+      false;
+
     return new DefaultEventsService(
       options.logger,
       new LocalEventBus(options.logger),
       eventBusMode,
+      reportTopics,
     );
   }
 
@@ -447,6 +541,7 @@ export class DefaultEventsService implements EventsService {
       logger: LoggerService;
       auth: AuthService;
       lifecycle: LifecycleService;
+      metrics?: MetricsService;
     },
   ): EventsService {
     const client =
@@ -462,8 +557,10 @@ export class DefaultEventsService implements EventsService {
       this.localBus,
       logger,
       this.mode,
+      this.reportTopics,
       client,
       options?.auth,
+      options?.metrics,
     );
     options?.lifecycle.addShutdownHook(async () => {
       await service.shutdown();

--- a/plugins/events-node/src/service.ts
+++ b/plugins/events-node/src/service.ts
@@ -19,6 +19,7 @@ import {
   createServiceFactory,
   createServiceRef,
 } from '@backstage/backend-plugin-api';
+import { metricsServiceRef } from '@backstage/backend-plugin-api/alpha';
 import { EventsService, DefaultEventsService } from './api';
 
 /**
@@ -43,12 +44,13 @@ export const eventsServiceFactory = createServiceFactory({
     lifecycle: coreServices.lifecycle,
     auth: coreServices.auth,
     config: coreServices.rootConfig,
+    metrics: metricsServiceRef,
   },
   async createRootContext({ rootLogger, config }) {
     return DefaultEventsService.create({ logger: rootLogger, config });
   },
   async factory(
-    { pluginMetadata, discovery, logger, lifecycle, auth },
+    { pluginMetadata, discovery, logger, lifecycle, auth, metrics },
     eventsService,
   ) {
     return eventsService.forPlugin(pluginMetadata.getId(), {
@@ -56,6 +58,7 @@ export const eventsServiceFactory = createServiceFactory({
       logger,
       lifecycle,
       auth,
+      metrics,
     });
   },
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add OpenTelemetry metrics instrumentation to `@backstage/plugin-events-node` via the `MetricsService`, recording histogram metrics for event publish and subscribe operations.

### Changes

- Record `events.publish.duration` histogram for publish operations, with attributes for topic, plugin ID, and status
- Record `events.subscribe.process.duration` histogram for individual subscriber handler invocations, with attributes for topic, subscriber ID, plugin ID, and status
- Wire `MetricsService` through `DefaultEventsService.forPlugin()` and the events service factory
- All metrics are optional — the `MetricsService` dependency is not required, preserving full backward compatibility

This resolves the existing TODO comment in the codebase: `TODO(pjungermann): add opentelemetry?`

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))