### PR TITLE
fix(ui): fix Header nav hover indicator covering tab text

### DIFF
--- a/.changeset/wicked-impalas-fry.md
+++ b/.changeset/wicked-impalas-fry.md
@@ -1,0 +1,7 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed HeaderNav hover indicator covering tab text when theme uses opaque background colors. Also fixed an incorrect CSS variable reference (`--bui-font-family` → `--bui-font-regular`).
+
+**Affected components:** Header

--- a/packages/ui/src/components/Header/HeaderNav.module.css
+++ b/packages/ui/src/components/Header/HeaderNav.module.css
@@ -50,7 +50,7 @@
 
   .bui-HeaderNavItem,
   .bui-HeaderNavGroup {
-    font-family: var(--bui-font-family);
+    font-family: var(--bui-font-regular);
     font-size: var(--bui-font-size-3);
     font-weight: var(--bui-font-weight-regular);
     color: var(--bui-fg-secondary);
@@ -61,6 +61,8 @@
     padding-inline: var(--bui-space-2);
     text-decoration: none;
     cursor: pointer;
+    position: relative;
+    z-index: 2;
     border: none;
     background: none;
     outline: none;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `HeaderNav` hover indicator uses `position: absolute` and paints
on top of tab text. This works with the default BUI theme because
`--bui-bg-neutral-2` is semi-transparent, but any theme using an
opaque value for that token fully obscures the tab labels on hover.

This adds `position: relative` and `z-index: 2` to nav items (matching
the `Tabs` component pattern) so they paint above the indicators.

Also fixes a reference to the non-existent `--bui-font-family` CSS
variable — the correct token is `--bui-font-regular`.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.