### PR TITLE
catalog: export CatalogIndexPage from alpha entry point

### DIFF
--- a/.changeset/catalog-nfs-page-header.md
+++ b/.changeset/catalog-nfs-page-header.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Exported the NFS variant of the catalog index page as `CatalogIndexPage` from the `./alpha` entry point, along with supporting types `CatalogIndexPageProps`, `CatalogTableRow`, and `CatalogTableColumnsFunc`. This allows adopters to use and customize the catalog index page within a `PageBlueprint` in the new frontend system.

--- a/plugins/catalog/report-alpha.api.md
+++ b/plugins/catalog/report-alpha.api.md
@@ -6,12 +6,16 @@
 import { AnyApiFactory } from '@backstage/frontend-plugin-api';
 import { AnyRouteRefParams } from '@backstage/frontend-plugin-api';
 import { ApiFactory } from '@backstage/frontend-plugin-api';
+import { CompoundEntityRef } from '@backstage/catalog-model';
 import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { defaultEntityContentGroups } from '@backstage/plugin-catalog-react/alpha';
 import { Entity } from '@backstage/catalog-model';
 import { EntityCardType } from '@backstage/plugin-catalog-react/alpha';
 import { EntityContentLayoutProps } from '@backstage/plugin-catalog-react/alpha';
 import { EntityContextMenuItemParams } from '@backstage/plugin-catalog-react/alpha';
+import { EntityListContextProps } from '@backstage/plugin-catalog-react';
+import { EntityListPagination } from '@backstage/plugin-catalog-react';
+import { EntityOwnerPickerProps } from '@backstage/plugin-catalog-react';
 import { ExtensionBlueprintParams } from '@backstage/frontend-plugin-api';
 import { ExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { ExtensionInput } from '@backstage/frontend-plugin-api';
@@ -21,16 +25,68 @@ import { IconComponent } from '@backstage/frontend-plugin-api';
 import { IconElement } from '@backstage/frontend-plugin-api';
 import { IconLinkVerticalProps } from '@backstage/core-components';
 import { JSX as JSX_2 } from 'react';
+import { JSX as JSX_3 } from 'react/jsx-runtime';
 import { JSXElementConstructor } from 'react';
 import { OverridableExtensionDefinition } from '@backstage/frontend-plugin-api';
 import { OverridableFrontendPlugin } from '@backstage/frontend-plugin-api';
 import { ReactElement } from 'react';
+import { ReactNode } from 'react';
 import { RouteRef } from '@backstage/core-plugin-api';
 import { RouteRef as RouteRef_2 } from '@backstage/frontend-plugin-api';
 import { SearchResultItemExtensionComponent } from '@backstage/plugin-search-react/alpha';
 import { SearchResultItemExtensionPredicate } from '@backstage/plugin-search-react/alpha';
 import { SearchResultListItemBlueprintParams } from '@backstage/plugin-search-react/alpha';
+import { TableColumn } from '@backstage/core-components';
+import { TableProps } from '@backstage/core-components';
 import { TranslationRef } from '@backstage/frontend-plugin-api';
+import { UserListFilterKind } from '@backstage/plugin-catalog-react';
+
+// @public (undocumented)
+export function CatalogIndexPage(props: CatalogIndexPageProps): JSX_3.Element;
+
+// @public
+export interface CatalogIndexPageProps {
+  // (undocumented)
+  actions?: TableProps<CatalogTableRow>['actions'];
+  // (undocumented)
+  columns?: TableColumn<CatalogTableRow>[] | CatalogTableColumnsFunc;
+  // (undocumented)
+  emptyContent?: ReactNode;
+  // (undocumented)
+  filters?: ReactNode;
+  // (undocumented)
+  initialKind?: string;
+  // (undocumented)
+  initiallySelectedFilter?: UserListFilterKind;
+  // (undocumented)
+  initiallySelectedNamespaces?: string[];
+  // (undocumented)
+  ownerPickerMode?: EntityOwnerPickerProps['mode'];
+  // (undocumented)
+  pagination?: EntityListPagination;
+  // (undocumented)
+  tableOptions?: TableProps<CatalogTableRow>['options'];
+}
+
+// @public
+export type CatalogTableColumnsFunc = (
+  entityListContext: EntityListContextProps,
+) => TableColumn<CatalogTableRow>[];
+
+// @public (undocumented)
+export interface CatalogTableRow {
+  // (undocumented)
+  entity: Entity;
+  // (undocumented)
+  resolved: {
+    name: string;
+    entityRef: string;
+    partOfSystemRelationTitle?: string;
+    partOfSystemRelations: CompoundEntityRef[];
+    ownedByRelationsTitle?: string;
+    ownedByRelations: CompoundEntityRef[];
+  };
+}
 
 // @alpha @deprecated (undocumented)
 export const catalogTranslationRef: TranslationRef<

--- a/plugins/catalog/src/alpha/index.ts
+++ b/plugins/catalog/src/alpha/index.ts
@@ -16,6 +16,13 @@
 
 export { default } from './plugin';
 
+export { NfsDefaultCatalogPage as CatalogIndexPage } from '../components/CatalogPage';
+export type { DefaultCatalogPageProps as CatalogIndexPageProps } from '../components/CatalogPage';
+export type {
+  CatalogTableRow,
+  CatalogTableColumnsFunc,
+} from '../components/CatalogTable';
+
 import { catalogTranslationRef as _catalogTranslationRef } from './translation';
 
 /**

--- a/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx
@@ -182,6 +182,7 @@ export function DefaultCatalogPage(props: DefaultCatalogPageProps) {
   );
 }
 
+/** @public */
 export function NfsDefaultCatalogPage(props: DefaultCatalogPageProps) {
   const {
     columns,

--- a/plugins/catalog/src/components/CatalogPage/index.ts
+++ b/plugins/catalog/src/components/CatalogPage/index.ts
@@ -15,7 +15,11 @@
  */
 
 export { CatalogPage } from './CatalogPage';
-export { BaseCatalogPage, DefaultCatalogPage } from './DefaultCatalogPage';
+export {
+  BaseCatalogPage,
+  DefaultCatalogPage,
+  NfsDefaultCatalogPage,
+} from './DefaultCatalogPage';
 export type {
   BaseCatalogPageProps,
   DefaultCatalogPageProps,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This exports `CatalogIndexPage` from the `./alpha` entry point of `@backstage/plugin-catalog`, along with supporting types `CatalogIndexPageProps`, `CatalogTableRow`, and `CatalogTableColumnsFunc`. This allows adopters to use and customize the catalog index page within a `PageBlueprint` in the new frontend system.

The `NfsDefaultCatalogPage` component already existed internally and was used by the alpha plugin's `PageBlueprint` loader, but wasn't accessible to adopters building custom pages. This re-exports it as `CatalogIndexPage` from `./alpha`, accepting the same `DefaultCatalogPageProps` (aliased as `CatalogIndexPageProps`) for customization.

No changes to the stable main entry point API.

Fixes #33532

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))