### PR TITLE
fix: Accordion Group Multiple Open example overflows in docs

### DIFF
--- a/docs-ui/src/app/components/accordion/page.mdx
+++ b/docs-ui/src/app/components/accordion/page.mdx
@@ -140,7 +140,7 @@ Allows multiple panels to be open simultaneously.
 <Snippet
   align="center"
   py={4}
-  height={280}
+  height="auto"
   preview={<GroupMultipleOpen />}
   code={groupMultipleOpenSnippet}
 />


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixed #33606

### What changed

This PR fixes the issue where the "AccordionGroup Multiple Open" example overflows its demo container in the Backstage UI docs.

The issue was caused by the container using a fixed height. When multiple accordions were opened, the content exceeded the available space and overflowed.

### Fix

Changed the height of `GroupMultipleAccordion` from a fixed value to `auto` so that the container expands based on the opened accordion content.

### Result

* The demo container now grows correctly when multiple accordions are opened
* No content is clipped or overflowed
* The example behaves as expected in the docs

<img width="1154" height="767" alt="Screenshot 2026-04-01 224307" src="https://github.com/user-attachments/assets/35c1a5af-0533-4030-b926-1d08c3847952" />


#### :heavy_check_mark: Checklist

* [ ] A changeset describing the change and affected packages.
* [x] Added or updated documentation
* [ ] Tests for new functionality and regression tests for bug fixes
* [x] Screenshots attached (for UI changes)
* [ ] All commits have a `Signed-off-by` line in the message.

