### PR TITLE
chore(dockerfile): modernize minimal hardened image

### DIFF
--- a/contrib/docker/minimal-hardened-image/Dockerfile
+++ b/contrib/docker/minimal-hardened-image/Dockerfile
@@ -3,40 +3,50 @@
 #
 # Before building this image, be sure to have run the following commands in the repo root:
 #
-# yarn install
+# yarn install --immutable
 # yarn tsc
 # yarn build:backend
 #
-# Once the commands have been run, you can build the image using `yarn docker-build`
+# Once the commands have been run, you can build the image using:
+#
+# docker build . -f contrib/docker/minimal-hardened-image/Dockerfile
 
-# syntax = docker/dockerfile:1.4
+ARG NODE_VERSION=24
+ARG PYTHON_VERSION=3.13
 
-# Build Python environment in a separate builder stage
-FROM cgr.dev/chainguard/python:latest-dev as python-builder
-
-ENV PATH=/venv/bin:$PATH
+# Build Python environment for TechDocs in a separate builder stage
+# NOTE: latest-dev tracks the current Chainguard Python version
+FROM cgr.dev/chainguard/python:latest-dev AS python-builder
 
 RUN --mount=type=cache,target=/home/nonroot/.cache/pip,uid=65532,gid=65532 \
     python3 -m venv /home/nonroot/venv && \
-    /home/nonroot/venv/bin/pip install mkdocs-techdocs-core==1.3.3
+    /home/nonroot/venv/bin/pip install mkdocs-techdocs-core==1.6.1
 
 # Build Node environment in a separate builder stage
-FROM cgr.dev/chainguard/wolfi-base:latest as node-builder
+FROM cgr.dev/chainguard/wolfi-base:latest AS node-builder
 
-ENV NODE_VERSION="20=~20.11"
+ARG NODE_VERSION
 ENV NODE_ENV=production
 
-RUN --mount=type=cache,target=/var/cache/apk,sharing=locked,uid=65532,gid=65532 \
-    --mount=type=cache,target=/var/lib/apk,sharing=locked,uid=65532,gid=65532 \
+RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \
+    --mount=type=cache,target=/var/lib/apk,sharing=locked \
     apk update && \
-    apk add nodejs-$NODE_VERSION yarn \
-    # Install isolate-vm dependencies, these are needed by the @backstage/plugin-scaffolder-backend.
-    openssl-dev brotli-dev c-ares-dev nghttp2-dev icu-dev zlib-dev gcc-12 libuv-dev build-base
+    apk add \
+    nodejs-${NODE_VERSION} \
+    yarn-berry \
+    # isolate-vm dependencies needed by @backstage/plugin-scaffolder-backend
+    build-base \
+    openssl-dev \
+    brotli-dev \
+    c-ares-dev \
+    nghttp2-dev \
+    icu-dev \
+    zlib-dev \
+    libuv-dev
 
 WORKDIR /app
-RUN chown -R nonroot:nonroot /app
-
-RUN mkdir -p /home/nonroot/.yarn/berry && chown -R 65532:65532 /home/nonroot/.yarn/berry
+RUN chown -R nonroot:nonroot /app && \
+    mkdir -p /home/nonroot/.yarn/berry && chown -R 65532:65532 /home/nonroot/.yarn/berry
 
 USER nonroot
 
@@ -52,36 +62,36 @@ RUN --mount=type=cache,target=/home/nonroot/.yarn/berry/cache,sharing=locked,uid
 # Final stage to build the application image
 FROM cgr.dev/chainguard/wolfi-base:latest
 
-ENV PYTHON_VERSION="3.12=~3.12"
-ENV NODE_VERSION="20=~20.14"
+ARG NODE_VERSION
+ARG PYTHON_VERSION
 ENV NODE_ENV=production
 
-RUN --mount=type=cache,target=/var/cache/apk,sharing=locked,uid=65532,gid=65532 \
-    --mount=type=cache,target=/var/lib/apk,sharing=locked,uid=65532,gid=65532 \
+RUN --mount=type=cache,target=/var/cache/apk,sharing=locked \
+    --mount=type=cache,target=/var/lib/apk,sharing=locked \
     apk update && \
     apk add \
     # add node for backstage
-    nodejs-$NODE_VERSION \
-    # add python for backstage techdocs
-    python-$PYTHON_VERSION \
+    nodejs-${NODE_VERSION} \
+    # add python for backstage TechDocs
+    python-${PYTHON_VERSION} \
     # add tini for init process
     tini
 
 WORKDIR /app
 
-COPY package.json app-config.yaml ./
-ADD packages/backend/dist/skeleton.tar.gz packages/backend/dist/bundle.tar.gz ./
-
-RUN chown -R 65532:65532 /app
-RUN chown -R 65532:65532 /tmp
-USER 65532:65532
+COPY --chown=65532:65532 package.json app-config.yaml ./
+ADD --chown=65532:65532 packages/backend/dist/skeleton.tar.gz packages/backend/dist/bundle.tar.gz ./
 
 COPY --from=node-builder --chown=65532:65532 /app/node_modules ./node_modules
 COPY --from=python-builder --chown=65532:65532 /home/nonroot/venv /home/nonroot/venv
-ENV PATH=/home/nonroot/venv/bin:$PATH
 
+RUN chown -R 65532:65532 /app /tmp
+
+ENV PATH=/home/nonroot/venv/bin:$PATH
 ENV NODE_OPTIONS="--no-node-snapshot"
 ENV GIT_PYTHON_REFRESH="quiet"
+
+USER 65532:65532
 
 ENTRYPOINT ["tini", "--"]
 CMD ["node", "packages/backend", "--config", "app-config.yaml"]

--- a/contrib/docker/minimal-hardened-image/README.md
+++ b/contrib/docker/minimal-hardened-image/README.md
@@ -8,12 +8,12 @@ The `Dockerfile` in this directory uses a [wolfi-base](https://github.com/wolfi-
 
 When converting, I utilized the upstream Dockerfile as a starting point.
 
-- Multi-stage build - The Dockerfile has been split up into a multistage build which reduces the files, packages, executables, and directories in the final image.
-  - Size savings = ~900mb
+- Multi-stage build - The Dockerfile has been split into a three-stage build (python-builder, node-builder, final) which reduces the files, packages, executables, and directories in the final image.
+  - Significant size savings compared to the standard Backstage Dockerfile
   - Reduced attack surface
 - Base Image - Swap to [wolfi-base](https://github.com/wolfi-dev) image from Chainguard Images
-  - Vulnerability Savings = ~239 at the time of updating this README
 - Entrypoint - Swap from `node` to `tini` as entrypoint to ensure that the default signal handlers work and zombie processes are handled properly
+- User - Uses Chainguard's `nonroot` user (UID 65532) instead of `node` (UID 1000)
 - Use `ADD` instead of `COPY` in dockerfile to reduce copied compressed files
   - When a `rm` is used to remove a compressed file it still makes its way into the final image. Using `ADD` is safe with local files.
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Update the Chainguard-based minimal hardened Dockerfile in `contrib/docker/`:

- Bump Node.js from 20 to 24, Python 3.12 to 3.13
- Switch from `yarn` to `yarn-berry`
- Update `mkdocs-techdocs-core` from 1.3.3 to 1.6.1
- Extract version variables for easier maintenance
- Improve Dockerfile layer ordering and cleanup

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
