### PR TITLE
Migrate Catalog Scm Events to use MetricsService

### DIFF
--- a/.changeset/thick-planets-read.md
+++ b/.changeset/thick-planets-read.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-node': patch
+---
+
+Migrated internal SCM events metrics to use the new alpha `MetricsService`

--- a/plugins/catalog-node/package.json
+++ b/plugins/catalog-node/package.json
@@ -68,7 +68,6 @@
     "@backstage/plugin-permission-common": "workspace:^",
     "@backstage/plugin-permission-node": "workspace:^",
     "@backstage/types": "workspace:^",
-    "@opentelemetry/api": "^1.9.0",
     "lodash": "^4.17.21",
     "yaml": "^2.0.0"
   },

--- a/plugins/catalog-node/src/scmEvents/DefaultCatalogScmEventsService.test.ts
+++ b/plugins/catalog-node/src/scmEvents/DefaultCatalogScmEventsService.test.ts
@@ -15,18 +15,15 @@
  */
 
 import { createDeferred } from '@backstage/types';
-import { MetricsAPI } from '@opentelemetry/api';
+import { metricsServiceMock } from '@backstage/backend-test-utils/alpha';
 import { DefaultCatalogScmEventsService } from './DefaultCatalogScmEventsService';
 
 describe('DefaultCatalogScmEventsService', () => {
-  const counterAdd = jest.fn();
-  const mockMetrics = {
-    getMeter: () => ({
-      createCounter: () => ({
-        add: counterAdd,
-      }),
-    }),
-  } as unknown as MetricsAPI;
+  let mockMetrics: ReturnType<typeof metricsServiceMock.mock>;
+
+  beforeEach(() => {
+    mockMetrics = metricsServiceMock.mock();
+  });
 
   it('should publish and subscribe to events', async () => {
     const service = new DefaultCatalogScmEventsService(mockMetrics);
@@ -118,6 +115,7 @@ describe('DefaultCatalogScmEventsService', () => {
 
     service.markEventActionTaken({ action: 'refresh' });
 
-    expect(counterAdd).toHaveBeenCalledWith(1, { action: 'refresh' });
+    const counter = mockMetrics.createCounter.mock.results[0].value;
+    expect(counter.add).toHaveBeenCalledWith(1, { action: 'refresh' });
   });
 });

--- a/plugins/catalog-node/src/scmEvents/DefaultCatalogScmEventsService.ts
+++ b/plugins/catalog-node/src/scmEvents/DefaultCatalogScmEventsService.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { Counter, MetricsAPI } from '@opentelemetry/api';
+import type {
+  MetricsService,
+  MetricsServiceCounter,
+} from '@backstage/backend-plugin-api/alpha';
 import {
   CatalogScmEvent,
   CatalogScmEventsService,
@@ -38,18 +41,17 @@ import {
 export class DefaultCatalogScmEventsService implements CatalogScmEventsService {
   readonly #subscribers: Set<CatalogScmEventsServiceSubscriber>;
   readonly #metrics: {
-    actions: Counter<{ action: string }>;
+    actions: MetricsServiceCounter<{ action: string }>;
   };
 
-  constructor(metrics: MetricsAPI) {
+  constructor(metrics: MetricsService) {
     this.#subscribers = new Set();
 
-    const meter = metrics.getMeter('default');
     this.#metrics = {
-      actions: meter.createCounter('catalog.events.scm.actions', {
+      actions: metrics.createCounter('catalog.events.scm.actions', {
         description:
           'Number of actions taken as a result of SCM event messages',
-        unit: 'short',
+        unit: '{action}',
       }),
     };
   }

--- a/plugins/catalog-node/src/scmEvents/catalogScmEventsServiceRef.ts
+++ b/plugins/catalog-node/src/scmEvents/catalogScmEventsServiceRef.ts
@@ -18,7 +18,7 @@ import {
   createServiceFactory,
   createServiceRef,
 } from '@backstage/backend-plugin-api';
-import { metrics } from '@opentelemetry/api';
+import { metricsServiceRef } from '@backstage/backend-plugin-api/alpha';
 import { CatalogScmEventsService } from './types';
 import { DefaultCatalogScmEventsService } from './DefaultCatalogScmEventsService';
 
@@ -35,15 +35,17 @@ import { DefaultCatalogScmEventsService } from './DefaultCatalogScmEventsService
 export const catalogScmEventsServiceRef =
   createServiceRef<CatalogScmEventsService>({
     id: 'catalog.scm-events.alpha',
-    defaultFactory: async service =>
-      createServiceFactory({
+    defaultFactory: async service => {
+      let sharedInstance: DefaultCatalogScmEventsService | undefined;
+      return createServiceFactory({
         service,
-        deps: {},
-        createRootContext() {
-          return new DefaultCatalogScmEventsService(metrics);
+        deps: { metrics: metricsServiceRef },
+        factory({ metrics }) {
+          if (!sharedInstance) {
+            sharedInstance = new DefaultCatalogScmEventsService(metrics);
+          }
+          return sharedInstance;
         },
-        factory(_, ctx) {
-          return ctx;
-        },
-      }),
+      });
+    },
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5293,7 +5293,6 @@ __metadata:
     "@backstage/plugin-permission-common": "workspace:^"
     "@backstage/plugin-permission-node": "workspace:^"
     "@backstage/types": "workspace:^"
-    "@opentelemetry/api": "npm:^1.9.0"
     lodash: "npm:^4.17.21"
     msw: "npm:^1.0.0"
     yaml: "npm:^2.0.0"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Related to https://github.com/backstage/backstage/issues/33328

Migrates the internal SCM events metrics in the `@backstage/plugin-catalog-node` package to use the new alpha `MetricsService` API, replacing the previous use of OpenTelemetry's metrics API. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
