### PR TITLE
630:P2 [ChatGPT] Centralize mapping of Backstage errors to MCP client messages

### DIFF
--- a/docs/CSCI630-P1-Implementation-Summary.md
+++ b/docs/CSCI630-P1-Implementation-Summary.md
@@ -1,0 +1,40 @@
+# CSCI 630 Project 1 - Implementation Summary
+
+Tracking repository: `https://github.com/shahtirth07/backstage`
+
+## Completed Issues Per Member
+
+- `salonitilekar`: 5 issues completed (`#1`, `#3`, `#5`, `#7`, `#9`) across 6 merged PRs:
+  - `https://github.com/shahtirth07/backstage/pull/15`
+  - `https://github.com/shahtirth07/backstage/pull/16`
+  - `https://github.com/shahtirth07/backstage/pull/17`
+  - `https://github.com/shahtirth07/backstage/pull/18`
+  - `https://github.com/shahtirth07/backstage/pull/19`
+  - `https://github.com/shahtirth07/backstage/pull/20`
+- `shahtirth07`: 5 issues completed (`#2`, `#4`, `#6`, `#8`, `#10`) across 5 merged PRs:
+  - `https://github.com/shahtirth07/backstage/pull/11`
+  - `https://github.com/shahtirth07/backstage/pull/12`
+  - `https://github.com/shahtirth07/backstage/pull/13`
+  - `https://github.com/shahtirth07/backstage/pull/14`
+  - `https://github.com/shahtirth07/backstage/pull/21`
+
+## Quantitative Characterization of Improvements
+
+- `630:P1` issues closed: 10 / 10
+- Merged `630:P1` PRs: 11
+- Files touched by merged `630:P1` PRs: 17
+  - Test files added/updated: 12
+  - Documentation files updated: 2
+  - Non-test support files: 3
+- Net line changes across merged `630:P1` PRs: +1374 / -368
+
+## Deferred Issues
+
+- No selected `630:P1` issues were deferred in the final scope.
+- Issue `#5` (flakiness) was intentionally split into two smaller PRs for faster review and lower merge risk.
+
+## Test Debt Uncovered
+
+- Some browser-level E2E tests remain more brittle than unit/integration tests due to UI text and selector sensitivity.
+- Additional integration opportunities remain for richer proxy payload propagation checks and MCP service-identity happy-path calls over HTTP.
+- OpenAPI aggregation tests were strengthened, but conflict-heavy merge fixtures can still be expanded in follow-up work.

--- a/packages/app/e2e-tests/CreateEntityFlow.test.ts
+++ b/packages/app/e2e-tests/CreateEntityFlow.test.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { test, expect } from '@playwright/test';
+import { failOnBrowserErrors } from '@backstage/e2e-test-utils';
+
+failOnBrowserErrors();
+
+test('user can register an existing component via catalog import', async ({
+  page,
+}) => {
+  // Stub catalog location creation to keep the flow deterministic.
+  await page.route('**/api/catalog/locations**', async route => {
+    if (route.request().method() !== 'POST') {
+      return route.continue();
+    }
+
+    const requestBody = route.request().postDataJSON() as {
+      target?: string;
+    };
+    const target =
+      requestBody?.target ??
+      'https://github.com/backstage/backstage/blob/master/catalog-info.yaml';
+
+    return route.fulfill({
+      status: 201,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        location: { type: 'url', target },
+        entities: [
+          {
+            kind: 'Component',
+            metadata: {
+              name: 'imported-component-e2e',
+              namespace: 'default',
+            },
+          },
+        ],
+        exists: route.request().url().includes('dryRun=true') ? false : false,
+      }),
+    });
+  });
+
+  await page.goto('/');
+
+  const enterButton = page.getByRole('button', { name: 'Enter' });
+  await expect(enterButton).toBeVisible();
+  await enterButton.click();
+
+  await expect(page).toHaveURL(/\/catalog/);
+
+  await page.goto('/catalog-import');
+
+  await expect(
+    page.getByRole('heading', { name: 'Register an existing component' }),
+  ).toBeVisible();
+
+  const exampleUrl =
+    'https://github.com/backstage/backstage/blob/master/catalog-info.yaml';
+
+  await page.getByLabel('URL').fill(exampleUrl);
+  await page.getByRole('button', { name: 'Analyze' }).click();
+
+  await expect(
+    page.getByText('The following entities will be added to the catalog:'),
+  ).toBeVisible();
+  await expect(page.getByText('imported-component-e2e')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Import' }).click();
+
+  await expect(
+    page.getByText('The following entities have been added to the catalog:'),
+  ).toBeVisible();
+  await expect(page.getByText('imported-component-e2e')).toBeVisible();
+});

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -85,6 +85,7 @@
     "zen-observable": "^0.10.0"
   },
   "devDependencies": {
+    "@backstage/e2e-test-utils": "workspace:^",
     "@backstage/test-utils": "workspace:^",
     "@playwright/test": "^1.32.3",
     "@testing-library/dom": "^10.0.0",

--- a/packages/backend-test-utils/README.md
+++ b/packages/backend-test-utils/README.md
@@ -12,6 +12,30 @@ cd plugins/my-plugin-backend
 yarn add --dev @backstage/backend-test-utils
 ```
 
+## TestDatabases quick usage
+
+`TestDatabases` helps run the same integration test logic against one or more
+database engines.
+
+```ts
+import { TestDatabases } from '@backstage/backend-test-utils';
+
+describe('my plugin', () => {
+  const databases = TestDatabases.create();
+
+  it.each(databases.eachSupportedId())('works on %p', async databaseId => {
+    const knex = await databases.init(databaseId);
+    // run migrations, then execute assertions against your service/router
+  });
+});
+```
+
+For fast local iteration, disable Docker-backed database targets:
+
+```sh
+BACKSTAGE_TEST_DISABLE_DOCKER=1 yarn test --no-watch plugins/my-plugin-backend/src
+```
+
 ## Environment variables
 
 - `BACKSTAGE_TEST_DISABLE_DOCKER`

--- a/packages/core-components/src/components/AlertDisplay/AlertDisplay.test.tsx
+++ b/packages/core-components/src/components/AlertDisplay/AlertDisplay.test.tsx
@@ -113,34 +113,42 @@ describe('<AlertDisplay />', () => {
 
     it('renders message and then removes it', async () => {
       jest.useFakeTimers();
-      const { queryByText } = await renderInTestApp(
-        <TestApiProvider apis={apis}>
-          <AlertDisplay />
-        </TestApiProvider>,
-      );
+      try {
+        const { queryByText } = await renderInTestApp(
+          <TestApiProvider apis={apis}>
+            <AlertDisplay />
+          </TestApiProvider>,
+        );
 
-      expect(queryByText('transient message one')).toBeInTheDocument();
-      act(() => {
-        jest.advanceTimersByTime(5005);
-      });
-      expect(queryByText('transient message one')).not.toBeInTheDocument();
-      jest.useRealTimers();
+        expect(queryByText('transient message one')).toBeInTheDocument();
+        act(() => {
+          jest.advanceTimersByTime(5005);
+        });
+        expect(queryByText('transient message one')).not.toBeInTheDocument();
+      } finally {
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+      }
     });
 
     it('respects transientTimeoutMs prop', async () => {
       jest.useFakeTimers();
-      const { queryByText } = await renderInTestApp(
-        <TestApiProvider apis={apis}>
-          <AlertDisplay transientTimeoutMs={2500} />
-        </TestApiProvider>,
-      );
+      try {
+        const { queryByText } = await renderInTestApp(
+          <TestApiProvider apis={apis}>
+            <AlertDisplay transientTimeoutMs={2500} />
+          </TestApiProvider>,
+        );
 
-      expect(queryByText('transient message one')).toBeInTheDocument();
-      act(() => {
-        jest.advanceTimersByTime(2505);
-      });
-      expect(queryByText('transient message one')).not.toBeInTheDocument();
-      jest.useRealTimers();
+        expect(queryByText('transient message one')).toBeInTheDocument();
+        act(() => {
+          jest.advanceTimersByTime(2505);
+        });
+        expect(queryByText('transient message one')).not.toBeInTheDocument();
+      } finally {
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+      }
     });
   });
 
@@ -177,111 +185,123 @@ describe('<AlertDisplay />', () => {
 
     it('renders message and then removes it', async () => {
       jest.useFakeTimers();
-      const { queryByText } = await renderInTestApp(
-        <TestApiProvider apis={apis}>
-          <AlertDisplay />
-        </TestApiProvider>,
-      );
-      // Validate adding messages
-      expect(queryByText('transient message one')).toBeInTheDocument();
-      act(() => {
-        jest.advanceTimersByTime(1000);
-      });
-      expect(queryByText('transient message one')).toBeInTheDocument();
-      expect(queryByText('(1 newer message)')).toBeInTheDocument();
-      act(() => {
-        jest.advanceTimersByTime(1000);
-      });
-      expect(queryByText('transient message one')).toBeInTheDocument();
-      expect(queryByText('(2 newer messages)')).toBeInTheDocument();
+      try {
+        const { queryByText } = await renderInTestApp(
+          <TestApiProvider apis={apis}>
+            <AlertDisplay />
+          </TestApiProvider>,
+        );
+        // Validate adding messages
+        expect(queryByText('transient message one')).toBeInTheDocument();
+        act(() => {
+          jest.advanceTimersByTime(1000);
+        });
+        expect(queryByText('transient message one')).toBeInTheDocument();
+        expect(queryByText('(1 newer message)')).toBeInTheDocument();
+        act(() => {
+          jest.advanceTimersByTime(1000);
+        });
+        expect(queryByText('transient message one')).toBeInTheDocument();
+        expect(queryByText('(2 newer messages)')).toBeInTheDocument();
 
-      // Validate removing messages
-      act(() => {
-        jest.advanceTimersByTime(5000);
-      });
-      expect(queryByText('transient message two')).toBeInTheDocument();
-      expect(queryByText('(1 newer message)')).toBeInTheDocument();
+        // Validate removing messages
+        act(() => {
+          jest.advanceTimersByTime(5000);
+        });
+        expect(queryByText('transient message two')).toBeInTheDocument();
+        expect(queryByText('(1 newer message)')).toBeInTheDocument();
 
-      act(() => {
-        jest.advanceTimersByTime(5000);
-      });
-      expect(queryByText('transient message three')).toBeInTheDocument();
+        act(() => {
+          jest.advanceTimersByTime(5000);
+        });
+        expect(queryByText('transient message three')).toBeInTheDocument();
 
-      act(() => {
-        jest.advanceTimersByTime(5000);
-      });
-      expect(queryByText('transient message')).not.toBeInTheDocument();
-      jest.useRealTimers();
+        act(() => {
+          jest.advanceTimersByTime(5000);
+        });
+        expect(queryByText('transient message')).not.toBeInTheDocument();
+      } finally {
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+      }
     });
 
     it('renders 3 different messages with overlapping timeout', async () => {
       jest.useFakeTimers();
-      const { queryByText } = await renderInTestApp(
-        <TestApiProvider apis={apis}>
-          <AlertDisplay transientTimeoutMs={1500} />
-        </TestApiProvider>,
-      );
+      try {
+        const { queryByText } = await renderInTestApp(
+          <TestApiProvider apis={apis}>
+            <AlertDisplay transientTimeoutMs={1500} />
+          </TestApiProvider>,
+        );
 
-      // 3 messages stacked with 1.5s each, display times: 0-1.5, 1.5-3, 3-4.5
+        // 3 messages stacked with 1.5s each, display times: 0-1.5, 1.5-3, 3-4.5
 
-      // 0s in, only message 1
-      expect(queryByText('transient message one')).toBeInTheDocument();
+        // 0s in, only message 1
+        expect(queryByText('transient message one')).toBeInTheDocument();
 
-      // 1s in, message 1 still shown, message 2 added in background
-      act(() => jest.advanceTimersByTime(1000));
-      expect(queryByText('transient message one')).toBeInTheDocument();
-      expect(queryByText('(1 newer message)')).toBeInTheDocument();
+        // 1s in, message 1 still shown, message 2 added in background
+        act(() => jest.advanceTimersByTime(1000));
+        expect(queryByText('transient message one')).toBeInTheDocument();
+        expect(queryByText('(1 newer message)')).toBeInTheDocument();
 
-      // 2s in, message 2 now shown, message 3 added
-      act(() => jest.advanceTimersByTime(1000));
-      expect(queryByText('transient message two')).toBeInTheDocument();
-      expect(queryByText('(1 newer message)')).toBeInTheDocument();
+        // 2s in, message 2 now shown, message 3 added
+        act(() => jest.advanceTimersByTime(1000));
+        expect(queryByText('transient message two')).toBeInTheDocument();
+        expect(queryByText('(1 newer message)')).toBeInTheDocument();
 
-      // 3.5s in, message 3 now shown
-      act(() => jest.advanceTimersByTime(1500));
-      expect(queryByText('transient message three')).toBeInTheDocument();
+        // 3.5s in, message 3 now shown
+        act(() => jest.advanceTimersByTime(1500));
+        expect(queryByText('transient message three')).toBeInTheDocument();
 
-      // 5s in, all messages gone
-      act(() => jest.advanceTimersByTime(1500));
-      expect(queryByText('transient message three')).not.toBeInTheDocument();
-      jest.useRealTimers();
+        // 5s in, all messages gone
+        act(() => jest.advanceTimersByTime(1500));
+        expect(queryByText('transient message three')).not.toBeInTheDocument();
+      } finally {
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+      }
     });
 
     it('renders 3 different messages with overlapping timeout and manual removal', async () => {
       jest.useFakeTimers();
-      const { queryByText } = await renderInTestApp(
-        <TestApiProvider apis={apis}>
-          <AlertDisplay transientTimeoutMs={1500} />
-        </TestApiProvider>,
-      );
+      try {
+        const { queryByText } = await renderInTestApp(
+          <TestApiProvider apis={apis}>
+            <AlertDisplay transientTimeoutMs={1500} />
+          </TestApiProvider>,
+        );
 
-      // 3 messages stacked with 1.5s each, display times: 0-1.5, 1.5-3, 3-4.5
+        // 3 messages stacked with 1.5s each, display times: 0-1.5, 1.5-3, 3-4.5
 
-      // 0s in, only message 1
-      expect(queryByText('transient message one')).toBeInTheDocument();
+        // 0s in, only message 1
+        expect(queryByText('transient message one')).toBeInTheDocument();
 
-      // 1s in, message 1 still shown, message 2 added in background
-      act(() => jest.advanceTimersByTime(1000));
-      expect(queryByText('transient message one')).toBeInTheDocument();
-      expect(queryByText('(1 newer message)')).toBeInTheDocument();
+        // 1s in, message 1 still shown, message 2 added in background
+        act(() => jest.advanceTimersByTime(1000));
+        expect(queryByText('transient message one')).toBeInTheDocument();
+        expect(queryByText('(1 newer message)')).toBeInTheDocument();
 
-      // manually remove message 1
-      fireEvent.click(screen.getByTestId('error-button-close'));
-      expect(screen.getByText('transient message two')).toBeInTheDocument();
+        // manually remove message 1
+        fireEvent.click(screen.getByTestId('error-button-close'));
+        expect(screen.getByText('transient message two')).toBeInTheDocument();
 
-      // 2s in, message 2 now shown, message 3 added
-      act(() => jest.advanceTimersByTime(1000));
-      expect(queryByText('transient message two')).toBeInTheDocument();
-      expect(queryByText('(1 newer message)')).toBeInTheDocument();
+        // 2s in, message 2 now shown, message 3 added
+        act(() => jest.advanceTimersByTime(1000));
+        expect(queryByText('transient message two')).toBeInTheDocument();
+        expect(queryByText('(1 newer message)')).toBeInTheDocument();
 
-      // 3s in, message 3 now shown
-      act(() => jest.advanceTimersByTime(1500));
-      expect(queryByText('transient message three')).toBeInTheDocument();
+        // 3s in, message 3 now shown
+        act(() => jest.advanceTimersByTime(1500));
+        expect(queryByText('transient message three')).toBeInTheDocument();
 
-      // 4s in, all messages gone
-      act(() => jest.advanceTimersByTime(1500));
-      expect(queryByText('transient message three')).not.toBeInTheDocument();
-      jest.useRealTimers();
+        // 4s in, all messages gone
+        act(() => jest.advanceTimersByTime(1500));
+        expect(queryByText('transient message three')).not.toBeInTheDocument();
+      } finally {
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+      }
     });
   });
 
@@ -318,39 +338,43 @@ describe('<AlertDisplay />', () => {
 
     it('renders message and then removes it', async () => {
       jest.useFakeTimers();
-      const { queryByText } = await renderInTestApp(
-        <TestApiProvider apis={apis}>
-          <AlertDisplay />
-        </TestApiProvider>,
-      );
-      // Validate adding messages
-      expect(queryByText('transient message one')).toBeInTheDocument();
-      act(() => {
-        jest.advanceTimersByTime(1000);
-      });
-      expect(queryByText('transient message one')).toBeInTheDocument();
-      expect(queryByText('(1 newer message)')).toBeInTheDocument();
-      act(() => {
-        jest.advanceTimersByTime(1000);
-      });
-      expect(queryByText('transient message one')).toBeInTheDocument();
-      expect(queryByText('(2 newer messages)')).toBeInTheDocument();
+      try {
+        const { queryByText } = await renderInTestApp(
+          <TestApiProvider apis={apis}>
+            <AlertDisplay />
+          </TestApiProvider>,
+        );
+        // Validate adding messages
+        expect(queryByText('transient message one')).toBeInTheDocument();
+        act(() => {
+          jest.advanceTimersByTime(1000);
+        });
+        expect(queryByText('transient message one')).toBeInTheDocument();
+        expect(queryByText('(1 newer message)')).toBeInTheDocument();
+        act(() => {
+          jest.advanceTimersByTime(1000);
+        });
+        expect(queryByText('transient message one')).toBeInTheDocument();
+        expect(queryByText('(2 newer messages)')).toBeInTheDocument();
 
-      // Validate removing messages
-      act(() => {
-        jest.advanceTimersByTime(5000);
-      });
-      expect(queryByText('permanent message')).toBeInTheDocument();
-      expect(queryByText('(1 newer message)')).toBeInTheDocument();
+        // Validate removing messages
+        act(() => {
+          jest.advanceTimersByTime(5000);
+        });
+        expect(queryByText('permanent message')).toBeInTheDocument();
+        expect(queryByText('(1 newer message)')).toBeInTheDocument();
 
-      fireEvent.click(screen.getByTestId('error-button-close'));
-      expect(queryByText('transient message three')).toBeInTheDocument();
+        fireEvent.click(screen.getByTestId('error-button-close'));
+        expect(queryByText('transient message three')).toBeInTheDocument();
 
-      act(() => {
-        jest.advanceTimersByTime(5000);
-      });
-      expect(queryByText('transient message')).not.toBeInTheDocument();
-      jest.useRealTimers();
+        act(() => {
+          jest.advanceTimersByTime(5000);
+        });
+        expect(queryByText('transient message')).not.toBeInTheDocument();
+      } finally {
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+      }
     });
   });
 });

--- a/packages/core-components/src/components/AutoLogout/disconnectedUsers.test.ts
+++ b/packages/core-components/src/components/AutoLogout/disconnectedUsers.test.ts
@@ -67,26 +67,29 @@ describe('useLogoutDisconnectedUserEffect', () => {
   it('should call signOut if idle timeout passed', () => {
     jest.useFakeTimers();
 
-    const props: UseLogoutDisconnectedUserEffectProps = {
-      enableEffect: true,
-      autologoutIsEnabled: true,
-      idleTimeoutSeconds: 1,
-      lastSeenOnlineStore: {
-        ...mockTimestampStore,
-        get: jest.fn().mockReturnValue(new Date(Date.now() - 2000)), // 2 seconds before now
-      },
-      identityApi: mockIdentityApi,
-    };
+    try {
+      const props: UseLogoutDisconnectedUserEffectProps = {
+        enableEffect: true,
+        autologoutIsEnabled: true,
+        idleTimeoutSeconds: 1,
+        lastSeenOnlineStore: {
+          ...mockTimestampStore,
+          get: jest.fn().mockReturnValue(new Date(Date.now() - 2000)), // 2 seconds before now
+        },
+        identityApi: mockIdentityApi,
+      };
 
-    renderHook(() => useLogoutDisconnectedUserEffect(props));
+      renderHook(() => useLogoutDisconnectedUserEffect(props));
 
-    act(() => {
-      jest.advanceTimersByTime(2000);
-    });
+      act(() => {
+        jest.advanceTimersByTime(2000);
+      });
 
-    expect(mockIdentityApi.signOut).toHaveBeenCalled();
-
-    jest.useRealTimers();
+      expect(mockIdentityApi.signOut).toHaveBeenCalled();
+    } finally {
+      jest.runOnlyPendingTimers();
+      jest.useRealTimers();
+    }
   });
 
   it('should save the current time to the store when app is loaded', () => {

--- a/plugins/catalog-backend-module-backstage-openapi/src/InternalOpenApiDocumentationProvider.test.ts
+++ b/plugins/catalog-backend-module-backstage-openapi/src/InternalOpenApiDocumentationProvider.test.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  OpenAPIObject,
+  OperationObject,
+  PathItemObject,
+} from 'openapi3-ts';
+import yaml from 'yaml';
+import {
+  formatDefinition,
+  mergeSpecs,
+} from './InternalOpenApiDocumentationProvider';
+
+describe('InternalOpenApiDocumentationProvider helpers', () => {
+  describe('mergeSpecs', () => {
+    it('merges multiple plugin specs into a single OpenAPI document with base server', async () => {
+      const baseUrl = 'https://backstage.example.com';
+
+      const specA: OpenAPIObject = {
+        openapi: '3.0.0',
+        info: { title: 'Service A', version: '1.0.0' },
+        paths: {
+          '/service-a': {
+            get: {
+              operationId: 'getServiceA',
+            } as OperationObject,
+          } as PathItemObject,
+        },
+      };
+
+      const specB: OpenAPIObject = {
+        openapi: '3.0.0',
+        info: { title: 'Service B', version: '1.0.0' },
+        paths: {
+          '/service-b': {
+            post: {
+              operationId: 'createServiceB',
+            } as OperationObject,
+          } as PathItemObject,
+        },
+      };
+
+      const merged = await mergeSpecs({ baseUrl, specs: [specA, specB] });
+
+      expect(merged.openapi).toBe('3.0.3');
+      expect(merged.info?.title).toBe('Backstage API');
+      expect(merged.info?.version).toBe('1');
+
+      expect(merged.servers?.[0]?.url).toBe(baseUrl);
+
+      expect(Object.keys(merged.paths ?? {})).toEqual(
+        expect.arrayContaining(['/service-a', '/service-b']),
+      );
+      expect(
+        (merged.paths?.['/service-a']?.get as OperationObject)?.operationId,
+      ).toBe('getServiceA');
+      expect(
+        (merged.paths?.['/service-b']?.post as OperationObject)?.operationId,
+      ).toBe('createServiceB');
+    });
+  });
+
+  describe('formatDefinition', () => {
+    const definition: OpenAPIObject = {
+      openapi: '3.0.3',
+      info: {
+        title: 'Backstage API',
+        version: '1.0.0',
+      },
+      paths: {},
+    };
+
+    it('formats definition as pretty-printed JSON', () => {
+      const result = formatDefinition(definition, 'json');
+      expect(typeof result).toBe('string');
+
+      const parsed = JSON.parse(result);
+      expect(parsed).toEqual(definition);
+    });
+
+    it('formats definition as YAML', () => {
+      const result = formatDefinition(definition, 'yaml');
+      expect(typeof result).toBe('string');
+
+      const parsed = yaml.parse(result);
+      expect(parsed).toEqual(definition);
+    });
+
+    it('throws for unsupported format', () => {
+      expect(() => formatDefinition(definition, 'xml')).toThrow(
+        'Unsupported format type: xml',
+      );
+    });
+  });
+});

--- a/plugins/catalog-backend-module-backstage-openapi/src/InternalOpenApiDocumentationProvider.ts
+++ b/plugins/catalog-backend-module-backstage-openapi/src/InternalOpenApiDocumentationProvider.ts
@@ -69,7 +69,7 @@ const addTagsToSpec = (spec: OpenAPIObject, tag: string) => {
   });
 };
 
-const mergeSpecs = async ({
+export const mergeSpecs = async ({
   baseUrl,
   specs,
 }: {
@@ -155,7 +155,7 @@ const loadSpecs = async ({
   return mergeSpecs({ baseUrl, specs });
 };
 
-const formatDefinition = (
+export const formatDefinition = (
   definition: any,
   format: string | 'json' | 'yaml',
 ) => {

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.test.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.test.tsx
@@ -263,12 +263,7 @@ describe('<EntityListProvider />', () => {
       expect(result.current.entities.length).toBe(1);
     });
     expect(result.current.totalItems).toBe(1);
-
-    await expect(() =>
-      waitFor(() => {
-        expect(mockCatalogApi.getEntities).not.toHaveBeenCalledTimes(1);
-      }),
-    ).rejects.toThrow();
+    expect(mockCatalogApi.getEntities).toHaveBeenCalledTimes(1);
   });
 
   it('debounces multiple filter changes', async () => {
@@ -895,40 +890,50 @@ describe(`<EntityListProvider pagination={{ mode: 'offset' }} />`, () => {
   });
 
   it('fetch when frontend filters change', async () => {
-    const { result } = renderHook(() => useEntityList(), {
-      wrapper: createWrapper({ pagination }),
-    });
+    jest.useFakeTimers();
+    try {
+      const { result } = renderHook(() => useEntityList(), {
+        wrapper: createWrapper({ pagination }),
+      });
 
-    await waitFor(() => {
+      await act(async () => {
+        jest.advanceTimersByTime(20);
+        await Promise.resolve();
+      });
+
       expect(result.current.entities.length).toBe(2);
       expect(mockCatalogApi.queryEntities).toHaveBeenCalledTimes(1);
-    });
 
-    act(() =>
-      result.current.updateFilters({
-        user: EntityUserFilter.owned(ownershipEntityRefs),
-      }),
-    );
+      act(() =>
+        result.current.updateFilters({
+          user: EntityUserFilter.owned(ownershipEntityRefs),
+        }),
+      );
 
-    await waitFor(() => {
+      await act(async () => {
+        jest.advanceTimersByTime(20);
+        await Promise.resolve();
+      });
+
       expect(result.current.entities.length).toBe(1);
-    });
-
-    await waitFor(() => {
       expect(mockCatalogApi.queryEntities).toHaveBeenCalledTimes(2);
-    });
 
-    act(() =>
-      result.current.updateFilters({
-        user: EntityUserFilter.owned(ownershipEntityRefs),
-      }),
-    );
+      act(() =>
+        result.current.updateFilters({
+          user: EntityUserFilter.owned(ownershipEntityRefs),
+        }),
+      );
 
-    await expect(() =>
-      waitFor(() => {
-        expect(mockCatalogApi.queryEntities).toHaveBeenCalledTimes(3);
-      }),
-    ).rejects.toThrow();
+      await act(async () => {
+        jest.advanceTimersByTime(20);
+        await Promise.resolve();
+      });
+
+      expect(mockCatalogApi.queryEntities).toHaveBeenCalledTimes(2);
+    } finally {
+      jest.runOnlyPendingTimers();
+      jest.useRealTimers();
+    }
   });
 
   it('fetch when limit change', async () => {

--- a/plugins/mcp-actions-backend/src/services/handleErrors.test.ts
+++ b/plugins/mcp-actions-backend/src/services/handleErrors.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  AuthenticationError,
+  NotAllowedError,
+  NotFoundError,
+} from '@backstage/errors';
+import { handleErrors } from './handleErrors';
+
+describe('handleErrors', () => {
+  it.each([
+    {
+      error: new NotFoundError('Action "missing" not found'),
+      expected: 'NotFoundError: Action "missing" not found',
+    },
+    {
+      error: new AuthenticationError('Missing token'),
+      expected: 'AuthenticationError: Missing token',
+    },
+    {
+      error: new NotAllowedError('Actions must be invoked by a service'),
+      expected: 'NotAllowedError: Actions must be invoked by a service',
+    },
+  ])(
+    'maps $error.name to a deterministic MCP message',
+    async ({ error, expected }) => {
+      const result = await handleErrors(async () => {
+        throw error;
+      });
+
+      expect(result).toEqual({
+        content: [{ type: 'text', text: expected }],
+        isError: true,
+      });
+    },
+  );
+
+  it('rethrows unknown errors', async () => {
+    await expect(async () =>
+      handleErrors(async () => {
+        throw new Error('unexpected');
+      }),
+    ).rejects.toThrow('unexpected');
+  });
+});

--- a/plugins/mcp-actions-backend/src/services/handleErrors.ts
+++ b/plugins/mcp-actions-backend/src/services/handleErrors.ts
@@ -23,17 +23,19 @@ import {
 
 import { Server as McpServer } from '@modelcontextprotocol/sdk/server/index.js';
 
-const knownErrors = new Set([
-  'InputError',
-  'AuthenticationError',
-  'NotAllowedError',
-  'NotFoundError',
-  'ConflictError',
-  'NotModifiedError',
-  'NotImplementedError',
-  'ResponseError',
-  'ServiceUnavailableError',
-]);
+type ErrorMessageFormatter = (message: string) => string;
+
+const errorMessagePolicy: Record<string, ErrorMessageFormatter> = {
+  InputError: message => `InputError: ${message}`,
+  AuthenticationError: message => `AuthenticationError: ${message}`,
+  NotAllowedError: message => `NotAllowedError: ${message}`,
+  NotFoundError: message => `NotFoundError: ${message}`,
+  ConflictError: message => `ConflictError: ${message}`,
+  NotModifiedError: message => `NotModifiedError: ${message}`,
+  NotImplementedError: message => `NotImplementedError: ${message}`,
+  ResponseError: message => `ResponseError: ${message}`,
+  ServiceUnavailableError: message => `ServiceUnavailableError: ${message}`,
+};
 
 // Extracts the cause error, if the provided error is `ResponseError` or
 // `ForwardedError` with a cause.
@@ -58,9 +60,10 @@ function describeError(err: unknown): string {
     const serialized = serializeError(err);
 
     const { name, message } = extractCause(serialized);
+    const formatter = errorMessagePolicy[name];
 
-    if (knownErrors.has(name)) {
-      return `${name}: ${message}`;
+    if (formatter) {
+      return formatter(message);
     }
   }
 

--- a/plugins/proxy-backend/src/service/router.integration.test.ts
+++ b/plugins/proxy-backend/src/service/router.integration.test.ts
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { authServiceFactory } from '@backstage/backend-defaults/auth';
+import { httpAuthServiceFactory } from '@backstage/backend-defaults/httpAuth';
+import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
+import * as http from 'node:http';
+import * as net from 'node:net';
+
+function createMockUpstream(
+  handlers: Record<string, { status: number; body: Record<string, unknown> }>,
+): Promise<{ server: http.Server; url: string }> {
+  return new Promise(resolve => {
+    const server = http.createServer((req, res) => {
+      const path = req.url ?? '/';
+      const handler = handlers[path] ??
+        handlers['*'] ?? {
+          status: 200,
+          body: { ok: true },
+        };
+      res.writeHead(handler.status, {
+        'Content-Type': 'application/json',
+      });
+      res.end(JSON.stringify(handler.body));
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const port = (server.address() as net.AddressInfo).port;
+      resolve({ server, url: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+describe('proxy integration', () => {
+  it('forwards requests to two different proxy targets and propagates responses', async () => {
+    const upstreamA = await createMockUpstream({
+      '/': { status: 200, body: { source: 'a', ok: true } },
+    });
+    const upstreamB = await createMockUpstream({
+      '/': { status: 200, body: { source: 'b', ok: true } },
+    });
+
+    const config = {
+      backend: {
+        baseUrl: 'http://localhost:0',
+        listen: { port: 0 },
+      },
+      proxy: {
+        endpoints: {
+          '/route-a': {
+            target: upstreamA.url,
+            credentials: 'dangerously-allow-unauthenticated',
+          },
+          '/route-b': {
+            target: upstreamB.url,
+            credentials: 'dangerously-allow-unauthenticated',
+          },
+        },
+      },
+    };
+
+    const backend = await startTestBackend({
+      features: [
+        import('..'),
+        mockServices.rootConfig.factory({ data: config }),
+        authServiceFactory,
+        httpAuthServiceFactory,
+      ],
+    });
+
+    try {
+      const baseUrl = `http://localhost:${backend.server.port()}`;
+
+      const resA = await fetch(`${baseUrl}/api/proxy/route-a`);
+      expect(resA.status).toBe(200);
+      const bodyA = await resA.json();
+      expect(bodyA).toEqual({ source: 'a', ok: true });
+
+      const resB = await fetch(`${baseUrl}/api/proxy/route-b`);
+      expect(resB.status).toBe(200);
+      const bodyB = await resB.json();
+      expect(bodyB).toEqual({ source: 'b', ok: true });
+    } finally {
+      await new Promise<void>(resolve =>
+        upstreamA.server.close(() => resolve()),
+      );
+      await new Promise<void>(resolve =>
+        upstreamB.server.close(() => resolve()),
+      );
+      await backend.stop();
+    }
+  });
+
+  it('returns 404 for unconfigured proxy route', async () => {
+    const upstream = await createMockUpstream({
+      '/': { status: 200, body: { ok: true } },
+    });
+
+    const config = {
+      backend: {
+        baseUrl: 'http://localhost:0',
+        listen: { port: 0 },
+        auth: {
+          externalAccess: [
+            {
+              type: 'static',
+              options: { token: 'test-token', subject: 'test-subject' },
+            },
+          ],
+        },
+      },
+      proxy: {
+        endpoints: {
+          '/only-route': {
+            target: upstream.url,
+            credentials: 'dangerously-allow-unauthenticated',
+          },
+        },
+      },
+    };
+
+    const backend = await startTestBackend({
+      features: [
+        import('..'),
+        mockServices.rootConfig.factory({ data: config }),
+        authServiceFactory,
+        httpAuthServiceFactory,
+      ],
+    });
+
+    try {
+      const baseUrl = `http://localhost:${backend.server.port()}`;
+      const res = await fetch(`${baseUrl}/api/proxy/nonexistent-route`, {
+        headers: { Authorization: 'Bearer test-token' },
+      });
+      expect(res.status).toBe(404);
+    } finally {
+      await new Promise<void>(resolve =>
+        upstream.server.close(() => resolve()),
+      );
+      await backend.stop();
+    }
+  });
+
+  it('propagates upstream 404 and 500 errors', async () => {
+    const upstream = await createMockUpstream({
+      '/': { status: 200, body: { ok: true } },
+      '/not-found': { status: 404, body: { error: 'Not found' } },
+      '/error': { status: 500, body: { error: 'Internal error' } },
+    });
+
+    const config = {
+      backend: {
+        baseUrl: 'http://localhost:0',
+        listen: { port: 0 },
+      },
+      proxy: {
+        endpoints: {
+          '/upstream': {
+            target: upstream.url,
+            credentials: 'dangerously-allow-unauthenticated',
+          },
+        },
+      },
+    };
+
+    const backend = await startTestBackend({
+      features: [
+        import('..'),
+        mockServices.rootConfig.factory({ data: config }),
+        authServiceFactory,
+        httpAuthServiceFactory,
+      ],
+    });
+
+    try {
+      const baseUrl = `http://localhost:${backend.server.port()}`;
+
+      const res404 = await fetch(`${baseUrl}/api/proxy/upstream/not-found`);
+      expect(res404.status).toBe(404);
+
+      const res500 = await fetch(`${baseUrl}/api/proxy/upstream/error`);
+      expect(res500.status).toBe(500);
+    } finally {
+      await new Promise<void>(resolve =>
+        upstream.server.close(() => resolve()),
+      );
+      await backend.stop();
+    }
+  });
+});

--- a/plugins/search-react/src/components/SearchFilter/hooks.test.tsx
+++ b/plugins/search-react/src/components/SearchFilter/hooks.test.tsx
@@ -25,6 +25,11 @@ import { configApiRef } from '@backstage/core-plugin-api';
 
 jest.useFakeTimers();
 
+afterEach(() => {
+  jest.runOnlyPendingTimers();
+  jest.useRealTimers();
+});
+
 describe('SearchFilter.hooks', () => {
   describe('useDefaultFilterValue', () => {
     const configApiMock = mockApis.config({
@@ -275,19 +280,19 @@ describe('SearchFilter.hooks', () => {
       const asyncFn = jest.fn().mockResolvedValue(expectedValues);
       renderHook(() => useAsyncFilterValues(asyncFn, '', undefined, 1000));
 
-      expect(asyncFn).not.toHaveBeenCalled();
+      expect(asyncFn).toHaveBeenCalledTimes(0);
 
-      // Advance timers by 600ms
+      // Advance timers by 600ms, still below the 1000ms debounce window
       await act(async () => {
         jest.advanceTimersByTime(600);
       });
-      expect(asyncFn).not.toHaveBeenCalled();
+      expect(asyncFn).toHaveBeenCalledTimes(0);
 
-      // Another 600ms to exceed the 1000ms debounce
+      // Advance past the debounce window and verify exactly one invocation
       await act(async () => {
         jest.advanceTimersByTime(600);
       });
-      expect(asyncFn).toHaveBeenCalled();
+      expect(asyncFn).toHaveBeenCalledTimes(1);
     });
 
     it('should call provided method once per provided input', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3777,7 +3777,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage/e2e-test-utils@workspace:*, @backstage/e2e-test-utils@workspace:packages/e2e-test-utils":
+"@backstage/e2e-test-utils@workspace:*, @backstage/e2e-test-utils@workspace:^, @backstage/e2e-test-utils@workspace:packages/e2e-test-utils":
   version: 0.0.0-use.local
   resolution: "@backstage/e2e-test-utils@workspace:packages/e2e-test-utils"
   dependencies:
@@ -30726,6 +30726,7 @@ __metadata:
     "@backstage/core-app-api": "workspace:^"
     "@backstage/core-components": "workspace:^"
     "@backstage/core-plugin-api": "workspace:^"
+    "@backstage/e2e-test-utils": "workspace:^"
     "@backstage/frontend-app-api": "workspace:^"
     "@backstage/integration-react": "workspace:^"
     "@backstage/plugin-api-docs": "workspace:^"


### PR DESCRIPTION
Closes #26

## Summary
- Refactored `handleErrors` to use a centralized Backstage-error-to-MCP-message policy map.
- Removed scattered magic-string set checks and consolidated mapping logic into one structured policy.
- Added unit tests for representative mapped errors and unknown-error passthrough behavior.

## Verification
- `yarn test --no-watch plugins/mcp-actions-backend/src/services/handleErrors.test.ts plugins/mcp-actions-backend/src/services/McpService.test.ts plugins/mcp-actions-backend/src/plugin.test.ts`

## Evidence
- Mapping policy is now explicit and centralized in one location.
- Representative Backstage errors are covered with deterministic MCP message assertions.
- Existing behavior for unknown errors remains safe (rethrow).

Time log in hours -
- Triage/Understand: 0:15
- Plan: 0:15
- Implement: 0:30
- Verify: 0:30
- PR overhead: 0:15
- Review time (as reviewer): 0:00
- Rework after review: 0:15
- Session total: 2:00