### PR TITLE
refactor(catalog-node,catalog-backend): permissions cleanup step 2

### DIFF
--- a/.changeset/catalog-backend-permissions-cleanup-step-2.md
+++ b/.changeset/catalog-backend-permissions-cleanup-step-2.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Removed the internal `addPermissions` and `addPermissionRules` methods from `CatalogBuilder`, and removed the `catalogPermissionExtensionPoint` wiring from `CatalogPlugin`. Custom permission rules and permissions should be registered via `coreServices.permissionsRegistry` directly.

--- a/.changeset/catalog-node-permissions-cleanup-step-2.md
+++ b/.changeset/catalog-node-permissions-cleanup-step-2.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-node': minor
+---
+
+**BREAKING ALPHA**: Removed the deprecated `CatalogPermissionRuleInput`, `CatalogPermissionExtensionPoint`, and `catalogPermissionExtensionPoint` exports. Use `coreServices.permissionsRegistry` directly to register catalog entity permission rules and permissions.

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -52,7 +52,6 @@ import {
   ScmLocationAnalyzer,
 } from '@backstage/plugin-catalog-node';
 import { EventsService } from '@backstage/plugin-events-node';
-import { Permission } from '@backstage/plugin-permission-common';
 import { createConditionTransformer } from '@backstage/plugin-permission-node';
 import { durationToMilliseconds } from '@backstage/types';
 import { DefaultCatalogDatabase } from '../database/DefaultCatalogDatabase';
@@ -101,7 +100,6 @@ import { DefaultRefreshService } from './DefaultRefreshService';
 import { entitiesResponseToObjects } from './response';
 import {
   catalogEntityPermissionResourceRef,
-  CatalogPermissionRuleInput,
   CatalogScmEventsService,
 } from '@backstage/plugin-catalog-node/alpha';
 import { filterAndSortProcessors, filterProviders } from './util';
@@ -167,8 +165,6 @@ export class CatalogBuilder {
   }) => Promise<void> | void;
   private processingInterval: ProcessingIntervalFunction;
   private locationAnalyzer: LocationAnalyzer | undefined = undefined;
-  private readonly permissions: Permission[];
-  private readonly permissionRules: CatalogPermissionRuleInput[];
   private allowedLocationType: string[];
 
   /**
@@ -189,8 +185,6 @@ export class CatalogBuilder {
     this.locationAnalyzers = [];
     this.processorsReplace = false;
     this.parser = undefined;
-    this.permissions = [...catalogPermissions];
-    this.permissionRules = Object.values(catalogPermissionRules);
     this.allowedLocationType = ['url'];
 
     this.processingInterval = CatalogBuilder.getDefaultProcessingInterval(
@@ -366,33 +360,6 @@ export class CatalogBuilder {
   }
 
   /**
-   * Adds additional permissions. See
-   * {@link @backstage/plugin-permission-node#Permission}.
-   *
-   * @param permissions - Additional permissions
-   */
-  addPermissions(...permissions: Array<Permission | Array<Permission>>) {
-    this.permissions.push(...permissions.flat());
-    return this;
-  }
-
-  /**
-   * Adds additional permission rules. Permission rules are used to evaluate
-   * catalog resources against queries. See
-   * {@link @backstage/plugin-permission-node#PermissionRule}.
-   *
-   * @param permissionRules - Additional permission rules
-   */
-  addPermissionRules(
-    ...permissionRules: Array<
-      CatalogPermissionRuleInput | Array<CatalogPermissionRuleInput>
-    >
-  ) {
-    this.permissionRules.push(...permissionRules.flat());
-    return this;
-  }
-
-  /**
    * Sets up the allowed location types from being registered via the location service.
    *
    * @param allowedLocationTypes - the allowed location types
@@ -500,8 +467,8 @@ export class CatalogBuilder {
     permissionsRegistry.addResourceType({
       resourceRef: catalogEntityPermissionResourceRef,
       getResources,
-      permissions: this.permissions,
-      rules: this.permissionRules,
+      permissions: [...catalogPermissions],
+      rules: Object.values(catalogPermissionRules),
     });
 
     const scmEventHandlingConfig = readScmEventHandlingConfig(config);

--- a/plugins/catalog-backend/src/service/CatalogPlugin.ts
+++ b/plugins/catalog-backend/src/service/CatalogPlugin.ts
@@ -36,13 +36,9 @@ import {
 import {
   CatalogModelExtensionPoint,
   catalogModelExtensionPoint,
-  CatalogPermissionExtensionPoint,
-  catalogPermissionExtensionPoint,
-  CatalogPermissionRuleInput,
   catalogScmEventsServiceRef,
 } from '@backstage/plugin-catalog-node/alpha';
 import { eventsServiceRef } from '@backstage/plugin-events-node';
-import { Permission } from '@backstage/plugin-permission-common';
 import { merge } from 'lodash';
 import { CatalogBuilder } from './CatalogBuilder';
 import {
@@ -63,33 +59,6 @@ class CatalogLocationsExtensionPointImpl
 
   get allowedLocationTypes() {
     return this.#locationTypes;
-  }
-}
-
-class CatalogPermissionExtensionPointImpl
-  implements CatalogPermissionExtensionPoint
-{
-  #permissions = new Array<Permission>();
-  #permissionRules = new Array<CatalogPermissionRuleInput>();
-
-  addPermissions(...permission: Array<Permission | Array<Permission>>): void {
-    this.#permissions.push(...permission.flat());
-  }
-
-  addPermissionRules(
-    ...rules: Array<
-      CatalogPermissionRuleInput | Array<CatalogPermissionRuleInput>
-    >
-  ): void {
-    this.#permissionRules.push(...rules.flat());
-  }
-
-  get permissions() {
-    return this.#permissions;
-  }
-
-  get permissionRules() {
-    return this.#permissionRules;
   }
 }
 
@@ -189,12 +158,6 @@ export const catalogPlugin = createBackendPlugin({
       },
     });
 
-    const permissionExtensions = new CatalogPermissionExtensionPointImpl();
-    env.registerExtensionPoint(
-      catalogPermissionExtensionPoint,
-      permissionExtensions,
-    );
-
     const modelExtensions = new CatalogModelExtensionPointImpl();
     env.registerExtensionPoint(catalogModelExtensionPoint, modelExtensions);
 
@@ -282,8 +245,6 @@ export const catalogPlugin = createBackendPlugin({
         } else {
           builder.addLocationAnalyzers(...scmLocationAnalyzers);
         }
-        builder.addPermissions(...permissionExtensions.permissions);
-        builder.addPermissionRules(...permissionExtensions.permissionRules);
         builder.setFieldFormatValidators(modelExtensions.fieldValidators);
 
         if (locationTypeExtensions.allowedLocationTypes) {

--- a/plugins/catalog-node/report-alpha.api.md
+++ b/plugins/catalog-node/report-alpha.api.md
@@ -11,10 +11,7 @@ import { CatalogProcessorParser } from '@backstage/plugin-catalog-node';
 import { EntitiesSearchFilter } from '@backstage/plugin-catalog-node';
 import { Entity } from '@backstage/catalog-model';
 import { ExtensionPoint } from '@backstage/backend-plugin-api';
-import { Permission } from '@backstage/plugin-permission-common';
 import { PermissionResourceRef } from '@backstage/plugin-permission-node';
-import { PermissionRule } from '@backstage/plugin-permission-node';
-import { PermissionRuleParams } from '@backstage/plugin-permission-common';
 import { ServiceRef } from '@backstage/backend-plugin-api';
 import { Validators } from '@backstage/catalog-model';
 
@@ -46,26 +43,6 @@ export interface CatalogModelExtensionPoint {
 
 // @alpha (undocumented)
 export const catalogModelExtensionPoint: ExtensionPoint<CatalogModelExtensionPoint>;
-
-// @alpha @deprecated (undocumented)
-export interface CatalogPermissionExtensionPoint {
-  // (undocumented)
-  addPermissionRules(
-    ...rules: Array<
-      CatalogPermissionRuleInput | Array<CatalogPermissionRuleInput>
-    >
-  ): void;
-  // (undocumented)
-  addPermissions(...permissions: Array<Permission | Array<Permission>>): void;
-}
-
-// @alpha @deprecated (undocumented)
-export const catalogPermissionExtensionPoint: ExtensionPoint<CatalogPermissionExtensionPoint>;
-
-// @alpha @deprecated (undocumented)
-export type CatalogPermissionRuleInput<
-  TParams extends PermissionRuleParams = PermissionRuleParams,
-> = PermissionRule<Entity, EntitiesSearchFilter, 'catalog-entity', TParams>;
 
 // @alpha @deprecated (undocumented)
 export type CatalogProcessingExtensionPoint = CatalogProcessingExtensionPoint_2;

--- a/plugins/catalog-node/src/alpha.ts
+++ b/plugins/catalog-node/src/alpha.ts
@@ -100,8 +100,5 @@ export const catalogAnalysisExtensionPoint = _catalogAnalysisExtensionPoint;
 
 export type { CatalogModelExtensionPoint } from './extensions';
 export { catalogModelExtensionPoint } from './extensions';
-export type { CatalogPermissionRuleInput } from './extensions';
-export type { CatalogPermissionExtensionPoint } from './extensions';
-export { catalogPermissionExtensionPoint } from './extensions';
 
 export * from './scmEvents';

--- a/plugins/catalog-node/src/extensions.ts
+++ b/plugins/catalog-node/src/extensions.ts
@@ -19,17 +19,11 @@ import { Entity, Validators } from '@backstage/catalog-model';
 import {
   CatalogProcessor,
   CatalogProcessorParser,
-  EntitiesSearchFilter,
   EntityProvider,
   PlaceholderResolver,
   LocationAnalyzer,
   ScmLocationAnalyzer,
 } from '@backstage/plugin-catalog-node';
-import {
-  Permission,
-  PermissionRuleParams,
-} from '@backstage/plugin-permission-common';
-import { PermissionRule } from '@backstage/plugin-permission-node';
 
 /**
  * @public
@@ -162,34 +156,4 @@ export const catalogAnalysisExtensionPoint =
 export const catalogModelExtensionPoint =
   createExtensionPoint<CatalogModelExtensionPoint>({
     id: 'catalog.model',
-  });
-
-/**
- * @alpha
- * @deprecated Use the `coreServices.permissionsRegistry` instead.
- */
-export type CatalogPermissionRuleInput<
-  TParams extends PermissionRuleParams = PermissionRuleParams,
-> = PermissionRule<Entity, EntitiesSearchFilter, 'catalog-entity', TParams>;
-
-/**
- * @alpha
- * @deprecated Use the `coreServices.permissionsRegistry` instead.
- */
-export interface CatalogPermissionExtensionPoint {
-  addPermissions(...permissions: Array<Permission | Array<Permission>>): void;
-  addPermissionRules(
-    ...rules: Array<
-      CatalogPermissionRuleInput | Array<CatalogPermissionRuleInput>
-    >
-  ): void;
-}
-
-/**
- * @alpha
- * @deprecated Use the `coreServices.permissionsRegistry` instead.
- */
-export const catalogPermissionExtensionPoint =
-  createExtensionPoint<CatalogPermissionExtensionPoint>({
-    id: 'catalog.permission',
   });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is step 2 of the catalog permissions cleanup, following #33743.

### Changes

**`@backstage/plugin-catalog-node`** (breaking alpha):
- Removed the deprecated `CatalogPermissionRuleInput` type
- Removed the deprecated `CatalogPermissionExtensionPoint` interface
- Removed the deprecated `catalogPermissionExtensionPoint` extension point

**`@backstage/plugin-catalog-backend`** (internal):
- Removed `CatalogPermissionExtensionPointImpl` class and its registration in `CatalogPlugin`
- Removed `addPermissions` and `addPermissionRules` methods from `CatalogBuilder`
- Inlined the built-in catalog permissions and rules directly into `permissionsRegistry.addResourceType`

Custom permission rules and permissions should now be registered via `coreServices.permissionsRegistry` directly.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Made with [Cursor](https://cursor.com)