### PR TITLE
fix(search-react): fix SearchFilter.Autocomplete with multiple prop 

### DIFF
--- a/.changeset/kind-lights-agree.md
+++ b/.changeset/kind-lights-agree.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-react': patch
+---
+
+fix(search-react): fix Autocomplete filter with multiple prop

--- a/plugins/search-react/src/components/SearchFilter/SearchFilter.Autocomplete.test.tsx
+++ b/plugins/search-react/src/components/SearchFilter/SearchFilter.Autocomplete.test.tsx
@@ -447,5 +447,101 @@ describe('SearchFilter.Autocomplete', () => {
         ).toBeInTheDocument();
       });
     });
+
+    it('allows typing after first selection', async () => {
+      const moreValues = ['value1', 'value2', 'value3'];
+      render(
+        <TestApiProvider
+          apis={[
+            [searchApiRef, searchApiMock],
+            [configApiRef, configApiMock],
+          ]}
+        >
+          <SearchContextProvider>
+            <SearchFilter.Autocomplete
+              multiple
+              name={name}
+              values={moreValues}
+            />
+            <SearchContextFilterSpy name={name} />
+          </SearchContextProvider>
+        </TestApiProvider>,
+      );
+
+      const autocomplete = screen.getByRole('combobox');
+      const input = within(autocomplete).getByRole('textbox');
+
+      // Select the first option.
+      await userEvent.click(input);
+      await waitFor(() => {
+        screen.getByRole('listbox');
+      });
+      await userEvent.click(
+        screen.getByRole('option', { name: moreValues[0] }),
+      );
+
+      // Verify the first value is selected.
+      await waitFor(() => {
+        expect(screen.getByTestId(`${name}-filter-spy`)).toHaveTextContent(
+          moreValues[0],
+        );
+      });
+
+      // Type into the input after the first selection.
+      await userEvent.type(input, 'value');
+
+      // The typed text should appear in the input (not be eaten).
+      await waitFor(() => {
+        expect(input).toHaveValue('value');
+      });
+    });
+
+    it('allows typing after removing a selection', async () => {
+      render(
+        <TestApiProvider
+          apis={[
+            [searchApiRef, searchApiMock],
+            [configApiRef, configApiMock],
+          ]}
+        >
+          <SearchContextProvider>
+            <SearchFilter.Autocomplete multiple name={name} values={values} />
+            <SearchContextFilterSpy name={name} />
+          </SearchContextProvider>
+        </TestApiProvider>,
+      );
+
+      const autocomplete = screen.getByRole('combobox');
+      const input = within(autocomplete).getByRole('textbox');
+
+      // Select the first option.
+      await userEvent.click(input);
+      await waitFor(() => {
+        screen.getByRole('listbox');
+      });
+      await userEvent.click(screen.getByRole('option', { name: values[0] }));
+
+      // Verify the first value is selected.
+      await waitFor(() => {
+        expect(screen.getByTestId(`${name}-filter-spy`)).toHaveTextContent(
+          values[0],
+        );
+      });
+
+      // Remove the selection via the Clear button.
+      const clearButton = within(autocomplete).getByLabelText('Clear');
+      await userEvent.click(clearButton);
+      await waitFor(() => {
+        expect(screen.getByTestId(`${name}-filter-spy`)).toHaveTextContent('');
+      });
+
+      // Type into the input after removing the selection.
+      await userEvent.type(input, 'val');
+
+      // The typed text should appear in the input.
+      await waitFor(() => {
+        expect(input).toHaveValue('val');
+      });
+    });
   });
 });

--- a/plugins/search-react/src/components/SearchFilter/SearchFilter.Autocomplete.tsx
+++ b/plugins/search-react/src/components/SearchFilter/SearchFilter.Autocomplete.tsx
@@ -153,7 +153,9 @@ export const AutocompleteFilter = (props: SearchAutocompleteFilterProps) => {
         }
       }}
       getOptionLabel={option => option.label}
-      getOptionSelected={(option, value) => !!value && option.value === value.value}
+      getOptionSelected={(option, value) =>
+        !!value && option.value === value.value
+      }
       renderInput={renderInput}
       renderTags={renderTags}
     />

--- a/plugins/search-react/src/components/SearchFilter/SearchFilter.Autocomplete.tsx
+++ b/plugins/search-react/src/components/SearchFilter/SearchFilter.Autocomplete.tsx
@@ -153,7 +153,7 @@ export const AutocompleteFilter = (props: SearchAutocompleteFilterProps) => {
         }
       }}
       getOptionLabel={option => option.label}
-      getOptionSelected={(option, value) => option.value === value.value}
+      getOptionSelected={(option, value) => !!value && option.value === value.value}
       renderInput={renderInput}
       renderTags={renderTags}
     />

--- a/plugins/search-react/src/components/SearchFilter/SearchFilter.Autocomplete.tsx
+++ b/plugins/search-react/src/components/SearchFilter/SearchFilter.Autocomplete.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ChangeEvent, useState, useMemo } from 'react';
+import { ChangeEvent, useState, useRef } from 'react';
 import Chip from '@material-ui/core/Chip';
 import TextField from '@material-ui/core/TextField';
 import Autocomplete, {
@@ -66,13 +66,22 @@ export const AutocompleteFilter = (props: SearchAutocompleteFilterProps) => {
     valuesDebounceMs,
   );
   const { filters, setFilters } = useSearch();
-  const filterValueWithLabel = ensureFilterValueWithLabel(
-    filters[name] as string | string[] | undefined,
-  );
-  const filterValue = useMemo(
-    () => filterValueWithLabel || (multiple ? [] : null),
-    [filterValueWithLabel, multiple],
-  );
+
+  // Stabilize filterValue to prevent referential changes on every render.
+  // ensureFilterValueWithLabel creates new objects each time, which would
+  // cause MUI Autocomplete to reset the input (via onInputChange 'reset').
+  const filterValueRef = useRef<
+    FilterValueWithLabel | FilterValueWithLabel[] | null
+  >(multiple ? [] : null);
+  const rawFilterValue = filters[name] as string | string[] | undefined;
+  const serializedRaw = JSON.stringify(rawFilterValue);
+  const prevSerializedRef = useRef<string | undefined>(undefined);
+  if (prevSerializedRef.current !== serializedRaw) {
+    prevSerializedRef.current = serializedRaw;
+    const withLabel = ensureFilterValueWithLabel(rawFilterValue);
+    filterValueRef.current = withLabel || (multiple ? [] : null);
+  }
+  const filterValue = filterValueRef.current;
 
   // Set new filter values on input change.
   const handleChange = (
@@ -92,6 +101,15 @@ export const AutocompleteFilter = (props: SearchAutocompleteFilterProps) => {
       }
       return { ...others };
     });
+
+    // Since we ignore 'reset' reason in onInputChange (to prevent the input
+    // from being cleared on every re-render), we must explicitly clear or
+    // update the input after a selection.
+    if (multiple) {
+      setInputValue('');
+    } else {
+      setInputValue(newValue && !Array.isArray(newValue) ? newValue.label : '');
+    }
   };
 
   // Provide the input field.
@@ -125,8 +143,17 @@ export const AutocompleteFilter = (props: SearchAutocompleteFilterProps) => {
       loading={loading}
       value={filterValue}
       onChange={handleChange}
-      onInputChange={(_, newValue) => setInputValue(newValue)}
+      inputValue={inputValue}
+      onInputChange={(_, newValue, reason) => {
+        // In multiple mode, ignore 'reset' to prevent MUI from clearing the
+        // input when the value prop reference changes on re-render.
+        // In single mode, 'reset' is needed to display the selected label.
+        if (reason !== 'reset' || !multiple) {
+          setInputValue(newValue);
+        }
+      }}
       getOptionLabel={option => option.label}
+      getOptionSelected={(option, value) => option.value === value.value}
       renderInput={renderInput}
       renderTags={renderTags}
     />


### PR DESCRIPTION
Fixed #33724

## Summary

Fixes an issue where `SearchFilter.Autocomplete` stopped accepting typed input after the first selection when used with `multiple`.

This also affected typing after removing a selected value.

## Root Cause

The issue was caused by a combination of:

* unstable `filterValue` object references on re-render
* missing `getOptionSelected` for value-based matching
* uncontrolled `inputValue`, which allowed MUI to clear input on internal resets

This caused MUI `Autocomplete` to trigger `onInputChange(..., 'reset')` and clear the typed input unexpectedly.

## Fix

* stabilized `filterValue` so it only updates when the underlying filter values change
* added `getOptionSelected={(option, value) => option.value === value.value}`
* controlled `inputValue` in `multiple` mode
* ignored `reason === 'reset'` in `multiple` mode
* explicitly cleared the input after selection

##After Fix
<img width="771" height="453" alt="backstage-fix" src="https://github.com/user-attachments/assets/e7f090e5-2820-4d21-bcdb-51311d603fb1" />

Single-select behavior remains unchanged.

## Tests

Added regression coverage for:

* typing after the first selection
* typing after removing a selection

All tests pass (`13/13`).

## Documentation

No user-facing API changes.

Regression tests were added to document and protect the expected `multiple` selection behavior.

## Checklist

* [x] A changeset describing the change and affected packages
* [ ] Added or updated documentation
* [x] Tests for new functionality and regression coverage for bug fixes
* [x] Screenshots attached (for UI changes)
* [x] All commits include a `Signed-off-by` line

