### PR TITLE
docs: fix typos and update stale links in docs

### DIFF
--- a/docs/features/kubernetes/authentication.md
+++ b/docs/features/kubernetes/authentication.md
@@ -145,8 +145,8 @@ The providers available as client side are:
 - `google`
 - `oidc`
 
-[1]: https://docs.microsoft.com/en-us/azure/aks/managed-aad
-[2]: https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest
+[1]: https://learn.microsoft.com/en-us/azure/aks/managed-aad
+[2]: https://learn.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest
 [3]: https://docs.aws.amazon.com/IAM/latest/UserGuide/when-to-use-iam.html
 [4]: https://github.com/backstage/backstage/blob/master/packages/integration-aws-node/README.md
 [5]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html

--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -124,9 +124,9 @@ Valid values are:
 - `multiTenant` - This configuration assumes that all components run on all the
   provided clusters.
 
-- `singleTenant` - This configuration assumes that current component run on one cluster in provided clusters.
+- `singleTenant` - This configuration assumes the current component runs on one of the provided clusters.
 
-- `catalogRelation` - This configuration assumes that the current component runs only on all clusters it is dependant on.
+- `catalogRelation` - This configuration assumes that the current component runs only on all clusters it is dependent on.
 
 ### `clusterLocatorMethods`
 
@@ -257,7 +257,7 @@ cluster. Valid values are:
 | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `aks`                  | This will use a user's AKS access token from the [Microsoft auth provider](https://backstage.io/docs/auth/microsoft/provider) to access the Kubernetes API on AKS clusters.                                                                                                                                                               |
 | `aws`                  | This will use AWS credentials to access resources in EKS clusters                                                                                                                                                                                                                                                                         |
-| `azure`                | This will use [Azure Identity](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview) to access resources in clusters                                                                                                                                                                       |
+| `azure`                | This will use [Azure Identity](https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview) to access resources in clusters                                                                                                                                                                       |
 | `google`               | This will use a user's Google access token from the [Google auth provider](https://backstage.io/docs/auth/google/provider) to access the Kubernetes API on GKE clusters.                                                                                                                                                                  |
 | `googleServiceAccount` | This will use the Google Cloud service account credentials to access resources in clusters                                                                                                                                                                                                                                                |
 | `oidc`                 | This will use [Oidc Tokens](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#openid-connect-tokens) to authenticate to the Kubernetes API. When this is used the `oidcTokenProvider` field should also be set. Please note the cluster must support OIDC, at the time of writing AKS clusters do not support OIDC. |

--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -126,7 +126,7 @@ Valid values are:
 
 - `singleTenant` - This configuration assumes the current component runs on one of the provided clusters.
 
-- `catalogRelation` - This configuration assumes that the current component runs only on all clusters it is dependent on.
+- `catalogRelation` - This configuration assumes that the current component runs only on the clusters it depends on.
 
 ### `clusterLocatorMethods`
 

--- a/docs/features/techdocs/configuration.md
+++ b/docs/features/techdocs/configuration.md
@@ -475,11 +475,11 @@ techdocs:
 
 (Required) An account name to write to a storage blob container.
 
-https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key
+https://learn.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key
 
 (Optional) An account key is required to write to a storage container. If missing, `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` environment variables will be used.
 
-https://docs.microsoft.com/en-us/azure/storage/common/storage-auth?toc=/azure/storage/blobs/toc.json
+https://learn.microsoft.com/en-us/azure/storage/common/storage-auth?toc=/azure/storage/blobs/toc.json
 
 **Example:**
 

--- a/docs/features/techdocs/configuring-ci-cd.md
+++ b/docs/features/techdocs/configuring-ci-cd.md
@@ -61,7 +61,7 @@ On GitHub Actions, you can add a step
 [`- uses: actions@checkout@v3`](https://github.com/actions/checkout).
 
 On CircleCI, you can add a special
-[`checkout`](https://circleci.com/docs/2.0/configuration-reference/#checkout)
+[`checkout`](https://circleci.com/docs/configuration-reference/#checkout)
 step.
 
 Eventually we are trying to do a `git clone <https://path/to/docs-repository/>`.

--- a/docs/features/techdocs/using-cloud-storage.md
+++ b/docs/features/techdocs/using-cloud-storage.md
@@ -360,7 +360,7 @@ you should be able to see
 ## Configuring Azure Blob Storage Container with TechDocs
 
 Follow the
-[official Azure Blob Storage documentation](https://docs.microsoft.com/en-us/azure/storage/common/storage-auth?toc=/azure/storage/blobs/toc.json)
+[official Azure Blob Storage documentation](https://learn.microsoft.com/en-us/azure/storage/common/storage-auth?toc=/azure/storage/blobs/toc.json)
 for the latest instructions on the following steps involving Azure Blob Storage.
 
 **1. Set `techdocs.publisher.type` config in your `app-config.yaml`**
@@ -376,7 +376,7 @@ techdocs:
 **2. Create an Azure Blob Storage Container**
 
 Create a dedicated container for TechDocs sites.
-[Refer to the official documentation](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-portal).
+[Refer to the official documentation](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-portal).
 
 TechDocs will publish documentation to this container and will fetch files from
 here to serve documentation in Backstage. Note that the container names are
@@ -410,7 +410,7 @@ If running in Azure Virtual Machines or Azure Kubernetes Service (AKS) with mana
 identity, no additional configuration apart from the `accountName` and
 `containerName` may be needed.
 For other scenarios, you can use a
-[service principal](https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal)
+[service principal](https://learn.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal)
 by setting:
 
 - `AZURE_CLIENT_ID`
@@ -446,7 +446,7 @@ follow these steps.
 
 To get credentials, access the Azure Portal and go to "Settings > Access Keys",
 and get your Storage account name and Primary Key.
-https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key
+https://learn.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key
 for more details.
 
 ```yaml

--- a/docs/frontend-system/building-plugins/06-swappable-components.md
+++ b/docs/frontend-system/building-plugins/06-swappable-components.md
@@ -20,9 +20,9 @@ import { createSwappableComponent } from '@backstage/frontend-plugin-api';
 export const ExampleSwappableComponent = createSwappableComponent({
   name: 'example',
 
-  // This is a loader for loading the default implementation of the component when there's no overriden
+  // This is a loader for loading the default implementation of the component when there's no overridden
   // implementation created with `SwappableComponentBlueprint`.
-  // It can be sync like below, but is can also be async like `loader: () => import('./DefaultImplementation').then(m => m.DefaultImplementation)`.
+  // It can be sync like below, but it can also be async like `loader: () => import('./DefaultImplementation').then(m => m.DefaultImplementation)`.
   loader: () => (props: { name: string }) =>
     <div>Your name is {props.name}</div>,
 
@@ -60,7 +60,7 @@ import appPlugin from '@backstage/plugin-app';
 
 const app = createApp({
   features: [
-    // Using a module to provide the extenion to the app
+    // Using a module to provide the extension to the app
     createFrontendModule({
       pluginId: 'app',
       extensions: [
@@ -74,7 +74,7 @@ const app = createApp({
         }),
       ],
     }),
-    // Core components that already ship with the app plugin can be overriden using getExtension()
+    // Core components that already ship with the app plugin can be overridden using getExtension()
     appPlugin.withOverrides({
       extensions: [
         appPlugin.getExtension('component:app/core-progress').override({

--- a/docs/getting-started/config/database.md
+++ b/docs/getting-started/config/database.md
@@ -17,7 +17,7 @@ By the end of this tutorial, you will have a working PostgreSQL database hooked 
 This guide assumes a basic understanding of working on a Linux based operating system and have some experience with the terminal, specifically, these commands: `apt-get`, `psql`, `yarn`.
 
 - Access to a Linux-based operating system, such as Linux, MacOS or
-  [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/)
+  [Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/)
 - An account with elevated rights to install prerequisites on your operating
   system
 - If the database is not hosted on the same server as the Backstage app, the

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -70,7 +70,7 @@ This guide also assumes a basic understanding of working on a Linux based operat
 - A minimum of 20 GB disk space to run the standalone Backstage application with demo data. NOTE: As you add more modules and plugins to an installation, the disk space requirements will increase, accordingly.
 - A minimum of 6 GB memory.
 - Access to a Unix-based operating system, such as Linux, macOS or
-  [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/). The Linux version must support the required Node.js version.
+  [Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/). The Linux version must support the required Node.js version.
 - A GNU-like build environment available at the command line.
   For example, on Debian/Ubuntu you will want to have the `make` and `build-essential` packages installed.
   On macOS, you will want to run `xcode-select --install` to get the XCode command line build tooling in place.

--- a/docs/golden-path/create-app/npx-create-app.md
+++ b/docs/golden-path/create-app/npx-create-app.md
@@ -27,7 +27,7 @@ To be clear, this is not a production-ready installation, and it does not contai
 This guide also assumes a basic understanding of working on a Linux based operating system and have some experience with the terminal, specifically, these commands: `npm`, `yarn`.
 
 - Access to a Unix-based operating system, such as Linux, macOS or
-  [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/)
+  [Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/)
 - A GNU-like build environment available at the command line.
   For example, on Debian/Ubuntu you will want to have the `make` and `build-essential` packages installed.
   On macOS, you will want to have run `xcode-select --install` to get the XCode command line build tooling in place.

--- a/docs/integrations/azure/discovery.md
+++ b/docs/integrations/azure/discovery.md
@@ -76,7 +76,7 @@ The parameters available are:
 
 :::note Note
 
-- The path parameter follows the same rules as the search on Azure DevOps web interface. For more details visit the [official search documentation](https://docs.microsoft.com/en-us/azure/devops/project/search/get-started-search?view=azure-devops).
+- The path parameter follows the same rules as the search on Azure DevOps web interface. For more details visit the [official search documentation](https://learn.microsoft.com/en-us/azure/devops/project/search/get-started-search?view=azure-devops).
 - To use branch parameters, it is necessary that the desired branch be added to the "Searchable branches" list within Azure DevOps Repositories. To do this, follow the instructions below:
 
 1. Access your Azure DevOps and open the repository in which you want to add the branch.

--- a/docs/integrations/azure/locations.md
+++ b/docs/integrations/azure/locations.md
@@ -82,7 +82,7 @@ integrations:
         - personalAccessToken: ${PERSONAL_ACCESS_TOKEN}
 ```
 
-See the Azure DevOps documentation on how to create a [personal access token](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate)
+See the Azure DevOps documentation on how to create a [personal access token](https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate)
 
 ### Using a service principal with a managed identity to generate the client assertion
 

--- a/docs/integrations/azure/org.md
+++ b/docs/integrations/azure/org.md
@@ -86,7 +86,7 @@ To authenticate with a certificate rather than a client secret, you can set the 
 If deploying to resources that supports Managed Identity, and has identities configured (e.g. Azure App Services, Azure Container Apps), Managed Identity should be picked up without any additional configuration.
 If your app has multiple managed identities, you may need to set the `AZURE_CLIENT_ID` environment variable to tell Azure Identity which identity to use.
 
-To grant the managed identity the same permissions as mentioned in _App Registration_ above, [please follow this guide](https://docs.microsoft.com/en-us/azure/app-service/tutorial-connect-app-access-microsoft-graph-as-app-javascript?tabs=azure-powershell)
+To grant the managed identity the same permissions as mentioned in _App Registration_ above, [please follow this guide](https://learn.microsoft.com/en-us/azure/app-service/tutorial-connect-app-access-microsoft-graph-as-app-javascript?tabs=azure-powershell)
 
 ## Filtering imported Users and Groups
 


### PR DESCRIPTION
Hey, I just made a Pull Request!

Fix typos and update stale external links across several docs.

**Typos:**
- `docs/frontend-system/building-plugins/06-swappable-components.md`: "overriden" → "overridden" (twice), "extenion" → "extension"
- `docs/features/kubernetes/configuration.md`: "dependant" → "dependent"

**Stale links:**
- `docs/features/techdocs/configuring-ci-cd.md`: CircleCI docs URL updated from `/docs/2.0/configuration-reference/` to `/docs/configuration-reference/` following CircleCI's docs restructure
- Multiple files: Updated 14 `docs.microsoft.com` links to `learn.microsoft.com`, consistent with links already present elsewhere in the same files

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. (not required — docs-only change)
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.