### PR TITLE
docs: document availableLanguages and defaultLanguage for i18n in new frontend system

### DIFF
--- a/docs/frontend-system/building-plugins/07-internationalization.md
+++ b/docs/frontend-system/building-plugins/07-internationalization.md
@@ -295,7 +295,7 @@ const app = createApp({
 
 ### Declaring available languages
 
-Installing translation extensions makes the translated messages available, but the language switcher in the Settings page only appears once you declare which languages your app supports. Configure this in your `app-config.yaml` using the `api:app/app-language` extension:
+Installing translation extensions makes the translated messages available, but the language switcher in the Settings page only appears once you declare two or more supported languages. Configure this in your `app-config.yaml` using the `api:app/app-language` extension:
 
 ```yaml
 app:
@@ -308,9 +308,9 @@ app:
           defaultLanguage: en
 ```
 
-The `availableLanguages` array controls which languages appear as options in the Settings page. The `defaultLanguage` sets the language used before the user makes a selection, and defaults to `en` if not specified.
+The `availableLanguages` array controls which languages appear as options in the Settings page. The `defaultLanguage` sets the language used before the user makes a selection, and defaults to `en` if not specified. If you configure `availableLanguages`, the `defaultLanguage` must be one of those entries — if you omit `defaultLanguage`, make sure `en` is included in `availableLanguages`, otherwise the app can fail to start.
 
-Go to the Settings page — you should see language switching buttons. Switch languages to verify your translations are loaded correctly.
+Go to the Settings page — you should see a language select dropdown. Switch languages to verify your translations are loaded correctly.
 
 ### Using the CLI for full translation workflows
 


### PR DESCRIPTION
Hey, I just made a Pull Request!

The "Adding language translations" section of the new frontend system i18n docs explains how to install translation extensions using `TranslationBlueprint`, but does not explain how to make the language switcher appear in the Settings page.

Support for `availableLanguages` and `defaultLanguage` was added to the `api:app/app-language` extension in v1.46.0 (`@backstage/plugin-app@0.3.3`), but was never documented in this page. Without declaring `availableLanguages` in `app-config.yaml`, the language toggle in Settings does not appear even when translations are correctly installed.

This adds a "Declaring available languages" section with the correct `app-config.yaml` syntax, sourced from the extension config schema in `plugins/app/src/extensions/AppLanguageApi.ts` and the example in the root `app-config.yaml`.

Closes #31538

#### ✔️ Checklist

- [ ] A changeset describing the change and affected packages. (not required — docs-only change)
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.
