### PR TITLE
fix(ui): hide Tabs active indicator when no tab matches route

### DIFF
--- a/.changeset/two-zoos-teach.md
+++ b/.changeset/two-zoos-teach.md
@@ -1,0 +1,7 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed the Tabs active indicator not hiding when no tab matches the current route.
+
+**Affected components:** Tabs

--- a/packages/ui/src/components/Tabs/Tabs.module.css
+++ b/packages/ui/src/components/Tabs/Tabs.module.css
@@ -26,6 +26,7 @@
     --active-tab-width: 0px;
     --active-tab-height: 0px;
     --active-transition-duration: 0s;
+    --active-tab-opacity: 0;
 
     --hovered-tab-left: 0px;
     --hovered-tab-right: 0px;
@@ -76,7 +77,7 @@
     border-radius: 4px;
     transition: left var(--active-transition-duration) ease-out,
       opacity 0.15s ease-out, width var(--active-transition-duration) ease-out;
-    opacity: 1;
+    opacity: var(--active-tab-opacity);
   }
 
   .bui-TabHovered {

--- a/packages/ui/src/components/Tabs/TabsIndicators.tsx
+++ b/packages/ui/src/components/Tabs/TabsIndicators.tsx
@@ -37,7 +37,7 @@ export const TabsIndicators = (props: TabsIndicatorsProps) => {
     const tabsRect = tabsRef.current.getBoundingClientRect();
 
     // Set active tab variables
-    if (state?.selectedKey) {
+    if (state?.selectedKey != null && state.selectedKey !== '') {
       const activeTab = tabRefs.current.get(state.selectedKey.toString());
 
       if (activeTab) {
@@ -98,7 +98,11 @@ export const TabsIndicators = (props: TabsIndicatorsProps) => {
           '--active-tab-height',
           `${activeRect.height}px`,
         );
+        tabsRef.current.style.setProperty('--active-tab-opacity', '1');
       }
+    } else {
+      tabsRef.current.style.setProperty('--active-tab-opacity', '0');
+      prevSelectedKey.current = null;
     }
 
     // Set hovered tab variables


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When all routed tabs lose their active state (e.g. navigating to a URL
that doesn't match any tab href), the active indicator line stayed
visible at its last position instead of hiding.

Root cause: the CSS had `opacity: 1` hardcoded on `.bui-TabActive`
instead of reading the `--active-tab-opacity` custom property, and the
JS never toggled that variable. The hovered indicator already used this
pattern correctly (`opacity: var(--hovered-tab-opacity)`).

Fix:
- Initialize `--active-tab-opacity: 0` in `.bui-Tabs`
- Use `var(--active-tab-opacity)` in `.bui-TabActive` instead of `1`
- Set the variable to `1` when a tab is active, `0` when none match

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.