### PR TITLE
Support spec.owners as an alternative to spec.owner in catalog entity…

### DIFF
--- a/.changeset/weak-breads-relax.md
+++ b/.changeset/weak-breads-relax.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-catalog-backend-module-scaffolder-entity-model': minor
+'@backstage/plugin-scaffolder-common': minor
+'@backstage/plugin-catalog-backend': minor
+'@backstage/catalog-model': minor
+---
+
+Added optional `spec.owners` (string array) field to Component, API, System, Domain, Resource, and Template kinds. When `spec.owners` is provided, ownership relations are emitted for all entries. Existing `spec.owner` usage is unaffected.

--- a/packages/catalog-model/report.api.md
+++ b/packages/catalog-model/report.api.md
@@ -42,7 +42,8 @@ interface ApiEntityV1alpha1 extends Entity {
   spec: {
     type: string;
     lifecycle: string;
-    owner: string;
+    owner?: string;
+    owners?: string[];
     definition: string;
     system?: string;
   };
@@ -82,7 +83,8 @@ interface ComponentEntityV1alpha1 extends Entity {
   spec: {
     type: string;
     lifecycle: string;
-    owner: string;
+    owner?: string;
+    owners?: string[];
     subcomponentOf?: string;
     providesApis?: string[];
     consumesApis?: string[];
@@ -122,7 +124,8 @@ interface DomainEntityV1alpha1 extends Entity {
   kind: 'Domain';
   // (undocumented)
   spec: {
-    owner: string;
+    owner?: string;
+    owners?: string[];
     subdomainOf?: string;
     type?: string;
   };
@@ -411,7 +414,8 @@ interface ResourceEntityV1alpha1 extends Entity {
   // (undocumented)
   spec: {
     type: string;
-    owner: string;
+    owner?: string;
+    owners?: string[];
     dependsOn?: string[];
     dependencyOf?: string[];
     system?: string;
@@ -454,7 +458,8 @@ interface SystemEntityV1alpha1 extends Entity {
   kind: 'System';
   // (undocumented)
   spec: {
-    owner: string;
+    owner?: string;
+    owners?: string[];
     domain?: string;
     type?: string;
   };

--- a/packages/catalog-model/src/kinds/ApiEntityV1alpha1.test.ts
+++ b/packages/catalog-model/src/kinds/ApiEntityV1alpha1.test.ts
@@ -124,8 +124,25 @@ components:
     await expect(validator.check(entity)).rejects.toThrow(/lifecycle/);
   });
 
-  it('rejects missing owner', async () => {
+  it('rejects missing owner and owners', async () => {
     delete (entity as any).spec.owner;
+    await expect(validator.check(entity)).rejects.toThrow(/owner/);
+  });
+
+  it('accepts owners array instead of owner', async () => {
+    delete (entity as any).spec.owner;
+    (entity as any).spec.owners = ['team-a', 'team-b'];
+    await expect(validator.check(entity)).resolves.toBe(true);
+  });
+
+  it('accepts both owner and owners', async () => {
+    (entity as any).spec.owners = ['team-a'];
+    await expect(validator.check(entity)).resolves.toBe(true);
+  });
+
+  it('rejects empty owners array', async () => {
+    delete (entity as any).spec.owner;
+    (entity as any).spec.owners = [];
     await expect(validator.check(entity)).rejects.toThrow(/owner/);
   });
 

--- a/packages/catalog-model/src/kinds/ApiEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/ApiEntityV1alpha1.ts
@@ -33,7 +33,8 @@ export interface ApiEntityV1alpha1 extends Entity {
   spec: {
     type: string;
     lifecycle: string;
-    owner: string;
+    owner?: string;
+    owners?: string[];
     definition: string;
     system?: string;
   };

--- a/packages/catalog-model/src/kinds/ComponentEntityV1alpha1.test.ts
+++ b/packages/catalog-model/src/kinds/ComponentEntityV1alpha1.test.ts
@@ -91,8 +91,25 @@ describe('ComponentV1alpha1Validator', () => {
     await expect(validator.check(entity)).rejects.toThrow(/lifecycle/);
   });
 
-  it('rejects missing owner', async () => {
+  it('rejects missing owner and owners', async () => {
     delete (entity as any).spec.owner;
+    await expect(validator.check(entity)).rejects.toThrow(/owner/);
+  });
+
+  it('accepts owners array instead of owner', async () => {
+    delete (entity as any).spec.owner;
+    (entity as any).spec.owners = ['team-a', 'team-b'];
+    await expect(validator.check(entity)).resolves.toBe(true);
+  });
+
+  it('accepts both owner and owners', async () => {
+    (entity as any).spec.owners = ['team-a'];
+    await expect(validator.check(entity)).resolves.toBe(true);
+  });
+
+  it('rejects empty owners array', async () => {
+    delete (entity as any).spec.owner;
+    (entity as any).spec.owners = [];
     await expect(validator.check(entity)).rejects.toThrow(/owner/);
   });
 

--- a/packages/catalog-model/src/kinds/ComponentEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/ComponentEntityV1alpha1.ts
@@ -33,7 +33,8 @@ export interface ComponentEntityV1alpha1 extends Entity {
   spec: {
     type: string;
     lifecycle: string;
-    owner: string;
+    owner?: string;
+    owners?: string[];
     subcomponentOf?: string;
     providesApis?: string[];
     consumesApis?: string[];

--- a/packages/catalog-model/src/kinds/DomainEntityV1alpha1.test.ts
+++ b/packages/catalog-model/src/kinds/DomainEntityV1alpha1.test.ts
@@ -56,8 +56,25 @@ describe('DomainV1alpha1Validator', () => {
     await expect(validator.check(entity)).resolves.toBe(false);
   });
 
-  it('rejects missing owner', async () => {
+  it('rejects missing owner and owners', async () => {
     delete (entity as any).spec.owner;
+    await expect(validator.check(entity)).rejects.toThrow(/owner/);
+  });
+
+  it('accepts owners array instead of owner', async () => {
+    delete (entity as any).spec.owner;
+    (entity as any).spec.owners = ['team-a', 'team-b'];
+    await expect(validator.check(entity)).resolves.toBe(true);
+  });
+
+  it('accepts both owner and owners', async () => {
+    (entity as any).spec.owners = ['team-a'];
+    await expect(validator.check(entity)).resolves.toBe(true);
+  });
+
+  it('rejects empty owners array', async () => {
+    delete (entity as any).spec.owner;
+    (entity as any).spec.owners = [];
     await expect(validator.check(entity)).rejects.toThrow(/owner/);
   });
 

--- a/packages/catalog-model/src/kinds/DomainEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/DomainEntityV1alpha1.ts
@@ -31,7 +31,8 @@ export interface DomainEntityV1alpha1 extends Entity {
   apiVersion: 'backstage.io/v1alpha1' | 'backstage.io/v1beta1';
   kind: 'Domain';
   spec: {
-    owner: string;
+    owner?: string;
+    owners?: string[];
     subdomainOf?: string;
     type?: string;
   };

--- a/packages/catalog-model/src/kinds/ResourceEntityV1alpha1.test.ts
+++ b/packages/catalog-model/src/kinds/ResourceEntityV1alpha1.test.ts
@@ -72,8 +72,25 @@ describe('ResourceV1alpha1Validator', () => {
     await expect(validator.check(entity)).rejects.toThrow(/type/);
   });
 
-  it('rejects missing owner', async () => {
+  it('rejects missing owner and owners', async () => {
     delete (entity as any).spec.owner;
+    await expect(validator.check(entity)).rejects.toThrow(/owner/);
+  });
+
+  it('accepts owners array instead of owner', async () => {
+    delete (entity as any).spec.owner;
+    (entity as any).spec.owners = ['team-a', 'team-b'];
+    await expect(validator.check(entity)).resolves.toBe(true);
+  });
+
+  it('accepts both owner and owners', async () => {
+    (entity as any).spec.owners = ['team-a'];
+    await expect(validator.check(entity)).resolves.toBe(true);
+  });
+
+  it('rejects empty owners array', async () => {
+    delete (entity as any).spec.owner;
+    (entity as any).spec.owners = [];
     await expect(validator.check(entity)).rejects.toThrow(/owner/);
   });
 

--- a/packages/catalog-model/src/kinds/ResourceEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/ResourceEntityV1alpha1.ts
@@ -32,7 +32,8 @@ export interface ResourceEntityV1alpha1 extends Entity {
   kind: 'Resource';
   spec: {
     type: string;
-    owner: string;
+    owner?: string;
+    owners?: string[];
     dependsOn?: string[];
     dependencyOf?: string[];
     system?: string;

--- a/packages/catalog-model/src/kinds/SystemEntityV1alpha1.test.ts
+++ b/packages/catalog-model/src/kinds/SystemEntityV1alpha1.test.ts
@@ -56,8 +56,25 @@ describe('SystemV1alpha1Validator', () => {
     await expect(validator.check(entity)).resolves.toBe(false);
   });
 
-  it('rejects missing owner', async () => {
+  it('rejects missing owner and owners', async () => {
     delete (entity as any).spec.owner;
+    await expect(validator.check(entity)).rejects.toThrow(/owner/);
+  });
+
+  it('accepts owners array instead of owner', async () => {
+    delete (entity as any).spec.owner;
+    (entity as any).spec.owners = ['team-a', 'team-b'];
+    await expect(validator.check(entity)).resolves.toBe(true);
+  });
+
+  it('accepts both owner and owners', async () => {
+    (entity as any).spec.owners = ['team-a'];
+    await expect(validator.check(entity)).resolves.toBe(true);
+  });
+
+  it('rejects empty owners array', async () => {
+    delete (entity as any).spec.owner;
+    (entity as any).spec.owners = [];
     await expect(validator.check(entity)).rejects.toThrow(/owner/);
   });
 

--- a/packages/catalog-model/src/kinds/SystemEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/SystemEntityV1alpha1.ts
@@ -31,7 +31,8 @@ export interface SystemEntityV1alpha1 extends Entity {
   apiVersion: 'backstage.io/v1alpha1' | 'backstage.io/v1beta1';
   kind: 'System';
   spec: {
-    owner: string;
+    owner?: string;
+    owners?: string[];
     domain?: string;
     type?: string;
   };

--- a/packages/catalog-model/src/schema/kinds/API.v1alpha1.schema.json
+++ b/packages/catalog-model/src/schema/kinds/API.v1alpha1.schema.json
@@ -41,7 +41,8 @@
         },
         "spec": {
           "type": "object",
-          "required": ["type", "lifecycle", "owner", "definition"],
+          "required": ["type", "lifecycle", "definition"],
+          "anyOf": [{ "required": ["owner"] }, { "required": ["owners"] }],
           "properties": {
             "type": {
               "type": "string",
@@ -60,6 +61,15 @@
               "description": "An entity reference to the owner of the API.",
               "examples": ["artist-relations-team", "user:john.johnson"],
               "minLength": 1
+            },
+            "owners": {
+              "type": "array",
+              "description": "An array of entity references to the owners of the API.",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minItems": 1
             },
             "system": {
               "type": "string",

--- a/packages/catalog-model/src/schema/kinds/Component.v1alpha1.schema.json
+++ b/packages/catalog-model/src/schema/kinds/Component.v1alpha1.schema.json
@@ -39,7 +39,8 @@
         },
         "spec": {
           "type": "object",
-          "required": ["type", "lifecycle", "owner"],
+          "required": ["type", "lifecycle"],
+          "anyOf": [{ "required": ["owner"] }, { "required": ["owners"] }],
           "properties": {
             "type": {
               "type": "string",
@@ -58,6 +59,15 @@
               "description": "An entity reference to the owner of the component.",
               "examples": ["artist-relations-team", "user:john.johnson"],
               "minLength": 1
+            },
+            "owners": {
+              "type": "array",
+              "description": "An array of entity references to the owners of the component.",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minItems": 1
             },
             "system": {
               "type": "string",

--- a/packages/catalog-model/src/schema/kinds/Domain.v1alpha1.schema.json
+++ b/packages/catalog-model/src/schema/kinds/Domain.v1alpha1.schema.json
@@ -33,13 +33,23 @@
         },
         "spec": {
           "type": "object",
-          "required": ["owner"],
+          "required": [],
+          "anyOf": [{ "required": ["owner"] }, { "required": ["owners"] }],
           "properties": {
             "owner": {
               "type": "string",
-              "description": "An entity reference to the owner of the component.",
+              "description": "An entity reference to the owner of the domain.",
               "examples": ["artist-relations-team", "user:john.johnson"],
               "minLength": 1
+            },
+            "owners": {
+              "type": "array",
+              "description": "An array of entity references to the owners of the domain.",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minItems": 1
             },
             "subdomainOf": {
               "type": "string",

--- a/packages/catalog-model/src/schema/kinds/Resource.v1alpha1.schema.json
+++ b/packages/catalog-model/src/schema/kinds/Resource.v1alpha1.schema.json
@@ -33,7 +33,8 @@
         },
         "spec": {
           "type": "object",
-          "required": ["type", "owner"],
+          "required": ["type"],
+          "anyOf": [{ "required": ["owner"] }, { "required": ["owners"] }],
           "properties": {
             "type": {
               "type": "string",
@@ -46,6 +47,15 @@
               "description": "An entity reference to the owner of the resource.",
               "examples": ["artist-relations-team", "user:john.johnson"],
               "minLength": 1
+            },
+            "owners": {
+              "type": "array",
+              "description": "An array of entity references to the owners of the resource.",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minItems": 1
             },
             "dependsOn": {
               "type": "array",

--- a/packages/catalog-model/src/schema/kinds/System.v1alpha1.schema.json
+++ b/packages/catalog-model/src/schema/kinds/System.v1alpha1.schema.json
@@ -33,13 +33,23 @@
         },
         "spec": {
           "type": "object",
-          "required": ["owner"],
+          "required": [],
+          "anyOf": [{ "required": ["owner"] }, { "required": ["owners"] }],
           "properties": {
             "owner": {
               "type": "string",
-              "description": "An entity reference to the owner of the component.",
+              "description": "An entity reference to the owner of the system.",
               "examples": ["artist-relations-team", "user:john.johnson"],
               "minLength": 1
+            },
+            "owners": {
+              "type": "array",
+              "description": "An array of entity references to the owners of the system.",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minItems": 1
             },
             "domain": {
               "type": "string",

--- a/plugins/catalog-backend-module-scaffolder-entity-model/src/processor/ScaffolderEntitiesProcessor.test.ts
+++ b/plugins/catalog-backend-module-scaffolder-entity-model/src/processor/ScaffolderEntitiesProcessor.test.ts
@@ -76,5 +76,104 @@ describe('ScaffolderEntitiesProcessor', () => {
         },
       });
     });
+    it('generates relations for template entities with owners array', async () => {
+      const processor = new ScaffolderEntitiesProcessor();
+      const emit = jest.fn();
+
+      const entity: TemplateEntityV1beta3 = {
+        ...mockEntity,
+        spec: {
+          ...mockEntity.spec,
+          owner: undefined,
+          owners: ['team-a', 'user:john'],
+        },
+      };
+
+      await processor.postProcessEntity(entity, mockLocation, emit);
+
+      expect(emit).toHaveBeenCalledTimes(4);
+      expect(emit).toHaveBeenCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'Template', namespace: 'default', name: 'n' },
+          type: 'ownedBy',
+          target: { kind: 'Group', namespace: 'default', name: 'team-a' },
+        },
+      });
+      expect(emit).toHaveBeenCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'Template', namespace: 'default', name: 'n' },
+          type: 'ownedBy',
+          target: { kind: 'User', namespace: 'default', name: 'john' },
+        },
+      });
+    });
+
+    it('owners takes precedence over owner for template entities', async () => {
+      const processor = new ScaffolderEntitiesProcessor();
+      const emit = jest.fn();
+
+      const entity: TemplateEntityV1beta3 = {
+        ...mockEntity,
+        spec: {
+          ...mockEntity.spec,
+          owner: 'o',
+          owners: ['team-a', 'user:john'],
+        },
+      };
+
+      await processor.postProcessEntity(entity, mockLocation, emit);
+
+      expect(emit).toHaveBeenCalledTimes(4);
+      expect(emit).toHaveBeenCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'Group', namespace: 'default', name: 'team-a' },
+          type: 'ownerOf',
+          target: { kind: 'Template', namespace: 'default', name: 'n' },
+        },
+      });
+      expect(emit).toHaveBeenCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'Template', namespace: 'default', name: 'n' },
+          type: 'ownedBy',
+          target: { kind: 'Group', namespace: 'default', name: 'team-a' },
+        },
+      });
+      expect(emit).toHaveBeenCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'User', namespace: 'default', name: 'john' },
+          type: 'ownerOf',
+          target: { kind: 'Template', namespace: 'default', name: 'n' },
+        },
+      });
+      expect(emit).toHaveBeenCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'Template', namespace: 'default', name: 'n' },
+          type: 'ownedBy',
+          target: { kind: 'User', namespace: 'default', name: 'john' },
+        },
+      });
+      expect(emit).not.toHaveBeenCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'Group', namespace: 'default', name: 'o' },
+          type: 'ownerOf',
+          target: { kind: 'Template', namespace: 'default', name: 'n' },
+        },
+      });
+      expect(emit).not.toHaveBeenCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'Template', namespace: 'default', name: 'n' },
+          type: 'ownedBy',
+          target: { kind: 'Group', namespace: 'default', name: 'o' },
+        },
+      });
+    });
   });
 });

--- a/plugins/catalog-backend-module-scaffolder-entity-model/src/processor/ScaffolderEntitiesProcessor.ts
+++ b/plugins/catalog-backend-module-scaffolder-entity-model/src/processor/ScaffolderEntitiesProcessor.ts
@@ -67,8 +67,10 @@ export class ScaffolderEntitiesProcessor implements CatalogProcessor {
     ) {
       const template = entity as TemplateEntityV1beta3;
 
-      const target = template.spec.owner;
-      if (target) {
+      const targets =
+        template.spec.owners ??
+        (template.spec.owner ? [template.spec.owner] : []);
+      for (const target of targets) {
         const targetRef = parseEntityRef(target, {
           defaultKind: 'Group',
           defaultNamespace: selfRef.namespace,

--- a/plugins/catalog-backend/src/processors/BuiltinKindsEntityProcessor.test.ts
+++ b/plugins/catalog-backend/src/processors/BuiltinKindsEntityProcessor.test.ts
@@ -67,6 +67,26 @@ describe('BuiltinKindsEntityProcessor', () => {
         },
       });
     });
+
+    it('should sort spec.owners for consistent hashing', async () => {
+      const entity: ComponentEntity = {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: { name: 'n' },
+        spec: {
+          type: 'service',
+          owners: ['team-b', 'team-a'],
+          lifecycle: 'l',
+        },
+      };
+
+      const ret = await processor.preProcessEntity(entity);
+
+      expect((ret as ComponentEntity).spec.owners).toEqual([
+        'team-a',
+        'team-b',
+      ]);
+    });
   });
 
   describe('postProcessEntity', () => {
@@ -241,6 +261,71 @@ describe('BuiltinKindsEntityProcessor', () => {
           target: { kind: 'System', namespace: 'default', name: 's' },
         },
       });
+    });
+
+    it('generates relations for component entities with owners array', async () => {
+      const entity: ComponentEntity = {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: { name: 'n' },
+        spec: {
+          type: 'service',
+          owners: ['team-a', 'user:john'],
+          lifecycle: 'l',
+          system: 's',
+        },
+      };
+
+      await processor.postProcessEntity(entity, location, emit);
+
+      expect(emit).toHaveBeenCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'Component', namespace: 'default', name: 'n' },
+          type: 'ownedBy',
+          target: { kind: 'Group', namespace: 'default', name: 'team-a' },
+        },
+      });
+      expect(emit).toHaveBeenCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'Component', namespace: 'default', name: 'n' },
+          type: 'ownedBy',
+          target: { kind: 'User', namespace: 'default', name: 'john' },
+        },
+      });
+    });
+
+    it('owners takes precedence over owner for component entities', async () => {
+      const entity: ComponentEntity = {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: { name: 'n' },
+        spec: {
+          type: 'service',
+          owner: 'ignored',
+          owners: ['team-a'],
+          lifecycle: 'l',
+        },
+      };
+
+      await processor.postProcessEntity(entity, location, emit);
+
+      expect(emit).toHaveBeenCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'Component', namespace: 'default', name: 'n' },
+          type: 'ownedBy',
+          target: { kind: 'Group', namespace: 'default', name: 'team-a' },
+        },
+      });
+      expect(emit).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          relation: expect.objectContaining({
+            target: expect.objectContaining({ name: 'ignored' }),
+          }),
+        }),
+      );
     });
 
     it('generates an error for component entities with unspecified dependsOn entity reference kinds', async () => {
@@ -554,6 +639,131 @@ describe('BuiltinKindsEntityProcessor', () => {
           source: { kind: 'Domain', namespace: 'default', name: 'p' },
           type: 'hasPart',
           target: { kind: 'Domain', namespace: 'default', name: 'n' },
+        },
+      });
+    });
+
+    it('generates relations for api entities with owners array', async () => {
+      const entity: ApiEntity = {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'API',
+        metadata: { name: 'n' },
+        spec: {
+          type: 'openapi',
+          owners: ['team-a', 'team-b'],
+          lifecycle: 'l',
+          definition: 'd',
+        },
+      };
+
+      await processor.postProcessEntity(entity, location, emit);
+
+      expect(emit).toHaveBeenCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'API', namespace: 'default', name: 'n' },
+          type: 'ownedBy',
+          target: { kind: 'Group', namespace: 'default', name: 'team-a' },
+        },
+      });
+      expect(emit).toHaveBeenCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'API', namespace: 'default', name: 'n' },
+          type: 'ownedBy',
+          target: { kind: 'Group', namespace: 'default', name: 'team-b' },
+        },
+      });
+    });
+
+    it('generates relations for resource entities with owners array', async () => {
+      const entity: ResourceEntity = {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Resource',
+        metadata: { name: 'n' },
+        spec: {
+          type: 'database',
+          owners: ['team-a', 'user:jane'],
+        },
+      };
+
+      await processor.postProcessEntity(entity, location, emit);
+
+      expect(emit).toHaveBeenCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'Resource', namespace: 'default', name: 'n' },
+          type: 'ownedBy',
+          target: { kind: 'Group', namespace: 'default', name: 'team-a' },
+        },
+      });
+      expect(emit).toHaveBeenCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'Resource', namespace: 'default', name: 'n' },
+          type: 'ownedBy',
+          target: { kind: 'User', namespace: 'default', name: 'jane' },
+        },
+      });
+    });
+
+    it('generates relations for system entities with owners array', async () => {
+      const entity: SystemEntity = {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'System',
+        metadata: { name: 'n' },
+        spec: {
+          owners: ['team-a', 'team-b'],
+          domain: 'd',
+        },
+      };
+
+      await processor.postProcessEntity(entity, location, emit);
+
+      expect(emit).toHaveBeenCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'System', namespace: 'default', name: 'n' },
+          type: 'ownedBy',
+          target: { kind: 'Group', namespace: 'default', name: 'team-a' },
+        },
+      });
+      expect(emit).toHaveBeenCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'System', namespace: 'default', name: 'n' },
+          type: 'ownedBy',
+          target: { kind: 'Group', namespace: 'default', name: 'team-b' },
+        },
+      });
+    });
+
+    it('generates relations for domain entities with owners array', async () => {
+      const entity: DomainEntity = {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Domain',
+        metadata: { name: 'n' },
+        spec: {
+          owners: ['team-a', 'user:jane'],
+        },
+      };
+
+      await processor.postProcessEntity(entity, location, emit);
+
+      expect(emit).toHaveBeenCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'Domain', namespace: 'default', name: 'n' },
+          type: 'ownedBy',
+          target: { kind: 'Group', namespace: 'default', name: 'team-a' },
+        },
+      });
+      expect(emit).toHaveBeenCalledWith({
+        type: 'relation',
+        relation: {
+          source: { kind: 'Domain', namespace: 'default', name: 'n' },
+          type: 'ownedBy',
+          target: { kind: 'User', namespace: 'default', name: 'jane' },
         },
       });
     });

--- a/plugins/catalog-backend/src/processors/BuiltinKindsEntityProcessor.ts
+++ b/plugins/catalog-backend/src/processors/BuiltinKindsEntityProcessor.ts
@@ -97,6 +97,7 @@ export class BuiltinKindsEntityProcessor implements CatalogProcessor {
     }
 
     // Sort the fields of the entity to ensure consistent hash
+    sortField('spec.owners');
     sortField('spec.providesApis');
     sortField('spec.consumesApis');
     sortField('spec.dependsOn');
@@ -162,7 +163,7 @@ export class BuiltinKindsEntityProcessor implements CatalogProcessor {
     if (entity.kind === 'Component') {
       const component = entity as ComponentEntity;
       doEmit(
-        component.spec.owner,
+        component.spec.owners ?? component.spec.owner,
         { defaultKind: 'Group', defaultNamespace: selfRef.namespace },
         RELATION_OWNED_BY,
         RELATION_OWNER_OF,
@@ -212,7 +213,7 @@ export class BuiltinKindsEntityProcessor implements CatalogProcessor {
     if (entity.kind === 'API') {
       const api = entity as ApiEntity;
       doEmit(
-        api.spec.owner,
+        api.spec.owners ?? api.spec.owner,
         { defaultKind: 'Group', defaultNamespace: selfRef.namespace },
         RELATION_OWNED_BY,
         RELATION_OWNER_OF,
@@ -232,7 +233,7 @@ export class BuiltinKindsEntityProcessor implements CatalogProcessor {
     if (entity.kind === 'Resource') {
       const resource = entity as ResourceEntity;
       doEmit(
-        resource.spec.owner,
+        resource.spec.owners ?? resource.spec.owner,
         { defaultKind: 'Group', defaultNamespace: selfRef.namespace },
         RELATION_OWNED_BY,
         RELATION_OWNER_OF,
@@ -304,7 +305,7 @@ export class BuiltinKindsEntityProcessor implements CatalogProcessor {
     if (entity.kind === 'System') {
       const system = entity as SystemEntity;
       doEmit(
-        system.spec.owner,
+        system.spec.owners ?? system.spec.owner,
         { defaultKind: 'Group', defaultNamespace: selfRef.namespace },
         RELATION_OWNED_BY,
         RELATION_OWNER_OF,
@@ -324,7 +325,7 @@ export class BuiltinKindsEntityProcessor implements CatalogProcessor {
     if (entity.kind === 'Domain') {
       const domain = entity as DomainEntity;
       doEmit(
-        domain.spec.owner,
+        domain.spec.owners ?? domain.spec.owner,
         { defaultKind: 'Group', defaultNamespace: selfRef.namespace },
         RELATION_OWNED_BY,
         RELATION_OWNER_OF,

--- a/plugins/scaffolder-common/report.api.md
+++ b/plugins/scaffolder-common/report.api.md
@@ -426,6 +426,7 @@ export interface TemplateEntityV1beta3 extends Entity {
       [name: string]: string;
     };
     owner?: string;
+    owners?: string[];
     lifecycle?: string;
   };
 }

--- a/plugins/scaffolder-common/src/Template.v1beta3.schema.json
+++ b/plugins/scaffolder-common/src/Template.v1beta3.schema.json
@@ -96,6 +96,15 @@
               "description": "The user (or group) owner of the template",
               "minLength": 1
             },
+            "owners": {
+              "type": "array",
+              "description": "An array of entity references to the owners of the template.",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minItems": 1
+            },
             "lifecycle": {
               "type": "string",
               "description": "The lifecycle state of the template.",

--- a/plugins/scaffolder-common/src/TemplateEntityV1beta3.ts
+++ b/plugins/scaffolder-common/src/TemplateEntityV1beta3.ts
@@ -88,6 +88,10 @@ export interface TemplateEntityV1beta3 extends Entity {
      */
     owner?: string;
     /**
+     * An array of owner entityRefs of the TemplateEntity
+     */
+    owners?: string[];
+    /**
      * Specifies the lifecycle phase of the TemplateEntity
      */
     lifecycle?: string;


### PR DESCRIPTION
… model #33695

## Hey, I just made a Pull Request!

Added optional `spec.owners` (string array) field to Component, API, System, Domain, and Resource kinds. Either `spec.owner` or `spec.owners` is accepted. Existing `spec.owner` usage is unaffected.

#### :heavy_check_mark: Checklist

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
