### PR TITLE
fix(cli-module-build): ignore MF version warning for secondary entry points

### DIFF
--- a/.changeset/plenty-weeks-stop.md
+++ b/.changeset/plenty-weeks-stop.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli-module-build': patch
+---
+
+Suppressed false-positive Module Federation warning for shared dependencies that use secondary entry points (e.g. `@mui/material/styles`). These sub-path `package.json` files lack a `version` field, causing the bundler to emit "No version specified" warnings that fail CI builds.

--- a/packages/cli-module-build/src/lib/bundler/config.ts
+++ b/packages/cli-module-build/src/lib/bundler/config.ts
@@ -394,5 +394,16 @@ export async function createConfig(
       }),
     },
     plugins,
+    ...(options.moduleFederationRemote && {
+      // TODO: remove this warning skipping as soon as the corresponding bundler limitation
+      // described in issue https://github.com/web-infra-dev/rspack/issues/13635 is fixed
+      // when PR: https://github.com/web-infra-dev/rspack/pull/13636 is merged.
+      ignoreWarnings: [
+        {
+          message:
+            /No version specified and unable to automatically determine one\. No version in description file/,
+        },
+      ],
+    }),
   };
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Suppress false-positive Module Federation "No version specified" warning for shared dependencies that use secondary entry points.

### Problem

When bundling Module Federation remotes (e.g. dynamic plugins) with `CI=true`, the build fails because the Backstage CLI promotes all bundler warnings to errors. The `ProvideSharedPlugin` emits a `"No version specified and unable to automatically determine one"` warning for sub-path exports like `@mui/material/styles`, because their directory-level `package.json` contains only module resolution metadata (`main`, `module`, `types`) but no `version` field. The version lives in the parent package (`@mui/material/package.json`), but the bundler stops at the nearest `package.json` per the Node.js resolution spec.

This is a known bundler limitation documented in [webpack#15864](https://github.com/webpack/webpack/issues/15864), [webpack#12942](https://github.com/webpack/webpack/issues/12942), and [webpack#13457](https://github.com/webpack/webpack/issues/13457). It affects MUI (150+ secondary entry points), Emotion, Apollo Client, and others.

### Fix

Add an `ignoreWarnings` entry to the bundler config when building a Module Federation remote, matching the specific two-sentence warning from `ProvideSharedPlugin`:

```typescript
...(options.moduleFederationRemote && {
  ignoreWarnings: [
    {
      message:
        /No version specified and unable to automatically determine one\. No version in description file/,
    },
  ],
}),
```

This is the simplest possible fix: a single config property, no logic changes, works identically for both Rspack and webpack bundler paths.

### Why this approach

**Why not resolve the version ourselves?** Resolving the version externally (e.g. via `require.resolve`) introduces a second resolution path alongside the bundler's internal resolver (`oxc-resolver` for Rspack, `enhanced-resolve` for webpack). In monorepo hoisting, symlink, or resolve-alias scenarios these could diverge — tagging a version that doesn't match the actually bundled code. A wrong version is worse than no version: it gives the MF runtime false confidence in version negotiation.

**Why not fix it in `bundle.ts`?** The CLI's warning-to-error promotion in `bundle.ts` doesn't display warnings in non-CI mode either, so filtering there vs. suppressing via `ignoreWarnings` provides no additional developer visibility. The config approach is simpler and produces a smaller diff.

### Impact

The missing version only affects the fallback copy bundled by the remote. In the current architecture the host always provides these modules, so the fallback path is not exercised. If the host stops providing a module in the future, the lack of version metadata means the MF runtime cannot perform semantic version comparison between competing fallbacks — but this is a theoretical edge case, and community plugins tend to provide similar dependency versions.

### Upstream fix

A proper fix for this limitation has been proposed upstream in [rspack#13636](https://github.com/web-infra-dev/rspack/pull/13636), which teaches `ProvideSharedPlugin` to walk up the directory tree and inherit the parent package's version for secondary entry points. Once merged and released, this `ignoreWarnings` workaround can be removed.

### References

- [webpack#15864](https://github.com/webpack/webpack/issues/15864) — *"Module federation cannot resolve version of secondary entry points with no version"*
- [webpack#12942](https://github.com/webpack/webpack/issues/12942) — *"Undetermined shared module version in federated module for specific dependency"*
- [webpack#13457](https://github.com/webpack/webpack/issues/13457) — *"Undetermined shared module version when importing a file from the module directly"*
- [rspack#13636](https://github.com/web-infra-dev/rspack/pull/13636) — upstream fix for `ProvideSharedPlugin` secondary entry point version resolution

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
