### PR TITLE
feat(catalog): create refresh entity mcp action to refresh an entity registered in the catalog #33729

### DIFF
--- a/.changeset/rare-times-make.md
+++ b/.changeset/rare-times-make.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend': minor
 ---
 
-Added a new `refresh-catalog-entity` actions registry action that refresh an entity registered in the catalog
+Added a new `refresh-catalog-entity` actions registry action that refreshes an entity registered in the catalog

--- a/.changeset/rare-times-make.md
+++ b/.changeset/rare-times-make.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': minor
+---
+
+Added a new `refresh-catalog-entity` actions registry action that refresh an entity registered in the catalog

--- a/docs/ai/well-known-actions.md
+++ b/docs/ai/well-known-actions.md
@@ -18,6 +18,7 @@ This is a (non-exhaustive) list of actions that are known to be part of the Acti
 
 - `catalog.get-catalog-entity` (Get Catalog Entity): This allows you to get a single entity from the software catalog.
 - `catalog.query-catalog-entities` (Query Catalog Entities): Query entities from the Backstage Software Catalog using predicate filters.
+- `catalog.refresh-catalog-entity` (Refresh entity from the Catalog): Refresh an entity stored inside the Backstage catalog.
 - `catalog.register-entity` (Register entity in the Catalog): Registers one or more entities in the Backstage catalog by creating a Location entity that points to a remote `catalog-info.yaml` file.
 - `catalog.unregister-entity` (Unregister entity from the Catalog): Unregisters a Location entity and all entities it owns from the Backstage catalog.
 - `catalog.validate-entity` (Validate Catalog Entity): This action can be used to validate `catalog-info.yaml` file contents meant to be used with the software catalog.

--- a/plugins/catalog-backend/src/actions/createRefreshCatalogEntityAction.test.ts
+++ b/plugins/catalog-backend/src/actions/createRefreshCatalogEntityAction.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The Backstage Authors
+ * Copyright 2026 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/catalog-backend/src/actions/createRefreshCatalogEntityAction.test.ts
+++ b/plugins/catalog-backend/src/actions/createRefreshCatalogEntityAction.test.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { createRefreshCatalogEntityAction } from './createRefreshCatalogEntityAction';
+import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
+import { actionsRegistryServiceMock } from '@backstage/backend-test-utils/alpha';
+
+describe('createRefreshCatalogEntityAction', () => {
+  it('should throw an error if the entity is not found', async () => {
+    const mockActionsRegistry = actionsRegistryServiceMock();
+    const mockCatalog = catalogServiceMock();
+
+    createRefreshCatalogEntityAction({
+      catalog: mockCatalog,
+      actionsRegistry: mockActionsRegistry,
+    });
+
+    await expect(
+      mockActionsRegistry.invoke({
+        id: 'test:refresh-catalog-entity',
+        input: { name: 'does-not-exist' },
+      }),
+    ).rejects.toThrow('No entity found with name "does-not-exist"');
+  });
+
+  it('should throw an error if multiple entities are found', async () => {
+    const mockActionsRegistry = actionsRegistryServiceMock();
+    const mockCatalog = catalogServiceMock({
+      entities: [
+        {
+          kind: 'Component',
+          apiVersion: 'backstage.io/v1alpha1',
+          metadata: {
+            name: 'my-service',
+            namespace: 'default',
+          },
+        },
+        {
+          kind: 'API',
+          apiVersion: 'backstage.io/v1alpha1',
+          metadata: {
+            name: 'my-service',
+            namespace: 'default',
+          },
+        },
+      ],
+    });
+
+    createRefreshCatalogEntityAction({
+      catalog: mockCatalog,
+      actionsRegistry: mockActionsRegistry,
+    });
+
+    await expect(
+      mockActionsRegistry.invoke({
+        id: 'test:refresh-catalog-entity',
+        input: { name: 'my-service' },
+      }),
+    ).rejects.toThrow(
+      'Multiple entities found with name "my-service", please provide more specific filters. Entities found: "component:default/my-service", "api:default/my-service"',
+    );
+  });
+
+  it('should successfully refresh an existing entity', async () => {
+    const mockActionsRegistry = actionsRegistryServiceMock();
+    const mockCatalog = catalogServiceMock({
+      entities: [
+        {
+          kind: 'Component',
+          apiVersion: 'backstage.io/v1alpha1',
+          metadata: {
+            name: 'my-service',
+            namespace: 'default',
+          },
+        },
+      ],
+    });
+
+    mockCatalog.refreshEntity = jest.fn().mockResolvedValue(undefined);
+
+    createRefreshCatalogEntityAction({
+      catalog: mockCatalog,
+      actionsRegistry: mockActionsRegistry,
+    });
+
+    const result = await mockActionsRegistry.invoke({
+      id: 'test:refresh-catalog-entity',
+      input: { name: 'my-service' },
+    });
+
+    expect(result.output).toEqual({
+      entityRef: 'component:default/my-service',
+    });
+    expect(mockCatalog.refreshEntity).toHaveBeenCalledWith(
+      'component:default/my-service',
+      expect.objectContaining({
+        credentials: expect.any(Object),
+      }),
+    );
+  });
+});

--- a/plugins/catalog-backend/src/actions/createRefreshCatalogEntityAction.ts
+++ b/plugins/catalog-backend/src/actions/createRefreshCatalogEntityAction.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ActionsRegistryService } from '@backstage/backend-plugin-api/alpha';
+import { stringifyEntityRef } from '@backstage/catalog-model';
+import { ConflictError, InputError } from '@backstage/errors';
+import { CatalogService } from '@backstage/plugin-catalog-node';
+
+export const createRefreshCatalogEntityAction = ({
+  catalog,
+  actionsRegistry,
+}: {
+  catalog: CatalogService;
+  actionsRegistry: ActionsRegistryService;
+}) => {
+  actionsRegistry.register({
+    name: 'refresh-catalog-entity',
+    title: 'Refresh Catalog Entity',
+    attributes: {
+      destructive: false,
+      readOnly: false,
+      idempotent: true,
+    },
+    description: `
+This allows you to refresh a single entity in the software catalog.
+Each entity in the software catalog has a unique name, kind, and namespace. The default namespace is "default".
+Each entity is identified by a unique entity reference, which is a string of the form "kind:namespace/name".
+    `,
+    schema: {
+      input: z =>
+        z.object({
+          kind: z
+            .string()
+            .describe(
+              'The kind of the entity to query. If the kind is unknown it can be omitted.',
+            )
+            .optional(),
+          namespace: z
+            .string()
+            .describe(
+              'The namespace of the entity to query. If the namespace is unknown it can be omitted.',
+            )
+            .optional(),
+          name: z.string().describe('The name of the entity to query'),
+        }),
+      output: z =>
+        z.object({
+          entityRef: z.string(),
+        }),
+    },
+    action: async ({ input, credentials }) => {
+      const filter: Record<string, string> = { 'metadata.name': input.name };
+
+      if (input.kind) {
+        filter.kind = input.kind;
+      }
+
+      if (input.namespace) {
+        filter['metadata.namespace'] = input.namespace;
+      }
+
+      const { items } = await catalog.queryEntities(
+        { filter },
+        { credentials },
+      );
+
+      if (items.length === 0) {
+        throw new InputError(`No entity found with name "${input.name}"`);
+      }
+
+      if (items.length > 1) {
+        throw new ConflictError(
+          `Multiple entities found with name "${
+            input.name
+          }", please provide more specific filters. Entities found: ${items
+            .map(item => `"${stringifyEntityRef(item)}"`)
+            .join(', ')}`,
+        );
+      }
+
+      const [entity] = items;
+      const entityRef = stringifyEntityRef(entity);
+
+      await catalog.refreshEntity(entityRef, { credentials });
+
+      return {
+        output: {
+          entityRef,
+        },
+      };
+    },
+  });
+};

--- a/plugins/catalog-backend/src/actions/createRefreshCatalogEntityAction.ts
+++ b/plugins/catalog-backend/src/actions/createRefreshCatalogEntityAction.ts
@@ -44,16 +44,16 @@ Each entity is identified by a unique entity reference, which is a string of the
           kind: z
             .string()
             .describe(
-              'The kind of the entity to query. If the kind is unknown it can be omitted.',
+              'The kind of the entity to refresh. If the kind is unknown it can be omitted.',
             )
             .optional(),
           namespace: z
             .string()
             .describe(
-              'The namespace of the entity to query. If the namespace is unknown it can be omitted.',
+              'The namespace of the entity to refresh. If the namespace is unknown it can be omitted.',
             )
             .optional(),
-          name: z.string().describe('The name of the entity to query'),
+          name: z.string().describe('The name of the entity to refresh'),
         }),
       output: z =>
         z.object({

--- a/plugins/catalog-backend/src/actions/index.ts
+++ b/plugins/catalog-backend/src/actions/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The Backstage Authors
+ * Copyright 2026 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import { createValidateEntityAction } from './createValidateEntityAction.ts';
 import { createRegisterCatalogEntitiesAction } from './createRegisterCatalogEntitiesAction.ts';
 import { createUnregisterCatalogEntitiesAction } from './createUnregisterCatalogEntitiesAction.ts';
 import { createQueryCatalogEntitiesAction } from './createQueryCatalogEntitiesAction.ts';
+import { createRefreshCatalogEntityAction } from './createRefreshCatalogEntityAction.ts';
 
 export const createCatalogActions = (options: {
   actionsRegistry: ActionsRegistryService;
@@ -30,4 +31,5 @@ export const createCatalogActions = (options: {
   createRegisterCatalogEntitiesAction(options);
   createUnregisterCatalogEntitiesAction(options);
   createQueryCatalogEntitiesAction(options);
+  createRefreshCatalogEntityAction(options);
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Addresses #33729.
This PR adds a new action to the MCP Actions Backend that allow to refresh an entity registered in the catalog.
The logic for finding the entity in the catalog is similar to the [`catalog.get-catalog-entity`](https://github.com/MattiaDellOca/backstage/blob/master/plugins/catalog-backend/src/actions/createGetCatalogEntityAction.ts) action and could therefore use some refactoring for unifying logic.

#### :heavy_check_mark: Checklist

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
