### PR TITLE
Fix embedded-postgres PID file written before initialization

### DIFF
--- a/.changeset/fix-embedded-db-pid-file-timing.md
+++ b/.changeset/fix-embedded-db-pid-file-timing.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli-module-build': patch
+---
+
+Fixed the embedded-postgres PID file being written before database initialization, which prevented the database from initializing successfully.

--- a/packages/cli-module-build/src/lib/runner/startEmbeddedDb.ts
+++ b/packages/cli-module-build/src/lib/runner/startEmbeddedDb.ts
@@ -78,8 +78,6 @@ export async function startEmbeddedDb() {
   const port = await getPortPromise();
   const tmpDir = await fs.mkdtemp(resolvePath(os.tmpdir(), TEMP_DIR_PREFIX));
 
-  await fs.writeFile(resolvePath(tmpDir, PID_FILE), String(process.pid));
-
   const pg = new EmbeddedPostgres({
     databaseDir: tmpDir,
     user,
@@ -94,6 +92,7 @@ export async function startEmbeddedDb() {
 
   try {
     await pg.initialise();
+    await fs.writeFile(resolvePath(tmpDir, PID_FILE), String(process.pid));
     await pg.start();
   } catch (error) {
     await pg.stop().catch(() => {});


### PR DESCRIPTION
The PID file for the embedded-postgres dev database was written to the database directory before `pg.initialise()`, which prevented initialization from succeeding because it expects the directory to only contain its own files. Moved the PID file write to just after initialization but before starting the database.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))