### PR TITLE
Update TechDocs CLI repo link, as the old repo was archived in 2021

### DIFF
--- a/docs/features/techdocs/troubleshooting.md
+++ b/docs/features/techdocs/troubleshooting.md
@@ -26,7 +26,7 @@ TechDocs architecture (documentation generated and published in CI/CD).
 
 ## MkDocs Build Errors
 
-Using the [TechDocs CLI](https://github.com/backstage/backstage/tree/master/packages/techdocs-cli), you can
+Using the [TechDocs CLI](https://backstage.io/docs/features/techdocs/cli), you can
 troubleshoot MkDocs build issues locally. Note this requires you have Docker
 available to launch images. First, `git clone` the target repository locally,
 then in the root of the repository, run:


### PR DESCRIPTION
**This is just a dead simple fix of a broken link**
