### PR TITLE
fix(auth-backend): use Firestore batched writes in FirestoreKeyStore.…

### DIFF
--- a/.changeset/fix-firestore-batch-delete.md
+++ b/.changeset/fix-firestore-batch-delete.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Optimized `FirestoreKeyStore.removeKeys` to use Firestore batched writes instead of sequential individual deletes, reducing N network round-trips to ⌈N/500⌉.

--- a/plugins/auth-backend/src/identity/FirestoreKeyStore.test.ts
+++ b/plugins/auth-backend/src/identity/FirestoreKeyStore.test.ts
@@ -166,6 +166,7 @@ describe('FirestoreKeyStore', () => {
     const keyStore = await FirestoreKeyStore.create(firestoreSettings);
     await keyStore.removeKeys(['123']);
 
+    expect(setTimeout).toHaveBeenCalledTimes(1);
     expect(firestoreMock.batch).toHaveBeenCalledTimes(1);
     expect(firestoreMock.collection).toHaveBeenCalledWith(path);
     expect(firestoreMock.doc).toHaveBeenCalledWith('123');
@@ -177,6 +178,7 @@ describe('FirestoreKeyStore', () => {
     const keyStore = await FirestoreKeyStore.create(firestoreSettings);
     await keyStore.removeKeys(['123', '456']);
 
+    expect(setTimeout).toHaveBeenCalledTimes(1);
     expect(firestoreMock.batch).toHaveBeenCalledTimes(1);
     expect(firestoreMock.collection).toHaveBeenCalledWith(path);
     expect(firestoreMock.doc).toHaveBeenCalledWith('123');
@@ -198,6 +200,7 @@ describe('FirestoreKeyStore', () => {
     const kids = Array.from({ length: 501 }, (_, i) => `key-${i}`);
     await keyStore.removeKeys(kids);
 
+    expect(setTimeout).toHaveBeenCalledTimes(2);
     expect(firestoreMock.batch).toHaveBeenCalledTimes(2);
     expect(batchDelete).toHaveBeenCalledTimes(501);
     expect(batchCommit).toHaveBeenCalledTimes(2);

--- a/plugins/auth-backend/src/identity/FirestoreKeyStore.test.ts
+++ b/plugins/auth-backend/src/identity/FirestoreKeyStore.test.ts
@@ -33,6 +33,9 @@ const get = jest.fn().mockReturnValue({
 });
 const set = jest.fn();
 
+const batchDelete = jest.fn();
+const batchCommit = jest.fn().mockResolvedValue([]);
+
 const firestoreMock = {
   limit: jest.fn().mockReturnThis(),
   collection: jest.fn().mockReturnThis(),
@@ -40,6 +43,10 @@ const firestoreMock = {
   doc: jest.fn().mockReturnThis(),
   set,
   get,
+  batch: jest.fn().mockReturnValue({
+    delete: batchDelete,
+    commit: batchCommit,
+  }),
 };
 
 jest.mock('@google-cloud/firestore', () => ({
@@ -73,6 +80,10 @@ describe('FirestoreKeyStore', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    firestoreMock.batch.mockReturnValue({
+      delete: batchDelete,
+      commit: batchCommit,
+    });
   });
 
   it('can create an instance without settings', async () => {
@@ -151,25 +162,45 @@ describe('FirestoreKeyStore', () => {
     });
   });
 
-  it('can delete a single key', async () => {
+  it('can delete a single key using a batch', async () => {
     const keyStore = await FirestoreKeyStore.create(firestoreSettings);
     await keyStore.removeKeys(['123']);
 
-    expect(setTimeout).toHaveBeenCalledTimes(1);
+    expect(firestoreMock.batch).toHaveBeenCalledTimes(1);
     expect(firestoreMock.collection).toHaveBeenCalledWith(path);
     expect(firestoreMock.doc).toHaveBeenCalledWith('123');
-    expect(firestoreMock.delete).toHaveBeenCalledTimes(1);
+    expect(batchDelete).toHaveBeenCalledTimes(1);
+    expect(batchCommit).toHaveBeenCalledTimes(1);
   });
 
-  it('can delete a multiple keys', async () => {
+  it('can delete multiple keys in a single batch', async () => {
     const keyStore = await FirestoreKeyStore.create(firestoreSettings);
     await keyStore.removeKeys(['123', '456']);
 
-    expect(setTimeout).toHaveBeenCalledTimes(2);
+    expect(firestoreMock.batch).toHaveBeenCalledTimes(1);
     expect(firestoreMock.collection).toHaveBeenCalledWith(path);
     expect(firestoreMock.doc).toHaveBeenCalledWith('123');
     expect(firestoreMock.doc).toHaveBeenCalledWith('456');
-    expect(firestoreMock.delete).toHaveBeenCalledTimes(2);
+    expect(batchDelete).toHaveBeenCalledTimes(2);
+    expect(batchCommit).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not create a batch when removing zero keys', async () => {
+    const keyStore = await FirestoreKeyStore.create(firestoreSettings);
+    await keyStore.removeKeys([]);
+
+    expect(firestoreMock.batch).not.toHaveBeenCalled();
+    expect(batchCommit).not.toHaveBeenCalled();
+  });
+
+  it('chunks deletes into batches of 500', async () => {
+    const keyStore = await FirestoreKeyStore.create(firestoreSettings);
+    const kids = Array.from({ length: 501 }, (_, i) => `key-${i}`);
+    await keyStore.removeKeys(kids);
+
+    expect(firestoreMock.batch).toHaveBeenCalledTimes(2);
+    expect(batchDelete).toHaveBeenCalledTimes(501);
+    expect(batchCommit).toHaveBeenCalledTimes(2);
   });
 
   it('can list keys', async () => {

--- a/plugins/auth-backend/src/identity/FirestoreKeyStore.ts
+++ b/plugins/auth-backend/src/identity/FirestoreKeyStore.ts
@@ -102,35 +102,20 @@ export class FirestoreKeyStore implements KeyStore {
   }
 
   async removeKeys(kids: string[]): Promise<void> {
-    // This is probably really slow, but it's done async in the background
-    for (const kid of kids) {
-      await this.withTimeout<WriteResult>(
-        this.database.collection(this.path).doc(kid).delete(),
-      );
+    if (kids.length === 0) {
+      return;
     }
 
-    /**
-     * This could be achieved with batching but there's a couple of limitations with that:
-     *
-     * - A batched write can contain a maximum of 500 operations
-     *  https://firebase.google.com/docs/firestore/manage-data/transactions#batched-writes
-     *
-     * - The "in" operator can combine a maximum of 10 equality clauses
-     *  https://firebase.google.com/docs/firestore/query-data/queries#in_not-in_and_array-contains-any
-     *
-     * Example:
-     *
-     *  const batch = this.database.batch();
-     *  const docs = await this.database
-     *    .collection(this.path)
-     *    .where('kid', 'in', kids)
-     *    .get();
-     *  docs.forEach(doc => {
-     *    batch.delete(doc.ref);
-     *  });
-     *  await batch.commit();
-     *
-     */
+    // Firestore batched writes support up to 500 operations per batch
+    const BATCH_SIZE = 500;
+    for (let i = 0; i < kids.length; i += BATCH_SIZE) {
+      const chunk = kids.slice(i, i + BATCH_SIZE);
+      const batch = this.database.batch();
+      for (const kid of chunk) {
+        batch.delete(this.database.collection(this.path).doc(kid));
+      }
+      await this.withTimeout<WriteResult[]>(batch.commit());
+    }
   }
 
   /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Fix N+1 database query in `FirestoreKeyStore.removeKeys`

The `removeKeys` method in `FirestoreKeyStore` was performing sequential individual Firestore delete operations for each key ID — a classic N+1 pattern. The existing code even acknowledged this with the comment:

> `// This is probably really slow, but it's done async in the background`

This PR replaces the sequential deletes with Firestore's `WriteBatch` API, reducing N network round-trips to ⌈N/500⌉ (one per batch, respecting Firestore's 500-operation batch limit).

**Before:**

```typescript
for (const kid of kids) {
  await this.withTimeout<WriteResult>(
    this.database.collection(this.path).doc(kid).delete(),
  );
}
```

**After:**

```typescript
const BATCH_SIZE = 500;
for (let i = 0; i < kids.length; i += BATCH_SIZE) {
  const chunk = kids.slice(i, i + BATCH_SIZE);
  const batch = this.database.batch();
  for (const kid of chunk) {
    batch.delete(this.database.collection(this.path).doc(kid));
  }
  await this.withTimeout<WriteResult[]>(batch.commit());
}
```

**Why `WriteBatch` over alternatives:**
- Direct doc ref deletes (no query needed since `kid` is already the document ID)
- Atomic per batch — consistent cleanup of expired signing keys
- Standard Firestore pattern recommended by [Google's documentation](https://firebase.google.com/docs/firestore/manage-data/transactions#batched-writes)

**Additional improvements:**
- Added early return guard for empty arrays
- Removed stale 20-line comment block that explained why batching wasn't implemented

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
