### PR TITLE
feat(catalog-react): allow getOptionLabel override in EntityAutocompl…

### DIFF
--- a/.changeset/entity-autocomplete-picker-get-option-label.md
+++ b/.changeset/entity-autocomplete-picker-get-option-label.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': minor
+---
+
+Added optional `getOptionLabel` and `renderOption` props to `EntityAutocompletePicker`, allowing consumers to customize how option labels and option rendering are displayed in the autocomplete dropdown.

--- a/plugins/catalog-react/report.api.md
+++ b/plugins/catalog-react/report.api.md
@@ -6,6 +6,7 @@
 import { ApiRef } from '@backstage/frontend-plugin-api';
 import { ApiRef as ApiRef_2 } from '@backstage/core-plugin-api';
 import { AutocompleteProps } from '@material-ui/lab/Autocomplete';
+import { AutocompleteRenderOptionState } from '@material-ui/lab/Autocomplete';
 import { CATALOG_FILTER_EXISTS } from '@backstage/catalog-client';
 import { CatalogApi } from '@backstage/catalog-client';
 import { ComponentEntity } from '@backstage/catalog-model';
@@ -346,6 +347,11 @@ export type EntityAutocompletePickerProps<
   initialSelectedOptions?: string[];
   filtersForAvailableValues?: Array<keyof T>;
   hidden?: boolean;
+  getOptionLabel?: (option: string) => string;
+  renderOption?: (
+    option: string,
+    state: AutocompleteRenderOptionState,
+  ) => ReactNode;
 };
 
 // @public

--- a/plugins/catalog-react/src/components/EntityAutocompletePicker/EntityAutocompletePicker.tsx
+++ b/plugins/catalog-react/src/components/EntityAutocompletePicker/EntityAutocompletePicker.tsx
@@ -17,7 +17,7 @@
 import Box from '@material-ui/core/Box';
 import { TextFieldProps } from '@material-ui/core/TextField';
 import { makeStyles } from '@material-ui/core/styles';
-import { useEffect, useMemo, useState } from 'react';
+import { ReactNode, useEffect, useMemo, useState } from 'react';
 import { useApi } from '@backstage/core-plugin-api';
 import useAsync from 'react-use/esm/useAsync';
 import { catalogApiRef } from '../../api';
@@ -29,6 +29,7 @@ import {
 import { EntityFilter } from '../../types';
 import { reduceBackendCatalogFilters } from '../../utils/filters';
 import { CatalogAutocomplete } from '../CatalogAutocomplete';
+import { AutocompleteRenderOptionState } from '@material-ui/lab/Autocomplete';
 import { isEqual } from 'lodash';
 
 /** @public */
@@ -54,6 +55,11 @@ export type EntityAutocompletePickerProps<
   initialSelectedOptions?: string[];
   filtersForAvailableValues?: Array<keyof T>;
   hidden?: boolean;
+  getOptionLabel?: (option: string) => string;
+  renderOption?: (
+    option: string,
+    state: AutocompleteRenderOptionState,
+  ) => ReactNode;
 };
 
 /** @public */
@@ -85,6 +91,8 @@ export function EntityAutocompletePicker<
     initialSelectedOptions = [],
     filtersForAvailableValues = ['kind'],
     hidden,
+    getOptionLabel,
+    renderOption,
   } = props;
   const classes = useStyles();
 
@@ -178,14 +186,18 @@ export function EntityAutocompletePicker<
         onChange={(_event: object, options: string[]) =>
           setSelectedOptions(options)
         }
-        renderOption={(option, { selected }) => (
-          <EntityAutocompletePickerOption
-            selected={selected}
-            value={option}
-            availableOptions={availableValues}
-            showCounts={!!showCounts}
-          />
-        )}
+        {...(getOptionLabel && { getOptionLabel })}
+        renderOption={
+          renderOption ??
+          ((option, { selected }) => (
+            <EntityAutocompletePickerOption
+              selected={selected}
+              value={option}
+              availableOptions={availableValues}
+              showCounts={!!showCounts}
+            />
+          ))
+        }
       />
     </Box>
   );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added an optional `getOptionLabel` prop to `EntityAutocompletePicker`, allowing consumers to customize how autocomplete option labels are rendered. When not provided, the default MUI Autocomplete behavior (identity for strings) applies.

This is useful when the raw facet values (e.g. `group:default/my-team`) need friendlier display labels in the dropdown.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.
