### PR TITLE
fix(ui): preserve external hrefs in BUI links

### DIFF
--- a/.changeset/fix-bui-external-href-resolution.md
+++ b/.changeset/fix-bui-external-href-resolution.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed external `href` handling in BUI link components. External URLs now bypass route-relative resolution so components like `ButtonLink` continue to navigate outside the Backstage app while relative internal links still resolve against the current route.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -60,7 +60,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",
-    "@testing-library/react": "^16.0.0",
+    "@backstage/test-utils": "workspace:^",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "@types/use-sync-external-store": "^1.0.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -60,6 +60,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",
+    "@testing-library/react": "^16.0.0",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "@types/use-sync-external-store": "^1.0.0",

--- a/packages/ui/src/components/ButtonLink/ButtonLink.test.tsx
+++ b/packages/ui/src/components/ButtonLink/ButtonLink.test.tsx
@@ -14,53 +14,45 @@
  * limitations under the License.
  */
 
-import { render, screen } from '@testing-library/react';
-import { MemoryRouter, Outlet, Route, Routes } from 'react-router-dom';
+import { renderInTestApp } from '@backstage/test-utils';
+import { Outlet, Route, Routes } from 'react-router-dom';
 import { ButtonLink } from './ButtonLink';
 
 describe('ButtonLink', () => {
-  it('keeps external href values unchanged', () => {
-    render(
-      <MemoryRouter
-        initialEntries={['/catalog/default/component/example']}
-        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
-      >
-        <Routes>
-          <Route
-            path="/catalog/:namespace/component/:name"
-            element={
-              <ButtonLink href="https://ui.backstage.io">
-                External docs
-              </ButtonLink>
-            }
-          />
-        </Routes>
-      </MemoryRouter>,
+  it('keeps external href values unchanged', async () => {
+    const rendered = await renderInTestApp(
+      <Routes>
+        <Route
+          path="/catalog/:namespace/component/:name"
+          element={
+            <ButtonLink href="https://ui.backstage.io">
+              External docs
+            </ButtonLink>
+          }
+        />
+      </Routes>,
+      { routeEntries: ['/catalog/default/component/example'] },
     );
 
-    const link = screen.getByRole('link', { name: 'External docs' });
+    const link = rendered.getByRole('link', { name: 'External docs' });
     expect(link.getAttribute('href')).toBe('https://ui.backstage.io');
   });
 
-  it('still resolves relative internal href values against the current route', () => {
-    render(
-      <MemoryRouter
-        initialEntries={['/catalog/default/component/example/details']}
-        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
-      >
-        <Routes>
-          <Route path="/catalog/:namespace/component/:name" element={<Outlet />}>
-            <Route
-              path="details"
-              element={<ButtonLink href="../docs">Docs</ButtonLink>}
-            />
-            <Route path="docs" element={<div>Docs page</div>} />
-          </Route>
-        </Routes>
-      </MemoryRouter>,
+  it('still resolves relative internal href values against the current route', async () => {
+    const rendered = await renderInTestApp(
+      <Routes>
+        <Route path="/catalog/:namespace/component/:name" element={<Outlet />}>
+          <Route
+            path="details"
+            element={<ButtonLink href="../docs">Docs</ButtonLink>}
+          />
+          <Route path="docs" element={<div>Docs page</div>} />
+        </Route>
+      </Routes>,
+      { routeEntries: ['/catalog/default/component/example/details'] },
     );
 
-    const link = screen.getByRole('link', { name: 'Docs' });
+    const link = rendered.getByRole('link', { name: 'Docs' });
     expect(link.getAttribute('href')).toBe(
       '/catalog/default/component/example/docs',
     );

--- a/packages/ui/src/components/ButtonLink/ButtonLink.test.tsx
+++ b/packages/ui/src/components/ButtonLink/ButtonLink.test.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Outlet, Route, Routes } from 'react-router-dom';
+import { ButtonLink } from './ButtonLink';
+
+describe('ButtonLink', () => {
+  it('keeps external href values unchanged', () => {
+    render(
+      <MemoryRouter
+        initialEntries={['/catalog/default/component/example']}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <Routes>
+          <Route
+            path="/catalog/:namespace/component/:name"
+            element={
+              <ButtonLink href="https://ui.backstage.io">
+                External docs
+              </ButtonLink>
+            }
+          />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const link = screen.getByRole('link', { name: 'External docs' });
+    expect(link.getAttribute('href')).toBe('https://ui.backstage.io');
+  });
+
+  it('still resolves relative internal href values against the current route', () => {
+    render(
+      <MemoryRouter
+        initialEntries={['/catalog/default/component/example/details']}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <Routes>
+          <Route path="/catalog/:namespace/component/:name" element={<Outlet />}>
+            <Route
+              path="details"
+              element={<ButtonLink href="../docs">Docs</ButtonLink>}
+            />
+            <Route path="docs" element={<div>Docs page</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const link = screen.getByRole('link', { name: 'Docs' });
+    expect(link.getAttribute('href')).toBe(
+      '/catalog/default/component/example/docs',
+    );
+  });
+});

--- a/packages/ui/src/hooks/useDefinition/useDefinition.tsx
+++ b/packages/ui/src/hooks/useDefinition/useDefinition.tsx
@@ -40,8 +40,9 @@ export function useDefinition<
 ): UseDefinitionResult<D, P> {
   const { breakpoint } = useBreakpoint();
 
-  // Turn internal relative hrefs into absolute paths using the current route
-  // context, so that client-side navigation works correctly.
+  // Resolve internal hrefs through the current route context. Relative hrefs
+  // become absolute route paths, while absolute internal paths stay within the
+  // app router.
   let hrefResolvedProps = props;
   const hasRouter = useInRouterContext();
   // useHref throws outside a Router, so we guard with useInRouterContext.

--- a/packages/ui/src/hooks/useDefinition/useDefinition.tsx
+++ b/packages/ui/src/hooks/useDefinition/useDefinition.tsx
@@ -22,6 +22,7 @@ import { resolveDefinitionProps, processUtilityProps } from './helpers';
 import { useAnalytics } from '../../analytics/useAnalytics';
 import { noopTracker } from '../../analytics/useAnalytics';
 import { useInRouterContext, useHref } from 'react-router-dom';
+import { isExternalLink } from '../../utils/linkUtils';
 import type {
   ComponentConfig,
   UseDefinitionOptions,
@@ -39,7 +40,7 @@ export function useDefinition<
 ): UseDefinitionResult<D, P> {
   const { breakpoint } = useBreakpoint();
 
-  // Turn relative href into an absolute path using the current route
+  // Turn internal relative hrefs into absolute paths using the current route
   // context, so that client-side navigation works correctly.
   let hrefResolvedProps = props;
   const hasRouter = useInRouterContext();
@@ -47,8 +48,11 @@ export function useDefinition<
   // The guard is safe because a component's router context does not
   // change during its lifetime, keeping the hook call count stable.
   if (hasRouter) {
-    const absoluteHref = useHref((props as any).href ?? '');
-    if ((props as any).href !== undefined) {
+    const rawHref = (props as any).href;
+    const shouldResolveHref = !!rawHref && !isExternalLink(rawHref);
+    const absoluteHref = useHref(shouldResolveHref ? rawHref : '');
+
+    if (shouldResolveHref) {
       hrefResolvedProps = { ...props, href: absoluteHref } as P;
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7992,7 +7992,7 @@ __metadata:
     "@react-stately/overlays": "npm:^3.6.23"
     "@remixicon/react": "npm:^4.6.0"
     "@tanstack/react-table": "npm:^8.21.3"
-    "@testing-library/react": "npm:^16.0.0"
+    "@backstage/test-utils": "workspace:^"
     "@types/react": "npm:^18.0.0"
     "@types/react-dom": "npm:^18.0.0"
     "@types/use-sync-external-store": "npm:^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7992,6 +7992,7 @@ __metadata:
     "@react-stately/overlays": "npm:^3.6.23"
     "@remixicon/react": "npm:^4.6.0"
     "@tanstack/react-table": "npm:^8.21.3"
+    "@testing-library/react": "npm:^16.0.0"
     "@types/react": "npm:^18.0.0"
     "@types/react-dom": "npm:^18.0.0"
     "@types/use-sync-external-store": "npm:^1.0.0"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes #33799.

External URLs started flowing through the route-relative href resolution added in #33597, which made BUI link components treat absolute URLs as in-app navigation targets. This keeps external hrefs untouched while still resolving relative internal hrefs against the current route, and adds regression coverage for both cases.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))