### PR TITLE
feat(home): add missing widgets for nfs

### DIFF
--- a/.changeset/itchy-dogs-help.md
+++ b/.changeset/itchy-dogs-help.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home': patch
+---
+
+Added missing home plugin widgets for NFS

--- a/.changeset/stale-icons-fry.md
+++ b/.changeset/stale-icons-fry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search': patch
+---
+
+Added missing home page search bar widget

--- a/plugins/home/report-alpha.api.md
+++ b/plugins/home/report-alpha.api.md
@@ -63,6 +63,15 @@ const _default: OverridableFrontendPlugin<
       inputs: {};
       params: HomePageWidgetBlueprintParams;
     }>;
+    'home-page-widget:home/recently-visited': OverridableExtensionDefinition<{
+      kind: 'home-page-widget';
+      name: 'recently-visited';
+      config: {};
+      configInput: {};
+      output: ExtensionDataRef<HomePageWidgetData, 'home.widget.data', {}>;
+      inputs: {};
+      params: HomePageWidgetBlueprintParams;
+    }>;
     'home-page-widget:home/starred-entities': OverridableExtensionDefinition<{
       kind: 'home-page-widget';
       name: 'starred-entities';
@@ -75,6 +84,24 @@ const _default: OverridableFrontendPlugin<
     'home-page-widget:home/toolkit': OverridableExtensionDefinition<{
       kind: 'home-page-widget';
       name: 'toolkit';
+      config: {};
+      configInput: {};
+      output: ExtensionDataRef<HomePageWidgetData, 'home.widget.data', {}>;
+      inputs: {};
+      params: HomePageWidgetBlueprintParams;
+    }>;
+    'home-page-widget:home/top-visited': OverridableExtensionDefinition<{
+      kind: 'home-page-widget';
+      name: 'top-visited';
+      config: {};
+      configInput: {};
+      output: ExtensionDataRef<HomePageWidgetData, 'home.widget.data', {}>;
+      inputs: {};
+      params: HomePageWidgetBlueprintParams;
+    }>;
+    'home-page-widget:home/welcome': OverridableExtensionDefinition<{
+      kind: 'home-page-widget';
+      name: 'welcome';
       config: {};
       configInput: {};
       output: ExtensionDataRef<HomePageWidgetData, 'home.widget.data', {}>;

--- a/plugins/home/src/alpha.tsx
+++ b/plugins/home/src/alpha.tsx
@@ -26,28 +26,29 @@
 
 import { lazy as reactLazy } from 'react';
 import {
+  ApiBlueprint,
+  AppRootElementBlueprint,
   createExtensionInput,
-  PageBlueprint,
-  NavItemBlueprint,
   createFrontendPlugin,
   createRouteRef,
-  AppRootElementBlueprint,
-  identityApiRef,
-  storageApiRef,
   errorApiRef,
-  ApiBlueprint,
   ExtensionBoundary,
+  identityApiRef,
+  NavItemBlueprint,
+  PageBlueprint,
+  storageApiRef,
 } from '@backstage/frontend-plugin-api';
 import { VisitListener } from './components/';
 import { visitsApiRef, VisitsStorageApi, VisitsWebStorageApi } from './api';
 import HomeIcon from '@material-ui/icons/Home';
 import {
-  homePageWidgetDataRef,
-  homePageLayoutComponentDataRef,
   HomePageLayoutBlueprint,
-  HomePageWidgetBlueprint,
+  homePageLayoutComponentDataRef,
   type HomePageLayoutProps,
+  HomePageWidgetBlueprint,
+  homePageWidgetDataRef,
 } from '@backstage/plugin-home-react/alpha';
+import { homeTranslationRef as _homeTranslationRef } from './translation';
 
 const rootRouteRef = createRouteRef();
 
@@ -152,6 +153,7 @@ const homePageToolkitWidget = HomePageWidgetBlueprint.make({
   },
 });
 
+// TODO: Move this to catalog plugin
 const homePageStarredEntitiesWidget = HomePageWidgetBlueprint.make({
   name: 'starred-entities',
   params: {
@@ -198,11 +200,70 @@ const homePageRandomJokeWidget = HomePageWidgetBlueprint.make({
   },
 });
 
+const homePageTopVisitedWidget = HomePageWidgetBlueprint.make({
+  name: 'top-visited',
+  disabled: true,
+  params: {
+    name: 'HomePageTopVisited',
+    title: 'Top Visited',
+    components: () =>
+      import('./homePageComponents/VisitedByType/TopVisited').then(m => ({
+        Content: m.Content,
+        Actions: m.Actions,
+        ContextProvider: m.ContextProvider,
+      })),
+  },
+});
+
+const homePageRecentlyVisitedWidget = HomePageWidgetBlueprint.make({
+  name: 'recently-visited',
+  disabled: true,
+  params: {
+    name: 'HomePageRecentlyVisited',
+    title: 'Recently Visited',
+    components: () =>
+      import('./homePageComponents/VisitedByType/RecentlyVisited').then(m => ({
+        Content: m.Content,
+        Actions: m.Actions,
+        ContextProvider: m.ContextProvider,
+      })),
+  },
+});
+
+const homePageWelcomeTitleWidget = HomePageWidgetBlueprint.make({
+  name: 'welcome',
+  params: {
+    name: 'HomePageWelcomeTitle',
+    title: 'Welcome',
+    components: () =>
+      import('./homePageComponents/WelcomeTitle').then(m => ({
+        Content: m.WelcomeTitle,
+      })),
+  },
+});
+
 /**
  * Home plugin for the new frontend system.
  *
  * Provides core homepage functionality with optional visit tracking extensions.
  * Visit tracking extensions are disabled by default and can be enabled via app-config.yaml.
+ *
+ * @remarks
+ * The following extensions are disabled by default and must be enabled together:
+ * - `api:home/visits` - The visits API for tracking page visits
+ * - `app-root-element:home/visit-listener` - Listener for tracking visits
+ * - `home-page-widget:home/top-visited` - Widget displaying top visited pages
+ * - `home-page-widget:home/recently-visited` - Widget displaying recently visited pages
+ *
+ * To enable visit tracking, add to your app-config.yaml:
+ * ```yaml
+ * app:
+ *   extensions:
+ *     - api:home/visits
+ *     - app-root-element:home/visit-listener
+ *     - home-page-widget:home/top-visited
+ *     - home-page-widget:home/recently-visited
+ * ```
  *
  * @alpha
  */
@@ -219,13 +280,14 @@ export default createFrontendPlugin({
     homePageToolkitWidget,
     homePageStarredEntitiesWidget,
     homePageRandomJokeWidget,
+    homePageTopVisitedWidget,
+    homePageRecentlyVisitedWidget,
+    homePageWelcomeTitleWidget,
   ],
   routes: {
     root: rootRouteRef,
   },
 });
-
-import { homeTranslationRef as _homeTranslationRef } from './translation';
 
 /**
  * @alpha

--- a/plugins/search/package.json
+++ b/plugins/search/package.json
@@ -63,6 +63,7 @@
     "@backstage/errors": "workspace:^",
     "@backstage/frontend-plugin-api": "workspace:^",
     "@backstage/plugin-catalog-react": "workspace:^",
+    "@backstage/plugin-home-react": "workspace:^",
     "@backstage/plugin-search-common": "workspace:^",
     "@backstage/plugin-search-react": "workspace:^",
     "@backstage/types": "workspace:^",

--- a/plugins/search/report-alpha.api.md
+++ b/plugins/search/report-alpha.api.md
@@ -10,6 +10,8 @@ import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { ExtensionBlueprintParams } from '@backstage/frontend-plugin-api';
 import { ExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { ExtensionInput } from '@backstage/frontend-plugin-api';
+import { HomePageWidgetBlueprintParams } from '@backstage/plugin-home-react/alpha';
+import { HomePageWidgetData } from '@backstage/plugin-home-react/alpha';
 import { IconComponent } from '@backstage/frontend-plugin-api';
 import { IconElement } from '@backstage/frontend-plugin-api';
 import { JSX as JSX_2 } from 'react';
@@ -43,6 +45,15 @@ const _default: OverridableFrontendPlugin<
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
       ) => ExtensionBlueprintParams<AnyApiFactory>;
+    }>;
+    'home-page-widget:search/search-bar': OverridableExtensionDefinition<{
+      kind: 'home-page-widget';
+      name: 'search-bar';
+      config: {};
+      configInput: {};
+      output: ExtensionDataRef<HomePageWidgetData, 'home.widget.data', {}>;
+      inputs: {};
+      params: HomePageWidgetBlueprintParams;
     }>;
     'nav-item:search': OverridableExtensionDefinition<{
       kind: 'nav-item';
@@ -192,6 +203,17 @@ const _default: OverridableFrontendPlugin<
   }
 >;
 export default _default;
+
+// @alpha (undocumented)
+export const homePageSearchBarWidget: OverridableExtensionDefinition<{
+  kind: 'home-page-widget';
+  name: 'search-bar';
+  config: {};
+  configInput: {};
+  output: ExtensionDataRef<HomePageWidgetData, 'home.widget.data', {}>;
+  inputs: {};
+  params: HomePageWidgetBlueprintParams;
+}>;
 
 // @alpha (undocumented)
 export const searchApi: OverridableExtensionDefinition<{

--- a/plugins/search/src/alpha.tsx
+++ b/plugins/search/src/alpha.tsx
@@ -62,6 +62,7 @@ import {
   SearchFilterResultTypeBlueprint,
   SearchFilterBlueprint,
 } from '@backstage/plugin-search-react/alpha';
+import { HomePageWidgetBlueprint } from '@backstage/plugin-home-react/alpha';
 
 import { rootRouteRef } from './plugin';
 import { SearchClient } from './apis';
@@ -269,12 +270,25 @@ export const searchNavItem = NavItemBlueprint.make({
 });
 
 /** @alpha */
+export const homePageSearchBarWidget = HomePageWidgetBlueprint.make({
+  name: 'search-bar',
+  params: {
+    name: 'HomePageSearchBar',
+    title: 'Search',
+    components: () =>
+      import('./components/HomePageComponent').then(m => ({
+        Content: m.HomePageSearchBar,
+      })),
+  },
+});
+
+/** @alpha */
 export default createFrontendPlugin({
   pluginId: 'search',
   title: 'Search',
   icon: <SearchIcon fontSize="inherit" />,
   info: { packageJson: () => import('../package.json') },
-  extensions: [searchApi, searchPage, searchNavItem],
+  extensions: [searchApi, searchPage, searchNavItem, homePageSearchBarWidget],
   routes: {
     root: rootRouteRef,
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7327,6 +7327,7 @@ __metadata:
     "@backstage/errors": "workspace:^"
     "@backstage/frontend-plugin-api": "workspace:^"
     "@backstage/plugin-catalog-react": "workspace:^"
+    "@backstage/plugin-home-react": "workspace:^"
     "@backstage/plugin-search-common": "workspace:^"
     "@backstage/plugin-search-react": "workspace:^"
     "@backstage/test-utils": "workspace:^"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

these were missing from the widget selection for the customizable home page.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
