### PR TITLE
feat(home): toolkit tools via config

### DIFF
--- a/.changeset/fresh-seas-brake.md
+++ b/.changeset/fresh-seas-brake.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home': patch
+---
+
+It is possible to define toolkit tools via application config

--- a/plugins/home/config.d.ts
+++ b/plugins/home/config.d.ts
@@ -64,5 +64,30 @@ export interface Config {
         value: string | number;
       }>;
     };
+    /**
+     * Toolkit plugin
+     * @visibility frontend
+     */
+    toolkit?: {
+      /**
+       * Tools to display in the toolkit
+       * @visibility frontend
+       */
+      tools?: Array<{
+        /**
+         * @visibility frontend
+         */
+        url: string;
+        /**
+         * @visibility frontend
+         */
+        label: string;
+        /**
+         * Icon key registered in the app's icon registry
+         * @visibility frontend
+         */
+        icon?: string;
+      }>;
+    };
   };
 }

--- a/plugins/home/report.api.md
+++ b/plugins/home/report.api.md
@@ -277,12 +277,12 @@ export const TemplateBackstageLogoIcon: () => JSX_2.Element;
 export type Tool = {
   label: string;
   url: string;
-  icon: ReactNode;
+  icon: ReactNode | string;
 };
 
 // @public
 export type ToolkitContentProps = {
-  tools: Tool[];
+  tools?: Tool[];
 };
 
 // @public

--- a/plugins/home/src/alpha.tsx
+++ b/plugins/home/src/alpha.tsx
@@ -140,15 +140,6 @@ const homePageToolkitWidget = HomePageWidgetBlueprint.make({
         Content: m.Content,
         ContextProvider: m.ContextProvider,
       })),
-    componentProps: {
-      tools: [
-        {
-          url: 'https://backstage.io',
-          label: 'Backstage Docs',
-          icon: <HomeIcon />,
-        },
-      ],
-    },
   },
 });
 

--- a/plugins/home/src/homePageComponents/Toolkit/Content.test.tsx
+++ b/plugins/home/src/homePageComponents/Toolkit/Content.test.tsx
@@ -14,9 +14,37 @@
  * limitations under the License.
  */
 
-import { renderInTestApp } from '@backstage/test-utils';
+import {
+  TestApiProvider,
+  renderInTestApp,
+  mockApis,
+} from '@backstage/test-utils';
+import { configApiRef } from '@backstage/core-plugin-api';
+import { iconsApiRef, IconsApi } from '@backstage/frontend-plugin-api';
 import { Content } from './Content';
 import { ContextProvider } from './Context';
+
+const mockIconsApi: IconsApi = {
+  icon: jest.fn((key: string) =>
+    key === 'test-icon' ? <span>test-icon-element</span> : null,
+  ),
+  getIcon: jest.fn(),
+  listIconKeys: jest.fn(() => []),
+};
+
+const mockConfigApi = mockApis.config({});
+
+const renderWithApis = (ui: JSX.Element) =>
+  renderInTestApp(
+    <TestApiProvider
+      apis={[
+        [configApiRef, mockConfigApi],
+        [iconsApiRef, mockIconsApi],
+      ]}
+    >
+      {ui}
+    </TestApiProvider>,
+  );
 
 describe('<ToolkitContent>', () => {
   const tools = [
@@ -25,7 +53,7 @@ describe('<ToolkitContent>', () => {
   ];
 
   test('should render list of tools', async () => {
-    const { getByText } = await renderInTestApp(<Content tools={tools} />);
+    const { getByText } = await renderWithApis(<Content tools={tools} />);
 
     expect(getByText('tool')).toBeInTheDocument();
     expect(getByText('tool 2')).toBeInTheDocument();
@@ -34,9 +62,9 @@ describe('<ToolkitContent>', () => {
   });
 
   test('should render list of tools using context', async () => {
-    const { getByText } = await renderInTestApp(
+    const { getByText } = await renderWithApis(
       <ContextProvider tools={tools}>
-        <Content tools={[]} />
+        <Content />
       </ContextProvider>,
     );
 
@@ -44,5 +72,74 @@ describe('<ToolkitContent>', () => {
     expect(getByText('tool 2')).toBeInTheDocument();
     expect(getByText('tool').closest('a')).toHaveAttribute('href', '/url');
     expect(getByText('tool 2').closest('a')).toHaveAttribute('href', '/url-2');
+  });
+
+  test('should render tools from config', async () => {
+    const configWithTools = mockApis.config({
+      data: {
+        home: {
+          toolkit: {
+            tools: [
+              { url: '/config-url', label: 'config tool', icon: 'test-icon' },
+            ],
+          },
+        },
+      },
+    });
+
+    const { getByText } = await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [configApiRef, configWithTools],
+          [iconsApiRef, mockIconsApi],
+        ]}
+      >
+        <Content />
+      </TestApiProvider>,
+    );
+
+    expect(getByText('config tool')).toBeInTheDocument();
+    expect(getByText('config tool').closest('a')).toHaveAttribute(
+      'href',
+      '/config-url',
+    );
+    expect(getByText('test-icon-element')).toBeInTheDocument();
+  });
+
+  test('should render ReactNode icons without iconsApiRef', async () => {
+    const { getByText } = await renderInTestApp(
+      <TestApiProvider apis={[[configApiRef, mockConfigApi]]}>
+        <Content tools={tools} />
+      </TestApiProvider>,
+    );
+
+    expect(getByText('tool')).toBeInTheDocument();
+    expect(getByText('tool 2')).toBeInTheDocument();
+  });
+
+  test('should deduplicate tools with the same url', async () => {
+    const configWithDuplicate = mockApis.config({
+      data: {
+        home: {
+          toolkit: {
+            tools: [{ url: '/url', label: 'config tool' }],
+          },
+        },
+      },
+    });
+
+    const { getAllByText, queryByText } = await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [configApiRef, configWithDuplicate],
+          [iconsApiRef, mockIconsApi],
+        ]}
+      >
+        <Content tools={tools} />
+      </TestApiProvider>,
+    );
+
+    expect(getAllByText('tool')).toHaveLength(1);
+    expect(queryByText('config tool')).not.toBeInTheDocument();
   });
 });

--- a/plugins/home/src/homePageComponents/Toolkit/Content.tsx
+++ b/plugins/home/src/homePageComponents/Toolkit/Content.tsx
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
+import { ReactNode } from 'react';
 import { Link } from '@backstage/core-components';
+import { configApiRef, useApi, useApiHolder } from '@backstage/core-plugin-api';
+import { iconsApiRef } from '@backstage/frontend-plugin-api';
 import List from '@material-ui/core/List';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
@@ -57,13 +60,44 @@ const useStyles = makeStyles(theme => ({
 export const Content = (props: ToolkitContentProps) => {
   const classes = useStyles();
   const toolkit = useToolkit();
-  const tools = toolkit?.tools ?? props.tools;
+  const configApi = useApi(configApiRef);
+  const iconsApi = useApiHolder().get(iconsApiRef);
+
+  const configTools: Tool[] = (
+    configApi.getOptionalConfigArray('home.toolkit.tools') ?? []
+  ).map(toolConfig => ({
+    url: toolConfig.getString('url'),
+    label: toolConfig.getString('label'),
+    icon: toolConfig.getOptionalString('icon'),
+  }));
+
+  const seenUrls = new Set<string>();
+  const tools = [
+    ...(toolkit?.tools ?? []),
+    ...(props.tools ?? []),
+    ...configTools,
+  ].filter(tool => {
+    if (seenUrls.has(tool.url)) {
+      return false;
+    }
+    seenUrls.add(tool.url);
+    return true;
+  });
+
+  const resolveIcon = (icon: ReactNode | string): ReactNode => {
+    if (typeof icon === 'string') {
+      return iconsApi?.icon(icon) ?? null;
+    }
+    return icon;
+  };
 
   return (
     <List className={classes.toolkit}>
       {tools.map((tool: Tool) => (
         <Link key={tool.url} to={tool.url} className={classes.tool}>
-          <ListItemIcon className={classes.icon}>{tool.icon}</ListItemIcon>
+          <ListItemIcon className={classes.icon}>
+            {resolveIcon(tool.icon)}
+          </ListItemIcon>
           <ListItemText
             secondaryTypographyProps={{ className: classes.label }}
             secondary={tool.label}
@@ -80,5 +114,5 @@ export const Content = (props: ToolkitContentProps) => {
  * @public
  */
 export type ToolkitContentProps = {
-  tools: Tool[];
+  tools?: Tool[];
 };

--- a/plugins/home/src/homePageComponents/Toolkit/Context.tsx
+++ b/plugins/home/src/homePageComponents/Toolkit/Context.tsx
@@ -20,7 +20,7 @@ import { ReactNode, useState, useContext, createContext } from 'react';
 export type Tool = {
   label: string;
   url: string;
-  icon: ReactNode;
+  icon: ReactNode | string;
 };
 
 type ToolkitContextValue = {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

allow defining toolkit tools via app config. this makes it more usable in the new frontend system without need to modify the home layout.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
