### PR TITLE
fix(ui): preserve active tab indicator for non-routed tabs

### DIFF
--- a/.changeset/fix-tabs-indicator-uncontrolled.md
+++ b/.changeset/fix-tabs-indicator-uncontrolled.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed the active tab indicator disappearing in non-routed (uncontrolled) Tabs. The indicator opacity is now only hidden when `selectedKey` is explicitly empty (routed tabs with no matching route), rather than when it is `null` or `undefined` (uncontrolled mode where React Aria manages selection internally).

--- a/.changeset/fix-tabs-indicator-uncontrolled.md
+++ b/.changeset/fix-tabs-indicator-uncontrolled.md
@@ -2,4 +2,4 @@
 '@backstage/ui': patch
 ---
 
-Fixed the active tab indicator disappearing in non-routed (uncontrolled) Tabs. The indicator opacity is now only hidden when `selectedKey` is explicitly empty (routed tabs with no matching route), rather than when it is `null` or `undefined` (uncontrolled mode where React Aria manages selection internally).
+Fixed the active tab indicator disappearing in non-routed (uncontrolled) Tabs on initial render. The indicator is now also correctly hidden when transitioning from a selected tab back to no selection in controlled mode.

--- a/.changeset/fix-tabs-indicator-uncontrolled.md
+++ b/.changeset/fix-tabs-indicator-uncontrolled.md
@@ -3,3 +3,5 @@
 ---
 
 Fixed the active tab indicator disappearing in non-routed (uncontrolled) Tabs on initial render. The indicator is now also correctly hidden when transitioning from a selected tab back to no selection in controlled mode.
+
+**Affected components:** Tabs

--- a/debug-tabs-indicator.md
+++ b/debug-tabs-indicator.md
@@ -1,0 +1,73 @@
+# Debug: Tab Indicator Opacity Not Updating After Remount
+
+## Context
+
+PR: https://github.com/backstage/backstage/pull/33835
+
+There's a bug where the active tab indicator disappears on page load for non-routed (uncontrolled) Tabs in Portal (but not in Storybook). The indicator briefly appears, then vanishes. Hovering a tab brings it back.
+
+## What We Know So Far
+
+### The component remounts
+
+Debug logging in `TabsIndicators` revealed that the component is being **unmounted and remounted** (likely by the consumer app or React Strict Mode). The logs show `prevSelectedKey` (a `useRef`) resetting from `'overview'` back to `null`, confirming a fresh instance.
+
+### First mount works, remount doesn't
+
+- **First mount:** 4 renders happen before effects fire (selectedKey: undefined → null → null → 'overview'). By the time `updateCSSVariables` runs, `selectedKey` has settled to `'overview'` → opacity set to `1`.
+- **Remount:** Effect fires with `selectedKey: undefined`, `tabRefsSize: 2` → hits the `else` branch → opacity set to `0`. Then `updateCSSVariables` **never fires again**, even though subsequent renders show `selectedKey: 'overview'`.
+
+### The renders are interleaved from two instances
+
+After the remount, the logs show renders from two different instances:
+
+- Instance with `selectedKey: 'overview'`, `prevSelectedKey: 'overview'` (old/surviving)
+- Instance with `selectedKey: undefined`, `prevSelectedKey: null` (remount)
+
+The remount instance's `selectedKey` **never changes from `undefined`**. The `TabListStateContext` update doesn't seem to propagate to it.
+
+### Console logs for reference
+
+```
+[TabsIndicators] render {selectedKey: undefined, prevSelectedKey: null, hoveredKey: undefined}
+[TabsIndicators] render {selectedKey: null, prevSelectedKey: null, hoveredKey: undefined}
+[TabsIndicators] updateCSSVariables {selectedKey: undefined, prevSelectedKey: null, tabRefsSize: 0}
+[TabsIndicators] updateCSSVariables {selectedKey: null, prevSelectedKey: null, tabRefsSize: 0}
+[TabsIndicators] render {selectedKey: null, prevSelectedKey: null, hoveredKey: undefined}
+[TabsIndicators] render {selectedKey: 'overview', prevSelectedKey: null, hoveredKey: undefined}
+[TabsIndicators] updateCSSVariables {selectedKey: 'overview', prevSelectedKey: null, tabRefsSize: 2}
+[TabsIndicators] → set opacity 1 {selectedKey: 'overview'}
+[TabsIndicators] render {selectedKey: undefined, prevSelectedKey: null, hoveredKey: undefined}
+[TabsIndicators] render {selectedKey: 'overview', prevSelectedKey: 'overview', hoveredKey: undefined}
+[TabsIndicators] updateCSSVariables {selectedKey: undefined, prevSelectedKey: null, tabRefsSize: 2}
+[TabsIndicators] render {selectedKey: 'overview', prevSelectedKey: 'overview', hoveredKey: undefined}
+[TabsIndicators] render {selectedKey: undefined, prevSelectedKey: null, hoveredKey: undefined}
+[TabsIndicators] render {selectedKey: 'overview', prevSelectedKey: 'overview', hoveredKey: undefined}
+[TabsIndicators] render {selectedKey: 'overview', prevSelectedKey: 'overview', hoveredKey: undefined}
+```
+
+## The Open Question
+
+**Why doesn't `TabListStateContext` update propagate to the remount instance?**
+
+The remount instance always sees `selectedKey: undefined` from `useContext(TabListStateContext)`. Meanwhile another instance in the same logs sees `selectedKey: 'overview'`. Either:
+
+1. The remount instance is under a **different `TabListStateContext` provider** that never settles
+2. The provider the remount instance consumes is **stale or disconnected**
+3. There's something about React Aria's internal `Tabs` → `TabsInner` → `Provider` chain that doesn't re-provide the context after the state settles during a remount
+4. React's reconciliation is reusing the DOM but creating a new component instance that doesn't subscribe to context updates properly
+
+## Key Files
+
+- `packages/ui/src/components/Tabs/TabsIndicators.tsx` — the component with the bug
+- `packages/ui/src/components/Tabs/Tabs.tsx` — where `TabsIndicators` is rendered inside `TabList`
+- `node_modules/react-aria-components/src/Tabs.tsx` — where `TabListStateContext` is provided (look at `TabsInner`, around line 180-220)
+- `node_modules/@react-stately/tabs/src/useTabListState.ts` — where `selectedKey` is managed (look at the effect with no dependency array, around line 48-64)
+
+## Suggested Investigation Steps
+
+1. Add an instance ID to `TabsIndicators` (e.g. `useRef(Math.random())`) to distinguish the two instances in logs
+2. Add logging to the `TabListStateContext` provider in react-aria-components to see if the context value is actually updating
+3. Check if the `Tabs`/`TabList` parent components are also remounting — if the provider remounts, the new provider's `useTabListState` would start fresh with `selectedKey: null`
+4. Check if Portal uses React Strict Mode (`<StrictMode>`) or if there's a Suspense boundary that could cause the remount
+5. Check if there's a key prop changing on a parent component that forces the subtree to remount

--- a/packages/ui/src/components/Tabs/TabsIndicators.tsx
+++ b/packages/ui/src/components/Tabs/TabsIndicators.tsx
@@ -100,11 +100,16 @@ export const TabsIndicators = (props: TabsIndicatorsProps) => {
         );
         tabsRef.current.style.setProperty('--active-tab-opacity', '1');
       }
-    } else if (state?.selectedKey === '') {
-      // Only hide the indicator when explicitly deselected (routed tabs with
-      // no matching route). When selectedKey is null/undefined (e.g. React
-      // Aria uncontrolled mode for non-routed tabs), leave the indicator
-      // state unchanged so it doesn't flash away before state settles.
+    } else if (
+      state?.selectedKey === '' ||
+      (state?.selectedKey == null && prevSelectedKey.current !== null)
+    ) {
+      // Hide the indicator when explicitly deselected (routed tabs with no
+      // matching route) or when transitioning from a selected tab back to no
+      // selection (controlled mode). When selectedKey is null/undefined and
+      // no tab was previously selected (e.g. React Aria uncontrolled mode
+      // settling on initial render), leave the indicator state unchanged so
+      // it doesn't flash away before state settles.
       tabsRef.current.style.setProperty('--active-tab-opacity', '0');
       prevSelectedKey.current = null;
     }

--- a/packages/ui/src/components/Tabs/TabsIndicators.tsx
+++ b/packages/ui/src/components/Tabs/TabsIndicators.tsx
@@ -36,16 +36,6 @@ export const TabsIndicators = (props: TabsIndicatorsProps) => {
 
     const tabsRect = tabsRef.current.getBoundingClientRect();
 
-    // Hide the indicator when explicitly deselected (routed tabs with no
-    // matching route) or when transitioning from a selected tab back to no
-    // selection (controlled mode). When selectedKey is null/undefined and
-    // no tab was previously selected (e.g. React Aria uncontrolled mode
-    // settling on initial render), leave the indicator state unchanged so
-    // it doesn't flash away before state settles.
-    const isDeselected =
-      state?.selectedKey === '' ||
-      (state?.selectedKey == null && prevSelectedKey.current !== null);
-
     // Set active tab variables
     if (state?.selectedKey != null && state.selectedKey !== '') {
       const activeTab = tabRefs.current.get(state.selectedKey.toString());
@@ -110,7 +100,13 @@ export const TabsIndicators = (props: TabsIndicatorsProps) => {
         );
         tabsRef.current.style.setProperty('--active-tab-opacity', '1');
       }
-    } else if (isDeselected) {
+    } else if (
+      // Hide indicator on explicit deselection (selectedKey === '') or when
+      // transitioning away from a previously selected tab. Skip when no tab
+      // was ever selected (uncontrolled mode settling on initial render).
+      state?.selectedKey === '' ||
+      (state?.selectedKey == null && prevSelectedKey.current !== null)
+    ) {
       tabsRef.current.style.setProperty('--active-tab-opacity', '0');
       prevSelectedKey.current = null;
     }

--- a/packages/ui/src/components/Tabs/TabsIndicators.tsx
+++ b/packages/ui/src/components/Tabs/TabsIndicators.tsx
@@ -31,10 +31,22 @@ export const TabsIndicators = (props: TabsIndicatorsProps) => {
   const state = useContext(TabListStateContext);
   const prevSelectedKey = useRef<string | null>(null);
 
+  console.log('[TabsIndicators] render', {
+    selectedKey: state?.selectedKey,
+    prevSelectedKey: prevSelectedKey.current,
+    hoveredKey,
+  });
+
   const updateCSSVariables = useCallback(() => {
     if (!tabsRef.current) return;
 
     const tabsRect = tabsRef.current.getBoundingClientRect();
+
+    console.log('[TabsIndicators] updateCSSVariables', {
+      selectedKey: state?.selectedKey,
+      prevSelectedKey: prevSelectedKey.current,
+      tabRefsSize: tabRefs.current.size,
+    });
 
     // Set active tab variables
     if (state?.selectedKey != null && state.selectedKey !== '') {
@@ -99,6 +111,9 @@ export const TabsIndicators = (props: TabsIndicatorsProps) => {
           `${activeRect.height}px`,
         );
         tabsRef.current.style.setProperty('--active-tab-opacity', '1');
+        console.log('[TabsIndicators] → set opacity 1', {
+          selectedKey: state.selectedKey.toString(),
+        });
       }
     } else if (
       // Hide indicator on explicit deselection (selectedKey === '') or when
@@ -108,6 +123,10 @@ export const TabsIndicators = (props: TabsIndicatorsProps) => {
       (state?.selectedKey == null && prevSelectedKey.current !== null)
     ) {
       tabsRef.current.style.setProperty('--active-tab-opacity', '0');
+      console.log('[TabsIndicators] → set opacity 0', {
+        selectedKey: state?.selectedKey,
+        prevSelectedKey: prevSelectedKey.current,
+      });
       prevSelectedKey.current = null;
     }
 

--- a/packages/ui/src/components/Tabs/TabsIndicators.tsx
+++ b/packages/ui/src/components/Tabs/TabsIndicators.tsx
@@ -100,7 +100,11 @@ export const TabsIndicators = (props: TabsIndicatorsProps) => {
         );
         tabsRef.current.style.setProperty('--active-tab-opacity', '1');
       }
-    } else {
+    } else if (state?.selectedKey === '') {
+      // Only hide the indicator when explicitly deselected (routed tabs with
+      // no matching route). When selectedKey is null/undefined (e.g. React
+      // Aria uncontrolled mode for non-routed tabs), leave the indicator
+      // state unchanged so it doesn't flash away before state settles.
       tabsRef.current.style.setProperty('--active-tab-opacity', '0');
       prevSelectedKey.current = null;
     }

--- a/packages/ui/src/components/Tabs/TabsIndicators.tsx
+++ b/packages/ui/src/components/Tabs/TabsIndicators.tsx
@@ -36,6 +36,16 @@ export const TabsIndicators = (props: TabsIndicatorsProps) => {
 
     const tabsRect = tabsRef.current.getBoundingClientRect();
 
+    // Hide the indicator when explicitly deselected (routed tabs with no
+    // matching route) or when transitioning from a selected tab back to no
+    // selection (controlled mode). When selectedKey is null/undefined and
+    // no tab was previously selected (e.g. React Aria uncontrolled mode
+    // settling on initial render), leave the indicator state unchanged so
+    // it doesn't flash away before state settles.
+    const isDeselected =
+      state?.selectedKey === '' ||
+      (state?.selectedKey == null && prevSelectedKey.current !== null);
+
     // Set active tab variables
     if (state?.selectedKey != null && state.selectedKey !== '') {
       const activeTab = tabRefs.current.get(state.selectedKey.toString());
@@ -100,16 +110,7 @@ export const TabsIndicators = (props: TabsIndicatorsProps) => {
         );
         tabsRef.current.style.setProperty('--active-tab-opacity', '1');
       }
-    } else if (
-      state?.selectedKey === '' ||
-      (state?.selectedKey == null && prevSelectedKey.current !== null)
-    ) {
-      // Hide the indicator when explicitly deselected (routed tabs with no
-      // matching route) or when transitioning from a selected tab back to no
-      // selection (controlled mode). When selectedKey is null/undefined and
-      // no tab was previously selected (e.g. React Aria uncontrolled mode
-      // settling on initial render), leave the indicator state unchanged so
-      // it doesn't flash away before state settles.
+    } else if (isDeselected) {
       tabsRef.current.style.setProperty('--active-tab-opacity', '0');
       prevSelectedKey.current = null;
     }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes the active tab indicator disappearing on initial render when using non-routed (uncontrolled) `Tabs` — i.e. `<Tab id="foo">` without an `href` prop. Also ensures the indicator correctly hides when transitioning from a selected tab back to no selection in controlled mode.

### Root Cause

PR #33784 changed `.bui-TabActive` from `opacity: 1` (hardcoded) to `opacity: var(--active-tab-opacity)`, initialized to `0`. The JS in `TabsIndicators` sets it to `1` when `state.selectedKey` is a valid key, and `0` otherwise.

For **routed tabs** (with `href`), the `Tabs` component passes `selectedKey=""` when no tab matches the current route — correctly hiding the indicator.

For **non-routed tabs** (no `href`), `selectedKey={undefined}` is passed to React Aria (uncontrolled mode). React Aria manages selection internally, but `state.selectedKey` from `TabListStateContext` can be `null` briefly before the state settles. The `else` branch in `updateCSSVariables` was treating this the same as `""`, setting opacity to `0` and hiding the indicator.

### Fix

The `else` branch is replaced with an `else if` that hides the indicator only when:

1. `selectedKey === ''` — explicitly deselected (routed tabs, no URL match)
2. `selectedKey` is `null`/`undefined` **and** a tab was previously selected — transitioning back to no selection (controlled mode deselection)

When `selectedKey` is `null`/`undefined` and no tab was previously selected (uncontrolled mode initial render), the indicator state is left unchanged so it doesn't flash away before React Aria's state settles.

### How to reproduce

Use `Tabs` without `href` on the `Tab` components:

```tsx
<Tabs>
  <TabList>
    <Tab id="overview">Overview</Tab>
    <Tab id="review">Review</Tab>
  </TabList>
  <TabPanel id="overview">...</TabPanel>
  <TabPanel id="review">...</TabPanel>
</Tabs>
```

The active indicator appears momentarily on page load, then disappears. It reappears when hovering any tab.

#### ✅ Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.