### PR TITLE
feat(api-docs): use catalog presentation for API titles

### DIFF
--- a/.changeset/young-facts-itch.md
+++ b/.changeset/young-facts-itch.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': minor
+---
+
+Use Entity Presentation API for entity display in api-docs plugin

--- a/plugins/api-docs/src/components/ApiDefinitionCard/ApiDefinitionCard.tsx
+++ b/plugins/api-docs/src/components/ApiDefinitionCard/ApiDefinitionCard.tsx
@@ -15,7 +15,10 @@
  */
 
 import { ApiEntity } from '@backstage/catalog-model';
-import { useEntity } from '@backstage/plugin-catalog-react';
+import {
+  useEntity,
+  useEntityPresentation,
+} from '@backstage/plugin-catalog-react';
 import { CardTab, TabbedCard } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
 import { useTranslationRef } from '@backstage/frontend-plugin-api';
@@ -30,17 +33,17 @@ export const ApiDefinitionCard = () => {
   const config = useApi(apiDocsConfigRef);
   const { getApiDefinitionWidget } = config;
   const { t } = useTranslationRef(apiDocsTranslationRef);
+  const { primaryTitle } = useEntityPresentation(entity);
 
   if (!entity) {
     return <Alert severity="error">{t('apiDefinitionCard.error.title')}</Alert>;
   }
 
   const definitionWidget = getApiDefinitionWidget(entity);
-  const entityTitle = entity.metadata.title ?? entity.metadata.name;
 
   if (definitionWidget) {
     return (
-      <TabbedCard title={entityTitle}>
+      <TabbedCard title={primaryTitle}>
         <CardTab label={definitionWidget.title} key="widget">
           {definitionWidget.component(entity.spec.definition)}
         </CardTab>
@@ -56,7 +59,7 @@ export const ApiDefinitionCard = () => {
 
   return (
     <TabbedCard
-      title={entityTitle}
+      title={primaryTitle}
       children={[
         // Has to be an array, otherwise typescript doesn't like that this has only a single child
         <CardTab label={entity.spec.type} key="raw">

--- a/plugins/api-docs/src/components/ApiDefinitionDialog/ApiDefinitionDialog.tsx
+++ b/plugins/api-docs/src/components/ApiDefinitionDialog/ApiDefinitionDialog.tsx
@@ -16,6 +16,7 @@
 
 import { ApiEntity } from '@backstage/catalog-model';
 import { useApi } from '@backstage/core-plugin-api';
+import { EntityDisplayName } from '@backstage/plugin-catalog-react';
 import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
 import Dialog from '@material-ui/core/Dialog';
@@ -137,7 +138,7 @@ export function ApiDefinitionDialog(props: {
           {definitionWidget?.title ?? t('apiDefinitionDialog.rawButtonTitle')}
         </Typography>
         <Typography className={classes.title} variant="h1">
-          {entity.metadata.title ?? entity.metadata.name}
+          <EntityDisplayName entityRef={entity} />
         </Typography>
       </DialogTitle>
       <DialogContent dividers className={classes.root}>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This updates API Docs to use the Catalog presentation API when displaying API entity titles.

Changes:
- `ApiDefinitionDialog` now renders the API entity title with `EntityDisplayName`
- `ApiDefinitionCard` now uses `useEntityPresentation(entity).primaryTitle` for the `TabbedCard` title

This avoids direct display usage of `metadata.title ?? metadata.name` and keeps API entity presentation consistent with the rest of the catalog UI.

Refs #20955.

Testing:
- `yarn tsc`
- `yarn workspace @backstage/plugin-api-docs test --watchAll=false --runInBand`

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
