### PR TITLE
fix: handle limit=0 in getNotifications query

### DIFF
--- a/.changeset/fix-notifications-limit-zero.md
+++ b/.changeset/fix-notifications-limit-zero.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications-backend': patch
+---
+
+Fix handling of `limit=0` in `getNotifications` query to return empty results instead of all notifications

--- a/plugins/notifications-backend/src/database/DatabaseNotificationsStore.test.ts
+++ b/plugins/notifications-backend/src/database/DatabaseNotificationsStore.test.ts
@@ -469,6 +469,11 @@ describe.each(databases.eachSupportedId())(
           id3,
         ]);
       });
+
+      it('should return empty array when limit is 0', async () => {
+        const result = await storage.getNotifications({ user, limit: 0 });
+        expect(result).toEqual([]);
+      });
     });
 
     describe('getNotifications sorting', () => {

--- a/plugins/notifications-backend/src/database/DatabaseNotificationsStore.ts
+++ b/plugins/notifications-backend/src/database/DatabaseNotificationsStore.ts
@@ -289,11 +289,11 @@ export class DatabaseNotificationsStore implements NotificationsStore {
       }
     }
 
-    if (options.limit) {
+    if (options.limit !== undefined) {
       query.limit(options.limit);
     }
 
-    if (options.offset) {
+    if (options.offset !== undefined) {
       query.offset(options.offset);
     }
 


### PR DESCRIPTION
### **SUMMARY**

This PR fixes a pagination bug where `limit=0` returned all notifications instead of an empty list.
The issue was in `DatabaseNotificationsStore.getNotifications()` due to incorrect checks for `limit` and `offset`.

---

### **FIX**

#### **Before**

```ts
if (options.limit) {
  query.limit(options.limit);
}
```

#### **After**

```ts
if (options.limit !== undefined) {
  query.limit(options.limit);
}
```

---

### **VERIFICATION**

Calling the API with `limit=0` previously returned all notifications.
Now it correctly returns an empty array.
Other values behave exactly the same.
