### PR TITLE
refactor(notifications): Extract link resolution from notification email into common node library

### DIFF
--- a/.changeset/wise-gifts-appear.md
+++ b/.changeset/wise-gifts-appear.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-notifications-backend-module-email': patch
+'@backstage/plugin-notifications-backend-module-slack': patch
+'@backstage/plugin-notifications-node': patch
+---
+
+Added `resolveNotificationLink` utility function that resolves relative notification links to absolute URLs using a provided base URL. This can be used by notification processor modules to ensure links are absolute before forwarding them to external systems.

--- a/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.ts
+++ b/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.ts
@@ -273,12 +273,13 @@ export class NotificationsEmailProcessor implements NotificationProcessor {
     );
   }
 
-  private getNotificationLink(notification: Notification) {
+  private getNotificationLink(notification: Notification): string {
     if (notification.payload.link) {
-      return resolveNotificationLink(
+      const resolvedLink = resolveNotificationLink(
         notification.payload.link,
         this.frontendBaseUrl,
       );
+      return resolvedLink ?? notification.payload.link;
     }
     return `${this.frontendBaseUrl}/notifications`;
   }

--- a/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.ts
+++ b/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.ts
@@ -17,6 +17,7 @@
 import {
   NotificationProcessor,
   NotificationSendOptions,
+  resolveNotificationLink,
 } from '@backstage/plugin-notifications-node';
 import {
   AuthService,
@@ -274,19 +275,12 @@ export class NotificationsEmailProcessor implements NotificationProcessor {
 
   private getNotificationLink(notification: Notification) {
     if (notification.payload.link) {
-      const stripLeadingSlash = (s: string) => s.replace(/^\//, '');
-      const ensureTrailingSlash = (s: string) => s.replace(/\/?$/, '/');
-
-      try {
-        const url = new URL(
-          stripLeadingSlash(notification.payload.link),
-          ensureTrailingSlash(this.frontendBaseUrl),
-        );
-        return url.toString();
-      } catch (_e) {
-        // noop: fallback to relative URL
-      }
-      return notification.payload.link;
+      return (
+        resolveNotificationLink(
+          notification.payload.link,
+          this.frontendBaseUrl,
+        ) ?? notification.payload.link
+      );
     }
     return `${this.frontendBaseUrl}/notifications`;
   }

--- a/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.ts
+++ b/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.ts
@@ -275,11 +275,9 @@ export class NotificationsEmailProcessor implements NotificationProcessor {
 
   private getNotificationLink(notification: Notification) {
     if (notification.payload.link) {
-      return (
-        resolveNotificationLink(
-          notification.payload.link,
-          this.frontendBaseUrl,
-        ) ?? notification.payload.link
+      return resolveNotificationLink(
+        notification.payload.link,
+        this.frontendBaseUrl,
       );
     }
     return `${this.frontendBaseUrl}/notifications`;

--- a/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.ts
+++ b/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.ts
@@ -325,12 +325,13 @@ export class NotificationsEmailProcessor implements NotificationProcessor {
     );
   }
 
-  private getNotificationLink(notification: Notification) {
+  private getNotificationLink(notification: Notification): string {
     if (notification.payload.link) {
-      return resolveNotificationLink(
+      const resolvedLink = resolveNotificationLink(
         notification.payload.link,
         this.frontendBaseUrl,
       );
+      return resolvedLink ?? notification.payload.link;
     }
     return `${this.frontendBaseUrl}/notifications`;
   }

--- a/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.ts
+++ b/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.ts
@@ -327,11 +327,9 @@ export class NotificationsEmailProcessor implements NotificationProcessor {
 
   private getNotificationLink(notification: Notification) {
     if (notification.payload.link) {
-      return (
-        resolveNotificationLink(
-          notification.payload.link,
-          this.frontendBaseUrl,
-        ) ?? notification.payload.link
+      return resolveNotificationLink(
+        notification.payload.link,
+        this.frontendBaseUrl,
       );
     }
     return `${this.frontendBaseUrl}/notifications`;

--- a/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.ts
+++ b/plugins/notifications-backend-module-email/src/processor/NotificationsEmailProcessor.ts
@@ -17,6 +17,7 @@
 import {
   NotificationProcessor,
   NotificationSendOptions,
+  resolveNotificationLink,
 } from '@backstage/plugin-notifications-node';
 import {
   AuthService,
@@ -326,19 +327,12 @@ export class NotificationsEmailProcessor implements NotificationProcessor {
 
   private getNotificationLink(notification: Notification) {
     if (notification.payload.link) {
-      const stripLeadingSlash = (s: string) => s.replace(/^\//, '');
-      const ensureTrailingSlash = (s: string) => s.replace(/\/?$/, '/');
-
-      try {
-        const url = new URL(
-          stripLeadingSlash(notification.payload.link),
-          ensureTrailingSlash(this.frontendBaseUrl),
-        );
-        return url.toString();
-      } catch (_e) {
-        // noop: fallback to relative URL
-      }
-      return notification.payload.link;
+      return (
+        resolveNotificationLink(
+          notification.payload.link,
+          this.frontendBaseUrl,
+        ) ?? notification.payload.link
+      );
     }
     return `${this.frontendBaseUrl}/notifications`;
   }

--- a/plugins/notifications-backend-module-slack/src/lib/SlackNotificationProcessor.test.ts
+++ b/plugins/notifications-backend-module-slack/src/lib/SlackNotificationProcessor.test.ts
@@ -218,6 +218,79 @@ describe('SlackNotificationProcessor', () => {
     });
   });
 
+  it('should resolve a relative link to an absolute URL', async () => {
+    const slack = new WebClient();
+
+    const processor = SlackNotificationProcessor.fromConfig(config, {
+      auth,
+      logger,
+      catalog: catalogServiceMock({
+        entities: DEFAULT_ENTITIES_RESPONSE.items,
+      }),
+      metrics,
+      slack,
+    })[0];
+
+    await processor.processOptions({
+      recipients: { type: 'entity', entityRef: 'group:default/mock' },
+      payload: { title: 'notification', link: '/announcements/view/123' },
+    });
+
+    expect(slack.chat.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attachments: [
+          expect.objectContaining({
+            blocks: expect.arrayContaining([
+              expect.objectContaining({
+                accessory: expect.objectContaining({
+                  url: 'https://example.org/announcements/view/123',
+                }),
+              }),
+            ]),
+          }),
+        ],
+      }),
+    );
+  });
+
+  it('should pass through an absolute link unchanged', async () => {
+    const slack = new WebClient();
+
+    const processor = SlackNotificationProcessor.fromConfig(config, {
+      auth,
+      logger,
+      catalog: catalogServiceMock({
+        entities: DEFAULT_ENTITIES_RESPONSE.items,
+      }),
+      metrics,
+      slack,
+    })[0];
+
+    await processor.processOptions({
+      recipients: { type: 'entity', entityRef: 'group:default/mock' },
+      payload: {
+        title: 'notification',
+        link: 'https://other.example.com/page',
+      },
+    });
+
+    expect(slack.chat.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attachments: [
+          expect.objectContaining({
+            blocks: expect.arrayContaining([
+              expect.objectContaining({
+                accessory: expect.objectContaining({
+                  url: 'https://other.example.com/page',
+                }),
+              }),
+            ]),
+          }),
+        ],
+      }),
+    );
+  });
+
   it('should use a custom block kit renderer when provided', async () => {
     const slack = new WebClient();
     const customBlocks: KnownBlock[] = [

--- a/plugins/notifications-backend-module-slack/src/lib/SlackNotificationProcessor.ts
+++ b/plugins/notifications-backend-module-slack/src/lib/SlackNotificationProcessor.ts
@@ -266,6 +266,9 @@ export class SlackNotificationProcessor implements NotificationProcessor {
     }
 
     const entityRefs = [options.recipients.entityRef].flat();
+    const formattedPayload = await this.formatPayloadDescriptionForSlack(
+      options.payload,
+    );
 
     const outbound: ChatPostMessageArguments[] = [];
     await Promise.all(
@@ -299,13 +302,7 @@ export class SlackNotificationProcessor implements NotificationProcessor {
 
         const payload = toChatPostMessageArgs({
           channel,
-          payload: {
-            ...options.payload,
-            link: resolveNotificationLink(
-              options.payload.link,
-              this.frontendBaseUrl,
-            ),
-          },
+          payload: formattedPayload,
           username: this.username,
           blockKitRenderer: this.blockKitRenderer,
         });

--- a/plugins/notifications-backend-module-slack/src/lib/SlackNotificationProcessor.ts
+++ b/plugins/notifications-backend-module-slack/src/lib/SlackNotificationProcessor.ts
@@ -32,6 +32,7 @@ import { Notification } from '@backstage/plugin-notifications-common';
 import {
   NotificationProcessor,
   NotificationSendOptions,
+  resolveNotificationLink,
 } from '@backstage/plugin-notifications-node';
 import { durationToMilliseconds } from '@backstage/types';
 import {
@@ -67,9 +68,10 @@ export class SlackNotificationProcessor implements NotificationProcessor {
   private readonly messagesFailed: MetricsServiceCounter;
   private readonly messagesUpdated: MetricsServiceCounter;
   private db?: Knex;
+  private readonly frontendBaseUrl: string;
+  private readonly entityLoader: DataLoader<string, Entity | undefined>;
   private readonly broadcastChannels?: string[];
   private readonly broadcastRoutes?: BroadcastRoute[];
-  private readonly entityLoader: DataLoader<string, Entity | undefined>;
   private readonly username?: string;
   private readonly concurrencyLimit: number;
   private readonly throttleInterval: number;
@@ -104,6 +106,7 @@ export class SlackNotificationProcessor implements NotificationProcessor {
             readDurationFromConfig(c, { key: 'throttleInterval' }),
           )
         : durationToMilliseconds({ minutes: 1 });
+      const frontendBaseUrl = config.getString('app.baseUrl');
       return new SlackNotificationProcessor({
         slack,
         broadcastChannels,
@@ -111,6 +114,7 @@ export class SlackNotificationProcessor implements NotificationProcessor {
         username,
         concurrencyLimit,
         throttleInterval,
+        frontendBaseUrl,
         ...options,
       });
     });
@@ -122,6 +126,7 @@ export class SlackNotificationProcessor implements NotificationProcessor {
     logger: LoggerService;
     catalog: CatalogService;
     metrics: MetricsService;
+    frontendBaseUrl: string;
     broadcastChannels?: string[];
     broadcastRoutes?: BroadcastRoute[];
     username?: string;
@@ -134,6 +139,7 @@ export class SlackNotificationProcessor implements NotificationProcessor {
       catalog,
       logger,
       metrics,
+      frontendBaseUrl,
       slack,
       broadcastChannels,
       broadcastRoutes,
@@ -145,6 +151,7 @@ export class SlackNotificationProcessor implements NotificationProcessor {
     this.logger = logger;
     this.catalog = catalog;
     this.auth = auth;
+    this.frontendBaseUrl = frontendBaseUrl;
     this.slack = slack;
     this.broadcastChannels = broadcastChannels;
     this.broadcastRoutes = broadcastRoutes;
@@ -292,7 +299,13 @@ export class SlackNotificationProcessor implements NotificationProcessor {
 
         const payload = toChatPostMessageArgs({
           channel,
-          payload: options.payload,
+          payload: {
+            ...options.payload,
+            link: resolveNotificationLink(
+              options.payload.link,
+              this.frontendBaseUrl,
+            ),
+          },
           username: this.username,
           blockKitRenderer: this.blockKitRenderer,
         });
@@ -383,6 +396,7 @@ export class SlackNotificationProcessor implements NotificationProcessor {
   ) {
     return {
       ...payload,
+      link: resolveNotificationLink(payload.link, this.frontendBaseUrl),
       description: await this.replaceUserRefsWithSlackIds(payload.description),
     };
   }

--- a/plugins/notifications-backend-module-slack/src/lib/SlackNotificationProcessor.ts
+++ b/plugins/notifications-backend-module-slack/src/lib/SlackNotificationProcessor.ts
@@ -32,6 +32,7 @@ import { Notification } from '@backstage/plugin-notifications-common';
 import {
   NotificationProcessor,
   NotificationSendOptions,
+  resolveNotificationLink,
 } from '@backstage/plugin-notifications-node';
 import { durationToMilliseconds } from '@backstage/types';
 import {
@@ -67,9 +68,10 @@ export class SlackNotificationProcessor implements NotificationProcessor {
   private readonly messagesFailed: MetricsServiceCounter;
   private readonly messagesUpdated: MetricsServiceCounter;
   private db?: Knex;
+  private readonly frontendBaseUrl: string;
+  private readonly entityLoader: DataLoader<string, Entity | undefined>;
   private readonly broadcastChannels?: string[];
   private readonly broadcastRoutes?: BroadcastRoute[];
-  private readonly entityLoader: DataLoader<string, Entity | undefined>;
   private readonly username?: string;
   private readonly concurrencyLimit: number;
   private readonly throttleInterval: number;
@@ -104,6 +106,7 @@ export class SlackNotificationProcessor implements NotificationProcessor {
             readDurationFromConfig(c, { key: 'throttleInterval' }),
           )
         : durationToMilliseconds({ minutes: 1 });
+      const frontendBaseUrl = config.getString('app.baseUrl');
       return new SlackNotificationProcessor({
         slack,
         broadcastChannels,
@@ -111,6 +114,7 @@ export class SlackNotificationProcessor implements NotificationProcessor {
         username,
         concurrencyLimit,
         throttleInterval,
+        frontendBaseUrl,
         ...options,
       });
     });
@@ -122,6 +126,7 @@ export class SlackNotificationProcessor implements NotificationProcessor {
     logger: LoggerService;
     catalog: CatalogService;
     metrics: MetricsService;
+    frontendBaseUrl: string;
     broadcastChannels?: string[];
     broadcastRoutes?: BroadcastRoute[];
     username?: string;
@@ -134,6 +139,7 @@ export class SlackNotificationProcessor implements NotificationProcessor {
       catalog,
       logger,
       metrics,
+      frontendBaseUrl,
       slack,
       broadcastChannels,
       broadcastRoutes,
@@ -145,6 +151,7 @@ export class SlackNotificationProcessor implements NotificationProcessor {
     this.logger = logger;
     this.catalog = catalog;
     this.auth = auth;
+    this.frontendBaseUrl = frontendBaseUrl;
     this.slack = slack;
     this.broadcastChannels = broadcastChannels;
     this.broadcastRoutes = broadcastRoutes;
@@ -299,7 +306,13 @@ export class SlackNotificationProcessor implements NotificationProcessor {
 
         const payload = toChatPostMessageArgs({
           channel,
-          payload: options.payload,
+          payload: {
+            ...options.payload,
+            link: resolveNotificationLink(
+              options.payload.link,
+              this.frontendBaseUrl,
+            ),
+          },
           username: this.username,
           blockKitRenderer: this.blockKitRenderer,
         });
@@ -390,6 +403,7 @@ export class SlackNotificationProcessor implements NotificationProcessor {
   ) {
     return {
       ...payload,
+      link: resolveNotificationLink(payload.link, this.frontendBaseUrl),
       description: await this.replaceUserRefsWithSlackIds(payload.description),
     };
   }

--- a/plugins/notifications-backend-module-slack/src/lib/SlackNotificationProcessor.ts
+++ b/plugins/notifications-backend-module-slack/src/lib/SlackNotificationProcessor.ts
@@ -32,7 +32,6 @@ import { Notification } from '@backstage/plugin-notifications-common';
 import {
   NotificationProcessor,
   NotificationSendOptions,
-  resolveNotificationLink,
 } from '@backstage/plugin-notifications-node';
 import { durationToMilliseconds } from '@backstage/types';
 import {
@@ -310,6 +309,7 @@ export class SlackNotificationProcessor implements NotificationProcessor {
         const payload = toChatPostMessageArgs({
           channel,
           payload: formattedPayload,
+          frontendBaseUrl: this.frontendBaseUrl,
           username: this.username,
           blockKitRenderer: this.blockKitRenderer,
         });
@@ -378,6 +378,7 @@ export class SlackNotificationProcessor implements NotificationProcessor {
       toChatPostMessageArgs({
         channel,
         payload: formattedPayload,
+        frontendBaseUrl: this.frontendBaseUrl,
         username: this.username,
         blockKitRenderer: this.blockKitRenderer,
       }),
@@ -400,7 +401,6 @@ export class SlackNotificationProcessor implements NotificationProcessor {
   ) {
     return {
       ...payload,
-      link: resolveNotificationLink(payload.link, this.frontendBaseUrl),
       description: await this.replaceUserRefsWithSlackIds(payload.description),
     };
   }

--- a/plugins/notifications-backend-module-slack/src/lib/SlackNotificationProcessor.ts
+++ b/plugins/notifications-backend-module-slack/src/lib/SlackNotificationProcessor.ts
@@ -269,6 +269,9 @@ export class SlackNotificationProcessor implements NotificationProcessor {
     const metadataChannel = options.payload.metadata?.slackChannel as
       | string
       | undefined;
+    const formattedPayload = await this.formatPayloadDescriptionForSlack(
+      options.payload,
+    );
 
     const outbound: ChatPostMessageArguments[] = [];
     await Promise.all(
@@ -306,13 +309,7 @@ export class SlackNotificationProcessor implements NotificationProcessor {
 
         const payload = toChatPostMessageArgs({
           channel,
-          payload: {
-            ...options.payload,
-            link: resolveNotificationLink(
-              options.payload.link,
-              this.frontendBaseUrl,
-            ),
-          },
+          payload: formattedPayload,
           username: this.username,
           blockKitRenderer: this.blockKitRenderer,
         });

--- a/plugins/notifications-backend-module-slack/src/lib/util.ts
+++ b/plugins/notifications-backend-module-slack/src/lib/util.ts
@@ -18,17 +18,24 @@ import {
   NotificationPayload,
   NotificationSeverity,
 } from '@backstage/plugin-notifications-common';
+import { resolveNotificationLink } from '@backstage/plugin-notifications-node';
 import { ChatPostMessageArguments, KnownBlock } from '@slack/web-api';
 import { SlackBlockKitRenderer } from '../extensions';
 
 export function toChatPostMessageArgs(options: {
   channel: string;
   payload: NotificationPayload;
+  frontendBaseUrl: string;
   username?: string;
   blockKitRenderer?: SlackBlockKitRenderer;
 }): ChatPostMessageArguments {
-  const { channel, payload, username, blockKitRenderer } = options;
-  const blocks = (blockKitRenderer ?? toSlackBlockKit)(payload);
+  const { channel, payload, frontendBaseUrl, username, blockKitRenderer } =
+    options;
+  const normalizedPayload = {
+    ...payload,
+    link: resolveNotificationLink(payload.link, frontendBaseUrl),
+  };
+  const blocks = (blockKitRenderer ?? toSlackBlockKit)(normalizedPayload);
 
   const args: ChatPostMessageArguments = {
     channel,

--- a/plugins/notifications-backend-module-slack/src/lib/utils.test.ts
+++ b/plugins/notifications-backend-module-slack/src/lib/utils.test.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { KnownBlock } from '@slack/web-api';
+import { toChatPostMessageArgs } from './util';
+
+describe('toChatPostMessageArgs', () => {
+  const frontendBaseUrl = 'https://example.org';
+
+  it('resolves a relative link to an absolute URL', () => {
+    const args = toChatPostMessageArgs({
+      channel: 'C12345678',
+      frontendBaseUrl,
+      payload: {
+        title: 'notification',
+        link: '/announcements/view/123',
+      },
+    });
+
+    expect(args).toEqual(
+      expect.objectContaining({
+        attachments: [
+          expect.objectContaining({
+            blocks: expect.arrayContaining([
+              expect.objectContaining({
+                accessory: expect.objectContaining({
+                  url: 'https://example.org/announcements/view/123',
+                }),
+              }),
+            ]),
+          }),
+        ],
+      }),
+    );
+  });
+
+  it('passes through an absolute link unchanged', () => {
+    const args = toChatPostMessageArgs({
+      channel: 'C12345678',
+      frontendBaseUrl,
+      payload: {
+        title: 'notification',
+        link: 'https://other.example.com/page',
+      },
+    });
+
+    expect(args).toEqual(
+      expect.objectContaining({
+        attachments: [
+          expect.objectContaining({
+            blocks: expect.arrayContaining([
+              expect.objectContaining({
+                accessory: expect.objectContaining({
+                  url: 'https://other.example.com/page',
+                }),
+              }),
+            ]),
+          }),
+        ],
+      }),
+    );
+  });
+
+  it('passes normalized links to a custom block kit renderer', () => {
+    const customBlocks: KnownBlock[] = [
+      {
+        type: 'section',
+        text: { type: 'mrkdwn', text: 'Custom block' },
+      },
+    ];
+
+    const blockKitRenderer = jest.fn().mockReturnValue(customBlocks);
+
+    const args = toChatPostMessageArgs({
+      channel: 'C12345678',
+      frontendBaseUrl,
+      payload: {
+        title: 'notification',
+        link: '/catalog/default/component/example',
+      },
+      blockKitRenderer,
+    });
+
+    expect(blockKitRenderer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        link: 'https://example.org/catalog/default/component/example',
+      }),
+    );
+    expect(args).toEqual(
+      expect.objectContaining({
+        attachments: [
+          expect.objectContaining({
+            blocks: customBlocks,
+          }),
+        ],
+      }),
+    );
+  });
+});

--- a/plugins/notifications-node/report.api.md
+++ b/plugins/notifications-node/report.api.md
@@ -102,4 +102,10 @@ export interface NotificationsProcessingExtensionPoint {
 
 // @public (undocumented)
 export const notificationsProcessingExtensionPoint: ExtensionPoint<NotificationsProcessingExtensionPoint>;
+
+// @public
+export function resolveNotificationLink(
+  link: string | undefined,
+  baseUrl: string,
+): string | undefined;
 ```

--- a/plugins/notifications-node/src/utils.test.ts
+++ b/plugins/notifications-node/src/utils.test.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { resolveNotificationLink } from './utils';
+
+describe('resolveNotificationLink', () => {
+  it('resolves relative links when baseUrl has a sub-path', () => {
+    expect(
+      resolveNotificationLink(
+        '/catalog/default/component/example',
+        'https://backstage.example.com',
+      ),
+    ).toBe('https://backstage.example.com/catalog/default/component/example');
+  });
+
+  it('normalizes links with multiple leading slashes', () => {
+    expect(
+      resolveNotificationLink('///catalog', 'https://backstage.example.com'),
+    ).toBe('https://backstage.example.com/catalog');
+  });
+
+  it('returns already-absolute URLs unchanged', () => {
+    expect(
+      resolveNotificationLink(
+        'https://other.example.com/path?query=1#section',
+        'https://backstage.example.com',
+      ),
+    ).toBe('https://other.example.com/path?query=1#section');
+  });
+});

--- a/plugins/notifications-node/src/utils.test.ts
+++ b/plugins/notifications-node/src/utils.test.ts
@@ -17,13 +17,24 @@
 import { resolveNotificationLink } from './utils';
 
 describe('resolveNotificationLink', () => {
-  it('resolves relative links when baseUrl has a sub-path', () => {
+  it('resolves relative links when baseUrl has no sub-path', () => {
     expect(
       resolveNotificationLink(
         '/catalog/default/component/example',
         'https://backstage.example.com',
       ),
     ).toBe('https://backstage.example.com/catalog/default/component/example');
+  });
+
+  it('resolves relative links when baseUrl has a sub-path', () => {
+    expect(
+      resolveNotificationLink(
+        '/catalog/default/component/example',
+        'https://backstage.example.com/backstage',
+      ),
+    ).toBe(
+      'https://backstage.example.com/backstage/catalog/default/component/example',
+    );
   });
 
   it('normalizes links with multiple leading slashes', () => {

--- a/plugins/notifications-node/src/utils.ts
+++ b/plugins/notifications-node/src/utils.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 The Backstage Authors
+ * Copyright 2026 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,12 +15,22 @@
  */
 
 /**
- * Node.js library for the notifications plugin.
- *
- * @packageDocumentation
+ * Resolves a relative notification link to an absolute URL using the provided base URL.
+ * @public
  */
-
-export * from './service';
-export * from './lib';
-export * from './extensions';
-export * from './utils';
+export function resolveNotificationLink(
+  link: string | undefined,
+  baseUrl: string,
+): string | undefined {
+  if (!link) return undefined;
+  const stripLeadingSlash = (s: string) => s.replace(/^\//, '');
+  const ensureTrailingSlash = (s: string) => s.replace(/\/?$/, '/');
+  try {
+    return new URL(
+      stripLeadingSlash(link),
+      ensureTrailingSlash(baseUrl),
+    ).toString();
+  } catch {
+    return link;
+  }
+}

--- a/plugins/notifications-node/src/utils.ts
+++ b/plugins/notifications-node/src/utils.ts
@@ -23,7 +23,7 @@ export function resolveNotificationLink(
   baseUrl: string,
 ): string | undefined {
   if (!link) return undefined;
-  const stripLeadingSlash = (s: string) => s.replace(/^\//, '');
+  const stripLeadingSlash = (s: string) => s.replace(/^\/+/, '');
   const ensureTrailingSlash = (s: string) => s.replace(/\/?$/, '/');
   try {
     return new URL(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes [#8470](https://github.com/backstage/community-plugins/issues/8470) in the announcements plugin when sending notifications to Slack.


As noted by @drodil in this [PR](https://github.com/backstage/community-plugins/pull/8471#discussion_r3064099673), the URL resolution was already implemented in `notifications-backend-module-email`.

This PR extracts and moves the `resolveNotificationLink` function to common utils so it can be reused in other notifications module, including Slack.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
