### PR TITLE
signals-node: remove deprecated `SignalService` and `DefaultSignalService`

### DIFF
--- a/.changeset/remove-deprecated-signal-service-aliases.md
+++ b/.changeset/remove-deprecated-signal-service-aliases.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-signals-node': minor
+---
+
+**BREAKING**: Removed the deprecated `SignalService` and `DefaultSignalService` exports. Use `SignalsService` and `DefaultSignalsService` instead.

--- a/plugins/signals-node/report.api.md
+++ b/plugins/signals-node/report.api.md
@@ -7,9 +7,6 @@ import { EventsService } from '@backstage/plugin-events-node';
 import { JsonObject } from '@backstage/types';
 import { ServiceRef } from '@backstage/backend-plugin-api';
 
-// @public @deprecated (undocumented)
-export const DefaultSignalService: typeof DefaultSignalsService;
-
 // @public (undocumented)
 export class DefaultSignalsService implements SignalsService {
   // (undocumented)
@@ -32,9 +29,6 @@ export type SignalPayload<TMessage extends JsonObject = JsonObject> = {
   channel: string;
   message: TMessage;
 };
-
-// @public @deprecated (undocumented)
-export interface SignalService extends SignalsService {}
 
 // @public @deprecated (undocumented)
 export const signalService: ServiceRef<SignalsService, 'plugin', 'singleton'>;

--- a/plugins/signals-node/src/DefaultSignalsService.ts
+++ b/plugins/signals-node/src/DefaultSignalsService.ts
@@ -43,9 +43,3 @@ export class DefaultSignalsService implements SignalsService {
     });
   }
 }
-
-/**
- * @public
- * @deprecated Use `DefaultSignalsService` instead
- */
-export const DefaultSignalService = DefaultSignalsService;

--- a/plugins/signals-node/src/SignalsService.ts
+++ b/plugins/signals-node/src/SignalsService.ts
@@ -26,9 +26,3 @@ export interface SignalsService {
     signal: SignalPayload<TMessage>,
   ): Promise<void>;
 }
-
-/**
- * @public
- * @deprecated Use `SignalsService` instead
- */
-export interface SignalService extends SignalsService {}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This removes the deprecated `SignalService` interface and `DefaultSignalService` const alias from `@backstage/plugin-signals-node`. These were deprecated in favor of `SignalsService` and `DefaultSignalsService` respectively.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))