### PR TITLE
Add HypoStage plugin to plugin directory

### DIFF
--- a/microsite/data/plugins/hypo-stage.yaml
+++ b/microsite/data/plugins/hypo-stage.yaml
@@ -5,7 +5,7 @@ authorUrl: https://github.com/ArchHypo
 category: Discovery
 description: Document architectural assumptions, track uncertainty, and validate decisions with hypothesis management, quality attributes, and technical planning.
 documentation: https://github.com/ArchHypo/hypo-stage/blob/main/README.md
-iconUrl: 'https://avatars.githubusercontent.com/u/241217195?s=400&u=de66fa64fcad1d10f09f7bd2ebacdc9dd12ec9b2&v=4'
+iconUrl: 'https://raw.githubusercontent.com/ArchHypo/hypo-stage/main/docs/backstage-directory/icon/hypo-stage.png'
 npmPackageName: '@archhypo/plugin-hypo-stage'
 addedDate: '2026-04-14'
 status: active

--- a/microsite/data/plugins/hypo-stage.yaml
+++ b/microsite/data/plugins/hypo-stage.yaml
@@ -1,0 +1,11 @@
+---
+title: HypoStage
+author: ArchHypo
+authorUrl: https://github.com/ArchHypo
+category: Discovery
+description: Document architectural assumptions, track uncertainty, and validate decisions with hypothesis management, quality attributes, and technical planning.
+documentation: https://github.com/ArchHypo/hypo-stage/blob/main/README.md
+iconUrl: 'https://avatars.githubusercontent.com/u/241217195?s=400&u=de66fa64fcad1d10f09f7bd2ebacdc9dd12ec9b2&v=4'
+npmPackageName: '@archhypo/plugin-hypo-stage'
+addedDate: '2026-04-14'
+status: active

--- a/microsite/data/plugins/hypo-stage.yaml
+++ b/microsite/data/plugins/hypo-stage.yaml
@@ -4,7 +4,7 @@ author: ArchHypo
 authorUrl: https://github.com/ArchHypo
 category: Discovery
 description: Document architectural assumptions, track uncertainty, and validate decisions with hypothesis management, quality attributes, and technical planning.
-documentation: https://github.com/ArchHypo/hypo-stage/blob/main/README.md
+documentation: https://github.com/ArchHypo/hypo-stage/blob/v1.0.0/README.md
 iconUrl: 'https://raw.githubusercontent.com/ArchHypo/hypo-stage/main/docs/backstage-directory/icon/hypo-stage.png'
 npmPackageName: '@archhypo/plugin-hypo-stage'
 addedDate: '2026-04-14'


### PR DESCRIPTION
## Plugin

**HypoStage** — architectural hypothesis management for Backstage: uncertainty/impact, quality attributes, technical planning, catalog integration.

- **NPM (frontend):** https://www.npmjs.com/package/@archhypo/plugin-hypo-stage
- **NPM (backend):** https://www.npmjs.com/package/@archhypo/plugin-hypo-stage-backend
- **Docs / repo:** https://github.com/ArchHypo/hypo-stage

Both packages are public at **v1.0.0**; install the same version of frontend + backend.

## Checklist

- [x] `microsite/data/plugins/hypo-stage.yaml` added
- [x] `node ./scripts/verify-plugin-directory.js` passes
- [x] `npmPackageName` matches published package `@archhypo/plugin-hypo-stage`
- [x] `iconUrl` points to permitted branding (org avatar); happy to switch to `/img/...` in this repo if preferred
