### PR TITLE
feat: change resource url to comply with RFC 9728 Section 7.3

### DIFF
--- a/.changeset/shaky-years-doubt.md
+++ b/.changeset/shaky-years-doubt.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-mcp-actions-backend': minor
+---
+
+Fixed the `.well-known/oauth-protected-resource` resource URL to comply with
+[RFC 9728 Section 7.3](https://datatracker.ietf.org/doc/html/rfc9728#name-impersonation-attacks).

--- a/.changeset/shaky-years-doubt.md
+++ b/.changeset/shaky-years-doubt.md
@@ -3,4 +3,4 @@
 ---
 
 Fixed the `.well-known/oauth-protected-resource` resource URL to comply with
-[RFC 9728 Section 7.3](https://datatracker.ietf.org/doc/html/rfc9728#name-impersonation-attacks).
+[RFC 9728 Section 7.3](https://datatracker.ietf.org/doc/html/rfc9728#name-impersonation-attacks). Enabling dynamic resource paths.

--- a/.changeset/shaky-years-doubt.md
+++ b/.changeset/shaky-years-doubt.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-mcp-actions-backend': minor
+'@backstage/plugin-mcp-actions-backend': patch
 ---
 
 Fixed the `.well-known/oauth-protected-resource` resource URL to comply with

--- a/plugins/mcp-actions-backend/src/plugin.test.ts
+++ b/plugins/mcp-actions-backend/src/plugin.test.ts
@@ -306,7 +306,7 @@ describe('Mcp Backend', () => {
       expect(response.status).toBe(404);
     });
 
-    it('should expose oauth-protected-resource when DCR is enabled', async () => {
+    it('should expose default oauth-protected-resource when DCR is enabled', async () => {
       const mockExternalBaseUrl = 'http://external.local:0/api';
       const mockDiscovery = mockServices.discovery.mock({
         getExternalBaseUrl: async pluginId =>
@@ -336,10 +336,10 @@ describe('Mcp Backend', () => {
       });
 
       const response = await request(server).get(
-        '/.well-known/oauth-protected-resource',
+        '/.well-known/oauth-protected-resource/api/mcp-actions/v1',
       );
       expect(response.status).toBe(200);
-      expect(response.body.resource).toMatch(/\/api\/mcp-actions\/v\d+$/);
+      expect(response.body.resource).toMatch(/\/api\/mcp-actions\/v1$/);
       expect(response.body.authorization_servers).toHaveLength(1);
       expect(response.body.authorization_servers[0]).toMatch(/\/api\/auth$/);
       expect(response.body.resource).toContain(`${mockExternalBaseUrl}`);
@@ -347,6 +347,65 @@ describe('Mcp Backend', () => {
         `${mockExternalBaseUrl}/`,
       );
     });
+
+    const pathTestCases = [
+      { name: 'auth', suffix: '/v1/auth' },
+      { name: 'catalog', suffix: '/v1/catalog' },
+      { name: 'scaffolder', suffix: '/v1/scaffolder' },
+    ];
+
+    it.each(pathTestCases)(
+      'should expose dynamic oauth-protected-resource for $name',
+      async ({ suffix }) => {
+        const mockExternalBaseUrl = 'http://external.local:0/api';
+        const mockDiscovery = mockServices.discovery.mock({
+          getExternalBaseUrl: async pluginId =>
+            `${mockExternalBaseUrl}/${pluginId}`,
+        });
+
+        const { server } = await startTestBackend({
+          features: [
+            mcpPlugin,
+            mockPluginWithActions,
+            mockDiscovery.factory,
+            mockServices.rootConfig.factory({
+              data: {
+                backend: {
+                  actions: {
+                    pluginSources: ['local'],
+                  },
+                },
+                auth: {
+                  experimentalDynamicClientRegistration: {
+                    enabled: true,
+                  },
+                },
+                mcpActions: {
+                  servers: {
+                    auth: { name: 'Auth', filter: { include: [] } },
+                    catalog: { name: 'Catalog', filter: { include: [] } },
+                    scaffolder: { name: 'Scaffolder', filter: { include: [] } },
+                  },
+                },
+              },
+            }),
+          ],
+        });
+
+        const response = await request(server).get(
+          `/.well-known/oauth-protected-resource/api/mcp-actions${suffix}`,
+        );
+        expect(response.status).toBe(200);
+        const expectedResourceRegex = new RegExp(`/api/mcp-actions${suffix}$`);
+        expect(response.body.resource).toMatch(expectedResourceRegex);
+        expect(response.body.authorization_servers).toHaveLength(1);
+        expect(response.body.authorization_servers[0]).toMatch(/\/api\/auth$/);
+        expect(response.body.resource).toContain(`${mockExternalBaseUrl}`);
+        expect(response.body.authorization_servers[0]).toContain(
+          `${mockExternalBaseUrl}/`,
+        );
+      },
+    );
 
     it('should expose oauth-protected-resource when CIMD is enabled', async () => {
       const { server } = await startTestBackend({
@@ -371,10 +430,10 @@ describe('Mcp Backend', () => {
       });
 
       const response = await request(server).get(
-        '/.well-known/oauth-protected-resource',
+        '/.well-known/oauth-protected-resource/api/mcp-actions/v1',
       );
       expect(response.status).toBe(200);
-      expect(response.body.resource).toMatch(/\/api\/mcp-actions\/v\d+$/);
+      expect(response.body.resource).toMatch(/\/api\/mcp-actions\/v1$/);
       expect(response.body.authorization_servers).toHaveLength(1);
       expect(response.body.authorization_servers[0]).toMatch(/\/api\/auth$/);
     });

--- a/plugins/mcp-actions-backend/src/plugin.test.ts
+++ b/plugins/mcp-actions-backend/src/plugin.test.ts
@@ -339,7 +339,7 @@ describe('Mcp Backend', () => {
         '/.well-known/oauth-protected-resource',
       );
       expect(response.status).toBe(200);
-      expect(response.body.resource).toMatch(/\/api\/mcp-actions$/);
+      expect(response.body.resource).toMatch(/\/api\/mcp-actions\/v\d+$/);
       expect(response.body.authorization_servers).toHaveLength(1);
       expect(response.body.authorization_servers[0]).toMatch(/\/api\/auth$/);
       expect(response.body.resource).toContain(`${mockExternalBaseUrl}`);
@@ -374,7 +374,7 @@ describe('Mcp Backend', () => {
         '/.well-known/oauth-protected-resource',
       );
       expect(response.status).toBe(200);
-      expect(response.body.resource).toMatch(/\/api\/mcp-actions$/);
+      expect(response.body.resource).toMatch(/\/api\/mcp-actions\/v\d+$/);
       expect(response.body.authorization_servers).toHaveLength(1);
       expect(response.body.authorization_servers[0]).toMatch(/\/api\/auth$/);
     });

--- a/plugins/mcp-actions-backend/src/plugin.ts
+++ b/plugins/mcp-actions-backend/src/plugin.ts
@@ -140,36 +140,42 @@ export const mcpPlugin = createBackendPlugin({
           // Protected Resource Metadata (RFC 9728)
           // https://datatracker.ietf.org/doc/html/rfc9728
           // This allows MCP clients to discover the authorization server for this resource
-          const serverSuffixes: string[] = [];
+          rootRouter.use(
+            '/.well-known/oauth-protected-resource/*',
+            async (req, res) => {
+              const requestedResourcePath = `/${req.params[0]}`;
 
-          if (serverConfigs && serverConfigs.size > 0) {
-            for (const key of serverConfigs.keys()) {
-              serverSuffixes.push(`/v1/${key}`);
-            }
-          } else {
-            serverSuffixes.push('/v1');
-          }
+              const serverSuffixes =
+                serverConfigs && serverConfigs.size > 0
+                  ? [...serverConfigs.keys()].map(key => `/v1/${key}`)
+                  : ['/v1'];
 
-          const [authBaseUrl, mcpBaseUrl] = await Promise.all([
-            discovery.getExternalBaseUrl('auth'),
-            discovery.getExternalBaseUrl('mcp-actions'),
-          ]);
+              const [authBaseUrl, mcpBaseUrlString] = await Promise.all([
+                discovery.getExternalBaseUrl('auth'),
+                discovery.getExternalBaseUrl('mcp-actions'),
+              ]);
 
-          const mcpBasePath = new URL(mcpBaseUrl).pathname;
+              const mcpBaseUrl = new URL(mcpBaseUrlString);
 
-          for (const suffix of serverSuffixes) {
-            const mcpResourcePath = `${mcpBasePath}${suffix}`;
+              const availableResourcePaths = new Set(
+                serverSuffixes.map(suffix => `${mcpBaseUrl.pathname}${suffix}`),
+              );
 
-            rootRouter.use(
-              `/.well-known/oauth-protected-resource${mcpResourcePath}`,
-              async (_req, res) => {
-                res.json({
-                  resource: `${mcpBaseUrl}${suffix}`,
-                  authorization_servers: [authBaseUrl],
-                });
-              },
-            );
-          }
+              if (!availableResourcePaths.has(requestedResourcePath)) {
+                return res.sendStatus(404);
+              }
+
+              const resourceUrl = new URL(
+                requestedResourcePath,
+                mcpBaseUrl.origin,
+              );
+
+              return res.json({
+                resource: resourceUrl.toString(),
+                authorization_servers: [authBaseUrl],
+              });
+            },
+          );
         }
       },
     });

--- a/plugins/mcp-actions-backend/src/plugin.ts
+++ b/plugins/mcp-actions-backend/src/plugin.ts
@@ -140,19 +140,36 @@ export const mcpPlugin = createBackendPlugin({
           // Protected Resource Metadata (RFC 9728)
           // https://datatracker.ietf.org/doc/html/rfc9728
           // This allows MCP clients to discover the authorization server for this resource
-          rootRouter.use(
-            '/.well-known/oauth-protected-resource',
-            async (_, res) => {
-              const [authBaseUrl, mcpBaseUrl] = await Promise.all([
-                discovery.getExternalBaseUrl('auth'),
-                discovery.getExternalBaseUrl('mcp-actions'),
-              ]);
-              res.json({
-                resource: `${mcpBaseUrl}/v1`,
-                authorization_servers: [authBaseUrl],
-              });
-            },
-          );
+          const serverSuffixes: string[] = [];
+
+          if (serverConfigs && serverConfigs.size > 0) {
+            for (const key of serverConfigs.keys()) {
+              serverSuffixes.push(`/v1/${key}`);
+            }
+          } else {
+            serverSuffixes.push('/v1');
+          }
+
+          const [authBaseUrl, mcpBaseUrl] = await Promise.all([
+            discovery.getExternalBaseUrl('auth'),
+            discovery.getExternalBaseUrl('mcp-actions'),
+          ]);
+
+          const mcpBasePath = new URL(mcpBaseUrl).pathname;
+
+          for (const suffix of serverSuffixes) {
+            const mcpResourcePath = `${mcpBasePath}${suffix}`;
+
+            rootRouter.use(
+              `/.well-known/oauth-protected-resource${mcpResourcePath}`,
+              async (_req, res) => {
+                res.json({
+                  resource: `${mcpBaseUrl}${suffix}`,
+                  authorization_servers: [authBaseUrl],
+                });
+              },
+            );
+          }
         }
       },
     });

--- a/plugins/mcp-actions-backend/src/plugin.ts
+++ b/plugins/mcp-actions-backend/src/plugin.ts
@@ -148,7 +148,7 @@ export const mcpPlugin = createBackendPlugin({
                 discovery.getExternalBaseUrl('mcp-actions'),
               ]);
               res.json({
-                resource: mcpBaseUrl,
+                resource: `${mcpBaseUrl}/v1`,
                 authorization_servers: [authBaseUrl],
               });
             },

--- a/plugins/mcp-actions-backend/src/plugin.ts
+++ b/plugins/mcp-actions-backend/src/plugin.ts
@@ -140,42 +140,28 @@ export const mcpPlugin = createBackendPlugin({
           // Protected Resource Metadata (RFC 9728)
           // https://datatracker.ietf.org/doc/html/rfc9728
           // This allows MCP clients to discover the authorization server for this resource
-          rootRouter.use(
-            '/.well-known/oauth-protected-resource/*',
-            async (req, res) => {
-              const requestedResourcePath = `/${req.params[0]}`;
+          const serverSuffixes = serverConfigs?.size
+            ? [...serverConfigs.keys()].map(key => `/v1/${key}`)
+            : ['/v1'];
 
-              const serverSuffixes =
-                serverConfigs && serverConfigs.size > 0
-                  ? [...serverConfigs.keys()].map(key => `/v1/${key}`)
-                  : ['/v1'];
+          for (const suffix of serverSuffixes) {
+            const mcpBasePath = `/api/mcp-actions${suffix}`;
 
-              const [authBaseUrl, mcpBaseUrlString] = await Promise.all([
-                discovery.getExternalBaseUrl('auth'),
-                discovery.getExternalBaseUrl('mcp-actions'),
-              ]);
+            rootRouter.use(
+              `/.well-known/oauth-protected-resource${mcpBasePath}`,
+              async (_req, res) => {
+                const [authBaseUrl, mcpBaseUrl] = await Promise.all([
+                  discovery.getExternalBaseUrl('auth'),
+                  discovery.getExternalBaseUrl('mcp-actions'),
+                ]);
 
-              const mcpBaseUrl = new URL(mcpBaseUrlString);
-
-              const availableResourcePaths = new Set(
-                serverSuffixes.map(suffix => `${mcpBaseUrl.pathname}${suffix}`),
-              );
-
-              if (!availableResourcePaths.has(requestedResourcePath)) {
-                return res.sendStatus(404);
-              }
-
-              const resourceUrl = new URL(
-                requestedResourcePath,
-                mcpBaseUrl.origin,
-              );
-
-              return res.json({
-                resource: resourceUrl.toString(),
-                authorization_servers: [authBaseUrl],
-              });
-            },
-          );
+                res.json({
+                  resource: `${mcpBaseUrl}${suffix}`,
+                  authorization_servers: [authBaseUrl],
+                });
+              },
+            );
+          }
         }
       },
     });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixed the `.well-known/oauth-protected-resource` resource URL to comply with
[RFC 9728 Section 7.3](https://datatracker.ietf.org/doc/html/rfc9728#name-impersonation-attacks).

Partially addresses #33750

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
