### PR TITLE
Remove unused `isDev` constant from CLI version module

### DIFF
--- a/.changeset/remove-unused-isdev-constant.md
+++ b/.changeset/remove-unused-isdev-constant.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+Removed the unused `isDev` export from the internal version module.

--- a/packages/cli/src/wiring/version.ts
+++ b/packages/cli/src/wiring/version.ts
@@ -26,4 +26,3 @@ export function findVersion() {
 }
 
 export const version = findVersion();
-export const isDev = fs.pathExistsSync(ownPaths.resolve('src'));


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `isDev` export in `packages/cli/src/wiring/version.ts` was never imported anywhere in the codebase. This removes it to reduce dead code.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))