### PR TITLE
repo-tools: remove unused OpenAPI generator constants

### DIFF
--- a/.changeset/remove-unused-openapi-generator-constants.md
+++ b/.changeset/remove-unused-openapi-generator-constants.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': patch
+---
+
+Internal code cleanup.

--- a/packages/repo-tools/src/lib/openapi/constants.ts
+++ b/packages/repo-tools/src/lib/openapi/constants.ts
@@ -18,15 +18,9 @@ export const YAML_SCHEMA_PATH = 'src/schema/openapi.yaml';
 
 export const OUTPUT_PATH = 'src/schema/openapi/generated';
 
-export const TS_MODULE = `${OUTPUT_PATH}/router`;
-
 export const OLD_SCHEMA_PATH = `src/schema/openapi.generated.ts`;
 
-export const TS_SCHEMA_PATH = `${TS_MODULE}.ts`;
-
-export const GENERATOR_VERSION = `1.0.0`;
-export const GENERATOR_NAME = 'typescript-backstage';
-export const GENERATOR_FILE = `packages/template-openapi-plugin-client/generator/target/${GENERATOR_NAME}-openapi-generator-${GENERATOR_VERSION}.jar`;
+export const TS_SCHEMA_PATH = `${OUTPUT_PATH}/router.ts`;
 
 export const OPENAPI_IGNORE_FILES = [
   // Get rid of the default files.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

🧹

Removes unused exported constants `GENERATOR_VERSION`, `GENERATOR_NAME`, `GENERATOR_FILE`, and `TS_MODULE` from the OpenAPI constants module. The `TS_MODULE` intermediate variable is inlined into `TS_SCHEMA_PATH`.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))