### PR TITLE
Have `assertError` delegate to `isError` in `@backstage/errors`

### DIFF
--- a/.changeset/assert-error-delegate-to-is-error.md
+++ b/.changeset/assert-error-delegate-to-is-error.md
@@ -1,0 +1,5 @@
+---
+'@backstage/errors': patch
+---
+
+Simplified `assertError` to delegate to `isError` instead of duplicating the same checks.

--- a/packages/errors/src/errors/assertion.ts
+++ b/packages/errors/src/errors/assertion.ts
@@ -58,17 +58,8 @@ export function isError(value: unknown): value is ErrorLike {
  * @param value - an unknown value
  */
 export function assertError(value: unknown): asserts value is ErrorLike {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-    throw new Error(`Encountered invalid error, not an object, got '${value}'`);
-  }
-  const maybe = value as Partial<ErrorLike>;
-  if (typeof maybe.name !== 'string' || maybe.name === '') {
-    throw new Error(`Encountered error object without a name, got '${value}'`);
-  }
-  if (typeof maybe.message !== 'string') {
-    throw new Error(
-      `Encountered error object without a message, got '${value}'`,
-    );
+  if (!isError(value)) {
+    throw new Error(`Encountered invalid error, got '${value}'`);
   }
 }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Simplify the `assertError` implementation by delegating to `isError` instead of duplicating the same validation checks. This removes redundant code and ensures the two functions stay in sync.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))