### PR TITLE
backend-plugin-api: tighten internal any usage

### DIFF
--- a/.changeset/tighten-internal-any-usage.md
+++ b/.changeset/tighten-internal-any-usage.md
@@ -2,4 +2,4 @@
 '@backstage/backend-plugin-api': patch
 ---
 
-Tightened internal `any` usage in `isDatabaseConflictError`.
+Added stricter type checks in `isDatabaseConflictError`.

--- a/.changeset/tighten-internal-any-usage.md
+++ b/.changeset/tighten-internal-any-usage.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-plugin-api': patch
+---
+
+Tightened internal `any` usage in `isDatabaseConflictError`.

--- a/packages/backend-plugin-api/src/services/system/types.ts
+++ b/packages/backend-plugin-api/src/services/system/types.ts
@@ -136,8 +136,8 @@ export function createServiceRef<
   TService,
   TInstances extends 'singleton' | 'multiton',
 >(
-  options: ServiceRefOptions<TService, any, TInstances>,
-): ServiceRef<TService, any, TInstances> {
+  options: ServiceRefOptions<TService, 'root' | 'plugin', TInstances>,
+): ServiceRef<TService, 'root' | 'plugin', TInstances> {
   const { id, scope = 'plugin', multiton = false, defaultFactory } = options;
   return {
     id,

--- a/packages/backend-plugin-api/src/services/utilities/database.ts
+++ b/packages/backend-plugin-api/src/services/utilities/database.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { isError } from '@backstage/errors';
+
 /**
  * Tries to deduce whether a thrown error is a database conflict.
  *
@@ -23,8 +25,7 @@
  *          known database engine
  */
 export function isDatabaseConflictError(e: unknown) {
-  const message =
-    e instanceof Error ? e.message : (e as { message?: unknown })?.message;
+  const message = isError(e) ? e.message : undefined;
 
   return (
     typeof message === 'string' &&

--- a/packages/backend-plugin-api/src/services/utilities/database.ts
+++ b/packages/backend-plugin-api/src/services/utilities/database.ts
@@ -23,7 +23,8 @@
  *          known database engine
  */
 export function isDatabaseConflictError(e: unknown) {
-  const message = (e as any)?.message;
+  const message =
+    e instanceof Error ? e.message : (e as { message?: unknown })?.message;
 
   return (
     typeof message === 'string' &&

--- a/packages/backend-plugin-api/src/wiring/types.ts
+++ b/packages/backend-plugin-api/src/wiring/types.ts
@@ -56,7 +56,11 @@ type DepsToInstances<
     [key in string]: ServiceRef<unknown> | ExtensionPoint<unknown>;
   },
 > = {
-  [key in keyof TDeps]: TDeps[key] extends ServiceRef<unknown, any, 'multiton'>
+  [key in keyof TDeps]: TDeps[key] extends ServiceRef<
+    unknown,
+    'root' | 'plugin',
+    'multiton'
+  >
     ? Array<TDeps[key]['T']>
     : TDeps[key]['T'];
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

🧹

Replaces internal `any` type annotations with more precise types in the `backend-plugin-api` package:

- **`DepsToInstances` conditional type** — `ServiceRef<unknown, any, 'multiton'>` → `ServiceRef<unknown, 'root' | 'plugin', 'multiton'>`
- **`createServiceRef` implementation signature** — `any` scope param → `'root' | 'plugin'`
- **`isDatabaseConflictError`** — `(e as any)?.message` → `instanceof Error` check with `{ message?: unknown }` cast fallback

No public API changes — the remaining `any` usages in public API signatures (`Request<any, ...>`, `PermissionRule<any, ...>`) are intentional since they need to accept any concrete type parameter due to variance constraints.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))