### PR TITLE
scaffolder-backend: remove unused hasProperty permission rule

### DIFF
--- a/plugins/scaffolder-backend/src/service/rules.test.ts
+++ b/plugins/scaffolder-backend/src/service/rules.test.ts
@@ -14,19 +14,15 @@
  * limitations under the License.
  */
 
-import { JsonObject, JsonPrimitive } from '@backstage/types';
+import { JsonObject } from '@backstage/types';
 import {
   hasActionId,
   hasBooleanProperty,
   hasNumberProperty,
-  hasProperty,
   hasStringProperty,
   hasTag,
   isTaskOwner,
 } from './rules';
-import { createConditionAuthorizer } from '@backstage/plugin-permission-node';
-import { RESOURCE_TYPE_SCAFFOLDER_ACTION } from '@backstage/plugin-scaffolder-common/alpha';
-import { AuthorizeResult } from '@backstage/plugin-permission-common';
 import { SerializedTask } from '@backstage/plugin-scaffolder-node';
 import { TaskSpec } from '@backstage/plugin-scaffolder-common';
 
@@ -136,162 +132,6 @@ const input: JsonObject = {
   propwitharray: ['item', 0, true, false],
   nested: { propwithstring: '1', nested: { propwithnumber: 1 } },
 };
-
-describe('hasProperty', () => {
-  describe('apply', () => {
-    it.each([
-      'foo',
-      'bar',
-      'prop.prop',
-      'nested.nonexisting',
-      '',
-      'propwitharray.100',
-    ])(`returns false when a property doesn't exist in the input`, key => {
-      expect(hasProperty.apply({ action: 'action', input }, { key })).toEqual(
-        false,
-      );
-    });
-
-    it.each([
-      'propwithstring',
-      'propwithnumber',
-      'propwithobject',
-      'propwithnull',
-      'propwithfalse',
-      'propwithtrue',
-      'propwitharray',
-      'propwitharray.1',
-      'nested.propwithstring',
-      'nested.nested',
-      'nested.nested.propwithnumber',
-    ])(`returns true when a property exists, property=%s`, key => {
-      expect(hasProperty.apply({ action: 'action', input }, { key })).toEqual(
-        true,
-      );
-    });
-
-    it.each([
-      ['propwithstring', 1],
-      ['propwithnumber', '2'],
-      ['propwithnumber', true],
-      ['propwithobject', [{}]],
-      ['propwithnull', false],
-      ['propwithfalse', true],
-      ['propwithtrue', null],
-      ['propwitharray', 'nonexistingitem'],
-      ['propwitharray.0', 'nonmatchingitem'],
-      ['nested.propwithstring', 'x'],
-      ['nested.nested', '1'],
-      ['nested.nested.propwithnumber', 'ops'],
-    ])(
-      `returns false when a property exists but the value doesn't match, key=%s value=%o`,
-      (key, value) => {
-        expect(
-          hasProperty.apply(
-            { action: 'action', input },
-            { key, value: value as JsonPrimitive },
-          ),
-        ).toEqual(false);
-      },
-    );
-
-    it.each([
-      ['propwithstring', '1'],
-      ['propwithnumber', 2],
-      ['propwithnull', null],
-      ['propwithfalse', false],
-      ['propwithtrue', true],
-      ['propwitharray.0', 'item'],
-      ['nested.propwithstring', '1'],
-      ['nested.nested.propwithnumber', 1],
-    ])(
-      `returns true when a property exists and the value matches, key=%s value=%o`,
-      (key, value) => {
-        expect(
-          hasProperty.apply({ action: 'action', input }, { key, value }),
-        ).toEqual(true);
-      },
-    );
-
-    it('should throw if params are invalid', () => {
-      const isActionAuthorized = createConditionAuthorizer([hasProperty]);
-
-      expect(() =>
-        isActionAuthorized(
-          {
-            resourceType: RESOURCE_TYPE_SCAFFOLDER_ACTION,
-            pluginId: 'scaffolder',
-            result: AuthorizeResult.CONDITIONAL,
-            conditions: {
-              resourceType: RESOURCE_TYPE_SCAFFOLDER_ACTION,
-              rule: 'HAS_PROPERTY',
-              params: {
-                key: 1,
-              },
-            },
-          },
-          { action: 'an-action', input: {} },
-        ),
-      ).toThrow();
-      expect(() =>
-        isActionAuthorized(
-          {
-            resourceType: RESOURCE_TYPE_SCAFFOLDER_ACTION,
-            pluginId: 'scaffolder',
-            result: AuthorizeResult.CONDITIONAL,
-            conditions: {
-              resourceType: RESOURCE_TYPE_SCAFFOLDER_ACTION,
-              rule: 'HAS_PROPERTY',
-              params: {},
-            },
-          },
-          { action: 'an-action', input: {} },
-        ),
-      ).toThrow();
-    });
-
-    it('should not throw if params are valid', () => {
-      const isActionAuthorized = createConditionAuthorizer([hasProperty]);
-
-      expect(() =>
-        isActionAuthorized(
-          {
-            resourceType: RESOURCE_TYPE_SCAFFOLDER_ACTION,
-            pluginId: 'scaffolder',
-            result: AuthorizeResult.CONDITIONAL,
-            conditions: {
-              resourceType: RESOURCE_TYPE_SCAFFOLDER_ACTION,
-              rule: 'HAS_PROPERTY',
-              params: {
-                key: 'key',
-              },
-            },
-          },
-          { action: 'an-action', input: {} },
-        ),
-      ).not.toThrow();
-
-      expect(() =>
-        isActionAuthorized(
-          {
-            resourceType: RESOURCE_TYPE_SCAFFOLDER_ACTION,
-            pluginId: 'scaffolder',
-            result: AuthorizeResult.CONDITIONAL,
-            conditions: {
-              resourceType: RESOURCE_TYPE_SCAFFOLDER_ACTION,
-              rule: 'HAS_PROPERTY',
-              params: {
-                key: 'key',
-                value: 'value',
-              },
-            },
-          },
-          { action: 'an-action', input: {} },
-        ),
-      ).not.toThrow();
-    });
-  });
-});
 
 describe('hasBooleanProperty', () => {
   describe('apply', () => {

--- a/plugins/scaffolder-backend/src/service/rules.ts
+++ b/plugins/scaffolder-backend/src/service/rules.ts
@@ -74,12 +74,6 @@ export const hasActionId = createActionPermissionRule({
   toQuery: () => ({}),
 });
 
-export const hasProperty = buildHasProperty({
-  name: 'HAS_PROPERTY',
-  valueSchema: z.union([z.string(), z.number(), z.boolean(), z.null()]),
-  validateProperty: false,
-});
-
 export const hasBooleanProperty = buildHasProperty({
   name: 'HAS_BOOLEAN_PROPERTY',
   valueSchema: z.boolean(),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

🧹

The `hasProperty` permission rule in `scaffolder-backend` was never included in the `scaffolderActionRules` export or the public API report — it was dead code. This removes it along with its tests.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))