### PR TITLE
docs: clarify Auth0 logout changeset description

### DIFF
--- a/.changeset/auth0-federated-logout.md
+++ b/.changeset/auth0-federated-logout.md
@@ -2,4 +2,6 @@
 '@backstage/plugin-auth-backend-module-auth0-provider': minor
 ---
 
-Added federated logout support. Set `federatedLogout: true` in the Auth0 provider config to clear both the Auth0 session and any upstream IdP session on sign-out. The authenticator returns a logout URL that redirects the browser to Auth0's `/v2/logout?federated` endpoint, ensuring users must fully re-authenticate after signing out.
+Sign-out now redirects the browser to Auth0's `/v2/logout` endpoint, clearing the Auth0 session cookie so that users must re-authenticate on next sign-in. Previously, only the Backstage session was cleared, allowing users to sign back in without re-entering credentials.
+
+Set `federatedLogout: true` in the Auth0 provider config to additionally clear the upstream IdP session (e.g. Okta, Google), requiring full re-authentication across the entire SSO chain.

--- a/.changeset/auth0-federated-logout.md
+++ b/.changeset/auth0-federated-logout.md
@@ -2,6 +2,6 @@
 '@backstage/plugin-auth-backend-module-auth0-provider': minor
 ---
 
-Sign-out now redirects the browser to Auth0's `/v2/logout` endpoint, clearing the Auth0 session cookie so that users must re-authenticate on next sign-in. Previously, only the Backstage session was cleared, allowing users to sign back in without re-entering credentials.
+Sign-out now redirects the browser to Auth0's `/v2/logout` endpoint, clearing the Auth0 session cookie so that the next sign-in creates a new Auth0 session. Previously, only the Backstage session was cleared, allowing users to sign back in without going through Auth0 logout first.
 
-Set `federatedLogout: true` in the Auth0 provider config to additionally clear the upstream IdP session (e.g. Okta, Google), requiring full re-authentication across the entire SSO chain.
+Set `federatedLogout: true` in the Auth0 provider config to additionally clear the upstream IdP session (e.g. Okta, Google). This is what guarantees a full re-login across the entire SSO chain and may require users to re-enter credentials.


### PR DESCRIPTION
## Summary

- Updates the Auth0 federated logout changeset from #33703 to accurately describe the behavior

The original changeset implied the logout redirect only happens when `federatedLogout: true`. In reality, sign-out **always** redirects to Auth0's `/v2/logout` to clear the Auth0 session cookie. The `federatedLogout` flag only controls whether the upstream IdP session is also terminated.

## Test plan

- [ ] Changeset wording is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)