### PR TITLE
feat: use presentation API for entity display and sorting in techdocs and home 

### DIFF
--- a/.changeset/proud-badgers-find.md
+++ b/.changeset/proud-badgers-find.md
@@ -1,6 +1,6 @@
 ---
-'@backstage/plugin-techdocs': major
-'@backstage/plugin-home': major
+'@backstage/plugin-techdocs': patch
+'@backstage/plugin-home': patch
 ---
 
 Use presentation API for entity display and sorting in techdocs and home

--- a/.changeset/proud-badgers-find.md
+++ b/.changeset/proud-badgers-find.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-techdocs': major
+'@backstage/plugin-home': major
+---
+
+Use presentation API for entity display and sorting in techdocs and home

--- a/plugins/home/report.api.md
+++ b/plugins/home/report.api.md
@@ -127,7 +127,16 @@ export type GetLabelFunction = (visit: Visit) => string;
 // @public
 export const HeaderWorldClock: (props: {
   clockConfigs: ClockConfig[];
-  customTimeFormat?: Intl.DateTimeFormatOptions;
+  customTimeFormat?: /**
+   * A component to display a company logo for the user.
+   *
+   * @public
+   */
+  /**
+   * A component to display a company logo for the user.
+   *
+   * @public
+   */ Intl.DateTimeFormatOptions;
 }) => JSX_2.Element | null;
 
 // @public

--- a/plugins/home/report.api.md
+++ b/plugins/home/report.api.md
@@ -127,16 +127,7 @@ export type GetLabelFunction = (visit: Visit) => string;
 // @public
 export const HeaderWorldClock: (props: {
   clockConfigs: ClockConfig[];
-  customTimeFormat?: /**
-   * A component to display a company logo for the user.
-   *
-   * @public
-   */
-  /**
-   * A component to display a company logo for the user.
-   *
-   * @public
-   */ Intl.DateTimeFormatOptions;
+  customTimeFormat?: Intl.DateTimeFormatOptions;
 }) => JSX_2.Element | null;
 
 // @public

--- a/plugins/home/src/homePageComponents/StarredEntities/Content.test.tsx
+++ b/plugins/home/src/homePageComponents/StarredEntities/Content.test.tsx
@@ -15,8 +15,10 @@
  */
 
 import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
+import { screen } from '@testing-library/react';
 import {
   catalogApiRef,
+  entityPresentationApiRef,
   starredEntitiesApiRef,
   MockStarredEntitiesApi,
   entityRouteRef,
@@ -72,6 +74,31 @@ describe('StarredEntitiesContent', () => {
       <TestApiProvider
         apis={[
           [catalogApiRef, mockCatalogApi],
+          [
+            entityPresentationApiRef,
+            {
+              forEntity: (entity: any) => ({
+                snapshot: {
+                  entityRef: entity.metadata.name,
+                  primaryTitle:
+                    entity.metadata.annotations?.[
+                      'backstage.io/presentation-title'
+                    ] ??
+                    entity.metadata.title ??
+                    entity.metadata.name,
+                },
+                promise: Promise.resolve({
+                  entityRef: entity.metadata.name,
+                  primaryTitle:
+                    entity.metadata.annotations?.[
+                      'backstage.io/presentation-title'
+                    ] ??
+                    entity.metadata.title ??
+                    entity.metadata.name,
+                }),
+              }),
+            },
+          ],
           [starredEntitiesApiRef, mockedApi],
         ]}
       >
@@ -110,6 +137,21 @@ describe('StarredEntitiesContent', () => {
       <TestApiProvider
         apis={[
           [catalogApiRef, mockCatalogApi],
+          [
+            entityPresentationApiRef,
+            {
+              forEntity: (entity: any) => ({
+                snapshot: {
+                  entityRef: entity.metadata.name,
+                  primaryTitle: entity.metadata.title ?? entity.metadata.name,
+                },
+                promise: Promise.resolve({
+                  entityRef: entity.metadata.name,
+                  primaryTitle: entity.metadata.title ?? entity.metadata.name,
+                }),
+              }),
+            },
+          ],
           [starredEntitiesApiRef, mockedApi],
         ]}
       >
@@ -140,6 +182,21 @@ describe('StarredEntitiesContent', () => {
       <TestApiProvider
         apis={[
           [catalogApiRef, mockCatalogApi],
+          [
+            entityPresentationApiRef,
+            {
+              forEntity: (entity: any) => ({
+                snapshot: {
+                  entityRef: entity.metadata.name,
+                  primaryTitle: entity.metadata.title ?? entity.metadata.name,
+                },
+                promise: Promise.resolve({
+                  entityRef: entity.metadata.name,
+                  primaryTitle: entity.metadata.title ?? entity.metadata.name,
+                }),
+              }),
+            },
+          ],
           [starredEntitiesApiRef, mockedApi],
         ]}
       >
@@ -153,5 +210,159 @@ describe('StarredEntitiesContent', () => {
     );
 
     expect(getByText('foo')).toBeInTheDocument();
+  });
+
+  it('should sort starred entities by presentation title', async () => {
+    const mockedApi = new MockStarredEntitiesApi();
+    mockedApi.toggleStarred('component:default/z-name');
+    mockedApi.toggleStarred('component:default/a-name');
+
+    const mockCatalogApi = catalogApiMock.mock({
+      getEntitiesByRefs: jest.fn().mockResolvedValue({
+        items: [
+          {
+            apiVersion: '1',
+            kind: 'Component',
+            metadata: {
+              name: 'z-name',
+              annotations: {
+                'backstage.io/presentation-title': 'A title',
+              },
+            },
+          },
+          {
+            apiVersion: '1',
+            kind: 'Component',
+            metadata: {
+              name: 'a-name',
+              annotations: {
+                'backstage.io/presentation-title': 'Z title',
+              },
+            },
+          },
+        ],
+      }),
+    });
+
+    await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [catalogApiRef, mockCatalogApi],
+          [
+            entityPresentationApiRef,
+            {
+              forEntity: (entity: any) => ({
+                snapshot: {
+                  entityRef: entity.metadata.name,
+                  primaryTitle:
+                    entity.metadata.annotations?.[
+                      'backstage.io/presentation-title'
+                    ] ?? entity.metadata.name,
+                },
+                promise: Promise.resolve({
+                  entityRef: entity.metadata.name,
+                  primaryTitle:
+                    entity.metadata.annotations?.[
+                      'backstage.io/presentation-title'
+                    ] ?? entity.metadata.name,
+                }),
+              }),
+            },
+          ],
+          [starredEntitiesApiRef, mockedApi],
+        ]}
+      >
+        <Content />
+      </TestApiProvider>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+        },
+      },
+    );
+
+    const firstTitle = await screen.findByText('A title');
+    const secondTitle = await screen.findByText('Z title');
+    expect(
+      firstTitle.compareDocumentPosition(secondTitle) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it('should sort grouped starred entities by presentation title', async () => {
+    const mockedApi = new MockStarredEntitiesApi();
+    mockedApi.toggleStarred('component:default/z-name');
+    mockedApi.toggleStarred('component:default/a-name');
+
+    const mockCatalogApi = catalogApiMock.mock({
+      getEntitiesByRefs: jest.fn().mockResolvedValue({
+        items: [
+          {
+            apiVersion: '1',
+            kind: 'Component',
+            metadata: {
+              name: 'z-name',
+              annotations: {
+                'backstage.io/presentation-title': 'A title',
+              },
+            },
+          },
+          {
+            apiVersion: '1',
+            kind: 'Component',
+            metadata: {
+              name: 'a-name',
+              annotations: {
+                'backstage.io/presentation-title': 'Z title',
+              },
+            },
+          },
+        ],
+      }),
+    });
+
+    await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [catalogApiRef, mockCatalogApi],
+          [
+            entityPresentationApiRef,
+            {
+              forEntity: (entity: any) => ({
+                snapshot: {
+                  entityRef: entity.metadata.name,
+                  primaryTitle:
+                    entity.metadata.annotations?.[
+                      'backstage.io/presentation-title'
+                    ] ?? entity.metadata.name,
+                },
+                promise: Promise.resolve({
+                  entityRef: entity.metadata.name,
+                  primaryTitle:
+                    entity.metadata.annotations?.[
+                      'backstage.io/presentation-title'
+                    ] ?? entity.metadata.name,
+                }),
+              }),
+            },
+          ],
+          [starredEntitiesApiRef, mockedApi],
+        ]}
+      >
+        <Content groupByKind />
+      </TestApiProvider>,
+      {
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+        },
+      },
+    );
+
+    const firstTitle = await screen.findByText('A title');
+    const secondTitle = await screen.findByText('Z title');
+    expect(
+      firstTitle.compareDocumentPosition(secondTitle) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 });

--- a/plugins/home/src/homePageComponents/StarredEntities/Content.tsx
+++ b/plugins/home/src/homePageComponents/StarredEntities/Content.tsx
@@ -130,14 +130,16 @@ export const Content = ({
     <div>
       {!groupByKind && (
         <List className={classes.list}>
-          {entities.value?.sort(sortEntitiesByPresentation).map(entity => (
-            <StarredEntityListItem
-              key={stringifyEntityRef(entity)}
-              entity={entity}
-              onToggleStarredEntity={toggleStarredEntity}
-              showKind
-            />
-          ))}
+          {[...(entities.value || [])]
+            .sort(sortEntitiesByPresentation)
+            .map(entity => (
+              <StarredEntityListItem
+                key={stringifyEntityRef(entity)}
+                entity={entity}
+                onToggleStarredEntity={toggleStarredEntity}
+                showKind
+              />
+            ))}
         </List>
       )}
 
@@ -160,14 +162,16 @@ export const Content = ({
         groupByKindEntries.map(([kind, entitiesByKind], index) => (
           <div key={kind} hidden={groupByKind && activeTab !== index}>
             <List className={classes.list}>
-              {entitiesByKind?.sort(sortEntitiesByPresentation).map(entity => (
-                <StarredEntityListItem
-                  key={stringifyEntityRef(entity)}
-                  entity={entity}
-                  onToggleStarredEntity={toggleStarredEntity}
-                  showKind={false}
-                />
-              ))}
+              {[...(entitiesByKind || [])]
+                .sort(sortEntitiesByPresentation)
+                .map(entity => (
+                  <StarredEntityListItem
+                    key={stringifyEntityRef(entity)}
+                    entity={entity}
+                    onToggleStarredEntity={toggleStarredEntity}
+                    showKind={false}
+                  />
+                ))}
             </List>
           </div>
         ))}

--- a/plugins/home/src/homePageComponents/StarredEntities/Content.tsx
+++ b/plugins/home/src/homePageComponents/StarredEntities/Content.tsx
@@ -16,6 +16,8 @@
 
 import {
   catalogApiRef,
+  entityPresentationApiRef,
+  entityPresentationSnapshot,
   useStarredEntities,
 } from '@backstage/plugin-catalog-react';
 import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
@@ -63,6 +65,7 @@ export const Content = ({
 }: StarredEntitiesProps) => {
   const classes = useStyles();
   const catalogApi = useApi(catalogApiRef);
+  const entityPresentationApi = useApi(entityPresentationApiRef);
   const { starredEntities, toggleStarredEntity } = useStarredEntities();
   const [activeTab, setActiveTab] = useState(0);
   const { t } = useTranslationRef(homeTranslationRef);
@@ -110,6 +113,15 @@ export const Content = ({
   });
 
   const groupByKindEntries = Object.entries(groupedEntities);
+  const sortEntitiesByPresentation = (a: Entity, b: Entity) =>
+    entityPresentationSnapshot(
+      a,
+      undefined,
+      entityPresentationApi,
+    ).primaryTitle.localeCompare(
+      entityPresentationSnapshot(b, undefined, entityPresentationApi)
+        .primaryTitle,
+    );
 
   return entities.error ? (
     <ResponseErrorPanel error={entities.error} />
@@ -117,20 +129,14 @@ export const Content = ({
     <div>
       {!groupByKind && (
         <List className={classes.list}>
-          {entities.value
-            ?.sort((a, b) =>
-              (a.metadata.title ?? a.metadata.name).localeCompare(
-                b.metadata.title ?? b.metadata.name,
-              ),
-            )
-            .map(entity => (
-              <StarredEntityListItem
-                key={stringifyEntityRef(entity)}
-                entity={entity}
-                onToggleStarredEntity={toggleStarredEntity}
-                showKind
-              />
-            ))}
+          {entities.value?.sort(sortEntitiesByPresentation).map(entity => (
+            <StarredEntityListItem
+              key={stringifyEntityRef(entity)}
+              entity={entity}
+              onToggleStarredEntity={toggleStarredEntity}
+              showKind
+            />
+          ))}
         </List>
       )}
 
@@ -153,20 +159,14 @@ export const Content = ({
         groupByKindEntries.map(([kind, entitiesByKind], index) => (
           <div key={kind} hidden={groupByKind && activeTab !== index}>
             <List className={classes.list}>
-              {entitiesByKind
-                ?.sort((a, b) =>
-                  (a.metadata.title ?? a.metadata.name).localeCompare(
-                    b.metadata.title ?? b.metadata.name,
-                  ),
-                )
-                .map(entity => (
-                  <StarredEntityListItem
-                    key={stringifyEntityRef(entity)}
-                    entity={entity}
-                    onToggleStarredEntity={toggleStarredEntity}
-                    showKind={false}
-                  />
-                ))}
+              {entitiesByKind?.sort(sortEntitiesByPresentation).map(entity => (
+                <StarredEntityListItem
+                  key={stringifyEntityRef(entity)}
+                  entity={entity}
+                  onToggleStarredEntity={toggleStarredEntity}
+                  showKind={false}
+                />
+              ))}
             </List>
           </div>
         ))}

--- a/plugins/home/src/homePageComponents/StarredEntities/Content.tsx
+++ b/plugins/home/src/homePageComponents/StarredEntities/Content.tsx
@@ -21,7 +21,7 @@ import {
   useStarredEntities,
 } from '@backstage/plugin-catalog-react';
 import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
-import { useApi } from '@backstage/core-plugin-api';
+import { useApi, useApiHolder } from '@backstage/core-plugin-api';
 import { Progress, ResponseErrorPanel } from '@backstage/core-components';
 import List from '@material-ui/core/List';
 import Typography from '@material-ui/core/Typography';
@@ -65,7 +65,8 @@ export const Content = ({
 }: StarredEntitiesProps) => {
   const classes = useStyles();
   const catalogApi = useApi(catalogApiRef);
-  const entityPresentationApi = useApi(entityPresentationApiRef);
+  const apis = useApiHolder();
+  const entityPresentationApi = apis.get(entityPresentationApiRef);
   const { starredEntities, toggleStarredEntity } = useStarredEntities();
   const [activeTab, setActiveTab] = useState(0);
   const { t } = useTranslationRef(homeTranslationRef);

--- a/plugins/search-react/report-alpha.api.md
+++ b/plugins/search-react/report-alpha.api.md
@@ -134,7 +134,10 @@ export const SearchResultListItemBlueprint: ExtensionBlueprint<{
     {
       predicate?: SearchResultItemExtensionPredicate;
       component: SearchResultItemExtensionComponent;
-      icon?: JSX_2.Element;
+      icon?: JSX_2.Element
+      /**
+       * The icon of the result item.
+       */;
     },
     'search.search-result-list-item.item',
     {}
@@ -151,7 +154,10 @@ export const SearchResultListItemBlueprint: ExtensionBlueprint<{
       {
         predicate?: SearchResultItemExtensionPredicate;
         component: SearchResultItemExtensionComponent;
-        icon?: JSX_2.Element;
+        icon?: JSX_2.Element
+        /**
+         * The icon of the result item.
+         */;
       },
       'search.search-result-list-item.item',
       {}

--- a/plugins/techdocs/report.api.md
+++ b/plugins/techdocs/report.api.md
@@ -13,6 +13,7 @@ import { Entity } from '@backstage/catalog-model';
 import { EntityFilterQuery } from '@backstage/catalog-client';
 import { EntityListPagination } from '@backstage/plugin-catalog-react';
 import { EntityOwnerPickerProps } from '@backstage/plugin-catalog-react';
+import { EntityPresentationApi } from '@backstage/plugin-catalog-react';
 import { FC } from 'react';
 import { FetchApi } from '@backstage/core-plugin-api';
 import { IdentityApi } from '@backstage/core-plugin-api';
@@ -98,10 +99,15 @@ export type DocsGroupConfig = {
 export const DocsTable: {
   (props: DocsTableProps): JSX_2.Element | null;
   columns: {
-    createTitleColumn(options?: {
-      hidden?: boolean;
-    }): TableColumn<DocsTableRow>;
-    createNameColumn(): TableColumn<DocsTableRow>;
+    createTitleColumn(
+      options?: {
+        hidden?: boolean;
+      },
+      entityPresentationApi?: EntityPresentationApi,
+    ): TableColumn<DocsTableRow>;
+    createNameColumn(
+      entityPresentationApi?: EntityPresentationApi,
+    ): TableColumn<DocsTableRow>;
     createOwnerColumn(): TableColumn<DocsTableRow>;
     createKindColumn(): TableColumn<DocsTableRow>;
     createTypeColumn(): TableColumn<DocsTableRow>;
@@ -167,10 +173,15 @@ export type EntityListDocsGridPageProps = {
 export const EntityListDocsTable: {
   (props: EntityListDocsTableProps): JSX_2.Element;
   columns: {
-    createTitleColumn(options?: {
-      hidden?: boolean;
-    }): TableColumn<DocsTableRow>;
-    createNameColumn(): TableColumn<DocsTableRow>;
+    createTitleColumn(
+      options?: {
+        hidden?: boolean;
+      },
+      entityPresentationApi?: EntityPresentationApi,
+    ): TableColumn<DocsTableRow>;
+    createNameColumn(
+      entityPresentationApi?: EntityPresentationApi,
+    ): TableColumn<DocsTableRow>;
     createOwnerColumn(): TableColumn<DocsTableRow>;
     createKindColumn(): TableColumn<DocsTableRow>;
     createTypeColumn(): TableColumn<DocsTableRow>;

--- a/plugins/techdocs/src/home/components/Grids/DocsCardGrid.test.tsx
+++ b/plugins/techdocs/src/home/components/Grids/DocsCardGrid.test.tsx
@@ -15,8 +15,9 @@
  */
 
 import { configApiRef } from '@backstage/core-plugin-api';
-import { renderInTestApp } from '@backstage/test-utils';
+import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
 import { screen } from '@testing-library/react';
+import { entityPresentationApiRef } from '@backstage/plugin-catalog-react';
 import { rootDocsRouteRef } from '../../../routes';
 import { DocsCardGrid } from './DocsCardGrid';
 
@@ -46,30 +47,50 @@ describe('Entity Docs Card Grid', () => {
 
   it('should render all entities passed to it', async () => {
     await renderInTestApp(
-      <DocsCardGrid
-        entities={[
-          {
-            apiVersion: 'version',
-            kind: 'TestKind',
-            metadata: {
-              name: 'testName',
+      <TestApiProvider
+        apis={[
+          [
+            entityPresentationApiRef,
+            {
+              forEntity: (entity: any) => ({
+                snapshot: {
+                  entityRef: entity.metadata.name,
+                  primaryTitle: entity.metadata.title ?? entity.metadata.name,
+                },
+                promise: Promise.resolve({
+                  entityRef: entity.metadata.name,
+                  primaryTitle: entity.metadata.title ?? entity.metadata.name,
+                }),
+              }),
             },
-            spec: {
-              owner: 'techdocs@example.com',
-            },
-          },
-          {
-            apiVersion: 'version',
-            kind: 'TestKind2',
-            metadata: {
-              name: 'testName2',
-            },
-            spec: {
-              owner: 'not-owned@example.com',
-            },
-          },
+          ],
         ]}
-      />,
+      >
+        <DocsCardGrid
+          entities={[
+            {
+              apiVersion: 'version',
+              kind: 'TestKind',
+              metadata: {
+                name: 'testName',
+              },
+              spec: {
+                owner: 'techdocs@example.com',
+              },
+            },
+            {
+              apiVersion: 'version',
+              kind: 'TestKind2',
+              metadata: {
+                name: 'testName2',
+              },
+              spec: {
+                owner: 'not-owned@example.com',
+              },
+            },
+          ]}
+        />
+      </TestApiProvider>,
       {
         mountedRoutes: {
           '/docs/:namespace/:kind/:name/*': rootDocsRouteRef,
@@ -91,21 +112,41 @@ describe('Entity Docs Card Grid', () => {
     getOptionalBooleanMock.mockReturnValue(true);
 
     await renderInTestApp(
-      <DocsCardGrid
-        entities={[
-          {
-            apiVersion: 'version',
-            kind: 'TestKind',
-            metadata: {
-              name: 'testName',
-              namespace: 'SomeNamespace',
+      <TestApiProvider
+        apis={[
+          [
+            entityPresentationApiRef,
+            {
+              forEntity: (entity: any) => ({
+                snapshot: {
+                  entityRef: entity.metadata.name,
+                  primaryTitle: entity.metadata.title ?? entity.metadata.name,
+                },
+                promise: Promise.resolve({
+                  entityRef: entity.metadata.name,
+                  primaryTitle: entity.metadata.title ?? entity.metadata.name,
+                }),
+              }),
             },
-            spec: {
-              owner: 'techdocs@example.com',
-            },
-          },
+          ],
         ]}
-      />,
+      >
+        <DocsCardGrid
+          entities={[
+            {
+              apiVersion: 'version',
+              kind: 'TestKind',
+              metadata: {
+                name: 'testName',
+                namespace: 'SomeNamespace',
+              },
+              spec: {
+                owner: 'techdocs@example.com',
+              },
+            },
+          ]}
+        />
+      </TestApiProvider>,
       {
         mountedRoutes: {
           '/techdocs/:namespace/:kind/:name/*': rootDocsRouteRef,
@@ -124,21 +165,41 @@ describe('Entity Docs Card Grid', () => {
 
   it('should render entity title if available', async () => {
     await renderInTestApp(
-      <DocsCardGrid
-        entities={[
-          {
-            apiVersion: 'version',
-            kind: 'TestKind',
-            metadata: {
-              name: 'testName',
-              title: 'TestTitle',
+      <TestApiProvider
+        apis={[
+          [
+            entityPresentationApiRef,
+            {
+              forEntity: (entity: any) => ({
+                snapshot: {
+                  entityRef: entity.metadata.name,
+                  primaryTitle: entity.metadata.title ?? entity.metadata.name,
+                },
+                promise: Promise.resolve({
+                  entityRef: entity.metadata.name,
+                  primaryTitle: entity.metadata.title ?? entity.metadata.name,
+                }),
+              }),
             },
-            spec: {
-              owner: 'techdocs@example.com',
-            },
-          },
+          ],
         ]}
-      />,
+      >
+        <DocsCardGrid
+          entities={[
+            {
+              apiVersion: 'version',
+              kind: 'TestKind',
+              metadata: {
+                name: 'testName',
+                title: 'TestTitle',
+              },
+              spec: {
+                owner: 'techdocs@example.com',
+              },
+            },
+          ]}
+        />
+      </TestApiProvider>,
       {
         mountedRoutes: {
           '/docs/:namespace/:kind/:name/*': rootDocsRouteRef,
@@ -146,5 +207,50 @@ describe('Entity Docs Card Grid', () => {
       },
     );
     expect(await screen.findByText('TestTitle')).toBeInTheDocument();
+  });
+
+  it('should render entity display name if available', async () => {
+    await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [
+            entityPresentationApiRef,
+            {
+              forEntity: () => ({
+                snapshot: {
+                  entityRef: 'component:default/testName',
+                  primaryTitle: 'Presentation Title',
+                },
+                promise: Promise.resolve({
+                  entityRef: 'component:default/testName',
+                  primaryTitle: 'Presentation Title',
+                }),
+              }),
+            },
+          ],
+        ]}
+      >
+        <DocsCardGrid
+          entities={[
+            {
+              apiVersion: 'version',
+              kind: 'Component',
+              metadata: {
+                name: 'testName',
+                title: 'TestTitle',
+              },
+            },
+          ]}
+        />
+      </TestApiProvider>,
+      {
+        mountedRoutes: {
+          '/docs/:namespace/:kind/:name/*': rootDocsRouteRef,
+        },
+      },
+    );
+
+    expect(await screen.findByText('Presentation Title')).toBeInTheDocument();
+    expect(screen.queryByText('TestTitle')).not.toBeInTheDocument();
   });
 });

--- a/plugins/techdocs/src/home/components/Grids/DocsCardGrid.tsx
+++ b/plugins/techdocs/src/home/components/Grids/DocsCardGrid.tsx
@@ -19,10 +19,11 @@ import { toLowerMaybe } from '../../../helpers';
 import { Entity } from '@backstage/catalog-model';
 import { useApi, useRouteRef, configApiRef } from '@backstage/core-plugin-api';
 import {
-  LinkButton,
   ItemCardGrid,
   ItemCardHeader,
+  LinkButton,
 } from '@backstage/core-components';
+import { EntityDisplayName } from '@backstage/plugin-catalog-react';
 import Card from '@material-ui/core/Card';
 import CardActions from '@material-ui/core/CardActions';
 import CardContent from '@material-ui/core/CardContent';
@@ -55,7 +56,7 @@ export const DocsCardGrid = (props: DocsCardGridProps) => {
             <Card key={index}>
               <CardMedia>
                 <ItemCardHeader
-                  title={entity.metadata.title ?? entity.metadata.name}
+                  title={<EntityDisplayName entityRef={entity} hideIcon />}
                 />
               </CardMedia>
               <CardContent>{entity.metadata.description}</CardContent>

--- a/plugins/techdocs/src/home/components/Grids/EntityListDocsGrid.test.tsx
+++ b/plugins/techdocs/src/home/components/Grids/EntityListDocsGrid.test.tsx
@@ -18,6 +18,7 @@ import { ApiProvider } from '@backstage/core-app-api';
 import { configApiRef, storageApiRef } from '@backstage/core-plugin-api';
 import {
   catalogApiRef,
+  entityPresentationApiRef,
   starredEntitiesApiRef,
   MockStarredEntitiesApi,
 } from '@backstage/plugin-catalog-react';
@@ -75,6 +76,31 @@ describe('Entity List Docs Grid', () => {
     [configApiRef, configApi],
     [storageApiRef, mockApis.storage()],
     [starredEntitiesApiRef, new MockStarredEntitiesApi()],
+    [
+      entityPresentationApiRef,
+      {
+        forEntity: (entity: any) => ({
+          snapshot: {
+            entityRef: entity.metadata.name,
+            primaryTitle:
+              entity.metadata.annotations?.[
+                'backstage.io/presentation-title'
+              ] ??
+              entity.metadata.title ??
+              entity.metadata.name,
+          },
+          promise: Promise.resolve({
+            entityRef: entity.metadata.name,
+            primaryTitle:
+              entity.metadata.annotations?.[
+                'backstage.io/presentation-title'
+              ] ??
+              entity.metadata.title ??
+              entity.metadata.name,
+          }),
+        }),
+      },
+    ],
   );
 
   it('should render all entities without filtering', async () => {
@@ -171,5 +197,55 @@ describe('Entity List Docs Grid', () => {
     expect(screen.queryByText('Documentation #1')).not.toBeInTheDocument();
     expect(screen.queryByText('Documentation #2')).not.toBeInTheDocument();
     expect(screen.getByTestId('doc-not-found')).toBeInTheDocument();
+  });
+
+  it('should sort entities by presentation title', async () => {
+    const unsortedEntities = [
+      {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: {
+          name: 'z-doc',
+          namespace: 'default',
+          annotations: {
+            'backstage.io/presentation-title': 'A Doc',
+          },
+        },
+        spec: {
+          type: 'documentation',
+        },
+      },
+      {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: {
+          name: 'a-doc',
+          namespace: 'default',
+          annotations: {
+            'backstage.io/presentation-title': 'Z Doc',
+          },
+        },
+        spec: {
+          type: 'documentation',
+        },
+      },
+    ];
+
+    await renderInTestApp(
+      <ApiProvider apis={apiRegistry}>
+        <MockEntityListContextProvider value={{ entities: unsortedEntities }}>
+          <EntityListDocsGrid />
+        </MockEntityListContextProvider>
+      </ApiProvider>,
+      {
+        mountedRoutes: {
+          '/docs/:namespace/:kind/:name/*': rootDocsRouteRef,
+        },
+      },
+    );
+
+    const headings = screen.getAllByRole('heading', { level: 4 });
+    expect(headings[0]).toHaveTextContent('A Doc');
+    expect(headings[1]).toHaveTextContent('Z Doc');
   });
 });

--- a/plugins/techdocs/src/home/components/Grids/EntityListDocsGrid.tsx
+++ b/plugins/techdocs/src/home/components/Grids/EntityListDocsGrid.tsx
@@ -26,10 +26,13 @@ import {
 } from '@backstage/core-components';
 import {
   useEntityList,
+  entityPresentationApiRef,
+  entityPresentationSnapshot,
   useEntityOwnership,
 } from '@backstage/plugin-catalog-react';
 import Typography from '@material-ui/core/Typography';
 import { ReactNode } from 'react';
+import { useApiHolder } from '@backstage/core-plugin-api';
 
 /**
  * Props for {@link EntityListDocsGrid}
@@ -103,6 +106,8 @@ const EntityListDocsGridGroup = (props: {
  */
 export const EntityListDocsGrid = (props: EntityListDocsGridPageProps) => {
   const { loading, error, entities } = useEntityList();
+  const apis = useApiHolder();
+  const entityPresentationApi = apis.get(entityPresentationApiRef);
 
   if (error) {
     return (
@@ -134,8 +139,13 @@ export const EntityListDocsGrid = (props: EntityListDocsGridPageProps) => {
   }
 
   entities.sort((a, b) =>
-    (a.metadata.title ?? a.metadata.name).localeCompare(
-      b.metadata.title ?? b.metadata.name,
+    entityPresentationSnapshot(
+      a,
+      undefined,
+      entityPresentationApi,
+    ).primaryTitle.localeCompare(
+      entityPresentationSnapshot(b, undefined, entityPresentationApi)
+        .primaryTitle,
     ),
   );
 

--- a/plugins/techdocs/src/home/components/Grids/EntityListDocsGrid.tsx
+++ b/plugins/techdocs/src/home/components/Grids/EntityListDocsGrid.tsx
@@ -138,7 +138,7 @@ export const EntityListDocsGrid = (props: EntityListDocsGridPageProps) => {
     );
   }
 
-  entities.sort((a, b) =>
+  const sortedEntities = [...entities].sort((a, b) =>
     entityPresentationSnapshot(
       a,
       undefined,
@@ -153,7 +153,7 @@ export const EntityListDocsGrid = (props: EntityListDocsGridPageProps) => {
     <Content>
       {(props.groups || [allEntitiesGroup]).map((group, index: number) => (
         <EntityListDocsGridGroup
-          entities={entities}
+          entities={sortedEntities}
           group={group}
           key={`${group.title}-${index}`}
         />

--- a/plugins/techdocs/src/home/components/Tables/DocsTable.test.tsx
+++ b/plugins/techdocs/src/home/components/Tables/DocsTable.test.tsx
@@ -15,11 +15,14 @@
  */
 
 import { screen } from '@testing-library/react';
-import { renderInTestApp } from '@backstage/test-utils';
+import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
 import { configApiRef } from '@backstage/core-plugin-api';
 import { DocsTable } from './DocsTable';
 import { rootDocsRouteRef } from '../../../routes';
-import { entityRouteRef } from '@backstage/plugin-catalog-react';
+import {
+  entityPresentationApiRef,
+  entityRouteRef,
+} from '@backstage/plugin-catalog-react';
 
 // Hacky way to mock a specific boolean config value.
 const getOptionalBooleanMock = jest.fn().mockReturnValue(false);
@@ -41,48 +44,78 @@ jest.mock('@backstage/core-plugin-api', () => ({
 }));
 
 describe('DocsTable test', () => {
+  const mockEntityPresentationApi = {
+    forEntity: (entityOrRef: any) => {
+      const entityRef =
+        typeof entityOrRef === 'string'
+          ? entityOrRef
+          : `${entityOrRef.kind}:${
+              entityOrRef.metadata.namespace ?? 'default'
+            }/${entityOrRef.metadata.name}`;
+      const primaryTitle =
+        typeof entityOrRef === 'string'
+          ? entityOrRef
+          : entityOrRef.metadata.title ?? entityOrRef.metadata.name;
+
+      return {
+        snapshot: {
+          entityRef,
+          primaryTitle,
+        },
+        promise: Promise.resolve({
+          entityRef,
+          primaryTitle,
+        }),
+      };
+    },
+  };
+
   beforeEach(() => {
     jest.resetAllMocks();
   });
 
   it('should render documents passed', async () => {
     await renderInTestApp(
-      <DocsTable
-        entities={[
-          {
-            apiVersion: 'version',
-            kind: 'TestKind',
-            metadata: {
-              name: 'testName',
-            },
-            spec: {
-              owner: 'user:owned',
-            },
-            relations: [
-              {
-                targetRef: 'user:default/owned',
-                type: 'ownedBy',
+      <TestApiProvider
+        apis={[[entityPresentationApiRef, mockEntityPresentationApi]]}
+      >
+        <DocsTable
+          entities={[
+            {
+              apiVersion: 'version',
+              kind: 'TestKind',
+              metadata: {
+                name: 'testName',
               },
-            ],
-          },
-          {
-            apiVersion: 'version',
-            kind: 'TestKind2',
-            metadata: {
-              name: 'testName2',
-            },
-            spec: {
-              owner: 'not-owned@example.com',
-            },
-            relations: [
-              {
-                targetRef: 'user:default/not-owned',
-                type: 'ownedBy',
+              spec: {
+                owner: 'user:owned',
               },
-            ],
-          },
-        ]}
-      />,
+              relations: [
+                {
+                  targetRef: 'user:default/owned',
+                  type: 'ownedBy',
+                },
+              ],
+            },
+            {
+              apiVersion: 'version',
+              kind: 'TestKind2',
+              metadata: {
+                name: 'testName2',
+              },
+              spec: {
+                owner: 'not-owned@example.com',
+              },
+              relations: [
+                {
+                  targetRef: 'user:default/not-owned',
+                  type: 'ownedBy',
+                },
+              ],
+            },
+          ]}
+        />
+      </TestApiProvider>,
       {
         mountedRoutes: {
           '/docs/:namespace/:kind/:name/*': rootDocsRouteRef,
@@ -107,27 +140,31 @@ describe('DocsTable test', () => {
     getOptionalBooleanMock.mockReturnValue(true);
 
     await renderInTestApp(
-      <DocsTable
-        entities={[
-          {
-            apiVersion: 'version',
-            kind: 'TestKind',
-            metadata: {
-              name: 'testName',
-              namespace: 'SomeNamespace',
-            },
-            spec: {
-              owner: 'user:owned',
-            },
-            relations: [
-              {
-                targetRef: 'user:default/owned',
-                type: 'ownedBy',
+      <TestApiProvider
+        apis={[[entityPresentationApiRef, mockEntityPresentationApi]]}
+      >
+        <DocsTable
+          entities={[
+            {
+              apiVersion: 'version',
+              kind: 'TestKind',
+              metadata: {
+                name: 'testName',
+                namespace: 'SomeNamespace',
               },
-            ],
-          },
-        ]}
-      />,
+              spec: {
+                owner: 'user:owned',
+              },
+              relations: [
+                {
+                  targetRef: 'user:default/owned',
+                  type: 'ownedBy',
+                },
+              ],
+            },
+          ]}
+        />
+      </TestApiProvider>,
       {
         mountedRoutes: {
           '/techdocs/:namespace/:kind/:name/*': rootDocsRouteRef,
@@ -146,12 +183,19 @@ describe('DocsTable test', () => {
   });
 
   it('should render empty state if no owned documents exist', async () => {
-    await renderInTestApp(<DocsTable entities={[]} />, {
-      mountedRoutes: {
-        '/docs/:namespace/:kind/:name/*': rootDocsRouteRef,
-        '/catalog/:namespace/:kind/:name': entityRouteRef,
+    await renderInTestApp(
+      <TestApiProvider
+        apis={[[entityPresentationApiRef, mockEntityPresentationApi]]}
+      >
+        <DocsTable entities={[]} />
+      </TestApiProvider>,
+      {
+        mountedRoutes: {
+          '/docs/:namespace/:kind/:name/*': rootDocsRouteRef,
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+        },
       },
-    });
+    );
 
     expect(await screen.findByText('No documents to show')).toBeInTheDocument();
   });

--- a/plugins/techdocs/src/home/components/Tables/DocsTable.tsx
+++ b/plugins/techdocs/src/home/components/Tables/DocsTable.tsx
@@ -16,7 +16,12 @@
 
 import useCopyToClipboard from 'react-use/esm/useCopyToClipboard';
 
-import { configApiRef, useApi, useRouteRef } from '@backstage/core-plugin-api';
+import {
+  configApiRef,
+  useApi,
+  useApiHolder,
+  useRouteRef,
+} from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
 import { rootDocsRouteRef } from '../../../routes';
 import {
@@ -28,9 +33,10 @@ import {
   TableProps,
 } from '@backstage/core-components';
 import { actionFactories } from './actions';
-import { columnFactories, defaultColumns } from './columns';
+import { columnFactories, createDefaultColumns } from './columns';
 import { DocsTableRow } from './types';
 import { entitiesToDocsMapper } from './helpers';
+import { entityPresentationApiRef } from '@backstage/plugin-catalog-react';
 
 /**
  * Props for {@link DocsTable}.
@@ -56,12 +62,15 @@ export const DocsTable = (props: DocsTableProps) => {
   const [, copyToClipboard] = useCopyToClipboard();
   const getRouteToReaderPageFor = useRouteRef(rootDocsRouteRef);
   const config = useApi(configApiRef);
+  const apis = useApiHolder();
+  const entityPresentationApi = apis.get(entityPresentationApiRef);
   if (!entities) return null;
 
   const documents = entitiesToDocsMapper(
     entities,
     getRouteToReaderPageFor,
     config,
+    entityPresentationApi,
   );
 
   const defaultActions: TableProps<DocsTableRow>['actions'] = [
@@ -84,7 +93,7 @@ export const DocsTable = (props: DocsTableProps) => {
             ...options,
           }}
           data={documents}
-          columns={columns || defaultColumns}
+          columns={columns || createDefaultColumns(entityPresentationApi)}
           actions={actions || defaultActions}
           title={
             title

--- a/plugins/techdocs/src/home/components/Tables/DocsTable.tsx
+++ b/plugins/techdocs/src/home/components/Tables/DocsTable.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { useMemo } from 'react';
 import useCopyToClipboard from 'react-use/esm/useCopyToClipboard';
 
 import {
@@ -64,6 +65,12 @@ export const DocsTable = (props: DocsTableProps) => {
   const config = useApi(configApiRef);
   const apis = useApiHolder();
   const entityPresentationApi = apis.get(entityPresentationApiRef);
+
+  const defaultColumns = useMemo(
+    () => createDefaultColumns(entityPresentationApi),
+    [entityPresentationApi],
+  );
+
   if (!entities) return null;
 
   const documents = entitiesToDocsMapper(
@@ -93,7 +100,7 @@ export const DocsTable = (props: DocsTableProps) => {
             ...options,
           }}
           data={documents}
-          columns={columns || createDefaultColumns(entityPresentationApi)}
+          columns={columns || defaultColumns}
           actions={actions || defaultActions}
           title={
             title

--- a/plugins/techdocs/src/home/components/Tables/EntityListDocsTable.tsx
+++ b/plugins/techdocs/src/home/components/Tables/EntityListDocsTable.tsx
@@ -23,8 +23,14 @@ import {
   TableProps,
   WarningPanel,
 } from '@backstage/core-components';
-import { configApiRef, useApi, useRouteRef } from '@backstage/core-plugin-api';
 import {
+  configApiRef,
+  useApi,
+  useApiHolder,
+  useRouteRef,
+} from '@backstage/core-plugin-api';
+import {
+  entityPresentationApiRef,
   useEntityList,
   useStarredEntities,
 } from '@backstage/plugin-catalog-react';
@@ -32,7 +38,7 @@ import { DocsTable } from './DocsTable';
 import { OffsetPaginatedDocsTable } from './OffsetPaginatedDocsTable';
 import { CursorPaginatedDocsTable } from './CursorPaginatedDocsTable';
 import { actionFactories } from './actions';
-import { columnFactories, defaultColumns } from './columns';
+import { columnFactories, createDefaultColumns } from './columns';
 import { DocsTableRow } from './types';
 import { rootDocsRouteRef } from '../../../routes';
 import { entitiesToDocsMapper } from './helpers';
@@ -61,6 +67,8 @@ export const EntityListDocsTable = (props: EntityListDocsTableProps) => {
   const [, copyToClipboard] = useCopyToClipboard();
   const getRouteToReaderPageFor = useRouteRef(rootDocsRouteRef);
   const config = useApi(configApiRef);
+  const apis = useApiHolder();
+  const entityPresentationApi = apis.get(entityPresentationApiRef);
 
   const title = capitalize(filters.user?.value ?? 'all');
 
@@ -76,12 +84,13 @@ export const EntityListDocsTable = (props: EntityListDocsTableProps) => {
     entities,
     getRouteToReaderPageFor,
     config,
+    entityPresentationApi,
   );
 
   if (paginationMode === 'cursor') {
     return (
       <CursorPaginatedDocsTable
-        columns={columns || defaultColumns}
+        columns={columns || createDefaultColumns(entityPresentationApi)}
         isLoading={loading}
         title={title}
         actions={actions || defaultActions}
@@ -94,7 +103,7 @@ export const EntityListDocsTable = (props: EntityListDocsTableProps) => {
   } else if (paginationMode === 'offset') {
     return (
       <OffsetPaginatedDocsTable
-        columns={columns || defaultColumns}
+        columns={columns || createDefaultColumns(entityPresentationApi)}
         isLoading={loading}
         title={title}
         actions={actions || defaultActions}

--- a/plugins/techdocs/src/home/components/Tables/EntityListDocsTable.tsx
+++ b/plugins/techdocs/src/home/components/Tables/EntityListDocsTable.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { useMemo } from 'react';
 import useCopyToClipboard from 'react-use/esm/useCopyToClipboard';
 import { capitalize } from 'lodash';
 import {
@@ -87,10 +88,15 @@ export const EntityListDocsTable = (props: EntityListDocsTableProps) => {
     entityPresentationApi,
   );
 
+  const defaultColumns = useMemo(
+    () => createDefaultColumns(entityPresentationApi),
+    [entityPresentationApi],
+  );
+
   if (paginationMode === 'cursor') {
     return (
       <CursorPaginatedDocsTable
-        columns={columns || createDefaultColumns(entityPresentationApi)}
+        columns={columns || defaultColumns}
         isLoading={loading}
         title={title}
         actions={actions || defaultActions}
@@ -103,7 +109,7 @@ export const EntityListDocsTable = (props: EntityListDocsTableProps) => {
   } else if (paginationMode === 'offset') {
     return (
       <OffsetPaginatedDocsTable
-        columns={columns || createDefaultColumns(entityPresentationApi)}
+        columns={columns || defaultColumns}
         isLoading={loading}
         title={title}
         actions={actions || defaultActions}

--- a/plugins/techdocs/src/home/components/Tables/columns.tsx
+++ b/plugins/techdocs/src/home/components/Tables/columns.tsx
@@ -57,6 +57,13 @@ export const columnFactories = {
       highlight: true,
       searchable: true,
       defaultSort: 'asc',
+      customFilterAndSearch: (filter, row) => {
+        const title = customTitle(
+          row.entity,
+          entityPresentationApi,
+        ).toLocaleLowerCase();
+        return title.includes(filter.toLocaleLowerCase());
+      },
       customSort: (row1, row2) => {
         const title1 = customTitle(
           row1.entity,

--- a/plugins/techdocs/src/home/components/Tables/columns.tsx
+++ b/plugins/techdocs/src/home/components/Tables/columns.tsx
@@ -15,12 +15,20 @@
  */
 
 import { Link, SubvalueCell, TableColumn } from '@backstage/core-components';
-import { EntityRefLinks } from '@backstage/plugin-catalog-react';
+import {
+  EntityPresentationApi,
+  EntityRefLinks,
+  entityPresentationSnapshot,
+} from '@backstage/plugin-catalog-react';
 import { Entity } from '@backstage/catalog-model';
 import { DocsTableRow } from './types';
 
-function customTitle(entity: Entity): string {
-  return entity.metadata.title || entity.metadata.name;
+function customTitle(
+  entity: Entity,
+  entityPresentationApi?: EntityPresentationApi,
+): string {
+  return entityPresentationSnapshot(entity, undefined, entityPresentationApi)
+    .primaryTitle;
 }
 
 /**
@@ -29,15 +37,20 @@ function customTitle(entity: Entity): string {
  * @public
  */
 export const columnFactories = {
-  createTitleColumn(options?: { hidden?: boolean }): TableColumn<DocsTableRow> {
-    const nameCol = columnFactories.createNameColumn();
+  createTitleColumn(
+    options?: { hidden?: boolean },
+    entityPresentationApi?: EntityPresentationApi,
+  ): TableColumn<DocsTableRow> {
+    const nameCol = columnFactories.createNameColumn(entityPresentationApi);
     return {
       ...nameCol,
       field: 'entity.metadata.title',
       hidden: options?.hidden,
     };
   },
-  createNameColumn(): TableColumn<DocsTableRow> {
+  createNameColumn(
+    entityPresentationApi?: EntityPresentationApi,
+  ): TableColumn<DocsTableRow> {
     return {
       title: 'Document',
       field: 'entity.metadata.name',
@@ -45,14 +58,22 @@ export const columnFactories = {
       searchable: true,
       defaultSort: 'asc',
       customSort: (row1, row2) => {
-        const title1 = customTitle(row1.entity).toLocaleLowerCase();
-        const title2 = customTitle(row2.entity).toLocaleLowerCase();
+        const title1 = customTitle(
+          row1.entity,
+          entityPresentationApi,
+        ).toLocaleLowerCase();
+        const title2 = customTitle(
+          row2.entity,
+          entityPresentationApi,
+        ).toLocaleLowerCase();
         return title1.localeCompare(title2);
       },
       render: (row: DocsTableRow) => (
         <SubvalueCell
           value={
-            <Link to={row.resolved.docsUrl}>{customTitle(row.entity)}</Link>
+            <Link to={row.resolved.docsUrl}>
+              {customTitle(row.entity, entityPresentationApi)}
+            </Link>
           }
           subvalue={row.entity.metadata.description}
         />
@@ -85,10 +106,15 @@ export const columnFactories = {
   },
 };
 
-export const defaultColumns: TableColumn<DocsTableRow>[] = [
-  columnFactories.createTitleColumn({ hidden: true }),
-  columnFactories.createNameColumn(),
+export const createDefaultColumns = (
+  entityPresentationApi?: EntityPresentationApi,
+): TableColumn<DocsTableRow>[] => [
+  columnFactories.createTitleColumn({ hidden: true }, entityPresentationApi),
+  columnFactories.createNameColumn(entityPresentationApi),
   columnFactories.createOwnerColumn(),
   columnFactories.createKindColumn(),
   columnFactories.createTypeColumn(),
 ];
+
+export const defaultColumns: TableColumn<DocsTableRow>[] =
+  createDefaultColumns();


### PR DESCRIPTION


## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
## Description

Migrates TechDocs and Home plugins to use the Catalog Presentation API
instead of direct usage of `metadata.title` and `metadata.name`.

- TechDocs:
  - Updated entity display using `EntityDisplayName`
  - Updated sorting using `entityPresentationSnapshot`

- Home:
  - Updated entity sorting to use the presentation API

This ensures consistent entity name rendering and sorting across plugins.

## Related Issue

Refer #20955 

This is a follow up PR of https://github.com/backstage/backstage/pull/33838

## Testing
  - `yarn workspace @backstage/plugin-home test --watchAll=false`
  - `yarn workspace @backstage/plugin-techdocs test --watchAll=false`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
