### PR TITLE
backend-test-utils: deduplicate test readiness-polling helpers

### DIFF
--- a/.changeset/deduplicate-test-readiness-polling.md
+++ b/.changeset/deduplicate-test-readiness-polling.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-test-utils': patch
+---
+
+Deduplicated internal readiness-polling helpers used by the database and cache test infrastructure.

--- a/packages/backend-test-utils/src/cache/helpers.ts
+++ b/packages/backend-test-utils/src/cache/helpers.ts
@@ -31,10 +31,22 @@ export async function attemptKeyvConnection(
 
   await waitForReady(async () => {
     const store = createStore(connection);
-    keyv = new Keyv({ store });
-    const value = uuid();
-    await keyv.set('test', value);
-    return (await keyv.get('test')) === value;
+    const attemptKeyv = new Keyv({ store });
+    let succeeded = false;
+
+    try {
+      const value = uuid();
+      await attemptKeyv.set('test', value);
+      succeeded = (await attemptKeyv.get('test')) === value;
+      if (succeeded) {
+        keyv = attemptKeyv;
+      }
+      return succeeded;
+    } finally {
+      if (!succeeded) {
+        await attemptKeyv.disconnect();
+      }
+    }
   }, label);
 
   return keyv!;

--- a/packages/backend-test-utils/src/cache/helpers.ts
+++ b/packages/backend-test-utils/src/cache/helpers.ts
@@ -14,51 +14,57 @@
  * limitations under the License.
  */
 
-import KeyvMemcache from '@keyv/memcache';
+import Keyv, { type KeyvStoreAdapter } from 'keyv';
+import { v4 as uuid } from 'uuid';
+import { waitForReady } from '../util/waitForReady';
 import { Instance } from './types';
-import { attemptKeyvConnection } from './helpers';
 
-const createStore = (connection: string) => new KeyvMemcache(connection);
-
-export async function connectToExternalMemcache(
+/**
+ * Polls a Keyv store until a set/get round-trip succeeds.
+ */
+export async function attemptKeyvConnection(
+  createStore: (connection: string) => KeyvStoreAdapter,
   connection: string,
-): Promise<Instance> {
-  const keyv = await attemptKeyvConnection(
-    createStore,
-    connection,
-    'memcached',
-  );
-  return {
-    store: 'memcache',
-    connection,
-    keyv,
-    stop: async () => await keyv.disconnect(),
-  };
+  label: string,
+): Promise<Keyv> {
+  let keyv: Keyv | undefined;
+
+  await waitForReady(async () => {
+    const store = createStore(connection);
+    keyv = new Keyv({ store });
+    const value = uuid();
+    await keyv.set('test', value);
+    return (await keyv.get('test')) === value;
+  }, label);
+
+  return keyv!;
 }
 
-export async function startMemcachedContainer(
+/**
+ * Starts a Redis-protocol-compatible container (Redis, Valkey, etc.) on port
+ * 6379 and waits until a Keyv round-trip succeeds.
+ */
+export async function startRedisLikeContainer(
   image: string,
+  store: string,
+  createStore: (connection: string) => KeyvStoreAdapter,
 ): Promise<Instance> {
   // Lazy-load to avoid side-effect of importing testcontainers
   const { GenericContainer } =
     require('testcontainers') as typeof import('testcontainers');
 
   const container = await new GenericContainer(image)
-    .withExposedPorts(11211)
+    .withExposedPorts(6379)
     .start();
 
   const host = container.getHost();
-  const port = container.getMappedPort(11211);
-  const connection = `${host}:${port}`;
+  const port = container.getMappedPort(6379);
+  const connection = `redis://${host}:${port}`;
 
-  const keyv = await attemptKeyvConnection(
-    createStore,
-    connection,
-    'memcached',
-  );
+  const keyv = await attemptKeyvConnection(createStore, connection, store);
 
   return {
-    store: 'memcache',
+    store,
     connection,
     keyv,
     stop: async () => {

--- a/packages/backend-test-utils/src/cache/redis.ts
+++ b/packages/backend-test-utils/src/cache/redis.ts
@@ -14,39 +14,16 @@
  * limitations under the License.
  */
 
-import Keyv from 'keyv';
 import KeyvRedis from '@keyv/redis';
-import { v4 as uuid } from 'uuid';
 import { Instance } from './types';
+import { attemptKeyvConnection, startRedisLikeContainer } from './helpers';
 
-async function attemptRedisConnection(connection: string): Promise<Keyv> {
-  const startTime = Date.now();
-
-  for (;;) {
-    try {
-      const store = new KeyvRedis(connection);
-      const keyv = new Keyv({ store });
-      const value = uuid();
-      await keyv.set('test', value);
-      if ((await keyv.get('test')) === value) {
-        return keyv;
-      }
-    } catch (e) {
-      if (Date.now() - startTime > 30_000) {
-        throw new Error(
-          `Timed out waiting for redis to be ready for connections, ${e}`,
-        );
-      }
-    }
-
-    await new Promise(resolve => setTimeout(resolve, 100));
-  }
-}
+const createStore = (connection: string) => new KeyvRedis(connection);
 
 export async function connectToExternalRedis(
   connection: string,
 ): Promise<Instance> {
-  const keyv = await attemptRedisConnection(connection);
+  const keyv = await attemptKeyvConnection(createStore, connection, 'redis');
   return {
     store: 'redis',
     connection,
@@ -56,27 +33,5 @@ export async function connectToExternalRedis(
 }
 
 export async function startRedisContainer(image: string): Promise<Instance> {
-  // Lazy-load to avoid side-effect of importing testcontainers
-  const { GenericContainer } =
-    require('testcontainers') as typeof import('testcontainers');
-
-  const container = await new GenericContainer(image)
-    .withExposedPorts(6379)
-    .start();
-
-  const host = container.getHost();
-  const port = container.getMappedPort(6379);
-  const connection = `redis://${host}:${port}`;
-
-  const keyv = await attemptRedisConnection(connection);
-
-  return {
-    store: 'redis',
-    connection,
-    keyv,
-    stop: async () => {
-      await keyv.disconnect();
-      await container.stop({ timeout: 10_000 });
-    },
-  };
+  return startRedisLikeContainer(image, 'redis', createStore);
 }

--- a/packages/backend-test-utils/src/cache/valkey.ts
+++ b/packages/backend-test-utils/src/cache/valkey.ts
@@ -14,39 +14,16 @@
  * limitations under the License.
  */
 
-import Keyv from 'keyv';
 import KeyvValkey from '@keyv/valkey';
-import { v4 as uuid } from 'uuid';
 import { Instance } from './types';
+import { attemptKeyvConnection, startRedisLikeContainer } from './helpers';
 
-async function attemptValkeyConnection(connection: string): Promise<Keyv> {
-  const startTime = Date.now();
-
-  for (;;) {
-    try {
-      const store = new KeyvValkey(connection);
-      const keyv = new Keyv({ store });
-      const value = uuid();
-      await keyv.set('test', value);
-      if ((await keyv.get('test')) === value) {
-        return keyv;
-      }
-    } catch (e) {
-      if (Date.now() - startTime > 30_000) {
-        throw new Error(
-          `Timed out waiting for valkey to be ready for connections, ${e}`,
-        );
-      }
-    }
-
-    await new Promise(resolve => setTimeout(resolve, 100));
-  }
-}
+const createStore = (connection: string) => new KeyvValkey(connection);
 
 export async function connectToExternalValkey(
   connection: string,
 ): Promise<Instance> {
-  const keyv = await attemptValkeyConnection(connection);
+  const keyv = await attemptKeyvConnection(createStore, connection, 'valkey');
   return {
     store: 'valkey',
     connection,
@@ -56,27 +33,5 @@ export async function connectToExternalValkey(
 }
 
 export async function startValkeyContainer(image: string): Promise<Instance> {
-  // Lazy-load to avoid side-effect of importing testcontainers
-  const { GenericContainer } =
-    require('testcontainers') as typeof import('testcontainers');
-
-  const container = await new GenericContainer(image)
-    .withExposedPorts(6379)
-    .start();
-
-  const host = container.getHost();
-  const port = container.getMappedPort(6379);
-  const connection = `redis://${host}:${port}`;
-
-  const keyv = await attemptValkeyConnection(connection);
-
-  return {
-    store: 'valkey',
-    connection,
-    keyv,
-    stop: async () => {
-      await keyv.disconnect();
-      await container.stop({ timeout: 10_000 });
-    },
-  };
+  return startRedisLikeContainer(image, 'valkey', createStore);
 }

--- a/packages/backend-test-utils/src/database/mysql.ts
+++ b/packages/backend-test-utils/src/database/mysql.ts
@@ -14,54 +14,31 @@
  * limitations under the License.
  */
 
-import { stringifyError } from '@backstage/errors';
 import { randomBytes } from 'node:crypto';
 import knexFactory, { Knex } from 'knex';
 import { v4 as uuid } from 'uuid';
 import yn from 'yn';
+import { waitForReady } from '../util/waitForReady';
 import { Engine, LARGER_POOL_CONFIG, TestDatabaseProperties } from './types';
 
 async function waitForMysqlReady(
   connection: Knex.MySqlConnectionConfig,
 ): Promise<void> {
-  const startTime = Date.now();
-
-  let lastError: Error | undefined;
-  let attempts = 0;
-  for (;;) {
-    attempts += 1;
-
-    let knex: Knex | undefined;
+  await waitForReady(async () => {
+    const knex = knexFactory({
+      client: 'mysql2',
+      connection: {
+        // make a copy because the driver mutates this
+        ...connection,
+      },
+    });
     try {
-      knex = knexFactory({
-        client: 'mysql2',
-        connection: {
-          // make a copy because the driver mutates this
-          ...connection,
-        },
-      });
       const result = await knex.select(knex.raw('version() AS version'));
-      if (Array.isArray(result) && result[0]?.version) {
-        return;
-      }
-    } catch (e) {
-      lastError = e;
+      return Array.isArray(result) && Boolean(result[0]?.version);
     } finally {
-      await knex?.destroy();
+      await knex.destroy();
     }
-
-    if (Date.now() - startTime > 30_000) {
-      throw new Error(
-        `Timed out waiting for the database to be ready for connections, ${attempts} attempts, ${
-          lastError
-            ? `last error was ${stringifyError(lastError)}`
-            : '(no errors thrown)'
-        }`,
-      );
-    }
-
-    await new Promise(resolve => setTimeout(resolve, 100));
-  }
+  }, 'the database');
 }
 
 export async function startMysqlContainer(image: string): Promise<{

--- a/packages/backend-test-utils/src/database/postgres.ts
+++ b/packages/backend-test-utils/src/database/postgres.ts
@@ -14,54 +14,31 @@
  * limitations under the License.
  */
 
-import { stringifyError } from '@backstage/errors';
 import { randomBytes } from 'node:crypto';
 import knexFactory, { Knex } from 'knex';
 import { parse as parsePgConnectionString } from 'pg-connection-string';
 import { v4 as uuid } from 'uuid';
+import { waitForReady } from '../util/waitForReady';
 import { Engine, LARGER_POOL_CONFIG, TestDatabaseProperties } from './types';
 
 async function waitForPostgresReady(
   connection: Knex.PgConnectionConfig,
 ): Promise<void> {
-  const startTime = Date.now();
-
-  let lastError: Error | undefined;
-  let attempts = 0;
-  for (;;) {
-    attempts += 1;
-
-    let knex: Knex | undefined;
+  await waitForReady(async () => {
+    const knex = knexFactory({
+      client: 'pg',
+      connection: {
+        // make a copy because the driver mutates this
+        ...connection,
+      },
+    });
     try {
-      knex = knexFactory({
-        client: 'pg',
-        connection: {
-          // make a copy because the driver mutates this
-          ...connection,
-        },
-      });
       const result = await knex.select(knex.raw('version()'));
-      if (Array.isArray(result) && result[0]?.version) {
-        return;
-      }
-    } catch (e) {
-      lastError = e;
+      return Array.isArray(result) && Boolean(result[0]?.version);
     } finally {
-      await knex?.destroy();
+      await knex.destroy();
     }
-
-    if (Date.now() - startTime > 30_000) {
-      throw new Error(
-        `Timed out waiting for the database to be ready for connections, ${attempts} attempts, ${
-          lastError
-            ? `last error was ${stringifyError(lastError)}`
-            : '(no errors thrown)'
-        }`,
-      );
-    }
-
-    await new Promise(resolve => setTimeout(resolve, 100));
-  }
+  }, 'the database');
 }
 
 export async function startPostgresContainer(image: string): Promise<{

--- a/packages/backend-test-utils/src/util/waitForReady.ts
+++ b/packages/backend-test-utils/src/util/waitForReady.ts
@@ -31,7 +31,7 @@ export async function waitForReady(
 ): Promise<void> {
   const startTime = Date.now();
 
-  let lastError: Error | undefined;
+  let lastError: unknown;
   let attempts = 0;
   for (;;) {
     attempts += 1;

--- a/packages/backend-test-utils/src/util/waitForReady.ts
+++ b/packages/backend-test-utils/src/util/waitForReady.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { stringifyError } from '@backstage/errors';
+
+/**
+ * Polls a probe function until it succeeds or the timeout is reached.
+ *
+ * @param probe - An async function that should return `true` when the
+ *   service is ready. Throwing is treated as "not ready yet".
+ * @param label - A human-readable label used in the timeout error message.
+ * @param timeoutMs - Maximum time to wait in milliseconds (default 30 000).
+ */
+export async function waitForReady(
+  probe: () => Promise<boolean>,
+  label: string,
+  timeoutMs: number = 30_000,
+): Promise<void> {
+  const startTime = Date.now();
+
+  let lastError: Error | undefined;
+  let attempts = 0;
+  for (;;) {
+    attempts += 1;
+
+    try {
+      if (await probe()) {
+        return;
+      }
+    } catch (e) {
+      lastError = e;
+    }
+
+    if (Date.now() - startTime > timeoutMs) {
+      throw new Error(
+        `Timed out waiting for ${label} to be ready for connections, ${attempts} attempts, ${
+          lastError
+            ? `last error was ${stringifyError(lastError)}`
+            : '(no errors thrown)'
+        }`,
+      );
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This deduplicates the near-identical readiness-polling loops spread across the database and cache test infrastructure. The shared helpers are:

- `waitForReady` — generic probe-until-ready loop with timeout, attempt counting, and `stringifyError` formatting. Used by both postgres and mysql database helpers.
- `attemptKeyvConnection` — generic Keyv set/get probe loop parameterized by store constructor and label. Used by redis, valkey, and memcached.
- `startRedisLikeContainer` — shared container-start for redis-protocol stores (redis and valkey), which were identical.

Also normalizes the cache timeout error messages to use `stringifyError` instead of `${e}` template coercion, matching the database helpers.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))