### PR TITLE
backend-plugin-api: harmonize phantom .T getter behavior

### DIFF
--- a/.changeset/harmonize-phantom-t-getter.md
+++ b/.changeset/harmonize-phantom-t-getter.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-plugin-api': patch
+---
+
+Harmonized the phantom `.T` getter on `ExtensionPoint` to consistently return `null` instead of throwing.

--- a/.changeset/harmonize-phantom-t-getter.md
+++ b/.changeset/harmonize-phantom-t-getter.md
@@ -2,4 +2,4 @@
 '@backstage/backend-plugin-api': patch
 ---
 
-Harmonized the phantom `.T` getter behavior on `ExtensionPoint` and `ServiceRef` to consistently return `null` instead of throwing, and added `toJSON()` parity for `ExtensionPoint`.
+Aligned `.T` behavior between `ExtensionPoint` and `ServiceRef` to consistently return `null` instead of throwing, and added `toJSON()` parity for `ExtensionPoint`.

--- a/.changeset/harmonize-phantom-t-getter.md
+++ b/.changeset/harmonize-phantom-t-getter.md
@@ -2,4 +2,4 @@
 '@backstage/backend-plugin-api': patch
 ---
 
-Aligned `.T` behavior between `ExtensionPoint` and `ServiceRef` to consistently return `null` instead of throwing, and added `toJSON()` parity for `ExtensionPoint`.
+Aligned `.T` behavior between `ExtensionPoint` and `ServiceRef` to consistently return `null` instead of throwing.

--- a/.changeset/harmonize-phantom-t-getter.md
+++ b/.changeset/harmonize-phantom-t-getter.md
@@ -2,4 +2,4 @@
 '@backstage/backend-plugin-api': patch
 ---
 
-Harmonized the phantom `.T` getter on `ExtensionPoint` to consistently return `null` instead of throwing.
+Harmonized the phantom `.T` getter behavior on `ExtensionPoint` and `ServiceRef` to consistently return `null` instead of throwing, and added `toJSON()` parity for `ExtensionPoint`.

--- a/packages/backend-plugin-api/src/services/system/types.test.ts
+++ b/packages/backend-plugin-api/src/services/system/types.test.ts
@@ -25,6 +25,18 @@ const rootDep = createServiceRef<number>({ id: 'y', scope: 'root' });
 const pluginDep = createServiceRef<boolean>({ id: 'z' });
 function unused(..._any: any[]) {}
 
+describe('createServiceRef', () => {
+  it('should create a ServiceRef', () => {
+    expect(ref.id).toBe('x');
+    expect(ref.scope).toBe('plugin');
+    expect(ref.T).toBe(null);
+    expect(String(ref)).toBe('serviceRef{x}');
+    expect(JSON.stringify(ref)).toBe(
+      '{"$$type":"@backstage/ServiceRef","id":"x","scope":"plugin","multiton":false}',
+    );
+  });
+});
+
 describe('createServiceFactory', () => {
   it('should create a plugin scoped factory', () => {
     const factory = createServiceFactory({

--- a/packages/backend-plugin-api/src/services/system/types.ts
+++ b/packages/backend-plugin-api/src/services/system/types.ts
@@ -144,13 +144,12 @@ export function createServiceRef<
     scope,
     multiton,
     get T(): TService {
-      throw new Error(`tried to read ServiceRef.T of ${this}`);
+      return null as TService;
     },
     toString() {
       return `serviceRef{${options.id}}`;
     },
     toJSON() {
-      // This avoids accidental calls to T happening e.g. in tests
       return {
         $$type: '@backstage/ServiceRef',
         id,

--- a/packages/backend-plugin-api/src/services/system/types.ts
+++ b/packages/backend-plugin-api/src/services/system/types.ts
@@ -143,9 +143,7 @@ export function createServiceRef<
     id,
     scope,
     multiton,
-    get T(): TService {
-      return null as TService;
-    },
+    T: null as TService,
     toString() {
       return `serviceRef{${options.id}}`;
     },

--- a/packages/backend-plugin-api/src/services/system/types.ts
+++ b/packages/backend-plugin-api/src/services/system/types.ts
@@ -50,7 +50,7 @@ export type ServiceRef<
 
   /**
    * Utility for getting the type of the service, using `typeof serviceRef.T`.
-   * Attempting to actually read this value will result in an exception.
+   * Reading this value will always return `null`. It is only intended for use with `typeof serviceRef.T`.
    */
   T: TService;
 

--- a/packages/backend-plugin-api/src/wiring/createExtensionPoint.test.ts
+++ b/packages/backend-plugin-api/src/wiring/createExtensionPoint.test.ts
@@ -18,10 +18,10 @@ import { createExtensionPoint } from './createExtensionPoint';
 
 describe('createExtensionPoint', () => {
   it('should create an ExtensionPoint', () => {
-    const extensionPoint = createExtensionPoint({ id: 'x' });
+    const extensionPoint = createExtensionPoint<string>({ id: 'x' });
     expect(extensionPoint).toBeDefined();
     expect(extensionPoint.id).toBe('x');
-    expect(() => extensionPoint.T).not.toThrow();
+    expect(extensionPoint.T).toBe(null);
     expect(String(extensionPoint)).toBe('extensionPoint{x}');
   });
 });

--- a/packages/backend-plugin-api/src/wiring/createExtensionPoint.ts
+++ b/packages/backend-plugin-api/src/wiring/createExtensionPoint.ts
@@ -44,11 +44,7 @@ export function createExtensionPoint<T>(
   return {
     id: options.id,
     get T(): T {
-      if (process.env.NODE_ENV === 'test') {
-        // Avoid throwing errors so tests asserting extensions' properties cannot be easily broken
-        return null as T;
-      }
-      throw new Error(`tried to read ExtensionPoint.T of ${this}`);
+      return null as T;
     },
     toString() {
       return `extensionPoint{${options.id}}`;

--- a/packages/backend-plugin-api/src/wiring/createExtensionPoint.ts
+++ b/packages/backend-plugin-api/src/wiring/createExtensionPoint.ts
@@ -43,9 +43,7 @@ export function createExtensionPoint<T>(
 ): ExtensionPoint<T> {
   return {
     id: options.id,
-    get T(): T {
-      return null as T;
-    },
+    T: null as T,
     toString() {
       return `extensionPoint{${options.id}}`;
     },

--- a/packages/backend-plugin-api/src/wiring/types.ts
+++ b/packages/backend-plugin-api/src/wiring/types.ts
@@ -27,7 +27,7 @@ export type ExtensionPoint<T> = {
 
   /**
    * Utility for getting the type of the extension point, using `typeof extensionPoint.T`.
-   * Attempting to actually read this value will result in an exception.
+   * Reading this value will always return `null`. It is only intended for use with `typeof extensionPoint.T`.
    */
   T: T;
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This harmonizes the phantom `.T` getter behavior between `ExtensionPoint` and `ServiceRef` in `@backstage/backend-plugin-api`. Both now consistently return `null` instead of having divergent behavior (extension points returned `null` only in test env, service refs always threw). Also added `toJSON()` to `ExtensionPoint` for parity with `ServiceRef`.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))