### PR TITLE
auth-backend: remove unused isCimdUrl function

### DIFF
--- a/plugins/auth-backend/src/service/CimdClient.test.ts
+++ b/plugins/auth-backend/src/service/CimdClient.test.ts
@@ -17,7 +17,7 @@
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
-import { isCimdUrl, validateCimdUrl, fetchCimdMetadata } from './CimdClient';
+import { validateCimdUrl, fetchCimdMetadata } from './CimdClient';
 import * as dns from 'node:dns/promises';
 
 jest.mock('dns/promises');
@@ -43,65 +43,6 @@ describe('CimdClient', () => {
   afterEach(() => {
     (process.env as Record<string, string | undefined>).NODE_ENV =
       originalNodeEnv;
-  });
-
-  describe('isCimdUrl', () => {
-    it('should return true for valid CIMD URLs', () => {
-      expect(isCimdUrl('https://example.com/oauth-metadata.json')).toBe(true);
-      expect(isCimdUrl('https://example.com/path/to/metadata')).toBe(true);
-      expect(
-        isCimdUrl('https://sub.example.com/.well-known/oauth-client'),
-      ).toBe(true);
-    });
-
-    it('should return false for URLs without path', () => {
-      expect(isCimdUrl('https://example.com')).toBe(false);
-      expect(isCimdUrl('https://example.com/')).toBe(false);
-    });
-
-    it('should return false for non-HTTPS URLs on public hosts', () => {
-      expect(isCimdUrl('http://example.com/metadata')).toBe(false);
-    });
-
-    it('should return true for HTTP localhost URLs (development)', () => {
-      expect(
-        isCimdUrl(
-          'http://localhost:7007/api/auth/.well-known/oauth-client/cli',
-        ),
-      ).toBe(true);
-      expect(
-        isCimdUrl(
-          'http://127.0.0.1:7007/api/auth/.well-known/oauth-client/cli',
-        ),
-      ).toBe(true);
-      expect(isCimdUrl('http://localhost/path')).toBe(true);
-    });
-
-    it('should return false for HTTP localhost URLs in production', () => {
-      (process.env as Record<string, string | undefined>).NODE_ENV =
-        'production';
-      expect(isCimdUrl('http://localhost:7007/path')).toBe(false);
-      expect(isCimdUrl('http://127.0.0.1:7007/path')).toBe(false);
-    });
-
-    it('should return false for non-URL strings', () => {
-      expect(isCimdUrl('not-a-url')).toBe(false);
-      expect(isCimdUrl('uuid-like-client-id')).toBe(false);
-      expect(isCimdUrl('')).toBe(false);
-    });
-
-    it('should return false for URLs with query strings', () => {
-      expect(isCimdUrl('https://example.com/metadata?foo=bar')).toBe(false);
-    });
-
-    it('should return false for URLs with dot path segments', () => {
-      expect(isCimdUrl('https://example.com/./metadata')).toBe(false);
-      expect(isCimdUrl('https://example.com/../metadata')).toBe(false);
-    });
-
-    it('should return false for URLs with fragments', () => {
-      expect(isCimdUrl('https://example.com/metadata#section')).toBe(false);
-    });
   });
 
   describe('validateCimdUrl', () => {

--- a/plugins/auth-backend/src/service/CimdClient.ts
+++ b/plugins/auth-backend/src/service/CimdClient.ts
@@ -111,19 +111,6 @@ export function validateCimdUrl(clientId: string): URL {
 }
 
 /**
- * Checks if a client_id is a valid CIMD URL.
- * Requires HTTPS for production, but allows HTTP for localhost (development).
- */
-export function isCimdUrl(clientId: string): boolean {
-  try {
-    validateCimdUrl(clientId);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-/**
  * SSRF (Server-Side Request Forgery) Protection
  *
  * When fetching CIMD metadata from client-provided URLs, we must prevent

--- a/plugins/auth-backend/src/service/OidcRouter.test.ts
+++ b/plugins/auth-backend/src/service/OidcRouter.test.ts
@@ -35,7 +35,7 @@ import { AuthDatabase } from '../database/AuthDatabase';
 import { OidcService } from '../service/OidcService';
 import { TokenIssuer } from '../identity/types';
 import { OfflineAccessService } from './OfflineAccessService';
-import { CimdClientInfo, isCimdUrl } from './CimdClient';
+import { CimdClientInfo, validateCimdUrl } from './CimdClient';
 
 jest.mock('./CimdClient', () => {
   const actual = jest.requireActual('./CimdClient');
@@ -1253,8 +1253,7 @@ describe('OidcRouter', () => {
         };
         mockFetchCimdMetadata.mockResolvedValue(cimdMetadata);
 
-        // Verify isCimdUrl works correctly
-        expect(isCimdUrl(cimdClientId)).toBe(true);
+        expect(() => validateCimdUrl(cimdClientId)).not.toThrow();
 
         const knex = await databases.init(databaseId);
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

🧹

Removes the unused `isCimdUrl` function from `CimdClient.ts`. It was a thin wrapper around `validateCimdUrl` that was never imported by production code — only by test files. Tests now use `validateCimdUrl` directly.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))