### PR TITLE
MembersListCard displayName -> title -> name

### DIFF
--- a/.changeset/clean-weeks-beg.md
+++ b/.changeset/clean-weeks-beg.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+The `MembersListCard` now prefers `metadata.title` over `metadata.name` when displaying the group membership card similarly to the rest of the `GroupProfileCards`

--- a/.changeset/clean-weeks-beg.md
+++ b/.changeset/clean-weeks-beg.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-org': patch
 ---
 
-The `MembersListCard` now prefers `metadata.title` over `metadata.name` when displaying the group membership card similarly to the rest of the `GroupProfileCards`
+The `MembersListCard` now prefers `metadata.title` over `metadata.name` when displaying the group membership card, similarly to the rest of the group profile cards

--- a/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
+++ b/plugins/org/src/components/Cards/Group/MembersList/MembersListCard.tsx
@@ -168,12 +168,12 @@ export const MembersListCard = (props: {
 
   const { entity: groupEntity } = useEntity<GroupEntity>();
   const {
-    metadata: { name: groupName, namespace: grpNamespace },
+    metadata: { name: groupName, namespace: grpNamespace, title: groupTitle },
     spec: { profile },
   } = groupEntity;
   const catalogApi = useApi(catalogApiRef);
 
-  const displayName = profile?.displayName ?? groupName;
+  const displayName = profile?.displayName ?? groupTitle ?? groupName;
   const cardTitle =
     memberDisplayTitle ??
     t('membersListCard.title', { groupName: displayName });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Everywhere else on the group entity page we prefer the displayName, then the title, then the name.

But in the MembersLIstCard we do displayName or name.

Found this while doing something internally.

Of course the correct way is to not use `metadata.title` for groups and prefer the `profile.displayName` but we might as well add the fallback here as its everywhere else on the page.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
