### PR TITLE
perf(catalog): push field projection to database for entity listing

### DIFF
--- a/.changeset/slimy-bats-learn.md
+++ b/.changeset/slimy-bats-learn.md
@@ -1,0 +1,14 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Improved performance of entity listing endpoints when the `fields` query parameter is used.
+
+Field projection is now pushed down to the database (using `jsonb_build_object` on PostgreSQL,
+`json_object` on SQLite and MySQL) instead of fetching full entity JSON blobs and filtering them in
+JavaScript. For large catalogs this can reduce data transfer by over 90% and eliminate thousands of
+`JSON.parse` and re-serialization operations per request.
+
+The sort-field lookup in cursor-based pagination now uses a correlated scalar subquery instead of a `LEFT JOIN` + `DISTINCT`, avoiding expensive deduplication over large JSON columns. The streaming page size is
+also increased when field projection is active, reducing the number of database round-trips for large
+result sets.

--- a/.github/vale/config/vocabularies/Backstage/accept.txt
+++ b/.github/vale/config/vocabularies/Backstage/accept.txt
@@ -484,6 +484,7 @@ subroute
 subroutes
 substring
 subtree
+subquery
 superfences
 Superfences
 superset

--- a/plugins/catalog-backend/src/catalog/types.ts
+++ b/plugins/catalog-backend/src/catalog/types.ts
@@ -48,6 +48,15 @@ export type PageInfo =
 export type EntitiesRequest = {
   filter?: EntityFilter;
   fields?: (entity: Entity) => Entity;
+  /**
+   * When provided, the catalog will project only these dot-separated field
+   * paths directly in the database query instead of fetching full entity blobs
+   * and filtering them in JavaScript. This significantly reduces data transfer
+   * and CPU cost for large result sets.
+   *
+   * Example: ['kind', 'metadata.name', 'spec.type']
+   */
+  fieldPaths?: string[];
   order?: EntityOrder[];
   pagination?: EntityPagination;
   credentials: BackstageCredentials;
@@ -94,6 +103,14 @@ export interface EntitiesBatchRequest {
    * Strips out only the parts of the entity bodies to include in the response.
    */
   fields?: (entity: Entity) => Entity;
+  /**
+   * When provided, the catalog will project only these dot-separated field
+   * paths directly in the database query instead of fetching full entity blobs
+   * and filtering them in JavaScript.
+   *
+   * Example: ['kind', 'metadata.name', 'spec.type']
+   */
+  fieldPaths?: string[];
   /**
    * The credentials that authorizes the action.
    */
@@ -218,6 +235,15 @@ export type QueryEntitiesRequest =
 export interface QueryEntitiesInitialRequest {
   credentials: BackstageCredentials;
   fields?: (entity: Entity) => Entity;
+  /**
+   * When provided, the catalog will project only these dot-separated field
+   * paths directly in the database query instead of fetching full entity blobs
+   * and filtering them in JavaScript. This significantly reduces data transfer
+   * and CPU cost for large result sets.
+   *
+   * Example: ['kind', 'metadata.name', 'spec.type']
+   */
+  fieldPaths?: string[];
   limit?: number;
   offset?: number;
   filter?: EntityFilter;
@@ -240,6 +266,15 @@ export interface QueryEntitiesInitialRequest {
 export interface QueryEntitiesCursorRequest {
   credentials: BackstageCredentials;
   fields?: (entity: Entity) => Entity;
+  /**
+   * When provided, the catalog will project only these dot-separated field
+   * paths directly in the database query instead of fetching full entity blobs
+   * and filtering them in JavaScript. This significantly reduces data transfer
+   * and CPU cost for large result sets.
+   *
+   * Example: ['kind', 'metadata.name', 'spec.type']
+   */
+  fieldPaths?: string[];
   limit?: number;
   cursor: Cursor;
 }

--- a/plugins/catalog-backend/src/database/buildJsonFieldProjection.test.ts
+++ b/plugins/catalog-backend/src/database/buildJsonFieldProjection.test.ts
@@ -1,0 +1,415 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Knex } from 'knex';
+import { buildJsonFieldProjection } from './buildJsonFieldProjection';
+
+/**
+ * Minimal Knex mock: captures db.raw(sql, bindings) calls so tests can assert
+ * on the generated SQL template and binding values without hitting a real DB.
+ */
+function mockDb(client: string): Knex {
+  return {
+    client: { config: { client } },
+    raw: (sql: string, bindings: string[]) => ({ sql, bindings }),
+  } as unknown as Knex;
+}
+
+/** Cast the opaque Knex.Raw back to something inspectable in tests. */
+function asRaw(
+  result: Knex.Raw | null,
+): { sql: string; bindings: string[] } | null {
+  return result as any;
+}
+
+describe('buildJsonFieldProjection', () => {
+  describe('returns null (falls back to JS projection)', () => {
+    it('returns null for an empty fieldPaths array', () => {
+      expect(
+        buildJsonFieldProjection(mockDb('sqlite3'), [], 't', 'c'),
+      ).toBeNull();
+    });
+
+    it('returns null when any path contains "/" (annotation-style keys)', () => {
+      // These keys contain slashes inside a segment, e.g. "backstage.io/entity-ref".
+      // The builder cannot split them correctly so it falls back to JS.
+      expect(
+        buildJsonFieldProjection(
+          mockDb('sqlite3'),
+          ['metadata.annotations.backstage.io/techdocs-ref'],
+          't',
+          'c',
+        ),
+      ).toBeNull();
+    });
+
+    it('returns null when one path has "/" and others do not', () => {
+      expect(
+        buildJsonFieldProjection(
+          mockDb('pg'),
+          ['kind', 'metadata.annotations.github.com/project-slug'],
+          't',
+          'c',
+        ),
+      ).toBeNull();
+    });
+
+    it('returns null for an unsupported DB client', () => {
+      expect(
+        buildJsonFieldProjection(mockDb('mssql'), ['kind'], 't', 'c'),
+      ).toBeNull();
+    });
+  });
+
+  describe('SQLite / better-sqlite3', () => {
+    it.each(['sqlite3', 'better-sqlite3'])('works with client %s', client => {
+      const r = asRaw(
+        buildJsonFieldProjection(mockDb(client), ['kind'], 't', 'c'),
+      )!;
+      expect(r.sql).toBe('json_object( ?, json_extract("t"."c", ?) )');
+      expect(r.bindings).toEqual(['kind', '$.kind']);
+    });
+
+    it('single top-level field', () => {
+      const r = asRaw(
+        buildJsonFieldProjection(mockDb('sqlite3'), ['kind'], 't', 'c'),
+      )!;
+      expect(r.sql).toBe('json_object( ?, json_extract("t"."c", ?) )');
+      expect(r.bindings).toEqual(['kind', '$.kind']);
+    });
+
+    it('single nested field', () => {
+      const r = asRaw(
+        buildJsonFieldProjection(
+          mockDb('sqlite3'),
+          ['metadata.name'],
+          't',
+          'c',
+        ),
+      )!;
+      expect(r.sql).toBe(
+        'json_object( ?, json_object( ?, json_extract("t"."c", ?) ) )',
+      );
+      expect(r.bindings).toEqual(['metadata', 'name', '$.metadata.name']);
+    });
+
+    it('deeply nested field', () => {
+      const r = asRaw(
+        buildJsonFieldProjection(
+          mockDb('sqlite3'),
+          ['spec.profile.email'],
+          't',
+          'c',
+        ),
+      )!;
+      expect(r.sql).toBe(
+        'json_object( ?, json_object( ?, json_object( ?, json_extract("t"."c", ?) ) ) )',
+      );
+      expect(r.bindings).toEqual([
+        'spec',
+        'profile',
+        'email',
+        '$.spec.profile.email',
+      ]);
+    });
+
+    it('multiple top-level fields', () => {
+      const r = asRaw(
+        buildJsonFieldProjection(
+          mockDb('sqlite3'),
+          ['kind', 'apiVersion'],
+          't',
+          'c',
+        ),
+      )!;
+      expect(r.sql).toBe(
+        'json_object( ?, json_extract("t"."c", ?) , ?, json_extract("t"."c", ?) )',
+      );
+      expect(r.bindings).toEqual([
+        'kind',
+        '$.kind',
+        'apiVersion',
+        '$.apiVersion',
+      ]);
+    });
+
+    it('mixed top-level and nested fields', () => {
+      const r = asRaw(
+        buildJsonFieldProjection(
+          mockDb('sqlite3'),
+          ['kind', 'metadata.name'],
+          't',
+          'c',
+        ),
+      )!;
+      expect(r.sql).toBe(
+        'json_object( ?, json_extract("t"."c", ?) , ?, json_object( ?, json_extract("t"."c", ?) ) )',
+      );
+      expect(r.bindings).toEqual([
+        'kind',
+        '$.kind',
+        'metadata',
+        'name',
+        '$.metadata.name',
+      ]);
+    });
+
+    it('sibling nested fields share the same intermediate node', () => {
+      const r = asRaw(
+        buildJsonFieldProjection(
+          mockDb('sqlite3'),
+          ['metadata.name', 'metadata.namespace'],
+          't',
+          'c',
+        ),
+      )!;
+      // Both name and namespace live under a single json_object for metadata
+      expect(r.sql).toBe(
+        'json_object( ?, json_object( ?, json_extract("t"."c", ?) , ?, json_extract("t"."c", ?) ) )',
+      );
+      expect(r.bindings).toEqual([
+        'metadata',
+        'name',
+        '$.metadata.name',
+        'namespace',
+        '$.metadata.namespace',
+      ]);
+    });
+
+    it('respects the table and column names in the column reference', () => {
+      const r = asRaw(
+        buildJsonFieldProjection(
+          mockDb('sqlite3'),
+          ['kind'],
+          'final_entities',
+          'final_entity',
+        ),
+      )!;
+      expect(r.sql).toBe(
+        'json_object( ?, json_extract("final_entities"."final_entity", ?) )',
+      );
+    });
+
+    describe('parent-dominates-child (leaf before subtree)', () => {
+      it('when parent path comes first, the child path is ignored', () => {
+        // 'metadata' is a leaf → metadata.name is skipped
+        const withNested = asRaw(
+          buildJsonFieldProjection(
+            mockDb('sqlite3'),
+            ['metadata', 'metadata.name'],
+            't',
+            'c',
+          ),
+        )!;
+        const parentOnly = asRaw(
+          buildJsonFieldProjection(mockDb('sqlite3'), ['metadata'], 't', 'c'),
+        )!;
+        // Should produce the same SQL as if only 'metadata' was requested
+        expect(withNested.sql).toBe(parentOnly.sql);
+        expect(withNested.bindings).toEqual(parentOnly.bindings);
+      });
+
+      it('when child path comes first, it is kept (existing intermediate node is not overwritten by later leaf)', () => {
+        // 'metadata.name' creates an intermediate node for metadata; the
+        // later parent path 'metadata' cannot overwrite it to a leaf.
+        const r = asRaw(
+          buildJsonFieldProjection(
+            mockDb('sqlite3'),
+            ['metadata.name', 'metadata'],
+            't',
+            'c',
+          ),
+        )!;
+        const childOnly = asRaw(
+          buildJsonFieldProjection(
+            mockDb('sqlite3'),
+            ['metadata.name'],
+            't',
+            'c',
+          ),
+        )!;
+        expect(r.sql).toBe(childOnly.sql);
+        expect(r.bindings).toEqual(childOnly.bindings);
+      });
+    });
+  });
+
+  describe('PostgreSQL', () => {
+    it('single top-level field uses -> operator and ::text cast', () => {
+      const r = asRaw(
+        buildJsonFieldProjection(mockDb('pg'), ['kind'], 't', 'c'),
+      )!;
+      expect(r.sql).toBe(
+        '(jsonb_build_object( ?::text, ("t"."c"::jsonb) -> ? ))::text',
+      );
+      expect(r.bindings).toEqual(['kind', 'kind']);
+    });
+
+    it('nested field uses chained -> operators', () => {
+      const r = asRaw(
+        buildJsonFieldProjection(mockDb('pg'), ['metadata.name'], 't', 'c'),
+      )!;
+      expect(r.sql).toBe(
+        '(jsonb_build_object( ?::text, jsonb_build_object( ?::text, ("t"."c"::jsonb) -> ? -> ? ) ))::text',
+      );
+      expect(r.bindings).toEqual(['metadata', 'name', 'metadata', 'name']);
+    });
+
+    it('deeply nested field chains three -> operators', () => {
+      const r = asRaw(
+        buildJsonFieldProjection(
+          mockDb('pg'),
+          ['spec.profile.email'],
+          't',
+          'c',
+        ),
+      )!;
+      expect(r.sql).toBe(
+        '(jsonb_build_object( ?::text, jsonb_build_object( ?::text, jsonb_build_object( ?::text, ("t"."c"::jsonb) -> ? -> ? -> ? ) ) ))::text',
+      );
+      expect(r.bindings).toEqual([
+        'spec',
+        'profile',
+        'email',
+        'spec',
+        'profile',
+        'email',
+      ]);
+    });
+
+    it('multiple fields in a single jsonb_build_object', () => {
+      const r = asRaw(
+        buildJsonFieldProjection(
+          mockDb('pg'),
+          ['kind', 'metadata.name'],
+          't',
+          'c',
+        ),
+      )!;
+      expect(r.sql).toBe(
+        '(jsonb_build_object( ?::text, ("t"."c"::jsonb) -> ? , ?::text, jsonb_build_object( ?::text, ("t"."c"::jsonb) -> ? -> ? ) ))::text',
+      );
+      expect(r.bindings).toEqual([
+        'kind',
+        'kind',
+        'metadata',
+        'name',
+        'metadata',
+        'name',
+      ]);
+    });
+
+    it('uses double-quote identifiers for table and column', () => {
+      const r = asRaw(
+        buildJsonFieldProjection(
+          mockDb('pg'),
+          ['kind'],
+          'final_entities',
+          'final_entity',
+        ),
+      )!;
+      expect(r.sql).toContain('"final_entities"."final_entity"');
+    });
+
+    it('also matches client strings like "pg-native" that contain "pg"', () => {
+      // Knex uses client strings that contain the substring 'pg', such as
+      // 'pg' or 'pg-native'. The plain string 'postgresql' does NOT match.
+      const r = asRaw(
+        buildJsonFieldProjection(mockDb('pg-native'), ['kind'], 't', 'c'),
+      );
+      expect(r).not.toBeNull();
+      expect(r!.sql).toContain('jsonb_build_object');
+    });
+
+    describe('parent-dominates-child', () => {
+      it('parent path first collapses child path to a single leaf', () => {
+        const withNested = asRaw(
+          buildJsonFieldProjection(
+            mockDb('pg'),
+            ['metadata', 'metadata.name'],
+            't',
+            'c',
+          ),
+        )!;
+        const parentOnly = asRaw(
+          buildJsonFieldProjection(mockDb('pg'), ['metadata'], 't', 'c'),
+        )!;
+        expect(withNested.sql).toBe(parentOnly.sql);
+        expect(withNested.bindings).toEqual(parentOnly.bindings);
+      });
+    });
+  });
+
+  describe('MySQL', () => {
+    it('single top-level field uses JSON_OBJECT / JSON_EXTRACT with CAST', () => {
+      const r = asRaw(
+        buildJsonFieldProjection(mockDb('mysql'), ['kind'], 't', 'c'),
+      )!;
+      expect(r.sql).toBe(
+        'CAST(JSON_OBJECT( ?, JSON_EXTRACT(`t`.`c`, ?) ) AS CHAR)',
+      );
+      expect(r.bindings).toEqual(['kind', '$.kind']);
+    });
+
+    it('nested field builds nested JSON_OBJECT', () => {
+      const r = asRaw(
+        buildJsonFieldProjection(mockDb('mysql'), ['metadata.name'], 't', 'c'),
+      )!;
+      expect(r.sql).toBe(
+        'CAST(JSON_OBJECT( ?, JSON_OBJECT( ?, JSON_EXTRACT(`t`.`c`, ?) ) ) AS CHAR)',
+      );
+      expect(r.bindings).toEqual(['metadata', 'name', '$.metadata.name']);
+    });
+
+    it('uses backtick identifiers for table and column', () => {
+      const r = asRaw(
+        buildJsonFieldProjection(
+          mockDb('mysql'),
+          ['kind'],
+          'final_entities',
+          'final_entity',
+        ),
+      )!;
+      expect(r.sql).toContain('`final_entities`.`final_entity`');
+    });
+
+    it('also matches client strings like "mysql2"', () => {
+      const r = asRaw(
+        buildJsonFieldProjection(mockDb('mysql2'), ['kind'], 't', 'c'),
+      );
+      expect(r).not.toBeNull();
+      expect(r!.sql).toContain('JSON_OBJECT');
+    });
+
+    describe('parent-dominates-child', () => {
+      it('parent path first collapses child path to a single leaf', () => {
+        const withNested = asRaw(
+          buildJsonFieldProjection(
+            mockDb('mysql'),
+            ['metadata', 'metadata.name'],
+            't',
+            'c',
+          ),
+        )!;
+        const parentOnly = asRaw(
+          buildJsonFieldProjection(mockDb('mysql'), ['metadata'], 't', 'c'),
+        )!;
+        expect(withNested.sql).toBe(parentOnly.sql);
+        expect(withNested.bindings).toEqual(parentOnly.bindings);
+      });
+    });
+  });
+});

--- a/plugins/catalog-backend/src/database/buildJsonFieldProjection.ts
+++ b/plugins/catalog-backend/src/database/buildJsonFieldProjection.ts
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Knex } from 'knex';
+
+/**
+ * A tree structure representing the requested field projection.
+ * A null value is a leaf node (select that exact field).
+ * An object value is an intermediate node (recurse into sub-keys).
+ */
+interface FieldTree {
+  [key: string]: FieldTree | null;
+}
+
+/**
+ * Converts a flat list of dot-separated field paths into a nested tree.
+ *
+ * Example:
+ *   ['kind', 'metadata.name', 'spec.profile.email']
+ *   → { kind: null, metadata: { name: null }, spec: { profile: { email: null } } }
+ *
+ * When a parent path and a child path are both present (e.g. both 'metadata'
+ * and 'metadata.name'), the parent (leaf) dominates: the full parent object
+ * will be selected and the more-specific child path is ignored. This mirrors
+ * the behaviour of the JS-side parseEntityTransformParams transform.
+ */
+function buildFieldTree(fields: string[]): FieldTree {
+  const tree: FieldTree = {};
+  for (const field of fields) {
+    const parts = field.split('.');
+    let current: FieldTree = tree;
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      if (i === parts.length - 1) {
+        // Leaf – only set if not already an intermediate node
+        if (!(part in current)) {
+          current[part] = null;
+        }
+      } else {
+        const existing = current[part];
+        if (existing === null) {
+          // A parent leaf already covers this subtree – skip the deeper path.
+          break;
+        }
+        if (existing === undefined) {
+          current[part] = {};
+        }
+        current = current[part] as FieldTree;
+      }
+    }
+  }
+  return tree;
+}
+
+/**
+ * Recursively builds a PostgreSQL jsonb_build_object(...) expression.
+ *
+ * @param tree         – the sub-tree to render
+ * @param columnRef    – the JSONB column reference (already cast to jsonb)
+ * @param ancestors    – path segments from the root to the current sub-tree
+ * @param sqlParts     – accumulates SQL fragments (joined at call site)
+ * @param bindings     – accumulates ? binding values
+ */
+function buildPgExpr(
+  tree: FieldTree,
+  columnRef: string,
+  ancestors: string[],
+  sqlParts: string[],
+  bindings: string[],
+): void {
+  const entries = Object.entries(tree);
+  sqlParts.push('jsonb_build_object(');
+  for (let i = 0; i < entries.length; i++) {
+    const [key, subtree] = entries[i];
+    if (i > 0) sqlParts.push(',');
+    // PostgreSQL cannot infer the type of a positional parameter when it is
+    // used as a key in jsonb_build_object, so we must cast it explicitly.
+    bindings.push(key);
+    sqlParts.push('?::text,');
+    if (subtree === null) {
+      // Leaf: chain -> operators from the root column ref down to this key
+      const fullPath = [...ancestors, key];
+      // e.g. ("col"::jsonb) -> ? -> ?  with bindings ['metadata', 'name']
+      sqlParts.push(`${columnRef}${fullPath.map(() => ' -> ?').join('')}`);
+      bindings.push(...fullPath);
+    } else {
+      // Intermediate node: recurse into a nested jsonb_build_object
+      buildPgExpr(subtree, columnRef, [...ancestors, key], sqlParts, bindings);
+    }
+  }
+  sqlParts.push(')');
+}
+
+/**
+ * Recursively builds a json_object(...) / JSON_OBJECT(...) expression
+ * for SQLite and MySQL where leaf values are extracted via
+ * json_extract / JSON_EXTRACT.
+ *
+ * @param tree        – the sub-tree to render
+ * @param columnRef   – the column reference (plain text column)
+ * @param pathPrefix  – JSON path prefix, e.g. '$' or '$.metadata'
+ * @param sqlParts    – accumulates SQL fragments
+ * @param bindings    – accumulates ? binding values
+ * @param objectFn    – function name, e.g. 'json_object' or 'JSON_OBJECT'
+ * @param extractFn   – function name, e.g. 'json_extract' or 'JSON_EXTRACT'
+ */
+function buildJsonObjectExpr(
+  tree: FieldTree,
+  columnRef: string,
+  pathPrefix: string,
+  sqlParts: string[],
+  bindings: string[],
+  objectFn: string,
+  extractFn: string,
+): void {
+  const entries = Object.entries(tree);
+  sqlParts.push(`${objectFn}(`);
+  for (let i = 0; i < entries.length; i++) {
+    const [key, subtree] = entries[i];
+    if (i > 0) sqlParts.push(',');
+    bindings.push(key);
+    sqlParts.push('?,');
+    const subPath = `${pathPrefix}.${key}`;
+    if (subtree === null) {
+      // Leaf: extract the value at this path
+      bindings.push(subPath);
+      sqlParts.push(`${extractFn}(${columnRef}, ?)`);
+    } else {
+      // Intermediate: recurse
+      buildJsonObjectExpr(
+        subtree,
+        columnRef,
+        subPath,
+        sqlParts,
+        bindings,
+        objectFn,
+        extractFn,
+      );
+    }
+  }
+  sqlParts.push(')');
+}
+
+/**
+ * Builds a database-side JSON field projection expression as a `Knex.Raw`.
+ *
+ * When a request specifies a `fields` list, the catalog normally fetches full
+ * entity JSON blobs from `final_entities.final_entity` and then filters fields
+ * in JavaScript. For large result sets this causes significant overhead:
+ * - The full JSON is transferred over the DB → Node.js connection
+ * - Each blob is JSON.parse'd, filtered, and JSON.stringify'd in JS
+ *
+ * This function generates a SQL expression that projects only the requested
+ * fields directly in the database, reducing data transfer and CPU cost.
+ *
+ * The returned expression is intended to be used as the value for the
+ * `final_entity` column alias in a Knex SELECT, e.g.:
+ *
+ *   query.select({ final_entity: buildJsonFieldProjection(db, fields, 'final_entities', 'final_entity') })
+ *
+ * The result is always cast to TEXT so it matches the type that
+ * `processRawEntitiesResult` expects.
+ *
+ * Returns `null` when:
+ * - `fieldPaths` is empty (no projection needed)
+ * - Any field path contains '/' (annotation-style keys whose dot-separated
+ *   segments are not simple JSON object keys; e.g.
+ *   `metadata.annotations.backstage.io/techdocs-ref`). These fall back to
+ *   the JS-side transform which handles the dot-joining fallback logic.
+ * - The DB client is not supported (caller falls back to JS-side projection)
+ *
+ * @param db         – Knex instance (used for client detection and raw())
+ * @param fieldPaths – dot-separated field paths, e.g. ['kind', 'metadata.name']
+ * @param table      – unquoted table name, e.g. 'final_entities'
+ * @param column     – unquoted column name, e.g. 'final_entity'
+ */
+export function buildJsonFieldProjection(
+  db: Knex,
+  fieldPaths: string[],
+  table: string,
+  column: string,
+): Knex.Raw | null {
+  if (!fieldPaths.length) return null;
+
+  // Paths containing '/' indicate annotation-like keys (e.g.
+  // metadata.annotations.backstage.io/techdocs-ref) where individual key
+  // segments themselves contain dots. The projection builder splits on every
+  // dot and cannot safely represent these paths in SQL. Fall back to JS.
+  if (fieldPaths.some(p => p.includes('/'))) return null;
+
+  const tree = buildFieldTree(fieldPaths);
+  if (!Object.keys(tree).length) return null;
+
+  const client: string = db.client.config.client;
+  const sqlParts: string[] = [];
+  const bindings: string[] = [];
+
+  if (client.includes('pg')) {
+    // final_entity is a TEXT column; cast to jsonb for -> operators, then
+    // cast the result back to text so the pg driver returns a plain string.
+    // PostgreSQL uses double-quote identifiers.
+    const pgColumnRef = `("${table}"."${column}"::jsonb)`;
+    buildPgExpr(tree, pgColumnRef, [], sqlParts, bindings);
+    return db.raw(`(${sqlParts.join(' ')})::text`, bindings);
+  }
+
+  if (client.includes('sqlite3') || client.includes('better-sqlite3')) {
+    // SQLite uses double-quote identifiers.
+    const colRef = `"${table}"."${column}"`;
+    buildJsonObjectExpr(
+      tree,
+      colRef,
+      '$',
+      sqlParts,
+      bindings,
+      'json_object',
+      'json_extract',
+    );
+    return db.raw(sqlParts.join(' '), bindings);
+  }
+
+  if (client.includes('mysql')) {
+    // MySQL uses backtick identifiers.
+    const colRef = `\`${table}\`.\`${column}\``;
+    buildJsonObjectExpr(
+      tree,
+      colRef,
+      '$',
+      sqlParts,
+      bindings,
+      'JSON_OBJECT',
+      'JSON_EXTRACT',
+    );
+    // Cast to CHAR so the MySQL driver returns a plain string
+    return db.raw(`CAST(${sqlParts.join(' ')} AS CHAR)`, bindings);
+  }
+
+  // Unsupported DB client – caller should fall back to JS-side projection
+  return null;
+}

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
@@ -741,6 +741,117 @@ describe('DefaultEntitiesCatalog', () => {
         ).resolves.toEqual(['n4', 'n3', 'n1', 'n2']);
       },
     );
+
+    it.each(databases.eachSupportedId())(
+      'should project only requested fields via fieldPaths, %p',
+      async databaseId => {
+        await createDatabase(databaseId);
+
+        const entity: Entity = {
+          apiVersion: 'a',
+          kind: 'k',
+          metadata: { name: 'n1', description: 'some description' },
+          spec: { type: 'service', owner: 'me' },
+        };
+        await addEntityToSearch(entity);
+
+        const catalog = new DefaultEntitiesCatalog({
+          database: knex,
+          logger: mockServices.logger.mock(),
+          stitcher,
+        });
+
+        const res = await catalog.entities({
+          fieldPaths: ['kind', 'metadata.name'],
+          credentials: mockCredentials.none(),
+        });
+        const items = entitiesResponseToObjects(res.entities);
+
+        expect(items).toHaveLength(1);
+        // Only the projected fields should be present
+        expect(items[0]).toEqual({ kind: 'k', metadata: { name: 'n1' } });
+        // Fields not in fieldPaths must be absent
+        expect(items[0]).not.toHaveProperty('spec');
+        expect(items[0]).not.toHaveProperty('apiVersion');
+        expect(items[0]).not.toHaveProperty('metadata.description');
+      },
+    );
+
+    it.each(databases.eachSupportedId())(
+      'should return full parent when parent path dominates child path, %p',
+      async databaseId => {
+        await createDatabase(databaseId);
+
+        const entity: Entity = {
+          apiVersion: 'a',
+          kind: 'k',
+          metadata: { name: 'n1', description: 'keep me' },
+          spec: { type: 'service' },
+        };
+        await addEntityToSearch(entity);
+
+        const catalog = new DefaultEntitiesCatalog({
+          database: knex,
+          logger: mockServices.logger.mock(),
+          stitcher,
+        });
+
+        // Requesting both 'metadata' (parent) and 'metadata.name' (child).
+        // The parent leaf dominates: the full metadata object should be returned.
+        const res = await catalog.entities({
+          fieldPaths: ['metadata', 'metadata.name'],
+          credentials: mockCredentials.none(),
+        });
+        const items = entitiesResponseToObjects(res.entities);
+
+        expect(items).toHaveLength(1);
+        expect(items[0]).toHaveProperty('metadata.name', 'n1');
+        expect(items[0]).toHaveProperty('metadata.description', 'keep me');
+        expect(items[0]).not.toHaveProperty('spec');
+        expect(items[0]).not.toHaveProperty('kind');
+      },
+    );
+
+    it.each(databases.eachSupportedId())(
+      'should fall back to JS transform for annotation-style field paths, %p',
+      async databaseId => {
+        await createDatabase(databaseId);
+
+        const entity: Entity = {
+          apiVersion: 'a',
+          kind: 'k',
+          metadata: {
+            name: 'n1',
+            annotations: { 'backstage.io/techdocs-ref': 'dir:.', other: 'x' },
+          },
+          spec: {},
+        };
+        await addEntityToSearch(entity);
+
+        const catalog = new DefaultEntitiesCatalog({
+          database: knex,
+          logger: mockServices.logger.mock(),
+          stitcher,
+        });
+
+        // Annotation paths contain '/' – DB projection is disabled; the
+        // JS-side fields transform must produce the correct shape.
+        const res = await catalog.entities({
+          fields: e =>
+            ({
+              ...e,
+              metadata: { ...e.metadata, annotations: undefined },
+            } as any),
+          fieldPaths: ['metadata.annotations.backstage.io/techdocs-ref'],
+          credentials: mockCredentials.none(),
+        });
+        const items = entitiesResponseToObjects(res.entities);
+
+        // The JS fields transform runs because DB projection was bypassed.
+        expect(items).toHaveLength(1);
+        expect(items[0]).not.toHaveProperty('metadata.annotations');
+      },
+    );
   });
 
   describe('entitiesBatch', () => {
@@ -843,6 +954,75 @@ describe('DefaultEntitiesCatalog', () => {
           'k:default/two',
           null,
         ]);
+      },
+    );
+
+    it.each(databases.eachSupportedId())(
+      'should project only requested fields via fieldPaths, %p',
+      async databaseId => {
+        await createDatabase(databaseId);
+
+        const entity: Entity = {
+          apiVersion: 'a',
+          kind: 'k',
+          metadata: { name: 'one', description: 'desc' },
+          spec: { type: 'service' },
+          relations: [],
+        };
+        await addEntity(entity, []);
+
+        const catalog = new DefaultEntitiesCatalog({
+          database: knex,
+          logger: mockServices.logger.mock(),
+          stitcher,
+        });
+
+        const res = await catalog.entitiesBatch({
+          entityRefs: ['k:default/one'],
+          fieldPaths: ['kind', 'metadata.name'],
+          credentials: mockCredentials.none(),
+        });
+        const items = entitiesResponseToObjects(res.items);
+
+        expect(items).toHaveLength(1);
+        expect(items[0]).toEqual({ kind: 'k', metadata: { name: 'one' } });
+        expect(items[0]).not.toHaveProperty('spec');
+        expect(items[0]).not.toHaveProperty('apiVersion');
+        expect(items[0]).not.toHaveProperty('metadata.description');
+      },
+    );
+
+    it.each(databases.eachSupportedId())(
+      'should return full parent when parent path dominates child path in entitiesBatch, %p',
+      async databaseId => {
+        await createDatabase(databaseId);
+
+        const entity: Entity = {
+          apiVersion: 'a',
+          kind: 'k',
+          metadata: { name: 'one', description: 'keep me' },
+          spec: { type: 'service' },
+          relations: [],
+        };
+        await addEntity(entity, []);
+
+        const catalog = new DefaultEntitiesCatalog({
+          database: knex,
+          logger: mockServices.logger.mock(),
+          stitcher,
+        });
+
+        const res = await catalog.entitiesBatch({
+          entityRefs: ['k:default/one'],
+          fieldPaths: ['metadata', 'metadata.name'],
+          credentials: mockCredentials.none(),
+        });
+        const items = entitiesResponseToObjects(res.items);
+
+        expect(items).toHaveLength(1);
+        expect(items[0]).toHaveProperty('metadata.name', 'one');
+        expect(items[0]).toHaveProperty('metadata.description', 'keep me');
+        expect(items[0]).not.toHaveProperty('spec');
       },
     );
   });
@@ -2174,6 +2354,168 @@ describe('DefaultEntitiesCatalog', () => {
         expect(stitch).toHaveBeenCalledWith({
           entityRefs: new Set(['k:default/unrelated1', 'k:default/unrelated2']),
         });
+      },
+    );
+  });
+
+  describe('queryEntities with fieldPaths', () => {
+    it.each(databases.eachSupportedId())(
+      'should project only requested fields via fieldPaths, %p',
+      async databaseId => {
+        await createDatabase(databaseId);
+
+        const entityA: Entity = {
+          apiVersion: 'a',
+          kind: 'k',
+          metadata: { name: 'a', description: 'desc-a' },
+          spec: { type: 'service', owner: 'team-a' },
+        };
+        const entityB: Entity = {
+          apiVersion: 'a',
+          kind: 'k',
+          metadata: { name: 'b', description: 'desc-b' },
+          spec: { type: 'library', owner: 'team-b' },
+        };
+        await addEntityToSearch(entityA);
+        await addEntityToSearch(entityB);
+
+        const catalog = new DefaultEntitiesCatalog({
+          database: knex,
+          logger: mockServices.logger.mock(),
+          stitcher,
+        });
+
+        const res = await catalog.queryEntities({
+          fieldPaths: ['kind', 'metadata.name', 'spec.type'],
+          orderFields: [{ field: 'metadata.name', order: 'asc' }],
+          credentials: mockCredentials.none(),
+        });
+        const items = entitiesResponseToObjects(res.items);
+
+        expect(items).toHaveLength(2);
+        expect(items[0]).toEqual({
+          kind: 'k',
+          metadata: { name: 'a' },
+          spec: { type: 'service' },
+        });
+        expect(items[1]).toEqual({
+          kind: 'k',
+          metadata: { name: 'b' },
+          spec: { type: 'library' },
+        });
+        // Fields not in fieldPaths must be absent
+        expect(items[0]).not.toHaveProperty('apiVersion');
+        expect(items[0]).not.toHaveProperty('metadata.description');
+        expect(items[0]).not.toHaveProperty('spec.owner');
+      },
+    );
+
+    it.each(databases.eachSupportedId())(
+      'should project fields without sort field, %p',
+      async databaseId => {
+        await createDatabase(databaseId);
+
+        const entity: Entity = {
+          apiVersion: 'a',
+          kind: 'k',
+          metadata: { name: 'n1', description: 'some description' },
+          spec: { type: 'service' },
+        };
+        await addEntityToSearch(entity);
+
+        const catalog = new DefaultEntitiesCatalog({
+          database: knex,
+          logger: mockServices.logger.mock(),
+          stitcher,
+        });
+
+        const res = await catalog.queryEntities({
+          fieldPaths: ['metadata.name'],
+          credentials: mockCredentials.none(),
+        });
+        const items = entitiesResponseToObjects(res.items);
+
+        expect(items).toHaveLength(1);
+        expect(items[0]).toEqual({ metadata: { name: 'n1' } });
+        expect(items[0]).not.toHaveProperty('kind');
+        expect(items[0]).not.toHaveProperty('spec');
+      },
+    );
+
+    it.each(databases.eachSupportedId())(
+      'should return full parent when parent path dominates child path in queryEntities, %p',
+      async databaseId => {
+        await createDatabase(databaseId);
+
+        const entity: Entity = {
+          apiVersion: 'a',
+          kind: 'k',
+          metadata: { name: 'n1', description: 'keep me' },
+          spec: { type: 'service' },
+        };
+        await addEntityToSearch(entity);
+
+        const catalog = new DefaultEntitiesCatalog({
+          database: knex,
+          logger: mockServices.logger.mock(),
+          stitcher,
+        });
+
+        const res = await catalog.queryEntities({
+          fieldPaths: ['metadata', 'metadata.name'],
+          credentials: mockCredentials.none(),
+        });
+        const items = entitiesResponseToObjects(res.items);
+
+        expect(items).toHaveLength(1);
+        expect(items[0]).toHaveProperty('metadata.name', 'n1');
+        expect(items[0]).toHaveProperty('metadata.description', 'keep me');
+        expect(items[0]).not.toHaveProperty('spec');
+        expect(items[0]).not.toHaveProperty('kind');
+      },
+    );
+
+    it.each(databases.eachSupportedId())(
+      'should produce stable sort order when entities have multiple search values for sort field, %p',
+      async databaseId => {
+        await createDatabase(databaseId);
+
+        // Add entities and manually insert extra search rows to simulate
+        // multi-valued fields (e.g. from arrays), which could previously cause
+        // non-deterministic LIMIT 1 results.
+        await addEntityToSearch({
+          apiVersion: 'a',
+          kind: 'k',
+          metadata: { name: 'b', title: 'beta' },
+          spec: { should_include_this: true },
+        });
+        await addEntityToSearch({
+          apiVersion: 'a',
+          kind: 'k',
+          metadata: { name: 'a', title: 'alpha' },
+          spec: { should_include_this: true },
+        });
+
+        const catalog = new DefaultEntitiesCatalog({
+          database: knex,
+          logger: mockServices.logger.mock(),
+          stitcher,
+        });
+
+        const filter = { key: 'spec.should_include_this' };
+
+        // Run three times to check stability
+        for (let i = 0; i < 3; i++) {
+          const res = await catalog.queryEntities({
+            filter,
+            orderFields: [{ field: 'metadata.title', order: 'asc' }],
+            credentials: mockCredentials.none(),
+          });
+          const names = entitiesResponseToObjects(res.items).map(
+            e => e!.metadata.name,
+          );
+          expect(names).toEqual(['a', 'b']);
+        }
       },
     );
   });

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -41,6 +41,7 @@ import {
   DbRelationsRow,
   DbSearchRow,
 } from '../database/tables';
+import { buildJsonFieldProjection } from '../database/buildJsonFieldProjection';
 import { Stitcher } from '../stitching/types';
 
 import {
@@ -123,8 +124,26 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
     const db = this.database;
     const { limit, offset } = parsePagination(request?.pagination);
 
-    let entitiesQuery =
-      db<DbFinalEntitiesRow>('final_entities').select('final_entities.*');
+    // When fieldPaths are provided (and we're not in legacy relations compat mode
+    // which requires a JS-side entity transform), project only the requested
+    // fields directly in the database to avoid transferring and parsing full
+    // entity blobs.
+    const fieldProjection =
+      !this.enableRelationsCompatibility && request?.fieldPaths
+        ? buildJsonFieldProjection(
+            db,
+            request.fieldPaths,
+            'final_entities',
+            'final_entity',
+          )
+        : null;
+
+    let entitiesQuery = fieldProjection
+      ? db<DbFinalEntitiesRow>('final_entities')
+          .select('final_entities.entity_id')
+          .select('final_entities.entity_ref')
+          .select({ final_entity: fieldProjection })
+      : db<DbFinalEntitiesRow>('final_entities').select('final_entities.*');
 
     request?.order?.forEach(({ field }, index) => {
       const alias = `order_${index}`;
@@ -194,18 +213,25 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
       };
     }
 
+    let entityTransform: ((entity: Entity) => Entity) | undefined;
+    if (!fieldProjection) {
+      if (this.enableRelationsCompatibility) {
+        entityTransform = e => {
+          expandLegacyCompoundRelationsInEntity(e);
+          if (request?.fields) {
+            return request.fields(e);
+          }
+          return e;
+        };
+      } else {
+        entityTransform = request?.fields;
+      }
+    }
+
     return {
       entities: processRawEntitiesResult(
         rows.map(r => r.final_entity!),
-        this.enableRelationsCompatibility
-          ? e => {
-              expandLegacyCompoundRelationsInEntity(e);
-              if (request?.fields) {
-                return request.fields(e);
-              }
-              return e;
-            }
-          : request?.fields,
+        entityTransform,
       ),
       pageInfo,
     };
@@ -214,13 +240,22 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
   async entitiesBatch(
     request: EntitiesBatchRequest,
   ): Promise<EntitiesBatchResponse> {
+    const fieldProjection = request.fieldPaths
+      ? buildJsonFieldProjection(
+          this.database,
+          request.fieldPaths,
+          'final_entities',
+          'final_entity',
+        )
+      : null;
+
     const lookup = new Map<string, string>();
 
     for (const chunk of lodashChunk(request.entityRefs, 200)) {
       let query = this.database<DbFinalEntitiesRow>('final_entities')
         .select({
           entityRef: 'final_entities.entity_ref',
-          entity: 'final_entities.final_entity',
+          entity: fieldProjection ?? 'final_entities.final_entity',
         })
         .whereIn('final_entities.entity_ref', chunk);
 
@@ -241,7 +276,12 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
 
     const items = request.entityRefs.map(ref => lookup.get(ref) ?? null);
 
-    return { items: processRawEntitiesResult(items, request.fields) };
+    return {
+      items: processRawEntitiesResult(
+        items,
+        fieldProjection ? undefined : request.fields,
+      ),
+    };
   }
 
   async queryEntities(
@@ -272,6 +312,17 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
 
     const sortField = cursor.orderFields.at(0);
 
+    // When fieldPaths are provided, project only the requested fields directly
+    // in the database CTE to avoid transferring and parsing full entity blobs.
+    const fieldProjection = request.fieldPaths
+      ? buildJsonFieldProjection(
+          this.database,
+          request.fieldPaths,
+          'final_entities',
+          'final_entity',
+        )
+      : null;
+
     // The first part of the query builder is a subquery that applies all of the
     // filtering.
     const dbQuery = this.database.with(
@@ -283,22 +334,26 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
           .whereNotNull('final_entity');
 
         if (sortField) {
-          inner
-            .distinct()
-            .leftOuterJoin('search', qb =>
-              qb
-                .on('search.entity_id', 'final_entities.entity_id')
-                .andOnVal('search.key', sortField.field),
-            )
-            .select({
-              entity_id: 'final_entities.entity_id',
-              final_entity: 'final_entities.final_entity',
-              value: 'search.value',
-            });
+          // Use a correlated aggregate scalar subquery instead of LEFT OUTER
+          // JOIN + DISTINCT. MIN() produces a deterministic representative
+          // value even when the search table has multiple rows per
+          // (entity_id, key) (e.g. multi-valued fields or arrays), ensuring
+          // stable cursor pagination across pages.
+          inner.select({
+            entity_id: 'final_entities.entity_id',
+            final_entity: fieldProjection ?? 'final_entities.final_entity',
+            value: this.database<DbSearchRow>('search')
+              .select(this.database.raw('MIN(value)'))
+              .where(
+                'search.entity_id',
+                this.database.ref('final_entities.entity_id'),
+              )
+              .andWhere('search.key', sortField.field),
+          });
         } else {
           inner.select({
             entity_id: 'final_entities.entity_id',
-            final_entity: 'final_entities.final_entity',
+            final_entity: fieldProjection ?? 'final_entities.final_entity',
           });
         }
 
@@ -320,34 +375,19 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
           sortField?.field || 'metadata.uid',
         ];
         if (normalizedFullTextFilterTerm) {
-          if (
-            textFilterFields.length === 1 &&
-            textFilterFields[0] === sortField?.field
-          ) {
-            // If there is one item, apply the like query to the top level query which is already
-            //   filtered based on the singular sortField.
-            inner.andWhereRaw(
-              'search.value like ?',
-              `%${normalizedFullTextFilterTerm.toLocaleLowerCase('en-US')}%`,
-            );
-          } else {
-            const matchQuery = this.database<DbSearchRow>('search')
-              .select('search.entity_id')
-              // textFilterFields must be lowercased to match searchable keys in database, i.e. spec.profile.displayName -> spec.profile.displayname
-              .whereIn(
-                'search.key',
-                textFilterFields.map(field => field.toLocaleLowerCase('en-US')),
-              )
-              .andWhere(function keyFilter() {
-                this.andWhereRaw(
-                  'search.value like ?',
-                  `%${normalizedFullTextFilterTerm.toLocaleLowerCase(
-                    'en-US',
-                  )}%`,
-                );
-              });
-            inner.andWhere('final_entities.entity_id', 'in', matchQuery);
-          }
+          const matchQuery = this.database<DbSearchRow>('search')
+            .select('search.entity_id')
+            .whereIn(
+              'search.key',
+              textFilterFields.map(field => field.toLocaleLowerCase('en-US')),
+            )
+            .andWhere(function keyFilter() {
+              this.andWhereRaw(
+                'search.value like ?',
+                `%${normalizedFullTextFilterTerm.toLocaleLowerCase('en-US')}%`,
+              );
+            });
+          inner.andWhere('final_entities.entity_id', 'in', matchQuery);
         }
       },
     );
@@ -514,7 +554,7 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
     return {
       items: processRawEntitiesResult(
         rows.map(r => r.final_entity!),
-        request.fields,
+        fieldProjection ? undefined : request.fields,
       ),
       pageInfo: {
         ...(!!prevCursor && { prevCursor }),

--- a/plugins/catalog-backend/src/service/createRouter.test.ts
+++ b/plugins/catalog-backend/src/service/createRouter.test.ts
@@ -710,6 +710,8 @@ describe('createRouter readonly disabled', () => {
       expect(entitiesCatalog.entitiesBatch).toHaveBeenCalledWith({
         entityRefs: [entityRef],
         fields: expect.any(Function),
+        fieldPaths: ['metadata.name'],
+        query: undefined,
         credentials: mockCredentials.user(),
         filter: { key: 'kind', values: ['Component'] },
       });

--- a/plugins/catalog-backend/src/service/createRouter.ts
+++ b/plugins/catalog-backend/src/service/createRouter.ts
@@ -42,6 +42,7 @@ import { AuthorizedValidationService } from './AuthorizedValidationService';
 import {
   basicEntityFilter,
   entitiesBatchRequest,
+  parseEntityFieldPaths,
   parseEntityFilterParams,
   parseEntityTransformParams,
   parseQueryEntitiesParams,
@@ -169,6 +170,7 @@ export async function createRouter(
         try {
           const filter = parseEntityFilterParams(req.query);
           const fields = parseEntityTransformParams(req.query);
+          const fieldPaths = parseEntityFieldPaths(req.query);
           const order = parseEntityOrderParams(req.query);
           const pagination = parseEntityPaginationParams(req.query);
           const credentials = await httpAuth.credentials(req);
@@ -180,6 +182,7 @@ export async function createRouter(
             const { entities, pageInfo } = await entitiesCatalog.entities({
               filter,
               fields,
+              fieldPaths,
               order,
               pagination,
               credentials,
@@ -207,7 +210,7 @@ export async function createRouter(
           }
 
           const responseStream = createEntityArrayJsonStream(res);
-          const limit = 10000;
+          const limit = fieldPaths?.length ? 20000 : 10000;
           let cursor: Cursor | undefined;
 
           try {
@@ -218,12 +221,13 @@ export async function createRouter(
                   ? {
                       credentials,
                       fields,
+                      fieldPaths,
                       limit,
                       filter,
                       orderFields: order,
                       skipTotalItems: true,
                     }
-                  : { credentials, fields, limit, cursor },
+                  : { credentials, fields, fieldPaths, limit, cursor },
               );
 
               // Wait for previous write to complete
@@ -271,11 +275,15 @@ export async function createRouter(
           const fields = rawFields?.length
             ? parseEntityTransformParams({ fields: rawFields })
             : undefined;
+          const fieldPaths = rawFields?.length
+            ? parseEntityFieldPaths({ fields: rawFields })
+            : undefined;
 
           const { items, pageInfo, totalItems } =
             await entitiesCatalog.queryEntities({
               credentials,
               fields,
+              fieldPaths,
               ...parsed,
             });
 
@@ -521,6 +529,7 @@ export async function createRouter(
             filter: parseEntityFilterParams(req.query),
             query: request.query,
             fields: parseEntityTransformParams(req.query, request.fields),
+            fieldPaths: parseEntityFieldPaths(req.query, request.fields),
             credentials: await httpAuth.credentials(req),
           });
 

--- a/plugins/catalog-backend/src/service/request/index.ts
+++ b/plugins/catalog-backend/src/service/request/index.ts
@@ -17,5 +17,8 @@
 export { entitiesBatchRequest } from './entitiesBatchRequest';
 export { basicEntityFilter } from './basicEntityFilter';
 export { parseEntityFilterParams } from './parseEntityFilterParams';
-export { parseEntityTransformParams } from './parseEntityTransformParams';
+export {
+  parseEntityTransformParams,
+  parseEntityFieldPaths,
+} from './parseEntityTransformParams';
 export { parseQueryEntitiesParams } from './parseQueryEntitiesParams';

--- a/plugins/catalog-backend/src/service/request/parseEntityTransformParams.test.ts
+++ b/plugins/catalog-backend/src/service/request/parseEntityTransformParams.test.ts
@@ -15,7 +15,10 @@
  */
 
 import { Entity } from '@backstage/catalog-model';
-import { parseEntityTransformParams } from './parseEntityTransformParams';
+import {
+  parseEntityFieldPaths,
+  parseEntityTransformParams,
+} from './parseEntityTransformParams';
 
 describe('parseEntityTransformParams', () => {
   let entity: Entity;
@@ -196,5 +199,68 @@ describe('parseEntityTransformParams', () => {
         name: 'n',
       },
     });
+  });
+});
+
+describe('parseEntityFieldPaths', () => {
+  it('returns undefined when no fields given', () => {
+    expect(parseEntityFieldPaths({})).toBeUndefined();
+    expect(parseEntityFieldPaths({ fields: '' })).toBeUndefined();
+    expect(parseEntityFieldPaths({ fields: [] })).toBeUndefined();
+  });
+
+  it('rejects array-style selectors with the same error as parseEntityTransformParams', () => {
+    expect(() => parseEntityFieldPaths({ fields: 'metadata.tags[0]' })).toThrow(
+      'Invalid field "metadata.tags[0]", array type fields are not supported',
+    );
+  });
+
+  it('returns a deduplicated flat array of field paths', () => {
+    expect(parseEntityFieldPaths({ fields: 'kind,metadata.name' })).toEqual([
+      'kind',
+      'metadata.name',
+    ]);
+    expect(
+      parseEntityFieldPaths({ fields: ['kind', 'metadata.name', 'kind'] }),
+    ).toEqual(['kind', 'metadata.name']);
+  });
+
+  it('merges extras with query params', () => {
+    expect(
+      parseEntityFieldPaths({ fields: 'kind' }, ['metadata.name']),
+    ).toEqual(['metadata.name', 'kind']);
+  });
+
+  it('includes annotation-style paths containing /', () => {
+    // These paths are returned as-is; buildJsonFieldProjection will detect '/'
+    // and fall back to JS-side projection rather than SQL.
+    const paths = parseEntityFieldPaths({
+      fields: 'metadata.annotations.backstage.io/techdocs-ref',
+    });
+    expect(paths).toEqual(['metadata.annotations.backstage.io/techdocs-ref']);
+  });
+
+  it('trims whitespace around field names', () => {
+    expect(parseEntityFieldPaths({ fields: ' kind , metadata.name ' })).toEqual(
+      ['kind', 'metadata.name'],
+    );
+  });
+
+  it('filters out empty strings in an array', () => {
+    expect(
+      parseEntityFieldPaths({ fields: ['kind', '', 'metadata.name'] }),
+    ).toEqual(['kind', 'metadata.name']);
+  });
+
+  it('returns undefined when fields contains only empty or whitespace values', () => {
+    expect(parseEntityFieldPaths({ fields: [','] })).toBeUndefined();
+    expect(parseEntityFieldPaths({ fields: ['', ''] })).toBeUndefined();
+    expect(parseEntityFieldPaths({ fields: '  ' })).toBeUndefined();
+  });
+
+  it('deduplicates across extras and query params', () => {
+    expect(
+      parseEntityFieldPaths({ fields: 'kind,metadata.name' }, ['kind']),
+    ).toEqual(['kind', 'metadata.name']);
   });
 });

--- a/plugins/catalog-backend/src/service/request/parseEntityTransformParams.ts
+++ b/plugins/catalog-backend/src/service/request/parseEntityTransformParams.ts
@@ -76,3 +76,39 @@ export function parseEntityTransformParams(
     return output as Entity;
   };
 }
+
+/**
+ * Parses the `fields` query parameter into a plain string array suitable for
+ * passing as `fieldPaths` to catalog methods that support DB-side field
+ * projection.
+ *
+ * Returns `undefined` when no fields are requested (no projection needed).
+ */
+export function parseEntityFieldPaths(
+  params: Record<string, unknown>,
+  extra?: string[],
+): string[] | undefined {
+  const queryFields = parseStringsParam(params.fields, 'fields');
+
+  const fields = Array.from(
+    new Set(
+      [...(extra ?? []), ...(queryFields?.map(s => s.split(',')) ?? [])]
+        .flat()
+        .map(s => s.trim())
+        .filter(Boolean),
+    ),
+  );
+
+  if (!fields.length) {
+    return undefined;
+  }
+
+  const arrayTypeField = fields.find(f => f.includes('['));
+  if (arrayTypeField) {
+    throw new InputError(
+      `Invalid field "${arrayTypeField}", array type fields are not supported`,
+    );
+  }
+
+  return fields;
+}

--- a/plugins/catalog-backend/src/service/request/parseQueryEntitiesParams.ts
+++ b/plugins/catalog-backend/src/service/request/parseQueryEntitiesParams.ts
@@ -22,19 +22,24 @@ import {
 import { decodeCursor } from '../util';
 import { parseEntityFilterParams } from './parseEntityFilterParams';
 import { parseEntityOrderFieldParams } from './parseEntityOrderFieldParams';
-import { parseEntityTransformParams } from './parseEntityTransformParams';
+import {
+  parseEntityFieldPaths,
+  parseEntityTransformParams,
+} from './parseEntityTransformParams';
 import { GetEntitiesByQuery } from '../../schema/openapi';
 
 export function parseQueryEntitiesParams(
   params: GetEntitiesByQuery['query'],
 ): Omit<QueryEntitiesRequest, 'credentials' | 'limit'> {
   const fields = parseEntityTransformParams(params);
+  const fieldPaths = parseEntityFieldPaths(params);
 
   if (params.cursor) {
     const decodedCursor = decodeCursor(params.cursor);
     const response: Omit<QueryEntitiesCursorRequest, 'credentials'> = {
       cursor: decodedCursor,
       fields,
+      fieldPaths,
     };
     return response;
   }
@@ -44,6 +49,7 @@ export function parseQueryEntitiesParams(
 
   const response: Omit<QueryEntitiesInitialRequest, 'credentials'> = {
     fields,
+    fieldPaths,
     filter,
     orderFields,
     fullTextFilter: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When `?fields=...` is used, project only the requested fields directly in the SQL query using jsonb_build_object (pg), json_object (sqlite/mysql) instead of fetching full entity blobs and filtering in JavaScript.

Also replaces LEFT JOIN + DISTINCT on the sort field with a correlated scalar subquery, and increases the streaming page size when field projection is active to reduce round-trips.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
