### PR TITLE
integration: use registerMswTestHooks from backend-test-utils

### DIFF
--- a/.changeset/move-registermswtesthooks-to-test-utils.md
+++ b/.changeset/move-registermswtesthooks-to-test-utils.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Moved `registerMswTestHooks` out of production code and into test files using `@backstage/backend-test-utils` instead.

--- a/.changeset/move-registermswtesthooks-to-test-utils.md
+++ b/.changeset/move-registermswtesthooks-to-test-utils.md
@@ -2,4 +2,4 @@
 '@backstage/integration': patch
 ---
 
-Moved `registerMswTestHooks` out of production code and into test files using `@backstage/backend-test-utils` instead.
+Moved `registerMswTestHooks` to test files.

--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -50,6 +50,7 @@
     "p-throttle": "^4.1.1"
   },
   "devDependencies": {
+    "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@backstage/config-loader": "workspace:^",
     "msw": "^1.0.0"

--- a/packages/integration/src/bitbucketCloud/core.test.ts
+++ b/packages/integration/src/bitbucketCloud/core.test.ts
@@ -16,7 +16,7 @@
 
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
-import { registerMswTestHooks } from '../helpers';
+import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { BitbucketCloudIntegrationConfig } from './config';
 import {
   getBitbucketCloudDefaultBranch,

--- a/packages/integration/src/bitbucketServer/core.test.ts
+++ b/packages/integration/src/bitbucketServer/core.test.ts
@@ -16,7 +16,7 @@
 
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
-import { registerMswTestHooks } from '../helpers';
+import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { BitbucketServerIntegrationConfig } from './config';
 import {
   getBitbucketServerDefaultBranch,

--- a/packages/integration/src/gerrit/core.test.ts
+++ b/packages/integration/src/gerrit/core.test.ts
@@ -17,7 +17,7 @@
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import fetch from 'cross-fetch';
-import { registerMswTestHooks } from '../helpers';
+import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { GerritIntegrationConfig } from './config';
 import {
   buildGerritGitilesArchiveUrlFromLocation,

--- a/packages/integration/src/gitea/core.test.ts
+++ b/packages/integration/src/gitea/core.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { setupServer } from 'msw/node';
-import { registerMswTestHooks } from '../helpers';
+import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { GiteaIntegrationConfig } from './config';
 import {
   getGiteaArchiveUrl,

--- a/packages/integration/src/gitlab/GitLabIntegration.test.ts
+++ b/packages/integration/src/gitlab/GitLabIntegration.test.ts
@@ -22,7 +22,7 @@ import {
   replaceGitLabUrlType,
   sleep,
 } from './GitLabIntegration';
-import { registerMswTestHooks } from '../helpers';
+import { registerMswTestHooks } from '@backstage/backend-test-utils';
 
 // Mock pThrottle to make testing easier
 jest.mock('p-throttle', () => {

--- a/packages/integration/src/harness/core.test.ts
+++ b/packages/integration/src/harness/core.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { setupServer } from 'msw/node';
-import { registerMswTestHooks } from '../helpers';
+import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { HarnessIntegrationConfig } from './config';
 import {
   getHarnessArchiveUrl,

--- a/packages/integration/src/helpers.ts
+++ b/packages/integration/src/helpers.ts
@@ -138,20 +138,3 @@ export function defaultScmResolveUrl(options: {
   }
   return updated.toString();
 }
-
-/**
- * Sets up handlers for request mocking
- *
- * Copied from test-utils, as that is a frontend-only package
- *
- * @param worker - service worker
- */
-export function registerMswTestHooks(worker: {
-  listen: (t: any) => void;
-  close: () => void;
-  resetHandlers: () => void;
-}) {
-  beforeAll(() => worker.listen({ onUnhandledRequest: 'error' }));
-  afterAll(() => worker.close());
-  afterEach(() => worker.resetHandlers());
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3937,6 +3937,7 @@ __metadata:
   dependencies:
     "@azure/identity": "npm:^4.0.0"
     "@azure/storage-blob": "npm:^12.5.0"
+    "@backstage/backend-test-utils": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/config": "workspace:^"
     "@backstage/config-loader": "workspace:^"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This removes the test-only `registerMswTestHooks` copy from `helpers.ts` and uses the shared version from `@backstage/backend-test-utils` instead.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([Changesets Docs](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))