### PR TITLE
repo-tools, create-app: replace duplicate error utilities with cli-common imports

### DIFF
--- a/.changeset/replace-duplicate-error-utilities.md
+++ b/.changeset/replace-duplicate-error-utilities.md
@@ -1,0 +1,6 @@
+---
+'@backstage/repo-tools': patch
+'@backstage/create-app': patch
+---
+
+Replaced internal error utilities with shared ones from `@backstage/cli-common`.

--- a/packages/create-app/src/lib/errors.ts
+++ b/packages/create-app/src/lib/errors.ts
@@ -14,26 +14,8 @@
  * limitations under the License.
  */
 
+import { ExitCodeError } from '@backstage/cli-common';
 import chalk from 'chalk';
-
-export class CustomError extends Error {
-  get name(): string {
-    return this.constructor.name;
-  }
-}
-
-export class ExitCodeError extends CustomError {
-  readonly code: number;
-
-  constructor(code: number, command?: string) {
-    if (command) {
-      super(`Command '${command}' exited with code ${code}`);
-    } else {
-      super(`Child exited with code ${code}`);
-    }
-    this.code = code;
-  }
-}
 
 export function exitWithError(error: Error): never {
   if (error instanceof ExitCodeError) {

--- a/packages/repo-tools/src/lib/errors.ts
+++ b/packages/repo-tools/src/lib/errors.ts
@@ -14,26 +14,8 @@
  * limitations under the License.
  */
 
+import { ExitCodeError } from '@backstage/cli-common';
 import chalk from 'chalk';
-
-export class CustomError extends Error {
-  get name(): string {
-    return this.constructor.name;
-  }
-}
-
-export class ExitCodeError extends CustomError {
-  readonly code: number;
-
-  constructor(code: number, command?: string) {
-    super(
-      command
-        ? `Command '${command}' exited with code ${code}`
-        : `Child exited with code ${code}`,
-    );
-    this.code = code;
-  }
-}
 
 export function exitWithError(error: Error): never {
   if (error instanceof ExitCodeError) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

🧹

Both `repo-tools` and `create-app` had local copies of `CustomError`, `ExitCodeError`, and `exitWithError` that were nearly identical to each other and to `@backstage/cli-common`. The `CustomError` and `ExitCodeError` classes were never instantiated locally — and the `instanceof ExitCodeError` check in `exitWithError` could never match errors thrown by `@backstage/cli-common`'s `run()` since those use a different class.

This replaces the local classes with an import of `ExitCodeError` from `@backstage/cli-common` so the `instanceof` check actually works, and removes the dead `CustomError` class.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))