### PR TITLE
config: make propsOfHumanDuration module-private

### DIFF
--- a/packages/config/src/readDurationFromConfig.test.ts
+++ b/packages/config/src/readDurationFromConfig.test.ts
@@ -14,11 +14,19 @@
  * limitations under the License.
  */
 
-import {
-  propsOfHumanDuration,
-  readDurationFromConfig,
-} from './readDurationFromConfig';
+import { readDurationFromConfig } from './readDurationFromConfig';
 import { ConfigReader } from './reader';
+
+const propsOfHumanDuration = [
+  'years',
+  'months',
+  'weeks',
+  'days',
+  'hours',
+  'minutes',
+  'seconds',
+  'milliseconds',
+];
 
 describe('readDurationFromConfig', () => {
   describe('ISO form', () => {

--- a/packages/config/src/readDurationFromConfig.ts
+++ b/packages/config/src/readDurationFromConfig.ts
@@ -19,7 +19,7 @@ import { HumanDuration } from '@backstage/types';
 import ms from 'ms';
 import { Config } from './types';
 
-export const propsOfHumanDuration = [
+const propsOfHumanDuration = [
   'years',
   'months',
   'weeks',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

🧹

`propsOfHumanDuration` was exported but never imported by any other package — it's not part of the public API and isn't in `report.api.md`. This removes the `export` keyword to make it module-private, and inlines the list in the test file.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))