### PR TITLE
fix(ui): use correct dark theme selector in Dialog

### DIFF
--- a/.changeset/fix-dialog-dark-theme-selector.md
+++ b/.changeset/fix-dialog-dark-theme-selector.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed dark mode background for Dialog component by correcting the theme attribute selector from `data-theme` to `data-theme-mode`.

--- a/.changeset/fix-dialog-dark-theme-selector.md
+++ b/.changeset/fix-dialog-dark-theme-selector.md
@@ -3,3 +3,5 @@
 ---
 
 Fixed dark mode background for Dialog component by correcting the theme attribute selector from `data-theme` to `data-theme-mode`.
+
+**Affected components:** Dialog

--- a/packages/ui/src/components/Dialog/Dialog.module.css
+++ b/packages/ui/src/components/Dialog/Dialog.module.css
@@ -30,7 +30,7 @@
     z-index: 1000;
   }
 
-  [data-theme='dark'] .bui-Dialog {
+  [data-theme-mode='dark'] .bui-Dialog {
     background: rgba(0, 0, 0, 0.5);
   }
 


### PR DESCRIPTION
The Dialog component used `[data-theme='dark']` while every other BUI component and the global token system uses `[data-theme-mode='dark']`. 
This mismatch meant the dark mode background rule never matched.

| Before | After |
|--------|--------|
| <img width="539" height="295" alt="image" src="https://github.com/user-attachments/assets/10229329-4479-49f6-8b4c-946a4d6ad6ec" /> | <img width="568" height="316" alt="image" src="https://github.com/user-attachments/assets/a081153a-cf64-4629-aa70-3e5c087945c0" /> | 


## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] ~Added or updated documentation~
- [ ] ~Tests for new functionality and regression tests for bug fixes~
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
