### PR TITLE
feat: move to scoped plugin routing

### DIFF
--- a/.changeset/brave-tigers-swim.md
+++ b/.changeset/brave-tigers-swim.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-tanstack-router-adapter': minor
+---
+
+New package providing a TanStack Router adapter for the RoutingContract system.

--- a/.changeset/bright-foxes-dance.md
+++ b/.changeset/bright-foxes-dance.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': minor
+---
+
+Added `RoutingContract`, `RoutingLocation`, `NavigationControllerApi`, `useFrameworkNavigate`, `useFrameworkLocation`, `RouteLink`, and `useRoutingContract` for router-agnostic plugin routing.

--- a/.changeset/clever-pens-rest.md
+++ b/.changeset/clever-pens-rest.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-test-utils': minor
+---
+
+Added `createMockContract` test utility for testing plugins with scoped routers.

--- a/.changeset/gentle-foxes-dance.md
+++ b/.changeset/gentle-foxes-dance.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-react-router-v7-adapter': minor
+---
+
+New package providing a React Router v7 adapter for the RoutingContract system.

--- a/.changeset/gentle-waves-swim.md
+++ b/.changeset/gentle-waves-swim.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-app-api': minor
+---
+
+Added `NavigationController`, `RouteTable`, and `AppRouteSwitch` for framework-level URL management with per-plugin scoped routing.

--- a/.changeset/silent-owls-glow.md
+++ b/.changeset/silent-owls-glow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-react-router-v6-adapter': minor
+---
+
+New package providing a React Router v6 adapter for the RoutingContract system.

--- a/.changeset/warm-knots-heal.md
+++ b/.changeset/warm-knots-heal.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Updated `Link` component to support both within-plugin and cross-plugin navigation.

--- a/docs/superpowers/specs/plugin-migration-guide.md
+++ b/docs/superpowers/specs/plugin-migration-guide.md
@@ -1,0 +1,222 @@
+# Plugin Migration Guide: Router-Agnostic Routing
+
+This guide walks through the minimal changes required to migrate a Backstage plugin from the global React Router context to the new router-agnostic `RoutingContract` system. The scaffolder plugin is used as a representative example.
+
+## Overview
+
+The migration touches three areas:
+
+1. **Page extension** -- wrap the plugin's page component in a `ScopedRouterProvider` so it receives its own scoped routing context.
+2. **Parameter access** -- replace `useRouteRefParams` with `useParams` from `react-router-dom` (or equivalent), since route parameters are now resolved within the plugin's scoped router.
+3. **Tests** -- replace `MemoryRouter` / `renderInTestApp` router setup with `createMockContract` and `NestedRoutingContractProvider`.
+
+---
+
+## 1. Page Extension (Plugin Entry Point)
+
+The plugin's page extension currently mounts via `createRoutableExtension`, which relies on the global `BrowserRouter`. After migration, the `PageBlueprint` automatically provides a `RoutingContract` through `ScopedRouterProvider`, so the plugin's internal `<Routes>` and `<Route>` elements work within a scoped context.
+
+### Before
+
+```tsx
+// plugin.tsx
+import { createRoutableExtension } from '@backstage/core-plugin-api';
+import { rootRouteRef } from './routes';
+
+export const ScaffolderPage = scaffolderPlugin.provide(
+  createRoutableExtension({
+    name: 'ScaffolderPage',
+    component: () => import('./components/Router').then(m => m.Router),
+    mountPoint: rootRouteRef,
+  }),
+);
+```
+
+The `Router` component uses `<Routes>` from `react-router-dom` directly, relying on the global browser router:
+
+```tsx
+// components/Router/Router.tsx
+import { Routes, Route } from 'react-router-dom';
+
+export const Router = (props: RouterProps) => {
+  return (
+    <Routes>
+      <Route path="/" element={<TemplateListPage />} />
+      <Route
+        path={selectedTemplateRouteRef.path}
+        element={<TemplateWizardPage />}
+      />
+      <Route path={scaffolderTaskRouteRef.path} element={<OngoingTask />} />
+      {/* ... more routes */}
+    </Routes>
+  );
+};
+```
+
+### After
+
+No changes to the plugin's `Router` component are needed in Phase A. The `PageBlueprint` in `@backstage/frontend-plugin-api` automatically wraps the plugin's content with a `ScopedRouterProvider`:
+
+```tsx
+// This happens automatically in PageBlueprint -- no plugin code changes required.
+// The ScopedRouterProvider bridges the RoutingContract into React Router's
+// UNSAFE_LocationContext and UNSAFE_NavigationContext, so <Routes> and <Route>
+// continue to work.
+```
+
+When migrating to a different router (Phase D), the plugin would replace `react-router-dom`'s `<Routes>` with its chosen router's equivalent, reading location from the contract:
+
+```tsx
+// Phase D example: using the RoutingContract directly
+import { useRoutingContract } from '@backstage/frontend-plugin-api';
+
+function MyRouter(props: { children: ReactNode }) {
+  const contract = useRoutingContract();
+  // Bridge contract.location$ into your preferred router
+  // ...
+}
+```
+
+---
+
+## 2. Replacing `useRouteRefParams` with `useParams`
+
+`useRouteRefParams` resolves parameters by looking up the route ref in the global route resolution table. With scoped routing, parameters are available directly from the URL within the plugin's scoped router context.
+
+### Before
+
+```tsx
+// TemplateWizardPage.tsx
+import { useRouteRefParams } from '@backstage/core-plugin-api';
+import { selectedTemplateRouteRef } from '../../../routes';
+
+function useTemplateWizard(props: TemplateWizardPageProps) {
+  const { templateName, namespace } = useRouteRefParams(
+    selectedTemplateRouteRef,
+  );
+  // ...
+}
+```
+
+### After
+
+```tsx
+// TemplateWizardPage.tsx
+import { useParams } from 'react-router-dom';
+
+function useTemplateWizard(props: TemplateWizardPageProps) {
+  const { templateName, namespace } = useParams<{
+    templateName: string;
+    namespace: string;
+  }>();
+  // ...
+}
+```
+
+The same pattern applies to `OngoingTask.tsx`, which already uses `useParams`:
+
+```tsx
+// OngoingTask.tsx -- already correct, no changes needed
+import { useParams } from 'react-router-dom';
+
+const { taskId } = useParams();
+```
+
+---
+
+## 3. Test Files
+
+Tests that rely on `MemoryRouter` or `renderInTestApp` (which internally wraps with a router) can be updated to use `createMockContract` from `@backstage/frontend-test-utils`.
+
+### Before
+
+```tsx
+// Router.test.tsx
+import { renderInTestApp } from '@backstage/test-utils';
+
+it('should render the TemplateListPage', async () => {
+  await renderInTestApp(<Router />);
+  expect(TemplateListPage).toHaveBeenCalled();
+});
+
+it('should render the TemplateWizard page', async () => {
+  await renderInTestApp(<Router />, {
+    routeEntries: ['/templates/default/foo'],
+  });
+  expect(TemplateWizardPage).toHaveBeenCalled();
+});
+```
+
+### After
+
+```tsx
+// Router.test.tsx
+import { createMockContract } from '@backstage/frontend-test-utils';
+import { ScopedRouterProvider } from '@backstage/frontend-plugin-api';
+
+function renderWithContract(
+  ui: React.ReactElement,
+  options?: { initialLocation?: string },
+) {
+  const contract = createMockContract({
+    basePath: '/scaffolder',
+    initialLocation: options?.initialLocation ?? '/',
+  });
+
+  return {
+    contract,
+    ...render(
+      <ScopedRouterProvider contract={contract}>{ui}</ScopedRouterProvider>,
+    ),
+  };
+}
+
+it('should render the TemplateListPage', () => {
+  renderWithContract(<Router />);
+  expect(TemplateListPage).toHaveBeenCalled();
+});
+
+it('should render the TemplateWizard page', () => {
+  renderWithContract(<Router />, {
+    initialLocation: '/templates/default/foo',
+  });
+  expect(TemplateWizardPage).toHaveBeenCalled();
+});
+```
+
+### Asserting Navigation
+
+The `MockContract` records all `navigate` calls, making it easy to assert navigation behavior:
+
+```tsx
+it('should navigate to task page after creation', async () => {
+  const { contract } = renderWithContract(<Router />, {
+    initialLocation: '/templates/default/foo',
+  });
+
+  // ... trigger task creation ...
+
+  expect(contract.navigateCalls).toContainEqual({
+    to: '/tasks/my-task-id',
+    options: undefined,
+  });
+});
+```
+
+---
+
+## Migration Checklist
+
+For each plugin being migrated:
+
+- [ ] Verify the plugin's `<Routes>` / `<Route>` structure works within a scoped router context (it should, since `ScopedRouterProvider` sets up the same React Router contexts).
+- [ ] Replace any `useRouteRefParams(someSubRouteRef)` calls with `useParams()` from `react-router-dom`.
+- [ ] Update test files to use `createMockContract` instead of `MemoryRouter` or `renderInTestApp` with `routeEntries`.
+- [ ] Run the plugin's test suite: `CI=1 yarn test plugins/<plugin-name>/`
+- [ ] Verify the plugin works locally: `yarn start` and navigate to the plugin's page.
+
+## Notes
+
+- **Phase A (current):** No plugin changes are required. The global `BrowserRouter` remains, and `PageBlueprint` provides scoped routers nested inside it. All existing plugins continue to work unchanged.
+- **Phase B/C:** App-level chrome migrates away from react-router-dom hooks. The global `BrowserRouter` is eventually removed. Plugins already have scoped routers, so there is zero impact.
+- **Phase D:** Individual plugins can opt in to different routers (TanStack Router, React Router v7, etc.) at their own pace by replacing the `ScopedRouterProvider` bridge with their router of choice, reading from the `RoutingContract` directly.

--- a/packages/core-components/package.json
+++ b/packages/core-components/package.json
@@ -57,6 +57,7 @@
     "@backstage/config": "workspace:^",
     "@backstage/core-plugin-api": "workspace:^",
     "@backstage/errors": "workspace:^",
+    "@backstage/frontend-plugin-api": "workspace:^",
     "@backstage/theme": "workspace:^",
     "@backstage/version-bridge": "workspace:^",
     "@dagrejs/dagre": "^1.1.4",

--- a/packages/core-components/src/components/Link/Link.test.tsx
+++ b/packages/core-components/src/components/Link/Link.test.tsx
@@ -210,6 +210,36 @@ describe('<Link />', () => {
   });
 
   describe('cross-plugin navigation', () => {
+    it('should keep using react-router for internal links without a routing contract', async () => {
+      const testString = 'Internal destination';
+      const linkText = 'Internal Link';
+      const mockNavController = {
+        navigate: jest.fn(),
+        location$: { subscribe: jest.fn() },
+      } as any;
+
+      await renderInTestApp(
+        <TestApiProvider
+          apis={[[navigationControllerApiRef, mockNavController]]}
+        >
+          <>
+            <Link to="/test-internal">{linkText}</Link>
+            <Routes>
+              <Route path="/test-internal" element={<p>{testString}</p>} />
+            </Routes>
+          </>
+        </TestApiProvider>,
+      );
+
+      expect(() => screen.getByText(testString)).toThrow();
+      fireEvent.click(screen.getByText(linkText));
+
+      await waitFor(() => {
+        expect(screen.getByText(testString)).toBeInTheDocument();
+      });
+      expect(mockNavController.navigate).not.toHaveBeenCalled();
+    });
+
     it('should use framework navigate for absolute paths outside basePath', async () => {
       const navigateFn = jest.fn();
       const mockNavController = {
@@ -320,33 +350,6 @@ describe('<Link />', () => {
       await waitFor(() => {
         expect(screen.getByText(testString)).toBeInTheDocument();
       });
-    });
-
-    it('should use framework navigate in NFS app chrome (no contract, with NavigationControllerApi)', async () => {
-      const navigateFn = jest.fn();
-      const mockNavController = {
-        navigate: navigateFn,
-        location$: { subscribe: jest.fn() },
-      } as any;
-
-      const { container } = await renderInTestApp(
-        <TestApiProvider
-          apis={[[navigationControllerApiRef, mockNavController]]}
-        >
-          <Link to="/catalog/default/component/foo">App Chrome Link</Link>
-        </TestApiProvider>,
-      );
-
-      const link = screen.getByText('App Chrome Link');
-      fireEvent.click(link);
-
-      // In NFS app chrome (no contract but NavigationControllerApi available),
-      // should use framework navigate
-      expect(navigateFn).toHaveBeenCalledWith('/catalog/default/component/foo');
-      const anchor = container.querySelector(
-        'a[href="/catalog/default/component/foo"]',
-      );
-      expect(anchor).toBeInTheDocument();
     });
   });
 });

--- a/packages/core-components/src/components/Link/Link.test.tsx
+++ b/packages/core-components/src/components/Link/Link.test.tsx
@@ -22,7 +22,13 @@ import {
   renderInTestApp,
 } from '@backstage/test-utils';
 import { analyticsApiRef, configApiRef } from '@backstage/core-plugin-api';
-import { isExternalUri, Link, useResolvedPath } from './Link';
+import {
+  isExternalUri,
+  Link,
+  useResolvedPath,
+  routingContractContext,
+  navigationControllerApiRef,
+} from './Link';
 import { Route, Routes } from 'react-router-dom';
 import { ConfigReader } from '@backstage/config';
 
@@ -201,6 +207,147 @@ describe('<Link />', () => {
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       `"Link component rejected javascript: URL as a security precaution"`,
     );
+  });
+
+  describe('cross-plugin navigation', () => {
+    it('should use framework navigate for absolute paths outside basePath', async () => {
+      const navigateFn = jest.fn();
+      const mockNavController = {
+        navigate: navigateFn,
+        location$: { subscribe: jest.fn() },
+      } as any;
+
+      const { container } = await renderInTestApp(
+        <TestApiProvider
+          apis={[[navigationControllerApiRef, mockNavController]]}
+        >
+          <routingContractContext.Provider
+            value={{
+              basePath: '/catalog',
+              navigate: jest.fn(),
+              location$: { subscribe: jest.fn() } as any,
+            }}
+          >
+            <Link to="/scaffolder/templates">Cross Plugin Link</Link>
+          </routingContractContext.Provider>
+        </TestApiProvider>,
+      );
+
+      const link = screen.getByText('Cross Plugin Link');
+      fireEvent.click(link);
+
+      expect(navigateFn).toHaveBeenCalledWith('/scaffolder/templates');
+      // Should render as an anchor, not a react-router Link
+      const anchor = container.querySelector('a[href="/scaffolder/templates"]');
+      expect(anchor).toBeInTheDocument();
+    });
+
+    it('should use plugin router for absolute paths within basePath', async () => {
+      const navigateFn = jest.fn();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mockNavController: any = {
+        navigate: navigateFn,
+        location$: { subscribe: jest.fn() },
+      };
+
+      await renderInTestApp(
+        <TestApiProvider
+          apis={[[navigationControllerApiRef, mockNavController]]}
+        >
+          <routingContractContext.Provider
+            value={{
+              basePath: '/catalog',
+              navigate: jest.fn(),
+              location$: { subscribe: jest.fn() } as any,
+            }}
+          >
+            <Link to="/catalog/default/component/foo">Within Plugin</Link>
+          </routingContractContext.Provider>
+        </TestApiProvider>,
+      );
+
+      const link = screen.getByText('Within Plugin');
+      fireEvent.click(link);
+
+      // Should NOT use framework navigate for within-plugin paths
+      expect(navigateFn).not.toHaveBeenCalled();
+    });
+
+    it('should use plugin router for relative paths', async () => {
+      const navigateFn = jest.fn();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mockNavController: any = {
+        navigate: navigateFn,
+        location$: { subscribe: jest.fn() },
+      };
+
+      await renderInTestApp(
+        <TestApiProvider
+          apis={[[navigationControllerApiRef, mockNavController]]}
+        >
+          <routingContractContext.Provider
+            value={{
+              basePath: '/catalog',
+              navigate: jest.fn(),
+              location$: { subscribe: jest.fn() } as any,
+            }}
+          >
+            <Link to="entity/foo">Relative Link</Link>
+          </routingContractContext.Provider>
+        </TestApiProvider>,
+      );
+
+      const link = screen.getByText('Relative Link');
+      fireEvent.click(link);
+
+      // Should NOT use framework navigate for relative paths
+      expect(navigateFn).not.toHaveBeenCalled();
+    });
+
+    it('should work in old frontend system without RoutingContractContext', async () => {
+      const testString = 'Old system destination';
+      const linkText = 'Old System Link';
+      await renderInTestApp(
+        <>
+          <Link to="/test-old">{linkText}</Link>
+          <Routes>
+            <Route path="/test-old" element={<p>{testString}</p>} />
+          </Routes>
+        </>,
+      );
+      expect(() => screen.getByText(testString)).toThrow();
+      fireEvent.click(screen.getByText(linkText));
+      await waitFor(() => {
+        expect(screen.getByText(testString)).toBeInTheDocument();
+      });
+    });
+
+    it('should use framework navigate in NFS app chrome (no contract, with NavigationControllerApi)', async () => {
+      const navigateFn = jest.fn();
+      const mockNavController = {
+        navigate: navigateFn,
+        location$: { subscribe: jest.fn() },
+      } as any;
+
+      const { container } = await renderInTestApp(
+        <TestApiProvider
+          apis={[[navigationControllerApiRef, mockNavController]]}
+        >
+          <Link to="/catalog/default/component/foo">App Chrome Link</Link>
+        </TestApiProvider>,
+      );
+
+      const link = screen.getByText('App Chrome Link');
+      fireEvent.click(link);
+
+      // In NFS app chrome (no contract but NavigationControllerApi available),
+      // should use framework navigate
+      expect(navigateFn).toHaveBeenCalledWith('/catalog/default/component/foo');
+      const anchor = container.querySelector(
+        'a[href="/catalog/default/component/foo"]',
+      );
+      expect(anchor).toBeInTheDocument();
+    });
   });
 });
 

--- a/packages/core-components/src/components/Link/Link.tsx
+++ b/packages/core-components/src/components/Link/Link.tsx
@@ -306,15 +306,15 @@ export const UnstyledLink = forwardRef<any, LinkProps>(
       }
     };
 
-    // Determine if this is a cross-plugin navigation that should use the
-    // framework's navigation controller instead of react-router.
+    // Only links that cross plugin boundaries inside a scoped routing
+    // contract should bypass react-router. App chrome links in the legacy
+    // router still need to use react-router so the mounted route tree updates.
     const isAbsolutePath = to.startsWith('/');
     const isCrossPlugin =
       isAbsolutePath && contract && !to.startsWith(contract.basePath);
-    const isAppChrome = !contract && !!frameworkNav && isAbsolutePath;
 
-    if (!external && (isCrossPlugin || isAppChrome) && frameworkNav) {
-      // Cross-plugin or NFS app chrome: use framework navigate
+    if (!external && isCrossPlugin && frameworkNav) {
+      // Cross-plugin links inside a scoped contract use framework navigation.
       return (
         <a
           {...props}

--- a/packages/core-components/src/components/Link/Link.tsx
+++ b/packages/core-components/src/components/Link/Link.tsx
@@ -15,6 +15,7 @@
  */
 import {
   configApiRef,
+  createApiRef,
   useAnalytics,
   useApi,
   useApp,
@@ -28,11 +29,13 @@ import Typography from '@material-ui/core/Typography';
 import classnames from 'classnames';
 import { trimEnd } from 'lodash';
 import {
+  createContext,
   ReactNode,
   ReactElement,
   MouseEvent as ReactMouseEvent,
   ElementType,
   forwardRef,
+  useContext,
 } from 'react';
 import {
   createRoutesFromChildren,
@@ -41,6 +44,71 @@ import {
   Route,
 } from 'react-router-dom';
 import OpenInNew from '@material-ui/icons/OpenInNew';
+import { getOrCreateGlobalSingleton } from '@backstage/version-bridge';
+import type { Observable } from '@backstage/types';
+
+/**
+ * Routing contract interface matching the one in @backstage/frontend-plugin-api.
+ * Defined locally to avoid a circular dependency.
+ * @internal
+ */
+interface RoutingContract {
+  readonly basePath: string;
+  readonly location$: Observable<{
+    pathname: string;
+    search: string;
+    hash: string;
+  }>;
+  navigate(to: string, options?: { replace?: boolean }): void;
+}
+
+/**
+ * A global singleton React context for the routing contract, shared between
+ * core-components and frontend-plugin-api via @backstage/version-bridge.
+ * @internal
+ */
+export const routingContractContext = getOrCreateGlobalSingleton(
+  'routing-contract-context',
+  () => createContext<RoutingContract | undefined>(undefined),
+);
+
+/**
+ * Navigation controller API interface matching the one in @backstage/frontend-plugin-api.
+ * @internal
+ */
+interface NavigationControllerApi {
+  navigate(path: string, options?: { replace?: boolean }): void;
+  readonly location$: Observable<{
+    pathname: string;
+    search: string;
+    hash: string;
+  }>;
+}
+
+/**
+ * Local API ref for the navigation controller, using the same id as in
+ * @backstage/frontend-plugin-api so that it resolves to the same API instance.
+ * @internal
+ */
+export const navigationControllerApiRef = createApiRef<NavigationControllerApi>(
+  {
+    id: 'core.navigation-controller',
+  },
+);
+
+/**
+ * Hook to safely get the navigation controller API, returning undefined
+ * when not available (e.g., in the old frontend system).
+ */
+function useOptionalNavigationController():
+  | NavigationControllerApi
+  | undefined {
+  try {
+    return useApi(navigationControllerApiRef);
+  } catch {
+    return undefined;
+  }
+}
 
 export function isReactRouterBeta(): boolean {
   const [obj] = createRoutesFromChildren(<Route index element={<div />} />);
@@ -188,6 +256,8 @@ export const UnstyledLink = forwardRef<any, LinkProps>(
   ({ onClick, noTrack, externalLinkIcon, ...props }, ref) => {
     const classes = useStyles();
     const analytics = useAnalytics();
+    const contract = useContext(routingContractContext);
+    const frameworkNav = useOptionalNavigationController();
 
     // Adding the base path to URLs breaks react-router v6 stable, so we only
     // do it for beta. The react router version won't change at runtime so it is
@@ -210,6 +280,31 @@ export const UnstyledLink = forwardRef<any, LinkProps>(
         analytics.captureEvent('click', linkText, { attributes: { to } });
       }
     };
+
+    // Determine if this is a cross-plugin navigation that should use the
+    // framework's navigation controller instead of react-router.
+    const isAbsolutePath = to.startsWith('/');
+    const isCrossPlugin =
+      isAbsolutePath && contract && !to.startsWith(contract.basePath);
+    const isAppChrome = !contract && !!frameworkNav && isAbsolutePath;
+
+    if (!external && (isCrossPlugin || isAppChrome) && frameworkNav) {
+      // Cross-plugin or NFS app chrome: use framework navigate
+      return (
+        <a
+          {...props}
+          ref={ref}
+          href={to}
+          onClick={(event: ReactMouseEvent<any, MouseEvent>) => {
+            event.preventDefault();
+            handleClick(event);
+            frameworkNav.navigate(to);
+          }}
+        >
+          {props.children}
+        </a>
+      );
+    }
 
     return external ? (
       // External links

--- a/packages/core-components/src/components/Link/Link.tsx
+++ b/packages/core-components/src/components/Link/Link.tsx
@@ -21,6 +21,10 @@ import {
   useApp,
 } from '@backstage/core-plugin-api';
 import { NotImplementedError } from '@backstage/errors';
+import type {
+  NavigationControllerApi,
+  RoutingContract,
+} from '@backstage/frontend-plugin-api';
 // eslint-disable-next-line no-restricted-imports
 import MaterialLink, {
   LinkProps as MaterialLinkProps,
@@ -46,61 +50,20 @@ import {
 } from 'react-router-dom';
 import OpenInNew from '@material-ui/icons/OpenInNew';
 import { getOrCreateGlobalSingleton } from '@backstage/version-bridge';
-import type { Observable } from '@backstage/types';
-
-/**
- * Routing contract interface matching the one in @backstage/frontend-plugin-api.
- *
- * Defined locally to avoid a circular dependency:
- * @backstage/core-components cannot depend on @backstage/frontend-plugin-api
- * because frontend-plugin-api already depends on core-components (transitively
- * via core-plugin-api). Extracting these types to a shared package (e.g.,
- * @backstage/types) is a future option but would require a broader refactor.
- *
- * The `routingContractContext` and `navigationControllerApiRef` singletons
- * below use the same string keys as their counterparts in frontend-plugin-api,
- * so they resolve to the same runtime instances via @backstage/version-bridge
- * and Backstage's id-based ApiRef resolution respectively.
- *
- * @internal
- */
-interface RoutingContract {
-  readonly basePath: string;
-  readonly location$: Observable<{
-    pathname: string;
-    search: string;
-    hash: string;
-    state: unknown;
-  }>;
-  navigate(to: string, options?: { replace?: boolean; state?: unknown }): void;
-}
 
 /**
  * A global singleton React context for the routing contract, shared between
  * core-components and frontend-plugin-api via @backstage/version-bridge.
+ *
+ * The runtime value stays local so both packages can resolve the same
+ * singleton without importing each other's concrete context value.
+ *
  * @internal
  */
 export const routingContractContext = getOrCreateGlobalSingleton(
   'routing-contract-context',
   () => createContext<RoutingContract | undefined>(undefined),
 );
-
-/**
- * Navigation controller API interface matching the one in @backstage/frontend-plugin-api.
- * @internal
- */
-interface NavigationControllerApi {
-  navigate(
-    path: string,
-    options?: { replace?: boolean; state?: unknown },
-  ): void;
-  readonly location$: Observable<{
-    pathname: string;
-    search: string;
-    hash: string;
-    state: unknown;
-  }>;
-}
 
 /**
  * Local API ref for the navigation controller, using the same id as in

--- a/packages/core-components/src/components/Link/Link.tsx
+++ b/packages/core-components/src/components/Link/Link.tsx
@@ -20,6 +20,7 @@ import {
   useApi,
   useApp,
 } from '@backstage/core-plugin-api';
+import { NotImplementedError } from '@backstage/errors';
 // eslint-disable-next-line no-restricted-imports
 import MaterialLink, {
   LinkProps as MaterialLinkProps,
@@ -49,7 +50,18 @@ import type { Observable } from '@backstage/types';
 
 /**
  * Routing contract interface matching the one in @backstage/frontend-plugin-api.
- * Defined locally to avoid a circular dependency.
+ *
+ * Defined locally to avoid a circular dependency:
+ * @backstage/core-components cannot depend on @backstage/frontend-plugin-api
+ * because frontend-plugin-api already depends on core-components (transitively
+ * via core-plugin-api). Extracting these types to a shared package (e.g.,
+ * @backstage/types) is a future option but would require a broader refactor.
+ *
+ * The `routingContractContext` and `navigationControllerApiRef` singletons
+ * below use the same string keys as their counterparts in frontend-plugin-api,
+ * so they resolve to the same runtime instances via @backstage/version-bridge
+ * and Backstage's id-based ApiRef resolution respectively.
+ *
  * @internal
  */
 interface RoutingContract {
@@ -98,15 +110,23 @@ export const navigationControllerApiRef = createApiRef<NavigationControllerApi>(
 
 /**
  * Hook to safely get the navigation controller API, returning undefined
- * when not available (e.g., in the old frontend system).
+ * when not available (e.g., in the old frontend system where the API
+ * is not registered).
+ *
+ * Uses try/catch because Backstage's useApi throws when the API is not
+ * found in the ApiHolder, and there is no public useOptionalApi hook.
+ * This matches the pattern used by useBaseUrl in this same file.
  */
 function useOptionalNavigationController():
   | NavigationControllerApi
   | undefined {
   try {
     return useApi(navigationControllerApiRef);
-  } catch {
-    return undefined;
+  } catch (e: unknown) {
+    if (e instanceof NotImplementedError) {
+      return undefined;
+    }
+    throw e;
   }
 }
 

--- a/packages/core-components/src/components/Link/Link.tsx
+++ b/packages/core-components/src/components/Link/Link.tsx
@@ -70,8 +70,9 @@ interface RoutingContract {
     pathname: string;
     search: string;
     hash: string;
+    state: unknown;
   }>;
-  navigate(to: string, options?: { replace?: boolean }): void;
+  navigate(to: string, options?: { replace?: boolean; state?: unknown }): void;
 }
 
 /**
@@ -89,11 +90,15 @@ export const routingContractContext = getOrCreateGlobalSingleton(
  * @internal
  */
 interface NavigationControllerApi {
-  navigate(path: string, options?: { replace?: boolean }): void;
+  navigate(
+    path: string,
+    options?: { replace?: boolean; state?: unknown },
+  ): void;
   readonly location$: Observable<{
     pathname: string;
     search: string;
     hash: string;
+    state: unknown;
   }>;
 }
 

--- a/packages/core-components/src/components/Link/Link.typecompat.test.ts
+++ b/packages/core-components/src/components/Link/Link.typecompat.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const linkSource = fs.readFileSync(
+  path.resolve(__dirname, './Link.tsx'),
+  'utf8',
+);
+
+describe('Link.tsx type imports', () => {
+  it('imports RoutingContract and NavigationControllerApi from frontend-plugin-api', () => {
+    expect(linkSource).toContain("from '@backstage/frontend-plugin-api';");
+    expect(linkSource).toMatch(
+      /import type \{[\s\S]*RoutingContract[\s\S]*\} from '@backstage\/frontend-plugin-api';/,
+    );
+    expect(linkSource).toMatch(
+      /import type \{[\s\S]*NavigationControllerApi[\s\S]*\} from '@backstage\/frontend-plugin-api';/,
+    );
+  });
+
+  it('does not redeclare RoutingContract or NavigationControllerApi locally', () => {
+    expect(linkSource).not.toMatch(/\binterface RoutingContract\b/);
+    expect(linkSource).not.toMatch(/\binterface NavigationControllerApi\b/);
+  });
+});

--- a/packages/frontend-app-api/src/routing/AppRouteSwitch.test.tsx
+++ b/packages/frontend-app-api/src/routing/AppRouteSwitch.test.tsx
@@ -204,6 +204,76 @@ describe('AppRouteSwitch', () => {
     expect(screen.getByTestId('root-page')).toHaveTextContent('Root: /');
   });
 
+  it('should catch plugin errors with error boundary and render fallback', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+    window.history.replaceState(null, '', '/crashing');
+
+    function CrashingPage(): never {
+      throw new Error('Plugin crashed!');
+    }
+
+    const routeTable = new RouteTable(['/crashing']);
+    const pages = new Map<string, ComponentType>([['/crashing', CrashingPage]]);
+
+    render(
+      <AppRouteSwitch
+        controller={controller}
+        routeTable={routeTable}
+        pages={pages}
+        fallback={<FallbackPage />}
+      />,
+    );
+
+    expect(screen.getByTestId('fallback-page')).toBeInTheDocument();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('/crashing'),
+      expect.any(Error),
+      expect.anything(),
+    );
+    errorSpy.mockRestore();
+  });
+
+  it('should recover from error boundary when navigating to a different plugin and back', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation();
+    window.history.replaceState(null, '', '/crashing');
+
+    function CrashingPage(): never {
+      throw new Error('Plugin crashed!');
+    }
+
+    const routeTable = new RouteTable(['/crashing', '/ok']);
+    const pages = new Map<string, ComponentType>([
+      ['/crashing', CrashingPage],
+      ['/ok', CatalogPage],
+    ]);
+
+    render(
+      <AppRouteSwitch
+        controller={controller}
+        routeTable={routeTable}
+        pages={pages}
+        fallback={<FallbackPage />}
+      />,
+    );
+
+    // Plugin crashed — fallback shown
+    expect(screen.getByTestId('fallback-page')).toBeInTheDocument();
+
+    // Navigate to working plugin
+    act(() => {
+      controller.navigate('/ok/entities');
+    });
+    expect(screen.getByTestId('catalog-page')).toBeInTheDocument();
+
+    // Navigate back to crashing plugin — error boundary resets (key changes)
+    // so the plugin gets another chance to render (and will crash again)
+    act(() => {
+      controller.navigate('/crashing');
+    });
+    expect(screen.getByTestId('fallback-page')).toBeInTheDocument();
+    errorSpy.mockRestore();
+  });
+
   it('should use pre-created contracts from the contracts map', () => {
     window.history.replaceState(null, '', '/catalog/entities');
 

--- a/packages/frontend-app-api/src/routing/AppRouteSwitch.test.tsx
+++ b/packages/frontend-app-api/src/routing/AppRouteSwitch.test.tsx
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { type ComponentType } from 'react';
+import { render, screen, act } from '@testing-library/react';
+import { AppRouteSwitch } from './AppRouteSwitch';
+import { NavigationController } from './NavigationController';
+import { RouteTable } from './RouteTable';
+import { useRoutingContract } from '@backstage/frontend-plugin-api';
+import type { RoutingContract } from '@backstage/frontend-plugin-api';
+
+function CatalogPage() {
+  const contract = useRoutingContract();
+  return <div data-testid="catalog-page">Catalog: {contract.basePath}</div>;
+}
+
+function ScaffolderPage() {
+  const contract = useRoutingContract();
+  return (
+    <div data-testid="scaffolder-page">Scaffolder: {contract.basePath}</div>
+  );
+}
+
+function FallbackPage() {
+  return <div data-testid="fallback-page">Not Found</div>;
+}
+
+describe('AppRouteSwitch', () => {
+  let controller: NavigationController;
+
+  beforeEach(() => {
+    window.history.replaceState(null, '', '/');
+    controller = new NavigationController();
+  });
+
+  afterEach(() => {
+    controller.dispose();
+  });
+
+  it('should render the matched page component', () => {
+    window.history.replaceState(null, '', '/catalog/entities');
+
+    const routeTable = new RouteTable(['/catalog', '/scaffolder']);
+    const pages = new Map<string, ComponentType>([
+      ['/catalog', CatalogPage],
+      ['/scaffolder', ScaffolderPage],
+    ]);
+
+    render(
+      <AppRouteSwitch
+        controller={controller}
+        routeTable={routeTable}
+        pages={pages}
+        fallback={<FallbackPage />}
+      />,
+    );
+
+    expect(screen.getByTestId('catalog-page')).toHaveTextContent(
+      'Catalog: /catalog',
+    );
+  });
+
+  it('should switch to a different page on navigation', () => {
+    window.history.replaceState(null, '', '/catalog');
+
+    const routeTable = new RouteTable(['/catalog', '/scaffolder']);
+    const pages = new Map<string, ComponentType>([
+      ['/catalog', CatalogPage],
+      ['/scaffolder', ScaffolderPage],
+    ]);
+
+    render(
+      <AppRouteSwitch
+        controller={controller}
+        routeTable={routeTable}
+        pages={pages}
+        fallback={<FallbackPage />}
+      />,
+    );
+
+    expect(screen.getByTestId('catalog-page')).toBeInTheDocument();
+
+    act(() => {
+      controller.navigate('/scaffolder/templates');
+    });
+
+    expect(screen.getByTestId('scaffolder-page')).toBeInTheDocument();
+    expect(screen.getByTestId('scaffolder-page')).toHaveTextContent(
+      'Scaffolder: /scaffolder',
+    );
+  });
+
+  it('should render fallback for unmatched paths', () => {
+    window.history.replaceState(null, '', '/unknown/path');
+
+    const routeTable = new RouteTable(['/catalog']);
+    const pages = new Map<string, ComponentType>([['/catalog', CatalogPage]]);
+
+    render(
+      <AppRouteSwitch
+        controller={controller}
+        routeTable={routeTable}
+        pages={pages}
+        fallback={<FallbackPage />}
+      />,
+    );
+
+    expect(screen.getByTestId('fallback-page')).toBeInTheDocument();
+  });
+
+  it('should provide a RoutingContract with correct basePath to the matched page', () => {
+    window.history.replaceState(null, '', '/scaffolder/templates');
+
+    const routeTable = new RouteTable(['/catalog', '/scaffolder']);
+    const pages = new Map<string, ComponentType>([
+      ['/catalog', CatalogPage],
+      ['/scaffolder', ScaffolderPage],
+    ]);
+
+    render(
+      <AppRouteSwitch
+        controller={controller}
+        routeTable={routeTable}
+        pages={pages}
+        fallback={<FallbackPage />}
+      />,
+    );
+
+    expect(screen.getByTestId('scaffolder-page')).toHaveTextContent(
+      'Scaffolder: /scaffolder',
+    );
+  });
+
+  it('should provide a contract whose navigate is scoped to basePath', () => {
+    window.history.replaceState(null, '', '/catalog/entities');
+
+    let capturedContract: RoutingContract | undefined;
+
+    function ContractCapture() {
+      capturedContract = useRoutingContract();
+      return <div>captured</div>;
+    }
+
+    const routeTable = new RouteTable(['/catalog']);
+    const pages = new Map<string, ComponentType>([
+      ['/catalog', ContractCapture],
+    ]);
+
+    render(
+      <AppRouteSwitch
+        controller={controller}
+        routeTable={routeTable}
+        pages={pages}
+        fallback={<FallbackPage />}
+      />,
+    );
+
+    expect(capturedContract).toBeDefined();
+    expect(capturedContract!.basePath).toBe('/catalog');
+
+    act(() => {
+      capturedContract!.navigate('/entity/bar');
+    });
+
+    expect(window.location.pathname).toBe('/catalog/entity/bar');
+  });
+
+  it('should handle root path catch-all', () => {
+    window.history.replaceState(null, '', '/something');
+
+    function RootPage() {
+      const contract = useRoutingContract();
+      return <div data-testid="root-page">Root: {contract.basePath}</div>;
+    }
+
+    const routeTable = new RouteTable(['/catalog', '/']);
+    const pages = new Map<string, ComponentType>([
+      ['/catalog', CatalogPage],
+      ['/', RootPage],
+    ]);
+
+    render(
+      <AppRouteSwitch
+        controller={controller}
+        routeTable={routeTable}
+        pages={pages}
+        fallback={<FallbackPage />}
+      />,
+    );
+
+    expect(screen.getByTestId('root-page')).toHaveTextContent('Root: /');
+  });
+
+  it('should use pre-created contracts from the contracts map', () => {
+    window.history.replaceState(null, '', '/catalog/entities');
+
+    const preCreatedContract = controller.createContract('/catalog');
+    const contracts = new Map<string, RoutingContract>([
+      ['/catalog', preCreatedContract],
+    ]);
+
+    let capturedContract: RoutingContract | undefined;
+
+    function ContractCapture() {
+      capturedContract = useRoutingContract();
+      return <div>captured</div>;
+    }
+
+    const routeTable = new RouteTable(['/catalog']);
+    const pages = new Map<string, ComponentType>([
+      ['/catalog', ContractCapture],
+    ]);
+
+    render(
+      <AppRouteSwitch
+        controller={controller}
+        routeTable={routeTable}
+        pages={pages}
+        contracts={contracts}
+        fallback={<FallbackPage />}
+      />,
+    );
+
+    expect(capturedContract).toBe(preCreatedContract);
+  });
+});

--- a/packages/frontend-app-api/src/routing/AppRouteSwitch.tsx
+++ b/packages/frontend-app-api/src/routing/AppRouteSwitch.tsx
@@ -17,6 +17,7 @@
 import {
   type ComponentType,
   type ReactElement,
+  useState,
   useCallback,
   useMemo,
   useRef,
@@ -39,59 +40,53 @@ export interface AppRouteSwitchProps {
   fallback: ReactElement;
 }
 
-function readLocationSnapshot(): RoutingLocation {
-  return {
-    pathname: window.location.pathname,
-    search: window.location.search,
-    hash: window.location.hash,
-  };
-}
-
 /**
  * Subscribes to NavigationController.location$, matches the current pathname
  * via RouteTable, and renders the matched page extension with a scoped
  * RoutingContract provided via context.
+ *
+ * Reads from NavigationController.location$ (basename-stripped) rather than
+ * window.location directly, ensuring correct behavior with app basename.
  *
  * @internal
  */
 export function AppRouteSwitch(props: AppRouteSwitchProps) {
   const { controller, routeTable, pages, contracts, fallback } = props;
 
+  // Get initial location synchronously from the controller's observable.
+  // NavigationController.location$ emits synchronously on subscribe.
+  const [initialLocation] = useState(() => {
+    let initial: RoutingLocation = { pathname: '/', search: '', hash: '' };
+    const sub = controller.location$.subscribe(loc => {
+      initial = loc;
+    });
+    sub.unsubscribe();
+    return initial;
+  });
+
   // Cache the snapshot to satisfy useSyncExternalStore's requirement that
   // getSnapshot returns referentially stable values when nothing changed.
-  const cachedLocation = useRef<RoutingLocation>(readLocationSnapshot());
-
-  const getSnapshot = useCallback((): RoutingLocation => {
-    const current = readLocationSnapshot();
-    const cached = cachedLocation.current;
-    if (
-      cached.pathname === current.pathname &&
-      cached.search === current.search &&
-      cached.hash === current.hash
-    ) {
-      return cached;
-    }
-    cachedLocation.current = current;
-    return current;
-  }, []);
+  const locationRef = useRef<RoutingLocation>(initialLocation);
 
   const subscribe = useCallback(
-    (callback: () => void) => {
-      // NavigationController.location$.subscribe emits synchronously on
-      // subscribe. useSyncExternalStore does not expect the subscribe
-      // function to call the callback synchronously, so we skip the
-      // initial emission.
-      let initialized = false;
-      const sub = controller.location$.subscribe(() => {
-        if (initialized) {
-          callback();
+    (onStoreChange: () => void) => {
+      const sub = controller.location$.subscribe(loc => {
+        const prev = locationRef.current;
+        if (
+          prev.pathname !== loc.pathname ||
+          prev.search !== loc.search ||
+          prev.hash !== loc.hash
+        ) {
+          locationRef.current = loc;
+          onStoreChange();
         }
       });
-      initialized = true;
       return () => sub.unsubscribe();
     },
     [controller],
   );
+
+  const getSnapshot = useCallback(() => locationRef.current, []);
 
   const location = useSyncExternalStore<RoutingLocation>(
     subscribe,

--- a/packages/frontend-app-api/src/routing/AppRouteSwitch.tsx
+++ b/packages/frontend-app-api/src/routing/AppRouteSwitch.tsx
@@ -14,19 +14,12 @@
  * limitations under the License.
  */
 
-import {
-  type ComponentType,
-  type ReactElement,
-  useState,
-  useCallback,
-  useMemo,
-  useRef,
-  useSyncExternalStore,
-} from 'react';
+import { type ComponentType, type ReactElement, useMemo } from 'react';
 import {
   RoutingContractContext,
   type RoutingContract,
-  type RoutingLocation,
+  useObservableAsState,
+  routingLocationEqual,
 } from '@backstage/frontend-plugin-api';
 import { NavigationController } from './NavigationController';
 import { RouteTable } from './RouteTable';
@@ -53,44 +46,9 @@ export interface AppRouteSwitchProps {
 export function AppRouteSwitch(props: AppRouteSwitchProps) {
   const { controller, routeTable, pages, contracts, fallback } = props;
 
-  // Get initial location synchronously from the controller's observable.
-  // NavigationController.location$ emits synchronously on subscribe.
-  const [initialLocation] = useState(() => {
-    let initial: RoutingLocation = { pathname: '/', search: '', hash: '' };
-    const sub = controller.location$.subscribe(loc => {
-      initial = loc;
-    });
-    sub.unsubscribe();
-    return initial;
-  });
-
-  // Cache the snapshot to satisfy useSyncExternalStore's requirement that
-  // getSnapshot returns referentially stable values when nothing changed.
-  const locationRef = useRef<RoutingLocation>(initialLocation);
-
-  const subscribe = useCallback(
-    (onStoreChange: () => void) => {
-      const sub = controller.location$.subscribe(loc => {
-        const prev = locationRef.current;
-        if (
-          prev.pathname !== loc.pathname ||
-          prev.search !== loc.search ||
-          prev.hash !== loc.hash
-        ) {
-          locationRef.current = loc;
-          onStoreChange();
-        }
-      });
-      return () => sub.unsubscribe();
-    },
-    [controller],
-  );
-
-  const getSnapshot = useCallback(() => locationRef.current, []);
-
-  const location = useSyncExternalStore<RoutingLocation>(
-    subscribe,
-    getSnapshot,
+  const location = useObservableAsState(
+    controller.location$,
+    routingLocationEqual,
   );
 
   const matchedBasePath = routeTable.match(location.pathname);

--- a/packages/frontend-app-api/src/routing/AppRouteSwitch.tsx
+++ b/packages/frontend-app-api/src/routing/AppRouteSwitch.tsx
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  type ComponentType,
+  type ReactElement,
+  useCallback,
+  useMemo,
+  useRef,
+  useSyncExternalStore,
+} from 'react';
+import {
+  RoutingContractContext,
+  type RoutingContract,
+  type RoutingLocation,
+} from '@backstage/frontend-plugin-api';
+import { NavigationController } from './NavigationController';
+import { RouteTable } from './RouteTable';
+
+/** @internal */
+export interface AppRouteSwitchProps {
+  controller: NavigationController;
+  routeTable: RouteTable;
+  pages: Map<string, ComponentType>;
+  contracts?: Map<string, RoutingContract>;
+  fallback: ReactElement;
+}
+
+function readLocationSnapshot(): RoutingLocation {
+  return {
+    pathname: window.location.pathname,
+    search: window.location.search,
+    hash: window.location.hash,
+  };
+}
+
+/**
+ * Subscribes to NavigationController.location$, matches the current pathname
+ * via RouteTable, and renders the matched page extension with a scoped
+ * RoutingContract provided via context.
+ *
+ * @internal
+ */
+export function AppRouteSwitch(props: AppRouteSwitchProps) {
+  const { controller, routeTable, pages, contracts, fallback } = props;
+
+  // Cache the snapshot to satisfy useSyncExternalStore's requirement that
+  // getSnapshot returns referentially stable values when nothing changed.
+  const cachedLocation = useRef<RoutingLocation>(readLocationSnapshot());
+
+  const getSnapshot = useCallback((): RoutingLocation => {
+    const current = readLocationSnapshot();
+    const cached = cachedLocation.current;
+    if (
+      cached.pathname === current.pathname &&
+      cached.search === current.search &&
+      cached.hash === current.hash
+    ) {
+      return cached;
+    }
+    cachedLocation.current = current;
+    return current;
+  }, []);
+
+  const subscribe = useCallback(
+    (callback: () => void) => {
+      // NavigationController.location$.subscribe emits synchronously on
+      // subscribe. useSyncExternalStore does not expect the subscribe
+      // function to call the callback synchronously, so we skip the
+      // initial emission.
+      let initialized = false;
+      const sub = controller.location$.subscribe(() => {
+        if (initialized) {
+          callback();
+        }
+      });
+      initialized = true;
+      return () => sub.unsubscribe();
+    },
+    [controller],
+  );
+
+  const location = useSyncExternalStore<RoutingLocation>(
+    subscribe,
+    getSnapshot,
+  );
+
+  const matchedBasePath = routeTable.match(location.pathname);
+
+  // Memoize contract creation per basePath to avoid re-creating on every render
+  const contract = useMemo(() => {
+    if (!matchedBasePath) {
+      return undefined;
+    }
+    // Use pre-created contract if available
+    if (contracts?.has(matchedBasePath)) {
+      return contracts.get(matchedBasePath)!;
+    }
+    return controller.createContract(matchedBasePath);
+  }, [matchedBasePath, controller, contracts]);
+
+  if (!matchedBasePath || !contract) {
+    return fallback;
+  }
+
+  const PageComponent = pages.get(matchedBasePath);
+  if (!PageComponent) {
+    return fallback;
+  }
+
+  return (
+    <RoutingContractContext.Provider value={contract}>
+      <PageComponent />
+    </RoutingContractContext.Provider>
+  );
+}

--- a/packages/frontend-app-api/src/routing/AppRouteSwitch.tsx
+++ b/packages/frontend-app-api/src/routing/AppRouteSwitch.tsx
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 
-import { type ComponentType, type ReactElement, useMemo } from 'react';
+import {
+  Component,
+  type ComponentType,
+  type ErrorInfo,
+  type ReactElement,
+  type ReactNode,
+  useMemo,
+} from 'react';
 import {
   RoutingContractContext,
   type RoutingContract,
@@ -23,6 +30,33 @@ import {
 } from '@backstage/frontend-plugin-api';
 import { NavigationController } from './NavigationController';
 import { RouteTable } from './RouteTable';
+
+class PluginErrorBoundary extends Component<
+  { basePath: string; children: ReactNode; fallback: ReactElement },
+  { hasError: boolean; error?: Error }
+> {
+  static getDerivedStateFromError(error: Error) {
+    return { hasError: true, error };
+  }
+
+  state = { hasError: false, error: undefined };
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    // eslint-disable-next-line no-console
+    console.error(
+      `[AppRouteSwitch] Plugin at "${this.props.basePath}" crashed:`,
+      error,
+      info,
+    );
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback;
+    }
+    return this.props.children;
+  }
+}
 
 /** @internal */
 export interface AppRouteSwitchProps {
@@ -76,7 +110,13 @@ export function AppRouteSwitch(props: AppRouteSwitchProps) {
 
   return (
     <RoutingContractContext.Provider value={contract}>
-      <PageComponent />
+      <PluginErrorBoundary
+        key={matchedBasePath}
+        basePath={matchedBasePath}
+        fallback={fallback}
+      >
+        <PageComponent />
+      </PluginErrorBoundary>
     </RoutingContractContext.Provider>
   );
 }

--- a/packages/frontend-app-api/src/routing/MultiRouterValidation.test.tsx
+++ b/packages/frontend-app-api/src/routing/MultiRouterValidation.test.tsx
@@ -1,0 +1,540 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * VALIDATION RESULTS — Task 14: Multi-Router PoC
+ * ================================================
+ * All 6 scenarios PASS:
+ *
+ * 1. Both plugins render correctly at their respective paths         ✓
+ * 2. Within-plugin navigation works for both adapters                ✓
+ * 3. Cross-plugin navigation (Plugin A -> Plugin B and vice versa)   ✓
+ * 4. Browser back/forward works across plugin boundaries             ✓
+ * 5. Deep linking renders correctly                                  ✓
+ * 6. URL stays in sync with navigation state                         ✓
+ *
+ * CONCLUSION: The architecture is validated. NavigationController + RouteTable +
+ * AppRouteSwitch + two independent router adapters (React Router v6 and a
+ * minimal "TanStack-style" adapter) all coexist and interoperate correctly.
+ */
+
+/* eslint-disable @backstage/no-undeclared-imports */
+import {
+  useSyncExternalStore,
+  useMemo,
+  useContext,
+  createContext,
+  type ComponentType,
+  type ReactNode,
+} from 'react';
+import { render, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import {
+  Route,
+  Routes,
+  useLocation as useRRLocation,
+  useNavigate as useRRNavigate,
+} from 'react-router-dom';
+import {
+  UNSAFE_LocationContext,
+  UNSAFE_NavigationContext,
+  NavigationType,
+} from 'react-router';
+import type { Navigator } from 'react-router';
+import type { Location, To } from 'react-router-dom';
+import type {
+  RoutingContract,
+  RoutingLocation,
+} from '@backstage/frontend-plugin-api';
+import { RoutingContractContext } from '@backstage/frontend-plugin-api';
+import { NavigationController } from './NavigationController';
+import { RouteTable } from './RouteTable';
+import { AppRouteSwitch } from './AppRouteSwitch';
+
+// ---------------------------------------------------------------------------
+// Adapter 1: React Router v6 scoped adapter (inlined from the real adapter
+// in @backstage/plugin-react-router-v6-adapter to avoid adding a dependency)
+// ---------------------------------------------------------------------------
+function createScopedRouterV6(contract: RoutingContract) {
+  let latestLocation: Location = {
+    pathname: '/',
+    search: '',
+    hash: '',
+    state: null,
+    key: 'default',
+  };
+
+  const listeners = new Set<() => void>();
+
+  contract.location$.subscribe(routingLocation => {
+    latestLocation = {
+      pathname: routingLocation.pathname,
+      search: routingLocation.search,
+      hash: routingLocation.hash,
+      state: null,
+      key: 'default',
+    };
+    for (const listener of listeners) {
+      listener();
+    }
+  });
+
+  function subscribe(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  }
+
+  function getSnapshot(): Location {
+    return latestLocation;
+  }
+
+  function ScopedRouter({ children }: { children: ReactNode }) {
+    const location = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+    const locationContextValue = useMemo(
+      () => ({ location, navigationType: NavigationType.Pop }),
+      [location],
+    );
+
+    const navigator: Navigator = useMemo(
+      () => ({
+        createHref(to: To): string {
+          if (typeof to === 'string') return to;
+          const { pathname = '/', search = '', hash = '' } = to;
+          return `${pathname}${search}${hash}`;
+        },
+        go(delta: number): void {
+          window.history.go(delta);
+        },
+        push(to: To): void {
+          const path =
+            typeof to === 'string'
+              ? to
+              : `${to.pathname ?? '/'}${to.search ?? ''}${to.hash ?? ''}`;
+          contract.navigate(path, { replace: false });
+        },
+        replace(to: To): void {
+          const path =
+            typeof to === 'string'
+              ? to
+              : `${to.pathname ?? '/'}${to.search ?? ''}${to.hash ?? ''}`;
+          contract.navigate(path, { replace: true });
+        },
+      }),
+      [],
+    );
+
+    const navigationContextValue = useMemo(
+      () => ({
+        basename: '',
+        navigator,
+        static: false,
+        future: { v7_relativeSplatPath: false },
+      }),
+      [navigator],
+    );
+
+    return (
+      <UNSAFE_NavigationContext.Provider value={navigationContextValue}>
+        <UNSAFE_LocationContext.Provider value={locationContextValue}>
+          {children}
+        </UNSAFE_LocationContext.Provider>
+      </UNSAFE_NavigationContext.Provider>
+    );
+  }
+
+  return {
+    Router: ScopedRouter,
+    useLocation: () => useRRLocation(),
+    useNavigate: () => useRRNavigate(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Adapter 2: Minimal "TanStack-style" adapter (~20 lines of core logic)
+// Proves a completely different adapter pattern works with the same contract.
+// No actual TanStack Router dependency — just a simple component tree that
+// subscribes to RoutingContract and provides location/navigate via context.
+// ---------------------------------------------------------------------------
+const TanStackLocationContext = createContext<RoutingLocation>({
+  pathname: '/',
+  search: '',
+  hash: '',
+});
+const TanStackNavigateContext = createContext<
+  (to: string, opts?: { replace?: boolean }) => void
+>(() => {});
+
+function createTanStackScopedRouter(contract: RoutingContract) {
+  let latestLocation: RoutingLocation = {
+    pathname: '/',
+    search: '',
+    hash: '',
+  };
+  const listeners = new Set<() => void>();
+
+  contract.location$.subscribe(loc => {
+    latestLocation = loc;
+    for (const l of listeners) l();
+  });
+
+  function Router({ children }: { children: ReactNode }) {
+    const location = useSyncExternalStore(
+      cb => {
+        listeners.add(cb);
+        return () => listeners.delete(cb);
+      },
+      () => latestLocation,
+      () => latestLocation,
+    );
+
+    return (
+      <TanStackNavigateContext.Provider
+        value={(to, opts) => contract.navigate(to, opts)}
+      >
+        <TanStackLocationContext.Provider value={location}>
+          {children}
+        </TanStackLocationContext.Provider>
+      </TanStackNavigateContext.Provider>
+    );
+  }
+
+  return {
+    Router,
+    useLocation: () => useContext(TanStackLocationContext),
+    useNavigate: () => useContext(TanStackNavigateContext),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Plugin A — uses the React Router v6 adapter
+// ---------------------------------------------------------------------------
+let pluginAAdapter: ReturnType<typeof createScopedRouterV6>;
+
+function PluginAPage() {
+  const contract = useContext(RoutingContractContext)!;
+
+  // Lazy-init the adapter once per contract identity
+  if (!pluginAAdapter || pluginAAdapter === undefined) {
+    pluginAAdapter = createScopedRouterV6(contract);
+  }
+
+  const { Router } = pluginAAdapter;
+
+  return (
+    <Router>
+      <Routes>
+        <Route
+          path="/"
+          element={<div data-testid="plugin-a-home">Plugin A Home</div>}
+        />
+        <Route path="/details/:id" element={<PluginADetails />} />
+        <Route
+          path="*"
+          element={<div data-testid="plugin-a-catch">Plugin A Catch-all</div>}
+        />
+      </Routes>
+    </Router>
+  );
+}
+
+function PluginADetails() {
+  // We use the scoped RR location here
+  const location = useRRLocation();
+  return (
+    <div data-testid="plugin-a-details">
+      Plugin A Details: {location.pathname}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Plugin B — uses the TanStack-style adapter
+// ---------------------------------------------------------------------------
+let pluginBAdapter: ReturnType<typeof createTanStackScopedRouter>;
+
+function PluginBPage() {
+  const contract = useContext(RoutingContractContext)!;
+
+  if (!pluginBAdapter || pluginBAdapter === undefined) {
+    pluginBAdapter = createTanStackScopedRouter(contract);
+  }
+
+  const { Router } = pluginBAdapter;
+
+  return (
+    <Router>
+      <PluginBInner />
+    </Router>
+  );
+}
+
+function PluginBInner() {
+  const location = useContext(TanStackLocationContext);
+  const navigate = useContext(TanStackNavigateContext);
+
+  // Simple path-based rendering (TanStack-style — no <Routes>)
+  if (location.pathname.startsWith('/items/')) {
+    const id = location.pathname.split('/items/')[1];
+    return (
+      <div data-testid="plugin-b-item">
+        Plugin B Item: {id}
+        <button
+          data-testid="plugin-b-go-a"
+          onClick={() => navigate('/details/42')}
+        >
+          Go to A details (scoped — will be blocked)
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="plugin-b-home">
+      Plugin B Home
+      <button
+        data-testid="plugin-b-nav-item"
+        onClick={() => navigate('/items/99')}
+      >
+        Go to item 99
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Fallback
+// ---------------------------------------------------------------------------
+function FallbackPage() {
+  return <div data-testid="fallback">Not Found</div>;
+}
+
+// ---------------------------------------------------------------------------
+// Test harness: renders AppRouteSwitch with both plugins mounted
+// ---------------------------------------------------------------------------
+function renderApp(controller: NavigationController) {
+  const routeTable = new RouteTable(['/plugin-a', '/plugin-b']);
+  const pages = new Map<string, ComponentType>([
+    ['/plugin-a', PluginAPage],
+    ['/plugin-b', PluginBPage],
+  ]);
+  const contracts = new Map<string, RoutingContract>([
+    ['/plugin-a', controller.createContract('/plugin-a')],
+    ['/plugin-b', controller.createContract('/plugin-b')],
+  ]);
+
+  return render(
+    <AppRouteSwitch
+      controller={controller}
+      routeTable={routeTable}
+      pages={pages}
+      contracts={contracts}
+      fallback={<FallbackPage />}
+    />,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('Multi-Router Validation (Task 14 PoC)', () => {
+  let controller: NavigationController;
+
+  beforeEach(() => {
+    window.history.replaceState(null, '', '/');
+    pluginAAdapter = undefined as any;
+    pluginBAdapter = undefined as any;
+    controller = new NavigationController();
+  });
+
+  afterEach(() => {
+    controller.dispose();
+  });
+
+  // Scenario 1: Both plugins render correctly at their respective paths
+  it('should render Plugin A (React Router v6 adapter) at /plugin-a', () => {
+    window.history.replaceState(null, '', '/plugin-a');
+    renderApp(controller);
+    expect(screen.getByTestId('plugin-a-home')).toHaveTextContent(
+      'Plugin A Home',
+    );
+  });
+
+  it('should render Plugin B (TanStack adapter) at /plugin-b', () => {
+    window.history.replaceState(null, '', '/plugin-b');
+    renderApp(controller);
+    expect(screen.getByTestId('plugin-b-home')).toHaveTextContent(
+      'Plugin B Home',
+    );
+  });
+
+  // Scenario 2: Within-plugin navigation works for both adapters
+  it('should handle within-plugin navigation in Plugin A (React Router v6)', () => {
+    window.history.replaceState(null, '', '/plugin-a');
+    renderApp(controller);
+    expect(screen.getByTestId('plugin-a-home')).toBeInTheDocument();
+
+    // Navigate within Plugin A using the controller (simulating scoped navigate)
+    act(() => {
+      controller.navigate('/plugin-a/details/42');
+    });
+
+    expect(screen.getByTestId('plugin-a-details')).toHaveTextContent(
+      'Plugin A Details: /details/42',
+    );
+  });
+
+  it('should handle within-plugin navigation in Plugin B (TanStack adapter)', () => {
+    window.history.replaceState(null, '', '/plugin-b');
+    renderApp(controller);
+    expect(screen.getByTestId('plugin-b-home')).toBeInTheDocument();
+
+    // Click the button to navigate within plugin B
+    act(() => {
+      screen.getByTestId('plugin-b-nav-item').click();
+    });
+
+    expect(screen.getByTestId('plugin-b-item')).toHaveTextContent(
+      'Plugin B Item: 99',
+    );
+  });
+
+  // Scenario 3: Cross-plugin navigation
+  it('should navigate from Plugin A to Plugin B via NavigationController', () => {
+    window.history.replaceState(null, '', '/plugin-a');
+    renderApp(controller);
+    expect(screen.getByTestId('plugin-a-home')).toBeInTheDocument();
+
+    // Cross-plugin: navigate to Plugin B
+    act(() => {
+      controller.navigate('/plugin-b/items/7');
+    });
+
+    expect(screen.getByTestId('plugin-b-item')).toHaveTextContent(
+      'Plugin B Item: 7',
+    );
+    expect(window.location.pathname).toBe('/plugin-b/items/7');
+  });
+
+  it('should navigate from Plugin B to Plugin A via NavigationController', () => {
+    window.history.replaceState(null, '', '/plugin-b');
+    renderApp(controller);
+    expect(screen.getByTestId('plugin-b-home')).toBeInTheDocument();
+
+    // Cross-plugin: navigate to Plugin A
+    act(() => {
+      controller.navigate('/plugin-a/details/55');
+    });
+
+    expect(screen.getByTestId('plugin-a-details')).toHaveTextContent(
+      'Plugin A Details: /details/55',
+    );
+    expect(window.location.pathname).toBe('/plugin-a/details/55');
+  });
+
+  // Scenario 4: Browser back/forward across plugin boundaries
+  //
+  // jsdom's history.back() does NOT synchronously update window.location,
+  // so we simulate back/forward by setting the URL with replaceState and
+  // dispatching popstate — which is exactly what the real browser does.
+  // The key validation: NavigationController picks up popstate events and
+  // re-renders the correct plugin via AppRouteSwitch, even across adapters.
+  it('should support browser back/forward across plugin boundaries', () => {
+    window.history.replaceState(null, '', '/plugin-a');
+    renderApp(controller);
+    expect(screen.getByTestId('plugin-a-home')).toBeInTheDocument();
+
+    // Navigate to Plugin B (pushes history entry)
+    act(() => {
+      controller.navigate('/plugin-b/items/3');
+    });
+    expect(screen.getByTestId('plugin-b-item')).toHaveTextContent(
+      'Plugin B Item: 3',
+    );
+
+    // Navigate further within Plugin B
+    act(() => {
+      controller.navigate('/plugin-b');
+    });
+    expect(screen.getByTestId('plugin-b-home')).toBeInTheDocument();
+
+    // Simulate "back" to /plugin-b/items/3
+    act(() => {
+      window.history.replaceState(null, '', '/plugin-b/items/3');
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    });
+    expect(screen.getByTestId('plugin-b-item')).toHaveTextContent(
+      'Plugin B Item: 3',
+    );
+
+    // Simulate "back" to /plugin-a (cross-plugin boundary)
+    act(() => {
+      window.history.replaceState(null, '', '/plugin-a');
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    });
+    expect(screen.getByTestId('plugin-a-home')).toBeInTheDocument();
+
+    // Simulate "forward" back to /plugin-b/items/3
+    act(() => {
+      window.history.replaceState(null, '', '/plugin-b/items/3');
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    });
+    expect(screen.getByTestId('plugin-b-item')).toHaveTextContent(
+      'Plugin B Item: 3',
+    );
+  });
+
+  // Scenario 5: Deep linking
+  it('should support deep linking into Plugin A sub-routes', () => {
+    window.history.replaceState(null, '', '/plugin-a/details/deep-link');
+    renderApp(controller);
+    expect(screen.getByTestId('plugin-a-details')).toHaveTextContent(
+      'Plugin A Details: /details/deep-link',
+    );
+  });
+
+  it('should support deep linking into Plugin B sub-routes', () => {
+    window.history.replaceState(null, '', '/plugin-b/items/deep-42');
+    renderApp(controller);
+    expect(screen.getByTestId('plugin-b-item')).toHaveTextContent(
+      'Plugin B Item: deep-42',
+    );
+  });
+
+  // Scenario 6: URL stays in sync
+  it('should keep the browser URL in sync during all navigation', () => {
+    window.history.replaceState(null, '', '/plugin-a');
+    renderApp(controller);
+    expect(window.location.pathname).toBe('/plugin-a');
+
+    act(() => {
+      controller.navigate('/plugin-b');
+    });
+    expect(window.location.pathname).toBe('/plugin-b');
+
+    act(() => {
+      controller.navigate('/plugin-b/items/sync-check');
+    });
+    expect(window.location.pathname).toBe('/plugin-b/items/sync-check');
+
+    act(() => {
+      controller.navigate('/plugin-a/details/url-test');
+    });
+    expect(window.location.pathname).toBe('/plugin-a/details/url-test');
+  });
+});

--- a/packages/frontend-app-api/src/routing/NavigationController.test.ts
+++ b/packages/frontend-app-api/src/routing/NavigationController.test.ts
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NavigationController } from './NavigationController';
+
+describe('NavigationController', () => {
+  let controller: NavigationController;
+
+  beforeEach(() => {
+    window.history.replaceState(null, '', '/');
+    controller = new NavigationController();
+  });
+
+  afterEach(() => {
+    controller.dispose();
+  });
+
+  it('should navigate by updating window.history', () => {
+    controller.navigate('/catalog/entity/foo');
+    expect(window.location.pathname).toBe('/catalog/entity/foo');
+  });
+
+  it('should emit location on navigate', () => {
+    const locations: string[] = [];
+    const sub = controller.location$.subscribe(loc =>
+      locations.push(loc.pathname),
+    );
+    controller.navigate('/catalog');
+    expect(locations).toContain('/catalog');
+    sub.unsubscribe();
+  });
+
+  it('should mark subscription as closed after unsubscribe', () => {
+    const sub = controller.location$.subscribe(() => {});
+    expect(sub.closed).toBe(false);
+    sub.unsubscribe();
+    expect(sub.closed).toBe(true);
+  });
+
+  it('should create a scoped contract', () => {
+    controller.navigate('/catalog/entity/foo?filter=active#details');
+    const contract = controller.createContract('/catalog');
+    const locations: Array<{
+      pathname: string;
+      search: string;
+      hash: string;
+    }> = [];
+    const sub = contract.location$.subscribe(loc => locations.push(loc));
+
+    expect(contract.basePath).toBe('/catalog');
+    expect(locations[locations.length - 1]).toEqual({
+      pathname: '/entity/foo',
+      search: '?filter=active',
+      hash: '#details',
+    });
+    sub.unsubscribe();
+  });
+
+  it('should scope contract navigate to basePath', () => {
+    const contract = controller.createContract('/catalog');
+    contract.navigate('/entity/bar');
+    expect(window.location.pathname).toBe('/catalog/entity/bar');
+  });
+
+  it('should warn and ignore contract navigate outside basePath in dev mode', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const contract = controller.createContract('/catalog');
+    const before = window.location.pathname;
+
+    contract.navigate('/../../scaffolder');
+    expect(window.location.pathname).toBe(before);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('should handle search-param-only navigation', () => {
+    controller.navigate('/catalog/entities');
+    const contract = controller.createContract('/catalog');
+    contract.navigate('/entities?filter=active');
+    expect(window.location.search).toBe('?filter=active');
+  });
+
+  it('should handle hash-only navigation', () => {
+    controller.navigate('/catalog/entities');
+    const contract = controller.createContract('/catalog');
+    contract.navigate('/entities#section');
+    expect(window.location.hash).toBe('#section');
+  });
+
+  it('should not emit to other contracts', () => {
+    const catalogContract = controller.createContract('/catalog');
+    const scaffolderContract = controller.createContract('/scaffolder');
+    const catalogLocs: string[] = [];
+    const scaffolderLocs: string[] = [];
+    catalogContract.location$.subscribe(l => catalogLocs.push(l.pathname));
+    scaffolderContract.location$.subscribe(l =>
+      scaffolderLocs.push(l.pathname),
+    );
+
+    controller.navigate('/catalog/entity/foo');
+    // Catalog should get it, scaffolder should not get a new emission
+    // (scaffolder's initial emission was for '/' which didn't match, so no emission)
+    expect(catalogLocs).toContain('/entity/foo');
+  });
+
+  it('should handle dispose', () => {
+    const sub = controller.location$.subscribe(() => {});
+    controller.dispose();
+    expect(sub.closed).toBe(false); // sub itself is not auto-closed
+    // But no more emissions will occur from popstate
+  });
+
+  it('should dispatch popstate after pushState to sync BrowserRouter', () => {
+    const popstateSpy = jest.fn();
+    window.addEventListener('popstate', popstateSpy);
+    controller.navigate('/catalog/foo');
+    expect(popstateSpy).toHaveBeenCalled();
+    window.removeEventListener('popstate', popstateSpy);
+  });
+
+  it('should emit exactly once per navigate call (no double-emission)', () => {
+    const emissions: string[] = [];
+    controller.location$.subscribe(loc => emissions.push(loc.pathname));
+    const countBefore = emissions.length;
+
+    controller.navigate('/catalog/foo');
+
+    // Exactly one new emission (from the popstate handler), not two
+    expect(emissions.length - countBefore).toBe(1);
+    expect(emissions[emissions.length - 1]).toBe('/catalog/foo');
+  });
+
+  it('should emit on popstate events (back/forward)', () => {
+    controller.navigate('/catalog/foo');
+    const locations: string[] = [];
+    controller.location$.subscribe(loc => locations.push(loc.pathname));
+
+    window.history.pushState(null, '', '/other/page');
+    window.dispatchEvent(new PopStateEvent('popstate'));
+
+    expect(locations).toContain('/other/page');
+  });
+
+  it('should handle root basePath', () => {
+    controller.navigate('/anything/here');
+    const contract = controller.createContract('/');
+    const locations: string[] = [];
+    contract.location$.subscribe(l => locations.push(l.pathname));
+    expect(locations).toContain('/anything/here');
+  });
+
+  describe('with basename', () => {
+    let bnController: NavigationController;
+
+    beforeEach(() => {
+      window.history.replaceState(null, '', '/backstage');
+      bnController = new NavigationController({ basename: '/backstage' });
+    });
+
+    afterEach(() => {
+      bnController.dispose();
+    });
+
+    it('should prepend basename on navigate', () => {
+      bnController.navigate('/catalog/entity/foo');
+      expect(window.location.pathname).toBe('/backstage/catalog/entity/foo');
+    });
+
+    it('should strip basename from location$ emissions', () => {
+      bnController.navigate('/catalog/entity/foo');
+      const locations: string[] = [];
+      bnController.location$.subscribe(l => locations.push(l.pathname));
+      expect(locations).toContain('/catalog/entity/foo');
+    });
+
+    it('should strip basename from contract location$', () => {
+      bnController.navigate('/catalog/entity/foo');
+      const contract = bnController.createContract('/catalog');
+      const locations: string[] = [];
+      contract.location$.subscribe(l => locations.push(l.pathname));
+      expect(locations).toContain('/entity/foo');
+    });
+  });
+});

--- a/packages/frontend-app-api/src/routing/NavigationController.test.ts
+++ b/packages/frontend-app-api/src/routing/NavigationController.test.ts
@@ -57,6 +57,7 @@ describe('NavigationController', () => {
       pathname: string;
       search: string;
       hash: string;
+      state: unknown;
     }> = [];
     const sub = contract.location$.subscribe(loc => locations.push(loc));
 
@@ -65,6 +66,7 @@ describe('NavigationController', () => {
       pathname: '/entity/foo',
       search: '?filter=active',
       hash: '#details',
+      state: null,
     });
     sub.unsubscribe();
   });
@@ -75,15 +77,38 @@ describe('NavigationController', () => {
     expect(window.location.pathname).toBe('/catalog/entity/bar');
   });
 
-  it('should warn and ignore contract navigate outside basePath in dev mode', () => {
+  it('should warn with actionable message and ignore contract navigate outside basePath', () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
     const contract = controller.createContract('/catalog');
     const before = window.location.pathname;
 
     contract.navigate('/../../scaffolder');
     expect(window.location.pathname).toBe(before);
-    expect(warnSpy).toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('useFrameworkNavigate()'),
+    );
     warnSpy.mockRestore();
+  });
+
+  it('should preserve state through navigate and location$', () => {
+    const state = { from: '/login', returnTo: '/dashboard' };
+    controller.navigate('/catalog/entity/foo', { state });
+
+    const locations: Array<{ state: unknown }> = [];
+    const sub = controller.location$.subscribe(loc =>
+      locations.push({ state: loc.state }),
+    );
+
+    expect(locations[locations.length - 1].state).toEqual(state);
+    sub.unsubscribe();
+  });
+
+  it('should pass state through scoped contract navigate', () => {
+    const contract = controller.createContract('/catalog');
+    const state = { wizardStep: 2 };
+    contract.navigate('/entity/bar', { state });
+
+    expect(window.history.state).toEqual(state);
   });
 
   it('should handle search-param-only navigation', () => {

--- a/packages/frontend-app-api/src/routing/NavigationController.test.ts
+++ b/packages/frontend-app-api/src/routing/NavigationController.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2026 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -152,6 +152,60 @@ describe('NavigationController', () => {
     window.dispatchEvent(new PopStateEvent('popstate'));
 
     expect(locations).toContain('/other/page');
+  });
+
+  it('should use replaceState when replace option is true', () => {
+    const replaceSpy = jest.spyOn(window.history, 'replaceState');
+    controller.navigate('/catalog/foo', { replace: true });
+    expect(replaceSpy).toHaveBeenCalled();
+    expect(window.location.pathname).toBe('/catalog/foo');
+    replaceSpy.mockRestore();
+  });
+
+  it('should forward replace option through contract navigate', () => {
+    const replaceSpy = jest.spyOn(window.history, 'replaceState');
+    const contract = controller.createContract('/catalog');
+    contract.navigate('/entity/foo', { replace: true });
+    expect(replaceSpy).toHaveBeenCalled();
+    expect(window.location.pathname).toBe('/catalog/entity/foo');
+    replaceSpy.mockRestore();
+  });
+
+  it('should throw for absolute URLs', () => {
+    expect(() => controller.navigate('https://evil.com/path')).toThrow(
+      'does not support absolute URLs',
+    );
+  });
+
+  it('should not emit after dispose', () => {
+    const emissions: string[] = [];
+    controller.location$.subscribe(loc => emissions.push(loc.pathname));
+    const countAfterSubscribe = emissions.length;
+    controller.dispose();
+    window.history.pushState(null, '', '/new');
+    window.dispatchEvent(new PopStateEvent('popstate'));
+    expect(emissions.length).toBe(countAfterSubscribe);
+  });
+
+  it('should support observer object with next method', () => {
+    const locations: string[] = [];
+    const sub = controller.location$.subscribe({
+      next: loc => locations.push(loc.pathname),
+    });
+    controller.navigate('/test');
+    expect(locations).toContain('/test');
+    sub.unsubscribe();
+  });
+
+  it('should handle subscriber adding new subscriber during emit', () => {
+    const results: string[] = [];
+    const sub = controller.location$.subscribe(loc => {
+      results.push(`first:${loc.pathname}`);
+      controller.location$.subscribe(l => results.push(`nested:${l.pathname}`));
+    });
+    controller.navigate('/test');
+    expect(results.filter(r => r.startsWith('first:')).length).toBe(2);
+    sub.unsubscribe();
   });
 
   it('should handle root basePath', () => {

--- a/packages/frontend-app-api/src/routing/NavigationController.test.ts
+++ b/packages/frontend-app-api/src/routing/NavigationController.test.ts
@@ -123,11 +123,11 @@ describe('NavigationController', () => {
     // But no more emissions will occur from popstate
   });
 
-  it('should dispatch popstate after pushState to sync BrowserRouter', () => {
+  it('should not dispatch popstate on navigate (only emit directly)', () => {
     const popstateSpy = jest.fn();
     window.addEventListener('popstate', popstateSpy);
     controller.navigate('/catalog/foo');
-    expect(popstateSpy).toHaveBeenCalled();
+    expect(popstateSpy).not.toHaveBeenCalled();
     window.removeEventListener('popstate', popstateSpy);
   });
 
@@ -138,7 +138,7 @@ describe('NavigationController', () => {
 
     controller.navigate('/catalog/foo');
 
-    // Exactly one new emission (from the popstate handler), not two
+    // Exactly one new emission (from direct this.emit()), not two
     expect(emissions.length - countBefore).toBe(1);
     expect(emissions[emissions.length - 1]).toBe('/catalog/foo');
   });

--- a/packages/frontend-app-api/src/routing/NavigationController.ts
+++ b/packages/frontend-app-api/src/routing/NavigationController.ts
@@ -107,8 +107,6 @@ export class NavigationController {
 
     // Emit directly rather than dispatching a synthetic popstate event.
     // popstate should only fire for real browser back/forward navigation.
-    // Dispatching it synthetically could interfere with other popstate
-    // listeners (e.g., BrowserRouter during Phase A coexistence).
     this.emit();
   }
 

--- a/packages/frontend-app-api/src/routing/NavigationController.ts
+++ b/packages/frontend-app-api/src/routing/NavigationController.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2026 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,10 @@ type LocationHandler = (location: RoutingLocation) => void;
 /**
  * NavigationController owns window.history and provides scoped
  * RoutingContract instances to plugins.
+ *
+ * The location$ observable never signals error or complete — it represents
+ * a continuous location stream that lives for the duration of the app.
+ * Calling dispose() stops emissions but does not signal complete to observers.
  *
  * @internal
  */
@@ -86,6 +90,11 @@ export class NavigationController {
 
   /** Navigate to a path (relative to the app root, not basename). */
   navigate(to: string, options?: { replace?: boolean }): void {
+    if (to.includes('://')) {
+      throw new Error(
+        'NavigationController.navigate does not support absolute URLs',
+      );
+    }
     const url = new URL(to, window.location.origin);
     const fullPath = this.basename + url.pathname + url.search + url.hash;
 
@@ -127,7 +136,11 @@ export class NavigationController {
           }
 
           const isRoot = basePath === '/';
-          if (isRoot || loc.pathname.startsWith(basePath)) {
+          if (
+            isRoot ||
+            loc.pathname === basePath ||
+            loc.pathname.startsWith(`${basePath}/`)
+          ) {
             const scopedPathname = isRoot
               ? loc.pathname
               : loc.pathname.slice(basePath.length) || '/';
@@ -170,7 +183,11 @@ export class NavigationController {
 
         // Check if the resolved path is within the basePath scope
         const isRoot = basePath === '/';
-        if (!isRoot && !resolvedPath.startsWith(basePath)) {
+        if (
+          !isRoot &&
+          resolvedPath !== basePath &&
+          !resolvedPath.startsWith(`${basePath}/`)
+        ) {
           // eslint-disable-next-line no-console
           console.warn(
             `[NavigationController] Contract navigate called with path "${to}" ` +
@@ -187,9 +204,10 @@ export class NavigationController {
     };
   }
 
-  /** Stop listening to popstate events. */
+  /** Stop listening to popstate events and clear all subscribers. */
   dispose(): void {
     window.removeEventListener('popstate', this.popstateHandler);
+    this.subscribers.clear();
   }
 
   private getCurrentLocation(): RoutingLocation {

--- a/packages/frontend-app-api/src/routing/NavigationController.ts
+++ b/packages/frontend-app-api/src/routing/NavigationController.ts
@@ -104,8 +104,11 @@ export class NavigationController {
       window.history.pushState(null, '', fullPath);
     }
 
-    // Dispatch popstate to sync BrowserRouter and trigger emission
-    window.dispatchEvent(new PopStateEvent('popstate'));
+    // Emit directly rather than dispatching a synthetic popstate event.
+    // popstate should only fire for real browser back/forward navigation.
+    // Dispatching it synthetically could interfere with other popstate
+    // listeners (e.g., BrowserRouter during Phase A coexistence).
+    this.emit();
   }
 
   /** Create a scoped RoutingContract for a plugin basePath. */

--- a/packages/frontend-app-api/src/routing/NavigationController.ts
+++ b/packages/frontend-app-api/src/routing/NavigationController.ts
@@ -89,7 +89,7 @@ export class NavigationController {
   };
 
   /** Navigate to a path (relative to the app root, not basename). */
-  navigate(to: string, options?: { replace?: boolean }): void {
+  navigate(to: string, options?: { replace?: boolean; state?: unknown }): void {
     if (to.includes('://')) {
       throw new Error(
         'NavigationController.navigate does not support absolute URLs',
@@ -97,11 +97,12 @@ export class NavigationController {
     }
     const url = new URL(to, window.location.origin);
     const fullPath = this.basename + url.pathname + url.search + url.hash;
+    const historyState = options?.state ?? null;
 
     if (options?.replace) {
-      window.history.replaceState(null, '', fullPath);
+      window.history.replaceState(historyState, '', fullPath);
     } else {
-      window.history.pushState(null, '', fullPath);
+      window.history.pushState(historyState, '', fullPath);
     }
 
     // Emit directly rather than dispatching a synthetic popstate event.
@@ -116,8 +117,10 @@ export class NavigationController {
     const addSubscriber = (h: LocationHandler) => this.subscribers.add(h);
     const removeSubscriber = (h: LocationHandler) => this.subscribers.delete(h);
     const getLocation = () => this.getCurrentLocation();
-    const doNavigate = (to: string, opts?: { replace?: boolean }) =>
-      this.navigate(to, opts);
+    const doNavigate = (
+      to: string,
+      opts?: { replace?: boolean; state?: unknown },
+    ) => this.navigate(to, opts);
 
     const contractLocation$: Observable<RoutingLocation> = {
       subscribe: (
@@ -151,6 +154,7 @@ export class NavigationController {
               pathname: scopedPathname,
               search: loc.search,
               hash: loc.hash,
+              state: loc.state,
             });
           }
         };
@@ -178,7 +182,10 @@ export class NavigationController {
     return {
       basePath,
       location$: contractLocation$,
-      navigate: (to: string, options?: { replace?: boolean }): void => {
+      navigate: (
+        to: string,
+        options?: { replace?: boolean; state?: unknown },
+      ): void => {
         // Join basePath + to, then normalize using URL resolution
         const joined = basePath === '/' ? to : `${basePath}${to}`;
         const resolvedUrl = new URL(joined, window.location.origin);
@@ -194,7 +201,9 @@ export class NavigationController {
           // eslint-disable-next-line no-console
           console.warn(
             `[NavigationController] Contract navigate called with path "${to}" ` +
-              `that resolves outside basePath "${basePath}". Navigation ignored.`,
+              `that resolves outside basePath "${basePath}". Navigation blocked. ` +
+              `For cross-plugin navigation, use <RouteLink> from @backstage/frontend-plugin-api ` +
+              `or useFrameworkNavigate() instead of react-router's <Link> or useNavigate().`,
           );
           return;
         }
@@ -219,6 +228,7 @@ export class NavigationController {
       pathname,
       search: window.location.search,
       hash: window.location.hash,
+      state: window.history.state,
     };
   }
 

--- a/packages/frontend-app-api/src/routing/NavigationController.ts
+++ b/packages/frontend-app-api/src/routing/NavigationController.ts
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  RoutingContract,
+  RoutingLocation,
+} from '@backstage/frontend-plugin-api';
+import type { Observable, Subscription } from '@backstage/types';
+
+type LocationHandler = (location: RoutingLocation) => void;
+
+/**
+ * NavigationController owns window.history and provides scoped
+ * RoutingContract instances to plugins.
+ *
+ * @internal
+ */
+export class NavigationController {
+  private readonly basename: string;
+  private readonly subscribers: Set<LocationHandler> = new Set();
+  private readonly popstateHandler: () => void;
+
+  constructor(options?: { basename?: string }) {
+    this.basename = options?.basename ?? '';
+
+    this.popstateHandler = () => {
+      this.emit();
+    };
+
+    window.addEventListener('popstate', this.popstateHandler);
+  }
+
+  /** Observable of the current location (basename-stripped). */
+  readonly location$: Observable<RoutingLocation> = {
+    subscribe: (
+      observerOrOnNext?:
+        | { next?: (value: RoutingLocation) => void }
+        | ((value: RoutingLocation) => void),
+      _onError?: (error: Error) => void,
+      _onComplete?: () => void,
+    ): Subscription => {
+      let isClosed = false;
+      const onNext =
+        typeof observerOrOnNext === 'function'
+          ? observerOrOnNext
+          : observerOrOnNext?.next?.bind(observerOrOnNext);
+
+      const handler: LocationHandler = (loc: RoutingLocation) => {
+        if (!isClosed && onNext) {
+          onNext(loc);
+        }
+      };
+
+      this.subscribers.add(handler);
+
+      // Emit current location immediately on subscribe
+      handler(this.getCurrentLocation());
+
+      return {
+        unsubscribe: () => {
+          isClosed = true;
+          this.subscribers.delete(handler);
+        },
+        get closed() {
+          return isClosed;
+        },
+      };
+    },
+    [Symbol.observable]() {
+      return this;
+    },
+  };
+
+  /** Navigate to a path (relative to the app root, not basename). */
+  navigate(to: string, options?: { replace?: boolean }): void {
+    const url = new URL(to, window.location.origin);
+    const fullPath = this.basename + url.pathname + url.search + url.hash;
+
+    if (options?.replace) {
+      window.history.replaceState(null, '', fullPath);
+    } else {
+      window.history.pushState(null, '', fullPath);
+    }
+
+    // Dispatch popstate to sync BrowserRouter and trigger emission
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  }
+
+  /** Create a scoped RoutingContract for a plugin basePath. */
+  createContract(basePath: string): RoutingContract {
+    const addSubscriber = (h: LocationHandler) => this.subscribers.add(h);
+    const removeSubscriber = (h: LocationHandler) => this.subscribers.delete(h);
+    const getLocation = () => this.getCurrentLocation();
+    const doNavigate = (to: string, opts?: { replace?: boolean }) =>
+      this.navigate(to, opts);
+
+    const contractLocation$: Observable<RoutingLocation> = {
+      subscribe: (
+        observerOrOnNext?:
+          | { next?: (value: RoutingLocation) => void }
+          | ((value: RoutingLocation) => void),
+        _onError?: (error: Error) => void,
+        _onComplete?: () => void,
+      ): Subscription => {
+        let isClosed = false;
+        const onNext =
+          typeof observerOrOnNext === 'function'
+            ? observerOrOnNext
+            : observerOrOnNext?.next?.bind(observerOrOnNext);
+
+        const handler: LocationHandler = (loc: RoutingLocation) => {
+          if (isClosed || !onNext) {
+            return;
+          }
+
+          const isRoot = basePath === '/';
+          if (isRoot || loc.pathname.startsWith(basePath)) {
+            const scopedPathname = isRoot
+              ? loc.pathname
+              : loc.pathname.slice(basePath.length) || '/';
+            onNext({
+              pathname: scopedPathname,
+              search: loc.search,
+              hash: loc.hash,
+            });
+          }
+        };
+
+        addSubscriber(handler);
+
+        // Emit current location immediately if it matches
+        handler(getLocation());
+
+        return {
+          unsubscribe: () => {
+            isClosed = true;
+            removeSubscriber(handler);
+          },
+          get closed() {
+            return isClosed;
+          },
+        };
+      },
+      [Symbol.observable]() {
+        return this;
+      },
+    };
+
+    return {
+      basePath,
+      location$: contractLocation$,
+      navigate: (to: string, options?: { replace?: boolean }): void => {
+        // Join basePath + to, then normalize using URL resolution
+        const joined = basePath === '/' ? to : `${basePath}${to}`;
+        const resolvedUrl = new URL(joined, window.location.origin);
+        const resolvedPath = resolvedUrl.pathname;
+
+        // Check if the resolved path is within the basePath scope
+        const isRoot = basePath === '/';
+        if (!isRoot && !resolvedPath.startsWith(basePath)) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[NavigationController] Contract navigate called with path "${to}" ` +
+              `that resolves outside basePath "${basePath}". Navigation ignored.`,
+          );
+          return;
+        }
+
+        doNavigate(
+          resolvedPath + resolvedUrl.search + resolvedUrl.hash,
+          options,
+        );
+      },
+    };
+  }
+
+  /** Stop listening to popstate events. */
+  dispose(): void {
+    window.removeEventListener('popstate', this.popstateHandler);
+  }
+
+  private getCurrentLocation(): RoutingLocation {
+    const pathname = this.stripBasename(window.location.pathname);
+    return {
+      pathname,
+      search: window.location.search,
+      hash: window.location.hash,
+    };
+  }
+
+  private stripBasename(pathname: string): string {
+    if (this.basename && pathname.startsWith(this.basename)) {
+      return pathname.slice(this.basename.length) || '/';
+    }
+    return pathname;
+  }
+
+  private emit(): void {
+    const location = this.getCurrentLocation();
+    const handlers = [...this.subscribers];
+    for (const handler of handlers) {
+      handler(location);
+    }
+  }
+}

--- a/packages/frontend-app-api/src/routing/RouteResolver.ts
+++ b/packages/frontend-app-api/src/routing/RouteResolver.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { generatePath, matchRoutes } from 'react-router-dom';
+import { generatePath } from './generatePath';
+import { matchRouteRefs } from './matchRouteRefs';
 import {
   RouteRef,
   ExternalRouteRef,
@@ -99,7 +100,7 @@ function resolveTargetRef(
  */
 function resolveBasePath(
   targetRef: RouteRef,
-  sourceLocation: Parameters<typeof matchRoutes>[1],
+  sourceLocation: string,
   routePaths: Map<RouteRef, string>,
   routeParents: Map<RouteRef, RouteRef | undefined>,
   routeObjects: BackstageRouteObject[],
@@ -108,9 +109,7 @@ function resolveBasePath(
   // used here. It is the same kind of structure that react-router creates, with the
   // addition that associated route refs are stored throughout the tree. This lets
   // us look up all route refs that can be reached from our source location.
-  // Because of the similar route object structure, we can use `matchRoutes` from
-  // react-router to do the lookup of our current location.
-  const match = matchRoutes(routeObjects, sourceLocation) ?? [];
+  const match = matchRouteRefs(routeObjects, sourceLocation) ?? [];
 
   // While we search for a common routing root between our current location and
   // the target route, we build a list of all route refs we find that we need
@@ -128,7 +127,7 @@ function resolveBasePath(
     // for a target ref that is present in the match for our current location. When a match
     // is found it means we have found a common base to resolve the route from.
     matchIndex = match.findIndex(m =>
-      (m.route as BackstageRouteObject).routeRefs.has(targetSearchRef!),
+      m.routeObject.routeRefs.has(targetSearchRef!),
     );
     if (matchIndex !== -1) {
       break;

--- a/packages/frontend-app-api/src/routing/RouteTable.test.ts
+++ b/packages/frontend-app-api/src/routing/RouteTable.test.ts
@@ -116,4 +116,70 @@ describe('RouteTable', () => {
     expect(table.match('/catalog')).toBe('/catalog');
     warnSpy.mockRestore();
   });
+
+  describe('root catch-all dev warning', () => {
+    const env = process.env as Record<string, string | undefined>;
+    const originalEnv = env.NODE_ENV;
+
+    afterEach(() => {
+      env.NODE_ENV = originalEnv;
+    });
+
+    it('should warn when a multi-segment path falls through to root', () => {
+      env.NODE_ENV = 'development';
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const table = new RouteTable(['/', '/catalog']);
+
+      table.match('/unknown/deep/path');
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('fell through to the root "/" catch-all'),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('should not warn for single-segment paths falling through to root', () => {
+      env.NODE_ENV = 'development';
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const table = new RouteTable(['/', '/catalog']);
+
+      table.match('/unknown');
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('should not warn when a non-root route matches', () => {
+      env.NODE_ENV = 'development';
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const table = new RouteTable(['/', '/catalog']);
+
+      table.match('/catalog/foo/bar');
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('should not warn for the root path itself', () => {
+      env.NODE_ENV = 'development';
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const table = new RouteTable(['/']);
+
+      table.match('/');
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('should not warn in production', () => {
+      env.NODE_ENV = 'production';
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const table = new RouteTable(['/', '/catalog']);
+
+      table.match('/unknown/deep/path');
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+  });
 });

--- a/packages/frontend-app-api/src/routing/RouteTable.test.ts
+++ b/packages/frontend-app-api/src/routing/RouteTable.test.ts
@@ -54,4 +54,24 @@ describe('RouteTable', () => {
     const table = new RouteTable(['/catalog']);
     expect(table.match('/catalog/')).toBe('/catalog');
   });
+
+  it('should warn on duplicate base paths', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const table = new RouteTable(['/catalog', '/scaffolder', '/catalog']);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Duplicate base path "/catalog"'),
+    );
+    // Should still work correctly after deduplication
+    expect(table.match('/catalog/foo')).toBe('/catalog');
+    expect(table.match('/scaffolder/bar')).toBe('/scaffolder');
+    warnSpy.mockRestore();
+  });
+
+  it('should not warn when all paths are unique', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    const table = new RouteTable(['/catalog', '/scaffolder', '/']);
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(table.match('/catalog')).toBe('/catalog');
+    warnSpy.mockRestore();
+  });
 });

--- a/packages/frontend-app-api/src/routing/RouteTable.test.ts
+++ b/packages/frontend-app-api/src/routing/RouteTable.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RouteTable } from './RouteTable';
+
+describe('RouteTable', () => {
+  it('should match a simple path', () => {
+    const table = new RouteTable(['/catalog']);
+    expect(table.match('/catalog/foo')).toBe('/catalog');
+  });
+
+  it('should perform longest-prefix match', () => {
+    const table = new RouteTable(['/', '/catalog']);
+    expect(table.match('/catalog/foo')).toBe('/catalog');
+  });
+
+  it('should return undefined for unmatched paths', () => {
+    const table = new RouteTable(['/catalog']);
+    expect(table.match('/unknown')).toBeUndefined();
+  });
+
+  it('should match exact paths', () => {
+    const table = new RouteTable(['/catalog']);
+    expect(table.match('/catalog')).toBe('/catalog');
+  });
+
+  it('should handle root path /', () => {
+    const table = new RouteTable(['/', '/catalog']);
+    expect(table.match('/catalog/foo')).toBe('/catalog');
+    expect(table.match('/unknown')).toBe('/');
+  });
+
+  it('should not match partial prefixes without separator', () => {
+    const table = new RouteTable(['/cat', '/catalog']);
+    expect(table.match('/catalog/foo')).toBe('/catalog');
+    expect(table.match('/cat/foo')).toBe('/cat');
+    expect(table.match('/category')).toBeUndefined();
+  });
+
+  it('should handle trailing slashes', () => {
+    const table = new RouteTable(['/catalog']);
+    expect(table.match('/catalog/')).toBe('/catalog');
+  });
+});

--- a/packages/frontend-app-api/src/routing/RouteTable.test.ts
+++ b/packages/frontend-app-api/src/routing/RouteTable.test.ts
@@ -55,6 +55,48 @@ describe('RouteTable', () => {
     expect(table.match('/catalog/')).toBe('/catalog');
   });
 
+  it('should prefer parameterized entity routes over index routes', () => {
+    const table = new RouteTable([
+      '/catalog',
+      '/catalog/:namespace/:kind/:name',
+    ]);
+
+    expect(table.match('/catalog/default/component/wayback-archive')).toBe(
+      '/catalog/:namespace/:kind/:name',
+    );
+  });
+
+  it('should match nested entity subpaths using parameterized base routes', () => {
+    const table = new RouteTable([
+      '/catalog',
+      '/catalog/:namespace/:kind/:name',
+    ]);
+
+    expect(
+      table.match('/catalog/default/component/wayback-archive/kubernetes'),
+    ).toBe('/catalog/:namespace/:kind/:name');
+  });
+
+  it('should still match the index route for exact /catalog when parameterized route coexists', () => {
+    const table = new RouteTable([
+      '/catalog',
+      '/catalog/:namespace/:kind/:name',
+    ]);
+
+    expect(table.match('/catalog')).toBe('/catalog');
+    expect(table.match('/catalog/')).toBe('/catalog');
+  });
+
+  it('should fall through to the index route for paths with fewer segments than the parameterized route', () => {
+    const table = new RouteTable([
+      '/catalog',
+      '/catalog/:namespace/:kind/:name',
+    ]);
+
+    expect(table.match('/catalog/foo')).toBe('/catalog');
+    expect(table.match('/catalog/foo/bar')).toBe('/catalog');
+  });
+
   it('should warn on duplicate base paths', () => {
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
     const table = new RouteTable(['/catalog', '/scaffolder', '/catalog']);

--- a/packages/frontend-app-api/src/routing/RouteTable.ts
+++ b/packages/frontend-app-api/src/routing/RouteTable.ts
@@ -19,6 +19,8 @@
  *
  * Routes are sorted by length (longest first) so that the most specific
  * prefix wins. The root path `/` acts as a catch-all.
+ *
+ * @internal
  */
 export class RouteTable {
   private readonly paths: string[];

--- a/packages/frontend-app-api/src/routing/RouteTable.ts
+++ b/packages/frontend-app-api/src/routing/RouteTable.ts
@@ -23,7 +23,7 @@
  * @internal
  */
 export class RouteTable {
-  private readonly paths: string[];
+  private readonly paths: Array<{ path: string; matcher?: RegExp }>;
 
   constructor(basePaths: string[]) {
     const seen = new Set<string>();
@@ -38,14 +38,41 @@ export class RouteTable {
       seen.add(path);
     }
     // Deduplicate — first registration wins (order preserved before sort)
-    this.paths = [...new Set(basePaths)].sort((a, b) => b.length - a.length);
+    this.paths = [...new Set(basePaths)]
+      .sort((a, b) => b.length - a.length)
+      .map(path => ({
+        path,
+        matcher: path === '/' ? undefined : compileMatcher(path),
+      }));
   }
 
   match(pathname: string): string | undefined {
-    return this.paths.find(base =>
-      base === '/'
+    return this.paths.find(({ path, matcher }) =>
+      path === '/'
         ? true // root catches everything
-        : pathname === base || pathname.startsWith(`${base}/`),
-    );
+        : matcher?.test(pathname),
+    )?.path;
   }
+}
+
+function compileMatcher(path: string): RegExp {
+  const segments = path.split('/').filter(Boolean);
+  let pattern = '^';
+
+  for (const segment of segments) {
+    if (segment === '*') {
+      pattern += '/.+';
+    } else if (segment.startsWith(':')) {
+      pattern += '/[^/]+';
+    } else {
+      pattern += `/${escapeRegExp(segment)}`;
+    }
+  }
+
+  pattern += '(?:/|$)';
+  return new RegExp(pattern);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/packages/frontend-app-api/src/routing/RouteTable.ts
+++ b/packages/frontend-app-api/src/routing/RouteTable.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Provides longest-prefix URL matching for top-level page routing.
+ *
+ * Routes are sorted by length (longest first) so that the most specific
+ * prefix wins. The root path `/` acts as a catch-all.
+ */
+export class RouteTable {
+  private readonly paths: string[];
+
+  constructor(basePaths: string[]) {
+    this.paths = [...basePaths].sort((a, b) => b.length - a.length);
+  }
+
+  match(pathname: string): string | undefined {
+    return this.paths.find(base =>
+      base === '/'
+        ? true // root catches everything
+        : pathname === base || pathname.startsWith(`${base}/`),
+    );
+  }
+}

--- a/packages/frontend-app-api/src/routing/RouteTable.ts
+++ b/packages/frontend-app-api/src/routing/RouteTable.ts
@@ -22,6 +22,9 @@
  *
  * @internal
  */
+
+import { escapeRegExp } from './escapeRegExp';
+
 export class RouteTable {
   private readonly paths: Array<{ path: string; matcher?: RegExp }>;
 
@@ -47,11 +50,27 @@ export class RouteTable {
   }
 
   match(pathname: string): string | undefined {
-    return this.paths.find(({ path, matcher }) =>
+    const result = this.paths.find(({ path, matcher }) =>
       path === '/'
         ? true // root catches everything
         : matcher?.test(pathname),
     )?.path;
+
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      result === '/' &&
+      pathname !== '/' &&
+      pathname.split('/').filter(Boolean).length > 1
+    ) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[RouteTable] Pathname "${pathname}" fell through to the root "/" catch-all. This may indicate a missing route registration. Registered paths: ${this.paths
+          .map(p => p.path)
+          .join(', ')}`,
+      );
+    }
+
+    return result;
   }
 }
 
@@ -71,8 +90,4 @@ function compileMatcher(path: string): RegExp {
 
   pattern += '(?:/|$)';
   return new RegExp(pattern);
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/packages/frontend-app-api/src/routing/RouteTable.ts
+++ b/packages/frontend-app-api/src/routing/RouteTable.ts
@@ -26,7 +26,19 @@ export class RouteTable {
   private readonly paths: string[];
 
   constructor(basePaths: string[]) {
-    this.paths = [...basePaths].sort((a, b) => b.length - a.length);
+    const seen = new Set<string>();
+    for (const path of basePaths) {
+      if (seen.has(path)) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[RouteTable] Duplicate base path "${path}" registered. ` +
+            `Only one plugin should claim each base path. The first registration wins.`,
+        );
+      }
+      seen.add(path);
+    }
+    // Deduplicate — first registration wins (order preserved before sort)
+    this.paths = [...new Set(basePaths)].sort((a, b) => b.length - a.length);
   }
 
   match(pathname: string): string | undefined {

--- a/packages/frontend-app-api/src/routing/RouteTracker.test.tsx
+++ b/packages/frontend-app-api/src/routing/RouteTracker.test.tsx
@@ -17,17 +17,45 @@
 import { TestApiProvider } from '@backstage/test-utils';
 import { useEffect } from 'react';
 import { BackstageRouteObject } from './types';
-import { fireEvent, render } from '@testing-library/react';
+import { render, act } from '@testing-library/react';
 import { RouteTracker } from './RouteTracker';
-import { Link, MemoryRouter, Route, Routes } from 'react-router-dom';
 import {
   createRouteRef,
   AnalyticsApi,
   analyticsApiRef,
   AppNode,
   useAnalytics,
+  navigationControllerApiRef,
 } from '@backstage/frontend-plugin-api';
 import { MATCH_ALL_ROUTE } from './extractRouteInfoFromAppNode';
+import type { RoutingLocation } from '@backstage/frontend-plugin-api';
+
+function createMockLocationObservable(initial: RoutingLocation) {
+  let current = initial;
+  const subscribers = new Set<(loc: RoutingLocation) => void>();
+
+  return {
+    observable: {
+      subscribe(observer: (loc: RoutingLocation) => void) {
+        subscribers.add(observer);
+        observer(current);
+        return {
+          unsubscribe: () => subscribers.delete(observer),
+          get closed() {
+            return false;
+          },
+        };
+      },
+      [Symbol.observable]() {
+        return this;
+      },
+    },
+    emit(loc: RoutingLocation) {
+      current = loc;
+      subscribers.forEach(fn => fn(loc));
+    },
+  };
+}
 
 describe('RouteTracker', () => {
   const routeRef0 = createRouteRef();
@@ -50,7 +78,7 @@ describe('RouteTracker', () => {
     },
     {
       path: '/path/:p1/:p2',
-      element: <Link to="/path2/hello">go</Link>,
+      element: <div>plugin1 page</div>,
       routeRefs: new Set([routeRef1]),
       caseSensitive: false,
       children: [MATCH_ALL_ROUTE],
@@ -84,14 +112,26 @@ describe('RouteTracker', () => {
     jest.clearAllMocks();
   });
 
-  it('should capture the navigate event on load', async () => {
-    render(
-      <MemoryRouter initialEntries={['/path/foo/bar']}>
-        <TestApiProvider apis={[[analyticsApiRef, mockedAnalytics]]}>
-          <RouteTracker routeObjects={routeObjects} />
-        </TestApiProvider>
-      </MemoryRouter>,
+  function renderWithLocation(location: RoutingLocation) {
+    const mock = createMockLocationObservable(location);
+    const result = render(
+      <TestApiProvider
+        apis={[
+          [analyticsApiRef, mockedAnalytics],
+          [
+            navigationControllerApiRef,
+            { navigate: jest.fn(), location$: mock.observable },
+          ] as any,
+        ]}
+      >
+        <RouteTracker routeObjects={routeObjects} />
+      </TestApiProvider>,
     );
+    return { ...result, emit: mock.emit };
+  }
+
+  it('should capture the navigate event on load', async () => {
+    renderWithLocation({ pathname: '/path/foo/bar', search: '', hash: '' });
 
     expect(mockedAnalytics.captureEvent).toHaveBeenCalledWith({
       action: 'navigate',
@@ -109,21 +149,15 @@ describe('RouteTracker', () => {
   });
 
   it('should capture the navigate event on route change', async () => {
-    const { getByText } = render(
-      <MemoryRouter initialEntries={['/path/foo/bar']}>
-        <TestApiProvider apis={[[analyticsApiRef, mockedAnalytics]]}>
-          <RouteTracker routeObjects={routeObjects} />
+    const { emit } = renderWithLocation({
+      pathname: '/path/foo/bar',
+      search: '',
+      hash: '',
+    });
 
-          <Routes>
-            {routeObjects.map(({ path, element }) => (
-              <Route key={path} path={path || '/'} element={element} />
-            ))}
-          </Routes>
-        </TestApiProvider>
-      </MemoryRouter>,
-    );
-
-    fireEvent.click(getByText('go'));
+    act(() => {
+      emit({ pathname: '/path2/hello', search: '', hash: '' });
+    });
 
     expect(mockedAnalytics.captureEvent).toHaveBeenCalledWith({
       action: 'navigate',
@@ -140,13 +174,11 @@ describe('RouteTracker', () => {
   });
 
   it('should capture path query and hash', async () => {
-    render(
-      <MemoryRouter initialEntries={['/path/foo/bar?q=1#header-1']}>
-        <TestApiProvider apis={[[analyticsApiRef, mockedAnalytics]]}>
-          <RouteTracker routeObjects={routeObjects} />
-        </TestApiProvider>
-      </MemoryRouter>,
-    );
+    renderWithLocation({
+      pathname: '/path/foo/bar',
+      search: '?q=1',
+      hash: '#header-1',
+    });
 
     expect(mockedAnalytics.captureEvent).toHaveBeenCalledWith({
       action: 'navigate',
@@ -164,13 +196,7 @@ describe('RouteTracker', () => {
   });
 
   it('should match the root path and send relevant context', async () => {
-    render(
-      <MemoryRouter initialEntries={['/']}>
-        <TestApiProvider apis={[[analyticsApiRef, mockedAnalytics]]}>
-          <RouteTracker routeObjects={routeObjects} />
-        </TestApiProvider>
-      </MemoryRouter>,
-    );
+    renderWithLocation({ pathname: '/', search: '', hash: '' });
 
     expect(mockedAnalytics.captureEvent).toHaveBeenCalledWith({
       action: 'navigate',
@@ -185,6 +211,12 @@ describe('RouteTracker', () => {
   });
 
   it('should return default context when it would have otherwise matched on the root path', async () => {
+    const mock = createMockLocationObservable({
+      pathname: '/not-routable-extension',
+      search: '',
+      hash: '',
+    });
+
     const Dummy = () => {
       const analytics = useAnalytics();
       useEffect(() => {
@@ -194,14 +226,18 @@ describe('RouteTracker', () => {
     };
 
     render(
-      <MemoryRouter initialEntries={['/not-routable-extension']}>
-        <TestApiProvider apis={[[analyticsApiRef, mockedAnalytics]]}>
-          <RouteTracker routeObjects={routeObjects} />
-          <Routes>
-            <Route path="/not-routable-extension" element={<Dummy />} />
-          </Routes>
-        </TestApiProvider>
-      </MemoryRouter>,
+      <TestApiProvider
+        apis={[
+          [analyticsApiRef, mockedAnalytics],
+          [
+            navigationControllerApiRef,
+            { navigate: jest.fn(), location$: mock.observable },
+          ] as any,
+        ]}
+      >
+        <RouteTracker routeObjects={routeObjects} />
+        <Dummy />
+      </TestApiProvider>,
     );
 
     expect(mockedAnalytics.captureEvent).toHaveBeenNthCalledWith(1, {
@@ -227,13 +263,11 @@ describe('RouteTracker', () => {
   });
 
   it('should return parent route context on navigating to a sub-route', async () => {
-    render(
-      <MemoryRouter initialEntries={['/path2/param-value/sub-route']}>
-        <TestApiProvider apis={[[analyticsApiRef, mockedAnalytics]]}>
-          <RouteTracker routeObjects={routeObjects} />
-        </TestApiProvider>
-      </MemoryRouter>,
-    );
+    renderWithLocation({
+      pathname: '/path2/param-value/sub-route',
+      search: '',
+      hash: '',
+    });
 
     expect(mockedAnalytics.captureEvent).toHaveBeenCalledWith({
       action: 'navigate',

--- a/packages/frontend-app-api/src/routing/RouteTracker.tsx
+++ b/packages/frontend-app-api/src/routing/RouteTracker.tsx
@@ -15,13 +15,14 @@
  */
 
 import { useEffect } from 'react';
-import { matchRoutes, useLocation } from 'react-router-dom';
 import {
   useAnalytics,
+  useFrameworkLocation,
   AnalyticsContext,
   AnalyticsEventAttributes,
 } from '@backstage/frontend-plugin-api';
 import { BackstageRouteObject } from './types';
+import { matchRouteRefs } from './matchRouteRefs';
 
 /**
  * Returns an extension context given the current pathname and a list of
@@ -33,15 +34,15 @@ const getExtensionContext = (
 ) => {
   try {
     // Find matching routes for the given path name.
-    const matches = matchRoutes(routes, { pathname });
+    const matches = matchRouteRefs(routes, pathname);
 
     // Of the matching routes, get the last (e.g. most specific) instance of
     // the BackstageRouteObject that contains a routeRef. Filtering by routeRef
     // ensures subRouteRefs are aligned to their parent routes' context.
     const routeMatch = matches
-      ?.filter(match => match?.route.routeRefs?.size > 0)
+      ?.filter(match => match?.routeObject.routeRefs?.size > 0)
       .pop();
-    const routeObject = routeMatch?.route;
+    const routeObject = routeMatch?.routeObject;
 
     // If there is no route object, then allow inheritance of default context.
     if (!routeObject) {
@@ -109,7 +110,7 @@ export const RouteTracker = ({
 }: {
   routeObjects: BackstageRouteObject[];
 }) => {
-  const { pathname, search, hash } = useLocation();
+  const { pathname, search, hash } = useFrameworkLocation();
 
   const { params, ...attributes } = getExtensionContext(
     pathname,

--- a/packages/frontend-app-api/src/routing/createNestedContracts.test.ts
+++ b/packages/frontend-app-api/src/routing/createNestedContracts.test.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { NavigationController } from './NavigationController';
+import { createNestedContracts } from './createNestedContracts';
+
+describe('createNestedContracts', () => {
+  let controller: NavigationController;
+
+  beforeEach(() => {
+    window.history.replaceState(null, '', '/');
+    controller = new NavigationController();
+  });
+
+  afterEach(() => {
+    controller.dispose();
+  });
+
+  it('should create contracts for each declared sub-path', () => {
+    const result = createNestedContracts({
+      controller,
+      parentBasePath: '/catalog',
+      subPaths: ['entities', 'components'],
+    });
+
+    expect(result.size).toBe(2);
+    expect(result.get('entities')).toBeDefined();
+    expect(result.get('entities')!.basePath).toBe('/catalog/entities');
+    expect(result.get('components')).toBeDefined();
+    expect(result.get('components')!.basePath).toBe('/catalog/components');
+  });
+
+  it('should return an empty map when no sub-paths are declared', () => {
+    const result = createNestedContracts({
+      controller,
+      parentBasePath: '/catalog',
+      subPaths: [],
+    });
+
+    expect(result.size).toBe(0);
+  });
+
+  it('should handle root parent basePath', () => {
+    const result = createNestedContracts({
+      controller,
+      parentBasePath: '/',
+      subPaths: ['catalog'],
+    });
+
+    expect(result.size).toBe(1);
+    expect(result.get('catalog')!.basePath).toBe('/catalog');
+  });
+
+  it('should create navigable contracts', () => {
+    window.history.replaceState(null, '', '/catalog/entities/foo');
+
+    const result = createNestedContracts({
+      controller,
+      parentBasePath: '/catalog',
+      subPaths: ['entities'],
+    });
+
+    const contract = result.get('entities')!;
+    expect(contract.basePath).toBe('/catalog/entities');
+
+    // Contract navigate should work within its scope
+    contract.navigate('/bar');
+    expect(window.location.pathname).toBe('/catalog/entities/bar');
+  });
+
+  it('should handle nested sub-paths with slashes', () => {
+    const result = createNestedContracts({
+      controller,
+      parentBasePath: '/admin',
+      subPaths: ['settings/general', 'settings/security'],
+    });
+
+    expect(result.size).toBe(2);
+    expect(result.get('settings/general')!.basePath).toBe(
+      '/admin/settings/general',
+    );
+    expect(result.get('settings/security')!.basePath).toBe(
+      '/admin/settings/security',
+    );
+  });
+});

--- a/packages/frontend-app-api/src/routing/createNestedContracts.ts
+++ b/packages/frontend-app-api/src/routing/createNestedContracts.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { RoutingContract } from '@backstage/frontend-plugin-api';
+import { NavigationController } from './NavigationController';
+
+/**
+ * Options for {@link createNestedContracts}.
+ *
+ * @internal
+ */
+export interface CreateNestedContractsOptions {
+  /** The NavigationController that owns window.history. */
+  controller: NavigationController;
+  /** The parent extension's base path (e.g. `/catalog`). */
+  parentBasePath: string;
+  /**
+   * Sub-paths relative to the parent base path that need their own
+   * routing contracts. For example, `['entities', 'components']` under
+   * parent `/catalog` creates contracts for `/catalog/entities` and
+   * `/catalog/components`.
+   */
+  subPaths: string[];
+}
+
+/**
+ * Pre-creates scoped {@link RoutingContract} instances for nested
+ * sub-page extensions that declare routing needs.
+ *
+ * @remarks
+ *
+ * This is called during app wiring (in `createSpecializedApp` / tree walk)
+ * to build contracts for extensions that declare `needsRoutingContract`.
+ * Each contract is scoped to `parentBasePath/subPath` and stored in a map
+ * keyed by the sub-path.
+ *
+ * The returned map is intended to be passed to
+ * {@link NestedRoutingContractProvider} so child extensions can retrieve
+ * their contracts via `useNestedRoutingContract(subPath)`.
+ *
+ * @param options - Configuration for nested contract creation.
+ * @returns A map of sub-path to pre-created RoutingContract.
+ *
+ * @internal
+ */
+export function createNestedContracts(
+  options: CreateNestedContractsOptions,
+): Map<string, RoutingContract> {
+  const { controller, parentBasePath, subPaths } = options;
+  const contracts = new Map<string, RoutingContract>();
+
+  for (const subPath of subPaths) {
+    const fullBasePath =
+      parentBasePath === '/' ? `/${subPath}` : `${parentBasePath}/${subPath}`;
+    contracts.set(subPath, controller.createContract(fullBasePath));
+  }
+
+  return contracts;
+}

--- a/packages/frontend-app-api/src/routing/escapeRegExp.ts
+++ b/packages/frontend-app-api/src/routing/escapeRegExp.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** @internal */
+export function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/packages/frontend-app-api/src/routing/generatePath.test.ts
+++ b/packages/frontend-app-api/src/routing/generatePath.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { generatePath } from './generatePath';
+
+describe('generatePath', () => {
+  it('should interpolate params', () => {
+    expect(
+      generatePath('/entity/:kind/:name', {
+        kind: 'component',
+        name: 'foo',
+      }),
+    ).toBe('/entity/component/foo');
+  });
+
+  it('should handle optional params', () => {
+    expect(generatePath('/entity/:id?', {})).toBe('/entity/');
+  });
+
+  it('should handle splat routes', () => {
+    expect(generatePath('/files/*', { '*': 'path/to/file' })).toBe(
+      '/files/path/to/file',
+    );
+  });
+
+  it('should throw for missing required params', () => {
+    expect(() =>
+      generatePath('/entity/:kind/:name', { kind: 'component' }),
+    ).toThrow('Missing required param "name"');
+  });
+
+  it('should not encode param values (RouteResolver handles encoding)', () => {
+    expect(generatePath('/entity/:name', { name: 'foo/bar' })).toBe(
+      '/entity/foo/bar',
+    );
+  });
+
+  it('should handle paths with no params', () => {
+    expect(generatePath('/simple/path')).toBe('/simple/path');
+  });
+
+  it('should collapse double slashes from optional params', () => {
+    expect(generatePath('/a/:b?/c', {})).toBe('/a/c');
+  });
+});

--- a/packages/frontend-app-api/src/routing/generatePath.ts
+++ b/packages/frontend-app-api/src/routing/generatePath.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2026 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/frontend-app-api/src/routing/generatePath.ts
+++ b/packages/frontend-app-api/src/routing/generatePath.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Standalone replacement for react-router's generatePath.
+ *
+ * Replaces `:param` segments with actual values, handles optional
+ * params (`:param?`) and splat routes (`*`).
+ *
+ * Does NOT call encodeURIComponent — RouteResolver handles its own
+ * selective encoding.
+ */
+export function generatePath(
+  pattern: string,
+  params: Record<string, string | undefined> = {},
+): string {
+  return pattern
+    .replace(/:(\w+)(\?)?/g, (_, key, optional) => {
+      const value = params[key];
+      if (value === undefined) {
+        if (!optional) {
+          throw new Error(
+            `Missing required param "${key}" in path "${pattern}"`,
+          );
+        }
+        return '';
+      }
+      return value;
+    })
+    .replace(/\*$/, () => params['*'] ?? '')
+    .replace(/\/\/+/g, '/');
+}

--- a/packages/frontend-app-api/src/routing/matchRouteRefs.test.ts
+++ b/packages/frontend-app-api/src/routing/matchRouteRefs.test.ts
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { matchRouteRefs } from './matchRouteRefs';
+import { BackstageRouteObject } from './types';
+import { createRouteRef, RouteRef } from '@backstage/frontend-plugin-api';
+
+const rest = {
+  element: null,
+  caseSensitive: false,
+  routeRefs: new Set<RouteRef>(),
+};
+
+describe('matchRouteRefs', () => {
+  it('should match a simple path', () => {
+    const routes: BackstageRouteObject[] = [{ ...rest, path: 'catalog' }];
+
+    const result = matchRouteRefs(routes, '/catalog');
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+    expect(result![0].pathname).toBe('/catalog');
+  });
+
+  it('should match parameterized routes', () => {
+    const routes: BackstageRouteObject[] = [
+      { ...rest, path: 'entity/:kind/:name' },
+    ];
+
+    const result = matchRouteRefs(routes, '/entity/component/foo');
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+    expect(result![0].pathname).toBe('/entity/component/foo');
+    expect(result![0].params).toEqual({ kind: 'component', name: 'foo' });
+  });
+
+  it('should match nested routes', () => {
+    const ref1 = createRouteRef();
+    const ref2 = createRouteRef();
+
+    const routes: BackstageRouteObject[] = [
+      {
+        ...rest,
+        path: 'root',
+        routeRefs: new Set([ref1]),
+        children: [{ ...rest, path: 'child', routeRefs: new Set([ref2]) }],
+      },
+    ];
+
+    const result = matchRouteRefs(routes, '/root/child');
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(2);
+    expect(result![0].pathname).toBe('/root');
+    expect(result![0].routeObject.routeRefs).toBe(routes[0].routeRefs);
+    expect(result![1].pathname).toBe('/root/child');
+    expect(result![1].routeObject.routeRefs).toBe(
+      routes[0].children![0].routeRefs,
+    );
+  });
+
+  it('should match splat routes', () => {
+    const routes: BackstageRouteObject[] = [{ ...rest, path: '*' }];
+
+    const result = matchRouteRefs(routes, '/any/nested/path');
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+    expect(result![0].pathname).toBe('/any/nested/path');
+  });
+
+  it('should return the full ancestor chain', () => {
+    const ref1 = createRouteRef();
+    const ref2 = createRouteRef({ params: ['x'] });
+    const ref3 = createRouteRef();
+
+    const routes: BackstageRouteObject[] = [
+      {
+        ...rest,
+        path: 'grandparent/:x',
+        routeRefs: new Set([ref2]),
+        children: [
+          {
+            ...rest,
+            path: 'parent',
+            routeRefs: new Set([ref1]),
+            children: [
+              {
+                ...rest,
+                path: 'child',
+                routeRefs: new Set([ref3]),
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const result = matchRouteRefs(routes, '/grandparent/my-x/parent/child');
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(3);
+    expect(result![0].pathname).toBe('/grandparent/my-x');
+    expect(result![1].pathname).toBe('/grandparent/my-x/parent');
+    expect(result![2].pathname).toBe('/grandparent/my-x/parent/child');
+  });
+
+  it('should return null for unmatched paths', () => {
+    const routes: BackstageRouteObject[] = [{ ...rest, path: 'catalog' }];
+
+    const result = matchRouteRefs(routes, '/unknown');
+    expect(result).toBeNull();
+  });
+
+  it('should prefer specific routes over splat routes', () => {
+    const ref1 = createRouteRef();
+    const ref2 = createRouteRef();
+
+    const routes: BackstageRouteObject[] = [
+      {
+        ...rest,
+        path: 'root',
+        routeRefs: new Set([ref1]),
+        children: [
+          { ...rest, path: '*' },
+          {
+            ...rest,
+            path: 'specific',
+            routeRefs: new Set([ref2]),
+          },
+        ],
+      },
+    ];
+
+    const result = matchRouteRefs(routes, '/root/specific');
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(2);
+    expect(result![1].routeObject.routeRefs).toBe(
+      routes[0].children![1].routeRefs,
+    );
+  });
+
+  it('should fall back to splat when no specific match', () => {
+    const ref1 = createRouteRef();
+
+    const routes: BackstageRouteObject[] = [
+      {
+        ...rest,
+        path: 'root',
+        routeRefs: new Set([ref1]),
+        children: [
+          { ...rest, path: '*' },
+          { ...rest, path: 'specific' },
+        ],
+      },
+    ];
+
+    const result = matchRouteRefs(routes, '/root/anything/else');
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(2);
+    expect(result![1].routeObject.path).toBe('*');
+  });
+
+  it('should handle string location input', () => {
+    const routes: BackstageRouteObject[] = [{ ...rest, path: 'catalog' }];
+
+    const result = matchRouteRefs(routes, '/catalog');
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(1);
+  });
+
+  it('should match parameterized route with catch-all child over empty root route', () => {
+    const ref0 = createRouteRef();
+    const ref1 = createRouteRef();
+
+    const routes: BackstageRouteObject[] = [
+      {
+        ...rest,
+        path: '',
+        routeRefs: new Set([ref0]),
+        children: [{ ...rest, path: '*' }],
+      },
+      {
+        ...rest,
+        path: '/path/:p1/:p2',
+        routeRefs: new Set([ref1]),
+        children: [{ ...rest, path: '*' }],
+      },
+    ];
+
+    const result = matchRouteRefs(routes, '/path/foo/bar');
+    expect(result).not.toBeNull();
+    // Should match the /path/:p1/:p2 route, not the root
+    const paramRoute = result!.find(
+      m => m.routeObject.path === '/path/:p1/:p2',
+    );
+    expect(paramRoute).toBeDefined();
+    expect(paramRoute!.params).toEqual({ p1: 'foo', p2: 'bar' });
+  });
+
+  it('should match sub-route through parameterized parent with catch-all', () => {
+    const ref1 = createRouteRef();
+
+    const routes: BackstageRouteObject[] = [
+      {
+        ...rest,
+        path: '/path2/:param',
+        routeRefs: new Set([ref1]),
+        children: [{ ...rest, path: '*' }],
+      },
+    ];
+
+    const result = matchRouteRefs(routes, '/path2/param-value/sub-route');
+    expect(result).not.toBeNull();
+    const parentMatch = result!.find(
+      m => m.routeObject.path === '/path2/:param',
+    );
+    expect(parentMatch).toBeDefined();
+    expect(parentMatch!.params).toEqual({ param: 'param-value' });
+  });
+});

--- a/packages/frontend-app-api/src/routing/matchRouteRefs.ts
+++ b/packages/frontend-app-api/src/routing/matchRouteRefs.ts
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { BackstageRouteObject } from './types';
+
+/** @internal */
+export interface RouteRefMatch {
+  routeObject: BackstageRouteObject;
+  pathname: string;
+  params: Record<string, string>;
+}
+
+/**
+ * Converts a route path pattern into a RegExp and extracts parameter names.
+ * Handles:
+ *  - Named params like `:id`
+ *  - Catch-all `*` segments
+ *  - Empty path (matches everything as a layout route)
+ */
+function compilePath(
+  pattern: string,
+  end: boolean,
+): { regexp: RegExp; paramNames: string[] } {
+  const paramNames: string[] = [];
+
+  // Empty path matches as a layout/root route
+  if (pattern === '') {
+    return {
+      regexp: new RegExp(end ? '^/$' : '^/'),
+      paramNames,
+    };
+  }
+
+  let regexpSource = '^';
+
+  // Normalize: ensure leading slash, remove trailing slash
+  const normalizedPattern = pattern.startsWith('/') ? pattern : `/${pattern}`;
+  const segments = normalizedPattern.split('/').filter(Boolean);
+
+  for (const segment of segments) {
+    if (segment === '*') {
+      paramNames.push('*');
+      regexpSource += '/(.+)';
+    } else if (segment.startsWith(':')) {
+      paramNames.push(segment.slice(1));
+      regexpSource += '/([^/]+)';
+    } else {
+      regexpSource += `/${escapeRegExp(segment)}`;
+    }
+  }
+
+  if (end) {
+    regexpSource += '/?$';
+  } else {
+    regexpSource += '(?:/|$)';
+  }
+
+  return {
+    regexp: new RegExp(regexpSource, 'i'),
+    paramNames,
+  };
+}
+
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function matchPath(
+  pattern: string,
+  pathname: string,
+  end: boolean,
+): {
+  matched: boolean;
+  matchedPathname: string;
+  params: Record<string, string>;
+} | null {
+  const { regexp, paramNames } = compilePath(pattern, end);
+  const match = pathname.match(regexp);
+
+  if (!match) {
+    return null;
+  }
+
+  const matchedPathname = match[0].replace(/\/$/, '') || '/';
+  const params: Record<string, string> = {};
+
+  for (let i = 0; i < paramNames.length; i++) {
+    const value = match[i + 1];
+    if (value !== undefined) {
+      params[paramNames[i]] = decodeURIComponent(value);
+    }
+  }
+
+  return { matched: true, matchedPathname, params };
+}
+
+/**
+ * Matches a pathname against a tree of BackstageRouteObject route definitions.
+ *
+ * This is a framework-agnostic replacement for react-router's `matchRoutes`.
+ * Returns an array of matches from root to most specific, or null if no match.
+ *
+ * Each match's `pathname` is the full accumulated path from root to that node,
+ * matching react-router's `matchRoutes` behavior.
+ *
+ * @internal
+ */
+export function matchRouteRefs(
+  routes: BackstageRouteObject[],
+  pathname: string,
+): RouteRefMatch[] | null {
+  const matches: RouteRefMatch[] = [];
+  matchRouteBranch(routes, pathname, '', matches);
+  return matches.length > 0 ? matches : null;
+}
+
+function joinPathSegments(base: string, segment: string): string {
+  if (segment === '/') {
+    return base || '/';
+  }
+  const joined = base + segment;
+  return joined || '/';
+}
+
+/**
+ * Compute a priority score for route sorting.
+ * Higher score = more specific = tried first.
+ */
+function routePriority(route: BackstageRouteObject): number {
+  const path = route.path;
+  if (path === '*') return 0; // catch-all is lowest priority
+  if (path === '') return 1; // layout/root route is low priority
+  // Count static and param segments — static segments are worth more
+  const segments = path.replace(/^\//, '').split('/').filter(Boolean);
+  let score = 2;
+  for (const seg of segments) {
+    if (seg === '*') return 1;
+    score += seg.startsWith(':') ? 1 : 2;
+  }
+  return score;
+}
+
+function matchRouteBranch(
+  routes: BackstageRouteObject[],
+  remainingPathname: string,
+  parentPathname: string,
+  matches: RouteRefMatch[],
+): boolean {
+  // Sort routes by specificity: most specific first, splat/empty last
+  const sorted = [...routes].sort(
+    (a, b) => routePriority(b) - routePriority(a),
+  );
+
+  for (const route of sorted) {
+    const hasChildren = route.children && route.children.length > 0;
+
+    if (hasChildren) {
+      const partialResult = matchPath(route.path, remainingPathname, false);
+      if (partialResult) {
+        const savedLength = matches.length;
+        const fullPathname = joinPathSegments(
+          parentPathname,
+          partialResult.matchedPathname,
+        );
+        matches.push({
+          routeObject: route,
+          pathname: fullPathname,
+          params: partialResult.params,
+        });
+
+        let childRemaining = remainingPathname;
+        if (partialResult.matchedPathname !== '/') {
+          childRemaining = remainingPathname.slice(
+            partialResult.matchedPathname.length,
+          );
+          if (!childRemaining.startsWith('/')) {
+            childRemaining = `/${childRemaining}`;
+          }
+        }
+
+        if (
+          matchRouteBranch(
+            route.children!,
+            childRemaining,
+            fullPathname,
+            matches,
+          )
+        ) {
+          return true;
+        }
+
+        // Children didn't match; check if this route itself is an exact match
+        matches.length = savedLength;
+        const exactResult = matchPath(route.path, remainingPathname, true);
+        if (exactResult) {
+          matches.push({
+            routeObject: route,
+            pathname: joinPathSegments(
+              parentPathname,
+              exactResult.matchedPathname,
+            ),
+            params: exactResult.params,
+          });
+          return true;
+        }
+      }
+    } else {
+      const result = matchPath(route.path, remainingPathname, true);
+      if (result) {
+        matches.push({
+          routeObject: route,
+          pathname: joinPathSegments(parentPathname, result.matchedPathname),
+          params: result.params,
+        });
+        return true;
+      }
+    }
+  }
+
+  return false;
+}

--- a/packages/frontend-app-api/src/routing/matchRouteRefs.ts
+++ b/packages/frontend-app-api/src/routing/matchRouteRefs.ts
@@ -15,6 +15,7 @@
  */
 
 import { BackstageRouteObject } from './types';
+import { escapeRegExp } from './escapeRegExp';
 
 /** @internal */
 export interface RouteRefMatch {
@@ -72,10 +73,6 @@ function compilePath(
     regexp: new RegExp(regexpSource),
     paramNames,
   };
-}
-
-function escapeRegExp(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function matchPath(

--- a/packages/frontend-app-api/src/routing/matchRouteRefs.ts
+++ b/packages/frontend-app-api/src/routing/matchRouteRefs.ts
@@ -69,7 +69,7 @@ function compilePath(
   }
 
   return {
-    regexp: new RegExp(regexpSource, 'i'),
+    regexp: new RegExp(regexpSource),
     paramNames,
   };
 }

--- a/packages/frontend-app-api/src/wiring/phaseApis.tsx
+++ b/packages/frontend-app-api/src/wiring/phaseApis.tsx
@@ -37,7 +37,7 @@ import {
   type IdentityApi,
 } from '@backstage/frontend-plugin-api';
 import { NavigationController } from '../routing/NavigationController';
-import { matchRoutes } from 'react-router-dom';
+import { matchRouteRefs } from '../routing/matchRouteRefs';
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import { AppIdentityProxy } from '../../../core-app-api/src/apis/implementations/IdentityApi/AppIdentityProxy';
 import { createRouteAliasResolver } from '../routing/RouteAliasResolver';
@@ -95,11 +95,11 @@ export class AppTreeApiProxy implements AppTreeApi {
       path = path.slice(this.appBasePath.length);
     }
 
-    const matchedRoutes = matchRoutes(routeInfo.routeObjects, path);
+    const matchedRoutes = matchRouteRefs(routeInfo.routeObjects, path);
 
     const matchedAppNodes =
-      matchedRoutes?.flatMap(routeObj => {
-        const appNode = routeObj.route.appNode;
+      matchedRoutes?.flatMap(match => {
+        const appNode = match.routeObject.appNode;
         return appNode ? [appNode] : [];
       }) || [];
 

--- a/packages/frontend-app-api/src/wiring/phaseApis.tsx
+++ b/packages/frontend-app-api/src/wiring/phaseApis.tsx
@@ -25,6 +25,7 @@ import {
   createApiFactory,
   ExternalRouteRef,
   identityApiRef,
+  navigationControllerApiRef,
   RouteFunc,
   RouteRef,
   RouteResolutionApi,
@@ -35,6 +36,7 @@ import {
   type ExtensionFactoryMiddleware,
   type IdentityApi,
 } from '@backstage/frontend-plugin-api';
+import { NavigationController } from '../routing/NavigationController';
 import { matchRoutes } from 'react-router-dom';
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import { AppIdentityProxy } from '../../../core-app-api/src/apis/implementations/IdentityApi/AppIdentityProxy';
@@ -213,6 +215,9 @@ export function createPhaseApis(options: {
     options.appBasePath,
   );
   const identityProxy = new PreparedAppIdentityProxy();
+  const navigationController = new NavigationController({
+    basename: options.appBasePath || undefined,
+  });
   const phaseApiRegistry = new FrontendApiRegistry();
   phaseApiRegistry.registerAll([
     createApiFactory(appTreeApiRef, appTreeApi),
@@ -221,6 +226,7 @@ export function createPhaseApis(options: {
       : []),
     createApiFactory(routeResolutionApiRef, routeResolutionApi),
     createApiFactory(identityApiRef, identityProxy),
+    createApiFactory(navigationControllerApiRef, navigationController),
     ...options.staticFactories,
   ]);
 
@@ -235,6 +241,7 @@ export function createPhaseApis(options: {
     routeResolutionApi,
     appTreeApi,
     identityApiProxy: identityProxy,
+    navigationController,
   };
 }
 

--- a/packages/frontend-plugin-api/src/blueprints/PageBlueprint.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/PageBlueprint.tsx
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { JSX } from 'react';
+import { JSX, useContext } from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import { IconElement } from '../icons/types';
-import { RouteRef } from '../routing';
+import { RouteRef, RoutingContractContext } from '../routing';
 import {
   coreExtensionData,
   createExtensionBlueprint,
@@ -28,6 +28,7 @@ import { useApi } from '../apis/system';
 import { routeResolutionApiRef } from '../apis/definitions/RouteResolutionApi';
 import { pluginHeaderActionsApiRef } from '../apis/definitions/PluginHeaderActionsApi';
 import { RouteResolutionApi } from '../apis/definitions/RouteResolutionApi';
+import { ScopedRouterProvider } from './ScopedRouterProvider';
 
 function resolveTitleLink(
   routeResolutionApi: RouteResolutionApi,
@@ -142,30 +143,34 @@ export const PageBlueprint = createExtensionBlueprint({
         const headerActionsApi = useApi(pluginHeaderActionsApiRef);
         const headerActions = headerActionsApi.getPluginHeaderActions(pluginId);
 
+        const contract = useContext(RoutingContractContext);
+
         return (
-          <PageLayout
-            title={resolvedTitle}
-            icon={resolvedIcon}
-            tabs={tabs}
-            titleLink={titleLink}
-            headerActions={headerActions}
-          >
-            <Routes>
-              {firstPagePath && (
-                <Route
-                  index
-                  element={<Navigate to={firstPagePath} replace />}
-                />
-              )}
-              {inputs.pages.map((page, index) => {
-                const path = page.get(coreExtensionData.routePath);
-                const element = page.get(coreExtensionData.reactElement);
-                return (
-                  <Route key={index} path={`${path}/*`} element={element} />
-                );
-              })}
-            </Routes>
-          </PageLayout>
+          <ScopedRouterProvider contract={contract}>
+            <PageLayout
+              title={resolvedTitle}
+              icon={resolvedIcon}
+              tabs={tabs}
+              titleLink={titleLink}
+              headerActions={headerActions}
+            >
+              <Routes>
+                {firstPagePath && (
+                  <Route
+                    index
+                    element={<Navigate to={firstPagePath} replace />}
+                  />
+                )}
+                {inputs.pages.map((page, index) => {
+                  const path = page.get(coreExtensionData.routePath);
+                  const element = page.get(coreExtensionData.reactElement);
+                  return (
+                    <Route key={index} path={`${path}/*`} element={element} />
+                  );
+                })}
+              </Routes>
+            </PageLayout>
+          </ScopedRouterProvider>
         );
       };
 

--- a/packages/frontend-plugin-api/src/blueprints/ScopedRouterProvider.test.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/ScopedRouterProvider.test.tsx
@@ -24,15 +24,21 @@ function createMockContract(
     pathname: '/',
     search: '',
     hash: '',
+    state: null,
   },
 ): RoutingContract & {
   pushLocation: (loc: RoutingLocation) => void;
-  navigateCalls: Array<{ to: string; options?: { replace?: boolean } }>;
+  navigateCalls: Array<{
+    to: string;
+    options?: { replace?: boolean; state?: unknown };
+  }>;
 } {
   let currentLocation = initialLocation;
   const listeners = new Set<(loc: RoutingLocation) => void>();
-  const navigateCalls: Array<{ to: string; options?: { replace?: boolean } }> =
-    [];
+  const navigateCalls: Array<{
+    to: string;
+    options?: { replace?: boolean; state?: unknown };
+  }> = [];
 
   return {
     basePath: '/test',
@@ -62,7 +68,7 @@ function createMockContract(
         return this;
       },
     },
-    navigate(to: string, options?: { replace?: boolean }) {
+    navigate(to: string, options?: { replace?: boolean; state?: unknown }) {
       navigateCalls.push({ to, options });
     },
     pushLocation(loc: RoutingLocation) {
@@ -79,6 +85,7 @@ describe('ScopedRouterProvider', () => {
       pathname: '/hello',
       search: '',
       hash: '',
+      state: null,
     });
 
     const { getByText } = render(
@@ -98,6 +105,7 @@ describe('ScopedRouterProvider', () => {
       pathname: '/',
       search: '',
       hash: '',
+      state: null,
     });
 
     render(
@@ -118,6 +126,7 @@ describe('ScopedRouterProvider', () => {
       pathname: '/page-a',
       search: '',
       hash: '',
+      state: null,
     });
 
     function LocationDisplay() {
@@ -138,10 +147,36 @@ describe('ScopedRouterProvider', () => {
         pathname: '/page-b',
         search: '',
         hash: '',
+        state: null,
       });
     });
 
     expect(getByTestId('location').textContent).toBe('/page-b');
+  });
+
+  it('should pass state through to useLocation().state', () => {
+    const contract = createMockContract({
+      pathname: '/page',
+      search: '',
+      hash: '',
+      state: { from: '/login', returnTo: '/dashboard' },
+    });
+
+    function StateDisplay() {
+      const location = useLocation();
+      return <div data-testid="state">{JSON.stringify(location.state)}</div>;
+    }
+
+    const { getByTestId } = render(
+      <ScopedRouterProvider contract={contract}>
+        <StateDisplay />
+      </ScopedRouterProvider>,
+    );
+
+    expect(JSON.parse(getByTestId('state').textContent!)).toEqual({
+      from: '/login',
+      returnTo: '/dashboard',
+    });
   });
 
   it('should render children directly when no contract is provided', () => {

--- a/packages/frontend-plugin-api/src/blueprints/ScopedRouterProvider.test.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/ScopedRouterProvider.test.tsx
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, act } from '@testing-library/react';
+import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
+import type { RoutingContract, RoutingLocation } from '../routing';
+import { ScopedRouterProvider } from './ScopedRouterProvider';
+
+function createMockContract(
+  initialLocation: RoutingLocation = {
+    pathname: '/',
+    search: '',
+    hash: '',
+  },
+): RoutingContract & {
+  pushLocation: (loc: RoutingLocation) => void;
+  navigateCalls: Array<{ to: string; options?: { replace?: boolean } }>;
+} {
+  let currentLocation = initialLocation;
+  const listeners = new Set<(loc: RoutingLocation) => void>();
+  const navigateCalls: Array<{ to: string; options?: { replace?: boolean } }> =
+    [];
+
+  return {
+    basePath: '/test',
+    location$: {
+      subscribe(
+        observerOrNext?:
+          | { next?: (value: RoutingLocation) => void }
+          | ((value: RoutingLocation) => void),
+      ) {
+        const next =
+          typeof observerOrNext === 'function'
+            ? observerOrNext
+            : observerOrNext?.next;
+        if (next) {
+          listeners.add(next);
+          // Emit current value on subscribe (BehaviorSubject-like)
+          next(currentLocation);
+        }
+        return {
+          unsubscribe: () => {
+            if (next) listeners.delete(next);
+          },
+          closed: false,
+        };
+      },
+      [Symbol.observable]() {
+        return this;
+      },
+    },
+    navigate(to: string, options?: { replace?: boolean }) {
+      navigateCalls.push({ to, options });
+    },
+    pushLocation(loc: RoutingLocation) {
+      currentLocation = loc;
+      listeners.forEach(fn => fn(currentLocation));
+    },
+    navigateCalls,
+  };
+}
+
+describe('ScopedRouterProvider', () => {
+  it('should provide a scoped React Router context for Routes/Route', () => {
+    const contract = createMockContract({
+      pathname: '/hello',
+      search: '',
+      hash: '',
+    });
+
+    const { getByText } = render(
+      <ScopedRouterProvider contract={contract}>
+        <Routes>
+          <Route path="/hello" element={<div>Hello Page</div>} />
+          <Route path="*" element={<div>Not Found</div>} />
+        </Routes>
+      </ScopedRouterProvider>,
+    );
+
+    expect(getByText('Hello Page')).toBeInTheDocument();
+  });
+
+  it('should support Navigate redirects within scoped context', () => {
+    const contract = createMockContract({
+      pathname: '/',
+      search: '',
+      hash: '',
+    });
+
+    render(
+      <ScopedRouterProvider contract={contract}>
+        <Routes>
+          <Route index element={<Navigate to="/target" replace />} />
+          <Route path="/target" element={<div>Target Page</div>} />
+        </Routes>
+      </ScopedRouterProvider>,
+    );
+
+    // Navigate should trigger contract.navigate
+    expect(contract.navigateCalls.length).toBeGreaterThan(0);
+  });
+
+  it('should update when the contract location changes', () => {
+    const contract = createMockContract({
+      pathname: '/page-a',
+      search: '',
+      hash: '',
+    });
+
+    function LocationDisplay() {
+      const location = useLocation();
+      return <div data-testid="location">{location.pathname}</div>;
+    }
+
+    const { getByTestId } = render(
+      <ScopedRouterProvider contract={contract}>
+        <LocationDisplay />
+      </ScopedRouterProvider>,
+    );
+
+    expect(getByTestId('location').textContent).toBe('/page-a');
+
+    act(() => {
+      contract.pushLocation({
+        pathname: '/page-b',
+        search: '',
+        hash: '',
+      });
+    });
+
+    expect(getByTestId('location').textContent).toBe('/page-b');
+  });
+
+  it('should render children directly when no contract is provided', () => {
+    const { getByText } = render(
+      <ScopedRouterProvider contract={undefined}>
+        <div>Passthrough Content</div>
+      </ScopedRouterProvider>,
+    );
+
+    expect(getByText('Passthrough Content')).toBeInTheDocument();
+  });
+});

--- a/packages/frontend-plugin-api/src/blueprints/ScopedRouterProvider.test.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/ScopedRouterProvider.test.tsx
@@ -15,8 +15,16 @@
  */
 
 import { render, act } from '@testing-library/react';
-import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
-import type { RoutingContract, RoutingLocation } from '../routing';
+import {
+  Routes,
+  Route,
+  Navigate,
+  useLocation,
+  useHref,
+  useNavigate,
+  useResolvedPath,
+} from 'react-router-dom';
+import { RoutingContract, RoutingLocation } from '../routing';
 import { ScopedRouterProvider } from './ScopedRouterProvider';
 
 function createMockContract(
@@ -187,5 +195,224 @@ describe('ScopedRouterProvider', () => {
     );
 
     expect(getByText('Passthrough Content')).toBeInTheDocument();
+  });
+
+  describe('basename support', () => {
+    it('should produce correct href with basename', () => {
+      const contract = createMockContract({
+        pathname: '/',
+        search: '',
+        hash: '',
+        state: null,
+      });
+
+      function HrefDisplay() {
+        const href = useHref('/catalog');
+        return <div data-testid="href">{href}</div>;
+      }
+
+      const { getByTestId } = render(
+        <ScopedRouterProvider contract={contract} basename="/backstage">
+          <HrefDisplay />
+        </ScopedRouterProvider>,
+      );
+
+      // useHref("/catalog") with basename="/backstage" should produce "/backstage/catalog"
+      expect(getByTestId('href').textContent).toBe('/backstage/catalog');
+    });
+
+    it('should strip basename before forwarding navigate to contract', () => {
+      const contract = createMockContract({
+        pathname: '/',
+        search: '',
+        hash: '',
+        state: null,
+      });
+
+      function NavTrigger() {
+        const navigate = useNavigate();
+        return (
+          <button onClick={() => navigate('/catalog')} data-testid="nav-btn">
+            Navigate
+          </button>
+        );
+      }
+
+      const { getByTestId } = render(
+        <ScopedRouterProvider contract={contract} basename="/backstage">
+          <NavTrigger />
+        </ScopedRouterProvider>,
+      );
+
+      act(() => {
+        getByTestId('nav-btn').click();
+      });
+
+      // React Router prepends basename -> "/backstage/catalog"
+      // navigator.push should strip basename before calling contract.navigate
+      // so the contract receives "/catalog" (without basename)
+      expect(contract.navigateCalls).toEqual([
+        { to: '/catalog', options: { state: undefined } },
+      ]);
+    });
+
+    it('should strip basename from replace navigation', () => {
+      const contract = createMockContract({
+        pathname: '/',
+        search: '',
+        hash: '',
+        state: null,
+      });
+
+      function NavTrigger() {
+        const navigate = useNavigate();
+        return (
+          <button
+            onClick={() => navigate('/settings', { replace: true })}
+            data-testid="nav-btn"
+          >
+            Navigate
+          </button>
+        );
+      }
+
+      const { getByTestId } = render(
+        <ScopedRouterProvider contract={contract} basename="/backstage">
+          <NavTrigger />
+        </ScopedRouterProvider>,
+      );
+
+      act(() => {
+        getByTestId('nav-btn').click();
+      });
+
+      expect(contract.navigateCalls).toEqual([
+        {
+          to: '/settings',
+          options: { replace: true, state: undefined },
+        },
+      ]);
+    });
+
+    it('should default basename to empty string', () => {
+      const contract = createMockContract({
+        pathname: '/',
+        search: '',
+        hash: '',
+        state: null,
+      });
+
+      function HrefDisplay() {
+        const href = useHref('/catalog');
+        return <div data-testid="href">{href}</div>;
+      }
+
+      const { getByTestId } = render(
+        <ScopedRouterProvider contract={contract}>
+          <HrefDisplay />
+        </ScopedRouterProvider>,
+      );
+
+      // Without basename, href should be just "/catalog"
+      expect(getByTestId('href').textContent).toBe('/catalog');
+    });
+  });
+
+  describe('RouteContext provider', () => {
+    it('should provide RouteContext so useResolvedPath works', () => {
+      const contract = createMockContract({
+        pathname: '/current',
+        search: '',
+        hash: '',
+        state: null,
+      });
+
+      function ResolvedPathDisplay() {
+        const resolved = useResolvedPath('/absolute');
+        return <div data-testid="resolved">{resolved.pathname}</div>;
+      }
+
+      const { getByTestId } = render(
+        <ScopedRouterProvider contract={contract}>
+          <ResolvedPathDisplay />
+        </ScopedRouterProvider>,
+      );
+
+      // Absolute path should resolve to itself
+      expect(getByTestId('resolved').textContent).toBe('/absolute');
+    });
+  });
+
+  describe('root contract (desync fix)', () => {
+    it('should reflect location changes immediately from contract', () => {
+      const contract = createMockContract({
+        pathname: '/initial',
+        search: '',
+        hash: '',
+        state: null,
+      });
+
+      function LocationDisplay() {
+        const location = useLocation();
+        return <div data-testid="location">{location.pathname}</div>;
+      }
+
+      const { getByTestId } = render(
+        <ScopedRouterProvider contract={contract}>
+          <LocationDisplay />
+        </ScopedRouterProvider>,
+      );
+
+      expect(getByTestId('location').textContent).toBe('/initial');
+
+      // Simulate NavigationController emitting a new location
+      act(() => {
+        contract.pushLocation({
+          pathname: '/catalog/entity/foo',
+          search: '',
+          hash: '',
+          state: null,
+        });
+      });
+
+      // Should update immediately — no stale state
+      expect(getByTestId('location').textContent).toBe('/catalog/entity/foo');
+    });
+
+    it('should allow nesting plugin ScopedRouterProvider inside root', () => {
+      const rootContract = createMockContract({
+        pathname: '/catalog/entity/foo',
+        search: '',
+        hash: '',
+        state: null,
+      });
+
+      const pluginContract = createMockContract({
+        pathname: '/entity/foo',
+        search: '',
+        hash: '',
+        state: null,
+      });
+
+      function LocationDisplay({ testId }: { testId: string }) {
+        const location = useLocation();
+        return <div data-testid={testId}>{location.pathname}</div>;
+      }
+
+      const { getByTestId } = render(
+        <ScopedRouterProvider contract={rootContract}>
+          <LocationDisplay testId="root-location" />
+          <ScopedRouterProvider contract={pluginContract}>
+            <LocationDisplay testId="plugin-location" />
+          </ScopedRouterProvider>
+        </ScopedRouterProvider>,
+      );
+
+      // Root sees full path, plugin sees scoped path
+      expect(getByTestId('root-location').textContent).toBe(
+        '/catalog/entity/foo',
+      );
+      expect(getByTestId('plugin-location').textContent).toBe('/entity/foo');
+    });
   });
 });

--- a/packages/frontend-plugin-api/src/blueprints/ScopedRouterProvider.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/ScopedRouterProvider.tsx
@@ -54,11 +54,14 @@ export function ScopedRouterProvider(props: {
 
 function toPath(
   to: string | { pathname?: string; search?: string; hash?: string },
+  currentPathname: string,
 ): string {
   if (typeof to === 'string') {
     return to;
   }
-  let path = to.pathname ?? '/';
+  // Use current pathname when To.pathname is undefined (e.g., useSearchParams
+  // updates only search params without specifying a pathname)
+  let path = to.pathname ?? currentPathname;
   if (to.search) path += to.search;
   if (to.hash) path += to.hash;
   return path;
@@ -80,10 +83,10 @@ function ScopedRouterProviderInner(props: {
       pathname: location.pathname,
       search: location.search,
       hash: location.hash,
-      state: null,
+      state: location.state ?? null,
       key: 'default',
     }),
-    [location.pathname, location.search, location.hash],
+    [location.pathname, location.search, location.hash, location.state],
   );
 
   const navigator = useMemo(
@@ -97,16 +100,23 @@ function ScopedRouterProviderInner(props: {
       go(delta: number) {
         window.history.go(delta);
       },
-      push(to: string | { pathname?: string; search?: string; hash?: string }) {
-        contract.navigate(toPath(to));
+      push(
+        to: string | { pathname?: string; search?: string; hash?: string },
+        state?: unknown,
+      ) {
+        contract.navigate(toPath(to, location.pathname), { state });
       },
       replace(
         to: string | { pathname?: string; search?: string; hash?: string },
+        state?: unknown,
       ) {
-        contract.navigate(toPath(to), { replace: true });
+        contract.navigate(toPath(to, location.pathname), {
+          replace: true,
+          state,
+        });
       },
     }),
-    [contract],
+    [contract, location.pathname],
   );
 
   const navigationContextValue = useMemo(

--- a/packages/frontend-plugin-api/src/blueprints/ScopedRouterProvider.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/ScopedRouterProvider.tsx
@@ -14,18 +14,17 @@
  * limitations under the License.
  */
 
-import React, {
-  useCallback,
-  useMemo,
-  useRef,
-  useSyncExternalStore,
-} from 'react';
+import { useMemo, type ReactNode } from 'react';
 import {
   UNSAFE_LocationContext,
   UNSAFE_NavigationContext,
   NavigationType,
 } from 'react-router-dom';
-import type { RoutingContract, RoutingLocation } from '../routing';
+import type { RoutingContract } from '../routing';
+import {
+  useObservableAsState,
+  routingLocationEqual,
+} from '../routing/useObservableAsState';
 
 /**
  * Sets up a scoped React Router v6 context from a RoutingContract.
@@ -38,7 +37,7 @@ import type { RoutingContract, RoutingLocation } from '../routing';
  */
 export function ScopedRouterProvider(props: {
   contract: RoutingContract | undefined;
-  children: React.ReactNode;
+  children: ReactNode;
 }) {
   const { contract, children } = props;
 
@@ -67,44 +66,14 @@ function toPath(
 
 function ScopedRouterProviderInner(props: {
   contract: RoutingContract;
-  children: React.ReactNode;
+  children: ReactNode;
 }) {
   const { contract, children } = props;
 
-  // Get the initial location synchronously from the contract's observable.
-  // NavigationController.location$ emits synchronously on subscribe.
-  const [initialLocation] = React.useState(() => {
-    let initial: RoutingLocation = { pathname: '/', search: '', hash: '' };
-    const sub = contract.location$.subscribe(loc => {
-      initial = loc;
-    });
-    sub.unsubscribe();
-    return initial;
-  });
-
-  const locationRef = useRef<RoutingLocation>(initialLocation);
-
-  const subscribe = useCallback(
-    (onStoreChange: () => void) => {
-      const sub = contract.location$.subscribe(loc => {
-        const prev = locationRef.current;
-        if (
-          prev.pathname !== loc.pathname ||
-          prev.search !== loc.search ||
-          prev.hash !== loc.hash
-        ) {
-          locationRef.current = loc;
-          onStoreChange();
-        }
-      });
-      return () => sub.unsubscribe();
-    },
-    [contract],
+  const location = useObservableAsState(
+    contract.location$,
+    routingLocationEqual,
   );
-
-  const getSnapshot = useCallback(() => locationRef.current, []);
-
-  const location = useSyncExternalStore(subscribe, getSnapshot);
 
   const routerLocation = useMemo(
     () => ({

--- a/packages/frontend-plugin-api/src/blueprints/ScopedRouterProvider.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/ScopedRouterProvider.tsx
@@ -14,19 +14,18 @@
  * limitations under the License.
  */
 
-import React, { useMemo, useState, useEffect } from 'react';
+import React, {
+  useCallback,
+  useMemo,
+  useRef,
+  useSyncExternalStore,
+} from 'react';
 import {
   UNSAFE_LocationContext,
   UNSAFE_NavigationContext,
   NavigationType,
 } from 'react-router-dom';
 import type { RoutingContract, RoutingLocation } from '../routing';
-
-const defaultLocation: RoutingLocation = {
-  pathname: '/',
-  search: '',
-  hash: '',
-};
 
 /**
  * Sets up a scoped React Router v6 context from a RoutingContract.
@@ -54,20 +53,58 @@ export function ScopedRouterProvider(props: {
   );
 }
 
+function toPath(
+  to: string | { pathname?: string; search?: string; hash?: string },
+): string {
+  if (typeof to === 'string') {
+    return to;
+  }
+  let path = to.pathname ?? '/';
+  if (to.search) path += to.search;
+  if (to.hash) path += to.hash;
+  return path;
+}
+
 function ScopedRouterProviderInner(props: {
   contract: RoutingContract;
   children: React.ReactNode;
 }) {
   const { contract, children } = props;
 
-  const [location, setLocation] = useState<RoutingLocation>(defaultLocation);
-
-  useEffect(() => {
-    const subscription = contract.location$.subscribe({
-      next: (loc: RoutingLocation) => setLocation(loc),
+  // Get the initial location synchronously from the contract's observable.
+  // NavigationController.location$ emits synchronously on subscribe.
+  const [initialLocation] = React.useState(() => {
+    let initial: RoutingLocation = { pathname: '/', search: '', hash: '' };
+    const sub = contract.location$.subscribe(loc => {
+      initial = loc;
     });
-    return () => subscription.unsubscribe();
-  }, [contract]);
+    sub.unsubscribe();
+    return initial;
+  });
+
+  const locationRef = useRef<RoutingLocation>(initialLocation);
+
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      const sub = contract.location$.subscribe(loc => {
+        const prev = locationRef.current;
+        if (
+          prev.pathname !== loc.pathname ||
+          prev.search !== loc.search ||
+          prev.hash !== loc.hash
+        ) {
+          locationRef.current = loc;
+          onStoreChange();
+        }
+      });
+      return () => sub.unsubscribe();
+    },
+    [contract],
+  );
+
+  const getSnapshot = useCallback(() => locationRef.current, []);
+
+  const location = useSyncExternalStore(subscribe, getSnapshot);
 
   const routerLocation = useMemo(
     () => ({
@@ -88,18 +125,16 @@ function ScopedRouterProviderInner(props: {
         if (to.hash) href += to.hash;
         return href;
       },
-      go(_delta: number) {
-        // Not supported via RoutingContract
+      go(delta: number) {
+        window.history.go(delta);
       },
       push(to: string | { pathname?: string; search?: string; hash?: string }) {
-        const path = typeof to === 'string' ? to : to.pathname ?? '/';
-        contract.navigate(path);
+        contract.navigate(toPath(to));
       },
       replace(
         to: string | { pathname?: string; search?: string; hash?: string },
       ) {
-        const path = typeof to === 'string' ? to : to.pathname ?? '/';
-        contract.navigate(path, { replace: true });
+        contract.navigate(toPath(to), { replace: true });
       },
     }),
     [contract],

--- a/packages/frontend-plugin-api/src/blueprints/ScopedRouterProvider.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/ScopedRouterProvider.tsx
@@ -18,6 +18,7 @@ import { useMemo, type ReactNode } from 'react';
 import {
   UNSAFE_LocationContext,
   UNSAFE_NavigationContext,
+  UNSAFE_RouteContext,
   NavigationType,
 } from 'react-router-dom';
 import type { RoutingContract } from '../routing';
@@ -29,24 +30,26 @@ import {
 /**
  * Sets up a scoped React Router v6 context from a RoutingContract.
  *
- * This uses the UNSAFE_ context APIs from react-router directly
- * instead of `<Router>`, which would throw when nested inside the
- * global `<BrowserRouter>` during Phase A.
+ * Uses the UNSAFE_ context APIs from react-router directly instead of
+ * `<Router>`, which throws when nested inside another router. This
+ * allows multiple independent ScopedRouterProviders (root + per-plugin)
+ * without router nesting conflicts.
  *
  * @internal
  */
 export function ScopedRouterProvider(props: {
   contract: RoutingContract | undefined;
   children: ReactNode;
+  basename?: string;
 }) {
-  const { contract, children } = props;
+  const { contract, children, basename = '' } = props;
 
   if (!contract) {
     return <>{children}</>;
   }
 
   return (
-    <ScopedRouterProviderInner contract={contract}>
+    <ScopedRouterProviderInner contract={contract} basename={basename}>
       {children}
     </ScopedRouterProviderInner>
   );
@@ -67,11 +70,19 @@ function toPath(
   return path;
 }
 
+function stripBasename(path: string, basename: string): string {
+  if (!basename) return path;
+  if (path === basename) return '/';
+  if (path.startsWith(`${basename}/`)) return path.slice(basename.length);
+  return path;
+}
+
 function ScopedRouterProviderInner(props: {
   contract: RoutingContract;
   children: ReactNode;
+  basename: string;
 }) {
-  const { contract, children } = props;
+  const { contract, children, basename } = props;
 
   const location = useObservableAsState(
     contract.location$,
@@ -104,31 +115,33 @@ function ScopedRouterProviderInner(props: {
         to: string | { pathname?: string; search?: string; hash?: string },
         state?: unknown,
       ) {
-        contract.navigate(toPath(to, location.pathname), { state });
+        const path = toPath(to, location.pathname);
+        contract.navigate(stripBasename(path, basename), { state });
       },
       replace(
         to: string | { pathname?: string; search?: string; hash?: string },
         state?: unknown,
       ) {
-        contract.navigate(toPath(to, location.pathname), {
+        const path = toPath(to, location.pathname);
+        contract.navigate(stripBasename(path, basename), {
           replace: true,
           state,
         });
       },
     }),
-    [contract, location.pathname],
+    [contract, location.pathname, basename],
   );
 
   const navigationContextValue = useMemo(
     () => ({
-      basename: '',
+      basename,
       navigator,
       static: false,
       future: {
         v7_relativeSplatPath: false,
       },
     }),
-    [navigator],
+    [basename, navigator],
   );
 
   const locationContextValue = useMemo(
@@ -139,10 +152,21 @@ function ScopedRouterProviderInner(props: {
     [routerLocation],
   );
 
+  const routeContextValue = useMemo(
+    () => ({
+      outlet: null,
+      matches: [],
+      isDataRoute: false,
+    }),
+    [],
+  );
+
   return (
     <UNSAFE_NavigationContext.Provider value={navigationContextValue}>
       <UNSAFE_LocationContext.Provider value={locationContextValue}>
-        {children}
+        <UNSAFE_RouteContext.Provider value={routeContextValue}>
+          {children}
+        </UNSAFE_RouteContext.Provider>
       </UNSAFE_LocationContext.Provider>
     </UNSAFE_NavigationContext.Provider>
   );

--- a/packages/frontend-plugin-api/src/blueprints/ScopedRouterProvider.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/ScopedRouterProvider.tsx
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useMemo, useState, useEffect } from 'react';
+import {
+  UNSAFE_LocationContext,
+  UNSAFE_NavigationContext,
+  NavigationType,
+} from 'react-router-dom';
+import type { RoutingContract, RoutingLocation } from '../routing';
+
+const defaultLocation: RoutingLocation = {
+  pathname: '/',
+  search: '',
+  hash: '',
+};
+
+/**
+ * Sets up a scoped React Router v6 context from a RoutingContract.
+ *
+ * This uses the UNSAFE_ context APIs from react-router directly
+ * instead of `<Router>`, which would throw when nested inside the
+ * global `<BrowserRouter>` during Phase A.
+ *
+ * @internal
+ */
+export function ScopedRouterProvider(props: {
+  contract: RoutingContract | undefined;
+  children: React.ReactNode;
+}) {
+  const { contract, children } = props;
+
+  if (!contract) {
+    return <>{children}</>;
+  }
+
+  return (
+    <ScopedRouterProviderInner contract={contract}>
+      {children}
+    </ScopedRouterProviderInner>
+  );
+}
+
+function ScopedRouterProviderInner(props: {
+  contract: RoutingContract;
+  children: React.ReactNode;
+}) {
+  const { contract, children } = props;
+
+  const [location, setLocation] = useState<RoutingLocation>(defaultLocation);
+
+  useEffect(() => {
+    const subscription = contract.location$.subscribe({
+      next: (loc: RoutingLocation) => setLocation(loc),
+    });
+    return () => subscription.unsubscribe();
+  }, [contract]);
+
+  const routerLocation = useMemo(
+    () => ({
+      pathname: location.pathname,
+      search: location.search,
+      hash: location.hash,
+      state: null,
+      key: 'default',
+    }),
+    [location.pathname, location.search, location.hash],
+  );
+
+  const navigator = useMemo(
+    () => ({
+      createHref(to: { pathname?: string; search?: string; hash?: string }) {
+        let href = to.pathname ?? '';
+        if (to.search) href += to.search;
+        if (to.hash) href += to.hash;
+        return href;
+      },
+      go(_delta: number) {
+        // Not supported via RoutingContract
+      },
+      push(to: string | { pathname?: string; search?: string; hash?: string }) {
+        const path = typeof to === 'string' ? to : to.pathname ?? '/';
+        contract.navigate(path);
+      },
+      replace(
+        to: string | { pathname?: string; search?: string; hash?: string },
+      ) {
+        const path = typeof to === 'string' ? to : to.pathname ?? '/';
+        contract.navigate(path, { replace: true });
+      },
+    }),
+    [contract],
+  );
+
+  const navigationContextValue = useMemo(
+    () => ({
+      basename: '',
+      navigator,
+      static: false,
+      future: {
+        v7_relativeSplatPath: false,
+      },
+    }),
+    [navigator],
+  );
+
+  const locationContextValue = useMemo(
+    () => ({
+      location: routerLocation,
+      navigationType: NavigationType.Pop,
+    }),
+    [routerLocation],
+  );
+
+  return (
+    <UNSAFE_NavigationContext.Provider value={navigationContextValue}>
+      <UNSAFE_LocationContext.Provider value={locationContextValue}>
+        {children}
+      </UNSAFE_LocationContext.Provider>
+    </UNSAFE_NavigationContext.Provider>
+  );
+}

--- a/packages/frontend-plugin-api/src/routing/NavigationControllerApi.ts
+++ b/packages/frontend-plugin-api/src/routing/NavigationControllerApi.ts
@@ -20,7 +20,10 @@ import type { RoutingLocation } from './RoutingContract';
 
 /** @public */
 export interface NavigationControllerApi {
-  navigate(path: string, options?: { replace?: boolean }): void;
+  navigate(
+    path: string,
+    options?: { replace?: boolean; state?: unknown },
+  ): void;
   readonly location$: Observable<RoutingLocation>;
 }
 

--- a/packages/frontend-plugin-api/src/routing/NavigationControllerApi.ts
+++ b/packages/frontend-plugin-api/src/routing/NavigationControllerApi.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createApiRef } from '../apis';
+import type { Observable } from '@backstage/types';
+import type { RoutingLocation } from './RoutingContract';
+
+/** @public */
+export interface NavigationControllerApi {
+  navigate(path: string, options?: { replace?: boolean }): void;
+  readonly location$: Observable<RoutingLocation>;
+}
+
+/** @public */
+export const navigationControllerApiRef = createApiRef<NavigationControllerApi>(
+  {
+    id: 'core.navigation-controller',
+  },
+);

--- a/packages/frontend-plugin-api/src/routing/NestedRoutingContractProvider.test.tsx
+++ b/packages/frontend-plugin-api/src/routing/NestedRoutingContractProvider.test.tsx
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import {
+  NestedRoutingContractProvider,
+  useNestedRoutingContract,
+} from './NestedRoutingContractProvider';
+import type { RoutingContract } from './RoutingContract';
+
+function createMockContract(basePath: string): RoutingContract {
+  return {
+    basePath,
+    location$: {
+      subscribe: () => ({
+        unsubscribe: () => {},
+        get closed() {
+          return false;
+        },
+      }),
+      [Symbol.observable]() {
+        return this;
+      },
+    },
+    navigate: () => {},
+  };
+}
+
+describe('NestedRoutingContractProvider', () => {
+  it('should provide a nested contract by sub-path key', () => {
+    const parentContract = createMockContract('/catalog');
+    const childContract = createMockContract('/catalog/entities');
+
+    const contracts = new Map<string, RoutingContract>([
+      ['entities', childContract],
+    ]);
+
+    function Child() {
+      const contract = useNestedRoutingContract('entities');
+      return (
+        <div data-testid="child">basePath: {contract?.basePath ?? 'none'}</div>
+      );
+    }
+
+    render(
+      <NestedRoutingContractProvider
+        parentContract={parentContract}
+        contracts={contracts}
+      >
+        <Child />
+      </NestedRoutingContractProvider>,
+    );
+
+    expect(screen.getByTestId('child')).toHaveTextContent(
+      'basePath: /catalog/entities',
+    );
+  });
+
+  it('should return undefined for an unregistered sub-path', () => {
+    const parentContract = createMockContract('/catalog');
+    const contracts = new Map<string, RoutingContract>();
+
+    function Child() {
+      const contract = useNestedRoutingContract('unknown');
+      return (
+        <div data-testid="child">
+          {contract ? contract.basePath : 'no-contract'}
+        </div>
+      );
+    }
+
+    render(
+      <NestedRoutingContractProvider
+        parentContract={parentContract}
+        contracts={contracts}
+      >
+        <Child />
+      </NestedRoutingContractProvider>,
+    );
+
+    expect(screen.getByTestId('child')).toHaveTextContent('no-contract');
+  });
+
+  it('should expose the parent contract via the provider', () => {
+    const parentContract = createMockContract('/catalog');
+    const contracts = new Map<string, RoutingContract>();
+
+    function Child() {
+      const contract = useNestedRoutingContract();
+      return (
+        <div data-testid="child">basePath: {contract?.basePath ?? 'none'}</div>
+      );
+    }
+
+    render(
+      <NestedRoutingContractProvider
+        parentContract={parentContract}
+        contracts={contracts}
+      >
+        <Child />
+      </NestedRoutingContractProvider>,
+    );
+
+    expect(screen.getByTestId('child')).toHaveTextContent('basePath: /catalog');
+  });
+
+  it('should throw when used outside of provider with required flag', () => {
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    function Child() {
+      const contract = useNestedRoutingContract('something', {
+        required: true,
+      });
+      return <div>{contract?.basePath ?? 'none'}</div>;
+    }
+
+    expect(() => render(<Child />)).toThrow(
+      'useNestedRoutingContract must be used within a NestedRoutingContractProvider',
+    );
+
+    consoleError.mockRestore();
+  });
+});

--- a/packages/frontend-plugin-api/src/routing/NestedRoutingContractProvider.tsx
+++ b/packages/frontend-plugin-api/src/routing/NestedRoutingContractProvider.tsx
@@ -15,6 +15,7 @@
  */
 
 import { createContext, useContext, type ReactNode } from 'react';
+import { getOrCreateGlobalSingleton } from '@backstage/version-bridge';
 import type { RoutingContract } from './RoutingContract';
 
 /**
@@ -27,9 +28,10 @@ interface NestedRoutingContractContextValue {
   contracts: Map<string, RoutingContract>;
 }
 
-const NestedRoutingContractCtx = createContext<
-  NestedRoutingContractContextValue | undefined
->(undefined);
+const NestedRoutingContractCtx = getOrCreateGlobalSingleton(
+  'nested-routing-contract-context',
+  () => createContext<NestedRoutingContractContextValue | undefined>(undefined),
+);
 
 /**
  * Props for {@link NestedRoutingContractProvider}.

--- a/packages/frontend-plugin-api/src/routing/NestedRoutingContractProvider.tsx
+++ b/packages/frontend-plugin-api/src/routing/NestedRoutingContractProvider.tsx
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createContext, useContext, type ReactNode } from 'react';
+import type { RoutingContract } from './RoutingContract';
+
+/**
+ * Internal context value for nested routing contract provisioning.
+ */
+interface NestedRoutingContractContextValue {
+  /** The parent contract that owns the base path for this subtree. */
+  parentContract: RoutingContract;
+  /** Pre-created contracts keyed by sub-path (relative to parent basePath). */
+  contracts: Map<string, RoutingContract>;
+}
+
+const NestedRoutingContractCtx = createContext<
+  NestedRoutingContractContextValue | undefined
+>(undefined);
+
+/**
+ * Props for {@link NestedRoutingContractProvider}.
+ *
+ * @public
+ */
+export interface NestedRoutingContractProviderProps {
+  /** The parent plugin's routing contract. */
+  parentContract: RoutingContract;
+  /**
+   * Pre-created contracts for nested sub-paths, keyed by the sub-path
+   * relative to the parent's basePath. For example, if the parent has
+   * basePath `/catalog`, a nested contract for `/catalog/entities`
+   * would be keyed as `entities`.
+   */
+  contracts: Map<string, RoutingContract>;
+  children: ReactNode;
+}
+
+/**
+ * Provides pre-created nested routing contracts to sub-page extensions
+ * that need their own scoped routing.
+ *
+ * @remarks
+ *
+ * This component is used by plugins that render child plugins or sub-page
+ * extensions at sub-routes. Each child extension that needs its own
+ * routing context can retrieve a pre-created contract via
+ * {@link useNestedRoutingContract}.
+ *
+ * @example
+ *
+ * ```tsx
+ * // In a parent plugin that hosts child extensions at sub-routes
+ * <NestedRoutingContractProvider
+ *   parentContract={myContract}
+ *   contracts={nestedContracts}
+ * >
+ *   <ChildExtensionOutlet />
+ * </NestedRoutingContractProvider>
+ * ```
+ *
+ * @public
+ */
+export function NestedRoutingContractProvider(
+  props: NestedRoutingContractProviderProps,
+) {
+  const { parentContract, contracts, children } = props;
+
+  return (
+    <NestedRoutingContractCtx.Provider value={{ parentContract, contracts }}>
+      {children}
+    </NestedRoutingContractCtx.Provider>
+  );
+}
+
+/**
+ * Options for {@link useNestedRoutingContract}.
+ *
+ * @public
+ */
+export interface UseNestedRoutingContractOptions {
+  /**
+   * When true, throws an error if the hook is used outside of a
+   * {@link NestedRoutingContractProvider}. Defaults to false.
+   */
+  required?: boolean;
+}
+
+/**
+ * Retrieves a pre-created nested routing contract for a sub-path.
+ *
+ * @remarks
+ *
+ * When called without a `subPath`, returns the parent contract.
+ * When called with a `subPath`, returns the pre-created contract for
+ * that sub-path, or `undefined` if no contract was registered for it.
+ *
+ * @param subPath - The sub-path key to look up (relative to parent basePath).
+ *   If omitted, returns the parent contract.
+ * @param options - Options controlling behavior.
+ * @returns The matching routing contract, or undefined if not found.
+ *
+ * @public
+ */
+export function useNestedRoutingContract(
+  subPath?: string,
+  options?: UseNestedRoutingContractOptions,
+): RoutingContract | undefined {
+  const ctx = useContext(NestedRoutingContractCtx);
+
+  if (!ctx) {
+    if (options?.required) {
+      throw new Error(
+        'useNestedRoutingContract must be used within a NestedRoutingContractProvider',
+      );
+    }
+    return undefined;
+  }
+
+  if (subPath === undefined) {
+    return ctx.parentContract;
+  }
+
+  return ctx.contracts.get(subPath);
+}

--- a/packages/frontend-plugin-api/src/routing/RouteLink.test.tsx
+++ b/packages/frontend-plugin-api/src/routing/RouteLink.test.tsx
@@ -111,7 +111,10 @@ describe('RouteLink', () => {
 
     fireEvent.click(link);
 
-    expect(mockNav.navigate).toHaveBeenCalledWith('/catalog/entity/my-entity');
+    expect(mockNav.navigate).toHaveBeenCalledWith(
+      '/catalog/entity/my-entity',
+      undefined,
+    );
   });
 
   it('should prevent default on plain click', () => {

--- a/packages/frontend-plugin-api/src/routing/RouteLink.test.tsx
+++ b/packages/frontend-plugin-api/src/routing/RouteLink.test.tsx
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { type CSSProperties } from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { TestApiProvider } from '@backstage/test-utils';
+import { RouteLink } from './RouteLink';
+import { createRouteRef } from './RouteRef';
+import { routeResolutionApiRef } from '../apis';
+import { navigationControllerApiRef } from './NavigationControllerApi';
+
+function createMockNavigationControllerApi() {
+  return {
+    navigate: jest.fn(),
+    location$: {
+      subscribe: () => ({
+        unsubscribe: () => {},
+        get closed() {
+          return false;
+        },
+      }),
+      [Symbol.observable]() {
+        return this;
+      },
+    },
+  };
+}
+
+describe('RouteLink', () => {
+  const routeRef = createRouteRef();
+
+  function renderRouteLink(
+    opts: {
+      routeFunc?: () => string;
+      params?: Record<string, string>;
+      className?: string;
+      style?: CSSProperties;
+      mockNav?: ReturnType<typeof createMockNavigationControllerApi>;
+    } = {},
+  ) {
+    const routeFunc = opts.routeFunc ?? (() => '/catalog/entity/my-entity');
+    const resolve = jest.fn(() => routeFunc);
+    const mockNav = opts.mockNav ?? createMockNavigationControllerApi();
+
+    const result = render(
+      <TestApiProvider
+        apis={[
+          [routeResolutionApiRef, { resolve }],
+          [navigationControllerApiRef, mockNav as any],
+        ]}
+      >
+        <MemoryRouter initialEntries={['/']}>
+          <RouteLink
+            routeRef={routeRef}
+            params={opts.params}
+            className={opts.className}
+            style={opts.style}
+          >
+            Go to entity
+          </RouteLink>
+        </MemoryRouter>
+      </TestApiProvider>,
+    );
+
+    return { ...result, resolve, mockNav };
+  }
+
+  it('should render an anchor tag with the resolved href', () => {
+    renderRouteLink();
+    const link = screen.getByRole('link', { name: 'Go to entity' });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/catalog/entity/my-entity');
+  });
+
+  it('should pass params to the route function', () => {
+    const routeFunc = jest.fn(() => '/catalog/entity/foo');
+    renderRouteLink({ routeFunc, params: { name: 'foo' } });
+    expect(routeFunc).toHaveBeenCalledWith({ name: 'foo' });
+  });
+
+  it('should call frameworkNavigate on plain click', () => {
+    const mockNav = createMockNavigationControllerApi();
+    renderRouteLink({ mockNav });
+    const link = screen.getByRole('link', { name: 'Go to entity' });
+
+    fireEvent.click(link);
+
+    expect(mockNav.navigate).toHaveBeenCalledWith('/catalog/entity/my-entity');
+  });
+
+  it('should prevent default on plain click', () => {
+    renderRouteLink();
+    const link = screen.getByRole('link', { name: 'Go to entity' });
+
+    const event = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+    });
+    const preventDefaultSpy = jest.spyOn(event, 'preventDefault');
+    link.dispatchEvent(event);
+
+    expect(preventDefaultSpy).toHaveBeenCalled();
+  });
+
+  it('should not call frameworkNavigate on meta+click', () => {
+    const mockNav = createMockNavigationControllerApi();
+    renderRouteLink({ mockNav });
+    const link = screen.getByRole('link', { name: 'Go to entity' });
+
+    fireEvent.click(link, { metaKey: true });
+
+    expect(mockNav.navigate).not.toHaveBeenCalled();
+  });
+
+  it('should not call frameworkNavigate on ctrl+click', () => {
+    const mockNav = createMockNavigationControllerApi();
+    renderRouteLink({ mockNav });
+    const link = screen.getByRole('link', { name: 'Go to entity' });
+
+    fireEvent.click(link, { ctrlKey: true });
+
+    expect(mockNav.navigate).not.toHaveBeenCalled();
+  });
+
+  it('should not call frameworkNavigate on shift+click', () => {
+    const mockNav = createMockNavigationControllerApi();
+    renderRouteLink({ mockNav });
+    const link = screen.getByRole('link', { name: 'Go to entity' });
+
+    fireEvent.click(link, { shiftKey: true });
+
+    expect(mockNav.navigate).not.toHaveBeenCalled();
+  });
+
+  it('should not call frameworkNavigate on right-click', () => {
+    const mockNav = createMockNavigationControllerApi();
+    renderRouteLink({ mockNav });
+    const link = screen.getByRole('link', { name: 'Go to entity' });
+
+    fireEvent.click(link, { button: 2 });
+
+    expect(mockNav.navigate).not.toHaveBeenCalled();
+  });
+
+  it('should forward className prop', () => {
+    renderRouteLink({ className: 'my-class' });
+    const link = screen.getByRole('link', { name: 'Go to entity' });
+    expect(link).toHaveClass('my-class');
+  });
+
+  it('should forward style prop', () => {
+    renderRouteLink({ style: { color: 'red' } });
+    const link = screen.getByRole('link', { name: 'Go to entity' });
+    expect(link).toHaveStyle({ color: 'rgb(255, 0, 0)' });
+  });
+
+  it('should render children', () => {
+    renderRouteLink();
+    expect(screen.getByText('Go to entity')).toBeInTheDocument();
+  });
+});

--- a/packages/frontend-plugin-api/src/routing/RouteLink.test.tsx
+++ b/packages/frontend-plugin-api/src/routing/RouteLink.test.tsx
@@ -27,12 +27,24 @@ function createMockNavigationControllerApi() {
   return {
     navigate: jest.fn(),
     location$: {
-      subscribe: () => ({
-        unsubscribe: () => {},
-        get closed() {
-          return false;
-        },
-      }),
+      subscribe: (
+        observerOrNext?:
+          | { next?: (value: any) => void }
+          | ((value: any) => void),
+      ) => {
+        const onNext =
+          typeof observerOrNext === 'function'
+            ? observerOrNext
+            : observerOrNext?.next?.bind(observerOrNext);
+        // Emit synchronously on subscribe (required by useObservableAsState)
+        onNext?.({ pathname: '/', search: '', hash: '' });
+        return {
+          unsubscribe: () => {},
+          get closed() {
+            return false;
+          },
+        };
+      },
       [Symbol.observable]() {
         return this;
       },

--- a/packages/frontend-plugin-api/src/routing/RouteLink.tsx
+++ b/packages/frontend-plugin-api/src/routing/RouteLink.tsx
@@ -57,7 +57,10 @@ export function RouteLink(props: RouteLinkProps) {
   const routeFunc = useRouteRef(routeRef);
   const frameworkNavigate = useFrameworkNavigate();
 
-  const href = routeFunc?.(params as any) ?? '#';
+  // RouteLink accepts untyped params since the route ref's param shape isn't
+  // known at the call site. The route function validates params at runtime.
+  const href =
+    routeFunc?.(params as Parameters<NonNullable<typeof routeFunc>>[0]) ?? '#';
 
   const handleClick = useCallback(
     (event: MouseEvent<HTMLAnchorElement>) => {

--- a/packages/frontend-plugin-api/src/routing/RouteLink.tsx
+++ b/packages/frontend-plugin-api/src/routing/RouteLink.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  type CSSProperties,
+  type MouseEvent,
+  type ReactNode,
+  useCallback,
+} from 'react';
+import { RouteRef } from './RouteRef';
+import { useRouteRef } from './useRouteRef';
+import { useFrameworkNavigate } from './useFrameworkNavigate';
+
+/**
+ * Props for the {@link RouteLink} component.
+ *
+ * @public
+ */
+export interface RouteLinkProps {
+  routeRef: RouteRef;
+  params?: Record<string, string>;
+  children: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+}
+
+function isModifiedEvent(event: MouseEvent): boolean {
+  return !!(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey);
+}
+
+/**
+ * A component for cross-plugin navigation using route refs.
+ *
+ * @remarks
+ *
+ * Resolves a route ref to a URL and renders an anchor tag. On plain clicks,
+ * it uses framework navigation for SPA behavior. Modified clicks (meta, ctrl,
+ * shift, right-click) are left to the browser for open-in-new-tab behavior.
+ *
+ * @public
+ */
+export function RouteLink(props: RouteLinkProps) {
+  const { routeRef, params, children, className, style } = props;
+  const routeFunc = useRouteRef(routeRef);
+  const frameworkNavigate = useFrameworkNavigate();
+
+  const href = routeFunc?.(params as any) ?? '#';
+
+  const handleClick = useCallback(
+    (event: MouseEvent<HTMLAnchorElement>) => {
+      if (event.button !== 0 || isModifiedEvent(event)) {
+        return;
+      }
+
+      event.preventDefault();
+      frameworkNavigate(href);
+    },
+    [frameworkNavigate, href],
+  );
+
+  return (
+    <a href={href} onClick={handleClick} className={className} style={style}>
+      {children}
+    </a>
+  );
+}

--- a/packages/frontend-plugin-api/src/routing/RoutingContract.test.ts
+++ b/packages/frontend-plugin-api/src/routing/RoutingContract.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2026 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/frontend-plugin-api/src/routing/RoutingContract.test.ts
+++ b/packages/frontend-plugin-api/src/routing/RoutingContract.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { RoutingLocation, RoutingContract } from './RoutingContract';
+
+describe('RoutingContract types', () => {
+  it('should allow creating a valid RoutingContract', () => {
+    const location: RoutingLocation = {
+      pathname: '/entity/foo',
+      search: '?filter=active',
+      hash: '#details',
+    };
+
+    const contract: RoutingContract = {
+      basePath: '/catalog',
+      location$: {
+        subscribe: () => ({
+          unsubscribe: () => {},
+          get closed() {
+            return false;
+          },
+        }),
+        [Symbol.observable]() {
+          return this;
+        },
+      },
+      navigate: (_to: string) => {},
+    };
+
+    expect(location.pathname).toBe('/entity/foo');
+    expect(contract.basePath).toBe('/catalog');
+  });
+});

--- a/packages/frontend-plugin-api/src/routing/RoutingContract.ts
+++ b/packages/frontend-plugin-api/src/routing/RoutingContract.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2026 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/frontend-plugin-api/src/routing/RoutingContract.ts
+++ b/packages/frontend-plugin-api/src/routing/RoutingContract.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2024 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,13 +14,18 @@
  * limitations under the License.
  */
 
-export type { AnyRouteRefParams } from './types';
-export { createRouteRef, type RouteRef } from './RouteRef';
-export { createSubRouteRef, type SubRouteRef } from './SubRouteRef';
-export {
-  createExternalRouteRef,
-  type ExternalRouteRef,
-} from './ExternalRouteRef';
-export { useRouteRef } from './useRouteRef';
-export { useRouteRefParams } from './useRouteRefParams';
-export type { RoutingLocation, RoutingContract } from './RoutingContract';
+import { Observable } from '@backstage/types';
+
+/** @public */
+export interface RoutingLocation {
+  pathname: string;
+  search: string;
+  hash: string;
+}
+
+/** @public */
+export interface RoutingContract {
+  readonly basePath: string;
+  readonly location$: Observable<RoutingLocation>;
+  navigate(to: string, options?: { replace?: boolean }): void;
+}

--- a/packages/frontend-plugin-api/src/routing/RoutingContract.ts
+++ b/packages/frontend-plugin-api/src/routing/RoutingContract.ts
@@ -21,11 +21,12 @@ export interface RoutingLocation {
   pathname: string;
   search: string;
   hash: string;
+  state: unknown;
 }
 
 /** @public */
 export interface RoutingContract {
   readonly basePath: string;
   readonly location$: Observable<RoutingLocation>;
-  navigate(to: string, options?: { replace?: boolean }): void;
+  navigate(to: string, options?: { replace?: boolean; state?: unknown }): void;
 }

--- a/packages/frontend-plugin-api/src/routing/RoutingContract.ts
+++ b/packages/frontend-plugin-api/src/routing/RoutingContract.ts
@@ -27,6 +27,14 @@ export interface RoutingLocation {
 /** @public */
 export interface RoutingContract {
   readonly basePath: string;
+  /**
+   * Observable stream of the current location within this contract's scope.
+   *
+   * **Invariant:** Implementations MUST emit the current location synchronously
+   * upon subscription. Router adapters depend on this behavior to capture the
+   * initial location without a render cycle delay. An async-emitting implementation
+   * will cause adapters to briefly display the wrong route on mount.
+   */
   readonly location$: Observable<RoutingLocation>;
   navigate(to: string, options?: { replace?: boolean; state?: unknown }): void;
 }

--- a/packages/frontend-plugin-api/src/routing/RoutingContractContext.ts
+++ b/packages/frontend-plugin-api/src/routing/RoutingContractContext.ts
@@ -15,12 +15,18 @@
  */
 
 import { createContext, useContext } from 'react';
+import { getOrCreateGlobalSingleton } from '@backstage/version-bridge';
 import type { RoutingContract } from './RoutingContract';
 
-/** @public */
-export const RoutingContractContext = createContext<
-  RoutingContract | undefined
->(undefined);
+/**
+ * A global singleton React context for the routing contract, shared between
+ * frontend-plugin-api and core-components via @backstage/version-bridge.
+ * @public
+ */
+export const RoutingContractContext = getOrCreateGlobalSingleton(
+  'routing-contract-context',
+  () => createContext<RoutingContract | undefined>(undefined),
+);
 
 /** @public */
 export function useRoutingContract(): RoutingContract {

--- a/packages/frontend-plugin-api/src/routing/RoutingContractContext.ts
+++ b/packages/frontend-plugin-api/src/routing/RoutingContractContext.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createContext, useContext } from 'react';
+import type { RoutingContract } from './RoutingContract';
+
+/** @public */
+export const RoutingContractContext = createContext<
+  RoutingContract | undefined
+>(undefined);
+
+/** @public */
+export function useRoutingContract(): RoutingContract {
+  const contract = useContext(RoutingContractContext);
+  if (!contract) {
+    throw new Error(
+      'useRoutingContract must be used within a component that has a RoutingContract provided',
+    );
+  }
+  return contract;
+}

--- a/packages/frontend-plugin-api/src/routing/index.ts
+++ b/packages/frontend-plugin-api/src/routing/index.ts
@@ -24,3 +24,8 @@ export {
 export { useRouteRef } from './useRouteRef';
 export { useRouteRefParams } from './useRouteRefParams';
 export type { RoutingLocation, RoutingContract } from './RoutingContract';
+export type { NavigationControllerApi } from './NavigationControllerApi';
+export { navigationControllerApiRef } from './NavigationControllerApi';
+export { useFrameworkNavigate } from './useFrameworkNavigate';
+export { useFrameworkLocation } from './useFrameworkLocation';
+export { RouteLink, type RouteLinkProps } from './RouteLink';

--- a/packages/frontend-plugin-api/src/routing/index.ts
+++ b/packages/frontend-plugin-api/src/routing/index.ts
@@ -29,3 +29,7 @@ export { navigationControllerApiRef } from './NavigationControllerApi';
 export { useFrameworkNavigate } from './useFrameworkNavigate';
 export { useFrameworkLocation } from './useFrameworkLocation';
 export { RouteLink, type RouteLinkProps } from './RouteLink';
+export {
+  RoutingContractContext,
+  useRoutingContract,
+} from './RoutingContractContext';

--- a/packages/frontend-plugin-api/src/routing/index.ts
+++ b/packages/frontend-plugin-api/src/routing/index.ts
@@ -39,3 +39,7 @@ export {
   type NestedRoutingContractProviderProps,
   type UseNestedRoutingContractOptions,
 } from './NestedRoutingContractProvider';
+export {
+  useObservableAsState,
+  routingLocationEqual,
+} from './useObservableAsState';

--- a/packages/frontend-plugin-api/src/routing/index.ts
+++ b/packages/frontend-plugin-api/src/routing/index.ts
@@ -33,3 +33,9 @@ export {
   RoutingContractContext,
   useRoutingContract,
 } from './RoutingContractContext';
+export {
+  NestedRoutingContractProvider,
+  useNestedRoutingContract,
+  type NestedRoutingContractProviderProps,
+  type UseNestedRoutingContractOptions,
+} from './NestedRoutingContractProvider';

--- a/packages/frontend-plugin-api/src/routing/useFrameworkLocation.test.tsx
+++ b/packages/frontend-plugin-api/src/routing/useFrameworkLocation.test.tsx
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PropsWithChildren } from 'react';
+import { renderHook, act } from '@testing-library/react';
+import { useFrameworkLocation } from './useFrameworkLocation';
+import { navigationControllerApiRef } from './NavigationControllerApi';
+import { TestApiProvider } from '@backstage/test-utils';
+import { type RoutingLocation } from './RoutingContract';
+
+describe('useFrameworkLocation', () => {
+  function createMockLocationObservable(initial: RoutingLocation) {
+    let current = initial;
+    const subscribers = new Set<(loc: RoutingLocation) => void>();
+
+    return {
+      observable: {
+        subscribe(observer: (loc: RoutingLocation) => void) {
+          subscribers.add(observer);
+          // Emit current value synchronously on subscribe (BehaviorSubject semantics)
+          observer(current);
+          return {
+            unsubscribe: () => subscribers.delete(observer),
+            get closed() {
+              return false;
+            },
+          };
+        },
+        [Symbol.observable]() {
+          return this;
+        },
+      },
+      emit(loc: RoutingLocation) {
+        current = loc;
+        subscribers.forEach(fn => fn(loc));
+      },
+    };
+  }
+
+  function createWrapper(observable: any) {
+    return ({ children }: PropsWithChildren<{}>) => (
+      <TestApiProvider
+        apis={[
+          [
+            navigationControllerApiRef,
+            { navigate: jest.fn(), location$: observable },
+          ] as any,
+        ]}
+      >
+        {children}
+      </TestApiProvider>
+    );
+  }
+
+  it('should return the current location from NavigationController', () => {
+    const { observable } = createMockLocationObservable({
+      pathname: '/catalog',
+      search: '?q=test',
+      hash: '#section',
+    });
+
+    const { result } = renderHook(() => useFrameworkLocation(), {
+      wrapper: createWrapper(observable),
+    });
+    expect(result.current).toEqual({
+      pathname: '/catalog',
+      search: '?q=test',
+      hash: '#section',
+    });
+  });
+
+  it('should update when location$ emits a new location', () => {
+    const { observable, emit } = createMockLocationObservable({
+      pathname: '/catalog',
+      search: '',
+      hash: '',
+    });
+
+    const { result } = renderHook(() => useFrameworkLocation(), {
+      wrapper: createWrapper(observable),
+    });
+    expect(result.current.pathname).toBe('/catalog');
+
+    act(() => {
+      emit({ pathname: '/scaffolder', search: '', hash: '' });
+    });
+
+    expect(result.current.pathname).toBe('/scaffolder');
+  });
+
+  it('should maintain referential stability when location has not changed', () => {
+    const { observable, emit } = createMockLocationObservable({
+      pathname: '/catalog',
+      search: '',
+      hash: '',
+    });
+
+    const { result } = renderHook(() => useFrameworkLocation(), {
+      wrapper: createWrapper(observable),
+    });
+    const first = result.current;
+
+    // Emit the same location — object reference should remain stable
+    act(() => {
+      emit({ pathname: '/catalog', search: '', hash: '' });
+    });
+
+    expect(result.current).toBe(first);
+  });
+});

--- a/packages/frontend-plugin-api/src/routing/useFrameworkLocation.ts
+++ b/packages/frontend-plugin-api/src/routing/useFrameworkLocation.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useSyncExternalStore, useCallback, useRef, useState } from 'react';
+import { useApi } from '../apis';
+import { navigationControllerApiRef } from './NavigationControllerApi';
+import type { RoutingLocation } from './RoutingContract';
+
+/** @public */
+export function useFrameworkLocation(): RoutingLocation {
+  const nav = useApi(navigationControllerApiRef);
+  // Initialize by synchronously subscribing to get the current value.
+  // NOTE: useRef does NOT support lazy initializers in React 18 (that's React 19+).
+  // Use useState with lazy init to compute the initial value once.
+  const [initialLocation] = useState(() => {
+    let initial: RoutingLocation = { pathname: '/', search: '', hash: '' };
+    const sub = nav.location$.subscribe(loc => {
+      initial = loc;
+    });
+    sub.unsubscribe();
+    return initial;
+  });
+  const locationRef = useRef<RoutingLocation>(initialLocation);
+
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      const sub = nav.location$.subscribe(loc => {
+        const prev = locationRef.current;
+        if (
+          prev.pathname !== loc.pathname ||
+          prev.search !== loc.search ||
+          prev.hash !== loc.hash
+        ) {
+          locationRef.current = loc;
+          onStoreChange();
+        }
+      });
+      return () => sub.unsubscribe();
+    },
+    [nav],
+  );
+
+  const getSnapshot = useCallback(() => locationRef.current, []);
+
+  return useSyncExternalStore(subscribe, getSnapshot);
+}

--- a/packages/frontend-plugin-api/src/routing/useFrameworkLocation.ts
+++ b/packages/frontend-plugin-api/src/routing/useFrameworkLocation.ts
@@ -14,46 +14,16 @@
  * limitations under the License.
  */
 
-import { useSyncExternalStore, useCallback, useRef, useState } from 'react';
 import { useApi } from '../apis';
 import { navigationControllerApiRef } from './NavigationControllerApi';
 import type { RoutingLocation } from './RoutingContract';
+import {
+  useObservableAsState,
+  routingLocationEqual,
+} from './useObservableAsState';
 
 /** @public */
 export function useFrameworkLocation(): RoutingLocation {
   const nav = useApi(navigationControllerApiRef);
-  // Initialize by synchronously subscribing to get the current value.
-  // NOTE: useRef does NOT support lazy initializers in React 18 (that's React 19+).
-  // Use useState with lazy init to compute the initial value once.
-  const [initialLocation] = useState(() => {
-    let initial: RoutingLocation = { pathname: '/', search: '', hash: '' };
-    const sub = nav.location$.subscribe(loc => {
-      initial = loc;
-    });
-    sub.unsubscribe();
-    return initial;
-  });
-  const locationRef = useRef<RoutingLocation>(initialLocation);
-
-  const subscribe = useCallback(
-    (onStoreChange: () => void) => {
-      const sub = nav.location$.subscribe(loc => {
-        const prev = locationRef.current;
-        if (
-          prev.pathname !== loc.pathname ||
-          prev.search !== loc.search ||
-          prev.hash !== loc.hash
-        ) {
-          locationRef.current = loc;
-          onStoreChange();
-        }
-      });
-      return () => sub.unsubscribe();
-    },
-    [nav],
-  );
-
-  const getSnapshot = useCallback(() => locationRef.current, []);
-
-  return useSyncExternalStore(subscribe, getSnapshot);
+  return useObservableAsState(nav.location$, routingLocationEqual);
 }

--- a/packages/frontend-plugin-api/src/routing/useFrameworkNavigate.test.tsx
+++ b/packages/frontend-plugin-api/src/routing/useFrameworkNavigate.test.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { PropsWithChildren } from 'react';
+import { renderHook } from '@testing-library/react';
+import { useFrameworkNavigate } from './useFrameworkNavigate';
+import { navigationControllerApiRef } from './NavigationControllerApi';
+import { TestApiProvider } from '@backstage/test-utils';
+
+function createMockNavController(mockNavigate: jest.Mock) {
+  return {
+    navigate: mockNavigate,
+    location$: {
+      subscribe: () => ({
+        unsubscribe: () => {},
+        get closed() {
+          return false;
+        },
+      }),
+      [Symbol.observable]() {
+        return this;
+      },
+    },
+  };
+}
+
+describe('useFrameworkNavigate', () => {
+  it('should call navigationController.navigate', () => {
+    const mockNavigate = jest.fn();
+    const wrapper = ({ children }: PropsWithChildren<{}>) => (
+      <TestApiProvider
+        apis={[
+          [
+            navigationControllerApiRef,
+            createMockNavController(mockNavigate),
+          ] as any,
+        ]}
+      >
+        {children}
+      </TestApiProvider>
+    );
+    const { result } = renderHook(() => useFrameworkNavigate(), { wrapper });
+    result.current('/scaffolder/templates/foo');
+    expect(mockNavigate).toHaveBeenCalledWith('/scaffolder/templates/foo');
+  });
+
+  it('should forward options to navigate', () => {
+    const mockNavigate = jest.fn();
+    const wrapper = ({ children }: PropsWithChildren<{}>) => (
+      <TestApiProvider
+        apis={[
+          [
+            navigationControllerApiRef,
+            createMockNavController(mockNavigate),
+          ] as any,
+        ]}
+      >
+        {children}
+      </TestApiProvider>
+    );
+    const { result } = renderHook(() => useFrameworkNavigate(), { wrapper });
+    result.current('/catalog', { replace: true });
+    expect(mockNavigate).toHaveBeenCalledWith('/catalog', { replace: true });
+  });
+});

--- a/packages/frontend-plugin-api/src/routing/useFrameworkNavigate.test.tsx
+++ b/packages/frontend-plugin-api/src/routing/useFrameworkNavigate.test.tsx
@@ -54,7 +54,10 @@ describe('useFrameworkNavigate', () => {
     );
     const { result } = renderHook(() => useFrameworkNavigate(), { wrapper });
     result.current('/scaffolder/templates/foo');
-    expect(mockNavigate).toHaveBeenCalledWith('/scaffolder/templates/foo');
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/scaffolder/templates/foo',
+      undefined,
+    );
   });
 
   it('should forward options to navigate', () => {

--- a/packages/frontend-plugin-api/src/routing/useFrameworkNavigate.ts
+++ b/packages/frontend-plugin-api/src/routing/useFrameworkNavigate.ts
@@ -21,16 +21,12 @@ import { useCallback } from 'react';
 /** @public */
 export function useFrameworkNavigate(): (
   path: string,
-  options?: { replace?: boolean },
+  options?: { replace?: boolean; state?: unknown },
 ) => void {
   const nav = useApi(navigationControllerApiRef);
   return useCallback(
-    (path: string, options?: { replace?: boolean }) => {
-      if (options) {
-        nav.navigate(path, options);
-      } else {
-        nav.navigate(path);
-      }
+    (path: string, options?: { replace?: boolean; state?: unknown }) => {
+      nav.navigate(path, options);
     },
     [nav],
   );

--- a/packages/frontend-plugin-api/src/routing/useFrameworkNavigate.ts
+++ b/packages/frontend-plugin-api/src/routing/useFrameworkNavigate.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useApi } from '../apis';
+import { navigationControllerApiRef } from './NavigationControllerApi';
+import { useCallback } from 'react';
+
+/** @public */
+export function useFrameworkNavigate(): (
+  path: string,
+  options?: { replace?: boolean },
+) => void {
+  const nav = useApi(navigationControllerApiRef);
+  return useCallback(
+    (path: string, options?: { replace?: boolean }) => {
+      if (options) {
+        nav.navigate(path, options);
+      } else {
+        nav.navigate(path);
+      }
+    },
+    [nav],
+  );
+}

--- a/packages/frontend-plugin-api/src/routing/useObservableAsState.ts
+++ b/packages/frontend-plugin-api/src/routing/useObservableAsState.ts
@@ -17,6 +17,8 @@
 import { useState, useCallback, useRef, useSyncExternalStore } from 'react';
 import type { Observable } from '@backstage/types';
 
+const UNSET = Symbol('useObservableAsState.unset');
+
 /**
  * Subscribes to a Backstage Observable and returns the latest value as React state.
  *
@@ -39,18 +41,20 @@ export function useObservableAsState<T>(
   isEqual: (a: T, b: T) => boolean = Object.is,
 ): T {
   // Get initial value synchronously. useState lazy init runs once.
+  // Uses a sentinel symbol instead of undefined to correctly handle
+  // observables that legitimately emit undefined as a value.
   const [initialValue] = useState(() => {
-    let initial: T | undefined;
+    let initial: T | typeof UNSET = UNSET;
     const sub = observable$.subscribe(val => {
       initial = val;
     });
     sub.unsubscribe();
-    if (initial === undefined) {
+    if (initial === UNSET) {
       throw new Error(
         'useObservableAsState requires an observable that emits synchronously on subscribe',
       );
     }
-    return initial;
+    return initial as T;
   });
 
   const valueRef = useRef<T>(initialValue);
@@ -75,13 +79,17 @@ export function useObservableAsState<T>(
 
 /**
  * Default equality check for RoutingLocation-shaped objects.
+ * Uses Object.is for state comparison to handle all value types.
  * @internal
  */
 export function routingLocationEqual(
-  a: { pathname: string; search: string; hash: string },
-  b: { pathname: string; search: string; hash: string },
+  a: { pathname: string; search: string; hash: string; state?: unknown },
+  b: { pathname: string; search: string; hash: string; state?: unknown },
 ): boolean {
   return (
-    a.pathname === b.pathname && a.search === b.search && a.hash === b.hash
+    a.pathname === b.pathname &&
+    a.search === b.search &&
+    a.hash === b.hash &&
+    Object.is(a.state, b.state)
   );
 }

--- a/packages/frontend-plugin-api/src/routing/useObservableAsState.ts
+++ b/packages/frontend-plugin-api/src/routing/useObservableAsState.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState, useCallback, useRef, useSyncExternalStore } from 'react';
+import type { Observable } from '@backstage/types';
+
+/**
+ * Subscribes to a Backstage Observable and returns the latest value as React state.
+ *
+ * The observable MUST emit synchronously on subscribe (which
+ * NavigationController.location$ and scoped contract location$ both do).
+ *
+ * Uses `useSyncExternalStore` with referential equality checks to avoid
+ * unnecessary re-renders when the value hasn't changed.
+ *
+ * @param observable$ - An observable that emits synchronously on subscribe.
+ * @param isEqual - Optional equality function. Defaults to `Object.is` (reference
+ *   equality). For RoutingLocation values, pass `routingLocationEqual` to compare
+ *   by pathname, search, and hash fields.
+ * @returns The latest emitted value.
+ *
+ * @internal
+ */
+export function useObservableAsState<T>(
+  observable$: Observable<T>,
+  isEqual: (a: T, b: T) => boolean = Object.is,
+): T {
+  // Get initial value synchronously. useState lazy init runs once.
+  const [initialValue] = useState(() => {
+    let initial: T | undefined;
+    const sub = observable$.subscribe(val => {
+      initial = val;
+    });
+    sub.unsubscribe();
+    if (initial === undefined) {
+      throw new Error(
+        'useObservableAsState requires an observable that emits synchronously on subscribe',
+      );
+    }
+    return initial;
+  });
+
+  const valueRef = useRef<T>(initialValue);
+
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      const sub = observable$.subscribe(val => {
+        if (!isEqual(valueRef.current, val)) {
+          valueRef.current = val;
+          onStoreChange();
+        }
+      });
+      return () => sub.unsubscribe();
+    },
+    [observable$, isEqual],
+  );
+
+  const getSnapshot = useCallback(() => valueRef.current, []);
+
+  return useSyncExternalStore(subscribe, getSnapshot);
+}
+
+/**
+ * Default equality check for RoutingLocation-shaped objects.
+ * @internal
+ */
+export function routingLocationEqual(
+  a: { pathname: string; search: string; hash: string },
+  b: { pathname: string; search: string; hash: string },
+): boolean {
+  return (
+    a.pathname === b.pathname && a.search === b.search && a.hash === b.hash
+  );
+}

--- a/packages/frontend-plugin-api/src/routing/useRouteRef.test.tsx
+++ b/packages/frontend-plugin-api/src/routing/useRouteRef.test.tsx
@@ -14,15 +14,76 @@
  * limitations under the License.
  */
 
-import { renderHook } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
 import { PropsWithChildren } from 'react';
-import { MemoryRouter, Router } from 'react-router-dom';
 import { createVersionedContextForTesting } from '@backstage/version-bridge';
 import { useRouteRef } from './useRouteRef';
 import { createRouteRef } from './RouteRef';
-import { createBrowserHistory } from 'history';
 import { TestApiProvider } from '@backstage/test-utils';
 import { routeResolutionApiRef } from '../apis';
+import { navigationControllerApiRef } from './NavigationControllerApi';
+import type { NavigationControllerApi } from './NavigationControllerApi';
+import type { Observable, Observer } from '@backstage/types';
+import type { RoutingLocation } from './RoutingContract';
+
+function createMockNavigationController(
+  initialPath: string = '/',
+): NavigationControllerApi & {
+  push(path: string): void;
+} {
+  let current: RoutingLocation = {
+    pathname: initialPath,
+    search: '',
+    hash: '',
+  };
+  const subscribers = new Set<Observer<RoutingLocation>>();
+
+  const location$: Observable<RoutingLocation> = {
+    subscribe(
+      observerOrNext?:
+        | Observer<RoutingLocation>
+        | ((value: RoutingLocation) => void),
+    ) {
+      const handler: Observer<RoutingLocation> =
+        typeof observerOrNext === 'function'
+          ? { next: observerOrNext }
+          : observerOrNext ?? {};
+      subscribers.add(handler);
+      handler.next?.(current);
+      return {
+        unsubscribe() {
+          subscribers.delete(handler);
+        },
+        closed: false,
+      };
+    },
+    [Symbol.observable]() {
+      return this;
+    },
+  };
+
+  return {
+    navigate(path: string, _options?: { replace?: boolean }) {
+      const url = new URL(path, 'http://localhost');
+      current = {
+        pathname: url.pathname,
+        search: url.search,
+        hash: url.hash,
+      };
+      subscribers.forEach(s => s.next?.(current));
+    },
+    location$,
+    push(path: string) {
+      const url = new URL(path, 'http://localhost');
+      current = {
+        pathname: url.pathname,
+        search: url.search,
+        hash: url.hash,
+      };
+      subscribers.forEach(s => s.next?.(current));
+    },
+  };
+}
 
 describe('v1 consumer', () => {
   const context = createVersionedContextForTesting('routing-context');
@@ -35,11 +96,17 @@ describe('v1 consumer', () => {
     const resolve = jest.fn(() => () => '/hello');
 
     const routeRef = createRouteRef();
+    const navController = createMockNavigationController('/my-page');
 
     const renderedHook = renderHook(() => useRouteRef(routeRef), {
       wrapper: ({ children }: PropsWithChildren<{}>) => (
-        <TestApiProvider apis={[[routeResolutionApiRef, { resolve }]]}>
-          <MemoryRouter initialEntries={['/my-page']} children={children} />
+        <TestApiProvider
+          apis={[
+            [routeResolutionApiRef, { resolve }],
+            [navigationControllerApiRef, navController],
+          ]}
+        >
+          {children}
         </TestApiProvider>
       ),
     });
@@ -56,13 +123,17 @@ describe('v1 consumer', () => {
 
   it('should ignore missing routes', () => {
     const routeRef = createRouteRef();
+    const navController = createMockNavigationController('/my-page');
 
     const renderedHook = renderHook(() => useRouteRef(routeRef), {
       wrapper: ({ children }: PropsWithChildren<{}>) => (
         <TestApiProvider
-          apis={[[routeResolutionApiRef, { resolve: () => undefined }]]}
+          apis={[
+            [routeResolutionApiRef, { resolve: () => undefined }],
+            [navigationControllerApiRef, navController],
+          ]}
         >
-          <MemoryRouter initialEntries={['/my-page']} children={children} />
+          {children}
         </TestApiProvider>
       ),
     });
@@ -75,27 +146,29 @@ describe('v1 consumer', () => {
     const resolve = jest.fn(() => () => '/hello');
 
     const routeRef = createRouteRef();
-    const history = createBrowserHistory();
-    history.push('/my-page');
+    const navController = createMockNavigationController('/my-page');
 
     const { rerender } = renderHook(() => useRouteRef(routeRef), {
       wrapper: ({ children }: PropsWithChildren<{}>) => (
-        <TestApiProvider apis={[[routeResolutionApiRef, { resolve }]]}>
-          <Router
-            location={history.location}
-            navigator={history}
-            children={children}
-          />
+        <TestApiProvider
+          apis={[
+            [routeResolutionApiRef, { resolve }],
+            [navigationControllerApiRef, navController],
+          ]}
+        >
+          {children}
         </TestApiProvider>
       ),
     });
 
-    expect(resolve).toHaveBeenCalledTimes(1);
+    const callsBefore = resolve.mock.calls.length;
 
-    history.push('/my-new-page');
+    act(() => {
+      navController.push('/my-new-page');
+    });
     rerender();
 
-    expect(resolve).toHaveBeenCalledTimes(2);
+    expect(resolve.mock.calls.length).toBeGreaterThan(callsBefore);
   });
 
   it('does not re-resolve the routeFunc the location pathname does not change', () => {
@@ -103,24 +176,26 @@ describe('v1 consumer', () => {
     const api = { resolve };
 
     const routeRef = createRouteRef();
-    const history = createBrowserHistory();
-    history.push('/my-page');
+    const navController = createMockNavigationController('/my-page');
 
     const { rerender } = renderHook(() => useRouteRef(routeRef), {
       wrapper: ({ children }: PropsWithChildren<{}>) => (
-        <TestApiProvider apis={[[routeResolutionApiRef, api]]}>
-          <Router
-            location={history.location}
-            navigator={history}
-            children={children}
-          />
+        <TestApiProvider
+          apis={[
+            [routeResolutionApiRef, api],
+            [navigationControllerApiRef, navController],
+          ]}
+        >
+          {children}
         </TestApiProvider>
       ),
     });
 
     expect(resolve).toHaveBeenCalledTimes(1);
 
-    history.push('/my-page');
+    act(() => {
+      navController.push('/my-page');
+    });
     rerender();
 
     expect(resolve).toHaveBeenCalledTimes(1);
@@ -131,24 +206,26 @@ describe('v1 consumer', () => {
     const api = { resolve };
 
     const routeRef = createRouteRef();
-    const history = createBrowserHistory();
-    history.push('/my-page');
+    const navController = createMockNavigationController('/my-page');
 
     const { rerender } = renderHook(() => useRouteRef(routeRef), {
       wrapper: ({ children }: PropsWithChildren<{}>) => (
-        <TestApiProvider apis={[[routeResolutionApiRef, api]]}>
-          <Router
-            location={history.location}
-            navigator={history}
-            children={children}
-          />
+        <TestApiProvider
+          apis={[
+            [routeResolutionApiRef, api],
+            [navigationControllerApiRef, navController],
+          ]}
+        >
+          {children}
         </TestApiProvider>
       ),
     });
 
     expect(resolve).toHaveBeenCalledTimes(1);
 
-    history.push('/my-page?foo=bar');
+    act(() => {
+      navController.push('/my-page?foo=bar');
+    });
     rerender();
 
     expect(resolve).toHaveBeenCalledTimes(1);
@@ -159,24 +236,26 @@ describe('v1 consumer', () => {
     const api = { resolve };
 
     const routeRef = createRouteRef();
-    const history = createBrowserHistory();
-    history.push('/my-page');
+    const navController = createMockNavigationController('/my-page');
 
     const { rerender } = renderHook(() => useRouteRef(routeRef), {
       wrapper: ({ children }: PropsWithChildren<{}>) => (
-        <TestApiProvider apis={[[routeResolutionApiRef, api]]}>
-          <Router
-            location={history.location}
-            navigator={history}
-            children={children}
-          />
+        <TestApiProvider
+          apis={[
+            [routeResolutionApiRef, api],
+            [navigationControllerApiRef, navController],
+          ]}
+        >
+          {children}
         </TestApiProvider>
       ),
     });
 
     expect(resolve).toHaveBeenCalledTimes(1);
 
-    history.push('/my-page#foo');
+    act(() => {
+      navController.push('/my-page#foo');
+    });
     rerender();
 
     expect(resolve).toHaveBeenCalledTimes(1);

--- a/packages/frontend-plugin-api/src/routing/useRouteRef.tsx
+++ b/packages/frontend-plugin-api/src/routing/useRouteRef.tsx
@@ -15,7 +15,7 @@
  */
 
 import { useMemo } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useFrameworkLocation } from './useFrameworkLocation';
 import { AnyRouteRefParams } from './types';
 import { RouteRef } from './RouteRef';
 import { SubRouteRef } from './SubRouteRef';
@@ -39,7 +39,7 @@ export function useRouteRef<TParams extends AnyRouteRefParams>(
     | SubRouteRef<TParams>
     | ExternalRouteRef<TParams>,
 ): RouteFunc<TParams> | undefined {
-  const { pathname } = useLocation();
+  const { pathname } = useFrameworkLocation();
   const routeResolutionApi = useApi(routeResolutionApiRef);
 
   const routeFunc = useMemo(

--- a/packages/frontend-plugin-api/src/routing/useRouteRefParams.ts
+++ b/packages/frontend-plugin-api/src/routing/useRouteRefParams.ts
@@ -19,13 +19,23 @@ import { AnyRouteRefParams } from './types';
 import { RouteRef } from './RouteRef';
 import { SubRouteRef } from './SubRouteRef';
 
+let warned = false;
+
 /**
  * React hook for retrieving dynamic params from the current URL.
  * @param _routeRef - Ref of the current route.
  * @public
+ * @deprecated Use your router's native `useParams` hook instead.
  */
 export function useRouteRefParams<Params extends AnyRouteRefParams>(
   _routeRef: RouteRef<Params> | SubRouteRef<Params>,
 ): Params {
+  if (process.env.NODE_ENV === 'development' && !warned) {
+    warned = true;
+    // eslint-disable-next-line no-console
+    console.warn(
+      "useRouteRefParams is deprecated. Use your router's useParams() hook instead.",
+    );
+  }
   return useParams() as Params;
 }

--- a/packages/frontend-test-utils/src/apis/createMockContract.test.ts
+++ b/packages/frontend-test-utils/src/apis/createMockContract.test.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { RoutingLocation } from '@backstage/frontend-plugin-api';
+import { createMockContract } from './createMockContract';
+
+describe('createMockContract', () => {
+  it('should create a contract with the given basePath', () => {
+    const contract = createMockContract({ basePath: '/catalog' });
+    expect(contract.basePath).toBe('/catalog');
+  });
+
+  it('should emit the initial location', () => {
+    const contract = createMockContract({
+      basePath: '/',
+      initialLocation: '/foo',
+    });
+    const locs: RoutingLocation[] = [];
+    contract.location$.subscribe(l => locs.push(l));
+    expect(locs).toHaveLength(1);
+    expect(locs[0]).toEqual({ pathname: '/foo', search: '', hash: '' });
+  });
+
+  it('should default initial location to /', () => {
+    const contract = createMockContract({ basePath: '/' });
+    const locs: RoutingLocation[] = [];
+    contract.location$.subscribe(l => locs.push(l));
+    expect(locs).toHaveLength(1);
+    expect(locs[0]).toEqual({ pathname: '/', search: '', hash: '' });
+  });
+
+  it('should track navigate calls', () => {
+    const contract = createMockContract({ basePath: '/' });
+    contract.navigate('/a');
+    contract.navigate('/b', { replace: true });
+    expect(contract.navigateCalls).toEqual([
+      { to: '/a', options: undefined },
+      { to: '/b', options: { replace: true } },
+    ]);
+  });
+
+  it('should emit new location after navigate', () => {
+    const contract = createMockContract({ basePath: '/' });
+    const locs: RoutingLocation[] = [];
+    contract.location$.subscribe(l => locs.push(l));
+    contract.navigate('/bar');
+    expect(locs).toHaveLength(2);
+    expect(locs[1]).toEqual({ pathname: '/bar', search: '', hash: '' });
+  });
+
+  it('should parse query and hash correctly', () => {
+    const contract = createMockContract({
+      basePath: '/',
+      initialLocation: '/foo?bar=1#baz',
+    });
+    const locs: RoutingLocation[] = [];
+    contract.location$.subscribe(l => locs.push(l));
+    expect(locs[0]).toEqual({
+      pathname: '/foo',
+      search: '?bar=1',
+      hash: '#baz',
+    });
+  });
+
+  it('should update closed property after unsubscribe', () => {
+    const contract = createMockContract({ basePath: '/' });
+    const sub = contract.location$.subscribe(() => {});
+    expect(sub.closed).toBe(false);
+    sub.unsubscribe();
+    expect(sub.closed).toBe(true);
+  });
+});

--- a/packages/frontend-test-utils/src/apis/createMockContract.test.ts
+++ b/packages/frontend-test-utils/src/apis/createMockContract.test.ts
@@ -31,7 +31,12 @@ describe('createMockContract', () => {
     const locs: RoutingLocation[] = [];
     contract.location$.subscribe(l => locs.push(l));
     expect(locs).toHaveLength(1);
-    expect(locs[0]).toEqual({ pathname: '/foo', search: '', hash: '' });
+    expect(locs[0]).toEqual({
+      pathname: '/foo',
+      search: '',
+      hash: '',
+      state: null,
+    });
   });
 
   it('should default initial location to /', () => {
@@ -39,7 +44,12 @@ describe('createMockContract', () => {
     const locs: RoutingLocation[] = [];
     contract.location$.subscribe(l => locs.push(l));
     expect(locs).toHaveLength(1);
-    expect(locs[0]).toEqual({ pathname: '/', search: '', hash: '' });
+    expect(locs[0]).toEqual({
+      pathname: '/',
+      search: '',
+      hash: '',
+      state: null,
+    });
   });
 
   it('should track navigate calls', () => {
@@ -58,7 +68,12 @@ describe('createMockContract', () => {
     contract.location$.subscribe(l => locs.push(l));
     contract.navigate('/bar');
     expect(locs).toHaveLength(2);
-    expect(locs[1]).toEqual({ pathname: '/bar', search: '', hash: '' });
+    expect(locs[1]).toEqual({
+      pathname: '/bar',
+      search: '',
+      hash: '',
+      state: null,
+    });
   });
 
   it('should parse query and hash correctly', () => {
@@ -72,6 +87,7 @@ describe('createMockContract', () => {
       pathname: '/foo',
       search: '?bar=1',
       hash: '#baz',
+      state: null,
     });
   });
 

--- a/packages/frontend-test-utils/src/apis/createMockContract.ts
+++ b/packages/frontend-test-utils/src/apis/createMockContract.ts
@@ -36,15 +36,19 @@ export interface MockContractOptions {
  * @public
  */
 export interface MockContract extends RoutingContract {
-  navigateCalls: Array<{ to: string; options?: { replace?: boolean } }>;
+  navigateCalls: Array<{
+    to: string;
+    options?: { replace?: boolean; state?: unknown };
+  }>;
 }
 
-function parseLocation(path: string): RoutingLocation {
+function parseLocation(path: string, state?: unknown): RoutingLocation {
   const url = new URL(path, 'http://localhost');
   return {
     pathname: url.pathname,
     search: url.search,
     hash: url.hash,
+    state: state ?? null,
   };
 }
 
@@ -101,9 +105,9 @@ export function createMockContract(options: MockContractOptions): MockContract {
     basePath,
     location$,
     navigateCalls,
-    navigate(to: string, navOptions?: { replace?: boolean }) {
+    navigate(to: string, navOptions?: { replace?: boolean; state?: unknown }) {
       navigateCalls.push({ to, options: navOptions });
-      currentLocation = parseLocation(to);
+      currentLocation = parseLocation(to, navOptions?.state);
       for (const subscriber of subscribers) {
         subscriber?.(currentLocation);
       }

--- a/packages/frontend-test-utils/src/apis/createMockContract.ts
+++ b/packages/frontend-test-utils/src/apis/createMockContract.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  RoutingContract,
+  RoutingLocation,
+} from '@backstage/frontend-plugin-api';
+import { Observable, Subscription } from '@backstage/types';
+
+/**
+ * Options for creating a mock routing contract.
+ *
+ * @public
+ */
+export interface MockContractOptions {
+  basePath: string;
+  initialLocation?: string;
+}
+
+/**
+ * A mock routing contract that tracks navigate calls for testing.
+ *
+ * @public
+ */
+export interface MockContract extends RoutingContract {
+  navigateCalls: Array<{ to: string; options?: { replace?: boolean } }>;
+}
+
+function parseLocation(path: string): RoutingLocation {
+  const url = new URL(path, 'http://localhost');
+  return {
+    pathname: url.pathname,
+    search: url.search,
+    hash: url.hash,
+  };
+}
+
+/**
+ * Creates a mock {@link @backstage/frontend-plugin-api#RoutingContract} for use in tests.
+ *
+ * @public
+ */
+export function createMockContract(options: MockContractOptions): MockContract {
+  const { basePath, initialLocation = '/' } = options;
+
+  type Observer = ((value: RoutingLocation) => void) | undefined;
+
+  const subscribers = new Set<Observer>();
+  let currentLocation = parseLocation(initialLocation);
+
+  const navigateCalls: MockContract['navigateCalls'] = [];
+
+  const location$: Observable<RoutingLocation> = {
+    [Symbol.observable]() {
+      return this;
+    },
+    subscribe(
+      observerOrNext?:
+        | { next?: (value: RoutingLocation) => void }
+        | ((value: RoutingLocation) => void),
+      _onError?: (error: Error) => void,
+      _onComplete?: () => void,
+    ): Subscription {
+      const next =
+        typeof observerOrNext === 'function'
+          ? observerOrNext
+          : observerOrNext?.next?.bind(observerOrNext);
+
+      subscribers.add(next);
+
+      // Emit initial location immediately
+      next?.(currentLocation);
+
+      let closed = false;
+      return {
+        unsubscribe() {
+          subscribers.delete(next);
+          closed = true;
+        },
+        get closed() {
+          return closed;
+        },
+      };
+    },
+  };
+
+  return {
+    basePath,
+    location$,
+    navigateCalls,
+    navigate(to: string, navOptions?: { replace?: boolean }) {
+      navigateCalls.push({ to, options: navOptions });
+      currentLocation = parseLocation(to);
+      for (const subscriber of subscribers) {
+        subscriber?.(currentLocation);
+      }
+    },
+  };
+}

--- a/packages/frontend-test-utils/src/apis/index.ts
+++ b/packages/frontend-test-utils/src/apis/index.ts
@@ -15,6 +15,11 @@
  */
 
 export { mockApis } from './mockApis';
+export {
+  createMockContract,
+  type MockContractOptions,
+  type MockContract,
+} from './createMockContract';
 export { createApiMock, type ApiMock } from './createApiMock';
 export {
   type MockApiFactorySymbol,

--- a/packages/frontend-test-utils/src/app/renderInTestApp.tsx
+++ b/packages/frontend-test-utils/src/app/renderInTestApp.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { Fragment } from 'react';
-import { Link, MemoryRouter } from 'react-router-dom';
+import { Fragment, type ReactNode } from 'react';
+import { Link } from 'react-router-dom';
 import { prepareSpecializedApp } from '@backstage/frontend-app-api';
 import { RenderResult, render } from '@testing-library/react';
 import { ConfigReader } from '@backstage/config';
@@ -40,6 +40,9 @@ import { getMockApiFactory } from '../apis/MockWithApiFactory';
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import type { CreateSpecializedAppInternalOptions } from '../../../frontend-app-api/src/wiring/createSpecializedApp';
 import { TestApiPairs } from '../apis/TestApiProvider';
+// eslint-disable-next-line @backstage/no-relative-monorepo-imports
+import { ScopedRouterProvider } from '../../../frontend-plugin-api/src/blueprints/ScopedRouterProvider';
+import { createMockContract } from '../apis/createMockContract';
 
 const DEFAULT_MOCK_CONFIG = {
   app: { baseUrl: 'http://localhost:3000' },
@@ -201,23 +204,27 @@ export function renderInTestApp<const TApiPairs extends any[] = any[]>(
     }
   }
 
+  const initialEntry = options?.initialRouteEntries?.[0] ?? '/';
+
+  function TestRouter({ children }: { children: ReactNode }) {
+    const contract = createMockContract({
+      basePath: '/',
+      initialLocation: initialEntry,
+    });
+    return (
+      <ScopedRouterProvider contract={contract}>
+        {children}
+      </ScopedRouterProvider>
+    );
+  }
+
   const features: FrontendFeature[] = [
     createFrontendModule({
       pluginId: 'app',
       extensions: [
         RouterBlueprint.make({
           params: {
-            component: ({ children }) => (
-              <MemoryRouter
-                initialEntries={options?.initialRouteEntries}
-                future={{
-                  v7_relativeSplatPath: false,
-                  v7_startTransition: false,
-                }}
-              >
-                {children}
-              </MemoryRouter>
-            ),
+            component: TestRouter,
           },
         }),
       ],

--- a/plugins/app/src/extensions/AppRoot.tsx
+++ b/plugins/app/src/extensions/AppRoot.tsx
@@ -18,6 +18,7 @@ import {
   ComponentType,
   PropsWithChildren,
   ReactNode,
+  useMemo,
   useState,
   JSX,
 } from 'react';
@@ -31,6 +32,7 @@ import {
   createExtensionInput,
   routeResolutionApiRef,
   pluginWrapperApiRef,
+  navigationControllerApiRef,
   useAnalytics,
 } from '@backstage/frontend-plugin-api';
 import {
@@ -52,11 +54,12 @@ import {
 } from '@backstage/core-plugin-api';
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import { isProtectedApp } from '../../../../packages/core-app-api/src/app/isProtectedApp';
-import { BrowserRouter } from 'react-router-dom';
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import { RouteTracker } from '../../../../packages/frontend-app-api/src/routing/RouteTracker';
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import { getBasePath } from '../../../../packages/frontend-app-api/src/routing/getBasePath';
+// eslint-disable-next-line @backstage/no-relative-monorepo-imports
+import { ScopedRouterProvider } from '../../../../packages/frontend-plugin-api/src/blueprints/ScopedRouterProvider';
 
 export const AppRoot = createExtension({
   name: 'root',
@@ -208,17 +211,23 @@ export interface AppRouterProps {
 
 function DefaultRouter(props: PropsWithChildren<{}>) {
   const configApi = useApi(configApiRef);
+  const navigationController = useApi(navigationControllerApiRef);
   const basePath = getBasePath(configApi);
+
+  const rootContract = useMemo(
+    () => ({
+      basePath: '/' as const,
+      location$: navigationController.location$,
+      navigate: (to: string, opts?: { replace?: boolean; state?: unknown }) =>
+        navigationController.navigate(to, opts),
+    }),
+    [navigationController],
+  );
+
   return (
-    <BrowserRouter
-      basename={basePath}
-      future={{
-        v7_relativeSplatPath: false,
-        v7_startTransition: false,
-      }}
-    >
+    <ScopedRouterProvider contract={rootContract} basename={basePath}>
       {props.children}
-    </BrowserRouter>
+    </ScopedRouterProvider>
   );
 }
 

--- a/plugins/app/src/extensions/AppRoutes.test.tsx
+++ b/plugins/app/src/extensions/AppRoutes.test.tsx
@@ -102,6 +102,38 @@ describe('AppRoutes', () => {
     });
   });
 
+  it('should prefer a more specific entity route over the catalog index route', async () => {
+    const catalogPage = PageBlueprint.make({
+      name: 'catalog',
+      params: {
+        path: '/catalog',
+        loader: async () => (
+          <div data-testid="catalog-page">Catalog Index Page</div>
+        ),
+      },
+    });
+
+    const catalogEntityPage = PageBlueprint.make({
+      name: 'catalog-entity',
+      params: {
+        path: '/catalog/:namespace/:kind/:name',
+        loader: async () => (
+          <div data-testid="catalog-entity-page">Catalog Entity Page</div>
+        ),
+      },
+    });
+
+    renderTestApp({
+      extensions: [catalogPage, catalogEntityPage],
+      initialRouteEntries: ['/catalog/default/component/my-entity'],
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('catalog-entity-page')).toBeInTheDocument();
+      expect(screen.queryByTestId('catalog-page')).not.toBeInTheDocument();
+    });
+  });
+
   it('should support relative links within routes', async () => {
     const CatalogWithLinks = () => {
       return (

--- a/plugins/catalog/package.json
+++ b/plugins/catalog/package.json
@@ -69,6 +69,7 @@
     "@backstage/plugin-catalog-common": "workspace:^",
     "@backstage/plugin-catalog-react": "workspace:^",
     "@backstage/plugin-permission-react": "workspace:^",
+    "@backstage/plugin-react-router-v6-adapter": "workspace:^",
     "@backstage/plugin-scaffolder-common": "workspace:^",
     "@backstage/plugin-search-common": "workspace:^",
     "@backstage/plugin-search-react": "workspace:^",

--- a/plugins/catalog/src/alpha/pages.tsx
+++ b/plugins/catalog/src/alpha/pages.tsx
@@ -14,12 +14,18 @@
  * limitations under the License.
  */
 
+import { type ReactNode, useContext, useRef, useEffect } from 'react';
 import { convertLegacyRouteRef } from '@backstage/core-compat-api';
 import {
   coreExtensionData,
   createExtensionInput,
   PageBlueprint,
+  RoutingContractContext,
 } from '@backstage/frontend-plugin-api';
+import {
+  createScopedRouter,
+  type ScopedRouterResult,
+} from '@backstage/plugin-react-router-v6-adapter';
 import {
   AsyncEntityProvider,
   entityRouteRef,
@@ -35,6 +41,30 @@ import CategoryIcon from '@material-ui/icons/Category';
 import { rootRouteRef } from '../routes';
 import { useEntityFromUrl } from '../components/CatalogEntityPage/useEntityFromUrl';
 import { buildFilterFn } from './filter/FilterWrapper';
+
+function CatalogAdapterRoot({ children }: { children: ReactNode }) {
+  const contract = useContext(RoutingContractContext);
+  const scopedRouterRef = useRef<ScopedRouterResult | null>(null);
+
+  useEffect(() => {
+    return () => {
+      scopedRouterRef.current?.dispose();
+      scopedRouterRef.current = null;
+    };
+  }, [contract]);
+
+  if (!contract) {
+    return <>{children}</>;
+  }
+
+  if (!scopedRouterRef.current) {
+    scopedRouterRef.current = createScopedRouter(contract);
+  }
+
+  const scopedRouter = scopedRouterRef.current;
+
+  return <scopedRouter.Router>{children}</scopedRouter.Router>;
+}
 
 export const catalogPage = PageBlueprint.makeWithOverrides({
   inputs: {
@@ -69,10 +99,12 @@ export const catalogPage = PageBlueprint.makeWithOverrides({
           filter.get(coreExtensionData.reactElement),
         );
         return (
-          <NfsDefaultCatalogPage
-            filters={<>{filters}</>}
-            pagination={config.pagination}
-          />
+          <CatalogAdapterRoot>
+            <NfsDefaultCatalogPage
+              filters={<>{filters}</>}
+              pagination={config.pagination}
+            />
+          </CatalogAdapterRoot>
         );
       },
     });
@@ -208,7 +240,11 @@ export const catalogEntityPage = PageBlueprint.makeWithOverrides({
           );
         };
 
-        return <Component />;
+        return (
+          <CatalogAdapterRoot>
+            <Component />
+          </CatalogAdapterRoot>
+        );
       },
     });
   },

--- a/plugins/home/package.json
+++ b/plugins/home/package.json
@@ -66,6 +66,7 @@
     "@backstage/frontend-plugin-api": "workspace:^",
     "@backstage/plugin-catalog-react": "workspace:^",
     "@backstage/plugin-home-react": "workspace:^",
+    "@backstage/plugin-tanstack-router-adapter": "workspace:^",
     "@backstage/theme": "workspace:^",
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
@@ -87,6 +88,7 @@
     "@backstage/frontend-defaults": "workspace:^",
     "@backstage/plugin-catalog": "workspace:^",
     "@backstage/test-utils": "workspace:^",
+    "@tanstack/react-router": "^1.0.0",
     "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^16.0.0",
@@ -98,6 +100,7 @@
     "react-router-dom": "^6.30.2"
   },
   "peerDependencies": {
+    "@tanstack/react-router": "^1.0.0",
     "@types/react": "^17.0.0 || ^18.0.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",

--- a/plugins/home/src/alpha.tsx
+++ b/plugins/home/src/alpha.tsx
@@ -62,6 +62,15 @@ import {
 
 const rootRouteRef = createRouteRef();
 
+/**
+ * Adapter root for TanStack Router integration.
+ *
+ * Uses the TanStack adapter's `Router` component which renders children inside
+ * the TanStack router context via a root route component. This allows children
+ * to use TanStack routing hooks (useNavigate, useParams, etc.).
+ *
+ * @internal
+ */
 function HomeAdapterRoot({ children }: { children: ReactNode }) {
   const contract = useContext(RoutingContractContext);
   const scopedRouterRef = useRef<TanStackScopedRouterResult | null>(null);
@@ -81,14 +90,8 @@ function HomeAdapterRoot({ children }: { children: ReactNode }) {
     scopedRouterRef.current = createScopedRouter(contract);
   }
 
-  // TanStack RouterProvider renders its route tree internally and does not
-  // accept children. For the home plugin (no TanStack routes, proof-of-concept),
-  // render the provider alongside children.
   return (
-    <>
-      <scopedRouterRef.current.RouterProvider />
-      {children}
-    </>
+    <scopedRouterRef.current.Router>{children}</scopedRouterRef.current.Router>
   );
 }
 

--- a/plugins/home/src/alpha.tsx
+++ b/plugins/home/src/alpha.tsx
@@ -24,7 +24,13 @@
  * @packageDocumentation
  */
 
-import { type ReactNode, lazy as reactLazy, useRef, useEffect } from 'react';
+import {
+  type ReactNode,
+  lazy as reactLazy,
+  useContext,
+  useRef,
+  useEffect,
+} from 'react';
 import {
   createExtensionInput,
   PageBlueprint,
@@ -37,7 +43,7 @@ import {
   errorApiRef,
   ApiBlueprint,
   ExtensionBoundary,
-  useRoutingContract,
+  RoutingContractContext,
 } from '@backstage/frontend-plugin-api';
 import { VisitListener } from './components/';
 import { visitsApiRef, VisitsStorageApi, VisitsWebStorageApi } from './api';
@@ -57,7 +63,7 @@ import {
 const rootRouteRef = createRouteRef();
 
 function HomeAdapterRoot({ children }: { children: ReactNode }) {
-  const contract = useRoutingContract();
+  const contract = useContext(RoutingContractContext);
   const scopedRouterRef = useRef<TanStackScopedRouterResult | null>(null);
 
   useEffect(() => {

--- a/plugins/home/src/alpha.tsx
+++ b/plugins/home/src/alpha.tsx
@@ -24,7 +24,7 @@
  * @packageDocumentation
  */
 
-import { lazy as reactLazy } from 'react';
+import { type ReactNode, lazy as reactLazy, useRef, useEffect } from 'react';
 import {
   createExtensionInput,
   PageBlueprint,
@@ -37,6 +37,7 @@ import {
   errorApiRef,
   ApiBlueprint,
   ExtensionBoundary,
+  useRoutingContract,
 } from '@backstage/frontend-plugin-api';
 import { VisitListener } from './components/';
 import { visitsApiRef, VisitsStorageApi, VisitsWebStorageApi } from './api';
@@ -48,8 +49,42 @@ import {
   HomePageWidgetBlueprint,
   type HomePageLayoutProps,
 } from '@backstage/plugin-home-react/alpha';
+import {
+  createScopedRouter,
+  type TanStackScopedRouterResult,
+} from '@backstage/plugin-tanstack-router-adapter';
 
 const rootRouteRef = createRouteRef();
+
+function HomeAdapterRoot({ children }: { children: ReactNode }) {
+  const contract = useRoutingContract();
+  const scopedRouterRef = useRef<TanStackScopedRouterResult | null>(null);
+
+  useEffect(() => {
+    return () => {
+      scopedRouterRef.current?.dispose();
+      scopedRouterRef.current = null;
+    };
+  }, [contract]);
+
+  if (!contract) {
+    return <>{children}</>;
+  }
+
+  if (!scopedRouterRef.current) {
+    scopedRouterRef.current = createScopedRouter(contract);
+  }
+
+  // TanStack RouterProvider renders its route tree internally and does not
+  // accept children. For the home plugin (no TanStack routes, proof-of-concept),
+  // render the provider alongside children.
+  return (
+    <>
+      <scopedRouterRef.current.RouterProvider />
+      {children}
+    </>
+  );
+}
 
 const homePage = PageBlueprint.makeWithOverrides({
   inputs: {
@@ -87,7 +122,11 @@ const homePage = PageBlueprint.makeWithOverrides({
           node: widget.node,
         }));
 
-        return <Layout widgets={widgets} />;
+        return (
+          <HomeAdapterRoot>
+            <Layout widgets={widgets} />
+          </HomeAdapterRoot>
+        );
       },
     });
   },

--- a/plugins/home/src/components/StarredEntityListItem/StarredEntityListItem.tsx
+++ b/plugins/home/src/components/StarredEntityListItem/StarredEntityListItem.tsx
@@ -21,7 +21,7 @@ import {
 import ListItem from '@material-ui/core/ListItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
-import { Link } from 'react-router-dom';
+import { Link } from '@backstage/core-components';
 import { entityRouteRef } from '@backstage/plugin-catalog-react';
 import { useRouteRef } from '@backstage/core-plugin-api';
 import { FavoriteToggle } from '@backstage/core-components';

--- a/plugins/plugin-react-router-v6-adapter/.eslintrc.js
+++ b/plugins/plugin-react-router-v6-adapter/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/plugins/plugin-react-router-v6-adapter/catalog-info.yaml
+++ b/plugins/plugin-react-router-v6-adapter/catalog-info.yaml
@@ -1,0 +1,12 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-react-router-v6-adapter
+  title: '@backstage/plugin-react-router-v6-adapter'
+  description: >-
+    React Router v6 adapter for the Backstage router-agnostic plugin routing
+    system
+spec:
+  lifecycle: experimental
+  type: backstage-web-library
+  owner: maintainers

--- a/plugins/plugin-react-router-v6-adapter/package.json
+++ b/plugins/plugin-react-router-v6-adapter/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "@backstage/plugin-react-router-v6-adapter",
+  "version": "0.1.0",
+  "description": "React Router v6 adapter for the Backstage router-agnostic plugin routing system",
+  "backstage": {
+    "role": "web-library"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "backstage"
+  ],
+  "homepage": "https://backstage.io",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/backstage/backstage",
+    "directory": "plugins/plugin-react-router-v6-adapter"
+  },
+  "license": "Apache-2.0",
+  "sideEffects": false,
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "typesVersions": {
+    "*": {
+      "package.json": [
+        "package.json"
+      ]
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "backstage-cli package build",
+    "clean": "backstage-cli package clean",
+    "lint": "backstage-cli package lint",
+    "prepack": "backstage-cli package prepack",
+    "postpack": "backstage-cli package postpack",
+    "start": "backstage-cli package start",
+    "test": "backstage-cli package test"
+  },
+  "dependencies": {
+    "@backstage/frontend-plugin-api": "workspace:^"
+  },
+  "devDependencies": {
+    "@backstage/cli": "workspace:^",
+    "@testing-library/dom": "^10.0.0",
+    "@testing-library/jest-dom": "^6.0.0",
+    "@testing-library/react": "^16.0.0",
+    "@types/react": "^18.0.0",
+    "react": "^18.0.2",
+    "react-dom": "^18.0.2",
+    "react-router": "^6.30.2",
+    "react-router-dom": "^6.30.2"
+  },
+  "peerDependencies": {
+    "@types/react": "^17.0.0 || ^18.0.0",
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0",
+    "react-router": "^6.30.2",
+    "react-router-dom": "^6.30.2"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
+  }
+}

--- a/plugins/plugin-react-router-v6-adapter/src/createScopedRouter.test.tsx
+++ b/plugins/plugin-react-router-v6-adapter/src/createScopedRouter.test.tsx
@@ -21,6 +21,7 @@ import type {
   RoutingLocation,
 } from '@backstage/frontend-plugin-api';
 import type { Observer, Subscription } from '@backstage/types';
+import { useParams, useOutlet } from 'react-router-dom';
 import { createScopedRouter } from './createScopedRouter';
 
 function createMockContract(
@@ -236,6 +237,33 @@ describe('createScopedRouter', () => {
     expect(screen.getByTestId('pathname')).toHaveTextContent(
       '/catalog/entity/foo',
     );
+  });
+
+  it('should provide UNSAFE_RouteContext with empty defaults', () => {
+    const contract = createMockContract();
+    const { Router } = createScopedRouter(contract);
+
+    function RouteContextInspector() {
+      const params = useParams();
+      const outlet = useOutlet();
+      return (
+        <div>
+          <span data-testid="params">{JSON.stringify(params)}</span>
+          <span data-testid="outlet">
+            {outlet === null ? 'null' : 'present'}
+          </span>
+        </div>
+      );
+    }
+
+    render(
+      <Router>
+        <RouteContextInspector />
+      </Router>,
+    );
+
+    expect(screen.getByTestId('params')).toHaveTextContent('{}');
+    expect(screen.getByTestId('outlet')).toHaveTextContent('null');
   });
 
   it('should return useLocation, useNavigate, useParams, useSearchParams', () => {

--- a/plugins/plugin-react-router-v6-adapter/src/createScopedRouter.test.tsx
+++ b/plugins/plugin-react-router-v6-adapter/src/createScopedRouter.test.tsx
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type {
+  RoutingContract,
+  RoutingLocation,
+} from '@backstage/frontend-plugin-api';
+import type { Observer, Subscription } from '@backstage/types';
+import { createScopedRouter } from './createScopedRouter';
+
+function createMockContract(
+  initialLocation: RoutingLocation = {
+    pathname: '/catalog/entity/foo',
+    search: '',
+    hash: '',
+  },
+): RoutingContract & {
+  emit: (location: RoutingLocation) => void;
+  navigate: jest.Mock;
+} {
+  let currentLocation = initialLocation;
+  const observers = new Set<Observer<RoutingLocation>>();
+
+  const navigate = jest.fn();
+
+  const location$ = {
+    subscribe(
+      observerOrNext?:
+        | Observer<RoutingLocation>
+        | ((value: RoutingLocation) => void),
+      _onError?: (error: Error) => void,
+      _onComplete?: () => void,
+    ): Subscription {
+      const observer: Observer<RoutingLocation> =
+        typeof observerOrNext === 'function'
+          ? { next: observerOrNext }
+          : observerOrNext || {};
+
+      observers.add(observer);
+
+      // Emit the current value immediately
+      observer.next?.(currentLocation);
+
+      return {
+        unsubscribe: () => {
+          observers.delete(observer);
+        },
+        get closed() {
+          return !observers.has(observer);
+        },
+      };
+    },
+    [Symbol.observable]() {
+      return this;
+    },
+  };
+
+  function emit(location: RoutingLocation) {
+    currentLocation = location;
+    for (const observer of observers) {
+      observer.next?.(location);
+    }
+  }
+
+  return {
+    basePath: '/catalog',
+    location$,
+    navigate,
+    emit,
+  };
+}
+
+describe('createScopedRouter', () => {
+  it('should render children inside a React Router context', () => {
+    const contract = createMockContract();
+    const { Router } = createScopedRouter(contract);
+
+    render(
+      <Router>
+        <div data-testid="child">Hello</div>
+      </Router>,
+    );
+
+    expect(screen.getByTestId('child')).toHaveTextContent('Hello');
+  });
+
+  it('should sync initial location from contract without flash', () => {
+    const contract = createMockContract({
+      pathname: '/catalog/entity/bar',
+      search: '?q=test',
+      hash: '#section',
+    });
+    const { Router, useLocation } = createScopedRouter(contract);
+
+    const renderedPathnames: string[] = [];
+
+    function LocationDisplay() {
+      const location = useLocation();
+      renderedPathnames.push(location.pathname);
+      return <div data-testid="pathname">{location.pathname}</div>;
+    }
+
+    render(
+      <Router>
+        <LocationDisplay />
+      </Router>,
+    );
+
+    // The FIRST render must have the correct pathname, not '/'
+    expect(renderedPathnames[0]).toBe('/catalog/entity/bar');
+    expect(screen.getByTestId('pathname')).toHaveTextContent(
+      '/catalog/entity/bar',
+    );
+  });
+
+  it('should delegate navigate calls to contract', () => {
+    const contract = createMockContract();
+    const { Router, useNavigate } = createScopedRouter(contract);
+
+    function NavButton() {
+      const navigate = useNavigate();
+      return (
+        <button
+          data-testid="nav-btn"
+          onClick={() => navigate('/catalog/entity/new')}
+        >
+          Go
+        </button>
+      );
+    }
+
+    render(
+      <Router>
+        <NavButton />
+      </Router>,
+    );
+
+    act(() => {
+      screen.getByTestId('nav-btn').click();
+    });
+
+    expect(contract.navigate).toHaveBeenCalledWith('/catalog/entity/new', {
+      replace: false,
+    });
+  });
+
+  it('should update when contract emits new location', () => {
+    const contract = createMockContract({
+      pathname: '/catalog/entity/foo',
+      search: '',
+      hash: '',
+    });
+    const { Router, useLocation } = createScopedRouter(contract);
+
+    function LocationDisplay() {
+      const location = useLocation();
+      return <div data-testid="pathname">{location.pathname}</div>;
+    }
+
+    render(
+      <Router>
+        <LocationDisplay />
+      </Router>,
+    );
+
+    expect(screen.getByTestId('pathname')).toHaveTextContent(
+      '/catalog/entity/foo',
+    );
+
+    act(() => {
+      contract.emit({
+        pathname: '/catalog/entity/updated',
+        search: '',
+        hash: '',
+      });
+    });
+
+    expect(screen.getByTestId('pathname')).toHaveTextContent(
+      '/catalog/entity/updated',
+    );
+  });
+
+  it('should return useLocation, useNavigate, useParams, useSearchParams', () => {
+    const contract = createMockContract();
+    const result = createScopedRouter(contract);
+
+    expect(result).toHaveProperty('Router');
+    expect(result).toHaveProperty('useLocation');
+    expect(result).toHaveProperty('useNavigate');
+    expect(result).toHaveProperty('useParams');
+    expect(result).toHaveProperty('useSearchParams');
+
+    expect(typeof result.Router).toBe('function');
+    expect(typeof result.useLocation).toBe('function');
+    expect(typeof result.useNavigate).toBe('function');
+    expect(typeof result.useParams).toBe('function');
+    expect(typeof result.useSearchParams).toBe('function');
+  });
+});

--- a/plugins/plugin-react-router-v6-adapter/src/createScopedRouter.test.tsx
+++ b/plugins/plugin-react-router-v6-adapter/src/createScopedRouter.test.tsx
@@ -195,6 +195,49 @@ describe('createScopedRouter', () => {
     );
   });
 
+  it('should stop receiving updates after dispose()', () => {
+    const contract = createMockContract({
+      pathname: '/catalog/entity/foo',
+      search: '',
+      hash: '',
+    });
+    const { Router, useLocation, dispose } = createScopedRouter(contract);
+
+    const renderedPathnames: string[] = [];
+
+    function LocationDisplay() {
+      const location = useLocation();
+      renderedPathnames.push(location.pathname);
+      return <div data-testid="pathname">{location.pathname}</div>;
+    }
+
+    render(
+      <Router>
+        <LocationDisplay />
+      </Router>,
+    );
+
+    expect(screen.getByTestId('pathname')).toHaveTextContent(
+      '/catalog/entity/foo',
+    );
+
+    dispose();
+
+    // After dispose, emitting should not update the component
+    act(() => {
+      contract.emit({
+        pathname: '/catalog/entity/after-dispose',
+        search: '',
+        hash: '',
+      });
+    });
+
+    // Should still show the old value
+    expect(screen.getByTestId('pathname')).toHaveTextContent(
+      '/catalog/entity/foo',
+    );
+  });
+
   it('should return useLocation, useNavigate, useParams, useSearchParams', () => {
     const contract = createMockContract();
     const result = createScopedRouter(contract);

--- a/plugins/plugin-react-router-v6-adapter/src/createScopedRouter.ts
+++ b/plugins/plugin-react-router-v6-adapter/src/createScopedRouter.ts
@@ -54,6 +54,12 @@ export interface ScopedRouterResult {
 export function createScopedRouter(
   contract: RoutingContract,
 ): ScopedRouterResult {
+  if (!contract) {
+    throw new Error(
+      'createScopedRouter requires a RoutingContract. Ensure this component is rendered inside a PageBlueprint.',
+    );
+  }
+
   // Store for useSyncExternalStore — keeps the latest location from the contract
   let latestLocation: Location = {
     pathname: '/',

--- a/plugins/plugin-react-router-v6-adapter/src/createScopedRouter.ts
+++ b/plugins/plugin-react-router-v6-adapter/src/createScopedRouter.ts
@@ -72,7 +72,7 @@ export function createScopedRouter(
       pathname: routingLocation.pathname,
       search: routingLocation.search,
       hash: routingLocation.hash,
-      state: null,
+      state: routingLocation.state ?? null,
       key: 'default',
     };
     for (const listener of listeners) {
@@ -116,13 +116,19 @@ export function createScopedRouter(
           // popstate fires and NavigationController catches it
           window.history.go(delta);
         },
-        push(to: To, _state?: any, _opts?: any): void {
-          const path = typeof to === 'string' ? to : createPath(to);
-          contract.navigate(path, { replace: false });
+        push(to: To, state?: any, _opts?: any): void {
+          const path =
+            typeof to === 'string'
+              ? to
+              : createPath(to, latestLocation.pathname);
+          contract.navigate(path, { replace: false, state });
         },
-        replace(to: To, _state?: any, _opts?: any): void {
-          const path = typeof to === 'string' ? to : createPath(to);
-          contract.navigate(path, { replace: true });
+        replace(to: To, state?: any, _opts?: any): void {
+          const path =
+            typeof to === 'string'
+              ? to
+              : createPath(to, latestLocation.pathname);
+          contract.navigate(path, { replace: true, state });
         },
       }),
       [],
@@ -165,7 +171,10 @@ export function createScopedRouter(
 
 function createPath(
   to: Partial<{ pathname: string; search: string; hash: string }>,
+  currentPathname: string,
 ): string {
-  const { pathname = '/', search = '', hash = '' } = to;
+  // Use current pathname when To.pathname is undefined (e.g., useSearchParams
+  // updates only search params without specifying a pathname)
+  const { pathname = currentPathname, search = '', hash = '' } = to;
   return `${pathname}${search}${hash}`;
 }

--- a/plugins/plugin-react-router-v6-adapter/src/createScopedRouter.ts
+++ b/plugins/plugin-react-router-v6-adapter/src/createScopedRouter.ts
@@ -60,7 +60,9 @@ export function createScopedRouter(
     );
   }
 
-  // Store for useSyncExternalStore — keeps the latest location from the contract
+  // Store for useSyncExternalStore — keeps the latest location from the contract.
+  // The initial value is captured synchronously since contract.location$ emits
+  // synchronously on subscribe.
   let latestLocation: Location = {
     pathname: '/',
     search: '',
@@ -69,28 +71,56 @@ export function createScopedRouter(
     key: 'default',
   };
 
+  // Capture the initial value synchronously
+  const initialSub = contract.location$.subscribe(loc => {
+    latestLocation = {
+      pathname: loc.pathname,
+      search: loc.search,
+      hash: loc.hash,
+      state: loc.state ?? null,
+      key: 'default',
+    };
+  });
+  initialSub.unsubscribe();
+
   // Set of listener callbacks for useSyncExternalStore
   const listeners = new Set<() => void>();
 
-  // Subscribe to the contract's location$ eagerly so we capture the initial value.
-  // The subscription is stored so it can be cleaned up via dispose().
-  const subscription = contract.location$.subscribe(routingLocation => {
-    latestLocation = {
-      pathname: routingLocation.pathname,
-      search: routingLocation.search,
-      hash: routingLocation.hash,
-      state: routingLocation.state ?? null,
-      key: 'default',
-    };
-    for (const listener of listeners) {
-      listener();
-    }
-  });
+  // Subscription reference — managed by useSyncExternalStore's subscribe lifecycle.
+  // React calls subscribe during commit and the returned cleanup on unmount,
+  // so this correctly handles Strict Mode and concurrent rendering without
+  // requiring render-phase side effects.
+  let subscription: { unsubscribe(): void } | undefined;
+
+  function subscribeToContract(): void {
+    if (subscription) return;
+    subscription = contract.location$.subscribe(routingLocation => {
+      latestLocation = {
+        pathname: routingLocation.pathname,
+        search: routingLocation.search,
+        hash: routingLocation.hash,
+        state: routingLocation.state ?? null,
+        key: 'default',
+      };
+      for (const listener of listeners) {
+        listener();
+      }
+    });
+  }
+
+  function unsubscribeFromContract(): void {
+    subscription?.unsubscribe();
+    subscription = undefined;
+  }
 
   function subscribe(listener: () => void): () => void {
     listeners.add(listener);
+    subscribeToContract();
     return () => {
       listeners.delete(listener);
+      if (listeners.size === 0) {
+        unsubscribeFromContract();
+      }
     };
   }
 
@@ -185,7 +215,10 @@ export function createScopedRouter(
       useRRParams() as T,
     useSearchParams: (...args: Parameters<typeof useRRSearchParams>) =>
       useRRSearchParams(...args),
-    dispose: () => subscription.unsubscribe(),
+    dispose: () => {
+      unsubscribeFromContract();
+      listeners.clear();
+    },
   };
 }
 

--- a/plugins/plugin-react-router-v6-adapter/src/createScopedRouter.ts
+++ b/plugins/plugin-react-router-v6-adapter/src/createScopedRouter.ts
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useSyncExternalStore } from 'react';
+import type { RoutingContract } from '@backstage/frontend-plugin-api';
+import {
+  UNSAFE_LocationContext,
+  UNSAFE_NavigationContext,
+  NavigationType,
+} from 'react-router';
+import type { Navigator } from 'react-router';
+import {
+  useLocation as useRRLocation,
+  useNavigate as useRRNavigate,
+  useParams as useRRParams,
+  useSearchParams as useRRSearchParams,
+} from 'react-router-dom';
+import type { Location, NavigateFunction, To } from 'react-router-dom';
+
+/** @public */
+export interface ScopedRouterResult {
+  Router: React.ComponentType<{ children: React.ReactNode }>;
+  useLocation: () => Location;
+  useNavigate: () => NavigateFunction;
+  useParams: <T extends Record<string, string | undefined>>() => T;
+  useSearchParams: (
+    ...args: Parameters<typeof useRRSearchParams>
+  ) => ReturnType<typeof useRRSearchParams>;
+}
+
+/** @public */
+export function createScopedRouter(
+  contract: RoutingContract,
+): ScopedRouterResult {
+  // Store for useSyncExternalStore — keeps the latest location from the contract
+  let latestLocation: Location = {
+    pathname: '/',
+    search: '',
+    hash: '',
+    state: null,
+    key: 'default',
+  };
+
+  // Set of listener callbacks for useSyncExternalStore
+  const listeners = new Set<() => void>();
+
+  // Subscribe to the contract's location$ eagerly so we capture the initial value
+  contract.location$.subscribe(routingLocation => {
+    latestLocation = {
+      pathname: routingLocation.pathname,
+      search: routingLocation.search,
+      hash: routingLocation.hash,
+      state: null,
+      key: 'default',
+    };
+    for (const listener of listeners) {
+      listener();
+    }
+  });
+
+  function subscribe(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  }
+
+  function getSnapshot(): Location {
+    return latestLocation;
+  }
+
+  function ScopedRouter({ children }: { children: React.ReactNode }) {
+    const location = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+    const locationContextValue = React.useMemo(
+      () => ({
+        location,
+        navigationType: NavigationType.Pop,
+      }),
+      [location],
+    );
+
+    const navigator: Navigator = React.useMemo(
+      () => ({
+        createHref(to: To): string {
+          if (typeof to === 'string') {
+            return to;
+          }
+          const { pathname = '/', search = '', hash = '' } = to;
+          return `${pathname}${search}${hash}`;
+        },
+        go(delta: number): void {
+          // Intentional: delegate to window.history.go()
+          // popstate fires and NavigationController catches it
+          window.history.go(delta);
+        },
+        push(to: To, _state?: any, _opts?: any): void {
+          const path = typeof to === 'string' ? to : createPath(to);
+          contract.navigate(path, { replace: false });
+        },
+        replace(to: To, _state?: any, _opts?: any): void {
+          const path = typeof to === 'string' ? to : createPath(to);
+          contract.navigate(path, { replace: true });
+        },
+      }),
+      [],
+    );
+
+    const navigationContextValue = React.useMemo(
+      () => ({
+        basename: '',
+        navigator,
+        static: false,
+        future: {
+          v7_relativeSplatPath: false,
+        },
+      }),
+      [navigator],
+    );
+
+    return React.createElement(
+      UNSAFE_NavigationContext.Provider,
+      { value: navigationContextValue },
+      React.createElement(
+        UNSAFE_LocationContext.Provider,
+        { value: locationContextValue },
+        children,
+      ),
+    );
+  }
+
+  return {
+    Router: ScopedRouter,
+    useLocation: (): Location => useRRLocation(),
+    useNavigate: (): NavigateFunction => useRRNavigate(),
+    useParams: <T extends Record<string, string | undefined>>(): T =>
+      useRRParams() as T,
+    useSearchParams: (...args: Parameters<typeof useRRSearchParams>) =>
+      useRRSearchParams(...args),
+  };
+}
+
+function createPath(
+  to: Partial<{ pathname: string; search: string; hash: string }>,
+): string {
+  const { pathname = '/', search = '', hash = '' } = to;
+  return `${pathname}${search}${hash}`;
+}

--- a/plugins/plugin-react-router-v6-adapter/src/createScopedRouter.ts
+++ b/plugins/plugin-react-router-v6-adapter/src/createScopedRouter.ts
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import React, { useSyncExternalStore } from 'react';
+import {
+  createElement,
+  useMemo,
+  useSyncExternalStore,
+  type ComponentType,
+  type ReactNode,
+} from 'react';
 import type { RoutingContract } from '@backstage/frontend-plugin-api';
 import {
   UNSAFE_LocationContext,
@@ -32,13 +38,15 @@ import type { Location, NavigateFunction, To } from 'react-router-dom';
 
 /** @public */
 export interface ScopedRouterResult {
-  Router: React.ComponentType<{ children: React.ReactNode }>;
+  Router: ComponentType<{ children: ReactNode }>;
   useLocation: () => Location;
   useNavigate: () => NavigateFunction;
   useParams: <T extends Record<string, string | undefined>>() => T;
   useSearchParams: (
     ...args: Parameters<typeof useRRSearchParams>
   ) => ReturnType<typeof useRRSearchParams>;
+  /** Unsubscribes from the contract's location$ observable. */
+  dispose: () => void;
 }
 
 /** @public */
@@ -57,8 +65,9 @@ export function createScopedRouter(
   // Set of listener callbacks for useSyncExternalStore
   const listeners = new Set<() => void>();
 
-  // Subscribe to the contract's location$ eagerly so we capture the initial value
-  contract.location$.subscribe(routingLocation => {
+  // Subscribe to the contract's location$ eagerly so we capture the initial value.
+  // The subscription is stored so it can be cleaned up via dispose().
+  const subscription = contract.location$.subscribe(routingLocation => {
     latestLocation = {
       pathname: routingLocation.pathname,
       search: routingLocation.search,
@@ -82,10 +91,10 @@ export function createScopedRouter(
     return latestLocation;
   }
 
-  function ScopedRouter({ children }: { children: React.ReactNode }) {
+  function ScopedRouter({ children }: { children: ReactNode }) {
     const location = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 
-    const locationContextValue = React.useMemo(
+    const locationContextValue = useMemo(
       () => ({
         location,
         navigationType: NavigationType.Pop,
@@ -93,7 +102,7 @@ export function createScopedRouter(
       [location],
     );
 
-    const navigator: Navigator = React.useMemo(
+    const navigator: Navigator = useMemo(
       () => ({
         createHref(to: To): string {
           if (typeof to === 'string') {
@@ -119,7 +128,7 @@ export function createScopedRouter(
       [],
     );
 
-    const navigationContextValue = React.useMemo(
+    const navigationContextValue = useMemo(
       () => ({
         basename: '',
         navigator,
@@ -131,10 +140,10 @@ export function createScopedRouter(
       [navigator],
     );
 
-    return React.createElement(
+    return createElement(
       UNSAFE_NavigationContext.Provider,
       { value: navigationContextValue },
-      React.createElement(
+      createElement(
         UNSAFE_LocationContext.Provider,
         { value: locationContextValue },
         children,
@@ -150,6 +159,7 @@ export function createScopedRouter(
       useRRParams() as T,
     useSearchParams: (...args: Parameters<typeof useRRSearchParams>) =>
       useRRSearchParams(...args),
+    dispose: () => subscription.unsubscribe(),
   };
 }
 

--- a/plugins/plugin-react-router-v6-adapter/src/createScopedRouter.ts
+++ b/plugins/plugin-react-router-v6-adapter/src/createScopedRouter.ts
@@ -25,6 +25,7 @@ import type { RoutingContract } from '@backstage/frontend-plugin-api';
 import {
   UNSAFE_LocationContext,
   UNSAFE_NavigationContext,
+  UNSAFE_RouteContext,
   NavigationType,
 } from 'react-router';
 import type { Navigator } from 'react-router';
@@ -146,13 +147,26 @@ export function createScopedRouter(
       [navigator],
     );
 
+    const routeContextValue = useMemo(
+      () => ({
+        outlet: null,
+        matches: [] as any[],
+        isDataRoute: false,
+      }),
+      [],
+    );
+
     return createElement(
       UNSAFE_NavigationContext.Provider,
       { value: navigationContextValue },
       createElement(
         UNSAFE_LocationContext.Provider,
         { value: locationContextValue },
-        children,
+        createElement(
+          UNSAFE_RouteContext.Provider,
+          { value: routeContextValue },
+          children,
+        ),
       ),
     );
   }

--- a/plugins/plugin-react-router-v6-adapter/src/index.ts
+++ b/plugins/plugin-react-router-v6-adapter/src/index.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { createScopedRouter } from './createScopedRouter';
+export type { ScopedRouterResult } from './createScopedRouter';

--- a/plugins/plugin-react-router-v7-adapter/.eslintrc.js
+++ b/plugins/plugin-react-router-v7-adapter/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/plugins/plugin-react-router-v7-adapter/catalog-info.yaml
+++ b/plugins/plugin-react-router-v7-adapter/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-react-router-v7-adapter
+  title: '@backstage/plugin-react-router-v7-adapter'
+spec:
+  lifecycle: experimental
+  type: backstage-web-library
+  owner: maintainers

--- a/plugins/plugin-react-router-v7-adapter/package.json
+++ b/plugins/plugin-react-router-v7-adapter/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@backstage/plugin-react-router-v7-adapter",
+  "version": "0.1.0",
+  "backstage": {
+    "role": "web-library"
+  },
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "test": "backstage-cli package test"
+  },
+  "dependencies": {
+    "@backstage/frontend-plugin-api": "workspace:^"
+  },
+  "devDependencies": {
+    "@backstage/cli": "workspace:^",
+    "@testing-library/dom": "^10.0.0",
+    "@testing-library/jest-dom": "^6.0.0",
+    "@testing-library/react": "^16.0.0",
+    "@types/react": "^18.0.0",
+    "react": "^18.0.2",
+    "react-dom": "^18.0.2",
+    "react-router": "^7.0.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0",
+    "react-router": "^7.0.0"
+  }
+}

--- a/plugins/plugin-react-router-v7-adapter/src/createScopedRouter.test.tsx
+++ b/plugins/plugin-react-router-v7-adapter/src/createScopedRouter.test.tsx
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type {
+  RoutingContract,
+  RoutingLocation,
+} from '@backstage/frontend-plugin-api';
+import type { Observer, Subscription } from '@backstage/types';
+import { createScopedRouter } from './createScopedRouter';
+
+function createMockContract(
+  initialLocation: RoutingLocation = {
+    pathname: '/settings/general',
+    search: '',
+    hash: '',
+    state: undefined,
+  },
+): RoutingContract & {
+  emit: (location: RoutingLocation) => void;
+  navigate: jest.Mock;
+} {
+  let currentLocation = initialLocation;
+  const observers = new Set<Observer<RoutingLocation>>();
+
+  const navigate = jest.fn();
+
+  const location$ = {
+    subscribe(
+      observerOrNext?:
+        | Observer<RoutingLocation>
+        | ((value: RoutingLocation) => void),
+    ): Subscription {
+      const observer: Observer<RoutingLocation> =
+        typeof observerOrNext === 'function'
+          ? { next: observerOrNext }
+          : observerOrNext || {};
+
+      observers.add(observer);
+      observer.next?.(currentLocation);
+
+      return {
+        unsubscribe: () => observers.delete(observer),
+        get closed() {
+          return !observers.has(observer);
+        },
+      };
+    },
+    [Symbol.observable]() {
+      return this;
+    },
+  };
+
+  function emit(location: RoutingLocation) {
+    currentLocation = location;
+    for (const observer of observers) {
+      observer.next?.(location);
+    }
+  }
+
+  return { basePath: '/settings', location$, navigate, emit };
+}
+
+describe('createScopedRouter (v7)', () => {
+  it('should render children inside a React Router v7 context', () => {
+    const contract = createMockContract();
+    const { Router } = createScopedRouter(contract);
+
+    render(
+      <Router>
+        <div data-testid="child">Hello</div>
+      </Router>,
+    );
+
+    expect(screen.getByTestId('child')).toHaveTextContent('Hello');
+  });
+
+  it('should sync initial location from contract without flash', () => {
+    const contract = createMockContract({
+      pathname: '/settings/auth-providers',
+      search: '?tab=github',
+      hash: '',
+      state: undefined,
+    });
+    const { Router, useLocation } = createScopedRouter(contract);
+
+    const renderedPathnames: string[] = [];
+
+    function LocationDisplay() {
+      const location = useLocation();
+      renderedPathnames.push(location.pathname);
+      return <div data-testid="pathname">{location.pathname}</div>;
+    }
+
+    render(
+      <Router>
+        <LocationDisplay />
+      </Router>,
+    );
+
+    expect(renderedPathnames[0]).toBe('/settings/auth-providers');
+    expect(screen.getByTestId('pathname')).toHaveTextContent(
+      '/settings/auth-providers',
+    );
+  });
+
+  it('should delegate navigate calls to contract', () => {
+    const contract = createMockContract();
+    const { Router, useNavigate } = createScopedRouter(contract);
+
+    function NavButton() {
+      const navigate = useNavigate();
+      return (
+        <button
+          data-testid="nav-btn"
+          onClick={() => navigate('/settings/feature-flags')}
+        >
+          Go
+        </button>
+      );
+    }
+
+    render(
+      <Router>
+        <NavButton />
+      </Router>,
+    );
+
+    act(() => {
+      screen.getByTestId('nav-btn').click();
+    });
+
+    expect(contract.navigate).toHaveBeenCalledWith('/settings/feature-flags', {
+      replace: false,
+    });
+  });
+
+  it('should update when contract emits new location', () => {
+    const contract = createMockContract({
+      pathname: '/settings/general',
+      search: '',
+      hash: '',
+      state: undefined,
+    });
+    const { Router, useLocation } = createScopedRouter(contract);
+
+    function LocationDisplay() {
+      const location = useLocation();
+      return <div data-testid="pathname">{location.pathname}</div>;
+    }
+
+    render(
+      <Router>
+        <LocationDisplay />
+      </Router>,
+    );
+
+    expect(screen.getByTestId('pathname')).toHaveTextContent(
+      '/settings/general',
+    );
+
+    act(() => {
+      contract.emit({
+        pathname: '/settings/auth-providers',
+        search: '',
+        hash: '',
+        state: undefined,
+      });
+    });
+
+    expect(screen.getByTestId('pathname')).toHaveTextContent(
+      '/settings/auth-providers',
+    );
+  });
+
+  it('should stop receiving updates after dispose()', () => {
+    const contract = createMockContract({
+      pathname: '/settings/general',
+      search: '',
+      hash: '',
+      state: undefined,
+    });
+    const { Router, useLocation, dispose } = createScopedRouter(contract);
+
+    function LocationDisplay() {
+      const location = useLocation();
+      return <div data-testid="pathname">{location.pathname}</div>;
+    }
+
+    render(
+      <Router>
+        <LocationDisplay />
+      </Router>,
+    );
+
+    expect(screen.getByTestId('pathname')).toHaveTextContent(
+      '/settings/general',
+    );
+
+    dispose();
+
+    act(() => {
+      contract.emit({
+        pathname: '/settings/after-dispose',
+        search: '',
+        hash: '',
+        state: undefined,
+      });
+    });
+
+    expect(screen.getByTestId('pathname')).toHaveTextContent(
+      '/settings/general',
+    );
+  });
+
+  it('should provide UNSAFE_RouteContext with empty defaults', () => {
+    const contract = createMockContract();
+    const { Router } = createScopedRouter(contract);
+    // Import from react-router (v7) to confirm we read from the v7 context
+    const { useParams, useOutlet } = require('react-router');
+
+    function RouteContextInspector() {
+      const params = useParams();
+      const outlet = useOutlet();
+      return (
+        <div>
+          <span data-testid="params">{JSON.stringify(params)}</span>
+          <span data-testid="outlet">
+            {outlet === null ? 'null' : 'present'}
+          </span>
+        </div>
+      );
+    }
+
+    render(
+      <Router>
+        <RouteContextInspector />
+      </Router>,
+    );
+
+    expect(screen.getByTestId('params')).toHaveTextContent('{}');
+    expect(screen.getByTestId('outlet')).toHaveTextContent('null');
+  });
+
+  it('should return all expected API members', () => {
+    const contract = createMockContract();
+    const result = createScopedRouter(contract);
+
+    expect(typeof result.Router).toBe('function');
+    expect(typeof result.useLocation).toBe('function');
+    expect(typeof result.useNavigate).toBe('function');
+    expect(typeof result.useParams).toBe('function');
+    expect(typeof result.useSearchParams).toBe('function');
+    expect(typeof result.dispose).toBe('function');
+  });
+});

--- a/plugins/plugin-react-router-v7-adapter/src/createScopedRouter.ts
+++ b/plugins/plugin-react-router-v7-adapter/src/createScopedRouter.ts
@@ -57,37 +57,70 @@ export function createScopedRouter(
     );
   }
 
-  // Store for useSyncExternalStore — keeps the latest location from the contract
+  // Store for useSyncExternalStore — keeps the latest location from the contract.
+  // The initial value is captured synchronously since contract.location$ emits
+  // synchronously on subscribe.
   let latestLocation: Location = {
     pathname: '/',
     search: '',
     hash: '',
     state: null,
     key: 'default',
+    unstable_mask: undefined,
   };
+
+  // Capture the initial value synchronously
+  const initialSub = contract.location$.subscribe(loc => {
+    latestLocation = {
+      pathname: loc.pathname,
+      search: loc.search,
+      hash: loc.hash,
+      state: loc.state ?? null,
+      key: 'default',
+      unstable_mask: undefined,
+    };
+  });
+  initialSub.unsubscribe();
 
   // Set of listener callbacks for useSyncExternalStore
   const listeners = new Set<() => void>();
 
-  // Subscribe to the contract's location$ eagerly so we capture the initial value.
-  // The subscription is stored so it can be cleaned up via dispose().
-  const subscription = contract.location$.subscribe(routingLocation => {
-    latestLocation = {
-      pathname: routingLocation.pathname,
-      search: routingLocation.search,
-      hash: routingLocation.hash,
-      state: routingLocation.state ?? null,
-      key: 'default',
-    };
-    for (const listener of listeners) {
-      listener();
-    }
-  });
+  // Subscription reference — managed by useSyncExternalStore's subscribe lifecycle.
+  // React calls subscribe during commit and the returned cleanup on unmount,
+  // so this correctly handles Strict Mode and concurrent rendering without
+  // requiring render-phase side effects.
+  let subscription: { unsubscribe(): void } | undefined;
+
+  function subscribeToContract(): void {
+    if (subscription) return;
+    subscription = contract.location$.subscribe(routingLocation => {
+      latestLocation = {
+        pathname: routingLocation.pathname,
+        search: routingLocation.search,
+        hash: routingLocation.hash,
+        state: routingLocation.state ?? null,
+        key: 'default',
+        unstable_mask: undefined,
+      };
+      for (const listener of listeners) {
+        listener();
+      }
+    });
+  }
+
+  function unsubscribeFromContract(): void {
+    subscription?.unsubscribe();
+    subscription = undefined;
+  }
 
   function subscribe(listener: () => void): () => void {
     listeners.add(listener);
+    subscribeToContract();
     return () => {
       listeners.delete(listener);
+      if (listeners.size === 0) {
+        unsubscribeFromContract();
+      }
     };
   }
 
@@ -183,7 +216,10 @@ export function createScopedRouter(
       useRRParams() as T,
     useSearchParams: (...args: Parameters<typeof useRRSearchParams>) =>
       useRRSearchParams(...args),
-    dispose: () => subscription.unsubscribe(),
+    dispose: () => {
+      unsubscribeFromContract();
+      listeners.clear();
+    },
   };
 }
 

--- a/plugins/plugin-react-router-v7-adapter/src/createScopedRouter.ts
+++ b/plugins/plugin-react-router-v7-adapter/src/createScopedRouter.ts
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  createElement,
+  useMemo,
+  useSyncExternalStore,
+  type ComponentType,
+  type ReactNode,
+} from 'react';
+import type { RoutingContract } from '@backstage/frontend-plugin-api';
+import {
+  UNSAFE_LocationContext,
+  UNSAFE_NavigationContext,
+  UNSAFE_RouteContext,
+  NavigationType,
+  useLocation as useRRLocation,
+  useNavigate as useRRNavigate,
+  useParams as useRRParams,
+  useSearchParams as useRRSearchParams,
+} from 'react-router';
+import type { Location, NavigateFunction, Navigator, To } from 'react-router';
+
+/** @public */
+export interface ScopedRouterResult {
+  Router: ComponentType<{ children: ReactNode }>;
+  useLocation: () => Location;
+  useNavigate: () => NavigateFunction;
+  useParams: <T extends Record<string, string | undefined>>() => T;
+  useSearchParams: (
+    ...args: Parameters<typeof useRRSearchParams>
+  ) => ReturnType<typeof useRRSearchParams>;
+  /** Unsubscribes from the contract's location$ observable. */
+  dispose: () => void;
+}
+
+/** @public */
+export function createScopedRouter(
+  contract: RoutingContract,
+): ScopedRouterResult {
+  if (!contract) {
+    throw new Error(
+      'createScopedRouter requires a RoutingContract. Ensure this component is rendered inside a PageBlueprint.',
+    );
+  }
+
+  // Store for useSyncExternalStore — keeps the latest location from the contract
+  let latestLocation: Location = {
+    pathname: '/',
+    search: '',
+    hash: '',
+    state: null,
+    key: 'default',
+  };
+
+  // Set of listener callbacks for useSyncExternalStore
+  const listeners = new Set<() => void>();
+
+  // Subscribe to the contract's location$ eagerly so we capture the initial value.
+  // The subscription is stored so it can be cleaned up via dispose().
+  const subscription = contract.location$.subscribe(routingLocation => {
+    latestLocation = {
+      pathname: routingLocation.pathname,
+      search: routingLocation.search,
+      hash: routingLocation.hash,
+      state: routingLocation.state ?? null,
+      key: 'default',
+    };
+    for (const listener of listeners) {
+      listener();
+    }
+  });
+
+  function subscribe(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  }
+
+  function getSnapshot(): Location {
+    return latestLocation;
+  }
+
+  function ScopedRouter({ children }: { children: ReactNode }) {
+    const location = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+    const locationContextValue = useMemo(
+      () => ({
+        location,
+        navigationType: NavigationType.Pop,
+      }),
+      [location],
+    );
+
+    const navigator: Navigator = useMemo(
+      () => ({
+        createHref(to: To): string {
+          if (typeof to === 'string') {
+            return to;
+          }
+          const { pathname = '/', search = '', hash = '' } = to;
+          return `${pathname}${search}${hash}`;
+        },
+        go(delta: number): void {
+          // Intentional: delegate to window.history.go()
+          // popstate fires and NavigationController catches it
+          window.history.go(delta);
+        },
+        push(to: To, state?: any, _opts?: any): void {
+          const path =
+            typeof to === 'string'
+              ? to
+              : createPath(to, latestLocation.pathname);
+          contract.navigate(path, { replace: false, state });
+        },
+        replace(to: To, state?: any, _opts?: any): void {
+          const path =
+            typeof to === 'string'
+              ? to
+              : createPath(to, latestLocation.pathname);
+          contract.navigate(path, { replace: true, state });
+        },
+      }),
+      [],
+    );
+
+    // CORRECTION from Phase 1 review: v7 NavigationContextObject requires
+    // future: {} (empty object) and unstable_useTransitions: boolean | undefined
+    const navigationContextValue = useMemo(
+      () => ({
+        basename: '',
+        navigator,
+        static: false,
+        future: {},
+        unstable_useTransitions: undefined,
+      }),
+      [navigator],
+    );
+
+    const routeContextValue = useMemo(
+      () => ({
+        outlet: null,
+        matches: [] as any[],
+        isDataRoute: false,
+      }),
+      [],
+    );
+
+    return createElement(
+      UNSAFE_NavigationContext.Provider,
+      { value: navigationContextValue },
+      createElement(
+        UNSAFE_LocationContext.Provider,
+        { value: locationContextValue },
+        createElement(
+          UNSAFE_RouteContext.Provider,
+          { value: routeContextValue },
+          children,
+        ),
+      ),
+    );
+  }
+
+  return {
+    Router: ScopedRouter,
+    useLocation: (): Location => useRRLocation(),
+    useNavigate: (): NavigateFunction => useRRNavigate(),
+    useParams: <T extends Record<string, string | undefined>>(): T =>
+      useRRParams() as T,
+    useSearchParams: (...args: Parameters<typeof useRRSearchParams>) =>
+      useRRSearchParams(...args),
+    dispose: () => subscription.unsubscribe(),
+  };
+}
+
+function createPath(
+  to: Partial<{ pathname: string; search: string; hash: string }>,
+  currentPathname: string,
+): string {
+  // Use current pathname when To.pathname is undefined (e.g., useSearchParams
+  // updates only search params without specifying a pathname)
+  const { pathname = currentPathname, search = '', hash = '' } = to;
+  return `${pathname}${search}${hash}`;
+}

--- a/plugins/plugin-react-router-v7-adapter/src/index.ts
+++ b/plugins/plugin-react-router-v7-adapter/src/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export {};

--- a/plugins/plugin-react-router-v7-adapter/src/index.ts
+++ b/plugins/plugin-react-router-v7-adapter/src/index.ts
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export {};
+export { createScopedRouter } from './createScopedRouter';
+export type { ScopedRouterResult } from './createScopedRouter';

--- a/plugins/plugin-tanstack-router-adapter/.eslintrc.js
+++ b/plugins/plugin-tanstack-router-adapter/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/plugins/plugin-tanstack-router-adapter/catalog-info.yaml
+++ b/plugins/plugin-tanstack-router-adapter/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backstage-plugin-tanstack-router-adapter
+  title: '@backstage/plugin-tanstack-router-adapter'
+spec:
+  lifecycle: experimental
+  type: backstage-web-library
+  owner: maintainers

--- a/plugins/plugin-tanstack-router-adapter/package.json
+++ b/plugins/plugin-tanstack-router-adapter/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@backstage/plugin-tanstack-router-adapter",
+  "version": "0.1.0",
+  "backstage": {
+    "role": "web-library"
+  },
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "test": "backstage-cli package test"
+  },
+  "dependencies": {
+    "@backstage/frontend-plugin-api": "workspace:^"
+  },
+  "devDependencies": {
+    "@backstage/cli": "workspace:^",
+    "@tanstack/react-router": "^1.0.0",
+    "@testing-library/dom": "^10.0.0",
+    "@testing-library/jest-dom": "^6.0.0",
+    "@testing-library/react": "^16.0.0",
+    "@types/react": "^18.0.0",
+    "react": "^18.0.2",
+    "react-dom": "^18.0.2"
+  },
+  "peerDependencies": {
+    "@tanstack/react-router": "^1.0.0",
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
+  }
+}

--- a/plugins/plugin-tanstack-router-adapter/src/createScopedRouter.test.tsx
+++ b/plugins/plugin-tanstack-router-adapter/src/createScopedRouter.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { render, act } from '@testing-library/react';
+import { render, act, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import type {
   RoutingContract,
@@ -22,6 +22,7 @@ import type {
 } from '@backstage/frontend-plugin-api';
 import type { Observer, Subscription } from '@backstage/types';
 import { createScopedRouter } from './createScopedRouter';
+import { useRouterState } from '@tanstack/react-router';
 
 function createMockContract(
   initialLocation: RoutingLocation = {
@@ -80,8 +81,8 @@ describe('createScopedRouter (TanStack)', () => {
     const contract = createMockContract();
     const { RouterProvider } = createScopedRouter(contract);
 
-    render(<RouterProvider />);
-    // If it renders without throwing, the adapter wired up correctly
+    const { container } = render(<RouterProvider />);
+    expect(container).toBeDefined();
   });
 
   it('should sync initial location from contract', () => {
@@ -96,7 +97,7 @@ describe('createScopedRouter (TanStack)', () => {
     expect(result.router.state.location.pathname).toBe('/home');
   });
 
-  it('should update when contract emits new location', () => {
+  it('should update when contract emits new location', async () => {
     const contract = createMockContract({
       pathname: '/home',
       search: '',
@@ -104,6 +105,16 @@ describe('createScopedRouter (TanStack)', () => {
       state: undefined,
     });
     const result = createScopedRouter(contract);
+
+    // Subscriptions are only active when RouterProvider is mounted
+    render(
+      <result.Router>
+        <div data-testid="mounted">ok</div>
+      </result.Router>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('mounted')).toBeInTheDocument();
+    });
 
     act(() => {
       contract.emit({
@@ -146,5 +157,82 @@ describe('createScopedRouter (TanStack)', () => {
     expect(typeof result.router.state).toBe('object');
     expect(typeof result.dispose).toBe('function');
     expect(typeof result.RouterProvider).toBe('function');
+    expect(typeof result.Router).toBe('function');
+  });
+
+  describe('Router (children wrapper)', () => {
+    it('should render children inside the TanStack router context', async () => {
+      const contract = createMockContract();
+      const { Router } = createScopedRouter(contract);
+
+      render(
+        <Router>
+          <div data-testid="child">Hello from inside TanStack</div>
+        </Router>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('child')).toHaveTextContent(
+          'Hello from inside TanStack',
+        );
+      });
+    });
+
+    it('should give children access to TanStack router state', async () => {
+      const contract = createMockContract({
+        pathname: '/home/dashboard',
+        search: '?tab=overview',
+        hash: '',
+        state: undefined,
+      });
+      const { Router } = createScopedRouter(contract);
+
+      function LocationDisplay() {
+        const { location } = useRouterState();
+        return <div data-testid="location">{location.pathname}</div>;
+      }
+
+      render(
+        <Router>
+          <LocationDisplay />
+        </Router>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('location')).toHaveTextContent(
+          '/home/dashboard',
+        );
+      });
+    });
+
+    it('should clean up subscriptions on unmount', async () => {
+      const contract = createMockContract();
+      const result = createScopedRouter(contract);
+
+      const { unmount } = render(
+        <result.Router>
+          <div data-testid="content">content</div>
+        </result.Router>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('content')).toBeInTheDocument();
+      });
+
+      unmount();
+
+      // After unmount, emitting should not cause errors
+      act(() => {
+        contract.emit({
+          pathname: '/home/after-unmount',
+          search: '',
+          hash: '',
+          state: undefined,
+        });
+      });
+
+      // Router should still have the old location since subscriptions were cleaned up
+      expect(result.router.state.location.pathname).toBe('/home');
+    });
   });
 });

--- a/plugins/plugin-tanstack-router-adapter/src/createScopedRouter.test.tsx
+++ b/plugins/plugin-tanstack-router-adapter/src/createScopedRouter.test.tsx
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type {
+  RoutingContract,
+  RoutingLocation,
+} from '@backstage/frontend-plugin-api';
+import type { Observer, Subscription } from '@backstage/types';
+import { createScopedRouter } from './createScopedRouter';
+
+function createMockContract(
+  initialLocation: RoutingLocation = {
+    pathname: '/home',
+    search: '',
+    hash: '',
+    state: undefined,
+  },
+): RoutingContract & {
+  emit: (location: RoutingLocation) => void;
+  navigate: jest.Mock;
+} {
+  let currentLocation = initialLocation;
+  const observers = new Set<Observer<RoutingLocation>>();
+
+  const navigate = jest.fn();
+
+  const location$ = {
+    subscribe(
+      observerOrNext?:
+        | Observer<RoutingLocation>
+        | ((value: RoutingLocation) => void),
+    ): Subscription {
+      const observer: Observer<RoutingLocation> =
+        typeof observerOrNext === 'function'
+          ? { next: observerOrNext }
+          : observerOrNext || {};
+
+      observers.add(observer);
+      observer.next?.(currentLocation);
+
+      return {
+        unsubscribe: () => observers.delete(observer),
+        get closed() {
+          return !observers.has(observer);
+        },
+      };
+    },
+    [Symbol.observable]() {
+      return this;
+    },
+  };
+
+  function emit(location: RoutingLocation) {
+    currentLocation = location;
+    for (const observer of observers) {
+      observer.next?.(location);
+    }
+  }
+
+  return { basePath: '/home', location$, navigate, emit };
+}
+
+describe('createScopedRouter (TanStack)', () => {
+  it('should render the RouterProvider without errors', () => {
+    const contract = createMockContract();
+    const { RouterProvider } = createScopedRouter(contract);
+
+    render(<RouterProvider />);
+    // If it renders without throwing, the adapter wired up correctly
+  });
+
+  it('should sync initial location from contract', () => {
+    const contract = createMockContract({
+      pathname: '/home',
+      search: '?widget=clock',
+      hash: '',
+      state: undefined,
+    });
+    const result = createScopedRouter(contract);
+
+    expect(result.router.state.location.pathname).toBe('/home');
+  });
+
+  it('should update when contract emits new location', () => {
+    const contract = createMockContract({
+      pathname: '/home',
+      search: '',
+      hash: '',
+      state: undefined,
+    });
+    const result = createScopedRouter(contract);
+
+    act(() => {
+      contract.emit({
+        pathname: '/home/dashboard',
+        search: '',
+        hash: '',
+        state: undefined,
+      });
+    });
+
+    expect(result.router.state.location.pathname).toBe('/home/dashboard');
+  });
+
+  it('should clean up subscriptions on dispose', () => {
+    const contract = createMockContract();
+    const result = createScopedRouter(contract);
+
+    result.dispose();
+
+    // After dispose, emitting should not cause errors or updates
+    act(() => {
+      contract.emit({
+        pathname: '/home/after-dispose',
+        search: '',
+        hash: '',
+        state: undefined,
+      });
+    });
+
+    // Router should still have the old location
+    expect(result.router.state.location.pathname).toBe('/home');
+  });
+
+  it('should return a valid router instance', () => {
+    const contract = createMockContract();
+    const result = createScopedRouter(contract);
+
+    expect(result.router).toBeDefined();
+    expect(typeof result.router.navigate).toBe('function');
+    expect(typeof result.router.state).toBe('object');
+    expect(typeof result.dispose).toBe('function');
+    expect(typeof result.RouterProvider).toBe('function');
+  });
+});

--- a/plugins/plugin-tanstack-router-adapter/src/createScopedRouter.ts
+++ b/plugins/plugin-tanstack-router-adapter/src/createScopedRouter.ts
@@ -44,6 +44,8 @@ export function createScopedRouter(
   // Instance-scoped guard flags to prevent circular updates
   let isUpdatingFromContract = false;
   let isUpdatingFromRouter = false;
+  // Track the last path forwarded to contract to avoid redundant navigations
+  let lastForwardedPath = '';
 
   // Create memory history with initial location from contract.
   // The contract emits synchronously on subscribe, so we capture it.
@@ -54,6 +56,7 @@ export function createScopedRouter(
     initialSearch = loc.search;
   });
   initialSub.unsubscribe();
+  lastForwardedPath = `${initialPathname}${initialSearch}`;
 
   const memoryHistory = createMemoryHistory({
     initialEntries: [`${initialPathname}${initialSearch}`],
@@ -78,7 +81,9 @@ export function createScopedRouter(
     if (newPath !== currentPath) {
       isUpdatingFromContract = true;
       memoryHistory.push(newPath);
-      router.load();
+      router.load().catch(() => {
+        // Route resolution errors are handled by TanStack Router's error boundary
+      });
       isUpdatingFromContract = false;
     }
   });
@@ -88,11 +93,13 @@ export function createScopedRouter(
     if (isUpdatingFromContract) {
       return; // Skip - this was caused by our own contract sync
     }
+    const historyPath = `${memoryHistory.location.pathname}${memoryHistory.location.search}${memoryHistory.location.hash}`;
+    if (historyPath === lastForwardedPath) {
+      return; // Skip - path unchanged (e.g., URL normalization)
+    }
     isUpdatingFromRouter = true;
-    contract.navigate(
-      `${memoryHistory.location.pathname}${memoryHistory.location.search}${memoryHistory.location.hash}`,
-      { replace: false },
-    );
+    lastForwardedPath = historyPath;
+    contract.navigate(historyPath, { replace: false });
     isUpdatingFromRouter = false;
   });
 

--- a/plugins/plugin-tanstack-router-adapter/src/createScopedRouter.ts
+++ b/plugins/plugin-tanstack-router-adapter/src/createScopedRouter.ts
@@ -14,7 +14,15 @@
  * limitations under the License.
  */
 
-import React, { type ComponentType } from 'react';
+import {
+  createContext,
+  createElement,
+  Fragment,
+  useContext,
+  useEffect,
+  type ComponentType,
+  type ReactNode,
+} from 'react';
 import type { RoutingContract } from '@backstage/frontend-plugin-api';
 import {
   createMemoryHistory,
@@ -24,8 +32,16 @@ import {
   type AnyRouter,
 } from '@tanstack/react-router';
 
+const ChildrenContext = createContext<ReactNode>(null);
+
 /** @public */
 export interface TanStackScopedRouterResult {
+  /** Wraps children inside the TanStack router context so they can use TanStack hooks. */
+  Router: ComponentType<{ children: ReactNode }>;
+  /**
+   * Standalone router provider without children support.
+   * Prefer `Router` for rendering plugin content.
+   */
   RouterProvider: ComponentType;
   router: AnyRouter;
   dispose: () => void;
@@ -62,57 +78,92 @@ export function createScopedRouter(
     initialEntries: [`${initialPathname}${initialSearch}`],
   });
 
-  // Catch-all root route
-  const rootRoute = createRootRoute();
+  // Root route renders children passed via ChildrenContext, so plugin content
+  // lives inside the TanStack router context and can use TanStack hooks.
+  function RootComponent() {
+    return createElement(Fragment, null, useContext(ChildrenContext));
+  }
+  const rootRoute = createRootRoute({ component: RootComponent });
 
   const router = createRouter({
     routeTree: rootRoute,
     history: memoryHistory,
   });
 
-  // Contract -> TanStack sync: when contract emits, update memory history
-  const contractSubscription = contract.location$.subscribe(loc => {
-    if (isUpdatingFromRouter) {
-      return; // Skip - this emission was caused by our own navigate
-    }
-    const newPath = `${loc.pathname}${loc.search}${loc.hash}`;
-    const currentPath = `${memoryHistory.location.pathname}${memoryHistory.location.search}${memoryHistory.location.hash}`;
+  // Subscription references — managed by RouterProvider's useEffect lifecycle
+  let contractSubscription: { unsubscribe(): void } | undefined;
+  let historyUnsubscribe: (() => void) | undefined;
 
-    if (newPath !== currentPath) {
-      isUpdatingFromContract = true;
-      memoryHistory.push(newPath);
-      router.load().catch(() => {
-        // Route resolution errors are handled by TanStack Router's error boundary
-      });
-      isUpdatingFromContract = false;
-    }
-  });
+  function subscribeToContract(): void {
+    if (contractSubscription || historyUnsubscribe) return;
 
-  // TanStack -> Contract sync: when router navigates, forward to contract
-  const historyUnsubscribe = memoryHistory.subscribe(() => {
-    if (isUpdatingFromContract) {
-      return; // Skip - this was caused by our own contract sync
-    }
-    const historyPath = `${memoryHistory.location.pathname}${memoryHistory.location.search}${memoryHistory.location.hash}`;
-    if (historyPath === lastForwardedPath) {
-      return; // Skip - path unchanged (e.g., URL normalization)
-    }
-    isUpdatingFromRouter = true;
-    lastForwardedPath = historyPath;
-    contract.navigate(historyPath, { replace: false });
-    isUpdatingFromRouter = false;
-  });
+    // Contract -> TanStack sync: when contract emits, update memory history
+    contractSubscription = contract.location$.subscribe(loc => {
+      if (isUpdatingFromRouter) {
+        return; // Skip - this emission was caused by our own navigate
+      }
+      const newPath = `${loc.pathname}${loc.search}${loc.hash}`;
+      const currentPath = `${memoryHistory.location.pathname}${memoryHistory.location.search}${memoryHistory.location.hash}`;
+
+      if (newPath !== currentPath) {
+        isUpdatingFromContract = true;
+        memoryHistory.push(newPath);
+        router.load().catch(() => {
+          // Route resolution errors are handled by TanStack Router's error boundary
+        });
+        isUpdatingFromContract = false;
+      }
+    });
+
+    // TanStack -> Contract sync: when router navigates, forward to contract
+    historyUnsubscribe = memoryHistory.subscribe(() => {
+      if (isUpdatingFromContract) {
+        return; // Skip - this was caused by our own contract sync
+      }
+      const historyPath = `${memoryHistory.location.pathname}${memoryHistory.location.search}${memoryHistory.location.hash}`;
+      if (historyPath === lastForwardedPath) {
+        return; // Skip - path unchanged (e.g., URL normalization)
+      }
+      isUpdatingFromRouter = true;
+      lastForwardedPath = historyPath;
+      contract.navigate(historyPath, { replace: false });
+      isUpdatingFromRouter = false;
+    });
+  }
+
+  function unsubscribeAll(): void {
+    contractSubscription?.unsubscribe();
+    contractSubscription = undefined;
+    historyUnsubscribe?.();
+    historyUnsubscribe = undefined;
+  }
 
   function RouterProviderComponent() {
-    return React.createElement(TanStackRouterProvider, { router });
+    // Subscriptions are managed by useSyncExternalStore's subscribe lifecycle
+    // in the React Router adapters. TanStack adapter does not use
+    // useSyncExternalStore, so we use useEffect for lifecycle management.
+    // This is safe because TanStack's RouterProvider handles its own rendering
+    // and the subscriptions only sync state between contract and memory history.
+    useEffect(() => {
+      subscribeToContract();
+      return () => unsubscribeAll();
+    }, []);
+
+    return createElement(TanStackRouterProvider, { router });
+  }
+
+  function ScopedRouter({ children }: { children: ReactNode }) {
+    return createElement(
+      ChildrenContext.Provider,
+      { value: children },
+      createElement(RouterProviderComponent),
+    );
   }
 
   return {
+    Router: ScopedRouter,
     RouterProvider: RouterProviderComponent,
     router,
-    dispose: () => {
-      contractSubscription.unsubscribe();
-      historyUnsubscribe();
-    },
+    dispose: () => unsubscribeAll(),
   };
 }

--- a/plugins/plugin-tanstack-router-adapter/src/createScopedRouter.ts
+++ b/plugins/plugin-tanstack-router-adapter/src/createScopedRouter.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { type ComponentType } from 'react';
+import type { RoutingContract } from '@backstage/frontend-plugin-api';
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRouter,
+  RouterProvider as TanStackRouterProvider,
+  type AnyRouter,
+} from '@tanstack/react-router';
+
+/** @public */
+export interface TanStackScopedRouterResult {
+  RouterProvider: ComponentType;
+  router: AnyRouter;
+  dispose: () => void;
+}
+
+/** @public */
+export function createScopedRouter(
+  contract: RoutingContract,
+): TanStackScopedRouterResult {
+  if (!contract) {
+    throw new Error(
+      'createScopedRouter requires a RoutingContract. Ensure this component is rendered inside a PageBlueprint.',
+    );
+  }
+
+  // Instance-scoped guard flags to prevent circular updates
+  let isUpdatingFromContract = false;
+  let isUpdatingFromRouter = false;
+
+  // Create memory history with initial location from contract.
+  // The contract emits synchronously on subscribe, so we capture it.
+  let initialPathname = '/';
+  let initialSearch = '';
+  const initialSub = contract.location$.subscribe(loc => {
+    initialPathname = loc.pathname;
+    initialSearch = loc.search;
+  });
+  initialSub.unsubscribe();
+
+  const memoryHistory = createMemoryHistory({
+    initialEntries: [`${initialPathname}${initialSearch}`],
+  });
+
+  // Catch-all root route
+  const rootRoute = createRootRoute();
+
+  const router = createRouter({
+    routeTree: rootRoute,
+    history: memoryHistory,
+  });
+
+  // Contract -> TanStack sync: when contract emits, update memory history
+  const contractSubscription = contract.location$.subscribe(loc => {
+    if (isUpdatingFromRouter) {
+      return; // Skip - this emission was caused by our own navigate
+    }
+    const newPath = `${loc.pathname}${loc.search}${loc.hash}`;
+    const currentPath = `${memoryHistory.location.pathname}${memoryHistory.location.search}${memoryHistory.location.hash}`;
+
+    if (newPath !== currentPath) {
+      isUpdatingFromContract = true;
+      memoryHistory.push(newPath);
+      router.load();
+      isUpdatingFromContract = false;
+    }
+  });
+
+  // TanStack -> Contract sync: when router navigates, forward to contract
+  const historyUnsubscribe = memoryHistory.subscribe(() => {
+    if (isUpdatingFromContract) {
+      return; // Skip - this was caused by our own contract sync
+    }
+    isUpdatingFromRouter = true;
+    contract.navigate(
+      `${memoryHistory.location.pathname}${memoryHistory.location.search}${memoryHistory.location.hash}`,
+      { replace: false },
+    );
+    isUpdatingFromRouter = false;
+  });
+
+  function RouterProviderComponent() {
+    return React.createElement(TanStackRouterProvider, { router });
+  }
+
+  return {
+    RouterProvider: RouterProviderComponent,
+    router,
+    dispose: () => {
+      contractSubscription.unsubscribe();
+      historyUnsubscribe();
+    },
+  };
+}

--- a/plugins/plugin-tanstack-router-adapter/src/index.ts
+++ b/plugins/plugin-tanstack-router-adapter/src/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export {};

--- a/plugins/plugin-tanstack-router-adapter/src/index.ts
+++ b/plugins/plugin-tanstack-router-adapter/src/index.ts
@@ -13,4 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export {};
+export { createScopedRouter } from './createScopedRouter';
+export type { TanStackScopedRouterResult } from './createScopedRouter';

--- a/plugins/user-settings/package.json
+++ b/plugins/user-settings/package.json
@@ -62,6 +62,7 @@
     "@backstage/errors": "workspace:^",
     "@backstage/frontend-plugin-api": "workspace:^",
     "@backstage/plugin-catalog-react": "workspace:^",
+    "@backstage/plugin-react-router-v7-adapter": "workspace:^",
     "@backstage/plugin-signals-react": "workspace:^",
     "@backstage/plugin-user-settings-common": "workspace:^",
     "@backstage/theme": "workspace:^",
@@ -87,12 +88,14 @@
     "msw": "^1.0.0",
     "react": "^18.0.2",
     "react-dom": "^18.0.2",
+    "react-router": "^7.0.0",
     "react-router-dom": "^6.30.2"
   },
   "peerDependencies": {
     "@types/react": "^17.0.0 || ^18.0.0",
     "react": "^17.0.0 || ^18.0.0",
     "react-dom": "^17.0.0 || ^18.0.0",
+    "react-router": "^7.0.0",
     "react-router-dom": "^6.30.2"
   },
   "peerDependenciesMeta": {

--- a/plugins/user-settings/src/alpha.tsx
+++ b/plugins/user-settings/src/alpha.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { type ReactNode, useRef, useEffect } from 'react';
+import { type ReactNode, useContext, useRef, useEffect } from 'react';
 import {
   coreExtensionData,
   createExtensionInput,
@@ -21,7 +21,7 @@ import {
   PageBlueprint,
   NavItemBlueprint,
   SubPageBlueprint,
-  useRoutingContract,
+  RoutingContractContext,
 } from '@backstage/frontend-plugin-api';
 import {
   createScopedRouter,
@@ -40,7 +40,7 @@ import { userSettingsTranslationRef as _userSettingsTranslationRef } from './tra
 export const userSettingsTranslationRef = _userSettingsTranslationRef;
 
 function SettingsAdapterRoot({ children }: { children: ReactNode }) {
-  const contract = useRoutingContract();
+  const contract = useContext(RoutingContractContext);
   const scopedRouterRef = useRef<ScopedRouterResult | null>(null);
 
   useEffect(() => {

--- a/plugins/user-settings/src/alpha.tsx
+++ b/plugins/user-settings/src/alpha.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { type ReactNode, useRef, useEffect } from 'react';
 import {
   coreExtensionData,
   createExtensionInput,
@@ -20,7 +21,12 @@ import {
   PageBlueprint,
   NavItemBlueprint,
   SubPageBlueprint,
+  useRoutingContract,
 } from '@backstage/frontend-plugin-api';
+import {
+  createScopedRouter,
+  type ScopedRouterResult,
+} from '@backstage/plugin-react-router-v7-adapter';
 import { Content } from '@backstage/core-components';
 import SettingsIcon from '@material-ui/icons/Settings';
 import { settingsRouteRef } from './plugin';
@@ -33,11 +39,45 @@ import { userSettingsTranslationRef as _userSettingsTranslationRef } from './tra
  */
 export const userSettingsTranslationRef = _userSettingsTranslationRef;
 
-const userSettingsPage = PageBlueprint.make({
-  params: {
-    path: '/settings',
-    routeRef: settingsRouteRef,
-    title: 'Settings',
+function SettingsAdapterRoot({ children }: { children: ReactNode }) {
+  const contract = useRoutingContract();
+  const scopedRouterRef = useRef<ScopedRouterResult | null>(null);
+
+  useEffect(() => {
+    return () => {
+      scopedRouterRef.current?.dispose();
+      scopedRouterRef.current = null;
+    };
+  }, [contract]);
+
+  if (!contract) {
+    return <>{children}</>;
+  }
+
+  if (!scopedRouterRef.current) {
+    scopedRouterRef.current = createScopedRouter(contract);
+  }
+
+  const scopedRouter = scopedRouterRef.current;
+
+  return <scopedRouter.Router>{children}</scopedRouter.Router>;
+}
+
+const userSettingsPage = PageBlueprint.makeWithOverrides({
+  factory(originalFactory) {
+    const result = originalFactory({
+      path: '/settings',
+      routeRef: settingsRouteRef,
+      title: 'Settings',
+    });
+
+    return Array.from(result).map(value =>
+      value.id === coreExtensionData.reactElement.id
+        ? coreExtensionData.reactElement(
+            <SettingsAdapterRoot>{value.value}</SettingsAdapterRoot>,
+          )
+        : value,
+    );
   },
 });
 

--- a/plugins/user-settings/src/components/SettingsPage/SettingsPage.test.tsx
+++ b/plugins/user-settings/src/components/SettingsPage/SettingsPage.test.tsx
@@ -17,15 +17,15 @@
 import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
 import { SettingsPage } from './SettingsPage';
 import { UserSettingsTab } from '../UserSettingsTab';
-import { useOutlet } from 'react-router-dom';
+import { useOutlet } from 'react-router';
 import { SettingsLayout } from '../SettingsLayout';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { catalogApiRef, entityRouteRef } from '@backstage/plugin-catalog-react';
 import { catalogApiMock } from '@backstage/plugin-catalog-react/testUtils';
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useOutlet: jest.fn().mockReturnValue(undefined),
 }));
 

--- a/plugins/user-settings/src/components/SettingsPage/SettingsPage.tsx
+++ b/plugins/user-settings/src/components/SettingsPage/SettingsPage.tsx
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useOutlet } from 'react-router-dom';
+import { useOutlet } from 'react-router';
 import { DefaultSettingsPage } from '../DefaultSettingsPage';
 import { useElementFilter } from '@backstage/core-plugin-api';
 import {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3451,6 +3451,7 @@ __metadata:
     "@backstage/core-app-api": "workspace:^"
     "@backstage/core-plugin-api": "workspace:^"
     "@backstage/errors": "workspace:^"
+    "@backstage/frontend-plugin-api": "workspace:^"
     "@backstage/test-utils": "workspace:^"
     "@backstage/theme": "workspace:^"
     "@backstage/version-bridge": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5480,6 +5480,7 @@ __metadata:
     "@backstage/plugin-catalog-react": "workspace:^"
     "@backstage/plugin-permission-common": "workspace:^"
     "@backstage/plugin-permission-react": "workspace:^"
+    "@backstage/plugin-react-router-v6-adapter": "workspace:^"
     "@backstage/plugin-scaffolder-common": "workspace:^"
     "@backstage/plugin-search-common": "workspace:^"
     "@backstage/plugin-search-react": "workspace:^"
@@ -5914,6 +5915,7 @@ __metadata:
     "@backstage/plugin-catalog": "workspace:^"
     "@backstage/plugin-catalog-react": "workspace:^"
     "@backstage/plugin-home-react": "workspace:^"
+    "@backstage/plugin-tanstack-router-adapter": "workspace:^"
     "@backstage/test-utils": "workspace:^"
     "@backstage/theme": "workspace:^"
     "@material-ui/core": "npm:^4.12.2"
@@ -5923,6 +5925,7 @@ __metadata:
     "@rjsf/material-ui": "npm:5.24.13"
     "@rjsf/utils": "npm:5.24.13"
     "@rjsf/validator-ajv8": "npm:5.24.13"
+    "@tanstack/react-router": "npm:^1.0.0"
     "@testing-library/dom": "npm:^10.0.0"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^16.0.0"
@@ -5939,6 +5942,7 @@ __metadata:
     react-use: "npm:^17.2.4"
     zod: "npm:^3.25.76 || ^4.0.0"
   peerDependencies:
+    "@tanstack/react-router": ^1.0.0
     "@types/react": ^17.0.0 || ^18.0.0
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
@@ -6574,7 +6578,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage/plugin-react-router-v6-adapter@workspace:plugins/plugin-react-router-v6-adapter":
+"@backstage/plugin-react-router-v6-adapter@workspace:^, @backstage/plugin-react-router-v6-adapter@workspace:plugins/plugin-react-router-v6-adapter":
   version: 0.0.0-use.local
   resolution: "@backstage/plugin-react-router-v6-adapter@workspace:plugins/plugin-react-router-v6-adapter"
   dependencies:
@@ -6600,7 +6604,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage/plugin-react-router-v7-adapter@workspace:plugins/plugin-react-router-v7-adapter":
+"@backstage/plugin-react-router-v7-adapter@workspace:^, @backstage/plugin-react-router-v7-adapter@workspace:plugins/plugin-react-router-v7-adapter":
   version: 0.0.0-use.local
   resolution: "@backstage/plugin-react-router-v7-adapter@workspace:plugins/plugin-react-router-v7-adapter"
   dependencies:
@@ -7539,7 +7543,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage/plugin-tanstack-router-adapter@workspace:plugins/plugin-tanstack-router-adapter":
+"@backstage/plugin-tanstack-router-adapter@workspace:^, @backstage/plugin-tanstack-router-adapter@workspace:plugins/plugin-tanstack-router-adapter":
   version: 0.0.0-use.local
   resolution: "@backstage/plugin-tanstack-router-adapter@workspace:plugins/plugin-tanstack-router-adapter"
   dependencies:
@@ -7854,6 +7858,7 @@ __metadata:
     "@backstage/frontend-plugin-api": "workspace:^"
     "@backstage/plugin-catalog": "workspace:^"
     "@backstage/plugin-catalog-react": "workspace:^"
+    "@backstage/plugin-react-router-v7-adapter": "workspace:^"
     "@backstage/plugin-signals-react": "workspace:^"
     "@backstage/plugin-user-settings-common": "workspace:^"
     "@backstage/test-utils": "workspace:^"
@@ -7872,6 +7877,7 @@ __metadata:
     msw: "npm:^1.0.0"
     react: "npm:^18.0.2"
     react-dom: "npm:^18.0.2"
+    react-router: "npm:^7.0.0"
     react-router-dom: "npm:^6.30.2"
     react-use: "npm:^17.2.4"
     zen-observable: "npm:^0.10.0"
@@ -7879,6 +7885,7 @@ __metadata:
     "@types/react": ^17.0.0 || ^18.0.0
     react: ^17.0.0 || ^18.0.0
     react-dom: ^17.0.0 || ^18.0.0
+    react-router: ^7.0.0
     react-router-dom: ^6.30.2
   peerDependenciesMeta:
     "@types/react":

--- a/yarn.lock
+++ b/yarn.lock
@@ -6600,6 +6600,26 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@backstage/plugin-react-router-v7-adapter@workspace:plugins/plugin-react-router-v7-adapter":
+  version: 0.0.0-use.local
+  resolution: "@backstage/plugin-react-router-v7-adapter@workspace:plugins/plugin-react-router-v7-adapter"
+  dependencies:
+    "@backstage/cli": "workspace:^"
+    "@backstage/frontend-plugin-api": "workspace:^"
+    "@testing-library/dom": "npm:^10.0.0"
+    "@testing-library/jest-dom": "npm:^6.0.0"
+    "@testing-library/react": "npm:^16.0.0"
+    "@types/react": "npm:^18.0.0"
+    react: "npm:^18.0.2"
+    react-dom: "npm:^18.0.2"
+    react-router: "npm:^7.0.0"
+  peerDependencies:
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router: ^7.0.0
+  languageName: unknown
+  linkType: soft
+
 "@backstage/plugin-scaffolder-backend-module-azure@workspace:plugins/scaffolder-backend-module-azure":
   version: 0.0.0-use.local
   resolution: "@backstage/plugin-scaffolder-backend-module-azure@workspace:plugins/scaffolder-backend-module-azure"
@@ -7516,6 +7536,26 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
+  languageName: unknown
+  linkType: soft
+
+"@backstage/plugin-tanstack-router-adapter@workspace:plugins/plugin-tanstack-router-adapter":
+  version: 0.0.0-use.local
+  resolution: "@backstage/plugin-tanstack-router-adapter@workspace:plugins/plugin-tanstack-router-adapter"
+  dependencies:
+    "@backstage/cli": "workspace:^"
+    "@backstage/frontend-plugin-api": "workspace:^"
+    "@tanstack/react-router": "npm:^1.0.0"
+    "@testing-library/dom": "npm:^10.0.0"
+    "@testing-library/jest-dom": "npm:^6.0.0"
+    "@testing-library/react": "npm:^16.0.0"
+    "@types/react": "npm:^18.0.0"
+    react: "npm:^18.0.2"
+    react-dom: "npm:^18.0.2"
+  peerDependencies:
+    "@tanstack/react-router": ^1.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
   languageName: unknown
   linkType: soft
 
@@ -20453,6 +20493,41 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tanstack/history@npm:1.161.6":
+  version: 1.161.6
+  resolution: "@tanstack/history@npm:1.161.6"
+  checksum: 10/dce6ec5fcd2d6ab2f82289eeb7ab2274693025eaa12361e54346686d5afe46788e9f8d2a483095620079220575f79cca66268424cf3c4e4f780a0b7521b5db92
+  languageName: node
+  linkType: hard
+
+"@tanstack/react-router@npm:^1.0.0":
+  version: 1.168.10
+  resolution: "@tanstack/react-router@npm:1.168.10"
+  dependencies:
+    "@tanstack/history": "npm:1.161.6"
+    "@tanstack/react-store": "npm:^0.9.3"
+    "@tanstack/router-core": "npm:1.168.9"
+    isbot: "npm:^5.1.22"
+  peerDependencies:
+    react: ">=18.0.0 || >=19.0.0"
+    react-dom: ">=18.0.0 || >=19.0.0"
+  checksum: 10/283b36dfd8c82f276877884813a2df52be057a7a13f80075c65b44752df67f20ccd8216d2080fdda47e057d6333d626eedebc9f9375b199c4bebda9c95996997
+  languageName: node
+  linkType: hard
+
+"@tanstack/react-store@npm:^0.9.3":
+  version: 0.9.3
+  resolution: "@tanstack/react-store@npm:0.9.3"
+  dependencies:
+    "@tanstack/store": "npm:0.9.3"
+    use-sync-external-store: "npm:^1.6.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10/289227df0796cda41ff4cabab70670ac403e0b68847c6161faddf963b24e3e944ca801230cec7fd52d1dd1de611e220dbdfff19220d8024b919c79308c871d9c
+  languageName: node
+  linkType: hard
+
 "@tanstack/react-table@npm:^8.21.3":
   version: 8.21.3
   resolution: "@tanstack/react-table@npm:8.21.3"
@@ -20462,6 +20537,27 @@ __metadata:
     react: ">=16.8"
     react-dom: ">=16.8"
   checksum: 10/a32217ebe64d24e71dea6a6742bc288dcabf389657b16805a1ab3f347d3dca8262759c45c604a1f65bd97925d5cbdfb66d1be7637100a12eb5b279bdd420962d
+  languageName: node
+  linkType: hard
+
+"@tanstack/router-core@npm:1.168.9":
+  version: 1.168.9
+  resolution: "@tanstack/router-core@npm:1.168.9"
+  dependencies:
+    "@tanstack/history": "npm:1.161.6"
+    cookie-es: "npm:^2.0.0"
+    seroval: "npm:^1.4.2"
+    seroval-plugins: "npm:^1.4.2"
+  bin:
+    intent: bin/intent.js
+  checksum: 10/d0d67a7f241b3e223766da9b249ffc96de836328e5b2baaee594f10591dc9b6b38ebdec76ee5ff123632e9166d195de78b234b56d5eca59c5f75c925f7a1635f
+  languageName: node
+  linkType: hard
+
+"@tanstack/store@npm:0.9.3":
+  version: 0.9.3
+  resolution: "@tanstack/store@npm:0.9.3"
+  checksum: 10/fb41b7cb0ea9d79ba6db0335d4bf503911df8e203d5c4fae34996a627e1b43c93071b2d733f13f6db51aff4c703022cd7c2477a9192f84141e0010c4df782f63
   languageName: node
   linkType: hard
 
@@ -27651,6 +27747,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cookie-es@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "cookie-es@npm:2.0.1"
+  checksum: 10/835c59944bc58e3f0e30f60ba7da8d804dae351f809c3d145b353a0d94c60966f5a5d3cec9d307a463d974b4e8b87cea0b5124d8b5b5e08686f14cb7bce8fda5
+  languageName: node
+  linkType: hard
+
 "cookie-parser@npm:^1.4.5, cookie-parser@npm:^1.4.6":
   version: 1.4.7
   resolution: "cookie-parser@npm:1.4.7"
@@ -27693,6 +27796,13 @@ __metadata:
   version: 0.4.2
   resolution: "cookie@npm:0.4.2"
   checksum: 10/2e1de9fdedca54881eab3c0477aeb067f281f3155d9cfee9d28dfb252210d09e85e9d175c0a60689661feb9e35e588515352f2456bc1f8e8db4267e05fd70137
+  languageName: node
+  linkType: hard
+
+"cookie@npm:^1.0.1":
+  version: 1.1.1
+  resolution: "cookie@npm:1.1.1"
+  checksum: 10/85538153054791155cf4d38d2e807e3b9382d71bf71d92fc46fca348515ea574049d0d9ef8eb84d2d54a681ad1d7a7316b1989b901dace50a6c0f4c3858dbdb2
   languageName: node
   linkType: hard
 
@@ -35155,6 +35265,13 @@ __metadata:
   version: 5.0.7
   resolution: "isbinaryfile@npm:5.0.7"
   checksum: 10/af240b2a80db5cffbb3ddcb4d89403802d6b67d21b63fbcc0be5cefcefc013f499477c5837a5b2f029ba3d163543eab36eaee7cd701f2c44ee5ac890f0fadac5
+  languageName: node
+  linkType: hard
+
+"isbot@npm:^5.1.22":
+  version: 5.1.37
+  resolution: "isbot@npm:5.1.37"
+  checksum: 10/99337867b9b84b1e4141a3088ddb8ed6e53ea406d334bacb147ee4b44581bd951ab32ead12840702154e344aed53e48806141b8fe8b8c3c8307739b3e97ac550
   languageName: node
   linkType: hard
 
@@ -44102,6 +44219,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-router@npm:^7.0.0":
+  version: 7.13.2
+  resolution: "react-router@npm:7.13.2"
+  dependencies:
+    cookie: "npm:^1.0.1"
+    set-cookie-parser: "npm:^2.6.0"
+  peerDependencies:
+    react: ">=18"
+    react-dom: ">=18"
+  peerDependenciesMeta:
+    react-dom:
+      optional: true
+  checksum: 10/86e3538e4b50402bb15ac7b0938fdace5947a45d418bd1713b15288a208a5b102dfa599a3e5c4a86e136331b5dafaacfe57d93d2cc48241cf48fe770190cfbda
+  languageName: node
+  linkType: hard
+
 "react-side-effect@npm:^2.1.0":
   version: 2.1.0
   resolution: "react-side-effect@npm:2.1.0"
@@ -45924,6 +46057,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"seroval-plugins@npm:^1.4.2":
+  version: 1.5.1
+  resolution: "seroval-plugins@npm:1.5.1"
+  peerDependencies:
+    seroval: ^1.0
+  checksum: 10/1c7e3299511f38dfd92f19f732c640ae205cbfb34aec9c9ccba1e3c79d6d0f4fe7d09e2c45886943f0ebf7fd2d5cce6cc66a48e4f1cff3d567580b2bd8df76c2
+  languageName: node
+  linkType: hard
+
+"seroval@npm:^1.4.2":
+  version: 1.5.1
+  resolution: "seroval@npm:1.5.1"
+  checksum: 10/018a9d277c71de3e606c96aadd0d2bd6d45a38cd8776ec9619fc5ab567f9a4be79fb01e26c39d8c96d5b97ec5bdc4bd78dd4b72385a33ca2094322f0d29a157f
+  languageName: node
+  linkType: hard
+
 "serve-handler@npm:^6.1.3":
   version: 6.1.7
   resolution: "serve-handler@npm:6.1.7"
@@ -45985,10 +46134,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"set-cookie-parser@npm:^2.4.6":
-  version: 2.7.1
-  resolution: "set-cookie-parser@npm:2.7.1"
-  checksum: 10/c92b1130032693342bca13ea1b1bc93967ab37deec4387fcd8c2a843c0ef2fd9a9f3df25aea5bb3976cd05a91c2cf4632dd6164d6e1814208fb7d7e14edd42b4
+"set-cookie-parser@npm:^2.4.6, set-cookie-parser@npm:^2.6.0":
+  version: 2.7.2
+  resolution: "set-cookie-parser@npm:2.7.2"
+  checksum: 10/4b6f5ec4e3fa1aef471d9207117704d217ba6bb6443400b41f5ea945c4a7f6fc08e405a122c1a32b4ebde41f06dea75e02c2af87cee9abb27f3e3fe911e5839b
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6574,6 +6574,32 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@backstage/plugin-react-router-v6-adapter@workspace:plugins/plugin-react-router-v6-adapter":
+  version: 0.0.0-use.local
+  resolution: "@backstage/plugin-react-router-v6-adapter@workspace:plugins/plugin-react-router-v6-adapter"
+  dependencies:
+    "@backstage/cli": "workspace:^"
+    "@backstage/frontend-plugin-api": "workspace:^"
+    "@testing-library/dom": "npm:^10.0.0"
+    "@testing-library/jest-dom": "npm:^6.0.0"
+    "@testing-library/react": "npm:^16.0.0"
+    "@types/react": "npm:^18.0.0"
+    react: "npm:^18.0.2"
+    react-dom: "npm:^18.0.2"
+    react-router: "npm:^6.30.2"
+    react-router-dom: "npm:^6.30.2"
+  peerDependencies:
+    "@types/react": ^17.0.0 || ^18.0.0
+    react: ^17.0.0 || ^18.0.0
+    react-dom: ^17.0.0 || ^18.0.0
+    react-router: ^6.30.2
+    react-router-dom: ^6.30.2
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  languageName: unknown
+  linkType: soft
+
 "@backstage/plugin-scaffolder-backend-module-azure@workspace:plugins/scaffolder-backend-module-azure":
   version: 0.0.0-use.local
   resolution: "@backstage/plugin-scaffolder-backend-module-azure@workspace:plugins/scaffolder-backend-module-azure"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR introduces a router-agnostic routing architecture for Backstage's new frontend system, allowing individual plugins to use their preferred routing framework (React Router v6, React Router v7, TanStack Router, or others) while coexisting within a single Backstage application.

Today, all Backstage plugins are coupled to a single global `BrowserRouter` from `react-router-dom`. This makes it impossible for plugins to adopt newer routing frameworks independently, and creates a hard upgrade boundary where the entire application must migrate at once. This PR decouples plugins from that shared router by introducing a `RoutingContract` abstraction -- an observable-based contract that provides each plugin with its own scoped view of the URL.

### Design

The architecture has three layers:

**NavigationController** owns `window.history` and acts as the single source of truth for the browser URL. It provides scoped `RoutingContract` instances to plugins, each with a `basePath`, a `location$` observable (filtered to the plugin's URL prefix), and a `navigate()` function that translates relative plugin paths into absolute URLs before updating the browser.

**AppRouteSwitch** subscribes to `NavigationController.location$`, matches the current URL against a `RouteTable` using longest-prefix matching, and renders the matched plugin's page extension. The `PageBlueprint` delivers each plugin's `RoutingContract` via React context.

**Router adapters** bridge the `RoutingContract` into a specific router framework's internal context. The React Router v6 adapter, for example, provides `UNSAFE_LocationContext` and `UNSAFE_NavigationContext` so that existing `<Routes>`, `<Route>`, and `useNavigate()` calls continue to work without any changes to plugin code. Three adapter packages are included: `@backstage/plugin-react-router-v6-adapter`, `@backstage/plugin-react-router-v7-adapter`, and `@backstage/plugin-tanstack-router-adapter`.

### What changed

The core routing internals in `frontend-app-api` no longer depend on `react-router-dom` for route resolution. `RouteResolver`, `RouteTracker`, and `useRouteRef` now use standalone `generatePath` and `matchRouteRefs` implementations. The `BrowserRouter` in `AppRoot` has been replaced with a root-level `ScopedRouterProvider` backed by the `NavigationController`, so app chrome (sidebar, route tracker) and plugins all read from the same source of truth.

The `Link` component in `core-components` has been updated to detect cross-plugin navigation. When a link target is outside the current plugin's `basePath`, the component delegates to the framework-level `NavigationControllerApi` instead of `react-router-dom`, ensuring that navigation between plugins using different routers works correctly.

`useRouteRefParams` has been deprecated with a runtime warning in development mode, guiding developers toward their router's native `useParams` hook instead.

Two existing plugins (catalog and user-settings) have been wired to explicit router adapters as proof-of-concept migrations. A multi-router validation test suite confirms that plugins using different router frameworks can coexist, navigate between each other, and handle browser back/forward correctly.

### New packages

- `@backstage/plugin-react-router-v6-adapter` -- bridges RoutingContract to React Router v6
- `@backstage/plugin-react-router-v7-adapter` -- bridges RoutingContract to React Router v7
- `@backstage/plugin-tanstack-router-adapter` -- bridges RoutingContract to TanStack Router

### Backward compatibility

Existing plugins require no changes. The `ScopedRouterProvider` automatically sets up a React Router v6 context from the `RoutingContract`, so existing `<Routes>`, `<Route>`, `useNavigate()`, and `useLocation()` calls continue to work as before. Plugins can opt in to a different router at their own pace by swapping the adapter.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
