### PR TITLE
Patch release: upgrade `tar` to v7 for v1.44.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.44.2",
+  "version": "1.44.3",
   "backstage": {
     "cli": {
       "new": {

--- a/packages/repo-tools/CHANGELOG.md
+++ b/packages/repo-tools/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/repo-tools
 
+## 0.15.4
+
+### Patch Changes
+
+- Upgraded `tar` dependency to v7.
+
 ## 0.15.3
 
 ### Patch Changes

--- a/packages/repo-tools/package.json
+++ b/packages/repo-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/repo-tools",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "description": "CLI for Backstage repo tooling ",
   "backstage": {
     "role": "cli"

--- a/packages/repo-tools/package.json
+++ b/packages/repo-tools/package.json
@@ -80,7 +80,7 @@
     "minimatch": "^9.0.0",
     "p-limit": "^3.0.2",
     "portfinder": "^1.0.32",
-    "tar": "^6.1.12",
+    "tar": "^7.4.3",
     "ts-morph": "^24.0.0",
     "yaml-diff-patch": "^2.0.0",
     "zod": "^3.22.4"

--- a/packages/repo-tools/src/commands/generate-patch/generate-patch.ts
+++ b/packages/repo-tools/src/commands/generate-patch/generate-patch.ts
@@ -28,7 +28,7 @@ import { ForwardedError } from '@backstage/errors';
 import { Readable } from 'stream';
 import { finished } from 'stream/promises';
 import { ReadableStream } from 'stream/web';
-import tar from 'tar';
+import * as tar from 'tar';
 
 // TODO: add option for this
 const DEFAULT_REGISTRY_URL = 'https://registry.npmjs.org';

--- a/yarn.lock
+++ b/yarn.lock
@@ -7838,7 +7838,7 @@ __metadata:
     minimatch: "npm:^9.0.0"
     p-limit: "npm:^3.0.2"
     portfinder: "npm:^1.0.32"
-    tar: "npm:^6.1.12"
+    tar: "npm:^7.4.3"
     ts-morph: "npm:^24.0.0"
     typedoc: "npm:^0.28.0"
     yaml-diff-patch: "npm:^2.0.0"


### PR DESCRIPTION
Backports https://github.com/backstage/backstage/pull/32471

This release fixes a dependency on the deprecated `tar` v6 by upgrading to `tar` v7.

This is a partial patch — only the packages whose latest published patch version falls within the v1.44.x release line are bumped here:

- `@backstage/repo-tools` `0.15.3` → `0.15.4`

The remaining affected packages (`@backstage/backend-defaults`, `@backstage/cli`, `@backstage/plugin-scaffolder-backend`, `@backstage/plugin-scaffolder-node`) have their latest patch versions published in other Backstage releases and are covered by separate patch PRs against those branches.