### PR TITLE
Patch release: upgrade `tar` to v7 for v1.46.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.46.5",
+  "version": "1.46.6",
   "backstage": {
     "cli": {
       "new": {

--- a/packages/backend-defaults/CHANGELOG.md
+++ b/packages/backend-defaults/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/backend-defaults
 
+## 0.14.2
+
+### Patch Changes
+
+- Upgraded `tar` dependency to v7.
+
 ## 0.14.1
 
 ### Patch Changes

--- a/packages/backend-defaults/package.json
+++ b/packages/backend-defaults/package.json
@@ -187,7 +187,7 @@
     "rate-limit-redis": "^4.2.0",
     "raw-body": "^2.4.1",
     "selfsigned": "^2.0.0",
-    "tar": "^6.1.12",
+    "tar": "^7.4.3",
     "triple-beam": "^1.4.1",
     "uuid": "^11.0.0",
     "winston": "^3.2.1",

--- a/packages/backend-defaults/package.json
+++ b/packages/backend-defaults/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/backend-defaults",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Backend defaults used by Backstage backend apps",
   "backstage": {
     "role": "node-library"

--- a/packages/backend-defaults/report-urlReader.api.md
+++ b/packages/backend-defaults/report-urlReader.api.md
@@ -12,6 +12,7 @@ import { AzureIntegration } from '@backstage/integration';
 import { BitbucketCloudIntegration } from '@backstage/integration';
 import { BitbucketIntegration } from '@backstage/integration';
 import { BitbucketServerIntegration } from '@backstage/integration';
+import { Config } from '@backstage/config';
 import { GerritIntegration } from '@backstage/integration';
 import { GiteaIntegration } from '@backstage/integration';
 import { GithubCredentialsProvider } from '@backstage/integration';
@@ -224,6 +225,8 @@ export class BitbucketUrlReader implements UrlReaderService {
 // @public
 export class FetchUrlReader implements UrlReaderService {
   static factory: ReaderFactory;
+  // (undocumented)
+  static fromConfig(config: Config): FetchUrlReader;
   // (undocumented)
   read(url: string): Promise<Buffer>;
   // (undocumented)

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/tree/ReadableArrayResponse.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/tree/ReadableArrayResponse.ts
@@ -25,7 +25,7 @@ import platformPath, { dirname } from 'path';
 import getRawBody from 'raw-body';
 import fs from 'fs-extra';
 import { promisify } from 'util';
-import tar from 'tar';
+import * as tar from 'tar';
 import { pipeline as pipelineCb, Readable } from 'stream';
 import { FromReadableArrayOptions } from '../types';
 

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/tree/TarArchiveResponse.test.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/tree/TarArchiveResponse.test.ts
@@ -18,7 +18,7 @@ import fs from 'fs-extra';
 import { resolve as resolvePath, join as joinPath } from 'path';
 import { TarArchiveResponse } from './TarArchiveResponse';
 import { createMockDirectory } from '@backstage/backend-test-utils';
-import tar from 'tar';
+import * as tar from 'tar';
 
 const archiveData = fs.readFileSync(
   resolvePath(__filename, '../../__fixtures__/mock-main.tar.gz'),

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/tree/TarArchiveResponse.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/tree/TarArchiveResponse.ts
@@ -24,12 +24,10 @@ import concatStream from 'concat-stream';
 import fs from 'fs-extra';
 import platformPath from 'path';
 import { pipeline as pipelineCb, Readable } from 'stream';
-import tar, { FileStat, Parse, ParseStream, ReadEntry } from 'tar';
+import * as tar from 'tar';
+import type { ReadEntry } from 'tar';
 import { promisify } from 'util';
 import { stripFirstDirectoryFromPath } from './util';
-
-// Tar types for `Parse` is not a proper constructor, but it should be
-const TarParseStream = Parse as unknown as { new (): ParseStream };
 
 const pipeline = promisify(pipelineCb);
 
@@ -85,7 +83,7 @@ export class TarArchiveResponse implements UrlReaderServiceReadTreeResponse {
     this.onlyOnce();
 
     const files = Array<UrlReaderServiceReadTreeResponseFile>();
-    const parser = new TarParseStream();
+    const parser = new tar.Parser();
 
     parser.on('entry', (entry: ReadEntry & Readable) => {
       if (entry.type === 'Directory') {
@@ -184,7 +182,7 @@ export class TarArchiveResponse implements UrlReaderServiceReadTreeResponse {
           }
 
           // Block symlinks/hardlinks that escape the extraction directory
-          const entry = stat as FileStat & { type?: string; linkpath?: string };
+          const entry = stat as ReadEntry;
           if (
             (entry.type === 'SymbolicLink' || entry.type === 'Link') &&
             entry.linkpath

--- a/yarn.lock
+++ b/yarn.lock
@@ -3044,7 +3044,7 @@ __metadata:
     raw-body: "npm:^2.4.1"
     selfsigned: "npm:^2.0.0"
     supertest: "npm:^7.0.0"
-    tar: "npm:^6.1.12"
+    tar: "npm:^7.4.3"
     triple-beam: "npm:^1.4.1"
     uuid: "npm:^11.0.0"
     wait-for-expect: "npm:^3.0.2"


### PR DESCRIPTION
Backports https://github.com/backstage/backstage/pull/32471

This release fixes a dependency on the deprecated `tar` v6 by upgrading to `tar` v7.

This is a partial patch — only the packages whose latest published patch version falls within the v1.46.x release line are bumped here:

- `@backstage/backend-defaults` `0.14.1` → `0.14.2`

The remaining affected packages (`@backstage/cli`, `@backstage/repo-tools`, `@backstage/plugin-scaffolder-backend`, `@backstage/plugin-scaffolder-node`) have their latest patch versions published in other Backstage releases and are covered by separate patch PRs against those branches.