### PR TITLE
feat(techdocs): make sidebar positioning configurable via CSS custom properties

### DIFF
--- a/.changeset/free-ways-flow.md
+++ b/.changeset/free-ways-flow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Made the TechDocs sidebar positioning at tablet breakpoints configurable via CSS custom properties, allowing apps with custom sidebar widths to override the defaults. The available properties are `--techdocs-sidebar-closed-offset-pinned`, `--techdocs-sidebar-closed-offset-collapsed`, and `--techdocs-sidebar-open-translate`.

--- a/.patches/pr-33908.txt
+++ b/.patches/pr-33908.txt
@@ -1,0 +1,1 @@
+Make TechDocs sidebar positioning configurable via CSS custom properties

--- a/plugins/techdocs/src/reader/transformers/styles/rules/layout.ts
+++ b/plugins/techdocs/src/reader/transformers/styles/rules/layout.ts
@@ -16,7 +16,9 @@
 
 import { RuleOptions } from './types';
 
-const SIDEBAR_WIDTH = '224px';
+const TECHDOCS_SIDEBAR_WIDTH = '16rem';
+const APP_SIDEBAR_WIDTH_PINNED = '224px';
+const APP_SIDEBAR_WIDTH_COLLAPSED = '72px';
 
 export default ({ theme, sidebar }: RuleOptions) => `
 
@@ -80,10 +82,10 @@ export default ({ theme, sidebar }: RuleOptions) => `
 .md-sidebar {
   bottom: 75px;
   position: fixed;
-  width: 16rem;
+  width: ${TECHDOCS_SIDEBAR_WIDTH};
 }
 .md-sidebar .md-sidebar__scrollwrap {
-  width: calc(16rem);
+  width: calc(${TECHDOCS_SIDEBAR_WIDTH});
   height: 100%
 }
 
@@ -97,13 +99,13 @@ export default ({ theme, sidebar }: RuleOptions) => `
 }
 
 .md-content {
-  max-width: calc(100% - 16rem * 2);
-  margin-left: 16rem;
+  max-width: calc(100% - ${TECHDOCS_SIDEBAR_WIDTH} * 2);
+  margin-left: ${TECHDOCS_SIDEBAR_WIDTH};
   margin-bottom: 50px;
 }
 
 .md-content > .md-sidebar {
-  left: 16rem;
+  left: ${TECHDOCS_SIDEBAR_WIDTH};
 }
 
 .md-footer {
@@ -120,7 +122,7 @@ export default ({ theme, sidebar }: RuleOptions) => `
   background-color: unset;
 }
 .md-footer-nav__link, .md-footer__link {
-  width: 16rem;
+  width: ${TECHDOCS_SIDEBAR_WIDTH};
 }
 
 .md-dialog {
@@ -185,12 +187,12 @@ export default ({ theme, sidebar }: RuleOptions) => `
     height: 100%;
   }
   .md-sidebar--primary {
-    width: 16rem !important;
+    width: ${TECHDOCS_SIDEBAR_WIDTH} !important;
     z-index: 200;
     left: ${
       sidebar.isPinned
-        ? `calc(-16rem + ${SIDEBAR_WIDTH})`
-        : 'calc(-16rem + 72px)'
+        ? `calc(-${TECHDOCS_SIDEBAR_WIDTH} + var(--techdocs-sidebar-closed-offset-pinned, ${APP_SIDEBAR_WIDTH_PINNED}))`
+        : `calc(-${TECHDOCS_SIDEBAR_WIDTH} + var(--techdocs-sidebar-closed-offset-collapsed, ${APP_SIDEBAR_WIDTH_COLLAPSED}))`
     } !important;
   }
   .md-sidebar--secondary:not([hidden]) {
@@ -198,7 +200,7 @@ export default ({ theme, sidebar }: RuleOptions) => `
   }
 
   [data-md-toggle=drawer]:checked~.md-container .md-sidebar--primary {
-    transform: translateX(16rem);
+    transform: translateX(var(--techdocs-sidebar-open-translate, ${TECHDOCS_SIDEBAR_WIDTH}));
   }
 
   .md-content {
@@ -228,8 +230,8 @@ export default ({ theme, sidebar }: RuleOptions) => `
 
 @media screen and (max-width: 600px) {
   .md-sidebar--primary {
-    left: -16rem !important;
-    width: 16rem;
+    left: -${TECHDOCS_SIDEBAR_WIDTH} !important;
+    width: ${TECHDOCS_SIDEBAR_WIDTH};
   }
 }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The TechDocs sidebar layout at tablet breakpoints hardcodes the Backstage app sidebar widths (`224px` pinned, `72px` collapsed) to calculate its positioning. Apps with custom sidebar widths have no way to adjust this, causing the TechDocs navigation to render on top of or behind other content.

This replaces the hardcoded values with CSS custom properties that inherit through the shadow DOM boundary:

- `--techdocs-sidebar-closed-offset-pinned` (default: `224px`) — closed position offset when app sidebar is pinned
- `--techdocs-sidebar-closed-offset-collapsed` (default: `72px`) — closed position offset when app sidebar is collapsed
- `--techdocs-sidebar-open-translate` (default: `16rem`) — slide distance when the drawer is opened

Example usage for an app with a wider sidebar:
```css
:root {
  --techdocs-sidebar-closed-offset-pinned: 300px;
  --techdocs-sidebar-closed-offset-collapsed: 100px;
}
```

Or to fully hide the sidebar off-screen and have it overlay when opened:
```css
:root {
  --techdocs-sidebar-closed-offset-pinned: 0px;
  --techdocs-sidebar-closed-offset-collapsed: 0px;
}
```

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.