### PR TITLE
docs: fix missing closing parenthesis in services guide

### DIFF
--- a/docs/backend-system/architecture/03-services.md
+++ b/docs/backend-system/architecture/03-services.md
@@ -196,7 +196,7 @@ When declaring a service factory you may also want to make the export the buildi
 ```ts
 export class DefaultFooService {
   static create(options: { transform: (foo: string) => string }) {
-    return new DefaultFooService(options.transform ?? ((foo) => foo);
+    return new DefaultFooService(options.transform ?? (foo => foo));
   }
 
   private constructor(private readonly transform: (foo: string) => string) {}

--- a/docs/backend-system/architecture/03-services.md
+++ b/docs/backend-system/architecture/03-services.md
@@ -195,7 +195,7 @@ When declaring a service factory you may also want to make the export the buildi
 
 ```ts
 export class DefaultFooService {
-  static create(options: { transform: (foo: string) => string }) {
+  static create(options: { transform?: (foo: string) => string }) {
     return new DefaultFooService(options.transform ?? (foo => foo));
   }
 
@@ -264,7 +264,7 @@ In some cases it might be beneficial to allow users of your service factory to p
 
 ```ts
 const fooServiceFactoryWithOptions = (options?: {
-  transform: (foo: string) => string;
+  transform?: (foo: string) => string;
 }) =>
   createServiceFactory<FooService>({
     service: fooServiceRef,


### PR DESCRIPTION
Fixes a missing closing `)` in a code example in the backend services documentation.

The line `return new DefaultFooService(options.transform ?? ((foo) => foo);` was missing a closing parenthesis before the semicolon.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))