### PR TITLE
cli: fix config path resolution for embedded-postgres detection

### DIFF
--- a/.changeset/fix-embedded-postgres-config-paths.md
+++ b/.changeset/fix-embedded-postgres-config-paths.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli-module-build': patch
+---
+
+Fixed config path resolution for the embedded-postgres database client detection to resolve paths relative to the target package directory rather than the workspace root.

--- a/.patches/pr-33914.txt
+++ b/.patches/pr-33914.txt
@@ -1,0 +1,1 @@
+Fix config path resolution for embedded-postgres detection in `repo start`

--- a/packages/cli-module-build/src/lib/runner/runBackend.test.ts
+++ b/packages/cli-module-build/src/lib/runner/runBackend.test.ts
@@ -50,10 +50,11 @@ jest.mock('ctrlc-windows', () => ({
 }));
 
 const mockToConfig = jest.fn();
+const mockConfigSourcesDefault = jest.fn().mockReturnValue({});
 
 jest.mock('@backstage/config-loader', () => ({
   ConfigSources: {
-    default: () => ({}),
+    default: (...args: any[]) => mockConfigSourcesDefault(...args),
     toConfig: (...args: any[]) => mockToConfig(...args),
   },
 }));
@@ -214,6 +215,26 @@ describe('runBackend', () => {
           port: 5555,
         },
       });
+    });
+
+    it('should resolve config paths relative to targetDir', async () => {
+      mockToConfig.mockResolvedValue({
+        close: jest.fn(),
+        getOptionalString: () => undefined,
+      });
+
+      runBackend({
+        entry: 'src/index',
+        targetDir: '/root/packages/backend',
+        configPaths: ['../../config/local.yaml'],
+      });
+      await jest.advanceTimersByTimeAsync(100);
+
+      expect(mockConfigSourcesDefault).toHaveBeenCalledWith(
+        expect.objectContaining({
+          argv: ['--config', '/root/config/local.yaml'],
+        }),
+      );
     });
 
     it('should not start embedded DB for other database clients', async () => {

--- a/packages/cli-module-build/src/lib/runner/runBackend.ts
+++ b/packages/cli-module-build/src/lib/runner/runBackend.ts
@@ -68,7 +68,10 @@ export async function runBackend(options: RunBackendOptions) {
 
   let embeddedDb: Awaited<ReturnType<typeof startEmbeddedDb>> | undefined;
 
-  const dbClient = await readDatabaseClient(options.configPaths);
+  const dbClient = await readDatabaseClient(
+    options.configPaths,
+    options.targetDir,
+  );
   if (dbClient === 'embedded-postgres') {
     embeddedDb = await startEmbeddedDb();
     extraEnv.APP_CONFIG_backend_database = JSON.stringify({
@@ -220,14 +223,16 @@ export async function runBackend(options: RunBackendOptions) {
 
 async function readDatabaseClient(
   configPaths?: string[],
+  targetDir?: string,
 ): Promise<string | undefined> {
   const rootDir = targetPaths.rootDir;
+  const configBaseDir = targetDir ?? rootDir;
   const source = ConfigSources.default({
     rootDir,
     allowMissingDefaultConfig: true,
     argv: (configPaths ?? []).flatMap(p => [
       '--config',
-      isAbsolutePath(p) ? p : resolvePath(rootDir, p),
+      isAbsolutePath(p) ? p : resolvePath(configBaseDir, p),
     ]),
   });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes an issue where `repo start --config` would resolve config file paths inconsistently between the frontend and backend. The embedded-postgres config detection added in 1.50 resolves paths relative to the workspace root, while the rest of the system resolves relative to the target package directory. This meant that no single relative path worked for both the app and backend when using `repo start`.

The fix aligns `readDatabaseClient` to resolve config paths relative to the target package directory, matching the existing behavior.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))