### PR TITLE
errors: add explicit name property to ServiceUnavailableError

### DIFF
--- a/.changeset/add-service-unavailable-error-name.md
+++ b/.changeset/add-service-unavailable-error-name.md
@@ -1,0 +1,5 @@
+---
+'@backstage/errors': patch
+---
+
+Added explicit `name` property to `ServiceUnavailableError` for consistency with all other error classes, making it resilient to minification.

--- a/packages/errors/report.api.md
+++ b/packages/errors/report.api.md
@@ -151,7 +151,10 @@ export function serializeError(
 ): SerializedError;
 
 // @public
-export class ServiceUnavailableError extends CustomErrorBase {}
+export class ServiceUnavailableError extends CustomErrorBase {
+  // (undocumented)
+  name: 'ServiceUnavailableError';
+}
 
 // @public
 export function stringifyError(error: unknown): string;

--- a/packages/errors/src/errors/common.ts
+++ b/packages/errors/src/errors/common.ts
@@ -100,7 +100,9 @@ export class NotImplementedError extends CustomErrorBase {
  *
  * @public
  */
-export class ServiceUnavailableError extends CustomErrorBase {}
+export class ServiceUnavailableError extends CustomErrorBase {
+  name = 'ServiceUnavailableError' as const;
+}
 
 /**
  * An error that forwards an underlying cause with additional context in the message.

--- a/packages/errors/src/serialization/error.test.ts
+++ b/packages/errors/src/serialization/error.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { NotModifiedError } from '../errors';
+import { NotModifiedError, ServiceUnavailableError } from '../errors';
 import { deserializeError, serializeError, stringifyError } from './error';
 
 class CustomError extends Error {
@@ -75,6 +75,16 @@ describe('serialization', () => {
     expect(withoutStack2.stack).not.toBeDefined();
     expect(withoutStack1.cause.stack).not.toBeDefined();
     expect(withoutStack2.cause.stack).not.toBeDefined();
+  });
+
+  it('round-trips a ServiceUnavailableError', () => {
+    const before = new ServiceUnavailableError('service down');
+    const after = deserializeError(
+      serializeError(before, { includeStack: true }),
+    );
+    expect(after.name).toEqual('ServiceUnavailableError');
+    expect(after.message).toEqual('service down');
+    expect(after.stack).toEqual(before.stack);
   });
 
   it('stringifies all supported forms', () => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Every \`CustomErrorBase\` subclass explicitly sets \`name = 'ClassName' as const\` — except \`ServiceUnavailableError\`, which relied on the \`CustomErrorBase\` constructor's fallback that reads \`this.constructor.name\`. This is fragile under minification/bundling where constructor names get mangled. This adds the explicit name property for consistency with all other error classes.

Also added a serialization round-trip test to verify \`serializeError\`/\`deserializeError\` works correctly with the explicit name.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))