### PR TITLE
backend: deduplicate isPromise and unwrapFeature helpers

### DIFF
--- a/.changeset/deduplicate-ispromise-unwrapfeature.md
+++ b/.changeset/deduplicate-ispromise-unwrapfeature.md
@@ -3,4 +3,4 @@
 '@backstage/backend-test-utils': patch
 ---
 
-Deduplicated internal `isPromise` and `unwrapFeature` helpers.
+Internal refactor.

--- a/.changeset/deduplicate-ispromise-unwrapfeature.md
+++ b/.changeset/deduplicate-ispromise-unwrapfeature.md
@@ -1,0 +1,6 @@
+---
+'@backstage/backend-app-api': patch
+'@backstage/backend-test-utils': patch
+---
+
+Deduplicated internal `isPromise` and `unwrapFeature` helpers.

--- a/packages/backend-app-api/src/wiring/BackendInitializer.ts
+++ b/packages/backend-app-api/src/wiring/BackendInitializer.ts
@@ -29,7 +29,10 @@ import {
   ExtensionPointFactoryMiddleware,
   ServiceOrExtensionPoint,
 } from './types';
-import { OpaqueExtensionPointFactoryMiddleware } from '@internal/backend';
+import {
+  OpaqueExtensionPointFactoryMiddleware,
+  unwrapFeature,
+} from '@internal/backend';
 // Direct internal import to avoid duplication
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import type {
@@ -43,7 +46,7 @@ import { ConflictError, ForwardedError, toError } from '@backstage/errors';
 import { DependencyGraph } from '../lib/DependencyGraph';
 import { ServiceRegistry } from './ServiceRegistry';
 import { createInitializationResultCollector } from './createInitializationResultCollector';
-import { deepFreeze, unwrapFeature } from './helpers';
+import { deepFreeze } from './helpers';
 import type { RootInstanceMetadataServicePluginInfo } from '@backstage/backend-plugin-api';
 import { BackendStartupResult } from './types';
 import { BackendStartupError } from './BackendStartupError';

--- a/packages/backend-app-api/src/wiring/BackstageBackend.ts
+++ b/packages/backend-app-api/src/wiring/BackstageBackend.ts
@@ -16,7 +16,7 @@
 
 import { BackendFeature, ServiceFactory } from '@backstage/backend-plugin-api';
 import { BackendInitializer } from './BackendInitializer';
-import { unwrapFeature } from './helpers';
+import { isPromise, unwrapFeature } from './helpers';
 import {
   Backend,
   BackendStartupResult,
@@ -51,13 +51,4 @@ export class BackstageBackend implements Backend {
   async stop(): Promise<void> {
     await this.#initializer.stop();
   }
-}
-
-function isPromise<T>(value: unknown | Promise<T>): value is Promise<T> {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'then' in value &&
-    typeof value.then === 'function'
-  );
 }

--- a/packages/backend-app-api/src/wiring/BackstageBackend.ts
+++ b/packages/backend-app-api/src/wiring/BackstageBackend.ts
@@ -15,8 +15,8 @@
  */
 
 import { BackendFeature, ServiceFactory } from '@backstage/backend-plugin-api';
+import { isPromise, unwrapFeature } from '@internal/backend';
 import { BackendInitializer } from './BackendInitializer';
-import { isPromise, unwrapFeature } from './helpers';
 import {
   Backend,
   BackendStartupResult,

--- a/packages/backend-app-api/src/wiring/helpers.ts
+++ b/packages/backend-app-api/src/wiring/helpers.ts
@@ -14,13 +14,6 @@
  * limitations under the License.
  */
 
-// Direct internal import to avoid duplication
-// eslint-disable-next-line @backstage/no-relative-monorepo-imports
-export {
-  isPromise,
-  unwrapFeature,
-} from '../../../backend-internal/src/wiring/helpers';
-
 /** @internal */
 export type DeepReadonly<T> = {
   readonly [K in keyof T]: T[K] extends object ? DeepReadonly<T[K]> : T[K];

--- a/packages/backend-app-api/src/wiring/helpers.ts
+++ b/packages/backend-app-api/src/wiring/helpers.ts
@@ -14,26 +14,12 @@
  * limitations under the License.
  */
 
-import { BackendFeature } from '@backstage/backend-plugin-api';
-
-/** @internal */
-export function unwrapFeature(
-  feature: BackendFeature | { default: BackendFeature },
-): BackendFeature {
-  if ('$$type' in feature) {
-    return feature;
-  }
-
-  // This is a workaround where default exports get transpiled to `exports['default'] = ...`
-  // in CommonJS modules, which in turn results in a double `{ default: { default: ... } }` nesting
-  // when importing using a dynamic import.
-  // TODO: This is a broader issue than just this piece of code, and should move away from CommonJS.
-  if ('default' in feature) {
-    return feature.default;
-  }
-
-  return feature;
-}
+// Direct internal import to avoid duplication
+// eslint-disable-next-line @backstage/no-relative-monorepo-imports
+export {
+  isPromise,
+  unwrapFeature,
+} from '../../../backend-internal/src/wiring/helpers';
 
 /** @internal */
 export type DeepReadonly<T> = {

--- a/packages/backend-internal/package.json
+++ b/packages/backend-internal/package.json
@@ -22,6 +22,9 @@
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test"
   },
+  "dependencies": {
+    "@backstage/backend-plugin-api": "workspace:^"
+  },
   "devDependencies": {
     "@backstage/cli": "workspace:^"
   }

--- a/packages/backend-internal/src/index.ts
+++ b/packages/backend-internal/src/index.ts
@@ -14,4 +14,5 @@
  * limitations under the License.
  */
 
+export { isPromise, unwrapFeature } from './wiring';
 export { OpaqueExtensionPointFactoryMiddleware } from './wiring';

--- a/packages/backend-internal/src/wiring/helpers.ts
+++ b/packages/backend-internal/src/wiring/helpers.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { BackendFeature } from '@backstage/backend-plugin-api';
+
+/** @internal */
+export function isPromise<T>(value: unknown | Promise<T>): value is Promise<T> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'then' in value &&
+    typeof value.then === 'function'
+  );
+}
+
+/**
+ * Unwraps a backend feature from a possibly double-nested default export.
+ * This is a workaround where default exports get transpiled to
+ * `exports['default'] = ...` in CommonJS modules, which in turn results
+ * in a double `{ default: { default: ... } }` nesting when importing
+ * using a dynamic import.
+ *
+ * @internal
+ */
+export function unwrapFeature(
+  feature: BackendFeature | { default: BackendFeature },
+): BackendFeature {
+  if ('$$type' in feature) {
+    return feature;
+  }
+
+  if ('default' in feature) {
+    return feature.default;
+  }
+
+  return feature;
+}

--- a/packages/backend-internal/src/wiring/index.ts
+++ b/packages/backend-internal/src/wiring/index.ts
@@ -14,4 +14,5 @@
  * limitations under the License.
  */
 
+export { isPromise, unwrapFeature } from './helpers';
 export { OpaqueExtensionPointFactoryMiddleware } from './OpaqueExtensionPointFactoryMiddleware';

--- a/packages/backend-test-utils/src/wiring/TestBackend.ts
+++ b/packages/backend-test-utils/src/wiring/TestBackend.ts
@@ -26,12 +26,7 @@ import {
 import { mockServices } from '../services';
 import { ConfigReader } from '@backstage/config';
 import express from 'express';
-// Direct internal import to avoid duplication
-// eslint-disable-next-line @backstage/no-relative-monorepo-imports
-import {
-  isPromise,
-  unwrapFeature,
-} from '../../../backend-internal/src/wiring/helpers';
+import { isPromise, unwrapFeature } from '@internal/backend';
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import {
   InternalBackendFeature,

--- a/packages/backend-test-utils/src/wiring/TestBackend.ts
+++ b/packages/backend-test-utils/src/wiring/TestBackend.ts
@@ -29,6 +29,11 @@ import express from 'express';
 // Direct internal import to avoid duplication
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import {
+  isPromise,
+  unwrapFeature,
+} from '../../../backend-internal/src/wiring/helpers';
+// eslint-disable-next-line @backstage/no-relative-monorepo-imports
+import {
   InternalBackendFeature,
   InternalBackendRegistrations,
 } from '../../../backend-plugin-api/src/wiring/types';
@@ -216,30 +221,6 @@ function createExtensionPointTestModules(
   }
 
   return modules;
-}
-
-function isPromise<T>(value: unknown | Promise<T>): value is Promise<T> {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    'then' in value &&
-    typeof value.then === 'function'
-  );
-}
-
-// Same as in the backend-app-api, handles double defaults from dynamic imports
-function unwrapFeature(
-  feature: BackendFeature | { default: BackendFeature },
-): BackendFeature {
-  if ('$$type' in feature) {
-    return feature;
-  }
-
-  if ('default' in feature) {
-    return feature.default;
-  }
-
-  return feature;
 }
 
 const backendInstancesToCleanUp = new Array<Backend>();

--- a/yarn.lock
+++ b/yarn.lock
@@ -10044,6 +10044,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@internal/backend@workspace:packages/backend-internal"
   dependencies:
+    "@backstage/backend-plugin-api": "workspace:^"
     "@backstage/cli": "workspace:^"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This deduplicates the internal `isPromise` and `unwrapFeature` helper functions that were copy-pasted between `backend-app-api` and `backend-test-utils`. They now live in a single shared location in `backend-plugin-api` (as internal, non-exported helpers), and are imported via direct relative monorepo imports — same pattern used for the internal types.

This eliminates drift risk where a bug fix in one copy isn't applied to the other. The `TestBackend.ts` copy even had a comment acknowledging the duplication.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))