### PR TITLE
ui: inline `ColumnSize` and `ColumnStaticSize` types from `@react-types/table`

### DIFF
--- a/.changeset/fix-react-types-table-imports.md
+++ b/.changeset/fix-react-types-table-imports.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Replaced the transitive `@react-types/table` import of `ColumnSize` and `ColumnStaticSize` with locally defined type aliases.

--- a/packages/ui/report.api.md
+++ b/packages/ui/report.api.md
@@ -8,8 +8,6 @@ import { CellProps as CellProps_2 } from 'react-aria-components';
 import type { CheckboxGroupProps as CheckboxGroupProps_2 } from 'react-aria-components';
 import type { CheckboxProps as CheckboxProps_2 } from 'react-aria-components';
 import { ColumnProps as ColumnProps_2 } from 'react-aria-components';
-import type { ColumnSize } from '@react-types/table';
-import type { ColumnStaticSize } from '@react-types/table';
 import type { ComponentProps } from 'react';
 import type { ComponentPropsWithoutRef } from 'react';
 import type { ComponentPropsWithRef } from 'react';
@@ -984,6 +982,12 @@ export type Columns =
   | '11'
   | '12'
   | 'auto';
+
+// @public (undocumented)
+export type ColumnSize = ColumnStaticSize | `${number}fr`;
+
+// @public (undocumented)
+export type ColumnStaticSize = number | `${number}` | `${number}%`;
 
 // @public (undocumented)
 export interface CompletePaginationOptions extends PaginationOptions {

--- a/packages/ui/src/components/Table/index.ts
+++ b/packages/ui/src/components/Table/index.ts
@@ -46,6 +46,8 @@ export type {
   TableRootProps,
   TableItem,
   ColumnConfig,
+  ColumnSize,
+  ColumnStaticSize,
   RowConfig,
   RowRenderFn,
   TableSelection,

--- a/packages/ui/src/components/Table/types.ts
+++ b/packages/ui/src/components/Table/types.ts
@@ -24,8 +24,13 @@ import {
 } from 'react-aria-components';
 import type { ReactElement, ReactNode } from 'react';
 import type { SortDescriptor as ReactStatelySortDescriptor } from 'react-stately';
-import type { ColumnSize, ColumnStaticSize } from '@react-types/table';
 import type { TextColors } from '../../types';
+
+/** @public */
+export type ColumnStaticSize = number | `${number}` | `${number}%`;
+
+/** @public */
+export type ColumnSize = ColumnStaticSize | `${number}fr`;
 import { TablePaginationProps } from '../TablePagination';
 
 /**


### PR DESCRIPTION
The `ColumnSize` and `ColumnStaticSize` types were imported from `@react-types/table`, which is not a direct dependency of `@backstage/ui` — it was only available as a transitive dependency that can break across version bumps.

Since these are simple type aliases (`ColumnStaticSize = number | `${number}` | `${number}%`` and `ColumnSize = ColumnStaticSize | `${number}fr``), this replaces the import with locally defined types. They are also now explicitly exported from the package.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))