### PR TITLE
fix: forward per-request token in BitbucketServerUrlReader

### DIFF
--- a/.changeset/bitbucket-server-token-forwarding-backend-defaults.md
+++ b/.changeset/bitbucket-server-token-forwarding-backend-defaults.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Fixed `BitbucketServerUrlReader` to forward the per-request `token` from `UrlReaderServiceReadUrlOptions` to all Bitbucket Server API calls, matching the behavior of the GitHub and GitLab readers. Setups that rely on per-request tokens instead of a static token in the integration config will now authenticate correctly.

--- a/.changeset/bitbucket-server-token-forwarding-integration.md
+++ b/.changeset/bitbucket-server-token-forwarding-integration.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Added an optional token parameter to `getBitbucketServerRequestOptions`, `getBitbucketServerDefaultBranch`, and `getBitbucketServerDownloadUrl`. When provided, it takes priority over the token from the integration config, letting callers pass per-request credentials.

--- a/.changeset/bitbucket-server-token-forwarding.md
+++ b/.changeset/bitbucket-server-token-forwarding.md
@@ -1,6 +1,0 @@
----
-'@backstage/integration': patch
-'@backstage/backend-defaults': patch
----
-
-Fixed `BitbucketServerUrlReader` to forward the per-request `token` from `UrlReaderServiceReadUrlOptions` to all Bitbucket Server API calls, matching the behavior of the GitHub and GitLab readers. Added an optional token parameter to `getBitbucketServerRequestOptions`, `getBitbucketServerDefaultBranch`, and `getBitbucketServerDownloadUrl` that takes priority over the token from the integration config.

--- a/.changeset/bitbucket-server-token-forwarding.md
+++ b/.changeset/bitbucket-server-token-forwarding.md
@@ -1,0 +1,6 @@
+---
+'@backstage/integration': patch
+'@backstage/backend-defaults': patch
+---
+
+Fixed `BitbucketServerUrlReader` to forward the per-request `token` from `UrlReaderServiceReadUrlOptions` to all Bitbucket Server API calls, matching the behavior of the GitHub and GitLab readers. Added an optional `token` parameter to `getBitbucketServerRequestOptions` that takes priority over the token from the integration config.

--- a/.changeset/bitbucket-server-token-forwarding.md
+++ b/.changeset/bitbucket-server-token-forwarding.md
@@ -3,4 +3,4 @@
 '@backstage/backend-defaults': patch
 ---
 
-Fixed `BitbucketServerUrlReader` to forward the per-request `token` from `UrlReaderServiceReadUrlOptions` to all Bitbucket Server API calls, matching the behavior of the GitHub and GitLab readers. Added an optional `token` parameter to `getBitbucketServerRequestOptions` that takes priority over the token from the integration config.
+Fixed `BitbucketServerUrlReader` to forward the per-request `token` from `UrlReaderServiceReadUrlOptions` to all Bitbucket Server API calls, matching the behavior of the GitHub and GitLab readers. Added an optional token parameter to `getBitbucketServerRequestOptions`, `getBitbucketServerDefaultBranch`, and `getBitbucketServerDownloadUrl` that takes priority over the token from the integration config.

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/BitbucketServerUrlReader.test.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/BitbucketServerUrlReader.test.ts
@@ -434,6 +434,62 @@ describe('BitbucketServerUrlReader', () => {
       expect(authHeaders.archive).toBe('Bearer tree-token');
     });
 
+    it('should forward token to default branch lookup API calls in readTree', async () => {
+      const authHeaders: Record<string, string | null | undefined> = {};
+      worker.use(
+        rest.get(
+          'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/branches/default',
+          (req, res, ctx) => {
+            authHeaders.branchesDefault = req.headers.get('Authorization');
+            return res(
+              ctx.status(200),
+              ctx.json({
+                displayId: 'master',
+                latestCommit: '12ab34cd56ef78gh90ij12kl34mn56op78qr90st',
+              }),
+            );
+          },
+        ),
+        rest.get(
+          'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/default-branch',
+          (req, res, ctx) => {
+            authHeaders.defaultBranch = req.headers.get('Authorization');
+            return res(
+              ctx.status(200),
+              ctx.json({
+                displayId: 'master',
+                latestCommit: '12ab34cd56ef78gh90ij12kl34mn56op78qr90st',
+              }),
+            );
+          },
+        ),
+        rest.get(
+          'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/archive',
+          (req, res, ctx) => {
+            authHeaders.archive = req.headers.get('Authorization');
+            return res(
+              ctx.status(200),
+              ctx.set('Content-Type', 'application/zip'),
+              ctx.set(
+                'content-disposition',
+                'attachment; filename=backstage-mock.tgz',
+              ),
+              ctx.body(new Uint8Array(repoBuffer)),
+            );
+          },
+        ),
+      );
+      await readerWithoutConfigToken.readTree(
+        'https://bitbucket.mycompany.net/projects/backstage/repos/mock/browse/docs',
+        { token: 'tree-token' },
+      );
+      expect([
+        authHeaders.branchesDefault,
+        authHeaders.defaultBranch,
+      ]).toContain('Bearer tree-token');
+      expect(authHeaders.archive).toBe('Bearer tree-token');
+    });
+
     it('should send no auth header when neither token nor config is set', async () => {
       let authHeader: string | null = null;
       worker.use(

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/BitbucketServerUrlReader.test.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/BitbucketServerUrlReader.test.ts
@@ -483,10 +483,8 @@ describe('BitbucketServerUrlReader', () => {
         'https://bitbucket.mycompany.net/projects/backstage/repos/mock/browse/docs',
         { token: 'tree-token' },
       );
-      expect([
-        authHeaders.branchesDefault,
-        authHeaders.defaultBranch,
-      ]).toContain('Bearer tree-token');
+      expect(authHeaders.branchesDefault).toBe('Bearer tree-token');
+      expect(authHeaders.defaultBranch).toBe('Bearer tree-token');
       expect(authHeaders.archive).toBe('Bearer tree-token');
     });
 
@@ -507,6 +505,53 @@ describe('BitbucketServerUrlReader', () => {
       );
 
       expect(authHeader).toBeNull();
+    });
+
+    it('should forward token when search uses glob pattern', async () => {
+      const authHeaders: Record<string, string | null> = {};
+      worker.use(
+        rest.get(
+          'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/branches',
+          (req, res, ctx) => {
+            authHeaders.branches = req.headers.get('Authorization');
+            return res(
+              ctx.status(200),
+              ctx.json({
+                size: 1,
+                values: [
+                  {
+                    displayId: 'some-branch',
+                    latestCommit: '12ab34cd56ef78gh90ij12kl34mn56op78qr90st',
+                  },
+                ],
+              }),
+            );
+          },
+        ),
+        rest.get(
+          'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/archive',
+          (req, res, ctx) => {
+            authHeaders.archive = req.headers.get('Authorization');
+            return res(
+              ctx.status(200),
+              ctx.set('Content-Type', 'application/zip'),
+              ctx.set(
+                'content-disposition',
+                'attachment; filename=backstage-mock.tgz',
+              ),
+              ctx.body(new Uint8Array(repoBuffer)),
+            );
+          },
+        ),
+      );
+
+      await readerWithoutConfigToken.search(
+        'https://bitbucket.mycompany.net/projects/backstage/repos/mock/browse/docs/*.yaml?at=some-branch',
+        { token: 'search-token' },
+      );
+
+      expect(authHeaders.branches).toBe('Bearer search-token');
+      expect(authHeaders.archive).toBe('Bearer search-token');
     });
   });
 });

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/BitbucketServerUrlReader.test.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/BitbucketServerUrlReader.test.ts
@@ -297,4 +297,160 @@ describe('BitbucketServerUrlReader', () => {
       expect((await result.files[0].content()).toString()).toEqual('content');
     });
   });
+
+  describe('token forwarding', () => {
+    const repoBuffer = fs.readFileSync(
+      path.resolve(__dirname, '__fixtures__/bitbucket-server-repo.tar.gz'),
+    );
+
+    const readerWithoutConfigToken = new BitbucketServerUrlReader(
+      new BitbucketServerIntegration(
+        readBitbucketServerIntegrationConfig(
+          new ConfigReader({
+            host: 'bitbucket.mycompany.net',
+            apiBaseUrl: 'https://api.bitbucket.mycompany.net/rest/api/1.0',
+          }),
+        ),
+      ),
+      { treeResponseFactory },
+    );
+
+    const readerWithConfigToken = new BitbucketServerUrlReader(
+      new BitbucketServerIntegration(
+        readBitbucketServerIntegrationConfig(
+          new ConfigReader({
+            host: 'bitbucket.mycompany.net',
+            apiBaseUrl: 'https://api.bitbucket.mycompany.net/rest/api/1.0',
+            token: 'config-token',
+          }),
+        ),
+      ),
+      { treeResponseFactory },
+    );
+
+    it('should use the passed token in readUrl requests', async () => {
+      let authHeader: string | null = null;
+      worker.use(
+        rest.get(
+          'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/raw/docs/catalog.yaml',
+          (req, res, ctx) => {
+            authHeader = req.headers.get('Authorization');
+            return res(ctx.status(200), ctx.text('file content'));
+          },
+        ),
+      );
+
+      await readerWithoutConfigToken.readUrl(
+        'https://bitbucket.mycompany.net/projects/backstage/repos/mock/browse/docs/catalog.yaml',
+        { token: 'my-token' },
+      );
+
+      expect(authHeader).toBe('Bearer my-token');
+    });
+
+    it('should fall back to config token when no token is passed', async () => {
+      let authHeader: string | null = null;
+      worker.use(
+        rest.get(
+          'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/raw/docs/catalog.yaml',
+          (req, res, ctx) => {
+            authHeader = req.headers.get('Authorization');
+            return res(ctx.status(200), ctx.text('file content'));
+          },
+        ),
+      );
+
+      await readerWithConfigToken.readUrl(
+        'https://bitbucket.mycompany.net/projects/backstage/repos/mock/browse/docs/catalog.yaml',
+      );
+
+      expect(authHeader).toBe('Bearer config-token');
+    });
+
+    it('should prefer passed token over config token', async () => {
+      let authHeader: string | null = null;
+      worker.use(
+        rest.get(
+          'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/raw/docs/catalog.yaml',
+          (req, res, ctx) => {
+            authHeader = req.headers.get('Authorization');
+            return res(ctx.status(200), ctx.text('file content'));
+          },
+        ),
+      );
+
+      await readerWithConfigToken.readUrl(
+        'https://bitbucket.mycompany.net/projects/backstage/repos/mock/browse/docs/catalog.yaml',
+        { token: 'passed-token' },
+      );
+
+      expect(authHeader).toBe('Bearer passed-token');
+    });
+
+    it('should forward token to all API calls in readTree', async () => {
+      const authHeaders: Record<string, string | null> = {};
+      worker.use(
+        rest.get(
+          'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/branches',
+          (req, res, ctx) => {
+            authHeaders.branches = req.headers.get('Authorization');
+            return res(
+              ctx.status(200),
+              ctx.json({
+                size: 1,
+                values: [
+                  {
+                    displayId: 'some-branch',
+                    latestCommit: '12ab34cd56ef78gh90ij12kl34mn56op78qr90st',
+                  },
+                ],
+              }),
+            );
+          },
+        ),
+        rest.get(
+          'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/archive',
+          (req, res, ctx) => {
+            authHeaders.archive = req.headers.get('Authorization');
+            return res(
+              ctx.status(200),
+              ctx.set('Content-Type', 'application/zip'),
+              ctx.set(
+                'content-disposition',
+                'attachment; filename=backstage-mock.tgz',
+              ),
+              ctx.body(new Uint8Array(repoBuffer)),
+            );
+          },
+        ),
+      );
+
+      await readerWithoutConfigToken.readTree(
+        'https://bitbucket.mycompany.net/projects/backstage/repos/mock/browse/docs?at=some-branch',
+        { token: 'tree-token' },
+      );
+
+      expect(authHeaders.branches).toBe('Bearer tree-token');
+      expect(authHeaders.archive).toBe('Bearer tree-token');
+    });
+
+    it('should send no auth header when neither token nor config is set', async () => {
+      let authHeader: string | null = null;
+      worker.use(
+        rest.get(
+          'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/raw/docs/catalog.yaml',
+          (req, res, ctx) => {
+            authHeader = req.headers.get('Authorization');
+            return res(ctx.status(200), ctx.text('file content'));
+          },
+        ),
+      );
+
+      await readerWithoutConfigToken.readUrl(
+        'https://bitbucket.mycompany.net/projects/backstage/repos/mock/browse/docs/catalog.yaml',
+      );
+
+      expect(authHeader).toBeNull();
+    });
+  });
 });

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/BitbucketServerUrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/BitbucketServerUrlReader.ts
@@ -138,6 +138,7 @@ export class BitbucketServerUrlReader implements UrlReaderService {
     const downloadUrl = await getBitbucketServerDownloadUrl(
       url,
       this.integration.config,
+      options?.token,
     );
     const archiveResponse = await fetch(
       downloadUrl,

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/BitbucketServerUrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/BitbucketServerUrlReader.ts
@@ -74,13 +74,14 @@ export class BitbucketServerUrlReader implements UrlReaderService {
     url: string,
     options?: UrlReaderServiceReadUrlOptions,
   ): Promise<UrlReaderServiceReadUrlResponse> {
-    const { etag, lastModifiedAfter, signal } = options ?? {};
+    const { etag, lastModifiedAfter, signal, token } = options ?? {};
     const bitbucketUrl = getBitbucketServerFileFetchUrl(
       url,
       this.integration.config,
     );
     const requestOptions = getBitbucketServerRequestOptions(
       this.integration.config,
+      token,
     );
 
     let response: Response;
@@ -126,7 +127,10 @@ export class BitbucketServerUrlReader implements UrlReaderService {
   ): Promise<UrlReaderServiceReadTreeResponse> {
     const { filepath } = parseGitUrl(url);
 
-    const lastCommitShortHash = await this.getLastCommitShortHash(url);
+    const lastCommitShortHash = await this.getLastCommitShortHash(
+      url,
+      options?.token,
+    );
     if (options?.etag && options.etag === lastCommitShortHash) {
       throw new NotModifiedError();
     }
@@ -137,7 +141,7 @@ export class BitbucketServerUrlReader implements UrlReaderService {
     );
     const archiveResponse = await fetch(
       downloadUrl,
-      getBitbucketServerRequestOptions(this.integration.config),
+      getBitbucketServerRequestOptions(this.integration.config, options?.token),
     );
     if (!archiveResponse.ok) {
       const message = `Failed to read tree from ${url}, ${archiveResponse.status} ${archiveResponse.statusText}`;
@@ -199,6 +203,7 @@ export class BitbucketServerUrlReader implements UrlReaderService {
     const tree = await this.readTree(treeUrl, {
       etag: options?.etag,
       filter: path => matcher.match(path),
+      token: options?.token,
     });
     const files = await tree.files();
 
@@ -221,7 +226,10 @@ export class BitbucketServerUrlReader implements UrlReaderService {
     return `bitbucketServer{host=${host},authed=${authed}}`;
   }
 
-  private async getLastCommitShortHash(url: string): Promise<string> {
+  private async getLastCommitShortHash(
+    url: string,
+    token?: string,
+  ): Promise<string> {
     const { name: repoName, owner: project, ref: branch } = parseGitUrl(url);
 
     // If a branch is provided use that otherwise fall back to the default branch
@@ -234,7 +242,7 @@ export class BitbucketServerUrlReader implements UrlReaderService {
 
     const branchListResponse = await fetch(
       branchListUrl,
-      getBitbucketServerRequestOptions(this.integration.config),
+      getBitbucketServerRequestOptions(this.integration.config, token),
     );
     if (!branchListResponse.ok) {
       const message = `Failed to retrieve branch list from ${branchListUrl}, ${branchListResponse.status} ${branchListResponse.statusText}`;

--- a/packages/integration/report.api.md
+++ b/packages/integration/report.api.md
@@ -437,6 +437,7 @@ export function getBitbucketServerFileFetchUrl(
 // @public
 export function getBitbucketServerRequestOptions(
   config: BitbucketServerIntegrationConfig,
+  token?: string,
 ): {
   headers: Record<string, string>;
 };

--- a/packages/integration/report.api.md
+++ b/packages/integration/report.api.md
@@ -420,12 +420,14 @@ export function getBitbucketCloudRequestOptions(
 export function getBitbucketServerDefaultBranch(
   url: string,
   config: BitbucketServerIntegrationConfig,
+  token?: string,
 ): Promise<string>;
 
 // @public
 export function getBitbucketServerDownloadUrl(
   url: string,
   config: BitbucketServerIntegrationConfig,
+  token?: string,
 ): Promise<string>;
 
 // @public

--- a/packages/integration/src/bitbucketServer/core.test.ts
+++ b/packages/integration/src/bitbucketServer/core.test.ts
@@ -73,6 +73,42 @@ describe('bitbucketServer core', () => {
           .Authorization,
       ).toBeUndefined();
     });
+
+    it('prefers per-request token over config token', () => {
+      const config: BitbucketServerIntegrationConfig = {
+        host: '',
+        apiBaseUrl: '',
+        token: 'config-token',
+      };
+      expect(
+        getBitbucketServerRequestOptions(config, 'request-token').headers
+          .Authorization,
+      ).toEqual('Bearer request-token');
+    });
+
+    it('prefers per-request token over basic auth', () => {
+      const config: BitbucketServerIntegrationConfig = {
+        host: '',
+        apiBaseUrl: '',
+        username: 'u',
+        password: 'p',
+      };
+      expect(
+        getBitbucketServerRequestOptions(config, 'request-token').headers
+          .Authorization,
+      ).toEqual('Bearer request-token');
+    });
+
+    it('falls back to config token when no per-request token is provided', () => {
+      const config: BitbucketServerIntegrationConfig = {
+        host: '',
+        apiBaseUrl: '',
+        token: 'config-token',
+      };
+      expect(
+        getBitbucketServerRequestOptions(config).headers.Authorization,
+      ).toEqual('Bearer config-token');
+    });
   });
 
   describe('getBitbucketServerFileFetchUrl', () => {
@@ -250,6 +286,81 @@ describe('bitbucketServer core', () => {
         config,
       );
       expect(defaultBranch).toEqual('main');
+    });
+
+    it('forwards per-request token to the default branch API call', async () => {
+      let authHeader: string | null = null;
+      worker.use(
+        rest.get(
+          'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/default-branch',
+          (req, res, ctx) => {
+            authHeader = req.headers.get('Authorization');
+            return res(ctx.status(200), ctx.json({ displayId: 'main' }));
+          },
+        ),
+      );
+      const config: BitbucketServerIntegrationConfig = {
+        host: 'bitbucket.mycompany.net',
+        apiBaseUrl: 'https://api.bitbucket.mycompany.net/rest/api/1.0',
+      };
+      await getBitbucketServerDefaultBranch(
+        'https://bitbucket.mycompany.net/projects/backstage/repos/mock/browse/README.md',
+        config,
+        'my-token',
+      );
+      expect(authHeader).toBe('Bearer my-token');
+    });
+
+    it('forwards per-request token to the fallback API call for older Bitbucket versions', async () => {
+      let authHeader: string | null = null;
+      worker.use(
+        rest.get(
+          'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/default-branch',
+          (_, res, ctx) => res(ctx.status(404)),
+        ),
+        rest.get(
+          'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/branches/default',
+          (req, res, ctx) => {
+            authHeader = req.headers.get('Authorization');
+            return res(ctx.status(200), ctx.json({ displayId: 'main' }));
+          },
+        ),
+      );
+      const config: BitbucketServerIntegrationConfig = {
+        host: 'bitbucket.mycompany.net',
+        apiBaseUrl: 'https://api.bitbucket.mycompany.net/rest/api/1.0',
+      };
+      await getBitbucketServerDefaultBranch(
+        'https://bitbucket.mycompany.net/projects/backstage/repos/mock/browse/README.md',
+        config,
+        'my-token',
+      );
+      expect(authHeader).toBe('Bearer my-token');
+    });
+  });
+
+  describe('getBitbucketServerDownloadUrl token forwarding', () => {
+    it('forwards per-request token to default branch lookup', async () => {
+      let authHeader: string | null = null;
+      worker.use(
+        rest.get(
+          'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/default-branch',
+          (req, res, ctx) => {
+            authHeader = req.headers.get('Authorization');
+            return res(ctx.status(200), ctx.json({ displayId: 'main' }));
+          },
+        ),
+      );
+      const config: BitbucketServerIntegrationConfig = {
+        host: 'bitbucket.mycompany.net',
+        apiBaseUrl: 'https://api.bitbucket.mycompany.net/rest/api/1.0',
+      };
+      await getBitbucketServerDownloadUrl(
+        'https://bitbucket.mycompany.net/projects/backstage/repos/mock/browse/docs',
+        config,
+        'my-token',
+      );
+      expect(authHeader).toBe('Bearer my-token');
     });
   });
 });

--- a/packages/integration/src/bitbucketServer/core.ts
+++ b/packages/integration/src/bitbucketServer/core.ts
@@ -24,11 +24,13 @@ import { BitbucketServerIntegrationConfig } from './config';
  *
  * @param url - A URL pointing to a path
  * @param config - The relevant provider config
+ * @param token - An optional per-request token to use for authentication
  * @public
  */
 export async function getBitbucketServerDefaultBranch(
   url: string,
   config: BitbucketServerIntegrationConfig,
+  token?: string,
 ): Promise<string> {
   const { name: repoName, owner: project } = parseGitUrl(url);
 
@@ -37,14 +39,17 @@ export async function getBitbucketServerDefaultBranch(
 
   let response = await fetch(
     branchUrl,
-    getBitbucketServerRequestOptions(config),
+    getBitbucketServerRequestOptions(config, token),
   );
 
   if (response.status === 404) {
     // First try the new format, and then if it gets specifically a 404 it should try the old format
     // (to support old  Atlassian Bitbucket Server v5.11.1 format )
     branchUrl = `${config.apiBaseUrl}/projects/${project}/repos/${repoName}/branches/default`;
-    response = await fetch(branchUrl, getBitbucketServerRequestOptions(config));
+    response = await fetch(
+      branchUrl,
+      getBitbucketServerRequestOptions(config, token),
+    );
   }
 
   if (!response.ok) {
@@ -69,11 +74,13 @@ export async function getBitbucketServerDefaultBranch(
  *
  * @param url - A URL pointing to a path
  * @param config - The relevant provider config
+ * @param token - An optional per-request token to use for authentication
  * @public
  */
 export async function getBitbucketServerDownloadUrl(
   url: string,
   config: BitbucketServerIntegrationConfig,
+  token?: string,
 ): Promise<string> {
   const {
     name: repoName,
@@ -84,7 +91,7 @@ export async function getBitbucketServerDownloadUrl(
 
   let branch = ref;
   if (!branch) {
-    branch = await getBitbucketServerDefaultBranch(url, config);
+    branch = await getBitbucketServerDefaultBranch(url, config, token);
   }
   // path will limit the downloaded content
   // /docs will only download the docs folder and everything below it
@@ -136,6 +143,7 @@ export function getBitbucketServerFileFetchUrl(
  * Gets the request options necessary to make requests to a given provider.
  *
  * @param config - The relevant provider config
+ * @param token - An optional per-request token to use for authentication, which takes precedence over the config token
  * @public
  */
 export function getBitbucketServerRequestOptions(

--- a/packages/integration/src/bitbucketServer/core.ts
+++ b/packages/integration/src/bitbucketServer/core.ts
@@ -140,10 +140,13 @@ export function getBitbucketServerFileFetchUrl(
  */
 export function getBitbucketServerRequestOptions(
   config: BitbucketServerIntegrationConfig,
+  token?: string,
 ): { headers: Record<string, string> } {
   const headers: Record<string, string> = {};
 
-  if (config.token) {
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  } else if (config.token) {
     headers.Authorization = `Bearer ${config.token}`;
   } else if (config.username && config.password) {
     const buffer = Buffer.from(`${config.username}:${config.password}`, 'utf8');


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `BitbucketServerUrlReader` ignored the per-request `token` from `UrlReaderServiceReadUrlOptions`, unlike the GitHub and GitLab readers which already forward it. This caused requests to fail for setups that rely on per-request tokens rather than a static token in the integration config.

To address this, the token is now passed through readUrl, readTree, search, and getLastCommitShortHash. The getBitbucketServerRequestOptions, getBitbucketServerDefaultBranch, and getBitbucketServerDownloadUrl functions were extended to accept an optional token that takes priority over the statically configured token.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] ~Screenshots attached (for UI changes)~
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
