### PR TITLE
frontend-test-utils: fix implicit any types for TypeScript 6 compatibility

### DIFF
--- a/.changeset/fix-implicit-any-renderInTestApp.md
+++ b/.changeset/fix-implicit-any-renderInTestApp.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-test-utils': patch
+---
+
+Added explicit type annotations to `.map()` callback parameters in `renderInTestApp` to avoid implicit `any` errors with newer TypeScript versions.

--- a/packages/frontend-test-utils/src/app/renderInTestApp.tsx
+++ b/packages/frontend-test-utils/src/app/renderInTestApp.tsx
@@ -137,20 +137,22 @@ const appPluginOverride = appPlugin.withOverrides({
           coreExtensionData.reactElement(
             <nav>
               <ul>
-                {inputs.items.map((item, index) => {
-                  const { icon, title, routeRef } = item.get(
-                    NavItemBlueprint.dataRefs.target,
-                  );
+                {inputs.items.map(
+                  (item: (typeof inputs.items)[number], index: number) => {
+                    const { icon, title, routeRef } = item.get(
+                      NavItemBlueprint.dataRefs.target,
+                    );
 
-                  return (
-                    <NavItem
-                      key={index}
-                      icon={icon}
-                      title={title}
-                      routeRef={routeRef}
-                    />
-                  );
-                })}
+                    return (
+                      <NavItem
+                        key={index}
+                        icon={icon}
+                        title={title}
+                        routeRef={routeRef}
+                      />
+                    );
+                  },
+                )}
               </ul>
             </nav>,
           ),

--- a/yarn.lock
+++ b/yarn.lock
@@ -11908,8 +11908,8 @@ __metadata:
   linkType: hard
 
 "@mswjs/interceptors@npm:^0.39.1":
-  version: 0.39.6
-  resolution: "@mswjs/interceptors@npm:0.39.6"
+  version: 0.39.8
+  resolution: "@mswjs/interceptors@npm:0.39.8"
   dependencies:
     "@open-draft/deferred-promise": "npm:^2.2.0"
     "@open-draft/logger": "npm:^0.3.0"
@@ -11917,7 +11917,7 @@ __metadata:
     is-node-process: "npm:^1.2.0"
     outvariant: "npm:^1.4.3"
     strict-event-emitter: "npm:^0.5.1"
-  checksum: 10/c87d3edf08353bde825c87b151b24d538070540ab419206cef1774c932e888af0f920183182fb7c94c3eee42068da5a0a5855853fded8514f33c870921ef37ec
+  checksum: 10/d92546cf9bf670ddb927c53f5fa19f0554b7475a264ead4e1ae2339874f4312fe4ada5d42588f27eea3577bee29fa8f46889d398f0e7ecb3f7a4c1d3e0b71bdc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Preparatory fix for TypeScript 6 compatibility. This addresses two of the issues found when testing the repo with `typescript@^6`:

1. **`packages/frontend-test-utils`**: Added explicit type annotations to `.map()` callback parameters in `renderInTestApp`. TypeScript 6 no longer infers the types for `item` and `index` in certain generic extension input contexts, causing TS7006 (implicit `any`) errors.

2. **`@mswjs/interceptors`**: Updated from `0.39.6` to `0.39.8` within the existing `^0.39.1` range in `yarn.lock`.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Made with [Cursor](https://cursor.com)