### PR TITLE
frontend-plugin-api: remove deprecated PortableSchema .schema property

### DIFF
--- a/.changeset/remove-portable-schema-deprecated-prop.md
+++ b/.changeset/remove-portable-schema-deprecated-prop.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': minor
+---
+
+**BREAKING**: Removed the deprecated property form of `PortableSchema.schema`. The `schema` member is now a plain method that must be called as `schema()` — direct property access like `schema.type` or `schema.properties` is no longer supported.

--- a/packages/frontend-plugin-api/report-alpha.api.md
+++ b/packages/frontend-plugin-api/report-alpha.api.md
@@ -821,11 +821,8 @@ export type PluginWrapperDefinition<TValue = unknown | never> = {
 // @public (undocumented)
 export type PortableSchema<TOutput = unknown, TInput = TOutput> = {
   parse: (input: TInput) => TOutput;
-  schema: {
-    (): {
-      schema: JsonObject;
-    };
-    [key: string]: any;
+  schema: () => {
+    schema: JsonObject;
   };
 };
 

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -2409,11 +2409,8 @@ export type PluginWrapperDefinition<TValue = unknown | never> = {
 // @public (undocumented)
 export type PortableSchema<TOutput = unknown, TInput = TOutput> = {
   parse: (input: TInput) => TOutput;
-  schema: {
-    (): {
-      schema: JsonObject;
-    };
-    [key: string]: any;
+  schema: () => {
+    schema: JsonObject;
   };
 };
 

--- a/packages/frontend-plugin-api/src/blueprints/ApiBlueprint.test.ts
+++ b/packages/frontend-plugin-api/src/blueprints/ApiBlueprint.test.ts
@@ -182,14 +182,8 @@ describe('ApiBlueprint', () => {
           "input": "apis",
         },
         "configSchema": {
-          "_fields": {
-            "test": {
-              "required": false,
-              "toJsonSchema": [Function],
-              "validate": [Function],
-            },
-          },
           "parse": [Function],
+          "schema": [Function],
         },
         "disabled": false,
         "factory": [Function],

--- a/packages/frontend-plugin-api/src/blueprints/NavItemBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/NavItemBlueprint.test.tsx
@@ -39,14 +39,8 @@ describe('NavItemBlueprint', () => {
           "input": "items",
         },
         "configSchema": {
-          "_fields": {
-            "title": {
-              "required": false,
-              "toJsonSchema": [Function],
-              "validate": [Function],
-            },
-          },
           "parse": [Function],
+          "schema": [Function],
         },
         "disabled": false,
         "factory": [Function],

--- a/packages/frontend-plugin-api/src/blueprints/PageBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/PageBlueprint.test.tsx
@@ -48,19 +48,8 @@ describe('PageBlueprint', () => {
           "input": "routes",
         },
         "configSchema": {
-          "_fields": {
-            "path": {
-              "required": false,
-              "toJsonSchema": [Function],
-              "validate": [Function],
-            },
-            "title": {
-              "required": false,
-              "toJsonSchema": [Function],
-              "validate": [Function],
-            },
-          },
           "parse": [Function],
+          "schema": [Function],
         },
         "disabled": false,
         "factory": [Function],

--- a/packages/frontend-plugin-api/src/schema/createPortableSchema.test.ts
+++ b/packages/frontend-plugin-api/src/schema/createPortableSchema.test.ts
@@ -143,13 +143,14 @@ describe('createConfigSchema', () => {
       });
     });
 
-    it('should support backward-compatible property access on schema', () => {
+    it('should return the schema as a method', () => {
       const schema = createConfigSchema({
         title: zodV4.string(),
       });
 
-      expect(schema.schema.type).toBe('object');
-      expect(schema.schema.properties).toBeDefined();
+      const result = schema.schema();
+      expect(result.schema.type).toBe('object');
+      expect(result.schema.properties).toBeDefined();
     });
   });
 

--- a/packages/frontend-plugin-api/src/schema/createPortableSchema.ts
+++ b/packages/frontend-plugin-api/src/schema/createPortableSchema.ts
@@ -143,27 +143,20 @@ function buildPortableSchema<TOutput = unknown>(
     return result as TOutput;
   }
 
+  let cached: { schema: JsonObject } | undefined;
+
   const result: MergeablePortableSchema<TOutput> = {
     parse,
-    schema: undefined as any,
-    _fields: fields,
-  };
-
-  // Lazy getter — computes JSON Schema on first access, then caches it.
-  let cached: PortableSchema['schema'] | undefined;
-  Object.defineProperty(result, 'schema', {
-    get() {
+    schema() {
       if (!cached) {
-        const jsonSchema = buildObjectJsonSchema(fields);
-        const callable = Object.assign(
-          () => ({ schema: jsonSchema }),
-          jsonSchema,
-        );
-        cached = callable as PortableSchema['schema'];
+        cached = { schema: buildObjectJsonSchema(fields) };
       }
       return cached;
     },
-    configurable: true,
+  } as MergeablePortableSchema<TOutput>;
+
+  Object.defineProperty(result, '_fields', {
+    value: fields,
     enumerable: false,
   });
 

--- a/packages/frontend-plugin-api/src/schema/types.ts
+++ b/packages/frontend-plugin-api/src/schema/types.ts
@@ -19,14 +19,5 @@ import { JsonObject } from '@backstage/types';
 /** @public */
 export type PortableSchema<TOutput = unknown, TInput = TOutput> = {
   parse: (input: TInput) => TOutput;
-  /**
-   * The JSON Schema for this portable schema.
-   *
-   * @remarks
-   * Can be accessed as a property for backward compatibility (returns the
-   * JSON Schema object directly), or called as a method which returns
-   * `{ schema: JsonObject }`. Both forms compute the schema lazily on
-   * first access. The property form is deprecated — prefer `schema()`.
-   */
-  schema: { (): { schema: JsonObject }; [key: string]: any };
+  schema: () => { schema: JsonObject };
 };

--- a/plugins/catalog-react/src/alpha/blueprints/EntityCardBlueprint.test.tsx
+++ b/plugins/catalog-react/src/alpha/blueprints/EntityCardBlueprint.test.tsx
@@ -45,19 +45,8 @@ describe('EntityCardBlueprint', () => {
           "input": "cards",
         },
         "configSchema": {
-          "_fields": {
-            "filter": {
-              "required": false,
-              "toJsonSchema": [Function],
-              "validate": [Function],
-            },
-            "type": {
-              "required": false,
-              "toJsonSchema": [Function],
-              "validate": [Function],
-            },
-          },
           "parse": [Function],
+          "schema": [Function],
         },
         "disabled": false,
         "factory": [Function],

--- a/plugins/catalog-react/src/alpha/blueprints/EntityContentBlueprint.test.tsx
+++ b/plugins/catalog-react/src/alpha/blueprints/EntityContentBlueprint.test.tsx
@@ -47,34 +47,8 @@ describe('EntityContentBlueprint', () => {
           "input": "contents",
         },
         "configSchema": {
-          "_fields": {
-            "filter": {
-              "required": false,
-              "toJsonSchema": [Function],
-              "validate": [Function],
-            },
-            "group": {
-              "required": false,
-              "toJsonSchema": [Function],
-              "validate": [Function],
-            },
-            "icon": {
-              "required": false,
-              "toJsonSchema": [Function],
-              "validate": [Function],
-            },
-            "path": {
-              "required": false,
-              "toJsonSchema": [Function],
-              "validate": [Function],
-            },
-            "title": {
-              "required": false,
-              "toJsonSchema": [Function],
-              "validate": [Function],
-            },
-          },
           "parse": [Function],
+          "schema": [Function],
         },
         "disabled": false,
         "factory": [Function],

--- a/plugins/catalog-react/src/alpha/blueprints/EntityContextMenuItemBlueprint.test.tsx
+++ b/plugins/catalog-react/src/alpha/blueprints/EntityContextMenuItemBlueprint.test.tsx
@@ -63,14 +63,8 @@ describe('EntityContextMenuItemBlueprint', () => {
           "input": "contextMenuItems",
         },
         "configSchema": {
-          "_fields": {
-            "filter": {
-              "required": false,
-              "toJsonSchema": [Function],
-              "validate": [Function],
-            },
-          },
           "parse": [Function],
+          "schema": [Function],
         },
         "disabled": false,
         "factory": [Function],

--- a/plugins/search-react/src/alpha/blueprints/SearchResultListItemBlueprint.test.tsx
+++ b/plugins/search-react/src/alpha/blueprints/SearchResultListItemBlueprint.test.tsx
@@ -45,14 +45,8 @@ describe('SearchResultListItemBlueprint', () => {
           "input": "items",
         },
         "configSchema": {
-          "_fields": {
-            "noTrack": {
-              "required": false,
-              "toJsonSchema": [Function],
-              "validate": [Function],
-            },
-          },
           "parse": [Function],
+          "schema": [Function],
         },
         "disabled": false,
         "factory": [Function],


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This removes the deprecated property form of `PortableSchema.schema`. The `schema` member was previously a callable object that also exposed JSON Schema properties directly (e.g. `schema.type`, `schema.properties`). It's now a plain method — you call `schema()` to get `{ schema: JsonObject }`.

The property form was deprecated in favor of the method call, and this finishes the cleanup.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))