### PR TITLE
docs: improve v1.50 release notes for Standard Schema section

### DIFF
--- a/docs/releases/v1.50.0.md
+++ b/docs/releases/v1.50.0.md
@@ -16,9 +16,23 @@ The `auth.omitIdentityTokenOwnershipClaim` setting now defaults to `true`. Backs
 
 To get ownership info for the current user, code should use the `userInfo` core service. The setting can still be set back to `false` if needed, but it will be removed entirely in a future release.
 
-### **BREAKING**: Standard Schema replaces `createSchemaFromZod`
+### **BREAKING**: Standard Schema for new frontend system extension config
 
-The deprecated `createSchemaFromZod` helper has been removed from `@backstage/frontend-plugin-api`. A new `configSchema` option for `createExtension` and `createExtensionBlueprint` accepts direct schema values from any [Standard Schema](https://github.com/standard-schema/standard-schema) compatible library with JSON Schema support, such as zod v4 or the `zod/v4` subpath from zod v3. Note that direct zod v3 schemas are not supported by the new option — use `import { z } from 'zod/v4'` from the zod v3 package, or upgrade to zod v4.
+The new frontend system now uses [Standard Schema](https://github.com/standard-schema/standard-schema) for extension configuration. A new `configSchema` option has been added to `createExtension`, `createExtensionBlueprint`, as well as the `override` and `makeWithOverrides` methods on extension definitions and blueprints. This option accepts direct schema values from any Standard Schema compatible library with JSON Schema support, replacing the old `config.schema` callback format which is now deprecated.
+
+To use the new `configSchema` option with Zod, you need Zod v4 or the `zod/v4` subpath export from the Zod v3 package. The `zod/v4` subpath requires a minimum Zod version of **3.25.0** — make sure to update your Zod dependency if needed:
+
+```ts
+// Either use Zod v4 directly:
+import { z } from 'zod';
+
+// Or the v4 subpath from the Zod v3 package (requires zod@^3.25.0):
+import { z } from 'zod/v4';
+```
+
+Note that direct Zod v3 schemas are **not** supported by the new `configSchema` option — they only work with the deprecated `config.schema` callback format.
+
+The deprecated `createSchemaFromZod` helper has been removed from `@backstage/frontend-plugin-api`.
 
 See the [1.50 migration documentation](https://backstage.io/docs/frontend-system/architecture/migrations#150) for more information.
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This improves the Standard Schema section in the v1.50 release notes to better highlight the new `configSchema` option for the new frontend system, list all the APIs that accept it, and call out the minimum Zod version (3.25.0) needed for the `zod/v4` subpath import.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))