### PR TITLE
.patches: remove entries released in v1.50.1

### DIFF
--- a/.patches/pr-33913.txt
+++ b/.patches/pr-33913.txt
@@ -1,1 +1,0 @@
-Replaced old config schema values from existing extensions and blueprints.

--- a/.patches/pr-33914.txt
+++ b/.patches/pr-33914.txt
@@ -1,1 +1,0 @@
-Fix config path resolution for embedded-postgres detection in `repo start`

--- a/.patches/pr-33918.txt
+++ b/.patches/pr-33918.txt
@@ -1,1 +1,0 @@
-Update React Aria to v1.17.0 and migrate to monopackage imports


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This removes the patch entries that were released as part of v1.50.1:

- `pr-33913.txt`
- `pr-33914.txt`
- `pr-33918.txt`

PR #33908 is still pending and kept as-is.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))