### PR TITLE
frontend-app-api: deduplicate joinPaths utility in routing

### DIFF
--- a/.changeset/deduplicate-joinpaths-routing.md
+++ b/.changeset/deduplicate-joinpaths-routing.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-app-api': patch
+---
+
+Internal cleanup of routing utilities.

--- a/packages/frontend-app-api/src/routing/RouteResolver.ts
+++ b/packages/frontend-app-api/src/routing/RouteResolver.ts
@@ -31,15 +31,7 @@ import {
   OpaqueSubRouteRef,
 } from '@internal/frontend';
 import { RouteAliasResolver } from './RouteAliasResolver';
-
-// Joins a list of paths together, avoiding trailing and duplicate slashes
-export function joinPaths(...paths: string[]): string {
-  const normalized = paths.join('/').replace(/\/\/+/g, '/');
-  if (normalized !== '/' && normalized.endsWith('/')) {
-    return normalized.slice(0, -1);
-  }
-  return normalized;
-}
+import { joinPaths } from './joinPaths';
 
 /**
  * Resolves the absolute route ref that our target route ref is pointing pointing to, as well

--- a/packages/frontend-app-api/src/routing/extractRouteInfoFromAppNode.ts
+++ b/packages/frontend-app-api/src/routing/extractRouteInfoFromAppNode.ts
@@ -21,6 +21,7 @@ import {
   createExactRouteAliasResolver,
   RouteAliasResolver,
 } from './RouteAliasResolver';
+import { joinPaths } from './joinPaths';
 
 /** @internal */
 export type RouteInfo = {
@@ -40,15 +41,6 @@ export const MATCH_ALL_ROUTE: BackstageRouteObject = {
   element: 'match-all', // These elements aren't used, so we add in a bit of debug information
   routeRefs: new Set(),
 };
-
-// Joins a list of paths together, avoiding trailing and duplicate slashes
-export function joinPaths(...paths: string[]): string {
-  const normalized = paths.join('/').replace(/\/\/+/g, '/');
-  if (normalized !== '/' && normalized.endsWith('/')) {
-    return normalized.slice(0, -1);
-  }
-  return normalized;
-}
 
 export function extractRouteInfoFromAppNode(
   node: AppNode,

--- a/packages/frontend-app-api/src/routing/joinPaths.ts
+++ b/packages/frontend-app-api/src/routing/joinPaths.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Joins a list of paths together, avoiding trailing and duplicate slashes
+export function joinPaths(...paths: string[]): string {
+  const normalized = paths.join('/').replace(/\/\/+/g, '/');
+  if (normalized !== '/' && normalized.endsWith('/')) {
+    return normalized.slice(0, -1);
+  }
+  return normalized;
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This extracts the duplicated `joinPaths` utility function from `extractRouteInfoFromAppNode.ts` and `RouteResolver.ts` into a shared `joinPaths.ts` module within the same routing directory, and imports it from both consumers. The two implementations were character-for-character identical. No public API changes.

🧹

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))