### PR TITLE
core-components: remove unused onSignInFailure and onSignInStarted type aliases

### DIFF
--- a/packages/core-components/src/layout/SignInPage/types.ts
+++ b/packages/core-components/src/layout/SignInPage/types.ts
@@ -35,15 +35,6 @@ export type SignInProviderConfig = {
 /** @public */
 export type IdentityProviders = ('guest' | 'custom' | SignInProviderConfig)[];
 
-/**
- * Invoked when the sign-in process has failed.
- */
-export type onSignInFailure = () => void;
-/**
- * Invoked when the sign-in process has started.
- */
-export type onSignInStarted = () => void;
-
 export type ProviderComponent = ComponentType<
   SignInPageProps & {
     config: SignInProviderConfig;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

🧹

Removes the unused `onSignInFailure` and `onSignInStarted` type aliases from the `SignInPage` types. These were standalone type aliases that weren't imported anywhere — the actual prop signatures are defined inline in the `ProviderComponent` type.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))