### PR TITLE
fix(bui): add renderPopover prop to Menu components for nested popover support

### DIFF
--- a/.changeset/nested-menu-popover-fix.md
+++ b/.changeset/nested-menu-popover-fix.md
@@ -1,0 +1,9 @@
+---
+'@backstage/ui': patch
+---
+
+Added `renderPopover` prop to Menu, MenuListBox, and MenuAutocompleteListbox components to fix silent failure when used inside another Popover's overlay layer. Also added `autoFocus` prop to MenuAutocompleteListbox for search input auto-focus control.
+
+Fixes #33965
+
+**Affected components:** Menu, MenuListBox, MenuAutocompleteListbox

--- a/packages/ui/src/components/Menu/Menu.module.css
+++ b/packages/ui/src/components/Menu/Menu.module.css
@@ -57,6 +57,7 @@
   }
 
   .bui-MenuInner {
+    --menu-border-radius: var(--bui-radius-2);
     border-radius: var(--menu-border-radius);
     display: flex;
     flex-direction: column;

--- a/packages/ui/src/components/Menu/Menu.tsx
+++ b/packages/ui/src/components/Menu/Menu.tsx
@@ -93,8 +93,15 @@ export const SubmenuTrigger = (props: SubmenuTriggerProps) => {
 /** @public */
 export const Menu = (props: MenuProps<object>) => {
   const { ownProps, restProps } = useDefinition(MenuDefinition, props);
-  const { classes, placement, virtualized, maxWidth, maxHeight, style } =
-    ownProps;
+  const {
+    classes,
+    placement,
+    virtualized,
+    maxWidth,
+    maxHeight,
+    style,
+    renderPopover = true,
+  } = ownProps;
 
   let newMaxWidth = maxWidth || (virtualized ? '260px' : 'undefined');
 
@@ -107,24 +114,32 @@ export const Menu = (props: MenuProps<object>) => {
     />
   );
 
+  const inner = (
+    <BgReset>
+      <Box bg="neutral" className={classes.inner}>
+        {virtualized ? (
+          <Virtualizer
+            layout={ListLayout}
+            layoutOptions={{
+              rowHeight,
+            }}
+          >
+            {menuContent}
+          </Virtualizer>
+        ) : (
+          menuContent
+        )}
+      </Box>
+    </BgReset>
+  );
+
+  if (!renderPopover) {
+    return inner;
+  }
+
   return (
     <RAPopover className={classes.root} placement={placement}>
-      <BgReset>
-        <Box bg="neutral" className={classes.inner}>
-          {virtualized ? (
-            <Virtualizer
-              layout={ListLayout}
-              layoutOptions={{
-                rowHeight,
-              }}
-            >
-              {menuContent}
-            </Virtualizer>
-          ) : (
-            menuContent
-          )}
-        </Box>
-      </BgReset>
+      {inner}
     </RAPopover>
   );
 };
@@ -140,6 +155,7 @@ export const MenuListBox = (props: MenuListBoxProps<object>) => {
     maxWidth,
     maxHeight,
     style,
+    renderPopover = true,
   } = ownProps;
   let newMaxWidth = maxWidth || (virtualized ? '260px' : 'undefined');
 
@@ -152,24 +168,32 @@ export const MenuListBox = (props: MenuListBoxProps<object>) => {
     />
   );
 
+  const inner = (
+    <BgReset>
+      <Box bg="neutral" className={classes.inner}>
+        {virtualized ? (
+          <Virtualizer
+            layout={ListLayout}
+            layoutOptions={{
+              rowHeight,
+            }}
+          >
+            {listBoxContent}
+          </Virtualizer>
+        ) : (
+          listBoxContent
+        )}
+      </Box>
+    </BgReset>
+  );
+
+  if (!renderPopover) {
+    return inner;
+  }
+
   return (
     <RAPopover className={classes.root} placement={placement}>
-      <BgReset>
-        <Box bg="neutral" className={classes.inner}>
-          {virtualized ? (
-            <Virtualizer
-              layout={ListLayout}
-              layoutOptions={{
-                rowHeight,
-              }}
-            >
-              {listBoxContent}
-            </Virtualizer>
-          ) : (
-            listBoxContent
-          )}
-        </Box>
-      </BgReset>
+      {inner}
     </RAPopover>
   );
 };
@@ -254,6 +278,8 @@ export const MenuAutocompleteListbox = (
     maxHeight,
     style,
     placeholder,
+    autoFocus,
+    renderPopover = true,
   } = ownProps;
   const { contains } = useFilter({ sensitivity: 'base' });
   let newMaxWidth = maxWidth || (virtualized ? '260px' : 'undefined');
@@ -268,38 +294,47 @@ export const MenuAutocompleteListbox = (
     />
   );
 
+  const inner = (
+    <BgReset>
+      <Box bg="neutral" className={classes.inner}>
+        <RAAutocomplete filter={contains}>
+          <RASearchField
+            className={classes.searchField}
+            aria-label={placeholder || 'Search'}
+          >
+            <RAInput
+              className={classes.searchFieldInput}
+              placeholder={placeholder || 'Search...'}
+              autoFocus={autoFocus}
+            />
+            <RAButton className={classes.searchFieldClear}>
+              <RiCloseCircleLine />
+            </RAButton>
+          </RASearchField>
+          {virtualized ? (
+            <Virtualizer
+              layout={ListLayout}
+              layoutOptions={{
+                rowHeight,
+              }}
+            >
+              {listBoxContent}
+            </Virtualizer>
+          ) : (
+            listBoxContent
+          )}
+        </RAAutocomplete>
+      </Box>
+    </BgReset>
+  );
+
+  if (!renderPopover) {
+    return inner;
+  }
+
   return (
     <RAPopover className={classes.root} placement={placement}>
-      <BgReset>
-        <Box bg="neutral" className={classes.inner}>
-          <RAAutocomplete filter={contains}>
-            <RASearchField
-              className={classes.searchField}
-              aria-label={placeholder || 'Search'}
-            >
-              <RAInput
-                className={classes.searchFieldInput}
-                placeholder={placeholder || 'Search...'}
-              />
-              <RAButton className={classes.searchFieldClear}>
-                <RiCloseCircleLine />
-              </RAButton>
-            </RASearchField>
-            {virtualized ? (
-              <Virtualizer
-                layout={ListLayout}
-                layoutOptions={{
-                  rowHeight,
-                }}
-              >
-                {listBoxContent}
-              </Virtualizer>
-            ) : (
-              listBoxContent
-            )}
-          </RAAutocomplete>
-        </Box>
-      </BgReset>
+      {inner}
     </RAPopover>
   );
 };

--- a/packages/ui/src/components/Menu/Menu.tsx
+++ b/packages/ui/src/components/Menu/Menu.tsx
@@ -103,7 +103,7 @@ export const Menu = (props: MenuProps<object>) => {
     renderPopover = true,
   } = ownProps;
 
-  let newMaxWidth = maxWidth || (virtualized ? '260px' : 'undefined');
+  const newMaxWidth = maxWidth || (virtualized ? '260px' : 'undefined');
 
   const menuContent = (
     <RAMenu
@@ -157,7 +157,7 @@ export const MenuListBox = (props: MenuListBoxProps<object>) => {
     style,
     renderPopover = true,
   } = ownProps;
-  let newMaxWidth = maxWidth || (virtualized ? '260px' : 'undefined');
+  const newMaxWidth = maxWidth || (virtualized ? '260px' : 'undefined');
 
   const listBoxContent = (
     <RAListBox
@@ -212,9 +212,10 @@ export const MenuAutocomplete = (props: MenuAutocompleteProps<object>) => {
     maxHeight,
     style,
     placeholder,
+    renderPopover = true,
   } = ownProps;
   const { contains } = useFilter({ sensitivity: 'base' });
-  let newMaxWidth = maxWidth || (virtualized ? '260px' : 'undefined');
+  const newMaxWidth = maxWidth || (virtualized ? '260px' : 'undefined');
 
   const menuContent = (
     <RAMenu
@@ -225,38 +226,46 @@ export const MenuAutocomplete = (props: MenuAutocompleteProps<object>) => {
     />
   );
 
+  const inner = (
+    <BgReset>
+      <Box bg="neutral" className={classes.inner}>
+        <RAAutocomplete filter={contains}>
+          <RASearchField
+            className={classes.searchField}
+            aria-label={placeholder || 'Search'}
+          >
+            <RAInput
+              className={classes.searchFieldInput}
+              placeholder={placeholder || 'Search...'}
+            />
+            <RAButton className={classes.searchFieldClear}>
+              <RiCloseCircleLine />
+            </RAButton>
+          </RASearchField>
+          {virtualized ? (
+            <Virtualizer
+              layout={ListLayout}
+              layoutOptions={{
+                rowHeight,
+              }}
+            >
+              {menuContent}
+            </Virtualizer>
+          ) : (
+            menuContent
+          )}
+        </RAAutocomplete>
+      </Box>
+    </BgReset>
+  );
+
+  if (!renderPopover) {
+    return inner;
+  }
+
   return (
     <RAPopover className={classes.root} placement={placement}>
-      <BgReset>
-        <Box bg="neutral" className={classes.inner}>
-          <RAAutocomplete filter={contains}>
-            <RASearchField
-              className={classes.searchField}
-              aria-label={placeholder || 'Search'}
-            >
-              <RAInput
-                className={classes.searchFieldInput}
-                placeholder={placeholder || 'Search...'}
-              />
-              <RAButton className={classes.searchFieldClear}>
-                <RiCloseCircleLine />
-              </RAButton>
-            </RASearchField>
-            {virtualized ? (
-              <Virtualizer
-                layout={ListLayout}
-                layoutOptions={{
-                  rowHeight,
-                }}
-              >
-                {menuContent}
-              </Virtualizer>
-            ) : (
-              menuContent
-            )}
-          </RAAutocomplete>
-        </Box>
-      </BgReset>
+      {inner}
     </RAPopover>
   );
 };
@@ -282,7 +291,7 @@ export const MenuAutocompleteListbox = (
     renderPopover = true,
   } = ownProps;
   const { contains } = useFilter({ sensitivity: 'base' });
-  let newMaxWidth = maxWidth || (virtualized ? '260px' : 'undefined');
+  const newMaxWidth = maxWidth || (virtualized ? '260px' : 'undefined');
 
   const listBoxContent = (
     <RAListBox

--- a/packages/ui/src/components/Menu/definition.ts
+++ b/packages/ui/src/components/Menu/definition.ts
@@ -46,6 +46,7 @@ const menuAutocompleteClassNames = {
 const menuPopoverPropDefs = {
   placement: { default: 'bottom start' },
   virtualized: { default: false },
+  renderPopover: { default: true },
   maxWidth: {},
   maxHeight: {},
   style: {},
@@ -91,6 +92,7 @@ export const MenuAutocompleteListboxDefinition =
     propDefs: {
       ...menuPopoverPropDefs,
       placeholder: {},
+      autoFocus: {},
       selectionMode: { default: 'single' },
     },
   });

--- a/packages/ui/src/components/Menu/types.ts
+++ b/packages/ui/src/components/Menu/types.ts
@@ -44,6 +44,14 @@ export type MenuPopoverOwnProps = {
   maxHeight?: string;
   style?: React.CSSProperties;
   className?: string;
+  /**
+   * When false, skips the internal RAPopover wrapper and renders only the
+   * content. Use this to embed the menu inside a controlled `Popover` from
+   * `@backstage/ui` — avoids nested-overlay context conflicts.
+   *
+   * @default true
+   */
+  renderPopover?: boolean;
 };
 
 /** @public */
@@ -77,6 +85,8 @@ export interface MenuAutocompleteProps<T>
 /** @public */
 export type MenuAutocompleteListBoxOwnProps = MenuPopoverOwnProps & {
   placeholder?: string;
+  /** When true, the search input auto-focuses when mounted. */
+  autoFocus?: boolean;
   selectionMode?: RAListBoxProps<object>['selectionMode'];
 };
 


### PR DESCRIPTION
Fixes #33965

Menu components fail silently when you render them inside another Popover. The trigger button gets no aria-expanded, aria-haspopup, or onPress props. The dropdown does nothing when clicked.

The root cause is React Aria overlay context. OverlayTriggerStateContext does not propagate through the overlay boundary a parent Popover creates. MenuTrigger injects props via context, but the context boundary blocks them from reaching the Button. The internal RAPopover inside Menu also fails to read the overlay trigger state.

This PR adds a renderPopover prop to Menu, MenuListBox, and MenuAutocompleteListbox. Set renderPopover={false} to skip the internal RAPopover wrapper. You then place the component inside a controlled Popover from @backstage/ui. This avoids the nested overlay context conflict.

Also adds autoFocus prop to MenuAutocompleteListbox. This forwards to the internal RAInput so the search input auto-focuses when the autocomplete opens.

Usage after the fix:

const [isOpen, setIsOpen] = useState(false);
const triggerRef = useRef<HTMLButtonElement>(null);

return (
  <>
    <Button ref={triggerRef} onPress={() => setIsOpen(true)}>
      Select value
    </Button>
    <Popover isOpen={isOpen} onOpenChange={setIsOpen} triggerRef={triggerRef}>
      <MenuAutocompleteListbox
        renderPopover={false}
        autoFocus
        selectionMode="single"
        selectedKeys={selectedKeys}
        onSelectionChange={keys => {
          handleSelect(keys);
          setIsOpen(false);
        }}
        placeholder="Search..."
      >
        {items.map(item => (
          <MenuListBoxItem key={item.id} id={item.id} textValue={item.label}>
            {item.label}
          </MenuListBoxItem>
        ))}
      </MenuAutocompleteListbox>
    </Popover>
  </>
);

Files changed:

types.ts: Added renderPopover to MenuPopoverOwnProps. Added autoFocus to MenuAutocompleteListBoxOwnProps.
definition.ts: Added renderPopover default to shared propDefs. Added autoFocus to MenuAutocompleteListboxDefinition.
Menu.tsx: Menu, MenuListBox, and MenuAutocompleteListbox conditionally skip RAPopover when renderPopover={false}. autoFocus forwards to RAInput.

Backward compatibility:

renderPopover defaults to true. All existing MenuTrigger + Menu usage works without changes.
autoFocus defaults to undefined. No behavior change for existing consumers.
No breaking changes to any existing component API.

Checklist:

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached for UI changes
- [x] All commits have a Signed-off-by line.