### PR TITLE
docs: Fix TechDocs url location reference for GitLab

### DIFF
--- a/docs/features/techdocs/how-to-guides--old.md
+++ b/docs/features/techdocs/how-to-guides--old.md
@@ -92,7 +92,7 @@ the source code hosting provider. Notice that instead of the `dir:` prefix, the
 `url:` prefix is used instead. For example:
 
 - **GitHub**: `url:https://githubhost.com/org/repo/tree/<branch_name>`
-- **GitLab**: `url:https://gitlabhost.com/org/repo/tree/<branch_name>`
+- **GitLab**: `url:https://gitlabhost.com/org/repo`
 - **Bitbucket**: `url:https://bitbuckethost.com/project/repo/src/<branch_name>`
 - **Azure**: `url:https://azurehost.com/organization/project/_git/repository`
 

--- a/docs/features/techdocs/how-to-guides.md
+++ b/docs/features/techdocs/how-to-guides.md
@@ -93,7 +93,7 @@ the source code hosting provider. Notice that instead of the `dir:` prefix, the
 `url:` prefix is used instead. For example:
 
 - **GitHub**: `url:https://githubhost.com/org/repo/tree/<branch_name>`
-- **GitLab**: `url:https://gitlabhost.com/org/repo/tree/<branch_name>`
+- **GitLab**: `url:https://gitlabhost.com/org/repo`
 - **Bitbucket**: `url:https://bitbuckethost.com/project/repo/src/<branch_name>`
 - **Azure**: `url:https://azurehost.com/organization/project/_git/repository`
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixed url location reference for GitLab in TechDocs documentation.

When TechDocs source content is managed and stored in a location separate from your catalog-info.yaml, the URL location reference for GitLab was incorrect and docs could not be rendered.

Instead of 

`url:https://gitlabhost.com/org/repo/tree/<branch_name>`

the location reference should be 

`url:https://gitlabhost.com/org/repo` 

for Backstage to render TechDocs properly.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
