### PR TITLE
ui, app-visualizer: pin react-aria-components for v1.46

### DIFF
--- a/.changeset/pin-react-aria-ranges.md
+++ b/.changeset/pin-react-aria-ranges.md
@@ -1,0 +1,6 @@
+---
+'@backstage/ui': patch
+'@backstage/plugin-app-visualizer': patch
+---
+
+Pinned `react-aria-components` dependency range from `^` (caret) to `~` (tilde) to avoid picking up breaking changes in minor releases.

--- a/.changeset/pin-react-aria-ranges.md
+++ b/.changeset/pin-react-aria-ranges.md
@@ -1,6 +1,0 @@
----
-'@backstage/ui': patch
-'@backstage/plugin-app-visualizer': patch
----
-
-Pinned `react-aria-components` dependency range from `^` (caret) to `~` (tilde) to avoid picking up breaking changes in minor releases.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.46.6",
+  "version": "1.46.7",
   "backstage": {
     "cli": {
       "new": {

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/ui
 
+## 0.10.1
+
+### Patch Changes
+
+- Pinned `react-aria-components` dependency range from `^` (caret) to `~` (tilde) to avoid picking up breaking changes in minor releases.
+
 ## 0.10.0
 
 ### Minor Changes

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -43,7 +43,7 @@
     "@remixicon/react": "^4.6.0",
     "@tanstack/react-table": "^8.21.3",
     "clsx": "^2.1.1",
-    "react-aria-components": "^1.13.0"
+    "react-aria-components": "~1.13.0"
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/ui",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "backstage": {
     "role": "web-library"
   },

--- a/plugins/app-visualizer/CHANGELOG.md
+++ b/plugins/app-visualizer/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @backstage/plugin-app-visualizer
 
+## 0.1.27
+
+### Patch Changes
+
+- Pinned `react-aria-components` dependency range from `^` (caret) to `~` (tilde) to avoid picking up breaking changes in minor releases.
+- Updated dependencies
+  - @backstage/ui@0.10.1
+
 ## 0.1.26
 
 ### Patch Changes

--- a/plugins/app-visualizer/package.json
+++ b/plugins/app-visualizer/package.json
@@ -39,7 +39,7 @@
     "@backstage/frontend-plugin-api": "workspace:^",
     "@backstage/ui": "workspace:^",
     "@remixicon/react": "^4.6.0",
-    "react-aria-components": "^1.13.0"
+    "react-aria-components": "~1.13.0"
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",

--- a/plugins/app-visualizer/package.json
+++ b/plugins/app-visualizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/plugin-app-visualizer",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "description": "Visualizes the Backstage app structure",
   "backstage": {
     "role": "frontend-plugin",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4165,7 +4165,7 @@ __metadata:
     "@remixicon/react": "npm:^4.6.0"
     "@types/react": "npm:^18.0.0"
     react: "npm:^18.0.2"
-    react-aria-components: "npm:^1.13.0"
+    react-aria-components: "npm:~1.13.0"
     react-dom: "npm:^18.0.2"
     react-router-dom: "npm:^6.3.0"
   peerDependencies:
@@ -7949,7 +7949,7 @@ __metadata:
     lightningcss: "npm:^1.29.1"
     mini-css-extract-plugin: "npm:^2.9.2"
     react: "npm:^18.0.2"
-    react-aria-components: "npm:^1.13.0"
+    react-aria-components: "npm:~1.13.0"
     react-dom: "npm:^18.0.2"
     react-router-dom: "npm:^6.3.0"
     storybook: "npm:^9.1.7"
@@ -43226,7 +43226,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-aria-components@npm:^1.13.0":
+"react-aria-components@npm:~1.13.0":
   version: 1.13.0
   resolution: "react-aria-components@npm:1.13.0"
   dependencies:


### PR DESCRIPTION
This release pins React Aria dependencies to a `~` range. This is to prevent accidentally pulling in breaking changes through minor updates, since React Aria does not strictly follow SemVer.