### PR TITLE
ui: pin react-aria-components for 1.47

### DIFF
--- a/.changeset/pin-react-aria-components.md
+++ b/.changeset/pin-react-aria-components.md
@@ -1,0 +1,6 @@
+---
+'@backstage/ui': patch
+'@backstage/plugin-app-visualizer': patch
+---
+
+Pinned `react-aria-components` dependency range to use tilde (`~`) instead of caret (`^`) to avoid pulling in minor version bumps that may include breaking changes.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -44,7 +44,7 @@
     "@remixicon/react": "^4.6.0",
     "@tanstack/react-table": "^8.21.3",
     "clsx": "^2.1.1",
-    "react-aria-components": "^1.13.0"
+    "react-aria-components": "~1.13.0"
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",

--- a/plugins/app-visualizer/package.json
+++ b/plugins/app-visualizer/package.json
@@ -39,7 +39,7 @@
     "@backstage/frontend-plugin-api": "workspace:^",
     "@backstage/ui": "workspace:^",
     "@remixicon/react": "^4.6.0",
-    "react-aria-components": "^1.13.0"
+    "react-aria-components": "~1.13.0"
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4196,7 +4196,7 @@ __metadata:
     "@remixicon/react": "npm:^4.6.0"
     "@types/react": "npm:^18.0.0"
     react: "npm:^18.0.2"
-    react-aria-components: "npm:^1.13.0"
+    react-aria-components: "npm:~1.13.0"
     react-dom: "npm:^18.0.2"
     react-router-dom: "npm:^6.3.0"
   peerDependencies:
@@ -8011,7 +8011,7 @@ __metadata:
     lightningcss: "npm:^1.29.1"
     mini-css-extract-plugin: "npm:^2.9.2"
     react: "npm:^18.0.2"
-    react-aria-components: "npm:^1.13.0"
+    react-aria-components: "npm:~1.13.0"
     react-dom: "npm:^18.0.2"
     react-router-dom: "npm:^6.3.0"
     storybook: "npm:^10.2.0-alpha.7"
@@ -43628,7 +43628,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-aria-components@npm:^1.13.0":
+"react-aria-components@npm:~1.13.0":
   version: 1.13.0
   resolution: "react-aria-components@npm:1.13.0"
   dependencies:


### PR DESCRIPTION
This release pins React Aria dependencies to a `~` range. This is to prevent accidentally pulling in breaking changes through minor updates, since React Aria does not strictly follow SemVer.