### PR TITLE
ui: pin react-aria-components for 1.48

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "1.48.5",
+  "version": "1.48.6",
   "backstage": {
     "cli": {
       "new": {

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @backstage/ui
 
+## 0.12.1
+
+### Patch Changes
+
+- Pinned React Aria–family dependency ranges to use tilde (`~`) instead of caret (`^`), since React Aria does not strictly follow semver and may ship breaking changes in minor releases.
+
 ## 0.12.0
 
 ### Minor Changes

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@backstage/ui",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "backstage": {
     "role": "web-library"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -50,7 +50,7 @@
     "@remixicon/react": "^4.6.0",
     "@tanstack/react-table": "^8.21.3",
     "clsx": "^2.1.1",
-    "react-aria-components": "^1.14.0"
+    "react-aria-components": "~1.14.0"
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",

--- a/plugins/app-visualizer/package.json
+++ b/plugins/app-visualizer/package.json
@@ -39,7 +39,7 @@
     "@backstage/frontend-plugin-api": "workspace:^",
     "@backstage/ui": "workspace:^",
     "@remixicon/react": "^4.6.0",
-    "react-aria-components": "^1.14.0"
+    "react-aria-components": "~1.14.0"
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4266,7 +4266,7 @@ __metadata:
     "@remixicon/react": "npm:^4.6.0"
     "@types/react": "npm:^18.0.0"
     react: "npm:^18.0.2"
-    react-aria-components: "npm:^1.14.0"
+    react-aria-components: "npm:~1.14.0"
     react-dom: "npm:^18.0.2"
     react-router-dom: "npm:^6.30.2"
   peerDependencies:
@@ -43921,7 +43921,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-aria-components@npm:^1.14.0, react-aria-components@npm:~1.14.0":
+"react-aria-components@npm:~1.14.0":
   version: 1.14.0
   resolution: "react-aria-components@npm:1.14.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -8128,7 +8128,7 @@ __metadata:
     glob: "npm:^11.0.1"
     globals: "npm:^15.11.0"
     react: "npm:^18.0.2"
-    react-aria-components: "npm:^1.14.0"
+    react-aria-components: "npm:~1.14.0"
     react-dom: "npm:^18.0.2"
     react-router-dom: "npm:^6.30.2"
     storybook: "npm:^10.3.0-alpha.1"
@@ -43921,7 +43921,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-aria-components@npm:^1.14.0":
+"react-aria-components@npm:^1.14.0, react-aria-components@npm:~1.14.0":
   version: 1.14.0
   resolution: "react-aria-components@npm:1.14.0"
   dependencies:


### PR DESCRIPTION
This release pins React Aria dependencies to a `~` range. This is to prevent accidentally pulling in breaking changes through minor updates, since React Aria does not strictly follow SemVer.