### PR TITLE
fix: clamp React Aria dependency ranges to patch-only updates

### DIFF
--- a/.changeset/clamp-react-aria-deps.md
+++ b/.changeset/clamp-react-aria-deps.md
@@ -1,0 +1,8 @@
+---
+'@backstage/ui': patch
+'@backstage/plugin-app': patch
+'@backstage/plugin-app-visualizer': patch
+'@backstage/plugin-notifications': patch
+---
+
+Tightened React Aria dependency version ranges from `^` to `~` to prevent unintended minor version upgrades.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -50,9 +50,9 @@
     "@remixicon/react": "^4.6.0",
     "@tanstack/react-table": "^8.21.3",
     "clsx": "^2.1.1",
-    "react-aria": "^3.48.0",
-    "react-aria-components": "^1.17.0",
-    "react-stately": "^3.46.0",
+    "react-aria": "~3.48.0",
+    "react-aria-components": "~1.17.0",
+    "react-stately": "~3.46.0",
     "use-sync-external-store": "^1.4.0"
   },
   "devDependencies": {

--- a/plugins/app-visualizer/package.json
+++ b/plugins/app-visualizer/package.json
@@ -39,7 +39,7 @@
     "@backstage/frontend-plugin-api": "workspace:^",
     "@backstage/ui": "workspace:^",
     "@remixicon/react": "^4.6.0",
-    "react-aria-components": "^1.14.0"
+    "react-aria-components": "~1.17.0"
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",

--- a/plugins/app/package.json
+++ b/plugins/app/package.json
@@ -68,8 +68,8 @@
     "@react-hookz/web": "^24.0.0",
     "@remixicon/react": "^4.6.0",
     "motion": "^12.0.0",
-    "react-aria": "^3.48.0",
-    "react-stately": "^3.46.0",
+    "react-aria": "~3.48.0",
+    "react-stately": "~3.46.0",
     "react-use": "^17.2.4",
     "zen-observable": "^0.10.0",
     "zod": "^3.25.76 || ^4.0.0"

--- a/plugins/notifications/package.json
+++ b/plugins/notifications/package.json
@@ -62,7 +62,7 @@
     "@remixicon/react": "^4.6.0",
     "lodash": "^4.17.21",
     "notistack": "^3.0.1",
-    "react-aria-components": "^1.17.0",
+    "react-aria-components": "~1.17.0",
     "react-relative-time": "^0.0.9",
     "react-use": "^17.2.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4139,7 +4139,7 @@ __metadata:
     "@remixicon/react": "npm:^4.6.0"
     "@types/react": "npm:^18.0.0"
     react: "npm:^18.0.2"
-    react-aria-components: "npm:^1.14.0"
+    react-aria-components: "npm:~1.17.0"
     react-dom: "npm:^18.0.2"
     react-router-dom: "npm:^6.30.2"
   peerDependencies:
@@ -4185,10 +4185,10 @@ __metadata:
     motion: "npm:^12.0.0"
     msw: "npm:^1.0.0"
     react: "npm:^18.0.2"
-    react-aria: "npm:^3.48.0"
+    react-aria: "npm:~3.48.0"
     react-dom: "npm:^18.0.2"
     react-router-dom: "npm:^6.30.2"
-    react-stately: "npm:^3.46.0"
+    react-stately: "npm:~3.46.0"
     react-use: "npm:^17.2.4"
     zen-observable: "npm:^0.10.0"
     zod: "npm:^3.25.76 || ^4.0.0"
@@ -6330,7 +6330,7 @@ __metadata:
     msw: "npm:^1.0.0"
     notistack: "npm:^3.0.1"
     react: "npm:^18.0.2"
-    react-aria-components: "npm:^1.17.0"
+    react-aria-components: "npm:~1.17.0"
     react-dom: "npm:^18.0.2"
     react-relative-time: "npm:^0.0.9"
     react-router-dom: "npm:^6.30.2"
@@ -7984,11 +7984,11 @@ __metadata:
     glob: "npm:^13.0.0"
     globals: "npm:^17.0.0"
     react: "npm:^18.0.2"
-    react-aria: "npm:^3.48.0"
-    react-aria-components: "npm:^1.17.0"
+    react-aria: "npm:~3.48.0"
+    react-aria-components: "npm:~1.17.0"
     react-dom: "npm:^18.0.2"
     react-router-dom: "npm:^6.30.2"
-    react-stately: "npm:^3.46.0"
+    react-stately: "npm:~3.46.0"
     storybook: "npm:^10.3.3"
     use-sync-external-store: "npm:^1.4.0"
   peerDependencies:
@@ -41515,7 +41515,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-aria-components@npm:^1.14.0, react-aria-components@npm:^1.17.0":
+"react-aria-components@npm:~1.17.0":
   version: 1.17.0
   resolution: "react-aria-components@npm:1.17.0"
   dependencies:
@@ -41532,7 +41532,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-aria@npm:3.48.0, react-aria@npm:^3.48.0":
+"react-aria@npm:3.48.0, react-aria@npm:~3.48.0":
   version: 3.48.0
   resolution: "react-aria@npm:3.48.0"
   dependencies:
@@ -42168,7 +42168,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-stately@npm:3.46.0, react-stately@npm:^3.46.0":
+"react-stately@npm:3.46.0, react-stately@npm:~3.46.0":
   version: 3.46.0
   resolution: "react-stately@npm:3.46.0"
   dependencies:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Changed version ranges for `react-aria`, `react-aria-components`, and `react-stately` from `^` (minor-compatible) to `~` (patch-only) across all consuming packages to prevent unintended minor version upgrades that could introduce breaking changes.

Also aligned `app-visualizer`'s `react-aria-components` from `1.14` to `1.17` to match the rest of the repo.

**Affected packages:** `@backstage/ui`, `@backstage/plugin-app`, `@backstage/plugin-app-visualizer`, `@backstage/plugin-notifications`

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.