### PR TITLE
ui, app-visualizer, notifications: pin react-aria-components to tilde range

### DIFF
--- a/.changeset/pin-react-aria-components.md
+++ b/.changeset/pin-react-aria-components.md
@@ -1,0 +1,7 @@
+---
+'@backstage/ui': patch
+'@backstage/plugin-app-visualizer': patch
+'@backstage/plugin-notifications': patch
+---
+
+Pinned `react-aria-components` dependency to a tilde range to avoid pulling in minor versions with unexpected breaking changes.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -51,7 +51,7 @@
     "@tanstack/react-table": "^8.21.3",
     "clsx": "^2.1.1",
     "react-aria": "^3.48.0",
-    "react-aria-components": "^1.17.0",
+    "react-aria-components": "~1.17.0",
     "react-stately": "^3.46.0",
     "use-sync-external-store": "^1.4.0"
   },

--- a/plugins/app-visualizer/package.json
+++ b/plugins/app-visualizer/package.json
@@ -39,7 +39,7 @@
     "@backstage/frontend-plugin-api": "workspace:^",
     "@backstage/ui": "workspace:^",
     "@remixicon/react": "^4.6.0",
-    "react-aria-components": "^1.14.0"
+    "react-aria-components": "~1.14.0"
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",

--- a/plugins/notifications/package.json
+++ b/plugins/notifications/package.json
@@ -62,7 +62,7 @@
     "@remixicon/react": "^4.6.0",
     "lodash": "^4.17.21",
     "notistack": "^3.0.1",
-    "react-aria-components": "^1.17.0",
+    "react-aria-components": "~1.17.0",
     "react-relative-time": "^0.0.9",
     "react-use": "^17.2.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,6 +26,49 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@adobe/react-spectrum-ui@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@adobe/react-spectrum-ui@npm:1.2.1"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 10/1916d0057c37845a3ad042ad76202ecb5d9c7e4152ccc97a1d6cb234ae31e7ccc4dd50711a311afc35bdbe433d41c3183f1a741a2643507bf9ccd934eb7fe1ce
+  languageName: node
+  linkType: hard
+
+"@adobe/react-spectrum-workflow@npm:2.3.5":
+  version: 2.3.5
+  resolution: "@adobe/react-spectrum-workflow@npm:2.3.5"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 10/2ec4b337d1aaa88ccddb9b70f60ddfeb9af74670f949b4a26fd6e4ec1068c9542d4178b222d95a5cda7304563df1a47a8427c70ec4f419cf9751081b6aef3c1a
+  languageName: node
+  linkType: hard
+
+"@adobe/react-spectrum@npm:3.47.0":
+  version: 3.47.0
+  resolution: "@adobe/react-spectrum@npm:3.47.0"
+  dependencies:
+    "@internationalized/date": "npm:^3.12.1"
+    "@react-types/shared": "npm:^3.34.0"
+    "@spectrum-icons/ui": "npm:^3.7.0"
+    "@spectrum-icons/workflow": "npm:^4.3.0"
+    "@swc/helpers": "npm:^0.5.0"
+    client-only: "npm:^0.0.1"
+    clsx: "npm:^2.0.0"
+    react-aria: "npm:3.48.0"
+    react-aria-components: "npm:1.17.0"
+    react-stately: "npm:3.46.0"
+    react-transition-group: "npm:^4.4.5"
+    use-sync-external-store: "npm:^1.6.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/c2008f1144670230a35906d71488c513517dca640b6abe6a3178f70735d55f8103a7d51ed0e2eb1ad4fe6e42c6c4931d97403ab96bc5c3fb4847b34f7900e552
+  languageName: node
+  linkType: hard
+
 "@algolia/cache-browser-local-storage@npm:4.23.2":
   version: 4.23.2
   resolution: "@algolia/cache-browser-local-storage@npm:4.23.2"
@@ -2440,10 +2483,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.6, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.20.6, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.26.0, @babel/runtime@npm:^7.28.4, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.4.4, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.0, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.3, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
-  version: 7.28.4
-  resolution: "@babel/runtime@npm:7.28.4"
-  checksum: 10/6c9a70452322ea80b3c9b2a412bcf60771819213a67576c8cec41e88a95bb7bf01fc983754cda35dc19603eef52df22203ccbf7777b9d6316932f9fb77c25163
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.6, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.20.6, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.24.4, @babel/runtime@npm:^7.26.0, @babel/runtime@npm:^7.28.4, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.4.4, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.0, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.3, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
+  version: 7.29.2
+  resolution: "@babel/runtime@npm:7.29.2"
+  checksum: 10/f55ba4052aa0255055b34371a145fbe69c29b37b49eaea14805b095bfb4153701486416e89392fd27ec8abafa53868be86e960b9f8f959fff91f2c8ac2a14b02
   languageName: node
   linkType: hard
 
@@ -4139,7 +4182,7 @@ __metadata:
     "@remixicon/react": "npm:^4.6.0"
     "@types/react": "npm:^18.0.0"
     react: "npm:^18.0.2"
-    react-aria-components: "npm:^1.14.0"
+    react-aria-components: "npm:~1.14.0"
     react-dom: "npm:^18.0.2"
     react-router-dom: "npm:^6.30.2"
   peerDependencies:
@@ -6330,7 +6373,7 @@ __metadata:
     msw: "npm:^1.0.0"
     notistack: "npm:^3.0.1"
     react: "npm:^18.0.2"
-    react-aria-components: "npm:^1.17.0"
+    react-aria-components: "npm:~1.17.0"
     react-dom: "npm:^18.0.2"
     react-relative-time: "npm:^0.0.9"
     react-router-dom: "npm:^6.30.2"
@@ -7985,7 +8028,7 @@ __metadata:
     globals: "npm:^17.0.0"
     react: "npm:^18.0.2"
     react-aria: "npm:^3.48.0"
-    react-aria-components: "npm:^1.17.0"
+    react-aria-components: "npm:~1.17.0"
     react-dom: "npm:^18.0.2"
     react-router-dom: "npm:^6.30.2"
     react-stately: "npm:^3.46.0"
@@ -9200,6 +9243,57 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@formatjs/ecma402-abstract@npm:2.3.6":
+  version: 2.3.6
+  resolution: "@formatjs/ecma402-abstract@npm:2.3.6"
+  dependencies:
+    "@formatjs/fast-memoize": "npm:2.2.7"
+    "@formatjs/intl-localematcher": "npm:0.6.2"
+    decimal.js: "npm:^10.4.3"
+    tslib: "npm:^2.8.0"
+  checksum: 10/30b1b5cd6b62ba46245f934429936592df5500bc1b089dc92dd49c826757b873dd92c305dcfe370701e4df6b057bf007782113abb9b65db550d73be4961718bc
+  languageName: node
+  linkType: hard
+
+"@formatjs/fast-memoize@npm:2.2.7":
+  version: 2.2.7
+  resolution: "@formatjs/fast-memoize@npm:2.2.7"
+  dependencies:
+    tslib: "npm:^2.8.0"
+  checksum: 10/e7e6efc677d63a13d99a854305db471b69f64cbfebdcb6dbe507dab9aa7eaae482ca5de86f343c856ca0a2c8f251672bd1f37c572ce14af602c0287378097d43
+  languageName: node
+  linkType: hard
+
+"@formatjs/icu-messageformat-parser@npm:2.11.4":
+  version: 2.11.4
+  resolution: "@formatjs/icu-messageformat-parser@npm:2.11.4"
+  dependencies:
+    "@formatjs/ecma402-abstract": "npm:2.3.6"
+    "@formatjs/icu-skeleton-parser": "npm:1.8.16"
+    tslib: "npm:^2.8.0"
+  checksum: 10/2acb100c06c2ade666d72787fb9f9795b1ace41e8e73bfadc2b1a7b8562e81f655e484f0f33d8c39473aa17bf0ad96fb2228871806a9b3dc4f5f876754a0de3a
+  languageName: node
+  linkType: hard
+
+"@formatjs/icu-skeleton-parser@npm:1.8.16":
+  version: 1.8.16
+  resolution: "@formatjs/icu-skeleton-parser@npm:1.8.16"
+  dependencies:
+    "@formatjs/ecma402-abstract": "npm:2.3.6"
+    tslib: "npm:^2.8.0"
+  checksum: 10/428001e5bed81889b276a2356a1393157af91dc59220b765a1a132f6407ac5832b7ac6ae9737674ac38e44035295c0c1c310b2630f383f2b5779ea90bf2849e6
+  languageName: node
+  linkType: hard
+
+"@formatjs/intl-localematcher@npm:0.6.2":
+  version: 0.6.2
+  resolution: "@formatjs/intl-localematcher@npm:0.6.2"
+  dependencies:
+    tslib: "npm:^2.8.0"
+  checksum: 10/eb12a7f5367bbecdfafc20d7f005559ce840f420e970f425c5213d35e94e86dfe75bde03464971a26494bf8427d4961269db22ecad2834f2a19d888b5d9cc064
+  languageName: node
+  linkType: hard
+
 "@gar/promise-retry@npm:^1.0.0":
   version: 1.0.2
   resolution: "@gar/promise-retry@npm:1.0.2"
@@ -10127,12 +10221,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@internationalized/date@npm:^3.12.1":
+"@internationalized/date@npm:^3.10.1, @internationalized/date@npm:^3.12.1":
   version: 3.12.1
   resolution: "@internationalized/date@npm:3.12.1"
   dependencies:
     "@swc/helpers": "npm:^0.5.0"
   checksum: 10/a8178a73e65cb86357008e39e589bf5899b47a4ebd6123d96b54e3b19aade31c136d8e5f9c48c4627110f26d857e15aa4be9e189e56386a4b26c616df4ea1795
+  languageName: node
+  linkType: hard
+
+"@internationalized/message@npm:^3.1.9":
+  version: 3.1.9
+  resolution: "@internationalized/message@npm:3.1.9"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    intl-messageformat: "npm:^10.1.0"
+  checksum: 10/fdbe622e23e365af6a75cee95cbdf022715c20299a1bc4b73d8a2e3f9e8ec71fc80056ce2c6459906ffa1a1fd19a993b222922d7caa82c52bce42d31f9e29625
   languageName: node
   linkType: hard
 
@@ -10145,7 +10249,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@internationalized/string@npm:^3.2.8":
+"@internationalized/string@npm:^3.2.7, @internationalized/string@npm:^3.2.8":
   version: 3.2.8
   resolution: "@internationalized/string@npm:3.2.8"
   dependencies:
@@ -15352,6 +15456,248 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-aria/autocomplete@npm:3.0.0-rc.4":
+  version: 3.0.0-rc.4
+  resolution: "@react-aria/autocomplete@npm:3.0.0-rc.4"
+  dependencies:
+    "@react-aria/combobox": "npm:^3.14.1"
+    "@react-aria/focus": "npm:^3.21.3"
+    "@react-aria/i18n": "npm:^3.12.14"
+    "@react-aria/interactions": "npm:^3.26.0"
+    "@react-aria/listbox": "npm:^3.15.1"
+    "@react-aria/searchfield": "npm:^3.8.10"
+    "@react-aria/textfield": "npm:^3.18.3"
+    "@react-aria/utils": "npm:^3.32.0"
+    "@react-stately/autocomplete": "npm:3.0.0-beta.4"
+    "@react-stately/combobox": "npm:^3.12.1"
+    "@react-types/autocomplete": "npm:3.0.0-alpha.36"
+    "@react-types/button": "npm:^3.14.1"
+    "@react-types/shared": "npm:^3.32.1"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/3901ea60c43ff68b381a04db64577de07e46bc63e95c7cb122ace6053a0c54f58ba206704a2cd19799499f4a31ce6413ba65e8af39e675b5cedd66e9a5870729
+  languageName: node
+  linkType: hard
+
+"@react-aria/button@npm:^3.15.0":
+  version: 3.15.0
+  resolution: "@react-aria/button@npm:3.15.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/bf2e23d3bd96e249e773d4c8666ce183949b954aa185453ceb0605196fcf8dc679916c7654d091e53336aadea70d77ec8260494074d85c93bcdcb72dec4a2cdc
+  languageName: node
+  linkType: hard
+
+"@react-aria/collections@npm:^3.0.1":
+  version: 3.1.0
+  resolution: "@react-aria/collections@npm:3.1.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/e2a943f89a4f396a905c4e1008e409aa43601c91375d4387ec2bee3a265293986f8bd9914b2b71eaf389e839c831f81cf285e453e5cf4012531bd5fcec348b8a
+  languageName: node
+  linkType: hard
+
+"@react-aria/combobox@npm:^3.14.1, @react-aria/combobox@npm:^3.16.0":
+  version: 3.16.0
+  resolution: "@react-aria/combobox@npm:3.16.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/fc03d0027d7815bb6947af6dbec0d7e26df0ad59043a2ad15ad7d240e1e4884b0d72799387a6853a2d4be4e451f05631da965e85abbe91659bafbb6a31417a23
+  languageName: node
+  linkType: hard
+
+"@react-aria/dnd@npm:^3.11.4":
+  version: 3.12.0
+  resolution: "@react-aria/dnd@npm:3.12.0"
+  dependencies:
+    "@react-types/shared": "npm:^3.34.0"
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/cd20b5eaa674bc454ecdcdb7ee8b8bcb9d50c2c00c79786706b11a37231de672e488260d3332b0865230586c412deeb7e5304afc9c4cca5db1b4e36c108b85a4
+  languageName: node
+  linkType: hard
+
+"@react-aria/focus@npm:^3.21.3":
+  version: 3.22.0
+  resolution: "@react-aria/focus@npm:3.22.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/6467625ad37e4dd6f16669145f19ef75a44134364bd116959369407f1b3ff309f86fc25610b4e7c3736a1a4befd178112429749fad505b944e11cec25e3847c1
+  languageName: node
+  linkType: hard
+
+"@react-aria/i18n@npm:^3.12.14":
+  version: 3.13.0
+  resolution: "@react-aria/i18n@npm:3.13.0"
+  dependencies:
+    "@internationalized/date": "npm:^3.12.1"
+    "@internationalized/message": "npm:^3.1.9"
+    "@internationalized/string": "npm:^3.2.8"
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/8782cc79e7cc4071c61a35876afb7c01126c6a5db04abd960669d111af63b756f821b6d1b8b42878b25b1925370211ce560ae71f09f37ad05b5999e694f0a5de
+  languageName: node
+  linkType: hard
+
+"@react-aria/interactions@npm:^3.26.0":
+  version: 3.28.0
+  resolution: "@react-aria/interactions@npm:3.28.0"
+  dependencies:
+    "@react-types/shared": "npm:^3.34.0"
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/f845180e29ac0607ec16cb85ff4605076c3d8f6de06f6530b3fdec8009272b711c7057af5a7c793851d568ef41626b8fc965cac7a8cee5a043dcf5f27fec2239
+  languageName: node
+  linkType: hard
+
+"@react-aria/listbox@npm:^3.15.1":
+  version: 3.16.0
+  resolution: "@react-aria/listbox@npm:3.16.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/56a7754fd52d75a312db47548b85410a2bba781d8878ec817f653771afadd37ba5230f3f9a3b653b1a8d6a0df66d54a0e79a62aeab978a8b6e2b0e738b5818f5
+  languageName: node
+  linkType: hard
+
+"@react-aria/live-announcer@npm:^3.4.4":
+  version: 3.5.0
+  resolution: "@react-aria/live-announcer@npm:3.5.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/63682d976483c9b351a8dd2c7ae86bba2ef2d47435b5fdf03ab732297167a75befd4e05bdb2a99c9de5f3985608e4fcaacbd4e822d892222293cfbceb243ddf5
+  languageName: node
+  linkType: hard
+
+"@react-aria/overlays@npm:^3.31.0":
+  version: 3.32.0
+  resolution: "@react-aria/overlays@npm:3.32.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/88ad62c437d0e82ab5ab1087415be87981f72c805f60400d5f0680fa459c7699d98e2f3464c56043693e1be5f06a71a0e98968003be3d36b4915dd865af370b6
+  languageName: node
+  linkType: hard
+
+"@react-aria/searchfield@npm:^3.8.10, @react-aria/searchfield@npm:^3.9.0":
+  version: 3.9.0
+  resolution: "@react-aria/searchfield@npm:3.9.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/fa77c05127fb74cdf9cb7a932a7f173bdac17e66f727d888f401951cc036533217f3a4b5eae165e6f894e4d773b5375f07fe9323535fc2b31a16bf6e214c493f
+  languageName: node
+  linkType: hard
+
+"@react-aria/ssr@npm:^3.9.10":
+  version: 3.10.0
+  resolution: "@react-aria/ssr@npm:3.10.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/01ca62df73f382e511958bb34a698aa07ca79d8487cafbe5c4a8a44b8a23e6f6bd2520a0b3af158c2d882e60f97b6d8ee8d7e64c65ff7c72fd7aec6550b59030
+  languageName: node
+  linkType: hard
+
+"@react-aria/textfield@npm:^3.18.3":
+  version: 3.19.0
+  resolution: "@react-aria/textfield@npm:3.19.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/3b1bd1280ee7419ded0fa692ed39bb021842406acb67b80f51f7437102ec1483a0cedd60197a133c7abd826732a7d3885fc90c83abdb27026ab57b3eaa043dd6
+  languageName: node
+  linkType: hard
+
+"@react-aria/toolbar@npm:3.0.0-beta.22":
+  version: 3.0.0-beta.22
+  resolution: "@react-aria/toolbar@npm:3.0.0-beta.22"
+  dependencies:
+    "@react-aria/focus": "npm:^3.21.3"
+    "@react-aria/i18n": "npm:^3.12.14"
+    "@react-aria/utils": "npm:^3.32.0"
+    "@react-types/shared": "npm:^3.32.1"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/587ddaff3b11e58e4d0fb0cef59d8d7fc0481eb43f473c3cbaf6fe174a5e9ff52323636f767e2ada6b41e74ae73bab0a816846232ec1e33f35709cf91abcf49c
+  languageName: node
+  linkType: hard
+
+"@react-aria/utils@npm:^3.32.0":
+  version: 3.34.0
+  resolution: "@react-aria/utils@npm:3.34.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/55a120c1b33510bd18154128f8e6c7ca17de38d3950e474c92d2cd154f01c2db9c3248103d6183330f8793db47a138e02fb40ce1763736aea469f3a15d673de9
+  languageName: node
+  linkType: hard
+
+"@react-aria/virtualizer@npm:^4.1.11":
+  version: 4.2.0
+  resolution: "@react-aria/virtualizer@npm:4.2.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/ffa75f2c514a5bea2def1207ee29924e930e3fb54a766d982e7bf352d3e67b9e47e652dbb25d9f926d9db01f76dc7efc34c1e04c9769327a9328bd9e1ec992b3
+  languageName: node
+  linkType: hard
+
 "@react-hookz/deep-equal@npm:^1.0.4":
   version: 1.0.4
   resolution: "@react-hookz/deep-equal@npm:1.0.4"
@@ -15375,12 +15721,294 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-types/shared@npm:^3.34.0":
+"@react-spectrum/button@npm:^3.18.0":
+  version: 3.18.0
+  resolution: "@react-spectrum/button@npm:3.18.0"
+  dependencies:
+    "@adobe/react-spectrum": "npm:3.47.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/01831e8c57a862c1fc1766fabd19dc3285d029aa44bc07842f264b15a846391fdaec4e707350641de74f6e817f74f578ec72ebe81d481ca86dc10709147d3563
+  languageName: node
+  linkType: hard
+
+"@react-spectrum/combobox@npm:^3.17.0":
+  version: 3.17.0
+  resolution: "@react-spectrum/combobox@npm:3.17.0"
+  dependencies:
+    "@adobe/react-spectrum": "npm:3.47.0"
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/b32efcaece9d33a009fce5b36c97492bd99940fcd542b8193bcd15ac5af40a88a5021b53a9daf89cbd10fce4a016df601bf49f735cdd53c5f45fe382cb170d4f
+  languageName: node
+  linkType: hard
+
+"@react-spectrum/form@npm:^3.8.0":
+  version: 3.8.0
+  resolution: "@react-spectrum/form@npm:3.8.0"
+  dependencies:
+    "@adobe/react-spectrum": "npm:3.47.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/81178345d479cd7ebf8887d073570dcb72173c85091c0807c0b6bcc4fca0a0c46b84f06ff28753219b3aa4b7c96b1a622aa53db38bbde07ca84f08987fe6fec3
+  languageName: node
+  linkType: hard
+
+"@react-spectrum/searchfield@npm:^3.9.0":
+  version: 3.9.0
+  resolution: "@react-spectrum/searchfield@npm:3.9.0"
+  dependencies:
+    "@adobe/react-spectrum": "npm:3.47.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/9bdbaa47badcdba0705f7517fe3435cd46edc26432e2581152ef204546ca40222b8be511935f00cdcfaff8afd42a20557c4bc02c29cfc3913f0d6d8ac2faf18f
+  languageName: node
+  linkType: hard
+
+"@react-spectrum/table@npm:^3.18.0":
+  version: 3.18.0
+  resolution: "@react-spectrum/table@npm:3.18.0"
+  dependencies:
+    "@adobe/react-spectrum": "npm:3.47.0"
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/169131ef935b5d6103c24c45bee46c9cac59378cff49ff6636f3c68cfb71afe698a957c49439ea3b3b5f541c8e3f9948199956d5f7f61bf1666722a57e356707
+  languageName: node
+  linkType: hard
+
+"@react-stately/autocomplete@npm:3.0.0-beta.4":
+  version: 3.0.0-beta.4
+  resolution: "@react-stately/autocomplete@npm:3.0.0-beta.4"
+  dependencies:
+    "@react-stately/utils": "npm:^3.11.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/482a58cd5753df054edb27bf308d3922da2c7757c4e2227cefda3806ae2eb14ad771a7d3741eb57c00cee3e8c3cb4fc1c81006c2e920d64b18330f533043ba2a
+  languageName: node
+  linkType: hard
+
+"@react-stately/combobox@npm:^3.12.1, @react-stately/combobox@npm:^3.14.0":
+  version: 3.14.0
+  resolution: "@react-stately/combobox@npm:3.14.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/c22f8fa85fcc6aee30d8aa3136bb1cfe4ed588482f3cc8e155db22aafd13b12160d397c431008b72bd87e153bdbef9cd033bfe12651ee3987df247919b84fa36
+  languageName: node
+  linkType: hard
+
+"@react-stately/grid@npm:^3.12.0":
+  version: 3.12.0
+  resolution: "@react-stately/grid@npm:3.12.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/c86335070644fc1547bf0a8abd002a1a66ec6c86b947cfbe241f4543fc2d42719a17f85bc2ccef52b821641f473848922d17eada9c91c17609f5025c6e1b89a9
+  languageName: node
+  linkType: hard
+
+"@react-stately/layout@npm:^4.5.2":
+  version: 4.7.0
+  resolution: "@react-stately/layout@npm:4.7.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/c8bd96dd798be3e8ea8138ded259f09ab343ce8719c8378381e84eaa3fb06f14dab64928971fd5d37096788eefa6a66f1a4114ac58aed935ad6d68e006334a22
+  languageName: node
+  linkType: hard
+
+"@react-stately/searchfield@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "@react-stately/searchfield@npm:3.6.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/36106af2d94665822db952d51ca4e1c4e40b118b70aa3f96f0c4211de8f062e3a21a3e0c2f8d734f03013dbc5a3c94c29f96d504ca3ffa4e7faa396c2d65df30
+  languageName: node
+  linkType: hard
+
+"@react-stately/selection@npm:^3.20.7":
+  version: 3.21.0
+  resolution: "@react-stately/selection@npm:3.21.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/8b3a26e32075e8233d70be8c6002e9b1ae4a6dfd59e05ff8e3a0cb3acfade3ea1c603c4eb6742b10996b657cd5ed2e3b523394f57c0941151282d327204ebd29
+  languageName: node
+  linkType: hard
+
+"@react-stately/table@npm:^3.15.2, @react-stately/table@npm:^3.16.0":
+  version: 3.16.0
+  resolution: "@react-stately/table@npm:3.16.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/383d4e525b71a2b6d5be7a0ac5454e5b81381fb65acbe87041ddcb49fb91d26cd2c607d9de51180fb7acdfeedc75f3c4fc9b981e77c5179317fdca9c04313095
+  languageName: node
+  linkType: hard
+
+"@react-stately/utils@npm:^3.11.0":
+  version: 3.12.0
+  resolution: "@react-stately/utils@npm:3.12.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/6190977e056edc1603fd34459ee065a4bc11d381443ff50de48133606233420afa2ce068f7dabef0edc92aefb80ca10d1a055a52167fe8fae5761a54580c230d
+  languageName: node
+  linkType: hard
+
+"@react-stately/virtualizer@npm:^4.4.4":
+  version: 4.5.0
+  resolution: "@react-stately/virtualizer@npm:4.5.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/1b8d22d266e4f733d45f62b3fd428e3e7af9d61d4bcc8fe6425f529571d32d2ea0695b4169dd14617221dda9f7a58d279ac00ceca4fa7a2611c746a3ea0f4559
+  languageName: node
+  linkType: hard
+
+"@react-types/autocomplete@npm:3.0.0-alpha.36":
+  version: 3.0.0-alpha.36
+  resolution: "@react-types/autocomplete@npm:3.0.0-alpha.36"
+  dependencies:
+    "@react-types/combobox": "npm:^3.13.10"
+    "@react-types/searchfield": "npm:^3.6.6"
+    "@react-types/shared": "npm:^3.32.1"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/054b3d186d50f02fbd48e5370a447a3cfaafecf3aaddc04cdb0411cf9e170d11ceec5ca6f8fb654fbd32a65a74ae52c7a900af6ebe3683ad94f36860d4e8ee8f
+  languageName: node
+  linkType: hard
+
+"@react-types/button@npm:^3.14.1":
+  version: 3.16.0
+  resolution: "@react-types/button@npm:3.16.0"
+  dependencies:
+    "@react-aria/button": "npm:^3.15.0"
+    "@react-spectrum/button": "npm:^3.18.0"
+  peerDependencies:
+    "@react-spectrum/provider": ^3.0.0
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/c2bbbbd9f7a0e8899d527b7416d477f709073ce9b1fdfae4c1bbc9e89e9b8cac957ca490ca5527cb0a81c61e14be54c0483b2c9c4b1d74935164b1ec00d7e92e
+  languageName: node
+  linkType: hard
+
+"@react-types/combobox@npm:^3.13.10":
+  version: 3.15.0
+  resolution: "@react-types/combobox@npm:3.15.0"
+  dependencies:
+    "@react-aria/combobox": "npm:^3.16.0"
+    "@react-spectrum/combobox": "npm:^3.17.0"
+    "@react-stately/combobox": "npm:^3.14.0"
+  peerDependencies:
+    "@react-spectrum/provider": ^3.0.0
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/dce9cacfc6771e3c917bb58adffaae9a299ba6e17dbab59c3f66deffd231df38dd1b0ebec997e8f593bca4d02289f6e8a6c9eab7f0fa86c10712db074480c769
+  languageName: node
+  linkType: hard
+
+"@react-types/form@npm:^3.7.16":
+  version: 3.8.0
+  resolution: "@react-types/form@npm:3.8.0"
+  dependencies:
+    "@react-spectrum/form": "npm:^3.8.0"
+    "@react-types/shared": "npm:^3.34.0"
+  peerDependencies:
+    "@react-spectrum/provider": ^3.0.0
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/b7ae09fb10b0df5df58fdcd2eda8879ee48a54d060b32504e2d728477274f1ca243d0988196fd0af7655c9b6a58c66a26daf0a116e90bfbce945412a5b50d681
+  languageName: node
+  linkType: hard
+
+"@react-types/grid@npm:^3.3.6":
+  version: 3.4.0
+  resolution: "@react-types/grid@npm:3.4.0"
+  dependencies:
+    "@react-stately/grid": "npm:^3.12.0"
+  peerDependencies:
+    "@react-spectrum/provider": ^3.0.0
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/4db7eaedc00646f18a8074f5884f3623598291d25b88bcb795dacd100bf7e2520f63bc7ac4b3cd9018d6bd5b3b6b1566668628f7ea186ef6b9916785a5368756
+  languageName: node
+  linkType: hard
+
+"@react-types/searchfield@npm:^3.6.6":
+  version: 3.7.0
+  resolution: "@react-types/searchfield@npm:3.7.0"
+  dependencies:
+    "@react-aria/searchfield": "npm:^3.9.0"
+    "@react-spectrum/searchfield": "npm:^3.9.0"
+    "@react-stately/searchfield": "npm:^3.6.0"
+  peerDependencies:
+    "@react-spectrum/provider": ^3.0.0
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/7ad57aaf17ce4b5a6b5c7bd1720d2dc7a305551c7e6d7c50d2507ba68182ce7315d819bf54211ead510ea6df0cc123df537218193a0d51373cfca8f825da0a3a
+  languageName: node
+  linkType: hard
+
+"@react-types/shared@npm:^3.32.1, @react-types/shared@npm:^3.34.0":
   version: 3.34.0
   resolution: "@react-types/shared@npm:3.34.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
   checksum: 10/d28b0a3a3f68f94167fd7b4f474803430093b1a31f5f50cef6ddd755b923ba3af35dde40ffcc1f320926892744823a039b4a396c671f7c59aa49634811f0c43a
+  languageName: node
+  linkType: hard
+
+"@react-types/table@npm:^3.13.4":
+  version: 3.14.0
+  resolution: "@react-types/table@npm:3.14.0"
+  dependencies:
+    "@react-spectrum/table": "npm:^3.18.0"
+    "@react-stately/table": "npm:^3.16.0"
+    "@react-types/shared": "npm:^3.34.0"
+  peerDependencies:
+    "@react-spectrum/provider": ^3.0.0
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/df3944c12ba409188332db75a7b5c376452fe5ef8d594e39202790f298bff1f3d9aa582f180460477d6a2eced177306c9722f50ba608e53bedc2de5ccf090ad4
   languageName: node
   linkType: hard
 
@@ -17312,6 +17940,35 @@ __metadata:
     color: "npm:^5.0.2"
     text-hex: "npm:1.0.x"
   checksum: 10/fc3285e5cb9a458d255aa678d9453174ca40689a4c692f1617907996ab8eb78839542439604ced484c4f674a5297f7ba8b0e63fcfe901174f43c3d9c3c881b52
+  languageName: node
+  linkType: hard
+
+"@spectrum-icons/ui@npm:^3.7.0":
+  version: 3.7.0
+  resolution: "@spectrum-icons/ui@npm:3.7.0"
+  dependencies:
+    "@adobe/react-spectrum-ui": "npm:1.2.1"
+    "@babel/runtime": "npm:^7.24.4"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    "@adobe/react-spectrum": ^3.47.0
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/50c0c14a5be2b057bf68d60e61e3c4608f4ce22cbbe7da5d519e99cd32f60a550ca6e04a507f18f7cb8f02cb0b3c93f45cdac91f3e0b9aaa26c35b292ec10325
+  languageName: node
+  linkType: hard
+
+"@spectrum-icons/workflow@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "@spectrum-icons/workflow@npm:4.3.0"
+  dependencies:
+    "@adobe/react-spectrum-workflow": "npm:2.3.5"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    "@adobe/react-spectrum": ^3.47.0
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/0d4b2d03e92684aa8d74b1d313f9b39b3ad55aba90eea2993e06edc2b076866332b5a4175a2d4184b14020ba3672f377ecb64c6ba399272c3c530435e47c0774
   languageName: node
   linkType: hard
 
@@ -32474,6 +33131,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"intl-messageformat@npm:^10.1.0":
+  version: 10.7.18
+  resolution: "intl-messageformat@npm:10.7.18"
+  dependencies:
+    "@formatjs/ecma402-abstract": "npm:2.3.6"
+    "@formatjs/fast-memoize": "npm:2.2.7"
+    "@formatjs/icu-messageformat-parser": "npm:2.11.4"
+    tslib: "npm:^2.8.0"
+  checksum: 10/96650d673912763d21bbfa14b50749b992d45f1901092a020e3155961e3c70f4644dd1731c3ecb1207a1eb94d84bedf4c34b1ac8127c29ad6b015b6a2a4045cb
+  languageName: node
+  linkType: hard
+
 "into-stream@npm:^6.0.0":
   version: 6.0.0
   resolution: "into-stream@npm:6.0.0"
@@ -41515,7 +42184,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-aria-components@npm:^1.14.0, react-aria-components@npm:^1.17.0":
+"react-aria-components@npm:1.17.0, react-aria-components@npm:~1.17.0":
   version: 1.17.0
   resolution: "react-aria-components@npm:1.17.0"
   dependencies:
@@ -41532,7 +42201,47 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-aria@npm:3.48.0, react-aria@npm:^3.48.0":
+"react-aria-components@npm:~1.14.0":
+  version: 1.14.0
+  resolution: "react-aria-components@npm:1.14.0"
+  dependencies:
+    "@internationalized/date": "npm:^3.10.1"
+    "@internationalized/string": "npm:^3.2.7"
+    "@react-aria/autocomplete": "npm:3.0.0-rc.4"
+    "@react-aria/collections": "npm:^3.0.1"
+    "@react-aria/dnd": "npm:^3.11.4"
+    "@react-aria/focus": "npm:^3.21.3"
+    "@react-aria/interactions": "npm:^3.26.0"
+    "@react-aria/live-announcer": "npm:^3.4.4"
+    "@react-aria/overlays": "npm:^3.31.0"
+    "@react-aria/ssr": "npm:^3.9.10"
+    "@react-aria/textfield": "npm:^3.18.3"
+    "@react-aria/toolbar": "npm:3.0.0-beta.22"
+    "@react-aria/utils": "npm:^3.32.0"
+    "@react-aria/virtualizer": "npm:^4.1.11"
+    "@react-stately/autocomplete": "npm:3.0.0-beta.4"
+    "@react-stately/layout": "npm:^4.5.2"
+    "@react-stately/selection": "npm:^3.20.7"
+    "@react-stately/table": "npm:^3.15.2"
+    "@react-stately/utils": "npm:^3.11.0"
+    "@react-stately/virtualizer": "npm:^4.4.4"
+    "@react-types/form": "npm:^3.7.16"
+    "@react-types/grid": "npm:^3.3.6"
+    "@react-types/shared": "npm:^3.32.1"
+    "@react-types/table": "npm:^3.13.4"
+    "@swc/helpers": "npm:^0.5.0"
+    client-only: "npm:^0.0.1"
+    react-aria: "npm:^3.45.0"
+    react-stately: "npm:^3.43.0"
+    use-sync-external-store: "npm:^1.4.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/cc842f03a6cb10a11ac6c95fbdcc97329a2bce7cf9203bd3fc9f4f4ea248bd308bc31b39f6df3c6b427be5adc370813e04b7a4cf41e8a0193195dde048462d9b
+  languageName: node
+  linkType: hard
+
+"react-aria@npm:3.48.0, react-aria@npm:^3.45.0, react-aria@npm:^3.48.0":
   version: 3.48.0
   resolution: "react-aria@npm:3.48.0"
   dependencies:
@@ -42168,7 +42877,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-stately@npm:3.46.0, react-stately@npm:^3.46.0":
+"react-stately@npm:3.46.0, react-stately@npm:^3.43.0, react-stately@npm:^3.46.0":
   version: 3.46.0
   resolution: "react-stately@npm:3.46.0"
   dependencies:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

React Aria packages don't strictly follow semver and occasionally ship breaking changes in minor releases. This pins the `react-aria-components` dependency to a tilde range (`~`) across all packages that use it, so only patch updates are pulled in automatically.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))