### PR TITLE
ui, notifications: pin React Aria dependencies to v1.16.0

### DIFF
--- a/.changeset/pin-react-aria-app-visualizer.md
+++ b/.changeset/pin-react-aria-app-visualizer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-app-visualizer': patch
+---
+
+Pinned `react-aria-components` dependency range to use tilde instead of caret, targeting the v1.16.0 release line. React Aria does not strictly follow semver and may ship breaking changes in minor releases, so only patch-level updates are now picked up automatically.

--- a/.changeset/pin-react-aria-notifications.md
+++ b/.changeset/pin-react-aria-notifications.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications': patch
+---
+
+Pinned `react-aria-components` dependency range to use tilde instead of caret, targeting the v1.16.0 release line. React Aria does not strictly follow semver and may ship breaking changes in minor releases, so only patch-level updates are now picked up automatically.

--- a/.changeset/pin-react-aria-plugin-app.md
+++ b/.changeset/pin-react-aria-plugin-app.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-app': patch
+---
+
+Pinned `react-aria` and `react-stately` dependency ranges to use tilde instead of caret, targeting the v1.16.0 release line. React Aria does not strictly follow semver and may ship breaking changes in minor releases, so only patch-level updates are now picked up automatically.

--- a/.changeset/pin-react-aria-ui.md
+++ b/.changeset/pin-react-aria-ui.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Pinned React Aria dependency ranges to use tilde instead of caret, targeting the v1.16.0 release line. React Aria does not strictly follow semver and may ship breaking changes in minor releases, so only patch-level updates are now picked up automatically.

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -50,9 +50,9 @@
     "@remixicon/react": "^4.6.0",
     "@tanstack/react-table": "^8.21.3",
     "clsx": "^2.1.1",
-    "react-aria": "^3.48.0",
-    "react-aria-components": "^1.17.0",
-    "react-stately": "^3.46.0",
+    "react-aria": "~3.47.0",
+    "react-aria-components": "~1.16.0",
+    "react-stately": "~3.45.0",
     "use-sync-external-store": "^1.4.0"
   },
   "devDependencies": {

--- a/plugins/app-visualizer/package.json
+++ b/plugins/app-visualizer/package.json
@@ -39,7 +39,7 @@
     "@backstage/frontend-plugin-api": "workspace:^",
     "@backstage/ui": "workspace:^",
     "@remixicon/react": "^4.6.0",
-    "react-aria-components": "^1.14.0"
+    "react-aria-components": "~1.16.0"
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",

--- a/plugins/app/package.json
+++ b/plugins/app/package.json
@@ -68,8 +68,8 @@
     "@react-hookz/web": "^24.0.0",
     "@remixicon/react": "^4.6.0",
     "motion": "^12.0.0",
-    "react-aria": "^3.48.0",
-    "react-stately": "^3.46.0",
+    "react-aria": "~3.47.0",
+    "react-stately": "~3.45.0",
     "react-use": "^17.2.4",
     "zen-observable": "^0.10.0",
     "zod": "^4.0.0"

--- a/plugins/notifications/package.json
+++ b/plugins/notifications/package.json
@@ -62,7 +62,7 @@
     "@remixicon/react": "^4.6.0",
     "lodash": "^4.17.21",
     "notistack": "^3.0.1",
-    "react-aria-components": "^1.17.0",
+    "react-aria-components": "~1.16.0",
     "react-relative-time": "^0.0.9",
     "react-use": "^17.2.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,6 +26,49 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@adobe/react-spectrum-ui@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@adobe/react-spectrum-ui@npm:1.2.1"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 10/1916d0057c37845a3ad042ad76202ecb5d9c7e4152ccc97a1d6cb234ae31e7ccc4dd50711a311afc35bdbe433d41c3183f1a741a2643507bf9ccd934eb7fe1ce
+  languageName: node
+  linkType: hard
+
+"@adobe/react-spectrum-workflow@npm:2.3.5":
+  version: 2.3.5
+  resolution: "@adobe/react-spectrum-workflow@npm:2.3.5"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0
+  checksum: 10/2ec4b337d1aaa88ccddb9b70f60ddfeb9af74670f949b4a26fd6e4ec1068c9542d4178b222d95a5cda7304563df1a47a8427c70ec4f419cf9751081b6aef3c1a
+  languageName: node
+  linkType: hard
+
+"@adobe/react-spectrum@npm:3.47.0":
+  version: 3.47.0
+  resolution: "@adobe/react-spectrum@npm:3.47.0"
+  dependencies:
+    "@internationalized/date": "npm:^3.12.1"
+    "@react-types/shared": "npm:^3.34.0"
+    "@spectrum-icons/ui": "npm:^3.7.0"
+    "@spectrum-icons/workflow": "npm:^4.3.0"
+    "@swc/helpers": "npm:^0.5.0"
+    client-only: "npm:^0.0.1"
+    clsx: "npm:^2.0.0"
+    react-aria: "npm:3.48.0"
+    react-aria-components: "npm:1.17.0"
+    react-stately: "npm:3.46.0"
+    react-transition-group: "npm:^4.4.5"
+    use-sync-external-store: "npm:^1.6.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/c2008f1144670230a35906d71488c513517dca640b6abe6a3178f70735d55f8103a7d51ed0e2eb1ad4fe6e42c6c4931d97403ab96bc5c3fb4847b34f7900e552
+  languageName: node
+  linkType: hard
+
 "@algolia/cache-browser-local-storage@npm:4.23.2":
   version: 4.23.2
   resolution: "@algolia/cache-browser-local-storage@npm:4.23.2"
@@ -2440,10 +2483,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.6, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.20.6, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.26.0, @babel/runtime@npm:^7.28.4, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.4.4, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.0, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.3, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
-  version: 7.28.4
-  resolution: "@babel/runtime@npm:7.28.4"
-  checksum: 10/6c9a70452322ea80b3c9b2a412bcf60771819213a67576c8cec41e88a95bb7bf01fc983754cda35dc19603eef52df22203ccbf7777b9d6316932f9fb77c25163
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.10.1, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.6, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.20.6, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.23.9, @babel/runtime@npm:^7.24.4, @babel/runtime@npm:^7.26.0, @babel/runtime@npm:^7.28.4, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.4.4, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.6.0, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.3, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
+  version: 7.29.2
+  resolution: "@babel/runtime@npm:7.29.2"
+  checksum: 10/f55ba4052aa0255055b34371a145fbe69c29b37b49eaea14805b095bfb4153701486416e89392fd27ec8abafa53868be86e960b9f8f959fff91f2c8ac2a14b02
   languageName: node
   linkType: hard
 
@@ -4139,7 +4182,7 @@ __metadata:
     "@remixicon/react": "npm:^4.6.0"
     "@types/react": "npm:^18.0.0"
     react: "npm:^18.0.2"
-    react-aria-components: "npm:^1.14.0"
+    react-aria-components: "npm:~1.16.0"
     react-dom: "npm:^18.0.2"
     react-router-dom: "npm:^6.30.2"
   peerDependencies:
@@ -4185,10 +4228,10 @@ __metadata:
     motion: "npm:^12.0.0"
     msw: "npm:^1.0.0"
     react: "npm:^18.0.2"
-    react-aria: "npm:^3.48.0"
+    react-aria: "npm:~3.47.0"
     react-dom: "npm:^18.0.2"
     react-router-dom: "npm:^6.30.2"
-    react-stately: "npm:^3.46.0"
+    react-stately: "npm:~3.45.0"
     react-use: "npm:^17.2.4"
     zen-observable: "npm:^0.10.0"
     zod: "npm:^4.0.0"
@@ -6330,7 +6373,7 @@ __metadata:
     msw: "npm:^1.0.0"
     notistack: "npm:^3.0.1"
     react: "npm:^18.0.2"
-    react-aria-components: "npm:^1.17.0"
+    react-aria-components: "npm:~1.16.0"
     react-dom: "npm:^18.0.2"
     react-relative-time: "npm:^0.0.9"
     react-router-dom: "npm:^6.30.2"
@@ -7984,11 +8027,11 @@ __metadata:
     glob: "npm:^13.0.0"
     globals: "npm:^17.0.0"
     react: "npm:^18.0.2"
-    react-aria: "npm:^3.48.0"
-    react-aria-components: "npm:^1.17.0"
+    react-aria: "npm:~3.47.0"
+    react-aria-components: "npm:~1.16.0"
     react-dom: "npm:^18.0.2"
     react-router-dom: "npm:^6.30.2"
-    react-stately: "npm:^3.46.0"
+    react-stately: "npm:~3.45.0"
     storybook: "npm:^10.3.3"
     use-sync-external-store: "npm:^1.4.0"
   peerDependencies:
@@ -9200,6 +9243,57 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@formatjs/ecma402-abstract@npm:2.3.6":
+  version: 2.3.6
+  resolution: "@formatjs/ecma402-abstract@npm:2.3.6"
+  dependencies:
+    "@formatjs/fast-memoize": "npm:2.2.7"
+    "@formatjs/intl-localematcher": "npm:0.6.2"
+    decimal.js: "npm:^10.4.3"
+    tslib: "npm:^2.8.0"
+  checksum: 10/30b1b5cd6b62ba46245f934429936592df5500bc1b089dc92dd49c826757b873dd92c305dcfe370701e4df6b057bf007782113abb9b65db550d73be4961718bc
+  languageName: node
+  linkType: hard
+
+"@formatjs/fast-memoize@npm:2.2.7":
+  version: 2.2.7
+  resolution: "@formatjs/fast-memoize@npm:2.2.7"
+  dependencies:
+    tslib: "npm:^2.8.0"
+  checksum: 10/e7e6efc677d63a13d99a854305db471b69f64cbfebdcb6dbe507dab9aa7eaae482ca5de86f343c856ca0a2c8f251672bd1f37c572ce14af602c0287378097d43
+  languageName: node
+  linkType: hard
+
+"@formatjs/icu-messageformat-parser@npm:2.11.4":
+  version: 2.11.4
+  resolution: "@formatjs/icu-messageformat-parser@npm:2.11.4"
+  dependencies:
+    "@formatjs/ecma402-abstract": "npm:2.3.6"
+    "@formatjs/icu-skeleton-parser": "npm:1.8.16"
+    tslib: "npm:^2.8.0"
+  checksum: 10/2acb100c06c2ade666d72787fb9f9795b1ace41e8e73bfadc2b1a7b8562e81f655e484f0f33d8c39473aa17bf0ad96fb2228871806a9b3dc4f5f876754a0de3a
+  languageName: node
+  linkType: hard
+
+"@formatjs/icu-skeleton-parser@npm:1.8.16":
+  version: 1.8.16
+  resolution: "@formatjs/icu-skeleton-parser@npm:1.8.16"
+  dependencies:
+    "@formatjs/ecma402-abstract": "npm:2.3.6"
+    tslib: "npm:^2.8.0"
+  checksum: 10/428001e5bed81889b276a2356a1393157af91dc59220b765a1a132f6407ac5832b7ac6ae9737674ac38e44035295c0c1c310b2630f383f2b5779ea90bf2849e6
+  languageName: node
+  linkType: hard
+
+"@formatjs/intl-localematcher@npm:0.6.2":
+  version: 0.6.2
+  resolution: "@formatjs/intl-localematcher@npm:0.6.2"
+  dependencies:
+    tslib: "npm:^2.8.0"
+  checksum: 10/eb12a7f5367bbecdfafc20d7f005559ce840f420e970f425c5213d35e94e86dfe75bde03464971a26494bf8427d4961269db22ecad2834f2a19d888b5d9cc064
+  languageName: node
+  linkType: hard
+
 "@gar/promise-retry@npm:^1.0.0":
   version: 1.0.2
   resolution: "@gar/promise-retry@npm:1.0.2"
@@ -10127,12 +10221,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@internationalized/date@npm:^3.12.1":
+"@internationalized/date@npm:^3.12.0, @internationalized/date@npm:^3.12.1":
   version: 3.12.1
   resolution: "@internationalized/date@npm:3.12.1"
   dependencies:
     "@swc/helpers": "npm:^0.5.0"
   checksum: 10/a8178a73e65cb86357008e39e589bf5899b47a4ebd6123d96b54e3b19aade31c136d8e5f9c48c4627110f26d857e15aa4be9e189e56386a4b26c616df4ea1795
+  languageName: node
+  linkType: hard
+
+"@internationalized/message@npm:^3.1.9":
+  version: 3.1.9
+  resolution: "@internationalized/message@npm:3.1.9"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    intl-messageformat: "npm:^10.1.0"
+  checksum: 10/fdbe622e23e365af6a75cee95cbdf022715c20299a1bc4b73d8a2e3f9e8ec71fc80056ce2c6459906ffa1a1fd19a993b222922d7caa82c52bce42d31f9e29625
   languageName: node
   linkType: hard
 
@@ -10145,7 +10249,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@internationalized/string@npm:^3.2.8":
+"@internationalized/string@npm:^3.2.7, @internationalized/string@npm:^3.2.8":
   version: 3.2.8
   resolution: "@internationalized/string@npm:3.2.8"
   dependencies:
@@ -15352,6 +15456,618 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-aria/autocomplete@npm:3.0.0-rc.6":
+  version: 3.0.0-rc.6
+  resolution: "@react-aria/autocomplete@npm:3.0.0-rc.6"
+  dependencies:
+    "@react-aria/combobox": "npm:^3.15.0"
+    "@react-aria/focus": "npm:^3.21.5"
+    "@react-aria/i18n": "npm:^3.12.16"
+    "@react-aria/interactions": "npm:^3.27.1"
+    "@react-aria/listbox": "npm:^3.15.3"
+    "@react-aria/searchfield": "npm:^3.8.12"
+    "@react-aria/textfield": "npm:^3.18.5"
+    "@react-aria/utils": "npm:^3.33.1"
+    "@react-stately/autocomplete": "npm:3.0.0-beta.4"
+    "@react-stately/combobox": "npm:^3.13.0"
+    "@react-types/autocomplete": "npm:3.0.0-alpha.38"
+    "@react-types/button": "npm:^3.15.1"
+    "@react-types/shared": "npm:^3.33.1"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/5368f7597369d4b6054562a1812c6fce4ef9276a9618d1a7d043a89e9788415ed5a519ac1172edbaf4e458e5ca179ee6eca354f279515807eb7da8789c0ded90
+  languageName: node
+  linkType: hard
+
+"@react-aria/breadcrumbs@npm:^3.5.32":
+  version: 3.6.0
+  resolution: "@react-aria/breadcrumbs@npm:3.6.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/13bf44315b0a81b2b177ef59ac6a11aca7a43ff05ab59de75007ab7ff2e76390d52582cd0986eead3ea3bdfb5526a6ee6e1b6f755a60173b922cf63838ecef88
+  languageName: node
+  linkType: hard
+
+"@react-aria/button@npm:^3.14.5, @react-aria/button@npm:^3.15.0":
+  version: 3.15.0
+  resolution: "@react-aria/button@npm:3.15.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/bf2e23d3bd96e249e773d4c8666ce183949b954aa185453ceb0605196fcf8dc679916c7654d091e53336aadea70d77ec8260494074d85c93bcdcb72dec4a2cdc
+  languageName: node
+  linkType: hard
+
+"@react-aria/calendar@npm:^3.9.5":
+  version: 3.10.0
+  resolution: "@react-aria/calendar@npm:3.10.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/dc43185407f11f8397e8ee6f0654e1a37026e2c2b52defffc72cfc6a19986a25725dbcf9a757376e8e8d9a4b9de93bbde8951568d2a315d9e32c6535db80be96
+  languageName: node
+  linkType: hard
+
+"@react-aria/checkbox@npm:^3.16.5":
+  version: 3.17.0
+  resolution: "@react-aria/checkbox@npm:3.17.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/fea21f2e16bc0ee7debe15ef7f5e8e410303f0e1f4422375af8562feb3f3d2ca19c6cfecb34082a5c0635e11c3abb83bde5b9e4787916339e5369a9c3dff7b38
+  languageName: node
+  linkType: hard
+
+"@react-aria/collections@npm:^3.0.3":
+  version: 3.1.0
+  resolution: "@react-aria/collections@npm:3.1.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/e2a943f89a4f396a905c4e1008e409aa43601c91375d4387ec2bee3a265293986f8bd9914b2b71eaf389e839c831f81cf285e453e5cf4012531bd5fcec348b8a
+  languageName: node
+  linkType: hard
+
+"@react-aria/color@npm:^3.1.5":
+  version: 3.2.0
+  resolution: "@react-aria/color@npm:3.2.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/4426ff277e32802c19aea08e53857c27990822a6818360ca04f3c48d65511bf1d96bac9eab51f7691e26e4db4ab5c20ef6ba80a1c1944071faaed965a883cb81
+  languageName: node
+  linkType: hard
+
+"@react-aria/combobox@npm:^3.15.0, @react-aria/combobox@npm:^3.16.0":
+  version: 3.16.0
+  resolution: "@react-aria/combobox@npm:3.16.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/fc03d0027d7815bb6947af6dbec0d7e26df0ad59043a2ad15ad7d240e1e4884b0d72799387a6853a2d4be4e451f05631da965e85abbe91659bafbb6a31417a23
+  languageName: node
+  linkType: hard
+
+"@react-aria/datepicker@npm:^3.16.1":
+  version: 3.17.0
+  resolution: "@react-aria/datepicker@npm:3.17.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/0b1c24c81c0dee8300d70c2c7723e1b3b6af1562e19bc53842eb7ef8734d6fa398ffd8561d800c0c7c86efba5a7eebb0944cf5e5f609395a0f215b845cbdbf88
+  languageName: node
+  linkType: hard
+
+"@react-aria/dialog@npm:^3.5.34":
+  version: 3.6.0
+  resolution: "@react-aria/dialog@npm:3.6.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/62eab83980bcb4cb059ab9784ce7ca21c598c7158af4a46ee39d598702ee775159d26d0231f6b4c4414a4616fe1bddcb165fddd4cceab20e34e7e9876722557c
+  languageName: node
+  linkType: hard
+
+"@react-aria/disclosure@npm:^3.1.3":
+  version: 3.2.0
+  resolution: "@react-aria/disclosure@npm:3.2.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/a12d30d3edee864d7cf352e03609a12584b2e5694fdc10fb9d1bb296c87687662ac7ed1859b90162d07374799adb7d4288781d8aa03500e57533bc3ad8eb7dc8
+  languageName: node
+  linkType: hard
+
+"@react-aria/dnd@npm:^3.11.6":
+  version: 3.12.0
+  resolution: "@react-aria/dnd@npm:3.12.0"
+  dependencies:
+    "@react-types/shared": "npm:^3.34.0"
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/cd20b5eaa674bc454ecdcdb7ee8b8bcb9d50c2c00c79786706b11a37231de672e488260d3332b0865230586c412deeb7e5304afc9c4cca5db1b4e36c108b85a4
+  languageName: node
+  linkType: hard
+
+"@react-aria/focus@npm:^3.21.5":
+  version: 3.22.0
+  resolution: "@react-aria/focus@npm:3.22.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/6467625ad37e4dd6f16669145f19ef75a44134364bd116959369407f1b3ff309f86fc25610b4e7c3736a1a4befd178112429749fad505b944e11cec25e3847c1
+  languageName: node
+  linkType: hard
+
+"@react-aria/gridlist@npm:^3.14.4":
+  version: 3.15.0
+  resolution: "@react-aria/gridlist@npm:3.15.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/0083871293f2c6389f3e0b5c882e41e431e292b26f0ae1ad00d26b104a992f4fa6896e91e7beb1ea72c792a412fb492b26619fb1eff45a5b76c946117ac050cc
+  languageName: node
+  linkType: hard
+
+"@react-aria/i18n@npm:^3.12.16":
+  version: 3.13.0
+  resolution: "@react-aria/i18n@npm:3.13.0"
+  dependencies:
+    "@internationalized/date": "npm:^3.12.1"
+    "@internationalized/message": "npm:^3.1.9"
+    "@internationalized/string": "npm:^3.2.8"
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/8782cc79e7cc4071c61a35876afb7c01126c6a5db04abd960669d111af63b756f821b6d1b8b42878b25b1925370211ce560ae71f09f37ad05b5999e694f0a5de
+  languageName: node
+  linkType: hard
+
+"@react-aria/interactions@npm:^3.27.1":
+  version: 3.28.0
+  resolution: "@react-aria/interactions@npm:3.28.0"
+  dependencies:
+    "@react-types/shared": "npm:^3.34.0"
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/f845180e29ac0607ec16cb85ff4605076c3d8f6de06f6530b3fdec8009272b711c7057af5a7c793851d568ef41626b8fc965cac7a8cee5a043dcf5f27fec2239
+  languageName: node
+  linkType: hard
+
+"@react-aria/label@npm:^3.7.25":
+  version: 3.8.0
+  resolution: "@react-aria/label@npm:3.8.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/23f51686103f0903823ffa0960938678715cfb2b5796daa692b37edae1f44a2f56da740db23498aedb62e4aab82bc09efdc00747d99aff82fb5dadbe698f642b
+  languageName: node
+  linkType: hard
+
+"@react-aria/landmark@npm:^3.0.10":
+  version: 3.1.0
+  resolution: "@react-aria/landmark@npm:3.1.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/a9ade5abf5dc849b79f1847bccf3f293e4f33fcb9cf2ab5f1ce6307afadb5eeb108a61db1ff2f5cd458a74b69c1825dbada2bcb27384da08308a364ddcc64bbc
+  languageName: node
+  linkType: hard
+
+"@react-aria/link@npm:^3.8.9":
+  version: 3.9.0
+  resolution: "@react-aria/link@npm:3.9.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/e66e9a0c7385e7e10e6383fe7b0540e8c335dd5424c2ab6f13363ca0aee67b6c4ffdd0c3265a504090e18f8d18764d668b2bbc64c4f028b58010742e9c320b89
+  languageName: node
+  linkType: hard
+
+"@react-aria/listbox@npm:^3.15.3":
+  version: 3.16.0
+  resolution: "@react-aria/listbox@npm:3.16.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/56a7754fd52d75a312db47548b85410a2bba781d8878ec817f653771afadd37ba5230f3f9a3b653b1a8d6a0df66d54a0e79a62aeab978a8b6e2b0e738b5818f5
+  languageName: node
+  linkType: hard
+
+"@react-aria/live-announcer@npm:^3.4.4":
+  version: 3.5.0
+  resolution: "@react-aria/live-announcer@npm:3.5.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/63682d976483c9b351a8dd2c7ae86bba2ef2d47435b5fdf03ab732297167a75befd4e05bdb2a99c9de5f3985608e4fcaacbd4e822d892222293cfbceb243ddf5
+  languageName: node
+  linkType: hard
+
+"@react-aria/menu@npm:^3.21.0":
+  version: 3.22.0
+  resolution: "@react-aria/menu@npm:3.22.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/f0067984bdc50f8a1aab110a04a27291586b439290d9410bacc57a9aaf154fae73f990da3d1176dab53d14fea807c8d9c01041588f87d49f2df640cf4fb45461
+  languageName: node
+  linkType: hard
+
+"@react-aria/meter@npm:^3.4.30":
+  version: 3.5.0
+  resolution: "@react-aria/meter@npm:3.5.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/1d00a13fd48c07909c559543789803442646e644b66eb4287a90b592ab6d616ac0a7c502e2c4226e9243a713928912acface489c9b5a40422b8e8d90715e954e
+  languageName: node
+  linkType: hard
+
+"@react-aria/numberfield@npm:^3.12.5":
+  version: 3.13.0
+  resolution: "@react-aria/numberfield@npm:3.13.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/2aefb2084a62c182793b3d8daab6a58279ca309270e43c0c28f84bd4ec2833efe47903aa682a2d37c5f7cfc0fa49cfbdf2e195cdf17d1c49a7a708e7b06c8c1b
+  languageName: node
+  linkType: hard
+
+"@react-aria/overlays@npm:^3.31.2":
+  version: 3.32.0
+  resolution: "@react-aria/overlays@npm:3.32.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/88ad62c437d0e82ab5ab1087415be87981f72c805f60400d5f0680fa459c7699d98e2f3464c56043693e1be5f06a71a0e98968003be3d36b4915dd865af370b6
+  languageName: node
+  linkType: hard
+
+"@react-aria/progress@npm:^3.4.30":
+  version: 3.5.0
+  resolution: "@react-aria/progress@npm:3.5.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/f859521e0e570545eb7fbf127fb98880df6a36458cfe3090ae81ff83d6395949343dd7168f062f96ff7882e3a96f7efdf45a2ae98de44e75201538c954e3260c
+  languageName: node
+  linkType: hard
+
+"@react-aria/radio@npm:^3.12.5":
+  version: 3.13.0
+  resolution: "@react-aria/radio@npm:3.13.0"
+  dependencies:
+    "@react-types/shared": "npm:^3.34.0"
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/606133761589b399b6595c0150e0aee977f13f1ea683c44a70b5ed9f2fe4a10d9afd963ed5e4866e15496d08e373bd0c28e9fc9d90eeda84a62be7cb8a584503
+  languageName: node
+  linkType: hard
+
+"@react-aria/searchfield@npm:^3.8.12, @react-aria/searchfield@npm:^3.9.0":
+  version: 3.9.0
+  resolution: "@react-aria/searchfield@npm:3.9.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/fa77c05127fb74cdf9cb7a932a7f173bdac17e66f727d888f401951cc036533217f3a4b5eae165e6f894e4d773b5375f07fe9323535fc2b31a16bf6e214c493f
+  languageName: node
+  linkType: hard
+
+"@react-aria/select@npm:^3.17.3":
+  version: 3.18.0
+  resolution: "@react-aria/select@npm:3.18.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/86c5970a2b8ca3ace57bbe61bdbb8d0c902c406124ef98d9a46cd6c0788ee8e1b2710258da90063338aab3625ef44bedb646f343a2055f2518488c6b310c2f46
+  languageName: node
+  linkType: hard
+
+"@react-aria/selection@npm:^3.27.2":
+  version: 3.28.0
+  resolution: "@react-aria/selection@npm:3.28.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/d453950962a1e99a98366b09b20d825337067a43f3b3aaa787ddbb789489d432eaea904eb96f2348cb78009abfd04b5812685a5aa5fc5410ab5a4d957b4a47b8
+  languageName: node
+  linkType: hard
+
+"@react-aria/separator@npm:^3.4.16":
+  version: 3.5.0
+  resolution: "@react-aria/separator@npm:3.5.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/7ea07475f5c8e8945df5f632dc3c7c0ec58f0939e0d2476379a431805a1b58a8bd9a81d846aa4aa1181bdd2e1e35566382f7447af346add5922a2dd5f2bb3ceb
+  languageName: node
+  linkType: hard
+
+"@react-aria/slider@npm:^3.8.5":
+  version: 3.9.0
+  resolution: "@react-aria/slider@npm:3.9.0"
+  dependencies:
+    "@react-types/shared": "npm:^3.34.0"
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/9eff7183049898f59059c17bcc310256f6cf97996fedbd9a7cf8cc654509e499deb0bf1b0ffb378ded360dfeae57d293c392a1f9725b4b2871ad22367b9f2789
+  languageName: node
+  linkType: hard
+
+"@react-aria/ssr@npm:^3.9.10":
+  version: 3.10.0
+  resolution: "@react-aria/ssr@npm:3.10.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/01ca62df73f382e511958bb34a698aa07ca79d8487cafbe5c4a8a44b8a23e6f6bd2520a0b3af158c2d882e60f97b6d8ee8d7e64c65ff7c72fd7aec6550b59030
+  languageName: node
+  linkType: hard
+
+"@react-aria/switch@npm:^3.7.11":
+  version: 3.8.0
+  resolution: "@react-aria/switch@npm:3.8.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/88d5d23850e0e5faafcea1914b0e52b87772d8d091124f31d2e34363613ea8a927dd11b28df8eb016b7d0cbea643919ba7bf7861ae9d21e6a42ddf81ac5994c5
+  languageName: node
+  linkType: hard
+
+"@react-aria/table@npm:^3.17.11":
+  version: 3.18.0
+  resolution: "@react-aria/table@npm:3.18.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/5b48e52a8795e84dd77e7ba75c9e4c951b641dbe3adafd98f8a30b895a818fc7c83a629f1dff4adf464f89fe17b165b6e4f9d0026a9326793c2a5253e4ba4c9b
+  languageName: node
+  linkType: hard
+
+"@react-aria/tabs@npm:^3.11.1":
+  version: 3.12.0
+  resolution: "@react-aria/tabs@npm:3.12.0"
+  dependencies:
+    "@react-types/shared": "npm:^3.34.0"
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/eb6f83a5beec53b4bd759c612a5469da9871c0a5f65e84dffa43ef4e2e2494f5cbcdaa9042efc755c1c8315f3e9968a98290e88989792d339fcbe4948ac1a933
+  languageName: node
+  linkType: hard
+
+"@react-aria/tag@npm:^3.8.1":
+  version: 3.9.0
+  resolution: "@react-aria/tag@npm:3.9.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/9f3d42db031a8dc1cb1d4fa6ad2d509ba935fe68a706fb3df836019a002399b0e271c935211fd0621617e8aacbb55161ac067a5aad5bf0150da07da2fd79423c
+  languageName: node
+  linkType: hard
+
+"@react-aria/textfield@npm:^3.18.5":
+  version: 3.19.0
+  resolution: "@react-aria/textfield@npm:3.19.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/3b1bd1280ee7419ded0fa692ed39bb021842406acb67b80f51f7437102ec1483a0cedd60197a133c7abd826732a7d3885fc90c83abdb27026ab57b3eaa043dd6
+  languageName: node
+  linkType: hard
+
+"@react-aria/toast@npm:^3.0.11":
+  version: 3.1.0
+  resolution: "@react-aria/toast@npm:3.1.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/23b319202432bfaa57a14a27b81ce66b4eca8d4b15f17d38a92cc530070614babd5b87dc19fb31a42d99f37213300e048c6c1094fcddd2ba946808c235ed783d
+  languageName: node
+  linkType: hard
+
+"@react-aria/toolbar@npm:3.0.0-beta.24":
+  version: 3.0.0-beta.24
+  resolution: "@react-aria/toolbar@npm:3.0.0-beta.24"
+  dependencies:
+    "@react-aria/focus": "npm:^3.21.5"
+    "@react-aria/i18n": "npm:^3.12.16"
+    "@react-aria/utils": "npm:^3.33.1"
+    "@react-types/shared": "npm:^3.33.1"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/04daf89e29c916454721d8b9462e2bfa7e1a883df2f6a3550425bf96fcd969a7bd60cef28da41aa5f24e0a34fa44fc1dd142dcedb7161476dc00aebecc78c398
+  languageName: node
+  linkType: hard
+
+"@react-aria/tooltip@npm:^3.9.2":
+  version: 3.10.0
+  resolution: "@react-aria/tooltip@npm:3.10.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/41865123c7f8d0150a93542c82c1707531b60e8b4e50098ce362f06ba017952301b5b1470c7b17905ce3f6242f5bc09c85d40d021cf0b1b5045fbe7af95e9e57
+  languageName: node
+  linkType: hard
+
+"@react-aria/tree@npm:^3.1.7":
+  version: 3.2.0
+  resolution: "@react-aria/tree@npm:3.2.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/c980b1cf62e7486081922df1ca9f5f429bbf2fd5fd0d1ec82e354847f6a60e4a065c2ecb6c8eeb00142ec90256f2a83a7c129b4ecdfff2d03f1649a5aa8f8547
+  languageName: node
+  linkType: hard
+
+"@react-aria/utils@npm:^3.33.1":
+  version: 3.34.0
+  resolution: "@react-aria/utils@npm:3.34.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/55a120c1b33510bd18154128f8e6c7ca17de38d3950e474c92d2cd154f01c2db9c3248103d6183330f8793db47a138e02fb40ce1763736aea469f3a15d673de9
+  languageName: node
+  linkType: hard
+
+"@react-aria/virtualizer@npm:^4.1.13":
+  version: 4.2.0
+  resolution: "@react-aria/virtualizer@npm:4.2.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/ffa75f2c514a5bea2def1207ee29924e930e3fb54a766d982e7bf352d3e67b9e47e652dbb25d9f926d9db01f76dc7efc34c1e04c9769327a9328bd9e1ec992b3
+  languageName: node
+  linkType: hard
+
+"@react-aria/visually-hidden@npm:^3.8.31":
+  version: 3.9.0
+  resolution: "@react-aria/visually-hidden@npm:3.9.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-aria: "npm:3.48.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/78335fe835c7470e3aea33ab22b47589cfe8670788f8af06813cfd7886d99bd12cbdc4db842896afa143d9f9795623e8fcfbe02125fad9cff28b1669f68199a1
+  languageName: node
+  linkType: hard
+
 "@react-hookz/deep-equal@npm:^1.0.4":
   version: 1.0.4
   resolution: "@react-hookz/deep-equal@npm:1.0.4"
@@ -15375,12 +16091,567 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-types/shared@npm:^3.34.0":
+"@react-spectrum/button@npm:^3.18.0":
+  version: 3.18.0
+  resolution: "@react-spectrum/button@npm:3.18.0"
+  dependencies:
+    "@adobe/react-spectrum": "npm:3.47.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/01831e8c57a862c1fc1766fabd19dc3285d029aa44bc07842f264b15a846391fdaec4e707350641de74f6e817f74f578ec72ebe81d481ca86dc10709147d3563
+  languageName: node
+  linkType: hard
+
+"@react-spectrum/combobox@npm:^3.17.0":
+  version: 3.17.0
+  resolution: "@react-spectrum/combobox@npm:3.17.0"
+  dependencies:
+    "@adobe/react-spectrum": "npm:3.47.0"
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/b32efcaece9d33a009fce5b36c97492bd99940fcd542b8193bcd15ac5af40a88a5021b53a9daf89cbd10fce4a016df601bf49f735cdd53c5f45fe382cb170d4f
+  languageName: node
+  linkType: hard
+
+"@react-spectrum/form@npm:^3.8.0":
+  version: 3.8.0
+  resolution: "@react-spectrum/form@npm:3.8.0"
+  dependencies:
+    "@adobe/react-spectrum": "npm:3.47.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/81178345d479cd7ebf8887d073570dcb72173c85091c0807c0b6bcc4fca0a0c46b84f06ff28753219b3aa4b7c96b1a622aa53db38bbde07ca84f08987fe6fec3
+  languageName: node
+  linkType: hard
+
+"@react-spectrum/searchfield@npm:^3.9.0":
+  version: 3.9.0
+  resolution: "@react-spectrum/searchfield@npm:3.9.0"
+  dependencies:
+    "@adobe/react-spectrum": "npm:3.47.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/9bdbaa47badcdba0705f7517fe3435cd46edc26432e2581152ef204546ca40222b8be511935f00cdcfaff8afd42a20557c4bc02c29cfc3913f0d6d8ac2faf18f
+  languageName: node
+  linkType: hard
+
+"@react-spectrum/table@npm:^3.18.0":
+  version: 3.18.0
+  resolution: "@react-spectrum/table@npm:3.18.0"
+  dependencies:
+    "@adobe/react-spectrum": "npm:3.47.0"
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/169131ef935b5d6103c24c45bee46c9cac59378cff49ff6636f3c68cfb71afe698a957c49439ea3b3b5f541c8e3f9948199956d5f7f61bf1666722a57e356707
+  languageName: node
+  linkType: hard
+
+"@react-stately/autocomplete@npm:3.0.0-beta.4":
+  version: 3.0.0-beta.4
+  resolution: "@react-stately/autocomplete@npm:3.0.0-beta.4"
+  dependencies:
+    "@react-stately/utils": "npm:^3.11.0"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/482a58cd5753df054edb27bf308d3922da2c7757c4e2227cefda3806ae2eb14ad771a7d3741eb57c00cee3e8c3cb4fc1c81006c2e920d64b18330f533043ba2a
+  languageName: node
+  linkType: hard
+
+"@react-stately/calendar@npm:^3.9.3":
+  version: 3.10.0
+  resolution: "@react-stately/calendar@npm:3.10.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/ceec2c2fa2ec11fb830c05040b36ac9762553083a359cd1813abe65ac3523facc10f4e1ff90fd3b0a320c10b11a56bd1be576b2630f4dbcc238d84accb9e70f8
+  languageName: node
+  linkType: hard
+
+"@react-stately/checkbox@npm:^3.7.5":
+  version: 3.8.0
+  resolution: "@react-stately/checkbox@npm:3.8.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/97398cbd2b439b2f3a1fadfdbdff345afe56979494f6cb1e01b2f7ad4e3a14f4b078751abd32a12d6653689e327f274d477d9dcbda63dff11bd8f4bab8887331
+  languageName: node
+  linkType: hard
+
+"@react-stately/collections@npm:^3.12.10":
+  version: 3.13.0
+  resolution: "@react-stately/collections@npm:3.13.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/0e19a1416e1055bea94962adb4579dac36d0cd71447354ead5b7c6625b01a7c7ad7134d570feedbcee3cb81e8902baaf8bf8f75192d92c09a864843a1a6a38e8
+  languageName: node
+  linkType: hard
+
+"@react-stately/color@npm:^3.9.5":
+  version: 3.10.0
+  resolution: "@react-stately/color@npm:3.10.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/c71051598d680e7f1bd0586f4c033c9404381f708ed336de44867a6561b7a709ebc7a2cd3f378ee6f618cd9ba08dbc6f5ba90b46a53178f6748e803cbeb19953
+  languageName: node
+  linkType: hard
+
+"@react-stately/combobox@npm:^3.13.0, @react-stately/combobox@npm:^3.14.0":
+  version: 3.14.0
+  resolution: "@react-stately/combobox@npm:3.14.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/c22f8fa85fcc6aee30d8aa3136bb1cfe4ed588482f3cc8e155db22aafd13b12160d397c431008b72bd87e153bdbef9cd033bfe12651ee3987df247919b84fa36
+  languageName: node
+  linkType: hard
+
+"@react-stately/data@npm:^3.15.2":
+  version: 3.16.0
+  resolution: "@react-stately/data@npm:3.16.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/59dd5d37f82accee0deceb78c07086ce2ad584a448651db5ef75816beb912da458110f097ff4f8458fe1d2773cd3103d64c7caf1cbdb13c2e2458b9df417804d
+  languageName: node
+  linkType: hard
+
+"@react-stately/datepicker@npm:^3.16.1":
+  version: 3.17.0
+  resolution: "@react-stately/datepicker@npm:3.17.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/bd84b1e7d6ba0374121878b9b42d34ab0fb4d8549d04a68261318bc602a969f36d9495ab757d9cbc0cb75cd180d7c273a43920f1e8721993ea644595214bb299
+  languageName: node
+  linkType: hard
+
+"@react-stately/disclosure@npm:^3.0.11":
+  version: 3.1.0
+  resolution: "@react-stately/disclosure@npm:3.1.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/d902e3ce25aa0c987b5ff4fabb4a281290cc6a3a42f6c849fde15109888a4fe5d3e5a8e447b77b1e81d574539ee242189fced306bd57a8fcfe33ead8024b53d8
+  languageName: node
+  linkType: hard
+
+"@react-stately/dnd@npm:^3.7.4":
+  version: 3.8.0
+  resolution: "@react-stately/dnd@npm:3.8.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/497a7df554a6421a69116c260a0bb00112bdcad18f422ced13097b8185a69acf0768a3917f2157e914ff0285564e720c995b829ce65f6bffb759663ac14c484d
+  languageName: node
+  linkType: hard
+
+"@react-stately/form@npm:^3.2.4":
+  version: 3.3.0
+  resolution: "@react-stately/form@npm:3.3.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/765405fd926c7cd379c8157a7b2a8bf5fb8af292321691ec11e5f01029701a439b875a841a4cc0b35aa8c47f1ac172b3e93a0b03589a3e437c8d0347bf90850f
+  languageName: node
+  linkType: hard
+
+"@react-stately/grid@npm:^3.12.0":
+  version: 3.12.0
+  resolution: "@react-stately/grid@npm:3.12.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/c86335070644fc1547bf0a8abd002a1a66ec6c86b947cfbe241f4543fc2d42719a17f85bc2ccef52b821641f473848922d17eada9c91c17609f5025c6e1b89a9
+  languageName: node
+  linkType: hard
+
+"@react-stately/layout@npm:^4.6.0":
+  version: 4.7.0
+  resolution: "@react-stately/layout@npm:4.7.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/c8bd96dd798be3e8ea8138ded259f09ab343ce8719c8378381e84eaa3fb06f14dab64928971fd5d37096788eefa6a66f1a4114ac58aed935ad6d68e006334a22
+  languageName: node
+  linkType: hard
+
+"@react-stately/list@npm:^3.13.4":
+  version: 3.14.0
+  resolution: "@react-stately/list@npm:3.14.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/79f0be2e87ca808520a585b17c8a08c259ee7b95dbae431e1bf49656873c012c61a71c93608176257648a651905f28c8f2d9868c16868ca4945ee6ed3fbcd505
+  languageName: node
+  linkType: hard
+
+"@react-stately/menu@npm:^3.9.11":
+  version: 3.10.0
+  resolution: "@react-stately/menu@npm:3.10.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/354ff6fd8c2d391ffa79b0e39ea8ad1479182d3370ad3b58d3879194090abed01e5bdca7e3b984b56cd7887b87c61e688aee8d4399bf4b507ca872972ade66cc
+  languageName: node
+  linkType: hard
+
+"@react-stately/numberfield@npm:^3.11.0":
+  version: 3.12.0
+  resolution: "@react-stately/numberfield@npm:3.12.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/7145952e4b225e30e30810631804772443fc211320284ddc603196abdf94a781cc7ab6ee9387e285d792abaaffbdfb944c457ecd280ce9c720a592c85afd5e62
+  languageName: node
+  linkType: hard
+
+"@react-stately/overlays@npm:^3.6.23":
+  version: 3.7.0
+  resolution: "@react-stately/overlays@npm:3.7.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/c50b401fbe66949e47bc620bf89ed0636c3217e51cbd7f3fb6b2b1af204c3e92c0a8f2c969d3cf5890d1637cb41fd28a5582b7cec07425bc7d982a7bf6430d29
+  languageName: node
+  linkType: hard
+
+"@react-stately/radio@npm:^3.11.5":
+  version: 3.12.0
+  resolution: "@react-stately/radio@npm:3.12.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/66c3a42d6ed6dcedfbc84b3964f3207b65565251c6639e6fee597f6773c3a5ba36f574ca6ce09b35b68c3acce48a555d97fe91aff1e61849091fae669848e8ca
+  languageName: node
+  linkType: hard
+
+"@react-stately/searchfield@npm:^3.5.19, @react-stately/searchfield@npm:^3.6.0":
+  version: 3.6.0
+  resolution: "@react-stately/searchfield@npm:3.6.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/36106af2d94665822db952d51ca4e1c4e40b118b70aa3f96f0c4211de8f062e3a21a3e0c2f8d734f03013dbc5a3c94c29f96d504ca3ffa4e7faa396c2d65df30
+  languageName: node
+  linkType: hard
+
+"@react-stately/select@npm:^3.9.2":
+  version: 3.10.0
+  resolution: "@react-stately/select@npm:3.10.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/14e4235e9b159ce43dda851eceb7707ec060603d8da1fc2bbef13ed0adb7f406e7656051ef5d3b3bc9b94054aee6e7215bdea5c44d7fd7ae6a28b6a8f44459a7
+  languageName: node
+  linkType: hard
+
+"@react-stately/selection@npm:^3.20.9":
+  version: 3.21.0
+  resolution: "@react-stately/selection@npm:3.21.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/8b3a26e32075e8233d70be8c6002e9b1ae4a6dfd59e05ff8e3a0cb3acfade3ea1c603c4eb6742b10996b657cd5ed2e3b523394f57c0941151282d327204ebd29
+  languageName: node
+  linkType: hard
+
+"@react-stately/slider@npm:^3.7.5":
+  version: 3.8.0
+  resolution: "@react-stately/slider@npm:3.8.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/eaaeb280e7738ad1fb3e8343535a6a01dc353cb4cb1efee06bb35bb0e56111f45a1ccf2fe744922267f2c3eb6687e26fbe5d73adcc3f2f4221b0c8b205397bdc
+  languageName: node
+  linkType: hard
+
+"@react-stately/table@npm:^3.15.4, @react-stately/table@npm:^3.16.0":
+  version: 3.16.0
+  resolution: "@react-stately/table@npm:3.16.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/383d4e525b71a2b6d5be7a0ac5454e5b81381fb65acbe87041ddcb49fb91d26cd2c607d9de51180fb7acdfeedc75f3c4fc9b981e77c5179317fdca9c04313095
+  languageName: node
+  linkType: hard
+
+"@react-stately/tabs@npm:^3.8.9":
+  version: 3.9.0
+  resolution: "@react-stately/tabs@npm:3.9.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/9d69a4a858ec1130df9fc662d43a3a5a6fddcf94ac89a3831169042b4dfebff98cb9ff9b1a1c088543c197e99d2cfc828b4ae549f1024e64f3e4cf82e383eb38
+  languageName: node
+  linkType: hard
+
+"@react-stately/toast@npm:^3.1.3":
+  version: 3.2.0
+  resolution: "@react-stately/toast@npm:3.2.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/22b4665d6b0f1dae49106fcbde4344f9c92e1685f242c5eae933105771f9f97b4180805eba43b30f712daa2f6f723d2d678bf88db51185dd55ac4607a63ad892
+  languageName: node
+  linkType: hard
+
+"@react-stately/toggle@npm:^3.9.5":
+  version: 3.10.0
+  resolution: "@react-stately/toggle@npm:3.10.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/07cfecff3f4e93b0f37a1373d0a44aa4a7c2523c1f6c7f6fde0576ccd5a463d6276a959ccee3752dce16a2a7d86780521b86193f6e1f5ed616d8f03fa9f072d9
+  languageName: node
+  linkType: hard
+
+"@react-stately/tooltip@npm:^3.5.11":
+  version: 3.6.0
+  resolution: "@react-stately/tooltip@npm:3.6.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/6f7cd9d791a83b79ac9b77bc6f547b4e296cdc7f7a96d17507f905e7c331aec5ed912f708fc522405e014757d915e5f35fea12169554100b22fa013afdd3fa08
+  languageName: node
+  linkType: hard
+
+"@react-stately/tree@npm:^3.9.6":
+  version: 3.10.0
+  resolution: "@react-stately/tree@npm:3.10.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/dba19d783a51908526799aa34c7ed72f09614bfc5796f13387dafdeb011f5b855d4100d764040ed765f3ced03c7c80f6ac73d64312347042d593f575b506dce4
+  languageName: node
+  linkType: hard
+
+"@react-stately/utils@npm:^3.11.0":
+  version: 3.12.0
+  resolution: "@react-stately/utils@npm:3.12.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/6190977e056edc1603fd34459ee065a4bc11d381443ff50de48133606233420afa2ce068f7dabef0edc92aefb80ca10d1a055a52167fe8fae5761a54580c230d
+  languageName: node
+  linkType: hard
+
+"@react-stately/virtualizer@npm:^4.4.6":
+  version: 4.5.0
+  resolution: "@react-stately/virtualizer@npm:4.5.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+    react-stately: "npm:3.46.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/1b8d22d266e4f733d45f62b3fd428e3e7af9d61d4bcc8fe6425f529571d32d2ea0695b4169dd14617221dda9f7a58d279ac00ceca4fa7a2611c746a3ea0f4559
+  languageName: node
+  linkType: hard
+
+"@react-types/autocomplete@npm:3.0.0-alpha.38":
+  version: 3.0.0-alpha.38
+  resolution: "@react-types/autocomplete@npm:3.0.0-alpha.38"
+  dependencies:
+    "@react-types/combobox": "npm:^3.14.0"
+    "@react-types/searchfield": "npm:^3.6.8"
+    "@react-types/shared": "npm:^3.33.1"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/4134c885eb90bf73b268fa5d8ed67f076ab0eccd76843c530665e1dcc1063bbb5d7ac1a88a57e2cd4866f90c908e90f5d1d9b51753873b5e3d432ab2a3403d51
+  languageName: node
+  linkType: hard
+
+"@react-types/button@npm:^3.15.1":
+  version: 3.16.0
+  resolution: "@react-types/button@npm:3.16.0"
+  dependencies:
+    "@react-aria/button": "npm:^3.15.0"
+    "@react-spectrum/button": "npm:^3.18.0"
+  peerDependencies:
+    "@react-spectrum/provider": ^3.0.0
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/c2bbbbd9f7a0e8899d527b7416d477f709073ce9b1fdfae4c1bbc9e89e9b8cac957ca490ca5527cb0a81c61e14be54c0483b2c9c4b1d74935164b1ec00d7e92e
+  languageName: node
+  linkType: hard
+
+"@react-types/combobox@npm:^3.14.0":
+  version: 3.15.0
+  resolution: "@react-types/combobox@npm:3.15.0"
+  dependencies:
+    "@react-aria/combobox": "npm:^3.16.0"
+    "@react-spectrum/combobox": "npm:^3.17.0"
+    "@react-stately/combobox": "npm:^3.14.0"
+  peerDependencies:
+    "@react-spectrum/provider": ^3.0.0
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/dce9cacfc6771e3c917bb58adffaae9a299ba6e17dbab59c3f66deffd231df38dd1b0ebec997e8f593bca4d02289f6e8a6c9eab7f0fa86c10712db074480c769
+  languageName: node
+  linkType: hard
+
+"@react-types/form@npm:^3.7.18":
+  version: 3.8.0
+  resolution: "@react-types/form@npm:3.8.0"
+  dependencies:
+    "@react-spectrum/form": "npm:^3.8.0"
+    "@react-types/shared": "npm:^3.34.0"
+  peerDependencies:
+    "@react-spectrum/provider": ^3.0.0
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/b7ae09fb10b0df5df58fdcd2eda8879ee48a54d060b32504e2d728477274f1ca243d0988196fd0af7655c9b6a58c66a26daf0a116e90bfbce945412a5b50d681
+  languageName: node
+  linkType: hard
+
+"@react-types/grid@npm:^3.3.8":
+  version: 3.4.0
+  resolution: "@react-types/grid@npm:3.4.0"
+  dependencies:
+    "@react-stately/grid": "npm:^3.12.0"
+  peerDependencies:
+    "@react-spectrum/provider": ^3.0.0
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/4db7eaedc00646f18a8074f5884f3623598291d25b88bcb795dacd100bf7e2520f63bc7ac4b3cd9018d6bd5b3b6b1566668628f7ea186ef6b9916785a5368756
+  languageName: node
+  linkType: hard
+
+"@react-types/searchfield@npm:^3.6.8":
+  version: 3.7.0
+  resolution: "@react-types/searchfield@npm:3.7.0"
+  dependencies:
+    "@react-aria/searchfield": "npm:^3.9.0"
+    "@react-spectrum/searchfield": "npm:^3.9.0"
+    "@react-stately/searchfield": "npm:^3.6.0"
+  peerDependencies:
+    "@react-spectrum/provider": ^3.0.0
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/7ad57aaf17ce4b5a6b5c7bd1720d2dc7a305551c7e6d7c50d2507ba68182ce7315d819bf54211ead510ea6df0cc123df537218193a0d51373cfca8f825da0a3a
+  languageName: node
+  linkType: hard
+
+"@react-types/shared@npm:^3.33.1, @react-types/shared@npm:^3.34.0":
   version: 3.34.0
   resolution: "@react-types/shared@npm:3.34.0"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
   checksum: 10/d28b0a3a3f68f94167fd7b4f474803430093b1a31f5f50cef6ddd755b923ba3af35dde40ffcc1f320926892744823a039b4a396c671f7c59aa49634811f0c43a
+  languageName: node
+  linkType: hard
+
+"@react-types/table@npm:^3.13.6":
+  version: 3.14.0
+  resolution: "@react-types/table@npm:3.14.0"
+  dependencies:
+    "@react-spectrum/table": "npm:^3.18.0"
+    "@react-stately/table": "npm:^3.16.0"
+    "@react-types/shared": "npm:^3.34.0"
+  peerDependencies:
+    "@react-spectrum/provider": ^3.0.0
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/df3944c12ba409188332db75a7b5c376452fe5ef8d594e39202790f298bff1f3d9aa582f180460477d6a2eced177306c9722f50ba608e53bedc2de5ccf090ad4
   languageName: node
   linkType: hard
 
@@ -17312,6 +18583,35 @@ __metadata:
     color: "npm:^5.0.2"
     text-hex: "npm:1.0.x"
   checksum: 10/fc3285e5cb9a458d255aa678d9453174ca40689a4c692f1617907996ab8eb78839542439604ced484c4f674a5297f7ba8b0e63fcfe901174f43c3d9c3c881b52
+  languageName: node
+  linkType: hard
+
+"@spectrum-icons/ui@npm:^3.7.0":
+  version: 3.7.0
+  resolution: "@spectrum-icons/ui@npm:3.7.0"
+  dependencies:
+    "@adobe/react-spectrum-ui": "npm:1.2.1"
+    "@babel/runtime": "npm:^7.24.4"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    "@adobe/react-spectrum": ^3.47.0
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/50c0c14a5be2b057bf68d60e61e3c4608f4ce22cbbe7da5d519e99cd32f60a550ca6e04a507f18f7cb8f02cb0b3c93f45cdac91f3e0b9aaa26c35b292ec10325
+  languageName: node
+  linkType: hard
+
+"@spectrum-icons/workflow@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "@spectrum-icons/workflow@npm:4.3.0"
+  dependencies:
+    "@adobe/react-spectrum-workflow": "npm:2.3.5"
+    "@swc/helpers": "npm:^0.5.0"
+  peerDependencies:
+    "@adobe/react-spectrum": ^3.47.0
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/0d4b2d03e92684aa8d74b1d313f9b39b3ad55aba90eea2993e06edc2b076866332b5a4175a2d4184b14020ba3672f377ecb64c6ba399272c3c530435e47c0774
   languageName: node
   linkType: hard
 
@@ -32474,6 +33774,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"intl-messageformat@npm:^10.1.0":
+  version: 10.7.18
+  resolution: "intl-messageformat@npm:10.7.18"
+  dependencies:
+    "@formatjs/ecma402-abstract": "npm:2.3.6"
+    "@formatjs/fast-memoize": "npm:2.2.7"
+    "@formatjs/icu-messageformat-parser": "npm:2.11.4"
+    tslib: "npm:^2.8.0"
+  checksum: 10/96650d673912763d21bbfa14b50749b992d45f1901092a020e3155961e3c70f4644dd1731c3ecb1207a1eb94d84bedf4c34b1ac8127c29ad6b015b6a2a4045cb
+  languageName: node
+  linkType: hard
+
 "into-stream@npm:^6.0.0":
   version: 6.0.0
   resolution: "into-stream@npm:6.0.0"
@@ -41515,7 +42827,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-aria-components@npm:^1.14.0, react-aria-components@npm:^1.17.0":
+"react-aria-components@npm:1.17.0":
   version: 1.17.0
   resolution: "react-aria-components@npm:1.17.0"
   dependencies:
@@ -41532,7 +42844,47 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-aria@npm:3.48.0, react-aria@npm:^3.48.0":
+"react-aria-components@npm:~1.16.0":
+  version: 1.16.0
+  resolution: "react-aria-components@npm:1.16.0"
+  dependencies:
+    "@internationalized/date": "npm:^3.12.0"
+    "@internationalized/string": "npm:^3.2.7"
+    "@react-aria/autocomplete": "npm:3.0.0-rc.6"
+    "@react-aria/collections": "npm:^3.0.3"
+    "@react-aria/dnd": "npm:^3.11.6"
+    "@react-aria/focus": "npm:^3.21.5"
+    "@react-aria/interactions": "npm:^3.27.1"
+    "@react-aria/live-announcer": "npm:^3.4.4"
+    "@react-aria/overlays": "npm:^3.31.2"
+    "@react-aria/ssr": "npm:^3.9.10"
+    "@react-aria/textfield": "npm:^3.18.5"
+    "@react-aria/toolbar": "npm:3.0.0-beta.24"
+    "@react-aria/utils": "npm:^3.33.1"
+    "@react-aria/virtualizer": "npm:^4.1.13"
+    "@react-stately/autocomplete": "npm:3.0.0-beta.4"
+    "@react-stately/layout": "npm:^4.6.0"
+    "@react-stately/selection": "npm:^3.20.9"
+    "@react-stately/table": "npm:^3.15.4"
+    "@react-stately/utils": "npm:^3.11.0"
+    "@react-stately/virtualizer": "npm:^4.4.6"
+    "@react-types/form": "npm:^3.7.18"
+    "@react-types/grid": "npm:^3.3.8"
+    "@react-types/shared": "npm:^3.33.1"
+    "@react-types/table": "npm:^3.13.6"
+    "@swc/helpers": "npm:^0.5.0"
+    client-only: "npm:^0.0.1"
+    react-aria: "npm:^3.47.0"
+    react-stately: "npm:^3.45.0"
+    use-sync-external-store: "npm:^1.6.0"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/091ff728a31b703e2a0c9218fab9486c797773054676380080b050c5af4afb614c9822c3cf08b7f932acec8eed4cd0b04fad7ac78cb782827e8352851dc50220
+  languageName: node
+  linkType: hard
+
+"react-aria@npm:3.48.0, react-aria@npm:^3.47.0":
   version: 3.48.0
   resolution: "react-aria@npm:3.48.0"
   dependencies:
@@ -41549,6 +42901,59 @@ __metadata:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
     react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
   checksum: 10/e70ba3a21f99967daffcb7399e6c4cc33fe9ae0ba4b13216ac3fbc150f37416d882b68ecd52f3c59852b87ef61a1c4b184066083d699d5afda1ad8b38fab8b99
+  languageName: node
+  linkType: hard
+
+"react-aria@npm:~3.47.0":
+  version: 3.47.0
+  resolution: "react-aria@npm:3.47.0"
+  dependencies:
+    "@internationalized/string": "npm:^3.2.7"
+    "@react-aria/breadcrumbs": "npm:^3.5.32"
+    "@react-aria/button": "npm:^3.14.5"
+    "@react-aria/calendar": "npm:^3.9.5"
+    "@react-aria/checkbox": "npm:^3.16.5"
+    "@react-aria/color": "npm:^3.1.5"
+    "@react-aria/combobox": "npm:^3.15.0"
+    "@react-aria/datepicker": "npm:^3.16.1"
+    "@react-aria/dialog": "npm:^3.5.34"
+    "@react-aria/disclosure": "npm:^3.1.3"
+    "@react-aria/dnd": "npm:^3.11.6"
+    "@react-aria/focus": "npm:^3.21.5"
+    "@react-aria/gridlist": "npm:^3.14.4"
+    "@react-aria/i18n": "npm:^3.12.16"
+    "@react-aria/interactions": "npm:^3.27.1"
+    "@react-aria/label": "npm:^3.7.25"
+    "@react-aria/landmark": "npm:^3.0.10"
+    "@react-aria/link": "npm:^3.8.9"
+    "@react-aria/listbox": "npm:^3.15.3"
+    "@react-aria/menu": "npm:^3.21.0"
+    "@react-aria/meter": "npm:^3.4.30"
+    "@react-aria/numberfield": "npm:^3.12.5"
+    "@react-aria/overlays": "npm:^3.31.2"
+    "@react-aria/progress": "npm:^3.4.30"
+    "@react-aria/radio": "npm:^3.12.5"
+    "@react-aria/searchfield": "npm:^3.8.12"
+    "@react-aria/select": "npm:^3.17.3"
+    "@react-aria/selection": "npm:^3.27.2"
+    "@react-aria/separator": "npm:^3.4.16"
+    "@react-aria/slider": "npm:^3.8.5"
+    "@react-aria/ssr": "npm:^3.9.10"
+    "@react-aria/switch": "npm:^3.7.11"
+    "@react-aria/table": "npm:^3.17.11"
+    "@react-aria/tabs": "npm:^3.11.1"
+    "@react-aria/tag": "npm:^3.8.1"
+    "@react-aria/textfield": "npm:^3.18.5"
+    "@react-aria/toast": "npm:^3.0.11"
+    "@react-aria/tooltip": "npm:^3.9.2"
+    "@react-aria/tree": "npm:^3.1.7"
+    "@react-aria/utils": "npm:^3.33.1"
+    "@react-aria/visually-hidden": "npm:^3.8.31"
+    "@react-types/shared": "npm:^3.33.1"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+    react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/9afb9079939553d222c09630fd8e59949c586a716500a79298fff0f5c830a6f1c83dc017a74811c42f5606ddae4d1f4f1e724c803d70c073cd5598b5eb07140e
   languageName: node
   linkType: hard
 
@@ -42168,7 +43573,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-stately@npm:3.46.0, react-stately@npm:^3.46.0":
+"react-stately@npm:3.46.0, react-stately@npm:^3.45.0":
   version: 3.46.0
   resolution: "react-stately@npm:3.46.0"
   dependencies:
@@ -42181,6 +43586,42 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
   checksum: 10/ee2d8b0633c6ba82eb159197ddaaeb0832d318c6ed1304c7e14273d0c3dc3156c48aef0c8cf4207481dbca1cf054c6726c42c089259605213d1f08f35bebf321
+  languageName: node
+  linkType: hard
+
+"react-stately@npm:~3.45.0":
+  version: 3.45.0
+  resolution: "react-stately@npm:3.45.0"
+  dependencies:
+    "@react-stately/calendar": "npm:^3.9.3"
+    "@react-stately/checkbox": "npm:^3.7.5"
+    "@react-stately/collections": "npm:^3.12.10"
+    "@react-stately/color": "npm:^3.9.5"
+    "@react-stately/combobox": "npm:^3.13.0"
+    "@react-stately/data": "npm:^3.15.2"
+    "@react-stately/datepicker": "npm:^3.16.1"
+    "@react-stately/disclosure": "npm:^3.0.11"
+    "@react-stately/dnd": "npm:^3.7.4"
+    "@react-stately/form": "npm:^3.2.4"
+    "@react-stately/list": "npm:^3.13.4"
+    "@react-stately/menu": "npm:^3.9.11"
+    "@react-stately/numberfield": "npm:^3.11.0"
+    "@react-stately/overlays": "npm:^3.6.23"
+    "@react-stately/radio": "npm:^3.11.5"
+    "@react-stately/searchfield": "npm:^3.5.19"
+    "@react-stately/select": "npm:^3.9.2"
+    "@react-stately/selection": "npm:^3.20.9"
+    "@react-stately/slider": "npm:^3.7.5"
+    "@react-stately/table": "npm:^3.15.4"
+    "@react-stately/tabs": "npm:^3.8.9"
+    "@react-stately/toast": "npm:^3.1.3"
+    "@react-stately/toggle": "npm:^3.9.5"
+    "@react-stately/tooltip": "npm:^3.5.11"
+    "@react-stately/tree": "npm:^3.9.6"
+    "@react-types/shared": "npm:^3.33.1"
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+  checksum: 10/5a34d8832b3867e06582bba57dbfd5dfbacd2ee7489ab8fa21ff25d6f0716e9fbf018d2390d5c5af62b99d53f3100c703b372234b0421934a3910e3160ec8d4a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Replaces the previous attempt that went in the wrong direction.

This pins all React Aria family dependencies (`react-aria`, `react-aria-components`, `react-stately`) to tilde ranges targeting the v1.16.0 release line. React Aria doesn't strictly follow semver and has shipped breaking changes in minor releases, so this makes sure we only pick up patch-level updates automatically.

Affected packages:
- `@backstage/ui` — `react-aria` ~3.47.0, `react-aria-components` ~1.16.0, `react-stately` ~3.45.0
- `@backstage/plugin-app` — `react-aria` ~3.47.0, `react-stately` ~3.45.0
- `@backstage/plugin-app-visualizer` — `react-aria-components` ~1.16.0
- `@backstage/plugin-notifications` — `react-aria-components` ~1.16.0

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))