### PR TITLE
patches: add entry for #33975

### DIFF
--- a/.patches/pr-33975.txt
+++ b/.patches/pr-33975.txt
@@ -1,0 +1,1 @@
+Clamp React Aria dependency ranges to patch-only updates to prevent unintended minor version upgrades


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds a `.patches` entry for #33975, to include the React Aria dependency range clamping fix in the next patch release.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))