### PR TITLE
fix(ui): keep Tabs active indicator visible on uncontrolled tabs

### DIFF
--- a/.changeset/fix-tabs-active-indicator-disappearing.md
+++ b/.changeset/fix-tabs-active-indicator-disappearing.md
@@ -1,0 +1,7 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed an issue where the active tab indicator would disappear shortly after page load for uncontrolled Tabs.
+
+**Affected components:** Tabs

--- a/.patches/pr-33984.txt
+++ b/.patches/pr-33984.txt
@@ -1,0 +1,1 @@
+Fix active tab indicator disappearing on uncontrolled Tabs in @backstage/ui

--- a/packages/ui/src/components/Tabs/TabsIndicators.tsx
+++ b/packages/ui/src/components/Tabs/TabsIndicators.tsx
@@ -32,6 +32,12 @@ export const TabsIndicators = (props: TabsIndicatorsProps) => {
   const prevSelectedKey = useRef<string | null>(null);
 
   const updateCSSVariables = useCallback(() => {
+    // When rendered inside CollectionBuilder's hidden tree (for collection
+    // building), there is no TabListStateContext provider, so state is null.
+    // Bail out to avoid overwriting CSS variables on the shared tabsRef DOM
+    // element that the real instance also writes to.
+    if (state == null) return;
+
     if (!tabsRef.current) return;
 
     const tabsRect = tabsRef.current.getBoundingClientRect();


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes a bug where the active tab indicator on uncontrolled `<Tabs>` (no `href` props) briefly appears on page load and then disappears, only coming back on hover.

React Aria's `CollectionBuilder` renders `TabList`'s children into both a hidden collection-building tree and the real DOM. The hidden `TabsIndicators` instance sits outside the `TabListStateContext` provider, so its `state` is `null` — its `updateCSSVariables` effect takes the `else` branch and writes `--active-tab-opacity: 0` to the `tabsRef` DOM element that the real instance also writes to. Under the right render ordering, the hidden write lands after the real instance's `opacity: 1` and hides the indicator.

Fix: guard `updateCSSVariables` with an early return when `state == null` so the hidden instance never writes to the shared DOM element.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.