### PR TITLE
catalog-client: use POST endpoint for getEntities

### DIFF
--- a/.changeset/catalog-client-getentities-via-post.md
+++ b/.changeset/catalog-client-getentities-via-post.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-client': patch
+---
+
+The `getEntities` method now uses the `POST /entities/by-query` endpoint instead of `GET /entities`, avoiding request URL size limits when filters or other parameters are large. When the legacy `after` cursor parameter is provided, the old `GET /entities` endpoint is still used as a fallback.

--- a/packages/catalog-client/src/CatalogClient.test.ts
+++ b/packages/catalog-client/src/CatalogClient.test.ts
@@ -18,11 +18,7 @@ import { Entity } from '@backstage/catalog-model';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { CatalogClient } from './CatalogClient';
-import {
-  CATALOG_FILTER_EXISTS,
-  GetEntitiesResponse,
-  QueryEntitiesResponse,
-} from './types/api';
+import { CATALOG_FILTER_EXISTS, QueryEntitiesResponse } from './types/api';
 import { DiscoveryApi } from './types/discovery';
 import { GetLocations200ResponseInner } from './schema/openapi';
 
@@ -65,37 +61,31 @@ describe('CatalogClient', () => {
         },
       },
     ];
-    const defaultResponse: GetEntitiesResponse = {
-      items: defaultServiceResponse.reverse(),
-    };
 
-    beforeEach(() => {
-      server.use(
-        rest.get(`${mockBaseUrl}/entities`, (_, res, ctx) => {
-          return res(ctx.json(defaultServiceResponse));
-        }),
-      );
-    });
+    it('should fetch entities via POST endpoint', async () => {
+      const mockedEndpoint = jest.fn().mockImplementation((_req, res, ctx) => {
+        return res(
+          ctx.json({
+            items: defaultServiceResponse,
+            totalItems: 2,
+            pageInfo: {},
+          }),
+        );
+      });
 
-    it('should fetch entities from correct endpoint', async () => {
+      server.use(rest.post(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
+
       const response = await client.getEntities({}, { token });
-      expect(response).toEqual(defaultResponse);
+      expect(response).toEqual({ items: defaultServiceResponse });
+      expect(mockedEndpoint).toHaveBeenCalledTimes(1);
     });
 
     it('builds multiple entity search filters properly', async () => {
-      expect.assertions(2);
+      const mockedEndpoint = jest.fn().mockImplementation((_req, res, ctx) => {
+        return res(ctx.json({ items: [], totalItems: 0, pageInfo: {} }));
+      });
 
-      server.use(
-        rest.get(`${mockBaseUrl}/entities`, (req, res, ctx) => {
-          const queryParams = new URLSearchParams(req.url.search);
-          expect(queryParams.getAll('filter')).toEqual([
-            'a=1,b=2,b=3,ö==',
-            'a=2',
-            'c',
-          ]);
-          return res(ctx.json([]));
-        }),
-      );
+      server.use(rest.post(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
 
       const response = await client.getEntities(
         {
@@ -117,18 +107,23 @@ describe('CatalogClient', () => {
       );
 
       expect(response.items).toEqual([]);
+      expect(mockedEndpoint).toHaveBeenCalledTimes(1);
+      const body = await mockedEndpoint.mock.calls[0][0].json();
+      expect(body.query).toEqual({
+        $any: [
+          { $all: [{ a: '1' }, { b: { $in: ['2', '3'] } }, { ö: '=' }] },
+          { a: '2' },
+          { c: { $exists: true } },
+        ],
+      });
     });
 
     it('builds single entity search filter properly', async () => {
-      expect.assertions(2);
+      const mockedEndpoint = jest.fn().mockImplementation((_req, res, ctx) => {
+        return res(ctx.json({ items: [], totalItems: 0, pageInfo: {} }));
+      });
 
-      server.use(
-        rest.get(`${mockBaseUrl}/entities`, (req, res, ctx) => {
-          const queryParams = new URLSearchParams(req.url.search);
-          expect(queryParams.getAll('filter')).toEqual(['a=1,b=2,b=3,ö==,c']);
-          return res(ctx.json([]));
-        }),
-      );
+      server.use(rest.post(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
 
       const response = await client.getEntities(
         {
@@ -143,6 +138,16 @@ describe('CatalogClient', () => {
       );
 
       expect(response.items).toEqual([]);
+      expect(mockedEndpoint).toHaveBeenCalledTimes(1);
+      const body = await mockedEndpoint.mock.calls[0][0].json();
+      expect(body.query).toEqual({
+        $all: [
+          { a: '1' },
+          { b: { $in: ['2', '3'] } },
+          { ö: '=' },
+          { c: { $exists: true } },
+        ],
+      });
     });
 
     it('builds search filters property even those with URL unsafe values', async () => {
@@ -178,15 +183,11 @@ describe('CatalogClient', () => {
     });
 
     it('builds entity field selectors properly', async () => {
-      expect.assertions(2);
+      const mockedEndpoint = jest.fn().mockImplementation((_req, res, ctx) => {
+        return res(ctx.json({ items: [], totalItems: 0, pageInfo: {} }));
+      });
 
-      server.use(
-        rest.get(`${mockBaseUrl}/entities`, (req, res, ctx) => {
-          const queryParams = new URLSearchParams(req.url.search);
-          expect(queryParams.getAll('fields')).toEqual(['a.b,ö']);
-          return res(ctx.json([]));
-        }),
-      );
+      server.use(rest.post(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
 
       const response = await client.getEntities(
         {
@@ -196,12 +197,21 @@ describe('CatalogClient', () => {
       );
 
       expect(response.items).toEqual([]);
+      expect(mockedEndpoint).toHaveBeenCalledTimes(1);
+      const body = await mockedEndpoint.mock.calls[0][0].json();
+      expect(body.fields).toEqual(['a.b', 'ö']);
     });
 
     it('handles field filtered entities', async () => {
       server.use(
-        rest.get(`${mockBaseUrl}/entities`, (_req, res, ctx) => {
-          return res(ctx.json([{ apiVersion: '1' }, { apiVersion: '2' }]));
+        rest.post(`${mockBaseUrl}/entities/by-query`, (_req, res, ctx) => {
+          return res(
+            ctx.json({
+              items: [{ apiVersion: '1' }, { apiVersion: '2' }],
+              totalItems: 2,
+              pageInfo: {},
+            }),
+          );
         }),
       );
 
@@ -218,7 +228,7 @@ describe('CatalogClient', () => {
       ]);
     });
 
-    it('builds paging parameters properly', async () => {
+    it('falls back to GET for legacy after cursor', async () => {
       expect.assertions(2);
 
       server.use(
@@ -237,22 +247,22 @@ describe('CatalogClient', () => {
     });
 
     it('handles ordering properly', async () => {
-      expect.assertions(2);
       const sortedEntities = [
         { apiVersion: '1', kind: 'Component', metadata: { name: 'b' } },
         { apiVersion: '1', kind: 'Component', metadata: { name: 'a' } },
       ];
 
-      server.use(
-        rest.get(`${mockBaseUrl}/entities`, (req, res, ctx) => {
-          const queryParams = new URLSearchParams(req.url.search);
-          expect(queryParams.getAll('order')).toEqual([
-            'asc:kind',
-            'desc:metadata.name',
-          ]);
-          return res(ctx.json(sortedEntities));
-        }),
-      );
+      const mockedEndpoint = jest.fn().mockImplementation((_req, res, ctx) => {
+        return res(
+          ctx.json({
+            items: sortedEntities,
+            totalItems: 2,
+            pageInfo: {},
+          }),
+        );
+      });
+
+      server.use(rest.post(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
 
       const response = await client.getEntities(
         {
@@ -265,6 +275,12 @@ describe('CatalogClient', () => {
       );
 
       expect(response.items).toEqual(sortedEntities);
+      expect(mockedEndpoint).toHaveBeenCalledTimes(1);
+      const body = await mockedEndpoint.mock.calls[0][0].json();
+      expect(body.orderBy).toEqual([
+        { field: 'kind', order: 'asc' },
+        { field: 'metadata.name', order: 'desc' },
+      ]);
     });
   });
 

--- a/packages/catalog-client/src/CatalogClient.ts
+++ b/packages/catalog-client/src/CatalogClient.ts
@@ -195,39 +195,27 @@ export class CatalogClient implements CatalogApi {
     request?: GetEntitiesRequest,
     options?: CatalogRequestOptions,
   ): Promise<GetEntitiesResponse> {
-    const {
-      filter = [],
-      fields = [],
-      order,
-      offset,
-      limit,
-      after,
-    } = request ?? {};
-    const encodedOrder = [];
-    if (order) {
-      for (const directive of [order].flat()) {
-        if (directive) {
-          encodedOrder.push(`${directive.order}:${directive.field}`);
-        }
-      }
+    const { filter, fields, order, offset, limit, after } = request ?? {};
+
+    // The `after` cursor is specific to the legacy GET /entities pagination
+    // and is not compatible with the POST endpoint's cursor format. Fall back
+    // to the GET endpoint when it is provided.
+    if (after !== undefined) {
+      return this.getEntitiesViaGet(request!, options);
     }
 
-    const entities = await this.requestRequired(
-      await this.apiClient.getEntities(
-        {
-          query: {
-            fields,
-            limit,
-            filter: this.getFilterValue(filter),
-            offset,
-            after,
-            order: order ? encodedOrder : undefined,
-          },
-        },
-        options,
-      ),
+    const result = await this.queryEntitiesByPredicate(
+      {
+        filter,
+        fields,
+        orderFields: order,
+        offset,
+        limit,
+      },
+      options,
     );
-    return { items: entities };
+
+    return { items: result.items };
   }
 
   /**
@@ -755,6 +743,42 @@ export class CatalogClient implements CatalogApi {
     }
 
     return await response.json();
+  }
+
+  /**
+   * Legacy fallback for getEntities when the `after` cursor parameter is used,
+   * which is not compatible with the POST endpoint's cursor format.
+   */
+  private async getEntitiesViaGet(
+    request: GetEntitiesRequest,
+    options?: CatalogRequestOptions,
+  ): Promise<GetEntitiesResponse> {
+    const { filter = [], fields = [], order, offset, limit, after } = request;
+    const encodedOrder = [];
+    if (order) {
+      for (const directive of [order].flat()) {
+        if (directive) {
+          encodedOrder.push(`${directive.order}:${directive.field}`);
+        }
+      }
+    }
+
+    const entities = await this.requestRequired(
+      await this.apiClient.getEntities(
+        {
+          query: {
+            fields,
+            limit,
+            filter: this.getFilterValue(filter),
+            offset,
+            after,
+            order: order ? encodedOrder : undefined,
+          },
+        },
+        options,
+      ),
+    );
+    return { items: entities };
   }
 
   private getFilterValue(filter: EntityFilterQuery = []) {

--- a/plugins/catalog-node/src/catalogService.test.ts
+++ b/plugins/catalog-node/src/catalogService.test.ts
@@ -60,15 +60,18 @@ describe('catalogServiceRef', () => {
     expect.assertions(1);
 
     server.use(
-      rest.get('http://localhost/api/catalog/entities', (req, res, ctx) => {
-        expect(req.headers.get('authorization')).toBe(
-          mockCredentials.service.header({
-            onBehalfOf: mockCredentials.user(),
-            targetPluginId: 'catalog',
-          }),
-        );
-        return res(ctx.json({}));
-      }),
+      rest.post(
+        'http://localhost/api/catalog/entities/by-query',
+        (req, res, ctx) => {
+          expect(req.headers.get('authorization')).toBe(
+            mockCredentials.service.header({
+              onBehalfOf: mockCredentials.user(),
+              targetPluginId: 'catalog',
+            }),
+          );
+          return res(ctx.json({ items: [], totalItems: 0, pageInfo: {} }));
+        },
+      ),
     );
     const tester = ServiceFactoryTester.from(
       createServiceFactory({
@@ -91,15 +94,18 @@ describe('catalogServiceRef', () => {
     expect.assertions(1);
 
     server.use(
-      rest.get('http://localhost/api/catalog/entities', (req, res, ctx) => {
-        expect(req.headers.get('authorization')).toBe(
-          mockCredentials.service.header({
-            onBehalfOf: mockCredentials.service(),
-            targetPluginId: 'catalog',
-          }),
-        );
-        return res(ctx.json({}));
-      }),
+      rest.post(
+        'http://localhost/api/catalog/entities/by-query',
+        (req, res, ctx) => {
+          expect(req.headers.get('authorization')).toBe(
+            mockCredentials.service.header({
+              onBehalfOf: mockCredentials.service(),
+              targetPluginId: 'catalog',
+            }),
+          );
+          return res(ctx.json({ items: [], totalItems: 0, pageInfo: {} }));
+        },
+      ),
     );
     const tester = ServiceFactoryTester.from(
       createServiceFactory({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Reimplement `CatalogClient.getEntities()` to use `POST /entities/by-query` instead of `GET /entities`, avoiding request URL size limits when filters or other parameters are large.

The problem with `getEntities` is that it uses the GET verb and hits request size limits for large requests. The `POST /entities/by-query` endpoint already exists and supports the same semantics (filtering, ordering, pagination, field selection), so this change delegates to it internally via the existing private `queryEntitiesByPredicate()` method.

**Key details:**

- The public `GetEntitiesRequest` / `GetEntitiesResponse` types and behavior are completely unchanged
- The `EntityFilterQuery` key-value filter format is converted to `FilterPredicate` format using the existing `convertFilterToPredicate` utility
- `order` maps to `orderFields`, `fields`/`offset`/`limit` map directly
- When the legacy `after` cursor parameter is provided, the method falls back to the original `GET /entities` endpoint since the cursor formats are incompatible
- API reports show no changes, confirming the public API surface is untouched

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Made with [Cursor](https://cursor.com)