### PR TITLE
feat: add support for techdocs build strict parameter

### DIFF
--- a/.changeset/fair-drinks-battle.md
+++ b/.changeset/fair-drinks-battle.md
@@ -1,0 +1,6 @@
+---
+'@techdocs/cli': minor
+'@backstage/plugin-techdocs-node': minor
+---
+
+Added `--mkdocs-parameter-strict` option to `techdocs-cli generate` in order to support `mkdocs build --strict`

--- a/docs/features/techdocs/cli.md
+++ b/docs/features/techdocs/cli.md
@@ -157,6 +157,7 @@ Options:
   --disableExternalFonts          Disable external font downloads for all TechDocs sites. Useful for air-gapped environments
                                   where Google fonts cannot be accessed. (default: false)
   --runAsDefaultUser              Bypass setting the container user as the same user and group id as host for Linux and MacOS (default: false)
+  --mkdocsParameterStrict         If present, the `--strict` option will be used when invoking mkdocs build.
   -v, --verbose                   Enable verbose output. (default: false)
   -h, --help                      display help for command
 ```

--- a/docs/features/techdocs/cli.md
+++ b/docs/features/techdocs/cli.md
@@ -157,7 +157,7 @@ Options:
   --disableExternalFonts          Disable external font downloads for all TechDocs sites. Useful for air-gapped environments
                                   where Google fonts cannot be accessed. (default: false)
   --runAsDefaultUser              Bypass setting the container user as the same user and group id as host for Linux and MacOS (default: false)
-  --mkdocsParameterStrict         If present, the `--strict` option will be used when invoking mkdocs build.
+  --mkdocs-parameter-strict       Pass "--strict" parameter to mkdocs build
   -v, --verbose                   Enable verbose output. (default: false)
   -h, --help                      display help for command
 ```

--- a/packages/techdocs-cli/cli-e2e-tests/techdocs-cli.test.ts
+++ b/packages/techdocs-cli/cli-e2e-tests/techdocs-cli.test.ts
@@ -90,6 +90,44 @@ describe('end-to-end', () => {
     expect(proc.exit).toEqual(0);
   });
 
+  it('can generate docs without warnings when using --mkdocs-parameter-strict', async () => {
+    const proc = await executeCommand(
+      entryPoint,
+      [
+        'generate',
+        '--no-docker',
+        '--mkdocs-parameter-strict',
+        '--source-dir',
+        '../example-docs/sub-docs',
+      ],
+      {
+        cwd,
+        timeout,
+      },
+    );
+    expect(proc.stdout).toContain('Successfully generated docs');
+    expect(proc.exit).toEqual(0);
+  });
+
+  it('can not generate docs with warnings when using --mkdocs-parameter-strict', async () => {
+    const proc = await executeCommand(
+      entryPoint,
+      [
+        'generate',
+        '--no-docker',
+        '--mkdocs-parameter-strict',
+        '--source-dir',
+        '../example-docs/sub-docs-with-warnings',
+      ],
+      {
+        cwd,
+        timeout,
+      },
+    );
+    expect(proc.stderr).toContain('Failed to generate');
+    expect(proc.exit).toEqual(1);
+  });
+
   it('can generate with DOCKER_* TLS variables and --no-docker option', async () => {
     const env = {
       DOCKER_HOST: 'tcp://localhost:2376',

--- a/packages/techdocs-cli/cli-e2e-tests/techdocs-cli.test.ts
+++ b/packages/techdocs-cli/cli-e2e-tests/techdocs-cli.test.ts
@@ -109,7 +109,7 @@ describe('end-to-end', () => {
     expect(proc.exit).toEqual(0);
   });
 
-  it('can not generate docs with warnings when using --mkdocs-parameter-strict', async () => {
+  it('cannot generate docs with warnings when using --mkdocs-parameter-strict', async () => {
     const proc = await executeCommand(
       entryPoint,
       [

--- a/packages/techdocs-cli/cli-report.md
+++ b/packages/techdocs-cli/cli-report.md
@@ -31,12 +31,12 @@ Options:
   --docker-image <DOCKER_IMAGE>
   --etag <ETAG>
   --legacyCopyReadmeMdToIndexMd
+  --mkdocs-parameter-strict
   --no-docker
   --no-pull
   --omitTechdocsCoreMkdocsPlugin
   --output-dir <PATH>
   --runAsDefaultUser
-  --mkdocs-parameter-strict
   --site-name
   --source-dir <PATH>
   --techdocs-ref <HOST_TYPE:URL>

--- a/packages/techdocs-cli/cli-report.md
+++ b/packages/techdocs-cli/cli-report.md
@@ -36,6 +36,7 @@ Options:
   --omitTechdocsCoreMkdocsPlugin
   --output-dir <PATH>
   --runAsDefaultUser
+  --mkdocs-parameter-strict
   --site-name
   --source-dir <PATH>
   --techdocs-ref <HOST_TYPE:URL>

--- a/packages/techdocs-cli/src/commands/generate/generate.ts
+++ b/packages/techdocs-cli/src/commands/generate/generate.ts
@@ -103,6 +103,7 @@ export default async function generate(opts: OptionValues) {
     logStream: getLogStream(logger),
     siteOptions: { name: opts.siteName },
     runAsDefaultUser: opts.runAsDefaultUser,
+    mkdocsParameterStrict: opts.mkdocsParameterStrict,
   });
 
   if (configIsTemporary) {

--- a/packages/techdocs-cli/src/commands/index.ts
+++ b/packages/techdocs-cli/src/commands/index.ts
@@ -85,6 +85,11 @@ export function registerCommands(program: Command) {
       'Bypass setting the container user as the same user and group id as host for Linux and MacOS',
       false,
     )
+    .option(
+      '--mkdocs-parameter-strict',
+      'Pass "--strict" parameter to mkdocs build',
+      false,
+    )
     .alias('build')
     .action(lazy(() => import('./generate/generate'), 'default'));
 

--- a/packages/techdocs-cli/src/example-docs/sub-docs-with-warnings/docs/index.md
+++ b/packages/techdocs-cli/src/example-docs/sub-docs-with-warnings/docs/index.md
@@ -1,0 +1,4 @@
+# This will have an invalid reference
+
+The picture reference below is invalid and should trigger a warning in `mkdocs build`.
+![picture](images/invalid-reference-file.jpg)

--- a/packages/techdocs-cli/src/example-docs/sub-docs-with-warnings/mkdocs.yml
+++ b/packages/techdocs-cli/src/example-docs/sub-docs-with-warnings/mkdocs.yml
@@ -1,0 +1,5 @@
+site_name: subdocs
+nav:
+  - Home 2: index.md
+plugins:
+  - techdocs-core

--- a/plugins/techdocs-node/report.api.md
+++ b/plugins/techdocs-node/report.api.md
@@ -76,6 +76,7 @@ export type GeneratorRunOptions = {
     name?: string;
   };
   runAsDefaultUser?: boolean;
+  mkdocsParameterStrict?: boolean;
 };
 
 // @public

--- a/plugins/techdocs-node/src/stages/generate/techdocs.ts
+++ b/plugins/techdocs-node/src/stages/generate/techdocs.ts
@@ -106,6 +106,7 @@ export class TechdocsGenerator implements GeneratorBase {
       logStream,
       siteOptions,
       runAsDefaultUser,
+      mkdocsParameterStrict,
     } = options;
 
     // Do some updates to mkdocs.yml before generating docs e.g. adding repo_url
@@ -176,12 +177,14 @@ export class TechdocsGenerator implements GeneratorBase {
       [outputDir]: '/output',
     };
 
+    const mkdocsBuildArgs = mkdocsParameterStrict ? ['--strict'] : [];
+
     try {
       switch (this.options.runIn) {
         case 'local':
           await runCommand({
             command: 'mkdocs',
-            args: ['build', '-f', mkdocsYmlPath, '-d', outputDir, '-v'],
+            args: ['build', '-f', mkdocsYmlPath, '-d', outputDir, '-v', ...mkdocsBuildArgs],
             options: {
               cwd: inputDir,
             },
@@ -203,6 +206,7 @@ export class TechdocsGenerator implements GeneratorBase {
               `/input/${path.basename(mkdocsYmlPath)}`,
               '-d',
               '/output',
+              ...mkdocsBuildArgs,
             ],
             logStream,
             mountDirs,

--- a/plugins/techdocs-node/src/stages/generate/types.ts
+++ b/plugins/techdocs-node/src/stages/generate/types.ts
@@ -78,6 +78,7 @@ export type GeneratorConfig = {
  * @param logger - A logger that forwards the messages to the caller to be displayed outside of the backend.
  * @param logStream - A log stream that can send raw log messages to the caller to be displayed outside of the backend.
  * @param siteOptions - Options for the site: The `name` property will be used in mkdocs.yml config for the required `site_name` property, default value is "Documentation Site"
+ * @param mkdocsParameterStrict - If present, the `--strict` option will be used when invoking mkdocs build".
  */
 export type GeneratorRunOptions = {
   inputDir: string;

--- a/plugins/techdocs-node/src/stages/generate/types.ts
+++ b/plugins/techdocs-node/src/stages/generate/types.ts
@@ -88,6 +88,7 @@ export type GeneratorRunOptions = {
   logStream?: Writable;
   siteOptions?: { name?: string };
   runAsDefaultUser?: boolean;
+  mkdocsParameterStrict?: boolean;
 };
 
 /**

--- a/plugins/techdocs-node/src/stages/generate/types.ts
+++ b/plugins/techdocs-node/src/stages/generate/types.ts
@@ -78,7 +78,8 @@ export type GeneratorConfig = {
  * @param logger - A logger that forwards the messages to the caller to be displayed outside of the backend.
  * @param logStream - A log stream that can send raw log messages to the caller to be displayed outside of the backend.
  * @param siteOptions - Options for the site: The `name` property will be used in mkdocs.yml config for the required `site_name` property, default value is "Documentation Site"
- * @param mkdocsParameterStrict - If present, the `--strict` option will be used when invoking mkdocs build".
+ * @param runAsDefaultUser - If present, will bypass running the docker builds as host user for macOS and Linux.
+ * @param mkdocsParameterStrict - If present, the `--strict` option will be used when invoking mkdocs build.
  */
 export type GeneratorRunOptions = {
   inputDir: string;

--- a/scripts/verify-links.js
+++ b/scripts/verify-links.js
@@ -21,7 +21,14 @@ const { resolve: resolvePath, join: joinPath, dirname } = require('node:path');
 const fs = require('node:fs').promises;
 const { existsSync, statSync } = require('node:fs');
 
-const IGNORED_DIRS = ['node_modules', 'dist', 'bin', '.git'];
+// sub-docs-with-warnings is excluded since we intentionally added missing links on it to verify techdocs-cli build ---mkdocs-parameter-strict
+const IGNORED_DIRS = [
+  'node_modules',
+  'dist',
+  'bin',
+  '.git',
+  'sub-docs-with-warnings',
+];
 const projectRoot = resolvePath(__dirname, '..');
 
 // Zero-width and other invisible Unicode characters that shouldn't appear in URLs

--- a/scripts/verify-links.js
+++ b/scripts/verify-links.js
@@ -21,7 +21,7 @@ const { resolve: resolvePath, join: joinPath, dirname } = require('node:path');
 const fs = require('node:fs').promises;
 const { existsSync, statSync } = require('node:fs');
 
-// sub-docs-with-warnings is excluded since we intentionally added missing links on it to verify techdocs-cli build ---mkdocs-parameter-strict
+// sub-docs-with-warnings is excluded since we intentionally added missing links on it to verify techdocs-cli build --mkdocs-parameter-strict
 const IGNORED_DIRS = [
   'node_modules',
   'dist',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Hi, the `mkdocs build --strict` is not supported during the `techdocs-cli build` command. In #21403, support was added to the `techdocs-cli serve` command, but I would like to make it possible to fail the build step.

This could help us during CI pipelines, to break builds when warnings are found during the building of the docs.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
