### PR TITLE
Add server-side search to scaffolder task list

### DIFF
--- a/.changeset/scaffolder-task-search-backend.md
+++ b/.changeset/scaffolder-task-search-backend.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Added a `search` query parameter to the `GET /v2/tasks` endpoint, enabling server-side filtering of tasks by ID or template name.

--- a/.changeset/scaffolder-task-search-backend.md
+++ b/.changeset/scaffolder-task-search-backend.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-backend': minor
 ---
 
-Added a `search` query parameter to the `GET /v2/tasks` endpoint, enabling server-side filtering of tasks by ID or template name.
+Added a `fullTextFilter` query parameter to the `GET /v2/tasks` endpoint, enabling server-side filtering of tasks by ID or template name.

--- a/.changeset/scaffolder-task-search-common.md
+++ b/.changeset/scaffolder-task-search-common.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-common': minor
 ---
 
-Added an optional `search` parameter to `ScaffolderApi.listTasks` and `ScaffolderClient`, enabling server-side task search.
+Added an optional `fullTextFilter` parameter to `ScaffolderApi.listTasks` and `ScaffolderClient`, enabling server-side task filtering.

--- a/.changeset/scaffolder-task-search-common.md
+++ b/.changeset/scaffolder-task-search-common.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-common': minor
+---
+
+Added an optional `search` parameter to `ScaffolderApi.listTasks` and `ScaffolderClient`, enabling server-side task search.

--- a/.changeset/scaffolder-task-search-frontend.md
+++ b/.changeset/scaffolder-task-search-frontend.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Fixed the task list search to work across all pages instead of only filtering the currently visible page.

--- a/.changeset/scaffolder-task-search-node.md
+++ b/.changeset/scaffolder-task-search-node.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-node': patch
+---
+
+Added an optional `search` field to the `TaskBroker.list` options, allowing task listing to be filtered by a search string.

--- a/.changeset/scaffolder-task-search-node.md
+++ b/.changeset/scaffolder-task-search-node.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-node': patch
 ---
 
-Added an optional `search` field to the `TaskBroker.list` options, allowing task listing to be filtered by a search string.
+Added an optional `fullTextFilter` field to the `TaskBroker.list` options, allowing task listing to be filtered by a free-form text string.

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.test.ts
@@ -582,7 +582,9 @@ describe('DatabaseTaskStore', () => {
     });
 
     const idFragment = taskId1.slice(0, 8);
-    const { tasks, totalTasks } = await store.list({ search: idFragment });
+    const { tasks, totalTasks } = await store.list({
+      filters: { search: idFragment },
+    });
     expect(totalTasks).toBe(1);
     expect(tasks).toHaveLength(1);
     expect(tasks[0].id).toBe(taskId1);
@@ -604,7 +606,7 @@ describe('DatabaseTaskStore', () => {
     });
 
     const { tasks, totalTasks } = await store.list({
-      search: 'my-template',
+      filters: { search: 'my-template' },
     });
     expect(totalTasks).toBe(1);
     expect(tasks).toHaveLength(1);
@@ -634,17 +636,21 @@ describe('DatabaseTaskStore', () => {
       createdBy: 'user:default/alice',
     });
 
-    const { tasks: both } = await store.list({ search: 'create service' });
+    const { tasks: both } = await store.list({
+      filters: { search: 'create service' },
+    });
     expect(both).toHaveLength(1);
     expect(both[0].spec.templateInfo?.entityRef).toBe(
       'template:default/create-service',
     );
 
-    const { tasks: createOnly } = await store.list({ search: 'create' });
+    const { tasks: createOnly } = await store.list({
+      filters: { search: 'create' },
+    });
     expect(createOnly).toHaveLength(2);
 
     const { tasks: noMatch } = await store.list({
-      search: 'create nonexistent',
+      filters: { search: 'create nonexistent' },
     });
     expect(noMatch).toHaveLength(0);
   });
@@ -660,10 +666,14 @@ describe('DatabaseTaskStore', () => {
       createdBy: 'me',
     });
 
-    const { tasks: wildcardSearch } = await store.list({ search: '%' });
+    const { tasks: wildcardSearch } = await store.list({
+      filters: { search: '%' },
+    });
     expect(wildcardSearch).toHaveLength(0);
 
-    const { tasks: underscoreSearch } = await store.list({ search: 'f_o' });
+    const { tasks: underscoreSearch } = await store.list({
+      filters: { search: 'f_o' },
+    });
     expect(underscoreSearch).toHaveLength(0);
   });
 
@@ -683,8 +693,7 @@ describe('DatabaseTaskStore', () => {
     });
 
     const { tasks, totalTasks } = await store.list({
-      search: 'service',
-      filters: { createdBy: 'user:default/alice' },
+      filters: { search: 'service', createdBy: 'user:default/alice' },
     });
     expect(totalTasks).toBe(1);
     expect(tasks).toHaveLength(1);

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.test.ts
@@ -583,7 +583,7 @@ describe('DatabaseTaskStore', () => {
   });
 
   it.each(databases.eachSupportedId())(
-    'should filter tasks by search term matching task ID, %p',
+    'should filter tasks by fullTextFilter matching task ID, %p',
     async databaseId => {
       const { store } = await createStoreForDb(databaseId);
       const { taskId: taskId1 } = await store.createTask({
@@ -601,7 +601,7 @@ describe('DatabaseTaskStore', () => {
 
       const idFragment = taskId1.slice(0, 8);
       const { tasks, totalTasks } = await store.list({
-        filters: { search: idFragment },
+        filters: { fullTextFilter: idFragment },
       });
       expect(Number(totalTasks)).toBe(1);
       expect(tasks).toHaveLength(1);
@@ -610,7 +610,7 @@ describe('DatabaseTaskStore', () => {
   );
 
   it.each(databases.eachSupportedId())(
-    'should filter tasks by search term matching spec content, %p',
+    'should filter tasks by fullTextFilter matching spec content, %p',
     async databaseId => {
       const { store } = await createStoreForDb(databaseId);
       await store.createTask({
@@ -627,7 +627,7 @@ describe('DatabaseTaskStore', () => {
       });
 
       const { tasks, totalTasks } = await store.list({
-        filters: { search: 'my-template' },
+        filters: { fullTextFilter: 'my-template' },
       });
       expect(Number(totalTasks)).toBe(1);
       expect(tasks).toHaveLength(1);
@@ -638,7 +638,7 @@ describe('DatabaseTaskStore', () => {
   );
 
   it.each(databases.eachSupportedId())(
-    'should require all search terms to match for multi-word queries, %p',
+    'should require all fullTextFilter terms to match for multi-word queries, %p',
     async databaseId => {
       const { store } = await createStoreForDb(databaseId);
       await store.createTask({
@@ -661,7 +661,7 @@ describe('DatabaseTaskStore', () => {
       });
 
       const { tasks: both } = await store.list({
-        filters: { search: 'create service' },
+        filters: { fullTextFilter: 'create service' },
       });
       expect(both).toHaveLength(1);
       expect(both[0].spec.templateInfo?.entityRef).toBe(
@@ -669,19 +669,19 @@ describe('DatabaseTaskStore', () => {
       );
 
       const { tasks: createOnly } = await store.list({
-        filters: { search: 'create' },
+        filters: { fullTextFilter: 'create' },
       });
       expect(createOnly).toHaveLength(2);
 
       const { tasks: noMatch } = await store.list({
-        filters: { search: 'create nonexistent' },
+        filters: { fullTextFilter: 'create nonexistent' },
       });
       expect(noMatch).toHaveLength(0);
     },
   );
 
   it.each(databases.eachSupportedId())(
-    'should escape LIKE wildcards in search terms, %p',
+    'should escape LIKE wildcards in fullTextFilter terms, %p',
     async databaseId => {
       const { store } = await createStoreForDb(databaseId);
       await store.createTask({
@@ -698,19 +698,19 @@ describe('DatabaseTaskStore', () => {
       });
 
       const { tasks: wildcardSearch } = await store.list({
-        filters: { search: '%' },
+        filters: { fullTextFilter: '%' },
       });
       expect(wildcardSearch).toHaveLength(0);
 
       const { tasks: underscoreSearch } = await store.list({
-        filters: { search: 'f_o' },
+        filters: { fullTextFilter: 'f_o' },
       });
       expect(underscoreSearch).toHaveLength(0);
     },
   );
 
   it.each(databases.eachSupportedId())(
-    'should combine search with other filters, %p',
+    'should combine fullTextFilter with other filters, %p',
     async databaseId => {
       const { store } = await createStoreForDb(databaseId);
       await store.createTask({
@@ -727,7 +727,7 @@ describe('DatabaseTaskStore', () => {
       });
 
       const { tasks, totalTasks } = await store.list({
-        filters: { search: 'service', createdBy: 'user:default/alice' },
+        filters: { fullTextFilter: 'service', createdBy: 'user:default/alice' },
       });
       expect(Number(totalTasks)).toBe(1);
       expect(tasks).toHaveLength(1);

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.test.ts
@@ -30,6 +30,8 @@ import { EventsService } from '@backstage/plugin-events-node';
 import { PermissionCriteria } from '@backstage/plugin-permission-common';
 import { TaskFilters } from '@backstage/plugin-scaffolder-node';
 
+jest.setTimeout(60_000);
+
 const createStore = async (events?: EventsService) => {
   const manager = DatabaseManager.fromConfig(
     new ConfigReader({
@@ -605,7 +607,6 @@ describe('DatabaseTaskStore', () => {
       expect(tasks).toHaveLength(1);
       expect(tasks[0].id).toBe(taskId1);
     },
-    60_000,
   );
 
   it.each(databases.eachSupportedId())(
@@ -634,7 +635,6 @@ describe('DatabaseTaskStore', () => {
         'template:default/my-template',
       );
     },
-    60_000,
   );
 
   it.each(databases.eachSupportedId())(
@@ -678,7 +678,6 @@ describe('DatabaseTaskStore', () => {
       });
       expect(noMatch).toHaveLength(0);
     },
-    60_000,
   );
 
   it.each(databases.eachSupportedId())(
@@ -708,7 +707,6 @@ describe('DatabaseTaskStore', () => {
       });
       expect(underscoreSearch).toHaveLength(0);
     },
-    60_000,
   );
 
   it.each(databases.eachSupportedId())(
@@ -735,7 +733,6 @@ describe('DatabaseTaskStore', () => {
       expect(tasks).toHaveLength(1);
       expect(tasks[0].createdBy).toBe('user:default/alice');
     },
-    60_000,
   );
 
   it('serialize and restore the workspace', async () => {

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.test.ts
@@ -22,6 +22,8 @@ import { ConflictError } from '@backstage/errors';
 import {
   mockServices,
   createMockDirectory,
+  TestDatabaseId,
+  TestDatabases,
 } from '@backstage/backend-test-utils';
 import fs from 'fs-extra';
 import { EventsService } from '@backstage/plugin-events-node';
@@ -48,6 +50,14 @@ const createStore = async (events?: EventsService) => {
   });
   return { store, manager };
 };
+
+const databases = TestDatabases.create();
+
+async function createStoreForDb(databaseId: TestDatabaseId) {
+  const knex = await databases.init(databaseId);
+  const store = await DatabaseTaskStore.create({ database: knex });
+  return { store, knex };
+}
 
 const workspaceDir = createMockDirectory({
   content: {
@@ -570,135 +580,163 @@ describe('DatabaseTaskStore', () => {
     });
   });
 
-  it('should filter tasks by search term matching task ID', async () => {
-    const { store } = await createStore();
-    const { taskId: taskId1 } = await store.createTask({
-      spec: { templateInfo: { entityRef: 'template:default/a' } } as TaskSpec,
-      createdBy: 'me',
-    });
-    await store.createTask({
-      spec: { templateInfo: { entityRef: 'template:default/b' } } as TaskSpec,
-      createdBy: 'me',
-    });
+  it.each(databases.eachSupportedId())(
+    'should filter tasks by search term matching task ID, %p',
+    async databaseId => {
+      const { store } = await createStoreForDb(databaseId);
+      const { taskId: taskId1 } = await store.createTask({
+        spec: {
+          templateInfo: { entityRef: 'template:default/a' },
+        } as TaskSpec,
+        createdBy: 'me',
+      });
+      await store.createTask({
+        spec: {
+          templateInfo: { entityRef: 'template:default/b' },
+        } as TaskSpec,
+        createdBy: 'me',
+      });
 
-    const idFragment = taskId1.slice(0, 8);
-    const { tasks, totalTasks } = await store.list({
-      filters: { search: idFragment },
-    });
-    expect(totalTasks).toBe(1);
-    expect(tasks).toHaveLength(1);
-    expect(tasks[0].id).toBe(taskId1);
-  });
+      const idFragment = taskId1.slice(0, 8);
+      const { tasks, totalTasks } = await store.list({
+        filters: { search: idFragment },
+      });
+      expect(Number(totalTasks)).toBe(1);
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].id).toBe(taskId1);
+    },
+    60_000,
+  );
 
-  it('should filter tasks by search term matching spec content', async () => {
-    const { store } = await createStore();
-    await store.createTask({
-      spec: {
-        templateInfo: { entityRef: 'template:default/my-template' },
-      } as TaskSpec,
-      createdBy: 'me',
-    });
-    await store.createTask({
-      spec: {
-        templateInfo: { entityRef: 'template:default/other' },
-      } as TaskSpec,
-      createdBy: 'me',
-    });
+  it.each(databases.eachSupportedId())(
+    'should filter tasks by search term matching spec content, %p',
+    async databaseId => {
+      const { store } = await createStoreForDb(databaseId);
+      await store.createTask({
+        spec: {
+          templateInfo: { entityRef: 'template:default/my-template' },
+        } as TaskSpec,
+        createdBy: 'me',
+      });
+      await store.createTask({
+        spec: {
+          templateInfo: { entityRef: 'template:default/other' },
+        } as TaskSpec,
+        createdBy: 'me',
+      });
 
-    const { tasks, totalTasks } = await store.list({
-      filters: { search: 'my-template' },
-    });
-    expect(totalTasks).toBe(1);
-    expect(tasks).toHaveLength(1);
-    expect(tasks[0].spec.templateInfo?.entityRef).toBe(
-      'template:default/my-template',
-    );
-  });
+      const { tasks, totalTasks } = await store.list({
+        filters: { search: 'my-template' },
+      });
+      expect(Number(totalTasks)).toBe(1);
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].spec.templateInfo?.entityRef).toBe(
+        'template:default/my-template',
+      );
+    },
+    60_000,
+  );
 
-  it('should require all search terms to match for multi-word queries', async () => {
-    const { store } = await createStore();
-    await store.createTask({
-      spec: {
-        templateInfo: { entityRef: 'template:default/create-service' },
-      } as TaskSpec,
-      createdBy: 'user:default/alice',
-    });
-    await store.createTask({
-      spec: {
-        templateInfo: { entityRef: 'template:default/create-website' },
-      } as TaskSpec,
-      createdBy: 'user:default/bob',
-    });
-    await store.createTask({
-      spec: {
-        templateInfo: { entityRef: 'template:default/delete-service' },
-      } as TaskSpec,
-      createdBy: 'user:default/alice',
-    });
+  it.each(databases.eachSupportedId())(
+    'should require all search terms to match for multi-word queries, %p',
+    async databaseId => {
+      const { store } = await createStoreForDb(databaseId);
+      await store.createTask({
+        spec: {
+          templateInfo: { entityRef: 'template:default/create-service' },
+        } as TaskSpec,
+        createdBy: 'user:default/alice',
+      });
+      await store.createTask({
+        spec: {
+          templateInfo: { entityRef: 'template:default/create-website' },
+        } as TaskSpec,
+        createdBy: 'user:default/bob',
+      });
+      await store.createTask({
+        spec: {
+          templateInfo: { entityRef: 'template:default/delete-service' },
+        } as TaskSpec,
+        createdBy: 'user:default/alice',
+      });
 
-    const { tasks: both } = await store.list({
-      filters: { search: 'create service' },
-    });
-    expect(both).toHaveLength(1);
-    expect(both[0].spec.templateInfo?.entityRef).toBe(
-      'template:default/create-service',
-    );
+      const { tasks: both } = await store.list({
+        filters: { search: 'create service' },
+      });
+      expect(both).toHaveLength(1);
+      expect(both[0].spec.templateInfo?.entityRef).toBe(
+        'template:default/create-service',
+      );
 
-    const { tasks: createOnly } = await store.list({
-      filters: { search: 'create' },
-    });
-    expect(createOnly).toHaveLength(2);
+      const { tasks: createOnly } = await store.list({
+        filters: { search: 'create' },
+      });
+      expect(createOnly).toHaveLength(2);
 
-    const { tasks: noMatch } = await store.list({
-      filters: { search: 'create nonexistent' },
-    });
-    expect(noMatch).toHaveLength(0);
-  });
+      const { tasks: noMatch } = await store.list({
+        filters: { search: 'create nonexistent' },
+      });
+      expect(noMatch).toHaveLength(0);
+    },
+    60_000,
+  );
 
-  it('should escape LIKE wildcards in search terms', async () => {
-    const { store } = await createStore();
-    await store.createTask({
-      spec: { templateInfo: { entityRef: 'template:default/foo' } } as TaskSpec,
-      createdBy: 'me',
-    });
-    await store.createTask({
-      spec: { templateInfo: { entityRef: 'template:default/bar' } } as TaskSpec,
-      createdBy: 'me',
-    });
+  it.each(databases.eachSupportedId())(
+    'should escape LIKE wildcards in search terms, %p',
+    async databaseId => {
+      const { store } = await createStoreForDb(databaseId);
+      await store.createTask({
+        spec: {
+          templateInfo: { entityRef: 'template:default/foo' },
+        } as TaskSpec,
+        createdBy: 'me',
+      });
+      await store.createTask({
+        spec: {
+          templateInfo: { entityRef: 'template:default/bar' },
+        } as TaskSpec,
+        createdBy: 'me',
+      });
 
-    const { tasks: wildcardSearch } = await store.list({
-      filters: { search: '%' },
-    });
-    expect(wildcardSearch).toHaveLength(0);
+      const { tasks: wildcardSearch } = await store.list({
+        filters: { search: '%' },
+      });
+      expect(wildcardSearch).toHaveLength(0);
 
-    const { tasks: underscoreSearch } = await store.list({
-      filters: { search: 'f_o' },
-    });
-    expect(underscoreSearch).toHaveLength(0);
-  });
+      const { tasks: underscoreSearch } = await store.list({
+        filters: { search: 'f_o' },
+      });
+      expect(underscoreSearch).toHaveLength(0);
+    },
+    60_000,
+  );
 
-  it('should combine search with other filters', async () => {
-    const { store } = await createStore();
-    await store.createTask({
-      spec: {
-        templateInfo: { entityRef: 'template:default/service' },
-      } as TaskSpec,
-      createdBy: 'user:default/alice',
-    });
-    await store.createTask({
-      spec: {
-        templateInfo: { entityRef: 'template:default/service' },
-      } as TaskSpec,
-      createdBy: 'user:default/bob',
-    });
+  it.each(databases.eachSupportedId())(
+    'should combine search with other filters, %p',
+    async databaseId => {
+      const { store } = await createStoreForDb(databaseId);
+      await store.createTask({
+        spec: {
+          templateInfo: { entityRef: 'template:default/service' },
+        } as TaskSpec,
+        createdBy: 'user:default/alice',
+      });
+      await store.createTask({
+        spec: {
+          templateInfo: { entityRef: 'template:default/service' },
+        } as TaskSpec,
+        createdBy: 'user:default/bob',
+      });
 
-    const { tasks, totalTasks } = await store.list({
-      filters: { search: 'service', createdBy: 'user:default/alice' },
-    });
-    expect(totalTasks).toBe(1);
-    expect(tasks).toHaveLength(1);
-    expect(tasks[0].createdBy).toBe('user:default/alice');
-  });
+      const { tasks, totalTasks } = await store.list({
+        filters: { search: 'service', createdBy: 'user:default/alice' },
+      });
+      expect(Number(totalTasks)).toBe(1);
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0].createdBy).toBe('user:default/alice');
+    },
+    60_000,
+  );
 
   it('serialize and restore the workspace', async () => {
     const { store } = await createStore();

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.test.ts
@@ -570,6 +570,127 @@ describe('DatabaseTaskStore', () => {
     });
   });
 
+  it('should filter tasks by search term matching task ID', async () => {
+    const { store } = await createStore();
+    const { taskId: taskId1 } = await store.createTask({
+      spec: { templateInfo: { entityRef: 'template:default/a' } } as TaskSpec,
+      createdBy: 'me',
+    });
+    await store.createTask({
+      spec: { templateInfo: { entityRef: 'template:default/b' } } as TaskSpec,
+      createdBy: 'me',
+    });
+
+    const idFragment = taskId1.slice(0, 8);
+    const { tasks, totalTasks } = await store.list({ search: idFragment });
+    expect(totalTasks).toBe(1);
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].id).toBe(taskId1);
+  });
+
+  it('should filter tasks by search term matching spec content', async () => {
+    const { store } = await createStore();
+    await store.createTask({
+      spec: {
+        templateInfo: { entityRef: 'template:default/my-template' },
+      } as TaskSpec,
+      createdBy: 'me',
+    });
+    await store.createTask({
+      spec: {
+        templateInfo: { entityRef: 'template:default/other' },
+      } as TaskSpec,
+      createdBy: 'me',
+    });
+
+    const { tasks, totalTasks } = await store.list({
+      search: 'my-template',
+    });
+    expect(totalTasks).toBe(1);
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].spec.templateInfo?.entityRef).toBe(
+      'template:default/my-template',
+    );
+  });
+
+  it('should require all search terms to match for multi-word queries', async () => {
+    const { store } = await createStore();
+    await store.createTask({
+      spec: {
+        templateInfo: { entityRef: 'template:default/create-service' },
+      } as TaskSpec,
+      createdBy: 'user:default/alice',
+    });
+    await store.createTask({
+      spec: {
+        templateInfo: { entityRef: 'template:default/create-website' },
+      } as TaskSpec,
+      createdBy: 'user:default/bob',
+    });
+    await store.createTask({
+      spec: {
+        templateInfo: { entityRef: 'template:default/delete-service' },
+      } as TaskSpec,
+      createdBy: 'user:default/alice',
+    });
+
+    const { tasks: both } = await store.list({ search: 'create service' });
+    expect(both).toHaveLength(1);
+    expect(both[0].spec.templateInfo?.entityRef).toBe(
+      'template:default/create-service',
+    );
+
+    const { tasks: createOnly } = await store.list({ search: 'create' });
+    expect(createOnly).toHaveLength(2);
+
+    const { tasks: noMatch } = await store.list({
+      search: 'create nonexistent',
+    });
+    expect(noMatch).toHaveLength(0);
+  });
+
+  it('should escape LIKE wildcards in search terms', async () => {
+    const { store } = await createStore();
+    await store.createTask({
+      spec: { templateInfo: { entityRef: 'template:default/foo' } } as TaskSpec,
+      createdBy: 'me',
+    });
+    await store.createTask({
+      spec: { templateInfo: { entityRef: 'template:default/bar' } } as TaskSpec,
+      createdBy: 'me',
+    });
+
+    const { tasks: wildcardSearch } = await store.list({ search: '%' });
+    expect(wildcardSearch).toHaveLength(0);
+
+    const { tasks: underscoreSearch } = await store.list({ search: 'f_o' });
+    expect(underscoreSearch).toHaveLength(0);
+  });
+
+  it('should combine search with other filters', async () => {
+    const { store } = await createStore();
+    await store.createTask({
+      spec: {
+        templateInfo: { entityRef: 'template:default/service' },
+      } as TaskSpec,
+      createdBy: 'user:default/alice',
+    });
+    await store.createTask({
+      spec: {
+        templateInfo: { entityRef: 'template:default/service' },
+      } as TaskSpec,
+      createdBy: 'user:default/bob',
+    });
+
+    const { tasks, totalTasks } = await store.list({
+      search: 'service',
+      filters: { createdBy: 'user:default/alice' },
+    });
+    expect(totalTasks).toBe(1);
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].createdBy).toBe('user:default/alice');
+  });
+
   it('serialize and restore the workspace', async () => {
     const { store } = await createStore();
     const { taskId } = await store.createTask({

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.test.ts
@@ -582,156 +582,169 @@ describe('DatabaseTaskStore', () => {
     });
   });
 
-  it.each(databases.eachSupportedId())(
-    'should filter tasks by fullTextFilter matching task ID, %p',
-    async databaseId => {
-      const { store } = await createStoreForDb(databaseId);
-      const { taskId: taskId1 } = await store.createTask({
-        spec: {
-          templateInfo: { entityRef: 'template:default/a' },
-        } as TaskSpec,
-        createdBy: 'me',
-      });
-      await store.createTask({
-        spec: {
-          templateInfo: { entityRef: 'template:default/b' },
-        } as TaskSpec,
-        createdBy: 'me',
+  describe.each(databases.eachSupportedId())(
+    'fullTextFilter, %p',
+    databaseId => {
+      it('should filter by matching task ID', async () => {
+        const { store, knex } = await createStoreForDb(databaseId);
+        try {
+          const { taskId: taskId1 } = await store.createTask({
+            spec: {
+              templateInfo: { entityRef: 'template:default/a' },
+            } as TaskSpec,
+            createdBy: 'me',
+          });
+          await store.createTask({
+            spec: {
+              templateInfo: { entityRef: 'template:default/b' },
+            } as TaskSpec,
+            createdBy: 'me',
+          });
+
+          const idFragment = taskId1.slice(0, 8);
+          const { tasks, totalTasks } = await store.list({
+            filters: { fullTextFilter: idFragment },
+          });
+          expect(Number(totalTasks)).toBe(1);
+          expect(tasks).toHaveLength(1);
+          expect(tasks[0].id).toBe(taskId1);
+        } finally {
+          await knex.destroy();
+        }
       });
 
-      const idFragment = taskId1.slice(0, 8);
-      const { tasks, totalTasks } = await store.list({
-        filters: { fullTextFilter: idFragment },
-      });
-      expect(Number(totalTasks)).toBe(1);
-      expect(tasks).toHaveLength(1);
-      expect(tasks[0].id).toBe(taskId1);
-    },
-  );
+      it('should filter by matching spec content', async () => {
+        const { store, knex } = await createStoreForDb(databaseId);
+        try {
+          await store.createTask({
+            spec: {
+              templateInfo: { entityRef: 'template:default/my-template' },
+            } as TaskSpec,
+            createdBy: 'me',
+          });
+          await store.createTask({
+            spec: {
+              templateInfo: { entityRef: 'template:default/other' },
+            } as TaskSpec,
+            createdBy: 'me',
+          });
 
-  it.each(databases.eachSupportedId())(
-    'should filter tasks by fullTextFilter matching spec content, %p',
-    async databaseId => {
-      const { store } = await createStoreForDb(databaseId);
-      await store.createTask({
-        spec: {
-          templateInfo: { entityRef: 'template:default/my-template' },
-        } as TaskSpec,
-        createdBy: 'me',
-      });
-      await store.createTask({
-        spec: {
-          templateInfo: { entityRef: 'template:default/other' },
-        } as TaskSpec,
-        createdBy: 'me',
-      });
-
-      const { tasks, totalTasks } = await store.list({
-        filters: { fullTextFilter: 'my-template' },
-      });
-      expect(Number(totalTasks)).toBe(1);
-      expect(tasks).toHaveLength(1);
-      expect(tasks[0].spec.templateInfo?.entityRef).toBe(
-        'template:default/my-template',
-      );
-    },
-  );
-
-  it.each(databases.eachSupportedId())(
-    'should require all fullTextFilter terms to match for multi-word queries, %p',
-    async databaseId => {
-      const { store } = await createStoreForDb(databaseId);
-      await store.createTask({
-        spec: {
-          templateInfo: { entityRef: 'template:default/create-service' },
-        } as TaskSpec,
-        createdBy: 'user:default/alice',
-      });
-      await store.createTask({
-        spec: {
-          templateInfo: { entityRef: 'template:default/create-website' },
-        } as TaskSpec,
-        createdBy: 'user:default/bob',
-      });
-      await store.createTask({
-        spec: {
-          templateInfo: { entityRef: 'template:default/delete-service' },
-        } as TaskSpec,
-        createdBy: 'user:default/alice',
+          const { tasks, totalTasks } = await store.list({
+            filters: { fullTextFilter: 'my-template' },
+          });
+          expect(Number(totalTasks)).toBe(1);
+          expect(tasks).toHaveLength(1);
+          expect(tasks[0].spec.templateInfo?.entityRef).toBe(
+            'template:default/my-template',
+          );
+        } finally {
+          await knex.destroy();
+        }
       });
 
-      const { tasks: both } = await store.list({
-        filters: { fullTextFilter: 'create service' },
-      });
-      expect(both).toHaveLength(1);
-      expect(both[0].spec.templateInfo?.entityRef).toBe(
-        'template:default/create-service',
-      );
+      it('should require all terms to match for multi-word queries', async () => {
+        const { store, knex } = await createStoreForDb(databaseId);
+        try {
+          await store.createTask({
+            spec: {
+              templateInfo: { entityRef: 'template:default/create-service' },
+            } as TaskSpec,
+            createdBy: 'user:default/alice',
+          });
+          await store.createTask({
+            spec: {
+              templateInfo: { entityRef: 'template:default/create-website' },
+            } as TaskSpec,
+            createdBy: 'user:default/bob',
+          });
+          await store.createTask({
+            spec: {
+              templateInfo: { entityRef: 'template:default/delete-service' },
+            } as TaskSpec,
+            createdBy: 'user:default/alice',
+          });
 
-      const { tasks: createOnly } = await store.list({
-        filters: { fullTextFilter: 'create' },
-      });
-      expect(createOnly).toHaveLength(2);
+          const { tasks: both } = await store.list({
+            filters: { fullTextFilter: 'create service' },
+          });
+          expect(both).toHaveLength(1);
+          expect(both[0].spec.templateInfo?.entityRef).toBe(
+            'template:default/create-service',
+          );
 
-      const { tasks: noMatch } = await store.list({
-        filters: { fullTextFilter: 'create nonexistent' },
-      });
-      expect(noMatch).toHaveLength(0);
-    },
-  );
+          const { tasks: createOnly } = await store.list({
+            filters: { fullTextFilter: 'create' },
+          });
+          expect(createOnly).toHaveLength(2);
 
-  it.each(databases.eachSupportedId())(
-    'should escape LIKE wildcards in fullTextFilter terms, %p',
-    async databaseId => {
-      const { store } = await createStoreForDb(databaseId);
-      await store.createTask({
-        spec: {
-          templateInfo: { entityRef: 'template:default/foo' },
-        } as TaskSpec,
-        createdBy: 'me',
-      });
-      await store.createTask({
-        spec: {
-          templateInfo: { entityRef: 'template:default/bar' },
-        } as TaskSpec,
-        createdBy: 'me',
-      });
-
-      const { tasks: wildcardSearch } = await store.list({
-        filters: { fullTextFilter: '%' },
-      });
-      expect(wildcardSearch).toHaveLength(0);
-
-      const { tasks: underscoreSearch } = await store.list({
-        filters: { fullTextFilter: 'f_o' },
-      });
-      expect(underscoreSearch).toHaveLength(0);
-    },
-  );
-
-  it.each(databases.eachSupportedId())(
-    'should combine fullTextFilter with other filters, %p',
-    async databaseId => {
-      const { store } = await createStoreForDb(databaseId);
-      await store.createTask({
-        spec: {
-          templateInfo: { entityRef: 'template:default/service' },
-        } as TaskSpec,
-        createdBy: 'user:default/alice',
-      });
-      await store.createTask({
-        spec: {
-          templateInfo: { entityRef: 'template:default/service' },
-        } as TaskSpec,
-        createdBy: 'user:default/bob',
+          const { tasks: noMatch } = await store.list({
+            filters: { fullTextFilter: 'create nonexistent' },
+          });
+          expect(noMatch).toHaveLength(0);
+        } finally {
+          await knex.destroy();
+        }
       });
 
-      const { tasks, totalTasks } = await store.list({
-        filters: { fullTextFilter: 'service', createdBy: 'user:default/alice' },
+      it('should escape LIKE wildcards in filter terms', async () => {
+        const { store, knex } = await createStoreForDb(databaseId);
+        try {
+          await store.createTask({
+            spec: {
+              templateInfo: { entityRef: 'template:default/foo' },
+            } as TaskSpec,
+            createdBy: 'me',
+          });
+          await store.createTask({
+            spec: {
+              templateInfo: { entityRef: 'template:default/bar' },
+            } as TaskSpec,
+            createdBy: 'me',
+          });
+
+          const { tasks: wildcardSearch } = await store.list({
+            filters: { fullTextFilter: '%' },
+          });
+          expect(wildcardSearch).toHaveLength(0);
+
+          const { tasks: underscoreSearch } = await store.list({
+            filters: { fullTextFilter: 'f_o' },
+          });
+          expect(underscoreSearch).toHaveLength(0);
+        } finally {
+          await knex.destroy();
+        }
       });
-      expect(Number(totalTasks)).toBe(1);
-      expect(tasks).toHaveLength(1);
-      expect(tasks[0].createdBy).toBe('user:default/alice');
+
+      it('should combine with other filters', async () => {
+        const { store, knex } = await createStoreForDb(databaseId);
+        try {
+          await store.createTask({
+            spec: {
+              templateInfo: { entityRef: 'template:default/service' },
+            } as TaskSpec,
+            createdBy: 'user:default/alice',
+          });
+          await store.createTask({
+            spec: {
+              templateInfo: { entityRef: 'template:default/service' },
+            } as TaskSpec,
+            createdBy: 'user:default/bob',
+          });
+
+          const { tasks, totalTasks } = await store.list({
+            filters: {
+              fullTextFilter: 'service',
+              createdBy: 'user:default/alice',
+            },
+          });
+          expect(Number(totalTasks)).toBe(1);
+          expect(tasks).toHaveLength(1);
+          expect(tasks[0].createdBy).toBe('user:default/alice');
+        } finally {
+          await knex.destroy();
+        }
+      });
     },
   );
 

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.ts
@@ -249,6 +249,7 @@ export class DatabaseTaskStore implements TaskStore {
       createdBy?: string | string[];
       status?: TaskStatus | TaskStatus[];
     };
+    search?: string;
     pagination?: {
       limit?: number;
       offset?: number;
@@ -256,8 +257,15 @@ export class DatabaseTaskStore implements TaskStore {
     order?: { order: 'asc' | 'desc'; field: string }[];
     permissionFilters?: PermissionCriteria<TaskFilters>;
   }): Promise<{ tasks: SerializedTask[]; totalTasks?: number }> {
-    const { createdBy, status, pagination, order, filters, permissionFilters } =
-      options ?? {};
+    const {
+      createdBy,
+      status,
+      search,
+      pagination,
+      order,
+      filters,
+      permissionFilters,
+    } = options ?? {};
     const queryBuilder = this.db<RawDbTaskRow & { count: number }>('tasks');
 
     const createdByValues = flattenParams<string>(
@@ -287,6 +295,13 @@ export class DatabaseTaskStore implements TaskStore {
         filters?.status,
       );
       queryBuilder.whereIn('status', [...new Set(arr)]);
+    }
+
+    if (search) {
+      const pattern = `%${search}%`;
+      queryBuilder.andWhere(sub => {
+        sub.where('id', 'like', pattern).orWhere('spec', 'like', pattern);
+      });
     }
 
     const countQuery = queryBuilder.clone();

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.ts
@@ -248,7 +248,7 @@ export class DatabaseTaskStore implements TaskStore {
     filters?: {
       createdBy?: string | string[];
       status?: TaskStatus | TaskStatus[];
-      search?: string;
+      fullTextFilter?: string;
     };
     pagination?: {
       limit?: number;
@@ -259,7 +259,7 @@ export class DatabaseTaskStore implements TaskStore {
   }): Promise<{ tasks: SerializedTask[]; totalTasks?: number }> {
     const { createdBy, status, pagination, order, filters, permissionFilters } =
       options ?? {};
-    const { search } = filters ?? {};
+    const { fullTextFilter } = filters ?? {};
     const queryBuilder = this.db<RawDbTaskRow & { count: number }>('tasks');
 
     const createdByValues = flattenParams<string>(
@@ -291,8 +291,8 @@ export class DatabaseTaskStore implements TaskStore {
       queryBuilder.whereIn('status', [...new Set(arr)]);
     }
 
-    if (search) {
-      const terms = search.split(/\s+/).filter(Boolean);
+    if (fullTextFilter) {
+      const terms = fullTextFilter.split(/\s+/).filter(Boolean);
       const isPg = this.db.client.config.client === 'pg';
       const idExpr = isPg ? 'CAST(?? AS TEXT)' : '??';
       const like = isPg ? 'ILIKE' : 'LIKE';

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.ts
@@ -293,8 +293,10 @@ export class DatabaseTaskStore implements TaskStore {
 
     if (search) {
       const terms = search.split(/\s+/).filter(Boolean);
-      const isPg = this.db.client.config.client === 'pg';
-      const idExpr = isPg ? 'CAST("id" AS TEXT)' : '"id"';
+      const client = this.db.client.config.client;
+      const q = client === 'mysql2' ? '`' : '"';
+      const idExpr =
+        client === 'pg' ? `CAST(${q}id${q} AS TEXT)` : `${q}id${q}`;
 
       for (const term of terms) {
         const escaped = term.replace(/[%_\\]/g, '\\$&');
@@ -302,7 +304,7 @@ export class DatabaseTaskStore implements TaskStore {
         queryBuilder.andWhere(sub => {
           sub
             .whereRaw(`${idExpr} LIKE ? ESCAPE ?`, [pattern, '\\'])
-            .orWhereRaw('"spec" LIKE ? ESCAPE ?', [pattern, '\\']);
+            .orWhereRaw(`${q}spec${q} LIKE ? ESCAPE ?`, [pattern, '\\']);
         });
       }
     }

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.ts
@@ -293,18 +293,16 @@ export class DatabaseTaskStore implements TaskStore {
 
     if (search) {
       const terms = search.split(/\s+/).filter(Boolean);
-      const client = this.db.client.config.client;
-      const q = client === 'mysql2' ? '`' : '"';
-      const idExpr =
-        client === 'pg' ? `CAST(${q}id${q} AS TEXT)` : `${q}id${q}`;
+      const isPg = this.db.client.config.client === 'pg';
+      const idExpr = isPg ? 'CAST(?? AS TEXT)' : '??';
 
       for (const term of terms) {
         const escaped = term.replace(/[%_\\]/g, '\\$&');
         const pattern = `%${escaped}%`;
         queryBuilder.andWhere(sub => {
           sub
-            .whereRaw(`${idExpr} LIKE ? ESCAPE ?`, [pattern, '\\'])
-            .orWhereRaw(`${q}spec${q} LIKE ? ESCAPE ?`, [pattern, '\\']);
+            .whereRaw(`${idExpr} LIKE ? ESCAPE ?`, ['id', pattern, '\\'])
+            .orWhereRaw('?? LIKE ? ESCAPE ?', ['spec', pattern, '\\']);
         });
       }
     }

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.ts
@@ -248,8 +248,8 @@ export class DatabaseTaskStore implements TaskStore {
     filters?: {
       createdBy?: string | string[];
       status?: TaskStatus | TaskStatus[];
+      search?: string;
     };
-    search?: string;
     pagination?: {
       limit?: number;
       offset?: number;
@@ -257,15 +257,9 @@ export class DatabaseTaskStore implements TaskStore {
     order?: { order: 'asc' | 'desc'; field: string }[];
     permissionFilters?: PermissionCriteria<TaskFilters>;
   }): Promise<{ tasks: SerializedTask[]; totalTasks?: number }> {
-    const {
-      createdBy,
-      status,
-      search,
-      pagination,
-      order,
-      filters,
-      permissionFilters,
-    } = options ?? {};
+    const { createdBy, status, pagination, order, filters, permissionFilters } =
+      options ?? {};
+    const { search } = filters ?? {};
     const queryBuilder = this.db<RawDbTaskRow & { count: number }>('tasks');
 
     const createdByValues = flattenParams<string>(

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.ts
@@ -295,14 +295,15 @@ export class DatabaseTaskStore implements TaskStore {
       const terms = search.split(/\s+/).filter(Boolean);
       const isPg = this.db.client.config.client === 'pg';
       const idExpr = isPg ? 'CAST(?? AS TEXT)' : '??';
+      const like = isPg ? 'ILIKE' : 'LIKE';
 
       for (const term of terms) {
         const escaped = term.replace(/[%_\\]/g, '\\$&');
         const pattern = `%${escaped}%`;
         queryBuilder.andWhere(sub => {
           sub
-            .whereRaw(`${idExpr} LIKE ? ESCAPE ?`, ['id', pattern, '\\'])
-            .orWhereRaw('?? LIKE ? ESCAPE ?', ['spec', pattern, '\\']);
+            .whereRaw(`${idExpr} ${like} ? ESCAPE ?`, ['id', pattern, '\\'])
+            .orWhereRaw(`?? ${like} ? ESCAPE ?`, ['spec', pattern, '\\']);
         });
       }
     }

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.ts
@@ -303,7 +303,8 @@ export class DatabaseTaskStore implements TaskStore {
         queryBuilder.andWhere(sub => {
           sub
             .whereRaw(`${idExpr} ${like} ? ESCAPE ?`, ['id', pattern, '\\'])
-            .orWhereRaw(`?? ${like} ? ESCAPE ?`, ['spec', pattern, '\\']);
+            .orWhereRaw(`?? ${like} ? ESCAPE ?`, ['spec', pattern, '\\'])
+            .orWhereRaw(`?? ${like} ? ESCAPE ?`, ['status', pattern, '\\']);
         });
       }
     }

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.ts
@@ -298,10 +298,19 @@ export class DatabaseTaskStore implements TaskStore {
     }
 
     if (search) {
-      const pattern = `%${search}%`;
-      queryBuilder.andWhere(sub => {
-        sub.where('id', 'like', pattern).orWhere('spec', 'like', pattern);
-      });
+      const terms = search.split(/\s+/).filter(Boolean);
+      const isPg = this.db.client.config.client === 'pg';
+      const idExpr = isPg ? 'CAST("id" AS TEXT)' : '"id"';
+
+      for (const term of terms) {
+        const escaped = term.replace(/[%_\\]/g, '\\$&');
+        const pattern = `%${escaped}%`;
+        queryBuilder.andWhere(sub => {
+          sub
+            .whereRaw(`${idExpr} LIKE ? ESCAPE ?`, [pattern, '\\'])
+            .orWhereRaw('"spec" LIKE ? ESCAPE ?', [pattern, '\\']);
+        });
+      }
     }
 
     const countQuery = queryBuilder.clone();

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/StorageTaskBroker.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/StorageTaskBroker.ts
@@ -295,8 +295,8 @@ export class StorageTaskBroker implements TaskBroker {
     filters?: {
       createdBy?: string | string[];
       status?: TaskStatus | TaskStatus[];
+      search?: string;
     };
-    search?: string;
     pagination?: {
       limit?: number;
       offset?: number;

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/StorageTaskBroker.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/StorageTaskBroker.ts
@@ -296,6 +296,7 @@ export class StorageTaskBroker implements TaskBroker {
       createdBy?: string | string[];
       status?: TaskStatus | TaskStatus[];
     };
+    search?: string;
     pagination?: {
       limit?: number;
       offset?: number;

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/StorageTaskBroker.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/StorageTaskBroker.ts
@@ -295,7 +295,7 @@ export class StorageTaskBroker implements TaskBroker {
     filters?: {
       createdBy?: string | string[];
       status?: TaskStatus | TaskStatus[];
-      search?: string;
+      fullTextFilter?: string;
     };
     pagination?: {
       limit?: number;

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/types.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/types.ts
@@ -114,7 +114,7 @@ export interface TaskStore {
     filters?: {
       createdBy?: string | string[];
       status?: TaskStatus | TaskStatus[];
-      search?: string;
+      fullTextFilter?: string;
     };
     pagination?: {
       limit?: number;

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/types.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/types.ts
@@ -114,8 +114,8 @@ export interface TaskStore {
     filters?: {
       createdBy?: string | string[];
       status?: TaskStatus | TaskStatus[];
+      search?: string;
     };
-    search?: string;
     pagination?: {
       limit?: number;
       offset?: number;

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/types.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/types.ts
@@ -115,6 +115,7 @@ export interface TaskStore {
       createdBy?: string | string[];
       status?: TaskStatus | TaskStatus[];
     };
+    search?: string;
     pagination?: {
       limit?: number;
       offset?: number;

--- a/plugins/scaffolder-backend/src/schema/openapi.yaml
+++ b/plugins/scaffolder-backend/src/schema/openapi.yaml
@@ -77,6 +77,14 @@ components:
         type: array
         items:
           type: string
+    search:
+      name: search
+      in: query
+      description: Search string to filter tasks by ID or template name.
+      required: false
+      allowReserved: true
+      schema:
+        type: string
     status:
       name: status
       in: query
@@ -577,6 +585,7 @@ paths:
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/offset'
         - $ref: '#/components/parameters/order'
+        - $ref: '#/components/parameters/search'
         - $ref: '#/components/parameters/status'
     post:
       operationId: Scaffold

--- a/plugins/scaffolder-backend/src/schema/openapi.yaml
+++ b/plugins/scaffolder-backend/src/schema/openapi.yaml
@@ -77,8 +77,8 @@ components:
         type: array
         items:
           type: string
-    search:
-      name: search
+    fullTextFilter:
+      name: fullTextFilter
       in: query
       description: Search string to filter tasks by ID or template name.
       required: false
@@ -585,7 +585,7 @@ paths:
         - $ref: '#/components/parameters/limit'
         - $ref: '#/components/parameters/offset'
         - $ref: '#/components/parameters/order'
-        - $ref: '#/components/parameters/search'
+        - $ref: '#/components/parameters/fullTextFilter'
         - $ref: '#/components/parameters/status'
     post:
       operationId: Scaffold

--- a/plugins/scaffolder-backend/src/schema/openapi/generated/apis/Api.server.ts
+++ b/plugins/scaffolder-backend/src/schema/openapi/generated/apis/Api.server.ts
@@ -98,6 +98,7 @@ export type ListTasks = {
     limit?: number;
     offset?: number;
     order?: Array<string>;
+    search?: string;
     status?: Array<string>;
   };
   response: ListTasksResponse;

--- a/plugins/scaffolder-backend/src/schema/openapi/generated/apis/Api.server.ts
+++ b/plugins/scaffolder-backend/src/schema/openapi/generated/apis/Api.server.ts
@@ -98,7 +98,7 @@ export type ListTasks = {
     limit?: number;
     offset?: number;
     order?: Array<string>;
-    search?: string;
+    fullTextFilter?: string;
     status?: Array<string>;
   };
   response: ListTasksResponse;

--- a/plugins/scaffolder-backend/src/schema/openapi/generated/router.ts
+++ b/plugins/scaffolder-backend/src/schema/openapi/generated/router.ts
@@ -124,8 +124,8 @@ export const spec = {
           },
         },
       },
-      search: {
-        name: 'search',
+      fullTextFilter: {
+        name: 'fullTextFilter',
         in: 'query',
         description: 'Search string to filter tasks by ID or template name.',
         required: false,
@@ -863,7 +863,7 @@ export const spec = {
             $ref: '#/components/parameters/order',
           },
           {
-            $ref: '#/components/parameters/search',
+            $ref: '#/components/parameters/fullTextFilter',
           },
           {
             $ref: '#/components/parameters/status',

--- a/plugins/scaffolder-backend/src/schema/openapi/generated/router.ts
+++ b/plugins/scaffolder-backend/src/schema/openapi/generated/router.ts
@@ -124,6 +124,16 @@ export const spec = {
           },
         },
       },
+      search: {
+        name: 'search',
+        in: 'query',
+        description: 'Search string to filter tasks by ID or template name.',
+        required: false,
+        allowReserved: true,
+        schema: {
+          type: 'string',
+        },
+      },
       status: {
         name: 'status',
         in: 'query',
@@ -851,6 +861,9 @@ export const spec = {
           },
           {
             $ref: '#/components/parameters/order',
+          },
+          {
+            $ref: '#/components/parameters/search',
           },
           {
             $ref: '#/components/parameters/status',

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -687,8 +687,8 @@ export async function createRouter(
           filters: {
             createdBy,
             status: status ? (status as TaskStatus[]) : undefined,
+            search: typeof search === 'string' ? search : undefined,
           },
-          search: typeof search === 'string' ? search : undefined,
           order,
           pagination: {
             limit,

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -674,7 +674,7 @@ export async function createRouter(
           };
         });
 
-        const { limit, offset } = req.query;
+        const { limit, offset, search } = req.query;
 
         const taskPermissionFilters = await getAuthorizeConditions({
           credentials: credentials,
@@ -688,6 +688,7 @@ export async function createRouter(
             createdBy,
             status: status ? (status as TaskStatus[]) : undefined,
           },
+          search: typeof search === 'string' ? search : undefined,
           order,
           pagination: {
             limit,

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -674,7 +674,7 @@ export async function createRouter(
           };
         });
 
-        const { limit, offset, search } = req.query;
+        const { limit, offset, fullTextFilter } = req.query;
 
         const taskPermissionFilters = await getAuthorizeConditions({
           credentials: credentials,
@@ -687,7 +687,8 @@ export async function createRouter(
           filters: {
             createdBy,
             status: status ? (status as TaskStatus[]) : undefined,
-            search: typeof search === 'string' ? search : undefined,
+            fullTextFilter:
+              typeof fullTextFilter === 'string' ? fullTextFilter : undefined,
           },
           order,
           pagination: {

--- a/plugins/scaffolder-common/report.api.md
+++ b/plugins/scaffolder-common/report.api.md
@@ -104,7 +104,7 @@ export interface ScaffolderApi {
       filterByOwnership: 'owned' | 'all';
       limit?: number;
       offset?: number;
-      search?: string;
+      fullTextFilter?: string;
     },
     options?: ScaffolderRequestOptions,
   ): Promise<{
@@ -196,7 +196,7 @@ export class ScaffolderClient implements ScaffolderApi {
       filterByOwnership: 'owned' | 'all';
       limit?: number;
       offset?: number;
-      search?: string;
+      fullTextFilter?: string;
     },
     options?: ScaffolderRequestOptions,
   ): Promise<{

--- a/plugins/scaffolder-common/report.api.md
+++ b/plugins/scaffolder-common/report.api.md
@@ -104,6 +104,7 @@ export interface ScaffolderApi {
       filterByOwnership: 'owned' | 'all';
       limit?: number;
       offset?: number;
+      search?: string;
     },
     options?: ScaffolderRequestOptions,
   ): Promise<{
@@ -195,6 +196,7 @@ export class ScaffolderClient implements ScaffolderApi {
       filterByOwnership: 'owned' | 'all';
       limit?: number;
       offset?: number;
+      search?: string;
     },
     options?: ScaffolderRequestOptions,
   ): Promise<{

--- a/plugins/scaffolder-common/src/ScaffolderClient.ts
+++ b/plugins/scaffolder-common/src/ScaffolderClient.ts
@@ -92,7 +92,7 @@ export class ScaffolderClient implements ScaffolderApi {
       filterByOwnership: 'owned' | 'all';
       limit?: number;
       offset?: number;
-      search?: string;
+      fullTextFilter?: string;
     },
     options?: ScaffolderRequestOptions,
   ): Promise<{ tasks: ScaffolderTask[]; totalTasks?: number }> {
@@ -114,7 +114,7 @@ export class ScaffolderClient implements ScaffolderApi {
                 : undefined,
             limit: request.limit,
             offset: request.offset,
-            search: request.search || undefined,
+            fullTextFilter: request.fullTextFilter || undefined,
           },
         },
         options,

--- a/plugins/scaffolder-common/src/ScaffolderClient.ts
+++ b/plugins/scaffolder-common/src/ScaffolderClient.ts
@@ -92,6 +92,7 @@ export class ScaffolderClient implements ScaffolderApi {
       filterByOwnership: 'owned' | 'all';
       limit?: number;
       offset?: number;
+      search?: string;
     },
     options?: ScaffolderRequestOptions,
   ): Promise<{ tasks: ScaffolderTask[]; totalTasks?: number }> {
@@ -113,6 +114,7 @@ export class ScaffolderClient implements ScaffolderApi {
                 : undefined,
             limit: request.limit,
             offset: request.offset,
+            search: request.search || undefined,
           },
         },
         options,

--- a/plugins/scaffolder-common/src/api.ts
+++ b/plugins/scaffolder-common/src/api.ts
@@ -297,7 +297,7 @@ export interface ScaffolderApi {
       filterByOwnership: 'owned' | 'all';
       limit?: number;
       offset?: number;
-      search?: string;
+      fullTextFilter?: string;
     },
     options?: ScaffolderRequestOptions,
   ): Promise<{ tasks: ScaffolderTask[]; totalTasks?: number }>;

--- a/plugins/scaffolder-common/src/api.ts
+++ b/plugins/scaffolder-common/src/api.ts
@@ -297,6 +297,7 @@ export interface ScaffolderApi {
       filterByOwnership: 'owned' | 'all';
       limit?: number;
       offset?: number;
+      search?: string;
     },
     options?: ScaffolderRequestOptions,
   ): Promise<{ tasks: ScaffolderTask[]; totalTasks?: number }>;

--- a/plugins/scaffolder-common/src/schema/openapi/generated/apis/Api.client.ts
+++ b/plugins/scaffolder-common/src/schema/openapi/generated/apis/Api.client.ts
@@ -110,6 +110,7 @@ export type ListTasks = {
     limit?: number;
     offset?: number;
     order?: Array<string>;
+    search?: string;
     status?: Array<string>;
   };
 };
@@ -325,6 +326,7 @@ export class DefaultApiClient {
    * @param limit - Number of records to return in the response.
    * @param offset - Number of records to skip in the query page.
    * @param order - Order
+   * @param search - Search string to filter tasks by ID or template name.
    * @param status - Status
    */
   public async listTasks(
@@ -334,7 +336,7 @@ export class DefaultApiClient {
   ): Promise<TypedResponse<ListTasksResponse>> {
     const baseUrl = await this.discoveryApi.getBaseUrl(pluginId);
 
-    const uriTemplate = `/v2/tasks{?createdBy*,limit,offset,order*,status*}`;
+    const uriTemplate = `/v2/tasks{?createdBy*,limit,offset,order*,search,status*}`;
 
     const uri = parser.parse(uriTemplate).expand({
       ...request.query,

--- a/plugins/scaffolder-common/src/schema/openapi/generated/apis/Api.client.ts
+++ b/plugins/scaffolder-common/src/schema/openapi/generated/apis/Api.client.ts
@@ -110,7 +110,7 @@ export type ListTasks = {
     limit?: number;
     offset?: number;
     order?: Array<string>;
-    search?: string;
+    fullTextFilter?: string;
     status?: Array<string>;
   };
 };
@@ -326,7 +326,7 @@ export class DefaultApiClient {
    * @param limit - Number of records to return in the response.
    * @param offset - Number of records to skip in the query page.
    * @param order - Order
-   * @param search - Search string to filter tasks by ID or template name.
+   * @param fullTextFilter - Search string to filter tasks by ID or template name.
    * @param status - Status
    */
   public async listTasks(
@@ -336,7 +336,7 @@ export class DefaultApiClient {
   ): Promise<TypedResponse<ListTasksResponse>> {
     const baseUrl = await this.discoveryApi.getBaseUrl(pluginId);
 
-    const uriTemplate = `/v2/tasks{?createdBy*,limit,offset,order*,search,status*}`;
+    const uriTemplate = `/v2/tasks{?createdBy*,limit,offset,order*,fullTextFilter,status*}`;
 
     const uri = parser.parse(uriTemplate).expand({
       ...request.query,

--- a/plugins/scaffolder-node/report.api.md
+++ b/plugins/scaffolder-node/report.api.md
@@ -515,6 +515,7 @@ export interface TaskBroker {
       createdBy?: string | string[];
       status?: TaskStatus | TaskStatus[];
     };
+    search?: string;
     pagination?: {
       limit?: number;
       offset?: number;

--- a/plugins/scaffolder-node/report.api.md
+++ b/plugins/scaffolder-node/report.api.md
@@ -514,8 +514,8 @@ export interface TaskBroker {
     filters?: {
       createdBy?: string | string[];
       status?: TaskStatus | TaskStatus[];
+      search?: string;
     };
-    search?: string;
     pagination?: {
       limit?: number;
       offset?: number;

--- a/plugins/scaffolder-node/report.api.md
+++ b/plugins/scaffolder-node/report.api.md
@@ -514,7 +514,7 @@ export interface TaskBroker {
     filters?: {
       createdBy?: string | string[];
       status?: TaskStatus | TaskStatus[];
-      search?: string;
+      fullTextFilter?: string;
     };
     pagination?: {
       limit?: number;

--- a/plugins/scaffolder-node/src/tasks/types.ts
+++ b/plugins/scaffolder-node/src/tasks/types.ts
@@ -225,8 +225,8 @@ export interface TaskBroker {
     filters?: {
       createdBy?: string | string[];
       status?: TaskStatus | TaskStatus[];
+      search?: string;
     };
-    search?: string;
     pagination?: {
       limit?: number;
       offset?: number;

--- a/plugins/scaffolder-node/src/tasks/types.ts
+++ b/plugins/scaffolder-node/src/tasks/types.ts
@@ -225,7 +225,7 @@ export interface TaskBroker {
     filters?: {
       createdBy?: string | string[];
       status?: TaskStatus | TaskStatus[];
-      search?: string;
+      fullTextFilter?: string;
     };
     pagination?: {
       limit?: number;

--- a/plugins/scaffolder-node/src/tasks/types.ts
+++ b/plugins/scaffolder-node/src/tasks/types.ts
@@ -226,6 +226,7 @@ export interface TaskBroker {
       createdBy?: string | string[];
       status?: TaskStatus | TaskStatus[];
     };
+    search?: string;
     pagination?: {
       limit?: number;
       offset?: number;

--- a/plugins/scaffolder/src/components/ListTasksPage/ListTasksPage.tsx
+++ b/plugins/scaffolder/src/components/ListTasksPage/ListTasksPage.tsx
@@ -65,16 +65,16 @@ export const ListTaskPageContent = (props: MyTaskPageProps) => {
   const { t } = useTranslationRef(scaffolderTranslationRef);
   const [limit, setLimit] = useState(5);
   const [page, setPage] = useState(0);
-  const [searchInput, setSearchInput] = useState('');
-  const [search, setSearch] = useState('');
+  const [filterInput, setFilterInput] = useState('');
+  const [fullTextFilter, setFullTextFilter] = useState('');
 
   useDebounce(
     () => {
-      setSearch(searchInput);
+      setFullTextFilter(filterInput);
       setPage(0);
     },
     300,
-    [searchInput],
+    [filterInput],
   );
 
   const scaffolderApi = useApi(scaffolderApiRef);
@@ -88,7 +88,7 @@ export const ListTaskPageContent = (props: MyTaskPageProps) => {
         filterByOwnership: ownerFilter,
         limit,
         offset: page * limit,
-        search: search || undefined,
+        fullTextFilter: fullTextFilter || undefined,
       });
     }
 
@@ -98,7 +98,7 @@ export const ListTaskPageContent = (props: MyTaskPageProps) => {
     );
 
     return Promise.resolve({ tasks: [], totalTasks: 0 });
-  }, [scaffolderApi, ownerFilter, limit, page, search]);
+  }, [scaffolderApi, ownerFilter, limit, page, fullTextFilter]);
 
   if (!value && loading) {
     return <Progress />;
@@ -140,7 +140,7 @@ export const ListTaskPageContent = (props: MyTaskPageProps) => {
             setLimit(pageSize);
           }}
           onPageChange={newPage => setPage(newPage)}
-          onSearchChange={text => setSearchInput(text)}
+          onSearchChange={text => setFilterInput(text)}
           options={{
             pageSize: limit,
             emptyRowsWhenPaging: false,

--- a/plugins/scaffolder/src/components/ListTasksPage/ListTasksPage.tsx
+++ b/plugins/scaffolder/src/components/ListTasksPage/ListTasksPage.tsx
@@ -68,7 +68,18 @@ export const ListTaskPageContent = (props: MyTaskPageProps) => {
   const [searchInput, setSearchInput] = useState('');
   const [search, setSearch] = useState('');
 
-  useDebounce(() => setSearch(searchInput), 300, [searchInput]);
+  useDebounce(
+    () => {
+      setSearch(prev => {
+        if (prev !== searchInput) {
+          setPage(0);
+        }
+        return searchInput;
+      });
+    },
+    300,
+    [searchInput],
+  );
 
   const scaffolderApi = useApi(scaffolderApiRef);
   const rootLink = useRouteRef(rootRouteRef);
@@ -132,10 +143,7 @@ export const ListTaskPageContent = (props: MyTaskPageProps) => {
             setLimit(pageSize);
           }}
           onPageChange={newPage => setPage(newPage)}
-          onSearchChange={text => {
-            setPage(0);
-            setSearchInput(text);
-          }}
+          onSearchChange={text => setSearchInput(text)}
           options={{
             pageSize: limit,
             emptyRowsWhenPaging: false,

--- a/plugins/scaffolder/src/components/ListTasksPage/ListTasksPage.tsx
+++ b/plugins/scaffolder/src/components/ListTasksPage/ListTasksPage.tsx
@@ -163,6 +163,7 @@ export const ListTaskPageContent = (props: MyTaskPageProps) => {
             {
               title: t('listTaskPage.content.tableCell.taskID'),
               field: 'id',
+              searchable: false,
               render: row => (
                 <Link to={`${rootLink()}/tasks/${row.id}`}>{row.id}</Link>
               ),
@@ -170,6 +171,7 @@ export const ListTaskPageContent = (props: MyTaskPageProps) => {
             {
               title: t('listTaskPage.content.tableCell.template'),
               field: 'spec.templateInfo.entity.metadata.title',
+              searchable: false,
               render: row => (
                 <TemplateTitleColumn
                   entityRef={row.spec.templateInfo?.entityRef}
@@ -179,11 +181,13 @@ export const ListTaskPageContent = (props: MyTaskPageProps) => {
             {
               title: t('listTaskPage.content.tableCell.created'),
               field: 'createdAt',
+              searchable: false,
               render: row => <CreatedAtColumn createdAt={row.createdAt} />,
             },
             {
               title: t('listTaskPage.content.tableCell.owner'),
               field: 'createdBy',
+              searchable: false,
               render: row => (
                 <OwnerEntityColumn entityRef={row.spec?.user?.ref} />
               ),
@@ -191,6 +195,7 @@ export const ListTaskPageContent = (props: MyTaskPageProps) => {
             {
               title: t('listTaskPage.content.tableCell.status'),
               field: 'status',
+              searchable: false,
               render: row => <TaskStatusColumn status={row.status} />,
             },
           ]}

--- a/plugins/scaffolder/src/components/ListTasksPage/ListTasksPage.tsx
+++ b/plugins/scaffolder/src/components/ListTasksPage/ListTasksPage.tsx
@@ -26,6 +26,7 @@ import {
 import { useApi, useRouteRef } from '@backstage/core-plugin-api';
 import { CatalogFilterLayout } from '@backstage/plugin-catalog-react';
 import useAsync from 'react-use/esm/useAsync';
+import useDebounce from 'react-use/esm/useDebounce';
 import { useState } from 'react';
 import {
   scaffolderApiRef,
@@ -64,6 +65,10 @@ export const ListTaskPageContent = (props: MyTaskPageProps) => {
   const { t } = useTranslationRef(scaffolderTranslationRef);
   const [limit, setLimit] = useState(5);
   const [page, setPage] = useState(0);
+  const [searchInput, setSearchInput] = useState('');
+  const [search, setSearch] = useState('');
+
+  useDebounce(() => setSearch(searchInput), 300, [searchInput]);
 
   const scaffolderApi = useApi(scaffolderApiRef);
   const rootLink = useRouteRef(rootRouteRef);
@@ -75,6 +80,7 @@ export const ListTaskPageContent = (props: MyTaskPageProps) => {
         filterByOwnership: ownerFilter,
         limit,
         offset: page * limit,
+        search: search || undefined,
       });
     }
 
@@ -84,7 +90,7 @@ export const ListTaskPageContent = (props: MyTaskPageProps) => {
     );
 
     return Promise.resolve({ tasks: [], totalTasks: 0 });
-  }, [scaffolderApi, ownerFilter, limit, page]);
+  }, [scaffolderApi, ownerFilter, limit, page, search]);
 
   if (loading) {
     return <Progress />;
@@ -126,7 +132,16 @@ export const ListTaskPageContent = (props: MyTaskPageProps) => {
             setLimit(pageSize);
           }}
           onPageChange={newPage => setPage(newPage)}
-          options={{ pageSize: limit, emptyRowsWhenPaging: false }}
+          onSearchChange={text => {
+            setPage(0);
+            setSearchInput(text);
+          }}
+          options={{
+            pageSize: limit,
+            emptyRowsWhenPaging: false,
+            search: true,
+            searchAutoFocus: true,
+          }}
           data={value?.tasks ?? []}
           page={page}
           totalCount={value?.totalTasks ?? 0}

--- a/plugins/scaffolder/src/components/ListTasksPage/ListTasksPage.tsx
+++ b/plugins/scaffolder/src/components/ListTasksPage/ListTasksPage.tsx
@@ -20,6 +20,7 @@ import {
   Header,
   Link,
   Page,
+  Progress,
   Table,
 } from '@backstage/core-components';
 import { useApi, useRouteRef } from '@backstage/core-plugin-api';
@@ -99,6 +100,10 @@ export const ListTaskPageContent = (props: MyTaskPageProps) => {
     return Promise.resolve({ tasks: [], totalTasks: 0 });
   }, [scaffolderApi, ownerFilter, limit, page, search]);
 
+  if (!value && loading) {
+    return <Progress />;
+  }
+
   if (error) {
     return (
       <CatalogFilterLayout>
@@ -130,7 +135,6 @@ export const ListTaskPageContent = (props: MyTaskPageProps) => {
       </CatalogFilterLayout.Filters>
       <CatalogFilterLayout.Content>
         <Table<ScaffolderTask>
-          isLoading={loading}
           onRowsPerPageChange={pageSize => {
             setPage(0);
             setLimit(pageSize);

--- a/plugins/scaffolder/src/components/ListTasksPage/ListTasksPage.tsx
+++ b/plugins/scaffolder/src/components/ListTasksPage/ListTasksPage.tsx
@@ -154,7 +154,7 @@ export const ListTaskPageContent = (props: MyTaskPageProps) => {
             {
               title: t('listTaskPage.content.tableCell.taskID'),
               field: 'id',
-              searchable: false,
+              customFilterAndSearch: () => true,
               render: row => (
                 <Link to={`${rootLink()}/tasks/${row.id}`}>{row.id}</Link>
               ),
@@ -162,7 +162,6 @@ export const ListTaskPageContent = (props: MyTaskPageProps) => {
             {
               title: t('listTaskPage.content.tableCell.template'),
               field: 'spec.templateInfo.entity.metadata.title',
-              searchable: false,
               render: row => (
                 <TemplateTitleColumn
                   entityRef={row.spec.templateInfo?.entityRef}
@@ -172,13 +171,11 @@ export const ListTaskPageContent = (props: MyTaskPageProps) => {
             {
               title: t('listTaskPage.content.tableCell.created'),
               field: 'createdAt',
-              searchable: false,
               render: row => <CreatedAtColumn createdAt={row.createdAt} />,
             },
             {
               title: t('listTaskPage.content.tableCell.owner'),
               field: 'createdBy',
-              searchable: false,
               render: row => (
                 <OwnerEntityColumn entityRef={row.spec?.user?.ref} />
               ),
@@ -186,7 +183,6 @@ export const ListTaskPageContent = (props: MyTaskPageProps) => {
             {
               title: t('listTaskPage.content.tableCell.status'),
               field: 'status',
-              searchable: false,
               render: row => <TaskStatusColumn status={row.status} />,
             },
           ]}

--- a/plugins/scaffolder/src/components/ListTasksPage/ListTasksPage.tsx
+++ b/plugins/scaffolder/src/components/ListTasksPage/ListTasksPage.tsx
@@ -27,7 +27,7 @@ import { useApi, useRouteRef } from '@backstage/core-plugin-api';
 import { CatalogFilterLayout } from '@backstage/plugin-catalog-react';
 import useAsync from 'react-use/esm/useAsync';
 import useDebounce from 'react-use/esm/useDebounce';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   scaffolderApiRef,
   ScaffolderTask,
@@ -68,29 +68,27 @@ export const ListTaskPageContent = (props: MyTaskPageProps) => {
   const [searchInput, setSearchInput] = useState('');
   const [search, setSearch] = useState('');
 
-  useDebounce(
-    () => {
-      setSearch(prev => {
-        if (prev !== searchInput) {
-          setPage(0);
-        }
-        return searchInput;
-      });
-    },
-    300,
-    [searchInput],
-  );
+  useDebounce(() => setSearch(searchInput), 300, [searchInput]);
 
   const scaffolderApi = useApi(scaffolderApiRef);
   const rootLink = useRouteRef(rootRouteRef);
 
   const [ownerFilter, setOwnerFilter] = useState(initiallySelectedFilter);
+
+  const searchChangedRef = useRef(false);
+  const prevSearchRef = useRef(search);
+  if (search !== prevSearchRef.current) {
+    prevSearchRef.current = search;
+    searchChangedRef.current = true;
+  }
+  const offset = searchChangedRef.current ? 0 : page * limit;
+
   const { value, loading, error } = useAsync(() => {
     if (scaffolderApi.listTasks) {
       return scaffolderApi.listTasks?.({
         filterByOwnership: ownerFilter,
         limit,
-        offset: page * limit,
+        offset,
         search: search || undefined,
       });
     }
@@ -101,7 +99,14 @@ export const ListTaskPageContent = (props: MyTaskPageProps) => {
     );
 
     return Promise.resolve({ tasks: [], totalTasks: 0 });
-  }, [scaffolderApi, ownerFilter, limit, page, search]);
+  }, [scaffolderApi, ownerFilter, limit, offset, search]);
+
+  useEffect(() => {
+    if (!loading && searchChangedRef.current) {
+      searchChangedRef.current = false;
+      setPage(0);
+    }
+  }, [loading]);
 
   if (loading) {
     return <Progress />;

--- a/plugins/scaffolder/src/components/ListTasksPage/ListTasksPage.tsx
+++ b/plugins/scaffolder/src/components/ListTasksPage/ListTasksPage.tsx
@@ -154,6 +154,9 @@ export const ListTaskPageContent = (props: MyTaskPageProps) => {
             {
               title: t('listTaskPage.content.tableCell.taskID'),
               field: 'id',
+              // Disable client-side search filtering; search is handled
+              // server-side. Without this, material-table filters out all
+              // rows when the search field has text.
               customFilterAndSearch: () => true,
               render: row => (
                 <Link to={`${rootLink()}/tasks/${row.id}`}>{row.id}</Link>

--- a/plugins/scaffolder/src/components/ListTasksPage/ListTasksPage.tsx
+++ b/plugins/scaffolder/src/components/ListTasksPage/ListTasksPage.tsx
@@ -27,7 +27,7 @@ import { useApi, useRouteRef } from '@backstage/core-plugin-api';
 import { CatalogFilterLayout } from '@backstage/plugin-catalog-react';
 import useAsync from 'react-use/esm/useAsync';
 import useDebounce from 'react-use/esm/useDebounce';
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import {
   scaffolderApiRef,
   ScaffolderTask,
@@ -68,27 +68,26 @@ export const ListTaskPageContent = (props: MyTaskPageProps) => {
   const [searchInput, setSearchInput] = useState('');
   const [search, setSearch] = useState('');
 
-  useDebounce(() => setSearch(searchInput), 300, [searchInput]);
+  useDebounce(
+    () => {
+      setSearch(searchInput);
+      setPage(0);
+    },
+    300,
+    [searchInput],
+  );
 
   const scaffolderApi = useApi(scaffolderApiRef);
   const rootLink = useRouteRef(rootRouteRef);
 
   const [ownerFilter, setOwnerFilter] = useState(initiallySelectedFilter);
 
-  const searchChangedRef = useRef(false);
-  const prevSearchRef = useRef(search);
-  if (search !== prevSearchRef.current) {
-    prevSearchRef.current = search;
-    searchChangedRef.current = true;
-  }
-  const offset = searchChangedRef.current ? 0 : page * limit;
-
   const { value, loading, error } = useAsync(() => {
     if (scaffolderApi.listTasks) {
       return scaffolderApi.listTasks?.({
         filterByOwnership: ownerFilter,
         limit,
-        offset,
+        offset: page * limit,
         search: search || undefined,
       });
     }
@@ -99,14 +98,7 @@ export const ListTaskPageContent = (props: MyTaskPageProps) => {
     );
 
     return Promise.resolve({ tasks: [], totalTasks: 0 });
-  }, [scaffolderApi, ownerFilter, limit, offset, search]);
-
-  useEffect(() => {
-    if (!loading && searchChangedRef.current) {
-      searchChangedRef.current = false;
-      setPage(0);
-    }
-  }, [loading]);
+  }, [scaffolderApi, ownerFilter, limit, page, search]);
 
   if (loading) {
     return <Progress />;
@@ -153,7 +145,6 @@ export const ListTaskPageContent = (props: MyTaskPageProps) => {
             pageSize: limit,
             emptyRowsWhenPaging: false,
             search: true,
-            searchAutoFocus: true,
           }}
           data={value?.tasks ?? []}
           page={page}

--- a/plugins/scaffolder/src/components/ListTasksPage/ListTasksPage.tsx
+++ b/plugins/scaffolder/src/components/ListTasksPage/ListTasksPage.tsx
@@ -20,7 +20,6 @@ import {
   Header,
   Link,
   Page,
-  Progress,
   Table,
 } from '@backstage/core-components';
 import { useApi, useRouteRef } from '@backstage/core-plugin-api';
@@ -100,10 +99,6 @@ export const ListTaskPageContent = (props: MyTaskPageProps) => {
     return Promise.resolve({ tasks: [], totalTasks: 0 });
   }, [scaffolderApi, ownerFilter, limit, page, search]);
 
-  if (loading) {
-    return <Progress />;
-  }
-
   if (error) {
     return (
       <CatalogFilterLayout>
@@ -135,6 +130,7 @@ export const ListTaskPageContent = (props: MyTaskPageProps) => {
       </CatalogFilterLayout.Filters>
       <CatalogFilterLayout.Content>
         <Table<ScaffolderTask>
+          isLoading={loading}
           onRowsPerPageChange={pageSize => {
             setPage(0);
             setLimit(pageSize);

--- a/plugins/scaffolder/src/components/ListTasksPage/columns/CreatedAtColumn.tsx
+++ b/plugins/scaffolder/src/components/ListTasksPage/columns/CreatedAtColumn.tsx
@@ -34,5 +34,5 @@ export const CreatedAtColumn: FC<CreatedAtColumnProps> = ({
     ...DateTime.DATETIME_SHORT_WITH_SECONDS,
   });
 
-  return <Typography paragraph>{formatted}</Typography>;
+  return <Typography>{formatted}</Typography>;
 };

--- a/plugins/scaffolder/src/components/ListTasksPage/columns/OwnerEntityColumn.tsx
+++ b/plugins/scaffolder/src/components/ListTasksPage/columns/OwnerEntityColumn.tsx
@@ -30,7 +30,7 @@ export const OwnerEntityColumn = ({ entityRef }: { entityRef?: string }) => {
   );
 
   if (!entityRef) {
-    return <Typography paragraph>Unknown</Typography>;
+    return <Typography>Unknown</Typography>;
   }
 
   if (loading || error) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes https://github.com/backstage/backstage/issues/30542

The scaffolder task list page's search box previously only filtered the currently visible page of results, because data is fetched with server-side pagination but the search was purely client-side (material-table filtering the in-memory `data` array).

This PR adds a `search` query parameter to the `GET /v2/tasks` backend endpoint and wires it through the full stack:

- **Backend**: `DatabaseTaskStore.list` applies a SQL `LIKE` filter on both the `id` and `spec` columns when a `search` string is provided
- **OpenAPI schema**: New `search` parameter added to `GET /v2/tasks`
- **Client**: `ScaffolderApi.listTasks` and `ScaffolderClient` accept and pass through the `search` parameter
- **Frontend**: The task list page captures the search text via material-table's `onSearchChange`, debounces it (300ms), and passes it to the API. The page resets to page 0 on each new search.

The search matches against task IDs and the JSON-serialized task spec (which contains template names, user info, etc.), so users can search by task UUID fragments, template names, or other spec content.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Made with [Cursor](https://cursor.com)