### PR TITLE
Log debug warning when a GitHub App installation is missing for an org in GithubMultiOrgEntityProvider

### DIFF
--- a/.changeset/github-multiorg-not-found-debug-log.md
+++ b/.changeset/github-multiorg-not-found-debug-log.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+`GithubMultiOrgEntityProvider` now emits a debug-level log when a GitHub App installation is not found for an organization during a read. The message points to the GitHub Apps troubleshooting docs, making it easier to diagnose cases where the app is not installed on the org or where the authenticated user lacks the Organization Owner role required to see the installation.

--- a/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.test.ts
@@ -969,6 +969,36 @@ describe('GithubMultiOrgEntityProvider', () => {
 
       expect(entityProviderConnection.applyMutation).not.toHaveBeenCalled();
     });
+
+    it('should log a debug hint and rethrow when getCredentials fails with NotFoundError', async () => {
+      entityProvider = new GithubMultiOrgEntityProvider({
+        id: 'my-id',
+        gitHubConfig,
+        githubCredentialsProvider: {
+          getCredentials: mockGetCredentials,
+        },
+        githubUrl: 'https://github.com',
+        logger,
+        orgs: ['orgA'],
+      });
+
+      await entityProvider.connect(entityProviderConnection);
+
+      const notFound = new Error('No GitHub App installation found');
+      notFound.name = 'NotFoundError';
+      mockGetCredentials.mockRejectedValueOnce(notFound);
+
+      await expect(entityProvider.read()).rejects.toThrow(
+        'No GitHub App installation found',
+      );
+
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'No GitHub App installation found for org "orgA"',
+        ),
+      );
+      expect(entityProviderConnection.applyMutation).not.toHaveBeenCalled();
+    });
   });
 
   describe('withLocations', () => {

--- a/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
@@ -25,6 +25,7 @@ import {
   stringifyEntityRef,
 } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
+import { isError } from '@backstage/errors';
 import {
   DefaultGithubCredentialsProvider,
   GithubAppCredentialsMux,
@@ -297,10 +298,21 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       : await this.getAllOrgs(this.options.gitHubConfig);
 
     for (const org of orgsToProcess) {
-      const { headers, type: tokenType } =
-        await this.options.githubCredentialsProvider.getCredentials({
-          url: `${this.options.githubUrl}/${org}`,
-        });
+      let credentials;
+      try {
+        credentials =
+          await this.options.githubCredentialsProvider.getCredentials({
+            url: `${this.options.githubUrl}/${org}`,
+          });
+      } catch (error) {
+        if (isError(error) && error.name === 'NotFoundError') {
+          logger.debug(
+            `No GitHub App installation found for org "${org}". This often means the GitHub App is not installed on that organization, or the authenticated user does not have the Organization Owner role required to see the installation. See https://backstage.io/docs/integrations/github/github-apps/#troubleshooting for more information.`,
+          );
+        }
+        throw error;
+      }
+      const { headers, type: tokenType } = credentials;
       const client = graphql.defaults({
         baseUrl: this.options.gitHubConfig.apiBaseUrl,
         headers,

--- a/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
@@ -29,6 +29,7 @@ import { isError } from '@backstage/errors';
 import {
   DefaultGithubCredentialsProvider,
   GithubAppCredentialsMux,
+  GithubCredentials,
   GithubCredentialsProvider,
   GithubIntegrationConfig,
   ScmIntegrations,
@@ -298,7 +299,7 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       : await this.getAllOrgs(this.options.gitHubConfig);
 
     for (const org of orgsToProcess) {
-      let credentials;
+      let credentials: GithubCredentials;
       try {
         credentials =
           await this.options.githubCredentialsProvider.getCredentials({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes #32972

When `GithubMultiOrgEntityProvider.read` iterates over the configured orgs, `GithubCredentialsProvider.getCredentials` throws a `NotFoundError: No app installation found for <org> in <appId>` if the GitHub App is not installed on that org, or if the authenticated user does not have the Organization Owner role required to see the installation. Previously this error bubbled up with no additional context, and the common root cause was only documented in the [GitHub Apps troubleshooting guide](https://backstage.io/docs/integrations/github/github-apps/#troubleshooting).

This change wraps the `getCredentials` call in a `try/catch`. On a `NotFoundError` we emit a `logger.debug` message that names the org, explains the two common causes, and links to the troubleshooting docs. The error is then re-thrown so existing behavior is preserved. Debug level keeps this quiet for deployments that intentionally run the provider against a superset of orgs and rely on `orgs` filtering, while still making the hint discoverable by anyone turning on debug logs to diagnose the original opaque error.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.