### PR TITLE
fix: adding required permissions to top level and jobs in the workflow

### DIFF
--- a/.github/workflows/api-breaking-changes-comment.yml
+++ b/.github/workflows/api-breaking-changes-comment.yml
@@ -7,6 +7,8 @@ on:
     types:
       - completed
 
+permissions: {}
+
 jobs:
   setup:
     name: Add values from previous step

--- a/.github/workflows/api-breaking-changes.yml
+++ b/.github/workflows/api-breaking-changes.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - '**/openapi.yaml'
 
+permissions:
+  contents: read
+
 jobs:
   get-backstage-changes:
     env:

--- a/.github/workflows/automate_issue_labels.yml
+++ b/.github/workflows/automate_issue_labels.yml
@@ -4,6 +4,9 @@ on:
     types:
       - labeled
 
+permissions:
+  contents: read
+
 jobs:
   stale:
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
       - 'microsite/data/**'
       - '!beps/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '*/5 * * * *'
 
+permissions:
+  contents: read
+
 jobs:
   cron:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy_docker-image.yml
+++ b/.github/workflows/deploy_docker-image.yml
@@ -5,6 +5,9 @@ on:
   repository_dispatch:
     types: [release-published]
 
+permissions:
+  contents: read
+
 env:
   RELEASE_VERSION: v${{ github.event.client_payload.version }}
   TAG_VERSION: ghcr.io/${{ github.repository_owner }}/backstage:${{ github.event.client_payload.version }}

--- a/.github/workflows/deploy_packages.yml
+++ b/.github/workflows/deploy_packages.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches: [master, patch/*]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync_bui-docs.yml
+++ b/.github/workflows/sync_bui-docs.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   sync-docs-ui:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync_code-formatting.yml
+++ b/.github/workflows/sync_code-formatting.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   autofix-markdown:
     name: Autofix Markdown files using Prettier

--- a/.github/workflows/sync_dependabot-changesets.yml
+++ b/.github/workflows/sync_dependabot-changesets.yml
@@ -5,6 +5,9 @@ on:
       - '.github/workflows/sync_dependabot-changesets.yml'
       - '**/yarn.lock'
 
+permissions:
+  contents: read
+
 jobs:
   generate-changeset:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync_patch-release.yml
+++ b/.github/workflows/sync_patch-release.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - '.patches/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: sync-patch-release
   cancel-in-progress: true

--- a/.github/workflows/sync_pull-requests-trigger.yml
+++ b/.github/workflows/sync_pull-requests-trigger.yml
@@ -16,6 +16,9 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   trigger:
     if: >

--- a/.github/workflows/sync_pull-requests.yml
+++ b/.github/workflows/sync_pull-requests.yml
@@ -6,6 +6,9 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync_release-manifest.yml
+++ b/.github/workflows/sync_release-manifest.yml
@@ -3,6 +3,9 @@ on:
   repository_dispatch:
     types: [release-published]
 
+permissions:
+  contents: read
+
 jobs:
   create-new-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync_renovate-changesets.yml
+++ b/.github/workflows/sync_renovate-changesets.yml
@@ -5,6 +5,9 @@ on:
       - '.github/workflows/sync_renovate-changesets.yml'
       - '**/yarn.lock'
 
+permissions:
+  contents: read
+
 jobs:
   generate-changeset:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync_snyk-github-issues.yml
+++ b/.github/workflows/sync_snyk-github-issues.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 */4 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   sync:
     if: github.repository == 'backstage/backstage' # prevent running on forks

--- a/.github/workflows/sync_version-packages.yml
+++ b/.github/workflows/sync_version-packages.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 concurrency:
   group: sync-version-packages
   cancel-in-progress: true

--- a/.github/workflows/verify_accessibility.yml
+++ b/.github/workflows/verify_accessibility.yml
@@ -14,6 +14,10 @@ on:
       - 'plugins/scaffolder-react/src/**'
       - 'plugins/search/src/**'
       - 'plugins/search-react/src/**'
+
+permissions:
+  contents: read
+
 jobs:
   lhci:
     name: Accessibility

--- a/.github/workflows/verify_chromatic.yml
+++ b/.github/workflows/verify_chromatic.yml
@@ -12,6 +12,9 @@ on:
       - 'packages/ui/**'
       - '**/*.stories.tsx'
 
+permissions:
+  contents: read
+
 jobs:
   chromatic:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/verify_docs-quality.yml
+++ b/.github/workflows/verify_docs-quality.yml
@@ -6,6 +6,8 @@ on:
       - '.github/workflows/verify_docs-quality.yml'
       - '**.md'
 
+permissions: {}
+
 jobs:
   check-docs:
     permissions:

--- a/.github/workflows/verify_e2e-linux.yml
+++ b/.github/workflows/verify_e2e-linux.yml
@@ -11,6 +11,9 @@ on:
   push:
     branches: [master]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/verify_e2e-windows.yml
+++ b/.github/workflows/verify_e2e-windows.yml
@@ -14,6 +14,9 @@ on:
   push:
     branches: [master]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/verify_microsite_accessibility.yml
+++ b/.github/workflows/verify_microsite_accessibility.yml
@@ -9,6 +9,10 @@ on:
       - 'beps/**'
       - 'mkdocs.yml'
       - 'docs/**'
+
+permissions:
+  contents: read
+
 jobs:
   lhci:
     name: Microsite Accessibility


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Currently the score for the Token Permissions is 0 because the top level permissions and a few job level permissions are missing in the workflows. With this change, the score will move to 10, since the workflow jobs will run with the minimal permissions. The PR retains conditions like `write` only at the job level, where it is necessary.

Fixes #33999

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] ~A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))~ (CI workflow-only change, no published packages affected)
- [ ] ~Added or updated documentation~ (not applicable)
- [ ] ~Tests for new functionality and regression tests for bug fixes~ (not applicable for CI infrastructure changes)
- [ ] ~Screenshots attached (for UI changes)~ (not applicable)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
