### PR TITLE
catalog-backend: fix facets endpoint performance regression

### DIFF
--- a/.changeset/fix-facets-perf-regression.md
+++ b/.changeset/fix-facets-perf-regression.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Fixed a performance regression in the `/entity-facets` endpoint when filters or permission conditions are applied, by routing the EXISTS-based filter through `final_entities` instead of correlating against the much larger `search` table.

--- a/.patches/pr-34001.txt
+++ b/.patches/pr-34001.txt
@@ -1,0 +1,1 @@
+Fix facets endpoint performance regression when filters or permissions are applied

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
@@ -2430,9 +2430,98 @@ describe('DefaultEntitiesCatalog', () => {
           }),
         ).resolves.toEqual({
           facets: {
-            'metadata.name': expect.arrayContaining([
-              { value: 'one', count: 1 },
-            ]),
+            'metadata.name': [{ value: 'one', count: 1 }],
+          },
+        });
+      },
+    );
+
+    async function setupFacetsCatalog(
+      databaseId: TestDatabaseId,
+      entities: Entity[],
+    ) {
+      await createDatabase(databaseId);
+      for (const entity of entities) {
+        await addEntityToSearch(entity);
+      }
+      return new DefaultEntitiesCatalog({
+        database: knex,
+        logger: mockServices.logger.mock(),
+        stitcher,
+      });
+    }
+
+    it.each(databases.eachSupportedId())(
+      'excludes not-yet-stitched entities, %p',
+      async databaseId => {
+        await createDatabase(databaseId);
+
+        await addEntityToSearch({
+          apiVersion: 'a',
+          kind: 'Component',
+          metadata: { name: 'stitched' },
+          spec: {},
+        });
+
+        // Insert an unstitched entity: final_entity is NULL but search
+        // rows exist. This simulates a race or future tombstone state.
+        const unstitchedId = v4();
+        await knex<DbRefreshStateRow>('refresh_state').insert({
+          entity_id: unstitchedId,
+          entity_ref: 'component:default/unstitched',
+          unprocessed_entity: '{}',
+          errors: '[]',
+          next_update_at: '2031-01-01 23:00:00',
+          last_discovery_at: '2021-04-01 13:37:00',
+        });
+        await knex<DbFinalEntitiesRow>('final_entities').insert({
+          entity_id: unstitchedId,
+          entity_ref: 'component:default/unstitched',
+          hash: '',
+        });
+        await knex<DbSearchRow>('search').insert([
+          {
+            entity_id: unstitchedId,
+            key: 'kind',
+            value: 'component',
+            original_value: 'Component',
+          },
+          {
+            entity_id: unstitchedId,
+            key: 'metadata.name',
+            value: 'unstitched',
+            original_value: 'unstitched',
+          },
+        ]);
+
+        const catalog = new DefaultEntitiesCatalog({
+          database: knex,
+          logger: mockServices.logger.mock(),
+          stitcher,
+        });
+
+        // Without filters: unstitched entity should be excluded
+        await expect(
+          catalog.facets({
+            facets: ['metadata.name'],
+            credentials: mockCredentials.none(),
+          }),
+        ).resolves.toEqual({
+          facets: {
+            'metadata.name': [{ value: 'stitched', count: 1 }],
+          },
+        });
+
+        // With filter: unstitched entity should also be excluded
+        await expect(
+          catalog.facets({
+            facets: ['metadata.name'],
+            filter: { key: 'kind', values: ['component'] },
+            credentials: mockCredentials.none(),
+          }),
+        ).resolves.toEqual({
+          facets: {
+            'metadata.name': [{ value: 'stitched', count: 1 }],
           },
         });
       },
@@ -2441,32 +2530,26 @@ describe('DefaultEntitiesCatalog', () => {
     it.each(databases.eachSupportedId())(
       'filters with a predicate query, %p',
       async databaseId => {
-        await createDatabase(databaseId);
-
-        await addEntityToSearch({
-          apiVersion: 'a',
-          kind: 'Component',
-          metadata: { name: 'one' },
-          spec: { type: 'service' },
-        });
-        await addEntityToSearch({
-          apiVersion: 'a',
-          kind: 'Component',
-          metadata: { name: 'two' },
-          spec: { type: 'library' },
-        });
-        await addEntityToSearch({
-          apiVersion: 'a',
-          kind: 'API',
-          metadata: { name: 'three' },
-          spec: { type: 'openapi' },
-        });
-
-        const catalog = new DefaultEntitiesCatalog({
-          database: knex,
-          logger: mockServices.logger.mock(),
-          stitcher,
-        });
+        const catalog = await setupFacetsCatalog(databaseId, [
+          {
+            apiVersion: 'a',
+            kind: 'Component',
+            metadata: { name: 'one' },
+            spec: { type: 'service' },
+          },
+          {
+            apiVersion: 'a',
+            kind: 'Component',
+            metadata: { name: 'two' },
+            spec: { type: 'library' },
+          },
+          {
+            apiVersion: 'a',
+            kind: 'API',
+            metadata: { name: 'three' },
+            spec: { type: 'openapi' },
+          },
+        ]);
 
         await expect(
           catalog.facets({
@@ -2476,10 +2559,10 @@ describe('DefaultEntitiesCatalog', () => {
           }),
         ).resolves.toEqual({
           facets: {
-            'spec.type': expect.arrayContaining([
-              { value: 'service', count: 1 },
+            'spec.type': [
               { value: 'library', count: 1 },
-            ]),
+              { value: 'service', count: 1 },
+            ],
           },
         });
       },
@@ -2488,32 +2571,26 @@ describe('DefaultEntitiesCatalog', () => {
     it.each(databases.eachSupportedId())(
       'filters with a predicate query using $in, %p',
       async databaseId => {
-        await createDatabase(databaseId);
-
-        await addEntityToSearch({
-          apiVersion: 'a',
-          kind: 'Component',
-          metadata: { name: 'one' },
-          spec: { type: 'service' },
-        });
-        await addEntityToSearch({
-          apiVersion: 'a',
-          kind: 'API',
-          metadata: { name: 'two' },
-          spec: { type: 'openapi' },
-        });
-        await addEntityToSearch({
-          apiVersion: 'a',
-          kind: 'System',
-          metadata: { name: 'three' },
-          spec: {},
-        });
-
-        const catalog = new DefaultEntitiesCatalog({
-          database: knex,
-          logger: mockServices.logger.mock(),
-          stitcher,
-        });
+        const catalog = await setupFacetsCatalog(databaseId, [
+          {
+            apiVersion: 'a',
+            kind: 'Component',
+            metadata: { name: 'one' },
+            spec: { type: 'service' },
+          },
+          {
+            apiVersion: 'a',
+            kind: 'API',
+            metadata: { name: 'two' },
+            spec: { type: 'openapi' },
+          },
+          {
+            apiVersion: 'a',
+            kind: 'System',
+            metadata: { name: 'three' },
+            spec: {},
+          },
+        ]);
 
         await expect(
           catalog.facets({
@@ -2523,10 +2600,10 @@ describe('DefaultEntitiesCatalog', () => {
           }),
         ).resolves.toEqual({
           facets: {
-            kind: expect.arrayContaining([
-              { value: 'Component', count: 1 },
+            kind: [
               { value: 'API', count: 1 },
-            ]),
+              { value: 'Component', count: 1 },
+            ],
           },
         });
       },
@@ -2535,32 +2612,26 @@ describe('DefaultEntitiesCatalog', () => {
     it.each(databases.eachSupportedId())(
       'filters with compound allOf filter, %p',
       async databaseId => {
-        await createDatabase(databaseId);
-
-        await addEntityToSearch({
-          apiVersion: 'a',
-          kind: 'Component',
-          metadata: { name: 'one' },
-          spec: { type: 'service' },
-        });
-        await addEntityToSearch({
-          apiVersion: 'a',
-          kind: 'Component',
-          metadata: { name: 'two' },
-          spec: { type: 'library' },
-        });
-        await addEntityToSearch({
-          apiVersion: 'a',
-          kind: 'API',
-          metadata: { name: 'three' },
-          spec: { type: 'openapi' },
-        });
-
-        const catalog = new DefaultEntitiesCatalog({
-          database: knex,
-          logger: mockServices.logger.mock(),
-          stitcher,
-        });
+        const catalog = await setupFacetsCatalog(databaseId, [
+          {
+            apiVersion: 'a',
+            kind: 'Component',
+            metadata: { name: 'one' },
+            spec: { type: 'service' },
+          },
+          {
+            apiVersion: 'a',
+            kind: 'Component',
+            metadata: { name: 'two' },
+            spec: { type: 'library' },
+          },
+          {
+            apiVersion: 'a',
+            kind: 'API',
+            metadata: { name: 'three' },
+            spec: { type: 'openapi' },
+          },
+        ]);
 
         await expect(
           catalog.facets({
@@ -2584,32 +2655,26 @@ describe('DefaultEntitiesCatalog', () => {
     it.each(databases.eachSupportedId())(
       'filters with compound anyOf filter, %p',
       async databaseId => {
-        await createDatabase(databaseId);
-
-        await addEntityToSearch({
-          apiVersion: 'a',
-          kind: 'Component',
-          metadata: { name: 'one' },
-          spec: { type: 'service' },
-        });
-        await addEntityToSearch({
-          apiVersion: 'a',
-          kind: 'API',
-          metadata: { name: 'two' },
-          spec: { type: 'openapi' },
-        });
-        await addEntityToSearch({
-          apiVersion: 'a',
-          kind: 'System',
-          metadata: { name: 'three' },
-          spec: {},
-        });
-
-        const catalog = new DefaultEntitiesCatalog({
-          database: knex,
-          logger: mockServices.logger.mock(),
-          stitcher,
-        });
+        const catalog = await setupFacetsCatalog(databaseId, [
+          {
+            apiVersion: 'a',
+            kind: 'Component',
+            metadata: { name: 'one' },
+            spec: { type: 'service' },
+          },
+          {
+            apiVersion: 'a',
+            kind: 'API',
+            metadata: { name: 'two' },
+            spec: { type: 'openapi' },
+          },
+          {
+            apiVersion: 'a',
+            kind: 'System',
+            metadata: { name: 'three' },
+            spec: {},
+          },
+        ]);
 
         await expect(
           catalog.facets({
@@ -2624,10 +2689,10 @@ describe('DefaultEntitiesCatalog', () => {
           }),
         ).resolves.toEqual({
           facets: {
-            'metadata.name': expect.arrayContaining([
+            'metadata.name': [
               { value: 'one', count: 1 },
               { value: 'two', count: 1 },
-            ]),
+            ],
           },
         });
       },
@@ -2636,32 +2701,26 @@ describe('DefaultEntitiesCatalog', () => {
     it.each(databases.eachSupportedId())(
       'filters with both filter and query combined, %p',
       async databaseId => {
-        await createDatabase(databaseId);
-
-        await addEntityToSearch({
-          apiVersion: 'a',
-          kind: 'Component',
-          metadata: { name: 'one' },
-          spec: { type: 'service' },
-        });
-        await addEntityToSearch({
-          apiVersion: 'a',
-          kind: 'Component',
-          metadata: { name: 'two' },
-          spec: { type: 'library' },
-        });
-        await addEntityToSearch({
-          apiVersion: 'a',
-          kind: 'API',
-          metadata: { name: 'three' },
-          spec: { type: 'openapi' },
-        });
-
-        const catalog = new DefaultEntitiesCatalog({
-          database: knex,
-          logger: mockServices.logger.mock(),
-          stitcher,
-        });
+        const catalog = await setupFacetsCatalog(databaseId, [
+          {
+            apiVersion: 'a',
+            kind: 'Component',
+            metadata: { name: 'one' },
+            spec: { type: 'service' },
+          },
+          {
+            apiVersion: 'a',
+            kind: 'Component',
+            metadata: { name: 'two' },
+            spec: { type: 'library' },
+          },
+          {
+            apiVersion: 'a',
+            kind: 'API',
+            metadata: { name: 'three' },
+            spec: { type: 'openapi' },
+          },
+        ]);
 
         await expect(
           catalog.facets({

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
@@ -2452,7 +2452,7 @@ describe('DefaultEntitiesCatalog', () => {
     }
 
     it.each(databases.eachSupportedId())(
-      'excludes not-yet-stitched entities, %p',
+      'excludes not-yet-stitched entities from filtered facets, %p',
       async databaseId => {
         await createDatabase(databaseId);
 
@@ -2500,19 +2500,8 @@ describe('DefaultEntitiesCatalog', () => {
           stitcher,
         });
 
-        // Without filters: unstitched entity should be excluded
-        await expect(
-          catalog.facets({
-            facets: ['metadata.name'],
-            credentials: mockCredentials.none(),
-          }),
-        ).resolves.toEqual({
-          facets: {
-            'metadata.name': [{ value: 'stitched', count: 1 }],
-          },
-        });
-
-        // With filter: unstitched entity should also be excluded
+        // With filter: unstitched entity should be excluded because the
+        // inner entityIdSubquery requires final_entity IS NOT NULL
         await expect(
           catalog.facets({
             facets: ['metadata.name'],

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
@@ -2437,6 +2437,246 @@ describe('DefaultEntitiesCatalog', () => {
         });
       },
     );
+
+    it.each(databases.eachSupportedId())(
+      'filters with a predicate query, %p',
+      async databaseId => {
+        await createDatabase(databaseId);
+
+        await addEntityToSearch({
+          apiVersion: 'a',
+          kind: 'Component',
+          metadata: { name: 'one' },
+          spec: { type: 'service' },
+        });
+        await addEntityToSearch({
+          apiVersion: 'a',
+          kind: 'Component',
+          metadata: { name: 'two' },
+          spec: { type: 'library' },
+        });
+        await addEntityToSearch({
+          apiVersion: 'a',
+          kind: 'API',
+          metadata: { name: 'three' },
+          spec: { type: 'openapi' },
+        });
+
+        const catalog = new DefaultEntitiesCatalog({
+          database: knex,
+          logger: mockServices.logger.mock(),
+          stitcher,
+        });
+
+        await expect(
+          catalog.facets({
+            facets: ['spec.type'],
+            query: { kind: 'component' },
+            credentials: mockCredentials.none(),
+          }),
+        ).resolves.toEqual({
+          facets: {
+            'spec.type': expect.arrayContaining([
+              { value: 'service', count: 1 },
+              { value: 'library', count: 1 },
+            ]),
+          },
+        });
+      },
+    );
+
+    it.each(databases.eachSupportedId())(
+      'filters with a predicate query using $in, %p',
+      async databaseId => {
+        await createDatabase(databaseId);
+
+        await addEntityToSearch({
+          apiVersion: 'a',
+          kind: 'Component',
+          metadata: { name: 'one' },
+          spec: { type: 'service' },
+        });
+        await addEntityToSearch({
+          apiVersion: 'a',
+          kind: 'API',
+          metadata: { name: 'two' },
+          spec: { type: 'openapi' },
+        });
+        await addEntityToSearch({
+          apiVersion: 'a',
+          kind: 'System',
+          metadata: { name: 'three' },
+          spec: {},
+        });
+
+        const catalog = new DefaultEntitiesCatalog({
+          database: knex,
+          logger: mockServices.logger.mock(),
+          stitcher,
+        });
+
+        await expect(
+          catalog.facets({
+            facets: ['kind'],
+            query: { kind: { $in: ['component', 'api'] } },
+            credentials: mockCredentials.none(),
+          }),
+        ).resolves.toEqual({
+          facets: {
+            kind: expect.arrayContaining([
+              { value: 'Component', count: 1 },
+              { value: 'API', count: 1 },
+            ]),
+          },
+        });
+      },
+    );
+
+    it.each(databases.eachSupportedId())(
+      'filters with compound allOf filter, %p',
+      async databaseId => {
+        await createDatabase(databaseId);
+
+        await addEntityToSearch({
+          apiVersion: 'a',
+          kind: 'Component',
+          metadata: { name: 'one' },
+          spec: { type: 'service' },
+        });
+        await addEntityToSearch({
+          apiVersion: 'a',
+          kind: 'Component',
+          metadata: { name: 'two' },
+          spec: { type: 'library' },
+        });
+        await addEntityToSearch({
+          apiVersion: 'a',
+          kind: 'API',
+          metadata: { name: 'three' },
+          spec: { type: 'openapi' },
+        });
+
+        const catalog = new DefaultEntitiesCatalog({
+          database: knex,
+          logger: mockServices.logger.mock(),
+          stitcher,
+        });
+
+        await expect(
+          catalog.facets({
+            facets: ['metadata.name'],
+            filter: {
+              allOf: [
+                { key: 'kind', values: ['component'] },
+                { key: 'spec.type', values: ['service'] },
+              ],
+            },
+            credentials: mockCredentials.none(),
+          }),
+        ).resolves.toEqual({
+          facets: {
+            'metadata.name': [{ value: 'one', count: 1 }],
+          },
+        });
+      },
+    );
+
+    it.each(databases.eachSupportedId())(
+      'filters with compound anyOf filter, %p',
+      async databaseId => {
+        await createDatabase(databaseId);
+
+        await addEntityToSearch({
+          apiVersion: 'a',
+          kind: 'Component',
+          metadata: { name: 'one' },
+          spec: { type: 'service' },
+        });
+        await addEntityToSearch({
+          apiVersion: 'a',
+          kind: 'API',
+          metadata: { name: 'two' },
+          spec: { type: 'openapi' },
+        });
+        await addEntityToSearch({
+          apiVersion: 'a',
+          kind: 'System',
+          metadata: { name: 'three' },
+          spec: {},
+        });
+
+        const catalog = new DefaultEntitiesCatalog({
+          database: knex,
+          logger: mockServices.logger.mock(),
+          stitcher,
+        });
+
+        await expect(
+          catalog.facets({
+            facets: ['metadata.name'],
+            filter: {
+              anyOf: [
+                { key: 'kind', values: ['component'] },
+                { key: 'kind', values: ['api'] },
+              ],
+            },
+            credentials: mockCredentials.none(),
+          }),
+        ).resolves.toEqual({
+          facets: {
+            'metadata.name': expect.arrayContaining([
+              { value: 'one', count: 1 },
+              { value: 'two', count: 1 },
+            ]),
+          },
+        });
+      },
+    );
+
+    it.each(databases.eachSupportedId())(
+      'filters with both filter and query combined, %p',
+      async databaseId => {
+        await createDatabase(databaseId);
+
+        await addEntityToSearch({
+          apiVersion: 'a',
+          kind: 'Component',
+          metadata: { name: 'one' },
+          spec: { type: 'service' },
+        });
+        await addEntityToSearch({
+          apiVersion: 'a',
+          kind: 'Component',
+          metadata: { name: 'two' },
+          spec: { type: 'library' },
+        });
+        await addEntityToSearch({
+          apiVersion: 'a',
+          kind: 'API',
+          metadata: { name: 'three' },
+          spec: { type: 'openapi' },
+        });
+
+        const catalog = new DefaultEntitiesCatalog({
+          database: knex,
+          logger: mockServices.logger.mock(),
+          stitcher,
+        });
+
+        await expect(
+          catalog.facets({
+            facets: ['spec.type'],
+            filter: { key: 'kind', values: ['component'] },
+            query: { 'metadata.name': 'one' },
+            credentials: mockCredentials.none(),
+          }),
+        ).resolves.toEqual({
+          facets: {
+            'spec.type': [{ value: 'service', count: 1 }],
+          },
+        });
+      },
+    );
   });
 });
 

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -695,9 +695,9 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
       // against one-row-per-entity rather than the much larger search
       // table. This keeps the facets aggregation fast even with many
       // filter clauses or permission conditions.
-      const entityIdSubquery = this.database('final_entities')
-        .select('final_entities.entity_id')
-        .whereNotNull('final_entities.final_entity');
+      const entityIdSubquery = this.database('final_entities').select(
+        'final_entities.entity_id',
+      );
 
       applyEntityFilterToQuery({
         filter: request.filter,

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -694,10 +694,12 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
       // final_entities, so that the EXISTS-based filters correlate
       // against one-row-per-entity rather than the much larger search
       // table. This keeps the facets aggregation fast even with many
-      // filter clauses or permission conditions.
-      const entityIdSubquery = this.database('final_entities').select(
-        'final_entities.entity_id',
-      );
+      // filter clauses or permission conditions. The whereNotNull guard
+      // ensures that not-yet-stitched (or future tombstoned) entities
+      // are excluded from results.
+      const entityIdSubquery = this.database('final_entities')
+        .select('final_entities.entity_id')
+        .whereNotNull('final_entities.final_entity');
 
       applyEntityFilterToQuery({
         filter: request.filter,

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -676,12 +676,20 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
   }
 
   async facets(request: EntityFacetsRequest): Promise<EntityFacetsResponse> {
+    // Exclude not-yet-stitched (or future tombstoned) entities by
+    // anti-joining the tiny set of null final_entity rows. This is
+    // nearly free (~3k rows) compared to confirming ~520k non-null rows.
+    const unstitchedSubquery = this.database('final_entities')
+      .select('final_entities.entity_id')
+      .whereNull('final_entities.final_entity');
+
     const query = this.database<DbSearchRow>('search')
       .whereIn(
         'search.key',
         request.facets.map(f => f.toLocaleLowerCase('en-US')),
       )
       .whereNotNull('search.original_value')
+      .whereNotIn('search.entity_id', unstitchedSubquery)
       .select({
         facet: 'search.key',
         value: 'search.original_value',
@@ -694,9 +702,7 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
       // final_entities, so that the EXISTS-based filters correlate
       // against one-row-per-entity rather than the much larger search
       // table. This keeps the facets aggregation fast even with many
-      // filter clauses or permission conditions. The whereNotNull guard
-      // ensures that not-yet-stitched (or future tombstoned) entities
-      // are excluded from results.
+      // filter clauses or permission conditions.
       const entityIdSubquery = this.database('final_entities')
         .select('final_entities.entity_id')
         .whereNotNull('final_entities.final_entity');

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -676,20 +676,12 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
   }
 
   async facets(request: EntityFacetsRequest): Promise<EntityFacetsResponse> {
-    // Exclude not-yet-stitched (or future tombstoned) entities by
-    // anti-joining the tiny set of null final_entity rows. This is
-    // nearly free (~3k rows) compared to confirming ~520k non-null rows.
-    const unstitchedSubquery = this.database('final_entities')
-      .select('final_entities.entity_id')
-      .whereNull('final_entities.final_entity');
-
     const query = this.database<DbSearchRow>('search')
       .whereIn(
         'search.key',
         request.facets.map(f => f.toLocaleLowerCase('en-US')),
       )
       .whereNotNull('search.original_value')
-      .whereNotIn('search.entity_id', unstitchedSubquery)
       .select({
         facet: 'search.key',
         value: 'search.original_value',
@@ -701,8 +693,8 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
       // Build a subquery that finds matching entity IDs via
       // final_entities, so that the EXISTS-based filters correlate
       // against one-row-per-entity rather than the much larger search
-      // table. This keeps the facets aggregation fast even with many
-      // filter clauses or permission conditions.
+      // table. The whereNotNull guard on final_entity excludes
+      // not-yet-stitched (or future tombstoned) entities.
       const entityIdSubquery = this.database('final_entities')
         .select('final_entities.entity_id')
         .whereNotNull('final_entities.final_entity');

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -690,13 +690,24 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
       .groupBy(['search.key', 'search.original_value']);
 
     if (request.filter || request.query) {
+      // Build a subquery that finds matching entity IDs via
+      // final_entities, so that the EXISTS-based filters correlate
+      // against one-row-per-entity rather than the much larger search
+      // table. This keeps the facets aggregation fast even with many
+      // filter clauses or permission conditions.
+      const entityIdSubquery = this.database('final_entities')
+        .select('final_entities.entity_id')
+        .whereNotNull('final_entities.final_entity');
+
       applyEntityFilterToQuery({
         filter: request.filter,
         query: request.query,
-        targetQuery: query,
-        onEntityIdField: 'search.entity_id',
+        targetQuery: entityIdSubquery,
+        onEntityIdField: 'final_entities.entity_id',
         knex: this.database,
       });
+
+      query.whereIn('search.entity_id', entityIdSubquery);
     }
 
     const rows = await query;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix a performance regression in the `/entity-facets` endpoint introduced in v1.50 (PR #33290) where
the switch from `IN (subquery)` to `EXISTS (correlated subquery)` caused severe slowness for the
facets query specifically.

### The problem

In #33290, `applyEntityFilterToQuery` was changed from `IN`-subquery filters to `EXISTS` correlated
subqueries. This was a major win for most catalog queries where the outer query is on `final_entities`
(one row per entity). However, the **facets** query is different — its outer query is on the `search`
table (~13.6M rows / ~26 rows per entity), so each `EXISTS` must probe per search row rather than per
entity, causing the query to become very expensive under certain planner conditions.

When PostgreSQL's planner doesn't choose hash joins (which can happen depending on statistics, memory
settings, or number of filter clauses), the EXISTS correlated subqueries on the search table degrade
to merge semi-joins with disk spill, causing a **2x+ regression**.

### The fix

Route the EXISTS-based filters through the `final_entities` table first (one row per entity), then
constrain the facets `search` table query with `WHERE search.entity_id IN (entityIdSubquery)`. This
ensures the expensive EXISTS correlated subqueries run against the small `final_entities` table
rather than the much larger `search` table.

The `entityIdSubquery` also includes `WHERE final_entities.final_entity IS NOT NULL`, which excludes
not-yet-stitched (or future tombstoned) entities from filtered facets results.

### Performance evidence

Benchmarked with `EXPLAIN ANALYZE` on a production-scale database (13.6M search rows, 515K entities).
All times are **server-reported execution time** (not affected by client conditions).

**No-filter path** (unchanged from 1.49.x):

| Version | Time | Notes |
|---|---|---|
| 1.49.x | 7.0s | Plain aggregation, parallel seq scan |
| 1.50.x | 7.0s | Same (this path was not changed) |
| **This PR** | **7.0s** | Same behavior as 1.49.x |

**Filtered path** (kind=component + lifecycle=production):

| Version | Time | Notes |
|---|---|---|
| 1.49.x | 2.6s | IN-subqueries on search table |
| 1.50.x (hashjoin on) | 2.6s | Planner converts EXISTS to hash join |
| 1.50.x (hashjoin off) | **5.5s** | EXISTS on search → merge semi-join (**the regression**) |
| **This PR** (hashjoin on) | **2.4s** | Filters via final_entities |
| **This PR** (hashjoin off) | **3.1s** | **44% faster** than 1.50.x regression path |

The "hashjoin off" scenario simulates what users hit when the planner doesn't choose hash joins
(common with many filter clauses from permissions, or with different `work_mem` settings).

### Future followup

The no-filter path is ~7s on large databases due to a full parallel seq scan of the search table.
This can be brought under 1.5s with a covering index `(key, original_value, entity_id) WHERE
original_value IS NOT NULL`, which enables index-only scans. That migration is planned as a
separate followup PR.

<!-- Flag to signal to the merge-queue-bot that this PR is ready for the merge queue, just waiting for reviews. Remove to take it out of the queue. -->
MERGE QUEUE

---

- [ ] [Changelog](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets) - Reviewed or added a changeset file to the PR
- [ ] [Docs](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#writing-documentation) - Reviewed or added relevant documentation changes if applicable