### PR TITLE
fix(ui): preserve external hrefs in BUI link components

### DIFF
--- a/.changeset/preserve-external-hrefs-useDefinition.md
+++ b/.changeset/preserve-external-hrefs-useDefinition.md
@@ -1,0 +1,7 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed external URLs in BUI link components being rewritten as in-app paths when the app is served under a non-root base path. Absolute URLs (`http://`, `https://`, `//`, `mailto:`, `tel:`) are now passed through unchanged. Internal `href` values are resolved against the current `basename` exactly once, which also fixes a latent issue where internal link clicks under a non-root base path could navigate to a URL with the `basename` prefix doubled.
+
+**Affected components:** ButtonLink, Card, Link, Menu, Tab, Table, Tag

--- a/.patches/pr-34004.txt
+++ b/.patches/pr-34004.txt
@@ -1,0 +1,1 @@
+Preserve external hrefs in BUI link components under non-root base path

--- a/packages/ui/src/components/Link/Link.tsx
+++ b/packages/ui/src/components/Link/Link.tsx
@@ -18,6 +18,7 @@ import { forwardRef, useRef } from 'react';
 import { useLink } from 'react-aria';
 import type { LinkProps } from './types';
 import { useDefinition } from '../../hooks/useDefinition';
+import { useResolvedHref } from '../../hooks/useResolvedHref';
 import { LinkDefinition } from './definition';
 import { getNodeText } from '../../analytics/getNodeText';
 
@@ -32,6 +33,7 @@ const LinkInternal = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
   const linkRef = (ref || internalRef) as React.RefObject<HTMLAnchorElement>;
 
   const { linkProps } = useLink(restProps, linkRef);
+  const resolvedHref = useResolvedHref(restProps.href);
 
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     linkProps.onClick?.(e);
@@ -49,6 +51,7 @@ const LinkInternal = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
       {...linkProps}
       {...dataAttributes}
       {...(restProps as React.AnchorHTMLAttributes<HTMLAnchorElement>)}
+      href={resolvedHref}
       ref={linkRef}
       title={title}
       className={classes.root}

--- a/packages/ui/src/hooks/useDefinition/useDefinition.tsx
+++ b/packages/ui/src/hooks/useDefinition/useDefinition.tsx
@@ -21,7 +21,8 @@ import { useBgProvider, useBgConsumer, BgProvider } from '../useBg';
 import { resolveDefinitionProps, processUtilityProps } from './helpers';
 import { useAnalytics } from '../../analytics/useAnalytics';
 import { noopTracker } from '../../analytics/useAnalytics';
-import { useInRouterContext, useHref } from 'react-router-dom';
+import { useHref, useInRouterContext } from 'react-router-dom';
+import { isExternalLink } from '../../utils/linkUtils';
 import type {
   ComponentConfig,
   UseDefinitionOptions,
@@ -39,17 +40,32 @@ export function useDefinition<
 ): UseDefinitionResult<D, P> {
   const { breakpoint } = useBreakpoint();
 
-  // Turn relative href into an absolute path using the current route
-  // context, so that client-side navigation works correctly.
+  // Pre-resolve href at component render time (where route context is
+  // correct), so that click-navigation has a correct absolute path
+  // regardless of where useNavigate is called. `useHref` returns the
+  // path with basename prepended; strip it so the output is the
+  // canonical pre-basename form that react-router's downstream useHref
+  // and navigate both expect as input (avoids double-prefixing).
+  // External URLs bypass resolution.
   let hrefResolvedProps = props;
   const hasRouter = useInRouterContext();
-  // useHref throws outside a Router, so we guard with useInRouterContext.
-  // The guard is safe because a component's router context does not
-  // change during its lifetime, keeping the hook call count stable.
   if (hasRouter) {
-    const absoluteHref = useHref((props as any).href ?? '');
-    if ((props as any).href !== undefined) {
-      hrefResolvedProps = { ...props, href: absoluteHref } as P;
+    const rawHref = (props as any).href;
+    // useHref('/') returns the router's basename. Strip trailing slashes
+    // so the prefix check works regardless of how the consumer configured
+    // their <Router basename>.
+    const basename = useHref('/').replace(/\/+$/, '') || '/';
+    const absoluteHref = useHref(rawHref ?? '');
+    if (rawHref !== undefined && !isExternalLink(rawHref)) {
+      let stripped = absoluteHref;
+      if (
+        basename !== '/' &&
+        (absoluteHref === basename || absoluteHref.startsWith(`${basename}/`))
+      ) {
+        stripped =
+          absoluteHref === basename ? '/' : absoluteHref.slice(basename.length);
+      }
+      hrefResolvedProps = { ...props, href: stripped } as P;
     }
   }
 

--- a/packages/ui/src/hooks/useResolvedHref.ts
+++ b/packages/ui/src/hooks/useResolvedHref.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useHref, useInRouterContext } from 'react-router-dom';
+import { isExternalLink } from '../utils/linkUtils';
+
+/**
+ * Resolves an href for rendering. External URLs are returned unchanged;
+ * internal paths are resolved through react-router's useHref so they
+ * respect the current basename and route context.
+ *
+ * @internal
+ */
+export function useResolvedHref(href: string): string;
+export function useResolvedHref(href: string | undefined): string | undefined;
+export function useResolvedHref(href: string | undefined): string | undefined {
+  const hasRouter = useInRouterContext();
+  // useHref throws outside a Router, so we guard with useInRouterContext.
+  // The guard is safe because a component's router context does not
+  // change during its lifetime, keeping the hook call count stable.
+  if (!hasRouter) {
+    return href;
+  }
+  const resolved = useHref(href ?? '');
+  if (!href || isExternalLink(href)) {
+    return href;
+  }
+  return resolved;
+}

--- a/packages/ui/src/provider/BUIProvider.tsx
+++ b/packages/ui/src/provider/BUIProvider.tsx
@@ -16,9 +16,10 @@
 
 import { useMemo, type ReactNode } from 'react';
 import { RouterProvider } from 'react-aria-components';
-import { useInRouterContext, useNavigate, useHref } from 'react-router-dom';
+import { useInRouterContext, useNavigate } from 'react-router-dom';
 import { createVersionedValueMap } from '@backstage/version-bridge';
 import { BUIContext } from '../analytics/useAnalytics';
+import { useResolvedHref } from '../hooks/useResolvedHref';
 import type { UseAnalyticsFn } from '../analytics/types';
 
 /** @public */
@@ -70,7 +71,7 @@ export function BUIProvider(props: BUIProviderProps) {
 function RoutedContent({ children }: { children: ReactNode }) {
   const navigate = useNavigate();
   return (
-    <RouterProvider navigate={navigate} useHref={useHref}>
+    <RouterProvider navigate={navigate} useHref={useResolvedHref}>
       {children}
     </RouterProvider>
   );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes [#33799](https://github.com/backstage/backstage/issues/33799). When a Backstage app is served under a non-root base path, passing an absolute URL to a BUI link component (`Link`, `ButtonLink`, `Tab`, `Tag`, `MenuItem`, `Card`, or a table row) rewrote the href as an in-app path — for example `<ButtonLink href="https://example.com">` rendered as `<a href="/basename/https:/example.com">`.

### What's actually broken

Setting up a reproduction with `app.baseUrl: http://localhost:3000/foo` surfaced three distinct failure points, not one.

**1. Mangling in `useDefinition`.** Every BUI link component passes its `href` through `useDefinition`, which calls react-router's `useHref`. `useHref` treats its input as a relative path and prepends the basename — so absolute URLs get turned into junk like `/foo/https:/example.com`.

**2. Mangling in React Aria's `RouterProvider`.** Most BUI link components render via React Aria Components (ButtonLink, Tag, MenuItem, Tab, Card, table rows). RA has its own router integration: at render time, RAC calls `router.useHref(props.href)` to produce the final `href` attribute. `BUIProvider` wires react-router's `useHref` directly into that slot, so the same mangling happens a second time inside RA — even if `useDefinition` had been patched, the RAC-backed components would still render broken external URLs.

**3. Latent double-prefix on internal clicks.** `useDefinition` resolved `/catalog` to `/foo/catalog` via `useHref`, storing the basename-prefixed form on `props.href`. On click, React Aria calls react-router's `navigate(props.href)`, which prepends basename again — so the click-navigation target became `/foo/foo/catalog`.

### What this PR does

- **`useDefinition`** still pre-resolves href in the component's render (preserves correct route context for relative hrefs), but strips the basename from the result so `props.href` holds the canonical pre-basename form that both `useHref` and `navigate` expect as input. External URLs bypass resolution entirely.
- **`useResolvedHref`** — a small internal helper — is the single place that decides "external → pass through, internal → call `useHref`". `BUIProvider` wires it into RA's `RouterProvider.useHref` (fixes point 2 for RAC components) and `Link.tsx` calls it directly (since `Link` bypasses RA's rendering pipeline).
- Net effect: basename is applied exactly once at render and exactly once at click-navigation, and external URLs flow through both paths unchanged.

### Why #33825 wouldn't close this

#33825 addresses only point 1 — not points 2 or 3.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))