### PR TITLE
Fix lockfile dependency removal detection in PackageGraph

### DIFF
--- a/.changeset/fix-lockfile-removal-detection.md
+++ b/.changeset/fix-lockfile-removal-detection.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli-node': patch
+---
+
+Fixed a bug in `PackageGraph.listChangedPackages` where removed dependencies were not detected during lockfile analysis. The dependency graph from the previous lockfile was not being merged, causing transitive dependency removals to be missed.

--- a/packages/cli-node/src/monorepo/PackageGraph.test.ts
+++ b/packages/cli-node/src/monorepo/PackageGraph.test.ts
@@ -222,4 +222,51 @@ c-dep@^2:
       'origin/master',
     );
   });
+
+  it('detects packages affected by a removed dependency in the lockfile', async () => {
+    const graph = PackageGraph.fromPackages(testPackages);
+
+    mockListChangedFiles.mockResolvedValueOnce(['yarn.lock']);
+
+    // The old lockfile (at the ref) has b depending on b-dep
+    mockReadFileAtRef.mockResolvedValueOnce(`
+a@^1:
+  version: "1.0.0"
+
+b@^1:
+  version: "1.0.0"
+  dependencies:
+      b-dep: ^1
+
+b-dep@^1:
+  version: "1.0.0"
+  integrity: sha512-old
+
+c@^1:
+  version: "1.0.0"
+`);
+
+    // The current lockfile no longer has b-dep at all
+    jest.spyOn(Lockfile, 'load').mockResolvedValueOnce(
+      Lockfile.parse(`
+a@^1:
+  version: "1.0.0"
+
+b@^1:
+  version: "1.0.0"
+
+c@^1:
+  version: "1.0.0"
+`),
+    );
+
+    await expect(
+      graph
+        .listChangedPackages({
+          ref: 'origin/master',
+          analyzeLockfile: true,
+        })
+        .then(pkgs => pkgs.map(pkg => pkg.name)),
+    ).resolves.toEqual(['b']);
+  });
 });

--- a/packages/cli-node/src/monorepo/PackageGraph.ts
+++ b/packages/cli-node/src/monorepo/PackageGraph.ts
@@ -393,7 +393,7 @@ export class PackageGraph extends Map<string, PackageGraphNode> {
       // Merge the dependency graph from the other lockfile into this one in
       // order to be able to detect removals accurately.
       {
-        const otherGraph = thisLockfile.createSimplifiedDependencyGraph();
+        const otherGraph = otherLockfile.createSimplifiedDependencyGraph();
         for (const [name, dependencies] of otherGraph) {
           const node = graph.get(name);
           if (node) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In `PackageGraph.listChangedPackages`, the `otherGraph` variable was created from `thisLockfile.createSimplifiedDependencyGraph()` instead of `otherLockfile.createSimplifiedDependencyGraph()`. This meant the merged dependency graph was just a duplicate of the current graph, so dependencies that only existed in the old lockfile were never included. As a result, packages affected by transitive dependency removals were not detected as changed.

The fix is a one-line change on line 396 to use `otherLockfile` instead of `thisLockfile`.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))