### PR TITLE
backend-app-api: extract type discriminator helpers for backend registrations

### DIFF
--- a/.changeset/extract-registration-type-helpers.md
+++ b/.changeset/extract-registration-type-helpers.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Internal refactor of type discrimination logic for backend registration types.

--- a/packages/backend-app-api/src/wiring/BackendInitializer.ts
+++ b/packages/backend-app-api/src/wiring/BackendInitializer.ts
@@ -458,16 +458,23 @@ export class BackendInitializer {
       try {
         const provides = new Set<ExtensionPoint<unknown>>();
 
-        const normalizedExtensionPoints =
-          r.type === 'plugin' || r.type === 'module'
-            ? r.extensionPoints.map(([ref, impl]) => ({
-                ref,
-                factory: () => impl,
-              }))
-            : r.extensionPoints.map(reg => ({
-                ref: reg.extensionPoint,
-                factory: reg.factory,
-              }));
+        let normalizedExtensionPoints: Array<{
+          ref: ExtensionPoint<unknown>;
+          factory: (context: ExtensionPointFactoryContext) => unknown;
+        }>;
+        if (r.type === 'plugin' || r.type === 'module') {
+          normalizedExtensionPoints = r.extensionPoints.map(([ref, impl]) => ({
+            ref,
+            factory: () => impl,
+          }));
+        } else if (r.type === 'plugin-v1.1' || r.type === 'module-v1.1') {
+          normalizedExtensionPoints = r.extensionPoints.map(reg => ({
+            ref: reg.extensionPoint,
+            factory: reg.factory,
+          }));
+        } else {
+          normalizedExtensionPoints = [];
+        }
 
         for (const { ref, factory } of normalizedExtensionPoints) {
           if (this.#extensionPoints.has(ref.id)) {

--- a/packages/backend-app-api/src/wiring/BackendInitializer.ts
+++ b/packages/backend-app-api/src/wiring/BackendInitializer.ts
@@ -35,6 +35,10 @@ import { OpaqueExtensionPointFactoryMiddleware } from '@internal/backend';
 import type {
   InternalBackendFeature,
   InternalBackendFeatureLoader,
+  InternalBackendModuleRegistration,
+  InternalBackendModuleRegistrationV1_1,
+  InternalBackendPluginRegistration,
+  InternalBackendPluginRegistrationV1_1,
   InternalBackendRegistrations,
 } from '../../../backend-plugin-api/src/wiring/types';
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
@@ -113,14 +117,8 @@ function createRootInstanceMetadataServiceFactory(
   const registrations = rawRegistrations
     .filter(registration => registration.featureType === 'registrations')
     .flatMap(registration => registration.getRegistrations());
-  const plugins = registrations.filter(
-    registration =>
-      registration.type === 'plugin' || registration.type === 'plugin-v1.1',
-  );
-  const modules = registrations.filter(
-    registration =>
-      registration.type === 'module' || registration.type === 'module-v1.1',
-  );
+  const plugins = registrations.filter(isPluginRegistration);
+  const modules = registrations.filter(isModuleRegistration);
   for (const plugin of plugins) {
     const { pluginId } = plugin;
     if (!installedPlugins.get(pluginId)) {
@@ -460,39 +458,32 @@ export class BackendInitializer {
       try {
         const provides = new Set<ExtensionPoint<unknown>>();
 
-        if (r.type === 'plugin' || r.type === 'module') {
-          // Handle v1 format: Array<readonly [ExtensionPoint<unknown>, unknown]>
-          for (const [extRef, extImpl] of r.extensionPoints) {
-            if (this.#extensionPoints.has(extRef.id)) {
-              throw new Error(
-                `ExtensionPoint with ID '${extRef.id}' is already registered`,
-              );
-            }
-            this.#extensionPoints.set(extRef.id, {
-              pluginId: r.pluginId,
-              factory: () => extImpl,
-            });
-            addedExtensionPointIds.push(extRef.id);
-            provides.add(extRef);
+        const normalizedExtensionPoints =
+          r.type === 'plugin' || r.type === 'module'
+            ? r.extensionPoints.map(([ref, impl]) => ({
+                ref,
+                factory: () => impl,
+              }))
+            : r.extensionPoints.map(reg => ({
+                ref: reg.extensionPoint,
+                factory: reg.factory,
+              }));
+
+        for (const { ref, factory } of normalizedExtensionPoints) {
+          if (this.#extensionPoints.has(ref.id)) {
+            throw new Error(
+              `ExtensionPoint with ID '${ref.id}' is already registered`,
+            );
           }
-        } else if (r.type === 'plugin-v1.1' || r.type === 'module-v1.1') {
-          // Handle v1.1 format: Array<ExtensionPointRegistration>
-          for (const extReg of r.extensionPoints) {
-            if (this.#extensionPoints.has(extReg.extensionPoint.id)) {
-              throw new Error(
-                `ExtensionPoint with ID '${extReg.extensionPoint.id}' is already registered`,
-              );
-            }
-            this.#extensionPoints.set(extReg.extensionPoint.id, {
-              pluginId: r.pluginId,
-              factory: extReg.factory,
-            });
-            addedExtensionPointIds.push(extReg.extensionPoint.id);
-            provides.add(extReg.extensionPoint);
-          }
+          this.#extensionPoints.set(ref.id, {
+            pluginId: r.pluginId,
+            factory,
+          });
+          addedExtensionPointIds.push(ref.id);
+          provides.add(ref);
         }
 
-        if (r.type === 'plugin' || r.type === 'plugin-v1.1') {
+        if (isPluginRegistration(r)) {
           if (pluginInits.has(r.pluginId)) {
             throw new Error(`Plugin '${r.pluginId}' is already registered`);
           }
@@ -501,7 +492,7 @@ export class BackendInitializer {
             consumes: new Set(Object.values(r.init.deps)),
             init: r.init,
           });
-        } else if (r.type === 'module' || r.type === 'module-v1.1') {
+        } else if (isModuleRegistration(r)) {
           let modules = moduleInits.get(r.pluginId);
           if (!modules) {
             modules = new Map();
@@ -571,7 +562,7 @@ export class BackendInitializer {
     const allPlugins = new Set<string>();
     for (const feature of this.#registrations) {
       for (const r of feature.getRegistrations()) {
-        if (r.type === 'plugin' || r.type === 'plugin-v1.1') {
+        if (isPluginRegistration(r)) {
           allPlugins.add(r.pluginId);
         }
       }
@@ -780,4 +771,24 @@ function isBackendFeatureLoader(
   feature: BackendFeature,
 ): feature is InternalBackendFeatureLoader {
   return toInternalBackendFeature(feature).featureType === 'loader';
+}
+
+type BackendRegistration = ReturnType<
+  InternalBackendRegistrations['getRegistrations']
+>[number];
+
+function isPluginRegistration(
+  r: BackendRegistration,
+): r is
+  | InternalBackendPluginRegistration
+  | InternalBackendPluginRegistrationV1_1 {
+  return r.type === 'plugin' || r.type === 'plugin-v1.1';
+}
+
+function isModuleRegistration(
+  r: BackendRegistration,
+): r is
+  | InternalBackendModuleRegistration
+  | InternalBackendModuleRegistrationV1_1 {
+  return r.type === 'module' || r.type === 'module-v1.1';
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This extracts `isPluginRegistration` and `isModuleRegistration` predicate helpers in `BackendInitializer` to encapsulate the version-aware type discrimination (`plugin`/`plugin-v1.1` and `module`/`module-v1.1`), replacing 5+ scattered compound type checks. Also consolidates the duplicated v1/v1.1 extension point registration loops into a single normalized path.

All changes are internal to `BackendInitializer` — no public API changes.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))