### PR TITLE
backend-defaults: deduplicate lifecycle hook runner logic

### DIFF
--- a/.changeset/fair-bees-rest.md
+++ b/.changeset/fair-bees-rest.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Deduplicated internal lifecycle hook runner logic between the lifecycle and root lifecycle services.

--- a/packages/backend-defaults/src/entrypoints/lifecycle/lifecycleServiceFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/lifecycle/lifecycleServiceFactory.ts
@@ -25,99 +25,44 @@ import {
   coreServices,
   createServiceFactory,
 } from '@backstage/backend-plugin-api';
+import { HookRunner } from '../../lib/HookRunner';
 
 /** @internal */
 export class BackendPluginLifecycleImpl implements LifecycleService {
-  private readonly logger: LoggerService;
-  private readonly pluginMetadata: PluginMetadataService;
+  readonly #logger: LoggerService;
+  readonly #pluginMetadata: PluginMetadataService;
+  readonly #startup: HookRunner<LifecycleServiceStartupOptions>;
+  readonly #shutdown: HookRunner<LifecycleServiceShutdownOptions>;
 
   constructor(logger: LoggerService, pluginMetadata: PluginMetadataService) {
-    this.logger = logger;
-    this.pluginMetadata = pluginMetadata;
+    this.#logger = logger;
+    this.#pluginMetadata = pluginMetadata;
+    this.#startup = new HookRunner('plugin startup', logger);
+    this.#shutdown = new HookRunner('plugin shutdown', logger);
   }
-
-  #hasStarted = false;
-  #hasShutdown = false;
-  #startupTasks: Array<{
-    hook: LifecycleServiceStartupHook;
-    options?: LifecycleServiceStartupOptions;
-  }> = [];
-  #shutdownTasks: Array<{
-    hook: LifecycleServiceShutdownHook;
-    options?: LifecycleServiceShutdownOptions;
-  }> = [];
 
   addStartupHook(
     hook: LifecycleServiceStartupHook,
     options?: LifecycleServiceStartupOptions,
   ): void {
-    if (this.#hasStarted) {
-      throw new Error('Attempted to add startup hook after startup');
-    }
-    this.#startupTasks.push({ hook, options });
+    this.#startup.add(hook, options);
   }
 
   async startup(): Promise<void> {
-    if (this.#hasStarted) {
-      return;
-    }
-    this.#hasStarted = true;
-
-    this.logger.debug(
-      `Running ${this.#startupTasks.length} plugin startup tasks...`,
-    );
-    await Promise.all(
-      this.#startupTasks.map(async ({ hook, options }) => {
-        const logger = options?.logger ?? this.logger;
-        try {
-          await hook();
-          logger.debug(`Plugin startup hook succeeded`);
-        } catch (error) {
-          logger.error(`Plugin startup hook failed, ${error}`);
-        }
-      }),
-    );
+    await this.#startup.run();
   }
 
   addShutdownHook(
     hook: LifecycleServiceShutdownHook,
     options?: LifecycleServiceShutdownOptions,
   ): void {
-    if (this.#hasShutdown) {
-      throw new Error('Attempted to add shutdown hook after shutdown');
-    }
-    const plugin = this.pluginMetadata.getId();
-    const logger = options?.logger?.child({ plugin }) ?? this.logger;
-    this.#shutdownTasks.push({
-      hook,
-      options: {
-        ...options,
-        logger,
-      },
-    });
+    const plugin = this.#pluginMetadata.getId();
+    const logger = options?.logger?.child({ plugin }) ?? this.#logger;
+    this.#shutdown.add(hook, { ...options, logger });
   }
 
   async shutdown(): Promise<void> {
-    if (this.#hasShutdown) {
-      return;
-    }
-    this.#hasShutdown = true;
-
-    this.logger.debug(
-      `Running ${this.#shutdownTasks.length} plugin shutdown tasks...`,
-    );
-
-    await Promise.all(
-      this.#shutdownTasks.map(async ({ hook, options }) => {
-        const logger = options?.logger ?? this.logger;
-        try {
-          await hook();
-          logger.debug(`Plugin shutdown hook succeeded`);
-        } catch (error) {
-          logger.error('Plugin shutdown hook failed', error);
-        }
-      }),
-    );
+    await this.#shutdown.run();
   }
 }
 

--- a/packages/backend-defaults/src/entrypoints/lifecycle/lifecycleServiceFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/lifecycle/lifecycleServiceFactory.ts
@@ -37,8 +37,14 @@ export class BackendPluginLifecycleImpl implements LifecycleService {
   constructor(logger: LoggerService, pluginMetadata: PluginMetadataService) {
     this.#logger = logger;
     this.#pluginMetadata = pluginMetadata;
-    this.#startup = new HookRunner('plugin startup', logger);
-    this.#shutdown = new HookRunner('plugin shutdown', logger);
+    this.#startup = new HookRunner('plugin startup', logger, {
+      lateAddMessage:
+        'Attempted to add plugin startup hook after startup has completed',
+    });
+    this.#shutdown = new HookRunner('plugin shutdown', logger, {
+      lateAddMessage:
+        'Attempted to add plugin shutdown hook after shutdown has started',
+    });
   }
 
   addStartupHook(

--- a/packages/backend-defaults/src/entrypoints/rootLifecycle/rootLifecycleServiceFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/rootLifecycle/rootLifecycleServiceFactory.ts
@@ -24,120 +24,48 @@ import {
   RootLifecycleService,
   LoggerService,
 } from '@backstage/backend-plugin-api';
+import { HookRunner } from '../../lib/HookRunner';
 
 /** @internal */
 export class BackendLifecycleImpl implements RootLifecycleService {
-  private readonly logger: LoggerService;
+  readonly #startup: HookRunner<LifecycleServiceStartupOptions>;
+  readonly #beforeShutdown: HookRunner<undefined>;
+  readonly #shutdown: HookRunner<LifecycleServiceShutdownOptions>;
 
   constructor(logger: LoggerService) {
-    this.logger = logger;
+    this.#startup = new HookRunner('startup', logger);
+    this.#beforeShutdown = new HookRunner('before shutdown', logger);
+    this.#shutdown = new HookRunner('shutdown', logger);
   }
-
-  #hasStarted = false;
-  #startupTasks: Array<{
-    hook: LifecycleServiceStartupHook;
-    options?: LifecycleServiceStartupOptions;
-  }> = [];
 
   addStartupHook(
     hook: LifecycleServiceStartupHook,
     options?: LifecycleServiceStartupOptions,
   ): void {
-    if (this.#hasStarted) {
-      throw new Error('Attempted to add startup hook after startup');
-    }
-    this.#startupTasks.push({ hook, options });
+    this.#startup.add(hook, options);
   }
 
   async startup(): Promise<void> {
-    if (this.#hasStarted) {
-      return;
-    }
-    this.#hasStarted = true;
-
-    this.logger.debug(`Running ${this.#startupTasks.length} startup tasks...`);
-    await Promise.all(
-      this.#startupTasks.map(async ({ hook, options }) => {
-        const logger = options?.logger ?? this.logger;
-        try {
-          await hook();
-          logger.debug(`Startup hook succeeded`);
-        } catch (error) {
-          logger.error(`Startup hook failed, ${error}`);
-        }
-      }),
-    );
+    await this.#startup.run();
   }
 
-  #hasBeforeShutdown = false;
-  #beforeShutdownTasks: Array<{ hook: () => void | Promise<void> }> = [];
-
   addBeforeShutdownHook(hook: () => void): void {
-    if (this.#hasBeforeShutdown) {
-      throw new Error(
-        'Attempt to add before shutdown hook after shutdown has started',
-      );
-    }
-    this.#beforeShutdownTasks.push({ hook });
+    this.#beforeShutdown.add(hook);
   }
 
   async beforeShutdown(): Promise<void> {
-    if (this.#hasBeforeShutdown) {
-      return;
-    }
-    this.#hasBeforeShutdown = true;
-
-    this.logger.debug(
-      `Running ${this.#beforeShutdownTasks.length} before shutdown tasks...`,
-    );
-    await Promise.all(
-      this.#beforeShutdownTasks.map(async ({ hook }) => {
-        try {
-          await hook();
-          this.logger.debug(`Before shutdown hook succeeded`);
-        } catch (error) {
-          this.logger.error(`Before shutdown hook failed, ${error}`);
-        }
-      }),
-    );
+    await this.#beforeShutdown.run();
   }
-
-  #hasShutdown = false;
-  #shutdownTasks: Array<{
-    hook: LifecycleServiceShutdownHook;
-    options?: LifecycleServiceShutdownOptions;
-  }> = [];
 
   addShutdownHook(
     hook: LifecycleServiceShutdownHook,
     options?: LifecycleServiceShutdownOptions,
   ): void {
-    if (this.#hasShutdown) {
-      throw new Error('Attempted to add shutdown hook after shutdown');
-    }
-    this.#shutdownTasks.push({ hook, options });
+    this.#shutdown.add(hook, options);
   }
 
   async shutdown(): Promise<void> {
-    if (this.#hasShutdown) {
-      return;
-    }
-    this.#hasShutdown = true;
-
-    this.logger.debug(
-      `Running ${this.#shutdownTasks.length} shutdown tasks...`,
-    );
-    await Promise.all(
-      this.#shutdownTasks.map(async ({ hook, options }) => {
-        const logger = options?.logger ?? this.logger;
-        try {
-          await hook();
-          logger.debug(`Shutdown hook succeeded`);
-        } catch (error) {
-          logger.error(`Shutdown hook failed, ${error}`);
-        }
-      }),
-    );
+    await this.#shutdown.run();
   }
 }
 

--- a/packages/backend-defaults/src/entrypoints/rootLifecycle/rootLifecycleServiceFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/rootLifecycle/rootLifecycleServiceFactory.ts
@@ -33,9 +33,18 @@ export class BackendLifecycleImpl implements RootLifecycleService {
   readonly #shutdown: HookRunner<LifecycleServiceShutdownOptions>;
 
   constructor(logger: LoggerService) {
-    this.#startup = new HookRunner('startup', logger);
-    this.#beforeShutdown = new HookRunner('before shutdown', logger);
-    this.#shutdown = new HookRunner('shutdown', logger);
+    this.#startup = new HookRunner('startup', logger, {
+      lateAddMessage:
+        'Attempted to add startup hook after startup has completed',
+    });
+    this.#beforeShutdown = new HookRunner('before shutdown', logger, {
+      lateAddMessage:
+        'Attempted to add before shutdown hook after shutdown has started',
+    });
+    this.#shutdown = new HookRunner('shutdown', logger, {
+      lateAddMessage:
+        'Attempted to add shutdown hook after shutdown has started',
+    });
   }
 
   addStartupHook(

--- a/packages/backend-defaults/src/lib/HookRunner.test.ts
+++ b/packages/backend-defaults/src/lib/HookRunner.test.ts
@@ -55,7 +55,8 @@ describe('HookRunner', () => {
     await expect(runner.run()).resolves.toBeUndefined();
     expect(ok).toHaveBeenCalled();
     expect(logger.error).toHaveBeenCalledWith(
-      'Shutdown hook failed, Error: boom',
+      'Shutdown hook failed',
+      expect.any(Error),
     );
   });
 
@@ -69,16 +70,19 @@ describe('HookRunner', () => {
 
     await expect(runner.run()).resolves.toBeUndefined();
     expect(logger.error).toHaveBeenCalledWith(
-      'Shutdown hook failed, Error: async boom',
+      'Shutdown hook failed',
+      expect.any(Error),
     );
   });
 
   it('should reject adding hooks after run', async () => {
     const logger = mockServices.logger.mock();
-    const runner = new HookRunner('startup', logger);
+    const runner = new HookRunner('startup', logger, {
+      lateAddMessage: 'Attempted to add startup hook after startup completed',
+    });
     await runner.run();
     expect(() => runner.add(() => {})).toThrow(
-      'Attempted to add startup hook after startup',
+      'Attempted to add startup hook after startup completed',
     );
   });
 

--- a/packages/backend-defaults/src/lib/HookRunner.test.ts
+++ b/packages/backend-defaults/src/lib/HookRunner.test.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mockServices } from '@backstage/backend-test-utils';
+import { HookRunner } from './HookRunner';
+import { LoggerService } from '@backstage/backend-plugin-api';
+
+describe('HookRunner', () => {
+  it('should run all registered hooks once and log results', async () => {
+    const logger = mockServices.logger.mock();
+    const runner = new HookRunner('startup', logger);
+
+    const order: string[] = [];
+    runner.add(() => {
+      order.push('a');
+    });
+    runner.add(() => {
+      order.push('b');
+    });
+
+    await runner.run();
+    expect(order).toEqual(['a', 'b']);
+    expect(logger.debug).toHaveBeenCalledWith('Running 2 startup tasks...');
+    expect(logger.debug).toHaveBeenCalledWith('Startup hook succeeded');
+
+    // Second run is a no-op
+    order.length = 0;
+    await runner.run();
+    expect(order).toEqual([]);
+  });
+
+  it('should catch errors from individual hooks without aborting others', async () => {
+    const logger = mockServices.logger.mock();
+    const runner = new HookRunner('shutdown', logger);
+
+    const ok = jest.fn();
+    runner.add(() => {
+      throw new Error('boom');
+    });
+    runner.add(ok);
+
+    await expect(runner.run()).resolves.toBeUndefined();
+    expect(ok).toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(
+      'Shutdown hook failed, Error: boom',
+    );
+  });
+
+  it('should catch async errors', async () => {
+    const logger = mockServices.logger.mock();
+    const runner = new HookRunner('shutdown', logger);
+
+    runner.add(async () => {
+      throw new Error('async boom');
+    });
+
+    await expect(runner.run()).resolves.toBeUndefined();
+    expect(logger.error).toHaveBeenCalledWith(
+      'Shutdown hook failed, Error: async boom',
+    );
+  });
+
+  it('should reject adding hooks after run', async () => {
+    const logger = mockServices.logger.mock();
+    const runner = new HookRunner('startup', logger);
+    await runner.run();
+    expect(() => runner.add(() => {})).toThrow(
+      'Attempted to add startup hook after startup',
+    );
+  });
+
+  it('should use per-hook logger from options when provided', async () => {
+    const defaultLogger = mockServices.logger.mock();
+    const hookLogger = mockServices.logger.mock();
+    const runner = new HookRunner<{ logger?: LoggerService }>(
+      'startup',
+      defaultLogger,
+    );
+
+    runner.add(() => {}, { logger: hookLogger });
+    await runner.run();
+
+    expect(hookLogger.debug).toHaveBeenCalledWith('Startup hook succeeded');
+    expect(defaultLogger.debug).not.toHaveBeenCalledWith(
+      'Startup hook succeeded',
+    );
+  });
+});

--- a/packages/backend-defaults/src/lib/HookRunner.ts
+++ b/packages/backend-defaults/src/lib/HookRunner.ts
@@ -16,15 +16,16 @@
 
 import { LoggerService } from '@backstage/backend-plugin-api';
 
+/** @internal */
+type HookRunnerOptions = { logger?: LoggerService } | undefined;
+
 /**
  * Manages a set of lifecycle hooks that fire once.
  *
  * @internal
  */
 export class HookRunner<
-  TOptions extends { logger?: LoggerService } | undefined =
-    | { logger?: LoggerService }
-    | undefined,
+  TOptions extends HookRunnerOptions = HookRunnerOptions,
 > {
   #hasFired = false;
   #tasks: Array<{
@@ -33,18 +34,24 @@ export class HookRunner<
   }> = [];
 
   readonly #label: string;
+  readonly #lateAddMessage: string;
   readonly #logger: LoggerService;
 
-  constructor(label: string, logger: LoggerService) {
+  constructor(
+    label: string,
+    logger: LoggerService,
+    options?: { lateAddMessage?: string },
+  ) {
     this.#label = label;
     this.#logger = logger;
+    this.#lateAddMessage =
+      options?.lateAddMessage ??
+      `Attempted to add ${label} hook after ${label}`;
   }
 
   add(hook: () => void | Promise<void>, options?: TOptions): void {
     if (this.#hasFired) {
-      throw new Error(
-        `Attempted to add ${this.#label} hook after ${this.#label}`,
-      );
+      throw new Error(this.#lateAddMessage);
     }
     this.#tasks.push({ hook, options });
   }
@@ -65,7 +72,7 @@ export class HookRunner<
           await hook();
           logger.debug(`${label} hook succeeded`);
         } catch (error) {
-          logger.error(`${label} hook failed, ${error}`);
+          logger.error(`${label} hook failed`, error);
         }
       }),
     );

--- a/packages/backend-defaults/src/lib/HookRunner.ts
+++ b/packages/backend-defaults/src/lib/HookRunner.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LoggerService } from '@backstage/backend-plugin-api';
+
+/**
+ * Manages a set of lifecycle hooks that fire once.
+ *
+ * @internal
+ */
+export class HookRunner<
+  TOptions extends { logger?: LoggerService } | undefined =
+    | { logger?: LoggerService }
+    | undefined,
+> {
+  #hasFired = false;
+  #tasks: Array<{
+    hook: () => void | Promise<void>;
+    options?: TOptions;
+  }> = [];
+
+  readonly #label: string;
+  readonly #logger: LoggerService;
+
+  constructor(label: string, logger: LoggerService) {
+    this.#label = label;
+    this.#logger = logger;
+  }
+
+  add(hook: () => void | Promise<void>, options?: TOptions): void {
+    if (this.#hasFired) {
+      throw new Error(
+        `Attempted to add ${this.#label} hook after ${this.#label}`,
+      );
+    }
+    this.#tasks.push({ hook, options });
+  }
+
+  async run(): Promise<void> {
+    if (this.#hasFired) {
+      return;
+    }
+    this.#hasFired = true;
+
+    const label = this.#label.charAt(0).toUpperCase() + this.#label.slice(1);
+
+    this.#logger.debug(`Running ${this.#tasks.length} ${this.#label} tasks...`);
+    await Promise.all(
+      this.#tasks.map(async ({ hook, options }) => {
+        const logger = options?.logger ?? this.#logger;
+        try {
+          await hook();
+          logger.debug(`${label} hook succeeded`);
+        } catch (error) {
+          logger.error(`${label} hook failed, ${error}`);
+        }
+      }),
+    );
+  }
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This extracts a shared internal `HookRunner` class to deduplicate the near-identical lifecycle hook runner pattern that was repeated across `BackendPluginLifecycleImpl` and `BackendLifecycleImpl`. Both classes now compose `HookRunner` instances instead of independently implementing the `hasFired` guard, hook accumulation, and `Promise.all`-based execution with per-hook error logging.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))