### PR TITLE
integration: remove unnecessary exports from internal helpers

### DIFF
--- a/packages/integration/src/awsCodeCommit/AwsCodeCommitIntegration.ts
+++ b/packages/integration/src/awsCodeCommit/AwsCodeCommitIntegration.ts
@@ -81,9 +81,8 @@ export class AwsCodeCommitIntegration implements ScmIntegration {
  *
  * @param url - The original URL
  * @param type - The desired type, e.g. 'blob', 'edit'
- * @public
  */
-export function replaceCodeCommitUrlType(
+function replaceCodeCommitUrlType(
   url: string,
   repositoryName: string,
   type: 'browse' | 'edit',

--- a/packages/integration/src/gerrit/core.ts
+++ b/packages/integration/src/gerrit/core.ts
@@ -209,11 +209,8 @@ export function buildGerritGitilesArchiveUrlFromLocation(
  * be used.
  *
  * @param config - A Gerrit provider config.
- * @public
  */
-export function getAuthenticationPrefix(
-  config: GerritIntegrationConfig,
-): string {
+function getAuthenticationPrefix(config: GerritIntegrationConfig): string {
   return config.password ? '/a/' : '/';
 }
 

--- a/packages/integration/src/github/core.ts
+++ b/packages/integration/src/github/core.ts
@@ -63,7 +63,7 @@ export function getGithubFileFetchUrl(
   }
 }
 
-export function chooseEndpoint(
+function chooseEndpoint(
   config: GithubIntegrationConfig,
   credentials: GithubCredentials,
 ): 'api' | 'raw' {

--- a/packages/integration/src/gitlab/GitLabIntegration.ts
+++ b/packages/integration/src/gitlab/GitLabIntegration.ts
@@ -138,6 +138,7 @@ export class GitLabIntegration implements ScmIntegration {
   }
 }
 
+/** @internal */
 export async function sleep(
   durationMs: number,
   abortSignal: AbortSignal | null | undefined,

--- a/packages/integration/src/gitlab/core.ts
+++ b/packages/integration/src/gitlab/core.ts
@@ -75,7 +75,7 @@ export function getGitLabRequestOptions(
 // Converts
 // from: https://gitlab.com/groupA/teams/teamA/subgroupA/repoA/-/blob/branch/filepath
 // to:   https://gitlab.com/api/v4/projects/groupA%2Fteams%2FteamA%2FsubgroupA%2FrepoA/repository/files/filepath/raw?ref=branch
-export function buildProjectUrl(
+function buildProjectUrl(
   target: string,
   projectPathOrID: string | Number,
   config: GitLabIntegrationConfig,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

🧹

Removes the `export` keyword from five internal helper functions in `@backstage/integration` that are not part of the published API and are only used within their own defining files:

- `chooseEndpoint` in `github/core.ts`
- `replaceCodeCommitUrlType` in `awsCodeCommit/AwsCodeCommitIntegration.ts`
- `getAuthenticationPrefix` in `gerrit/core.ts`
- `buildProjectUrl` in `gitlab/core.ts`
- `sleep` in `gitlab/GitLabIntegration.ts` — kept exported for test access but marked `@internal`

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))