### PR TITLE
[BEP] Add config-driven extension creation and cloning support

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -65,10 +65,53 @@ app:
 
     - nav-item:search: false
     - nav-item:user-settings: false
+
+    # Config-driven icon links (created from blueprint, no code needed)
+    - entity-icon-link:catalog/dashboard:
+        config:
+          label: Dashboard
+          icon: dashboard
+          title: Open monitoring dashboard
+          href: https://grafana.example.com/d/{{metadata.name}}
+
+    # Clone an existing icon link with different config
+    - entity-icon-link:catalog/view-source-for-apis:
+        from: entity-icon-link:catalog/view-source
+        config:
+          label: API Source
+          filter: { kind: api }
+
     - nav-item:catalog
     - nav-item:api-docs
     - nav-item:scaffolder
     - nav-item:app-visualizer
+
+    # Clone the catalog page for a "Teams" view
+    - page:catalog/teams:
+        from: page:catalog
+        config:
+          path: /teams
+          title: Teams
+
+    # Clone the kind filter locked to 'group', attached to the teams page
+    - catalog-filter:catalog/kind-for-teams:
+        from: catalog-filter:catalog/kind
+        attachTo: { id: 'page:catalog/teams', input: 'filters' }
+        config:
+          initialFilter: group
+          
+
+    # Clone the type filter for the teams page
+    - catalog-filter:catalog/type-for-teams:
+        from: catalog-filter:catalog/type
+        attachTo: { id: 'page:catalog/teams', input: 'filters' }
+
+    # Clone the list filter for the teams page
+    - catalog-filter:catalog/list-for-teams:
+        from: catalog-filter:catalog/list
+        attachTo: { id: 'page:catalog/teams', input: 'filters' }
+        config:
+          initialFilter: all
 
     # Pages
     - page:catalog/entity:

--- a/beps/NNNN-config-driven-extensions/README.md
+++ b/beps/NNNN-config-driven-extensions/README.md
@@ -1,0 +1,253 @@
+---
+title: Config-Driven Extension Creation
+status: provisional
+authors:
+  - '@sarabadu'
+owners:
+project-areas:
+  - core
+creation-date: 2026-04-20
+---
+
+# BEP: Config-Driven Extension Creation
+
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [Proposal](#proposal)
+  - [Feature 1: Create extensions from blueprints via config](#feature-1-create-extensions-from-blueprints-via-config)
+  - [Feature 2: Clone existing extensions via config](#feature-2-clone-existing-extensions-via-config)
+- [Design Details](#design-details)
+  - [Blueprint registration](#blueprint-registration)
+  - [Extension resolution order](#extension-resolution-order)
+  - [Clone mechanics](#clone-mechanics)
+  - [Config parameter: `from`](#config-parameter-from)
+  - [Nav item path resolution for cloned pages](#nav-item-path-resolution-for-cloned-pages)
+- [Release Plan](#release-plan)
+- [Dependencies](#dependencies)
+- [Alternatives](#alternatives)
+
+## Summary
+
+This proposal introduces two mechanisms to create frontend extensions purely from `app-config.yaml`, without writing code:
+
+1. **Blueprint-from-config**: Reference a blueprint's `kind` in the extension ID. If a matching blueprint is registered in the owning plugin, a new extension is created using the blueprint's `defaultParams`.
+
+2. **Clone-from-config**: Use a `from:` field to clone an existing extension with a new ID, optionally overriding `attachTo` and `config`.
+
+Both features are additive. Existing config behavior is unchanged. Extension IDs that match existing extensions continue to work as config overrides.
+
+## Motivation
+
+Some times we find the some usage for using the same extension with different configurations, for example https://github.com/backstage/backstage/issues/33342.
+Some possible simple extensions like "catalog column" could easily have a blueprint to generate more columns, would be really nice to be able to skip the code part when the extension could have a "default" where the only thing that changes is the configuration. see https://github.com/backstage/backstage/pull/32588#issuecomment-4163468952
+
+### Goals
+
+- Allow creating new extension instances from registered blueprints using only `app-config.yaml`.
+- Allow cloning existing extensions with different config, attachment points, and IDs using only `app-config.yaml`.
+- Promote the creation of more generic reusable blueprints sharing a common visual and behavioral contract, with config-driven variations.
+
+### Non-Goals
+
+- Runtime extension creation (all extensions are still resolved at app startup).
+- Auto-cloning child extensions tree when cloning a parent the clone or creation of child extension need to be wired up manually.
+
+## Proposal
+
+### Feature 1: Create extensions from blueprints via config
+
+When `app.extensions` references an extension ID that doesn't exist in code, the system parses the ID into `kind:namespace/name` and looks for a registered blueprint with matching `kind` in the plugin that owns the `namespace`. If found, a new extension is created using the blueprint's `defaultParams`.
+
+**Example: Creating an entity icon link from config**
+
+The `EntityIconLinkBlueprint` is registered in the catalog plugin with `defaultParams`:
+
+```yaml
+# app-config.yaml
+app:
+  extensions:
+    - entity-icon-link:catalog/dashboard:
+        config:
+          label: Dashboard
+          icon: dashboard
+          href: https://grafana.example.com/d/{{metadata.name}}
+```
+
+No code needed. The extension ID `entity-icon-link:catalog/dashboard` is parsed as:
+
+- `kind`: `entity-icon-link` → matches the blueprint
+- `namespace`: `catalog` → identifies the owning plugin
+- `name`: `dashboard` → names the new instance
+
+The blueprint's `defaultParams` provide sensible defaults. The config schema defines what adopters can customize.
+
+### Feature 2: Clone existing extensions via config
+
+The `from:` field creates a copy of an existing extension with a new ID. The clone shares the same factory, inputs, outputs, and config schema. `attachTo` and `config` can be overridden.
+
+**Example: Creating a "Teams" page by cloning the catalog page**
+
+```yaml
+# app-config.yaml
+app:
+  extensions:
+    # Clone the catalog page
+    - page:catalog/teams:
+        from: page:catalog
+        config:
+          path: /teams
+          title: Teams
+
+    # Clone filters and attach them to the new page
+    - catalog-filter:catalog/kind-for-teams:
+        from: catalog-filter:catalog/kind
+        attachTo: { id: 'page:catalog/teams', input: 'filters' }
+        config:
+          initialFilter: group
+
+    - catalog-filter:catalog/type-for-teams:
+        from: catalog-filter:catalog/type
+        attachTo: { id: 'page:catalog/teams', input: 'filters' }
+
+    - catalog-filter:catalog/list-for-teams:
+        from: catalog-filter:catalog/list
+        attachTo: { id: 'page:catalog/teams', input: 'filters' }
+        config:
+          initialFilter: all
+```
+
+This creates a fully functional `/teams` page with a sidebar nav entry, filtered to show only groups — all without writing a single line of code.
+
+## Design Details
+
+### Blueprint registration
+
+Blueprints opt in to config-driven creation by providing `defaultParams` in `createExtensionBlueprint`:
+
+```ts
+export const EntityIconLinkBlueprint = createExtensionBlueprint({
+  kind: 'entity-icon-link',
+  attachTo: { id: 'entity-card:catalog/about', input: 'iconLinks' },
+  output: [
+    /* ... */
+  ],
+  defaultParams: {
+    useProps: () => ({}),
+  },
+  config: {
+    schema: {
+      label: z => z.string().optional(),
+      href: z => z.string().optional(),
+      icon: z => z.string().optional(),
+    },
+  },
+  *factory(params, { config }) {
+    // ...
+  },
+});
+```
+
+Plugins register blueprints via the `blueprints` option in `createFrontendPlugin`:
+
+```ts
+createFrontendPlugin({
+  pluginId: 'catalog',
+  extensions: [
+    /* ... */
+  ],
+  blueprints: [EntityIconLinkBlueprint],
+});
+```
+
+The `ExtensionBlueprint` interface gains:
+
+| Property                   | Type                                       | Description                                                              |
+| -------------------------- | ------------------------------------------ | ------------------------------------------------------------------------ |
+| `defaultParams`            | `T['params'] \| undefined`                 | Default params for config-driven creation. `undefined` if not supported. |
+| `makeFromConfig({ name })` | `(args) => OverridableExtensionDefinition` | Creates an extension using `defaultParams`. Internal.                    |
+
+The `InternalFrontendPlugin` type gains a `blueprints: ExtensionBlueprint[]` field.
+
+### Extension resolution order
+
+During `resolveAppNodeSpecs`, each config entry is processed in order:
+
+```
+for each config entry with id:
+  1. if extension with that id exists → apply config overrides (existing behavior)
+  2. else if `from:` is set         → clone the source extension with the new id
+  3. else                            → try to create from a matching blueprint
+  4. else                            → report error
+```
+
+This preserves backward compatibility. Steps 2 and 3 are the new additions.
+
+### Clone mechanics
+
+`tryCloneExtension` creates a shallow copy of the source extension's internal representation with a new ID:
+
+```ts
+const clonedExtension = {
+  ...source.extension,
+  id: extensionId,
+  attachTo: overrideParam.attachTo ?? source.extension.attachTo,
+  disabled: overrideParam.disabled ?? source.extension.disabled,
+};
+```
+
+The clone shares the same factory function, inputs, outputs, and config schema. Only `id`, `attachTo`, `disabled`, and `config` can differ.
+
+Children are **not** auto-cloned. Each child extension that should exist under the cloned parent must be explicitly declared in config with its own `from:` entry and `attachTo` pointing to the new parent.
+
+### Config parameter: `from`
+
+The `ExtensionParameters` interface gains:
+
+```ts
+export interface ExtensionParameters {
+  id: string;
+  from?: string; // ← new
+  attachTo?: { id: string; input: string };
+  disabled?: boolean;
+  config?: unknown;
+}
+```
+
+`from` must be a string matching the ID of an existing extension. It is mutually exclusive with blueprint-from-config (if `from` is set, blueprint lookup is skipped).
+
+### Nav item path resolution for cloned pages
+
+> NOTE: please help not really sure if this vibe solution could cause other issues :pepe-think:
+
+Cloned pages share the same `routeRef` object as the source page. Since the nav system resolves hrefs via `routeResolutionApi.resolve(routeRef)` using object identity, both the original and cloned page would resolve to the same path.
+
+The fix: nav items now prefer `coreExtensionData.routePath` from the page node's output data (which reflects config overrides like `path: /teams`) over routeRef resolution:
+
+```ts
+const routePath = node.instance.getData(coreExtensionData.routePath);
+const to = routePath ?? tryResolveLink(routeResolutionApi, routeRef);
+```
+
+This ensures cloned pages with a custom `path` config get the correct nav item href.
+
+## Release Plan
+
+Both features are additive and backward-compatible. No existing APIs are broken.
+
+1. **Phase 1**: Ship `defaultParams`, `makeFromConfig`, and `blueprints` registration behind the existing extension system. No blueprint ships with `defaultParams` by default — this is opt-in per blueprint.
+
+2. **Phase 2**: Ship `from:` clone support in `resolveAppNodeSpecs` and the `from` field in `ExtensionParameters`.
+
+3. **Phase 3**: Add `defaultParams` to selected core blueprints (e.g. `EntityIconLinkBlueprint`, `CatalogFilterBlueprint`) to enable config-driven creation for common use cases.
+
+## Dependencies
+
+- New frontend system (`@backstage/frontend-plugin-api`, `@backstage/frontend-app-api`).
+- Extension ID format: `kind:plugin/name`.
+- `resolveAppNodeSpecs` as the single place where all extension specs are collected before tree construction.
+
+## Alternatives
+
+TBD

--- a/packages/core-components/package.json
+++ b/packages/core-components/package.json
@@ -57,6 +57,7 @@
     "@backstage/config": "workspace:^",
     "@backstage/core-plugin-api": "workspace:^",
     "@backstage/errors": "workspace:^",
+    "@backstage/frontend-plugin-api": "workspace:^",
     "@backstage/theme": "workspace:^",
     "@backstage/version-bridge": "workspace:^",
     "@dagrejs/dagre": "^1.1.4",

--- a/packages/core-components/src/components/HeaderIconLinkRow/IconLinkVertical.tsx
+++ b/packages/core-components/src/components/HeaderIconLinkRow/IconLinkVertical.tsx
@@ -20,6 +20,8 @@ import LinkIcon from '@material-ui/icons/Link';
 import { Link } from '../Link';
 import Box from '@material-ui/core/Box';
 import Typography from '@material-ui/core/Typography';
+import { iconsApiRef } from '@backstage/frontend-plugin-api';
+import { useApi } from '@backstage/frontend-plugin-api';
 
 export type IconLinkVerticalProps = {
   color?: 'primary' | 'secondary';
@@ -46,6 +48,7 @@ const useIconStyles = makeStyles(
       justifyItems: 'center',
       gridGap: 4,
       textAlign: 'center',
+      fontSize: theme.typography.pxToRem(24),
     },
     disabled: {
       color: theme.palette.text.secondary,
@@ -77,11 +80,13 @@ export function IconLinkVertical({
   title,
 }: IconLinkVerticalProps) {
   const classes = useIconStyles();
+  const icons = useApi(iconsApiRef);
+  const IconComponent = typeof icon === 'string' ? icons.icon(icon) : icon;
 
   if (disabled) {
     return (
       <Box title={title} className={classnames(classes.link, classes.disabled)}>
-        {icon}
+        {IconComponent}
         <Typography
           variant="caption"
           component="span"
@@ -100,7 +105,7 @@ export function IconLinkVertical({
       to={href}
       onClick={onClick}
     >
-      {icon}
+      {IconComponent}
       <Typography variant="caption" component="span" className={classes.label}>
         {label}
       </Typography>

--- a/packages/frontend-app-api/src/tree/readAppExtensionsConfig.ts
+++ b/packages/frontend-app-api/src/tree/readAppExtensionsConfig.ts
@@ -19,12 +19,13 @@ import { JsonValue } from '@backstage/types';
 
 export interface ExtensionParameters {
   id: string;
+  from?: string;
   attachTo?: { id: string; input: string };
   disabled?: boolean;
   config?: unknown;
 }
 
-const knownExtensionParameters = ['attachTo', 'disabled', 'config'];
+const knownExtensionParameters = ['from', 'attachTo', 'disabled', 'config'];
 
 // Since we'll never merge arrays in config the config reader context
 // isn't too much of a help. Fall back to manual config reading logic
@@ -136,6 +137,11 @@ export function expandShorthandExtensionParameters(
   const attachTo = value.attachTo as { id: string; input: string } | undefined;
   const disabled = value.disabled;
   const config = value.config;
+  const from = value.from;
+
+  if (from !== undefined && typeof from !== 'string') {
+    throw new Error(errorMsg('must be a string', id, 'from'));
+  }
 
   if (attachTo !== undefined) {
     if (
@@ -183,6 +189,7 @@ export function expandShorthandExtensionParameters(
 
   return {
     id,
+    from,
     attachTo,
     disabled,
     config,

--- a/packages/frontend-app-api/src/tree/resolveAppNodeSpecs.test.ts
+++ b/packages/frontend-app-api/src/tree/resolveAppNodeSpecs.test.ts
@@ -16,6 +16,7 @@
 
 import {
   createExtension,
+  createExtensionBlueprint,
   createExtensionDataRef,
   createFrontendModule,
   createFrontendPlugin,
@@ -707,5 +708,177 @@ describe('resolveAppNodeSpecs', () => {
     expect(overriddenSpecs[0].if).toEqual(overrideIf);
     expect(clearedSpecs).toHaveLength(1);
     expect(clearedSpecs[0].if).toBeUndefined();
+  });
+
+  describe('config-driven blueprint creation', () => {
+    const testDataRef = createExtensionDataRef<string>().with({
+      id: 'test.data',
+    });
+
+    const TestItemBlueprint = createExtensionBlueprint({
+      kind: 'test-item',
+      attachTo: { id: 'test-plugin', input: 'items' },
+      output: [testDataRef],
+      defaultParams: { label: 'default-label' },
+      *factory(params: { label: string }) {
+        yield testDataRef(params.label);
+      },
+    });
+
+    it('should create an extension from a blueprint when config references a non-existent extension', () => {
+      const plugin = createFrontendPlugin({
+        pluginId: 'test-plugin',
+        extensions: [],
+        blueprints: [TestItemBlueprint],
+      });
+
+      const specs = resolveAppNodeSpecs({
+        features: [plugin],
+        builtinExtensions: [],
+        parameters: [
+          {
+            id: 'test-item:test-plugin/my-new-item',
+            config: { title: 'Created from config' },
+          },
+        ],
+        collector,
+      });
+
+      expect(specs).toHaveLength(1);
+      expect(specs[0].id).toBe('test-item:test-plugin/my-new-item');
+      expect(specs[0].config).toEqual({ title: 'Created from config' });
+      expect(specs[0].plugin).toBe(plugin);
+      expect(specs[0].disabled).toBe(false);
+    });
+
+    it('should create multiple extensions from the same blueprint via config', () => {
+      const plugin = createFrontendPlugin({
+        pluginId: 'test-plugin',
+        extensions: [],
+        blueprints: [TestItemBlueprint],
+      });
+
+      const specs = resolveAppNodeSpecs({
+        features: [plugin],
+        builtinExtensions: [],
+        parameters: [
+          {
+            id: 'test-item:test-plugin/item-a',
+            config: { title: 'Item A' },
+          },
+          {
+            id: 'test-item:test-plugin/item-b',
+            config: { title: 'Item B' },
+          },
+        ],
+        collector,
+      });
+
+      expect(specs).toHaveLength(2);
+      expect(specs[0].id).toBe('test-item:test-plugin/item-a');
+      expect(specs[0].config).toEqual({ title: 'Item A' });
+      expect(specs[1].id).toBe('test-item:test-plugin/item-b');
+      expect(specs[1].config).toEqual({ title: 'Item B' });
+    });
+
+    it('should still override existing extensions rather than creating new ones', () => {
+      const plugin = createFrontendPlugin({
+        pluginId: 'test-plugin',
+        extensions: [
+          TestItemBlueprint.make({
+            name: 'existing',
+            params: { label: 'from code' },
+          }),
+        ],
+        blueprints: [TestItemBlueprint],
+      });
+
+      const specs = resolveAppNodeSpecs({
+        features: [plugin],
+        builtinExtensions: [],
+        parameters: [
+          {
+            id: 'test-item:test-plugin/existing',
+            config: { title: 'overridden' },
+          },
+        ],
+        collector,
+      });
+
+      expect(specs).toHaveLength(1);
+      expect(specs[0].id).toBe('test-item:test-plugin/existing');
+      expect(specs[0].config).toEqual({ title: 'overridden' });
+    });
+
+    it('should report an error when no matching blueprint exists for a non-existent extension', () => {
+      const plugin = createFrontendPlugin({
+        pluginId: 'test-plugin',
+        extensions: [],
+        blueprints: [], // no blueprints registered
+      });
+
+      const specs = resolveAppNodeSpecs({
+        features: [plugin],
+        builtinExtensions: [],
+        parameters: [
+          {
+            id: 'unknown-kind:test-plugin/something',
+          },
+        ],
+        collector,
+      });
+
+      expect(specs).toEqual([]);
+      expect(collector.collectErrors()).toEqual([
+        {
+          code: 'INVALID_EXTENSION_CONFIG_KEY',
+          message:
+            'Extension unknown-kind:test-plugin/something does not exist',
+          context: {
+            extensionId: 'unknown-kind:test-plugin/something',
+          },
+        },
+      ]);
+    });
+
+    it('should not create from a blueprint without defaultParams', () => {
+      const NoDefaultBlueprint = createExtensionBlueprint({
+        kind: 'no-default',
+        attachTo: { id: 'test-plugin', input: 'items' },
+        output: [testDataRef],
+        // no defaultParams
+        *factory(params: { label: string }) {
+          yield testDataRef(params.label);
+        },
+      });
+
+      const plugin = createFrontendPlugin({
+        pluginId: 'test-plugin',
+        extensions: [],
+        blueprints: [NoDefaultBlueprint],
+      });
+
+      const specs = resolveAppNodeSpecs({
+        features: [plugin],
+        builtinExtensions: [],
+        parameters: [
+          {
+            id: 'no-default:test-plugin/something',
+          },
+        ],
+        collector,
+      });
+
+      expect(specs).toEqual([]);
+      expect(collector.collectErrors()).toEqual([
+        {
+          code: 'INVALID_EXTENSION_CONFIG_KEY',
+          message: 'Extension no-default:test-plugin/something does not exist',
+          context: {
+            extensionId: 'no-default:test-plugin/something',
+          },
+        },
+      ]);
+    });
   });
 });

--- a/packages/frontend-app-api/src/tree/resolveAppNodeSpecs.ts
+++ b/packages/frontend-app-api/src/tree/resolveAppNodeSpecs.ts
@@ -30,8 +30,44 @@ import {
   toInternalFrontendModule,
 } from '../../../frontend-plugin-api/src/wiring/createFrontendModule';
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
-import { toInternalExtension } from '../../../frontend-plugin-api/src/wiring/resolveExtensionDefinition';
+import {
+  toInternalExtension,
+  resolveExtensionDefinition,
+} from '../../../frontend-plugin-api/src/wiring/resolveExtensionDefinition';
 import { ErrorCollector } from '../wiring/createErrorCollector';
+
+/**
+ * Parses an extension ID into its kind, namespace, and name components.
+ * Extension IDs follow the format: `kind:namespace/name` or `kind:namespace`
+ * @internal
+ */
+function parseExtensionId(extensionId: string): {
+  kind?: string;
+  namespace?: string;
+  name?: string;
+} {
+  let kind: string | undefined;
+  let rest: string;
+
+  const colonIndex = extensionId.indexOf(':');
+  if (colonIndex >= 0) {
+    kind = extensionId.substring(0, colonIndex);
+    rest = extensionId.substring(colonIndex + 1);
+  } else {
+    rest = extensionId;
+  }
+
+  const slashIndex = rest.indexOf('/');
+  if (slashIndex >= 0) {
+    return {
+      kind,
+      namespace: rest.substring(0, slashIndex),
+      name: rest.substring(slashIndex + 1),
+    };
+  }
+
+  return { kind, namespace: rest };
+}
 
 function normalizePlugin(plugin: FrontendPlugin): FrontendPlugin {
   // Ensure pluginId is always set for plugins in the app
@@ -62,6 +98,106 @@ function getExtensionPredicate(options: {
     return options.internalExtension.if;
   }
   return undefined;
+}
+
+/**
+ * Attempts to create a new extension from a registered blueprint when a
+ * config references an extension ID that doesn't exist in code.
+ *
+ * Parses the extension ID to extract kind/namespace/name, then looks for a
+ * matching blueprint in the plugin that owns that namespace.
+ *
+ * @internal
+ */
+function tryCreateFromBlueprint(
+  extensionId: string,
+  _overrideParam: ExtensionParameters,
+  plugins: FrontendPlugin[],
+): { extension: Extension<any, any>; plugin: FrontendPlugin } | undefined {
+  const { kind, namespace, name } = parseExtensionId(extensionId);
+
+  // We need kind, namespace, and name to create from a blueprint.
+  // kind is needed to find the right blueprint.
+  // namespace identifies the owning plugin.
+  // name is needed to distinguish the new extension from the default.
+  if (!kind || !namespace || !name) {
+    return undefined;
+  }
+
+  // Find the plugin that owns this namespace
+  const plugin = plugins.find(p => p.pluginId === namespace);
+  if (!plugin) {
+    return undefined;
+  }
+
+  // Look for a matching blueprint in the plugin's registered blueprints
+  const internalPlugin = OpaqueFrontendPlugin.toInternal(plugin);
+  const blueprints = internalPlugin.blueprints ?? [];
+  const blueprint = blueprints.find(bp => bp.kind === kind);
+
+  if (!blueprint) {
+    return undefined;
+  }
+
+  // The blueprint must have defaultParams to support config-driven creation
+  if (!blueprint.defaultParams) {
+    return undefined;
+  }
+
+  // Create the extension using the blueprint's defaults
+  const definition = blueprint.makeFromConfig({ name });
+  const extension = resolveExtensionDefinition(definition, { namespace });
+
+  return { extension, plugin };
+}
+
+/**
+ * Creates a clone of an existing extension with a new ID.
+ * The clone shares the same factory, inputs, outputs, and config schema
+ * but gets a new name and can have different config overrides.
+ *
+ * @internal
+ */
+function tryCloneExtension(
+  extensionId: string,
+  overrideParam: ExtensionParameters,
+  deduplicatedExtensions: Array<{
+    extension: ReturnType<typeof toInternalExtension>;
+    params: {
+      plugin: FrontendPlugin;
+      source: FrontendPlugin;
+      attachTo: any;
+      disabled: boolean;
+      if?: any;
+      config: unknown;
+    };
+  }>,
+) {
+  const sourceId = overrideParam.from!;
+  const source = deduplicatedExtensions.find(e => e.extension.id === sourceId);
+  if (!source) {
+    return undefined;
+  }
+
+  // Create a cloned extension with the new ID but same factory/inputs/outputs
+  const clonedExtension = {
+    ...source.extension,
+    id: extensionId,
+    attachTo: overrideParam.attachTo ?? source.extension.attachTo,
+    disabled: overrideParam.disabled ?? source.extension.disabled,
+  };
+
+  return {
+    extension: clonedExtension,
+    params: {
+      plugin: source.params.plugin,
+      source: source.params.source,
+      attachTo: overrideParam.attachTo ?? source.params.attachTo,
+      disabled: Boolean(overrideParam.disabled ?? source.params.disabled),
+      if: source.params.if,
+      config: overrideParam.config ?? source.params.config,
+    },
+  };
 }
 
 /** @internal */
@@ -268,14 +404,59 @@ export function resolveAppNodeSpecs(options: {
         existing.params.disabled = Boolean(overrideParam.disabled);
       }
       order.set(extensionId, existing);
+    } else if (overrideParam.from) {
+      // Clone an existing extension with a new ID and different config
+      const cloned = tryCloneExtension(
+        extensionId,
+        overrideParam,
+        deduplicatedExtensions,
+      );
+      if (cloned) {
+        deduplicatedExtensions.push(cloned);
+        seenExtensionIds.add(extensionId);
+        order.set(extensionId, cloned);
+      } else {
+        collector.report({
+          code: 'INVALID_EXTENSION_CONFIG_KEY',
+          message: `Cannot clone extension '${overrideParam.from}': source extension does not exist`,
+          context: {
+            extensionId,
+          },
+        });
+      }
     } else {
-      collector.report({
-        code: 'INVALID_EXTENSION_CONFIG_KEY',
-        message: `Extension ${extensionId} does not exist`,
-        context: {
-          extensionId,
-        },
-      });
+      // Try to create a new extension from a registered blueprint
+      const created = tryCreateFromBlueprint(
+        extensionId,
+        overrideParam,
+        plugins,
+      );
+      if (created) {
+        const { extension, plugin } = created;
+        const internalExtension = toInternalExtension(extension);
+        const newEntry = {
+          extension: internalExtension,
+          params: {
+            plugin,
+            source: plugin,
+            attachTo: overrideParam.attachTo ?? internalExtension.attachTo,
+            disabled: Boolean(overrideParam.disabled),
+            if: getExtensionPredicate({ internalExtension }),
+            config: overrideParam.config,
+          },
+        };
+        deduplicatedExtensions.push(newEntry);
+        seenExtensionIds.add(extensionId);
+        order.set(extensionId, newEntry);
+      } else {
+        collector.report({
+          code: 'INVALID_EXTENSION_CONFIG_KEY',
+          message: `Extension ${extensionId} does not exist`,
+          context: {
+            extensionId,
+          },
+        });
+      }
     }
   }
 

--- a/packages/frontend-internal/src/wiring/InternalFrontendPlugin.ts
+++ b/packages/frontend-internal/src/wiring/InternalFrontendPlugin.ts
@@ -16,6 +16,7 @@
 
 import {
   Extension,
+  ExtensionBlueprint,
   FeatureFlagConfig,
   IconElement,
   OverridableFrontendPlugin,
@@ -31,6 +32,7 @@ export const OpaqueFrontendPlugin = OpaqueType.create<{
     readonly title?: string;
     readonly icon?: IconElement;
     readonly extensions: Extension<unknown>[];
+    readonly blueprints: ExtensionBlueprint[];
     readonly featureFlags: FeatureFlagConfig[];
     readonly if?: FilterPredicate;
     readonly infoOptions?: {

--- a/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
+++ b/packages/frontend-plugin-api/src/wiring/createExtensionBlueprint.ts
@@ -173,6 +173,14 @@ export type CreateExtensionBlueprintOptions<
   defineParams?: TParams extends ExtensionBlueprintDefineParams
     ? TParams
     : 'The defineParams option must be a function if provided, see the docs for details';
+  /**
+   * Default params to use when creating extensions from config.
+   * When provided, the blueprint can be used to create extensions
+   * purely from app-config.yaml without any code-level params.
+   */
+  defaultParams?: TParams extends ExtensionBlueprintDefineParams
+    ? ReturnType<TParams>['T']
+    : TParams;
   factory(
     params: TParams extends ExtensionBlueprintDefineParams
       ? ReturnType<TParams>['T']
@@ -229,7 +237,22 @@ type AnyParamsInput<TParams extends object | ExtensionBlueprintDefineParams> =
 export interface ExtensionBlueprint<
   T extends ExtensionBlueprintParameters = ExtensionBlueprintParameters,
 > {
+  /** @internal */
+  readonly $$type: '@backstage/ExtensionBlueprint';
+  /** The kind identifier for this blueprint */
+  readonly kind: T['kind'];
   dataRefs: T['dataRefs'];
+  /** Default params used for config-driven extension creation. Undefined if not supported. */
+  readonly defaultParams: T['params'] | undefined;
+
+  /**
+   * Creates a new extension from the blueprint using only the blueprint's
+   * defaultParams and config from app-config.yaml. Used for config-driven
+   * extension creation when no code-level params are provided.
+   *
+   * @internal
+   */
+  makeFromConfig(args: { name: string }): OverridableExtensionDefinition;
 
   make<
     TName extends string | undefined,
@@ -586,6 +609,9 @@ export function createExtensionBlueprint<
     defineParams?: TParams extends ExtensionBlueprintDefineParams
       ? TParams
       : 'The defineParams option must be a function if provided, see the docs for details';
+    defaultParams?: TParams extends ExtensionBlueprintDefineParams
+      ? ReturnType<TParams>['T']
+      : TParams;
     factory(
       params: TParams extends ExtensionBlueprintDefineParams
         ? ReturnType<TParams>['T']
@@ -656,6 +682,9 @@ export function createExtensionBlueprint<
     defineParams?: TParams extends ExtensionBlueprintDefineParams
       ? TParams
       : 'The defineParams option must be a function if provided, see the docs for details';
+    defaultParams?: TParams extends ExtensionBlueprintDefineParams
+      ? ReturnType<TParams>['T']
+      : TParams;
     factory(
       params: TParams extends ExtensionBlueprintDefineParams
         ? ReturnType<TParams>['T']
@@ -710,7 +739,40 @@ export function createExtensionBlueprint(options: any): any {
     | undefined;
 
   return {
+    $$type: '@backstage/ExtensionBlueprint' as const,
+    kind: options.kind as string,
     dataRefs: options.dataRefs,
+    defaultParams: options.defaultParams,
+    /**
+     * Creates a new extension from the blueprint using only config values
+     * and the blueprint's defaultParams. This is used for config-driven
+     * extension creation where no code-level params are provided.
+     *
+     * @internal
+     */
+    makeFromConfig(args: { name: string }) {
+      const defaultParams = options.defaultParams;
+      if (!defaultParams) {
+        throw new Error(
+          `Blueprint with kind '${options.kind}' does not support config-driven creation (no defaultParams provided)`,
+        );
+      }
+      return createExtension({
+        kind: options.kind,
+        name: args.name,
+        attachTo: options.attachTo as ExtensionDefinitionAttachTo,
+        disabled: options.disabled,
+        if: options.if,
+        inputs: options.inputs,
+        output: options.output as ExtensionDataRef[],
+        config: options.config,
+        configSchema: options.configSchema as any,
+        factory: ctx =>
+          options.factory(defaultParams, ctx as any) as Iterable<
+            ExtensionDataValue<any, any>
+          >,
+      }) as OverridableExtensionDefinition;
+    },
     make(args) {
       return createExtension({
         kind: options.kind,

--- a/packages/frontend-plugin-api/src/wiring/createFrontendPlugin.ts
+++ b/packages/frontend-plugin-api/src/wiring/createFrontendPlugin.ts
@@ -30,6 +30,7 @@ import { IconElement } from '../icons/types';
 import { RouteRef, SubRouteRef, ExternalRouteRef } from '../routing';
 import { ID_PATTERN } from './constants';
 import { FilterPredicate } from '@backstage/filter-predicates';
+import { ExtensionBlueprint } from './createExtensionBlueprint';
 
 /**
  * Information about the plugin.
@@ -197,6 +198,13 @@ export interface CreateFrontendPluginOptions<
   routes?: TRoutes;
   externalRoutes?: TExternalRoutes;
   extensions?: TExtensions;
+  /**
+   * Blueprints that can be used to create extensions from app-config.yaml.
+   * When a config references an extension ID matching a blueprint's kind and
+   * the plugin's namespace, and no such extension exists in code, a new
+   * extension will be created using the blueprint's defaultParams.
+   */
+  blueprints?: ExtensionBlueprint[];
   featureFlags?: FeatureFlagConfig[];
   if?: FilterPredicate;
   info?: FrontendPluginInfoOptions;
@@ -287,6 +295,7 @@ export function createFrontendPlugin<
     featureFlags: options.featureFlags ?? [],
     if: options.if,
     extensions: extensions,
+    blueprints: options.blueprints ?? [],
     infoOptions: options.info,
 
     // This method is overridden when the plugin instance is installed in an app

--- a/plugins/app/src/extensions/AppNav.tsx
+++ b/plugins/app/src/extensions/AppNav.tsx
@@ -230,7 +230,11 @@ function NavContentRenderer(props: {
         return [];
       }
 
-      const to = tryResolveLink(routeResolutionApi, routeRef);
+      // Prefer the node's own routePath (reflects config overrides like
+      // `path: /teams` on cloned pages) over routeRef resolution, which can
+      // return the wrong path when multiple pages share the same routeRef.
+      const routePath = node.instance.getData(coreExtensionData.routePath);
+      const to = routePath ?? tryResolveLink(routeResolutionApi, routeRef);
       if (!to) {
         return [];
       }

--- a/plugins/catalog-react/src/alpha/blueprints/EntityIconLinkBlueprint.tsx
+++ b/plugins/catalog-react/src/alpha/blueprints/EntityIconLinkBlueprint.tsx
@@ -31,6 +31,21 @@ import {
 } from './extensionData';
 import { Entity } from '@backstage/catalog-model';
 import { resolveEntityFilterData } from './resolveEntityFilterData';
+import { useEntity } from '../../hooks';
+
+/**
+ * Resolves template expressions like `${metadata.name}` or `${spec.type}`
+ * against an entity object using dot-notation paths.
+ */
+function resolveEntityTemplate(template: string, entity: Entity): string {
+  return template.replace(/\{\{([^}]+)\}\}/g, (_, path: string) => {
+    const value = path
+      .trim()
+      .split('.')
+      .reduce((obj: any, key) => obj?.[key], entity);
+    return value !== null ? String(value) : '';
+  });
+}
 
 const entityIconLinkPropsDataRef = createExtensionDataRef<
   () => IconLinkVerticalProps
@@ -52,10 +67,15 @@ export const EntityIconLinkBlueprint = createExtensionBlueprint({
     filterFunction: entityFilterFunctionDataRef,
     filterExpression: entityFilterExpressionDataRef,
   },
+  defaultParams: {
+    useProps: () => ({}),
+  },
   config: {
     schema: {
       label: z => z.string().optional(),
       title: z => z.string().optional(),
+      icon: z => z.string().optional(),
+      href: z => z.string().optional(),
       filter: z => createZodV3FilterPredicateSchema(z).optional(),
     },
   },
@@ -80,6 +100,29 @@ export const EntityIconLinkBlueprint = createExtensionBlueprint({
           : rest,
       {},
     );
-    yield entityIconLinkPropsDataRef(() => ({ ...useProps(), ...configProps }));
+
+    const hrefTemplate =
+      typeof config.href === 'string' && config.href.includes('{{')
+        ? config.href
+        : undefined;
+
+    if (hrefTemplate) {
+      // When href contains template expressions, resolve them at render time
+      // using the current entity. useEntity() is safe here because useProps
+      // is always called inside a React component context.
+      yield entityIconLinkPropsDataRef(() => {
+        const { entity } = useEntity();
+        return {
+          ...useProps(),
+          ...configProps,
+          href: resolveEntityTemplate(hrefTemplate, entity),
+        };
+      });
+    } else {
+      yield entityIconLinkPropsDataRef(() => ({
+        ...useProps(),
+        ...configProps,
+      }));
+    }
   },
 });

--- a/plugins/catalog/src/alpha/plugin.tsx
+++ b/plugins/catalog/src/alpha/plugin.tsx
@@ -16,6 +16,7 @@
 
 import { createFrontendPlugin } from '@backstage/frontend-plugin-api';
 import { entityRouteRef } from '@backstage/plugin-catalog-react';
+import { EntityIconLinkBlueprint } from '@backstage/plugin-catalog-react/alpha';
 import CategoryIcon from '@material-ui/icons/Category';
 
 import {
@@ -65,4 +66,5 @@ export default createFrontendPlugin({
     ...contextMenuItems,
     ...searchResultItems,
   ],
+  blueprints: [EntityIconLinkBlueprint],
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3453,6 +3453,7 @@ __metadata:
     "@backstage/core-app-api": "workspace:^"
     "@backstage/core-plugin-api": "workspace:^"
     "@backstage/errors": "workspace:^"
+    "@backstage/frontend-plugin-api": "workspace:^"
     "@backstage/test-utils": "workspace:^"
     "@backstage/theme": "workspace:^"
     "@backstage/version-bridge": "workspace:^"


### PR DESCRIPTION
## Hey, I just made a Pull Request!
We kick off this topic on last framework SIG, adding this BEP to have a moreconcrete discussion

**RFC: Config-Driven Extension Creation**

This PR adds a BEP proposal for two new mechanisms that allow creating frontend extensions purely from `app-config.yaml`:

### 1. Blueprint-from-config

Blueprint authors opt in by providing `defaultParams` and registering the blueprint in the plugin:

```ts
// Define the blueprint with defaultParams to enable config-driven creation
export const EntityIconLinkBlueprint = createExtensionBlueprint({
  kind: 'entity-icon-link',
  attachTo: { id: 'entity-card:catalog/about', input: 'iconLinks' },
  output: [entityIconLinkPropsDataRef],
  defaultParams: {
    useProps: () => ({}),
  },
  config: {
    schema: {
      label: z => z.string().optional(),
      icon: z => z.string().optional(),
      href: z => z.string().optional(),
    },
  },
  *factory(params, { config }) {
    yield entityIconLinkPropsDataRef(() => ({ ...params.useProps(), ...config }));
  },
});

// Register the blueprint in the plugin
createFrontendPlugin({
  pluginId: 'catalog',
  extensions: [/* ... */],
  blueprints: [EntityIconLinkBlueprint],
});
```

Adopters can then create instances purely from config:

```yaml
app:
  extensions:
    # Create a Grafana dashboard link — no code needed
    # ID format: kind:namespace/name → entity-icon-link:catalog/dashboard
    - entity-icon-link:catalog/dashboard:
        config:
          label: Dashboard
          icon: dashboard
          # {{}} templates are resolved against the entity at render time
          href: https://grafana.example.com/d/{{metadata.name}}

    # Create a Jira link — same blueprint, different config
    - entity-icon-link:catalog/jira:
        config:
          label: Jira
          icon: bug
          href: https://jira.example.com/browse/{{metadata.annotations.jira/project-key}}
```

### 2. Clone-from-config

A `from:` field copies an existing extension with a new ID, sharing the same factory/inputs/outputs but allowing different `config` and `attachTo`:

```yaml
app:
  extensions:
    # Clone the catalog page with a different path and title (the extension will not have any inputs)
    - page:catalog/teams:
        from: page:catalog
        config:
          path: /teams
          title: Teams

    # Clone filters and re-attach to the new page
    - catalog-filter:catalog/kind-for-teams:
        from: catalog-filter:catalog/kind
        attachTo: { id: 'page:catalog/teams', input: 'filters' }
        config:
          initialFilter: group # Lock to groups only

    - catalog-filter:catalog/type-for-teams:
        from: catalog-filter:catalog/type
        attachTo: { id: 'page:catalog/teams', input: 'filters' }

    - catalog-filter:catalog/list-for-teams:
        from: catalog-filter:catalog/list
        attachTo: { id: 'page:catalog/teams', input: 'filters' }
        config:
          initialFilter: all
```

Both features are additive and backward-compatible. Existing config overrides work exactly as before.

**Motivation:** [#33342](https://github.com/backstage/backstage/issues/33342), [#32588 (comment)](https://github.com/backstage/backstage/pull/32588#issuecomment-4163468952)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
