### PR TITLE
Cache GitHub App installations to reduce rate limit usage

### DIFF
--- a/.changeset/github-installations-cache.md
+++ b/.changeset/github-installations-cache.md
@@ -1,0 +1,7 @@
+---
+'@backstage/integration': patch
+---
+
+GitHub integrations now cache the list of app installations for a short period, avoiding a full `GET /app/installations` pagination on every token fetch. This significantly reduces API usage against the 15k/hour GitHub App rate limit for organizations with many installations or frequent credential refreshes.
+
+The cache is refreshed on a 10-minute TTL, and is additionally invalidated when a lookup for a previously-unseen owner occurs (throttled to once per minute) or when GitHub reports that a cached installation is no longer available, so newly added or removed installations are still picked up promptly.

--- a/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.test.ts
+++ b/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.test.ts
@@ -351,7 +351,7 @@ describe('SingleInstanceGithubCredentialsProvider tests', () => {
       github.getCredentials({
         url: 'https://github.com/backstage',
       }),
-    ).rejects.toEqual({ status: 404, message: 'NotFound' });
+    ).rejects.toMatchObject({ status: 404, message: 'NotFound' });
   });
 
   it('should return the default token if no app is configured', async () => {
@@ -570,10 +570,256 @@ describe('SingleInstanceGithubCredentialsProvider tests', () => {
     await github.getCredentials({ url: 'https://github.com/backstage' });
     await github.getCredentials({ url: 'https://github.com/backstage' });
 
-    expect(octokit.apps.listInstallations.mock.calls.length).toBe(2);
+    // The installations cache is independent of the token cache, and stays
+    // fresh across token refreshes.
+    expect(octokit.apps.listInstallations.mock.calls.length).toBe(1);
     expect(octokit.apps.createInstallationAccessToken.mock.calls.length).toBe(
       2,
     );
+  });
+
+  it('should cache the installations list across requests for different owners', async () => {
+    octokit.apps.listInstallations.mockResolvedValue({
+      headers: {
+        etag: '123',
+      },
+      data: [
+        {
+          id: 1,
+          repository_selection: 'all',
+          account: { login: 'org-a' },
+        },
+        {
+          id: 2,
+          repository_selection: 'all',
+          account: { login: 'org-b' },
+        },
+      ],
+    } as RestEndpointMethodTypes['apps']['listInstallations']['response']);
+
+    octokit.apps.createInstallationAccessToken.mockResolvedValue({
+      data: {
+        expires_at: DateTime.local().plus({ hours: 1 }).toString(),
+        token: 'secret_token',
+      },
+    } as RestEndpointMethodTypes['apps']['createInstallationAccessToken']['response']);
+
+    await github.getCredentials({ url: 'https://github.com/org-a' });
+    await github.getCredentials({ url: 'https://github.com/org-b' });
+
+    expect(octokit.apps.listInstallations.mock.calls.length).toBe(1);
+  });
+
+  it('should de-duplicate concurrent installation lookups', async () => {
+    let resolveListInstallations!: (value: unknown) => void;
+    octokit.apps.listInstallations.mockReturnValue(
+      new Promise(resolve => {
+        resolveListInstallations = resolve;
+      }),
+    );
+
+    octokit.apps.createInstallationAccessToken.mockResolvedValue({
+      data: {
+        expires_at: DateTime.local().plus({ hours: 1 }).toString(),
+        token: 'secret_token',
+      },
+    } as RestEndpointMethodTypes['apps']['createInstallationAccessToken']['response']);
+
+    const first = github.getCredentials({
+      url: 'https://github.com/backstage',
+    });
+    const second = github.getCredentials({
+      url: 'https://github.com/backstage',
+    });
+
+    resolveListInstallations({
+      headers: { etag: '123' },
+      data: [
+        {
+          id: 1,
+          repository_selection: 'all',
+          account: { login: 'backstage' },
+        },
+      ],
+    });
+
+    await Promise.all([first, second]);
+
+    expect(octokit.apps.listInstallations.mock.calls.length).toBe(1);
+  });
+
+  it('should not cache a failed installation lookup', async () => {
+    octokit.apps.listInstallations
+      .mockRejectedValueOnce({ status: 500, message: 'Boom' })
+      .mockResolvedValueOnce({
+        headers: { etag: '123' },
+        data: [
+          {
+            id: 1,
+            repository_selection: 'all',
+            account: { login: 'backstage' },
+          },
+        ],
+      } as RestEndpointMethodTypes['apps']['listInstallations']['response']);
+
+    octokit.apps.createInstallationAccessToken.mockResolvedValue({
+      data: {
+        expires_at: DateTime.local().plus({ hours: 1 }).toString(),
+        token: 'secret_token',
+      },
+    } as RestEndpointMethodTypes['apps']['createInstallationAccessToken']['response']);
+
+    await expect(
+      github.getCredentials({ url: 'https://github.com/backstage' }),
+    ).rejects.toMatchObject({ status: 500, message: 'Boom' });
+
+    const { token } = await github.getCredentials({
+      url: 'https://github.com/backstage',
+    });
+    expect(token).toEqual('secret_token');
+    expect(octokit.apps.listInstallations.mock.calls.length).toBe(2);
+  });
+
+  it('should refresh the installations cache when a lookup misses the cached list', async () => {
+    jest.useFakeTimers({ now: new Date('2024-01-01T12:00:00Z') });
+    try {
+      octokit.apps.listInstallations
+        .mockResolvedValueOnce({
+          headers: { etag: '1' },
+          data: [],
+        } as unknown as RestEndpointMethodTypes['apps']['listInstallations']['response'])
+        .mockResolvedValueOnce({
+          headers: { etag: '2' },
+          data: [
+            {
+              id: 1,
+              repository_selection: 'all',
+              account: { login: 'backstage' },
+            },
+          ],
+        } as RestEndpointMethodTypes['apps']['listInstallations']['response']);
+
+      octokit.apps.createInstallationAccessToken.mockResolvedValue({
+        data: {
+          expires_at: DateTime.local().plus({ hours: 1 }).toString(),
+          token: 'secret_token',
+        },
+      } as RestEndpointMethodTypes['apps']['createInstallationAccessToken']['response']);
+
+      // Prime the cache with an empty installations list.
+      const first = await github.getCredentials({
+        url: 'https://github.com/backstage',
+      });
+      expect(first.type).toEqual('token');
+      expect(octokit.apps.listInstallations).toHaveBeenCalledTimes(1);
+
+      // Advance past the refresh throttle before the second lookup so the
+      // miss is allowed to trigger a refresh.
+      jest.setSystemTime(new Date('2024-01-01T12:02:00Z'));
+
+      const { token } = await github.getCredentials({
+        url: 'https://github.com/backstage',
+      });
+      expect(token).toEqual('secret_token');
+      expect(octokit.apps.listInstallations).toHaveBeenCalledTimes(2);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('should throttle on-miss refreshes of the installations cache', async () => {
+    jest.useFakeTimers({ now: new Date('2024-01-01T12:00:00Z') });
+    try {
+      octokit.apps.listInstallations.mockResolvedValue({
+        headers: { etag: '1' },
+        data: [],
+      } as unknown as RestEndpointMethodTypes['apps']['listInstallations']['response']);
+
+      // Prime the cache with an empty list.
+      await github.getCredentials({ url: 'https://github.com/x' });
+      expect(octokit.apps.listInstallations).toHaveBeenCalledTimes(1);
+
+      // Past the throttle window — miss triggers a single refresh.
+      jest.setSystemTime(new Date('2024-01-01T12:02:00Z'));
+      await github.getCredentials({ url: 'https://github.com/y' });
+      expect(octokit.apps.listInstallations).toHaveBeenCalledTimes(2);
+
+      // Inside the throttle window — subsequent misses reuse the cache.
+      jest.setSystemTime(new Date('2024-01-01T12:02:30Z'));
+      await github.getCredentials({ url: 'https://github.com/z' });
+      expect(octokit.apps.listInstallations).toHaveBeenCalledTimes(2);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('should drop the installations cache when the installation is no longer valid', async () => {
+    octokit.apps.listInstallations.mockResolvedValue({
+      headers: { etag: '1' },
+      data: [
+        {
+          id: 1,
+          repository_selection: 'all',
+          account: { login: 'backstage' },
+        },
+      ],
+    } as RestEndpointMethodTypes['apps']['listInstallations']['response']);
+
+    octokit.apps.createInstallationAccessToken
+      .mockRejectedValueOnce(
+        Object.assign(new Error('Gone'), { status: 410, name: 'HttpError' }),
+      )
+      .mockResolvedValueOnce({
+        data: {
+          expires_at: DateTime.local().plus({ hours: 1 }).toString(),
+          token: 'secret_token',
+        },
+      } as RestEndpointMethodTypes['apps']['createInstallationAccessToken']['response']);
+
+    await expect(
+      github.getCredentials({ url: 'https://github.com/backstage' }),
+    ).rejects.toMatchObject({ status: 410 });
+
+    const { token } = await github.getCredentials({
+      url: 'https://github.com/backstage',
+    });
+    expect(token).toEqual('secret_token');
+    // First call fetched installations, the error dropped the cache, so the
+    // second call re-fetches before succeeding.
+    expect(octokit.apps.listInstallations).toHaveBeenCalledTimes(2);
+  });
+
+  it('should refresh the installations cache after the TTL expires', async () => {
+    jest.useFakeTimers({ now: new Date('2024-01-01T12:00:00Z') });
+    try {
+      octokit.apps.listInstallations.mockResolvedValue({
+        headers: { etag: '123' },
+        data: [
+          {
+            id: 1,
+            repository_selection: 'all',
+            account: { login: 'backstage' },
+          },
+        ],
+      } as RestEndpointMethodTypes['apps']['listInstallations']['response']);
+
+      octokit.apps.createInstallationAccessToken.mockResolvedValue({
+        data: {
+          expires_at: DateTime.local().plus({ minutes: 9 }).toString(),
+          token: 'secret_token',
+        },
+      } as RestEndpointMethodTypes['apps']['createInstallationAccessToken']['response']);
+
+      await github.getCredentials({ url: 'https://github.com/backstage' });
+      expect(octokit.apps.listInstallations).toHaveBeenCalledTimes(1);
+
+      jest.setSystemTime(new Date('2024-01-01T12:15:00Z'));
+
+      await github.getCredentials({ url: 'https://github.com/backstage' });
+      expect(octokit.apps.listInstallations).toHaveBeenCalledTimes(2);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   describe('public access', () => {

--- a/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.test.ts
+++ b/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.test.ts
@@ -1092,6 +1092,62 @@ describe('SingleInstanceGithubCredentialsProvider tests', () => {
       );
     });
 
+    it('should drop the installations cache when a public access installation is no longer valid', async () => {
+      const githubProvider = SingleInstanceGithubCredentialsProvider.create({
+        host: 'github.com',
+        apps: [
+          {
+            appId: 1,
+            privateKey: 'privateKey',
+            webhookSecret: '123',
+            clientId: 'CLIENT_ID',
+            clientSecret: 'CLIENT_SECRET',
+            allowedInstallationOwners: ['installed-org'],
+            publicAccess: true,
+          },
+        ],
+      });
+
+      octokit.apps.listInstallations.mockResolvedValue({
+        headers: { etag: '1' },
+        data: [
+          {
+            id: 1,
+            repository_selection: 'all',
+            account: { login: 'installed-org' },
+          },
+        ],
+      } as RestEndpointMethodTypes['apps']['listInstallations']['response']);
+
+      octokit.apps.createInstallationAccessToken
+        .mockRejectedValueOnce(
+          Object.assign(new Error('Gone'), { status: 410, name: 'HttpError' }),
+        )
+        .mockResolvedValueOnce({
+          data: {
+            expires_at: DateTime.local().plus({ hours: 1 }).toString(),
+            token: 'public_access_token',
+          },
+        } as RestEndpointMethodTypes['apps']['createInstallationAccessToken']['response']);
+
+      // First call: stale public installation triggers 410.
+      const firstResult = await githubProvider.getCredentials({
+        url: 'https://github.com/some-public-org/some-repo',
+      });
+      // The 410 is not surfaced — the mux falls through and returns the
+      // default (undefined) token, so type is 'token'.
+      expect(firstResult.type).toEqual('token');
+
+      // Second call should succeed after the installations cache was dropped
+      // and re-fetched.
+      const secondResult = await githubProvider.getCredentials({
+        url: 'https://github.com/some-public-org/some-repo',
+      });
+      expect(secondResult.type).toEqual('app');
+      expect(secondResult.token).toEqual('public_access_token');
+      expect(octokit.apps.listInstallations).toHaveBeenCalledTimes(2);
+    });
+
     it('should use public access with multiple apps when only one has publicAccess enabled', async () => {
       const githubProvider = SingleInstanceGithubCredentialsProvider.create({
         host: 'github.com',

--- a/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.test.ts
+++ b/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.test.ts
@@ -40,7 +40,10 @@ jest.mock('@octokit/rest', () => {
   return { Octokit };
 });
 
-import { SingleInstanceGithubCredentialsProvider } from './SingleInstanceGithubCredentialsProvider';
+import {
+  GithubAppCredentialsMux,
+  SingleInstanceGithubCredentialsProvider,
+} from './SingleInstanceGithubCredentialsProvider';
 import { RestEndpointMethodTypes } from '@octokit/rest';
 import { DateTime } from 'luxon';
 
@@ -610,6 +613,38 @@ describe('SingleInstanceGithubCredentialsProvider tests', () => {
     expect(octokit.apps.listInstallations.mock.calls.length).toBe(1);
   });
 
+  it('should not expose cached installation data to mutation', async () => {
+    const mux = new GithubAppCredentialsMux({
+      host: 'github.com',
+      apps: [
+        {
+          appId: 1,
+          privateKey: 'privateKey',
+          webhookSecret: '123',
+          clientId: 'CLIENT_ID',
+          clientSecret: 'CLIENT_SECRET',
+        },
+      ],
+    });
+    octokit.apps.listInstallations.mockResolvedValue({
+      headers: { etag: '123' },
+      data: [
+        {
+          id: 1,
+          repository_selection: 'all',
+          account: { login: 'backstage' },
+        },
+      ],
+    } as RestEndpointMethodTypes['apps']['listInstallations']['response']);
+
+    const first = await mux.getAllInstallations();
+    (first[0].account as { login: string }).login = 'changed';
+
+    const second = await mux.getAllInstallations();
+    expect(second[0].account).toMatchObject({ login: 'backstage' });
+    expect(octokit.apps.listInstallations).toHaveBeenCalledTimes(1);
+  });
+
   it('should de-duplicate concurrent installation lookups', async () => {
     let resolveListInstallations!: (value: unknown) => void;
     octokit.apps.listInstallations.mockReturnValue(
@@ -747,6 +782,32 @@ describe('SingleInstanceGithubCredentialsProvider tests', () => {
       // Inside the throttle window — subsequent misses reuse the cache.
       jest.setSystemTime(new Date('2024-01-01T12:02:30Z'));
       await github.getCredentials({ url: 'https://github.com/z' });
+      expect(octokit.apps.listInstallations).toHaveBeenCalledTimes(2);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('should throttle failed on-miss refreshes of the installations cache', async () => {
+    jest.useFakeTimers({ now: new Date('2024-01-01T12:00:00Z') });
+    try {
+      octokit.apps.listInstallations
+        .mockResolvedValueOnce({
+          headers: { etag: '1' },
+          data: [],
+        } as unknown as RestEndpointMethodTypes['apps']['listInstallations']['response'])
+        .mockRejectedValueOnce({ status: 500, message: 'Boom' });
+
+      await github.getCredentials({ url: 'https://github.com/x' });
+      jest.setSystemTime(new Date('2024-01-01T12:02:00Z'));
+
+      await expect(
+        github.getCredentials({ url: 'https://github.com/y' }),
+      ).rejects.toMatchObject({ status: 500, message: 'Boom' });
+
+      jest.setSystemTime(new Date('2024-01-01T12:02:30Z'));
+      await github.getCredentials({ url: 'https://github.com/z' });
+
       expect(octokit.apps.listInstallations).toHaveBeenCalledTimes(2);
     } finally {
       jest.useRealTimers();

--- a/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.ts
+++ b/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.ts
@@ -254,7 +254,6 @@ class GithubAppManager {
       this.installationsCache &&
       DateTime.local() < this.installationsCache.expiresAt
     ) {
-      // Shallow copy so callers can't mutate our cached array.
       return [...this.installationsCache.data];
     }
     if (!this.pendingInstallations) {

--- a/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.ts
+++ b/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.ts
@@ -181,20 +181,7 @@ class GithubAppManager {
         throw new Error(`The GitHub application for ${owner} is suspended`);
       }
 
-      let result;
-      try {
-        result = await this.appClient.apps.createInstallationAccessToken({
-          installation_id: installationId,
-          headers: HEADERS,
-        });
-      } catch (error) {
-        // A 404/410 means the installation referenced in our cache no longer
-        // exists, so drop the cache to force a refresh on the next lookup.
-        if (isStaleInstallationError(error)) {
-          this.installationsCache = undefined;
-        }
-        throw error;
-      }
+      const result = await this.createInstallationAccessToken(installationId);
 
       let repositoryNames;
 
@@ -231,10 +218,9 @@ class GithubAppManager {
       `public:${installation.id}`,
       undefined,
       async () => {
-        const result = await this.appClient.apps.createInstallationAccessToken({
-          installation_id: installation.id,
-          headers: HEADERS,
-        });
+        const result = await this.createInstallationAccessToken(
+          installation.id,
+        );
 
         return {
           token: result.data.token,
@@ -242,6 +228,22 @@ class GithubAppManager {
         };
       },
     );
+  }
+
+  private async createInstallationAccessToken(installationId: number) {
+    try {
+      return await this.appClient.apps.createInstallationAccessToken({
+        installation_id: installationId,
+        headers: HEADERS,
+      });
+    } catch (error) {
+      // A 404/410 means the installation referenced in our cache no longer
+      // exists, so drop the cache to force a refresh on the next lookup.
+      if (isStaleInstallationError(error)) {
+        this.installationsCache = undefined;
+      }
+      throw error;
+    }
   }
 
   async getInstallations(

--- a/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.ts
+++ b/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.ts
@@ -91,6 +91,27 @@ const HEADERS = {
   Accept: 'application/vnd.github.machine-man-preview+json',
 };
 
+type Installations =
+  RestEndpointMethodTypes['apps']['listInstallations']['response']['data'];
+
+// Bound on how long a listInstallations response may be reused before it is
+// refetched. This matches the grace period applied to installation token
+// expiries, so the two caches age at the same rate.
+const INSTALLATIONS_CACHE_TTL_MINUTES = 10;
+
+// Minimum time between on-demand refreshes triggered by an owner miss. This
+// keeps the cache from being paginated on every lookup for an unknown owner,
+// while still letting a newly-added installation show up before the TTL.
+const INSTALLATIONS_REFRESH_THROTTLE_SECONDS = 60;
+
+function isStaleInstallationError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+  const status = (error as { status?: unknown }).status;
+  return status === 404 || status === 410;
+}
+
 /**
  * GithubAppManager issues and caches tokens for a specific GitHub App.
  */
@@ -100,6 +121,12 @@ class GithubAppManager {
   private readonly baseAuthConfig: { appId: number; privateKey: string };
   private readonly cache = new Cache();
   private readonly allowedInstallationOwners: string[] | undefined; // undefined allows all installations
+  private installationsCache?: {
+    data: Installations;
+    fetchedAt: DateTime;
+    expiresAt: DateTime;
+  };
+  private pendingInstallations?: Promise<Installations>;
   public readonly publicAccess: boolean;
 
   constructor(config: GithubAppConfig, baseUrl?: string) {
@@ -154,10 +181,20 @@ class GithubAppManager {
         throw new Error(`The GitHub application for ${owner} is suspended`);
       }
 
-      const result = await this.appClient.apps.createInstallationAccessToken({
-        installation_id: installationId,
-        headers: HEADERS,
-      });
+      let result;
+      try {
+        result = await this.appClient.apps.createInstallationAccessToken({
+          installation_id: installationId,
+          headers: HEADERS,
+        });
+      } catch (error) {
+        // A 404/410 means the installation referenced in our cache no longer
+        // exists, so drop the cache to force a refresh on the next lookup.
+        if (isStaleInstallationError(error)) {
+          this.installationsCache = undefined;
+        }
+        throw error;
+      }
 
       let repositoryNames;
 
@@ -207,21 +244,59 @@ class GithubAppManager {
     );
   }
 
-  getInstallations(): Promise<
-    RestEndpointMethodTypes['apps']['listInstallations']['response']['data']
-  > {
-    return this.appClient.paginate(this.appClient.apps.listInstallations);
+  async getInstallations(
+    options: { forceRefresh?: boolean } = {},
+  ): Promise<Installations> {
+    if (
+      !options.forceRefresh &&
+      this.installationsCache &&
+      DateTime.local() < this.installationsCache.expiresAt
+    ) {
+      // Shallow copy so callers can't mutate our cached array.
+      return [...this.installationsCache.data];
+    }
+    if (!this.pendingInstallations) {
+      const pending = this.appClient
+        .paginate(this.appClient.apps.listInstallations)
+        .then(data => {
+          const now = DateTime.local();
+          this.installationsCache = {
+            data,
+            fetchedAt: now,
+            expiresAt: now.plus({ minutes: INSTALLATIONS_CACHE_TTL_MINUTES }),
+          };
+          return data;
+        })
+        .finally(() => {
+          if (this.pendingInstallations === pending) {
+            this.pendingInstallations = undefined;
+          }
+        });
+      this.pendingInstallations = pending;
+    }
+    const data = await this.pendingInstallations;
+    return [...data];
   }
 
   private async getInstallationData(owner: string): Promise<InstallationData> {
-    const allInstallations = await this.getInstallations();
-    const installation = allInstallations.find(
-      inst =>
-        inst.account &&
-        'login' in inst.account &&
-        inst.account.login?.toLocaleLowerCase('en-US') ===
-          owner.toLocaleLowerCase('en-US'),
-    );
+    const find = (list: Installations) =>
+      list.find(
+        inst =>
+          inst.account &&
+          'login' in inst.account &&
+          inst.account.login?.toLocaleLowerCase('en-US') ===
+            owner.toLocaleLowerCase('en-US'),
+      );
+
+    let installations = await this.getInstallations();
+    let installation = find(installations);
+
+    // Owner not in cache — a newly-created installation may have appeared
+    // since we last paginated. Force a refresh (throttled) before failing.
+    if (!installation && this.canRefreshInstallations()) {
+      installations = await this.getInstallations({ forceRefresh: true });
+      installation = find(installations);
+    }
 
     if (installation) {
       return {
@@ -235,6 +310,16 @@ class GithubAppManager {
     );
     notFoundError.name = 'NotFoundError';
     throw notFoundError;
+  }
+
+  private canRefreshInstallations(): boolean {
+    if (!this.installationsCache) {
+      return true;
+    }
+    const age = DateTime.local()
+      .diff(this.installationsCache.fetchedAt)
+      .as('seconds');
+    return age >= INSTALLATIONS_REFRESH_THROTTLE_SECONDS;
   }
 }
 

--- a/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.ts
+++ b/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.ts
@@ -94,9 +94,9 @@ const HEADERS = {
 type Installations =
   RestEndpointMethodTypes['apps']['listInstallations']['response']['data'];
 
-// Bound on how long a listInstallations response may be reused before it is
-// refetched. This matches the grace period applied to installation token
-// expiries, so the two caches age at the same rate.
+// How long a listInstallations response may be reused before refetching.
+// Short enough that newly-added installations show up quickly, long enough
+// that token refresh cycles don't re-paginate on every miss.
 const INSTALLATIONS_CACHE_TTL_MINUTES = 10;
 
 // Minimum time between on-demand refreshes triggered by an owner miss. This

--- a/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.ts
+++ b/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.ts
@@ -280,13 +280,13 @@ class GithubAppManager {
   }
 
   private async getInstallationData(owner: string): Promise<InstallationData> {
+    const ownerLower = owner.toLocaleLowerCase('en-US');
     const find = (list: Installations) =>
       list.find(
         inst =>
           inst.account &&
           'login' in inst.account &&
-          inst.account.login?.toLocaleLowerCase('en-US') ===
-            owner.toLocaleLowerCase('en-US'),
+          inst.account.login?.toLocaleLowerCase('en-US') === ownerLower,
       );
 
     let installations = await this.getInstallations();

--- a/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.ts
+++ b/packages/integration/src/github/SingleInstanceGithubCredentialsProvider.ts
@@ -19,6 +19,7 @@ import { GithubAppConfig, GithubIntegrationConfig } from './config';
 import { createAppAuth } from '@octokit/auth-app';
 import { Octokit, RestEndpointMethodTypes } from '@octokit/rest';
 import { DateTime } from 'luxon';
+import { cloneDeep } from 'lodash';
 import {
   GithubCredentials,
   GithubCredentialsProvider,
@@ -126,6 +127,7 @@ class GithubAppManager {
     fetchedAt: DateTime;
     expiresAt: DateTime;
   };
+  private lastInstallationsRefreshAttempt?: DateTime;
   private pendingInstallations?: Promise<Installations>;
   public readonly publicAccess: boolean;
 
@@ -208,7 +210,7 @@ class GithubAppManager {
   }
 
   async getPublicInstallationToken(): Promise<{ accessToken: string }> {
-    const [installation] = await this.getInstallations();
+    const [installation] = await this.getCachedInstallations();
 
     if (!installation) {
       throw new Error(`No installation found for public app`);
@@ -246,7 +248,11 @@ class GithubAppManager {
     }
   }
 
-  async getInstallations(
+  async getInstallations(): Promise<Installations> {
+    return cloneDeep(await this.getCachedInstallations());
+  }
+
+  private async getCachedInstallations(
     options: { forceRefresh?: boolean } = {},
   ): Promise<Installations> {
     if (
@@ -254,7 +260,7 @@ class GithubAppManager {
       this.installationsCache &&
       DateTime.local() < this.installationsCache.expiresAt
     ) {
-      return [...this.installationsCache.data];
+      return this.installationsCache.data;
     }
     if (!this.pendingInstallations) {
       const pending = this.appClient
@@ -269,14 +275,14 @@ class GithubAppManager {
           return data;
         })
         .finally(() => {
+          this.lastInstallationsRefreshAttempt = DateTime.local();
           if (this.pendingInstallations === pending) {
             this.pendingInstallations = undefined;
           }
         });
       this.pendingInstallations = pending;
     }
-    const data = await this.pendingInstallations;
-    return [...data];
+    return await this.pendingInstallations;
   }
 
   private async getInstallationData(owner: string): Promise<InstallationData> {
@@ -289,13 +295,15 @@ class GithubAppManager {
           inst.account.login?.toLocaleLowerCase('en-US') === ownerLower,
       );
 
-    let installations = await this.getInstallations();
+    let installations = await this.getCachedInstallations();
     let installation = find(installations);
 
     // Owner not in cache — a newly-created installation may have appeared
     // since we last paginated. Force a refresh (throttled) before failing.
     if (!installation && this.canRefreshInstallations()) {
-      installations = await this.getInstallations({ forceRefresh: true });
+      installations = await this.getCachedInstallations({
+        forceRefresh: true,
+      });
       installation = find(installations);
     }
 
@@ -317,9 +325,9 @@ class GithubAppManager {
     if (!this.installationsCache) {
       return true;
     }
-    const age = DateTime.local()
-      .diff(this.installationsCache.fetchedAt)
-      .as('seconds');
+    const refreshReference =
+      this.lastInstallationsRefreshAttempt ?? this.installationsCache.fetchedAt;
+    const age = DateTime.local().diff(refreshReference).as('seconds');
     return age >= INSTALLATIONS_REFRESH_THROTTLE_SECONDS;
   }
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

GithubAppManager.getInstallations() previously paginated the full installations list on every token fetch, which quickly exhausted the 15k/hour GitHub App rate limit for organizations with many apps or frequent credential rollover.

Add a 10-minute TTL memoization with in-flight request deduplication, a throttled refresh when an owner lookup misses the cached list (so newly-added installations still surface before the TTL), and cache invalidation when createInstallationAccessToken returns 404/410 (so removed installations don't get served from a stale cache).

Fixes #33821

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
