### PR TITLE
catalog-backend: add deferred background index creation for search table

### DIFF
--- a/.changeset/deferred-search-covering-indices.md
+++ b/.changeset/deferred-search-covering-indices.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': minor
+---
+
+Added deferred background creation of covering indices on the `search` table for improved query performance. On PostgreSQL, indices are created concurrently after service startup to avoid blocking readiness and causing Kubernetes liveness probe failures on large databases. Advisory locking coordinates creation across multiple pods, and interrupted attempts are automatically cleaned up and retried.

--- a/plugins/catalog-backend/migrations/20260415000000_search_covering_indices.js
+++ b/plugins/catalog-backend/migrations/20260415000000_search_covering_indices.js
@@ -32,7 +32,8 @@
  * - search_key_value_entity_idx (key, value, entity_id)
  * - search_facets_covering_idx (key, original_value, entity_id) WHERE original_value IS NOT NULL
  *
- * These replace the older non-covering indices:
+ * On PostgreSQL, these replace the older non-covering indices as part of the
+ * deferred index management in `src/database/deferredIndices.ts`:
  * - search_key_value_idx (key, value) -> superseded by search_key_value_entity_idx
  * - search_key_original_value_idx (key, original_value) -> superseded by search_facets_covering_idx
  *

--- a/plugins/catalog-backend/migrations/20260415000000_search_covering_indices.js
+++ b/plugins/catalog-backend/migrations/20260415000000_search_covering_indices.js
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-check
+
+/**
+ * This migration is intentionally empty for PostgreSQL. The actual index
+ * creation happens in the background after service startup, implemented in
+ * `src/database/deferredIndices.ts`. This avoids blocking service startup for
+ * the several minutes that CREATE INDEX CONCURRENTLY takes on large tables,
+ * which would otherwise cause Kubernetes liveness probes to kill the pod.
+ *
+ * For MySQL and SQLite, the indices are created inline here since those
+ * engines don't support CONCURRENTLY and operate on smaller datasets where
+ * index creation is fast.
+ *
+ * The indices created are:
+ * - search_entity_key_value_idx (entity_id, key, value)
+ * - search_key_value_entity_idx (key, value, entity_id)
+ * - search_facets_covering_idx (key, original_value, entity_id) WHERE original_value IS NOT NULL
+ *
+ * These replace the older non-covering indices:
+ * - search_key_value_idx (key, value) -> superseded by search_key_value_entity_idx
+ * - search_key_original_value_idx (key, original_value) -> superseded by search_facets_covering_idx
+ *
+ * @param { import("knex").Knex } knex
+ */
+exports.up = async function up(knex) {
+  const client = knex.client.config.client;
+
+  if (client === 'pg') {
+    // PostgreSQL: indices are created in the background after startup.
+    // See src/database/deferredIndices.ts for the implementation.
+    return;
+  }
+
+  // MySQL and SQLite: create indices inline (fast on smaller datasets).
+  // The facets covering index omits the WHERE clause since MySQL does not
+  // support partial indices; it is still useful as a covering index.
+  await knex.schema.alterTable('search', table => {
+    table.index(['entity_id', 'key', 'value'], 'search_entity_key_value_idx');
+    table.index(['key', 'value', 'entity_id'], 'search_key_value_entity_idx');
+    table.index(
+      ['key', 'original_value', 'entity_id'],
+      'search_facets_covering_idx',
+    );
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ */
+exports.down = async function down(knex) {
+  const client = knex.client.config.client;
+
+  if (client === 'pg') {
+    await knex.raw(
+      'DROP INDEX CONCURRENTLY IF EXISTS search_facets_covering_idx',
+    );
+    await knex.raw(
+      'DROP INDEX CONCURRENTLY IF EXISTS search_key_value_entity_idx',
+    );
+    await knex.raw(
+      'DROP INDEX CONCURRENTLY IF EXISTS search_entity_key_value_idx',
+    );
+    // Restore the old indices
+    await knex.raw(
+      'CREATE INDEX CONCURRENTLY IF NOT EXISTS search_key_value_idx ON search (key, value)',
+    );
+    await knex.raw(
+      'CREATE INDEX CONCURRENTLY IF NOT EXISTS search_key_original_value_idx ON search (key, original_value)',
+    );
+  } else {
+    await knex.schema.alterTable('search', table => {
+      table.dropIndex([], 'search_facets_covering_idx');
+      table.dropIndex([], 'search_key_value_entity_idx');
+      table.dropIndex([], 'search_entity_key_value_idx');
+    });
+  }
+};
+
+exports.config = {
+  transaction: false,
+};

--- a/plugins/catalog-backend/src/database/deferredIndices.test.ts
+++ b/plugins/catalog-backend/src/database/deferredIndices.test.ts
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestDatabases, mockServices } from '@backstage/backend-test-utils';
+import { Knex } from 'knex';
+import { ensureDeferredIndices } from './deferredIndices';
+
+const migrationsDir = `${__dirname}/../../migrations`;
+
+jest.setTimeout(120_000);
+
+describe('ensureDeferredIndices', () => {
+  const databases = TestDatabases.create();
+  const logger = mockServices.logger.mock();
+
+  function isPg(databaseId: string) {
+    return databaseId.startsWith('POSTGRES');
+  }
+
+  async function initDatabase(databaseId: string): Promise<Knex> {
+    const knex = await databases.init(databaseId as any);
+    await knex.migrate.latest({ directory: migrationsDir });
+    return knex;
+  }
+
+  async function getIndexNames(knex: Knex, tableName: string) {
+    const result = await knex.raw(
+      `SELECT indexname FROM pg_indexes WHERE tablename = ?`,
+      [tableName],
+    );
+    return result.rows.map((r: any) => r.indexname) as string[];
+  }
+
+  async function isIndexValid(knex: Knex, indexName: string) {
+    const result = await knex.raw(
+      `SELECT i.indisvalid
+         FROM pg_class c
+         JOIN pg_index i ON i.indexrelid = c.oid
+        WHERE c.relname = ?`,
+      [indexName],
+    );
+    return result.rows.length > 0 && result.rows[0].indisvalid;
+  }
+
+  it.each(databases.eachSupportedId())(
+    'creates all deferred indices on a fresh database, %p',
+    async databaseId => {
+      if (!isPg(databaseId)) {
+        return;
+      }
+
+      const knex = await initDatabase(databaseId);
+      try {
+        await ensureDeferredIndices(knex, logger);
+
+        const indices = await getIndexNames(knex, 'search');
+
+        expect(indices).toContain('search_entity_key_value_idx');
+        expect(indices).toContain('search_key_value_entity_idx');
+        expect(indices).toContain('search_facets_covering_idx');
+
+        expect(await isIndexValid(knex, 'search_entity_key_value_idx')).toBe(
+          true,
+        );
+        expect(await isIndexValid(knex, 'search_key_value_entity_idx')).toBe(
+          true,
+        );
+        expect(await isIndexValid(knex, 'search_facets_covering_idx')).toBe(
+          true,
+        );
+
+        expect(indices).not.toContain('search_key_value_idx');
+        expect(indices).not.toContain('search_key_original_value_idx');
+      } finally {
+        await knex.destroy();
+      }
+    },
+  );
+
+  it.each(databases.eachSupportedId())(
+    'skips already-existing valid indices on second run, %p',
+    async databaseId => {
+      if (!isPg(databaseId)) {
+        return;
+      }
+
+      const knex = await initDatabase(databaseId);
+      try {
+        await ensureDeferredIndices(knex, logger);
+        await ensureDeferredIndices(knex, logger);
+
+        const indices = await getIndexNames(knex, 'search');
+        expect(indices).toContain('search_entity_key_value_idx');
+        expect(indices).toContain('search_key_value_entity_idx');
+        expect(indices).toContain('search_facets_covering_idx');
+      } finally {
+        await knex.destroy();
+      }
+    },
+  );
+
+  it.each(databases.eachSupportedId())(
+    'cleans up INVALID indices and recreates them, %p',
+    async databaseId => {
+      if (!isPg(databaseId)) {
+        return;
+      }
+
+      const knex = await initDatabase(databaseId);
+      try {
+        // Create a valid index first, then mark it invalid via pg_index to
+        // simulate an interrupted CREATE INDEX CONCURRENTLY.
+        await knex.raw(
+          'CREATE INDEX CONCURRENTLY IF NOT EXISTS search_entity_key_value_idx ON search (entity_id, key, value)',
+        );
+        await knex.raw(
+          `UPDATE pg_index SET indisvalid = false
+            WHERE indexrelid = 'search_entity_key_value_idx'::regclass`,
+        );
+        expect(await isIndexValid(knex, 'search_entity_key_value_idx')).toBe(
+          false,
+        );
+
+        await ensureDeferredIndices(knex, logger);
+
+        expect(await isIndexValid(knex, 'search_entity_key_value_idx')).toBe(
+          true,
+        );
+        expect(await isIndexValid(knex, 'search_key_value_entity_idx')).toBe(
+          true,
+        );
+        expect(await isIndexValid(knex, 'search_facets_covering_idx')).toBe(
+          true,
+        );
+      } finally {
+        await knex.destroy();
+      }
+    },
+  );
+
+  it.each(databases.eachSupportedId())(
+    'does not leave advisory locks held after completion, %p',
+    async databaseId => {
+      if (!isPg(databaseId)) {
+        return;
+      }
+
+      const knex = await initDatabase(databaseId);
+      try {
+        await ensureDeferredIndices(knex, logger);
+
+        // Verify no advisory locks are still held by querying pg_locks
+        const result = await knex.raw(
+          `SELECT count(*) AS count FROM pg_locks
+            WHERE locktype = 'advisory'
+              AND classid = ? AND objid = ?`,
+          [202604, 15],
+        );
+        expect(Number(result.rows[0].count)).toBe(0);
+      } finally {
+        await knex.destroy();
+      }
+    },
+  );
+
+  it.each(databases.eachSupportedId())(
+    'is a no-op on non-PostgreSQL engines, %p',
+    async databaseId => {
+      if (isPg(databaseId)) {
+        return;
+      }
+
+      const knex = await initDatabase(databaseId);
+      try {
+        await ensureDeferredIndices(knex, logger);
+      } finally {
+        await knex.destroy();
+      }
+    },
+  );
+});

--- a/plugins/catalog-backend/src/database/deferredIndices.ts
+++ b/plugins/catalog-backend/src/database/deferredIndices.ts
@@ -133,10 +133,10 @@ export async function ensureDeferredIndices(
       const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
       log?.info(`Deferred index creation completed in ${elapsed}s`);
     } finally {
-      // Restore session state before returning the connection to the pool.
-      // If the connection is dead these will fail harmlessly — PostgreSQL
-      // auto-releases advisory locks and resets session state when the
-      // session terminates.
+      // Release the advisory lock and reset statement_timeout to the server
+      // default before returning the connection to the pool. If the connection
+      // is dead these will fail harmlessly — PostgreSQL auto-releases advisory
+      // locks and resets session state when the session terminates.
       await conn
         .query('SELECT pg_advisory_unlock($1, $2)', [LOCK_NAMESPACE, LOCK_ID])
         .catch(() => {});

--- a/plugins/catalog-backend/src/database/deferredIndices.ts
+++ b/plugins/catalog-backend/src/database/deferredIndices.ts
@@ -31,22 +31,22 @@ interface PgConnection {
 
 interface DeferredIndex {
   name: string;
-  columns: string;
+  columnExpr: string;
   where?: string;
 }
 
 const DEFERRED_INDICES: DeferredIndex[] = [
   {
     name: 'search_entity_key_value_idx',
-    columns: '(entity_id, key, value)',
+    columnExpr: '(entity_id, key, value)',
   },
   {
     name: 'search_key_value_entity_idx',
-    columns: '(key, value, entity_id)',
+    columnExpr: '(key, value, entity_id)',
   },
   {
     name: 'search_facets_covering_idx',
-    columns: '(key, original_value, entity_id)',
+    columnExpr: '(key, original_value, entity_id)',
     where: 'WHERE original_value IS NOT NULL',
   },
 ];
@@ -94,7 +94,16 @@ export async function ensureDeferredIndices(
   // This is critical: Knex's normal knex.raw() picks a random connection
   // from the pool each time, which would cause the advisory lock to be
   // acquired on one connection while DDL runs on another.
-  const conn: PgConnection = await knex.client.acquireConnection();
+  let conn: PgConnection;
+  try {
+    conn = await knex.client.acquireConnection();
+  } catch (error) {
+    log?.warn(
+      'Failed to acquire database connection for deferred index creation',
+      error instanceof Error ? error : undefined,
+    );
+    return;
+  }
 
   try {
     // Skip on read replicas — indices replicate from the primary automatically
@@ -187,7 +196,7 @@ async function ensureIndex(
   log?.info(`Creating index ${index.name} concurrently`);
   const whereClause = index.where ? ` ${index.where}` : '';
   await conn.query(
-    `CREATE INDEX CONCURRENTLY IF NOT EXISTS ${index.name} ON search ${index.columns}${whereClause}`,
+    `CREATE INDEX CONCURRENTLY IF NOT EXISTS ${index.name} ON search ${index.columnExpr}${whereClause}`,
   );
   log?.info(`Index ${index.name} created successfully`);
 }

--- a/plugins/catalog-backend/src/database/deferredIndices.ts
+++ b/plugins/catalog-backend/src/database/deferredIndices.ts
@@ -31,22 +31,22 @@ interface PgConnection {
 
 interface DeferredIndex {
   name: string;
-  columnExpr: string;
+  columns: string[];
   where?: string;
 }
 
 const DEFERRED_INDICES: DeferredIndex[] = [
   {
     name: 'search_entity_key_value_idx',
-    columnExpr: '(entity_id, key, value)',
+    columns: ['entity_id', 'key', 'value'],
   },
   {
     name: 'search_key_value_entity_idx',
-    columnExpr: '(key, value, entity_id)',
+    columns: ['key', 'value', 'entity_id'],
   },
   {
     name: 'search_facets_covering_idx',
-    columnExpr: '(key, original_value, entity_id)',
+    columns: ['key', 'original_value', 'entity_id'],
     where: 'WHERE original_value IS NOT NULL',
   },
 ];
@@ -194,9 +194,10 @@ async function ensureIndex(
   }
 
   log?.info(`Creating index ${index.name} concurrently`);
+  const columnExpr = `(${index.columns.join(', ')})`;
   const whereClause = index.where ? ` ${index.where}` : '';
   await conn.query(
-    `CREATE INDEX CONCURRENTLY IF NOT EXISTS ${index.name} ON search ${index.columnExpr}${whereClause}`,
+    `CREATE INDEX CONCURRENTLY IF NOT EXISTS ${index.name} ON search ${columnExpr}${whereClause}`,
   );
   log?.info(`Index ${index.name} created successfully`);
 }

--- a/plugins/catalog-backend/src/database/deferredIndices.ts
+++ b/plugins/catalog-backend/src/database/deferredIndices.ts
@@ -143,9 +143,8 @@ async function getIndexState(
 ): Promise<'valid' | 'invalid' | 'missing'> {
   const result = await conn.query(
     `SELECT i.indisvalid
-       FROM pg_class c
-       JOIN pg_index i ON i.indexrelid = c.oid
-      WHERE c.relname = $1`,
+       FROM pg_index i
+      WHERE i.indexrelid = to_regclass($1)`,
     [indexName],
   );
 

--- a/plugins/catalog-backend/src/database/deferredIndices.ts
+++ b/plugins/catalog-backend/src/database/deferredIndices.ts
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LoggerService } from '@backstage/backend-plugin-api';
+import { Knex } from 'knex';
+
+// Stable lock key for the pg_advisory_lock two-argument form.
+const LOCK_NAMESPACE = 202604;
+const LOCK_ID = 15;
+
+/**
+ * Minimal interface for a raw PostgreSQL connection, as returned by the Knex
+ * pool's acquireConnection(). Avoids importing `pg` types directly.
+ */
+interface PgConnection {
+  query(text: string, values?: any[]): Promise<{ rows: Record<string, any>[] }>;
+}
+
+interface DeferredIndex {
+  name: string;
+  columns: string;
+  where?: string;
+}
+
+const DEFERRED_INDICES: DeferredIndex[] = [
+  {
+    name: 'search_entity_key_value_idx',
+    columns: '(entity_id, key, value)',
+  },
+  {
+    name: 'search_key_value_entity_idx',
+    columns: '(key, value, entity_id)',
+  },
+  {
+    name: 'search_facets_covering_idx',
+    columns: '(key, original_value, entity_id)',
+    where: 'WHERE original_value IS NOT NULL',
+  },
+];
+
+const SUPERSEDED_INDICES = [
+  'search_key_value_idx',
+  'search_key_original_value_idx',
+];
+
+/**
+ * Creates covering indices on the `search` table in the background, designed
+ * to run after service startup without blocking readiness. On PostgreSQL this
+ * uses `CREATE INDEX CONCURRENTLY` with advisory locking to coordinate across
+ * multiple pods. On other engines indices are created inline.
+ *
+ * @remarks
+ *
+ * All PostgreSQL operations run on a single dedicated connection acquired from
+ * the pool, ensuring that the session-level advisory lock, statement timeout,
+ * and DDL statements all share the same session. The connection is released
+ * back to the pool (with settings restored) when finished, or if the pod dies
+ * the session terminates and PostgreSQL auto-releases the lock and cancels any
+ * in-flight DDL.
+ *
+ * This function is intentionally fire-and-forget from the caller's perspective.
+ * Failures are logged but do not prevent the service from operating — the
+ * indices are a performance optimization, not a correctness requirement.
+ */
+export async function ensureDeferredIndices(
+  knex: Knex,
+  logger?: LoggerService,
+): Promise<void> {
+  const client = knex.client.config.client;
+  if (client !== 'pg') {
+    return;
+  }
+
+  const log = logger?.child({ task: 'deferred-indices' });
+  const startTime = Date.now();
+
+  log?.info('Attempting to create deferred search indices');
+
+  // Acquire a dedicated connection from the pool so that advisory lock,
+  // session settings, and DDL all execute on the same PostgreSQL session.
+  // This is critical: Knex's normal knex.raw() picks a random connection
+  // from the pool each time, which would cause the advisory lock to be
+  // acquired on one connection while DDL runs on another.
+  const conn: PgConnection = await knex.client.acquireConnection();
+
+  try {
+    const lockResult = await conn.query(
+      'SELECT pg_try_advisory_lock($1, $2) AS locked',
+      [LOCK_NAMESPACE, LOCK_ID],
+    );
+
+    if (!lockResult.rows[0].locked) {
+      log?.info(
+        'Another instance is already creating deferred indices, skipping',
+      );
+      return;
+    }
+
+    try {
+      await conn.query('SET statement_timeout = 3600000');
+
+      for (const index of DEFERRED_INDICES) {
+        await ensureIndex(conn, index, log);
+      }
+
+      for (const name of SUPERSEDED_INDICES) {
+        await dropSupersededIndex(conn, name, log);
+      }
+
+      const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+      log?.info(`Deferred index creation completed in ${elapsed}s`);
+    } finally {
+      // Restore session state before returning the connection to the pool.
+      // If the connection is dead these will fail harmlessly — PostgreSQL
+      // auto-releases advisory locks and resets session state when the
+      // session terminates.
+      await conn
+        .query('SELECT pg_advisory_unlock($1, $2)', [LOCK_NAMESPACE, LOCK_ID])
+        .catch(() => {});
+      await conn.query('RESET statement_timeout').catch(() => {});
+    }
+  } finally {
+    await knex.client.releaseConnection(conn);
+  }
+}
+
+async function getIndexState(
+  conn: PgConnection,
+  indexName: string,
+): Promise<'valid' | 'invalid' | 'missing'> {
+  const result = await conn.query(
+    `SELECT i.indisvalid
+       FROM pg_class c
+       JOIN pg_index i ON i.indexrelid = c.oid
+      WHERE c.relname = $1`,
+    [indexName],
+  );
+
+  if (result.rows.length === 0) {
+    return 'missing';
+  }
+
+  return result.rows[0].indisvalid ? 'valid' : 'invalid';
+}
+
+async function ensureIndex(
+  conn: PgConnection,
+  index: DeferredIndex,
+  log?: LoggerService,
+): Promise<void> {
+  const state = await getIndexState(conn, index.name);
+
+  if (state === 'valid') {
+    log?.debug(`Index ${index.name} already exists and is valid, skipping`);
+    return;
+  }
+
+  if (state === 'invalid') {
+    log?.warn(
+      `Index ${index.name} exists but is INVALID (likely from an interrupted creation), dropping and recreating`,
+    );
+    await conn.query(`DROP INDEX CONCURRENTLY IF EXISTS ${index.name}`);
+  }
+
+  log?.info(`Creating index ${index.name} concurrently`);
+  const whereClause = index.where ? ` ${index.where}` : '';
+  await conn.query(
+    `CREATE INDEX CONCURRENTLY IF NOT EXISTS ${index.name} ON search ${index.columns}${whereClause}`,
+  );
+  log?.info(`Index ${index.name} created successfully`);
+}
+
+async function dropSupersededIndex(
+  conn: PgConnection,
+  name: string,
+  log?: LoggerService,
+): Promise<void> {
+  const state = await getIndexState(conn, name);
+  if (state === 'missing') {
+    return;
+  }
+
+  log?.info(`Dropping superseded index ${name}`);
+  await conn.query(`DROP INDEX CONCURRENTLY IF EXISTS ${name}`);
+}

--- a/plugins/catalog-backend/src/database/deferredIndices.ts
+++ b/plugins/catalog-backend/src/database/deferredIndices.ts
@@ -15,6 +15,7 @@
  */
 
 import { LoggerService } from '@backstage/backend-plugin-api';
+import { isError } from '@backstage/errors';
 import { Knex } from 'knex';
 
 // Stable lock key for the pg_advisory_lock two-argument form.
@@ -100,7 +101,7 @@ export async function ensureDeferredIndices(
   } catch (error) {
     log?.warn(
       'Failed to acquire database connection for deferred index creation',
-      error instanceof Error ? error : undefined,
+      isError(error) ? error : undefined,
     );
     return;
   }

--- a/plugins/catalog-backend/src/database/deferredIndices.ts
+++ b/plugins/catalog-backend/src/database/deferredIndices.ts
@@ -59,18 +59,19 @@ const SUPERSEDED_INDICES = [
 
 /**
  * Creates covering indices on the `search` table in the background, designed
- * to run after service startup without blocking readiness. On PostgreSQL this
- * uses `CREATE INDEX CONCURRENTLY` with advisory locking to coordinate across
- * multiple pods. On other engines indices are created inline.
+ * to run after service startup without blocking readiness. This helper is
+ * PostgreSQL-specific and uses `CREATE INDEX CONCURRENTLY` with advisory
+ * locking to coordinate across multiple pods. On other engines, index creation
+ * happens inline in the migration rather than through this helper.
  *
  * @remarks
  *
  * All PostgreSQL operations run on a single dedicated connection acquired from
  * the pool, ensuring that the session-level advisory lock, statement timeout,
- * and DDL statements all share the same session. The connection is released
- * back to the pool (with settings restored) when finished, or if the pod dies
- * the session terminates and PostgreSQL auto-releases the lock and cancels any
- * in-flight DDL.
+ * and DDL statements all share the same session. When finished, the connection
+ * is released back to the pool after releasing the advisory lock and resetting
+ * `statement_timeout`; if the pod dies, the session terminates and PostgreSQL
+ * auto-releases the lock and cancels any in-flight DDL.
  *
  * This function is intentionally fire-and-forget from the caller's perspective.
  * Failures are logged but do not prevent the service from operating — the

--- a/plugins/catalog-backend/src/database/deferredIndices.ts
+++ b/plugins/catalog-backend/src/database/deferredIndices.ts
@@ -97,6 +97,16 @@ export async function ensureDeferredIndices(
   const conn: PgConnection = await knex.client.acquireConnection();
 
   try {
+    // Skip on read replicas — indices replicate from the primary automatically
+    // via streaming replication. pg_is_in_recovery() returns true on standbys.
+    const recoveryResult = await conn.query('SELECT pg_is_in_recovery() AS ro');
+    if (recoveryResult.rows[0].ro) {
+      log?.debug(
+        'Connected to a read replica (standby), skipping deferred index creation',
+      );
+      return;
+    }
+
     const lockResult = await conn.query(
       'SELECT pg_try_advisory_lock($1, $2) AS locked',
       [LOCK_NAMESPACE, LOCK_ID],

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -408,18 +408,16 @@ export class CatalogBuilder {
     if (!database.migrations?.skip) {
       logger.info('Performing database migration');
       await applyDatabaseMigrations(dbClient);
-    }
 
-    // Fire-and-forget: create covering indices in the background so that
-    // service startup is not blocked by long-running CREATE INDEX CONCURRENTLY.
-    // Runs regardless of migrations.skip since it's idempotent and handles
-    // installations where migrations are applied out-of-band.
-    ensureDeferredIndices(dbClient, logger).catch(error => {
-      logger.error(
-        'Background index creation failed',
-        isError(error) ? error : new Error(String(error)),
-      );
-    });
+      // Fire-and-forget: create covering indices in the background so that
+      // service startup is not blocked by long-running CREATE INDEX CONCURRENTLY.
+      ensureDeferredIndices(dbClient, logger).catch(error => {
+        logger.error(
+          'Background index creation failed',
+          isError(error) ? error : new Error(String(error)),
+        );
+      });
+    }
 
     const stitcher = DefaultStitcher.fromConfig(config, {
       knex: dbClient,

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -43,6 +43,7 @@ import {
   UrlReaderService,
 } from '@backstage/backend-plugin-api';
 import { Config, readDurationFromConfig } from '@backstage/config';
+import { isError } from '@backstage/errors';
 import { catalogPermissions } from '@backstage/plugin-catalog-common/alpha';
 import {
   CatalogProcessor,
@@ -414,7 +415,10 @@ export class CatalogBuilder {
     // Runs regardless of migrations.skip since it's idempotent and handles
     // installations where migrations are applied out-of-band.
     ensureDeferredIndices(dbClient, logger).catch(error => {
-      logger.error('Background index creation failed', { error });
+      logger.error(
+        'Background index creation failed',
+        isError(error) ? error : new Error(String(error)),
+      );
     });
 
     const stitcher = DefaultStitcher.fromConfig(config, {

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -57,6 +57,7 @@ import { durationToMilliseconds } from '@backstage/types';
 import { DefaultCatalogDatabase } from '../database/DefaultCatalogDatabase';
 import { DefaultProcessingDatabase } from '../database/DefaultProcessingDatabase';
 import { DefaultProviderDatabase } from '../database/DefaultProviderDatabase';
+import { ensureDeferredIndices } from '../database/deferredIndices';
 import { applyDatabaseMigrations } from '../database/migrations';
 import { DefaultCatalogRulesEnforcer } from '../ingestion/CatalogRules';
 import { RepoLocationAnalyzer } from '../ingestion/LocationAnalyzer';
@@ -407,6 +408,14 @@ export class CatalogBuilder {
       logger.info('Performing database migration');
       await applyDatabaseMigrations(dbClient);
     }
+
+    // Fire-and-forget: create covering indices in the background so that
+    // service startup is not blocked by long-running CREATE INDEX CONCURRENTLY.
+    // Runs regardless of migrations.skip since it's idempotent and handles
+    // installations where migrations are applied out-of-band.
+    ensureDeferredIndices(dbClient, logger).catch(error => {
+      logger.error('Background index creation failed', { error });
+    });
 
     const stitcher = DefaultStitcher.fromConfig(config, {
       knex: dbClient,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Problem

`CREATE INDEX CONCURRENTLY` on the `search` table (~13M+ rows in production) takes several minutes. The current migration system runs in-band during service startup, blocking readiness. Kubernetes liveness probes kill the pod before the index creation completes, leaving an INVALID index. On the next startup the migration tries again, finds the INVALID index, and the cycle repeats — a death loop where the indices never get created.

This is a prerequisite for landing PR #33661 (covering indices for improved query performance) without causing deployment issues for large Backstage installations.

### Solution

Split index creation into two parts:

1. **Placeholder migration** (`20260415000000_search_covering_indices.js`) — runs instantly during the normal migration pipeline. On PostgreSQL it's a no-op (defers to the background mechanism). On MySQL/SQLite it creates the indices inline since those engines are fast and don't support `CONCURRENTLY`.

2. **Background index creation** (`deferredIndices.ts`) — spawned as a fire-and-forget promise from `applyDatabaseMigrations` after `knex.migrate.latest()` completes. Service startup is not blocked; the pod becomes ready immediately.

The background mechanism handles:
- **Multiple pods**: `pg_try_advisory_lock` ensures only one pod attempts creation at a time; others skip gracefully
- **Interrupted attempts**: If a pod dies mid-creation, the advisory lock is released (session ends) and the next pod detects the INVALID index via `pg_index.indisvalid`, drops it, and retries
- **Superseded indices**: Old non-covering indices (`search_key_value_idx`, `search_key_original_value_idx`) are dropped only after their replacements are confirmed valid

### Indices created

| Index | Columns | Purpose |
|---|---|---|
| `search_entity_key_value_idx` | `(entity_id, key, value)` | EXISTS correlated subqueries |
| `search_key_value_entity_idx` | `(key, value, entity_id)` | Replaces old `(key, value)` index |
| `search_facets_covering_idx` | `(key, original_value, entity_id) WHERE original_value IS NOT NULL` | Facets index-only scans |

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))


Made with [Cursor](https://cursor.com)