### PR TITLE
Make NotificationDescription a swappable component

### DIFF
--- a/.changeset/swappable-notification-description.md
+++ b/.changeset/swappable-notification-description.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications': patch
+---
+
+The notification description used in the notifications table is now a swappable component, so that apps can replace its rendering with a custom implementation.

--- a/plugins/notifications/report.api.md
+++ b/plugins/notifications/report.api.md
@@ -14,6 +14,7 @@ import { NotificationSettings } from '@backstage/plugin-notifications-common';
 import { NotificationSeverity } from '@backstage/plugin-notifications-common';
 import { NotificationStatus } from '@backstage/plugin-notifications-common';
 import { RouteRef } from '@backstage/core-plugin-api';
+import { SwappableComponentRef } from '@backstage/frontend-plugin-api';
 import { TableProps } from '@backstage/core-components';
 import { TranslationRef } from '@backstage/frontend-plugin-api';
 
@@ -48,6 +49,21 @@ export type GetTopicsOptions = GetNotificationsCommonOptions;
 export type GetTopicsResponse = {
   topics: string[];
 };
+
+// @public
+export const NotificationDescription: {
+  (props: NotificationDescriptionProps): JSX.Element | null;
+  ref: SwappableComponentRef<
+    NotificationDescriptionProps,
+    NotificationDescriptionProps
+  >;
+};
+
+// @public
+export interface NotificationDescriptionProps {
+  // (undocumented)
+  description: string;
+}
 
 // @public (undocumented)
 export interface NotificationsApi {

--- a/plugins/notifications/report.api.md
+++ b/plugins/notifications/report.api.md
@@ -61,7 +61,6 @@ export const NotificationDescription: {
 
 // @public
 export interface NotificationDescriptionProps {
-  // (undocumented)
   description: string;
 }
 

--- a/plugins/notifications/src/components/NotificationsTable/DefaultNotificationDescription.tsx
+++ b/plugins/notifications/src/components/NotificationsTable/DefaultNotificationDescription.tsx
@@ -15,7 +15,7 @@
  */
 import { Text, Button } from '@backstage/ui';
 import { useState } from 'react';
-import { NotificationDescriptionProps } from './NotificationDescription';
+import type { NotificationDescriptionProps } from './NotificationDescription';
 
 const MAX_LENGTH = 100;
 

--- a/plugins/notifications/src/components/NotificationsTable/DefaultNotificationDescription.tsx
+++ b/plugins/notifications/src/components/NotificationsTable/DefaultNotificationDescription.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Text, Button } from '@backstage/ui';
+import { useState } from 'react';
+import { NotificationDescriptionProps } from './NotificationDescription';
+
+const MAX_LENGTH = 100;
+
+export const DefaultNotificationDescription = (
+  props: NotificationDescriptionProps,
+) => {
+  const { description } = props;
+  const [shown, setShown] = useState(false);
+  const isLong = description.length > MAX_LENGTH;
+
+  if (!isLong) {
+    return <Text variant="body-small">{description}</Text>;
+  }
+
+  if (shown) {
+    return (
+      <Text variant="body-small">
+        {description}{' '}
+        <Button
+          variant="tertiary"
+          onPress={() => {
+            setShown(false);
+          }}
+        >
+          Show less
+        </Button>
+      </Text>
+    );
+  }
+  return (
+    <Text variant="body-small">
+      {description.substring(0, MAX_LENGTH)}...{' '}
+      <Button
+        variant="tertiary"
+        onPress={() => {
+          setShown(true);
+        }}
+      >
+        Show more
+      </Button>
+    </Text>
+  );
+};

--- a/plugins/notifications/src/components/NotificationsTable/NotificationDescription.tsx
+++ b/plugins/notifications/src/components/NotificationsTable/NotificationDescription.tsx
@@ -15,10 +15,22 @@
  */
 import { Text, Button } from '@backstage/ui';
 import { useState } from 'react';
+import { createSwappableComponent } from '@backstage/frontend-plugin-api';
+
+/**
+ * Props for the {@link NotificationDescription} swappable component.
+ *
+ * @public
+ */
+export interface NotificationDescriptionProps {
+  description: string;
+}
 
 const MAX_LENGTH = 100;
 
-export const NotificationDescription = (props: { description: string }) => {
+const DefaultNotificationDescription = (
+  props: NotificationDescriptionProps,
+) => {
   const { description } = props;
   const [shown, setShown] = useState(false);
   const isLong = description.length > MAX_LENGTH;
@@ -56,3 +68,16 @@ export const NotificationDescription = (props: { description: string }) => {
     </Text>
   );
 };
+
+/**
+ * Swappable component that renders the description of a notification in the
+ * notifications table. Apps can override this to customize how descriptions
+ * are displayed.
+ *
+ * @public
+ */
+export const NotificationDescription =
+  createSwappableComponent<NotificationDescriptionProps>({
+    id: 'notifications.notification-description',
+    loader: () => DefaultNotificationDescription,
+  });

--- a/plugins/notifications/src/components/NotificationsTable/NotificationDescription.tsx
+++ b/plugins/notifications/src/components/NotificationsTable/NotificationDescription.tsx
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Text, Button } from '@backstage/ui';
-import { useState } from 'react';
 import { createSwappableComponent } from '@backstage/frontend-plugin-api';
 
 /**
@@ -26,49 +24,6 @@ export interface NotificationDescriptionProps {
   description: string;
 }
 
-const MAX_LENGTH = 100;
-
-const DefaultNotificationDescription = (
-  props: NotificationDescriptionProps,
-) => {
-  const { description } = props;
-  const [shown, setShown] = useState(false);
-  const isLong = description.length > MAX_LENGTH;
-
-  if (!isLong) {
-    return <Text variant="body-small">{description}</Text>;
-  }
-
-  if (shown) {
-    return (
-      <Text variant="body-small">
-        {description}{' '}
-        <Button
-          variant="tertiary"
-          onPress={() => {
-            setShown(false);
-          }}
-        >
-          Show less
-        </Button>
-      </Text>
-    );
-  }
-  return (
-    <Text variant="body-small">
-      {description.substring(0, MAX_LENGTH)}...{' '}
-      <Button
-        variant="tertiary"
-        onPress={() => {
-          setShown(true);
-        }}
-      >
-        Show more
-      </Button>
-    </Text>
-  );
-};
-
 /**
  * Swappable component that renders the description of a notification in the
  * notifications table. Apps can override this to customize how descriptions
@@ -79,5 +34,8 @@ const DefaultNotificationDescription = (
 export const NotificationDescription =
   createSwappableComponent<NotificationDescriptionProps>({
     id: 'notifications.notification-description',
-    loader: () => DefaultNotificationDescription,
+    loader: () =>
+      import('./DefaultNotificationDescription').then(
+        m => m.DefaultNotificationDescription,
+      ),
   });

--- a/plugins/notifications/src/components/NotificationsTable/NotificationDescription.tsx
+++ b/plugins/notifications/src/components/NotificationsTable/NotificationDescription.tsx
@@ -21,6 +21,9 @@ import { createSwappableComponent } from '@backstage/frontend-plugin-api';
  * @public
  */
 export interface NotificationDescriptionProps {
+  /**
+   * The plain-text description of the notification.
+   */
   description: string;
 }
 

--- a/plugins/notifications/src/components/NotificationsTable/index.ts
+++ b/plugins/notifications/src/components/NotificationsTable/index.ts
@@ -14,3 +14,4 @@
  * limitations under the License.
  */
 export * from './NotificationsTable';
+export * from './NotificationDescription';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Turns the `NotificationDescription` component used by the notifications table into a swappable component so that adopters can replace the way notification descriptions render (for example to support rich text, translations, or different expand/collapse behavior).

The component is created via `createSwappableComponent` with id `notifications.notification-description` and exported from `@backstage/plugin-notifications` alongside the `NotificationDescriptionProps` type. Existing usage within the plugin is unchanged — the default implementation preserves the previous "Show more"/"Show less" behavior.

To override it in an app:

```tsx
import {
  NotificationDescription,
} from '@backstage/plugin-notifications';
import { SwappableComponentBlueprint } from '@backstage/plugin-app-react';

SwappableComponentBlueprint.make({
  name: 'custom-notification-description',
  params: define =>
    define({
      component: NotificationDescription,
      loader: () => MyCustomDescription,
    }),
});
```

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)