### PR TITLE
backend-defaults: read only secret config paths during redaction

### DIFF
--- a/.changeset/secret-redaction-config-filtering.md
+++ b/.changeset/secret-redaction-config-filtering.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Changed the secret redaction system to read only secret configuration values instead of the entire configuration tree.

--- a/packages/backend-defaults/package.json
+++ b/packages/backend-defaults/package.json
@@ -173,6 +173,7 @@
     "infinispan": "^0.12.0",
     "is-glob": "^4.0.3",
     "jose": "^5.0.0",
+    "json-schema-traverse": "^1.0.0",
     "keyv": "^5.2.1",
     "knex": "^3.0.0",
     "lodash": "^4.17.21",

--- a/packages/backend-defaults/src/entrypoints/rootConfig/collectConfigSecrets.test.ts
+++ b/packages/backend-defaults/src/entrypoints/rootConfig/collectConfigSecrets.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Backstage Authors
+ * Copyright 2026 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,26 +15,26 @@
  */
 
 import { ConfigReader } from '@backstage/config';
-import {
-  extractSecretPaths,
-  collectSecretValues,
-} from './collectConfigSecrets';
+import { collectSecretValues } from './collectConfigSecrets';
 
-describe('extractSecretPaths', () => {
-  it('should find leaf secret paths', () => {
-    const paths = extractSecretPaths({
+describe('collectSecretValues', () => {
+  it('should collect a simple secret value', () => {
+    const config = new ConfigReader({ token: 'abc123', name: 'test' });
+    const secrets = collectSecretValues(config, {
       type: 'object',
       properties: {
-        token: { type: 'string', visibility: 'secret' },
+        token: { type: 'string', visibility: 'secret' } as any,
         name: { type: 'string' },
       },
     });
-
-    expect(paths).toEqual([{ parts: ['token'], deep: false }]);
+    expect(Array.from(secrets)).toEqual(['abc123']);
   });
 
-  it('should find nested secret paths', () => {
-    const paths = extractSecretPaths({
+  it('should collect nested secret values', () => {
+    const config = new ConfigReader({
+      backend: { auth: { secret: 'pass' } },
+    });
+    const secrets = collectSecretValues(config, {
       type: 'object',
       properties: {
         backend: {
@@ -43,88 +43,13 @@ describe('extractSecretPaths', () => {
             auth: {
               type: 'object',
               properties: {
-                secret: { type: 'string', visibility: 'secret' },
+                secret: { type: 'string', visibility: 'secret' } as any,
               },
             },
           },
         },
       },
     });
-
-    expect(paths).toEqual([{ parts: ['backend.auth.secret'], deep: false }]);
-  });
-
-  it('should find secrets inside array items', () => {
-    const paths = extractSecretPaths({
-      type: 'object',
-      properties: {
-        keys: {
-          type: 'array',
-          items: {
-            type: 'object',
-            properties: {
-              secret: { type: 'string', visibility: 'secret' },
-            },
-          },
-        },
-      },
-    });
-
-    expect(paths).toEqual([{ parts: ['keys', '[]', 'secret'], deep: false }]);
-  });
-
-  it('should find deepVisibility secret paths', () => {
-    const paths = extractSecretPaths({
-      type: 'object',
-      properties: {
-        credentials: {
-          type: 'object',
-          deepVisibility: 'secret',
-        },
-      },
-    });
-
-    expect(paths).toEqual([{ parts: ['credentials'], deep: true }]);
-  });
-
-  it('should find secrets under additionalProperties', () => {
-    const paths = extractSecretPaths({
-      type: 'object',
-      properties: {
-        providers: {
-          type: 'object',
-          additionalProperties: {
-            type: 'object',
-            properties: {
-              clientSecret: { type: 'string', visibility: 'secret' },
-            },
-          },
-        },
-      },
-    });
-
-    expect(paths).toEqual([
-      { parts: ['providers', '[*]', 'clientSecret'], deep: false },
-    ]);
-  });
-});
-
-describe('collectSecretValues', () => {
-  it('should collect a simple secret value', () => {
-    const config = new ConfigReader({ token: 'abc123', name: 'test' });
-    const secrets = collectSecretValues(config, [
-      { parts: ['token'], deep: false },
-    ]);
-    expect(Array.from(secrets)).toEqual(['abc123']);
-  });
-
-  it('should collect nested secret values', () => {
-    const config = new ConfigReader({
-      backend: { auth: { secret: 'pass' } },
-    });
-    const secrets = collectSecretValues(config, [
-      { parts: ['backend.auth.secret'], deep: false },
-    ]);
     expect(Array.from(secrets)).toEqual(['pass']);
   });
 
@@ -132,9 +57,20 @@ describe('collectSecretValues', () => {
     const config = new ConfigReader({
       keys: [{ secret: 'key1' }, { secret: 'key2' }],
     });
-    const secrets = collectSecretValues(config, [
-      { parts: ['keys', '[]', 'secret'], deep: false },
-    ]);
+    const secrets = collectSecretValues(config, {
+      type: 'object',
+      properties: {
+        keys: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              secret: { type: 'string', visibility: 'secret' } as any,
+            },
+          },
+        },
+      },
+    });
     expect(Array.from(secrets).sort()).toEqual(['key1', 'key2']);
   });
 
@@ -142,9 +78,15 @@ describe('collectSecretValues', () => {
     const config = new ConfigReader({
       credentials: { user: 'admin', pass: 'secret123' },
     });
-    const secrets = collectSecretValues(config, [
-      { parts: ['credentials'], deep: true },
-    ]);
+    const secrets = collectSecretValues(config, {
+      type: 'object',
+      properties: {
+        credentials: {
+          type: 'object',
+          deepVisibility: 'secret',
+        } as any,
+      },
+    });
     expect(Array.from(secrets).sort()).toEqual(['admin', 'secret123']);
   });
 
@@ -155,17 +97,44 @@ describe('collectSecretValues', () => {
         google: { clientSecret: 'goog-secret' },
       },
     });
-    const secrets = collectSecretValues(config, [
-      { parts: ['providers', '[*]', 'clientSecret'], deep: false },
-    ]);
+    const secrets = collectSecretValues(config, {
+      type: 'object',
+      properties: {
+        providers: {
+          type: 'object',
+          additionalProperties: {
+            type: 'object',
+            properties: {
+              clientSecret: { type: 'string', visibility: 'secret' } as any,
+            },
+          },
+        },
+      },
+    });
     expect(Array.from(secrets).sort()).toEqual(['gh-secret', 'goog-secret']);
   });
 
   it('should return empty set when config path does not exist', () => {
     const config = new ConfigReader({});
-    const secrets = collectSecretValues(config, [
-      { parts: ['missing'], deep: false },
-    ]);
+    const secrets = collectSecretValues(config, {
+      type: 'object',
+      properties: {
+        missing: { type: 'string', visibility: 'secret' } as any,
+      },
+    });
+    expect(Array.from(secrets)).toEqual([]);
+  });
+
+  it('should only collect strings for non-deep leaf secrets', () => {
+    const config = new ConfigReader({
+      token: { nested: 'should-not-appear' },
+    });
+    const secrets = collectSecretValues(config, {
+      type: 'object',
+      properties: {
+        token: { type: 'string', visibility: 'secret' } as any,
+      },
+    });
     expect(Array.from(secrets)).toEqual([]);
   });
 
@@ -176,7 +145,13 @@ describe('collectSecretValues', () => {
     });
     const spy = jest.spyOn(config, 'getOptional');
 
-    collectSecretValues(config, [{ parts: ['secret'], deep: false }]);
+    collectSecretValues(config, {
+      type: 'object',
+      properties: {
+        secret: { type: 'string', visibility: 'secret' } as any,
+        public: { type: 'string' },
+      },
+    });
 
     const calledKeys = spy.mock.calls.map(c => c[0]);
     expect(calledKeys).toContain('secret');

--- a/packages/backend-defaults/src/entrypoints/rootConfig/collectConfigSecrets.test.ts
+++ b/packages/backend-defaults/src/entrypoints/rootConfig/collectConfigSecrets.test.ts
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ConfigReader } from '@backstage/config';
+import {
+  extractSecretPaths,
+  collectSecretValues,
+} from './collectConfigSecrets';
+
+describe('extractSecretPaths', () => {
+  it('should find leaf secret paths', () => {
+    const paths = extractSecretPaths({
+      type: 'object',
+      properties: {
+        token: { type: 'string', visibility: 'secret' },
+        name: { type: 'string' },
+      },
+    });
+
+    expect(paths).toEqual([{ parts: ['token'], deep: false }]);
+  });
+
+  it('should find nested secret paths', () => {
+    const paths = extractSecretPaths({
+      type: 'object',
+      properties: {
+        backend: {
+          type: 'object',
+          properties: {
+            auth: {
+              type: 'object',
+              properties: {
+                secret: { type: 'string', visibility: 'secret' },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(paths).toEqual([{ parts: ['backend.auth.secret'], deep: false }]);
+  });
+
+  it('should find secrets inside array items', () => {
+    const paths = extractSecretPaths({
+      type: 'object',
+      properties: {
+        keys: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              secret: { type: 'string', visibility: 'secret' },
+            },
+          },
+        },
+      },
+    });
+
+    expect(paths).toEqual([{ parts: ['keys', '[]', 'secret'], deep: false }]);
+  });
+
+  it('should find deepVisibility secret paths', () => {
+    const paths = extractSecretPaths({
+      type: 'object',
+      properties: {
+        credentials: {
+          type: 'object',
+          deepVisibility: 'secret',
+        },
+      },
+    });
+
+    expect(paths).toEqual([{ parts: ['credentials'], deep: true }]);
+  });
+
+  it('should find secrets under additionalProperties', () => {
+    const paths = extractSecretPaths({
+      type: 'object',
+      properties: {
+        providers: {
+          type: 'object',
+          additionalProperties: {
+            type: 'object',
+            properties: {
+              clientSecret: { type: 'string', visibility: 'secret' },
+            },
+          },
+        },
+      },
+    });
+
+    expect(paths).toEqual([
+      { parts: ['providers', '[*]', 'clientSecret'], deep: false },
+    ]);
+  });
+});
+
+describe('collectSecretValues', () => {
+  it('should collect a simple secret value', () => {
+    const config = new ConfigReader({ token: 'abc123', name: 'test' });
+    const secrets = collectSecretValues(config, [
+      { parts: ['token'], deep: false },
+    ]);
+    expect(Array.from(secrets)).toEqual(['abc123']);
+  });
+
+  it('should collect nested secret values', () => {
+    const config = new ConfigReader({
+      backend: { auth: { secret: 'pass' } },
+    });
+    const secrets = collectSecretValues(config, [
+      { parts: ['backend.auth.secret'], deep: false },
+    ]);
+    expect(Array.from(secrets)).toEqual(['pass']);
+  });
+
+  it('should collect secrets from array items', () => {
+    const config = new ConfigReader({
+      keys: [{ secret: 'key1' }, { secret: 'key2' }],
+    });
+    const secrets = collectSecretValues(config, [
+      { parts: ['keys', '[]', 'secret'], deep: false },
+    ]);
+    expect(Array.from(secrets).sort()).toEqual(['key1', 'key2']);
+  });
+
+  it('should collect all strings for deep secret paths', () => {
+    const config = new ConfigReader({
+      credentials: { user: 'admin', pass: 'secret123' },
+    });
+    const secrets = collectSecretValues(config, [
+      { parts: ['credentials'], deep: true },
+    ]);
+    expect(Array.from(secrets).sort()).toEqual(['admin', 'secret123']);
+  });
+
+  it('should collect secrets from dynamic keys', () => {
+    const config = new ConfigReader({
+      providers: {
+        github: { clientSecret: 'gh-secret' },
+        google: { clientSecret: 'goog-secret' },
+      },
+    });
+    const secrets = collectSecretValues(config, [
+      { parts: ['providers', '[*]', 'clientSecret'], deep: false },
+    ]);
+    expect(Array.from(secrets).sort()).toEqual(['gh-secret', 'goog-secret']);
+  });
+
+  it('should return empty set when config path does not exist', () => {
+    const config = new ConfigReader({});
+    const secrets = collectSecretValues(config, [
+      { parts: ['missing'], deep: false },
+    ]);
+    expect(Array.from(secrets)).toEqual([]);
+  });
+
+  it('should not read non-secret config keys', () => {
+    const config = new ConfigReader({
+      secret: 'hidden',
+      public: 'visible',
+    });
+    const spy = jest.spyOn(config, 'getOptional');
+
+    collectSecretValues(config, [{ parts: ['secret'], deep: false }]);
+
+    const calledKeys = spy.mock.calls.map(c => c[0]);
+    expect(calledKeys).toContain('secret');
+    expect(calledKeys).not.toContain('public');
+    expect(calledKeys).not.toContain(undefined);
+  });
+});

--- a/packages/backend-defaults/src/entrypoints/rootConfig/collectConfigSecrets.ts
+++ b/packages/backend-defaults/src/entrypoints/rootConfig/collectConfigSecrets.ts
@@ -16,197 +16,97 @@
 
 import type { Config } from '@backstage/config';
 import type { JsonValue } from '@backstage/types';
-
-/**
- * A path to secret config values, represented as alternating dot-separated
- * key segments and expansion markers ('[]' for arrays, '[*]' for dynamic keys).
- *
- * Examples:
- *  - Simple:  { parts: ['backend.auth.secret'], deep: false }
- *  - Array:   { parts: ['backend.auth.keys', '[]', 'secret'], deep: false }
- *  - Dynamic: { parts: ['providers', '[*]', 'clientSecret'], deep: false }
- */
-export type SecretPath = {
-  parts: Array<string | '[]' | '[*]'>;
-  deep: boolean;
-};
-
-/**
- * Traverse a JSON schema object and extract paths to secret fields.
- */
-export function extractSecretPaths(schema: Record<string, any>): SecretPath[] {
-  const results: SecretPath[] = [];
-
-  function walk(node: Record<string, any>, keys: string[]): void {
-    if (!node || typeof node !== 'object') {
-      return;
-    }
-
-    if (node.deepVisibility === 'secret' || node.visibility === 'secret') {
-      results.push({
-        parts: keysToParts(keys),
-        deep: node.deepVisibility === 'secret',
-      });
-      return;
-    }
-
-    if (node.properties) {
-      for (const [key, value] of Object.entries(node.properties)) {
-        walk(value as Record<string, any>, [...keys, key]);
-      }
-    }
-
-    if (node.items) {
-      const items = Array.isArray(node.items) ? node.items : [node.items];
-      for (const item of items) {
-        walk(item as Record<string, any>, [...keys, '[]']);
-      }
-    }
-
-    if (
-      node.additionalProperties &&
-      typeof node.additionalProperties === 'object'
-    ) {
-      walk(node.additionalProperties as Record<string, any>, [...keys, '[*]']);
-    }
-  }
-
-  walk(schema, []);
-  return results;
-}
-
-/** Group consecutive plain keys into dot-separated strings, keeping markers separate. */
-function keysToParts(keys: string[]): Array<string | '[]' | '[*]'> {
-  const parts: Array<string | '[]' | '[*]'> = [];
-  const pending: string[] = [];
-
-  for (const key of keys) {
-    if (key === '[]' || key === '[*]') {
-      if (pending.length > 0) {
-        parts.push(pending.join('.'));
-        pending.length = 0;
-      }
-      parts.push(key);
-    } else {
-      pending.push(key);
-    }
-  }
-
-  if (pending.length > 0) {
-    parts.push(pending.join('.'));
-  }
-
-  return parts;
-}
+import type { JSONSchema7 as JSONSchema } from 'json-schema';
+import traverse from 'json-schema-traverse';
 
 /**
  * Collect all secret string values from a Config object by reading only the
- * paths described by the given secret path patterns.
+ * config paths that are marked as secret in the given merged JSON schema.
  */
 export function collectSecretValues(
   config: Config,
-  paths: SecretPath[],
+  mergedSchema: JSONSchema,
 ): Set<string> {
   const secrets = new Set<string>();
 
-  for (const { parts, deep } of paths) {
-    // Simple case: path is a single dot-separated key with no expansions
-    if (parts.length === 1 && parts[0] !== '[]' && parts[0] !== '[*]') {
-      readLeaf(config, parts[0], deep, secrets);
-      continue;
-    }
+  traverse(mergedSchema, (node, jsonPtr) => {
+    const s = node as JSONSchema & {
+      visibility?: string;
+      deepVisibility?: string;
+    };
 
-    // Complex case: path contains array or dynamic key expansions
-    expandAndRead(config, parts, 0, deep, secrets);
-  }
+    if (s.visibility === 'secret' || s.deepVisibility === 'secret') {
+      addSecrets(
+        config,
+        // Remove the leading '/' from the JSON pointer
+        jsonPtr.split('/').slice(1),
+        s.deepVisibility === 'secret',
+        secrets,
+      );
+    }
+  });
 
   return secrets;
 }
 
-/**
- * Walk the config following expansion markers ([] and [*]) in the path parts.
- * Static key segments are read directly; expansion markers enumerate the
- * matching config entries before continuing.
- *
- * The `prefix` parameter accumulates key segments from dynamic expansions
- * so that reads like `config.getOptional('github.clientSecret')` can be
- * made directly, avoiding intermediate getOptionalConfig calls.
- */
-function expandAndRead(
-  config: Config,
-  parts: Array<string | '[]' | '[*]'>,
-  index: number,
-  deep: boolean,
-  secrets: Set<string>,
-  prefix?: string,
-): void {
-  if (index >= parts.length) {
-    if (prefix) {
-      readLeaf(config, prefix, deep, secrets);
-    }
-    return;
-  }
-
-  const part = parts[index];
-
-  if (part === '[]') {
-    // Array expansion — read the array using the accumulated prefix
-    const key = prefix ?? '';
-    const arr = config.getOptionalConfigArray(key);
-    if (arr) {
-      for (const item of arr) {
-        expandAndRead(item, parts, index + 1, deep, secrets);
-      }
-    }
-    return;
-  }
-
-  if (part === '[*]') {
-    // Dynamic key expansion — enumerate keys under the prefix, then
-    // continue with each key prepended to the remaining path.
-    const parent = prefix ? config.getOptionalConfig(prefix) : config;
-    if (parent) {
-      for (const key of parent.keys()) {
-        expandAndRead(parent, parts, index + 1, deep, secrets, key);
-      }
-    }
-    return;
-  }
-
-  // Static key segment — accumulate into prefix and continue
-  const fullKey = prefix ? `${prefix}.${part}` : part;
-  expandAndRead(config, parts, index + 1, deep, secrets, fullKey);
-}
-
-function readLeaf(
-  config: Config,
-  key: string | undefined,
+function addSecrets(
+  config: Config | undefined,
+  segments: string[],
   deep: boolean,
   secrets: Set<string>,
 ): void {
-  if (deep) {
-    collectAllStrings(config.getOptional(key), secrets);
-  } else {
-    const value = config.getOptional(key);
-    if (typeof value === 'string') {
-      secrets.add(value);
+  if (!config) {
+    return;
+  }
+
+  if (segments.length === 0) {
+    readStringValues(config.getOptional(), deep, secrets);
+    return;
+  }
+
+  if (segments[0] === 'properties') {
+    const name = segments[1];
+    const rest = segments.slice(2);
+    if (rest.length === 0) {
+      // Leaf property — read its value directly
+      readStringValues(config.getOptional(name), deep, secrets);
+    } else if (rest[0] === 'items') {
+      // Property is an array — read it as an array, recurse into each element
+      config.getOptionalConfigArray(name)?.forEach(item => {
+        addSecrets(item, rest.slice(1), deep, secrets);
+      });
+    } else {
+      // Property is an object — descend into it
+      addSecrets(config.getOptionalConfig(name), rest, deep, secrets);
     }
+  } else if (segments[0] === 'additionalProperties') {
+    const rest = segments.slice(1);
+    config.keys().forEach(key => {
+      if (rest.length === 0) {
+        readStringValues(config.getOptional(key), deep, secrets);
+      } else {
+        addSecrets(config.getOptionalConfig(key), rest, deep, secrets);
+      }
+    });
   }
 }
 
-function collectAllStrings(
+function readStringValues(
   value: JsonValue | undefined,
+  deep: boolean,
   secrets: Set<string>,
 ): void {
   if (typeof value === 'string') {
     secrets.add(value);
-  } else if (Array.isArray(value)) {
-    for (const item of value) {
-      collectAllStrings(item, secrets);
-    }
-  } else if (value !== null && typeof value === 'object') {
-    for (const v of Object.values(value as Record<string, JsonValue>)) {
-      collectAllStrings(v, secrets);
+  } else if (deep) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        readStringValues(item, deep, secrets);
+      }
+    } else if (value !== null && typeof value === 'object') {
+      for (const v of Object.values(value as Record<string, JsonValue>)) {
+        readStringValues(v, deep, secrets);
+      }
     }
   }
 }

--- a/packages/backend-defaults/src/entrypoints/rootConfig/collectConfigSecrets.ts
+++ b/packages/backend-defaults/src/entrypoints/rootConfig/collectConfigSecrets.ts
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Config } from '@backstage/config';
+import type { JsonValue } from '@backstage/types';
+
+/**
+ * A path to secret config values, represented as alternating dot-separated
+ * key segments and expansion markers ('[]' for arrays, '[*]' for dynamic keys).
+ *
+ * Examples:
+ *  - Simple:  { parts: ['backend.auth.secret'], deep: false }
+ *  - Array:   { parts: ['backend.auth.keys', '[]', 'secret'], deep: false }
+ *  - Dynamic: { parts: ['providers', '[*]', 'clientSecret'], deep: false }
+ */
+export type SecretPath = {
+  parts: Array<string | '[]' | '[*]'>;
+  deep: boolean;
+};
+
+/**
+ * Traverse a JSON schema object and extract paths to secret fields.
+ */
+export function extractSecretPaths(schema: Record<string, any>): SecretPath[] {
+  const results: SecretPath[] = [];
+
+  function walk(node: Record<string, any>, keys: string[]): void {
+    if (!node || typeof node !== 'object') {
+      return;
+    }
+
+    if (node.deepVisibility === 'secret' || node.visibility === 'secret') {
+      results.push({
+        parts: keysToParts(keys),
+        deep: node.deepVisibility === 'secret',
+      });
+      return;
+    }
+
+    if (node.properties) {
+      for (const [key, value] of Object.entries(node.properties)) {
+        walk(value as Record<string, any>, [...keys, key]);
+      }
+    }
+
+    if (node.items) {
+      const items = Array.isArray(node.items) ? node.items : [node.items];
+      for (const item of items) {
+        walk(item as Record<string, any>, [...keys, '[]']);
+      }
+    }
+
+    if (
+      node.additionalProperties &&
+      typeof node.additionalProperties === 'object'
+    ) {
+      walk(node.additionalProperties as Record<string, any>, [...keys, '[*]']);
+    }
+  }
+
+  walk(schema, []);
+  return results;
+}
+
+/** Group consecutive plain keys into dot-separated strings, keeping markers separate. */
+function keysToParts(keys: string[]): Array<string | '[]' | '[*]'> {
+  const parts: Array<string | '[]' | '[*]'> = [];
+  const pending: string[] = [];
+
+  for (const key of keys) {
+    if (key === '[]' || key === '[*]') {
+      if (pending.length > 0) {
+        parts.push(pending.join('.'));
+        pending.length = 0;
+      }
+      parts.push(key);
+    } else {
+      pending.push(key);
+    }
+  }
+
+  if (pending.length > 0) {
+    parts.push(pending.join('.'));
+  }
+
+  return parts;
+}
+
+/**
+ * Collect all secret string values from a Config object by reading only the
+ * paths described by the given secret path patterns.
+ */
+export function collectSecretValues(
+  config: Config,
+  paths: SecretPath[],
+): Set<string> {
+  const secrets = new Set<string>();
+
+  for (const { parts, deep } of paths) {
+    // Simple case: path is a single dot-separated key with no expansions
+    if (parts.length === 1 && parts[0] !== '[]' && parts[0] !== '[*]') {
+      readLeaf(config, parts[0], deep, secrets);
+      continue;
+    }
+
+    // Complex case: path contains array or dynamic key expansions
+    expandAndRead(config, parts, 0, deep, secrets);
+  }
+
+  return secrets;
+}
+
+/**
+ * Walk the config following expansion markers ([] and [*]) in the path parts.
+ * Static key segments are read directly; expansion markers enumerate the
+ * matching config entries before continuing.
+ *
+ * The `prefix` parameter accumulates key segments from dynamic expansions
+ * so that reads like `config.getOptional('github.clientSecret')` can be
+ * made directly, avoiding intermediate getOptionalConfig calls.
+ */
+function expandAndRead(
+  config: Config,
+  parts: Array<string | '[]' | '[*]'>,
+  index: number,
+  deep: boolean,
+  secrets: Set<string>,
+  prefix?: string,
+): void {
+  if (index >= parts.length) {
+    if (prefix) {
+      readLeaf(config, prefix, deep, secrets);
+    }
+    return;
+  }
+
+  const part = parts[index];
+
+  if (part === '[]') {
+    // Array expansion — read the array using the accumulated prefix
+    const key = prefix ?? '';
+    const arr = config.getOptionalConfigArray(key);
+    if (arr) {
+      for (const item of arr) {
+        expandAndRead(item, parts, index + 1, deep, secrets);
+      }
+    }
+    return;
+  }
+
+  if (part === '[*]') {
+    // Dynamic key expansion — enumerate keys under the prefix, then
+    // continue with each key prepended to the remaining path.
+    const parent = prefix ? config.getOptionalConfig(prefix) : config;
+    if (parent) {
+      for (const key of parent.keys()) {
+        expandAndRead(parent, parts, index + 1, deep, secrets, key);
+      }
+    }
+    return;
+  }
+
+  // Static key segment — accumulate into prefix and continue
+  const fullKey = prefix ? `${prefix}.${part}` : part;
+  expandAndRead(config, parts, index + 1, deep, secrets, fullKey);
+}
+
+function readLeaf(
+  config: Config,
+  key: string | undefined,
+  deep: boolean,
+  secrets: Set<string>,
+): void {
+  if (deep) {
+    collectAllStrings(config.getOptional(key), secrets);
+  } else {
+    const value = config.getOptional(key);
+    if (typeof value === 'string') {
+      secrets.add(value);
+    }
+  }
+}
+
+function collectAllStrings(
+  value: JsonValue | undefined,
+  secrets: Set<string>,
+): void {
+  if (typeof value === 'string') {
+    secrets.add(value);
+  } else if (Array.isArray(value)) {
+    for (const item of value) {
+      collectAllStrings(item, secrets);
+    }
+  } else if (value !== null && typeof value === 'object') {
+    for (const v of Object.values(value as Record<string, JsonValue>)) {
+      collectAllStrings(v, secrets);
+    }
+  }
+}

--- a/packages/backend-defaults/src/entrypoints/rootConfig/createConfigSecretEnumerator.test.ts
+++ b/packages/backend-defaults/src/entrypoints/rootConfig/createConfigSecretEnumerator.test.ts
@@ -71,4 +71,50 @@ describe('createConfigSecretEnumerator', () => {
     );
     expect(Array.from(secrets)).toEqual(['my-secret']);
   });
+
+  it('should only read secret config paths, not the entire config', async () => {
+    const logger = mockServices.logger.mock();
+
+    const enumerate = await createConfigSecretEnumerator({
+      logger,
+      schema: await loadConfigSchema({
+        serialized: {
+          schemas: [
+            {
+              value: {
+                type: 'object',
+                properties: {
+                  secret: {
+                    visibility: 'secret',
+                    type: 'string',
+                  },
+                  other: {
+                    type: 'string',
+                  },
+                },
+              },
+              path: '/mock',
+            },
+          ],
+          backstageConfigSchemaVersion: 1,
+        },
+      }),
+    });
+
+    const config = mockServices.rootConfig({
+      data: {
+        secret: 'my-secret',
+        other: 'not-secret',
+      },
+    });
+
+    const getOptionalSpy = jest.spyOn(config, 'getOptional');
+    enumerate(config);
+
+    // Should read 'secret' but never read 'other' or the full config (no-arg call)
+    const calledKeys = getOptionalSpy.mock.calls.map(c => c[0]);
+    expect(calledKeys).not.toContain(undefined);
+    expect(calledKeys).not.toContain('other');
+    expect(calledKeys).toContain('secret');
+  });
 });

--- a/packages/backend-defaults/src/entrypoints/rootConfig/createConfigSecretEnumerator.ts
+++ b/packages/backend-defaults/src/entrypoints/rootConfig/createConfigSecretEnumerator.ts
@@ -16,8 +16,16 @@
 
 import { LoggerService } from '@backstage/backend-plugin-api';
 import type { Config } from '@backstage/config';
-import { ConfigSchema, loadConfigSchema } from '@backstage/config-loader';
+import {
+  ConfigSchema,
+  loadConfigSchema,
+  mergeConfigSchemas,
+} from '@backstage/config-loader';
 import { getPackages } from '@manypkg/get-packages';
+import {
+  extractSecretPaths,
+  collectSecretValues,
+} from './collectConfigSecrets';
 
 /** @public */
 export async function createConfigSecretEnumerator(options: {
@@ -33,19 +41,13 @@ export async function createConfigSecretEnumerator(options: {
       dependencies: packages.map(p => p.packageJson.name),
     }));
 
+  const serialized = schema.serialize();
+  const schemas = serialized.schemas as Array<{ value: Record<string, any> }>;
+  const merged = mergeConfigSchemas(schemas.map(s => s.value));
+  const secretPaths = extractSecretPaths(merged as Record<string, any>);
+
   return (config: Config) => {
-    const [secretsData] = schema.process(
-      [{ data: config.getOptional() ?? {}, context: 'schema-enumerator' }],
-      {
-        visibility: ['secret'],
-        ignoreSchemaErrors: true,
-      },
-    );
-    const secrets = new Set<string>();
-    JSON.parse(
-      JSON.stringify(secretsData.data),
-      (_, v) => typeof v === 'string' && secrets.add(v),
-    );
+    const secrets = collectSecretValues(config, secretPaths);
     logger.info(
       `Found ${secrets.size} new secrets in config that will be redacted`,
     );

--- a/packages/backend-defaults/src/entrypoints/rootConfig/createConfigSecretEnumerator.ts
+++ b/packages/backend-defaults/src/entrypoints/rootConfig/createConfigSecretEnumerator.ts
@@ -22,10 +22,7 @@ import {
   mergeConfigSchemas,
 } from '@backstage/config-loader';
 import { getPackages } from '@manypkg/get-packages';
-import {
-  extractSecretPaths,
-  collectSecretValues,
-} from './collectConfigSecrets';
+import { collectSecretValues } from './collectConfigSecrets';
 
 /** @public */
 export async function createConfigSecretEnumerator(options: {
@@ -43,11 +40,10 @@ export async function createConfigSecretEnumerator(options: {
 
   const serialized = schema.serialize();
   const schemas = serialized.schemas as Array<{ value: Record<string, any> }>;
-  const merged = mergeConfigSchemas(schemas.map(s => s.value));
-  const secretPaths = extractSecretPaths(merged as Record<string, any>);
+  const mergedSchema = mergeConfigSchemas(schemas.map(s => s.value));
 
   return (config: Config) => {
-    const secrets = collectSecretValues(config, secretPaths);
+    const secrets = collectSecretValues(config, mergedSchema);
     logger.info(
       `Found ${secrets.size} new secrets in config that will be redacted`,
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2601,6 +2601,7 @@ __metadata:
     infinispan: "npm:^0.12.0"
     is-glob: "npm:^4.0.3"
     jose: "npm:^5.0.0"
+    json-schema-traverse: "npm:^1.0.0"
     keyv: "npm:^5.2.1"
     knex: "npm:^3.0.0"
     lodash: "npm:^4.17.21"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The secret redaction system previously read the entire configuration tree to extract secret values to redact. Now, it extracts secret paths from the schema, and selectively reads each one individually to avoid reading extra configuration data unnecessarily.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
