### PR TITLE
chore: remove .patches entries already released in v1.50.2

### DIFF
--- a/.patches/pr-33908.txt
+++ b/.patches/pr-33908.txt
@@ -1,1 +1,0 @@
-Make TechDocs sidebar positioning configurable via CSS custom properties

--- a/.patches/pr-33952.txt
+++ b/.patches/pr-33952.txt
@@ -1,1 +1,0 @@
-Bump zod dependency to v4 for packages using configSchema and clarify that zod/v4 subpath from v3 is not supported

--- a/.patches/pr-33975.txt
+++ b/.patches/pr-33975.txt
@@ -1,1 +1,0 @@
-Clamp React Aria dependency ranges to patch-only updates to prevent unintended minor version upgrades

--- a/.patches/pr-33984.txt
+++ b/.patches/pr-33984.txt
@@ -1,1 +1,0 @@
-Fix active tab indicator disappearing on uncontrolled Tabs in @backstage/ui


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Remove `.patches` entries for PRs that were already included in the v1.50.2 patch release:

- `pr-33908.txt` — Make TechDocs sidebar positioning configurable via CSS custom properties
- `pr-33952.txt` — Bump zod dependency to v4 for packages using configSchema
- `pr-33975.txt` — Clamp React Aria dependency ranges to patch-only updates
- `pr-33984.txt` — Fix active tab indicator disappearing on uncontrolled Tabs in @backstage/ui

The remaining entries (`pr-33721` and `pr-34001`) have not yet been included in any patch release.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Made with [Cursor](https://cursor.com)