### PR TITLE
 Update TechDocs getting-started to reflect latest out-of-the-box behavior

### DIFF
--- a/docs/features/techdocs/addons--old.md
+++ b/docs/features/techdocs/addons--old.md
@@ -5,7 +5,7 @@ description: How to find, use, or create TechDocs Addons.
 ---
 
 :::info
-This documentation is written for [the old frontend system](./getting-started.md#adding-techdocs-frontend-plugin). If you are on the [new frontend system](../../frontend-system/index.md) you may want to read [its own article](./addons.md) instead.
+This documentation is written for [the old frontend system](./getting-started--old.md#adding-techdocs-frontend-plugin). If you are on the [new frontend system](../../frontend-system/index.md) you may want to read [its own article](./addons.md) instead.
 :::
 
 ## Concepts

--- a/docs/features/techdocs/addons.md
+++ b/docs/features/techdocs/addons.md
@@ -5,7 +5,7 @@ description: How to find, use, or create TechDocs Addons.
 ---
 
 :::info
-This documentation is written for [the new frontend system](../../frontend-system/index.md). If you are on the [old frontend system](./getting-started.md#adding-techdocs-frontend-plugin) you may want to read [its own article](./addons--old.md) instead.
+This documentation is written for [the new frontend system](../../frontend-system/index.md). If you are on the [old frontend system](./getting-started--old.md#adding-techdocs-frontend-plugin) you may want to read [its own article](./addons--old.md) instead.
 :::
 
 ## Concepts

--- a/docs/features/techdocs/getting-started.md
+++ b/docs/features/techdocs/getting-started.md
@@ -39,7 +39,7 @@ techdocs:
 This basic configuration allows you to get started quickly. It processes the component documentation, as follows:
 
 - **builder = local** - uses the TechDocs backend to generate the docs, publish to storage, and show the generated docs.
-- **generator.runIn = docker** - spin up the techdocs-container docker image running `mkdocs` inside it to process the documentation. The Docker image is automatically pulled by TechDocs.
+- **generator.runIn = docker** - spins up the techdocs-container docker image running `mkdocs` inside it to process the documentation. The Docker image is automatically pulled by TechDocs.
 - **publisher.type = local** - techdocs-backend will create a 'static' directory at its root to store generated documentation files.
 
 You can further refine the `generator` and `publisher` settings. **See [TechDocs Configuration Options](configuration.md) for complete configuration reference.**

--- a/docs/features/techdocs/getting-started.md
+++ b/docs/features/techdocs/getting-started.md
@@ -11,86 +11,38 @@ read the [old frontend system version of this guide](./getting-started--old.md)
 instead.
 ::::
 
-TechDocs functions as a plugin in Backstage and ships with it installed out of the box, so you will need to use Backstage to use TechDocs.
-
 If you haven't setup Backstage already, start [here](../../getting-started/index.md).
 
-## Adding TechDocs frontend plugin
+TechDocs functions as a plugin in Backstage and ships with it installed and added to the frontend and backend out of the box, so you will need to use Backstage to use TechDocs.
 
-The first step is to add the TechDocs plugin to your Backstage application.
-
-```bash title="From your Backstage root directory"
-yarn --cwd packages/app add @backstage/plugin-techdocs
-```
-
-Once installed, the plugin is automatically available in your app through the default feature discovery. For more details and alternative installation methods, see [installing plugins](../../frontend-system/building-apps/05-installing-plugins.md).
-
-The plugin provides a docs index page at `/docs` and a reader page for individual documentation sites, along with a "Docs" navigation item in the sidebar and a documentation tab on entity pages.
-
-## Using TechDocs Addons
-
-The TechDocs Addon framework lets you render React components in documentation pages. Addons are provided as separate plugin modules.
-
-For example, to add the Report Issue addon, first install the package:
-
-```bash title="From your Backstage root directory"
-yarn --cwd packages/app add @backstage/plugin-techdocs-module-addons-contrib
-```
-
-Then install the addon module in your app:
-
-```tsx title="packages/app/src/App.tsx"
-import { createApp } from '@backstage/frontend-defaults';
-import { techDocsReportIssueAddonModule } from '@backstage/plugin-techdocs-module-addons-contrib/alpha';
-
-const app = createApp({
-  features: [techDocsReportIssueAddonModule],
-});
-
-export default app.createRoot();
-```
-
-The same package also provides `techDocsExpandableNavigationAddonModule`, `techDocsTextSizeAddonModule`, and `techDocsLightBoxAddonModule`.
-
-You can see the Report Issue addon in action when you highlight text in your documentation:
-
-<!-- todo: Needs zoomable plugin -->
-
-![TechDocs Report Issue Add-on](../../assets/techdocs/report-issue-addon.png)
-
-By clicking the open new issue button, you are redirected to the new issue page according to the source code provider you are using:
-
-<!-- todo: Needs zoomable plugin -->
-
-![TechDocs Report Issue Template](../../assets/techdocs/report-issue-template.png)
-
-## Adding TechDocs Backend plugin
-
-First we need to install the `@backstage/plugin-techdocs-backend` package.
-
-```bash title="From your Backstage root directory"
-yarn --cwd packages/backend add @backstage/plugin-techdocs-backend
-```
-
-Then in your backend `index.ts` you will add the following line.
-
-```ts title="packages/backend/src/index.ts"
-const backend = createBackend();
-
-// Other plugins...
-
-/* highlight-add-start */
-backend.add(import('@backstage/plugin-techdocs-backend'));
-/* highlight-add-end */
-
-backend.start();
-```
-
-That's it! TechDocs frontend and backend have now been added to your Backstage app. Now let us tweak some configurations to suit your needs.
+Now let us tweak some configurations to suit your needs.
 
 ## Setting the configuration
 
-**See [TechDocs Configuration Options](configuration.md) for complete configuration reference.**
+The configuration of TechDocs is based on three primary settings:
+
+- `builder` - Are you generating the documentation locally using the TechDocs backend or just fetching it for display from an external source.
+- `generator` - Are you generating it with a Docker image running `mkdocs` or your own local copy of `mkdocs`.
+- `publisher` - Where is the generated documentation stored; on your local server or another location, such as a Google Cloud Storage Bucket.
+
+Out of the box, TechDocs is configured in `app-config.yaml` as:
+
+```yaml
+techdocs:
+  builder: 'local' # Alternatives - 'external'
+  generator:
+    runIn: 'docker' # Alternatives - 'local'
+  publisher:
+    type: 'local' # Alternatives - 'googleGcs' or 'awsS3'. Read documentation for using alternatives.
+```
+
+This basic configuration allows you to get started quickly. It processes the component documentation, as follows:
+
+- **builder = local** - uses the TechDocs backend to generate the docs, publish to storage, and show the generated docs.
+- **generator.runIn = docker** - spin up the techdocs-container docker image running `mkdocs` inside it to process the documentation. The Docker image is automatically pulled by TechDocs.
+- **publisher.type = local** - techdocs-backend will create a 'static' directory at its root to store generated documentation files.
+
+You can further refine the `generator` and `publisher` settings. **See [TechDocs Configuration Options](configuration.md) for complete configuration reference.**
 
 ### Should TechDocs Backend generate docs?
 
@@ -164,6 +116,43 @@ RUN pip3 install mkdocs-techdocs-core==1.2.3
 Note: We recommend Python version 3.11 or higher.
 
 > Caveat: Please install the `mkdocs-techdocs-core` package after all other Python packages. The order is important to make sure we get correct version of some of the dependencies.
+
+## Using TechDocs Addons
+
+The TechDocs Addon framework lets you render React components in documentation pages. Addons are provided as separate plugin modules.
+
+For example, to add the Report Issue addon, first install the package:
+
+```bash title="From your Backstage root directory"
+yarn --cwd packages/app add @backstage/plugin-techdocs-module-addons-contrib
+```
+
+Then install the addon module in your app:
+
+```tsx title="packages/app/src/App.tsx"
+import { createApp } from '@backstage/frontend-defaults';
+import { techDocsReportIssueAddonModule } from '@backstage/plugin-techdocs-module-addons-contrib/alpha';
+
+const app = createApp({
+  features: [techDocsReportIssueAddonModule],
+});
+
+export default app.createRoot();
+```
+
+The same package also provides `techDocsExpandableNavigationAddonModule`, `techDocsTextSizeAddonModule`, and `techDocsLightBoxAddonModule`.
+
+You can see the Report Issue addon in action when you highlight text in your documentation:
+
+<!-- todo: Needs zoomable plugin -->
+
+![TechDocs Report Issue Add-on](../../assets/techdocs/report-issue-addon.png)
+
+By clicking the open new issue button, you are redirected to the new issue page according to the source code provider you are using:
+
+<!-- todo: Needs zoomable plugin -->
+
+![TechDocs Report Issue Template](../../assets/techdocs/report-issue-template.png)
 
 ## Additional reading
 

--- a/docs/features/techdocs/getting-started.md
+++ b/docs/features/techdocs/getting-started.md
@@ -5,9 +5,10 @@ description: Getting Started Documentation
 ---
 
 ::::info
-This documentation is written for the new frontend system, which is the default in new Backstage apps. If your Backstage app still uses the old frontend system, or your `<backstage_app_root>/packages/backend/src/index.ts` file does not contain
-`backend.add(import('@backstage/plugin-techdocs-backend'));` then follow the TechDocs installation instructions in the [old frontend system version of this guide](./getting-started--old.md)
-instead.
+This documentation is written for the new frontend system, which is the default in new Backstage apps. If one of the following are true, then follow the TechDocs installation instructions in the [old frontend system version of this guide](./getting-started--old.md) instead:
+- your Backstage app still uses the old frontend system
+- you are using the new frontend, but your `<backstage_app_root>/packages/backend/src/index.ts` file does not contain
+`backend.add(import('@backstage/plugin-techdocs-backend'));`
 ::::
 
 If you haven't set up Backstage already, start [here](../../getting-started/index.md).

--- a/docs/features/techdocs/getting-started.md
+++ b/docs/features/techdocs/getting-started.md
@@ -5,7 +5,7 @@ description: Getting Started Documentation
 ---
 
 ::::info
-This documentation is written for the new frontend system, which is the default in new Backstage apps. If your Backstage app still uses the old frontend system, then follow the TechDocs installation instructions in the [old frontend system version of this guide](./getting-started--old.md) instead:
+This documentation is written for the new frontend system, which is the default in new Backstage apps. If your Backstage app still uses the old frontend system, then follow the TechDocs installation instructions in the [old frontend system version of this guide](./getting-started--old.md) instead.
 ::::
 
 If you haven't set up Backstage already, start [here](../../getting-started/index.md).

--- a/docs/features/techdocs/getting-started.md
+++ b/docs/features/techdocs/getting-started.md
@@ -10,7 +10,7 @@ This documentation is written for the new frontend system, which is the default 
 - your Backstage app still uses the old frontend system
 - you are using the new frontend, but your `<backstage_app_root>/packages/backend/src/index.ts` file does not contain
   `backend.add(import('@backstage/plugin-techdocs-backend'));`
-  ::::
+::::
 
 If you haven't set up Backstage already, start [here](../../getting-started/index.md).
 

--- a/docs/features/techdocs/getting-started.md
+++ b/docs/features/techdocs/getting-started.md
@@ -11,7 +11,7 @@ read the [old frontend system version of this guide](./getting-started--old.md)
 instead.
 ::::
 
-If you haven't setup Backstage already, start [here](../../getting-started/index.md).
+If you haven't set up Backstage already, start [here](../../getting-started/index.md).
 
 TechDocs functions as a plugin in Backstage and ships with it installed and added to the frontend and backend out of the box, so you will need to use Backstage to use TechDocs.
 

--- a/docs/features/techdocs/getting-started.md
+++ b/docs/features/techdocs/getting-started.md
@@ -18,7 +18,7 @@ Now let us tweak some configurations to suit your needs.
 
 The configuration of TechDocs is based on three primary settings:
 
-- `builder` - Determines whether the documentation is generated locally using the TechDocs backend or fetched for display from an external source.
+- `builder` - Determines whether the documentation is generated locally using the TechDocs backend or is built/published outside of Backstage and fetched for display from the configured publisher.
 - `generator` - Determines whether the documentation is generated with a Docker image running `mkdocs` or with your own local copy of `mkdocs`.
 - `publisher` - Specifies where the generated documentation is stored, such as on your local server or another location like a Google Cloud Storage bucket.
 

--- a/docs/features/techdocs/getting-started.md
+++ b/docs/features/techdocs/getting-started.md
@@ -40,7 +40,7 @@ This basic configuration allows you to get started quickly. It processes the com
 
 - **builder = local** - uses the TechDocs backend to generate the docs, publish to storage, and show the generated docs.
 - **generator.runIn = docker** - spins up the techdocs-container docker image running `mkdocs` inside it to process the documentation. The Docker image is automatically pulled by TechDocs.
-- **publisher.type = local** - techdocs-backend will create a 'static' directory at its root to store generated documentation files.
+- **publisher.type = local** - stores generated documentation files locally, by default in `@backstage/plugin-techdocs-backend/static/docs`, or in the path configured by `techdocs.publisher.local.publishDirectory`.
 
 You can further refine the `generator` and `publisher` settings. **See [TechDocs Configuration Options](configuration.md) for complete configuration reference.**
 

--- a/docs/features/techdocs/getting-started.md
+++ b/docs/features/techdocs/getting-started.md
@@ -5,11 +5,8 @@ description: Getting Started Documentation
 ---
 
 ::::info
-This documentation is written for the new frontend system, which is the default
-in new Backstage apps. If your Backstage app still uses the old frontend system, or 
-your `<backstage_app_root>/packages/backend/src/index.ts` file does not contain 
-`backend.add(import('@backstage/plugin-techdocs-backend'));` then follow the
-TechDocs installation instructions in the [old frontend system version of this guide](./getting-started--old.md)
+This documentation is written for the new frontend system, which is the default in new Backstage apps. If your Backstage app still uses the old frontend system, or your `<backstage_app_root>/packages/backend/src/index.ts` file does not contain
+`backend.add(import('@backstage/plugin-techdocs-backend'));` then follow the TechDocs installation instructions in the [old frontend system version of this guide](./getting-started--old.md)
 instead.
 ::::
 
@@ -122,6 +119,7 @@ Note: We recommend Python version 3.11 or higher.
 ## Using TechDocs Addons
 
 The TechDocs Addon framework lets you render React components in documentation pages. For installation instructions, available addon modules, and usage examples, see the dedicated [TechDocs Addons guide](./addons.md).
+
 ## Additional reading
 
 - [Creating and publishing your docs](creating-and-publishing.md)

--- a/docs/features/techdocs/getting-started.md
+++ b/docs/features/techdocs/getting-started.md
@@ -33,7 +33,7 @@ techdocs:
   generator:
     runIn: 'docker' # Alternatives - 'local'
   publisher:
-    type: 'local' # Alternatives - 'googleGcs' or 'awsS3'. Read documentation for using alternatives.
+    type: 'local' # Alternatives include 'googleGcs', 'awsS3', and other supported publishers. See configuration documentation for the full list.
 ```
 
 This basic configuration allows you to get started quickly. It processes the component documentation, as follows:

--- a/docs/features/techdocs/getting-started.md
+++ b/docs/features/techdocs/getting-started.md
@@ -119,41 +119,7 @@ Note: We recommend Python version 3.11 or higher.
 
 ## Using TechDocs Addons
 
-The TechDocs Addon framework lets you render React components in documentation pages. Addons are provided as separate plugin modules.
-
-For example, to add the Report Issue addon, first install the package:
-
-```bash title="From your Backstage root directory"
-yarn --cwd packages/app add @backstage/plugin-techdocs-module-addons-contrib
-```
-
-Then install the addon module in your app:
-
-```tsx title="packages/app/src/App.tsx"
-import { createApp } from '@backstage/frontend-defaults';
-import { techDocsReportIssueAddonModule } from '@backstage/plugin-techdocs-module-addons-contrib/alpha';
-
-const app = createApp({
-  features: [techDocsReportIssueAddonModule],
-});
-
-export default app.createRoot();
-```
-
-The same package also provides `techDocsExpandableNavigationAddonModule`, `techDocsTextSizeAddonModule`, and `techDocsLightBoxAddonModule`.
-
-You can see the Report Issue addon in action when you highlight text in your documentation:
-
-<!-- todo: Needs zoomable plugin -->
-
-![TechDocs Report Issue Add-on](../../assets/techdocs/report-issue-addon.png)
-
-By clicking the open new issue button, you are redirected to the new issue page according to the source code provider you are using:
-
-<!-- todo: Needs zoomable plugin -->
-
-![TechDocs Report Issue Template](../../assets/techdocs/report-issue-template.png)
-
+The TechDocs Addon framework lets you render React components in documentation pages. For installation instructions, available addon modules, and usage examples, see the dedicated [TechDocs Addons guide](./addons.md).
 ## Additional reading
 
 - [Creating and publishing your docs](creating-and-publishing.md)

--- a/docs/features/techdocs/getting-started.md
+++ b/docs/features/techdocs/getting-started.md
@@ -5,11 +5,7 @@ description: Getting Started Documentation
 ---
 
 ::::info
-This documentation is written for the new frontend system, which is the default in new Backstage apps. If one of the following is true, then follow the TechDocs installation instructions in the [old frontend system version of this guide](./getting-started--old.md) instead:
-
-- your Backstage app still uses the old frontend system
-- you are using the new frontend, but your `<backstage_app_root>/packages/backend/src/index.ts` file does not contain
-  `backend.add(import('@backstage/plugin-techdocs-backend'));`
+This documentation is written for the new frontend system, which is the default in new Backstage apps. If your Backstage app still uses the old frontend system, then follow the TechDocs installation instructions in the [old frontend system version of this guide](./getting-started--old.md) instead:
 ::::
 
 If you haven't set up Backstage already, start [here](../../getting-started/index.md).

--- a/docs/features/techdocs/getting-started.md
+++ b/docs/features/techdocs/getting-started.md
@@ -5,7 +5,7 @@ description: Getting Started Documentation
 ---
 
 ::::info
-This documentation is written for the new frontend system, which is the default in new Backstage apps. If your Backstage app still uses the old frontend system, then follow the TechDocs installation instructions in the [old frontend system version of this guide](./getting-started--old.md) instead.
+This documentation is written for the new frontend system, which is the default in new Backstage apps. If your Backstage app still uses the old frontend system, read the [old frontend system version of this guide](./getting-started--old.md) instead.
 ::::
 
 If you haven't set up Backstage already, start [here](../../getting-started/index.md).

--- a/docs/features/techdocs/getting-started.md
+++ b/docs/features/techdocs/getting-started.md
@@ -21,9 +21,9 @@ Now let us tweak some configurations to suit your needs.
 
 The configuration of TechDocs is based on three primary settings:
 
-- `builder` - Are you generating the documentation locally using the TechDocs backend or just fetching it for display from an external source.
-- `generator` - Are you generating it with a Docker image running `mkdocs` or your own local copy of `mkdocs`.
-- `publisher` - Where is the generated documentation stored; on your local server or another location, such as a Google Cloud Storage Bucket.
+- `builder` - Determines whether the documentation is generated locally using the TechDocs backend or fetched for display from an external source.
+- `generator` - Determines whether the documentation is generated with a Docker image running `mkdocs` or with your own local copy of `mkdocs`.
+- `publisher` - Specifies where the generated documentation is stored, such as on your local server or another location like a Google Cloud Storage bucket.
 
 Out of the box, TechDocs is configured in `app-config.yaml` as:
 

--- a/docs/features/techdocs/getting-started.md
+++ b/docs/features/techdocs/getting-started.md
@@ -5,11 +5,12 @@ description: Getting Started Documentation
 ---
 
 ::::info
-This documentation is written for the new frontend system, which is the default in new Backstage apps. If one of the following are true, then follow the TechDocs installation instructions in the [old frontend system version of this guide](./getting-started--old.md) instead:
+This documentation is written for the new frontend system, which is the default in new Backstage apps. If one of the following is true, then follow the TechDocs installation instructions in the [old frontend system version of this guide](./getting-started--old.md) instead:
+
 - your Backstage app still uses the old frontend system
 - you are using the new frontend, but your `<backstage_app_root>/packages/backend/src/index.ts` file does not contain
-`backend.add(import('@backstage/plugin-techdocs-backend'));`
-::::
+  `backend.add(import('@backstage/plugin-techdocs-backend'));`
+  ::::
 
 If you haven't set up Backstage already, start [here](../../getting-started/index.md).
 

--- a/docs/features/techdocs/getting-started.md
+++ b/docs/features/techdocs/getting-started.md
@@ -6,14 +6,16 @@ description: Getting Started Documentation
 
 ::::info
 This documentation is written for the new frontend system, which is the default
-in new Backstage apps. If your Backstage app still uses the old frontend system,
-read the [old frontend system version of this guide](./getting-started--old.md)
+in new Backstage apps. If your Backstage app still uses the old frontend system, or 
+your `<backstage_app_root>/packages/backend/src/index.ts` file does not contain 
+`backend.add(import('@backstage/plugin-techdocs-backend'));` then follow the
+TechDocs installation instructions in the [old frontend system version of this guide](./getting-started--old.md)
 instead.
 ::::
 
 If you haven't set up Backstage already, start [here](../../getting-started/index.md).
 
-TechDocs functions as a plugin in Backstage and ships with it installed and added to the frontend and backend out of the box, so you will need to use Backstage to use TechDocs.
+TechDocs functions as a plugin in Backstage, so you will need to use Backstage to use TechDocs. In newly scaffolded Backstage apps, created with the default `@backstage/create-app@latest` template, TechDocs is installed and wired into both the frontend and backend out of the box.
 
 Now let us tweak some configurations to suit your needs.
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Removed sections for installing TechDocs frontend and backend as that is already done in a fresh latest install of the Backstage app. Added an overview of the TechDocs configuration settings and what the out-of-the-box settings look like,

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
