### PR TITLE
fix(scaffolder-github): add GraphQL fallback when git push is blocked

### DIFF
--- a/.changeset/proxy-push-fallback.md
+++ b/.changeset/proxy-push-fallback.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-backend-module-github': patch
 ---
 
-Added a fallback for `publish:github` and `github:repo:push` actions that retries via the GitHub GraphQL when the git push fails with `ECONNRESET`. The git smart HTTP protocol sends binary pack data in a POST request which can be blocked by network proxies that perform deep packet inspection. The GraphQL fallback uses standard JSON requests which are not affected.
+Added a fallback for `publish:github` and `github:repo:push` actions that retries via the GitHub GraphQL API when the git push fails with a connection-level error (`ECONNRESET` or `ECONNREFUSED`, checked on both `error.code` and `error.cause.code`). The git smart HTTP protocol sends binary pack data in a POST request which can be blocked by network proxies that perform deep packet inspection. The GraphQL fallback uses standard JSON requests which are not affected.

--- a/.changeset/proxy-push-fallback.md
+++ b/.changeset/proxy-push-fallback.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-github': patch
+---
+
+Added a fallback for `publish:github` and `github:repo:push` actions that retries via the GitHub REST API when the git push fails with `ECONNRESET`. The git smart HTTP protocol sends binary pack data in a POST request which can be blocked by network proxies that perform deep packet inspection. The REST API fallback uses standard JSON requests which are not affected.

--- a/.changeset/proxy-push-fallback.md
+++ b/.changeset/proxy-push-fallback.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-backend-module-github': patch
 ---
 
-Added a fallback for `publish:github` and `github:repo:push` actions that retries via the GitHub REST API when the git push fails with `ECONNRESET`. The git smart HTTP protocol sends binary pack data in a POST request which can be blocked by network proxies that perform deep packet inspection. The REST API fallback uses standard JSON requests which are not affected.
+Added a fallback for `publish:github` and `github:repo:push` actions that retries via the GitHub GraphQL when the git push fails with `ECONNRESET`. The git smart HTTP protocol sends binary pack data in a POST request which can be blocked by network proxies that perform deep packet inspection. The GraphQL fallback uses standard JSON requests which are not affected.

--- a/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
@@ -96,14 +96,10 @@ const mockOctokit = {
     },
     git: {
       getRef: jest.fn(),
-      getCommit: jest.fn(),
-      createBlob: jest.fn(),
-      createTree: jest.fn(),
-      createCommit: jest.fn(),
-      updateRef: jest.fn(),
     },
   },
   request: jest.fn(),
+  graphql: jest.fn(),
 };
 jest.mock('octokit', () => ({
   Octokit: jest.fn(),
@@ -1902,7 +1898,7 @@ describe('publish:github', () => {
     });
   });
 
-  it('should fall back to REST API when git push fails with ECONNRESET', async () => {
+  it('should fall back to GraphQL API when git push fails with ECONNRESET', async () => {
     const econnError = new Error('socket hang up');
     (econnError as NodeJS.ErrnoException).code = 'ECONNRESET';
     initRepoAndPushMocked.mockRejectedValue(econnError);
@@ -1928,19 +1924,9 @@ describe('publish:github', () => {
     mockOctokit.rest.git.getRef.mockResolvedValue({
       data: { object: { sha: 'head-sha' } },
     });
-    mockOctokit.rest.git.getCommit.mockResolvedValue({
-      data: { tree: { sha: 'tree-sha' } },
+    mockOctokit.graphql.mockResolvedValue({
+      createCommitOnBranch: { commit: { oid: 'new-commit-sha' } },
     });
-    mockOctokit.rest.git.createBlob.mockResolvedValue({
-      data: { sha: 'blob-sha' },
-    });
-    mockOctokit.rest.git.createTree.mockResolvedValue({
-      data: { sha: 'new-tree-sha' },
-    });
-    mockOctokit.rest.git.createCommit.mockResolvedValue({
-      data: { sha: 'new-commit-sha' },
-    });
-    mockOctokit.rest.git.updateRef.mockResolvedValue({ data: {} });
 
     await action.handler({
       ...mockContext,
@@ -1948,10 +1934,24 @@ describe('publish:github', () => {
     });
 
     expect(initRepoAndPush).toHaveBeenCalled();
-    expect(mockOctokit.rest.git.createBlob).toHaveBeenCalledTimes(2);
-    expect(mockOctokit.rest.git.createTree).toHaveBeenCalled();
-    expect(mockOctokit.rest.git.createCommit).toHaveBeenCalled();
-    expect(mockOctokit.rest.git.updateRef).toHaveBeenCalled();
+    expect(mockOctokit.graphql).toHaveBeenCalledWith(
+      expect.stringContaining('createCommitOnBranch'),
+      expect.objectContaining({
+        input: expect.objectContaining({
+          branch: {
+            repositoryNameWithOwner: 'owner/repo',
+            branchName: 'main',
+          },
+          expectedHeadOid: 'head-sha',
+          fileChanges: {
+            additions: expect.arrayContaining([
+              expect.objectContaining({ path: 'README.md' }),
+              expect.objectContaining({ path: 'index.ts' }),
+            ]),
+          },
+        }),
+      }),
+    );
     expect(mockContext.output).toHaveBeenCalledWith(
       'commitHash',
       'new-commit-sha',
@@ -1984,19 +1984,9 @@ describe('publish:github', () => {
     mockOctokit.rest.repos.createOrUpdateFileContents.mockResolvedValue({
       data: { commit: { sha: 'init-sha' } },
     });
-    mockOctokit.rest.git.getCommit.mockResolvedValue({
-      data: { tree: { sha: 'tree-sha' } },
+    mockOctokit.graphql.mockResolvedValue({
+      createCommitOnBranch: { commit: { oid: 'new-commit-sha' } },
     });
-    mockOctokit.rest.git.createBlob.mockResolvedValue({
-      data: { sha: 'blob-sha' },
-    });
-    mockOctokit.rest.git.createTree.mockResolvedValue({
-      data: { sha: 'new-tree-sha' },
-    });
-    mockOctokit.rest.git.createCommit.mockResolvedValue({
-      data: { sha: 'new-commit-sha' },
-    });
-    mockOctokit.rest.git.updateRef.mockResolvedValue({ data: {} });
 
     await action.handler({
       ...mockContext,
@@ -2012,7 +2002,14 @@ describe('publish:github', () => {
         path: '.gitkeep',
       }),
     );
-    expect(mockOctokit.rest.git.createCommit).toHaveBeenCalled();
+    expect(mockOctokit.graphql).toHaveBeenCalledWith(
+      expect.stringContaining('createCommitOnBranch'),
+      expect.objectContaining({
+        input: expect.objectContaining({
+          expectedHeadOid: 'init-sha',
+        }),
+      }),
+    );
   });
 
   it('should rethrow non-ECONNRESET errors from git push', async () => {
@@ -2034,6 +2031,6 @@ describe('publish:github', () => {
       'Authentication failed',
     );
 
-    expect(mockOctokit.rest.git.createBlob).not.toHaveBeenCalled();
+    expect(mockOctokit.graphql).not.toHaveBeenCalled();
   });
 });

--- a/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
@@ -47,15 +47,14 @@ import {
   enableBranchProtectionOnDefaultRepoBranch,
   entityRefToName,
 } from './gitHelpers';
+import { promises as fsPromises } from 'node:fs';
+import { Octokit } from 'octokit';
 
 const publicKey = '2Sg8iYjAxxmI2LvUXpJjkYrMxURPc8r+dB7TJyvvcCU=';
 
 const initRepoAndPushMocked = initRepoAndPush as jest.Mock<
   Promise<{ commitHash: string }>
 >;
-
-import { promises as fsPromises } from 'node:fs';
-import { Octokit } from 'octokit';
 
 const octokitMock = Octokit as unknown as jest.Mock;
 const mockOctokit = {
@@ -1921,6 +1920,7 @@ describe('publish:github', () => {
         name: string;
         isDirectory?: boolean;
         isSymbolicLink?: boolean;
+        isFile?: boolean;
       }[],
       content: Buffer = Buffer.from('file content'),
     ) {
@@ -1929,6 +1929,9 @@ describe('publish:github', () => {
           name: f.name,
           isDirectory: () => f.isDirectory ?? false,
           isSymbolicLink: () => f.isSymbolicLink ?? false,
+          isFile: () =>
+            f.isFile ??
+            (!(f.isDirectory ?? false) && !(f.isSymbolicLink ?? false)),
         })),
       );
       readFileSpy.mockResolvedValue(content);
@@ -2167,11 +2170,13 @@ describe('publish:github', () => {
           name: 'README.md',
           isDirectory: () => false,
           isSymbolicLink: () => false,
+          isFile: () => true,
         },
         {
           name: 'dangerous-link',
           isDirectory: () => false,
           isSymbolicLink: () => true,
+          isFile: () => false,
         },
       ]);
       readFileSpy.mockResolvedValue(Buffer.from('content'));
@@ -2194,6 +2199,46 @@ describe('publish:github', () => {
       expect(additions[0].path).toBe('README.md');
     });
 
+    it('should skip unsupported filesystem entry types during file collection', async () => {
+      const econnError = new Error('socket hang up');
+      (econnError as NodeJS.ErrnoException).code = 'ECONNRESET';
+      setupFallbackMocks(econnError);
+
+      readdirSpy.mockResolvedValue([
+        {
+          name: 'README.md',
+          isDirectory: () => false,
+          isSymbolicLink: () => false,
+          isFile: () => true,
+        },
+        {
+          name: 'socket.sock',
+          isDirectory: () => false,
+          isSymbolicLink: () => false,
+          isFile: () => false,
+        },
+      ]);
+      readFileSpy.mockResolvedValue(Buffer.from('content'));
+
+      mockOctokit.rest.git.getRef.mockResolvedValue({
+        data: { object: { sha: 'head-sha' } },
+      });
+      mockOctokit.graphql.mockResolvedValue({
+        createCommitOnBranch: { commit: { oid: 'unsupported-type-sha' } },
+      });
+
+      await action.handler({
+        ...mockContext,
+        input: { ...mockContext.input, protectDefaultBranch: false },
+      });
+
+      expect(readFileSpy).toHaveBeenCalledTimes(1);
+      const graphqlCall = mockOctokit.graphql.mock.calls[0];
+      const additions = graphqlCall[1].input.fileChanges.additions;
+      expect(additions).toHaveLength(1);
+      expect(additions[0].path).toBe('README.md');
+    });
+
     it('should collect files from nested directories with correct paths', async () => {
       const econnError = new Error('socket hang up');
       (econnError as NodeJS.ErrnoException).code = 'ECONNRESET';
@@ -2205,16 +2250,19 @@ describe('publish:github', () => {
             name: 'README.md',
             isDirectory: () => false,
             isSymbolicLink: () => false,
+            isFile: () => true,
           },
           {
             name: '.git',
             isDirectory: () => true,
             isSymbolicLink: () => false,
+            isFile: () => false,
           },
           {
             name: 'src',
             isDirectory: () => true,
             isSymbolicLink: () => false,
+            isFile: () => false,
           },
         ])
         .mockResolvedValueOnce([
@@ -2222,11 +2270,13 @@ describe('publish:github', () => {
             name: 'index.ts',
             isDirectory: () => false,
             isSymbolicLink: () => false,
+            isFile: () => true,
           },
           {
             name: 'utils',
             isDirectory: () => true,
             isSymbolicLink: () => false,
+            isFile: () => false,
           },
         ])
         .mockResolvedValueOnce([
@@ -2234,6 +2284,7 @@ describe('publish:github', () => {
             name: 'helper.ts',
             isDirectory: () => false,
             isSymbolicLink: () => false,
+            isFile: () => true,
           },
         ]);
       readFileSpy.mockResolvedValue(Buffer.from('content'));

--- a/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
@@ -13,6 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+jest.mock('node:fs', () => {
+  const actual = jest.requireActual('node:fs');
+  return {
+    ...actual,
+    promises: {
+      ...actual.promises,
+      readdir: jest.fn().mockResolvedValue([]),
+      readFile: jest.fn().mockResolvedValue(Buffer.from('test content')),
+    },
+  };
+});
+
 jest.mock('./gitHelpers', () => {
   return {
     ...jest.requireActual('./gitHelpers'),
@@ -54,6 +66,7 @@ const initRepoAndPushMocked = initRepoAndPush as jest.Mock<
   Promise<{ commitHash: string }>
 >;
 
+import { promises as fsPromises } from 'node:fs';
 import { Octokit } from 'octokit';
 
 const octokitMock = Octokit as unknown as jest.Mock;
@@ -67,6 +80,7 @@ const mockOctokit = {
       createInOrg: jest.fn(),
       createForAuthenticatedUser: jest.fn(),
       replaceAllTopics: jest.fn(),
+      createOrUpdateFileContents: jest.fn(),
     },
     teams: {
       getByName: jest.fn(),
@@ -79,6 +93,14 @@ const mockOctokit = {
     },
     activity: {
       setRepoSubscription: jest.fn(),
+    },
+    git: {
+      getRef: jest.fn(),
+      getCommit: jest.fn(),
+      createBlob: jest.fn(),
+      createTree: jest.fn(),
+      createCommit: jest.fn(),
+      updateRef: jest.fn(),
     },
   },
   request: jest.fn(),
@@ -1878,5 +1900,140 @@ describe('publish:github', () => {
       subscribed: true,
       ignored: false,
     });
+  });
+
+  it('should fall back to REST API when git push fails with ECONNRESET', async () => {
+    const econnError = new Error('socket hang up');
+    (econnError as NodeJS.ErrnoException).code = 'ECONNRESET';
+    initRepoAndPushMocked.mockRejectedValue(econnError);
+
+    mockOctokit.rest.users.getByUsername.mockResolvedValue({
+      data: { type: 'User' },
+    });
+    mockOctokit.rest.repos.createForAuthenticatedUser.mockResolvedValue({
+      data: {
+        clone_url: 'https://github.com/clone/url.git',
+        html_url: 'https://github.com/html/url',
+      },
+    });
+
+    (fsPromises.readdir as jest.Mock).mockResolvedValue([
+      { name: 'README.md', isDirectory: () => false },
+      { name: 'index.ts', isDirectory: () => false },
+    ]);
+    (fsPromises.readFile as jest.Mock).mockResolvedValue(
+      Buffer.from('file content'),
+    );
+
+    mockOctokit.rest.git.getRef.mockResolvedValue({
+      data: { object: { sha: 'head-sha' } },
+    });
+    mockOctokit.rest.git.getCommit.mockResolvedValue({
+      data: { tree: { sha: 'tree-sha' } },
+    });
+    mockOctokit.rest.git.createBlob.mockResolvedValue({
+      data: { sha: 'blob-sha' },
+    });
+    mockOctokit.rest.git.createTree.mockResolvedValue({
+      data: { sha: 'new-tree-sha' },
+    });
+    mockOctokit.rest.git.createCommit.mockResolvedValue({
+      data: { sha: 'new-commit-sha' },
+    });
+    mockOctokit.rest.git.updateRef.mockResolvedValue({ data: {} });
+
+    await action.handler({
+      ...mockContext,
+      input: { ...mockContext.input, protectDefaultBranch: false },
+    });
+
+    expect(initRepoAndPush).toHaveBeenCalled();
+    expect(mockOctokit.rest.git.createBlob).toHaveBeenCalledTimes(2);
+    expect(mockOctokit.rest.git.createTree).toHaveBeenCalled();
+    expect(mockOctokit.rest.git.createCommit).toHaveBeenCalled();
+    expect(mockOctokit.rest.git.updateRef).toHaveBeenCalled();
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'commitHash',
+      'new-commit-sha',
+    );
+  });
+
+  it('should initialize empty repo via Contents API in fallback', async () => {
+    const econnError = new Error('socket hang up');
+    (econnError as NodeJS.ErrnoException).code = 'ECONNRESET';
+    initRepoAndPushMocked.mockRejectedValue(econnError);
+
+    mockOctokit.rest.users.getByUsername.mockResolvedValue({
+      data: { type: 'User' },
+    });
+    mockOctokit.rest.repos.createForAuthenticatedUser.mockResolvedValue({
+      data: {
+        clone_url: 'https://github.com/clone/url.git',
+        html_url: 'https://github.com/html/url',
+      },
+    });
+
+    (fsPromises.readdir as jest.Mock).mockResolvedValue([
+      { name: 'README.md', isDirectory: () => false },
+    ]);
+    (fsPromises.readFile as jest.Mock).mockResolvedValue(
+      Buffer.from('content'),
+    );
+
+    mockOctokit.rest.git.getRef.mockRejectedValue(new Error('Not Found'));
+    mockOctokit.rest.repos.createOrUpdateFileContents.mockResolvedValue({
+      data: { commit: { sha: 'init-sha' } },
+    });
+    mockOctokit.rest.git.getCommit.mockResolvedValue({
+      data: { tree: { sha: 'tree-sha' } },
+    });
+    mockOctokit.rest.git.createBlob.mockResolvedValue({
+      data: { sha: 'blob-sha' },
+    });
+    mockOctokit.rest.git.createTree.mockResolvedValue({
+      data: { sha: 'new-tree-sha' },
+    });
+    mockOctokit.rest.git.createCommit.mockResolvedValue({
+      data: { sha: 'new-commit-sha' },
+    });
+    mockOctokit.rest.git.updateRef.mockResolvedValue({ data: {} });
+
+    await action.handler({
+      ...mockContext,
+      input: { ...mockContext.input, protectDefaultBranch: false },
+    });
+
+    expect(
+      mockOctokit.rest.repos.createOrUpdateFileContents,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: 'owner',
+        repo: 'repo',
+        path: '.gitkeep',
+      }),
+    );
+    expect(mockOctokit.rest.git.createCommit).toHaveBeenCalled();
+  });
+
+  it('should rethrow non-ECONNRESET errors from git push', async () => {
+    const authError = new Error('Authentication failed');
+    (authError as NodeJS.ErrnoException).code = 'AuthError';
+    initRepoAndPushMocked.mockRejectedValue(authError);
+
+    mockOctokit.rest.users.getByUsername.mockResolvedValue({
+      data: { type: 'User' },
+    });
+    mockOctokit.rest.repos.createForAuthenticatedUser.mockResolvedValue({
+      data: {
+        clone_url: 'https://github.com/clone/url.git',
+        html_url: 'https://github.com/html/url',
+      },
+    });
+
+    await expect(action.handler(mockContext)).rejects.toThrow(
+      'Authentication failed',
+    );
+
+    expect(mockOctokit.rest.git.createBlob).not.toHaveBeenCalled();
   });
 });

--- a/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
@@ -2018,6 +2018,53 @@ describe('publish:github', () => {
     );
   });
 
+  it('should fall back to GraphQL API when error.cause.code is ECONNRESET', async () => {
+    const wrappedError = new Error('request failed');
+    (wrappedError as any).cause = Object.assign(new Error('socket hang up'), {
+      code: 'ECONNRESET',
+    });
+    initRepoAndPushMocked.mockRejectedValue(wrappedError);
+
+    mockOctokit.rest.users.getByUsername.mockResolvedValue({
+      data: { type: 'User' },
+    });
+    mockOctokit.rest.repos.createForAuthenticatedUser.mockResolvedValue({
+      data: {
+        clone_url: 'https://github.com/clone/url.git',
+        html_url: 'https://github.com/html/url',
+      },
+    });
+
+    (fsPromises.readdir as jest.Mock).mockResolvedValue([
+      { name: 'README.md', isDirectory: () => false },
+    ]);
+    (fsPromises.readFile as jest.Mock).mockResolvedValue(
+      Buffer.from('content'),
+    );
+
+    mockOctokit.rest.git.getRef.mockResolvedValue({
+      data: { object: { sha: 'head-sha' } },
+    });
+    mockOctokit.graphql.mockResolvedValue({
+      createCommitOnBranch: { commit: { oid: 'cause-commit-sha' } },
+    });
+
+    await action.handler({
+      ...mockContext,
+      input: { ...mockContext.input, protectDefaultBranch: false },
+    });
+
+    expect(initRepoAndPush).toHaveBeenCalled();
+    expect(mockOctokit.graphql).toHaveBeenCalledWith(
+      expect.stringContaining('createCommitOnBranch'),
+      expect.anything(),
+    );
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'commitHash',
+      'cause-commit-sha',
+    );
+  });
+
   it('should rethrow non-ECONNRESET errors from git push', async () => {
     const authError = new Error('Authentication failed');
     (authError as NodeJS.ErrnoException).code = 'AuthError';

--- a/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
@@ -64,7 +64,9 @@ const mockOctokit = {
       getByUsername: jest.fn(),
     },
     repos: {
-      get: jest.fn().mockResolvedValue({ data: {} }),
+      get: jest
+        .fn()
+        .mockResolvedValue({ data: { size: 0, default_branch: 'main' } }),
       addCollaborator: jest.fn(),
       createInOrg: jest.fn(),
       createForAuthenticatedUser: jest.fn(),
@@ -2014,6 +2016,9 @@ describe('publish:github', () => {
         status: 404,
       });
       mockOctokit.rest.git.getRef.mockRejectedValue(notFoundError);
+      mockOctokit.rest.repos.get.mockResolvedValue({
+        data: { size: 0, default_branch: 'main' },
+      });
       mockOctokit.rest.repos.createOrUpdateFileContents.mockResolvedValue({
         data: { commit: { sha: 'init-sha' } },
       });
@@ -2187,6 +2192,129 @@ describe('publish:github', () => {
       const additions = graphqlCall[1].input.fileChanges.additions;
       expect(additions).toHaveLength(1);
       expect(additions[0].path).toBe('README.md');
+    });
+
+    it('should collect files from nested directories with correct paths', async () => {
+      const econnError = new Error('socket hang up');
+      (econnError as NodeJS.ErrnoException).code = 'ECONNRESET';
+      setupFallbackMocks(econnError);
+
+      readdirSpy
+        .mockResolvedValueOnce([
+          {
+            name: 'README.md',
+            isDirectory: () => false,
+            isSymbolicLink: () => false,
+          },
+          {
+            name: '.git',
+            isDirectory: () => true,
+            isSymbolicLink: () => false,
+          },
+          {
+            name: 'src',
+            isDirectory: () => true,
+            isSymbolicLink: () => false,
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            name: 'index.ts',
+            isDirectory: () => false,
+            isSymbolicLink: () => false,
+          },
+          {
+            name: 'utils',
+            isDirectory: () => true,
+            isSymbolicLink: () => false,
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            name: 'helper.ts',
+            isDirectory: () => false,
+            isSymbolicLink: () => false,
+          },
+        ]);
+      readFileSpy.mockResolvedValue(Buffer.from('content'));
+
+      mockOctokit.rest.git.getRef.mockResolvedValue({
+        data: { object: { sha: 'head-sha' } },
+      });
+      mockOctokit.graphql.mockResolvedValue({
+        createCommitOnBranch: { commit: { oid: 'nested-sha' } },
+      });
+
+      await action.handler({
+        ...mockContext,
+        input: { ...mockContext.input, protectDefaultBranch: false },
+      });
+
+      const graphqlCall = mockOctokit.graphql.mock.calls[0];
+      const additions = graphqlCall[1].input.fileChanges.additions;
+      const paths = additions.map((a: { path: string }) => a.path).sort();
+      expect(paths).toEqual([
+        'README.md',
+        'src/index.ts',
+        'src/utils/helper.ts',
+      ]);
+    });
+
+    it('should throw when getRef returns 404 and repo is non-empty (wrong branch)', async () => {
+      const econnError = new Error('socket hang up');
+      (econnError as NodeJS.ErrnoException).code = 'ECONNRESET';
+      setupFallbackMocks(econnError);
+      mockFilesOnDisk([{ name: 'README.md' }]);
+
+      const refNotFound = Object.assign(new Error('Not Found'), {
+        status: 404,
+      });
+      mockOctokit.rest.git.getRef.mockRejectedValue(refNotFound);
+      mockOctokit.rest.repos.get.mockResolvedValue({
+        data: { size: 100, default_branch: 'master' },
+      });
+
+      await expect(
+        action.handler({
+          ...mockContext,
+          input: { ...mockContext.input, protectDefaultBranch: false },
+        }),
+      ).rejects.toThrow("Branch 'main' not found");
+
+      expect(
+        mockOctokit.rest.repos.createOrUpdateFileContents,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('should retry once on HEAD OID mismatch', async () => {
+      const econnError = new Error('socket hang up');
+      (econnError as NodeJS.ErrnoException).code = 'ECONNRESET';
+      setupFallbackMocks(econnError);
+      mockFilesOnDisk([{ name: 'README.md' }]);
+
+      mockOctokit.rest.git.getRef
+        .mockResolvedValueOnce({
+          data: { object: { sha: 'stale-sha' } },
+        })
+        .mockResolvedValueOnce({
+          data: { object: { sha: 'fresh-sha' } },
+        });
+      mockOctokit.graphql
+        .mockRejectedValueOnce(new Error('expectedHeadOid does not match'))
+        .mockResolvedValueOnce({
+          createCommitOnBranch: { commit: { oid: 'retry-commit-sha' } },
+        });
+
+      await action.handler({
+        ...mockContext,
+        input: { ...mockContext.input, protectDefaultBranch: false },
+      });
+
+      expect(mockOctokit.graphql).toHaveBeenCalledTimes(2);
+      expect(mockContext.output).toHaveBeenCalledWith(
+        'commitHash',
+        'retry-commit-sha',
+      );
     });
 
     it('should rethrow non-connection errors from git push', async () => {

--- a/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
@@ -2012,6 +2012,58 @@ describe('publish:github', () => {
     );
   });
 
+  it('should skip git push and use GraphQL API when HTTP proxy is detected', async () => {
+    const originalEnv = process.env.HTTPS_PROXY;
+    process.env.HTTPS_PROXY = 'http://proxy:3128';
+
+    try {
+      mockOctokit.rest.users.getByUsername.mockResolvedValue({
+        data: { type: 'User' },
+      });
+      mockOctokit.rest.repos.createForAuthenticatedUser.mockResolvedValue({
+        data: {
+          clone_url: 'https://github.com/clone/url.git',
+          html_url: 'https://github.com/html/url',
+        },
+      });
+
+      (fsPromises.readdir as jest.Mock).mockResolvedValue([
+        { name: 'README.md', isDirectory: () => false },
+      ]);
+      (fsPromises.readFile as jest.Mock).mockResolvedValue(
+        Buffer.from('content'),
+      );
+
+      mockOctokit.rest.git.getRef.mockResolvedValue({
+        data: { object: { sha: 'head-sha' } },
+      });
+      mockOctokit.graphql.mockResolvedValue({
+        createCommitOnBranch: { commit: { oid: 'proxy-commit-sha' } },
+      });
+
+      await action.handler({
+        ...mockContext,
+        input: { ...mockContext.input, protectDefaultBranch: false },
+      });
+
+      expect(initRepoAndPush).not.toHaveBeenCalled();
+      expect(mockOctokit.graphql).toHaveBeenCalledWith(
+        expect.stringContaining('createCommitOnBranch'),
+        expect.anything(),
+      );
+      expect(mockContext.output).toHaveBeenCalledWith(
+        'commitHash',
+        'proxy-commit-sha',
+      );
+    } finally {
+      if (originalEnv === undefined) {
+        delete process.env.HTTPS_PROXY;
+      } else {
+        process.env.HTTPS_PROXY = originalEnv;
+      }
+    }
+  });
+
   it('should rethrow non-ECONNRESET errors from git push', async () => {
     const authError = new Error('Authentication failed');
     (authError as NodeJS.ErrnoException).code = 'AuthError';

--- a/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
@@ -2012,58 +2012,6 @@ describe('publish:github', () => {
     );
   });
 
-  it('should skip git push and use GraphQL API when HTTP proxy is detected', async () => {
-    const originalEnv = process.env.HTTPS_PROXY;
-    process.env.HTTPS_PROXY = 'http://proxy:3128';
-
-    try {
-      mockOctokit.rest.users.getByUsername.mockResolvedValue({
-        data: { type: 'User' },
-      });
-      mockOctokit.rest.repos.createForAuthenticatedUser.mockResolvedValue({
-        data: {
-          clone_url: 'https://github.com/clone/url.git',
-          html_url: 'https://github.com/html/url',
-        },
-      });
-
-      (fsPromises.readdir as jest.Mock).mockResolvedValue([
-        { name: 'README.md', isDirectory: () => false },
-      ]);
-      (fsPromises.readFile as jest.Mock).mockResolvedValue(
-        Buffer.from('content'),
-      );
-
-      mockOctokit.rest.git.getRef.mockResolvedValue({
-        data: { object: { sha: 'head-sha' } },
-      });
-      mockOctokit.graphql.mockResolvedValue({
-        createCommitOnBranch: { commit: { oid: 'proxy-commit-sha' } },
-      });
-
-      await action.handler({
-        ...mockContext,
-        input: { ...mockContext.input, protectDefaultBranch: false },
-      });
-
-      expect(initRepoAndPush).not.toHaveBeenCalled();
-      expect(mockOctokit.graphql).toHaveBeenCalledWith(
-        expect.stringContaining('createCommitOnBranch'),
-        expect.anything(),
-      );
-      expect(mockContext.output).toHaveBeenCalledWith(
-        'commitHash',
-        'proxy-commit-sha',
-      );
-    } finally {
-      if (originalEnv === undefined) {
-        delete process.env.HTTPS_PROXY;
-      } else {
-        process.env.HTTPS_PROXY = originalEnv;
-      }
-    }
-  });
-
   it('should rethrow non-ECONNRESET errors from git push', async () => {
     const authError = new Error('Authentication failed');
     (authError as NodeJS.ErrnoException).code = 'AuthError';

--- a/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
@@ -1980,7 +1980,10 @@ describe('publish:github', () => {
       Buffer.from('content'),
     );
 
-    mockOctokit.rest.git.getRef.mockRejectedValue(new Error('Not Found'));
+    const notFoundError = Object.assign(new Error('Not Found'), {
+      status: 404,
+    });
+    mockOctokit.rest.git.getRef.mockRejectedValue(notFoundError);
     mockOctokit.rest.repos.createOrUpdateFileContents.mockResolvedValue({
       data: { commit: { sha: 'init-sha' } },
     });
@@ -2007,6 +2010,9 @@ describe('publish:github', () => {
       expect.objectContaining({
         input: expect.objectContaining({
           expectedHeadOid: 'init-sha',
+          fileChanges: expect.objectContaining({
+            deletions: [{ path: '.gitkeep' }],
+          }),
         }),
       }),
     );

--- a/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
@@ -13,18 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-jest.mock('node:fs', () => {
-  const actual = jest.requireActual('node:fs');
-  return {
-    ...actual,
-    promises: {
-      ...actual.promises,
-      readdir: jest.fn().mockResolvedValue([]),
-      readFile: jest.fn().mockResolvedValue(Buffer.from('test content')),
-    },
-  };
-});
-
 jest.mock('./gitHelpers', () => {
   return {
     ...jest.requireActual('./gitHelpers'),
@@ -76,6 +64,7 @@ const mockOctokit = {
       getByUsername: jest.fn(),
     },
     repos: {
+      get: jest.fn().mockResolvedValue({ data: {} }),
       addCollaborator: jest.fn(),
       createInOrg: jest.fn(),
       createForAuthenticatedUser: jest.fn(),
@@ -1898,192 +1887,328 @@ describe('publish:github', () => {
     });
   });
 
-  it('should fall back to GraphQL API when git push fails with ECONNRESET', async () => {
-    const econnError = new Error('socket hang up');
-    (econnError as NodeJS.ErrnoException).code = 'ECONNRESET';
-    initRepoAndPushMocked.mockRejectedValue(econnError);
+  describe('GraphQL API fallback', () => {
+    let readdirSpy: jest.SpyInstance;
+    let readFileSpy: jest.SpyInstance;
 
-    mockOctokit.rest.users.getByUsername.mockResolvedValue({
-      data: { type: 'User' },
-    });
-    mockOctokit.rest.repos.createForAuthenticatedUser.mockResolvedValue({
-      data: {
-        clone_url: 'https://github.com/clone/url.git',
-        html_url: 'https://github.com/html/url',
-      },
+    beforeEach(() => {
+      readdirSpy = jest.spyOn(fsPromises, 'readdir');
+      readFileSpy = jest.spyOn(fsPromises, 'readFile');
     });
 
-    (fsPromises.readdir as jest.Mock).mockResolvedValue([
-      { name: 'README.md', isDirectory: () => false },
-      { name: 'index.ts', isDirectory: () => false },
-    ]);
-    (fsPromises.readFile as jest.Mock).mockResolvedValue(
-      Buffer.from('file content'),
-    );
-
-    mockOctokit.rest.git.getRef.mockResolvedValue({
-      data: { object: { sha: 'head-sha' } },
-    });
-    mockOctokit.graphql.mockResolvedValue({
-      createCommitOnBranch: { commit: { oid: 'new-commit-sha' } },
+    afterEach(() => {
+      readdirSpy.mockRestore();
+      readFileSpy.mockRestore();
     });
 
-    await action.handler({
-      ...mockContext,
-      input: { ...mockContext.input, protectDefaultBranch: false },
-    });
+    function setupFallbackMocks(error: Error) {
+      initRepoAndPushMocked.mockRejectedValue(error);
+      mockOctokit.rest.users.getByUsername.mockResolvedValue({
+        data: { type: 'User' },
+      });
+      mockOctokit.rest.repos.createForAuthenticatedUser.mockResolvedValue({
+        data: {
+          clone_url: 'https://github.com/clone/url.git',
+          html_url: 'https://github.com/html/url',
+        },
+      });
+    }
 
-    expect(initRepoAndPush).toHaveBeenCalled();
-    expect(mockOctokit.graphql).toHaveBeenCalledWith(
-      expect.stringContaining('createCommitOnBranch'),
-      expect.objectContaining({
-        input: expect.objectContaining({
-          branch: {
-            repositoryNameWithOwner: 'owner/repo',
-            branchName: 'main',
-          },
-          expectedHeadOid: 'head-sha',
-          fileChanges: {
-            additions: expect.arrayContaining([
-              expect.objectContaining({ path: 'README.md' }),
-              expect.objectContaining({ path: 'index.ts' }),
-            ]),
-          },
-        }),
-      }),
-    );
-    expect(mockContext.output).toHaveBeenCalledWith(
-      'commitHash',
-      'new-commit-sha',
-    );
-  });
+    function mockFilesOnDisk(
+      files: {
+        name: string;
+        isDirectory?: boolean;
+        isSymbolicLink?: boolean;
+      }[],
+      content: Buffer = Buffer.from('file content'),
+    ) {
+      readdirSpy.mockResolvedValue(
+        files.map(f => ({
+          name: f.name,
+          isDirectory: () => f.isDirectory ?? false,
+          isSymbolicLink: () => f.isSymbolicLink ?? false,
+        })),
+      );
+      readFileSpy.mockResolvedValue(content);
+    }
 
-  it('should initialize empty repo via Contents API in fallback', async () => {
-    const econnError = new Error('socket hang up');
-    (econnError as NodeJS.ErrnoException).code = 'ECONNRESET';
-    initRepoAndPushMocked.mockRejectedValue(econnError);
+    it('should fall back to GraphQL API when git push fails with ECONNRESET', async () => {
+      const econnError = new Error('socket hang up');
+      (econnError as NodeJS.ErrnoException).code = 'ECONNRESET';
+      setupFallbackMocks(econnError);
+      mockFilesOnDisk([{ name: 'README.md' }, { name: 'index.ts' }]);
 
-    mockOctokit.rest.users.getByUsername.mockResolvedValue({
-      data: { type: 'User' },
-    });
-    mockOctokit.rest.repos.createForAuthenticatedUser.mockResolvedValue({
-      data: {
-        clone_url: 'https://github.com/clone/url.git',
-        html_url: 'https://github.com/html/url',
-      },
-    });
+      mockOctokit.rest.git.getRef.mockResolvedValue({
+        data: { object: { sha: 'head-sha' } },
+      });
+      mockOctokit.graphql.mockResolvedValue({
+        createCommitOnBranch: { commit: { oid: 'new-commit-sha' } },
+      });
 
-    (fsPromises.readdir as jest.Mock).mockResolvedValue([
-      { name: 'README.md', isDirectory: () => false },
-    ]);
-    (fsPromises.readFile as jest.Mock).mockResolvedValue(
-      Buffer.from('content'),
-    );
+      await action.handler({
+        ...mockContext,
+        input: { ...mockContext.input, protectDefaultBranch: false },
+      });
 
-    const notFoundError = Object.assign(new Error('Not Found'), {
-      status: 404,
-    });
-    mockOctokit.rest.git.getRef.mockRejectedValue(notFoundError);
-    mockOctokit.rest.repos.createOrUpdateFileContents.mockResolvedValue({
-      data: { commit: { sha: 'init-sha' } },
-    });
-    mockOctokit.graphql.mockResolvedValue({
-      createCommitOnBranch: { commit: { oid: 'new-commit-sha' } },
-    });
-
-    await action.handler({
-      ...mockContext,
-      input: { ...mockContext.input, protectDefaultBranch: false },
-    });
-
-    expect(
-      mockOctokit.rest.repos.createOrUpdateFileContents,
-    ).toHaveBeenCalledWith(
-      expect.objectContaining({
-        owner: 'owner',
-        repo: 'repo',
-        path: '.gitkeep',
-      }),
-    );
-    expect(mockOctokit.graphql).toHaveBeenCalledWith(
-      expect.stringContaining('createCommitOnBranch'),
-      expect.objectContaining({
-        input: expect.objectContaining({
-          expectedHeadOid: 'init-sha',
-          fileChanges: expect.objectContaining({
-            deletions: [{ path: '.gitkeep' }],
+      expect(initRepoAndPush).toHaveBeenCalled();
+      expect(mockOctokit.graphql).toHaveBeenCalledWith(
+        expect.stringContaining('createCommitOnBranch'),
+        expect.objectContaining({
+          input: expect.objectContaining({
+            branch: {
+              repositoryNameWithOwner: 'owner/repo',
+              branchName: 'main',
+            },
+            expectedHeadOid: 'head-sha',
+            fileChanges: {
+              additions: expect.arrayContaining([
+                expect.objectContaining({ path: 'README.md' }),
+                expect.objectContaining({ path: 'index.ts' }),
+              ]),
+            },
           }),
         }),
-      }),
-    );
-  });
-
-  it('should fall back to GraphQL API when error.cause.code is ECONNRESET', async () => {
-    const wrappedError = new Error('request failed');
-    (wrappedError as any).cause = Object.assign(new Error('socket hang up'), {
-      code: 'ECONNRESET',
-    });
-    initRepoAndPushMocked.mockRejectedValue(wrappedError);
-
-    mockOctokit.rest.users.getByUsername.mockResolvedValue({
-      data: { type: 'User' },
-    });
-    mockOctokit.rest.repos.createForAuthenticatedUser.mockResolvedValue({
-      data: {
-        clone_url: 'https://github.com/clone/url.git',
-        html_url: 'https://github.com/html/url',
-      },
+      );
+      expect(mockContext.output).toHaveBeenCalledWith(
+        'commitHash',
+        'new-commit-sha',
+      );
     });
 
-    (fsPromises.readdir as jest.Mock).mockResolvedValue([
-      { name: 'README.md', isDirectory: () => false },
-    ]);
-    (fsPromises.readFile as jest.Mock).mockResolvedValue(
-      Buffer.from('content'),
-    );
+    it('should fall back to GraphQL API when git push fails with ECONNREFUSED', async () => {
+      const econnError = new Error('connect ECONNREFUSED');
+      (econnError as NodeJS.ErrnoException).code = 'ECONNREFUSED';
+      setupFallbackMocks(econnError);
+      mockFilesOnDisk([{ name: 'README.md' }]);
 
-    mockOctokit.rest.git.getRef.mockResolvedValue({
-      data: { object: { sha: 'head-sha' } },
-    });
-    mockOctokit.graphql.mockResolvedValue({
-      createCommitOnBranch: { commit: { oid: 'cause-commit-sha' } },
-    });
+      mockOctokit.rest.git.getRef.mockResolvedValue({
+        data: { object: { sha: 'head-sha' } },
+      });
+      mockOctokit.graphql.mockResolvedValue({
+        createCommitOnBranch: { commit: { oid: 'refused-commit-sha' } },
+      });
 
-    await action.handler({
-      ...mockContext,
-      input: { ...mockContext.input, protectDefaultBranch: false },
-    });
+      await action.handler({
+        ...mockContext,
+        input: { ...mockContext.input, protectDefaultBranch: false },
+      });
 
-    expect(initRepoAndPush).toHaveBeenCalled();
-    expect(mockOctokit.graphql).toHaveBeenCalledWith(
-      expect.stringContaining('createCommitOnBranch'),
-      expect.anything(),
-    );
-    expect(mockContext.output).toHaveBeenCalledWith(
-      'commitHash',
-      'cause-commit-sha',
-    );
-  });
-
-  it('should rethrow non-ECONNRESET errors from git push', async () => {
-    const authError = new Error('Authentication failed');
-    (authError as NodeJS.ErrnoException).code = 'AuthError';
-    initRepoAndPushMocked.mockRejectedValue(authError);
-
-    mockOctokit.rest.users.getByUsername.mockResolvedValue({
-      data: { type: 'User' },
-    });
-    mockOctokit.rest.repos.createForAuthenticatedUser.mockResolvedValue({
-      data: {
-        clone_url: 'https://github.com/clone/url.git',
-        html_url: 'https://github.com/html/url',
-      },
+      expect(initRepoAndPush).toHaveBeenCalled();
+      expect(mockOctokit.graphql).toHaveBeenCalledWith(
+        expect.stringContaining('createCommitOnBranch'),
+        expect.anything(),
+      );
+      expect(mockContext.output).toHaveBeenCalledWith(
+        'commitHash',
+        'refused-commit-sha',
+      );
     });
 
-    await expect(action.handler(mockContext)).rejects.toThrow(
-      'Authentication failed',
-    );
+    it('should initialize empty repo via Contents API in fallback', async () => {
+      const econnError = new Error('socket hang up');
+      (econnError as NodeJS.ErrnoException).code = 'ECONNRESET';
+      setupFallbackMocks(econnError);
+      mockFilesOnDisk([{ name: 'README.md' }], Buffer.from('content'));
 
-    expect(mockOctokit.graphql).not.toHaveBeenCalled();
+      const notFoundError = Object.assign(new Error('Not Found'), {
+        status: 404,
+      });
+      mockOctokit.rest.git.getRef.mockRejectedValue(notFoundError);
+      mockOctokit.rest.repos.createOrUpdateFileContents.mockResolvedValue({
+        data: { commit: { sha: 'init-sha' } },
+      });
+      mockOctokit.graphql.mockResolvedValue({
+        createCommitOnBranch: { commit: { oid: 'new-commit-sha' } },
+      });
+
+      await action.handler({
+        ...mockContext,
+        input: { ...mockContext.input, protectDefaultBranch: false },
+      });
+
+      expect(
+        mockOctokit.rest.repos.createOrUpdateFileContents,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owner: 'owner',
+          repo: 'repo',
+          path: '.gitkeep',
+        }),
+      );
+      expect(mockOctokit.graphql).toHaveBeenCalledWith(
+        expect.stringContaining('createCommitOnBranch'),
+        expect.objectContaining({
+          input: expect.objectContaining({
+            expectedHeadOid: 'init-sha',
+            fileChanges: expect.objectContaining({
+              deletions: [{ path: '.gitkeep' }],
+            }),
+          }),
+        }),
+      );
+    });
+
+    it('should initialize empty repo via Contents API when getRef returns 409', async () => {
+      const econnError = new Error('socket hang up');
+      (econnError as NodeJS.ErrnoException).code = 'ECONNRESET';
+      setupFallbackMocks(econnError);
+      mockFilesOnDisk([{ name: 'README.md' }], Buffer.from('content'));
+
+      const emptyRepoError = Object.assign(
+        new Error('Git Repository is empty.'),
+        { status: 409 },
+      );
+      mockOctokit.rest.git.getRef.mockRejectedValue(emptyRepoError);
+      mockOctokit.rest.repos.createOrUpdateFileContents.mockResolvedValue({
+        data: { commit: { sha: 'init-sha-409' } },
+      });
+      mockOctokit.graphql.mockResolvedValue({
+        createCommitOnBranch: { commit: { oid: 'commit-from-409' } },
+      });
+
+      await action.handler({
+        ...mockContext,
+        input: { ...mockContext.input, protectDefaultBranch: false },
+      });
+
+      expect(
+        mockOctokit.rest.repos.createOrUpdateFileContents,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: '.gitkeep',
+        }),
+      );
+      expect(mockOctokit.graphql).toHaveBeenCalledWith(
+        expect.stringContaining('createCommitOnBranch'),
+        expect.objectContaining({
+          input: expect.objectContaining({
+            expectedHeadOid: 'init-sha-409',
+          }),
+        }),
+      );
+      expect(mockContext.output).toHaveBeenCalledWith(
+        'commitHash',
+        'commit-from-409',
+      );
+    });
+
+    it('should throw when getRef returns 404 and repo does not exist', async () => {
+      const econnError = new Error('socket hang up');
+      (econnError as NodeJS.ErrnoException).code = 'ECONNRESET';
+      setupFallbackMocks(econnError);
+      mockFilesOnDisk([{ name: 'README.md' }], Buffer.from('content'));
+
+      const refNotFound = Object.assign(new Error('Not Found'), {
+        status: 404,
+      });
+      mockOctokit.rest.git.getRef.mockRejectedValue(refNotFound);
+
+      const repoNotFound = Object.assign(new Error('Not Found'), {
+        status: 404,
+      });
+      mockOctokit.rest.repos.get.mockRejectedValue(repoNotFound);
+
+      await expect(
+        action.handler({
+          ...mockContext,
+          input: { ...mockContext.input, protectDefaultBranch: false },
+        }),
+      ).rejects.toThrow('Not Found');
+
+      expect(
+        mockOctokit.rest.repos.createOrUpdateFileContents,
+      ).not.toHaveBeenCalled();
+      expect(mockOctokit.graphql).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to GraphQL API when error.cause.code is ECONNRESET', async () => {
+      const wrappedError = new Error('request failed');
+      (wrappedError as any).cause = Object.assign(new Error('socket hang up'), {
+        code: 'ECONNRESET',
+      });
+      setupFallbackMocks(wrappedError);
+      mockFilesOnDisk([{ name: 'README.md' }], Buffer.from('content'));
+
+      mockOctokit.rest.git.getRef.mockResolvedValue({
+        data: { object: { sha: 'head-sha' } },
+      });
+      mockOctokit.graphql.mockResolvedValue({
+        createCommitOnBranch: { commit: { oid: 'cause-commit-sha' } },
+      });
+
+      await action.handler({
+        ...mockContext,
+        input: { ...mockContext.input, protectDefaultBranch: false },
+      });
+
+      expect(initRepoAndPush).toHaveBeenCalled();
+      expect(mockOctokit.graphql).toHaveBeenCalledWith(
+        expect.stringContaining('createCommitOnBranch'),
+        expect.anything(),
+      );
+      expect(mockContext.output).toHaveBeenCalledWith(
+        'commitHash',
+        'cause-commit-sha',
+      );
+    });
+
+    it('should skip symlinks during file collection in fallback', async () => {
+      const econnError = new Error('socket hang up');
+      (econnError as NodeJS.ErrnoException).code = 'ECONNRESET';
+      setupFallbackMocks(econnError);
+
+      readdirSpy.mockResolvedValue([
+        {
+          name: 'README.md',
+          isDirectory: () => false,
+          isSymbolicLink: () => false,
+        },
+        {
+          name: 'dangerous-link',
+          isDirectory: () => false,
+          isSymbolicLink: () => true,
+        },
+      ]);
+      readFileSpy.mockResolvedValue(Buffer.from('content'));
+
+      mockOctokit.rest.git.getRef.mockResolvedValue({
+        data: { object: { sha: 'head-sha' } },
+      });
+      mockOctokit.graphql.mockResolvedValue({
+        createCommitOnBranch: { commit: { oid: 'symlink-commit-sha' } },
+      });
+
+      await action.handler({
+        ...mockContext,
+        input: { ...mockContext.input, protectDefaultBranch: false },
+      });
+
+      const graphqlCall = mockOctokit.graphql.mock.calls[0];
+      const additions = graphqlCall[1].input.fileChanges.additions;
+      expect(additions).toHaveLength(1);
+      expect(additions[0].path).toBe('README.md');
+    });
+
+    it('should rethrow non-connection errors from git push', async () => {
+      const authError = new Error('Authentication failed');
+      (authError as NodeJS.ErrnoException).code = 'AuthError';
+      initRepoAndPushMocked.mockRejectedValue(authError);
+
+      mockOctokit.rest.users.getByUsername.mockResolvedValue({
+        data: { type: 'User' },
+      });
+      mockOctokit.rest.repos.createForAuthenticatedUser.mockResolvedValue({
+        data: {
+          clone_url: 'https://github.com/clone/url.git',
+          html_url: 'https://github.com/html/url',
+        },
+      });
+
+      await expect(action.handler(mockContext)).rejects.toThrow(
+        'Authentication failed',
+      );
+
+      expect(mockOctokit.graphql).not.toHaveBeenCalled();
+    });
   });
 });

--- a/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
@@ -430,7 +430,7 @@ async function collectFilesFromDir(
       results.push(
         ...(await collectFilesFromDir(fullPath, relativePath, root)),
       );
-    } else {
+    } else if (entry.isFile()) {
       results.push({
         filePath: relativePath,
         content: await fsPromises.readFile(fullPath),

--- a/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
@@ -465,16 +465,16 @@ async function pushFilesViaGitHubApi(input: {
     );
   }
 
-  const MAX_PAYLOAD_BYTES = 50 * 1024 * 1024; // 50 MB
-  const totalBytes = files.reduce((sum, f) => sum + f.content.length, 0);
-  if (totalBytes > MAX_PAYLOAD_BYTES) {
+  const totalRawBytes = files.reduce((sum, f) => sum + f.content.length, 0);
+  // base64 expands content by ~4/3; add 1 KB per file for JSON overhead
+  const estimatedPayload =
+    Math.ceil(totalRawBytes * (4 / 3)) + files.length * 1024;
+  const MAX_PAYLOAD_BYTES = 30 * 1024 * 1024; // 30 MB after encoding
+  if (estimatedPayload > MAX_PAYLOAD_BYTES) {
     throw new Error(
-      `GraphQL API fallback payload too large (${(
-        totalBytes /
-        1024 /
-        1024
-      ).toFixed(1)} MB). ` +
-        'The GitHub GraphQL API limits request size. ' +
+      `GraphQL API fallback payload too large ` +
+        `(${(totalRawBytes / 1024 / 1024).toFixed(1)} MB raw, ` +
+        `~${(estimatedPayload / 1024 / 1024).toFixed(1)} MB encoded). ` +
         'Consider reducing template size or resolving the network issue preventing git push.',
     );
   }
@@ -494,7 +494,13 @@ async function pushFilesViaGitHubApi(input: {
       throw refError;
     }
     if (status === 404) {
-      await client.rest.repos.get({ owner, repo });
+      const { data: repoData } = await client.rest.repos.get({ owner, repo });
+      if (repoData.size > 0) {
+        throw new Error(
+          `Branch '${defaultBranch}' not found in ${owner}/${repo}. ` +
+            `The repository exists and its default branch is '${repoData.default_branch}'.`,
+        );
+      }
     }
     logger.info(
       `No existing HEAD found for ${owner}/${repo}#${defaultBranch} ` +
@@ -527,19 +533,37 @@ async function pushFilesViaGitHubApi(input: {
     fileChanges.deletions = [{ path: '.gitkeep' }];
   }
 
-  const result: {
-    createCommitOnBranch: { commit: { oid: string } };
-  } = await client.graphql(CREATE_COMMIT_ON_BRANCH_MUTATION, {
-    input: {
-      branch: {
-        repositoryNameWithOwner: `${owner}/${repo}`,
-        branchName: defaultBranch,
-      },
-      message: { headline: commitMessage },
-      fileChanges,
-      expectedHeadOid: headOid,
+  const commitInput = {
+    branch: {
+      repositoryNameWithOwner: `${owner}/${repo}`,
+      branchName: defaultBranch,
     },
-  });
+    message: { headline: commitMessage },
+    fileChanges,
+    expectedHeadOid: headOid,
+  };
+
+  let result: { createCommitOnBranch: { commit: { oid: string } } };
+  try {
+    result = await client.graphql(CREATE_COMMIT_ON_BRANCH_MUTATION, {
+      input: commitInput,
+    });
+  } catch (commitError: unknown) {
+    const msg = String((commitError as Error).message ?? '');
+    if (!msg.includes('expectedHeadOid')) {
+      throw commitError;
+    }
+    logger.warn('HEAD OID changed since read, retrying once');
+    const { data: freshRef } = await client.rest.git.getRef({
+      owner,
+      repo,
+      ref: `heads/${defaultBranch}`,
+    });
+    commitInput.expectedHeadOid = freshRef.object.sha;
+    result = await client.graphql(CREATE_COMMIT_ON_BRANCH_MUTATION, {
+      input: commitInput,
+    });
+  }
 
   const commitHash = result.createCommitOnBranch.commit.oid;
   logger.info(

--- a/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
@@ -440,16 +440,8 @@ async function pushFilesViaGitHubApi(input: {
   gitAuthorInfo?: { name?: string; email?: string };
   logger: LoggerService;
 }): Promise<{ commitHash: string }> {
-  const {
-    dir,
-    owner,
-    repo,
-    client,
-    defaultBranch,
-    commitMessage,
-    gitAuthorInfo,
-    logger,
-  } = input;
+  const { dir, owner, repo, client, defaultBranch, commitMessage, logger } =
+    input;
 
   const files = await collectFilesFromDir(dir);
   logger.info(`Collected ${files.length} files for API push`);
@@ -475,7 +467,7 @@ async function pushFilesViaGitHubApi(input: {
       content: '',
       branch: defaultBranch,
     });
-    headOid = init.commit.sha;
+    headOid = init.commit.sha!;
   }
 
   const additions = files.map(file => ({

--- a/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
@@ -324,64 +324,41 @@ export async function initRepoPushAndProtect(
   const commitMessage =
     getGitCommitMessage(gitCommitMessage, config) || 'initial commit';
 
-  const useApiPush =
-    process.env.HTTP_PROXY ||
-    process.env.HTTPS_PROXY ||
-    process.env.http_proxy ||
-    process.env.https_proxy;
-
   let commitResult: { commitHash: string };
 
-  if (useApiPush) {
-    logger.info(
-      'HTTP proxy detected, pushing via GitHub API to avoid ' +
-        'potential issues with the git smart HTTP protocol.',
-    );
-    commitResult = await pushFilesViaGitHubApi({
+  try {
+    commitResult = await initRepoAndPush({
       dir: getRepoSourceDirectory(workspacePath, sourcePath),
-      owner,
-      repo,
-      client,
+      remoteUrl,
       defaultBranch,
+      auth: {
+        username: 'x-access-token',
+        password,
+      },
+      logger,
       commitMessage,
       gitAuthorInfo,
-      logger,
     });
-  } else {
-    try {
-      commitResult = await initRepoAndPush({
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ECONNRESET' || code === 'HttpError') {
+      logger.warn(
+        `Git push failed with ${code}, retrying via GitHub API. ` +
+          'This can happen when a network proxy blocks the binary payload ' +
+          'in the git smart HTTP protocol.',
+      );
+      commitResult = await pushFilesViaGitHubApi({
         dir: getRepoSourceDirectory(workspacePath, sourcePath),
-        remoteUrl,
+        owner,
+        repo,
+        client,
         defaultBranch,
-        auth: {
-          username: 'x-access-token',
-          password,
-        },
-        logger,
         commitMessage,
         gitAuthorInfo,
+        logger,
       });
-    } catch (error) {
-      const code = (error as NodeJS.ErrnoException).code;
-      if (code === 'ECONNRESET' || code === 'HttpError') {
-        logger.warn(
-          `Git push failed with ${code}, retrying via GitHub API. ` +
-            'This can happen when a network proxy blocks the binary payload ' +
-            'in the git smart HTTP protocol.',
-        );
-        commitResult = await pushFilesViaGitHubApi({
-          dir: getRepoSourceDirectory(workspacePath, sourcePath),
-          owner,
-          repo,
-          client,
-          defaultBranch,
-          commitMessage,
-          gitAuthorInfo,
-          logger,
-        });
-      } else {
-        throw error;
-      }
+    } else {
+      throw error;
     }
   }
 

--- a/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
@@ -17,6 +17,8 @@
 import { Config } from '@backstage/config';
 import { NotFoundError, toError } from '@backstage/errors';
 import { Octokit } from 'octokit';
+import { promises as fsPromises, Dirent } from 'node:fs';
+import { join } from 'node:path';
 
 import {
   getRepoSourceDirectory,
@@ -322,18 +324,42 @@ export async function initRepoPushAndProtect(
   const commitMessage =
     getGitCommitMessage(gitCommitMessage, config) || 'initial commit';
 
-  const commitResult = await initRepoAndPush({
-    dir: getRepoSourceDirectory(workspacePath, sourcePath),
-    remoteUrl,
-    defaultBranch,
-    auth: {
-      username: 'x-access-token',
-      password,
-    },
-    logger,
-    commitMessage,
-    gitAuthorInfo,
-  });
+  let commitResult: { commitHash: string };
+  try {
+    commitResult = await initRepoAndPush({
+      dir: getRepoSourceDirectory(workspacePath, sourcePath),
+      remoteUrl,
+      defaultBranch,
+      auth: {
+        username: 'x-access-token',
+        password,
+      },
+      logger,
+      commitMessage,
+      gitAuthorInfo,
+    });
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === 'ECONNRESET' || code === 'HttpError') {
+      logger.warn(
+        `Git push failed with ${code}, retrying via GitHub REST API. ` +
+          'This can happen when a network proxy blocks the binary payload ' +
+          'in the git smart HTTP protocol.',
+      );
+      commitResult = await pushFilesViaGitHubApi({
+        dir: getRepoSourceDirectory(workspacePath, sourcePath),
+        owner,
+        repo,
+        client,
+        defaultBranch,
+        commitMessage,
+        gitAuthorInfo,
+        logger,
+      });
+    } else {
+      throw error;
+    }
+  }
 
   if (protectDefaultBranch) {
     try {
@@ -366,6 +392,141 @@ export async function initRepoPushAndProtect(
   }
 
   return { commitHash: commitResult.commitHash };
+}
+
+async function collectFilesFromDir(
+  dirPath: string,
+  basePath: string = '',
+): Promise<{ filePath: string; content: Buffer }[]> {
+  const entries: Dirent[] = await fsPromises.readdir(dirPath, {
+    withFileTypes: true,
+  });
+  const results: { filePath: string; content: Buffer }[] = [];
+  for (const entry of entries) {
+    const fullPath = join(dirPath, entry.name);
+    const relativePath = basePath ? `${basePath}/${entry.name}` : entry.name;
+    if (entry.name === '.git') {
+      continue;
+    }
+    if (entry.isDirectory()) {
+      results.push(...(await collectFilesFromDir(fullPath, relativePath)));
+    } else {
+      results.push({
+        filePath: relativePath,
+        content: await fsPromises.readFile(fullPath),
+      });
+    }
+  }
+  return results;
+}
+
+async function pushFilesViaGitHubApi(input: {
+  dir: string;
+  owner: string;
+  repo: string;
+  client: Octokit;
+  defaultBranch: string;
+  commitMessage: string;
+  gitAuthorInfo?: { name?: string; email?: string };
+  logger: LoggerService;
+}): Promise<{ commitHash: string }> {
+  const {
+    dir,
+    owner,
+    repo,
+    client,
+    defaultBranch,
+    commitMessage,
+    gitAuthorInfo,
+    logger,
+  } = input;
+
+  const files = await collectFilesFromDir(dir);
+  logger.info(`Collected ${files.length} files for API push`);
+
+  const authorInfo = {
+    name: gitAuthorInfo?.name ?? 'Scaffolder',
+    email: gitAuthorInfo?.email ?? 'scaffolder@backstage.io',
+  };
+
+  let headSha: string | undefined;
+  try {
+    const { data: ref } = await client.rest.git.getRef({
+      owner,
+      repo,
+      ref: `heads/${defaultBranch}`,
+    });
+    headSha = ref.object.sha;
+  } catch {
+    logger.info(
+      `No existing HEAD found for ${owner}/${repo}#${defaultBranch}, ` +
+        'initializing repository',
+    );
+    const { data: init } = await client.rest.repos.createOrUpdateFileContents({
+      owner,
+      repo,
+      path: '.gitkeep',
+      message: 'initialize repository',
+      content: '',
+      branch: defaultBranch,
+    });
+    headSha = init.commit.sha;
+  }
+
+  // Create blobs for each file
+  const treeItems: {
+    path: string;
+    mode: '100644';
+    type: 'blob';
+    sha: string;
+  }[] = [];
+
+  for (const file of files) {
+    const { data: blob } = await client.rest.git.createBlob({
+      owner,
+      repo,
+      content: file.content.toString('base64'),
+      encoding: 'base64',
+    });
+    treeItems.push({
+      path: file.filePath,
+      mode: '100644',
+      type: 'blob',
+      sha: blob.sha,
+    });
+  }
+
+  const { data: headCommit } = await client.rest.git.getCommit({
+    owner,
+    repo,
+    commit_sha: headSha!,
+  });
+
+  const { data: tree } = await client.rest.git.createTree({
+    owner,
+    repo,
+    tree: treeItems,
+    base_tree: headCommit.tree.sha,
+  });
+
+  const { data: newCommit } = await client.rest.git.createCommit({
+    owner,
+    repo,
+    message: commitMessage,
+    tree: tree.sha,
+    parents: [headSha!],
+    author: { name: authorInfo.name, email: authorInfo.email },
+  });
+
+  await client.rest.git.updateRef({
+    owner,
+    repo,
+    ref: `heads/${defaultBranch}`,
+    sha: newCommit.sha,
+  });
+
+  logger.info(`Pushed ${files.length} files via GitHub API: ${newCommit.sha}`);
+  return { commitHash: newCommit.sha };
 }
 
 function extractCollaboratorName(

--- a/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+import { resolveSafeChildPath } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
 import { NotFoundError, toError } from '@backstage/errors';
 import { Octokit } from 'octokit';
 import { promises as fsPromises, Dirent } from 'node:fs';
-import { join } from 'node:path';
 
 import {
   getRepoSourceDirectory,
@@ -407,13 +407,18 @@ export async function initRepoPushAndProtect(
 async function collectFilesFromDir(
   dirPath: string,
   basePath: string = '',
+  rootPath?: string,
 ): Promise<{ filePath: string; content: Buffer }[]> {
+  const root = rootPath ?? dirPath;
   const entries: Dirent[] = await fsPromises.readdir(dirPath, {
     withFileTypes: true,
   });
   const results: { filePath: string; content: Buffer }[] = [];
   for (const entry of entries) {
-    const fullPath = join(dirPath, entry.name);
+    const fullPath = resolveSafeChildPath(
+      root,
+      basePath ? `${basePath}/${entry.name}` : entry.name,
+    );
     const relativePath = basePath ? `${basePath}/${entry.name}` : entry.name;
     if (entry.name === '.git') {
       continue;
@@ -422,7 +427,9 @@ async function collectFilesFromDir(
       continue;
     }
     if (entry.isDirectory()) {
-      results.push(...(await collectFilesFromDir(fullPath, relativePath)));
+      results.push(
+        ...(await collectFilesFromDir(fullPath, relativePath, root)),
+      );
     } else {
       results.push({
         filePath: relativePath,
@@ -456,7 +463,9 @@ async function pushFilesViaGitHubApi(input: {
     input;
 
   const files = await collectFilesFromDir(dir);
-  logger.info(`Collected ${files.length} files for API push`);
+  logger.info(
+    `Collected ${files.length} files for push via GraphQL to ${owner}/${repo}#${defaultBranch}`,
+  );
 
   if (files.length === 0) {
     throw new Error(
@@ -553,7 +562,9 @@ async function pushFilesViaGitHubApi(input: {
     if (!msg.includes('expectedHeadOid')) {
       throw commitError;
     }
-    logger.warn('HEAD OID changed since read, retrying once');
+    logger.warn(
+      `HEAD OID of ${owner}/${repo}#${defaultBranch} changed since read, retrying GraphQL commit once`,
+    );
     const { data: freshRef } = await client.rest.git.getRef({
       owner,
       repo,
@@ -567,7 +578,7 @@ async function pushFilesViaGitHubApi(input: {
 
   const commitHash = result.createCommitOnBranch.commit.oid;
   logger.info(
-    `Pushed ${files.length} files via GitHub GraphQL API: ${commitHash}`,
+    `Pushed ${files.length} files to ${owner}/${repo}#${defaultBranch} via GitHub GraphQL API (${commitHash})`,
   );
   return { commitHash };
 }

--- a/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
@@ -341,9 +341,19 @@ export async function initRepoPushAndProtect(
     });
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code;
-    if (code === 'ECONNRESET' || code === 'HttpError') {
+    const causeCode = (
+      (error as NodeJS.ErrnoException).cause as
+        | NodeJS.ErrnoException
+        | undefined
+    )?.code;
+    const isConnectionError =
+      code === 'ECONNRESET' ||
+      code === 'ECONNREFUSED' ||
+      causeCode === 'ECONNRESET' ||
+      causeCode === 'ECONNREFUSED';
+    if (isConnectionError) {
       logger.warn(
-        `Git push failed with ${code}, retrying via GitHub API. ` +
+        `Git push failed with ${code ?? causeCode}, retrying via GitHub API. ` +
           'This can happen when a network proxy blocks the binary payload ' +
           'in the git smart HTTP protocol.',
       );
@@ -354,7 +364,6 @@ export async function initRepoPushAndProtect(
         client,
         defaultBranch,
         commitMessage,
-        gitAuthorInfo,
         logger,
       });
     } else {
@@ -438,7 +447,6 @@ async function pushFilesViaGitHubApi(input: {
   client: Octokit;
   defaultBranch: string;
   commitMessage: string;
-  gitAuthorInfo?: { name?: string; email?: string };
   logger: LoggerService;
 }): Promise<{ commitHash: string }> {
   const { dir, owner, repo, client, defaultBranch, commitMessage, logger } =
@@ -448,6 +456,7 @@ async function pushFilesViaGitHubApi(input: {
   logger.info(`Collected ${files.length} files for API push`);
 
   let headOid: string;
+  let needsCleanup = false;
   try {
     const { data: ref } = await client.rest.git.getRef({
       owner,
@@ -455,7 +464,11 @@ async function pushFilesViaGitHubApi(input: {
       ref: `heads/${defaultBranch}`,
     });
     headOid = ref.object.sha;
-  } catch {
+  } catch (refError: unknown) {
+    const status = (refError as { status?: number }).status;
+    if (status !== 404) {
+      throw refError;
+    }
     logger.info(
       `No existing HEAD found for ${owner}/${repo}#${defaultBranch}, ` +
         'initializing repository',
@@ -469,12 +482,23 @@ async function pushFilesViaGitHubApi(input: {
       branch: defaultBranch,
     });
     headOid = init.commit.sha!;
+    needsCleanup = true;
   }
 
   const additions = files.map(file => ({
     path: file.filePath,
     contents: file.content.toString('base64'),
   }));
+
+  const fileChanges: {
+    additions: typeof additions;
+    deletions?: { path: string }[];
+  } = {
+    additions,
+  };
+  if (needsCleanup) {
+    fileChanges.deletions = [{ path: '.gitkeep' }];
+  }
 
   const result: {
     createCommitOnBranch: { commit: { oid: string } };
@@ -485,7 +509,7 @@ async function pushFilesViaGitHubApi(input: {
         branchName: defaultBranch,
       },
       message: { headline: commitMessage },
-      fileChanges: { additions },
+      fileChanges,
       expectedHeadOid: headOid,
     },
   });

--- a/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
@@ -418,6 +418,9 @@ async function collectFilesFromDir(
     if (entry.name === '.git') {
       continue;
     }
+    if (entry.isSymbolicLink()) {
+      continue;
+    }
     if (entry.isDirectory()) {
       results.push(...(await collectFilesFromDir(fullPath, relativePath)));
     } else {
@@ -455,6 +458,27 @@ async function pushFilesViaGitHubApi(input: {
   const files = await collectFilesFromDir(dir);
   logger.info(`Collected ${files.length} files for API push`);
 
+  if (files.length === 0) {
+    throw new Error(
+      'GraphQL API fallback found no files to push. ' +
+        'The workspace directory may be empty.',
+    );
+  }
+
+  const MAX_PAYLOAD_BYTES = 50 * 1024 * 1024; // 50 MB
+  const totalBytes = files.reduce((sum, f) => sum + f.content.length, 0);
+  if (totalBytes > MAX_PAYLOAD_BYTES) {
+    throw new Error(
+      `GraphQL API fallback payload too large (${(
+        totalBytes /
+        1024 /
+        1024
+      ).toFixed(1)} MB). ` +
+        'The GitHub GraphQL API limits request size. ' +
+        'Consider reducing template size or resolving the network issue preventing git push.',
+    );
+  }
+
   let headOid: string;
   let needsCleanup = false;
   try {
@@ -466,12 +490,15 @@ async function pushFilesViaGitHubApi(input: {
     headOid = ref.object.sha;
   } catch (refError: unknown) {
     const status = (refError as { status?: number }).status;
-    if (status !== 404) {
+    if (status !== 404 && status !== 409) {
       throw refError;
     }
+    if (status === 404) {
+      await client.rest.repos.get({ owner, repo });
+    }
     logger.info(
-      `No existing HEAD found for ${owner}/${repo}#${defaultBranch}, ` +
-        'initializing repository',
+      `No existing HEAD found for ${owner}/${repo}#${defaultBranch} ` +
+        `(status ${status}), initializing repository`,
     );
     const { data: init } = await client.rest.repos.createOrUpdateFileContents({
       owner,

--- a/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
@@ -324,40 +324,64 @@ export async function initRepoPushAndProtect(
   const commitMessage =
     getGitCommitMessage(gitCommitMessage, config) || 'initial commit';
 
+  const useApiPush =
+    process.env.HTTP_PROXY ||
+    process.env.HTTPS_PROXY ||
+    process.env.http_proxy ||
+    process.env.https_proxy;
+
   let commitResult: { commitHash: string };
-  try {
-    commitResult = await initRepoAndPush({
+
+  if (useApiPush) {
+    logger.info(
+      'HTTP proxy detected, pushing via GitHub API to avoid ' +
+        'potential issues with the git smart HTTP protocol.',
+    );
+    commitResult = await pushFilesViaGitHubApi({
       dir: getRepoSourceDirectory(workspacePath, sourcePath),
-      remoteUrl,
+      owner,
+      repo,
+      client,
       defaultBranch,
-      auth: {
-        username: 'x-access-token',
-        password,
-      },
-      logger,
       commitMessage,
       gitAuthorInfo,
+      logger,
     });
-  } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code;
-    if (code === 'ECONNRESET' || code === 'HttpError') {
-      logger.warn(
-        `Git push failed with ${code}, retrying via GitHub REST API. ` +
-          'This can happen when a network proxy blocks the binary payload ' +
-          'in the git smart HTTP protocol.',
-      );
-      commitResult = await pushFilesViaGitHubApi({
+  } else {
+    try {
+      commitResult = await initRepoAndPush({
         dir: getRepoSourceDirectory(workspacePath, sourcePath),
-        owner,
-        repo,
-        client,
+        remoteUrl,
         defaultBranch,
+        auth: {
+          username: 'x-access-token',
+          password,
+        },
+        logger,
         commitMessage,
         gitAuthorInfo,
-        logger,
       });
-    } else {
-      throw error;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === 'ECONNRESET' || code === 'HttpError') {
+        logger.warn(
+          `Git push failed with ${code}, retrying via GitHub API. ` +
+            'This can happen when a network proxy blocks the binary payload ' +
+            'in the git smart HTTP protocol.',
+        );
+        commitResult = await pushFilesViaGitHubApi({
+          dir: getRepoSourceDirectory(workspacePath, sourcePath),
+          owner,
+          repo,
+          client,
+          defaultBranch,
+          commitMessage,
+          gitAuthorInfo,
+          logger,
+        });
+      } else {
+        throw error;
+      }
     }
   }
 

--- a/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
@@ -420,6 +420,16 @@ async function collectFilesFromDir(
   return results;
 }
 
+const CREATE_COMMIT_ON_BRANCH_MUTATION = `
+  mutation CreateCommitOnBranch($input: CreateCommitOnBranchInput!) {
+    createCommitOnBranch(input: $input) {
+      commit {
+        oid
+      }
+    }
+  }
+`;
+
 async function pushFilesViaGitHubApi(input: {
   dir: string;
   owner: string;
@@ -444,19 +454,14 @@ async function pushFilesViaGitHubApi(input: {
   const files = await collectFilesFromDir(dir);
   logger.info(`Collected ${files.length} files for API push`);
 
-  const authorInfo = {
-    name: gitAuthorInfo?.name ?? 'Scaffolder',
-    email: gitAuthorInfo?.email ?? 'scaffolder@backstage.io',
-  };
-
-  let headSha: string | undefined;
+  let headOid: string;
   try {
     const { data: ref } = await client.rest.git.getRef({
       owner,
       repo,
       ref: `heads/${defaultBranch}`,
     });
-    headSha = ref.object.sha;
+    headOid = ref.object.sha;
   } catch {
     logger.info(
       `No existing HEAD found for ${owner}/${repo}#${defaultBranch}, ` +
@@ -470,63 +475,33 @@ async function pushFilesViaGitHubApi(input: {
       content: '',
       branch: defaultBranch,
     });
-    headSha = init.commit.sha;
+    headOid = init.commit.sha;
   }
 
-  // Create blobs for each file
-  const treeItems: {
-    path: string;
-    mode: '100644';
-    type: 'blob';
-    sha: string;
-  }[] = [];
+  const additions = files.map(file => ({
+    path: file.filePath,
+    contents: file.content.toString('base64'),
+  }));
 
-  for (const file of files) {
-    const { data: blob } = await client.rest.git.createBlob({
-      owner,
-      repo,
-      content: file.content.toString('base64'),
-      encoding: 'base64',
-    });
-    treeItems.push({
-      path: file.filePath,
-      mode: '100644',
-      type: 'blob',
-      sha: blob.sha,
-    });
-  }
-
-  const { data: headCommit } = await client.rest.git.getCommit({
-    owner,
-    repo,
-    commit_sha: headSha!,
+  const result: {
+    createCommitOnBranch: { commit: { oid: string } };
+  } = await client.graphql(CREATE_COMMIT_ON_BRANCH_MUTATION, {
+    input: {
+      branch: {
+        repositoryNameWithOwner: `${owner}/${repo}`,
+        branchName: defaultBranch,
+      },
+      message: { headline: commitMessage },
+      fileChanges: { additions },
+      expectedHeadOid: headOid,
+    },
   });
 
-  const { data: tree } = await client.rest.git.createTree({
-    owner,
-    repo,
-    tree: treeItems,
-    base_tree: headCommit.tree.sha,
-  });
-
-  const { data: newCommit } = await client.rest.git.createCommit({
-    owner,
-    repo,
-    message: commitMessage,
-    tree: tree.sha,
-    parents: [headSha!],
-    author: { name: authorInfo.name, email: authorInfo.email },
-  });
-
-  await client.rest.git.updateRef({
-    owner,
-    repo,
-    ref: `heads/${defaultBranch}`,
-    sha: newCommit.sha,
-  });
-
-  logger.info(`Pushed ${files.length} files via GitHub API: ${newCommit.sha}`);
-  return { commitHash: newCommit.sha };
+  const commitHash = result.createCommitOnBranch.commit.oid;
+  logger.info(
+    `Pushed ${files.length} files via GitHub GraphQL API: ${commitHash}`,
+  );
+  return { commitHash };
 }
 
 function extractCollaboratorName(


### PR DESCRIPTION
Fixes #34074

The proxy logs tell the whole story:
                                                                                                                                                                          
  [DPI] Killing POST to .../git-receive-pack    ← git push killed                                                                                                         
  POST https://api.github.com/user/repos        ← REST API works                                                                                                          
  POST https://api.github.com/repos/.../blobs   ← REST API works                                                                                                          
  POST https://api.github.com/repos/.../trees   ← REST API works                                                                                                          
  POST https://api.github.com/repos/.../commits ← REST API works                                                                                                          
  PATCH https://api.github.com/repos/.../refs   ← REST API works 
  
## Hey, I just made a Pull Request!

Reproduction and proof

This issue was reproduced on upstream Backstage using isomorphic-git v1.27.1 on Node v22.22.2, the same versions used in the Backstage scaffolder. A mitmproxy instance was deployed with a custom addon that simulates deep packet inspection by dropping POST requests to /git-receive-pack. This replicates the behavior observed in production environments where network proxies inspect TLS (transport layer security) intercepted traffic and drop requests containing binary payloads they cannot parse.

The publish:github and github:repo:push actions both call initRepoAndPush in @backstage/plugin-scaffolder-node, which uses isomorphic-git to push files to GitHub. The push flow makes two HTTP requests through the proxy: a GET to /info/refs?service=git-receive-pack for capability negotiation, and a POST to /git-receive-pack containing the binary git pack data. The GET succeeds because it returns plain text. The POST fails because the binary pack payload triggers the proxy's content inspection engine, which cannot parse it and drops the connection, resulting in **ECONNRESET**.

Every other operation in the scaffolder workflow goes through Octokit's REST API, which sends standard JSON over HTTPS. Proxies can inspect JSON without issues, so repo creation, catalog imports, webhook configuration, and branch protection all work. The git push is the only operation that sends binary data, and it is the only one that breaks.                                                                                                                                                            

This fix adds a transparent fallback in initRepoPushAndProtect. When initRepoAndPush fails with ECONNRESET, the code retries using GitHub's GraphQl API to create blobs, trees, commits, and refs. These are all standard JSON requests to api.github.com that pass through packet-inspecting proxies without issues. The fallback only triggers on connection reset errors, so there is no behavior change for users not behind inspecting proxies. Both publish:github and github:repo:push are covered since they both call initRepoPushAndProtect. All 52 existing tests pass without modification.

How to reproduce                                                                                                                                                        

You need a forward proxy that performs TLS interception and drops POST requests to /git-receive-pack. This simulates the behavior of network proxies that inspect HTTPS traffic and block requests containing binary payloads they cannot parse
1. Set up the proxy simulator                                                                                                                                           
Install mitmproxy (pip install mitmproxy or brew install mitmproxy) and create this addon file:                                                                         

# proxy_simulator.py                                                                                                                                                    
```
from mitmproxy import http, ctx                                                                                                                                         

class ProxySimulator:                                                                                                                                                   
  def request(self, flow: http.HTTPFlow) -> None:                                                                                                                     
    if (flow.request.method == "POST"
      and "git-receive-pack" in flow.request.path):                                                                                                               
      ctx.log.warn(f"Killing POST to {flow.request.url}")                                                                                                         
      flow.kill()                                                                                                                                                 
                                                                                                                                                                          
addons = [ProxySimulator()]
```
Start the proxy:                                                                                                                                                        

mitmdump --listen-port 3128 --ssl-insecure -s proxy_simulator.py                                                                                                        
                  
2. Reproduce the failure                                                                                                                                                

Install isomorphic-git at the same version Backstage uses (^1.23.0) and run the following script. This simulates the exact code path that publish:github and            
github:repo:push take when pushing scaffolded files to GitHub:
                                                                                                                                                                          
npm install isomorphic-git@1.27.1
                                                                                                                                                                          
// reproduce.js                                                                                                                                                         
```
// Run with:                                                                                                                                                            
//   HTTPS_PROXY=http://localhost:3128 NODE_USE_ENV_PROXY=1 \                                                                                                           
//   NODE_TLS_REJECT_UNAUTHORIZED=0 GITHUB_TOKEN=<your-token> \                                                                                                         
//   node reproduce.js                                                                                                                                                  
                                                                                                                                                                          
const git = require('isomorphic-git');                                                                                                                                  
const http = require('isomorphic-git/http/node');                                                                                                                       
const fs = require('fs');                                                                                                                                               
                                                                                                                                                                          
const TOKEN = process.env.GITHUB_TOKEN;                                                                                                                                 
const dir = '/tmp/repro-' + Date.now();                                                                                                                                 
fs.mkdirSync(dir, { recursive: true });                                                                                                                                 
                  
async function main() {                                                                                                                                                 
  console.log('Proxy:', process.env.HTTPS_PROXY);
  console.log('NODE_USE_ENV_PROXY:', process.env.NODE_USE_ENV_PROXY);                                                                                                   
  console.log('');                                                                                                                                                      
                                                                                                                                                                          
  // Step 1: Clone (GET /info/refs passes through the proxy)                                                                                                            
  console.log('git.clone() ...');
  await git.clone({                                                                                                                                                     
      fs, http, dir,                                                                                                                                                      
      url: 'https://github.com/<owner>/<any-repo>.git',                                                                                                                   
      singleBranch: true, depth: 1,                                                                                                                                       
      onAuth: () => ({ username: 'x-access-token', password: TOKEN }),                                                                                                    
    });
    console.log('Result: OK');                                                                                                                                            
                                                                                                                                                                          
    // Step 2: Create a commit locally                                                                                                                                    
    console.log('git.add() + git.commit() ...');                                                                                                                          
    fs.writeFileSync(dir + '/test.txt', 'test');                                                                                                                          
    await git.add({ fs, dir, filepath: 'test.txt' });                                                                                                                     
    await git.commit({                                                                                                                                                    
      fs, dir,                                                                                                                                                            
      message: 'initial commit',                                                                                                                                          
      author: { name: 'Scaffolder', email: 'scaffolder@backstage.io' },                                                                                                   
    });                                                                                                                                                                   
    console.log('Result: OK');                                                                                                                                            
                                                                                                                                                                          
    // Step 3: Push (POST /git-receive-pack with binary pack data — killed by proxy)                                                                                      
    console.log('git.push() ...');
    await git.push({                                                                                                                                                      
      fs, http, dir,
      remote: 'origin', ref: 'main',                                                                                                                                      
      onAuth: () => ({ username: 'x-access-token', password: TOKEN }),
    });                                                                                                                                                                   
    console.log('Result: OK');
  }                                                                                                                                                                       
                  
  main().catch(err => {                                                                                                                                                   
    console.log('Result: FAILED');
    console.log('Error:', err.code, '-', err.message);                                                                                                                    
  });                                                                                                                                                                     
                                                                                                                                                               
 
  Expected output                                                                                                                                                         
                  
  git.clone() ...
  Result: OK
  git.add() + git.commit() ...                                                                                                                                            
  Result: OK
  git.push() ...                                                                                                                                                          
  Result: FAILED  
  Error: ECONNRESET - socket hang up
 ```      


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))