### PR TITLE
docs(proxy): scaffold module example for proxyEndpointsExtensionPoint

### DIFF
--- a/docs/plugins/proxying.md
+++ b/docs/plugins/proxying.md
@@ -136,7 +136,7 @@ To fix the issue with missing request body passed by proxy to the target, set `p
 
 In that case, mind setting the `Content-Type` header to either `application/json` or `application/x-www-form-urlencoded`.
 
-### Proxy Extension Endpoint
+### Proxy Endpoints Extension Point
 
 The proxy plugin additionally supports a `proxyEndpointsExtensionPoint` which a
 proxy plugin module can utilize in order to programmatically register
@@ -163,7 +163,8 @@ export const proxyModuleDemoAdditionalEndpoints = createBackendModule({
         proxyEndpoints: proxyEndpointsExtensionPoint,
       },
       async init({ proxyEndpoints }) {
-        const largerExampleAuth: string = /* exercise for the reader */;
+        // Replace with however your setup obtains the credential.
+        const largerExampleAuth = 'Bearer <token>';
         proxyEndpoints.addProxyEndpoints({
           '/simple-example': 'http://simple.example.com:8080',
           '/larger-example/v1': {

--- a/docs/plugins/proxying.md
+++ b/docs/plugins/proxying.md
@@ -191,5 +191,7 @@ point (usually `packages/backend/src/index.ts`):
 
 ```ts
 backend.add(import('@backstage/plugin-proxy-backend'));
-backend.add(import('@internal/plugin-proxy-backend-module-demo-additional-endpoints'));
+backend.add(
+  import('@internal/plugin-proxy-backend-module-demo-additional-endpoints'),
+);
 ```

--- a/docs/plugins/proxying.md
+++ b/docs/plugins/proxying.md
@@ -147,8 +147,15 @@ override those registered in this manner.
 To scaffold a module package, run `yarn new`, select `backend-module`, and
 fill out the prompts with `proxy` as the plugin ID. This will create
 `plugins/proxy-backend-module-<moduleId>` with `src/module.ts` and
-`src/index.ts` files. Replace the generated `src/module.ts` with the example
-below:
+`src/index.ts` files. The scaffolded package only depends on
+`@backstage/backend-plugin-api`, so add the `@backstage/plugin-proxy-node`
+package that provides the extension point:
+
+```bash
+yarn --cwd plugins/proxy-backend-module-demo-additional-endpoints add @backstage/plugin-proxy-node
+```
+
+Then replace the generated `src/module.ts` with the example below:
 
 ```ts title="plugins/proxy-backend-module-demo-additional-endpoints/src/module.ts"
 import { createBackendModule } from '@backstage/backend-plugin-api';

--- a/docs/plugins/proxying.md
+++ b/docs/plugins/proxying.md
@@ -150,8 +150,7 @@ fill out the prompts with `proxy` as the plugin ID. This will create
 `src/index.ts` files. Replace the generated `src/module.ts` with the example
 below:
 
-```ts
-// plugins/proxy-backend-module-demo-additional-endpoints/src/module.ts
+```ts title="plugins/proxy-backend-module-demo-additional-endpoints/src/module.ts"
 import { createBackendModule } from '@backstage/backend-plugin-api';
 import { proxyEndpointsExtensionPoint } from '@backstage/plugin-proxy-node/alpha';
 
@@ -181,15 +180,14 @@ export const proxyModuleDemoAdditionalEndpoints = createBackendModule({
 });
 ```
 
-```ts
-// plugins/proxy-backend-module-demo-additional-endpoints/src/index.ts
+```ts title="plugins/proxy-backend-module-demo-additional-endpoints/src/index.ts"
 export { proxyModuleDemoAdditionalEndpoints as default } from './module';
 ```
 
 Then install the module alongside the proxy plugin in your backend entry
 point (usually `packages/backend/src/index.ts`):
 
-```ts
+```ts title="packages/backend/src/index.ts"
 backend.add(import('@backstage/plugin-proxy-backend'));
 backend.add(
   import('@internal/plugin-proxy-backend-module-demo-additional-endpoints'),

--- a/docs/plugins/proxying.md
+++ b/docs/plugins/proxying.md
@@ -138,42 +138,58 @@ In that case, mind setting the `Content-Type` header to either `application/json
 
 ### Proxy Extension Endpoint
 
-The proxy plugin additionally supports a `proxyExtensionEndpoint` which a proxy
-plugin module can utilize in order to programmatically register additional
-endpoints, whose payloads are specified exactly as in app-config (described
-above). Note that endpoints configured in app-config will always override those
-registered in this manner.
+The proxy plugin additionally supports a `proxyEndpointsExtensionPoint` which a
+proxy plugin module can utilize in order to programmatically register
+additional endpoints, whose payloads are specified exactly as in app-config
+(described above). Note that endpoints configured in app-config will always
+override those registered in this manner.
 
-Example:
+To scaffold a module package, run `yarn new`, select `backend-module`, and
+fill out the prompts with `proxy` as the plugin ID. This will create
+`plugins/proxy-backend-module-<moduleId>` with `src/module.ts` and
+`src/index.ts` files. Replace the generated `src/module.ts` with the example
+below:
 
 ```ts
+// plugins/proxy-backend-module-demo-additional-endpoints/src/module.ts
 import { createBackendModule } from '@backstage/backend-plugin-api';
 import { proxyEndpointsExtensionPoint } from '@backstage/plugin-proxy-node/alpha';
 
-backend.add(
-  createBackendModule({
-    pluginId: 'proxy',
-    moduleId: 'demo-additional-endpoints',
-    register: reg => {
-      reg.registerInit({
-        deps: {
-          proxyEndpoints: proxyEndpointsExtensionPoint,
-        },
-        init: async ({ proxyEndpoints }) => {
-          let largerExampleAuth: string = /* exercise for the reader */;
-          proxyEndpoints.addProxyEndpoints({
-            "/simple-example": "http://simple.example.com:8080",
-            "/larger-example/v1": {
-              target: "http://larger.example.com:8080/svc.v1",
-              credentials: "require",
-              headers: {
-                Authorization: largerExampleAuth
-              },
+export const proxyModuleDemoAdditionalEndpoints = createBackendModule({
+  pluginId: 'proxy',
+  moduleId: 'demo-additional-endpoints',
+  register(reg) {
+    reg.registerInit({
+      deps: {
+        proxyEndpoints: proxyEndpointsExtensionPoint,
+      },
+      async init({ proxyEndpoints }) {
+        const largerExampleAuth: string = /* exercise for the reader */;
+        proxyEndpoints.addProxyEndpoints({
+          '/simple-example': 'http://simple.example.com:8080',
+          '/larger-example/v1': {
+            target: 'http://larger.example.com:8080/svc.v1',
+            credentials: 'require',
+            headers: {
+              Authorization: largerExampleAuth,
             },
-          });
-        },
-      });
-    },
-  }),
-);
+          },
+        });
+      },
+    });
+  },
+});
+```
+
+```ts
+// plugins/proxy-backend-module-demo-additional-endpoints/src/index.ts
+export { proxyModuleDemoAdditionalEndpoints as default } from './module';
+```
+
+Then install the module alongside the proxy plugin in your backend entry
+point (usually `packages/backend/src/index.ts`):
+
+```ts
+backend.add(import('@backstage/plugin-proxy-backend'));
+backend.add(import('@internal/plugin-proxy-backend-module-demo-additional-endpoints'));
 ```


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### ✨ Changes

Rework the "Proxy Extension Endpoint" example in `docs/plugins/proxying.md` so readers can actually reproduce it. Per @awanlin's comment on the issue, the previous snippet was missing:

- Where the module file lives — now shows `src/module.ts` / `src/index.ts` with the `plugins/proxy-backend-module-<moduleId>` path.
- How to scaffold it — added the `yarn new` + `backend-module` instruction aligned with `docs/backend-system/building-plugins-and-modules/01-index.md`.
- How to install it — the `backend.add(import(...))` line is now shown separately from the module definition.

This matches the canonical pattern documented for other extension points (e.g. `catalogProcessingExtensionPoint`).

Closes #31539

### ✍️ Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
  - Docs-only change in `docs/plugins/proxying.md`; per CONTRIBUTING.md ("changesets are only needed for changes to packages within `packages/` or `plugins/`"), no changeset is required.
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
  - N/A for docs-only change.
- [x] Screenshots attached (for UI changes)
  - N/A.
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))