### PR TITLE
fix(catalog-github): warn and skip orgs without GitHub App installation

### DIFF
--- a/.changeset/github-multiorg-missing-app-install-warn.md
+++ b/.changeset/github-multiorg-missing-app-install-warn.md
@@ -1,0 +1,9 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+`GithubMultiOrgEntityProvider` now logs a warning and skips to the next org
+when a GitHub App is configured but not installed on one of the orgs listed
+in the provider config, instead of aborting the whole refresh with a
+`NotFoundError`. Orgs that do have the app installed continue to sync, and
+the warning points to the GitHub App troubleshooting documentation.

--- a/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.test.ts
@@ -969,6 +969,54 @@ describe('GithubMultiOrgEntityProvider', () => {
 
       expect(entityProviderConnection.applyMutation).not.toHaveBeenCalled();
     });
+
+    it('should warn and skip orgs without an app installation instead of aborting the refresh', async () => {
+      const notFoundError = new Error(
+        'No app installation found for orgB in 12345',
+      );
+      notFoundError.name = 'NotFoundError';
+
+      mockGetCredentials
+        .mockImplementationOnce(() => ({
+          headers: { token: 'blah' },
+          type: 'app',
+        }))
+        .mockImplementationOnce(() => {
+          throw notFoundError;
+        });
+
+      entityProvider = new GithubMultiOrgEntityProvider({
+        id: 'my-id',
+        gitHubConfig,
+        githubCredentialsProvider: {
+          getCredentials: mockGetCredentials,
+        },
+        githubUrl: 'https://github.com',
+        logger,
+        orgs: ['orgA', 'orgB'],
+      });
+
+      await entityProvider.connect(entityProviderConnection);
+
+      mockClient
+        .mockResolvedValueOnce({
+          organization: {
+            membersWithRole: { pageInfo: { hasNextPage: false }, nodes: [] },
+          },
+        })
+        .mockResolvedValueOnce({
+          organization: {
+            teams: { pageInfo: { hasNextPage: false }, nodes: [] },
+          },
+        });
+
+      await expect(entityProvider.read()).resolves.not.toThrow();
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Skipping GitHub org "orgB"'),
+      );
+      expect(entityProviderConnection.applyMutation).toHaveBeenCalled();
+    });
   });
 
   describe('withLocations', () => {

--- a/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
@@ -297,10 +297,27 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       : await this.getAllOrgs(this.options.gitHubConfig);
 
     for (const org of orgsToProcess) {
-      const { headers, type: tokenType } =
-        await this.options.githubCredentialsProvider.getCredentials({
-          url: `${this.options.githubUrl}/${org}`,
-        });
+      let headers: Record<string, string | undefined> | undefined;
+      let tokenType: string | undefined;
+      try {
+        ({ headers, type: tokenType } =
+          await this.options.githubCredentialsProvider.getCredentials({
+            url: `${this.options.githubUrl}/${org}`,
+          }));
+      } catch (error: any) {
+        // When a GitHub App is configured but not installed on one of the
+        // orgs listed in the provider config, `getCredentials` throws a
+        // NotFoundError. Skip that org with a clear warning rather than
+        // aborting the whole refresh, so orgs with the app installed still
+        // sync. See docs/integrations/github/github-apps.md#troubleshooting.
+        if (error?.name === 'NotFoundError') {
+          logger.warn(
+            `Skipping GitHub org "${org}": no app installation found. Check that the GitHub App is installed on this org (see https://backstage.io/docs/integrations/github/github-apps/#troubleshooting). Underlying error: ${error.message}`,
+          );
+          continue;
+        }
+        throw error;
+      }
       const client = graphql.defaults({
         baseUrl: this.options.gitHubConfig.apiBaseUrl,
         headers,

--- a/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
@@ -297,13 +297,12 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       : await this.getAllOrgs(this.options.gitHubConfig);
 
     for (const org of orgsToProcess) {
-      let headers: Record<string, string | undefined> | undefined;
-      let tokenType: string | undefined;
+      let credentials;
       try {
-        ({ headers, type: tokenType } =
+        credentials =
           await this.options.githubCredentialsProvider.getCredentials({
             url: `${this.options.githubUrl}/${org}`,
-          }));
+          });
       } catch (error: any) {
         // When a GitHub App is configured but not installed on one of the
         // orgs listed in the provider config, `getCredentials` throws a
@@ -318,6 +317,7 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
         }
         throw error;
       }
+      const { headers, type: tokenType } = credentials;
       const client = graphql.defaults({
         baseUrl: this.options.gitHubConfig.apiBaseUrl,
         headers,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### ✨ Changes

When a GitHub App is configured but not installed on one of the orgs listed in `GithubMultiOrgEntityProvider`'s config, `getCredentials` throws a `NotFoundError: No app installation found for <org> in <appId>`. Currently this aborts the whole refresh, so orgs that **do** have the app installed never sync either.

This PR wraps the per-org `getCredentials` call in the provider's `read()` loop with a `try/catch` that:
- On `NotFoundError`, emits `logger.warn(...)` naming the org, explaining the cause, and linking to `docs/integrations/github/github-apps.md#troubleshooting`, then `continue`s to the next org.
- Re-throws any other error unchanged (existing behavior preserved).

Added a test that mocks a `NotFoundError` for the second of two orgs and asserts (a) `read()` resolves, (b) `logger.warn` is called with a message containing `Skipping GitHub org "orgB"`, and (c) `applyMutation` still gets called with the first org's data.

Closes #32972

### ✍️ Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes) — N/A
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))