### PR TITLE
Add test suite for `useDefinition` hook in `@backstage/ui`

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -59,6 +59,8 @@
   "devDependencies": {
     "@backstage/cli": "workspace:^",
     "@storybook/react-vite": "^10.3.3",
+    "@testing-library/jest-dom": "^6.0.0",
+    "@testing-library/react": "^16.0.0",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "@types/use-sync-external-store": "^1.0.0",

--- a/packages/ui/src/hooks/useDefinition/helpers.test.ts
+++ b/packages/ui/src/hooks/useDefinition/helpers.test.ts
@@ -13,7 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { resolveResponsiveValue, resolveDefinitionProps } from './helpers';
+import {
+  resolveResponsiveValue,
+  resolveDefinitionProps,
+  processUtilityProps,
+} from './helpers';
 import type { ComponentConfig } from './types';
 
 describe('resolveResponsiveValue', () => {
@@ -286,5 +290,109 @@ describe('resolveDefinitionProps', () => {
     );
 
     expect(restProps).toEqual({});
+  });
+});
+
+describe('processUtilityProps', () => {
+  it('returns empty classes and style when no utility props are provided', () => {
+    const { utilityClasses, utilityStyle } = processUtilityProps({}, [
+      'm',
+      'p',
+    ]);
+    expect(utilityClasses).toBe('');
+    expect(utilityStyle).toEqual({});
+  });
+
+  it('returns empty classes and style when utility values are undefined', () => {
+    const { utilityClasses, utilityStyle } = processUtilityProps(
+      { m: undefined },
+      ['m'],
+    );
+    expect(utilityClasses).toBe('');
+    expect(utilityStyle).toEqual({});
+  });
+
+  it('returns empty classes and style when utility values are null', () => {
+    const { utilityClasses, utilityStyle } = processUtilityProps({ m: null }, [
+      'm',
+    ]);
+    expect(utilityClasses).toBe('');
+    expect(utilityStyle).toEqual({});
+  });
+
+  it('generates a utility class for a predefined spacing value', () => {
+    const { utilityClasses } = processUtilityProps({ m: '2' }, ['m']);
+    expect(utilityClasses).toBe('bui-m-2');
+  });
+
+  it('generates a CSS custom property for a custom value', () => {
+    const { utilityStyle } = processUtilityProps({ width: '100px' }, ['width']);
+    expect(utilityStyle).toEqual({ '--width': '100px' });
+  });
+
+  it('generates both the class name and CSS var for custom values', () => {
+    const { utilityClasses, utilityStyle } = processUtilityProps(
+      { width: '100px' },
+      ['width'],
+    );
+    expect(utilityClasses).toBe('bui-w');
+    expect(utilityStyle).toEqual({ '--width': '100px' });
+  });
+
+  it('handles responsive utility values with breakpoint prefixes', () => {
+    const { utilityClasses } = processUtilityProps(
+      { m: { initial: '2', md: '4' } },
+      ['m'],
+    );
+    expect(utilityClasses).toContain('bui-m-2');
+    expect(utilityClasses).toContain('md:bui-m-4');
+  });
+
+  it('uses no prefix for the initial breakpoint in responsive values', () => {
+    const { utilityClasses } = processUtilityProps({ m: { initial: '2' } }, [
+      'm',
+    ]);
+    expect(utilityClasses).toBe('bui-m-2');
+  });
+
+  it('applies the transform function (grow: true becomes 1)', () => {
+    const { utilityStyle } = processUtilityProps({ grow: true }, ['grow']);
+    expect(utilityStyle).toEqual({ '--grow': 1 });
+  });
+
+  it('applies the transform function (basis: 42 becomes "42px")', () => {
+    const { utilityStyle } = processUtilityProps({ basis: 42 }, ['basis']);
+    expect(utilityStyle).toEqual({ '--basis': '42px' });
+  });
+
+  it('ignores values not in the valid list for fixed-value props', () => {
+    const { utilityClasses, utilityStyle } = processUtilityProps(
+      { position: 'invalid' },
+      ['position'],
+    );
+    expect(utilityClasses).toBe('');
+    expect(utilityStyle).toEqual({});
+  });
+
+  it('combines classes and styles from multiple utility props', () => {
+    const { utilityClasses, utilityStyle } = processUtilityProps(
+      { m: '2', p: '4', width: '100px' },
+      ['m', 'p', 'width'],
+    );
+    expect(utilityClasses).toContain('bui-m-2');
+    expect(utilityClasses).toContain('bui-p-4');
+    expect(utilityClasses).toContain('bui-w');
+    expect(utilityStyle).toEqual({ '--width': '100px' });
+  });
+
+  it('handles a mix of predefined and custom values across different props', () => {
+    const { utilityClasses, utilityStyle } = processUtilityProps(
+      { m: '2', width: '100px', position: 'relative' },
+      ['m', 'width', 'position'],
+    );
+    expect(utilityClasses).toContain('bui-m-2');
+    expect(utilityClasses).toContain('bui-w');
+    expect(utilityClasses).toContain('bui-position-relative');
+    expect(utilityStyle).toEqual({ '--width': '100px' });
   });
 });

--- a/packages/ui/src/hooks/useDefinition/helpers.test.ts
+++ b/packages/ui/src/hooks/useDefinition/helpers.test.ts
@@ -19,4 +19,71 @@ describe('resolveResponsiveValue', () => {
   it('returns a plain string unchanged', () => {
     expect(resolveResponsiveValue('hello', 'md')).toBe('hello');
   });
+
+  it('returns a plain number unchanged', () => {
+    expect(resolveResponsiveValue(42, 'md')).toBe(42);
+  });
+
+  it('returns undefined unchanged', () => {
+    expect(resolveResponsiveValue(undefined, 'md')).toBeUndefined();
+  });
+
+  it('returns null unchanged', () => {
+    expect(resolveResponsiveValue(null, 'md')).toBeNull();
+  });
+
+  it('returns a non-breakpoint object unchanged', () => {
+    const obj = { foo: 'bar' };
+    expect(resolveResponsiveValue(obj, 'md')).toBe(obj);
+  });
+
+  it('returns an object with only an initial key unchanged (not detected as responsive)', () => {
+    const obj = { initial: 'base' };
+    expect(resolveResponsiveValue(obj, 'md')).toBe(obj);
+  });
+
+  it('resolves exact breakpoint match', () => {
+    expect(resolveResponsiveValue({ xs: 'small', md: 'medium' }, 'md')).toBe(
+      'medium',
+    );
+  });
+
+  it('falls back to the nearest smaller breakpoint', () => {
+    expect(resolveResponsiveValue({ xs: 'small', md: 'medium' }, 'sm')).toBe(
+      'small',
+    );
+  });
+
+  it('falls back across multiple missing breakpoints', () => {
+    expect(resolveResponsiveValue({ xs: 'small', xl: 'xlarge' }, 'lg')).toBe(
+      'small',
+    );
+  });
+
+  it('falls back to initial when no named breakpoint matches at or below current', () => {
+    expect(
+      resolveResponsiveValue({ initial: 'base', md: 'medium' }, 'sm'),
+    ).toBe('base');
+  });
+
+  it('falls forward to the smallest available breakpoint when nothing is at or below current', () => {
+    expect(
+      resolveResponsiveValue({ md: 'medium', xl: 'xlarge' }, 'initial'),
+    ).toBe('medium');
+  });
+
+  it('resolves initial breakpoint from a responsive object that includes initial', () => {
+    expect(
+      resolveResponsiveValue({ initial: 'base', xs: 'small' }, 'initial'),
+    ).toBe('base');
+  });
+
+  it('skips undefined values during fallback', () => {
+    expect(
+      resolveResponsiveValue(
+        { xs: undefined, sm: 'small', md: undefined },
+        'md',
+      ),
+    ).toBe('small');
+  });
 });

--- a/packages/ui/src/hooks/useDefinition/helpers.test.ts
+++ b/packages/ui/src/hooks/useDefinition/helpers.test.ts
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { resolveResponsiveValue } from './helpers';
+import { resolveResponsiveValue, resolveDefinitionProps } from './helpers';
+import type { ComponentConfig } from './types';
 
 describe('resolveResponsiveValue', () => {
   it('returns a plain string unchanged', () => {
@@ -85,5 +86,205 @@ describe('resolveResponsiveValue', () => {
         'md',
       ),
     ).toBe('small');
+  });
+});
+
+describe('resolveDefinitionProps', () => {
+  it('separates own props from rest props based on propDefs keys', () => {
+    const definition = {
+      propDefs: { variant: {}, size: {} },
+      utilityProps: [],
+      styles: {},
+      classNames: {},
+    } as ComponentConfig<any, any>;
+
+    const { ownPropsResolved, restProps } = resolveDefinitionProps(
+      definition,
+      { variant: 'primary', size: 'large', 'aria-label': 'test' },
+      'initial',
+    );
+
+    expect(ownPropsResolved).toEqual({ variant: 'primary', size: 'large' });
+    expect(restProps).toEqual({ 'aria-label': 'test' });
+  });
+
+  it('excludes utility props from rest props', () => {
+    const definition = {
+      propDefs: { variant: {} },
+      utilityProps: ['m', 'p'] as const,
+      styles: {},
+      classNames: {},
+    } as ComponentConfig<any, any>;
+
+    const { restProps } = resolveDefinitionProps(
+      definition,
+      { variant: 'primary', m: '2', p: '4', 'aria-label': 'test' },
+      'initial',
+    );
+
+    expect(restProps).toEqual({ 'aria-label': 'test' });
+  });
+
+  it('does not exclude utility props that are also in propDefs', () => {
+    const definition = {
+      propDefs: { gap: {} },
+      utilityProps: ['gap'] as const,
+      styles: {},
+      classNames: {},
+    } as ComponentConfig<any, any>;
+
+    const { ownPropsResolved } = resolveDefinitionProps(
+      definition,
+      { gap: '4' },
+      'initial',
+    );
+
+    expect(ownPropsResolved).toEqual({ gap: '4' });
+  });
+
+  it('applies default values from propDefs when prop is not provided', () => {
+    const definition = {
+      propDefs: { size: { default: 'medium' } },
+      utilityProps: [],
+      styles: {},
+      classNames: {},
+    } as ComponentConfig<any, any>;
+
+    const { ownPropsResolved } = resolveDefinitionProps(
+      definition,
+      {},
+      'initial',
+    );
+
+    expect(ownPropsResolved).toEqual({ size: 'medium' });
+  });
+
+  it('does not apply default when prop is explicitly provided', () => {
+    const definition = {
+      propDefs: { size: { default: 'medium' } },
+      utilityProps: [],
+      styles: {},
+      classNames: {},
+    } as ComponentConfig<any, any>;
+
+    const { ownPropsResolved } = resolveDefinitionProps(
+      definition,
+      { size: 'large' },
+      'initial',
+    );
+
+    expect(ownPropsResolved).toEqual({ size: 'large' });
+  });
+
+  it('preserves falsy prop values (false, 0, empty string) over defaults', () => {
+    const definition = {
+      propDefs: {
+        disabled: { default: true },
+        count: { default: 10 },
+        label: { default: 'default' },
+      },
+      utilityProps: [],
+      styles: {},
+      classNames: {},
+    } as ComponentConfig<any, any>;
+
+    const { ownPropsResolved } = resolveDefinitionProps(
+      definition,
+      { disabled: false, count: 0, label: '' },
+      'initial',
+    );
+
+    expect(ownPropsResolved).toEqual({
+      disabled: false,
+      count: 0,
+      label: '',
+    });
+  });
+
+  it('resolves responsive own prop values at the given breakpoint', () => {
+    const definition = {
+      propDefs: { variant: {} },
+      utilityProps: [],
+      styles: {},
+      classNames: {},
+    } as ComponentConfig<any, any>;
+
+    const { ownPropsResolved } = resolveDefinitionProps(
+      definition,
+      { variant: { xs: 'small', md: 'large' } },
+      'md',
+    );
+
+    expect(ownPropsResolved).toEqual({ variant: 'large' });
+  });
+
+  it('omits own props that are undefined and have no default', () => {
+    const definition = {
+      propDefs: { variant: {}, size: {} },
+      utilityProps: [],
+      styles: {},
+      classNames: {},
+    } as ComponentConfig<any, any>;
+
+    const { ownPropsResolved } = resolveDefinitionProps(
+      definition,
+      { variant: 'primary' },
+      'initial',
+    );
+
+    expect(ownPropsResolved).toEqual({ variant: 'primary' });
+    expect('size' in ownPropsResolved).toBe(false);
+  });
+
+  it('passes through rest props without responsive resolution', () => {
+    const definition = {
+      propDefs: { variant: {} },
+      utilityProps: [],
+      styles: {},
+      classNames: {},
+    } as ComponentConfig<any, any>;
+
+    const responsiveObj = { xs: 'small', md: 'large' };
+    const { restProps } = resolveDefinitionProps(
+      definition,
+      { variant: 'primary', 'data-value': responsiveObj },
+      'md',
+    );
+
+    expect(restProps['data-value']).toBe(responsiveObj);
+  });
+
+  it('returns empty ownPropsResolved when no props match propDefs', () => {
+    const definition = {
+      propDefs: { variant: {} },
+      utilityProps: [],
+      styles: {},
+      classNames: {},
+    } as ComponentConfig<any, any>;
+
+    const { ownPropsResolved } = resolveDefinitionProps(
+      definition,
+      { 'aria-label': 'test' },
+      'initial',
+    );
+
+    expect(ownPropsResolved).toEqual({});
+  });
+
+  it('returns empty restProps when all props are own or utility props', () => {
+    const definition = {
+      propDefs: { variant: {} },
+      utilityProps: ['m'] as const,
+      styles: {},
+      classNames: {},
+    } as ComponentConfig<any, any>;
+
+    const { restProps } = resolveDefinitionProps(
+      definition,
+      { variant: 'primary', m: '2' },
+      'initial',
+    );
+
+    expect(restProps).toEqual({});
   });
 });

--- a/packages/ui/src/hooks/useDefinition/helpers.test.ts
+++ b/packages/ui/src/hooks/useDefinition/helpers.test.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { resolveResponsiveValue } from './helpers';
+
+describe('resolveResponsiveValue', () => {
+  it('returns a plain string unchanged', () => {
+    expect(resolveResponsiveValue('hello', 'md')).toBe('hello');
+  });
+});

--- a/packages/ui/src/hooks/useDefinition/useDefinition.test.tsx
+++ b/packages/ui/src/hooks/useDefinition/useDefinition.test.tsx
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { type PropsWithChildren } from 'react';
+import { type PropsWithChildren, type ReactNode } from 'react';
 import { renderHook, render } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { useDefinition } from './useDefinition';
 import type { ComponentConfig } from './types';
 import { BgProvider, useBgConsumer } from '../useBg';
@@ -94,9 +95,57 @@ const analyticsDef = {
   analytics: true,
 } as ComponentConfig<any, any>;
 
+const hrefDef = {
+  styles: { root: 'css-root' },
+  classNames: { root: 'root' },
+  propDefs: {
+    href: {},
+    className: {},
+  },
+} as ComponentConfig<any, any>;
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+function createRouterWrapper({
+  basename,
+  currentRoute,
+}: {
+  basename?: string;
+  currentRoute: string;
+}) {
+  return function Wrapper({ children }: PropsWithChildren) {
+    const entry = basename ? `${basename}${currentRoute}` : currentRoute;
+    // Build nested Routes one level per path segment. Each parent uses a plain
+    // (non-splat) path so that `..` resolution works correctly at every depth.
+    const segments =
+      currentRoute === '/'
+        ? []
+        : currentRoute.replace(/^\//, '').split('/').filter(Boolean);
+
+    const buildRoutes = (segs: string[], el: ReactNode): ReactNode => {
+      if (segs.length === 0) return <Route index element={el} />;
+      const [head, ...tail] = segs;
+      if (tail.length === 0) {
+        return <Route path={head} element={el} />;
+      }
+      return <Route path={`${head}/*`}>{buildRoutes(tail, el)}</Route>;
+    };
+
+    return (
+      <MemoryRouter basename={basename} initialEntries={[entry]}>
+        <Routes>
+          {segments.length === 0 ? (
+            <Route path="*" element={children} />
+          ) : (
+            buildRoutes(segments, children)
+          )}
+        </Routes>
+      </MemoryRouter>
+    );
+  };
+}
 
 describe('useDefinition', () => {
   describe('prop resolution', () => {
@@ -501,6 +550,91 @@ describe('useDefinition', () => {
 
       // Without BUIProvider, useAnalytics() returns noopTracker
       expect(result.current.analytics).toBe(noopTracker);
+    });
+  });
+
+  describe('href resolution', () => {
+    describe('inside router context', () => {
+      describe.each([
+        ['no basename', undefined],
+        ['with basename /app', '/app'],
+      ] as const)('%s', (_label, basename) => {
+        it.each`
+          description                       | href                  | currentRoute        | expected
+          ${'absolute path'}                | ${'/foo'}             | ${'/catalog'}       | ${'/foo'}
+          ${'root /'}                       | ${'/'}                | ${'/catalog'}       | ${'/'}
+          ${'relative path "foo"'}          | ${'foo'}              | ${'/catalog'}       | ${'/catalog/foo'}
+          ${'relative path "./foo"'}        | ${'./foo'}            | ${'/catalog'}       | ${'/catalog/foo'}
+          ${'relative path "../foo"'}       | ${'../foo'}           | ${'/catalog/items'} | ${'/catalog/foo'}
+          ${'empty string'}                 | ${''}                 | ${'/catalog'}       | ${'/catalog'}
+          ${'absolute with query params'}   | ${'/foo?q=1'}         | ${'/catalog'}       | ${'/foo?q=1'}
+          ${'absolute with hash'}           | ${'/foo#section'}     | ${'/catalog'}       | ${'/foo#section'}
+          ${'absolute with query and hash'} | ${'/foo?q=1#section'} | ${'/catalog'}       | ${'/foo?q=1#section'}
+          ${'relative with query params'}   | ${'foo?q=1'}          | ${'/catalog'}       | ${'/catalog/foo?q=1'}
+        `(
+          'resolves $description — returns $expected',
+          ({
+            href,
+            currentRoute,
+            expected,
+          }: {
+            href: string;
+            currentRoute: string;
+            expected: string;
+          }) => {
+            const { result } = renderHook(
+              () => useDefinition(hrefDef, { href }),
+              {
+                wrapper: createRouterWrapper({ basename, currentRoute }),
+              },
+            );
+
+            expect(result.current.ownProps.href).toBe(expected);
+          },
+        );
+
+        it.each`
+          description                | href
+          ${'https:// URL'}          | ${'https://example.com'}
+          ${'http:// URL'}           | ${'http://example.com'}
+          ${'mailto: link'}          | ${'mailto:a@b.com'}
+          ${'tel: link'}             | ${'tel:123'}
+          ${'protocol-relative URL'} | ${'//example.com'}
+        `('leaves $description unchanged', ({ href }: { href: string }) => {
+          const { result } = renderHook(
+            () => useDefinition(hrefDef, { href }),
+            {
+              wrapper: createRouterWrapper({
+                basename,
+                currentRoute: '/catalog',
+              }),
+            },
+          );
+
+          expect(result.current.ownProps.href).toBe(href);
+        });
+
+        it('does not modify props when href is undefined', () => {
+          const { result } = renderHook(() => useDefinition(hrefDef, {}), {
+            wrapper: createRouterWrapper({
+              basename,
+              currentRoute: '/catalog',
+            }),
+          });
+
+          expect(result.current.ownProps).not.toHaveProperty('href');
+        });
+      });
+    });
+
+    describe('outside router context', () => {
+      it('passes all href values through unchanged', () => {
+        const { result } = renderHook(() =>
+          useDefinition(hrefDef, { href: '/foo' }),
+        );
+
+        expect(result.current.ownProps.href).toBe('/foo');
+      });
     });
   });
 });

--- a/packages/ui/src/hooks/useDefinition/useDefinition.test.tsx
+++ b/packages/ui/src/hooks/useDefinition/useDefinition.test.tsx
@@ -13,9 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { renderHook } from '@testing-library/react';
+import { type PropsWithChildren } from 'react';
+import { renderHook, render } from '@testing-library/react';
 import { useDefinition } from './useDefinition';
 import type { ComponentConfig } from './types';
+import { BgProvider, useBgConsumer } from '../useBg';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function BgReader() {
+  const { bg } = useBgConsumer();
+  return <span data-testid="bg">{bg ?? 'none'}</span>;
+}
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -49,6 +60,27 @@ const utilityDef = {
     className: {},
   },
   utilityProps: ['m', 'p', 'width'] as const,
+} as ComponentConfig<any, any>;
+
+const providerDef = {
+  styles: { root: 'css-root' },
+  classNames: { root: 'root' },
+  propDefs: {
+    bg: { dataAttribute: true } as const,
+    children: {},
+    className: {},
+  },
+  bg: 'provider' as const,
+} as ComponentConfig<any, any>;
+
+const consumerDef = {
+  styles: { root: 'css-root' },
+  classNames: { root: 'root' },
+  propDefs: {
+    variant: {},
+    className: {},
+  },
+  bg: 'consumer' as const,
 } as ComponentConfig<any, any>;
 
 // ---------------------------------------------------------------------------
@@ -255,7 +287,7 @@ describe('useDefinition', () => {
     });
 
     it('skips data-bg for bg prop when definition.bg is provider', () => {
-      const providerDef = {
+      const localProviderDef = {
         styles: { root: 'css-root' },
         classNames: { root: 'root' },
         propDefs: {
@@ -267,7 +299,7 @@ describe('useDefinition', () => {
       } as ComponentConfig<any, any>;
 
       const { result } = renderHook(() =>
-        useDefinition(providerDef, {
+        useDefinition(localProviderDef, {
           bg: 'danger',
           children: null,
         }),
@@ -275,6 +307,136 @@ describe('useDefinition', () => {
 
       // data-bg comes from the provider resolution path, not the propDef
       expect(result.current.dataAttributes['data-bg']).toBe('danger');
+    });
+  });
+
+  describe('bg: provider', () => {
+    it('sets data-bg from the resolved provider bg value', () => {
+      const { result } = renderHook(() =>
+        useDefinition(providerDef, {
+          bg: 'danger',
+          children: null,
+        }),
+      );
+
+      expect(result.current.dataAttributes['data-bg']).toBe('danger');
+    });
+
+    it('does not set data-bg when bg prop is undefined', () => {
+      const { result } = renderHook(() =>
+        useDefinition(providerDef, {
+          children: null,
+        }),
+      );
+
+      expect(result.current.dataAttributes).not.toHaveProperty('data-bg');
+    });
+
+    it('adds childrenWithBgProvider to ownProps', () => {
+      const { result } = renderHook(() =>
+        useDefinition(providerDef, {
+          bg: 'neutral',
+          children: 'hello',
+        }),
+      );
+
+      expect(result.current.ownProps).toHaveProperty('childrenWithBgProvider');
+    });
+
+    it('wraps children in BgProvider when bg resolves to a value', () => {
+      const { result } = renderHook(() =>
+        useDefinition(providerDef, {
+          bg: 'neutral',
+          children: <BgReader />,
+        }),
+      );
+
+      const { getByTestId } = render(
+        <>{result.current.ownProps.childrenWithBgProvider}</>,
+      );
+
+      expect(getByTestId('bg')).toHaveTextContent('neutral-1');
+    });
+
+    it('returns raw children as childrenWithBgProvider when bg is undefined', () => {
+      const childContent = <span>hello</span>;
+      const { result } = renderHook(() =>
+        useDefinition(providerDef, {
+          children: childContent,
+        }),
+      );
+
+      expect(result.current.ownProps.childrenWithBgProvider).toBe(childContent);
+    });
+
+    it('increments neutral bg level from parent context', () => {
+      const wrapper = ({ children }: PropsWithChildren) => (
+        <BgProvider bg="neutral-1">{children}</BgProvider>
+      );
+
+      const { result } = renderHook(
+        () =>
+          useDefinition(providerDef, {
+            bg: 'neutral',
+            children: <BgReader />,
+          }),
+        { wrapper },
+      );
+
+      expect(result.current.dataAttributes['data-bg']).toBe('neutral-2');
+    });
+  });
+
+  describe('bg: consumer', () => {
+    it('sets data-on-bg from parent BgProvider context', () => {
+      const wrapper = ({ children }: PropsWithChildren) => (
+        <BgProvider bg="neutral-1">{children}</BgProvider>
+      );
+
+      const { result } = renderHook(
+        () => useDefinition(consumerDef, { variant: 'primary' }),
+        { wrapper },
+      );
+
+      expect(result.current.dataAttributes['data-on-bg']).toBe('neutral-1');
+    });
+
+    it('does not set data-on-bg when no parent BgProvider exists', () => {
+      const { result } = renderHook(() =>
+        useDefinition(consumerDef, { variant: 'primary' }),
+      );
+
+      expect(result.current.dataAttributes).not.toHaveProperty('data-on-bg');
+    });
+
+    it('returns children (not childrenWithBgProvider) in ownProps', () => {
+      const { result } = renderHook(() =>
+        useDefinition(consumerDef, { variant: 'primary', children: 'hello' }),
+      );
+
+      expect(result.current.ownProps).toHaveProperty('children', 'hello');
+      expect(result.current.ownProps).not.toHaveProperty(
+        'childrenWithBgProvider',
+      );
+    });
+  });
+
+  describe('no bg config', () => {
+    it('does not set data-bg or data-on-bg', () => {
+      const { result } = renderHook(() =>
+        useDefinition(basicDef, { variant: 'primary' }),
+      );
+
+      expect(result.current.dataAttributes).not.toHaveProperty('data-bg');
+      expect(result.current.dataAttributes).not.toHaveProperty('data-on-bg');
+    });
+
+    it('returns children in ownProps', () => {
+      const { result } = renderHook(() =>
+        useDefinition(basicDef, { variant: 'primary', children: 'hello' }),
+      );
+
+      expect(result.current.ownProps).toHaveProperty('children', 'hello');
     });
   });
 });

--- a/packages/ui/src/hooks/useDefinition/useDefinition.test.tsx
+++ b/packages/ui/src/hooks/useDefinition/useDefinition.test.tsx
@@ -208,4 +208,73 @@ describe('useDefinition', () => {
       expect(result.current.ownProps.classes.content).not.toContain('custom');
     });
   });
+
+  describe('data attributes', () => {
+    it('generates data-* attributes for props with dataAttribute: true', () => {
+      const { result } = renderHook(() =>
+        useDefinition(basicDef, { variant: 'primary' }),
+      );
+
+      expect(result.current.dataAttributes['data-variant']).toBe('primary');
+    });
+
+    it('does not generate data-* for props without dataAttribute', () => {
+      const { result } = renderHook(() =>
+        useDefinition(basicDef, {
+          variant: 'primary',
+          className: 'custom',
+        }),
+      );
+
+      expect(result.current.dataAttributes).not.toHaveProperty(
+        'data-classname',
+      );
+    });
+
+    it('omits data-* when the prop value is undefined', () => {
+      const { result } = renderHook(() => useDefinition(basicDef, {}));
+
+      expect(result.current.dataAttributes).not.toHaveProperty('data-variant');
+    });
+
+    it('stringifies non-string prop values in data attributes', () => {
+      const numericDef = {
+        styles: { root: 'css-root' },
+        classNames: { root: 'root' },
+        propDefs: {
+          count: { dataAttribute: true } as const,
+          className: {},
+        },
+      } as ComponentConfig<any, any>;
+
+      const { result } = renderHook(() =>
+        useDefinition(numericDef, { count: 42 }),
+      );
+
+      expect(result.current.dataAttributes['data-count']).toBe('42');
+    });
+
+    it('skips data-bg for bg prop when definition.bg is provider', () => {
+      const providerDef = {
+        styles: { root: 'css-root' },
+        classNames: { root: 'root' },
+        propDefs: {
+          bg: { dataAttribute: true } as const,
+          children: {},
+          className: {},
+        },
+        bg: 'provider' as const,
+      } as ComponentConfig<any, any>;
+
+      const { result } = renderHook(() =>
+        useDefinition(providerDef, {
+          bg: 'danger',
+          children: null,
+        }),
+      );
+
+      // data-bg comes from the provider resolution path, not the propDef
+      expect(result.current.dataAttributes['data-bg']).toBe('danger');
+    });
+  });
 });

--- a/packages/ui/src/hooks/useDefinition/useDefinition.test.tsx
+++ b/packages/ui/src/hooks/useDefinition/useDefinition.test.tsx
@@ -637,4 +637,53 @@ describe('useDefinition', () => {
       });
     });
   });
+
+  describe('options', () => {
+    it('utilityTarget defaults to root', () => {
+      const { result } = renderHook(() =>
+        useDefinition(multiSlotDef, { variant: 'primary', m: '2' }),
+      );
+
+      expect(result.current.ownProps.classes.root).toContain('bui-m-2');
+      expect(result.current.ownProps.classes.content).not.toContain('bui-m-2');
+    });
+
+    it('classNameTarget defaults to root', () => {
+      const { result } = renderHook(() =>
+        useDefinition(multiSlotDef, {
+          variant: 'primary',
+          className: 'custom',
+        }),
+      );
+
+      expect(result.current.ownProps.classes.root).toContain('custom');
+      expect(result.current.ownProps.classes.content).not.toContain('custom');
+    });
+
+    it('custom utilityTarget applies utility classes to that slot', () => {
+      const { result } = renderHook(() =>
+        useDefinition(
+          multiSlotDef,
+          { variant: 'primary', m: '2' },
+          { utilityTarget: 'content' },
+        ),
+      );
+
+      expect(result.current.ownProps.classes.content).toContain('bui-m-2');
+      expect(result.current.ownProps.classes.root).not.toContain('bui-m-2');
+    });
+
+    it('custom classNameTarget applies className to that slot', () => {
+      const { result } = renderHook(() =>
+        useDefinition(
+          multiSlotDef,
+          { variant: 'primary', className: 'custom' },
+          { classNameTarget: 'content' },
+        ),
+      );
+
+      expect(result.current.ownProps.classes.content).toContain('custom');
+      expect(result.current.ownProps.classes.root).not.toContain('custom');
+    });
+  });
 });

--- a/packages/ui/src/hooks/useDefinition/useDefinition.test.tsx
+++ b/packages/ui/src/hooks/useDefinition/useDefinition.test.tsx
@@ -120,10 +120,10 @@ function createRouterWrapper({
   basename?: string;
   currentRoute: string;
 }) {
-  return function Wrapper({ children }: PropsWithChildren) {
+  return function RouterWrapper({ children }: PropsWithChildren) {
     const entry = basename ? `${basename}${currentRoute}` : currentRoute;
-    // Build nested Routes one level per path segment. Each parent uses a plain
-    // (non-splat) path so that `..` resolution works correctly at every depth.
+    // Build nested Routes one level per path segment. The leaf route uses a
+    // non-splat path so that `..` resolution works correctly.
     const segments =
       currentRoute === '/'
         ? []
@@ -380,7 +380,7 @@ describe('useDefinition', () => {
       expect(result.current.dataAttributes['data-count']).toBe('42');
     });
 
-    it('skips data-bg for bg prop when definition.bg is provider', () => {
+    it('does not generate data-bg from propDefs when bg=provider (uses provider path instead)', () => {
       const localProviderDef = {
         styles: { root: 'css-root' },
         classNames: { root: 'root' },

--- a/packages/ui/src/hooks/useDefinition/useDefinition.test.tsx
+++ b/packages/ui/src/hooks/useDefinition/useDefinition.test.tsx
@@ -18,6 +18,7 @@ import { renderHook, render } from '@testing-library/react';
 import { useDefinition } from './useDefinition';
 import type { ComponentConfig } from './types';
 import { BgProvider, useBgConsumer } from '../useBg';
+import { noopTracker } from '../../analytics/useAnalytics';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -81,6 +82,16 @@ const consumerDef = {
     className: {},
   },
   bg: 'consumer' as const,
+} as ComponentConfig<any, any>;
+
+const analyticsDef = {
+  styles: { root: 'css-root' },
+  classNames: { root: 'root' },
+  propDefs: {
+    noTrack: {},
+    className: {},
+  },
+  analytics: true,
 } as ComponentConfig<any, any>;
 
 // ---------------------------------------------------------------------------
@@ -437,6 +448,59 @@ describe('useDefinition', () => {
       );
 
       expect(result.current.ownProps).toHaveProperty('children', 'hello');
+    });
+  });
+
+  describe('utility style', () => {
+    it('returns utilityStyle with CSS custom properties from utility props', () => {
+      const { result } = renderHook(() =>
+        useDefinition(utilityDef, {
+          variant: 'primary',
+          width: '100px',
+        }),
+      );
+
+      expect(result.current.utilityStyle).toEqual({ '--width': '100px' });
+    });
+
+    it('returns empty utilityStyle when no utility props are provided', () => {
+      const { result } = renderHook(() =>
+        useDefinition(utilityDef, { variant: 'primary' }),
+      );
+
+      expect(result.current.utilityStyle).toEqual({});
+    });
+  });
+
+  describe('analytics', () => {
+    it('returns analytics tracker when definition.analytics is true', () => {
+      const { result } = renderHook(() => useDefinition(analyticsDef, {}));
+
+      expect(result.current).toHaveProperty('analytics');
+      expect(result.current.analytics).toHaveProperty('captureEvent');
+    });
+
+    it('does not include analytics key when definition.analytics is not set', () => {
+      const { result } = renderHook(() =>
+        useDefinition(basicDef, { variant: 'primary' }),
+      );
+
+      expect(result.current).not.toHaveProperty('analytics');
+    });
+
+    it('returns noopTracker when noTrack is true', () => {
+      const { result } = renderHook(() =>
+        useDefinition(analyticsDef, { noTrack: true }),
+      );
+
+      expect(result.current.analytics).toBe(noopTracker);
+    });
+
+    it('returns noopTracker when no BUIProvider is present', () => {
+      const { result } = renderHook(() => useDefinition(analyticsDef, {}));
+
+      // Without BUIProvider, useAnalytics() returns noopTracker
+      expect(result.current.analytics).toBe(noopTracker);
     });
   });
 });

--- a/packages/ui/src/hooks/useDefinition/useDefinition.test.tsx
+++ b/packages/ui/src/hooks/useDefinition/useDefinition.test.tsx
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { renderHook } from '@testing-library/react';
+import { useDefinition } from './useDefinition';
+import type { ComponentConfig } from './types';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const basicDef = {
+  styles: { root: 'css-root' },
+  classNames: { root: 'root' },
+  propDefs: {
+    variant: { dataAttribute: true } as const,
+    size: { dataAttribute: true, default: 'medium' } as const,
+    className: {},
+  },
+} as ComponentConfig<any, any>;
+
+const multiSlotDef = {
+  styles: { root: 'css-root', content: 'css-content' },
+  classNames: { root: 'root', content: 'content' },
+  propDefs: {
+    variant: { dataAttribute: true } as const,
+    className: {},
+  },
+  utilityProps: ['m'] as const,
+} as ComponentConfig<any, any>;
+
+const utilityDef = {
+  styles: { root: 'css-root' },
+  classNames: { root: 'root' },
+  propDefs: {
+    variant: {},
+    className: {},
+  },
+  utilityProps: ['m', 'p', 'width'] as const,
+} as ComponentConfig<any, any>;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useDefinition', () => {
+  describe('prop resolution', () => {
+    it('returns resolved own props from propDefs', () => {
+      const { result } = renderHook(() =>
+        useDefinition(basicDef, { variant: 'primary' }),
+      );
+
+      expect(result.current.ownProps.variant).toBe('primary');
+    });
+
+    it('applies default values for missing own props', () => {
+      const { result } = renderHook(() =>
+        useDefinition(basicDef, { variant: 'primary' }),
+      );
+
+      expect(result.current.ownProps.size).toBe('medium');
+    });
+
+    it('returns rest props for props not in propDefs or utilityProps', () => {
+      const { result } = renderHook(() =>
+        useDefinition(basicDef, {
+          variant: 'primary',
+          'aria-label': 'test',
+        }),
+      );
+
+      expect(result.current.restProps).toEqual({ 'aria-label': 'test' });
+    });
+
+    it('excludes utility props from both ownProps and restProps', () => {
+      const { result } = renderHook(() =>
+        useDefinition(utilityDef, {
+          variant: 'primary',
+          m: '2',
+          'aria-label': 'test',
+        }),
+      );
+
+      expect(result.current.ownProps).not.toHaveProperty('m');
+      expect(result.current.restProps).not.toHaveProperty('m');
+      expect(result.current.restProps).toEqual({ 'aria-label': 'test' });
+    });
+  });
+
+  describe('classes', () => {
+    it('builds a classes object with keys matching definition.classNames', () => {
+      const { result } = renderHook(() =>
+        useDefinition(multiSlotDef, { variant: 'primary' }),
+      );
+
+      expect(result.current.ownProps.classes).toHaveProperty('root');
+      expect(result.current.ownProps.classes).toHaveProperty('content');
+    });
+
+    it('includes the base CSS class from definition.styles', () => {
+      const { result } = renderHook(() =>
+        useDefinition(basicDef, { variant: 'primary' }),
+      );
+
+      expect(result.current.ownProps.classes.root).toContain('css-root');
+    });
+
+    it('appends user className to the root slot by default', () => {
+      const { result } = renderHook(() =>
+        useDefinition(basicDef, {
+          variant: 'primary',
+          className: 'custom',
+        }),
+      );
+
+      expect(result.current.ownProps.classes.root).toContain('custom');
+    });
+
+    it('appends utility classes to the root slot by default', () => {
+      const { result } = renderHook(() =>
+        useDefinition(utilityDef, { variant: 'primary', m: '2' }),
+      );
+
+      expect(result.current.ownProps.classes.root).toContain('bui-m-2');
+    });
+
+    it('appends user className to a custom classNameTarget slot', () => {
+      const { result } = renderHook(() =>
+        useDefinition(
+          multiSlotDef,
+          { variant: 'primary', className: 'custom' },
+          {
+            classNameTarget: 'content',
+          },
+        ),
+      );
+
+      expect(result.current.ownProps.classes.content).toContain('custom');
+      expect(result.current.ownProps.classes.root).not.toContain('custom');
+    });
+
+    it('appends utility classes to a custom utilityTarget slot', () => {
+      const { result } = renderHook(() =>
+        useDefinition(
+          multiSlotDef,
+          { variant: 'primary', m: '2' },
+          {
+            utilityTarget: 'content',
+          },
+        ),
+      );
+
+      expect(result.current.ownProps.classes.content).toContain('bui-m-2');
+      expect(result.current.ownProps.classes.root).not.toContain('bui-m-2');
+    });
+
+    it('does not append user className when classNameTarget is null', () => {
+      const { result } = renderHook(() =>
+        useDefinition(
+          basicDef,
+          { variant: 'primary', className: 'custom' },
+          {
+            classNameTarget: null,
+          },
+        ),
+      );
+
+      expect(result.current.ownProps.classes.root).not.toContain('custom');
+    });
+
+    it('does not append utility classes when utilityTarget is null', () => {
+      const { result } = renderHook(() =>
+        useDefinition(
+          utilityDef,
+          { variant: 'primary', m: '2' },
+          {
+            utilityTarget: null,
+          },
+        ),
+      );
+
+      expect(result.current.ownProps.classes.root).not.toContain('bui-m-2');
+    });
+
+    it('keeps non-targeted slots free of utility classes and user className', () => {
+      const { result } = renderHook(() =>
+        useDefinition(multiSlotDef, {
+          variant: 'primary',
+          m: '2',
+          className: 'custom',
+        }),
+      );
+
+      // Defaults target root — content should be clean
+      expect(result.current.ownProps.classes.content).not.toContain('bui-m-2');
+      expect(result.current.ownProps.classes.content).not.toContain('custom');
+    });
+  });
+});

--- a/packages/ui/src/hooks/useDefinition/useDefinition.test.tsx
+++ b/packages/ui/src/hooks/useDefinition/useDefinition.test.tsx
@@ -47,7 +47,7 @@ const basicDef = {
     size: { dataAttribute: true, default: 'medium' } as const,
     className: {},
   },
-} as ComponentConfig<any, any>;
+} as const satisfies ComponentConfig<any, any>;
 
 const multiSlotDef = {
   styles: { root: 'css-root', content: 'css-content' },
@@ -57,7 +57,7 @@ const multiSlotDef = {
     className: {},
   },
   utilityProps: ['m'] as const,
-} as ComponentConfig<any, any>;
+} as const satisfies ComponentConfig<any, any>;
 
 const utilityDef = {
   styles: { root: 'css-root' },
@@ -67,7 +67,7 @@ const utilityDef = {
     className: {},
   },
   utilityProps: ['m', 'p', 'width'] as const,
-} as ComponentConfig<any, any>;
+} as const satisfies ComponentConfig<any, any>;
 
 const providerDef = {
   styles: { root: 'css-root' },
@@ -78,7 +78,7 @@ const providerDef = {
     className: {},
   },
   bg: 'provider' as const,
-} as ComponentConfig<any, any>;
+} as const satisfies ComponentConfig<any, any>;
 
 const consumerDef = {
   styles: { root: 'css-root' },
@@ -88,7 +88,7 @@ const consumerDef = {
     className: {},
   },
   bg: 'consumer' as const,
-} as ComponentConfig<any, any>;
+} as const satisfies ComponentConfig<any, any>;
 
 const analyticsDef = {
   styles: { root: 'css-root' },
@@ -98,7 +98,7 @@ const analyticsDef = {
     className: {},
   },
   analytics: true,
-} as ComponentConfig<any, any>;
+} as const satisfies ComponentConfig<any, any>;
 
 const hrefDef = {
   styles: { root: 'css-root' },
@@ -107,7 +107,7 @@ const hrefDef = {
     href: {},
     className: {},
   },
-} as ComponentConfig<any, any>;
+} as const satisfies ComponentConfig<any, any>;
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -171,7 +171,7 @@ describe('useDefinition', () => {
         { wrapper: Wrapper },
       );
 
-      expect(result.current.ownProps.size).toBe('medium');
+      expect((result.current.ownProps as any).size).toBe('medium');
     });
 
     it('returns rest props for props not in propDefs or utilityProps', () => {
@@ -370,7 +370,7 @@ describe('useDefinition', () => {
           count: { dataAttribute: true } as const,
           className: {},
         },
-      } as ComponentConfig<any, any>;
+      } as const satisfies ComponentConfig<any, any>;
 
       const { result } = renderHook(
         () => useDefinition(numericDef, { count: 42 }),
@@ -390,7 +390,7 @@ describe('useDefinition', () => {
           className: {},
         },
         bg: 'provider' as const,
-      } as ComponentConfig<any, any>;
+      } as const satisfies ComponentConfig<any, any>;
 
       const { result } = renderHook(
         () =>

--- a/packages/ui/src/hooks/useDefinition/useDefinition.test.tsx
+++ b/packages/ui/src/hooks/useDefinition/useDefinition.test.tsx
@@ -20,6 +20,7 @@ import { useDefinition } from './useDefinition';
 import type { ComponentConfig } from './types';
 import { BgProvider, useBgConsumer } from '../useBg';
 import { noopTracker } from '../../analytics/useAnalytics';
+import { BUIProvider } from '../../provider';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -28,6 +29,10 @@ import { noopTracker } from '../../analytics/useAnalytics';
 function BgReader() {
   const { bg } = useBgConsumer();
   return <span data-testid="bg">{bg ?? 'none'}</span>;
+}
+
+function Wrapper({ children }: PropsWithChildren) {
+  return <BUIProvider>{children}</BUIProvider>;
 }
 
 // ---------------------------------------------------------------------------
@@ -135,13 +140,15 @@ function createRouterWrapper({
 
     return (
       <MemoryRouter basename={basename} initialEntries={[entry]}>
-        <Routes>
-          {segments.length === 0 ? (
-            <Route path="*" element={children} />
-          ) : (
-            buildRoutes(segments, children)
-          )}
-        </Routes>
+        <BUIProvider>
+          <Routes>
+            {segments.length === 0 ? (
+              <Route path="*" element={children} />
+            ) : (
+              buildRoutes(segments, children)
+            )}
+          </Routes>
+        </BUIProvider>
       </MemoryRouter>
     );
   };
@@ -150,39 +157,45 @@ function createRouterWrapper({
 describe('useDefinition', () => {
   describe('prop resolution', () => {
     it('returns resolved own props from propDefs', () => {
-      const { result } = renderHook(() =>
-        useDefinition(basicDef, { variant: 'primary' }),
+      const { result } = renderHook(
+        () => useDefinition(basicDef, { variant: 'primary' }),
+        { wrapper: Wrapper },
       );
 
       expect(result.current.ownProps.variant).toBe('primary');
     });
 
     it('applies default values for missing own props', () => {
-      const { result } = renderHook(() =>
-        useDefinition(basicDef, { variant: 'primary' }),
+      const { result } = renderHook(
+        () => useDefinition(basicDef, { variant: 'primary' }),
+        { wrapper: Wrapper },
       );
 
       expect(result.current.ownProps.size).toBe('medium');
     });
 
     it('returns rest props for props not in propDefs or utilityProps', () => {
-      const { result } = renderHook(() =>
-        useDefinition(basicDef, {
-          variant: 'primary',
-          'aria-label': 'test',
-        }),
+      const { result } = renderHook(
+        () =>
+          useDefinition(basicDef, {
+            variant: 'primary',
+            'aria-label': 'test',
+          }),
+        { wrapper: Wrapper },
       );
 
       expect(result.current.restProps).toEqual({ 'aria-label': 'test' });
     });
 
     it('excludes utility props from both ownProps and restProps', () => {
-      const { result } = renderHook(() =>
-        useDefinition(utilityDef, {
-          variant: 'primary',
-          m: '2',
-          'aria-label': 'test',
-        }),
+      const { result } = renderHook(
+        () =>
+          useDefinition(utilityDef, {
+            variant: 'primary',
+            m: '2',
+            'aria-label': 'test',
+          }),
+        { wrapper: Wrapper },
       );
 
       expect(result.current.ownProps).not.toHaveProperty('m');
@@ -193,8 +206,9 @@ describe('useDefinition', () => {
 
   describe('classes', () => {
     it('builds a classes object with keys matching definition.classNames', () => {
-      const { result } = renderHook(() =>
-        useDefinition(multiSlotDef, { variant: 'primary' }),
+      const { result } = renderHook(
+        () => useDefinition(multiSlotDef, { variant: 'primary' }),
+        { wrapper: Wrapper },
       );
 
       expect(result.current.ownProps.classes).toHaveProperty('root');
@@ -202,41 +216,47 @@ describe('useDefinition', () => {
     });
 
     it('includes the base CSS class from definition.styles', () => {
-      const { result } = renderHook(() =>
-        useDefinition(basicDef, { variant: 'primary' }),
+      const { result } = renderHook(
+        () => useDefinition(basicDef, { variant: 'primary' }),
+        { wrapper: Wrapper },
       );
 
       expect(result.current.ownProps.classes.root).toContain('css-root');
     });
 
     it('appends user className to the root slot by default', () => {
-      const { result } = renderHook(() =>
-        useDefinition(basicDef, {
-          variant: 'primary',
-          className: 'custom',
-        }),
+      const { result } = renderHook(
+        () =>
+          useDefinition(basicDef, {
+            variant: 'primary',
+            className: 'custom',
+          }),
+        { wrapper: Wrapper },
       );
 
       expect(result.current.ownProps.classes.root).toContain('custom');
     });
 
     it('appends utility classes to the root slot by default', () => {
-      const { result } = renderHook(() =>
-        useDefinition(utilityDef, { variant: 'primary', m: '2' }),
+      const { result } = renderHook(
+        () => useDefinition(utilityDef, { variant: 'primary', m: '2' }),
+        { wrapper: Wrapper },
       );
 
       expect(result.current.ownProps.classes.root).toContain('bui-m-2');
     });
 
     it('appends user className to a custom classNameTarget slot', () => {
-      const { result } = renderHook(() =>
-        useDefinition(
-          multiSlotDef,
-          { variant: 'primary', className: 'custom' },
-          {
-            classNameTarget: 'content',
-          },
-        ),
+      const { result } = renderHook(
+        () =>
+          useDefinition(
+            multiSlotDef,
+            { variant: 'primary', className: 'custom' },
+            {
+              classNameTarget: 'content',
+            },
+          ),
+        { wrapper: Wrapper },
       );
 
       expect(result.current.ownProps.classes.content).toContain('custom');
@@ -244,14 +264,16 @@ describe('useDefinition', () => {
     });
 
     it('appends utility classes to a custom utilityTarget slot', () => {
-      const { result } = renderHook(() =>
-        useDefinition(
-          multiSlotDef,
-          { variant: 'primary', m: '2' },
-          {
-            utilityTarget: 'content',
-          },
-        ),
+      const { result } = renderHook(
+        () =>
+          useDefinition(
+            multiSlotDef,
+            { variant: 'primary', m: '2' },
+            {
+              utilityTarget: 'content',
+            },
+          ),
+        { wrapper: Wrapper },
       );
 
       expect(result.current.ownProps.classes.content).toContain('bui-m-2');
@@ -259,40 +281,46 @@ describe('useDefinition', () => {
     });
 
     it('does not append user className when classNameTarget is null', () => {
-      const { result } = renderHook(() =>
-        useDefinition(
-          basicDef,
-          { variant: 'primary', className: 'custom' },
-          {
-            classNameTarget: null,
-          },
-        ),
+      const { result } = renderHook(
+        () =>
+          useDefinition(
+            basicDef,
+            { variant: 'primary', className: 'custom' },
+            {
+              classNameTarget: null,
+            },
+          ),
+        { wrapper: Wrapper },
       );
 
       expect(result.current.ownProps.classes.root).not.toContain('custom');
     });
 
     it('does not append utility classes when utilityTarget is null', () => {
-      const { result } = renderHook(() =>
-        useDefinition(
-          utilityDef,
-          { variant: 'primary', m: '2' },
-          {
-            utilityTarget: null,
-          },
-        ),
+      const { result } = renderHook(
+        () =>
+          useDefinition(
+            utilityDef,
+            { variant: 'primary', m: '2' },
+            {
+              utilityTarget: null,
+            },
+          ),
+        { wrapper: Wrapper },
       );
 
       expect(result.current.ownProps.classes.root).not.toContain('bui-m-2');
     });
 
     it('keeps non-targeted slots free of utility classes and user className', () => {
-      const { result } = renderHook(() =>
-        useDefinition(multiSlotDef, {
-          variant: 'primary',
-          m: '2',
-          className: 'custom',
-        }),
+      const { result } = renderHook(
+        () =>
+          useDefinition(multiSlotDef, {
+            variant: 'primary',
+            m: '2',
+            className: 'custom',
+          }),
+        { wrapper: Wrapper },
       );
 
       // Defaults target root — content should be clean
@@ -303,19 +331,22 @@ describe('useDefinition', () => {
 
   describe('data attributes', () => {
     it('generates data-* attributes for props with dataAttribute: true', () => {
-      const { result } = renderHook(() =>
-        useDefinition(basicDef, { variant: 'primary' }),
+      const { result } = renderHook(
+        () => useDefinition(basicDef, { variant: 'primary' }),
+        { wrapper: Wrapper },
       );
 
       expect(result.current.dataAttributes['data-variant']).toBe('primary');
     });
 
     it('does not generate data-* for props without dataAttribute', () => {
-      const { result } = renderHook(() =>
-        useDefinition(basicDef, {
-          variant: 'primary',
-          className: 'custom',
-        }),
+      const { result } = renderHook(
+        () =>
+          useDefinition(basicDef, {
+            variant: 'primary',
+            className: 'custom',
+          }),
+        { wrapper: Wrapper },
       );
 
       expect(result.current.dataAttributes).not.toHaveProperty(
@@ -324,7 +355,9 @@ describe('useDefinition', () => {
     });
 
     it('omits data-* when the prop value is undefined', () => {
-      const { result } = renderHook(() => useDefinition(basicDef, {}));
+      const { result } = renderHook(() => useDefinition(basicDef, {}), {
+        wrapper: Wrapper,
+      });
 
       expect(result.current.dataAttributes).not.toHaveProperty('data-variant');
     });
@@ -339,8 +372,9 @@ describe('useDefinition', () => {
         },
       } as ComponentConfig<any, any>;
 
-      const { result } = renderHook(() =>
-        useDefinition(numericDef, { count: 42 }),
+      const { result } = renderHook(
+        () => useDefinition(numericDef, { count: 42 }),
+        { wrapper: Wrapper },
       );
 
       expect(result.current.dataAttributes['data-count']).toBe('42');
@@ -358,11 +392,13 @@ describe('useDefinition', () => {
         bg: 'provider' as const,
       } as ComponentConfig<any, any>;
 
-      const { result } = renderHook(() =>
-        useDefinition(localProviderDef, {
-          bg: 'danger',
-          children: null,
-        }),
+      const { result } = renderHook(
+        () =>
+          useDefinition(localProviderDef, {
+            bg: 'danger',
+            children: null,
+          }),
+        { wrapper: Wrapper },
       );
 
       // data-bg comes from the provider resolution path, not the propDef
@@ -372,43 +408,51 @@ describe('useDefinition', () => {
 
   describe('bg: provider', () => {
     it('sets data-bg from the resolved provider bg value', () => {
-      const { result } = renderHook(() =>
-        useDefinition(providerDef, {
-          bg: 'danger',
-          children: null,
-        }),
+      const { result } = renderHook(
+        () =>
+          useDefinition(providerDef, {
+            bg: 'danger',
+            children: null,
+          }),
+        { wrapper: Wrapper },
       );
 
       expect(result.current.dataAttributes['data-bg']).toBe('danger');
     });
 
     it('does not set data-bg when bg prop is undefined', () => {
-      const { result } = renderHook(() =>
-        useDefinition(providerDef, {
-          children: null,
-        }),
+      const { result } = renderHook(
+        () =>
+          useDefinition(providerDef, {
+            children: null,
+          }),
+        { wrapper: Wrapper },
       );
 
       expect(result.current.dataAttributes).not.toHaveProperty('data-bg');
     });
 
     it('adds childrenWithBgProvider to ownProps', () => {
-      const { result } = renderHook(() =>
-        useDefinition(providerDef, {
-          bg: 'neutral',
-          children: 'hello',
-        }),
+      const { result } = renderHook(
+        () =>
+          useDefinition(providerDef, {
+            bg: 'neutral',
+            children: 'hello',
+          }),
+        { wrapper: Wrapper },
       );
 
       expect(result.current.ownProps).toHaveProperty('childrenWithBgProvider');
     });
 
     it('wraps children in BgProvider when bg resolves to a value', () => {
-      const { result } = renderHook(() =>
-        useDefinition(providerDef, {
-          bg: 'neutral',
-          children: <BgReader />,
-        }),
+      const { result } = renderHook(
+        () =>
+          useDefinition(providerDef, {
+            bg: 'neutral',
+            children: <BgReader />,
+          }),
+        { wrapper: Wrapper },
       );
 
       const { getByTestId } = render(
@@ -420,10 +464,12 @@ describe('useDefinition', () => {
 
     it('returns raw children as childrenWithBgProvider when bg is undefined', () => {
       const childContent = <span>hello</span>;
-      const { result } = renderHook(() =>
-        useDefinition(providerDef, {
-          children: childContent,
-        }),
+      const { result } = renderHook(
+        () =>
+          useDefinition(providerDef, {
+            children: childContent,
+          }),
+        { wrapper: Wrapper },
       );
 
       expect(result.current.ownProps.childrenWithBgProvider).toBe(childContent);
@@ -431,7 +477,9 @@ describe('useDefinition', () => {
 
     it('increments neutral bg level from parent context', () => {
       const wrapper = ({ children }: PropsWithChildren) => (
-        <BgProvider bg="neutral-1">{children}</BgProvider>
+        <BUIProvider>
+          <BgProvider bg="neutral-1">{children}</BgProvider>
+        </BUIProvider>
       );
 
       const { result } = renderHook(
@@ -450,7 +498,9 @@ describe('useDefinition', () => {
   describe('bg: consumer', () => {
     it('sets data-on-bg from parent BgProvider context', () => {
       const wrapper = ({ children }: PropsWithChildren) => (
-        <BgProvider bg="neutral-1">{children}</BgProvider>
+        <BUIProvider>
+          <BgProvider bg="neutral-1">{children}</BgProvider>
+        </BUIProvider>
       );
 
       const { result } = renderHook(
@@ -462,16 +512,19 @@ describe('useDefinition', () => {
     });
 
     it('does not set data-on-bg when no parent BgProvider exists', () => {
-      const { result } = renderHook(() =>
-        useDefinition(consumerDef, { variant: 'primary' }),
+      const { result } = renderHook(
+        () => useDefinition(consumerDef, { variant: 'primary' }),
+        { wrapper: Wrapper },
       );
 
       expect(result.current.dataAttributes).not.toHaveProperty('data-on-bg');
     });
 
     it('returns children (not childrenWithBgProvider) in ownProps', () => {
-      const { result } = renderHook(() =>
-        useDefinition(consumerDef, { variant: 'primary', children: 'hello' }),
+      const { result } = renderHook(
+        () =>
+          useDefinition(consumerDef, { variant: 'primary', children: 'hello' }),
+        { wrapper: Wrapper },
       );
 
       expect(result.current.ownProps).toHaveProperty('children', 'hello');
@@ -483,8 +536,9 @@ describe('useDefinition', () => {
 
   describe('no bg config', () => {
     it('does not set data-bg or data-on-bg', () => {
-      const { result } = renderHook(() =>
-        useDefinition(basicDef, { variant: 'primary' }),
+      const { result } = renderHook(
+        () => useDefinition(basicDef, { variant: 'primary' }),
+        { wrapper: Wrapper },
       );
 
       expect(result.current.dataAttributes).not.toHaveProperty('data-bg');
@@ -492,8 +546,10 @@ describe('useDefinition', () => {
     });
 
     it('returns children in ownProps', () => {
-      const { result } = renderHook(() =>
-        useDefinition(basicDef, { variant: 'primary', children: 'hello' }),
+      const { result } = renderHook(
+        () =>
+          useDefinition(basicDef, { variant: 'primary', children: 'hello' }),
+        { wrapper: Wrapper },
       );
 
       expect(result.current.ownProps).toHaveProperty('children', 'hello');
@@ -502,19 +558,22 @@ describe('useDefinition', () => {
 
   describe('utility style', () => {
     it('returns utilityStyle with CSS custom properties from utility props', () => {
-      const { result } = renderHook(() =>
-        useDefinition(utilityDef, {
-          variant: 'primary',
-          width: '100px',
-        }),
+      const { result } = renderHook(
+        () =>
+          useDefinition(utilityDef, {
+            variant: 'primary',
+            width: '100px',
+          }),
+        { wrapper: Wrapper },
       );
 
       expect(result.current.utilityStyle).toEqual({ '--width': '100px' });
     });
 
     it('returns empty utilityStyle when no utility props are provided', () => {
-      const { result } = renderHook(() =>
-        useDefinition(utilityDef, { variant: 'primary' }),
+      const { result } = renderHook(
+        () => useDefinition(utilityDef, { variant: 'primary' }),
+        { wrapper: Wrapper },
       );
 
       expect(result.current.utilityStyle).toEqual({});
@@ -523,32 +582,29 @@ describe('useDefinition', () => {
 
   describe('analytics', () => {
     it('returns analytics tracker when definition.analytics is true', () => {
-      const { result } = renderHook(() => useDefinition(analyticsDef, {}));
+      const { result } = renderHook(() => useDefinition(analyticsDef, {}), {
+        wrapper: Wrapper,
+      });
 
       expect(result.current).toHaveProperty('analytics');
       expect(result.current.analytics).toHaveProperty('captureEvent');
     });
 
     it('does not include analytics key when definition.analytics is not set', () => {
-      const { result } = renderHook(() =>
-        useDefinition(basicDef, { variant: 'primary' }),
+      const { result } = renderHook(
+        () => useDefinition(basicDef, { variant: 'primary' }),
+        { wrapper: Wrapper },
       );
 
       expect(result.current).not.toHaveProperty('analytics');
     });
 
     it('returns noopTracker when noTrack is true', () => {
-      const { result } = renderHook(() =>
-        useDefinition(analyticsDef, { noTrack: true }),
+      const { result } = renderHook(
+        () => useDefinition(analyticsDef, { noTrack: true }),
+        { wrapper: Wrapper },
       );
 
-      expect(result.current.analytics).toBe(noopTracker);
-    });
-
-    it('returns noopTracker when no BUIProvider is present', () => {
-      const { result } = renderHook(() => useDefinition(analyticsDef, {}));
-
-      // Without BUIProvider, useAnalytics() returns noopTracker
       expect(result.current.analytics).toBe(noopTracker);
     });
   });
@@ -629,8 +685,9 @@ describe('useDefinition', () => {
 
     describe('outside router context', () => {
       it('passes all href values through unchanged', () => {
-        const { result } = renderHook(() =>
-          useDefinition(hrefDef, { href: '/foo' }),
+        const { result } = renderHook(
+          () => useDefinition(hrefDef, { href: '/foo' }),
+          { wrapper: Wrapper },
         );
 
         expect(result.current.ownProps.href).toBe('/foo');
@@ -640,8 +697,9 @@ describe('useDefinition', () => {
 
   describe('options', () => {
     it('utilityTarget defaults to root', () => {
-      const { result } = renderHook(() =>
-        useDefinition(multiSlotDef, { variant: 'primary', m: '2' }),
+      const { result } = renderHook(
+        () => useDefinition(multiSlotDef, { variant: 'primary', m: '2' }),
+        { wrapper: Wrapper },
       );
 
       expect(result.current.ownProps.classes.root).toContain('bui-m-2');
@@ -649,11 +707,13 @@ describe('useDefinition', () => {
     });
 
     it('classNameTarget defaults to root', () => {
-      const { result } = renderHook(() =>
-        useDefinition(multiSlotDef, {
-          variant: 'primary',
-          className: 'custom',
-        }),
+      const { result } = renderHook(
+        () =>
+          useDefinition(multiSlotDef, {
+            variant: 'primary',
+            className: 'custom',
+          }),
+        { wrapper: Wrapper },
       );
 
       expect(result.current.ownProps.classes.root).toContain('custom');
@@ -661,12 +721,14 @@ describe('useDefinition', () => {
     });
 
     it('custom utilityTarget applies utility classes to that slot', () => {
-      const { result } = renderHook(() =>
-        useDefinition(
-          multiSlotDef,
-          { variant: 'primary', m: '2' },
-          { utilityTarget: 'content' },
-        ),
+      const { result } = renderHook(
+        () =>
+          useDefinition(
+            multiSlotDef,
+            { variant: 'primary', m: '2' },
+            { utilityTarget: 'content' },
+          ),
+        { wrapper: Wrapper },
       );
 
       expect(result.current.ownProps.classes.content).toContain('bui-m-2');
@@ -674,12 +736,14 @@ describe('useDefinition', () => {
     });
 
     it('custom classNameTarget applies className to that slot', () => {
-      const { result } = renderHook(() =>
-        useDefinition(
-          multiSlotDef,
-          { variant: 'primary', className: 'custom' },
-          { classNameTarget: 'content' },
-        ),
+      const { result } = renderHook(
+        () =>
+          useDefinition(
+            multiSlotDef,
+            { variant: 'primary', className: 'custom' },
+            { classNameTarget: 'content' },
+          ),
+        { wrapper: Wrapper },
       );
 
       expect(result.current.ownProps.classes.content).toContain('custom');

--- a/packages/ui/src/hooks/useDefinition/useDefinition.tsx
+++ b/packages/ui/src/hooks/useDefinition/useDefinition.tsx
@@ -122,8 +122,10 @@ export function useDefinition<
     analytics = ownPropsResolved.noTrack ? noopTracker : tracker;
   }
 
-  const utilityTarget = options?.utilityTarget ?? 'root';
-  const classNameTarget = options?.classNameTarget ?? 'root';
+  const utilityTarget =
+    options?.utilityTarget !== undefined ? options.utilityTarget : 'root';
+  const classNameTarget =
+    options?.classNameTarget !== undefined ? options.classNameTarget : 'root';
 
   const classes: Record<string, string> = {};
 

--- a/packages/ui/src/setupTests.ts
+++ b/packages/ui/src/setupTests.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import '@testing-library/jest-dom';

--- a/yarn.lock
+++ b/yarn.lock
@@ -7977,6 +7977,8 @@ __metadata:
     "@remixicon/react": "npm:^4.6.0"
     "@storybook/react-vite": "npm:^10.3.3"
     "@tanstack/react-table": "npm:^8.21.3"
+    "@testing-library/jest-dom": "npm:^6.0.0"
+    "@testing-library/react": "npm:^16.0.0"
     "@types/react": "npm:^18.0.0"
     "@types/react-dom": "npm:^18.0.0"
     "@types/use-sync-external-store": "npm:^1.0.0"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Introduces the first test suite in `@backstage/ui`, covering the
`useDefinition` hook and its helper functions with 108 tests across
two files:

- **`helpers.test.ts`** (37 tests) — unit tests for `resolveResponsiveValue`,
  `resolveDefinitionProps`, and `processUtilityProps`
- **`useDefinition.test.tsx`** (71 tests) — integration tests for prop
  resolution, classes composition, data attributes, background system
  (provider/consumer), utility styles, analytics, href resolution
  (parameterized across basename configurations), and options

Also fixes a minor bug in `useDefinition` where `utilityTarget: null`
and `classNameTarget: null` were treated as undefined due to the use
of `??` instead of an explicit `undefined` check. No existing
component passes `null` today, so no changeset is needed.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.