### PR TITLE
mcp-actions-backend: skip actions with invalid MCP tool schemas

### DIFF
--- a/.changeset/mcp-actions-skip-invalid-schemas.md
+++ b/.changeset/mcp-actions-skip-invalid-schemas.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-mcp-actions-backend': patch
+---
+
+Validate each action against the MCP tool schema when responding to `tools/list`, and skip any action that doesn't conform instead of failing the entire response. A single misbehaving action with a malformed input schema will now be logged as a warning and omitted from the tool list, letting the remaining actions continue to be served.

--- a/plugins/mcp-actions-backend/src/plugin.ts
+++ b/plugins/mcp-actions-backend/src/plugin.ts
@@ -74,6 +74,7 @@ export const mcpPlugin = createBackendPlugin({
         const mcpService = await McpService.create({
           actions,
           metrics,
+          logger,
           namespacedToolNames,
           tracingService: tracing,
           captureToolPayloads,

--- a/plugins/mcp-actions-backend/src/services/McpService.test.ts
+++ b/plugins/mcp-actions-backend/src/services/McpService.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { mockCredentials } from '@backstage/backend-test-utils';
+import { mockCredentials, mockServices } from '@backstage/backend-test-utils';
 import { McpService } from './McpService';
 import {
   actionsRegistryServiceMock,
@@ -156,6 +156,96 @@ describe('McpService', () => {
         'error.type': 'Error',
       }),
     );
+  });
+
+  it('should skip actions with invalid input schemas instead of failing the whole list', async () => {
+    const validAction = {
+      id: 'plugin:valid',
+      pluginId: 'plugin',
+      name: 'valid',
+      title: 'Valid',
+      description: 'Valid action',
+      schema: {
+        input: { type: 'object' as const },
+        output: { type: 'object' as const },
+      },
+      attributes: { destructive: false, readOnly: true, idempotent: true },
+    };
+    const badTypeAction = {
+      id: 'plugin:bad-type',
+      pluginId: 'plugin',
+      name: 'bad-type',
+      title: 'Bad Type',
+      description: 'inputSchema.type is not "object"',
+      schema: {
+        input: { type: 'string' as unknown as 'object' },
+        output: { type: 'object' as const },
+      },
+      attributes: { destructive: false, readOnly: true, idempotent: true },
+    };
+    const badRequiredAction = {
+      id: 'plugin:bad-required',
+      pluginId: 'plugin',
+      name: 'bad-required',
+      title: 'Bad Required',
+      description: 'inputSchema.required is not an array of strings',
+      schema: {
+        input: {
+          type: 'object' as const,
+          required: 'foo' as unknown as string[],
+        },
+        output: { type: 'object' as const },
+      },
+      attributes: { destructive: false, readOnly: true, idempotent: true },
+    };
+
+    const fakeActions: ActionsService = {
+      list: jest.fn(async () => ({
+        actions: [validAction, badTypeAction, badRequiredAction],
+      })),
+      invoke: jest.fn(async () => ({ output: {} })),
+    };
+
+    const logger = mockServices.logger.mock();
+    const mcpService = await McpService.create({
+      actions: fakeActions,
+      metrics: metricsServiceMock.mock(),
+      tracingService: tracingServiceMock.mock(),
+      logger,
+    });
+
+    const server = mcpService.getServer({
+      credentials: mockCredentials.user(),
+    });
+
+    const client = new Client({ name: 'test', version: '1.0' });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    await Promise.all([
+      client.connect(clientTransport),
+      server.connect(serverTransport),
+    ]);
+
+    const first = await client.request(
+      { method: 'tools/list' },
+      ListToolsResultSchema,
+    );
+    const second = await client.request(
+      { method: 'tools/list' },
+      ListToolsResultSchema,
+    );
+
+    expect(first.tools).toHaveLength(1);
+    expect(first.tools[0].name).toBe('plugin.valid');
+    expect(second.tools).toHaveLength(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('plugin:bad-type'),
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('plugin:bad-required'),
+    );
+    // Each bad action should only log once across repeated listings.
+    expect(logger.warn).toHaveBeenCalledTimes(2);
   });
 
   it('should call the action when the tool is invoked', async () => {

--- a/plugins/mcp-actions-backend/src/services/McpService.ts
+++ b/plugins/mcp-actions-backend/src/services/McpService.ts
@@ -13,11 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { BackstageCredentials } from '@backstage/backend-plugin-api';
+import {
+  BackstageCredentials,
+  LoggerService,
+} from '@backstage/backend-plugin-api';
 import { Server as McpServer } from '@modelcontextprotocol/sdk/server/index.js';
 import {
   ListToolsRequestSchema,
   CallToolRequestSchema,
+  ToolSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { JsonObject } from '@backstage/types';
 import {
@@ -76,19 +80,23 @@ function baggageAttributes(
 
 export class McpService {
   private readonly actions: ActionsService;
+  private readonly logger: LoggerService | undefined;
   private readonly namespacedToolNames: boolean;
   private readonly tracingService: TracingService;
   private readonly captureToolPayloads: boolean;
   private readonly operationDuration: MetricsServiceHistogram<McpServerOperationAttributes>;
+  private readonly warnedSkippedActionIds = new Set<string>();
 
   constructor(
     actions: ActionsService,
     metrics: MetricsService,
     tracingService: TracingService,
+    logger: LoggerService | undefined,
     namespacedToolNames?: boolean,
     captureToolPayloads?: boolean,
   ) {
     this.actions = actions;
+    this.logger = logger;
     this.namespacedToolNames = namespacedToolNames ?? true;
     this.tracingService = tracingService;
     this.captureToolPayloads = captureToolPayloads ?? false;
@@ -107,12 +115,14 @@ export class McpService {
     actions,
     metrics,
     tracingService,
+    logger,
     namespacedToolNames,
     captureToolPayloads,
   }: {
     actions: ActionsService;
     metrics: MetricsService;
     tracingService: TracingService;
+    logger?: LoggerService;
     namespacedToolNames?: boolean;
     captureToolPayloads?: boolean;
   }) {
@@ -120,6 +130,7 @@ export class McpService {
       actions,
       metrics,
       tracingService,
+      logger,
       namespacedToolNames,
       captureToolPayloads,
     );
@@ -155,8 +166,9 @@ export class McpService {
           ? this.filterActions(allActions, serverConfig)
           : allActions;
 
-        return {
-          tools: actions.map(action => ({
+        const tools = [];
+        for (const action of actions) {
+          const tool = {
             inputSchema: action.schema.input,
             name: this.getToolName(action),
             description: action.description,
@@ -167,8 +179,26 @@ export class McpService {
               readOnlyHint: action.attributes.readOnly,
               openWorldHint: false,
             },
-          })),
-        };
+          };
+
+          // Validate each tool against the MCP Tool schema so that a single
+          // malformed action (e.g. an inputSchema that isn't a JSON Schema
+          // object at the root) doesn't poison the whole tools/list response.
+          const parsed = ToolSchema.safeParse(tool);
+          if (!parsed.success) {
+            if (!this.warnedSkippedActionIds.has(action.id)) {
+              this.warnedSkippedActionIds.add(action.id);
+              this.logger?.warn(
+                `Skipping MCP tool for action "${action.id}": ${parsed.error.message}`,
+              );
+            }
+            continue;
+          }
+
+          tools.push(tool);
+        }
+
+        return { tools };
       } catch (err) {
         errorType = err instanceof Error ? err.name : 'Error';
         throw err;

--- a/plugins/mcp-actions-backend/src/services/McpService.ts
+++ b/plugins/mcp-actions-backend/src/services/McpService.ts
@@ -21,6 +21,7 @@ import { Server as McpServer } from '@modelcontextprotocol/sdk/server/index.js';
 import {
   ListToolsRequestSchema,
   CallToolRequestSchema,
+  Tool,
   ToolSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { JsonObject } from '@backstage/types';
@@ -166,7 +167,7 @@ export class McpService {
           ? this.filterActions(allActions, serverConfig)
           : allActions;
 
-        const tools = [];
+        const tools: Tool[] = [];
         for (const action of actions) {
           const tool = {
             inputSchema: action.schema.input,
@@ -195,7 +196,7 @@ export class McpService {
             continue;
           }
 
-          tools.push(tool);
+          tools.push(parsed.data);
         }
 
         return { tools };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

A single action whose generated tool fails the MCP SDK's ToolSchema validation (for example an inputSchema with a non-object root type) caused tools/list to fail entirely, so no tools were served at all.

Validate each candidate tool against ToolSchema inside the list handler and drop non-conforming actions with a one-time warning per action id, letting the remaining actions continue to be served.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
