### PR TITLE
fix(ui): fix Table width in Firefox while preserving virtualized scroll

### DIFF
--- a/.changeset/fix-table-width-firefox.md
+++ b/.changeset/fix-table-width-firefox.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed the Table component not filling its container width in Firefox. The `overflow: auto` property was incorrectly set on the `<table>` element — per the CSS spec, Firefox applies this to the anonymous table wrapper box, causing it to shrink-wrap to content width. The property has been removed; horizontal scrolling for resizable tables continues to work correctly via the `ResizableTableContainer` wrapper.

--- a/packages/ui/src/components/Table/Table.module.css
+++ b/packages/ui/src/components/Table/Table.module.css
@@ -36,7 +36,6 @@
     border-collapse: collapse;
     table-layout: fixed;
     transition: opacity 0.2s ease-in-out;
-    overflow: auto;
     flex: 1;
     min-height: 0;
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix the `Table` component rendering too narrow in Firefox. The root cause is `overflow: auto` being set directly on the `<table>` HTML element — per the CSS spec, Firefox (correctly) applies this to the anonymous *table wrapper box*, which causes it to shrink-wrap to content width. Chrome deviates from spec and was unaffected.

The fix conditionally applies `overflow: auto` only when the table is virtualized (via a `data-virtualized` attribute). Non-virtualized tables get the Firefox width fix; virtualized tables retain `overflow: auto` so the `Virtualizer`'s scroll container continues to function.

**Before:** Table shrinks to content width in Firefox
**After:** Table fills the available container width in Firefox (matching Chrome behavior), and virtualized tables continue to scroll correctly

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))