### PR TITLE
docs: rename Azure integration sidebar label to Azure DevOps

### DIFF
--- a/microsite/sidebars.ts
+++ b/microsite/sidebars.ts
@@ -395,7 +395,7 @@ export default {
           'integrations/azure-blobStorage/locations',
           'integrations/azure-blobStorage/discovery',
         ]),
-        sidebarElementWithIndex({ label: 'Azure' }, [
+        sidebarElementWithIndex({ label: 'Azure DevOps' }, [
           'integrations/azure/locations',
           'integrations/azure/discovery',
           'integrations/azure/org',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The sidebar entry labelled `Azure` under _Integrations_ groups pages that are specifically about Azure DevOps (plus the Microsoft Entra org data page used to authenticate against Azure DevOps). The generic `Azure` label is misleading for users landing on e.g. `/docs/integrations/azure/locations`, whose title is `Azure DevOps Locations`.

This PR renames the sidebar group label from `Azure` to `Azure DevOps` so the navigation matches the actual page content. The file paths and doc IDs are left untouched so existing links keep working.

Closes #31542

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. (N/A — microsite only)
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes (N/A)
- [ ] Screenshots attached (for UI changes) — N/A, one-word label change in the docs sidebar
- [x] All your commits have a `Signed-off-by` line in the message.