### PR TITLE
devtools: refresh scheduled tasks after trigger or cancel

### DIFF
--- a/.changeset/devtools-refresh-after-scheduled-task-action.md
+++ b/.changeset/devtools-refresh-after-scheduled-task-action.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-devtools': patch
+---
+
+Scheduled Tasks page now refreshes its table automatically after a task is triggered or cancelled, so the updated status is visible without reloading the browser.

--- a/plugins/devtools/src/components/Content/ScheduledTasksContent/ScheduledTasksContent.tsx
+++ b/plugins/devtools/src/components/Content/ScheduledTasksContent/ScheduledTasksContent.tsx
@@ -105,7 +105,8 @@ export const ScheduledTasksContent = () => {
   const plugins =
     configApi.getOptionalStringArray('devTools.scheduledTasks.plugins') || [];
   const [selectedPlugin, setSelectedPlugin] = useState(plugins[0] || '');
-  const { scheduledTasks, loading, error } = useScheduledTasks(selectedPlugin);
+  const { scheduledTasks, loading, error, refresh } =
+    useScheduledTasks(selectedPlugin);
   const { triggerTask, cancelTask, isLoading } = useScheduledTasksOperations();
 
   const [inputValue, setInputValue] = useState('');
@@ -227,6 +228,8 @@ export const ScheduledTasksContent = () => {
                       message: `Error triggering task ${rowData.taskId}: ${e.message}`,
                       severity: 'error',
                     });
+                  } finally {
+                    refresh();
                   }
                 }}
               >
@@ -249,6 +252,8 @@ export const ScheduledTasksContent = () => {
                       message: `Error cancelling task ${rowData.taskId}: ${e.message}`,
                       severity: 'error',
                     });
+                  } finally {
+                    refresh();
                   }
                 }}
               >

--- a/plugins/devtools/src/hooks/useScheduledTasks.ts
+++ b/plugins/devtools/src/hooks/useScheduledTasks.ts
@@ -15,7 +15,7 @@
  */
 import { devToolsApiRef } from '../api';
 import { useApi } from '@backstage/core-plugin-api';
-import useAsync from 'react-use/esm/useAsync';
+import useAsyncRetry from 'react-use/esm/useAsyncRetry';
 
 export const useScheduledTasks = (plugin: string) => {
   const api = useApi(devToolsApiRef);
@@ -24,7 +24,8 @@ export const useScheduledTasks = (plugin: string) => {
     value,
     loading,
     error: asyncError,
-  } = useAsync(async () => {
+    retry: refresh,
+  } = useAsyncRetry(async () => {
     return api.getScheduledTasksByPlugin(plugin);
   }, [api, plugin]);
 
@@ -33,6 +34,7 @@ export const useScheduledTasks = (plugin: string) => {
       scheduledTasks: undefined,
       loading: false,
       error: asyncError.message,
+      refresh,
     };
   }
 
@@ -40,5 +42,6 @@ export const useScheduledTasks = (plugin: string) => {
     scheduledTasks: value?.scheduledTasks,
     loading,
     error: value?.error,
+    refresh,
   };
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Triggering or cancelling a scheduled task from the DevTools _Scheduled Tasks_ page does not currently update the table — users have to manually refresh the browser, which also resets the plugin selector to its first option.

This PR switches `useScheduledTasks` from `useAsync` to `useAsyncRetry` so it exposes a `refresh` function. `ScheduledTasksContent` calls `refresh()` in a `finally` block after `triggerTask`/`cancelTask`, so the table reflects the new state regardless of whether the action itself succeeded or errored.

Closes #32861

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation (N/A)
- [ ] Tests for new functionality and regression tests for bug fixes — no existing tests for these hooks/components in this plugin
- [ ] Screenshots attached (for UI changes) — visible change is only that the table auto-updates rather than requiring a reload
- [x] All your commits have a `Signed-off-by` line in the message.