### PR TITLE
docs(techdocs): fix incorrect S3 permission in AWS configuration

### DIFF
--- a/docs/features/techdocs/using-cloud-storage.md
+++ b/docs/features/techdocs/using-cloud-storage.md
@@ -207,7 +207,7 @@ If you need to migrate documentation objects from an older-style path
 format including case-sensitive entity metadata, you will need to add some
 additional permissions to be able to perform the migration, including:
 
-- `s3:PutBucketAcl` (for copying files,
+- `s3:PutObjectAcl` (for copying files,
   [more info here](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObjectAcl.html))
 - `s3:DeleteObject` and `s3:DeleteObjectVersion` (for deleting migrated files,
   [more info here](https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObject.html))


### PR DESCRIPTION
## Summary

I noticed the TechDocs AWS S3 configuration documentation references
`s3:PutBucketAcl` when it should be `s3:PutObjectAcl`. This fix corrects
the permission name to match the actual AWS IAM action needed.

## Changes

- Fixed `s3:PutBucketAcl` → `s3:PutObjectAcl` in the AWS S3 bucket configuration docs

Fixes #32925