### PR TITLE
feat(catalog): add warning when GitHub App is not installed in GithubMultiOrgEntityProvider

### DIFF
--- a/.changeset/warn-github-app-not-installed.md
+++ b/.changeset/warn-github-app-not-installed.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+Added a warning log message to `GithubMultiOrgEntityProvider` when a GitHub App is not installed for an organization. This helps users diagnose authentication issues when the provider falls back to token authentication instead of using the GitHub App.

--- a/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.test.ts
@@ -969,6 +969,94 @@ describe('GithubMultiOrgEntityProvider', () => {
 
       expect(entityProviderConnection.applyMutation).not.toHaveBeenCalled();
     });
+
+    it('should log a warning when GitHub App is not installed for an organization', async () => {
+      const mockGetCredentialsWithTokenFallback = jest.fn().mockReturnValue({
+        headers: { token: 'blah' },
+        type: 'token',
+      });
+
+      entityProvider = new GithubMultiOrgEntityProvider({
+        id: 'my-id',
+        gitHubConfig,
+        githubCredentialsProvider: {
+          getCredentials: mockGetCredentialsWithTokenFallback,
+        },
+        githubUrl: 'https://github.com',
+        logger,
+        orgs: ['orgWithoutApp'],
+      });
+
+      await entityProvider.connect(entityProviderConnection);
+
+      mockClient
+        .mockResolvedValueOnce({
+          organization: {
+            membersWithRole: {
+              pageInfo: { hasNextPage: false },
+              nodes: [],
+            },
+          },
+        })
+        .mockResolvedValueOnce({
+          organization: {
+            teams: {
+              pageInfo: { hasNextPage: false },
+              nodes: [],
+            },
+          },
+        });
+
+      await entityProvider.read();
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'No GitHub App installation found for organization orgWithoutApp',
+        ),
+      );
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'https://backstage.io/docs/integrations/github/github-apps/#troubleshooting',
+        ),
+      );
+    });
+
+    it('should not log a warning when GitHub App is installed for an organization', async () => {
+      entityProvider = new GithubMultiOrgEntityProvider({
+        id: 'my-id',
+        gitHubConfig,
+        githubCredentialsProvider: {
+          getCredentials: mockGetCredentials,
+        },
+        githubUrl: 'https://github.com',
+        logger,
+        orgs: ['orgWithApp'],
+      });
+
+      await entityProvider.connect(entityProviderConnection);
+
+      mockClient
+        .mockResolvedValueOnce({
+          organization: {
+            membersWithRole: {
+              pageInfo: { hasNextPage: false },
+              nodes: [],
+            },
+          },
+        })
+        .mockResolvedValueOnce({
+          organization: {
+            teams: {
+              pageInfo: { hasNextPage: false },
+              nodes: [],
+            },
+          },
+        });
+
+      await entityProvider.read();
+
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
   });
 
   describe('withLocations', () => {

--- a/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
@@ -301,6 +301,16 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
         await this.options.githubCredentialsProvider.getCredentials({
           url: `${this.options.githubUrl}/${org}`,
         });
+
+      if (tokenType !== 'app') {
+        logger.warn(
+          `No GitHub App installation found for organization ${org}. ` +
+            `Falling back to token authentication. ` +
+            `This may indicate the GitHub App is not installed for this organization. ` +
+            `See https://backstage.io/docs/integrations/github/github-apps/#troubleshooting`,
+        );
+      }
+
       const client = graphql.defaults({
         baseUrl: this.options.gitHubConfig.apiBaseUrl,
         headers,


### PR DESCRIPTION
## Summary

I added a logged warning to `GithubMultiOrgEntityProvider` that alerts
when a GitHub App is not installed for an organization. This helps users
quickly identify configuration issues.

## Changes

- Added warning log when GitHub App installation is missing
- Added unit test for the warning behavior

Fixes #32972