### PR TITLE
Add Okta-backed MCP auth example and docs

### DIFF
--- a/.changeset/mcp-okta-auth-example.md
+++ b/.changeset/mcp-okta-auth-example.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-mcp-actions-backend': patch
+---
+
+Added documentation for using the MCP Actions Backend with Okta-backed authentication through Backstage auth and dynamic client registration.

--- a/docs/ai/mcp-actions.md
+++ b/docs/ai/mcp-actions.md
@@ -230,6 +230,95 @@ auth:
       - cursor://*
 ```
 
+#### Using Okta with Dynamic Client Registration
+
+If your Backstage instance uses Okta, MCP clients can authenticate through the standard Backstage auth flow without any MCP-specific Okta integration.
+
+You need:
+
+- the Okta auth provider configured in `app-config.yaml`
+- the Okta auth backend module registered in your backend
+- the `@backstage/plugin-auth` frontend plugin enabled in your app
+- `auth.experimentalDynamicClientRegistration.enabled: true`
+
+Register the Okta auth backend module in your backend:
+
+```ts title="packages/backend/src/index.ts"
+const backend = createBackend();
+
+backend.add(import('@backstage/plugin-auth-backend'));
+backend.add(import('@backstage/plugin-auth-backend-module-okta-provider'));
+backend.add(import('@backstage/plugin-mcp-actions-backend'));
+```
+
+Enable the auth frontend plugin in your app:
+
+```tsx title="packages/app/src/App.tsx"
+import authPlugin from '@backstage/plugin-auth';
+
+const app = createApp({
+  features: [
+    authPlugin,
+    // ...other features
+  ],
+});
+```
+
+MCP clients can then connect without a static token:
+
+```json
+{
+  "mcpServers": {
+    "backstage-actions": {
+      "url": "${BACKSTAGE_MCP_URL}"
+    }
+  }
+}
+```
+
+On first use, the client is redirected into the standard Backstage sign-in and approval flow. If Okta is your configured provider, the user authenticates with Okta, approves the client in Backstage, and the client can then continue using the MCP server with the issued token.
+
+#### Testing locally
+
+You can smoke-test the flow locally before connecting a real MCP client:
+
+1. Start Backstage:
+
+   ```bash
+   yarn dev
+   ```
+
+2. Verify that the OAuth discovery endpoints return JSON:
+
+   ```bash
+   curl -s http://localhost:7007/.well-known/oauth-authorization-server | jq .
+   curl -s http://localhost:7007/.well-known/oauth-protected-resource/api/mcp-actions/v1 | jq .
+   ```
+
+3. Add the MCP server to a client that supports OAuth and Dynamic Client Registration:
+
+   ```json
+   {
+     "mcpServers": {
+       "backstage-actions": {
+         "url": "${BACKSTAGE_MCP_URL}"
+       }
+     }
+   }
+   ```
+
+   Set `BACKSTAGE_MCP_URL` to the environment-specific value, for example:
+
+   - dev: `http://localhost:7007/api/mcp-actions/v1`
+   - prod: `https://backstage.example.com/api/mcp-actions/v1`
+
+4. Confirm the expected behavior:
+
+   - the client discovers the `.well-known` metadata
+   - Backstage opens the standard sign-in and approval flow
+   - Okta handles authentication if it is your configured provider
+   - the client can list and invoke MCP tools after approval
+
 ## Configuring MCP Clients
 
 The MCP server supports both **Server-Sent Events (SSE)** and **Streamable HTTP** protocols.
@@ -238,16 +327,32 @@ The MCP server supports both **Server-Sent Events (SSE)** and **Streamable HTTP*
 The SSE protocol is deprecated and will be removed in a future release.
 :::
 
+The recommended setup is to use an environment variable such as `BACKSTAGE_MCP_URL` in your MCP client config so the same config can point at dev or prod. If your client does not support environment variable expansion, replace the example URLs with your deployed Backstage URL directly.
+
 ### Endpoints
 
 - **Streamable HTTP:** `http://localhost:7007/api/mcp-actions/v1`
 - **SSE (deprecated):** `http://localhost:7007/api/mcp-actions/v1/sse`
 
+If your client supports OAuth with Dynamic Client Registration or Client ID Metadata Documents, start with just the MCP server URL:
+
 ```json
 {
   "mcpServers": {
     "backstage-actions": {
-      "url": "http://localhost:7007/api/mcp-actions/v1",
+      "url": "${BACKSTAGE_MCP_URL}"
+    }
+  }
+}
+```
+
+If your client does not support OAuth-based authentication yet, use a static external access token instead:
+
+```json
+{
+  "mcpServers": {
+    "backstage-actions": {
+      "url": "${BACKSTAGE_MCP_URL}",
       "headers": {
         "Authorization": "Bearer ${MCP_TOKEN}"
       }
@@ -258,6 +363,11 @@ The SSE protocol is deprecated and will be removed in a future release.
 
 The `${MCP_TOKEN}` environment variable would be an [external access static token](#external-access-with-static-tokens).
 
+Example values for `BACKSTAGE_MCP_URL`:
+
+- dev: `http://localhost:7007/api/mcp-actions/v1`
+- prod: `https://backstage.example.com/api/mcp-actions/v1`
+
 ### Multiple Servers
 
 When `mcpActions.servers` is configured, each server key becomes part of the URL. For example, with servers named `catalog` and `scaffolder`:
@@ -265,17 +375,34 @@ When `mcpActions.servers` is configured, each server key becomes part of the URL
 - `http://localhost:7007/api/mcp-actions/v1/catalog`
 - `http://localhost:7007/api/mcp-actions/v1/scaffolder`
 
+For OAuth-capable clients, configure just the MCP server URLs:
+
 ```json
 {
   "mcpServers": {
     "backstage-catalog": {
-      "url": "http://localhost:7007/api/mcp-actions/v1/catalog",
+      "url": "${BACKSTAGE_MCP_URL}/catalog"
+    },
+    "backstage-scaffolder": {
+      "url": "${BACKSTAGE_MCP_URL}/scaffolder"
+    }
+  }
+}
+```
+
+For clients that still require static tokens, include the `Authorization` header:
+
+```json
+{
+  "mcpServers": {
+    "backstage-catalog": {
+      "url": "${BACKSTAGE_MCP_URL}/catalog",
       "headers": {
         "Authorization": "Bearer ${MCP_TOKEN}"
       }
     },
     "backstage-scaffolder": {
-      "url": "http://localhost:7007/api/mcp-actions/v1/scaffolder",
+      "url": "${BACKSTAGE_MCP_URL}/scaffolder",
       "headers": {
         "Authorization": "Bearer ${MCP_TOKEN}"
       }

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -40,6 +40,7 @@ import {
   EntityTechdocsContent,
 } from '@backstage/plugin-techdocs';
 import appVisualizerPlugin from '@backstage/plugin-app-visualizer';
+import authPlugin from '@backstage/plugin-auth';
 import { convertLegacyAppRoot } from '@backstage/core-compat-api';
 import { FlatRoutes } from '@backstage/core-app-api';
 import { Route } from 'react-router';
@@ -134,6 +135,7 @@ const app = createApp({
     customizedCatalog,
     pagesPlugin,
     convertedTechdocsPlugin,
+    authPlugin,
     userSettingsPlugin,
     homePlugin,
     appVisualizerPlugin,

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -37,6 +37,7 @@
     "@backstage/plugin-auth-backend": "workspace:^",
     "@backstage/plugin-auth-backend-module-github-provider": "workspace:^",
     "@backstage/plugin-auth-backend-module-guest-provider": "workspace:^",
+    "@backstage/plugin-auth-backend-module-okta-provider": "workspace:^",
     "@backstage/plugin-auth-backend-module-openshift-provider": "workspace:^",
     "@backstage/plugin-auth-node": "workspace:^",
     "@backstage/plugin-catalog-backend": "workspace:^",

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -43,6 +43,7 @@ const searchLoader = createBackendFeatureLoader({
 backend.add(import('@backstage/plugin-auth-backend'));
 backend.add(import('./authModuleGithubProvider'));
 backend.add(import('@backstage/plugin-auth-backend-module-guest-provider'));
+backend.add(import('@backstage/plugin-auth-backend-module-okta-provider'));
 backend.add(import('@backstage/plugin-auth-backend-module-openshift-provider'));
 backend.add(import('@backstage/plugin-app-backend'));
 backend.add(import('@backstage/plugin-catalog-backend-module-unprocessed'));

--- a/plugins/mcp-actions-backend/README.md
+++ b/plugins/mcp-actions-backend/README.md
@@ -211,22 +211,128 @@ auth:
 > [!NOTE]
 > The `@backstage/plugin-auth` package is currently only available in the new frontend system.
 
+#### Using Okta with Dynamic Client Registration
+
+If your Backstage instance uses Okta, MCP clients can authenticate through the normal Backstage auth flow without any MCP-specific Okta integration.
+
+At a high level you need:
+
+- the Okta auth provider configured in `app-config.yaml`
+- the Okta auth backend module registered in your backend
+- the `@backstage/plugin-auth` frontend plugin enabled in your app
+- `auth.experimentalDynamicClientRegistration.enabled: true`
+
+For example, register the Okta auth backend module in your backend:
+
+```ts
+const backend = createBackend();
+
+backend.add(import('@backstage/plugin-auth-backend'));
+backend.add(import('@backstage/plugin-auth-backend-module-okta-provider'));
+backend.add(import('@backstage/plugin-mcp-actions-backend'));
+```
+
+And enable the auth frontend plugin in your app:
+
+```tsx
+import authPlugin from '@backstage/plugin-auth';
+
+const app = createApp({
+  features: [
+    authPlugin,
+    // ...other features
+  ],
+});
+```
+
+MCP clients can then connect without a static token:
+
+```json
+{
+  "mcpServers": {
+    "backstage-actions": {
+      "url": "${BACKSTAGE_MCP_URL}"
+    }
+  }
+}
+```
+
+On first use, the client is redirected into the standard Backstage sign-in and approval flow. If Okta is your configured provider, the user authenticates with Okta, approves the client in Backstage, and the client can then continue using the MCP server with the issued token.
+
+#### Testing locally
+
+You can verify the flow locally before trying a real MCP client:
+
+1. Start Backstage:
+
+   ```bash
+   yarn dev
+   ```
+
+2. Check that the OAuth metadata endpoints return JSON instead of HTML:
+
+   ```bash
+   curl -s http://localhost:7007/.well-known/oauth-authorization-server | jq .
+   curl -s http://localhost:7007/.well-known/oauth-protected-resource/api/mcp-actions/v1 | jq .
+   ```
+
+3. Add the MCP server to a client that supports OAuth and Dynamic Client Registration:
+
+   ```json
+   {
+     "mcpServers": {
+       "backstage-actions": {
+         "url": "${BACKSTAGE_MCP_URL}"
+       }
+     }
+   }
+   ```
+
+   Set `BACKSTAGE_MCP_URL` to the correct environment-specific value, for example:
+
+   - dev: `http://localhost:7007/api/mcp-actions/v1`
+   - prod: `https://backstage.example.com/api/mcp-actions/v1`
+
+4. Connect the client and confirm the expected flow:
+
+   - the client discovers `/.well-known/oauth-authorization-server`
+   - the client discovers `/.well-known/oauth-protected-resource/api/mcp-actions/v1`
+   - Backstage opens the standard sign-in and approval flow
+   - Okta handles authentication if it is your configured provider
+   - the client can list and invoke MCP tools after approval
+
 ## Configuring MCP Clients
 
 The MCP server supports both Server-Sent Events (SSE) and Streamable HTTP protocols.
 
 The SSE protocol is deprecated, and should be avoided as it will be removed in a future release.
 
+The recommended setup is to use an environment variable such as `BACKSTAGE_MCP_URL` in your MCP client config so the same config can point at dev or prod. If your client does not support environment variable expansion, replace the example URLs with your deployed Backstage URL directly.
+
 ### Single Server (default)
 
 - `Streamable HTTP`: `http://localhost:7007/api/mcp-actions/v1`
 - `SSE`: `http://localhost:7007/api/mcp-actions/v1/sse`
 
+If your client supports OAuth with Dynamic Client Registration or Client ID Metadata Documents, start with just the MCP server URL:
+
 ```json
 {
   "mcpServers": {
     "backstage-actions": {
-      "url": "http://localhost:7007/api/mcp-actions/v1",
+      "url": "${BACKSTAGE_MCP_URL}"
+    }
+  }
+}
+```
+
+If your client does not support OAuth-based authentication yet, use a static external access token instead:
+
+```json
+{
+  "mcpServers": {
+    "backstage-actions": {
+      "url": "${BACKSTAGE_MCP_URL}",
       "headers": {
         "Authorization": "Bearer ${MCP_TOKEN}"
       }
@@ -235,6 +341,11 @@ The SSE protocol is deprecated, and should be avoided as it will be removed in a
 }
 ```
 
+Example values for `BACKSTAGE_MCP_URL`:
+
+- dev: `http://localhost:7007/api/mcp-actions/v1`
+- prod: `https://backstage.example.com/api/mcp-actions/v1`
+
 ### Multiple Servers
 
 When `mcpActions.servers` is configured, each server key becomes part of the URL. For example, with servers named `catalog` and `scaffolder`:
@@ -242,17 +353,34 @@ When `mcpActions.servers` is configured, each server key becomes part of the URL
 - `http://localhost:7007/api/mcp-actions/v1/catalog`
 - `http://localhost:7007/api/mcp-actions/v1/scaffolder`
 
+For OAuth-capable clients, configure just the MCP server URLs:
+
 ```json
 {
   "mcpServers": {
     "backstage-catalog": {
-      "url": "http://localhost:7007/api/mcp-actions/v1/catalog",
+      "url": "${BACKSTAGE_MCP_URL}/catalog"
+    },
+    "backstage-scaffolder": {
+      "url": "${BACKSTAGE_MCP_URL}/scaffolder"
+    }
+  }
+}
+```
+
+For clients that still require static tokens, include the `Authorization` header:
+
+```json
+{
+  "mcpServers": {
+    "backstage-catalog": {
+      "url": "${BACKSTAGE_MCP_URL}/catalog",
       "headers": {
         "Authorization": "Bearer ${MCP_TOKEN}"
       }
     },
     "backstage-scaffolder": {
-      "url": "http://localhost:7007/api/mcp-actions/v1/scaffolder",
+      "url": "${BACKSTAGE_MCP_URL}/scaffolder",
       "headers": {
         "Authorization": "Bearer ${MCP_TOKEN}"
       }

--- a/plugins/mcp-actions-backend/src/plugin.test.ts
+++ b/plugins/mcp-actions-backend/src/plugin.test.ts
@@ -283,6 +283,75 @@ describe('Mcp Backend', () => {
   });
 
   describe('OAuth well-known endpoints', () => {
+    it('should proxy oauth-authorization-server metadata when DCR is enabled', async () => {
+      const mockAuthBaseUrl = 'http://auth.local:7007/api/auth';
+      const mockDiscovery = mockServices.discovery.mock({
+        getBaseUrl: async pluginId => {
+          if (pluginId !== 'auth') {
+            throw new Error(`Unexpected plugin ID ${pluginId}`);
+          }
+          return mockAuthBaseUrl;
+        },
+      });
+      const mockFetch = jest.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            issuer: mockAuthBaseUrl,
+            token_endpoint: `${mockAuthBaseUrl}/token`,
+            registration_endpoint: `${mockAuthBaseUrl}/v1/register`,
+          }),
+          {
+            headers: {
+              'content-type': 'application/json',
+            },
+          },
+        ),
+      );
+      const originalFetch = global.fetch;
+      global.fetch = mockFetch;
+
+      try {
+        const { server } = await startTestBackend({
+          features: [
+            mcpPlugin,
+            mockPluginWithActions,
+            mockDiscovery.factory,
+            mockServices.rootConfig.factory({
+              data: {
+                backend: {
+                  actions: {
+                    pluginSources: ['local'],
+                  },
+                },
+                auth: {
+                  experimentalDynamicClientRegistration: {
+                    enabled: true,
+                  },
+                },
+              },
+            }),
+          ],
+        });
+
+        const response = await request(server).get(
+          '/.well-known/oauth-authorization-server',
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.header['content-type']).toMatch(/application\/json/);
+        expect(response.body).toEqual({
+          issuer: mockAuthBaseUrl,
+          token_endpoint: `${mockAuthBaseUrl}/token`,
+          registration_endpoint: `${mockAuthBaseUrl}/v1/register`,
+        });
+        expect(mockFetch).toHaveBeenCalledWith(
+          `${mockAuthBaseUrl}/.well-known/openid-configuration`,
+        );
+      } finally {
+        global.fetch = originalFetch;
+      }
+    });
+
     it('should not expose oauth endpoints when neither DCR nor CIMD is enabled', async () => {
       const { server } = await startTestBackend({
         features: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -4508,7 +4508,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage/plugin-auth-backend-module-okta-provider@workspace:plugins/auth-backend-module-okta-provider":
+"@backstage/plugin-auth-backend-module-okta-provider@workspace:^, @backstage/plugin-auth-backend-module-okta-provider@workspace:plugins/auth-backend-module-okta-provider":
   version: 0.0.0-use.local
   resolution: "@backstage/plugin-auth-backend-module-okta-provider@workspace:plugins/auth-backend-module-okta-provider"
   dependencies:
@@ -29063,6 +29063,7 @@ __metadata:
     "@backstage/plugin-auth-backend": "workspace:^"
     "@backstage/plugin-auth-backend-module-github-provider": "workspace:^"
     "@backstage/plugin-auth-backend-module-guest-provider": "workspace:^"
+    "@backstage/plugin-auth-backend-module-okta-provider": "workspace:^"
     "@backstage/plugin-auth-backend-module-openshift-provider": "workspace:^"
     "@backstage/plugin-auth-node": "workspace:^"
     "@backstage/plugin-catalog-backend": "workspace:^"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

  This updates the example Backstage app and MCP Actions Backend docs to show how MCP authentication works with adopter-provided auth through the standard Backstage auth stack, using Okta as a concrete example.

  It includes:
  - wiring the Okta auth backend module into the example backend
  - enabling the `@backstage/plugin-auth` frontend plugin in the example app
  - documenting the Okta-backed MCP auth flow with Dynamic Client Registration
  - clarifying local vs production MCP URLs and recommending `BACKSTAGE_MCP_URL`
  - separating OAuth-based MCP client config from static-token fallback config
  - adding a regression test for `/.well-known/oauth-authorization-server`

  Refs #34003

  #### :heavy_check_mark: Checklist

  - [x] A changeset describing the change and affected packages.
  - [x] Added or updated documentation
  - [x] Tests for new functionality and regression tests for bug fixes
  - [ ] Screenshots attached (for UI changes)
  - [x] All your commits have a `Signed-off-by` line in the message.