### PR TITLE
fix(ui): set CardBody minimum height

### DIFF
--- a/.changeset/fix-cardbody-min-height.md
+++ b/.changeset/fix-cardbody-min-height.md
@@ -1,0 +1,7 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed `CardBody` showing an unwanted scrollbar when constrained below the scroll shadow height.
+
+**Affected components:** Card

--- a/packages/ui/src/components/Card/Card.module.css
+++ b/packages/ui/src/components/Card/Card.module.css
@@ -94,7 +94,7 @@
 
   .bui-CardBody {
     flex: 1;
-    min-height: 0;
+    min-height: var(--bui-space-6);
     overflow: auto;
     padding-inline: var(--bui-space-3);
     padding-block: var(--bui-space-3);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes `CardBody` showing an unwanted scrollbar when it is constrained below the scroll shadow height by setting its minimum height to the matching spacing token.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))