### PR TITLE
feat(devtools): migrate InfoContent to Backstage UI

### DIFF
--- a/.changeset/devtools-info-content-bui.md
+++ b/.changeset/devtools-info-content-bui.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-devtools': patch
+---
+
+The DevTools Info page now uses Backstage UI components for its layout and the "Copy Info to Clipboard" button, bringing it in line with the rest of the migrated DevTools content.

--- a/.changeset/devtools-info-content-bui.md
+++ b/.changeset/devtools-info-content-bui.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-devtools': patch
 ---
 
-The DevTools Info page now uses Backstage UI components for its layout and the "Copy Info to Clipboard" button, bringing it in line with the rest of the migrated DevTools content.
+Migrated `InfoContent` component from Material UI to Backstage UI (BUI).

--- a/plugins/devtools/package.json
+++ b/plugins/devtools/package.json
@@ -64,6 +64,7 @@
     "@material-ui/core": "^4.9.13",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.57",
+    "@remixicon/react": ">=4.6.0 <4.9.0",
     "lodash": "^4.17.21",
     "react-json-view": "^1.21.3",
     "react-use": "^17.2.4"

--- a/plugins/devtools/src/components/Content/InfoContent/InfoContent.tsx
+++ b/plugins/devtools/src/components/Content/InfoContent/InfoContent.tsx
@@ -110,6 +110,7 @@ export const InfoContent = () => {
                 />
               </Flex>
               <Button
+                variant="secondary"
                 onPress={() => copyToClipboard({ about })}
                 iconStart={<RiFileCopyLine />}
               >

--- a/plugins/devtools/src/components/Content/InfoContent/InfoContent.tsx
+++ b/plugins/devtools/src/components/Content/InfoContent/InfoContent.tsx
@@ -14,18 +14,9 @@
  * limitations under the License.
  */
 
+import type { ReactElement } from 'react';
 import { Progress } from '@backstage/core-components';
-import Avatar from '@material-ui/core/Avatar';
-import Box from '@material-ui/core/Box';
-import Divider from '@material-ui/core/Divider';
-import List from '@material-ui/core/List';
-import ListItem from '@material-ui/core/ListItem';
-import ListItemAvatar from '@material-ui/core/ListItemAvatar';
-import ListItemText from '@material-ui/core/ListItemText';
-import Paper from '@material-ui/core/Paper';
-import Button from '@material-ui/core/Button';
-import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
-import Alert from '@material-ui/lab/Alert';
+import { Alert, Box, Button, Card, CardBody, Flex, Text } from '@backstage/ui';
 import { useInfo } from '../../../hooks';
 import { InfoDependenciesTable } from './InfoDependenciesTable';
 import DescriptionIcon from '@material-ui/icons/Description';
@@ -34,24 +25,6 @@ import DeveloperBoardIcon from '@material-ui/icons/DeveloperBoard';
 import { BackstageLogoIcon } from './BackstageLogoIcon';
 import FileCopyIcon from '@material-ui/icons/FileCopy';
 import { DevToolsInfo } from '@backstage/plugin-devtools-common';
-
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    paperStyle: {
-      display: 'flex',
-      marginBottom: theme.spacing(2),
-    },
-    flexContainer: {
-      display: 'flex',
-      flexDirection: 'row',
-      padding: 0,
-    },
-    copyButton: {
-      float: 'left',
-      margin: theme.spacing(2),
-    },
-  }),
-);
 
 const copyToClipboard = ({ about }: { about: DevToolsInfo | undefined }) => {
   if (about) {
@@ -66,76 +39,84 @@ const copyToClipboard = ({ about }: { about: DevToolsInfo | undefined }) => {
   }
 };
 
+const InfoCell = ({
+  icon,
+  label,
+  value,
+}: {
+  icon: ReactElement;
+  label: string;
+  value: string | undefined;
+}) => (
+  <Flex direction="row" align="center" gap="2">
+    {icon}
+    <Flex direction="column" gap="0.5">
+      <Text variant="body-medium" weight="bold">
+        {label}
+      </Text>
+      <Text variant="body-small" color="secondary">
+        {value}
+      </Text>
+    </Flex>
+  </Flex>
+);
+
 /** @public */
 export const InfoContent = () => {
-  const classes = useStyles();
   const { about, loading, error } = useInfo();
 
   if (loading) {
     return <Progress />;
   } else if (error) {
-    return <Alert severity="error">{error.message}</Alert>;
+    return <Alert status="danger" icon title={error.message} role="alert" />;
   }
   return (
     <Box>
-      <Paper className={classes.paperStyle}>
-        <List className={classes.flexContainer}>
-          <ListItem>
-            <ListItemAvatar>
-              <Avatar>
-                <DeveloperBoardIcon />
-              </Avatar>
-            </ListItemAvatar>
-            <ListItemText
-              primary="Operating System"
-              secondary={about?.operatingSystem}
-            />
-          </ListItem>
-          <ListItem>
-            <ListItemAvatar>
-              <Avatar>
-                <MemoryIcon />
-              </Avatar>
-            </ListItemAvatar>
-            <ListItemText
-              primary="Resource utilization"
-              secondary={about?.resourceUtilization}
-            />
-          </ListItem>
-          <ListItem>
-            <ListItemAvatar>
-              <Avatar>
-                <DescriptionIcon />
-              </Avatar>
-            </ListItemAvatar>
-            <ListItemText
-              primary="NodeJS Version"
-              secondary={about?.nodeJsVersion}
-            />
-          </ListItem>
-          <ListItem>
-            <ListItemAvatar>
-              <Avatar>
-                <BackstageLogoIcon />
-              </Avatar>
-            </ListItemAvatar>
-            <ListItemText
-              primary="Backstage Version"
-              secondary={about?.backstageVersion}
-            />
-          </ListItem>
-        </List>
-        <Divider orientation="vertical" variant="middle" flexItem />
-        <Button
-          onClick={() => {
-            copyToClipboard({ about });
-          }}
-          className={classes.copyButton}
-          startIcon={<FileCopyIcon />}
-        >
-          Copy Info to Clipboard
-        </Button>
-      </Paper>
+      <Box mb="2">
+        <Card>
+          <CardBody>
+            <Flex
+              direction={{ initial: 'column', md: 'row' }}
+              align={{ initial: 'stretch', md: 'center' }}
+              justify="between"
+              gap="4"
+            >
+              <Flex
+                direction={{ initial: 'column', md: 'row' }}
+                align={{ initial: 'start', md: 'center' }}
+                gap={{ initial: '3', md: '6' }}
+              >
+                <InfoCell
+                  icon={<DeveloperBoardIcon />}
+                  label="Operating System"
+                  value={about?.operatingSystem}
+                />
+                <InfoCell
+                  icon={<MemoryIcon />}
+                  label="Resource utilization"
+                  value={about?.resourceUtilization}
+                />
+                <InfoCell
+                  icon={<DescriptionIcon />}
+                  label="NodeJS Version"
+                  value={about?.nodeJsVersion}
+                />
+                <InfoCell
+                  icon={<BackstageLogoIcon />}
+                  label="Backstage Version"
+                  value={about?.backstageVersion}
+                />
+              </Flex>
+              <Button
+                onPress={() => copyToClipboard({ about })}
+                iconStart={<FileCopyIcon />}
+              >
+                Copy Info to Clipboard
+              </Button>
+            </Flex>
+          </CardBody>
+        </Card>
+      </Box>
       <InfoDependenciesTable infoDependencies={about?.dependencies} />
     </Box>
   );

--- a/plugins/devtools/src/components/Content/InfoContent/InfoContent.tsx
+++ b/plugins/devtools/src/components/Content/InfoContent/InfoContent.tsx
@@ -19,11 +19,13 @@ import { Progress } from '@backstage/core-components';
 import { Alert, Box, Button, Card, CardBody, Flex, Text } from '@backstage/ui';
 import { useInfo } from '../../../hooks';
 import { InfoDependenciesTable } from './InfoDependenciesTable';
-import DescriptionIcon from '@material-ui/icons/Description';
-import MemoryIcon from '@material-ui/icons/Memory';
-import DeveloperBoardIcon from '@material-ui/icons/DeveloperBoard';
+import {
+  RiComputerLine,
+  RiCpuLine,
+  RiFileCopyLine,
+  RiNodejsLine,
+} from '@remixicon/react';
 import { BackstageLogoIcon } from './BackstageLogoIcon';
-import FileCopyIcon from '@material-ui/icons/FileCopy';
 import { DevToolsInfo } from '@backstage/plugin-devtools-common';
 
 const copyToClipboard = ({ about }: { about: DevToolsInfo | undefined }) => {
@@ -87,17 +89,17 @@ export const InfoContent = () => {
                 gap={{ initial: '3', md: '6' }}
               >
                 <InfoCell
-                  icon={<DeveloperBoardIcon />}
+                  icon={<RiComputerLine />}
                   label="Operating System"
                   value={about?.operatingSystem}
                 />
                 <InfoCell
-                  icon={<MemoryIcon />}
+                  icon={<RiCpuLine />}
                   label="Resource utilization"
                   value={about?.resourceUtilization}
                 />
                 <InfoCell
-                  icon={<DescriptionIcon />}
+                  icon={<RiNodejsLine />}
                   label="NodeJS Version"
                   value={about?.nodeJsVersion}
                 />
@@ -109,7 +111,7 @@ export const InfoContent = () => {
               </Flex>
               <Button
                 onPress={() => copyToClipboard({ about })}
-                iconStart={<FileCopyIcon />}
+                iconStart={<RiFileCopyLine />}
               >
                 Copy Info to Clipboard
               </Button>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5648,6 +5648,7 @@ __metadata:
     "@material-ui/core": "npm:^4.9.13"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:^4.0.0-alpha.57"
+    "@remixicon/react": "npm:>=4.6.0 <4.9.0"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@types/lodash": "npm:^4.14.151"
     "@types/react": "npm:^18.0.0"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Migrates the `InfoContent` component (the "About" panel on the DevTools Info page) from Material UI to Backstage UI. This continues the wider DevTools migration started in #33621 (`ExternalDependenciesContent`) and uses the same swap pattern.

Fixes #32747.

### What changed
- `Paper` + `makeStyles` row → BUI `Card` + `CardBody` with prop-based spacing.
- `List` / `ListItem` / `ListItemAvatar` / `ListItemText` row → BUI `Flex` rows of icon + bold label / secondary value, factored into a small local `InfoCell` helper.
- `Avatar` (used as a circular icon wrapper) → dropped. BUI `Avatar` is image / initials only and doesn't accept icon children, so the icons now sit inline next to their labels — same approach the other migrated DevTools content takes for non-status icons.
- `Divider` → dropped; `Flex justify="between"` separates the cells from the copy button.
- MUI `Button` (`onClick`, `startIcon`) → BUI `Button` (`onPress`, `iconStart`).
- MUI lab `Alert` for the error path → BUI `Alert status="danger" icon role="alert"`, mirroring the reference PR.
- The four cells now stack vertically below the `md` breakpoint (responsive `direction` on the outer / inner `Flex`), so the panel no longer crams onto one row on narrow viewports.

`@material-ui/icons/*` and the local `BackstageLogoIcon` (which wraps `@material-ui/core/SvgIcon`) are kept — same scope choice as #33621 which also kept its `Status*` icons. No public API change for `@backstage/plugin-devtools`.

### Screenshots

Wide viewport, light theme:

<img alt="DevTools Info page, wide light theme" src="https://raw.githubusercontent.com/alien2003/backstage/pr-devtools-info-content-bui-assets/info-light.png" width="900" />

Wide viewport, dark theme:

<img alt="DevTools Info page, wide dark theme" src="https://raw.githubusercontent.com/alien2003/backstage/pr-devtools-info-content-bui-assets/info-dark.png" width="900" />

Narrow viewport (≤ md breakpoint), dark theme — cells stack vertically and the copy button drops to its own row:

<img alt="DevTools Info page, narrow dark theme" src="https://raw.githubusercontent.com/alien2003/backstage/pr-devtools-info-content-bui-assets/info-narrow-dark.png" width="420" />

### Verification
- `yarn tsc` clean.
- `yarn backstage-cli repo lint --since master --fix` clean.
- `CI=1 yarn test plugins/devtools/src` — both existing suites pass.
- `yarn build:api-reports` — no public-API diff for `@backstage/plugin-devtools`.
- `yarn start` — verified the four info cells render in light + dark + narrow themes, "Copy Info to Clipboard" button writes the expected `OS / Resources / node / backstage / Dependencies` block to the clipboard, and the `Package Dependencies` table below is unaffected.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation (n/a — internal component refactor).
- [ ] Tests for new functionality and regression tests for bug fixes (n/a — no behaviour change; existing devtools suites still pass).
- [x] Screenshots attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message.