### PR TITLE
create-app: pin protobufjs and @protobufjs/inquire in yarn.lock seed

### DIFF
--- a/packages/create-app/seed-yarn.lock
+++ b/packages/create-app/seed-yarn.lock
@@ -37,3 +37,46 @@ fast-xml-builder@*:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/knex/-/knex-3.1.0.tgz#b6ddd5b5ad26a6315234a5b09ec38dc4a370bd8c"
   integrity sha512-GLoII6hR0c4ti243gMs5/1Rb3B+AjwMOfjYm97pu0FOQa7JH56hgBxYf5WK2525ceSbBY1cjeZ9yk99GPMB6Kw==
+
+// @protobufjs/inquire@1.1.1 dropped the eval-based workaround that hid its
+// dynamic require() from bundlers, which causes webpack/rspack to emit a
+// "Critical dependency: the request of a dependency is an expression" warning
+// that fails the build under CI=true. Pin to 1.1.0 until upstream is fixed.
+// See https://github.com/protobufjs/protobuf.js/issues/2057
+"@protobufjs/inquire@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.0.tgz#ff200e3e7cf2429e2dcafc1140828e8cc638f089"
+  integrity sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==
+
+// protobufjs@7.5.6 bumped its @protobufjs/inquire dependency to ^1.1.1, which
+// would bypass the pin above. Pin protobufjs to 7.5.5 (the last version that
+// requests inquire ^1.1.0) for all known workspace queries.
+"protobufjs@^7.0.0":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.5.5.tgz#b7089ca4410374c75150baf277353ef76db69f96"
+  integrity sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==
+
+"protobufjs@^7.2.5":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.5.5.tgz#b7089ca4410374c75150baf277353ef76db69f96"
+  integrity sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==
+
+"protobufjs@^7.2.6":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.5.5.tgz#b7089ca4410374c75150baf277353ef76db69f96"
+  integrity sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==
+
+"protobufjs@^7.3.2":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.5.5.tgz#b7089ca4410374c75150baf277353ef76db69f96"
+  integrity sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==
+
+"protobufjs@^7.4.0":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.5.5.tgz#b7089ca4410374c75150baf277353ef76db69f96"
+  integrity sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==
+
+"protobufjs@^7.5.3":
+  version "7.5.5"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.5.5.tgz#b7089ca4410374c75150baf277353ef76db69f96"
+  integrity sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes the E2E tests, which started failing on master and on the next-release PR ([#34024](https://github.com/backstage/backstage/pull/34024)) since yesterday. The fix is to pin `protobufjs` and `@protobufjs/inquire` in `packages/create-app/seed-yarn.lock` so that newly created apps (and our E2E tests) don't pull in the brand-new bad versions.

The break:

```
Error: Failed to compile '../../node_modules/@protobufjs/inquire/index.js':
  ⚠ Critical dependency: the request of a dependency is an expression
    ╭─[15:22]
 13 │       return null;
 14 │     }
 15 │     var mod = require(moduleName);
    ·                       ──────────
```

`@protobufjs/inquire@1.1.1` was published yesterday — first release in 5+ years (see [protobufjs/protobuf.js#2057](https://github.com/protobufjs/protobuf.js/issues/2057)) — and it dropped the `eval("quire".replace(...))` workaround that hid the dynamic `require()` from bundlers. Plain `require(moduleName)` makes webpack/rspack emit the "Critical dependency" warning, which CI promotes to an error.

Pinning just `@protobufjs/inquire@^1.1.0 → 1.1.0` isn't enough on its own, because `protobufjs@7.5.6` (also published in the last 24h) bumped its inquire range to `^1.1.1`. So this also pins `protobufjs` to `7.5.5` (the last version that asks for `^1.1.0`) across all the ranges we actually use in the workspace.

The committed workspace `yarn.lock` already happens to be on `protobufjs@7.5.5` + `@protobufjs/inquire@1.1.0`, which is why only the freshly-created E2E app blows up — its `yarn install` re-resolves everything from the registry and picks up the new bad versions.

The seed file is fetched directly from `master` at runtime by `@backstage/create-app` (and read from the workspace by the E2E runner), so this takes effect on merge with no republish needed — and ofc no changeset.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))