### PR TITLE
fix(scaffolder): support bitbucketCloud and bitbucketServer in RepoUrlPicker

### DIFF
--- a/.changeset/fix-bitbucket-picker-types.md
+++ b/.changeset/fix-bitbucket-picker-types.md
@@ -1,0 +1,5 @@
+---
+"@backstage/plugin-scaffolder": patch
+---
+
+Fixed an issue where Bitbucket Cloud and Bitbucket Server hosts would not render the correct repository and branch picker fields in the Scaffolder.

--- a/.changeset/fix-bitbucket-picker-types.md
+++ b/.changeset/fix-bitbucket-picker-types.md
@@ -1,5 +1,5 @@
 ---
-"@backstage/plugin-scaffolder": patch
+'@backstage/plugin-scaffolder': patch
 ---
 
 Fixed an issue where Bitbucket Cloud and Bitbucket Server hosts would not render the correct repository and branch picker fields in the Scaffolder.

--- a/plugins/scaffolder/src/components/fields/RepoBranchPicker/RepoBranchPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoBranchPicker/RepoBranchPicker.test.tsx
@@ -164,6 +164,41 @@ describe('RepoBranchPicker', () => {
       expect(getByText('test title')).toBeInTheDocument();
       expect(getByText('test description')).toBeInTheDocument();
     });
+
+    it('should render BitbucketRepoBranchPicker when host resolves to bitbucketCloud', async () => {
+      const mockIntegrationsApiBitbucket: Partial<ScmIntegrationsApi> = {
+        byHost: () => ({ type: 'bitbucketCloud' }),
+      };
+
+      await renderInTestApp(
+        <TestApiProvider
+          apis={[
+            [scmIntegrationsApiRef, mockIntegrationsApiBitbucket],
+            [scmAuthApiRef, {}],
+            [scaffolderApiRef, {}],
+          ]}
+        >
+          <SecretsContextProvider>
+            <Form
+              validator={validator}
+              schema={{ type: 'string' }}
+              uiSchema={{ 'ui:field': 'RepoBranchPicker' }}
+              fields={{
+                RepoBranchPicker:
+                  RepoBranchPicker as ScaffolderRJSFField<string>,
+              }}
+              formContext={{
+                formData: { repoUrl: 'bitbucket.org?repo=repo' },
+              }}
+            />
+          </SecretsContextProvider>
+        </TestApiProvider>,
+      );
+
+      expect(
+        screen.getByRole('combobox', { name: 'Branch' }),
+      ).toBeInTheDocument();
+    });
   });
 
   describe('requestUserCredentials', () => {

--- a/plugins/scaffolder/src/components/fields/RepoBranchPicker/RepoBranchPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoBranchPicker/RepoBranchPicker.tsx
@@ -125,6 +125,8 @@ export const RepoBranchPicker = (props: RepoBranchPickerProps) => {
   const renderRepoBranchPicker = () => {
     switch (hostType) {
       case 'bitbucket':
+      case 'bitbucketCloud':
+      case 'bitbucketServer':
         return (
           <BitbucketRepoBranchPicker
             onChange={updateLocalState}

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.test.tsx
@@ -242,6 +242,36 @@ describe('RepoUrlPicker', () => {
       expect(getByText('test title')).toBeInTheDocument();
       expect(getByText('test description')).toBeInTheDocument();
     });
+
+    it('should render BitbucketRepoPicker when host resolves to bitbucketCloud', async () => {
+      const mockIntegrationsApiBitbucket: Partial<ScmIntegrationsApi> = {
+        byHost: () => ({ type: 'bitbucketCloud' }),
+      };
+
+      const { getByText } = await renderInTestApp(
+        <TestApiProvider
+          apis={[
+            [scmIntegrationsApiRef, mockIntegrationsApiBitbucket],
+            [scmAuthApiRef, {}],
+            [scaffolderApiRef, mockScaffolderApi],
+          ]}
+        >
+          <SecretsContextProvider>
+            <Form
+              validator={validator}
+              schema={{ type: 'string' }}
+              uiSchema={{ 'ui:field': 'RepoUrlPicker' }}
+              fields={{
+                RepoUrlPicker: RepoUrlPicker as ScaffolderRJSFField<string>,
+              }}
+              formData="bitbucket.org"
+            />
+          </SecretsContextProvider>
+        </TestApiProvider>,
+      );
+
+      expect(getByText('Workspaces')).toBeInTheDocument();
+    });
   });
 
   describe('requestUserCredentials', () => {

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
@@ -226,7 +226,9 @@ export const RepoUrlPicker = (
           }
         />
       )}
-      {hostType === 'bitbucket' && (
+      {(hostType === 'bitbucket' ||
+        hostType === 'bitbucketCloud' ||
+        hostType === 'bitbucketServer') && (
         <BitbucketRepoPicker
           allowedOwners={allowedOwners}
           allowedProjects={allowedProjects}


### PR DESCRIPTION
## Description

Fixed a bug where bitbucket specific fields (like workspace and project) would disappear or fail to render in the Scaffolder when using bitbucket.org

### Root Cause
The `RepoUrlPicker` and `RepoBranchPicker` components were strictly checking for the legacy `bitbucket` integration type. However, the ScmIntegrations API now returns `bitbucketCloud` or `bitbucketServer`. This caused the components to fall back to the "default" picker, which doesn't include the necessary Bitbucket organizational fields.

This PR aligns the UI logic with the existing validation logic to support all current Bitbucket integration types.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation (N/A - Internal logic fix)
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.

Fixes #33887 
