### PR TITLE
docs(contribute): correct format issue in doc-style-guide.md

### DIFF
--- a/docs/contribute/doc-style-guide.md
+++ b/docs/contribute/doc-style-guide.md
@@ -361,7 +361,7 @@ A list of Backstage-specific terms and words to be used consistently across
 the site.
 
 | Term               | Usage                                                                                                                                  |
-| :----------------- | :------------------------------------------------------------------------------------------------------------------------------------- | --- |
+| :----------------- | :------------------------------------------------------------------------------------------------------------------------------------- |
 | Backstage          | Always capitalized.                                                                                                                    |
 | plugin             | Lowercase when referring to the concept. Use code style when referring to a specific package, for example `@backstage/plugin-catalog`. |
 | Software Catalog   | Capitalized as a product name. Use "catalog" (lowercase) when referring to the concept generically.                                    |
@@ -370,4 +370,4 @@ the site.
 | Scaffolder         | Capitalized as a product name.                                                                                                         |
 | app-config         | Use code style: `app-config.yaml`.                                                                                                     |
 | open source        | Two words, lowercase (unless starting a sentence).                                                                                     |
-| backend system     | Lowercase when referring to the Backstage backend framework.                                                                           |     |
+| backend system     | Lowercase when referring to the Backstage backend framework.                                                                           |


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes the formatting of the [Backstage word list](https://backstage.io/docs/contribute/doc-style-guide#backstage-word-list) table in Documentation Style Guide page.

<img width="1013" height="337" alt="image" src="https://github.com/user-attachments/assets/bf720cd8-c556-4d08-9c30-dc7de22b76ab" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] ~A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))~
- [X] Added or updated documentation
- [X] ~Tests for new functionality and regression tests for bug fixes~
- [X] ~Screenshots attached (for UI changes)~
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
