### PR TITLE
Updates two stale React Aria documentation links in the docs-ui compnent pages

### DIFF
--- a/docs-ui/src/app/components/button/page.mdx
+++ b/docs-ui/src/app/components/button/page.mdx
@@ -29,7 +29,7 @@ import {
 } from './components';
 
 export const reactAriaUrls = {
-  button: 'https://react-spectrum.adobe.com/react-aria/Button.html',
+  button: 'https://react-aria.adobe.com/Button',
 };
 
 <PageTitle

--- a/docs-ui/src/app/components/slider/page.mdx
+++ b/docs-ui/src/app/components/slider/page.mdx
@@ -28,7 +28,7 @@ import { ChangelogComponent } from '@/components/ChangelogComponent';
 import { SliderDefinition } from '../../../utils/definitions';
 
 export const reactAriaUrls = {
-  slider: 'https://react-spectrum.adobe.com/react-aria/Slider.html',
+  slider: 'https://react-aria.adobe.com/Slider',
 };
 
 <PageTitle


### PR DESCRIPTION
Fixed two stale React Aria documentation links in the `docs-ui` component pages. The `button` and `slider` pages were still pointing to the old `react-spectrum.adobe.com/react-aria/...html` URL format while all other component pages already use the current `react-aria.adobe.com/...` format.

**Before → After:**
- `button`: `https://react-spectrum.adobe.com/react-aria/Button.html` → `https://react-aria.adobe.com/Button`
- `slider`: `https://react-spectrum.adobe.com/react-aria/Slider.html` → `https://react-aria.adobe.com/Slider`