### PR TITLE
Fixed a heading case inconsistency

### DIFF
--- a/docs-ui/src/app/components/container/page.mdx
+++ b/docs-ui/src/app/components/container/page.mdx
@@ -29,7 +29,7 @@ import { ChangelogComponent } from '@/components/ChangelogComponent';
 
 Container provides the standard page layout for plugin content. It constrains content to a maximum width, centers it horizontally, and adds consistent horizontal gutters. Use it once per page to wrap your main content area.
 
-## API Reference
+## API reference
 
 <PropsTable data={containerPropDefs} />
 

--- a/docs-ui/src/app/components/table/page.mdx
+++ b/docs-ui/src/app/components/table/page.mdx
@@ -230,7 +230,7 @@ When the `Table` component doesn't support your use case, you can compose with t
 
 <Snippet preview={<PrimitivesExample />} code={tablePrimitivesSnippet} />
 
-## API Reference
+## API reference
 
 ### useTable
 


### PR DESCRIPTION
Fixed a heading case inconsistency in two `docs-ui` component pages. The `container` and `table` pages used `## API Reference` (capital R) while all 37 other component pages use `## API reference`.
