### PR TITLE
Add more examples to switch component

### DIFF
--- a/docs-ui/src/app/components/switch/components.tsx
+++ b/docs-ui/src/app/components/switch/components.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import { Switch } from '../../../../../packages/ui/src/components/Switch/Switch';
 
 export const Default = () => {
@@ -8,4 +9,23 @@ export const Default = () => {
 
 export const Disabled = () => {
   return <Switch label="Switch" isDisabled />;
+};
+
+export const DefaultSelected = () => {
+  return <Switch label="Switch" defaultSelected />;
+};
+
+export const ReadOnly = () => {
+  return <Switch label="Switch" isSelected isReadOnly />;
+};
+
+export const Controlled = () => {
+  const [selected, setSelected] = useState(false);
+  return (
+    <Switch
+      label={selected ? 'On' : 'Off'}
+      isSelected={selected}
+      onChange={setSelected}
+    />
+  );
 };

--- a/docs-ui/src/app/components/switch/page.mdx
+++ b/docs-ui/src/app/components/switch/page.mdx
@@ -3,8 +3,15 @@ import { Snippet } from '@/components/Snippet';
 import { CodeBlock } from '@/components/CodeBlock';
 import { ReactAriaLink } from '@/components/ReactAriaLink';
 import { switchPropDefs } from './props-definition';
-import { snippetUsage, defaultSnippet, disabledSnippet } from './snippets';
-import { Default, Disabled } from './components';
+import {
+  snippetUsage,
+  defaultSnippet,
+  disabledSnippet,
+  defaultSelectedSnippet,
+  readOnlySnippet,
+  controlledSnippet,
+} from './snippets';
+import { Default, Disabled, DefaultSelected, ReadOnly, Controlled } from './components';
 import { PageTitle } from '@/components/PageTitle';
 import { Theming } from '@/components/Theming';
 import { ChangelogComponent } from '@/components/ChangelogComponent';
@@ -35,7 +42,43 @@ export const reactAriaUrls = {
 
 ### Disabled
 
-<Snippet align="center" py={4} preview={<Disabled />} code={disabledSnippet} />
+<Snippet align="center" py={4} open preview={<Disabled />} code={disabledSnippet} />
+
+### Default selected
+
+Use `defaultSelected` to start the switch in the on state for uncontrolled usage.
+
+<Snippet
+  align="center"
+  py={4}
+  open
+  preview={<DefaultSelected />}
+  code={defaultSelectedSnippet}
+/>
+
+### Read only
+
+Use `isReadOnly` to prevent interaction while keeping the switch focusable and its value visible.
+
+<Snippet
+  align="center"
+  py={4}
+  open
+  preview={<ReadOnly />}
+  code={readOnlySnippet}
+/>
+
+### Controlled
+
+Use `isSelected` and `onChange` together for controlled state.
+
+<Snippet
+  align="center"
+  py={4}
+  open
+  preview={<Controlled />}
+  code={controlledSnippet}
+/>
 
 <Theming definition={SwitchDefinition} />
 

--- a/docs-ui/src/app/components/switch/page.mdx
+++ b/docs-ui/src/app/components/switch/page.mdx
@@ -11,7 +11,13 @@ import {
   readOnlySnippet,
   controlledSnippet,
 } from './snippets';
-import { Default, Disabled, DefaultSelected, ReadOnly, Controlled } from './components';
+import {
+  Default,
+  Disabled,
+  DefaultSelected,
+  ReadOnly,
+  Controlled,
+} from './components';
 import { PageTitle } from '@/components/PageTitle';
 import { Theming } from '@/components/Theming';
 import { ChangelogComponent } from '@/components/ChangelogComponent';
@@ -42,7 +48,13 @@ export const reactAriaUrls = {
 
 ### Disabled
 
-<Snippet align="center" py={4} open preview={<Disabled />} code={disabledSnippet} />
+<Snippet
+  align="center"
+  py={4}
+  open
+  preview={<Disabled />}
+  code={disabledSnippet}
+/>
 
 ### Default selected
 

--- a/docs-ui/src/app/components/switch/snippets.ts
+++ b/docs-ui/src/app/components/switch/snippets.ts
@@ -5,3 +5,18 @@ export const snippetUsage = `import { Switch } from '@backstage/ui';
 export const defaultSnippet = `<Switch label="Switch" />`;
 
 export const disabledSnippet = `<Switch label="Switch" isDisabled />`;
+
+export const defaultSelectedSnippet = `<Switch label="Switch" defaultSelected />`;
+
+export const readOnlySnippet = `<Switch label="Switch" isSelected isReadOnly />`;
+
+export const controlledSnippet = `import { useState } from 'react';
+import { Switch } from '@backstage/ui';
+
+const [selected, setSelected] = useState(false);
+
+<Switch
+  label={selected ? 'On' : 'Off'}
+  isSelected={selected}
+  onChange={setSelected}
+/>`;


### PR DESCRIPTION
The `Switch` component page had only one example ("Disabled") beyond the hero snippet, leaving key usage patterns undocumented. Developers had no reference for how to pre-select the switch, make it read-only, or manage it as controlled state — all common real-world needs.

Added three new examples across `components.tsx`, `snippets.ts`, and `page.mdx`:

- **Default selected** — shows `defaultSelected` for uncontrolled usage where the switch should start in the on state
- **Read only** — shows `isReadOnly` to render a non-interactive but focusable switch, useful in review/summary UIs
- **Controlled** — shows `isSelected` + `onChange` for fully controlled state, the most common pattern in forms

Also added the `open` prop to the existing Disabled snippet so the code tab is expanded by default, consistent with other component pages.


<img width="608" height="782" alt="image" src="https://github.com/user-attachments/assets/b0a48eee-3f8c-47a9-9e52-4fa34583fecb" />
