### PR TITLE
Handle empty gitlab:repo:push without calling GitLab’s commit API

### DIFF
--- a/.changeset/wise-paths-exist.md
+++ b/.changeset/wise-paths-exist.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gitlab': minor
+---
+
+The `gitlab:repo:push` template action no longer fails when there is nothing to commit, for example when the workspace is empty, when `sourcePath` yields no files, or when `commitAction: auto` skips every file because the branch already matches. In those cases the step now completes successfully, logs a warning that no commit was created, and the `commitHash` output is empty instead of calling GitLab and returning an error.

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.examples.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.examples.test.ts
@@ -119,7 +119,7 @@ describe('gitlab:repo:push', () => {
       mockDir.setContent({
         [workspacePath]: {
           'abcd.txt': 'Test message',
-          source: {
+          src: {
             'abcd.txt': 'Test message',
           },
         },
@@ -135,7 +135,7 @@ describe('gitlab:repo:push', () => {
         [
           {
             action: 'create',
-            filePath: 'abcd.txt',
+            filePath: 'dest/abcd.txt',
             content: 'VGVzdCBtZXNzYWdl',
             encoding: 'base64',
             execute_filemode: false,

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.test.ts
@@ -377,6 +377,34 @@ describe('createGitLabCommit', () => {
     });
   });
 
+  describe('when there are no files to commit', () => {
+    it('does not call Commits.create and outputs an empty commit hash', async () => {
+      mockGitlabClient.Commits.create.mockClear();
+      const input = {
+        repoUrl: 'gitlab.com?repo=repo&owner=owner',
+        commitMessage: 'Nothing to push',
+        branchName: 'some-branch',
+        sourcePath: 'source',
+      };
+      mockDir.setContent({
+        [workspacePath]: {
+          source: {},
+        },
+      });
+      const ctx = createMockActionContext({ input, workspacePath });
+      const warnSpy = jest.spyOn(ctx.logger, 'warn');
+      await instance.handler(ctx);
+
+      expect(mockGitlabClient.Commits.create).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('No commit created'),
+      );
+      expect(ctx.output).toHaveBeenCalledWith('commitHash', '');
+      expect(ctx.output).toHaveBeenCalledWith('projectid', 'owner/repo');
+      expect(ctx.output).toHaveBeenCalledWith('projectPath', 'owner/repo');
+    });
+  });
+
   describe('error handling', () => {
     it('throws appropriate error for create action when commit fails', async () => {
       const input = {

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.ts
@@ -95,7 +95,8 @@ export const createGitlabRepoPushAction = (options: {
           }),
         commitHash: z =>
           z.string({
-            description: 'The git commit hash of the commit',
+            description:
+              'The git commit hash of the commit. Might be empty if no files to commit.',
           }),
       },
     },
@@ -212,6 +213,12 @@ export const createGitlabRepoPushAction = (options: {
         const commitId = await ctx.checkpoint({
           key: `commit.create.${repoID}.${branchName}`,
           fn: async () => {
+            if (actions.length === 0) {
+              ctx.logger.warn(
+                `No commit created because no files to commit to ${repoID} (branch: ${branchName})`,
+              );
+              return '';
+            }
             const commit = await api.Commits.create(
               repoID,
               branchName,


### PR DESCRIPTION
Fixes #34098

The `gitlab:repo:push` scaffolder action used to call GitLab’s create-commit API with an empty `actions` list when there was nothing to push (for example an empty workspace or `sourcePath`, or `commitAction: auto` when every file matched the target branch). GitLab returned HTTP 400 (“Provide at least one action, or set allow_empty to true”), and Backstage surfaced a misleading `InputError`.

This change skips that API call when there are no file actions: the step completes successfully, logs a warning that no commit was created, and sets `commitHash` to an empty string. Tests cover the no-op behavior.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
