### PR TITLE
fix(ui): adjust plugin header spacing

### DIFF
--- a/.changeset/core-header-marker.md
+++ b/.changeset/core-header-marker.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Added a stable DOM marker to the legacy Header so adjacent layout components can coordinate spacing without relying on generated class names.

--- a/.changeset/core-header-marker.md
+++ b/.changeset/core-header-marker.md
@@ -2,4 +2,4 @@
 '@backstage/core-components': patch
 ---
 
-Added a stable DOM marker to the legacy Header so adjacent layout components can coordinate spacing without relying on generated class names.
+Added stable DOM markers to the legacy Page and Header so adjacent layout components can coordinate spacing without relying on generated class names.

--- a/.changeset/plugin-header-spacing.md
+++ b/.changeset/plugin-header-spacing.md
@@ -1,0 +1,7 @@
+---
+'@backstage/ui': patch
+---
+
+Adjusted PluginHeader spacing so headers with and without tabs align more consistently with surrounding page content.
+
+**Affected components:** PluginHeader, Header

--- a/.changeset/plugin-header-spacing.md
+++ b/.changeset/plugin-header-spacing.md
@@ -2,6 +2,6 @@
 '@backstage/ui': patch
 ---
 
-Adjusted PluginHeader spacing so headers with and without tabs align more consistently with surrounding page content.
+Adjusted PluginHeader spacing and borders so headers with and without tabs align more consistently with surrounding page content, including when paired with page headers.
 
 **Affected components:** PluginHeader, Header

--- a/.storybook/themes/spotify.css
+++ b/.storybook/themes/spotify.css
@@ -245,11 +245,12 @@
  * this file for easier scanning alongside other component overrides above.
  */
 [data-theme-name='spotify'] {
+  .bui-PluginHeader {
+    margin-top: var(--bui-space-4);
+  }
+
   .bui-PluginHeaderToolbar {
     height: 32px;
-    border: none;
-    background: none;
-    margin-top: var(--bui-space-4);
   }
 
   .bui-PluginHeaderTabsWrapper {
@@ -257,9 +258,5 @@
     background: none;
     margin-left: 0;
     margin-top: var(--bui-space-2);
-  }
-
-  .bui-HeaderTop {
-    padding-top: var(--bui-space-4);
   }
 }

--- a/.storybook/themes/spotify.css
+++ b/.storybook/themes/spotify.css
@@ -239,24 +239,3 @@
 
   --bui-ring: rgba(255, 255, 255, 0.2);
 }
-
-/*
- * Plugin header (@backstage/ui) and story shell header — kept at the bottom of
- * this file for easier scanning alongside other component overrides above.
- */
-[data-theme-name='spotify'] {
-  .bui-PluginHeader {
-    margin-top: var(--bui-space-4);
-  }
-
-  .bui-PluginHeaderToolbar {
-    height: 32px;
-  }
-
-  .bui-PluginHeaderTabsWrapper {
-    border: none;
-    background: none;
-    margin-left: 0;
-    margin-top: var(--bui-space-2);
-  }
-}

--- a/packages/core-components/src/layout/Header/Header.tsx
+++ b/packages/core-components/src/layout/Header/Header.tsx
@@ -228,7 +228,11 @@ export function Header(props: PropsWithChildren<Props>) {
   return (
     <>
       <Helmet titleTemplate={titleTemplate} defaultTitle={defaultTitle} />
-      <header style={style} className={classes.header}>
+      <header
+        style={style}
+        className={classes.header}
+        data-backstage-core-header=""
+      >
         <Box className={classes.leftItemsBox}>
           <TypeFragment
             classes={classes}

--- a/packages/core-components/src/layout/Page/Page.tsx
+++ b/packages/core-components/src/layout/Page/Page.tsx
@@ -59,7 +59,12 @@ export function Page(props: Props) {
         page: baseTheme.getPageTheme({ themeId }),
       })}
     >
-      <main className={classNames(classes.root, className)}>{children}</main>
+      <main
+        className={classNames(classes.root, className)}
+        data-backstage-core-page=""
+      >
+        {children}
+      </main>
     </ThemeProvider>
   );
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -60,6 +60,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",
+    "@backstage/core-components": "workspace:^",
     "@storybook/react-vite": "^10.3.3",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^16.0.0",

--- a/packages/ui/src/components/Header/Header.module.css
+++ b/packages/ui/src/components/Header/Header.module.css
@@ -32,10 +32,6 @@
     box-sizing: border-box;
   }
 
-  .bui-HeaderTop {
-    padding-top: var(--bui-space-6);
-  }
-
   .bui-HeaderStickySentinel {
     height: 1px;
     margin-bottom: -1px;

--- a/packages/ui/src/components/PluginHeader/PluginHeader.module.css
+++ b/packages/ui/src/components/PluginHeader/PluginHeader.module.css
@@ -21,10 +21,15 @@
     --bui-plugin-header-margin-bottom: var(--bui-space-6);
     --bui-plugin-header-toolbar-border-bottom: solid 1px var(--bui-border-1);
     --bui-plugin-header-tabs-border-bottom: 1px solid var(--bui-border-1);
+    --bui-plugin-header-toolbar-padding-bottom: var(--bui-space-4);
+    --bui-plugin-header-toolbar-tabs-padding-bottom: var(--bui-space-1);
+    --bui-plugin-header-background-color: transparent;
+    --bui-plugin-header-padding-top: var(--bui-space-4);
 
     margin-bottom: var(--bui-plugin-header-margin-bottom);
     padding-inline: var(--bui-space-5);
-    margin-top: var(--bui-space-4);
+    padding-top: var(--bui-plugin-header-padding-top);
+    background-color: var(--bui-plugin-header-background-color);
   }
 
   .bui-PluginHeader:has(+ .bui-HeaderTop),
@@ -35,6 +40,19 @@
     --bui-plugin-header-margin-bottom: 0;
     --bui-plugin-header-toolbar-border-bottom: none;
     --bui-plugin-header-tabs-border-bottom: none;
+    --bui-plugin-header-toolbar-padding-bottom: var(--bui-space-2);
+    --bui-plugin-header-toolbar-tabs-padding-bottom: var(--bui-space-2);
+    --bui-plugin-header-background-color: var(--bui-bg-neutral-1);
+    --bui-plugin-header-padding-top: var(--bui-space-2);
+  }
+
+  .bui-PluginHeader:has(+ [data-backstage-core-header])
+    .bui-PluginHeaderToolbarIcon,
+  .bui-PluginHeader:has(
+      + [data-backstage-core-page] [data-backstage-core-header]
+    )
+    .bui-PluginHeaderToolbarIcon {
+    background-color: var(--bui-bg-neutral-3);
   }
 
   .bui-PluginHeaderToolbar {
@@ -44,11 +62,11 @@
     justify-content: space-between;
     color: var(--bui-fg-primary);
     border-bottom: var(--bui-plugin-header-toolbar-border-bottom);
-    padding-bottom: var(--bui-space-4);
+    padding-bottom: var(--bui-plugin-header-toolbar-padding-bottom);
 
     &[data-has-tabs] {
       border-bottom: none;
-      padding-bottom: var(--bui-space-1);
+      padding-bottom: var(--bui-plugin-header-toolbar-tabs-padding-bottom);
     }
   }
 
@@ -69,7 +87,7 @@
     flex-shrink: 0;
   }
 
-  .bui-PluginHeaderToolbarIcon {
+  .bui-PluginHeader .bui-PluginHeaderToolbarIcon {
     display: flex;
     align-items: center;
     justify-content: center;

--- a/packages/ui/src/components/PluginHeader/PluginHeader.module.css
+++ b/packages/ui/src/components/PluginHeader/PluginHeader.module.css
@@ -17,15 +17,23 @@
 @layer tokens, base, components, utilities;
 
 @layer components {
+  .bui-PluginHeader {
+    margin-bottom: var(--bui-space-6);
+    padding-inline: var(--bui-space-5);
+  }
+
   .bui-PluginHeaderToolbar {
     display: flex;
     flex-direction: row;
     align-items: center;
     justify-content: space-between;
-    padding-inline: var(--bui-space-5);
     color: var(--bui-fg-primary);
     height: 52px;
-    border-bottom: 1px solid var(--bui-border-1);
+    border-bottom: solid 1px var(--bui-border-1);
+
+    &[data-has-tabs] {
+      border-bottom: none;
+    }
   }
 
   .bui-PluginHeaderToolbarContent {
@@ -69,7 +77,6 @@
   }
 
   .bui-PluginHeaderTabsWrapper {
-    padding-inline: var(--bui-space-3);
     border-bottom: 1px solid var(--bui-border-1);
   }
 }

--- a/packages/ui/src/components/PluginHeader/PluginHeader.module.css
+++ b/packages/ui/src/components/PluginHeader/PluginHeader.module.css
@@ -20,6 +20,7 @@
   .bui-PluginHeader {
     margin-bottom: var(--bui-space-6);
     padding-inline: var(--bui-space-5);
+    margin-top: var(--bui-space-4);
   }
 
   .bui-PluginHeaderToolbar {
@@ -28,11 +29,12 @@
     align-items: center;
     justify-content: space-between;
     color: var(--bui-fg-primary);
-    height: 52px;
     border-bottom: solid 1px var(--bui-border-1);
+    padding-bottom: var(--bui-space-4);
 
     &[data-has-tabs] {
       border-bottom: none;
+      padding-bottom: var(--bui-space-1);
     }
   }
 

--- a/packages/ui/src/components/PluginHeader/PluginHeader.module.css
+++ b/packages/ui/src/components/PluginHeader/PluginHeader.module.css
@@ -28,7 +28,10 @@
   }
 
   .bui-PluginHeader:has(+ .bui-HeaderTop),
-  .bui-PluginHeader:has(+ [data-backstage-core-header]) {
+  .bui-PluginHeader:has(+ [data-backstage-core-header]),
+  .bui-PluginHeader:has(
+      + [data-backstage-core-page] [data-backstage-core-header]
+    ) {
     --bui-plugin-header-margin-bottom: 0;
     --bui-plugin-header-toolbar-border-bottom: none;
     --bui-plugin-header-tabs-border-bottom: none;

--- a/packages/ui/src/components/PluginHeader/PluginHeader.module.css
+++ b/packages/ui/src/components/PluginHeader/PluginHeader.module.css
@@ -18,9 +18,20 @@
 
 @layer components {
   .bui-PluginHeader {
-    margin-bottom: var(--bui-space-6);
+    --bui-plugin-header-margin-bottom: var(--bui-space-6);
+    --bui-plugin-header-toolbar-border-bottom: solid 1px var(--bui-border-1);
+    --bui-plugin-header-tabs-border-bottom: 1px solid var(--bui-border-1);
+
+    margin-bottom: var(--bui-plugin-header-margin-bottom);
     padding-inline: var(--bui-space-5);
     margin-top: var(--bui-space-4);
+  }
+
+  .bui-PluginHeader:has(+ .bui-HeaderTop),
+  .bui-PluginHeader:has(+ [data-backstage-core-header]) {
+    --bui-plugin-header-margin-bottom: 0;
+    --bui-plugin-header-toolbar-border-bottom: none;
+    --bui-plugin-header-tabs-border-bottom: none;
   }
 
   .bui-PluginHeaderToolbar {
@@ -29,7 +40,7 @@
     align-items: center;
     justify-content: space-between;
     color: var(--bui-fg-primary);
-    border-bottom: solid 1px var(--bui-border-1);
+    border-bottom: var(--bui-plugin-header-toolbar-border-bottom);
     padding-bottom: var(--bui-space-4);
 
     &[data-has-tabs] {
@@ -79,6 +90,6 @@
   }
 
   .bui-PluginHeaderTabsWrapper {
-    border-bottom: 1px solid var(--bui-border-1);
+    border-bottom: var(--bui-plugin-header-tabs-border-bottom);
   }
 }

--- a/packages/ui/src/components/PluginHeader/PluginHeader.tsx
+++ b/packages/ui/src/components/PluginHeader/PluginHeader.tsx
@@ -25,7 +25,6 @@ import { Box } from '../Box';
 import { Link } from '../Link';
 import { RiShapesLine } from '@remixicon/react';
 import { Text } from '../Text';
-import { BgReset } from '../../hooks/useBg';
 
 declare module 'react-aria-components' {
   interface RouterConfig {
@@ -53,7 +52,7 @@ export const PluginHeader = (props: PluginHeaderProps) => {
   } = ownProps;
 
   const hasTabs = tabs && tabs.length > 0;
-  const headerRef = useRef<HTMLElement>(null);
+  const rootRef = useRef<HTMLDivElement>(null);
   const animationFrameRef = useRef<number | undefined>(undefined);
   const lastAppliedHeightRef = useRef<number | undefined>(undefined);
 
@@ -62,7 +61,7 @@ export const PluginHeader = (props: PluginHeaderProps) => {
   }, [customActions]);
 
   useIsomorphicLayoutEffect(() => {
-    const el = headerRef.current;
+    const el = rootRef.current;
     if (!el) {
       return undefined;
     }
@@ -125,50 +124,44 @@ export const PluginHeader = (props: PluginHeaderProps) => {
   const titleText = title || 'Your plugin';
 
   return (
-    <BgReset>
-      <header ref={headerRef} className={classes.root}>
-        <Box bg="neutral" className={classes.toolbar} data-has-tabs={hasTabs}>
-          <div className={classes.toolbarContent}>
-            <Box
-              bg="neutral"
-              className={classes.toolbarIcon}
-              aria-hidden="true"
-            >
-              {icon || <RiShapesLine />}
-            </Box>
-            <h1 className={classes.toolbarName}>
-              {titleLink ? (
-                <Link href={titleLink} standalone variant="body-medium">
-                  {titleText}
-                </Link>
-              ) : (
-                <Text as="span" variant="body-medium">
-                  {titleText}
-                </Text>
-              )}
-            </h1>
-          </div>
-          <div className={classes.toolbarControls}>{actionChildren}</div>
-        </Box>
-        {tabs && (
-          <Box bg="neutral" className={classes.tabs}>
-            <Tabs onSelectionChange={onTabSelectionChange}>
-              <TabList>
-                {tabs?.map(tab => (
-                  <Tab
-                    key={tab.id}
-                    id={tab.id}
-                    href={tab.href}
-                    matchStrategy={tab.matchStrategy}
-                  >
-                    {tab.label}
-                  </Tab>
-                ))}
-              </TabList>
-            </Tabs>
+    <div ref={rootRef} className={classes.root}>
+      <div className={classes.toolbar} data-has-tabs={hasTabs}>
+        <div className={classes.toolbarContent}>
+          <Box bg="neutral" className={classes.toolbarIcon} aria-hidden="true">
+            {icon || <RiShapesLine />}
           </Box>
-        )}
-      </header>
-    </BgReset>
+          <h1 className={classes.toolbarName}>
+            {titleLink ? (
+              <Link href={titleLink} standalone variant="body-medium">
+                {titleText}
+              </Link>
+            ) : (
+              <Text as="span" variant="body-medium">
+                {titleText}
+              </Text>
+            )}
+          </h1>
+        </div>
+        <div className={classes.toolbarControls}>{actionChildren}</div>
+      </div>
+      {tabs && (
+        <div className={classes.tabs}>
+          <Tabs onSelectionChange={onTabSelectionChange}>
+            <TabList>
+              {tabs?.map(tab => (
+                <Tab
+                  key={tab.id}
+                  id={tab.id}
+                  href={tab.href}
+                  matchStrategy={tab.matchStrategy}
+                >
+                  {tab.label}
+                </Tab>
+              ))}
+            </TabList>
+          </Tabs>
+        </div>
+      )}
+    </div>
   );
 };

--- a/packages/ui/src/components/PluginHeader/PluginHeader.tsx
+++ b/packages/ui/src/components/PluginHeader/PluginHeader.tsx
@@ -125,7 +125,7 @@ export const PluginHeader = (props: PluginHeaderProps) => {
 
   return (
     <div ref={rootRef} className={classes.root}>
-      <div className={classes.toolbar} data-has-tabs={hasTabs}>
+      <div className={classes.toolbar} data-has-tabs={hasTabs ? '' : undefined}>
         <div className={classes.toolbarContent}>
           <Box bg="neutral" className={classes.toolbarIcon} aria-hidden="true">
             {icon || <RiShapesLine />}
@@ -144,7 +144,7 @@ export const PluginHeader = (props: PluginHeaderProps) => {
         </div>
         <div className={classes.toolbarControls}>{actionChildren}</div>
       </div>
-      {tabs && (
+      {hasTabs && (
         <div className={classes.tabs}>
           <Tabs onSelectionChange={onTabSelectionChange}>
             <TabList>

--- a/packages/ui/src/recipes/PluginHeaderAndHeader.stories.tsx
+++ b/packages/ui/src/recipes/PluginHeaderAndHeader.stories.tsx
@@ -49,7 +49,7 @@ import {
 // ---------------------------------------------------------------------------
 
 const PageContent = () => (
-  <Container mt="6">
+  <Container>
     <Flex direction="row" gap="4">
       <Card style={{ minHeight: 120, flex: 1 }} />
       <Card style={{ minHeight: 120, flex: 1 }} />
@@ -59,7 +59,7 @@ const PageContent = () => (
 );
 
 const LongPageContent = () => (
-  <Container mt="6" pb="3">
+  <Container pb="3">
     <Flex direction="row" gap="4" mb="4">
       <Card style={{ minHeight: 200, flex: 1 }} />
       <Card style={{ minHeight: 200, flex: 1 }} />
@@ -99,6 +99,28 @@ export const NoHeader = meta.story({
   render: () => (
     <>
       <PluginHeader icon={<RiCodeSSlashLine />} title="APIs" />
+      <PageContent />
+    </>
+  ),
+});
+
+export const NoHeaderWithTabs = meta.story({
+  decorators: [withLayout],
+  render: () => (
+    <>
+      <PluginHeader
+        icon={<RiCodeSSlashLine />}
+        title="APIs"
+        tabs={[
+          { id: 'overview', label: 'Overview', href: '/apis' },
+          {
+            id: 'definitions',
+            label: 'Definitions',
+            href: '/apis/definitions',
+          },
+          { id: 'consumers', label: 'Consumers', href: '/apis/consumers' },
+        ]}
+      />
       <PageContent />
     </>
   ),

--- a/packages/ui/src/recipes/PluginHeaderAndHeader.stories.tsx
+++ b/packages/ui/src/recipes/PluginHeaderAndHeader.stories.tsx
@@ -15,6 +15,7 @@
  */
 
 import preview from '../../../../.storybook/preview';
+import { Header as CoreHeader } from '@backstage/core-components';
 import type { StoryFn } from '@storybook/react-vite';
 import { MemoryRouter } from 'react-router-dom';
 import { BUIProvider } from '../provider';
@@ -132,6 +133,40 @@ export const SimpleHeader = meta.story({
     <>
       <PluginHeader icon={<RiCodeSSlashLine />} title="APIs" />
       <Header title="payments-api" />
+      <PageContent />
+    </>
+  ),
+});
+
+export const CoreComponentsHeader = meta.story({
+  decorators: [withLayout],
+  render: () => (
+    <>
+      <PluginHeader icon={<RiCodeSSlashLine />} title="APIs" />
+      <CoreHeader title="payments-api" />
+      <PageContent />
+    </>
+  ),
+});
+
+export const CoreComponentsHeaderWithTabs = meta.story({
+  decorators: [withLayout],
+  render: () => (
+    <>
+      <PluginHeader
+        icon={<RiCodeSSlashLine />}
+        title="APIs"
+        tabs={[
+          { id: 'overview', label: 'Overview', href: '/apis' },
+          {
+            id: 'definitions',
+            label: 'Definitions',
+            href: '/apis/definitions',
+          },
+          { id: 'consumers', label: 'Consumers', href: '/apis/consumers' },
+        ]}
+      />
+      <CoreHeader title="payments-api" />
       <PageContent />
     </>
   ),

--- a/packages/ui/src/recipes/PluginHeaderAndHeader.stories.tsx
+++ b/packages/ui/src/recipes/PluginHeaderAndHeader.stories.tsx
@@ -15,7 +15,10 @@
  */
 
 import preview from '../../../../.storybook/preview';
-import { Header as CoreHeader } from '@backstage/core-components';
+import {
+  Header as CoreHeader,
+  Page as CorePage,
+} from '@backstage/core-components';
 import type { StoryFn } from '@storybook/react-vite';
 import { MemoryRouter } from 'react-router-dom';
 import { BUIProvider } from '../provider';
@@ -143,8 +146,10 @@ export const CoreComponentsHeader = meta.story({
   render: () => (
     <>
       <PluginHeader icon={<RiCodeSSlashLine />} title="APIs" />
-      <CoreHeader title="payments-api" />
-      <PageContent />
+      <CorePage themeId="home">
+        <CoreHeader title="payments-api" />
+        <PageContent />
+      </CorePage>
     </>
   ),
 });
@@ -166,8 +171,10 @@ export const CoreComponentsHeaderWithTabs = meta.story({
           { id: 'consumers', label: 'Consumers', href: '/apis/consumers' },
         ]}
       />
-      <CoreHeader title="payments-api" />
-      <PageContent />
+      <CorePage themeId="home">
+        <CoreHeader title="payments-api" />
+        <PageContent />
+      </CorePage>
     </>
   ),
 });

--- a/packages/ui/src/recipes/PluginHeaderAndHeader.stories.tsx
+++ b/packages/ui/src/recipes/PluginHeaderAndHeader.stories.tsx
@@ -53,7 +53,7 @@ import {
 // ---------------------------------------------------------------------------
 
 const PageContent = () => (
-  <Container>
+  <Container style={{ gridArea: 'pageContent' }}>
     <Flex direction="row" gap="4">
       <Card style={{ minHeight: 120, flex: 1 }} />
       <Card style={{ minHeight: 120, flex: 1 }} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -7949,6 +7949,7 @@ __metadata:
   resolution: "@backstage/ui@workspace:packages/ui"
   dependencies:
     "@backstage/cli": "workspace:^"
+    "@backstage/core-components": "workspace:^"
     "@backstage/version-bridge": "workspace:^"
     "@braintree/sanitize-url": "npm:^7.1.2"
     "@internationalized/date": "npm:^3.12.0"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adjusted `PluginHeader` spacing so tabbed and non-tabbed variants align consistently with surrounding page content. This also updates the Spotify Storybook theme override and adds a tabbed no-header recipe for visual coverage.

## Before
<img width="2588" height="808" alt="CleanShot 2026-04-29 at 15 45 09@2x" src="https://github.com/user-attachments/assets/fe7d8cf7-d11e-4e0c-8602-baecaac37cda" />

## After
<img width="1968" height="916" alt="CleanShot 2026-04-29 at 15 23 42@2x" src="https://github.com/user-attachments/assets/ef863bd5-97d6-4140-9ffd-5851bce38e0b" />

## With Header from `core-components`
<img width="3010" height="652" alt="CleanShot 2026-05-04 at 08 50 11@2x" src="https://github.com/user-attachments/assets/ba3ca90d-afef-4397-b91a-59e7e512348b" />

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

## Test plan

- `yarn prettier --write .storybook/themes/spotify.css packages/ui/src/components/Header/Header.module.css packages/ui/src/components/PluginHeader/PluginHeader.module.css packages/ui/src/components/PluginHeader/PluginHeader.tsx packages/ui/src/recipes/PluginHeaderAndHeader.stories.tsx .changeset/plugin-header-spacing.md`
- `yarn build:api-reports`