### PR TITLE
cli-module-build: forward user config to embedded Postgres

### DIFF
--- a/.changeset/forward-embedded-postgres-config.md
+++ b/.changeset/forward-embedded-postgres-config.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli-module-build': patch
+---
+
+The embedded Postgres database used during local development now respects user-provided connection configuration. If you configure `host`, `port`, `user`, or `password` under `backend.database.connection` alongside the `embedded-postgres` database client, those values will be forwarded to the embedded Postgres instance. Only values that you have not configured will be filled in with defaults. This makes it possible to run the embedded database on a specific host and port, for example to connect to it externally with `psql`.

--- a/packages/cli-module-build/src/lib/runner/runBackend.test.ts
+++ b/packages/cli-module-build/src/lib/runner/runBackend.test.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { mockServices } from '@backstage/backend-test-utils';
+import { ConfigSources } from '@backstage/config-loader';
 import { runBackend } from './runBackend';
 import spawn from 'cross-spawn';
 
@@ -49,13 +51,12 @@ jest.mock('ctrlc-windows', () => ({
   ctrlc: jest.fn(),
 }));
 
-const mockToConfig = jest.fn();
 const mockConfigSourcesDefault = jest.fn().mockReturnValue({});
 
 jest.mock('@backstage/config-loader', () => ({
   ConfigSources: {
     default: (...args: any[]) => mockConfigSourcesDefault(...args),
-    toConfig: (...args: any[]) => mockToConfig(...args),
+    toConfig: jest.fn(),
   },
 }));
 
@@ -69,6 +70,17 @@ describe('runBackend', () => {
   let originalEnv: NodeJS.ProcessEnv;
   let originalPlatform: string;
   const mockSpawn = spawn as jest.MockedFunction<typeof spawn>;
+  const mockToConfig = ConfigSources.toConfig as jest.MockedFunction<
+    typeof ConfigSources.toConfig
+  >;
+
+  function mockConfig(
+    overrides?: Parameters<typeof mockServices.rootConfig.mock>[0],
+  ) {
+    const config = mockServices.rootConfig.mock(overrides);
+    mockToConfig.mockResolvedValue(Object.assign(config, { close: jest.fn() }));
+    return config;
+  }
 
   beforeEach(() => {
     // Use fake timers to control debounce
@@ -85,12 +97,7 @@ describe('runBackend', () => {
     // Mock process.once to prevent actual signal handling
     jest.spyOn(process, 'once').mockReturnValue(process);
 
-    mockToConfig.mockResolvedValue({
-      close: jest.fn(),
-      getOptional: () => undefined,
-      getOptionalString: () => undefined,
-      getOptionalNumber: () => undefined,
-    });
+    mockConfig();
     mockStartEmbeddedDb.mockReset();
   });
 
@@ -183,12 +190,9 @@ describe('runBackend', () => {
 
   describe('embedded-postgres support', () => {
     it('should start embedded DB and inject all defaults when no user connection config is provided', async () => {
-      mockToConfig.mockResolvedValue({
-        close: jest.fn(),
-        getOptional: () => undefined,
+      mockConfig({
         getOptionalString: (key: string) =>
           key === 'backend.database.client' ? 'embedded-postgres' : undefined,
-        getOptionalNumber: () => undefined,
       });
       mockStartEmbeddedDb.mockResolvedValue({
         connection: {
@@ -232,9 +236,11 @@ describe('runBackend', () => {
         'backend.database.connection.host': '0.0.0.0',
         'backend.database.connection.port': 15432,
       };
-      mockToConfig.mockResolvedValue({
-        close: jest.fn(),
-        getOptional: () => ({ host: '0.0.0.0', port: 15432 }),
+      mockConfig({
+        getOptional: ((key: string) =>
+          key === 'backend.database.connection'
+            ? { host: '0.0.0.0', port: 15432 }
+            : undefined) as any,
         getOptionalString: (key: string) => {
           const val = configValues[key];
           return typeof val === 'string' ? val : undefined;
@@ -289,14 +295,16 @@ describe('runBackend', () => {
         'backend.database.connection.user': 'myuser',
         'backend.database.connection.password': 'mypass',
       };
-      mockToConfig.mockResolvedValue({
-        close: jest.fn(),
-        getOptional: () => ({
-          host: '0.0.0.0',
-          port: 15432,
-          user: 'myuser',
-          password: 'mypass',
-        }),
+      mockConfig({
+        getOptional: ((key: string) =>
+          key === 'backend.database.connection'
+            ? {
+                host: '0.0.0.0',
+                port: 15432,
+                user: 'myuser',
+                password: 'mypass',
+              }
+            : undefined) as any,
         getOptionalString: (key: string) => {
           const val = configValues[key];
           return typeof val === 'string' ? val : undefined;
@@ -335,13 +343,6 @@ describe('runBackend', () => {
     });
 
     it('should resolve config paths relative to targetDir', async () => {
-      mockToConfig.mockResolvedValue({
-        close: jest.fn(),
-        getOptional: () => undefined,
-        getOptionalString: () => undefined,
-        getOptionalNumber: () => undefined,
-      });
-
       runBackend({
         entry: 'src/index',
         targetDir: '/root/packages/backend',
@@ -357,12 +358,13 @@ describe('runBackend', () => {
     });
 
     it('should not start embedded DB for other database clients with a string connection', async () => {
-      mockToConfig.mockResolvedValue({
-        close: jest.fn(),
-        getOptional: () => ':memory:',
+      mockConfig({
+        getOptional: ((key: string) =>
+          key === 'backend.database.connection'
+            ? ':memory:'
+            : undefined) as any,
         getOptionalString: (key: string) =>
           key === 'backend.database.client' ? 'better-sqlite3' : undefined,
-        getOptionalNumber: () => undefined,
       });
 
       runBackend({ entry: 'src/index' });

--- a/packages/cli-module-build/src/lib/runner/runBackend.test.ts
+++ b/packages/cli-module-build/src/lib/runner/runBackend.test.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import { mockServices } from '@backstage/backend-test-utils';
-import { ConfigSources } from '@backstage/config-loader';
 import { runBackend } from './runBackend';
 import spawn from 'cross-spawn';
 
@@ -51,15 +49,6 @@ jest.mock('ctrlc-windows', () => ({
   ctrlc: jest.fn(),
 }));
 
-const mockConfigSourcesDefault = jest.fn().mockReturnValue({});
-
-jest.mock('@backstage/config-loader', () => ({
-  ConfigSources: {
-    default: (...args: any[]) => mockConfigSourcesDefault(...args),
-    toConfig: jest.fn(),
-  },
-}));
-
 const mockStartEmbeddedDb = jest.fn();
 
 jest.mock('./startEmbeddedDb', () => ({
@@ -70,17 +59,6 @@ describe('runBackend', () => {
   let originalEnv: NodeJS.ProcessEnv;
   let originalPlatform: string;
   const mockSpawn = spawn as jest.MockedFunction<typeof spawn>;
-  const mockToConfig = ConfigSources.toConfig as jest.MockedFunction<
-    typeof ConfigSources.toConfig
-  >;
-
-  function mockConfig(
-    overrides?: Parameters<typeof mockServices.rootConfig.mock>[0],
-  ) {
-    const config = mockServices.rootConfig.mock(overrides);
-    mockToConfig.mockResolvedValue(Object.assign(config, { close: jest.fn() }));
-    return config;
-  }
 
   beforeEach(() => {
     // Use fake timers to control debounce
@@ -97,8 +75,8 @@ describe('runBackend', () => {
     // Mock process.once to prevent actual signal handling
     jest.spyOn(process, 'once').mockReturnValue(process);
 
-    mockConfig();
     mockStartEmbeddedDb.mockReset();
+    mockStartEmbeddedDb.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -189,23 +167,16 @@ describe('runBackend', () => {
   });
 
   describe('embedded-postgres support', () => {
-    it('should start embedded DB and inject all defaults when no user connection config is provided', async () => {
-      mockConfig({
-        getOptionalString: (key: string) =>
-          key === 'backend.database.client' ? 'embedded-postgres' : undefined,
-      });
+    it('should inject config override from startEmbeddedDb when it returns a result', async () => {
       mockStartEmbeddedDb.mockResolvedValue({
-        connection: {
-          host: 'localhost',
-          user: 'postgres',
-          password: 'password',
-          port: 5555,
-        },
-        defaultedConnection: {
-          host: 'localhost',
-          user: 'postgres',
-          password: 'password',
-          port: 5555,
+        configOverride: {
+          client: 'pg',
+          connection: {
+            host: 'localhost',
+            user: 'postgres',
+            password: 'password',
+            port: 5555,
+          },
         },
         close: jest.fn(),
       });
@@ -213,7 +184,10 @@ describe('runBackend', () => {
       runBackend({ entry: 'src/index' });
       await jest.advanceTimersByTimeAsync(100);
 
-      expect(mockStartEmbeddedDb).toHaveBeenCalledWith(undefined);
+      expect(mockStartEmbeddedDb).toHaveBeenCalledWith({
+        configPaths: undefined,
+        targetDir: undefined,
+      });
       const spawnEnv = mockSpawn.mock.calls[0][2]?.env as Record<
         string,
         string
@@ -230,119 +204,7 @@ describe('runBackend', () => {
       });
     });
 
-    it('should forward user-provided connection config and only inject defaults for missing values', async () => {
-      const configValues: Record<string, string | number> = {
-        'backend.database.client': 'embedded-postgres',
-        'backend.database.connection.host': '0.0.0.0',
-        'backend.database.connection.port': 15432,
-      };
-      mockConfig({
-        getOptional: ((key: string) =>
-          key === 'backend.database.connection'
-            ? { host: '0.0.0.0', port: 15432 }
-            : undefined) as any,
-        getOptionalString: (key: string) => {
-          const val = configValues[key];
-          return typeof val === 'string' ? val : undefined;
-        },
-        getOptionalNumber: (key: string) => {
-          const val = configValues[key];
-          return typeof val === 'number' ? val : undefined;
-        },
-      });
-      mockStartEmbeddedDb.mockResolvedValue({
-        connection: {
-          host: '0.0.0.0',
-          user: 'postgres',
-          password: 'password',
-          port: 15432,
-        },
-        defaultedConnection: {
-          user: 'postgres',
-          password: 'password',
-        },
-        close: jest.fn(),
-      });
-
-      runBackend({ entry: 'src/index' });
-      await jest.advanceTimersByTimeAsync(100);
-
-      expect(mockStartEmbeddedDb).toHaveBeenCalledWith({
-        host: '0.0.0.0',
-        port: 15432,
-        user: undefined,
-        password: undefined,
-      });
-      const spawnEnv = mockSpawn.mock.calls[0][2]?.env as Record<
-        string,
-        string
-      >;
-      const injected = JSON.parse(spawnEnv.APP_CONFIG_backend_database);
-      expect(injected).toEqual({
-        client: 'pg',
-        connection: {
-          user: 'postgres',
-          password: 'password',
-        },
-      });
-    });
-
-    it('should not inject connection overrides when all values are user-provided', async () => {
-      const configValues: Record<string, string | number> = {
-        'backend.database.client': 'embedded-postgres',
-        'backend.database.connection.host': '0.0.0.0',
-        'backend.database.connection.port': 15432,
-        'backend.database.connection.user': 'myuser',
-        'backend.database.connection.password': 'mypass',
-      };
-      mockConfig({
-        getOptional: ((key: string) =>
-          key === 'backend.database.connection'
-            ? {
-                host: '0.0.0.0',
-                port: 15432,
-                user: 'myuser',
-                password: 'mypass',
-              }
-            : undefined) as any,
-        getOptionalString: (key: string) => {
-          const val = configValues[key];
-          return typeof val === 'string' ? val : undefined;
-        },
-        getOptionalNumber: (key: string) => {
-          const val = configValues[key];
-          return typeof val === 'number' ? val : undefined;
-        },
-      });
-      mockStartEmbeddedDb.mockResolvedValue({
-        connection: {
-          host: '0.0.0.0',
-          user: 'myuser',
-          password: 'mypass',
-          port: 15432,
-        },
-        defaultedConnection: {},
-        close: jest.fn(),
-      });
-
-      runBackend({ entry: 'src/index' });
-      await jest.advanceTimersByTimeAsync(100);
-
-      expect(mockStartEmbeddedDb).toHaveBeenCalledWith({
-        host: '0.0.0.0',
-        port: 15432,
-        user: 'myuser',
-        password: 'mypass',
-      });
-      const spawnEnv = mockSpawn.mock.calls[0][2]?.env as Record<
-        string,
-        string
-      >;
-      const injected = JSON.parse(spawnEnv.APP_CONFIG_backend_database);
-      expect(injected).toEqual({ client: 'pg' });
-    });
-
-    it('should resolve config paths relative to targetDir', async () => {
+    it('should forward configPaths and targetDir to startEmbeddedDb', async () => {
       runBackend({
         entry: 'src/index',
         targetDir: '/root/packages/backend',
@@ -350,27 +212,18 @@ describe('runBackend', () => {
       });
       await jest.advanceTimersByTimeAsync(100);
 
-      expect(mockConfigSourcesDefault).toHaveBeenCalledWith(
-        expect.objectContaining({
-          argv: ['--config', '/root/config/local.yaml'],
-        }),
-      );
+      expect(mockStartEmbeddedDb).toHaveBeenCalledWith({
+        configPaths: ['../../config/local.yaml'],
+        targetDir: '/root/packages/backend',
+      });
     });
 
-    it('should not start embedded DB for other database clients with a string connection', async () => {
-      mockConfig({
-        getOptional: ((key: string) =>
-          key === 'backend.database.connection'
-            ? ':memory:'
-            : undefined) as any,
-        getOptionalString: (key: string) =>
-          key === 'backend.database.client' ? 'better-sqlite3' : undefined,
-      });
+    it('should not inject config override when startEmbeddedDb returns undefined', async () => {
+      mockStartEmbeddedDb.mockResolvedValue(undefined);
 
       runBackend({ entry: 'src/index' });
       await jest.advanceTimersByTimeAsync(100);
 
-      expect(mockStartEmbeddedDb).not.toHaveBeenCalled();
       const spawnEnv = mockSpawn.mock.calls[0][2]?.env as Record<
         string,
         string

--- a/packages/cli-module-build/src/lib/runner/runBackend.test.ts
+++ b/packages/cli-module-build/src/lib/runner/runBackend.test.ts
@@ -88,6 +88,7 @@ describe('runBackend', () => {
     mockToConfig.mockResolvedValue({
       close: jest.fn(),
       getOptionalString: () => undefined,
+      getOptionalNumber: () => undefined,
     });
     mockStartEmbeddedDb.mockReset();
   });
@@ -180,14 +181,21 @@ describe('runBackend', () => {
   });
 
   describe('embedded-postgres support', () => {
-    it('should start embedded DB and inject config when database client is embedded-postgres', async () => {
+    it('should start embedded DB and inject all defaults when no user connection config is provided', async () => {
       mockToConfig.mockResolvedValue({
         close: jest.fn(),
         getOptionalString: (key: string) =>
           key === 'backend.database.client' ? 'embedded-postgres' : undefined,
+        getOptionalNumber: () => undefined,
       });
       mockStartEmbeddedDb.mockResolvedValue({
         connection: {
+          host: 'localhost',
+          user: 'postgres',
+          password: 'password',
+          port: 5555,
+        },
+        defaultedConnection: {
           host: 'localhost',
           user: 'postgres',
           password: 'password',
@@ -199,8 +207,7 @@ describe('runBackend', () => {
       runBackend({ entry: 'src/index' });
       await jest.advanceTimersByTimeAsync(100);
 
-      expect(mockStartEmbeddedDb).toHaveBeenCalled();
-      expect(mockSpawn).toHaveBeenCalled();
+      expect(mockStartEmbeddedDb).toHaveBeenCalledWith(undefined);
       const spawnEnv = mockSpawn.mock.calls[0][2]?.env as Record<
         string,
         string
@@ -217,10 +224,112 @@ describe('runBackend', () => {
       });
     });
 
+    it('should forward user-provided connection config and only inject defaults for missing values', async () => {
+      const configValues: Record<string, string | number> = {
+        'backend.database.client': 'embedded-postgres',
+        'backend.database.connection.host': '0.0.0.0',
+        'backend.database.connection.port': 15432,
+      };
+      mockToConfig.mockResolvedValue({
+        close: jest.fn(),
+        getOptionalString: (key: string) => {
+          const val = configValues[key];
+          return typeof val === 'string' ? val : undefined;
+        },
+        getOptionalNumber: (key: string) => {
+          const val = configValues[key];
+          return typeof val === 'number' ? val : undefined;
+        },
+      });
+      mockStartEmbeddedDb.mockResolvedValue({
+        connection: {
+          host: '0.0.0.0',
+          user: 'postgres',
+          password: 'password',
+          port: 15432,
+        },
+        defaultedConnection: {
+          user: 'postgres',
+          password: 'password',
+        },
+        close: jest.fn(),
+      });
+
+      runBackend({ entry: 'src/index' });
+      await jest.advanceTimersByTimeAsync(100);
+
+      expect(mockStartEmbeddedDb).toHaveBeenCalledWith({
+        host: '0.0.0.0',
+        port: 15432,
+        user: undefined,
+        password: undefined,
+      });
+      const spawnEnv = mockSpawn.mock.calls[0][2]?.env as Record<
+        string,
+        string
+      >;
+      const injected = JSON.parse(spawnEnv.APP_CONFIG_backend_database);
+      expect(injected).toEqual({
+        client: 'pg',
+        connection: {
+          user: 'postgres',
+          password: 'password',
+        },
+      });
+    });
+
+    it('should not inject connection overrides when all values are user-provided', async () => {
+      const configValues: Record<string, string | number> = {
+        'backend.database.client': 'embedded-postgres',
+        'backend.database.connection.host': '0.0.0.0',
+        'backend.database.connection.port': 15432,
+        'backend.database.connection.user': 'myuser',
+        'backend.database.connection.password': 'mypass',
+      };
+      mockToConfig.mockResolvedValue({
+        close: jest.fn(),
+        getOptionalString: (key: string) => {
+          const val = configValues[key];
+          return typeof val === 'string' ? val : undefined;
+        },
+        getOptionalNumber: (key: string) => {
+          const val = configValues[key];
+          return typeof val === 'number' ? val : undefined;
+        },
+      });
+      mockStartEmbeddedDb.mockResolvedValue({
+        connection: {
+          host: '0.0.0.0',
+          user: 'myuser',
+          password: 'mypass',
+          port: 15432,
+        },
+        defaultedConnection: {},
+        close: jest.fn(),
+      });
+
+      runBackend({ entry: 'src/index' });
+      await jest.advanceTimersByTimeAsync(100);
+
+      expect(mockStartEmbeddedDb).toHaveBeenCalledWith({
+        host: '0.0.0.0',
+        port: 15432,
+        user: 'myuser',
+        password: 'mypass',
+      });
+      const spawnEnv = mockSpawn.mock.calls[0][2]?.env as Record<
+        string,
+        string
+      >;
+      const injected = JSON.parse(spawnEnv.APP_CONFIG_backend_database);
+      expect(injected).toEqual({ client: 'pg' });
+    });
+
     it('should resolve config paths relative to targetDir', async () => {
       mockToConfig.mockResolvedValue({
         close: jest.fn(),
         getOptionalString: () => undefined,
+        getOptionalNumber: () => undefined,
       });
 
       runBackend({
@@ -242,13 +351,13 @@ describe('runBackend', () => {
         close: jest.fn(),
         getOptionalString: (key: string) =>
           key === 'backend.database.client' ? 'better-sqlite3' : undefined,
+        getOptionalNumber: () => undefined,
       });
 
       runBackend({ entry: 'src/index' });
       await jest.advanceTimersByTimeAsync(100);
 
       expect(mockStartEmbeddedDb).not.toHaveBeenCalled();
-      expect(mockSpawn).toHaveBeenCalled();
       const spawnEnv = mockSpawn.mock.calls[0][2]?.env as Record<
         string,
         string

--- a/packages/cli-module-build/src/lib/runner/runBackend.test.ts
+++ b/packages/cli-module-build/src/lib/runner/runBackend.test.ts
@@ -87,6 +87,7 @@ describe('runBackend', () => {
 
     mockToConfig.mockResolvedValue({
       close: jest.fn(),
+      getOptional: () => undefined,
       getOptionalString: () => undefined,
       getOptionalNumber: () => undefined,
     });
@@ -184,6 +185,7 @@ describe('runBackend', () => {
     it('should start embedded DB and inject all defaults when no user connection config is provided', async () => {
       mockToConfig.mockResolvedValue({
         close: jest.fn(),
+        getOptional: () => undefined,
         getOptionalString: (key: string) =>
           key === 'backend.database.client' ? 'embedded-postgres' : undefined,
         getOptionalNumber: () => undefined,
@@ -232,6 +234,7 @@ describe('runBackend', () => {
       };
       mockToConfig.mockResolvedValue({
         close: jest.fn(),
+        getOptional: () => ({ host: '0.0.0.0', port: 15432 }),
         getOptionalString: (key: string) => {
           const val = configValues[key];
           return typeof val === 'string' ? val : undefined;
@@ -288,6 +291,12 @@ describe('runBackend', () => {
       };
       mockToConfig.mockResolvedValue({
         close: jest.fn(),
+        getOptional: () => ({
+          host: '0.0.0.0',
+          port: 15432,
+          user: 'myuser',
+          password: 'mypass',
+        }),
         getOptionalString: (key: string) => {
           const val = configValues[key];
           return typeof val === 'string' ? val : undefined;
@@ -328,6 +337,7 @@ describe('runBackend', () => {
     it('should resolve config paths relative to targetDir', async () => {
       mockToConfig.mockResolvedValue({
         close: jest.fn(),
+        getOptional: () => undefined,
         getOptionalString: () => undefined,
         getOptionalNumber: () => undefined,
       });
@@ -346,9 +356,10 @@ describe('runBackend', () => {
       );
     });
 
-    it('should not start embedded DB for other database clients', async () => {
+    it('should not start embedded DB for other database clients with a string connection', async () => {
       mockToConfig.mockResolvedValue({
         close: jest.fn(),
+        getOptional: () => ':memory:',
         getOptionalString: (key: string) =>
           key === 'backend.database.client' ? 'better-sqlite3' : undefined,
         getOptionalNumber: () => undefined,

--- a/packages/cli-module-build/src/lib/runner/runBackend.ts
+++ b/packages/cli-module-build/src/lib/runner/runBackend.ts
@@ -252,6 +252,13 @@ async function readDatabaseConfig(
       return undefined;
     }
 
+    // Only read structured connection config if the value is an object;
+    // it can also be a plain string (e.g. ':memory:' for better-sqlite3).
+    const rawConnection = config.getOptional('backend.database.connection');
+    if (typeof rawConnection === 'string' || rawConnection === undefined) {
+      return { client };
+    }
+
     const host = config.getOptionalString('backend.database.connection.host');
     const port = config.getOptionalNumber('backend.database.connection.port');
     const user = config.getOptionalString('backend.database.connection.user');

--- a/packages/cli-module-build/src/lib/runner/runBackend.ts
+++ b/packages/cli-module-build/src/lib/runner/runBackend.ts
@@ -20,12 +20,8 @@ import { ctrlc } from 'ctrlc-windows';
 import { IpcServer, ServerDataStore } from '../ipc';
 import debounce from 'lodash/debounce';
 import { fileURLToPath } from 'node:url';
-import {
-  isAbsolute as isAbsolutePath,
-  resolve as resolvePath,
-} from 'node:path';
+import { isAbsolute as isAbsolutePath } from 'node:path';
 import { targetPaths } from '@backstage/cli-common';
-import { ConfigSources } from '@backstage/config-loader';
 
 import spawn from 'cross-spawn';
 import { startEmbeddedDb } from './startEmbeddedDb';
@@ -66,21 +62,14 @@ export async function runBackend(options: RunBackendOptions) {
 
   const extraEnv: Record<string, string> = {};
 
-  let embeddedDb: Awaited<ReturnType<typeof startEmbeddedDb>> | undefined;
-
-  const dbConfig = await readDatabaseConfig(
-    options.configPaths,
-    options.targetDir,
-  );
-  if (dbConfig?.client === 'embedded-postgres') {
-    embeddedDb = await startEmbeddedDb(dbConfig.connection);
-    const overrides: Record<string, unknown> = {
-      client: 'pg',
-    };
-    if (Object.keys(embeddedDb.defaultedConnection).length > 0) {
-      overrides.connection = embeddedDb.defaultedConnection;
-    }
-    extraEnv.APP_CONFIG_backend_database = JSON.stringify(overrides);
+  const embeddedDb = await startEmbeddedDb({
+    configPaths: options.configPaths,
+    targetDir: options.targetDir,
+  });
+  if (embeddedDb) {
+    extraEnv.APP_CONFIG_backend_database = JSON.stringify(
+      embeddedDb.configOverride,
+    );
   }
 
   let exiting = false;
@@ -222,60 +211,4 @@ export async function runBackend(options: RunBackendOptions) {
   });
 
   return () => exitPromise;
-}
-
-async function readDatabaseConfig(
-  configPaths?: string[],
-  targetDir?: string,
-): Promise<
-  | {
-      client: string;
-      connection?: import('./startEmbeddedDb').EmbeddedDbConnectionConfig;
-    }
-  | undefined
-> {
-  const rootDir = targetPaths.rootDir;
-  const configBaseDir = targetDir ?? rootDir;
-  const source = ConfigSources.default({
-    rootDir,
-    allowMissingDefaultConfig: true,
-    argv: (configPaths ?? []).flatMap(p => [
-      '--config',
-      isAbsolutePath(p) ? p : resolvePath(configBaseDir, p),
-    ]),
-  });
-
-  const config = await ConfigSources.toConfig(source);
-  try {
-    const client = config.getOptionalString('backend.database.client');
-    if (!client) {
-      return undefined;
-    }
-
-    // Only read structured connection config if the value is an object;
-    // it can also be a plain string (e.g. ':memory:' for better-sqlite3).
-    const rawConnection = config.getOptional('backend.database.connection');
-    if (typeof rawConnection === 'string' || rawConnection === undefined) {
-      return { client };
-    }
-
-    const host = config.getOptionalString('backend.database.connection.host');
-    const port = config.getOptionalNumber('backend.database.connection.port');
-    const user = config.getOptionalString('backend.database.connection.user');
-    const password = config.getOptionalString(
-      'backend.database.connection.password',
-    );
-
-    const connection =
-      host !== undefined ||
-      port !== undefined ||
-      user !== undefined ||
-      password !== undefined
-        ? { host, port, user, password }
-        : undefined;
-
-    return { client, connection };
-  } finally {
-    config.close();
-  }
 }

--- a/packages/cli-module-build/src/lib/runner/runBackend.ts
+++ b/packages/cli-module-build/src/lib/runner/runBackend.ts
@@ -68,16 +68,19 @@ export async function runBackend(options: RunBackendOptions) {
 
   let embeddedDb: Awaited<ReturnType<typeof startEmbeddedDb>> | undefined;
 
-  const dbClient = await readDatabaseClient(
+  const dbConfig = await readDatabaseConfig(
     options.configPaths,
     options.targetDir,
   );
-  if (dbClient === 'embedded-postgres') {
-    embeddedDb = await startEmbeddedDb();
-    extraEnv.APP_CONFIG_backend_database = JSON.stringify({
+  if (dbConfig?.client === 'embedded-postgres') {
+    embeddedDb = await startEmbeddedDb(dbConfig.connection);
+    const overrides: Record<string, unknown> = {
       client: 'pg',
-      connection: embeddedDb.connection,
-    });
+    };
+    if (Object.keys(embeddedDb.defaultedConnection).length > 0) {
+      overrides.connection = embeddedDb.defaultedConnection;
+    }
+    extraEnv.APP_CONFIG_backend_database = JSON.stringify(overrides);
   }
 
   let exiting = false;
@@ -221,10 +224,16 @@ export async function runBackend(options: RunBackendOptions) {
   return () => exitPromise;
 }
 
-async function readDatabaseClient(
+async function readDatabaseConfig(
   configPaths?: string[],
   targetDir?: string,
-): Promise<string | undefined> {
+): Promise<
+  | {
+      client: string;
+      connection?: import('./startEmbeddedDb').EmbeddedDbConnectionConfig;
+    }
+  | undefined
+> {
   const rootDir = targetPaths.rootDir;
   const configBaseDir = targetDir ?? rootDir;
   const source = ConfigSources.default({
@@ -238,7 +247,27 @@ async function readDatabaseClient(
 
   const config = await ConfigSources.toConfig(source);
   try {
-    return config.getOptionalString('backend.database.client');
+    const client = config.getOptionalString('backend.database.client');
+    if (!client) {
+      return undefined;
+    }
+
+    const host = config.getOptionalString('backend.database.connection.host');
+    const port = config.getOptionalNumber('backend.database.connection.port');
+    const user = config.getOptionalString('backend.database.connection.user');
+    const password = config.getOptionalString(
+      'backend.database.connection.password',
+    );
+
+    const connection =
+      host !== undefined ||
+      port !== undefined ||
+      user !== undefined ||
+      password !== undefined
+        ? { host, port, user, password }
+        : undefined;
+
+    return { client, connection };
   } finally {
     config.close();
   }

--- a/packages/cli-module-build/src/lib/runner/startEmbeddedDb.ts
+++ b/packages/cli-module-build/src/lib/runner/startEmbeddedDb.ts
@@ -16,9 +16,14 @@
 
 import os from 'node:os';
 import fs from 'fs-extra';
-import { resolve as resolvePath } from 'node:path';
+import {
+  isAbsolute as isAbsolutePath,
+  resolve as resolvePath,
+} from 'node:path';
 import { getPortPromise } from 'portfinder';
 import { ForwardedError } from '@backstage/errors';
+import { ConfigSources } from '@backstage/config-loader';
+import { targetPaths } from '@backstage/cli-common';
 import chalk from 'chalk';
 
 const TEMP_DIR_PREFIX = 'backstage-dev-db-';
@@ -59,7 +64,38 @@ export interface EmbeddedDbConnectionConfig {
   password?: string;
 }
 
-export async function startEmbeddedDb(userConfig?: EmbeddedDbConnectionConfig) {
+export interface StartEmbeddedDbOptions {
+  configPaths?: string[];
+  targetDir?: string;
+}
+
+/**
+ * Reads the database configuration from the app config and, if the client is
+ * `embedded-postgres`, starts an embedded Postgres instance. Returns the config
+ * override to inject into the child process, or `undefined` if the database
+ * client is not `embedded-postgres`.
+ */
+export async function startEmbeddedDb(options: StartEmbeddedDbOptions): Promise<
+  | {
+      configOverride: Record<string, unknown>;
+      close(): Promise<void>;
+    }
+  | undefined
+> {
+  const dbConfig = await readDatabaseConfig(
+    options.configPaths,
+    options.targetDir,
+  );
+  if (dbConfig?.client !== 'embedded-postgres') {
+    return undefined;
+  }
+
+  return startEmbeddedDbInternal(dbConfig.connection);
+}
+
+async function startEmbeddedDbInternal(
+  userConfig?: EmbeddedDbConnectionConfig,
+) {
   console.warn(
     chalk.yellow(
       'WARNING: Using embedded-postgres for local development is experimental and subject to change',
@@ -107,6 +143,9 @@ export async function startEmbeddedDb(userConfig?: EmbeddedDbConnectionConfig) {
     throw error;
   }
 
+  const configOverride: Record<string, unknown> = {
+    client: 'pg',
+  };
   const defaultedConnection: Record<string, string | number> = {};
   if (!userConfig?.host) {
     defaultedConnection.host = host;
@@ -120,18 +159,71 @@ export async function startEmbeddedDb(userConfig?: EmbeddedDbConnectionConfig) {
   if (!userConfig?.port) {
     defaultedConnection.port = port;
   }
+  if (Object.keys(defaultedConnection).length > 0) {
+    configOverride.connection = defaultedConnection;
+  }
 
   return {
-    connection: {
-      host,
-      user,
-      password,
-      port,
-    },
-    defaultedConnection,
+    configOverride,
     async close() {
       await pg.stop();
       await fs.remove(tmpDir);
     },
   };
+}
+
+async function readDatabaseConfig(
+  configPaths?: string[],
+  targetDir?: string,
+): Promise<
+  | {
+      client: string;
+      connection?: EmbeddedDbConnectionConfig;
+    }
+  | undefined
+> {
+  const rootDir = targetPaths.rootDir;
+  const configBaseDir = targetDir ?? rootDir;
+  const source = ConfigSources.default({
+    rootDir,
+    allowMissingDefaultConfig: true,
+    argv: (configPaths ?? []).flatMap(p => [
+      '--config',
+      isAbsolutePath(p) ? p : resolvePath(configBaseDir, p),
+    ]),
+  });
+
+  const config = await ConfigSources.toConfig(source);
+  try {
+    const client = config.getOptionalString('backend.database.client');
+    if (!client) {
+      return undefined;
+    }
+
+    // Only read structured connection config if the value is an object;
+    // it can also be a plain string (e.g. ':memory:' for better-sqlite3).
+    const rawConnection = config.getOptional('backend.database.connection');
+    if (typeof rawConnection === 'string' || rawConnection === undefined) {
+      return { client };
+    }
+
+    const host = config.getOptionalString('backend.database.connection.host');
+    const port = config.getOptionalNumber('backend.database.connection.port');
+    const user = config.getOptionalString('backend.database.connection.user');
+    const password = config.getOptionalString(
+      'backend.database.connection.password',
+    );
+
+    const connection =
+      host !== undefined ||
+      port !== undefined ||
+      user !== undefined ||
+      password !== undefined
+        ? { host, port, user, password }
+        : undefined;
+
+    return { client, connection };
+  } finally {
+    config.close();
+  }
 }

--- a/packages/cli-module-build/src/lib/runner/startEmbeddedDb.ts
+++ b/packages/cli-module-build/src/lib/runner/startEmbeddedDb.ts
@@ -52,7 +52,14 @@ async function cleanStaleDatabases() {
   );
 }
 
-export async function startEmbeddedDb() {
+export interface EmbeddedDbConnectionConfig {
+  host?: string;
+  port?: number;
+  user?: string;
+  password?: string;
+}
+
+export async function startEmbeddedDb(userConfig?: EmbeddedDbConnectionConfig) {
   console.warn(
     chalk.yellow(
       'WARNING: Using embedded-postgres for local development is experimental and subject to change',
@@ -72,10 +79,10 @@ export async function startEmbeddedDb() {
 
   await cleanStaleDatabases();
 
-  const host = 'localhost';
-  const user = 'postgres';
-  const password = 'password';
-  const port = await getPortPromise();
+  const host = userConfig?.host ?? 'localhost';
+  const user = userConfig?.user ?? 'postgres';
+  const password = userConfig?.password ?? 'password';
+  const port = userConfig?.port ?? (await getPortPromise());
   const tmpDir = await fs.mkdtemp(resolvePath(os.tmpdir(), TEMP_DIR_PREFIX));
 
   const pg = new EmbeddedPostgres({
@@ -100,6 +107,20 @@ export async function startEmbeddedDb() {
     throw error;
   }
 
+  const defaultedConnection: Record<string, string | number> = {};
+  if (!userConfig?.host) {
+    defaultedConnection.host = host;
+  }
+  if (!userConfig?.user) {
+    defaultedConnection.user = user;
+  }
+  if (!userConfig?.password) {
+    defaultedConnection.password = password;
+  }
+  if (!userConfig?.port) {
+    defaultedConnection.port = port;
+  }
+
   return {
     connection: {
       host,
@@ -107,6 +128,7 @@ export async function startEmbeddedDb() {
       password,
       port,
     },
+    defaultedConnection,
     async close() {
       await pg.stop();
       await fs.remove(tmpDir);

--- a/packages/cli-module-build/src/lib/runner/startEmbeddedDb.ts
+++ b/packages/cli-module-build/src/lib/runner/startEmbeddedDb.ts
@@ -117,7 +117,7 @@ async function startEmbeddedDbInternal(
 
   const host = userConfig?.host ?? 'localhost';
   const user = userConfig?.user ?? 'postgres';
-  const password = userConfig?.password ?? 'password';
+  const password = userConfig?.password ?? 'postgres';
   const port = userConfig?.port ?? (await getPortPromise());
   const tmpDir = await fs.mkdtemp(resolvePath(os.tmpdir(), TEMP_DIR_PREFIX));
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This updates the embedded Postgres setup used during `yarn start` so that user-provided connection configuration is forwarded to the embedded instance. Previously, the CLI would unconditionally override all connection values (host, port, user, password) with its own defaults. Now, if you've configured any of these values under `backend.database.connection`, the embedded Postgres instance will start using those values, and only the ones you haven't configured will be filled in with defaults.

This makes it possible to run the embedded database on a specific host/port and connect to it externally (e.g. with `psql`) while it's running.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))