### PR TITLE
feat(search-backend-module-pg): conditional load via feature loader

### DIFF
--- a/.changeset/search-backend-module-pg-feature-loader.md
+++ b/.changeset/search-backend-module-pg-feature-loader.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-module-pg': minor
+---
+
+The default export is now a feature loader that only registers the Postgres search engine when `backend.database.client` is `pg`, and the underlying module is now also exposed as a named export `searchModulePostgresEngine`.

--- a/plugins/search-backend-module-pg/report.api.md
+++ b/plugins/search-backend-module-pg/report.api.md
@@ -205,4 +205,7 @@ export interface RawDocumentRow {
   // (undocumented)
   type: string;
 }
+
+// @public
+export const searchModulePostgresEngine: BackendFeature;
 ```

--- a/plugins/search-backend-module-pg/src/index.ts
+++ b/plugins/search-backend-module-pg/src/index.ts
@@ -20,6 +20,6 @@
  * @packageDocumentation
  */
 
-export { default } from './module';
+export { default, searchModulePostgresEngine } from './module';
 export * from './database';
 export * from './PgSearchEngine';

--- a/plugins/search-backend-module-pg/src/module.test.ts
+++ b/plugins/search-backend-module-pg/src/module.test.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Config } from '@backstage/config';
+import { mockServices } from '@backstage/backend-test-utils';
+import searchModulePostgresEngineLoader from './module';
+
+type Registration = { pluginId: string; moduleId: string };
+
+type Loader = {
+  featureType: 'loader';
+  loader(deps: { config: Config }): Promise<
+    Array<{
+      $$type: '@backstage/BackendFeature';
+      featureType: string;
+      getRegistrations?: () => Registration[];
+    }>
+  >;
+};
+
+describe('searchModulePostgresEngineLoader', () => {
+  const loader = searchModulePostgresEngineLoader as unknown as Loader;
+
+  it('yields the postgres-engine module when client is pg, skips otherwise, and skips when backend.database is unset', async () => {
+    expect(loader.featureType).toBe('loader');
+
+    const pgFeatures = await loader.loader({
+      config: mockServices.rootConfig({
+        data: { backend: { database: { client: 'pg' } } },
+      }),
+    });
+    expect(pgFeatures).toHaveLength(1);
+    expect(pgFeatures[0].$$type).toBe('@backstage/BackendFeature');
+    expect(pgFeatures[0].featureType).toBe('registrations');
+    const registrations = pgFeatures[0].getRegistrations!();
+    expect(registrations).toHaveLength(1);
+    expect(registrations[0].pluginId).toBe('search');
+    expect(registrations[0].moduleId).toBe('postgres-engine');
+
+    const sqliteFeatures = await loader.loader({
+      config: mockServices.rootConfig({
+        data: { backend: { database: { client: 'better-sqlite3' } } },
+      }),
+    });
+    expect(sqliteFeatures).toHaveLength(0);
+
+    const noBackendFeatures = await loader.loader({
+      config: mockServices.rootConfig({ data: {} }),
+    });
+    expect(noBackendFeatures).toHaveLength(0);
+  });
+});

--- a/plugins/search-backend-module-pg/src/module.ts
+++ b/plugins/search-backend-module-pg/src/module.ts
@@ -15,6 +15,7 @@
  */
 import {
   coreServices,
+  createBackendFeatureLoader,
   createBackendModule,
 } from '@backstage/backend-plugin-api';
 import { searchEngineRegistryExtensionPoint } from '@backstage/plugin-search-backend-node/alpha';
@@ -24,7 +25,7 @@ import { PgSearchEngine } from './PgSearchEngine';
  * @public
  * Search backend module for the Postgres engine.
  */
-export default createBackendModule({
+export const searchModulePostgresEngine = createBackendModule({
   pluginId: 'search',
   moduleId: 'postgres-engine',
   register(env) {
@@ -50,5 +51,21 @@ export default createBackendModule({
         }
       },
     });
+  },
+});
+
+/**
+ * @public
+ * Search backend feature loader for the Postgres engine. Only loads the module
+ * when `backend.database.client` is `pg`.
+ */
+export default createBackendFeatureLoader({
+  deps: {
+    config: coreServices.rootConfig,
+  },
+  *loader({ config }) {
+    if (config.getOptionalString('backend.database.client') === 'pg') {
+      yield searchModulePostgresEngine;
+    }
   },
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!
Convert the default export to a feature loader that only registers the Postgres search engine module when `backend.database.client` is `pg`, and expose the module as a named export `searchModulePostgresEngine` for adopters who want to register it unconditionally.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
