### PR TITLE
fix(user-settings): Prioritize i18n translation for built-in theme names

### DIFF
--- a/.changeset/easy-goats-bow.md
+++ b/.changeset/easy-goats-bow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-user-settings': patch
+---
+
+Prioritize i18n translation over `theme.title` for built-in light/dark theme names in `UserSettingsThemeToggle`, so that translation overrides are no longer silently ignored.

--- a/plugins/user-settings/src/components/General/UserSettingsThemeToggle.test.tsx
+++ b/plugins/user-settings/src/components/General/UserSettingsThemeToggle.test.tsx
@@ -56,4 +56,44 @@ describe('<UserSettingsThemeToggle />', () => {
     fireEvent.click(themeButton);
     expect(themeApi?.getActiveThemeId()).toBe('light-theme');
   });
+
+  it('uses translated name instead of theme.title for built-in light/dark themes', async () => {
+    const builtInLightTheme: AppTheme = {
+      id: 'light',
+      title: 'My Custom Light',
+      variant: 'light',
+      Provider: ({ children }) => (
+        <ThemeProvider theme={lightTheme}>
+          <CssBaseline>{children}</CssBaseline>
+        </ThemeProvider>
+      ),
+    };
+
+    const builtInDarkTheme: AppTheme = {
+      id: 'dark',
+      title: 'My Custom Dark',
+      variant: 'dark',
+      Provider: ({ children }) => (
+        <ThemeProvider theme={lightTheme}>
+          <CssBaseline>{children}</CssBaseline>
+        </ThemeProvider>
+      ),
+    };
+
+    const builtInApiRegistry = TestApiRegistry.from([
+      appThemeApiRef,
+      AppThemeSelector.createWithStorage([builtInLightTheme, builtInDarkTheme]),
+    ]);
+
+    await renderInTestApp(
+      <ApiProvider apis={builtInApiRegistry}>
+        <UserSettingsThemeToggle />
+      </ApiProvider>,
+    );
+
+    expect(screen.getByText('Light')).toBeInTheDocument();
+    expect(screen.getByText('Dark')).toBeInTheDocument();
+    expect(screen.queryByText('My Custom Light')).not.toBeInTheDocument();
+    expect(screen.queryByText('My Custom Dark')).not.toBeInTheDocument();
+  });
 });

--- a/plugins/user-settings/src/components/General/UserSettingsThemeToggle.tsx
+++ b/plugins/user-settings/src/components/General/UserSettingsThemeToggle.tsx
@@ -142,10 +142,10 @@ export const UserSettingsThemeToggle = () => {
             const themeId = theme.id;
             const themeIcon = theme.icon;
             const themeTitle =
-              theme.title ||
-              (themeId === 'light' || themeId === 'dark'
+              themeId === 'light' || themeId === 'dark'
                 ? t(`themeToggle.names.${themeId}`)
-                : themeId);
+                : theme.title || themeId;
+
             return (
               <TooltipToggleButton
                 key={themeId}


### PR DESCRIPTION
## Fixes
- Fixed : https://github.com/backstage/backstage/issues/34123
## Description

- Fixes theme name resolution in `UserSettingsThemeToggle` so that
  i18n-translated names (`themeToggle.names.light` / `themeToggle.names.dark`)
  are used for the built-in `light` and `dark` themes, even when
  `theme.title` is set.
- Previously `theme.title` took precedence, which meant translation
  overrides for built-in theme names were silently ignored.

## UI after changes

https://github.com/user-attachments/assets/2e4584a2-742a-4269-b665-c6f1c0b37a16



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
