### PR TITLE
feat(gitlab): add skipReposMarkedForDeletion discovery option

### DIFF
--- a/.changeset/gitlab-skip-pending-delete.md
+++ b/.changeset/gitlab-skip-pending-delete.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-catalog-backend-module-gitlab': minor
+---
+
+Added a `skipReposMarkedForDeletion` option to the GitLab discovery provider (and the legacy `GitLabDiscoveryProcessor`). When set to `true`, projects that GitLab has marked for deletion (i.e. that report a non-empty `marked_for_deletion_on` value) are skipped during discovery. Defaults to `false`, so existing catalogs are unaffected.
+
+Enabling this option causes the discovery API call to omit `simple=true`, since the deletion marker is not returned in the simple GitLab project response.

--- a/plugins/catalog-backend-module-gitlab/config.d.ts
+++ b/plugins/catalog-backend-module-gitlab/config.d.ts
@@ -102,6 +102,13 @@ export interface Config {
            */
           includeArchivedRepos?: boolean;
           /**
+           * (Optional) Skip repositories that GitLab has marked for deletion
+           * (i.e. that report a non-empty `marked_for_deletion_on` value).
+           * Defaults to `false`. When enabled, the GitLab API call cannot use
+           * the `simple=true` payload optimization.
+           */
+          skipReposMarkedForDeletion?: boolean;
+          /**
            * (Optional) A list of strings containing the paths of the repositories to skip
            * Should be in the format group/subgroup/repo, with no leading or trailing slashes.
            */

--- a/plugins/catalog-backend-module-gitlab/report.api.md
+++ b/plugins/catalog-backend-module-gitlab/report.api.md
@@ -52,6 +52,7 @@ export class GitLabDiscoveryProcessor implements CatalogProcessor {
       skipReposWithoutExactFileMatch?: boolean;
       skipForkedRepos?: boolean;
       includeArchivedRepos?: boolean;
+      skipReposMarkedForDeletion?: boolean;
     },
   ): GitLabDiscoveryProcessor;
   // (undocumented)
@@ -119,6 +120,7 @@ export type GitlabProviderConfig = {
   schedule?: SchedulerServiceTaskScheduleDefinition;
   skipForkedRepos?: boolean;
   includeArchivedRepos?: boolean;
+  skipReposMarkedForDeletion?: boolean;
   excludeRepos?: string[];
   includeUsersWithoutSeat?: boolean;
   membership?: boolean;

--- a/plugins/catalog-backend-module-gitlab/src/GitLabDiscoveryProcessor.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/GitLabDiscoveryProcessor.test.ts
@@ -552,6 +552,48 @@ describe('GitlabDiscoveryProcessor', () => {
       expect(result).toHaveLength(0);
     });
 
+    it('does not set simple when skipReposMarkedForDeletion is true', async () => {
+      const processor = getProcessor({
+        options: { skipReposMarkedForDeletion: true },
+      });
+      setupFakeServer(
+        PROJECTS_URL,
+        _ => {
+          return {
+            data: [
+              {
+                id: 1,
+                archived: false,
+                default_branch: 'main',
+                last_activity_at: '2021-08-05T11:03:05.774Z',
+                web_url: 'https://gitlab.fake/1',
+                path_with_namespace: '1',
+              },
+              {
+                id: 2,
+                archived: false,
+                default_branch: 'main',
+                last_activity_at: '2021-08-05T11:03:05.774Z',
+                web_url: 'https://gitlab.fake/2',
+                path_with_namespace: '2',
+                marked_for_deletion_on: '2025-01-01',
+              },
+            ],
+          };
+        },
+        request => {
+          expect(request.url.searchParams.get('simple')).toBeNull();
+        },
+      );
+
+      const result: any[] = [];
+      await processor.readLocation(PROJECT_LOCATION, false, e => {
+        result.push(e);
+      });
+      // The pending-delete project is filtered out
+      expect(result).toHaveLength(1);
+    });
+
     it('sets default parameters correctly (archived=false, simple=true)', async () => {
       const processor = getProcessor(); // Uses defaults: skipForkedRepos=false, includeArchivedRepos=false
       setupFakeServer(

--- a/plugins/catalog-backend-module-gitlab/src/GitLabDiscoveryProcessor.ts
+++ b/plugins/catalog-backend-module-gitlab/src/GitLabDiscoveryProcessor.ts
@@ -40,6 +40,7 @@ export class GitLabDiscoveryProcessor implements CatalogProcessor {
   private readonly skipReposWithoutExactFileMatch: boolean;
   private readonly skipForkedRepos: boolean;
   private readonly includeArchivedRepos: boolean;
+  private readonly skipReposMarkedForDeletion: boolean;
 
   static fromConfig(
     config: Config,
@@ -48,6 +49,7 @@ export class GitLabDiscoveryProcessor implements CatalogProcessor {
       skipReposWithoutExactFileMatch?: boolean;
       skipForkedRepos?: boolean;
       includeArchivedRepos?: boolean;
+      skipReposMarkedForDeletion?: boolean;
     },
   ): GitLabDiscoveryProcessor {
     const integrations = ScmIntegrations.fromConfig(config);
@@ -68,6 +70,7 @@ export class GitLabDiscoveryProcessor implements CatalogProcessor {
     skipReposWithoutExactFileMatch?: boolean;
     skipForkedRepos?: boolean;
     includeArchivedRepos?: boolean;
+    skipReposMarkedForDeletion?: boolean;
   }) {
     this.integrations = options.integrations;
     this.cache = options.pluginCache;
@@ -76,6 +79,8 @@ export class GitLabDiscoveryProcessor implements CatalogProcessor {
       options.skipReposWithoutExactFileMatch || false;
     this.skipForkedRepos = options.skipForkedRepos || false;
     this.includeArchivedRepos = options.includeArchivedRepos || false;
+    this.skipReposMarkedForDeletion =
+      options.skipReposMarkedForDeletion || false;
   }
 
   getProcessorName(): string {
@@ -115,11 +120,12 @@ export class GitLabDiscoveryProcessor implements CatalogProcessor {
       // that the options doesn't include the key so that the API doesn't receive an empty query parameter.
       ...(lastActivity && { last_activity_after: lastActivity }),
       ...(!this.includeArchivedRepos && { archived: false }),
-      // Only use simple=true when we don't need to skip forked repos.
-      // The simple=true parameter reduces response size by returning fewer fields,
-      // but it excludes the 'forked_from_project' field which is required for fork detection.
-      // Therefore, we can only optimize with simple=true when skipForkedRepos is false.
-      ...(!this.skipForkedRepos && { simple: true }),
+      // The simple=true parameter reduces response size by returning fewer
+      // fields, but it omits both `forked_from_project` and
+      // `marked_for_deletion_on`. Drop the optimization whenever a filter
+      // depends on one of those fields.
+      ...(!this.skipForkedRepos &&
+        !this.skipReposMarkedForDeletion && { simple: true }),
     };
 
     const projects = paginated(options => client.listProjects(options), opts);
@@ -153,6 +159,10 @@ export class GitLabDiscoveryProcessor implements CatalogProcessor {
         this.skipForkedRepos &&
         project.hasOwnProperty('forked_from_project')
       ) {
+        continue;
+      }
+
+      if (this.skipReposMarkedForDeletion && project.marked_for_deletion_on) {
         continue;
       }
 

--- a/plugins/catalog-backend-module-gitlab/src/__testUtils__/mocks.ts
+++ b/plugins/catalog-backend-module-gitlab/src/__testUtils__/mocks.ts
@@ -379,6 +379,33 @@ export const config_single_integration_include_archived: MockObject = {
   },
 };
 
+export const config_single_integration_skip_marked_for_deletion: MockObject = {
+  integrations: {
+    gitlab: [
+      {
+        host: 'example.com',
+        apiBaseUrl: 'https://example.com/api/v4',
+        token: '1234',
+      },
+    ],
+  },
+  catalog: {
+    providers: {
+      gitlab: {
+        'test-id': {
+          host: 'example.com',
+          group: 'group1',
+          skipReposMarkedForDeletion: true,
+          schedule: {
+            frequency: 'PT30M',
+            timeout: 'PT3M',
+          },
+        },
+      },
+    },
+  },
+};
+
 export const config_single_integration_exclude_repos: MockObject = {
   integrations: {
     gitlab: [
@@ -1072,6 +1099,19 @@ export const all_projects_response: GitLabProject[] = [
     last_activity_at: new Date().toString(),
     web_url: 'https://example.com/group1/subgroup1/test-repo9',
     path_with_namespace: 'group1/subgroup1/test-repo9',
+  },
+  // project marked for deletion
+  {
+    id: 10,
+    description: 'Project Ten Description',
+    name: 'test-repo-pending-delete',
+    default_branch: 'main',
+    path: 'test-repo-pending-delete',
+    archived: false,
+    last_activity_at: new Date().toString(),
+    web_url: 'https://example.com/group1/test-repo-pending-delete',
+    path_with_namespace: 'group1/test-repo-pending-delete',
+    marked_for_deletion_on: '2025-01-01',
   },
 ];
 

--- a/plugins/catalog-backend-module-gitlab/src/lib/types.ts
+++ b/plugins/catalog-backend-module-gitlab/src/lib/types.ts
@@ -43,6 +43,7 @@ export type GitLabProject = {
   web_url: string;
   path_with_namespace?: string;
   forked_from_project?: GitlabProjectForkedFrom;
+  marked_for_deletion_on?: string | null;
 };
 
 export type GitLabCommit = {
@@ -269,6 +270,15 @@ export type GitlabProviderConfig = {
    * If the project is archived, include repository
    */
   includeArchivedRepos?: boolean;
+  /**
+   * If true, projects that GitLab has marked for deletion (reported as a
+   * non-empty `marked_for_deletion_on` timestamp) are skipped during discovery.
+   * Defaults to `false`.
+   *
+   * Setting this to `true` causes the GitLab API call to omit `simple=true`,
+   * since the deletion marker is not returned in the simple project response.
+   */
+  skipReposMarkedForDeletion?: boolean;
   /**
    * List of repositories to exclude from discovery, should be the full path to the repository, e.g. `group/project`
    * Paths should not start or end with a slash.

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.test.ts
@@ -276,6 +276,38 @@ describe('GitlabDiscoveryEntityProvider - refresh', () => {
     });
   });
 
+  it('should filter projects marked for deletion when skipReposMarkedForDeletion is true', async () => {
+    const config = new ConfigReader(
+      mock.config_single_integration_skip_marked_for_deletion,
+    );
+    const schedule = new PersistingTaskRunner();
+    const entityProviderConnection: EntityProviderConnection = {
+      applyMutation: jest.fn(),
+      refresh: jest.fn(),
+    };
+    const provider = GitlabDiscoveryEntityProvider.fromConfig(config, {
+      logger,
+      schedule,
+    })[0];
+
+    await provider.connect(entityProviderConnection);
+
+    await provider.refresh(logger);
+
+    expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith({
+      type: 'full',
+      entities: mock.expected_location_entities_default_branch.filter(
+        entity =>
+          !entity.entity.metadata.annotations[
+            'backstage.io/managed-by-location'
+          ].includes('pending-delete') &&
+          !entity.entity.metadata.annotations[
+            'backstage.io/managed-by-location'
+          ].includes('awesome'),
+      ),
+    });
+  });
+
   it('should filter repositories that are excluded', async () => {
     const config = new ConfigReader(
       mock.config_single_integration_exclude_repos,
@@ -769,6 +801,61 @@ describe('GitlabDiscoveryEntityProvider - simple parameter', () => {
       per_page: 50,
       archived: false,
       simple: true, // Should be set when skipForkedRepos is false
+    });
+  });
+
+  it('should not pass simple when skipReposMarkedForDeletion is true', async () => {
+    const config = new ConfigReader({
+      integrations: {
+        gitlab: [
+          {
+            host: 'example.com',
+            apiBaseUrl: 'https://example.com/api/v4',
+            token: 'test-token',
+          },
+        ],
+      },
+      catalog: {
+        providers: {
+          gitlab: {
+            'test-id': {
+              host: 'example.com',
+              group: 'test-group',
+              skipReposMarkedForDeletion: true,
+            },
+          },
+        },
+      },
+    });
+
+    const schedule = new PersistingTaskRunner();
+    const entityProviderConnection: EntityProviderConnection = {
+      applyMutation: jest.fn(),
+      refresh: jest.fn(),
+    };
+
+    const provider = GitlabDiscoveryEntityProvider.fromConfig(config, {
+      logger,
+      schedule,
+    })[0];
+
+    const mockListProjects = jest.fn().mockResolvedValue({
+      items: [],
+      nextPage: undefined,
+    });
+
+    (provider as any).gitLabClient.listProjects = mockListProjects;
+
+    await provider.connect(entityProviderConnection);
+    await provider.refresh(logger);
+
+    expect(mockListProjects).toHaveBeenCalledWith({
+      group: 'test-group',
+      page: undefined,
+      per_page: 50,
+      archived: false,
+      // simple should not be present when skipReposMarkedForDeletion is true,
+      // because the marked_for_deletion_on field is not returned by simple=true
     });
   });
 

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts
@@ -384,11 +384,12 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
         ...(!this.config.includeArchivedRepos && { archived: false }),
         ...(this.config.membership && { membership: true }),
         ...(this.config.topics && { topic: this.config.topics }),
-        // Only use simple=true when we don't need to skip forked repos.
-        // The simple=true parameter reduces response size by returning fewer fields,
-        // but it excludes the 'forked_from_project' field which is required for fork detection.
-        // Therefore, we can only optimize with simple=true when skipForkedRepos is false.
-        ...(!this.config.skipForkedRepos && { simple: true }),
+        // The simple=true parameter reduces response size by returning fewer
+        // fields, but it omits both `forked_from_project` and
+        // `marked_for_deletion_on`. Drop the optimization whenever a filter
+        // depends on one of those fields.
+        ...(!this.config.skipForkedRepos &&
+          !this.config.skipReposMarkedForDeletion && { simple: true }),
       },
     );
 
@@ -640,6 +641,16 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
     ) {
       this.logger.debug(
         `Skipping project ${project.path_with_namespace} as it is a forked project.`,
+      );
+      return false;
+    }
+
+    if (
+      this.config.skipReposMarkedForDeletion &&
+      project.marked_for_deletion_on
+    ) {
+      this.logger.debug(
+        `Skipping project ${project.path_with_namespace} as it is marked for deletion.`,
       );
       return false;
     }

--- a/plugins/catalog-backend-module-gitlab/src/providers/config.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/config.test.ts
@@ -62,6 +62,7 @@ describe('config', () => {
         schedule: undefined,
         skipForkedRepos: false,
         includeArchivedRepos: false,
+        skipReposMarkedForDeletion: false,
         excludeRepos: [],
         restrictUsersToGroup: false,
         includeUsersWithoutSeat: false,
@@ -109,6 +110,7 @@ describe('config', () => {
         schedule: undefined,
         skipForkedRepos: false,
         includeArchivedRepos: false,
+        skipReposMarkedForDeletion: false,
         excludeRepos: [],
         restrictUsersToGroup: false,
         includeUsersWithoutSeat: true,
@@ -158,6 +160,7 @@ describe('config', () => {
         excludeRepos: [],
         skipForkedRepos: true,
         includeArchivedRepos: false,
+        skipReposMarkedForDeletion: false,
         includeUsersWithoutSeat: false,
         membership: undefined,
         topics: undefined,
@@ -205,6 +208,55 @@ describe('config', () => {
         excludeRepos: [],
         skipForkedRepos: false,
         includeArchivedRepos: true,
+        skipReposMarkedForDeletion: false,
+        includeUsersWithoutSeat: false,
+        membership: undefined,
+        topics: undefined,
+        useSearch: false,
+      }),
+    );
+  });
+
+  it('valid config with skipReposMarkedForDeletion', () => {
+    const config = new ConfigReader({
+      catalog: {
+        providers: {
+          gitlab: {
+            test: {
+              group: 'group',
+              host: 'host',
+              branch: 'not-master',
+              fallbackBranch: 'main',
+              entityFilename: 'custom-file.yaml',
+              skipReposMarkedForDeletion: true,
+            },
+          },
+        },
+      },
+    });
+
+    const result = readGitlabConfigs(config);
+    expect(result).toHaveLength(1);
+    result.forEach(r =>
+      expect(r).toStrictEqual({
+        id: 'test',
+        group: 'group',
+        branch: 'not-master',
+        fallbackBranch: 'main',
+        host: 'host',
+        catalogFile: 'custom-file.yaml',
+        projectPattern: /[\s\S]*/,
+        groupPattern: /[\s\S]*/,
+        userPattern: /[\s\S]*/,
+        orgEnabled: false,
+        allowInherited: false,
+        relations: [],
+        schedule: undefined,
+        restrictUsersToGroup: false,
+        excludeRepos: [],
+        skipForkedRepos: false,
+        includeArchivedRepos: false,
+        skipReposMarkedForDeletion: true,
         includeUsersWithoutSeat: false,
         membership: undefined,
         topics: undefined,
@@ -252,6 +304,7 @@ describe('config', () => {
         restrictUsersToGroup: false,
         skipForkedRepos: false,
         includeArchivedRepos: false,
+        skipReposMarkedForDeletion: false,
         excludeRepos: ['foo/bar', 'quz/qux'],
         includeUsersWithoutSeat: false,
         membership: undefined,
@@ -299,6 +352,7 @@ describe('config', () => {
         relations: [],
         skipForkedRepos: false,
         includeArchivedRepos: false,
+        skipReposMarkedForDeletion: false,
         restrictUsersToGroup: false,
         excludeRepos: [],
         includeUsersWithoutSeat: false,
@@ -395,6 +449,7 @@ describe('config', () => {
         skipForkedRepos: false,
         includeUsersWithoutSeat: false,
         includeArchivedRepos: false,
+        skipReposMarkedForDeletion: false,
         membership: true,
         topics: undefined,
         useSearch: false,
@@ -442,6 +497,7 @@ describe('config', () => {
         skipForkedRepos: false,
         includeUsersWithoutSeat: false,
         includeArchivedRepos: false,
+        skipReposMarkedForDeletion: false,
         membership: undefined,
         topics: undefined,
         useSearch: false,
@@ -489,6 +545,7 @@ describe('config', () => {
         skipForkedRepos: false,
         includeUsersWithoutSeat: false,
         includeArchivedRepos: false,
+        skipReposMarkedForDeletion: false,
         membership: undefined,
         topics: 'topic1',
         useSearch: false,
@@ -536,6 +593,7 @@ describe('config', () => {
         skipForkedRepos: false,
         includeUsersWithoutSeat: false,
         includeArchivedRepos: false,
+        skipReposMarkedForDeletion: false,
         membership: undefined,
         topics: 'topic1,topic2,topic3',
         useSearch: false,

--- a/plugins/catalog-backend-module-gitlab/src/providers/config.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/config.ts
@@ -65,6 +65,8 @@ function readGitlabConfig(id: string, config: Config): GitlabProviderConfig {
 
   const includeArchivedRepos: boolean =
     config.getOptionalBoolean('includeArchivedRepos') ?? false;
+  const skipReposMarkedForDeletion: boolean =
+    config.getOptionalBoolean('skipReposMarkedForDeletion') ?? false;
   const excludeRepos: string[] =
     config.getOptionalStringArray('excludeRepos') ?? [];
 
@@ -101,6 +103,7 @@ function readGitlabConfig(id: string, config: Config): GitlabProviderConfig {
     relations,
     skipForkedRepos,
     includeArchivedRepos,
+    skipReposMarkedForDeletion,
     excludeRepos,
     restrictUsersToGroup,
     includeUsersWithoutSeat,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #34068.

Adds an opt-in `skipReposMarkedForDeletion` option to the GitLab discovery provider (and the legacy `GitLabDiscoveryProcessor`). When enabled, projects whose GitLab API response carries a non-empty `marked_for_deletion_on` value are dropped during discovery, mirroring the existing `skipForkedRepos` style.

The option defaults to `false`, so behavior is unchanged for existing adopters; setting it to `true` is the way to keep pending-delete projects out of the catalog.

When the flag is on, the API call drops the `simple=true` payload optimization, since `marked_for_deletion_on` is not part of the simple project response. This is the same trade-off `skipForkedRepos` makes for `forked_from_project`.

A maintainer-led decision to flip the default to "skip by default" later (the way `includeArchivedRepos` works) would be a one-line change.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))