### PR TITLE
fix(ui): show focus indicator on Card when used as a link

### DIFF
--- a/.changeset/link-focus-visible.md
+++ b/.changeset/link-focus-visible.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Fix `Card href=...` not showing a focus indicator on keyboard navigation. `Link` now composes `useFocusRing` and emits `data-focus-visible`, so the Card's existing focus-ring CSS matches when the trigger is focused.

--- a/.changeset/link-focus-visible.md
+++ b/.changeset/link-focus-visible.md
@@ -3,3 +3,5 @@
 ---
 
 Fix `Card href=...` not showing a focus indicator on keyboard navigation. `Link` now composes `useFocusRing` and emits `data-focus-visible`, so the Card's existing focus-ring CSS matches when the trigger is focused.
+
+*Affected components*: Card, Link

--- a/.changeset/link-focus-visible.md
+++ b/.changeset/link-focus-visible.md
@@ -2,6 +2,6 @@
 '@backstage/ui': patch
 ---
 
-Fix `Card href=...` not showing a focus indicator on keyboard navigation. `Link` now composes `useFocusRing` and emits `data-focus-visible`, so the Card's existing focus-ring CSS matches when the trigger is focused.
+Fix `Card href=...` not showing a focus indicator on keyboard navigation. `Link` now composes `useFocusRing`, emits `data-focus-visible`, and renders a `--bui-ring` outline when keyboard-focused. The Card's existing focus-ring CSS matches when the trigger is focused.
 
-*Affected components*: Card, Link
+_Affected components_: Card, Link

--- a/packages/ui/src/components/Link/Link.module.css
+++ b/packages/ui/src/components/Link/Link.module.css
@@ -37,6 +37,11 @@
       text-underline-offset: calc(0.025em + 2px);
       text-decoration-color: color-mix(in srgb, currentColor 30%, transparent);
     }
+
+    &[data-focus-visible] {
+      outline: 2px solid var(--bui-ring);
+      outline-offset: 2px;
+    }
   }
 
   .bui-Link[data-variant='title-large'] {

--- a/packages/ui/src/components/Link/Link.tsx
+++ b/packages/ui/src/components/Link/Link.tsx
@@ -15,7 +15,7 @@
  */
 
 import { forwardRef, useRef } from 'react';
-import { useLink } from 'react-aria';
+import { mergeProps, useFocusRing, useLink } from 'react-aria';
 import type { LinkProps } from './types';
 import { useDefinition } from '../../hooks/useDefinition';
 import { useResolvedHref } from '../../hooks/useResolvedHref';
@@ -33,6 +33,7 @@ const LinkInternal = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
   const linkRef = (ref || internalRef) as React.RefObject<HTMLAnchorElement>;
 
   const { linkProps } = useLink(restProps, linkRef);
+  const { isFocusVisible, focusProps } = useFocusRing();
   const resolvedHref = useResolvedHref(restProps.href);
 
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
@@ -48,13 +49,14 @@ const LinkInternal = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
 
   return (
     <a
-      {...linkProps}
+      {...mergeProps(linkProps, focusProps)}
       {...dataAttributes}
       {...(restProps as React.AnchorHTMLAttributes<HTMLAnchorElement>)}
       href={resolvedHref}
       ref={linkRef}
       title={title}
       className={classes.root}
+      data-focus-visible={isFocusVisible || undefined}
       onClick={handleClick}
     >
       {children}


### PR DESCRIPTION
## Hey, I just made a Pull Request!                                                                                                                                             
                                                                                                                                                                                    
  `Card` with an `href` was not showing a focus ring on keyboard navigation. Repro: tab to any `<Card href=...>` — no outline, even though the card is interactive.                 
                                                                                                                                                                                    
  #### Root cause                                                                                                                                                                   
                                                                                                                                                                                  
  The Card focus-ring CSS keys off `data-focus-visible` on the `bui-CardTrigger`:                                                                                                   
                                                                                                                                                                                  
  ```css                                                                                                                                                                            
  .bui-Card[data-interactive]:has(.bui-CardTrigger[data-focus-visible]) {                                                                                                         
    outline: 2px solid var(--bui-ring);                                                                                                                                             
    outline-offset: -2px;
  }                  
  ```                                                                                                                                                               
                                                                                                                                                                                  
 When onPress is given, the trigger is Button from react-aria-components, which automatically writes data-focus-visible, so the rule matches.                                      
   
When href is given, the trigger is BUI's own Link, which composes `useLink` from react-aria (the older hooks API). `useLink` does not track focus-visible state — that's useFocusRing's job — so the attribute is never set and the :has() never matches.                                                                                                
                                                                                                                                                                                    
**Fix**                                                                                                                                                                             
Compose `useFocusRing` in Link and write data-focus-visible on the rendered anchor. This makes the existing Card CSS work for href cards and gives any other [data-focus-visible] styling on Link something to react to.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
