### PR TITLE
chore: add @backstage/codemods-maintainers

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -223,6 +223,20 @@ Scope: The auditor core service, along with auditor usage in the main repository
 | ------------ | ------------ | ----------------------------------------------- | -------------- |
 | Paul Schultz | Red Hat      | [schultzp2020](https://github.com/schultzp2020) | `schultzp2020` |
 
+### Codemods
+
+Team: @backstage/codemods-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+reviewers%3Acodemods-maintainers)
+
+Scope: The official Backstage codemods and migration tooling in the [codemods repository](https://github.com/backstage/codemods)
+
+| Name                   | Organization | GitHub                                                | Discord        |
+| ---------------------- | ------------ | ----------------------------------------------------- | -------------- |
+| Paul Schultz           | Red Hat      | [schultzp2020](https://github.com/schultzp2020)       | `schultzp2020` |
+| Hope Hadfield          | Red Hat      | [hopehadfield](https://github.com/hopehadfield)       | `hh0p3`        |
+| Alex Bit               | Codemod      | [alexbit-codemod](https://github.com/alexbit-codemod) | `alex__bit`    |
+| Mo Mohebifar           | Codemod      | [mohebifar](https://github.com/mohebifar)             | `mohebifar`    |
+| Juan Pablo Garcia Ripa | SAS          | [Sarabadu](https://github.com/Sarabadu)               | `sarabadu`     |
+
 ### Events
 
 Team: @backstage/events-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+reviewers%3Aevents-maintainers)

--- a/OWNERS.md
+++ b/OWNERS.md
@@ -225,7 +225,7 @@ Scope: The auditor core service, along with auditor usage in the main repository
 
 ### Codemods
 
-Team: @backstage/codemods-maintainers — [Review board](https://github.com/orgs/backstage/projects/14/views/1?filterQuery=no%3Aassignee+reviewers%3Acodemods-maintainers)
+Team: @backstage/codemods-maintainers
 
 Scope: The official Backstage codemods and migration tooling in the [codemods repository](https://github.com/backstage/codemods)
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds `@backstage/codemods-maintainers` with a scope covering the official Backstage codemods and migration tooling in the [codemods repository](https://github.com/backstage/codemods). The scope may expand in the future to include additional migration tooling and automation.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))