### PR TITLE
Add relations.* filter key support to filterPredicateToFilterFunction

### DIFF
--- a/.changeset/catalog-client-entity-filter-resolver.md
+++ b/.changeset/catalog-client-entity-filter-resolver.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-client': minor
+---
+
+Added `entityFilterOptions` and `resolveEntityFilterValue` exports that enable the `relations.<relationType>` filter syntax when using `filterPredicateToFilterFunction` with catalog entities. This allows filters like `{ "relations.ownedBy": "group:default/my-team" }` to work in-memory with the same semantics as the catalog backend's search table.

--- a/.changeset/catalog-react-entity-filter-relations.md
+++ b/.changeset/catalog-react-entity-filter-relations.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Entity filter predicates used in blueprints now support the `relations.<relationType>` key syntax, matching the catalog backend's filter semantics.

--- a/.changeset/filter-predicate-relations-support.md
+++ b/.changeset/filter-predicate-relations-support.md
@@ -1,0 +1,5 @@
+---
+'@backstage/filter-predicates': patch
+---
+
+Added an optional `resolveValue` option to `evaluateFilterPredicate` and `filterPredicateToFilterFunction`, allowing custom value resolution for filter keys. When the resolver returns an array, the filter matches if any element satisfies the filter value — enabling multi-value field semantics like those used by the catalog search table.

--- a/packages/catalog-client/src/entityFilterResolver.ts
+++ b/packages/catalog-client/src/entityFilterResolver.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity } from '@backstage/catalog-model';
+import {
+  FilterPredicateOptions,
+  getJsonValueAtPath,
+} from '@backstage/filter-predicates';
+import { JsonValue } from '@backstage/types';
+
+/**
+ * Resolves a filter key to a value on a catalog entity, with support for the
+ * special `relations.<relationType>` syntax used by the catalog search table.
+ *
+ * @remarks
+ *
+ * When the key starts with `relations.`, the remainder is treated as a relation
+ * type and the resolver returns all matching `targetRef` values as an array.
+ * This enables filters like `{ "relations.ownedby": "group:default/my-team" }`
+ * to work in-memory with the same semantics as the catalog backend's search
+ * table, where each relation is stored as a separate row.
+ *
+ * For all other keys, the default dot-path lookup is used.
+ *
+ * @public
+ */
+export function resolveEntityFilterValue(
+  entity: unknown,
+  key: string,
+): unknown {
+  if (key.toLocaleLowerCase('en-US').startsWith('relations.')) {
+    const relationType = key.slice('relations.'.length);
+    const relations = (entity as Entity)?.relations;
+    if (!Array.isArray(relations)) {
+      return undefined;
+    }
+    const targetRefs = relations
+      .filter(
+        r =>
+          r.type.toLocaleLowerCase('en-US') ===
+          relationType.toLocaleLowerCase('en-US'),
+      )
+      .map(r => r.targetRef);
+    return targetRefs.length > 0 ? targetRefs : undefined;
+  }
+
+  return getJsonValueAtPath(entity as JsonValue, key);
+}
+
+/**
+ * Options for {@link @backstage/filter-predicates#filterPredicateToFilterFunction}
+ * that enable catalog entity relation filtering via the `relations.<type>` syntax.
+ *
+ * @public
+ */
+export const entityFilterOptions: FilterPredicateOptions = {
+  resolveValue: resolveEntityFilterValue,
+};

--- a/packages/catalog-client/src/index.ts
+++ b/packages/catalog-client/src/index.ts
@@ -21,4 +21,8 @@
  */
 
 export { CatalogClient } from './CatalogClient';
+export {
+  entityFilterOptions,
+  resolveEntityFilterValue,
+} from './entityFilterResolver';
 export * from './types';

--- a/packages/catalog-client/src/testUtils/InMemoryCatalogClient.ts
+++ b/packages/catalog-client/src/testUtils/InMemoryCatalogClient.ts
@@ -55,6 +55,7 @@ import {
   FilterPredicate,
   filterPredicateToFilterFunction,
 } from '@backstage/filter-predicates';
+import { entityFilterOptions } from '../entityFilterResolver';
 import lodash from 'lodash';
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import { traverse } from '../../../../plugins/catalog-backend/src/database/operations/stitcher/buildEntitySearch';
@@ -362,7 +363,7 @@ export class InMemoryCatalogClient implements CatalogApi {
   ): Promise<GetEntitiesByRefsResponse> {
     const filter = createFilter(request.filter);
     const queryFilter = request.query
-      ? filterPredicateToFilterFunction(request.query)
+      ? filterPredicateToFilterFunction(request.query, entityFilterOptions)
       : undefined;
     const refMap = this.#createEntityRefMap();
     const items = request.entityRefs
@@ -415,7 +416,9 @@ export class InMemoryCatalogClient implements CatalogApi {
 
     // Apply predicate-based query filter
     if (query) {
-      items = items.filter(filterPredicateToFilterFunction(query));
+      items = items.filter(
+        filterPredicateToFilterFunction(query, entityFilterOptions),
+      );
     }
 
     // Apply full-text filter, defaulting to the sort field or metadata.uid
@@ -514,7 +517,7 @@ export class InMemoryCatalogClient implements CatalogApi {
     let filteredEntities = this.#entities.filter(filter);
     if (request.query) {
       filteredEntities = filteredEntities.filter(
-        filterPredicateToFilterFunction(request.query),
+        filterPredicateToFilterFunction(request.query, entityFilterOptions),
       );
     }
     const facets = Object.fromEntries(

--- a/packages/filter-predicates/src/predicates/evaluate.test.ts
+++ b/packages/filter-predicates/src/predicates/evaluate.test.ts
@@ -18,7 +18,10 @@ import {
   evaluateFilterPredicate,
   filterPredicateToFilterFunction,
 } from './evaluate';
+import type { FilterPredicateOptions } from './evaluate';
 import { FilterPredicate } from './types';
+import { getJsonValueAtPath } from './getJsonValueAtPath';
+import { JsonValue } from '@backstage/types';
 
 describe('evaluate', () => {
   const entities = [
@@ -265,5 +268,131 @@ describe('evaluate', () => {
     expect(evaluateFilterPredicate(value, entities[0])).toBe(false);
     expect(filterPredicateToFilterFunction(operator)(entities[0])).toBe(false);
     expect(filterPredicateToFilterFunction(value)(entities[0])).toBe(false);
+  });
+
+  describe('with resolveValue option (relations support)', () => {
+    const resolveValue: FilterPredicateOptions['resolveValue'] = (
+      target,
+      key,
+    ) => {
+      if (key.toLocaleLowerCase('en-US').startsWith('relations.')) {
+        const relationType = key.slice('relations.'.length);
+        const relations = (target as any)?.relations;
+        if (!Array.isArray(relations)) return undefined;
+        const targetRefs = relations
+          .filter(
+            (r: any) =>
+              r.type.toLocaleLowerCase('en-US') ===
+              relationType.toLocaleLowerCase('en-US'),
+          )
+          .map((r: any) => r.targetRef);
+        return targetRefs.length > 0 ? targetRefs : undefined;
+      }
+      return getJsonValueAtPath(target as JsonValue, key);
+    };
+
+    const options: FilterPredicateOptions = { resolveValue };
+
+    it('matches relations by type and targetRef', () => {
+      const filter: FilterPredicate = {
+        'relations.ownedBy': 'group:default/g',
+      };
+      const filtered = entities.filter(e =>
+        evaluateFilterPredicate(filter, e, options),
+      );
+      expect(filtered.map(e => e.metadata.name).sort()).toEqual([
+        'a',
+        's',
+        'w',
+      ]);
+    });
+
+    it('matches relations with $in operator', () => {
+      const filter: FilterPredicate = {
+        'relations.providesApi': {
+          $in: ['api:default/a', 'api:default/b'],
+        },
+      };
+      const filtered = entities.filter(e =>
+        evaluateFilterPredicate(filter, e, options),
+      );
+      expect(filtered.map(e => e.metadata.name)).toEqual(['s']);
+    });
+
+    it('matches relations with $exists', () => {
+      const filter: FilterPredicate = {
+        'relations.dependsOn': { $exists: true },
+      };
+      const filtered = entities.filter(e =>
+        evaluateFilterPredicate(filter, e, options),
+      );
+      expect(filtered.map(e => e.metadata.name)).toEqual(['w']);
+    });
+
+    it('matches non-existent relation type with $exists false', () => {
+      const filter: FilterPredicate = {
+        'relations.dependsOn': { $exists: false },
+      };
+      const filtered = entities.filter(e =>
+        evaluateFilterPredicate(filter, e, options),
+      );
+      expect(filtered.map(e => e.metadata.name).sort()).toEqual([
+        'a',
+        'g',
+        's',
+      ]);
+    });
+
+    it('matches relations case-insensitively', () => {
+      const filter: FilterPredicate = {
+        'relations.OWNEDBY': 'GROUP:DEFAULT/G',
+      };
+      const filtered = entities.filter(e =>
+        evaluateFilterPredicate(filter, e, options),
+      );
+      expect(filtered.map(e => e.metadata.name).sort()).toEqual([
+        'a',
+        's',
+        'w',
+      ]);
+    });
+
+    it('combines relation filter with other field filters', () => {
+      const filter: FilterPredicate = {
+        kind: 'Component',
+        'relations.ownedBy': 'group:default/g',
+      };
+      const filtered = entities.filter(e =>
+        evaluateFilterPredicate(filter, e, options),
+      );
+      expect(filtered.map(e => e.metadata.name).sort()).toEqual(['s', 'w']);
+    });
+
+    it('works with filterPredicateToFilterFunction', () => {
+      const fn = filterPredicateToFilterFunction(
+        { 'relations.ownerOf': { $exists: true } },
+        options,
+      );
+      const filtered = entities.filter(fn);
+      expect(filtered.map(e => e.metadata.name)).toEqual(['g']);
+    });
+
+    it('works with $not on relations', () => {
+      const filter: FilterPredicate = {
+        $not: { 'relations.ownedBy': 'group:default/g' },
+      };
+      const filtered = entities.filter(e =>
+        evaluateFilterPredicate(filter, e, options),
+      );
+      expect(filtered.map(e => e.metadata.name)).toEqual(['g']);
+    });
+
+    it('still supports regular path lookups', () => {
+      const filter: FilterPredicate = { 'spec.type': 'service' };
+      const filtered = entities.filter(e =>
+        evaluateFilterPredicate(filter, e, options),
+      );
+      expect(filtered.map(e => e.metadata.name)).toEqual(['s']);
+    });
   });
 });

--- a/packages/filter-predicates/src/predicates/evaluate.ts
+++ b/packages/filter-predicates/src/predicates/evaluate.ts
@@ -19,6 +19,30 @@ import { FilterPredicate, FilterPredicateValue } from './types';
 import { getJsonValueAtPath } from './getJsonValueAtPath';
 
 /**
+ * Options for filter predicate evaluation.
+ *
+ * @public
+ */
+export interface FilterPredicateOptions {
+  /**
+   * Custom value resolver that overrides the default dot-path lookup.
+   *
+   * @remarks
+   *
+   * When provided, this function is called for each key in a filter expression
+   * to resolve the value from the target object. If not provided, the default
+   * {@link getJsonValueAtPath} is used.
+   *
+   * The resolver may return an array to indicate a multi-value field (e.g.
+   * relations). When an array is returned, the filter value is tested against
+   * each element and succeeds if ANY element matches.
+   *
+   * Return `undefined` to indicate that the key does not exist on the target.
+   */
+  resolveValue?: (target: unknown, key: string) => unknown;
+}
+
+/**
  * Evaluate a filter predicate against a value.
  *
  * @public
@@ -26,6 +50,7 @@ import { getJsonValueAtPath } from './getJsonValueAtPath';
 export function evaluateFilterPredicate(
   predicate: FilterPredicate,
   value: unknown,
+  options?: FilterPredicateOptions,
 ): boolean {
   if (
     typeof predicate !== 'object' ||
@@ -36,14 +61,18 @@ export function evaluateFilterPredicate(
   }
 
   if ('$all' in predicate) {
-    return predicate.$all.every(f => evaluateFilterPredicate(f, value));
+    return predicate.$all.every(f =>
+      evaluateFilterPredicate(f, value, options),
+    );
   }
   if ('$any' in predicate) {
-    return predicate.$any.some(f => evaluateFilterPredicate(f, value));
+    return predicate.$any.some(f => evaluateFilterPredicate(f, value, options));
   }
   if ('$not' in predicate) {
-    return !evaluateFilterPredicate(predicate.$not, value);
+    return !evaluateFilterPredicate(predicate.$not, value, options);
   }
+
+  const resolve = options?.resolveValue;
 
   for (const filterKey in predicate) {
     if (!Object.hasOwn(predicate, filterKey)) {
@@ -52,13 +81,17 @@ export function evaluateFilterPredicate(
     if (filterKey.startsWith('$')) {
       return false;
     }
-    if (
-      !evaluateFilterPredicateValue(
-        predicate[filterKey],
-        getJsonValueAtPath(value as JsonValue, filterKey),
-      )
-    ) {
-      return false;
+
+    if (resolve) {
+      const resolved = resolve(value, filterKey);
+      if (!evaluateResolvedValue(predicate[filterKey], resolved)) {
+        return false;
+      }
+    } else {
+      const resolved = getJsonValueAtPath(value as JsonValue, filterKey);
+      if (!evaluateFilterPredicateValue(predicate[filterKey], resolved)) {
+        return false;
+      }
     }
   }
 
@@ -72,8 +105,43 @@ export function evaluateFilterPredicate(
  */
 export function filterPredicateToFilterFunction<T = unknown>(
   predicate: FilterPredicate,
+  options?: FilterPredicateOptions,
 ): (value: T) => boolean {
-  return value => evaluateFilterPredicate(predicate, value);
+  return value => evaluateFilterPredicate(predicate, value, options);
+}
+
+/**
+ * Evaluates a resolved value against a filter. When the resolved value is an
+ * array (multi-value field), the filter succeeds if ANY element matches —
+ * mirroring the semantics of multi-row keys in the catalog search table.
+ */
+function evaluateResolvedValue(
+  filter: FilterPredicateValue,
+  resolved: unknown,
+): boolean {
+  if (Array.isArray(resolved)) {
+    // For $exists, check if the array has any elements
+    if (
+      typeof filter === 'object' &&
+      filter !== null &&
+      !Array.isArray(filter) &&
+      '$exists' in filter
+    ) {
+      return filter.$exists ? resolved.length > 0 : resolved.length === 0;
+    }
+    // For $contains, delegate directly since it expects an array
+    if (
+      typeof filter === 'object' &&
+      filter !== null &&
+      !Array.isArray(filter) &&
+      '$contains' in filter
+    ) {
+      return evaluateFilterPredicateValue(filter, resolved);
+    }
+    // For all other matchers, succeed if ANY element matches
+    return resolved.some(v => evaluateFilterPredicateValue(filter, v));
+  }
+  return evaluateFilterPredicateValue(filter, resolved);
 }
 
 /**

--- a/packages/filter-predicates/src/predicates/index.ts
+++ b/packages/filter-predicates/src/predicates/index.ts
@@ -23,6 +23,7 @@ export {
   evaluateFilterPredicate,
   filterPredicateToFilterFunction,
 } from './evaluate';
+export type { FilterPredicateOptions } from './evaluate';
 export { getJsonValueAtPath } from './getJsonValueAtPath';
 export {
   createZodV3FilterPredicateSchema,

--- a/plugins/catalog-react/src/alpha/blueprints/resolveEntityFilterData.ts
+++ b/plugins/catalog-react/src/alpha/blueprints/resolveEntityFilterData.ts
@@ -18,6 +18,7 @@ import {
   entityFilterExpressionDataRef,
   entityFilterFunctionDataRef,
 } from './extensionData';
+import { entityFilterOptions } from '@backstage/catalog-client';
 import {
   FilterPredicate,
   filterPredicateToFilterFunction,
@@ -38,7 +39,7 @@ export function* resolveEntityFilterData(
     yield entityFilterExpressionDataRef(config.filter);
   } else if (config.filter) {
     yield entityFilterFunctionDataRef(
-      filterPredicateToFilterFunction(config.filter),
+      filterPredicateToFilterFunction(config.filter, entityFilterOptions),
     );
   } else if (typeof filter === 'function') {
     yield entityFilterFunctionDataRef(filter);
@@ -49,6 +50,8 @@ export function* resolveEntityFilterData(
     );
     yield entityFilterExpressionDataRef(filter);
   } else if (filter) {
-    yield entityFilterFunctionDataRef(filterPredicateToFilterFunction(filter));
+    yield entityFilterFunctionDataRef(
+      filterPredicateToFilterFunction(filter, entityFilterOptions),
+    );
   }
 }


### PR DESCRIPTION
## Summary

- Adds an optional `resolveValue` option to `evaluateFilterPredicate` and `filterPredicateToFilterFunction` in `@backstage/filter-predicates`, enabling custom value resolution for filter keys. When the resolver returns an array, the filter matches if any element satisfies the filter value (multi-value field semantics).
- Exports `entityFilterOptions` and `resolveEntityFilterValue` from `@backstage/catalog-client` that enable the `relations.<relationType>` filter syntax when filtering catalog entities in-memory — matching the catalog backend's search table semantics.
- Updates `catalog-react` blueprint filter resolution and `InMemoryCatalogClient` to use the entity resolver.

This enables filters like `{ "relations.ownedBy": "group:default/my-team" }` to work with `filterPredicateToFilterFunction` on raw entity objects, achieving parity with the catalog backend's server-side filter behavior.

## Test plan

- [x] All existing tests pass (185 filter-predicates, 144 catalog-client)
- [x] New tests added for relation matching: equality, `$in`, `$exists`, case-insensitivity, `$not`, combined with other field filters
- [ ] API reports need regeneration once pre-existing `packages/ui` TS error is resolved


Made with [Cursor](https://cursor.com)