### PR TITLE
fix(scaffolder-node-test-utils): remove unnecessary React peer dependencies

### DIFF
--- a/.changeset/remove-react-peer-deps-from-scaffolder-node-test-utils.md
+++ b/.changeset/remove-react-peer-deps-from-scaffolder-node-test-utils.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-node-test-utils': patch
+---
+
+Removed unnecessary `react`, `react-dom`, `react-router-dom`, and `@types/react` peer and dev dependencies. This package is a `node-library` and does not use React in its source code, causing spurious peer dependency warnings in new Backstage installations.

--- a/plugins/scaffolder-node-test-utils/knip-report.md
+++ b/plugins/scaffolder-node-test-utils/knip-report.md
@@ -1,10 +1,2 @@
 # Knip report
 
-## Unused devDependencies (3)
-
-| Name             | Location          | Severity |
-| :--------------- | :---------------- | :------- |
-| react-router-dom | package.json:55:6 | error    |
-| react-dom        | package.json:54:6 | error    |
-| react            | package.json:53:6 | error    |
-

--- a/plugins/scaffolder-node-test-utils/package.json
+++ b/plugins/scaffolder-node-test-utils/package.json
@@ -48,21 +48,6 @@
     "winston-transport": "^4.7.0"
   },
   "devDependencies": {
-    "@backstage/cli": "workspace:^",
-    "@types/react": "^18.0.0",
-    "react": "^18.0.2",
-    "react-dom": "^18.0.2",
-    "react-router-dom": "^6.30.2"
-  },
-  "peerDependencies": {
-    "@types/react": "^17.0.0 || ^18.0.0",
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0",
-    "react-router-dom": "^6.30.2"
-  },
-  "peerDependenciesMeta": {
-    "@types/react": {
-      "optional": true
-    }
+    "@backstage/cli": "workspace:^"
   }
 }


### PR DESCRIPTION
## Summary

Fixes #31446

`@backstage/plugin-scaffolder-node-test-utils` is a `node-library` that does not use React anywhere in its source code. Despite this, it declared `react`, `react-dom`, `react-router-dom`, and `@types/react` as `peerDependencies`, causing spurious peer dependency warnings in freshly created Backstage applications.

### Changes
- Removed `react`, `react-dom`, `react-router-dom`, and `@types/react` from `peerDependencies`
- Removed the `peerDependenciesMeta` section
- Removed the same packages from `devDependencies` as they are unused

## Testing

No functional change — this is a dependency metadata fix only. Verified that no source file in this package imports React.
