### PR TITLE
fix(catalog): retry transactions on deadlock

### DIFF
--- a/.changeset/fix-catalog-provider-deadlock-retry.md
+++ b/.changeset/fix-catalog-provider-deadlock-retry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Fixed an issue where PostgreSQL deadlock errors during entity provider mutations were silently swallowed, causing entities to be dropped until the next full refresh. Transactions are now automatically retried on deadlock with exponential back-off.

--- a/plugins/catalog-backend/src/database/DefaultProviderDatabase.test.ts
+++ b/plugins/catalog-backend/src/database/DefaultProviderDatabase.test.ts
@@ -956,6 +956,64 @@ describe.each(databases.eachSupportedId())(
       });
     });
 
+    describe('transaction', () => {
+      it('retries the entire transaction on a PostgreSQL deadlock', async () => {
+        const deadlockError = Object.assign(new Error('deadlock detected'), {
+          code: '40P01',
+        });
+        const mockKnexInstance = {
+          client: { config: { client: 'pg' } },
+          transaction: jest.fn(async (fn: (tx: any) => Promise<void>) => {
+            await fn({});
+          }),
+        } as unknown as Knex;
+        const db = new DefaultProviderDatabase({
+          database: mockKnexInstance,
+          logger: mockServices.logger.mock(),
+        });
+
+        let attempt = 0;
+        const inner = jest.fn(async () => {
+          attempt++;
+          if (attempt === 1) {
+            throw deadlockError;
+          }
+          return 'ok';
+        });
+
+        const result = await db.transaction(inner);
+        expect(result).toBe('ok');
+        expect(inner).toHaveBeenCalledTimes(2);
+        expect(
+          (mockKnexInstance.transaction as jest.Mock).mock.calls,
+        ).toHaveLength(2);
+      });
+
+      it('propagates the deadlock error after exhausting retries', async () => {
+        const deadlockError = Object.assign(new Error('deadlock detected'), {
+          code: '40P01',
+        });
+        const mockKnexInstance = {
+          client: { config: { client: 'pg' } },
+          transaction: jest.fn(async (fn: (tx: any) => Promise<void>) => {
+            await fn({});
+          }),
+        } as unknown as Knex;
+        const db = new DefaultProviderDatabase({
+          database: mockKnexInstance,
+          logger: mockServices.logger.mock(),
+        });
+
+        await expect(
+          db.transaction(jest.fn().mockRejectedValue(deadlockError)),
+        ).rejects.toThrow('deadlock detected');
+        // 1 initial attempt + 3 retries (default)
+        expect(
+          (mockKnexInstance.transaction as jest.Mock).mock.calls,
+        ).toHaveLength(4);
+      });
+    });
+
     describe('listReferenceSourceKeys', () => {
       it('returns the source_keys from "refresh_state_references"', async () => {
         const { knex, db } = await createDatabase();

--- a/plugins/catalog-backend/src/database/DefaultProviderDatabase.ts
+++ b/plugins/catalog-backend/src/database/DefaultProviderDatabase.ts
@@ -32,7 +32,7 @@ import {
   ReplaceUnprocessedEntitiesOptions,
   Transaction,
 } from './types';
-import { generateStableHash } from './util';
+import { generateStableHash, isDeadlockError, retryOnDeadlock } from './util';
 import {
   LoggerService,
   isDatabaseConflictError,
@@ -54,26 +54,34 @@ export class DefaultProviderDatabase implements ProviderDatabase {
     this.options = options;
   }
 
+  /**
+   * Executes `fn` inside a database transaction, retrying automatically on
+   * deadlock (PostgreSQL error 40P01). Because the callback may be invoked
+   * more than once, it must not perform non-database side effects such as
+   * emitting events, mutating in-memory state, or calling external services.
+   */
   async transaction<T>(fn: (tx: Transaction) => Promise<T>): Promise<T> {
-    try {
-      let result: T | undefined = undefined;
-      await this.options.database.transaction(
-        async tx => {
-          // We can't return here, as knex swallows the return type in case the
-          // transaction is rolled back:
-          // https://github.com/knex/knex/blob/e37aeaa31c8ef9c1b07d2e4d3ec6607e557d800d/lib/transaction.js#L136
-          result = await fn(tx);
-        },
-        {
-          // If we explicitly trigger a rollback, don't fail.
-          doNotRejectOnRollback: true,
-        },
-      );
-      return result!;
-    } catch (e) {
-      this.options.logger.debug(`Error during transaction, ${e}`);
-      throw rethrowError(e);
-    }
+    return retryOnDeadlock(async () => {
+      try {
+        let result: T | undefined = undefined;
+        await this.options.database.transaction(
+          async tx => {
+            // We can't return here, as knex swallows the return type in case the
+            // transaction is rolled back:
+            // https://github.com/knex/knex/blob/e37aeaa31c8ef9c1b07d2e4d3ec6607e557d800d/lib/transaction.js#L136
+            result = await fn(tx);
+          },
+          {
+            // If we explicitly trigger a rollback, don't fail.
+            doNotRejectOnRollback: true,
+          },
+        );
+        return result!;
+      } catch (e) {
+        this.options.logger.debug(`Error during transaction, ${e}`);
+        throw rethrowError(e);
+      }
+    }, this.options.database);
   }
 
   async replaceUnprocessedEntities(
@@ -193,6 +201,9 @@ export class DefaultProviderDatabase implements ProviderDatabase {
             }
           }
         } catch (error) {
+          if (isDeadlockError(tx, error)) {
+            throw error;
+          }
           this.options.logger.error(
             `Failed to add '${entityRef}' from source '${options.sourceKey}', ${error}`,
           );

--- a/plugins/catalog-backend/src/database/util.test.ts
+++ b/plugins/catalog-backend/src/database/util.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { Knex } from 'knex';
-import { retryOnDeadlock } from './util';
+import { isDeadlockError, retryOnDeadlock } from './util';
 
 jest.mock('node:timers/promises', () => ({
   setTimeout: jest.fn(),
@@ -121,5 +121,27 @@ describe('retryOnDeadlock', () => {
       'deadlock detected',
     );
     expect(fn).toHaveBeenCalledTimes(4);
+  });
+});
+
+describe('isDeadlockError', () => {
+  it('returns true for PostgreSQL deadlock error code 40P01', () => {
+    expect(isDeadlockError(mockKnex('pg'), pgDeadlockError())).toBe(true);
+  });
+
+  it('returns false for non-deadlock PostgreSQL errors', () => {
+    const err = Object.assign(new Error('unique violation'), { code: '23505' });
+    expect(isDeadlockError(mockKnex('pg'), err)).toBe(false);
+  });
+
+  it('returns false for PostgreSQL deadlock code on non-PostgreSQL engines', () => {
+    expect(isDeadlockError(mockKnex('better-sqlite3'), pgDeadlockError())).toBe(
+      false,
+    );
+  });
+
+  it('returns false for non-Error values', () => {
+    expect(isDeadlockError(mockKnex('pg'), 'not an error')).toBe(false);
+    expect(isDeadlockError(mockKnex('pg'), null)).toBe(false);
   });
 });

--- a/plugins/catalog-backend/src/database/util.ts
+++ b/plugins/catalog-backend/src/database/util.ts
@@ -62,7 +62,7 @@ export async function retryOnDeadlock<T>(
 /**
  * Checks if the given error is a deadlock error for the database engine in use.
  */
-function isDeadlockError(
+export function isDeadlockError(
   knex: Knex | Knex.Transaction,
   e: unknown,
 ): e is ErrorLike {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

retry on deadlock added for all transactions happening, especially on upsert from time to time.

We are seeing these deadlocks from time to time in our instance, for example:

```
Failed to add 'location:default/generated-60a66a4aa380d8d6422f7ef69d5fda69abe9ef9c' from source 'github-provider:org', error: update "refresh_state" set "unprocessed_entity" = $1, "unprocessed_hash" = $2, "location_key" = $3, "last_discovery_at" = CURRENT_TIMESTAMP, "next_update_at" = CURRENT_TIMESTAMP where "entity_ref" = $4 and ("location_key" = $5 or "location_key" is null) - deadlock detected
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
