### PR TITLE
chore: remove unused json-schema dependency

### DIFF
--- a/.changeset/remove-json-schema-dependency.md
+++ b/.changeset/remove-json-schema-dependency.md
@@ -1,0 +1,10 @@
+---
+'@backstage/backend-plugin-api': patch
+'@backstage/config-loader': patch
+'@backstage/cli-module-config': patch
+'@backstage/plugin-scaffolder-common': patch
+'@backstage/plugin-scaffolder-react': patch
+'@backstage/plugin-scaffolder': patch
+---
+
+Removed unused `json-schema` runtime dependency. The package was only used for TypeScript types from `@types/json-schema`; affected imports have been converted to `import type` to allow safe removal.

--- a/packages/backend-plugin-api/package.json
+++ b/packages/backend-plugin-api/package.json
@@ -63,7 +63,6 @@
     "@types/express": "^4.17.6",
     "@types/json-schema": "^7.0.6",
     "@types/luxon": "^3.0.0",
-    "json-schema": "^0.4.0",
     "knex": "^3.0.0",
     "luxon": "^3.0.0",
     "zod": "^3.25.76 || ^4.0.0"

--- a/packages/backend-plugin-api/report-alpha.api.md
+++ b/packages/backend-plugin-api/report-alpha.api.md
@@ -7,7 +7,7 @@ import { AnyZodObject } from 'zod/v3';
 import { BackstageCredentials } from '@backstage/backend-plugin-api';
 import { BasicPermission } from '@backstage/plugin-permission-common';
 import { JsonObject } from '@backstage/types';
-import { JSONSchema7 } from 'json-schema';
+import type { JSONSchema7 } from 'json-schema';
 import { JsonValue } from '@backstage/types';
 import { LoggerService } from '@backstage/backend-plugin-api';
 import type { Request as Request_2 } from 'express';

--- a/packages/backend-plugin-api/src/alpha/ActionsService.ts
+++ b/packages/backend-plugin-api/src/alpha/ActionsService.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { JsonObject, JsonValue } from '@backstage/types';
-import { JSONSchema7 } from 'json-schema';
+import type { JSONSchema7 } from 'json-schema';
 import { BackstageCredentials } from '@backstage/backend-plugin-api';
 
 /**

--- a/packages/cli-module-config/package.json
+++ b/packages/cli-module-config/package.json
@@ -41,7 +41,6 @@
     "@manypkg/get-packages": "^1.1.3",
     "chalk": "^4.0.0",
     "cleye": "^2.6.0",
-    "json-schema": "^0.4.0",
     "react-dev-utils": "^12.0.0-next.60",
     "yaml": "^2.0.0"
   },

--- a/packages/cli-module-config/src/commands/docs.ts
+++ b/packages/cli-module-config/src/commands/docs.ts
@@ -17,7 +17,7 @@
 import { cli } from 'cleye';
 import { JsonObject } from '@backstage/types';
 import { mergeConfigSchemas } from '@backstage/config-loader';
-import { JSONSchema7 as JSONSchema } from 'json-schema';
+import type { JSONSchema7 as JSONSchema } from 'json-schema';
 import openBrowser from 'react-dev-utils/openBrowser';
 import chalk from 'chalk';
 import { loadCliConfig } from '../lib/config';

--- a/packages/cli-module-config/src/commands/schema.ts
+++ b/packages/cli-module-config/src/commands/schema.ts
@@ -15,7 +15,7 @@
  */
 
 import { cli } from 'cleye';
-import { JSONSchema7 as JSONSchema } from 'json-schema';
+import type { JSONSchema7 as JSONSchema } from 'json-schema';
 import { stringify as stringifyYaml } from 'yaml';
 import { loadCliConfig } from '../lib/config';
 import { JsonObject } from '@backstage/types';

--- a/packages/config-loader/package.json
+++ b/packages/config-loader/package.json
@@ -44,7 +44,6 @@
     "ajv": "^8.10.0",
     "chokidar": "^3.5.2",
     "fs-extra": "^11.2.0",
-    "json-schema": "^0.4.0",
     "json-schema-merge-allof": "^0.8.1",
     "json-schema-traverse": "^1.0.0",
     "lodash": "^4.17.21",

--- a/packages/config-loader/report.api.md
+++ b/packages/config-loader/report.api.md
@@ -7,7 +7,7 @@ import { AppConfig } from '@backstage/config';
 import { Config } from '@backstage/config';
 import { HumanDuration } from '@backstage/types';
 import { JsonObject } from '@backstage/types';
-import { JSONSchema7 } from 'json-schema';
+import type { JSONSchema7 } from 'json-schema';
 import { Observable } from '@backstage/types';
 
 // @public

--- a/packages/config-loader/src/schema/compile.ts
+++ b/packages/config-loader/src/schema/compile.ts
@@ -15,7 +15,7 @@
  */
 
 import Ajv from 'ajv';
-import { JSONSchema7 as JSONSchema } from 'json-schema';
+import type { JSONSchema7 as JSONSchema } from 'json-schema';
 import mergeAllOf, { Resolvers } from 'json-schema-merge-allof';
 import traverse from 'json-schema-traverse';
 import { ConfigReader } from '@backstage/config';

--- a/plugins/scaffolder-common/package.json
+++ b/plugins/scaffolder-common/package.json
@@ -68,7 +68,6 @@
     "@microsoft/fetch-event-source": "^2.0.1",
     "@types/json-schema": "^7.0.9",
     "cross-fetch": "^4.0.0",
-    "json-schema": "^0.4.0",
     "uri-template": "^2.0.0",
     "zen-observable": "^0.10.0"
   },

--- a/plugins/scaffolder-common/report.api.md
+++ b/plugins/scaffolder-common/report.api.md
@@ -7,7 +7,7 @@ import { Entity } from '@backstage/catalog-model';
 import type { EntityMeta } from '@backstage/catalog-model';
 import type { JsonArray } from '@backstage/types';
 import { JsonObject } from '@backstage/types';
-import { JSONSchema7 } from 'json-schema';
+import type { JSONSchema7 } from 'json-schema';
 import { JsonValue } from '@backstage/types';
 import { KindValidator } from '@backstage/catalog-model';
 import { Observable } from '@backstage/types';

--- a/plugins/scaffolder-common/src/api.ts
+++ b/plugins/scaffolder-common/src/api.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { JsonObject, JsonValue, Observable } from '@backstage/types';
-import { JSONSchema7 } from 'json-schema';
+import type { JSONSchema7 } from 'json-schema';
 import { TaskSpec, TaskStep } from './TaskSpec';
 import type {
   TemplateEntityV1beta3,

--- a/plugins/scaffolder-react/package.json
+++ b/plugins/scaffolder-react/package.json
@@ -90,7 +90,6 @@
     "flatted": "^3.4.2",
     "humanize-duration": "^3.25.1",
     "immer": "^9.0.6",
-    "json-schema": "^0.4.0",
     "json-schema-library": "^9.0.0",
     "lodash": "^4.17.21",
     "luxon": "^3.0.0",

--- a/plugins/scaffolder-react/report.api.md
+++ b/plugins/scaffolder-react/report.api.md
@@ -23,7 +23,7 @@ import { HTMLAttributes } from 'react';
 import { IChangeEvent } from '@rjsf/core';
 import { IdSchema } from '@rjsf/utils';
 import { JsonObject } from '@backstage/types';
-import { JSONSchema7 } from 'json-schema';
+import type { JSONSchema7 } from 'json-schema';
 import { JSX as JSX_2 } from 'react/jsx-runtime';
 import { ListActionsResponse as ListActionsResponse_2 } from '@backstage/plugin-scaffolder-common';
 import { ListTemplatingExtensionsResponse as ListTemplatingExtensionsResponse_2 } from '@backstage/plugin-scaffolder-common';

--- a/plugins/scaffolder-react/src/extensions/types.ts
+++ b/plugins/scaffolder-react/src/extensions/types.ts
@@ -16,7 +16,7 @@
 import { ApiHolder } from '@backstage/core-plugin-api';
 import { PropsWithChildren } from 'react';
 import { JsonObject } from '@backstage/types';
-import { JSONSchema7 } from 'json-schema';
+import type { JSONSchema7 } from 'json-schema';
 import { UiSchema, UIOptionsType, FieldValidation } from '@rjsf/utils';
 import { ScaffolderRJSFFieldProps } from './rjsf';
 

--- a/plugins/scaffolder-react/src/utils.ts
+++ b/plugins/scaffolder-react/src/utils.ts
@@ -15,7 +15,7 @@
  */
 
 import zodToJsonSchema from 'zod-to-json-schema';
-import { JSONSchema7 } from 'json-schema';
+import type { JSONSchema7 } from 'json-schema';
 import { z } from 'zod/v3';
 import {
   CustomFieldExtensionSchema,

--- a/plugins/scaffolder/package.json
+++ b/plugins/scaffolder/package.json
@@ -93,7 +93,6 @@
     "git-url-parse": "^15.0.0",
     "humanize-duration": "^3.25.1",
     "idb-keyval": "5.1.5",
-    "json-schema": "^0.4.0",
     "json-schema-library": "^9.0.0",
     "jszip": "^3.10.1",
     "lodash": "^4.17.21",

--- a/plugins/scaffolder/src/components/RenderSchema/RenderSchema.test.tsx
+++ b/plugins/scaffolder/src/components/RenderSchema/RenderSchema.test.tsx
@@ -21,7 +21,7 @@ import {
   within,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {
+import type {
   JSONSchema7,
   JSONSchema7Definition,
   JSONSchema7Type,

--- a/plugins/scaffolder/src/components/RenderSchema/RenderSchema.tsx
+++ b/plugins/scaffolder/src/components/RenderSchema/RenderSchema.tsx
@@ -26,7 +26,7 @@ import {
   Tooltip,
   TooltipTrigger,
 } from '@backstage/ui';
-import {
+import type {
   JSONSchema7,
   JSONSchema7Definition,
   JSONSchema7Type,

--- a/plugins/scaffolder/src/components/TemplatingExtensionsPage/functionArgs.ts
+++ b/plugins/scaffolder/src/components/TemplatingExtensionsPage/functionArgs.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { JSONSchema7, JSONSchema7Definition } from 'json-schema';
+import type { JSONSchema7, JSONSchema7Definition } from 'json-schema';
 
 function isSchema(d: JSONSchema7Definition): d is JSONSchema7 {
   return typeof d === 'object';

--- a/plugins/scaffolder/src/components/fields/utils.ts
+++ b/plugins/scaffolder/src/components/fields/utils.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { JSONSchema7 } from 'json-schema';
+import type { JSONSchema7 } from 'json-schema';
 import { z } from 'zod/v3';
 import zodToJsonSchema from 'zod-to-json-schema';
 import { FieldSchema as FieldSchemaType } from '@backstage/plugin-scaffolder-react';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2335,7 +2335,6 @@ __metadata:
     "@types/express": "npm:^4.17.6"
     "@types/json-schema": "npm:^7.0.6"
     "@types/luxon": "npm:^3.0.0"
-    json-schema: "npm:^0.4.0"
     knex: "npm:^3.0.0"
     luxon: "npm:^3.0.0"
     zod: "npm:^3.25.76 || ^4.0.0"
@@ -2598,7 +2597,6 @@ __metadata:
     "@types/json-schema": "npm:^7.0.6"
     chalk: "npm:^4.0.0"
     cleye: "npm:^2.6.0"
-    json-schema: "npm:^0.4.0"
     react-dev-utils: "npm:^12.0.0-next.60"
     yaml: "npm:^2.0.0"
   bin:
@@ -2934,7 +2932,6 @@ __metadata:
     ajv: "npm:^8.10.0"
     chokidar: "npm:^3.5.2"
     fs-extra: "npm:^11.2.0"
-    json-schema: "npm:^0.4.0"
     json-schema-merge-allof: "npm:^0.8.1"
     json-schema-traverse: "npm:^1.0.0"
     lodash: "npm:^4.17.21"
@@ -6563,7 +6560,6 @@ __metadata:
     "@microsoft/fetch-event-source": "npm:^2.0.1"
     "@types/json-schema": "npm:^7.0.9"
     cross-fetch: "npm:^4.0.0"
-    json-schema: "npm:^0.4.0"
     msw: "npm:^1.0.0"
     uri-template: "npm:^2.0.0"
     zen-observable: "npm:^0.10.0"
@@ -6679,7 +6675,6 @@ __metadata:
     flatted: "npm:^3.4.2"
     humanize-duration: "npm:^3.25.1"
     immer: "npm:^9.0.6"
-    json-schema: "npm:^0.4.0"
     json-schema-library: "npm:^9.0.0"
     lodash: "npm:^4.17.21"
     luxon: "npm:^3.0.0"
@@ -6765,7 +6760,6 @@ __metadata:
     git-url-parse: "npm:^15.0.0"
     humanize-duration: "npm:^3.25.1"
     idb-keyval: "npm:5.1.5"
-    json-schema: "npm:^0.4.0"
     json-schema-library: "npm:^9.0.0"
     jszip: "npm:^3.10.1"
     lodash: "npm:^4.17.21"
@@ -33853,13 +33847,6 @@ __metadata:
   version: 8.0.2
   resolution: "json-schema-typed@npm:8.0.2"
   checksum: 10/fa866d1fe91e3a94aa4fe007861475cd03dcaf47b719861cab171ef2f8598478007c634d29ae45de94ee34ddff4e13414c63ea5ff06c5b868b613142c699d511
-  languageName: node
-  linkType: hard
-
-"json-schema@npm:^0.4.0":
-  version: 0.4.0
-  resolution: "json-schema@npm:0.4.0"
-  checksum: 10/8b3b64eff4a807dc2a3045b104ed1b9335cd8d57aa74c58718f07f0f48b8baa3293b00af4dcfbdc9144c3aafea1e97982cc27cc8e150fc5d93c540649507a458
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes #34129.

Removes the unused `json-schema` runtime dependency from the six packages that declared it. The code only used `JSONSchema7` and related TypeScript types, which are provided by `@types/json-schema`, so the affected source imports were converted to `import type` in the same PR to keep lint passing after the runtime dependency is gone.

The two changes ship together because they're coupled — removing the runtime dep without the type-only conversion would leave the codebase importing from an undeclared dependency. `@types/json-schema` placement is deliberately unchanged, since those types are still used and some packages expose them through their public API surface.

Follows the same cleanup pattern as #33941.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info (https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))