### PR TITLE
fix(ui): prevent selection checkboxes from creating phantom scroll height

### DIFF
--- a/.changeset/hot-socks-cross.md
+++ b/.changeset/hot-socks-cross.md
@@ -1,0 +1,7 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed Table with row selection creating phantom scroll height on ancestor elements by establishing a containing block for visually-hidden checkbox inputs.
+
+**Affected components:** Table, TableRoot

--- a/packages/ui/src/components/Table/Table.module.css
+++ b/packages/ui/src/components/Table/Table.module.css
@@ -31,6 +31,8 @@
   }
 
   .bui-Table {
+    /* Establishes containing block for react-aria's absolutely positioned hidden checkbox inputs, preventing them from escaping to a distant ancestor and creating phantom scroll height. */
+    position: relative;
     width: 100%;
     caption-side: bottom;
     border-collapse: collapse;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When a BUI Table has row selection enabled, react-aria renders visually-hidden
`<span>` wrappers (with `position: absolute`) for each checkbox's native input.
Without a positioned ancestor inside the table, these spans position relative to
a distant ancestor (e.g. `<main>`), extending its scrollable area and creating
phantom scroll height.

This adds `position: relative` to `.bui-Table` so the table element itself
becomes the containing block for these hidden inputs. The fix covers both the
composed `Table` component and the atomic `TableRoot` usage.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.