### PR TITLE
feat(auth): add preferredUsernameMatchingUserEntityName sign-in resolver

### DIFF
--- a/.changeset/thirty-bobcats-grin.md
+++ b/.changeset/thirty-bobcats-grin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-oauth2-proxy-provider': minor
+---
+
+Added forwardedPreferredUsernameMatchingUserEntityName sign-in resolver

--- a/docs/auth/oauth2-proxy/provider.md
+++ b/docs/auth/oauth2-proxy/provider.md
@@ -42,6 +42,7 @@ This provider includes several resolvers out of the box that you can use:
 - `emailMatchingUserEntityProfileEmail`: Matches the email address from the auth provider with the User entity that has a matching `spec.profile.email`. If no match is found it will throw a `NotFoundError`.
 - `emailLocalPartMatchingUserEntityName`: Matches the [local part](https://en.wikipedia.org/wiki/Email_address#Local-part) of the email address from the auth provider with the User entity that has a matching `name`. If no match is found it will throw a `NotFoundError`.
 - `forwardedUserMatchingUserEntityName`: Matches the value in the `x-forwarded-user` header from the auth provider with the User entity that has a matching `name`. If no match is found it will throw a `NotFoundError`.
+- `forwardedPreferredUsernameMatchingUserEntityName`: Matches the value in the `x-forwarded-preferred-username` header from the auth provider with the User entity that has a matching `name`. If no match is found it will throw a `NotFoundError`.
 
 :::note Note
 

--- a/plugins/auth-backend-module-oauth2-proxy-provider/report.api.md
+++ b/plugins/auth-backend-module-oauth2-proxy-provider/report.api.md
@@ -42,5 +42,12 @@ export namespace oauth2ProxySignInResolvers {
         }
       | undefined
     >;
+  const forwardedPreferredUsernameMatchingUserEntityName: SignInResolverFactory<
+    OAuth2ProxyResult,
+    | {
+        dangerouslyAllowSignInWithoutUserInCatalog?: boolean | undefined;
+      }
+    | undefined
+  >;
 }
 ```

--- a/plugins/auth-backend-module-oauth2-proxy-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-oauth2-proxy-provider/src/resolvers.ts
@@ -53,4 +53,39 @@ export namespace oauth2ProxySignInResolvers {
         };
       },
     });
+
+  /**
+   * A sign-in resolver that looks up the user using the 'x-forwarded-preferred-username' header.
+   *
+   * @public
+   */
+  export const forwardedPreferredUsernameMatchingUserEntityName =
+    createSignInResolverFactory({
+      optionsSchema: z
+        .object({
+          dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().optional(),
+        })
+        .optional(),
+      create(options = {}) {
+        return async (info: SignInInfo<OAuth2ProxyResult>, ctx) => {
+          const preferredUsername = info.result.getHeader(
+            'x-forwarded-preferred-username',
+          );
+          if (!preferredUsername) {
+            throw new Error('Request did not contain a preferred username');
+          }
+          return ctx.signInWithCatalogUser(
+            {
+              entityRef: { name: preferredUsername },
+            },
+            {
+              dangerousEntityRefFallback:
+                options?.dangerouslyAllowSignInWithoutUserInCatalog
+                  ? { entityRef: { name: preferredUsername } }
+                  : undefined,
+            },
+          );
+        };
+      },
+    });
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added `forwardedPreferredUsernameMatchingUserEntityName` sign-in resolver for OAuth2 Proxy auth provider that matches users based on the x-forwarded-preferred-username.

### Motivation                                                

When using OAuth2Proxy with IdPs that set the `x-forwarded-preferred-username` header (e.g. display/ preferred name in Keycloak or Azure AD), we need to map this value directly to user entity names in the Backstage catalog. 

The existing [forwardedUserMatchingUserEntityName](https://github.com/backstage/backstage/blob/4bb649d511bf0258e125f82cffd4fb7eae265287/plugins/auth-backend-module-oauth2-proxy-provider/src/resolvers.ts#L28) resolver doesn't cover the case where the **preferred name** is expected to match the Backstage user entity name. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
