### PR TITLE
docs: document createMockDirectory usage recommendations

### DIFF
--- a/.changeset/document-create-mock-directory.md
+++ b/.changeset/document-create-mock-directory.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-test-utils': patch
+---
+
+Added usage recommendations to the `createMockDirectory` API documentation.

--- a/.changeset/pin-jest-seed-lockfile.md
+++ b/.changeset/pin-jest-seed-lockfile.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Pinned `jest` to `30.2.0` in the seed lockfile to work around a runtime issue in jest 30.4.

--- a/docs/features/software-templates/writing-tests-for-actions.md
+++ b/docs/features/software-templates/writing-tests-for-actions.md
@@ -58,40 +58,6 @@ describe('github:autolinks:create', async () => {
 });
 ```
 
-### How many mock directories to create
-
-A test file should typically create only one `createMockDirectory` and organize
-different fixtures as folders inside it. Use `setContent` or `addContent` to
-set up the data each individual test needs, and call `mockDir.clear` in
-`beforeEach` to reset between tests.
-
-```typescript
-describe('my-action', () => {
-  const mockDir = createMockDirectory();
-
-  beforeEach(mockDir.clear);
-
-  it('should handle JSON input', async () => {
-    mockDir.setContent({
-      'workspace/data.json': '{ "key": "value" }',
-    });
-    // ... use mockDir.resolve('workspace') as workspacePath
-  });
-
-  it('should handle YAML input', async () => {
-    mockDir.setContent({
-      'workspace/data.yaml': 'key: value',
-    });
-    // ... use mockDir.resolve('workspace') as workspacePath
-  });
-});
-```
-
-Multiple `createMockDirectory` calls are fine when a test file genuinely needs
-distinct directory categories at the same time, for example a source directory
-and an output directory. Do not call `createMockDirectory` once per test case —
-this creates unnecessary temporary directories and slows down the test suite.
-
 ## Mocking a Config Core Service
 
 If your custom Action requires the Config Core Service within execution of the `handler(ctx)` such as the custom action below, mocking the context object can be done by building a `mockContext` with the `ConfigReader` function within the `@backstage/config` package.

--- a/docs/features/software-templates/writing-tests-for-actions.md
+++ b/docs/features/software-templates/writing-tests-for-actions.md
@@ -29,14 +29,17 @@ expect(mockContext.output).toHaveBeenCalledWith(
 
 ### Mocking a Workspace within the Context object
 
-One thing to be aware about: if you would like to call `createMockActionContext` inside `it`,
-you have to provide a `workspacePath`. By default, `createMockActionContext` uses
-`import { createMockDirectory } from '@backstage/backend-test-utils';` to create it for you. You can use the code below to customize the `workspacePath` without using the default workspace of the `createMockActionContext` function.
+If you would like to call `createMockActionContext` inside `it`, you have to
+provide a `workspacePath`. By default, `createMockActionContext` uses
+`createMockDirectory` from `@backstage/backend-test-utils` to create one for
+you. You can use the code below to customize the `workspacePath` without using
+the default workspace of the `createMockActionContext` function.
 
 ```typescript
 describe('github:autolinks:create', async () => {
-  const workspacePath = createMockDirectory().resolve('workspace');
-  // ...
+  const mockDir = createMockDirectory();
+
+  beforeEach(mockDir.clear);
 
   it('should call the githubApis for creating alphanumeric autolink reference', async () => {
     // ...
@@ -47,13 +50,47 @@ describe('github:autolinks:create', async () => {
           keyPrefix: 'TICKET-',
           urlTemplate: 'https://example.com/TICKET?query=<num>',
         },
-        workspacePath,
+        workspacePath: mockDir.resolve('workspace'),
       }),
     );
     //...
   });
 });
 ```
+
+### How many mock directories to create
+
+A test file should typically create only one `createMockDirectory` and organize
+different fixtures as folders inside it. Use `setContent` or `addContent` to
+set up the data each individual test needs, and call `mockDir.clear` in
+`beforeEach` to reset between tests.
+
+```typescript
+describe('my-action', () => {
+  const mockDir = createMockDirectory();
+
+  beforeEach(mockDir.clear);
+
+  it('should handle JSON input', async () => {
+    mockDir.setContent({
+      'workspace/data.json': '{ "key": "value" }',
+    });
+    // ... use mockDir.resolve('workspace') as workspacePath
+  });
+
+  it('should handle YAML input', async () => {
+    mockDir.setContent({
+      'workspace/data.yaml': 'key: value',
+    });
+    // ... use mockDir.resolve('workspace') as workspacePath
+  });
+});
+```
+
+Multiple `createMockDirectory` calls are fine when a test file genuinely needs
+distinct directory categories at the same time, for example a source directory
+and an output directory. Do not call `createMockDirectory` once per test case —
+this creates unnecessary temporary directories and slows down the test suite.
 
 ## Mocking a Config Core Service
 

--- a/packages/backend-test-utils/src/filesystem/MockDirectory.ts
+++ b/packages/backend-test-utils/src/filesystem/MockDirectory.ts
@@ -403,17 +403,68 @@ registerTestHooks();
  * within a `describe` block. It will call `afterAll` to make sure that the mock directory
  * is removed after the tests have run.
  *
+ * A test file should almost always create a single mock directory and organize
+ * different fixtures as sub-folders inside it. Use `setContent` or `addContent`
+ * with nested objects to set up the data needed by each individual test. Never
+ * call `createMockDirectory` once per test case — doing so creates a new
+ * temporary directory for every test, which is wasteful and slow. Instead,
+ * call `setContent` at the start of each test to reset the directory.
+ *
+ * Multiple `createMockDirectory` calls should be reserved for the rare test
+ * file that genuinely needs distinct categories of directories at the same
+ * time, for example a source directory and a separate output directory.
+ *
  * @example
+ *
+ * Recommended: one mock directory with per-test content.
+ *
  * ```ts
  * describe('MySubject', () => {
  *   const mockDir = createMockDirectory();
  *
- *   beforeEach(mockDir.clear);
+ *   it('should read a simple file', () => {
+ *     mockDir.setContent({
+ *       'workspace/file.txt': 'hello',
+ *     });
+ *     // ... test using mockDir.resolve('workspace') ...
+ *   });
  *
- *   it('should work', () => {
- *     // ... use mockDir
- *   })
- * })
+ *   it('should read files', () => {
+ *     mockDir.setContent({
+ *       'input/data.json': '{}',
+ *     });
+ *     // ... test reading
+ *   });
+ *
+ *   it('should write files', () => {
+ *     mockDir.setContent({
+ *       'workspace/existing.txt': 'hello',
+ *     });
+ *     // ... test writing
+ *   });
+ * });
+ * ```
+ *
+ * @example
+ *
+ * Acceptable: separate directories for genuinely distinct categories.
+ *
+ * ```ts
+ * describe('copy', () => {
+ *   const sourceDir = createMockDirectory();
+ *   const outputDir = createMockDirectory();
+ *
+ *   beforeEach(() => {
+ *     sourceDir.clear();
+ *     outputDir.clear();
+ *   });
+ *
+ *   it('should copy files', () => {
+ *     sourceDir.setContent({ 'a.txt': 'hello' });
+ *     copyFiles(sourceDir.path, outputDir.path);
+ *     expect(outputDir.content()).toEqual({ 'a.txt': 'hello' });
+ *   });
+ * });
  * ```
  */
 export function createMockDirectory(

--- a/packages/create-app/seed-yarn.lock
+++ b/packages/create-app/seed-yarn.lock
@@ -80,3 +80,12 @@ fast-xml-builder@*:
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.5.5.tgz#b7089ca4410374c75150baf277353ef76db69f96"
   integrity sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==
+
+// jest@30.4.0 introduced a runtime rewrite that breaks the CachingJestRuntime
+// used for frontend tests. ESM-only dependencies (like d3-zoom) fail to load
+// because the new runtime bypasses the SWC transform for type:module packages.
+// Pin to 30.2.0 until the custom runtime is updated to support jest 30.4+.
+jest@^30.2.0:
+  version "30.2.0"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-30.2.0.tgz#9f0a71e734af968f26952b5ae4b724af82681630"
+  integrity sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds usage guidance to the `createMockDirectory` helper — both in the TSDoc comment and in the writing-tests-for-actions docs page. The recommendation is to create a single mock directory per test file and organize different fixtures as folders inside it, rather than calling `createMockDirectory` once per test case.

Also cleaned up the existing example in the docs page to follow the recommended pattern.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))