### PR TITLE
fix(catalog-backend): use INNER JOIN for filtered entity facets

### DIFF
--- a/.changeset/facets-inner-join.md
+++ b/.changeset/facets-inner-join.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Improved the performance of the entity facets endpoint when filters are applied. The filtered entity set is now combined with the search table through an inner join rather than a `WHERE entity_id IN (subquery)`. Results are unchanged; on large catalogs the query planner is able to choose dramatically cheaper plans, with measured improvements ranging from roughly 1.2× on already-fast cases to 7× or more on high-cardinality facets.

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -707,7 +707,17 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
         knex: this.database,
       });
 
-      query.whereIn('search.entity_id', entityIdSubquery);
+      // Use INNER JOIN rather than `WHERE search.entity_id IN (...)`. The
+      // results are the same but the JOIN form gives the planner more
+      // freedom in join shape and ordering. On PostgreSQL with large
+      // search tables, the IN form tends to materialize the full filtered
+      // entity set up front and spill to temp; the JOIN form lets the
+      // planner pick a much cheaper plan based on actual selectivities.
+      query.innerJoin(
+        entityIdSubquery.as('filtered_entities'),
+        'search.entity_id',
+        'filtered_entities.entity_id',
+      );
     }
 
     const rows = await query;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Replace the `WHERE search.entity_id IN (...)` form with an INNER JOIN against the filtered `final_entities` subquery in `DefaultEntitiesCatalog#facets`. The results are unchanged; the change just gives the query planner more freedom in join shape and ordering, which on large catalogs leads to dramatically cheaper plans.

Originally proposed in #34154.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes _(existing facets tests pass on MySQL/PG18/PG14/SQLite)_
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.