### PR TITLE
fix(kubernetes): use useEntityOptional to prevent crash in new frontend system

### DIFF
--- a/.changeset/fix-kubernetes-entity-context.md
+++ b/.changeset/fix-kubernetes-entity-context.md
@@ -1,0 +1,10 @@
+---
+'@backstage/plugin-catalog-react': patch
+'@backstage/plugin-kubernetes': patch
+---
+
+Added `useEntityOptional` hook that returns `undefined` instead of throwing
+when called outside of an `EntityProvider`. Fixed `KubernetesContentPage` to
+use `useEntityOptional` to prevent the "Entity context is not available" error
+in the new frontend system, where `EntityContentBlueprint` loaders are
+evaluated outside of `EntityProvider` when building sidebar/nav items.

--- a/plugins/catalog-react/src/hooks/index.ts
+++ b/plugins/catalog-react/src/hooks/index.ts
@@ -15,6 +15,7 @@
  */
 export {
   useEntity,
+  useEntityOptional,
   EntityProvider,
   AsyncEntityProvider,
   useAsyncEntity,

--- a/plugins/catalog-react/src/hooks/useEntity.test.tsx
+++ b/plugins/catalog-react/src/hooks/useEntity.test.tsx
@@ -19,6 +19,7 @@ import { renderHook } from '@testing-library/react';
 import {
   useEntity,
   useAsyncEntity,
+  useEntityOptional,
   EntityProvider,
   AsyncEntityProvider,
 } from './useEntity';
@@ -169,5 +170,52 @@ describe('useAsyncEntity', () => {
     expect(
       analyticsSpy.captureEvent.mock.calls[0][0].context,
     ).not.toHaveProperty('entityRef');
+  });
+});
+
+describe('useEntityOptional', () => {
+  it('should return undefined when called outside of an EntityProvider', () => {
+    const { result } = renderHook(() => useEntityOptional());
+    expect(result.current).toBeUndefined();
+  });
+
+  it('should return undefined when EntityProvider has no entity', () => {
+    const { result } = renderHook(() => useEntityOptional(), {
+      wrapper: ({ children }: PropsWithChildren<{}>) => (
+        <EntityProvider children={children} />
+      ),
+    });
+    expect(result.current).toBeUndefined();
+  });
+
+  it('should return undefined when AsyncEntityProvider has no entity', () => {
+    const { result } = renderHook(() => useEntityOptional(), {
+      wrapper: ({ children }: PropsWithChildren<{}>) => (
+        <AsyncEntityProvider loading={false} children={children} />
+      ),
+    });
+    expect(result.current).toBeUndefined();
+  });
+
+  it('should return the entity when EntityProvider has one', () => {
+    const { result } = renderHook(() => useEntityOptional(), {
+      wrapper: ({ children }: PropsWithChildren<{}>) => (
+        <EntityProvider entity={entity} children={children} />
+      ),
+    });
+    expect(result.current).toBe(entity);
+  });
+
+  it('should return the entity when AsyncEntityProvider has one', () => {
+    const { result } = renderHook(() => useEntityOptional(), {
+      wrapper: ({ children }: PropsWithChildren<{}>) => (
+        <AsyncEntityProvider
+          loading={false}
+          entity={entity}
+          children={children}
+        />
+      ),
+    });
+    expect(result.current).toBe(entity);
   });
 });

--- a/plugins/catalog-react/src/hooks/useEntity.tsx
+++ b/plugins/catalog-react/src/hooks/useEntity.tsx
@@ -163,9 +163,9 @@ export function useAsyncEntity<
  *
  * @public
  */
-export function useEntityOptional<
-  TEntity extends Entity = Entity,
->(): TEntity | undefined {
+export function useEntityOptional<TEntity extends Entity = Entity>():
+  | TEntity
+  | undefined {
   const versionedHolder = useVersionedContext<{ 1: EntityLoadingStatus }>(
     'entity-context',
   );

--- a/plugins/catalog-react/src/hooks/useEntity.tsx
+++ b/plugins/catalog-react/src/hooks/useEntity.tsx
@@ -104,7 +104,7 @@ export const EntityProvider = (props: EntityProviderProps) => (
  *
  * @public
  */
-export function useEntity<TEntity extends Entity = Entity>(): {
+ export function useEntityOptional<TEntity extends Entity = Entity>(): TEntity | undefined {  
   entity: TEntity;
 } {
   const versionedHolder = useVersionedContext<{ 1: EntityLoadingStatus }>(

--- a/plugins/catalog-react/src/hooks/useEntity.tsx
+++ b/plugins/catalog-react/src/hooks/useEntity.tsx
@@ -152,3 +152,32 @@ export function useAsyncEntity<
   const { entity, loading, error, refresh } = value;
   return { entity: entity as TEntity, loading, error, refresh };
 }
+
+/**
+ * Grab the current entity from the context without throwing.
+ * Returns undefined if the entity context is not available or the entity
+ * has not yet been loaded. Use this hook when a component may render outside
+ * of an EntityLayout, such as in the new frontend system where
+ * EntityContentBlueprint loaders are evaluated outside of EntityProvider
+ * when building sidebar/nav items.
+ *
+ * @public
+ */
+export function useEntityOptional<
+  TEntity extends Entity = Entity,
+>(): TEntity | undefined {
+  const versionedHolder = useVersionedContext<{ 1: EntityLoadingStatus }>(
+    'entity-context',
+  );
+
+  if (!versionedHolder) {
+    return undefined;
+  }
+
+  const value = versionedHolder.atVersion(1);
+  if (!value) {
+    return undefined;
+  }
+
+  return value.entity as TEntity | undefined;
+}

--- a/plugins/kubernetes/src/alpha/KubernetesContentPage.tsx
+++ b/plugins/kubernetes/src/alpha/KubernetesContentPage.tsx
@@ -13,11 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import { useEntity } from '@backstage/plugin-catalog-react';
+import { useEntityOptional } from '@backstage/plugin-catalog-react';
 import { KubernetesContent } from '../KubernetesContent';
 
 export function KubernetesContentPage() {
-  const { entity } = useEntity();
+  // useEntityOptional is used instead of useEntity to avoid the
+  // "Entity context is not available" error in the new frontend system,
+  // where the EntityContentBlueprint loader is evaluated outside of
+  // EntityProvider when building the sidebar/nav items.
+  // In the legacy plugin system this is a no-op: the component is always
+  // mounted inside EntityLayout so the entity is always available.
+  const entity = useEntityOptional();
+
+  if (!entity) return null;
+
   return <KubernetesContent entity={entity} />;
 }

--- a/plugins/kubernetes/src/alpha/KubernetesContentPage.tsx
+++ b/plugins/kubernetes/src/alpha/KubernetesContentPage.tsx
@@ -13,19 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useEntityOptional } from '@backstage/plugin-catalog-react';
+import { useEntity } from '@backstage/plugin-catalog-react';
 import { KubernetesContent } from '../KubernetesContent';
 
 export function KubernetesContentPage() {
-  // useEntityOptional is used instead of useEntity to avoid the
-  // "Entity context is not available" error in the new frontend system,
-  // where the EntityContentBlueprint loader is evaluated outside of
-  // EntityProvider when building the sidebar/nav items.
-  // In the legacy plugin system this is a no-op: the component is always
-  // mounted inside EntityLayout so the entity is always available.
-  const entity = useEntityOptional();
-
-  if (!entity) return null;
-
-  return <KubernetesContent entity={entity} />;
+  try {
+    const { entity } = useEntity();
+    return <KubernetesContent entity={entity} />;
+  } catch (e) {
+    if (e instanceof Error && e.message === 'Entity context is not available') {
+      return null;
+    }
+    throw e;
+  }
 }

--- a/plugins/kubernetes/src/alpha/KubernetesContentPage.tsx
+++ b/plugins/kubernetes/src/alpha/KubernetesContentPage.tsx
@@ -13,17 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useEntity } from '@backstage/plugin-catalog-react';
+import { useEntityOptional } from '@backstage/plugin-catalog-react';
 import { KubernetesContent } from '../KubernetesContent';
 
 export function KubernetesContentPage() {
-  try {
-    const { entity } = useEntity();
-    return <KubernetesContent entity={entity} />;
-  } catch (e) {
-    if (e instanceof Error && e.message === 'Entity context is not available') {
-      return null;
-    }
-    throw e;
-  }
+  // useEntityOptional is used instead of useEntity to avoid the
+  // "Entity context is not available" error in the new frontend system,
+  // where the EntityContentBlueprint loader is evaluated outside of
+  // EntityProvider when building the sidebar/nav items.
+  // In the legacy plugin system this is a no-op: the component is always
+  // mounted inside EntityLayout so the entity is always available.
+  const entity = useEntityOptional();
+
+  if (!entity) return null;
+
+  return <KubernetesContent entity={entity} />;
 }


### PR DESCRIPTION
Fixes #34148

In the new Backstage frontend system, the EntityContentBlueprint loader
is evaluated outside of EntityProvider when building sidebar/nav items,
causing `useEntity()` to throw "Entity context is not available".

Replacing `useEntity` with `useEntityOptional` + an early null return
fixes the crash while remaining fully backwards compatible with the
legacy plugin system, where the component is always mounted inside
EntityLayout and the entity is always available.