### PR TITLE
catalog-backend: drive paginated entity ordering from search-by-key

### DIFF
--- a/.changeset/entities-order-driver.md
+++ b/.changeset/entities-order-driver.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend': patch
 ---
 
-Restructured the entity listing endpoint so that, when a sort field is specified, the search-by-key index drives the query rather than being side-joined onto `final_entities`. This lets PostgreSQL walk the `(key, value, entity_id)` index in already-sorted order and short-circuit on `LIMIT`, reducing typical broad-filter paginated list times from seconds to milliseconds. Behavior change: entities that lack the order field are now excluded from sorted results rather than appearing at the end.
+Restructured the entity listing endpoint so that, when a sort field is specified, the search-by-key index drives the query rather than being side-joined onto `final_entities`. This lets PostgreSQL walk the `(key, value, entity_id)` index in already-sorted order and short-circuit on `LIMIT`, reducing typical broad-filter paginated list times from seconds to milliseconds. Entities that lack the sort field still appear at the end of sorted results (NULLS LAST semantics preserved), ordered by `entity_id`.

--- a/.changeset/entities-order-driver.md
+++ b/.changeset/entities-order-driver.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Restructured the entity listing endpoint so that, when a sort field is specified, the search-by-key index drives the query rather than being side-joined onto `final_entities`. This lets PostgreSQL walk the `(key, value, entity_id)` index in already-sorted order and short-circuit on `LIMIT`, reducing typical broad-filter paginated list times from seconds to milliseconds. Behavior change: entities that lack the order field are now excluded from sorted results rather than appearing at the end.

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
@@ -869,6 +869,57 @@ describe('DefaultEntitiesCatalog', () => {
         ]);
       },
     );
+
+    it.each(databases.eachSupportedId())(
+      'treats a null sort-field value the same as a missing sort field, %p',
+      async databaseId => {
+        await createDatabase(databaseId);
+
+        // n1 has spec.b with a real value (Phase 1)
+        // n2 has spec.b explicitly set to null — buildEntitySearch stores value=NULL
+        // n3 has no spec.b at all
+        // n2 and n3 must both end up in the NULLS-LAST bucket (Phase 2),
+        // ordered by entity_id, regardless of primary sort direction.
+        await addEntityToSearch({
+          apiVersion: 'a',
+          kind: 'k',
+          metadata: { name: 'n1' },
+          spec: { b: 'alpha' },
+        });
+        await addEntityToSearch({
+          apiVersion: 'a',
+          kind: 'k',
+          metadata: { name: 'n2', uid: 'aaaa-n2' },
+          spec: { b: null },
+        });
+        await addEntityToSearch({
+          apiVersion: 'a',
+          kind: 'k',
+          metadata: { name: 'n3', uid: 'bbbb-n3' },
+        });
+
+        const catalog = new DefaultEntitiesCatalog({
+          database: knex,
+          logger: mockServices.logger.mock(),
+          stitcher,
+        });
+
+        async function page(order: 'asc' | 'desc'): Promise<string[]> {
+          const r = await catalog.entities({
+            order: [{ field: 'spec.b', order }],
+            credentials: mockCredentials.none(),
+          });
+          return entitiesResponseToObjects(r.entities).map(
+            e => e!.metadata.name,
+          );
+        }
+
+        // n2 (null value) and n3 (missing key) must sort together after n1,
+        // ordered by entity_id ASC, regardless of primary direction
+        await expect(page('asc')).resolves.toEqual(['n1', 'n2', 'n3']);
+        await expect(page('desc')).resolves.toEqual(['n1', 'n2', 'n3']);
+      },
+    );
   });
 
   describe('entitiesBatch', () => {

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
@@ -741,6 +741,134 @@ describe('DefaultEntitiesCatalog', () => {
         ).resolves.toEqual(['n4', 'n3', 'n1', 'n2']);
       },
     );
+
+    it.each(databases.eachSupportedId())(
+      'paginates correctly through single-field ordering, %p',
+      async databaseId => {
+        await createDatabase(databaseId);
+
+        // All four entities have metadata.name — fast path uses Phase 1 only
+        for (const name of ['n1', 'n2', 'n3', 'n4']) {
+          await addEntityToSearch({
+            apiVersion: 'a',
+            kind: 'k',
+            metadata: { name },
+          });
+        }
+
+        const catalog = new DefaultEntitiesCatalog({
+          database: knex,
+          logger: mockServices.logger.mock(),
+          stitcher,
+        });
+
+        async function page(limit: number, offset?: number): Promise<string[]> {
+          const r = await catalog.entities({
+            order: [{ field: 'metadata.name', order: 'asc' }],
+            pagination: { limit, offset },
+            credentials: mockCredentials.none(),
+          });
+          return entitiesResponseToObjects(r.entities).map(
+            e => e!.metadata.name,
+          );
+        }
+
+        async function hasNext(
+          limit: number,
+          offset?: number,
+        ): Promise<boolean> {
+          const r = await catalog.entities({
+            order: [{ field: 'metadata.name', order: 'asc' }],
+            pagination: { limit, offset },
+            credentials: mockCredentials.none(),
+          });
+          return r.pageInfo.hasNextPage;
+        }
+
+        await expect(page(2)).resolves.toEqual(['n1', 'n2']);
+        expect(await hasNext(2)).toBe(true);
+
+        await expect(page(2, 2)).resolves.toEqual(['n3', 'n4']);
+        expect(await hasNext(2, 2)).toBe(false);
+
+        await expect(page(2, 1)).resolves.toEqual(['n2', 'n3']);
+        expect(await hasNext(2, 1)).toBe(true);
+
+        await expect(page(100)).resolves.toEqual(['n1', 'n2', 'n3', 'n4']);
+      },
+    );
+
+    it.each(databases.eachSupportedId())(
+      'paginates across the Phase 1 / Phase 2 boundary, %p',
+      async databaseId => {
+        await createDatabase(databaseId);
+
+        // n1 and n2 have spec.b (Phase 1); n3 and n4 do not (Phase 2).
+        // Explicit UIDs pin Phase 2 ordering (entity_id ASC) to a known sequence.
+        await addEntityToSearch({
+          apiVersion: 'a',
+          kind: 'k',
+          metadata: { name: 'n1' },
+          spec: { b: 'alpha' },
+        });
+        await addEntityToSearch({
+          apiVersion: 'a',
+          kind: 'k',
+          metadata: { name: 'n2' },
+          spec: { b: 'beta' },
+        });
+        await addEntityToSearch({
+          apiVersion: 'a',
+          kind: 'k',
+          metadata: { name: 'n3', uid: 'aaaa-n3' },
+        });
+        await addEntityToSearch({
+          apiVersion: 'a',
+          kind: 'k',
+          metadata: { name: 'n4', uid: 'bbbb-n4' },
+        });
+
+        const catalog = new DefaultEntitiesCatalog({
+          database: knex,
+          logger: mockServices.logger.mock(),
+          stitcher,
+        });
+
+        async function page(
+          limit: number,
+          offset?: number,
+          order: 'asc' | 'desc' = 'asc',
+        ): Promise<string[]> {
+          const r = await catalog.entities({
+            order: [{ field: 'spec.b', order }],
+            pagination: { limit, offset },
+            credentials: mockCredentials.none(),
+          });
+          return entitiesResponseToObjects(r.entities).map(
+            e => e!.metadata.name,
+          );
+        }
+
+        // Page that straddles the Phase 1 / Phase 2 boundary
+        await expect(page(3)).resolves.toEqual(['n1', 'n2', 'n3']);
+        await expect(page(3, 1)).resolves.toEqual(['n2', 'n3', 'n4']);
+
+        // Phase 2 entities (no spec.b) are always ordered ASC by entity_id
+        // regardless of the primary sort direction
+        await expect(page(4, 0, 'asc')).resolves.toEqual([
+          'n1',
+          'n2',
+          'n3',
+          'n4',
+        ]);
+        await expect(page(4, 0, 'desc')).resolves.toEqual([
+          'n2',
+          'n1',
+          'n3',
+          'n4',
+        ]);
+      },
+    );
   });
 
   describe('entitiesBatch', () => {

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -124,27 +124,19 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
     const { limit, offset } = parsePagination(request?.pagination);
     const primaryOrder = request?.order?.[0];
 
-    // When an order field is specified we run a two-phase fetch:
+    // When exactly one order field is specified we run a two-phase fetch
+    // that drives from the search-by-key index for that field. The index
+    // walks rows in already-sorted order, so the planner can short-circuit
+    // on LIMIT instead of having to materialise and sort the full filtered
+    // set. Phase 2 appends entities that lack the order field (NULLS LAST)
+    // and is skipped when phase 1 already fills the request.
     //
-    //   1. A "with-field" phase that drives from the search-by-key index for
-    //      the order column. Because that index walks rows already in sort
-    //      order, the planner can short-circuit on LIMIT instead of having
-    //      to materialize and sort the full filtered set. Entities that
-    //      lack the order field are *excluded* from this phase.
-    //
-    //   2. A "without-field" phase that picks up the entities that lack the
-    //      order field, in entity_id order, to preserve the established
-    //      `NULLS LAST` semantics. This phase is only consulted when the
-    //      first phase did not produce enough rows to satisfy
-    //      `offset + limit + 1` -- in the common UI case where every entity
-    //      has the order field (e.g. `metadata.name`), the second phase is
-    //      never run.
-    //
-    // The previous shape used a LEFT OUTER JOIN to side-fetch the order
-    // column and sorted afterwards, which on broad filters was orders of
-    // magnitude slower because the planner could not short-circuit on LIMIT.
+    // Multi-field ordering falls back to the original LEFT JOIN shape
+    // because tie-breaking on a second field requires materialisation of
+    // the full set anyway.
+    const useFastPath = primaryOrder && (request?.order?.length ?? 0) <= 1;
     let rows: DbFinalEntitiesRow[];
-    if (primaryOrder) {
+    if (useFastPath) {
       rows = await this.runOrderedEntitiesQuery(
         request!,
         primaryOrder,
@@ -152,10 +144,22 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
         offset,
       );
     } else {
-      let entitiesQuery: Knex.QueryBuilder<DbFinalEntitiesRow> =
-        db<DbFinalEntitiesRow>('final_entities')
-          .select('final_entities.*')
-          .whereNotNull('final_entities.final_entity');
+      let entitiesQuery =
+        db<DbFinalEntitiesRow>('final_entities').select('final_entities.*');
+
+      request?.order?.forEach(({ field }, index) => {
+        const alias = `order_${index}`;
+        entitiesQuery = entitiesQuery.leftOuterJoin(
+          { [alias]: 'search' },
+          function search(inner) {
+            inner
+              .on(`${alias}.entity_id`, 'final_entities.entity_id')
+              .andOn(`${alias}.key`, db.raw('?', [field]));
+          },
+        );
+      });
+
+      entitiesQuery = entitiesQuery.whereNotNull('final_entities.final_entity');
 
       if (request?.filter) {
         entitiesQuery = applyEntityFilterToQuery({
@@ -166,7 +170,30 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
         });
       }
 
-      entitiesQuery = entitiesQuery.orderBy('final_entities.entity_ref', 'asc');
+      if (request?.order) {
+        request.order.forEach(({ order }, index) => {
+          if (db.client.config.client === 'pg') {
+            entitiesQuery = entitiesQuery.orderBy([
+              { column: `order_${index}.value`, order, nulls: 'last' },
+            ]);
+          } else {
+            entitiesQuery = entitiesQuery.orderBy([
+              {
+                column: `order_${index}.value`,
+                order: undefined,
+                nulls: 'last',
+              },
+              { column: `order_${index}.value`, order },
+            ]);
+          }
+        });
+        entitiesQuery.orderBy('final_entities.entity_id', 'asc');
+      } else {
+        entitiesQuery = entitiesQuery.orderBy(
+          'final_entities.entity_ref',
+          'asc',
+        );
+      }
 
       if (limit !== undefined) {
         entitiesQuery = entitiesQuery.limit(limit + 1);
@@ -279,7 +306,7 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
       .whereNotExists(qb =>
         qb
           .from('search')
-          .where('search.entity_id', db.raw('"final_entities"."entity_id"'))
+          .where('search.entity_id', db.ref('final_entities.entity_id'))
           .andWhere('search.key', primaryOrder.field),
       );
     withoutField = applyFilter(withoutField);

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -312,7 +312,7 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
     withoutField = applyFilter(withoutField);
     withoutField = withoutField.orderBy(
       'final_entities.entity_id',
-      primaryOrder.order,
+      'asc',  // NULL group always stable-sorted ASC regardless of primary direction
     );
     if (limit !== undefined) {
       // Phase 2 only contributes the rows that phase 1 didn't cover.

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -312,7 +312,7 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
     withoutField = applyFilter(withoutField);
     withoutField = withoutField.orderBy(
       'final_entities.entity_id',
-      'asc',  // NULL group always stable-sorted ASC regardless of primary direction
+      'asc', // NULL group always stable-sorted ASC regardless of primary direction
     );
     if (limit !== undefined) {
       // Phase 2 only contributes the rows that phase 1 didn't cover.

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -123,22 +123,30 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
     const db = this.database;
     const { limit, offset } = parsePagination(request?.pagination);
 
-    let entitiesQuery =
-      db<DbFinalEntitiesRow>('final_entities').select('final_entities.*');
+    // When an order field is specified, build the query so that the search
+    // table for that key is the driving table. The `(key, value, entity_id)`
+    // index then walks rows already in sort order, letting LIMIT short-circuit
+    // before the entire filtered set is materialized. The previous shape used
+    // a LEFT JOIN to fetch the order column for every matched row and sorted
+    // afterwards, which was orders of magnitude slower on broad filters.
+    const primaryOrder = request?.order?.[0];
 
-    request?.order?.forEach(({ field }, index) => {
-      const alias = `order_${index}`;
-      entitiesQuery = entitiesQuery.leftOuterJoin(
-        { [alias]: 'search' },
-        function search(inner) {
-          inner
-            .on(`${alias}.entity_id`, 'final_entities.entity_id')
-            .andOn(`${alias}.key`, db.raw('?', [field]));
-        },
-      );
-    });
-
-    entitiesQuery = entitiesQuery.whereNotNull('final_entities.final_entity');
+    let entitiesQuery: Knex.QueryBuilder<DbFinalEntitiesRow>;
+    if (primaryOrder) {
+      entitiesQuery = db('search as order_0')
+        .innerJoin(
+          'final_entities',
+          'final_entities.entity_id',
+          'order_0.entity_id',
+        )
+        .where('order_0.key', primaryOrder.field)
+        .whereNotNull('final_entities.final_entity')
+        .select('final_entities.*');
+    } else {
+      entitiesQuery = db<DbFinalEntitiesRow>('final_entities')
+        .select('final_entities.*')
+        .whereNotNull('final_entities.final_entity');
+    }
 
     if (request?.filter) {
       entitiesQuery = applyEntityFilterToQuery({
@@ -149,27 +157,22 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
       });
     }
 
-    request?.order?.forEach(({ order }, index) => {
+    if (primaryOrder) {
+      const { order } = primaryOrder;
       if (db.client.config.client === 'pg') {
-        // pg correctly orders by the column value and handling nulls in one go
         entitiesQuery = entitiesQuery.orderBy([
-          { column: `order_${index}.value`, order, nulls: 'last' },
+          { column: 'order_0.value', order, nulls: 'last' },
+          { column: 'final_entities.entity_id', order: 'asc' },
         ]);
       } else {
-        // sqlite and mysql translate the above statement ONLY into "order by (value is null) asc"
-        // no matter what the order is, for some reason, so we have to manually add back the statement
-        // that translates to "order by value <order>" while avoiding to give an order
         entitiesQuery = entitiesQuery.orderBy([
-          { column: `order_${index}.value`, order: undefined, nulls: 'last' },
-          { column: `order_${index}.value`, order },
+          { column: 'order_0.value', order: undefined, nulls: 'last' },
+          { column: 'order_0.value', order },
+          { column: 'final_entities.entity_id', order: 'asc' },
         ]);
       }
-    });
-
-    if (!request?.order) {
-      entitiesQuery = entitiesQuery.orderBy('final_entities.entity_ref', 'asc'); // default sort
     } else {
-      entitiesQuery.orderBy('final_entities.entity_id', 'asc'); // stable sort
+      entitiesQuery = entitiesQuery.orderBy('final_entities.entity_ref', 'asc');
     }
 
     if (limit !== undefined) {
@@ -179,7 +182,7 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
       entitiesQuery = entitiesQuery.offset(offset);
     }
 
-    let rows = await entitiesQuery;
+    let rows: DbFinalEntitiesRow[] = await entitiesQuery;
     let pageInfo: DbPageInfo;
     if (limit === undefined || rows.length <= limit) {
       pageInfo = { hasNextPage: false };

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -122,67 +122,62 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
   async entities(request?: EntitiesRequest): Promise<EntitiesResponse> {
     const db = this.database;
     const { limit, offset } = parsePagination(request?.pagination);
-
-    // When an order field is specified, build the query so that the search
-    // table for that key is the driving table. The `(key, value, entity_id)`
-    // index then walks rows already in sort order, letting LIMIT short-circuit
-    // before the entire filtered set is materialized. The previous shape used
-    // a LEFT JOIN to fetch the order column for every matched row and sorted
-    // afterwards, which was orders of magnitude slower on broad filters.
     const primaryOrder = request?.order?.[0];
 
-    let entitiesQuery: Knex.QueryBuilder<DbFinalEntitiesRow>;
+    // When an order field is specified we run a two-phase fetch:
+    //
+    //   1. A "with-field" phase that drives from the search-by-key index for
+    //      the order column. Because that index walks rows already in sort
+    //      order, the planner can short-circuit on LIMIT instead of having
+    //      to materialize and sort the full filtered set. Entities that
+    //      lack the order field are *excluded* from this phase.
+    //
+    //   2. A "without-field" phase that picks up the entities that lack the
+    //      order field, in entity_id order, to preserve the established
+    //      `NULLS LAST` semantics. This phase is only consulted when the
+    //      first phase did not produce enough rows to satisfy
+    //      `offset + limit + 1` -- in the common UI case where every entity
+    //      has the order field (e.g. `metadata.name`), the second phase is
+    //      never run.
+    //
+    // The previous shape used a LEFT OUTER JOIN to side-fetch the order
+    // column and sorted afterwards, which on broad filters was orders of
+    // magnitude slower because the planner could not short-circuit on LIMIT.
+    let rows: DbFinalEntitiesRow[];
     if (primaryOrder) {
-      entitiesQuery = db('search as order_0')
-        .innerJoin(
-          'final_entities',
-          'final_entities.entity_id',
-          'order_0.entity_id',
-        )
-        .where('order_0.key', primaryOrder.field)
-        .whereNotNull('final_entities.final_entity')
-        .select('final_entities.*');
+      rows = await this.runOrderedEntitiesQuery(
+        request!,
+        primaryOrder,
+        limit,
+        offset,
+      );
     } else {
-      entitiesQuery = db<DbFinalEntitiesRow>('final_entities')
-        .select('final_entities.*')
-        .whereNotNull('final_entities.final_entity');
-    }
+      let entitiesQuery: Knex.QueryBuilder<DbFinalEntitiesRow> =
+        db<DbFinalEntitiesRow>('final_entities')
+          .select('final_entities.*')
+          .whereNotNull('final_entities.final_entity');
 
-    if (request?.filter) {
-      entitiesQuery = applyEntityFilterToQuery({
-        filter: request.filter,
-        targetQuery: entitiesQuery,
-        onEntityIdField: 'final_entities.entity_id',
-        knex: db,
-      });
-    }
-
-    if (primaryOrder) {
-      const { order } = primaryOrder;
-      if (db.client.config.client === 'pg') {
-        entitiesQuery = entitiesQuery.orderBy([
-          { column: 'order_0.value', order, nulls: 'last' },
-          { column: 'final_entities.entity_id', order: 'asc' },
-        ]);
-      } else {
-        entitiesQuery = entitiesQuery.orderBy([
-          { column: 'order_0.value', order: undefined, nulls: 'last' },
-          { column: 'order_0.value', order },
-          { column: 'final_entities.entity_id', order: 'asc' },
-        ]);
+      if (request?.filter) {
+        entitiesQuery = applyEntityFilterToQuery({
+          filter: request.filter,
+          targetQuery: entitiesQuery,
+          onEntityIdField: 'final_entities.entity_id',
+          knex: db,
+        });
       }
-    } else {
+
       entitiesQuery = entitiesQuery.orderBy('final_entities.entity_ref', 'asc');
+
+      if (limit !== undefined) {
+        entitiesQuery = entitiesQuery.limit(limit + 1);
+      }
+      if (offset !== undefined) {
+        entitiesQuery = entitiesQuery.offset(offset);
+      }
+
+      rows = await entitiesQuery;
     }
 
-    if (limit !== undefined) {
-      entitiesQuery = entitiesQuery.limit(limit + 1);
-    }
-    if (offset !== undefined) {
-      entitiesQuery = entitiesQuery.offset(offset);
-    }
-
-    let rows: DbFinalEntitiesRow[] = await entitiesQuery;
     let pageInfo: DbPageInfo;
     if (limit === undefined || rows.length <= limit) {
       pageInfo = { hasNextPage: false };
@@ -212,6 +207,100 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
       ),
       pageInfo,
     };
+  }
+
+  /**
+   * Two-phase fetch used when the caller has specified an order field.
+   * See entities() for a longer description of the rationale.
+   */
+  private async runOrderedEntitiesQuery(
+    request: EntitiesRequest,
+    primaryOrder: EntityOrder,
+    limit: number | undefined,
+    offset: number | undefined,
+  ): Promise<DbFinalEntitiesRow[]> {
+    const db = this.database;
+    const isPg = db.client.config.client === 'pg';
+    const wantedRows =
+      limit === undefined ? Number.MAX_SAFE_INTEGER : (offset ?? 0) + limit + 1;
+
+    const applyFilter = <T extends object>(
+      query: Knex.QueryBuilder<T>,
+    ): Knex.QueryBuilder<T> => {
+      if (!request.filter) {
+        return query;
+      }
+      return applyEntityFilterToQuery({
+        filter: request.filter,
+        targetQuery: query,
+        onEntityIdField: 'final_entities.entity_id',
+        knex: db,
+      });
+    };
+
+    // Phase 1 -- entities that have the order field, walked in sort order.
+    let withField = db('search as order_0')
+      .innerJoin(
+        'final_entities',
+        'final_entities.entity_id',
+        'order_0.entity_id',
+      )
+      .where('order_0.key', primaryOrder.field)
+      .whereNotNull('final_entities.final_entity')
+      .select<DbFinalEntitiesRow[]>('final_entities.*');
+    withField = applyFilter(withField);
+    withField = isPg
+      ? withField.orderBy([
+          { column: 'order_0.value', order: primaryOrder.order, nulls: 'last' },
+          { column: 'final_entities.entity_id', order: 'asc' },
+        ])
+      : withField.orderBy([
+          { column: 'order_0.value', order: undefined, nulls: 'last' },
+          { column: 'order_0.value', order: primaryOrder.order },
+          { column: 'final_entities.entity_id', order: 'asc' },
+        ]);
+    if (wantedRows < Number.MAX_SAFE_INTEGER) {
+      withField = withField.limit(wantedRows);
+    }
+    const withFieldRows = await withField;
+
+    // If phase 1 already covered everything we asked for, skip the second
+    // phase entirely. This is the common UI case where every entity in the
+    // filtered set has the order field.
+    if (withFieldRows.length >= wantedRows) {
+      const skip = offset ?? 0;
+      return withFieldRows.slice(skip, skip + (limit ?? wantedRows) + 1);
+    }
+
+    // Phase 2 -- entities that lack the order field, appended after.
+    let withoutField = db<DbFinalEntitiesRow>('final_entities')
+      .select<DbFinalEntitiesRow[]>('final_entities.*')
+      .whereNotNull('final_entities.final_entity')
+      .whereNotExists(qb =>
+        qb
+          .from('search')
+          .where('search.entity_id', db.raw('"final_entities"."entity_id"'))
+          .andWhere('search.key', primaryOrder.field),
+      );
+    withoutField = applyFilter(withoutField);
+    withoutField = withoutField.orderBy(
+      'final_entities.entity_id',
+      primaryOrder.order,
+    );
+    if (limit !== undefined) {
+      // Phase 2 only contributes the rows that phase 1 didn't cover.
+      const remaining =
+        wantedRows - Math.min(withFieldRows.length, (offset ?? 0) + limit + 1);
+      withoutField = withoutField.limit(Math.max(0, remaining));
+    }
+    const withoutFieldRows = await withoutField;
+
+    const combined = [...withFieldRows, ...withoutFieldRows];
+    if (limit === undefined) {
+      return combined;
+    }
+    const skip = offset ?? 0;
+    return combined.slice(skip, skip + limit + 1);
   }
 
   async entitiesBatch(

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -265,7 +265,12 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
       });
     };
 
-    // Phase 1 -- entities that have the order field, walked in sort order.
+    // Phase 1 -- entities that have a non-NULL value for the order field.
+    // Rows where the key exists but value IS NULL (e.g. the entity field is
+    // explicitly null, or exceeded MAX_VALUE_LENGTH in buildEntitySearch) are
+    // excluded here so they fall through to Phase 2 and sort in the same
+    // NULLS-LAST bucket as entities that have no row for the key at all —
+    // preserving the semantics of the previous LEFT JOIN approach.
     let withField = db('search as order_0')
       .innerJoin(
         'final_entities',
@@ -273,6 +278,7 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
         'order_0.entity_id',
       )
       .where('order_0.key', primaryOrder.field)
+      .whereNotNull('order_0.value')
       .whereNotNull('final_entities.final_entity')
       .select<DbFinalEntitiesRow[]>('final_entities.*');
     withField = applyFilter(withField);
@@ -307,7 +313,8 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
         qb
           .from('search')
           .where('search.entity_id', db.ref('final_entities.entity_id'))
-          .andWhere('search.key', primaryOrder.field),
+          .andWhere('search.key', primaryOrder.field)
+          .whereNotNull('search.value'),
       );
     withoutField = applyFilter(withoutField);
     withoutField = withoutField.orderBy(

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -324,7 +324,7 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
 
     const combined = [...withFieldRows, ...withoutFieldRows];
     if (limit === undefined) {
-      return combined;
+      return combined.slice(offset ?? 0);
     }
     const skip = offset ?? 0;
     return combined.slice(skip, skip + limit + 1);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This relies on the indices defined in https://github.com/backstage/backstage/pull/34177 and should not be merged before that lands.

> Draft. Demonstrates a query-shape rewrite for `entities()`. Several semantic edges are noted below and intentionally not yet handled.

### Problem

For the default catalog UI list (e.g. `/entities/by-query?limit=20&orderField=metadata.name,asc&filter=kind=component`), the catalog backend issues SQL of the shape:

```sql
SELECT final_entities.*
FROM final_entities
LEFT OUTER JOIN search AS order_0
  ON order_0.entity_id = final_entities.entity_id
  AND order_0.key = 'metadata.name'
WHERE final_entity IS NOT NULL
  AND EXISTS (... kind=component ...)
ORDER BY order_0.value ASC NULLS LAST, final_entities.entity_id ASC
LIMIT 21;
```

With `final_entities` as the driving relation and the order column on a side-joined table, the planner cannot short-circuit on `LIMIT`. It must:

1. Resolve the filter (find every matching entity_id — ~54k for `kind=component` on the production replica),
2. Side-join `search` to fetch the order column for each,
3. Sort everything,
4. Take top 21.

Measured on the production replica: **~940 ms** of execution, **~600k buffer hits**, with the bulk of cost in step 2 (per-row probe to fetch `metadata.name` for every matched component).

### Approach

When an order field is specified, treat `search WHERE key = <field>` as the driving relation and `INNER JOIN` `final_entities`. The `(key, value, entity_id)` index then walks rows already in sort order. PostgreSQL picks an `Index Only Scan` on that slice, probes the filter EXISTS per row, and stops as soon as `LIMIT` is satisfied.

Effectively the same semantic as before for the typical case (every component has a `metadata.name`), but a fundamentally different join shape that lets the planner do the right thing.

### Timings (production replica, ~462k entities, ~13.5M search rows, with https://github.com/backstage/backstage/pull/34177 's covering indices)

| Endpoint | Current shape | This PR | Speedup |
|---|---:|---:|---:|
| `/entities`, `kind=component` order=`metadata.name` LIMIT 20 | **940 ms** | **8 ms** | ~120× |
| `/entities/by-query`, first page (with count) | 1,075 ms | _378 ms (count: 370 + list: 8) — see below_ | ~3× |
| `/entities/by-query`, paginated (cursor cached count) | ~700 ms | _8 ms_ | ~90× |

The `/entities/by-query` numbers in italics are the *projected* result if the same pattern were applied there; this draft does not yet rewrite `queryEntities()`. The list-side cost is the same `8 ms` driven shape; the count phase is intrinsic to "how many total" and fires only on the first request.

The drop in buffer hits is the headline change: 601k → 3.8k for the same query. Plan strategy goes from `Sort top-N` over a fully materialized 56k-row inner result to a `Parallel Index Only Scan` walking ~620 candidate rows in name order to produce 21 matches.

### Plan diff (kind=component, ORDER BY metadata.name, LIMIT 20)

**Before:**
```
Limit  rows=21  (actual time=955.708..955.713)
  Buffers: shared hit=601562
  Sort top-N (key: order_0.value, entity_id)
    Nested Loop Left Join  rows=56k  (actual time=34..939)
      Nested Loop  rows=54k   (resolves EXISTS kind=component)
      Index Only Scan on search_entity_key_value_idx  (probes order_0 for each of 54k rows)
```

**After:**
```
Limit  rows=21  (actual time=8.114..8.124)
  Buffers: shared hit=3842
  Sort top-N (key: names.value, entity_id)
    Nested Loop Semi Join  (rows=20 across 3 workers)
      Parallel Index Only Scan on search_key_value_entity_idx  (key='metadata.name', walks in value order, 208 rows/worker)
      Index Only Scan on search_key_value_entity_idx (per outer, EXISTS kind=component)
      Memoize → final_entities_pkey lookup
```

### Caveats this draft does not yet address (intentionally)

1. **NULLs-last semantics.** The previous LEFT JOIN with `NULLS LAST` placed entities lacking the order field at the end of the sorted result. The INNER-JOIN-driven shape excludes them entirely. Four existing tests fail on this; a `UNION ALL` of the inner-joined slice with the no-field slice would restore the old behavior.
2. **Multi-field order.** The previous shape supported tie-breaking on a second field. This draft drives only from the first; subsequent fields are ignored. The 4 existing test failures are on this code path. Restoring tie-breakers needs either an additional left-join or a CTE.
3. **`queryEntities()` (/entities/by-query) is unchanged.** The same optimization applies but the existing CTE/cursor-pagination structure (with `DISTINCT` for de-duping, `filtered_count` cross-join, cursor seek expressions) makes the rewrite more involved. Worth a follow-up.

### Test status

- `entities()` tests pass except for `can order and combine with filtering` (the multi-field + NULLS-last case described above) — 4 of 160 fail.
- `queryEntities()` tests unaffected (that method is unchanged).

### Why now

Surfaced while validating the catalog UI's default-list query against production: the user-perceived 1.4 s for "list 20 components" is almost entirely this materialize-and-sort cost. Indices alone (#34015) help with the per-probe cost but cannot fix the join-shape choice. This PR is the structural change that does.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes _(4 known failures listed above; this draft does not yet update tests for behavior changes)_
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.