### PR TITLE
feat(catalog-backend-module-github): auto-exclude suspended users on GHE

### DIFF
--- a/.changeset/suspended-users-rest-api.md
+++ b/.changeset/suspended-users-rest-api.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog-backend-module-github': minor
+'@backstage/plugin-catalog-backend-module-github-org': minor
+---
+
+**BREAKING**: Suspended users are now excluded during ingestion by default. User suspended state is now checked using the REST API, which avoids the need for the `site_admin` scope. Both account-level suspension and org-membership suspension are detected. This replaces the previous `excludeSuspendedUsers` option (which defaulted to off) with `dangerouslySkipSuspendedUserCheck` (which defaults to off, meaning the check runs by default). Set `dangerouslySkipSuspendedUserCheck: true` to disable the check if needed.

--- a/plugins/catalog-backend-module-github-org/src/module.ts
+++ b/plugins/catalog-backend-module-github-org/src/module.ts
@@ -127,10 +127,9 @@ export const catalogModuleGithubOrgEntityProvider = createBackendModule({
               alwaysUseDefaultNamespace:
                 definitions.length === 1 && definition.orgs?.length === 1,
               pageSizes: definition.pageSizes,
-              excludeSuspendedUsers: definition.excludeSuspendedUsers,
+              dangerouslySkipSuspendedUserCheck:
+                definition.dangerouslySkipSuspendedUserCheck,
               cache,
-              experimental_checkForSuspendedUsersWithRest:
-                definition.experimental_checkForSuspendedUsersWithRest,
             }),
           );
         }
@@ -149,8 +148,7 @@ function readDefinitionsFromConfig(rootConfig: Config): Array<{
     teamMembers?: number;
     organizationMembers?: number;
   };
-  excludeSuspendedUsers?: boolean;
-  experimental_checkForSuspendedUsersWithRest?: boolean;
+  dangerouslySkipSuspendedUserCheck?: boolean;
   useVerifiedEmails?: boolean;
 }> {
   const baseKey = 'catalog.providers.githubOrg';
@@ -179,11 +177,8 @@ function readDefinitionsFromConfig(rootConfig: Config): Array<{
           ),
         }
       : undefined,
-    excludeSuspendedUsers:
-      c.getOptionalBoolean('excludeSuspendedUsers') ?? false,
-    experimental_checkForSuspendedUsersWithRest:
-      c.getOptionalBoolean('experimental_checkForSuspendedUsersWithRest') ??
-      false,
+    dangerouslySkipSuspendedUserCheck:
+      c.getOptionalBoolean('dangerouslySkipSuspendedUserCheck') ?? false,
     useVerifiedEmails:
       c.getOptionalBoolean('defaultUserTransformer.useVerifiedEmails') ?? false,
   }));

--- a/plugins/catalog-backend-module-github/config.d.ts
+++ b/plugins/catalog-backend-module-github/config.d.ts
@@ -265,18 +265,16 @@ export interface Config {
             orgs?: string[];
 
             /**
-             * (Optional) Only for GitHub Enterprise. Whether to exclude suspended users when querying organization users.
+             * (Optional) Whether to skip the suspended user check. By default,
+             * suspended users are automatically excluded on GitHub Enterprise
+             * instances using the REST API (without requiring site_admin scope).
+             * Set to `true` to disable the check if needed.
+             * Be aware that if this check is disabled, suspended
+             * users will appear in the catalog with no way of distinguishing
+             * them from active valid users.
              * Default: `false`.
              */
-            excludeSuspendedUsers?: boolean;
-
-            /**
-             * (Optional) When set to true alongside `excludeSuspendedUsers`, use the GitHub REST API
-             * to check for suspended users instead of the GraphQL `suspendedAt` field.
-             * REST responses are cached using conditional HTTP requests to minimize rate limit usage.
-             * Default: `false`.
-             */
-            experimental_checkForSuspendedUsersWithRest?: boolean;
+            dangerouslySkipSuspendedUserCheck?: boolean;
 
             /**
              * (Optional) Configuration for the default user transformer.
@@ -348,18 +346,16 @@ export interface Config {
             orgs?: string[];
 
             /**
-             * (Optional) Only for GitHub Enterprise. Whether to exclude suspended users when querying organization users.
+             * (Optional) Whether to skip the suspended user check. By default,
+             * suspended users are automatically excluded on GitHub Enterprise
+             * instances using the REST API (without requiring site_admin scope).
+             * Set to `true` to disable the check if needed.
+             * Be aware that if this check is disabled, suspended
+             * users will appear in the catalog with no way of distinguishing
+             * them from active valid users.
              * Default: `false`.
              */
-            excludeSuspendedUsers?: boolean;
-
-            /**
-             * (Optional) When set to true alongside `excludeSuspendedUsers`, use the GitHub REST API
-             * to check for suspended users instead of the GraphQL `suspendedAt` field.
-             * REST responses are cached using conditional HTTP requests to minimize rate limit usage.
-             * Default: `false`.
-             */
-            experimental_checkForSuspendedUsersWithRest?: boolean;
+            dangerouslySkipSuspendedUserCheck?: boolean;
 
             /**
              * (Optional) Configuration for the default user transformer.

--- a/plugins/catalog-backend-module-github/report.api.md
+++ b/plugins/catalog-backend-module-github/report.api.md
@@ -6,7 +6,6 @@
 import { AnalyzeOptions } from '@backstage/plugin-catalog-node';
 import { AuthService } from '@backstage/backend-plugin-api';
 import { BackendFeature } from '@backstage/backend-plugin-api';
-import { CacheService } from '@backstage/backend-plugin-api';
 import { CatalogProcessor } from '@backstage/plugin-catalog-node';
 import { CatalogProcessorEmit } from '@backstage/plugin-catalog-node';
 import { CatalogService } from '@backstage/plugin-catalog-node';
@@ -158,9 +157,8 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
     teamTransformer?: TeamTransformer;
     alwaysUseDefaultNamespace?: boolean;
     pageSizes?: Partial<GithubPageSizes>;
-    excludeSuspendedUsers?: boolean;
-    cache?: CacheService;
-    experimental_checkForSuspendedUsersWithRest?: boolean;
+    dangerouslySkipSuspendedUserCheck?: boolean;
+    cache: CacheService;
   });
   connect(connection: EntityProviderConnection): Promise<void>;
   // (undocumented)
@@ -175,10 +173,9 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
 // @public
 export interface GithubMultiOrgEntityProviderOptions {
   alwaysUseDefaultNamespace?: boolean;
-  cache?: CacheService;
+  cache: CacheService;
+  dangerouslySkipSuspendedUserCheck?: boolean;
   events?: EventsService;
-  excludeSuspendedUsers?: boolean;
-  experimental_checkForSuspendedUsersWithRest?: boolean;
   githubCredentialsProvider?: GithubCredentialsProvider;
   githubUrl: string;
   id: string;
@@ -241,9 +238,8 @@ export class GithubOrgEntityProvider implements EntityProvider {
     userTransformer?: UserTransformer;
     teamTransformer?: TeamTransformer;
     pageSizes?: Partial<GithubPageSizes>;
-    excludeSuspendedUsers?: boolean;
-    cache?: CacheService;
-    experimental_checkForSuspendedUsersWithRest?: boolean;
+    dangerouslySkipSuspendedUserCheck?: boolean;
+    cache: CacheService;
   });
   connect(connection: EntityProviderConnection): Promise<void>;
   // (undocumented)
@@ -260,10 +256,9 @@ export type GitHubOrgEntityProviderOptions = GithubOrgEntityProviderOptions;
 
 // @public
 export interface GithubOrgEntityProviderOptions {
-  cache?: CacheService;
+  cache: CacheService;
+  dangerouslySkipSuspendedUserCheck?: boolean;
   events?: EventsService;
-  excludeSuspendedUsers?: boolean;
-  experimental_checkForSuspendedUsersWithRest?: boolean;
   githubCredentialsProvider?: GithubCredentialsProvider;
   id: string;
   logger: LoggerService;
@@ -328,7 +323,6 @@ export type GithubUser = {
   email?: string;
   name?: string;
   organizationVerifiedDomainEmails?: string[];
-  suspendedAt?: string;
 };
 
 // @public

--- a/plugins/catalog-backend-module-github/src/lib/github.test.ts
+++ b/plugins/catalog-backend-module-github/src/lib/github.test.ts
@@ -37,8 +37,7 @@ import {
   createAddEntitiesOperation,
   createRemoveEntitiesOperation,
   createReplaceEntitiesOperation,
-  createGraphqlClient,
-  createRestClient,
+  createOctokit,
   getOrganizationTeamsForUser,
   isSuspended,
   isGitHubEnterprise,
@@ -56,6 +55,24 @@ describe('github', () => {
   registerMswTestHooks(server);
 
   const graphql = graphqlOctokit.defaults({});
+
+  function createMockOctokit(overrides?: {
+    auth?: Record<string, unknown>;
+    request?: jest.Mock;
+  }) {
+    return {
+      graphql,
+      request:
+        overrides?.request ?? jest.fn().mockResolvedValue({ headers: {} }),
+      auth: jest.fn().mockResolvedValue({
+        type: 'token',
+        headers: {},
+        ...overrides?.auth,
+      }),
+    } as any;
+  }
+
+  const mockOctokit = createMockOctokit();
 
   describe('getOrganizationTeamsForUser', () => {
     const org = 'my-org';
@@ -93,7 +110,7 @@ describe('github', () => {
       }));
 
       const { teams } = await getOrganizationTeamsForUser(
-        graphql as any,
+        mockOctokit,
         org,
         userLogin,
         mockTransformer as any,
@@ -120,7 +137,7 @@ describe('github', () => {
       );
       const mockTransformer = jest.fn().mockResolvedValue(undefined);
       const { teams } = await getOrganizationTeamsForUser(
-        graphql as any,
+        mockOctokit,
         org,
         userLogin,
         mockTransformer as any,
@@ -165,60 +182,12 @@ describe('github', () => {
         graphqlMsw.query('users', () => HttpResponse.json({ data: input })),
       );
 
-      await expect(
-        getOrganizationUsers(graphql, 'a', 'token'),
-      ).resolves.toEqual(output);
+      await expect(getOrganizationUsers(mockOctokit, 'a')).resolves.toEqual(
+        output,
+      );
     });
 
     it('reads members excluding suspended users', async () => {
-      const input: QueryResponse = {
-        organization: {
-          membersWithRole: {
-            pageInfo: { hasNextPage: false },
-            nodes: [
-              {
-                login: 'a',
-                name: 'b',
-                bio: 'c',
-                email: 'd',
-                avatarUrl: 'e',
-                suspendedAt: '2025-01-01',
-              },
-              {
-                login: 'a',
-                name: 'b',
-                bio: 'c',
-                email: 'd',
-                avatarUrl: 'e',
-                suspendedAt: undefined,
-              },
-            ],
-          },
-        },
-      };
-
-      const output = {
-        users: [
-          expect.objectContaining({
-            metadata: expect.objectContaining({ name: 'a', description: 'c' }),
-            spec: {
-              profile: { displayName: 'b', email: 'd', picture: 'e' },
-              memberOf: [],
-            },
-          }),
-        ],
-      };
-
-      server.use(
-        graphqlMsw.query('users', () => HttpResponse.json({ data: input })),
-      );
-
-      await expect(
-        getOrganizationUsers(graphql, 'a', 'token', undefined, undefined, true),
-      ).resolves.toEqual(output);
-    });
-
-    it('reads members excluding suspended users via REST when restClient provided', async () => {
       const input: QueryResponse = {
         organization: {
           membersWithRole: {
@@ -262,7 +231,7 @@ describe('github', () => {
         graphqlMsw.query('users', () => HttpResponse.json({ data: input })),
       );
 
-      const mockRestClient = {
+      const octokitWithSuspended = createMockOctokit({
         request: jest.fn().mockImplementation((route: string, params: any) => {
           if (route === 'GET /versions') {
             return Promise.resolve({
@@ -277,22 +246,20 @@ describe('github', () => {
           }
           return { data: { role: 'member', state: 'active' } };
         }),
-      } as any;
+      });
 
       await expect(
         getOrganizationUsers(
-          graphql,
+          octokitWithSuspended,
           'a',
-          'token',
           undefined,
           undefined,
           true,
-          mockRestClient,
         ),
       ).resolves.toEqual(output);
     });
 
-    it('reads members excluding org-membership-suspended users via REST', async () => {
+    it('reads members excluding org-membership-suspended users', async () => {
       const input: QueryResponse = {
         organization: {
           membersWithRole: {
@@ -321,7 +288,7 @@ describe('github', () => {
         graphqlMsw.query('users', () => HttpResponse.json({ data: input })),
       );
 
-      const mockRestClient = {
+      const octokitWithOrgSuspended = createMockOctokit({
         request: jest.fn().mockImplementation((route: string, params: any) => {
           if (route === 'GET /versions') {
             return Promise.resolve({
@@ -339,23 +306,21 @@ describe('github', () => {
           }
           return { data: {} };
         }),
-      } as any;
+      });
 
       const result = await getOrganizationUsers(
-        graphql,
+        octokitWithOrgSuspended,
         'a',
-        'token',
         undefined,
         undefined,
         true,
-        mockRestClient,
       );
 
       expect(result.users).toHaveLength(1);
       expect(result.users[0].metadata.name).toBe('active-user');
     });
 
-    it('skips REST suspended user check on non-enterprise GitHub', async () => {
+    it('returns all users when filterSuspendedUsers is false', async () => {
       const input: QueryResponse = {
         organization: {
           membersWithRole: {
@@ -384,32 +349,10 @@ describe('github', () => {
         graphqlMsw.query('users', () => HttpResponse.json({ data: input })),
       );
 
-      const nonEnterpriseRestClient = {
-        request: jest.fn().mockImplementation((route: string) => {
-          if (route === 'GET /versions') {
-            return Promise.resolve({ headers: {} });
-          }
-          throw new Error('isSuspended should not be called');
-        }),
-      } as any;
+      const result = await getOrganizationUsers(mockOctokit, 'a');
 
-      const result = await getOrganizationUsers(
-        graphql,
-        'a',
-        'token',
-        undefined,
-        undefined,
-        true,
-        nonEnterpriseRestClient,
-      );
-
-      // Both users should be returned because the REST check is skipped
-      // on non-enterprise (no suspendedAt field in query either since restClient is provided)
       expect(result.users).toHaveLength(2);
-      expect(nonEnterpriseRestClient.request).toHaveBeenCalledTimes(1);
-      expect(nonEnterpriseRestClient.request).toHaveBeenCalledWith(
-        'GET /versions',
-      );
+      expect(mockOctokit.request).not.toHaveBeenCalled();
     });
   });
 
@@ -471,7 +414,7 @@ describe('github', () => {
       );
 
       await expect(
-        getOrganizationUsers(graphql, 'a', 'token', customUserTransformer),
+        getOrganizationUsers(mockOctokit, 'a', customUserTransformer),
       ).resolves.toEqual(output);
     });
 
@@ -515,9 +458,8 @@ describe('github', () => {
       );
 
       const users = await getOrganizationUsers(
-        graphql,
+        mockOctokit,
         'a',
-        'token',
         customUserTransformer,
       );
 
@@ -525,7 +467,7 @@ describe('github', () => {
       expect(users).toEqual(output);
     });
 
-    it('reads members including suspended users', async () => {
+    it('returns all users when filterSuspendedUsers is false', async () => {
       const input: QueryResponse = {
         organization: {
           membersWithRole: {
@@ -544,7 +486,6 @@ describe('github', () => {
                 bio: 'cc',
                 email: 'dd',
                 avatarUrl: 'ee',
-                suspendedAt: '2025-01-01',
               },
             ],
           },
@@ -572,9 +513,8 @@ describe('github', () => {
 
       await expect(
         getOrganizationUsers(
-          graphql,
+          mockOctokit,
           'a',
-          'token',
           customUserTransformer,
           undefined,
           false,
@@ -646,7 +586,9 @@ describe('github', () => {
         graphqlMsw.query('teams', () => HttpResponse.json({ data: input })),
       );
 
-      await expect(getOrganizationTeams(graphql, 'a')).resolves.toEqual(output);
+      await expect(getOrganizationTeams(mockOctokit, 'a')).resolves.toEqual(
+        output,
+      );
     });
   });
 
@@ -747,7 +689,7 @@ describe('github', () => {
       );
 
       await expect(
-        getOrganizationTeams(graphql, 'a', customTeamTransformer),
+        getOrganizationTeams(mockOctokit, 'a', customTeamTransformer),
       ).resolves.toEqual(output);
     });
 
@@ -827,7 +769,7 @@ describe('github', () => {
       );
 
       const teams = await getOrganizationTeams(
-        graphql,
+        mockOctokit,
         'a',
         customTeamTransformer,
       );
@@ -862,7 +804,9 @@ describe('github', () => {
         graphqlMsw.query('orgs', () => HttpResponse.json({ data: input })),
       );
 
-      await expect(getOrganizationsFromUser(graphql, 'foo')).resolves.toEqual({
+      await expect(
+        getOrganizationsFromUser(mockOctokit, 'foo'),
+      ).resolves.toEqual({
         orgs: ['a', 'b', 'c'],
       });
     });
@@ -982,7 +926,7 @@ describe('github', () => {
       );
 
       await expect(
-        getOrganizationRepositories(graphql, 'a', 'catalog-info.yaml'),
+        getOrganizationRepositories(mockOctokit, 'a', 'catalog-info.yaml'),
       ).resolves.toEqual(output);
     });
 
@@ -1015,7 +959,7 @@ describe('github', () => {
       );
 
       await getOrganizationRepositories(
-        graphql as any,
+        mockOctokit,
         'my-org',
         '/catalog-info.yaml',
         undefined,
@@ -1049,7 +993,7 @@ describe('github', () => {
       );
 
       await getOrganizationRepository(
-        graphql as any,
+        mockOctokit,
         'my-org',
         'my-repo',
         'catalog-info.yaml',
@@ -1067,7 +1011,7 @@ describe('github', () => {
       );
 
       await getOrganizationRepository(
-        graphql as any,
+        mockOctokit,
         'my-org',
         'my-repo',
         'catalog-info.yaml',
@@ -1179,105 +1123,7 @@ describe('github', () => {
     });
   });
 
-  describe('createGraphqlClient', () => {
-    const headers = {};
-
-    const baseUrl = 'https://api.github.com';
-
-    const logger = mockServices.rootLogger();
-
-    const mockClient = jest.fn().mockImplementation();
-
-    const graphqlDefaults = jest.fn().mockReturnValue(mockClient);
-    const mockedOctokit = jest.fn().mockImplementation(() => ({
-      graphql: {
-        defaults: graphqlDefaults,
-      },
-    }));
-
-    let pluginSpy: jest.SpyInstance;
-
-    beforeEach(() => {
-      pluginSpy = jest
-        .spyOn(Octokit, 'plugin')
-        .mockReturnValue(mockedOctokit as any);
-    });
-
-    afterEach(() => {
-      pluginSpy.mockRestore();
-    });
-
-    const rateLimitOptions = {
-      method: 'POST',
-      url: '/graphql',
-    };
-
-    it('should return a graphql client with throttling and retry', async () => {
-      const client = createGraphqlClient({
-        headers,
-        baseUrl,
-        logger,
-      });
-      expect(client).toBeDefined();
-      expect(Octokit.plugin).toHaveBeenCalledWith(throttling, retry);
-    });
-
-    it('should return a graphql client with the correct options', async () => {
-      createGraphqlClient({
-        headers,
-        baseUrl,
-        logger,
-      });
-      expect(graphqlDefaults).toHaveBeenCalledWith({
-        baseUrl,
-        headers,
-      });
-    });
-
-    describe('onRateLimit', () => {
-      it.each([
-        { retryCount: 0, expectedResult: true },
-        { retryCount: 1, expectedResult: true },
-        { retryCount: 2, expectedResult: false },
-      ])('should return %s', async ({ retryCount, expectedResult }) => {
-        createGraphqlClient({ headers, baseUrl, logger });
-
-        const throttleOptions = mockedOctokit.mock.calls[0][0].throttle;
-
-        const result = throttleOptions.onRateLimit(
-          60,
-          rateLimitOptions,
-          undefined,
-          retryCount,
-        );
-
-        expect(result).toBe(expectedResult);
-      });
-    });
-
-    describe('onSecondaryRateLimit', () => {
-      it.each([
-        { retryCount: 0, expectedResult: true },
-        { retryCount: 1, expectedResult: true },
-        { retryCount: 2, expectedResult: false },
-      ])('should return %s', async ({ retryCount, expectedResult }) => {
-        createGraphqlClient({ headers, baseUrl, logger });
-
-        const throttleOptions = mockedOctokit.mock.calls[0][0].throttle;
-
-        const result = throttleOptions.onSecondaryRateLimit(
-          60,
-          rateLimitOptions,
-          undefined,
-          retryCount,
-        );
-
-        expect(result).toBe(expectedResult);
-      });
-    });
-  });
-
-  describe('createRestClient', () => {
+  describe('createOctokit', () => {
     const baseUrl = 'https://api.github.com';
     const orgUrl = 'https://github.com/my-org';
 
@@ -1287,6 +1133,92 @@ describe('github', () => {
         headers: { authorization: 'token test-token' },
       }),
     };
+
+    let pluginSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      pluginSpy = jest.spyOn(Octokit, 'plugin');
+    });
+
+    it('should construct an octokit with throttling and retry', async () => {
+      const octokit = createOctokit({
+        baseUrl,
+        orgUrl,
+        credentialsProvider: mockCredentialsProvider,
+        logger: mockServices.logger.mock(),
+        cache: mockServices.cache.mock(),
+      });
+
+      expect(octokit).toBeDefined();
+      expect(Octokit.plugin).toHaveBeenCalledWith(throttling, retry);
+    });
+
+    it('should construct an octokit with the correct options', async () => {
+      const mockedOctokitConstructor = jest.fn(() => ({
+        hook: { wrap: jest.fn() },
+      }));
+
+      pluginSpy.mockReturnValue(mockedOctokitConstructor);
+
+      try {
+        createOctokit({
+          baseUrl,
+          orgUrl,
+          credentialsProvider: mockCredentialsProvider,
+          logger: mockServices.logger.mock(),
+          cache: mockServices.cache.mock(),
+        });
+
+        expect(mockedOctokitConstructor).toHaveBeenCalledWith(
+          expect.objectContaining({
+            baseUrl,
+          }),
+        );
+      } finally {
+        pluginSpy.mockRestore();
+      }
+    });
+
+    it('auth() returns credentials from the provider', async () => {
+      const octokit = createOctokit({
+        baseUrl,
+        orgUrl,
+        credentialsProvider: mockCredentialsProvider,
+        logger: mockServices.logger.mock(),
+      });
+
+      const credentials = await octokit.auth();
+      expect(credentials).toEqual({
+        type: 'token',
+        headers: { authorization: 'token test-token' },
+      });
+      expect(mockCredentialsProvider.getCredentials).toHaveBeenCalledWith({
+        url: orgUrl,
+      });
+    });
+
+    it('auth strategy hook injects credentials headers into requests', async () => {
+      let receivedHeaders: Record<string, string> = {};
+      server.use(
+        http.get(`${baseUrl}/users/testuser`, ({ request }) => {
+          receivedHeaders = Object.fromEntries(request.headers.entries());
+          return HttpResponse.json({ login: 'testuser' });
+        }),
+      );
+
+      const octokit = createOctokit({
+        baseUrl,
+        orgUrl,
+        credentialsProvider: mockCredentialsProvider,
+        logger: mockServices.logger.mock(),
+      });
+
+      await octokit.request('GET /users/{username}', {
+        username: 'testuser',
+      });
+
+      expect(receivedHeaders.authorization).toBe('token test-token');
+    });
 
     describe('conditional request caching', () => {
       function createMockCache(): CacheService & {
@@ -1324,7 +1256,7 @@ describe('github', () => {
         );
 
         const cache = createMockCache();
-        const octokit = createRestClient({
+        const octokit = createOctokit({
           baseUrl,
           orgUrl,
           credentialsProvider: mockCredentialsProvider,
@@ -1365,7 +1297,7 @@ describe('github', () => {
           },
         );
 
-        const octokit = createRestClient({
+        const octokit = createOctokit({
           baseUrl,
           orgUrl,
           credentialsProvider: mockCredentialsProvider,
@@ -1403,7 +1335,7 @@ describe('github', () => {
           },
         );
 
-        const octokit = createRestClient({
+        const octokit = createOctokit({
           baseUrl,
           orgUrl,
           credentialsProvider: mockCredentialsProvider,
@@ -1442,7 +1374,7 @@ describe('github', () => {
           },
         );
 
-        const octokit = createRestClient({
+        const octokit = createOctokit({
           baseUrl,
           orgUrl,
           credentialsProvider: mockCredentialsProvider,
@@ -1469,7 +1401,7 @@ describe('github', () => {
         );
 
         const cache = createMockCache();
-        const octokit = createRestClient({
+        const octokit = createOctokit({
           baseUrl,
           orgUrl,
           credentialsProvider: mockCredentialsProvider,
@@ -1501,7 +1433,7 @@ describe('github', () => {
           },
         );
 
-        const octokit = createRestClient({
+        const octokit = createOctokit({
           baseUrl,
           orgUrl,
           credentialsProvider: mockCredentialsProvider,
@@ -1530,7 +1462,7 @@ describe('github', () => {
         );
 
         const cache = createMockCache();
-        const octokit = createRestClient({
+        const octokit = createOctokit({
           baseUrl,
           orgUrl,
           credentialsProvider: mockCredentialsProvider,
@@ -1564,7 +1496,7 @@ describe('github', () => {
           }),
         );
 
-        const octokit = createRestClient({
+        const octokit = createOctokit({
           baseUrl,
           orgUrl,
           credentialsProvider: mockCredentialsProvider,
@@ -1669,12 +1601,12 @@ describe('github', () => {
       await expect(isGitHubEnterprise(octokit)).resolves.toBe(false);
     });
 
-    it('returns false when the request throws', async () => {
+    it('propagates errors from the request', async () => {
       const octokit = {
         request: jest.fn().mockRejectedValue(new Error('Not Found')),
       } as any;
 
-      await expect(isGitHubEnterprise(octokit)).resolves.toBe(false);
+      await expect(isGitHubEnterprise(octokit)).rejects.toThrow('Not Found');
     });
   });
 
@@ -1713,7 +1645,7 @@ describe('github', () => {
         }),
       );
 
-      await getOrganizationTeams(graphql as any, org, undefined, {
+      await getOrganizationTeams(mockOctokit, org, undefined, {
         teams: 10,
         teamMembers: 20,
         organizationMembers: 20,
@@ -1747,7 +1679,7 @@ describe('github', () => {
         }),
       );
 
-      await getOrganizationUsers(graphql as any, org, 'token', undefined, {
+      await getOrganizationUsers(mockOctokit, org, undefined, {
         teams: 10,
         teamMembers: 20,
         organizationMembers: 30,
@@ -1784,7 +1716,7 @@ describe('github', () => {
       );
 
       await getOrganizationRepositories(
-        graphql as any,
+        mockOctokit,
         org,
         '/catalog-info.yaml',
         {
@@ -1814,7 +1746,7 @@ describe('github', () => {
         }),
       );
 
-      await getOrganizationTeams(graphql as any, org);
+      await getOrganizationTeams(mockOctokit, org);
     });
   });
 });

--- a/plugins/catalog-backend-module-github/src/lib/github.ts
+++ b/plugins/catalog-backend-module-github/src/lib/github.ts
@@ -18,7 +18,6 @@ import { Entity } from '@backstage/catalog-model';
 import {
   GithubCredentials,
   GithubCredentialsProvider,
-  GithubCredentialType,
 } from '@backstage/integration';
 import { graphql } from '@octokit/graphql';
 import { OctokitResponse, RequestParameters } from '@octokit/types';
@@ -125,7 +124,6 @@ export type GithubUser = {
   email?: string;
   name?: string;
   organizationVerifiedDomainEmails?: string[];
-  suspendedAt?: string;
 };
 
 /**
@@ -185,26 +183,19 @@ export type Connection<T> = {
  *
  * Note that the users will not have their memberships filled in.
  *
- * @param client - An octokit graphql client
+ * @param octokit - An octokit client
  * @param org - The slug of the org to read
- * @param tokenType - The type of GitHub credential
  * @param userTransformer - Optional transformer for user entities
  * @param pageSizes - Optional page sizes configuration
- * @param excludeSuspendedUsers - Optional flag to exclude suspended users (only for GitHub Enterprise instances)
- * @param restClient - Optional Octokit REST client; when provided alongside excludeSuspendedUsers, the REST API is used instead of the GraphQL suspendedAt field
+ * @param filterSuspendedUsers - When true, suspended users are excluded using the REST API. Callers should resolve this by checking isGitHubEnterprise() once at the start of a provider run.
  */
 export async function getOrganizationUsers(
-  client: typeof graphql,
+  octokit: Octokit,
   org: string,
-  tokenType: GithubCredentialType,
   userTransformer: UserTransformer = defaultUserTransformer,
   pageSizes: GithubPageSizes = DEFAULT_PAGE_SIZES,
-  excludeSuspendedUsers: boolean = false,
-  restClient?: Octokit,
+  filterSuspendedUsers: boolean = false,
 ): Promise<{ users: Entity[] }> {
-  const useRestForSuspension = excludeSuspendedUsers && !!restClient;
-  const suspendedAtField =
-    excludeSuspendedUsers && !useRestForSuspension ? 'suspendedAt,' : '';
   const query = `
     query users($org: String!, $email: Boolean!, $cursor: String, $organizationMembersPageSize: Int!) {
       organization(login: $org) {
@@ -217,42 +208,30 @@ export async function getOrganizationUsers(
             id,
             login,
             name,
-            ${suspendedAtField}
             organizationVerifiedDomainEmails(login: $org)
           }
         }
       }
     }`;
 
-  let restFilter:
-    | ((user: GithubUser) => Promise<boolean> | boolean)
-    | undefined;
-
-  if (useRestForSuspension) {
-    const isEnterprise = await isGitHubEnterprise(restClient);
-    if (isEnterprise) {
-      restFilter = async (user: GithubUser) =>
-        !(await isSuspended(user.login, restClient, { org }));
-    }
-  }
+  const email = ((await octokit.auth()) as GithubCredentials).type === 'token';
 
   // There is no user -> teams edge, so we leave the memberships empty for
   // now and let the team iteration handle it instead
-
   const users = await queryWithPaging({
-    client,
+    client: octokit.graphql,
     query,
     org,
     connection: r => r.organization?.membersWithRole,
     transformer: userTransformer,
     variables: {
       org,
-      email: tokenType === 'token',
+      email,
       organizationMembersPageSize: pageSizes.organizationMembers,
     },
-    filter: useRestForSuspension
-      ? restFilter
-      : u => (excludeSuspendedUsers ? !u.suspendedAt : true),
+    filter: filterSuspendedUsers
+      ? async user => !(await isSuspended(user.login, octokit, { org }))
+      : undefined,
   });
 
   return { users };
@@ -263,13 +242,13 @@ export async function getOrganizationUsers(
  *
  * Note that the teams will not have any relations apart from parent filled in.
  *
- * @param client - An octokit graphql client
+ * @param octokit - An octokit client
  * @param org - The slug of the org to read
  * @param teamTransformer - Optional transformer for team entities
  * @param pageSizes - Optional page sizes configuration
  */
 export async function getOrganizationTeams(
-  client: typeof graphql,
+  octokit: Octokit,
   org: string,
   teamTransformer: TeamTransformer = defaultOrganizationTeamTransformer,
   pageSizes: GithubPageSizes = DEFAULT_PAGE_SIZES,
@@ -340,7 +319,7 @@ export async function getOrganizationTeams(
   };
 
   const teams = await queryWithPaging({
-    client,
+    client: octokit.graphql,
     query,
     org,
     connection: r => r.organization?.teams,
@@ -356,7 +335,7 @@ export async function getOrganizationTeams(
 }
 
 export async function getOrganizationTeamsFromUsers(
-  client: typeof graphql,
+  octokit: Octokit,
   org: string,
   userLogins: string[],
   teamTransformer: TeamTransformer = defaultOrganizationTeamTransformer,
@@ -435,7 +414,7 @@ export async function getOrganizationTeamsFromUsers(
   };
 
   const teams = await queryWithPaging({
-    client,
+    client: octokit.graphql,
     query,
     org,
     connection: r => r.organization?.teams,
@@ -452,7 +431,7 @@ export async function getOrganizationTeamsFromUsers(
 }
 
 export async function getOrganizationTeamsForUser(
-  client: typeof graphql,
+  octokit: Octokit,
   org: string,
   userLogin: string,
   teamTransformer: TeamTransformer,
@@ -494,7 +473,7 @@ export async function getOrganizationTeamsForUser(
   };
 
   const teams = await queryWithPaging({
-    client,
+    client: octokit.graphql,
     query,
     org,
     connection: r => r.organization?.teams,
@@ -506,7 +485,7 @@ export async function getOrganizationTeamsForUser(
 }
 
 export async function getOrganizationsFromUser(
-  client: typeof graphql,
+  octokit: Octokit,
   user: string,
 ): Promise<{
   orgs: string[];
@@ -522,7 +501,7 @@ export async function getOrganizationsFromUser(
   }`;
 
   const orgs = await queryWithPaging({
-    client,
+    client: octokit.graphql,
     query,
     org: '',
     connection: r => r.user?.organizations,
@@ -534,7 +513,7 @@ export async function getOrganizationsFromUser(
 }
 
 export async function getOrganizationTeam(
-  client: typeof graphql,
+  octokit: Octokit,
   org: string,
   teamSlug: string,
   teamTransformer: TeamTransformer = defaultOrganizationTeamTransformer,
@@ -594,7 +573,7 @@ export async function getOrganizationTeam(
     return await teamTransformer(team, ctx);
   };
 
-  const response: QueryResponse = await client(query, {
+  const response: QueryResponse = await octokit.graphql(query, {
     org,
     teamSlug,
     membersPageSize: pageSizes.teamMembers,
@@ -605,7 +584,7 @@ export async function getOrganizationTeam(
 
   const team = await materialisedTeam(response.organization?.team, {
     query,
-    client,
+    client: octokit.graphql,
     org,
   });
 
@@ -615,7 +594,7 @@ export async function getOrganizationTeam(
 }
 
 export async function getOrganizationRepositories(
-  client: typeof graphql,
+  octokit: Octokit,
   org: string,
   catalogPath: string,
   pageSizes: GithubPageSizes = DEFAULT_PAGE_SIZES,
@@ -670,7 +649,7 @@ export async function getOrganizationRepositories(
     }`;
 
   const repositories = await queryWithPaging({
-    client,
+    client: octokit.graphql,
     query,
     org,
     connection: r => r.repositoryOwner?.repositories,
@@ -686,7 +665,7 @@ export async function getOrganizationRepositories(
 }
 
 export async function getOrganizationRepository(
-  client: typeof graphql,
+  octokit: Octokit,
   org: string,
   repoName: string,
   catalogPath: string,
@@ -733,7 +712,7 @@ export async function getOrganizationRepository(
       }
     }`;
 
-  const response: QueryResponse = await client(query, {
+  const response: QueryResponse = await octokit.graphql(query, {
     org,
     repoName,
     catalogPathRef,
@@ -836,17 +815,18 @@ export async function queryWithPaging<
       throw new Error(`Found no match for ${JSON.stringify(variables)}`);
     }
 
-    for (const node of conn.nodes) {
-      if (filter && !(await filter(node))) {
-        continue;
-      }
-      const transformedNode = await transformer(node, {
-        client,
-        query,
-        org,
-      });
-      if (transformedNode) {
-        result.push(transformedNode);
+    const transformed = await Promise.all(
+      conn.nodes.map(async node => {
+        if (filter && !(await filter(node))) {
+          return undefined;
+        }
+        return transformer(node, { client, query, org });
+      }),
+    );
+
+    for (const node of transformed) {
+      if (node) {
+        result.push(node);
       }
     }
 
@@ -897,61 +877,6 @@ export const createReplaceEntitiesOperation =
     };
   };
 
-/**
- * Creates a GraphQL Client with Throttling and Retries
- */
-export const createGraphqlClient = (args: {
-  headers:
-    | {
-        [name: string]: string;
-      }
-    | undefined;
-  baseUrl: string;
-  logger: LoggerService;
-}): typeof graphql => {
-  const { headers, baseUrl, logger } = args;
-  const ThrottledOctokit = Octokit.plugin(throttling, retry);
-  const octokit = new ThrottledOctokit({
-    throttle: {
-      onRateLimit: (retryAfter, rateLimitData, _, retryCount) => {
-        logger.warn(
-          `Request quota exhausted for request ${rateLimitData?.method} ${rateLimitData?.url}`,
-        );
-
-        if (retryCount < 2) {
-          logger.warn(
-            `Retrying after ${retryAfter} seconds for the ${retryCount} time due to Rate Limit!`,
-          );
-          return true;
-        }
-
-        return false;
-      },
-      onSecondaryRateLimit: (retryAfter, rateLimitData, _, retryCount) => {
-        logger.warn(
-          `Secondary Rate Limit Exhausted for request ${rateLimitData?.method} ${rateLimitData?.url}`,
-        );
-
-        if (retryCount < 2) {
-          logger.warn(
-            `Retrying after ${retryAfter} seconds for the ${retryCount} time due to Secondary Rate Limit!`,
-          );
-          return true;
-        }
-
-        return false;
-      },
-    },
-  });
-
-  const client = octokit.graphql.defaults({
-    headers,
-    baseUrl,
-  });
-
-  return client;
-};
-
 function octokitThrottlingOptions(logger: LoggerService): ThrottlingOptions {
   return {
     onRateLimit: (retryAfter, rateLimitData, _, retryCount) => {
@@ -991,7 +916,7 @@ function octokitThrottlingOptions(logger: LoggerService): ThrottlingOptions {
  *
  * @public
  */
-export function createRestClient(options: {
+export function createOctokit(options: {
   baseUrl: string | undefined;
   orgUrl: string;
   credentialsProvider: GithubCredentialsProvider;
@@ -1046,24 +971,23 @@ function installConditionalRequestCache(
   octokit: Octokit,
   cache: CacheService,
 ): void {
-  octokit.hook.wrap('request', async (request, wrappedOptions) => {
-    const resolvedUrl = (wrappedOptions.url || '').replace(
-      /\{([^}]+)\}/g,
-      (_, key) => encodeURIComponent((wrappedOptions as any)[key]),
+  octokit.hook.wrap('request', async (request, options) => {
+    const resolvedUrl = (options.url || '').replace(/\{([^}]+)\}/g, (_, key) =>
+      encodeURIComponent((options as any)[key]),
     );
-    const cacheKey = `catalog-backend-module-github:${wrappedOptions.method}:${wrappedOptions.baseUrl}${resolvedUrl}`;
+    const cacheKey = `catalog-backend-module-github:${options.method}:${options.baseUrl}${resolvedUrl}`;
     const cached = await cache
       .get<CachedGitHubResponse>(cacheKey)
       .catch(() => undefined);
 
     if (cached?.lastModified) {
-      wrappedOptions.headers['if-modified-since'] = cached.lastModified;
+      options.headers['if-modified-since'] = cached.lastModified;
     } else if (cached?.etag) {
-      wrappedOptions.headers['if-none-match'] = cached.etag;
+      options.headers['if-none-match'] = cached.etag;
     }
 
     try {
-      const response = await request(wrappedOptions);
+      const response = await request(options);
 
       const lastModified = response.headers['last-modified'];
       const etag = response.headers.etag;
@@ -1141,10 +1065,6 @@ export async function isSuspended(
  * Checks whether the GitHub instance is a GitHub Enterprise server.
  */
 export async function isGitHubEnterprise(octokit: Octokit): Promise<boolean> {
-  try {
-    const response = await octokit.request('GET /versions');
-    return !!response.headers['x-github-enterprise-version'];
-  } catch {
-    return false;
-  }
+  const response = await octokit.request('GET /versions');
+  return !!response.headers['x-github-enterprise-version'];
 }

--- a/plugins/catalog-backend-module-github/src/lib/index.ts
+++ b/plugins/catalog-backend-module-github/src/lib/index.ts
@@ -17,10 +17,10 @@
 export { readGithubMultiOrgConfig } from './config';
 export type { GithubMultiOrgConfig } from './config';
 export {
+  createOctokit,
   getOrganizationRepositories,
   getOrganizationTeams,
   getOrganizationUsers,
-  createRestClient,
   type GithubUser,
   type GithubTeam,
   type GithubPageSizes,

--- a/plugins/catalog-backend-module-github/src/processors/GithubDiscoveryProcessor.ts
+++ b/plugins/catalog-backend-module-github/src/processors/GithubDiscoveryProcessor.ts
@@ -27,8 +27,7 @@ import {
   LocationSpec,
   processingResult,
 } from '@backstage/plugin-catalog-node';
-import { graphql } from '@octokit/graphql';
-import { getOrganizationRepositories } from '../lib';
+import { createOctokit, getOrganizationRepositories } from '../lib';
 import { LoggerService } from '@backstage/backend-plugin-api';
 
 /**
@@ -108,13 +107,11 @@ export class GithubDiscoveryProcessor implements CatalogProcessor {
     // about how to handle the wild card which is special for this processor.
     const orgUrl = `https://${host}/${org}`;
 
-    const { headers } = await this.githubCredentialsProvider.getCredentials({
-      url: orgUrl,
-    });
-
-    const client = graphql.defaults({
+    const octokit = createOctokit({
       baseUrl: gitHubConfig.apiBaseUrl,
-      headers,
+      orgUrl: orgUrl,
+      credentialsProvider: this.githubCredentialsProvider,
+      logger: this.logger,
     });
 
     // Read out all of the raw data
@@ -122,7 +119,7 @@ export class GithubDiscoveryProcessor implements CatalogProcessor {
     this.logger.info(`Reading GitHub repositories from ${location.target}`);
 
     const { repositories } = await getOrganizationRepositories(
-      client,
+      octokit,
       org,
       catalogPath,
     );

--- a/plugins/catalog-backend-module-github/src/processors/GithubMultiOrgReaderProcessor.ts
+++ b/plugins/catalog-backend-module-github/src/processors/GithubMultiOrgReaderProcessor.ts
@@ -35,10 +35,10 @@ import {
   LocationSpec,
   processingResult,
 } from '@backstage/plugin-catalog-node';
-import { graphql } from '@octokit/graphql';
 import {
   assignGroupsToUsers,
   buildOrgHierarchy,
+  createOctokit,
   defaultOrganizationTeamTransformer,
   defaultUserTransformer,
   getOrganizationTeams,
@@ -131,13 +131,11 @@ export class GithubMultiOrgReaderProcessor implements CatalogProcessor {
 
     for (const orgConfig of orgsToProcess) {
       try {
-        const { headers, type: tokenType } =
-          await this.githubCredentialsProvider.getCredentials({
-            url: `${baseUrl}/${orgConfig.name}`,
-          });
-        const client = graphql.defaults({
+        const octokit = createOctokit({
           baseUrl: gitHubConfig.apiBaseUrl,
-          headers,
+          orgUrl: `${baseUrl}/${orgConfig.name}`,
+          credentialsProvider: this.githubCredentialsProvider,
+          logger: this.logger,
         });
 
         const startTimestamp = Date.now();
@@ -145,9 +143,8 @@ export class GithubMultiOrgReaderProcessor implements CatalogProcessor {
           `Reading GitHub users and teams for org: ${orgConfig.name}`,
         );
         const { users } = await getOrganizationUsers(
-          client,
+          octokit,
           orgConfig.name,
-          tokenType,
           async (githubUser, ctx): Promise<Entity | undefined> => {
             const result = this.options.userTransformer
               ? await this.options.userTransformer(githubUser, ctx)
@@ -162,7 +159,7 @@ export class GithubMultiOrgReaderProcessor implements CatalogProcessor {
         );
 
         const { teams } = await getOrganizationTeams(
-          client,
+          octokit,
           orgConfig.name,
           async (team, ctx): Promise<Entity | undefined> => {
             const result = this.options.teamTransformer

--- a/plugins/catalog-backend-module-github/src/processors/GithubOrgReaderProcessor.test.ts
+++ b/plugins/catalog-backend-module-github/src/processors/GithubOrgReaderProcessor.test.ts
@@ -20,11 +20,14 @@ import {
   ScmIntegrations,
 } from '@backstage/integration';
 import { LocationSpec } from '@backstage/plugin-catalog-node';
-import { graphql } from '@octokit/graphql';
 import { GithubOrgReaderProcessor } from './GithubOrgReaderProcessor';
 import { mockServices } from '@backstage/backend-test-utils';
+import { createOctokit } from '../lib';
 
-jest.mock('@octokit/graphql');
+jest.mock('../lib', () => ({
+  ...jest.requireActual('../lib'),
+  createOctokit: jest.fn(),
+}));
 
 describe('GithubOrgReaderProcessor', () => {
   describe('implementation', () => {
@@ -107,7 +110,13 @@ describe('GithubOrgReaderProcessor', () => {
           },
         });
 
-      (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
+      (createOctokit as jest.Mock).mockReturnValue({
+        graphql: mockClient,
+        request: jest.fn().mockResolvedValue({ headers: {} }),
+        auth: jest
+          .fn()
+          .mockResolvedValue({ type: 'app', headers: { token: 'blah' } }),
+      });
 
       const processor = new GithubOrgReaderProcessor({
         integrations,
@@ -164,7 +173,13 @@ describe('GithubOrgReaderProcessor', () => {
           },
         });
 
-      (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
+      (createOctokit as jest.Mock).mockReturnValue({
+        graphql: mockClient,
+        request: jest.fn().mockResolvedValue({ headers: {} }),
+        auth: jest
+          .fn()
+          .mockResolvedValue({ type: 'token', headers: { token: 'blah' } }),
+      });
 
       const processor = new GithubOrgReaderProcessor({
         integrations,

--- a/plugins/catalog-backend-module-github/src/processors/GithubOrgReaderProcessor.ts
+++ b/plugins/catalog-backend-module-github/src/processors/GithubOrgReaderProcessor.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+import { Octokit } from '@octokit/core';
 import { Config } from '@backstage/config';
 import {
   DefaultGithubCredentialsProvider,
   GithubCredentialsProvider,
-  GithubCredentialType,
   ScmIntegrationRegistry,
   ScmIntegrations,
 } from '@backstage/integration';
@@ -28,18 +28,16 @@ import {
   LocationSpec,
   processingResult,
 } from '@backstage/plugin-catalog-node';
-import { graphql } from '@octokit/graphql';
 import {
   assignGroupsToUsers,
   buildOrgHierarchy,
+  createOctokit,
   getOrganizationTeams,
   getOrganizationUsers,
   parseGithubOrgUrl,
 } from '../lib';
 import { areGroupEntities, areUserEntities } from '../lib/guards';
 import { LoggerService } from '@backstage/backend-plugin-api';
-
-type GraphQL = typeof graphql;
 
 /**
  * Extracts teams and users out of a GitHub org.
@@ -94,15 +92,15 @@ export class GithubOrgReaderProcessor implements CatalogProcessor {
       return false;
     }
 
-    const { client, tokenType } = await this.createClient(location.target);
+    const octokit = this.createClient(location.target);
     const { org } = parseGithubOrgUrl(location.target);
 
     // Read out all of the raw data
     const startTimestamp = Date.now();
     this.logger.info('Reading GitHub users and groups');
 
-    const { users } = await getOrganizationUsers(client, org, tokenType);
-    const { teams } = await getOrganizationTeams(client, org);
+    const { users } = await getOrganizationUsers(octokit, org);
+    const { teams } = await getOrganizationTeams(octokit, org);
 
     const duration = ((Date.now() - startTimestamp) / 1000).toFixed(1);
     this.logger.debug(
@@ -127,9 +125,7 @@ export class GithubOrgReaderProcessor implements CatalogProcessor {
     return true;
   }
 
-  private async createClient(
-    orgUrl: string,
-  ): Promise<{ client: GraphQL; tokenType: GithubCredentialType }> {
+  private createClient(orgUrl: string): Octokit {
     const gitHubConfig = this.integrations.github.byUrl(orgUrl)?.config;
 
     if (!gitHubConfig) {
@@ -138,16 +134,11 @@ export class GithubOrgReaderProcessor implements CatalogProcessor {
       );
     }
 
-    const { headers, type: tokenType } =
-      await this.githubCredentialsProvider.getCredentials({
-        url: orgUrl,
-      });
-
-    const client = graphql.defaults({
-      baseUrl: gitHubConfig.apiBaseUrl,
-      headers,
+    return createOctokit({
+      baseUrl: gitHubConfig.apiBaseUrl!,
+      orgUrl: orgUrl,
+      credentialsProvider: this.githubCredentialsProvider,
+      logger: this.logger,
     });
-
-    return { client, tokenType };
   }
 }

--- a/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.test.ts
@@ -47,7 +47,20 @@ type PartialDeep<T> = T extends (...args: unknown[]) => unknown
 jest.mock('../lib/github', () => {
   return {
     getOrganizationRepositories: jest.fn(),
-    createGraphqlClient: jest.fn().mockReturnValue(jest.fn()),
+    getOrganizationRepository: jest.fn(),
+    createOctokit: jest.fn().mockReturnValue({
+      graphql: jest.fn(),
+      request: jest.fn().mockResolvedValue({ headers: {} }),
+      auth: jest
+        .fn()
+        .mockResolvedValue({ type: 'app', headers: { token: 'blah' } }),
+    }),
+    DEFAULT_PAGE_SIZES: {
+      teams: 25,
+      teamMembers: 50,
+      organizationMembers: 50,
+      repositories: 25,
+    },
   };
 });
 class PersistingTaskRunner implements SchedulerServiceTaskRunner {

--- a/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.ts
@@ -38,7 +38,7 @@ import {
   readProviderConfigs,
 } from './GithubEntityProviderConfig';
 import {
-  createGraphqlClient,
+  createOctokit,
   getOrganizationRepositories,
   getOrganizationRepository,
   RepositoryResponse,
@@ -241,17 +241,14 @@ export class GithubEntityProvider implements EntityProvider, EventSubscriber {
       .filter(Boolean) as string[];
   }
 
-  private async createGraphqlClient(organization: string) {
+  private createOctokitForOrg(organization: string) {
     const host = this.integration.host;
     const orgUrl = `https://${host}/${organization}`;
 
-    const { headers } = await this.githubCredentialsProvider.getCredentials({
-      url: orgUrl,
-    });
-
-    return createGraphqlClient({
-      headers,
-      baseUrl: this.integration.apiBaseUrl!,
+    return createOctokit({
+      baseUrl: this.integration.apiBaseUrl,
+      orgUrl,
+      credentialsProvider: this.githubCredentialsProvider,
       logger: this.logger,
     });
   }
@@ -263,7 +260,7 @@ export class GithubEntityProvider implements EntityProvider, EventSubscriber {
 
     let repositories: Repository[] = [];
     for (const organization of organizations) {
-      const client = await this.createGraphqlClient(organization);
+      const client = this.createOctokitForOrg(organization);
 
       const pageSizes: GithubPageSizes = {
         ...DEFAULT_PAGE_SIZES,
@@ -659,7 +656,7 @@ export class GithubEntityProvider implements EntityProvider, EventSubscriber {
     if (this.config.validateLocationsExist) {
       const organization = repository.organization;
       const catalogPath = this.config.catalogPath;
-      const client = await this.createGraphqlClient(organization);
+      const client = this.createOctokitForOrg(organization);
 
       const repositoryFromGithub = await getOrganizationRepository(
         client,

--- a/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.test.ts
@@ -22,23 +22,17 @@ import {
   DefaultEventsService,
   EventsService,
 } from '@backstage/plugin-events-node';
-import { graphql } from '@octokit/graphql';
 import {
   GithubMultiOrgEntityProvider,
   withLocations,
 } from './GithubMultiOrgEntityProvider';
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { mockServices } from '@backstage/backend-test-utils';
-import {
-  createRestClient,
-  isGitHubEnterprise,
-  isSuspended,
-} from '../lib/github';
+import { createOctokit, isGitHubEnterprise, isSuspended } from '../lib/github';
 
-jest.mock('@octokit/graphql');
 jest.mock('../lib/github', () => ({
   ...jest.requireActual('../lib/github'),
-  createRestClient: jest.fn(),
+  createOctokit: jest.fn(),
   isGitHubEnterprise: jest.fn(),
   isSuspended: jest.fn(),
 }));
@@ -64,7 +58,13 @@ describe('GithubMultiOrgEntityProvider', () => {
 
     beforeEach(() => {
       mockClient = jest.fn();
-      (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
+      (createOctokit as jest.Mock).mockReturnValue({
+        graphql: mockClient,
+        request: jest.fn().mockResolvedValue({ headers: {} }),
+        auth: jest
+          .fn()
+          .mockResolvedValue({ type: 'app', headers: { token: 'blah' } }),
+      });
 
       entityProviderConnection = {
         applyMutation: jest.fn(),
@@ -93,6 +93,7 @@ describe('GithubMultiOrgEntityProvider', () => {
         githubUrl: 'https://github.com',
         logger,
         orgs: ['orgA', 'orgB'],
+        cache: mockServices.cache.mock(),
       });
 
       await entityProvider.connect(entityProviderConnection);
@@ -211,16 +212,26 @@ describe('GithubMultiOrgEntityProvider', () => {
           },
         });
 
-      (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
+      (createOctokit as jest.Mock).mockReturnValue({
+        graphql: mockClient,
+        request: jest.fn().mockResolvedValue({ headers: {} }),
+        auth: jest
+          .fn()
+          .mockResolvedValue({ type: 'app', headers: { token: 'blah' } }),
+      });
 
       await entityProvider.read();
 
-      expect(mockGetCredentials).toHaveBeenCalledWith({
-        url: 'https://github.com/orgA',
-      });
-      expect(mockGetCredentials).toHaveBeenCalledWith({
-        url: 'https://github.com/orgB',
-      });
+      expect(createOctokit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orgUrl: 'https://github.com/orgA',
+        }),
+      );
+      expect(createOctokit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orgUrl: 'https://github.com/orgB',
+        }),
+      );
 
       expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith({
         entities: expect.arrayContaining([
@@ -378,6 +389,7 @@ describe('GithubMultiOrgEntityProvider', () => {
         githubUrl: 'https://github.com',
         logger,
         orgs: ['orgA', 'orgB'],
+        cache: mockServices.cache.mock(),
       });
 
       await entityProvider.connect(entityProviderConnection);
@@ -511,7 +523,13 @@ describe('GithubMultiOrgEntityProvider', () => {
           },
         });
 
-      (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
+      (createOctokit as jest.Mock).mockReturnValue({
+        graphql: mockClient,
+        request: jest.fn().mockResolvedValue({ headers: {} }),
+        auth: jest
+          .fn()
+          .mockResolvedValue({ type: 'app', headers: { token: 'blah' } }),
+      });
 
       const githubCredentialsProvider: GithubCredentialsProvider = {
         getCredentials: mockGetCredentials,
@@ -523,18 +541,23 @@ describe('GithubMultiOrgEntityProvider', () => {
         githubCredentialsProvider,
         githubUrl: 'https://github.com',
         logger,
+        cache: mockServices.cache.mock(),
       });
 
       entityProvider.connect(entityProviderConnection);
 
       await entityProvider.read();
 
-      expect(mockGetCredentials).toHaveBeenCalledWith({
-        url: 'https://github.com/orgC',
-      });
-      expect(mockGetCredentials).toHaveBeenCalledWith({
-        url: 'https://github.com/orgD',
-      });
+      expect(createOctokit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orgUrl: 'https://github.com/orgC',
+        }),
+      );
+      expect(createOctokit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orgUrl: 'https://github.com/orgD',
+        }),
+      );
 
       expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith({
         entities: expect.arrayContaining([
@@ -797,7 +820,13 @@ describe('GithubMultiOrgEntityProvider', () => {
           },
         });
 
-      (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
+      (createOctokit as jest.Mock).mockReturnValue({
+        graphql: mockClient,
+        request: jest.fn().mockResolvedValue({ headers: {} }),
+        auth: jest
+          .fn()
+          .mockResolvedValue({ type: 'app', headers: { token: 'blah' } }),
+      });
 
       entityProvider = new GithubMultiOrgEntityProvider({
         id: 'my-id',
@@ -809,6 +838,7 @@ describe('GithubMultiOrgEntityProvider', () => {
         logger,
         orgs: ['orgA', 'orgB'],
         alwaysUseDefaultNamespace: true,
+        cache: mockServices.cache.mock(),
       });
 
       await entityProvider.connect(entityProviderConnection);
@@ -968,6 +998,7 @@ describe('GithubMultiOrgEntityProvider', () => {
         githubUrl: 'https://github.com',
         logger,
         orgs: ['orgA', 'orgB'],
+        cache: mockServices.cache.mock(),
       });
 
       await entityProvider.connect(entityProviderConnection);
@@ -1063,6 +1094,14 @@ describe('GithubMultiOrgEntityProvider', () => {
     };
 
     beforeEach(async () => {
+      (createOctokit as jest.Mock).mockReturnValue({
+        graphql: jest.fn(),
+        request: jest.fn().mockResolvedValue({ headers: {} }),
+        auth: jest
+          .fn()
+          .mockResolvedValue({ type: 'app', headers: { token: 'blah' } }),
+      });
+
       const logger = mockServices.logger.mock();
       events = DefaultEventsService.create({ logger });
       const config = new ConfigReader({
@@ -1091,6 +1130,7 @@ describe('GithubMultiOrgEntityProvider', () => {
         githubUrl: 'https://github.com',
         logger,
         orgs: ['orgA', 'orgB'],
+        cache: mockServices.cache.mock(),
       });
 
       await entityProvider.connect(entityProviderConnection);
@@ -1232,7 +1272,13 @@ describe('GithubMultiOrgEntityProvider', () => {
             },
           });
 
-        (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
+        (createOctokit as jest.Mock).mockReturnValue({
+          graphql: mockClient,
+          request: jest.fn().mockResolvedValue({ headers: {} }),
+          auth: jest
+            .fn()
+            .mockResolvedValue({ type: 'app', headers: { token: 'blah' } }),
+        });
 
         await events.publish({
           topic: 'github.installation',
@@ -1365,7 +1411,13 @@ describe('GithubMultiOrgEntityProvider', () => {
             },
           });
 
-        (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
+        (createOctokit as jest.Mock).mockReturnValue({
+          graphql: mockClient,
+          request: jest.fn().mockResolvedValue({ headers: {} }),
+          auth: jest
+            .fn()
+            .mockResolvedValue({ type: 'app', headers: { token: 'blah' } }),
+        });
 
         await events.publish({
           topic: 'github.organization',
@@ -1437,7 +1489,13 @@ describe('GithubMultiOrgEntityProvider', () => {
           },
         });
 
-        (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
+        (createOctokit as jest.Mock).mockReturnValue({
+          graphql: mockClient,
+          request: jest.fn().mockResolvedValue({ headers: {} }),
+          auth: jest
+            .fn()
+            .mockResolvedValue({ type: 'app', headers: { token: 'blah' } }),
+        });
 
         await events.publish({
           topic: 'github.organization',
@@ -1534,7 +1592,13 @@ describe('GithubMultiOrgEntityProvider', () => {
             },
           });
 
-        (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
+        (createOctokit as jest.Mock).mockReturnValue({
+          graphql: mockClient,
+          request: jest.fn().mockResolvedValue({ headers: {} }),
+          auth: jest
+            .fn()
+            .mockResolvedValue({ type: 'app', headers: { token: 'blah' } }),
+        });
 
         await events.publish({
           topic: 'github.organization',
@@ -1863,7 +1927,13 @@ describe('GithubMultiOrgEntityProvider', () => {
             },
           });
 
-        (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
+        (createOctokit as jest.Mock).mockReturnValue({
+          graphql: mockClient,
+          request: jest.fn().mockResolvedValue({ headers: {} }),
+          auth: jest
+            .fn()
+            .mockResolvedValue({ type: 'app', headers: { token: 'blah' } }),
+        });
 
         await events.publish({
           topic: 'github.team',
@@ -2058,7 +2128,13 @@ describe('GithubMultiOrgEntityProvider', () => {
             },
           });
 
-        (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
+        (createOctokit as jest.Mock).mockReturnValue({
+          graphql: mockClient,
+          request: jest.fn().mockResolvedValue({ headers: {} }),
+          auth: jest
+            .fn()
+            .mockResolvedValue({ type: 'app', headers: { token: 'blah' } }),
+        });
 
         await events.publish({
           topic: 'github.team',
@@ -2237,7 +2313,13 @@ describe('GithubMultiOrgEntityProvider', () => {
             },
           });
 
-        (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
+        (createOctokit as jest.Mock).mockReturnValue({
+          graphql: mockClient,
+          request: jest.fn().mockResolvedValue({ headers: {} }),
+          auth: jest
+            .fn()
+            .mockResolvedValue({ type: 'app', headers: { token: 'blah' } }),
+        });
 
         await events.publish({
           topic: 'github.membership',
@@ -2395,7 +2477,13 @@ describe('GithubMultiOrgEntityProvider', () => {
             },
           });
 
-        (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
+        (createOctokit as jest.Mock).mockReturnValue({
+          graphql: mockClient,
+          request: jest.fn().mockResolvedValue({ headers: {} }),
+          auth: jest
+            .fn()
+            .mockResolvedValue({ type: 'app', headers: { token: 'blah' } }),
+        });
 
         await events.publish({
           topic: 'github.membership',
@@ -2486,6 +2574,7 @@ describe('GithubMultiOrgEntityProvider', () => {
     describe('suspended user handling', () => {
       let suspendedEvents: EventsService;
       let suspendedConnection: EntityProviderConnection;
+      let suspendedMockClient: jest.Mock;
 
       beforeEach(async () => {
         const logger = mockServices.logger.mock();
@@ -2507,7 +2596,14 @@ describe('GithubMultiOrgEntityProvider', () => {
           type: 'app',
         });
 
-        (createRestClient as jest.Mock).mockReturnValue({});
+        suspendedMockClient = jest.fn();
+        (createOctokit as jest.Mock).mockReturnValue({
+          graphql: suspendedMockClient,
+          request: jest.fn().mockResolvedValue({ headers: {} }),
+          auth: jest
+            .fn()
+            .mockResolvedValue({ type: 'app', headers: { token: 'blah' } }),
+        });
         (isGitHubEnterprise as jest.Mock).mockResolvedValue(true);
         (isSuspended as jest.Mock).mockResolvedValue(true);
 
@@ -2518,8 +2614,6 @@ describe('GithubMultiOrgEntityProvider', () => {
           githubUrl: 'https://github.com',
           logger,
           orgs: ['orgA', 'orgB'],
-          excludeSuspendedUsers: true,
-          experimental_checkForSuspendedUsersWithRest: true,
           cache: mockServices.cache.mock(),
         });
 
@@ -2551,9 +2645,7 @@ describe('GithubMultiOrgEntityProvider', () => {
       });
 
       it('should exclude suspended user on membership event', async () => {
-        const mockClient = jest.fn();
-
-        mockClient.mockResolvedValueOnce({
+        suspendedMockClient.mockResolvedValueOnce({
           organization: {
             team: {
               slug: 'team',
@@ -2569,8 +2661,6 @@ describe('GithubMultiOrgEntityProvider', () => {
             },
           },
         });
-
-        (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
 
         await suspendedEvents.publish({
           topic: 'github.membership',

--- a/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
@@ -38,8 +38,6 @@ import {
   EntityProviderConnection,
 } from '@backstage/plugin-catalog-node';
 import { EventParams, EventsService } from '@backstage/plugin-events-node';
-import { Octokit } from '@octokit/core';
-import { graphql } from '@octokit/graphql';
 import {
   InstallationCreatedEvent,
   InstallationEvent,
@@ -54,6 +52,7 @@ import {
 } from '@octokit/webhooks-types';
 import { memoize, merge } from 'lodash';
 import { randomUUID } from 'node:crypto';
+import { Octokit } from '@octokit/core';
 
 import {
   assignGroupsToUsers,
@@ -75,7 +74,7 @@ import {
   ANNOTATION_GITHUB_USER_LOGIN,
 } from '../lib/annotation';
 import {
-  createRestClient,
+  createOctokit,
   getOrganizationsFromUser,
   getOrganizationTeam,
   getOrganizationTeamsForUser,
@@ -150,6 +149,14 @@ export interface GithubMultiOrgEntityProviderOptions {
   logger: LoggerService;
 
   /**
+   * Cache service used to make conditional HTTP requests when checking for
+   * suspended users. Responses are cached and revalidated using
+   * Last-Modified/ETag headers, so unchanged responses from GitHub don't count
+   * against the REST API rate limit.
+   */
+  cache: CacheService;
+
+  /**
    * Optionally supply a custom credentials provider, replacing the default one.
    */
   githubCredentialsProvider?: GithubCredentialsProvider;
@@ -181,27 +188,15 @@ export interface GithubMultiOrgEntityProviderOptions {
   pageSizes?: Partial<GithubPageSizes>;
 
   /**
-   * Optionally exclude suspended users when querying organization users.
-   * @defaultValue false
-   * @remarks
-   * Only for GitHub Enterprise instances. Will error if used against GitHub.com API.
-   */
-  excludeSuspendedUsers?: boolean;
-
-  /**
-   * Optional cache service used for conditional HTTP request caching when
-   * checking suspended users via the REST API.
-   */
-  cache?: CacheService;
-
-  /**
-   * When set to true alongside `excludeSuspendedUsers`, use the GitHub REST API
-   * to check for suspended users instead of the GraphQL `suspendedAt` field.
-   * REST responses are cached using conditional HTTP requests to minimize rate
-   * limit usage.
+   * Whether to skip the suspended user check when querying organization users.
+   * By default, suspended users are automatically excluded on GitHub Enterprise
+   * instances using the REST API (without requiring site_admin scope).
+   * Set this to true to disable the check if needed.
+   * Be aware that if this check is disabled, suspended users will appear in the
+   * catalog with no way of distinguishing them from active valid users.
    * @defaultValue false
    */
-  experimental_checkForSuspendedUsersWithRest?: boolean;
+  dangerouslySkipSuspendedUserCheck?: boolean;
 }
 
 type CreateDeltaOperation = (entities: Entity[]) => {
@@ -249,10 +244,9 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       events: options.events,
       alwaysUseDefaultNamespace: options.alwaysUseDefaultNamespace,
       pageSizes: options.pageSizes,
-      excludeSuspendedUsers: options.excludeSuspendedUsers,
+      dangerouslySkipSuspendedUserCheck:
+        options.dangerouslySkipSuspendedUserCheck,
       cache: options.cache,
-      experimental_checkForSuspendedUsersWithRest:
-        options.experimental_checkForSuspendedUsersWithRest,
     });
 
     provider.schedule(options.schedule);
@@ -273,9 +267,8 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       teamTransformer?: TeamTransformer;
       alwaysUseDefaultNamespace?: boolean;
       pageSizes?: Partial<GithubPageSizes>;
-      excludeSuspendedUsers?: boolean;
-      cache?: CacheService;
-      experimental_checkForSuspendedUsersWithRest?: boolean;
+      dangerouslySkipSuspendedUserCheck?: boolean;
+      cache: CacheService;
     },
   ) {}
 
@@ -284,50 +277,36 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
     return `GithubMultiOrgEntityProvider:${this.options.id}`;
   }
 
-  private getPageSizes(): GithubPageSizes {
-    return {
-      ...DEFAULT_PAGE_SIZES,
-      ...this.options.pageSizes,
-    };
-  }
-
-  private get useRestSuspendedCheck(): boolean {
-    return (
-      !!this.options.excludeSuspendedUsers &&
-      !!this.options.experimental_checkForSuspendedUsersWithRest
-    );
-  }
-
-  private readonly restClients = new Map<string, Octokit>();
-
-  private getRestClient(org: string): Octokit {
-    let client = this.restClients.get(org);
-    if (!client) {
-      client = createRestClient({
+  private octokit = memoize(
+    (org: string): Octokit =>
+      createOctokit({
         baseUrl: this.options.gitHubConfig.apiBaseUrl,
         orgUrl: `${this.options.githubUrl}/${org}`,
         credentialsProvider: this.options.githubCredentialsProvider,
         logger: this.options.logger,
         cache: this.options.cache,
-      });
-      this.restClients.set(org, client);
-    }
-    return client;
-  }
-
-  private isGitHubEnterprise = memoize((org: string) =>
-    isGitHubEnterprise(this.getRestClient(org)),
+      }),
   );
 
-  private async shouldExclude(login: string, org: string): Promise<boolean> {
-    if (!this.useRestSuspendedCheck) {
+  private async shouldFilterSuspendedUsers(org: string): Promise<boolean> {
+    if (this.options.dangerouslySkipSuspendedUserCheck) {
       return false;
     }
-    const restClient = this.getRestClient(org);
+    return isGitHubEnterprise(this.octokit(org));
+  }
+
+  private async shouldExclude(login: string, org: string): Promise<boolean> {
     return (
-      (await this.isGitHubEnterprise(org)) &&
-      (await isSuspended(login, restClient, { org }))
+      (await this.shouldFilterSuspendedUsers(org)) &&
+      (await isSuspended(login, this.octokit(org), { org }))
     );
+  }
+
+  private getPageSizes(): GithubPageSizes {
+    return {
+      ...DEFAULT_PAGE_SIZES,
+      ...this.options.pageSizes,
+    };
   }
 
   /** {@inheritdoc @backstage/plugin-catalog-node#EntityProvider.connect} */
@@ -361,31 +340,21 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       : await this.getAllOrgs(this.options.gitHubConfig);
 
     for (const org of orgsToProcess) {
-      const { headers, type: tokenType } =
-        await this.options.githubCredentialsProvider.getCredentials({
-          url: `${this.options.githubUrl}/${org}`,
-        });
-      const client = graphql.defaults({
-        baseUrl: this.options.gitHubConfig.apiBaseUrl,
-        headers,
-      });
-
       logger.info(`Reading GitHub users and teams for org: ${org}`);
 
       const pageSizes = this.getPageSizes();
+      const shouldFilter = await this.shouldFilterSuspendedUsers(org);
 
       const { users } = await getOrganizationUsers(
-        client,
+        this.octokit(org),
         org,
-        tokenType,
         this.options.userTransformer,
         pageSizes,
-        this.options.excludeSuspendedUsers,
-        this.useRestSuspendedCheck ? this.getRestClient(org) : undefined,
+        shouldFilter,
       );
 
       const { teams } = await getOrganizationTeams(
-        client,
+        this.octokit(org),
         org,
         this.defaultMultiOrgTeamTransformer.bind(this),
         pageSizes,
@@ -534,29 +503,19 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
     }
 
     const org = event.installation.account.login;
-    const { headers, type: tokenType } =
-      await this.options.githubCredentialsProvider.getCredentials({
-        url: `${this.options.githubUrl}/${org}`,
-      });
-    const client = graphql.defaults({
-      baseUrl: this.options.gitHubConfig.apiBaseUrl,
-      headers,
-    });
-
     const pageSizes = this.getPageSizes();
+    const shouldFilter = await this.shouldFilterSuspendedUsers(org);
 
     const { users } = await getOrganizationUsers(
-      client,
+      this.octokit(org),
       org,
-      tokenType,
       this.options.userTransformer,
       pageSizes,
-      this.options.excludeSuspendedUsers,
-      this.useRestSuspendedCheck ? this.getRestClient(org) : undefined,
+      shouldFilter,
     );
 
     const { teams } = await getOrganizationTeams(
-      client,
+      this.octokit(org),
       org,
       this.defaultMultiOrgTeamTransformer.bind(this),
       pageSizes,
@@ -566,17 +525,8 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       // Fetch group memberships of users in case they already exist and
       // have memberships in groups from other applicable orgs
       for (const userOrg of applicableOrgs) {
-        const { headers: orgHeaders } =
-          await this.options.githubCredentialsProvider.getCredentials({
-            url: `${this.options.githubUrl}/${userOrg}`,
-          });
-        const orgClient = graphql.defaults({
-          baseUrl: this.options.gitHubConfig.apiBaseUrl,
-          headers: orgHeaders,
-        });
-
         const { teams: userTeams } = await getOrganizationTeamsFromUsers(
-          orgClient,
+          this.octokit(userOrg),
           userOrg,
           users.map(
             u =>
@@ -630,16 +580,7 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       return;
     }
 
-    const { headers } =
-      await this.options.githubCredentialsProvider.getCredentials({
-        url: `${this.options.githubUrl}/${org}`,
-      });
-    const client = graphql.defaults({
-      baseUrl: this.options.gitHubConfig.apiBaseUrl,
-      headers,
-    });
-
-    const { orgs } = await getOrganizationsFromUser(client, login);
+    const { orgs } = await getOrganizationsFromUser(this.octokit(org), login);
     const userApplicableOrgs = orgs.filter(o => applicableOrgs.includes(o));
 
     let updateMemberships: boolean;
@@ -674,7 +615,7 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       },
       {
         org,
-        client,
+        client: this.octokit(org).graphql,
         query: '',
       },
     );
@@ -686,17 +627,8 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
     if (updateMemberships) {
       const pageSizes = this.getPageSizes();
       for (const userOrg of userApplicableOrgs) {
-        const { headers: orgHeaders } =
-          await this.options.githubCredentialsProvider.getCredentials({
-            url: `${this.options.githubUrl}/${userOrg}`,
-          });
-        const orgClient = graphql.defaults({
-          baseUrl: this.options.gitHubConfig.apiBaseUrl,
-          headers: orgHeaders,
-        });
-
         const { teams } = await getOrganizationTeamsForUser(
-          orgClient,
+          this.octokit(userOrg),
           userOrg,
           login,
           this.defaultMultiOrgTeamTransformer.bind(this),
@@ -725,14 +657,6 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
     }
 
     const org = event.organization.login;
-    const { headers } =
-      await this.options.githubCredentialsProvider.getCredentials({
-        url: `${this.options.githubUrl}/${org}`,
-      });
-    const client = graphql.defaults({
-      baseUrl: this.options.gitHubConfig.apiBaseUrl,
-      headers,
-    });
 
     const { name, html_url: url, description, slug } = event.team;
     const group = (await this.defaultMultiOrgTeamTransformer(
@@ -750,7 +674,7 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       },
       {
         org,
-        client,
+        client: this.octokit(org).graphql,
         query: '',
       },
     )) as Entity;
@@ -777,19 +701,11 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
     }
 
     const org = event.organization.login;
-    const { headers, type: tokenType } =
-      await this.options.githubCredentialsProvider.getCredentials({
-        url: `${this.options.githubUrl}/${org}`,
-      });
-    const client = graphql.defaults({
-      baseUrl: this.options.gitHubConfig.apiBaseUrl,
-      headers,
-    });
 
     const pageSizes = this.getPageSizes();
     const teamSlug = event.team.slug;
     const { team } = await getOrganizationTeam(
-      client,
+      this.octokit(org),
       org,
       teamSlug,
       this.defaultMultiOrgTeamTransformer.bind(this),
@@ -797,13 +713,11 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
     );
 
     const { users } = await getOrganizationUsers(
-      client,
+      this.octokit(org),
       org,
-      tokenType,
       this.options.userTransformer,
       pageSizes,
-      this.options.excludeSuspendedUsers,
-      this.useRestSuspendedCheck ? this.getRestClient(org) : undefined,
+      await this.shouldFilterSuspendedUsers(org),
     );
 
     const usersFromChangedGroup = isGroupEntity(team)
@@ -818,17 +732,8 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
     if (usersToRebuild.length) {
       // Update memberships of associated members of this group in case the group entity ref changed
       for (const userOrg of applicableOrgs) {
-        const { headers: orgHeaders } =
-          await this.options.githubCredentialsProvider.getCredentials({
-            url: `${this.options.githubUrl}/${userOrg}`,
-          });
-        const orgClient = graphql.defaults({
-          baseUrl: this.options.gitHubConfig.apiBaseUrl,
-          headers: orgHeaders,
-        });
-
         const { teams } = await getOrganizationTeamsFromUsers(
-          orgClient,
+          this.octokit(userOrg),
           userOrg,
           usersToRebuild.map(
             u =>
@@ -861,7 +766,7 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       },
       {
         org,
-        client,
+        client: this.octokit(org).graphql,
         query: '',
       },
     )) as Entity;
@@ -896,19 +801,10 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
     }
 
     const org = event.organization.login;
-    const { headers } =
-      await this.options.githubCredentialsProvider.getCredentials({
-        url: `${this.options.githubUrl}/${org}`,
-      });
-    const client = graphql.defaults({
-      baseUrl: this.options.gitHubConfig.apiBaseUrl,
-      headers,
-    });
-
     const pageSizes = this.getPageSizes();
     const teamSlug = event.team.slug;
     const { team } = await getOrganizationTeam(
-      client,
+      this.octokit(org),
       org,
       teamSlug,
       this.defaultMultiOrgTeamTransformer.bind(this),
@@ -928,7 +824,7 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       },
       {
         org,
-        client,
+        client: this.octokit(org).graphql,
         query: '',
       },
     );
@@ -940,20 +836,14 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       if (await this.shouldExclude(login, org)) {
         removedEntities.push(user);
       } else {
-        const { orgs } = await getOrganizationsFromUser(client, login);
+        const { orgs } = await getOrganizationsFromUser(
+          this.octokit(org),
+          login,
+        );
         const userApplicableOrgs = orgs.filter(o => applicableOrgs.includes(o));
         for (const userOrg of userApplicableOrgs) {
-          const { headers: orgHeaders } =
-            await this.options.githubCredentialsProvider.getCredentials({
-              url: `${this.options.githubUrl}/${userOrg}`,
-            });
-          const orgClient = graphql.defaults({
-            baseUrl: this.options.gitHubConfig.apiBaseUrl,
-            headers: orgHeaders,
-          });
-
           const { teams } = await getOrganizationTeamsForUser(
-            orgClient,
+            this.octokit(userOrg),
             userOrg,
             login,
             this.defaultMultiOrgTeamTransformer.bind(this),

--- a/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.test.ts
@@ -25,21 +25,13 @@ import {
   DefaultEventsService,
   EventParams,
 } from '@backstage/plugin-events-node';
-import { graphql } from '@octokit/graphql';
-import {
-  createGraphqlClient,
-  createRestClient,
-  isGitHubEnterprise,
-  isSuspended,
-} from '../lib/github';
+import { createOctokit, isGitHubEnterprise, isSuspended } from '../lib/github';
 import { withLocations } from '../lib/withLocations';
 import { GithubOrgEntityProvider } from './GithubOrgEntityProvider';
 
-jest.mock('@octokit/graphql');
 jest.mock('../lib/github', () => ({
   ...jest.requireActual('../lib/github'),
-  createGraphqlClient: jest.fn(),
-  createRestClient: jest.fn(),
+  createOctokit: jest.fn(),
   isGitHubEnterprise: jest.fn(),
   isSuspended: jest.fn(),
 }));
@@ -47,12 +39,13 @@ jest.mock('../lib/github', () => ({
 describe('GithubOrgEntityProvider', () => {
   describe('read', () => {
     let mockClient: any;
+    let mockOctokit: any;
     let entityProviderConnection: EntityProviderConnection;
     let entityProvider: GithubOrgEntityProvider;
 
     const setupMocks = (response: ((...args: any) => any) | undefined) => {
       mockClient = jest.fn().mockImplementation(response);
-      (createGraphqlClient as jest.Mock).mockReturnValue(mockClient);
+      mockOctokit.graphql = mockClient;
     };
 
     beforeEach(() => {
@@ -60,6 +53,15 @@ describe('GithubOrgEntityProvider', () => {
         applyMutation: jest.fn(),
         refresh: jest.fn(),
       };
+
+      mockOctokit = {
+        graphql: jest.fn(),
+        request: jest.fn().mockResolvedValue({ headers: {} }),
+        auth: jest
+          .fn()
+          .mockResolvedValue({ type: 'app', headers: { token: 'blah' } }),
+      };
+      (createOctokit as jest.Mock).mockReturnValue(mockOctokit);
 
       const logger = mockServices.logger.mock();
       const gitHubConfig = {
@@ -81,6 +83,7 @@ describe('GithubOrgEntityProvider', () => {
         orgUrl: 'https://github.com/backstage',
         gitHubConfig,
         logger,
+        cache: mockServices.cache.mock(),
       });
 
       entityProvider.connect(entityProviderConnection);
@@ -276,6 +279,16 @@ describe('GithubOrgEntityProvider', () => {
   });
 
   describe('receiving events from github', () => {
+    beforeEach(() => {
+      (createOctokit as jest.Mock).mockReturnValue({
+        graphql: jest.fn(),
+        request: jest.fn().mockResolvedValue({ headers: {} }),
+        auth: jest
+          .fn()
+          .mockResolvedValue({ type: 'app', headers: { token: 'blah' } }),
+      });
+    });
+
     afterEach(() => jest.resetAllMocks());
 
     it('should apply delta added on receive a new member in the organization', async () => {
@@ -306,6 +319,7 @@ describe('GithubOrgEntityProvider', () => {
         orgUrl: 'https://github.com/backstage',
         gitHubConfig,
         logger,
+        cache: mockServices.cache.mock(),
       });
 
       await entityProvider.connect(entityProviderConnection);
@@ -395,6 +409,7 @@ describe('GithubOrgEntityProvider', () => {
         orgUrl: 'https://github.com/backstage',
         gitHubConfig,
         logger,
+        cache: mockServices.cache.mock(),
       });
 
       await entityProvider.connect(entityProviderConnection);
@@ -456,6 +471,153 @@ describe('GithubOrgEntityProvider', () => {
       });
     });
 
+    it('should skip adding a suspended user on member_added event', async () => {
+      const entityProviderConnection: EntityProviderConnection = {
+        applyMutation: jest.fn(),
+        refresh: jest.fn(),
+      };
+
+      const logger = mockServices.logger.mock();
+      const events = DefaultEventsService.create({ logger });
+      const gitHubConfig: GithubIntegrationConfig = {
+        host: 'github.com',
+      };
+
+      const mockGetCredentials = jest.fn().mockReturnValue({
+        headers: { token: 'blah' },
+        type: 'app',
+        token: 'blah',
+      });
+
+      const githubCredentialsProvider: GithubCredentialsProvider = {
+        getCredentials: mockGetCredentials,
+      };
+
+      (createOctokit as jest.Mock).mockReturnValue({
+        graphql: jest.fn(),
+        request: jest.fn().mockResolvedValue({ headers: {} }),
+        auth: jest
+          .fn()
+          .mockResolvedValue({ type: 'app', headers: { token: 'blah' } }),
+      });
+      (isGitHubEnterprise as jest.Mock).mockResolvedValue(true);
+      (isSuspended as jest.Mock).mockResolvedValue(true);
+
+      const entityProvider = new GithubOrgEntityProvider({
+        events,
+        id: 'my-id',
+        githubCredentialsProvider,
+        orgUrl: 'https://github.com/backstage',
+        gitHubConfig,
+        logger,
+        cache: mockServices.cache.mock(),
+      });
+
+      await entityProvider.connect(entityProviderConnection);
+
+      const event: EventParams = {
+        topic: 'github.organization',
+        eventPayload: {
+          action: 'member_added',
+          membership: {
+            user: {
+              name: 'githubuser',
+              login: 'githubuser',
+              node_id: 'githubuserId',
+              avatar_url: 'https://avatars.githubusercontent.com/u/83820368',
+              email: 'user1@test.com',
+            },
+          },
+          organization: {
+            login: 'test-org',
+          },
+        },
+      };
+      await events.publish(event);
+
+      expect(entityProviderConnection.applyMutation).not.toHaveBeenCalled();
+      expect(isSuspended).toHaveBeenCalledWith(
+        'githubuser',
+        expect.anything(),
+        { org: 'test-org' },
+      );
+    });
+
+    it('should add suspended user on member_added when dangerouslySkipSuspendedUserCheck is set', async () => {
+      const entityProviderConnection: EntityProviderConnection = {
+        applyMutation: jest.fn(),
+        refresh: jest.fn(),
+      };
+
+      const logger = mockServices.logger.mock();
+      const events = DefaultEventsService.create({ logger });
+      const gitHubConfig: GithubIntegrationConfig = {
+        host: 'github.com',
+      };
+
+      const mockGetCredentials = jest.fn().mockReturnValue({
+        headers: { token: 'blah' },
+        type: 'app',
+        token: 'blah',
+      });
+
+      const githubCredentialsProvider: GithubCredentialsProvider = {
+        getCredentials: mockGetCredentials,
+      };
+
+      (isGitHubEnterprise as jest.Mock).mockResolvedValue(true);
+      (isSuspended as jest.Mock).mockResolvedValue(true);
+
+      const entityProvider = new GithubOrgEntityProvider({
+        events,
+        id: 'my-id',
+        githubCredentialsProvider,
+        orgUrl: 'https://github.com/backstage',
+        gitHubConfig,
+        logger,
+        dangerouslySkipSuspendedUserCheck: true,
+        cache: mockServices.cache.mock(),
+      });
+
+      await entityProvider.connect(entityProviderConnection);
+
+      const event: EventParams = {
+        topic: 'github.organization',
+        eventPayload: {
+          action: 'member_added',
+          membership: {
+            user: {
+              name: 'githubuser',
+              login: 'githubuser',
+              node_id: 'githubuserId',
+              avatar_url: 'https://avatars.githubusercontent.com/u/83820368',
+              email: 'user1@test.com',
+            },
+          },
+          organization: {
+            login: 'test-org',
+          },
+        },
+      };
+      await events.publish(event);
+
+      expect(entityProviderConnection.applyMutation).toHaveBeenCalledTimes(1);
+      expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith({
+        type: 'delta',
+        added: [
+          {
+            locationKey: 'github-org-provider:my-id',
+            entity: expect.objectContaining({
+              kind: 'User',
+              metadata: expect.objectContaining({ name: 'githubuser' }),
+            }),
+          },
+        ],
+        removed: [],
+      });
+      expect(isSuspended).not.toHaveBeenCalled();
+    });
+
     it('should apply delta added on receive a created team', async () => {
       const entityProviderConnection: EntityProviderConnection = {
         applyMutation: jest.fn(),
@@ -484,6 +646,7 @@ describe('GithubOrgEntityProvider', () => {
         orgUrl: 'https://github.com/backstage',
         gitHubConfig,
         logger,
+        cache: mockServices.cache.mock(),
       });
 
       entityProvider.connect(entityProviderConnection);
@@ -577,6 +740,7 @@ describe('GithubOrgEntityProvider', () => {
         orgUrl: 'https://github.com/backstage',
         gitHubConfig,
         logger,
+        cache: mockServices.cache.mock(),
       });
 
       entityProvider.connect(entityProviderConnection);
@@ -666,6 +830,7 @@ describe('GithubOrgEntityProvider', () => {
         orgUrl: 'https://github.com/backstage',
         gitHubConfig,
         logger,
+        cache: mockServices.cache.mock(),
       });
 
       await entityProvider.connect(entityProviderConnection);
@@ -753,15 +918,6 @@ describe('GithubOrgEntityProvider', () => {
         getCredentials: mockGetCredentials,
       };
 
-      const entityProvider = new GithubOrgEntityProvider({
-        events,
-        id: 'my-id',
-        githubCredentialsProvider,
-        orgUrl: 'https://github.com/backstage',
-        gitHubConfig,
-        logger,
-      });
-
       const mockClient = jest.fn();
 
       mockClient
@@ -836,7 +992,23 @@ describe('GithubOrgEntityProvider', () => {
           },
         });
 
-      (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
+      (createOctokit as jest.Mock).mockReturnValue({
+        graphql: mockClient,
+        request: jest.fn().mockResolvedValue({ headers: {} }),
+        auth: jest
+          .fn()
+          .mockResolvedValue({ type: 'app', headers: { token: 'blah' } }),
+      });
+
+      const entityProvider = new GithubOrgEntityProvider({
+        events,
+        id: 'my-id',
+        githubCredentialsProvider,
+        orgUrl: 'https://github.com/backstage',
+        gitHubConfig,
+        logger,
+        cache: mockServices.cache.mock(),
+      });
 
       await entityProvider.connect(entityProviderConnection);
 
@@ -1011,15 +1183,6 @@ describe('GithubOrgEntityProvider', () => {
         getCredentials: mockGetCredentials,
       };
 
-      const entityProvider = new GithubOrgEntityProvider({
-        events,
-        id: 'my-id',
-        githubCredentialsProvider,
-        orgUrl: 'https://github.com/backstage',
-        gitHubConfig,
-        logger,
-      });
-
       const mockClient = jest.fn();
 
       mockClient
@@ -1065,7 +1228,24 @@ describe('GithubOrgEntityProvider', () => {
           },
         });
 
-      (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
+      (createOctokit as jest.Mock).mockReturnValue({
+        graphql: mockClient,
+        request: jest.fn().mockResolvedValue({ headers: {} }),
+        auth: jest
+          .fn()
+          .mockResolvedValue({ type: 'app', headers: { token: 'blah' } }),
+      });
+
+      const entityProvider = new GithubOrgEntityProvider({
+        events,
+        id: 'my-id',
+        githubCredentialsProvider,
+        orgUrl: 'https://github.com/backstage',
+        gitHubConfig,
+        logger,
+        cache: mockServices.cache.mock(),
+      });
+
       await entityProvider.connect(entityProviderConnection);
 
       const event: EventParams = {
@@ -1181,15 +1361,6 @@ describe('GithubOrgEntityProvider', () => {
         getCredentials: mockGetCredentials,
       };
 
-      const entityProvider = new GithubOrgEntityProvider({
-        events,
-        id: 'my-id',
-        githubCredentialsProvider,
-        orgUrl: 'https://github.com/backstage',
-        gitHubConfig,
-        logger,
-      });
-
       const mockClient = jest.fn();
 
       mockClient
@@ -1224,7 +1395,24 @@ describe('GithubOrgEntityProvider', () => {
           },
         });
 
-      (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
+      (createOctokit as jest.Mock).mockReturnValue({
+        graphql: mockClient,
+        request: jest.fn().mockResolvedValue({ headers: {} }),
+        auth: jest
+          .fn()
+          .mockResolvedValue({ type: 'app', headers: { token: 'blah' } }),
+      });
+
+      const entityProvider = new GithubOrgEntityProvider({
+        events,
+        id: 'my-id',
+        githubCredentialsProvider,
+        orgUrl: 'https://github.com/backstage',
+        gitHubConfig,
+        logger,
+        cache: mockServices.cache.mock(),
+      });
+
       await entityProvider.connect(entityProviderConnection);
 
       const event: EventParams = {
@@ -1319,131 +1507,6 @@ describe('GithubOrgEntityProvider', () => {
       });
     });
 
-    it('should skip adding a suspended user on member_added event', async () => {
-      const entityProviderConnection: EntityProviderConnection = {
-        applyMutation: jest.fn(),
-        refresh: jest.fn(),
-      };
-
-      const logger = mockServices.logger.mock();
-      const events = DefaultEventsService.create({ logger });
-      const gitHubConfig: GithubIntegrationConfig = {
-        host: 'github.com',
-      };
-
-      const mockGetCredentials = jest.fn().mockReturnValue({
-        headers: { token: 'blah' },
-        type: 'app',
-        token: 'blah',
-      });
-
-      const githubCredentialsProvider: GithubCredentialsProvider = {
-        getCredentials: mockGetCredentials,
-      };
-
-      (createRestClient as jest.Mock).mockReturnValue({});
-      (isGitHubEnterprise as jest.Mock).mockResolvedValue(true);
-      (isSuspended as jest.Mock).mockResolvedValue(true);
-
-      const entityProvider = new GithubOrgEntityProvider({
-        events,
-        id: 'my-id',
-        githubCredentialsProvider,
-        orgUrl: 'https://github.com/backstage',
-        gitHubConfig,
-        logger,
-        excludeSuspendedUsers: true,
-        experimental_checkForSuspendedUsersWithRest: true,
-        cache: mockServices.cache.mock(),
-      });
-
-      await entityProvider.connect(entityProviderConnection);
-
-      const event: EventParams = {
-        topic: 'github.organization',
-        eventPayload: {
-          action: 'member_added',
-          membership: {
-            user: {
-              name: 'githubuser',
-              login: 'githubuser',
-              node_id: 'githubuserId',
-              avatar_url: 'https://avatars.githubusercontent.com/u/83820368',
-              email: 'user1@test.com',
-            },
-          },
-          organization: {
-            login: 'test-org',
-          },
-        },
-      };
-      await events.publish(event);
-
-      expect(entityProviderConnection.applyMutation).not.toHaveBeenCalled();
-      expect(isSuspended).toHaveBeenCalledWith(
-        'githubuser',
-        expect.anything(),
-        { org: 'test-org' },
-      );
-    });
-
-    it('should not skip member_added when experimental flag is off', async () => {
-      const entityProviderConnection: EntityProviderConnection = {
-        applyMutation: jest.fn(),
-        refresh: jest.fn(),
-      };
-
-      const logger = mockServices.logger.mock();
-      const events = DefaultEventsService.create({ logger });
-      const gitHubConfig: GithubIntegrationConfig = {
-        host: 'github.com',
-      };
-
-      const mockGetCredentials = jest.fn().mockReturnValue({
-        headers: { token: 'blah' },
-        type: 'app',
-      });
-
-      const githubCredentialsProvider: GithubCredentialsProvider = {
-        getCredentials: mockGetCredentials,
-      };
-
-      const entityProvider = new GithubOrgEntityProvider({
-        events,
-        id: 'my-id',
-        githubCredentialsProvider,
-        orgUrl: 'https://github.com/backstage',
-        gitHubConfig,
-        logger,
-        excludeSuspendedUsers: true,
-      });
-
-      await entityProvider.connect(entityProviderConnection);
-
-      const event: EventParams = {
-        topic: 'github.organization',
-        eventPayload: {
-          action: 'member_added',
-          membership: {
-            user: {
-              name: 'githubuser',
-              login: 'githubuser',
-              node_id: 'githubuserId',
-              avatar_url: 'https://avatars.githubusercontent.com/u/83820368',
-              email: 'user1@test.com',
-            },
-          },
-          organization: {
-            login: 'test-org',
-          },
-        },
-      };
-      await events.publish(event);
-
-      expect(entityProviderConnection.applyMutation).toHaveBeenCalledTimes(1);
-      expect(isSuspended).not.toHaveBeenCalled();
-    });
-
     it.each(['added', 'removed'])(
       'should exclude suspended user on membership %s event',
       async action => {
@@ -1468,9 +1531,41 @@ describe('GithubOrgEntityProvider', () => {
           getCredentials: mockGetCredentials,
         };
 
-        (createRestClient as jest.Mock).mockReturnValue({});
         (isGitHubEnterprise as jest.Mock).mockResolvedValue(true);
         (isSuspended as jest.Mock).mockResolvedValue(true);
+
+        const mockClient = jest.fn();
+
+        mockClient
+          // getOrganizationTeam
+          .mockResolvedValueOnce({
+            organization: {
+              team: {
+                slug: 'team',
+                combinedSlug: 'blah/team',
+                name: 'Team',
+                description: 'The one and only team',
+                avatarUrl: 'http://example.com/team.jpeg',
+                parentTeam: {
+                  slug: 'parent',
+                  combinedSlug: '',
+                  members: { pageInfo: { hasNextPage: false }, nodes: [] },
+                },
+                members: {
+                  pageInfo: { hasNextPage: false },
+                  nodes: [{ login: 'a' }, { login: 'githubuser' }],
+                },
+              },
+            },
+          });
+
+        (createOctokit as jest.Mock).mockReturnValue({
+          graphql: mockClient,
+          request: jest.fn().mockResolvedValue({ headers: {} }),
+          auth: jest
+            .fn()
+            .mockResolvedValue({ type: 'app', headers: { token: 'blah' } }),
+        });
 
         const entityProvider = new GithubOrgEntityProvider({
           events,
@@ -1479,35 +1574,9 @@ describe('GithubOrgEntityProvider', () => {
           orgUrl: 'https://github.com/backstage',
           gitHubConfig,
           logger,
-          excludeSuspendedUsers: true,
-          experimental_checkForSuspendedUsersWithRest: true,
           cache: mockServices.cache.mock(),
         });
 
-        const mockClient = jest.fn();
-
-        mockClient.mockResolvedValueOnce({
-          organization: {
-            team: {
-              slug: 'team',
-              combinedSlug: 'blah/team',
-              name: 'Team',
-              description: 'The one and only team',
-              avatarUrl: 'http://example.com/team.jpeg',
-              parentTeam: {
-                slug: 'parent',
-                combinedSlug: '',
-                members: { pageInfo: { hasNextPage: false }, nodes: [] },
-              },
-              members: {
-                pageInfo: { hasNextPage: false },
-                nodes: [{ login: 'a' }, { login: 'githubuser' }],
-              },
-            },
-          },
-        });
-
-        (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
         await entityProvider.connect(entityProviderConnection);
 
         const event: EventParams = {

--- a/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.ts
@@ -34,7 +34,6 @@ import {
 } from '@backstage/plugin-catalog-node';
 import { EventParams, EventsService } from '@backstage/plugin-events-node';
 import { Octokit } from '@octokit/core';
-import { graphql } from '@octokit/graphql';
 import {
   MembershipEvent,
   OrganizationEvent,
@@ -52,9 +51,8 @@ import {
 } from '../lib/defaultTransformers';
 import {
   createAddEntitiesOperation,
-  createGraphqlClient,
+  createOctokit,
   createRemoveEntitiesOperation,
-  createRestClient,
   DEFAULT_PAGE_SIZES,
   DeferredEntitiesBuilder,
   getOrganizationTeam,
@@ -75,7 +73,6 @@ import {
 } from '../lib/org';
 import { parseGithubOrgUrl } from '../lib/util';
 import { withLocations } from '../lib/withLocations';
-import { memoize } from 'lodash';
 
 const EVENT_TOPICS = [
   'github.membership',
@@ -129,6 +126,14 @@ export interface GithubOrgEntityProviderOptions {
   logger: LoggerService;
 
   /**
+   * Cache service used to make conditional HTTP requests when checking for
+   * suspended users. Responses are cached and revalidated using
+   * Last-Modified/ETag headers, so unchanged responses from GitHub don't count
+   * against the REST API rate limit.
+   */
+  cache: CacheService;
+
+  /**
    * Optionally supply a custom credentials provider, replacing the default one.
    */
   githubCredentialsProvider?: GithubCredentialsProvider;
@@ -150,27 +155,15 @@ export interface GithubOrgEntityProviderOptions {
   pageSizes?: Partial<GithubPageSizes>;
 
   /**
-   * Optionally exclude suspended users when querying organization users.
-   * @defaultValue false
-   * @remarks
-   * Only for GitHub Enterprise instances. Will error if used against GitHub.com API.
-   */
-  excludeSuspendedUsers?: boolean;
-
-  /**
-   * Optional cache service used for conditional HTTP request caching when
-   * checking suspended users via the REST API.
-   */
-  cache?: CacheService;
-
-  /**
-   * When set to true alongside `excludeSuspendedUsers`, use the GitHub REST API
-   * to check for suspended users instead of the GraphQL `suspendedAt` field.
-   * REST responses are cached using conditional HTTP requests to minimize rate
-   * limit usage.
+   * Whether to skip the suspended user check when querying organization users.
+   * By default, suspended users are automatically excluded on GitHub Enterprise
+   * instances using the REST API (without requiring site_admin scope).
+   * Set this to true to disable the check if needed.
+   * Be aware that if this check is disabled, suspended users will appear in the
+   * catalog with no way of distinguishing them from active valid users.
    * @defaultValue false
    */
-  experimental_checkForSuspendedUsersWithRest?: boolean;
+  dangerouslySkipSuspendedUserCheck?: boolean;
 }
 
 /**
@@ -180,7 +173,7 @@ export interface GithubOrgEntityProviderOptions {
  */
 export class GithubOrgEntityProvider implements EntityProvider {
   private readonly credentialsProvider: GithubCredentialsProvider;
-  private cachedRestClient?: Octokit;
+  private readonly octokit: Octokit;
   private connection?: EntityProviderConnection;
   private scheduleFn?: () => Promise<void>;
 
@@ -210,10 +203,9 @@ export class GithubOrgEntityProvider implements EntityProvider {
       teamTransformer: options.teamTransformer,
       events: options.events,
       pageSizes: options.pageSizes,
-      excludeSuspendedUsers: options.excludeSuspendedUsers,
+      dangerouslySkipSuspendedUserCheck:
+        options.dangerouslySkipSuspendedUserCheck,
       cache: options.cache,
-      experimental_checkForSuspendedUsersWithRest:
-        options.experimental_checkForSuspendedUsersWithRest,
     });
 
     provider.schedule(options.schedule);
@@ -232,14 +224,21 @@ export class GithubOrgEntityProvider implements EntityProvider {
       userTransformer?: UserTransformer;
       teamTransformer?: TeamTransformer;
       pageSizes?: Partial<GithubPageSizes>;
-      excludeSuspendedUsers?: boolean;
-      cache?: CacheService;
-      experimental_checkForSuspendedUsersWithRest?: boolean;
+      dangerouslySkipSuspendedUserCheck?: boolean;
+      cache: CacheService;
     },
   ) {
     this.credentialsProvider =
       options.githubCredentialsProvider ||
       SingleInstanceGithubCredentialsProvider.create(this.options.gitHubConfig);
+
+    this.octokit = createOctokit({
+      baseUrl: this.options.gitHubConfig.apiBaseUrl,
+      orgUrl: this.options.orgUrl,
+      credentialsProvider: this.credentialsProvider,
+      logger: this.options.logger,
+      cache: this.options.cache,
+    });
   }
 
   /** {@inheritdoc @backstage/plugin-catalog-node#EntityProvider.getProviderName} */
@@ -247,46 +246,25 @@ export class GithubOrgEntityProvider implements EntityProvider {
     return `GithubOrgEntityProvider:${this.options.id}`;
   }
 
+  private async shouldFilterSuspendedUsers(): Promise<boolean> {
+    if (this.options.dangerouslySkipSuspendedUserCheck) {
+      return false;
+    }
+    return isGitHubEnterprise(this.octokit);
+  }
+
+  private async shouldExclude(login: string, org: string): Promise<boolean> {
+    return (
+      (await this.shouldFilterSuspendedUsers()) &&
+      (await isSuspended(login, this.octokit, { org }))
+    );
+  }
+
   private getPageSizes(): GithubPageSizes {
     return {
       ...DEFAULT_PAGE_SIZES,
       ...this.options.pageSizes,
     };
-  }
-
-  private get useRestSuspendedCheck(): boolean {
-    return (
-      !!this.options.excludeSuspendedUsers &&
-      !!this.options.experimental_checkForSuspendedUsersWithRest
-    );
-  }
-
-  private isGitHubEnterprise = memoize(() =>
-    isGitHubEnterprise(this.getRestClient()),
-  );
-
-  private getRestClient(): Octokit {
-    if (!this.cachedRestClient) {
-      this.cachedRestClient = createRestClient({
-        baseUrl: this.options.gitHubConfig.apiBaseUrl,
-        orgUrl: this.options.orgUrl,
-        credentialsProvider: this.credentialsProvider,
-        logger: this.options.logger,
-        cache: this.options.cache,
-      });
-    }
-    return this.cachedRestClient;
-  }
-
-  private async shouldExclude(login: string, org: string): Promise<boolean> {
-    if (!this.useRestSuspendedCheck) {
-      return false;
-    }
-    const restClient = this.getRestClient();
-    return (
-      (await this.isGitHubEnterprise()) &&
-      (await isSuspended(login, restClient, { org }))
-    );
   }
 
   /** {@inheritdoc @backstage/plugin-catalog-node#EntityProvider.connect} */
@@ -312,31 +290,18 @@ export class GithubOrgEntityProvider implements EntityProvider {
     const logger = options?.logger ?? this.options.logger;
     const { markReadComplete } = trackProgress(logger);
 
-    const { headers, type: tokenType } =
-      await this.credentialsProvider.getCredentials({
-        url: this.options.orgUrl,
-      });
-
-    const client = createGraphqlClient({
-      headers,
-      baseUrl: this.options.gitHubConfig.apiBaseUrl!,
-      logger,
-    });
-
     const { org } = parseGithubOrgUrl(this.options.orgUrl);
     const pageSizes = this.getPageSizes();
-
+    const shouldFilter = await this.shouldFilterSuspendedUsers();
     const { users } = await getOrganizationUsers(
-      client,
+      this.octokit,
       org,
-      tokenType,
       this.options.userTransformer,
       pageSizes,
-      this.options.excludeSuspendedUsers,
-      this.useRestSuspendedCheck ? this.getRestClient() : undefined,
+      shouldFilter,
     );
     const { teams } = await getOrganizationTeams(
-      client,
+      this.octokit,
       org,
       this.options.teamTransformer,
       pageSizes,
@@ -439,32 +404,22 @@ export class GithubOrgEntityProvider implements EntityProvider {
     }
 
     const teamSlug = event.team.slug;
-    const { headers, type: tokenType } =
-      await this.credentialsProvider.getCredentials({
-        url: this.options.orgUrl,
-      });
-    const client = graphql.defaults({
-      baseUrl: this.options.gitHubConfig.apiBaseUrl,
-      headers,
-    });
 
     const { org } = parseGithubOrgUrl(this.options.orgUrl);
     const pageSizes = this.getPageSizes();
     const { team } = await getOrganizationTeam(
-      client,
+      this.octokit,
       org,
       teamSlug,
       this.options.teamTransformer,
     );
 
     const { users } = await getOrganizationUsers(
-      client,
+      this.octokit,
       org,
-      tokenType,
       this.options.userTransformer,
       pageSizes,
-      this.options.excludeSuspendedUsers,
-      this.useRestSuspendedCheck ? this.getRestClient() : undefined,
+      await this.shouldFilterSuspendedUsers(),
     );
 
     if (!isGroupEntity(team)) {
@@ -477,7 +432,7 @@ export class GithubOrgEntityProvider implements EntityProvider {
     );
 
     const { teams } = await getOrganizationTeamsFromUsers(
-      client,
+      this.octokit,
       org,
       usersToRebuild.map(u => u.metadata.name),
       this.options.teamTransformer,
@@ -510,7 +465,7 @@ export class GithubOrgEntityProvider implements EntityProvider {
       },
       {
         org,
-        client,
+        client: this.octokit.graphql,
         query: '',
       },
     )) as Entity;
@@ -543,18 +498,11 @@ export class GithubOrgEntityProvider implements EntityProvider {
     }
 
     const teamSlug = event.team.slug;
-    const { headers } = await this.credentialsProvider.getCredentials({
-      url: this.options.orgUrl,
-    });
-    const client = graphql.defaults({
-      baseUrl: this.options.gitHubConfig.apiBaseUrl,
-      headers,
-    });
 
     const { org } = parseGithubOrgUrl(this.options.orgUrl);
     const pageSizes = this.getPageSizes();
     const { team } = await getOrganizationTeam(
-      client,
+      this.octokit,
       org,
       teamSlug,
       this.options.teamTransformer,
@@ -574,7 +522,7 @@ export class GithubOrgEntityProvider implements EntityProvider {
       },
       {
         org,
-        client,
+        client: this.octokit.graphql,
         query: '',
       },
     );
@@ -583,13 +531,17 @@ export class GithubOrgEntityProvider implements EntityProvider {
     const removedEntities: Entity[] = [];
 
     if (user && isUserEntity(user)) {
+      // This event is nothing to do with the user's status, but any changes to
+      // their membership can affect their access, so it's a good moment to
+      // recheck whether they're suspended and remove them from the org if
+      // needed.
       if (await this.shouldExclude(login, org)) {
         removedEntities.push(user);
       } else {
         const teamTransformer =
           this.options.teamTransformer || defaultOrganizationTeamTransformer;
         const { teams } = await getOrganizationTeamsForUser(
-          client,
+          this.octokit,
           org,
           login,
           teamTransformer,
@@ -600,6 +552,10 @@ export class GithubOrgEntityProvider implements EntityProvider {
           assignGroupsToUser(user, teams);
         }
 
+        // This function handles both added and removed events, but the
+        // additions are to teams in the org, implying that in either case,
+        // they're a member of the org itself. So either way, an event implies
+        // that the user should be added to the catalog.
         addedEntities.push(user);
       }
     }
@@ -635,13 +591,6 @@ export class GithubOrgEntityProvider implements EntityProvider {
       this.options.teamTransformer || defaultOrganizationTeamTransformer;
     const { name, html_url: url, description, slug } = event.team;
     const org = event.organization.login;
-    const { headers } = await this.credentialsProvider.getCredentials({
-      url: this.options.orgUrl,
-    });
-    const client = graphql.defaults({
-      baseUrl: this.options.gitHubConfig.apiBaseUrl,
-      headers,
-    });
 
     const group = (await organizationTeamTransformer(
       {
@@ -658,7 +607,7 @@ export class GithubOrgEntityProvider implements EntityProvider {
       },
       {
         org,
-        client,
+        client: this.octokit.graphql,
         query: '',
       },
     )) as Entity;
@@ -698,14 +647,6 @@ export class GithubOrgEntityProvider implements EntityProvider {
       return;
     }
 
-    const { headers } = await this.credentialsProvider.getCredentials({
-      url: this.options.orgUrl,
-    });
-    const client = graphql.defaults({
-      baseUrl: this.options.gitHubConfig.apiBaseUrl,
-      headers,
-    });
-
     const user = (await userTransformer(
       {
         name,
@@ -718,7 +659,7 @@ export class GithubOrgEntityProvider implements EntityProvider {
       },
       {
         org,
-        client,
+        client: this.octokit.graphql,
         query: '',
       },
     )) as Entity;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

**Suspended users are now automatically excluded** on GitHub Enterprise instances, and `site_admin` scope is no longer required to check for user suspension. To encourage adoption, the previous `excludeSuspendedUsers` option (default false) has been replaced with `dangerouslySkipSuspendedUserCheck` (opposite behavior, also default false).

Since this new behavior makes much heavier use of rate limits, this PR also introduces conditional requests for the REST API consumption in the providers. Response data, headers, etags and last-modified dates are stored in the cacheService cache with a long TTL and included with future requests, meaning that only the first load of user data will typically result in a big rate limit hit. The cache TTL can be really long, because we never return the data in the cache without getting a 304 back from GitHub to indicate it's up to date.

Without this caching system in place, this change would add 2 REST API rate-limit points _per user_ to every provider run when suspended user checking is enabled, so it seems unavoidable that we add it.

### How it works

- Uses the REST API (`GET /users/{username}` and `GET /orgs/{org}/memberships/{username}`) to detect both account-level suspension and suspension of organization membership.
- Automatically detects whether the target is a GitHub Enterprise instance via `GET /versions` and skips the check on github.com where suspension isn't supported
- Uses Octokit's throttling and retry plugins to handle rate limiting
- Filters suspended users during GraphQL pagination via an async filter in `queryWithPaging`

### Breaking change

`excludeSuspendedUsers` config and option is removed. The suspended user check now runs by default. To opt out, set `dangerouslySkipSuspendedUserCheck: true` in config or the provider options.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

🤖 Generated with [Claude Code](https://claude.com/claude-code)