### PR TITLE
fix(catalog-react): tolerate non-string annotation/label values in Inspect dialog

### DIFF
--- a/.changeset/inspect-entity-dialog-non-string-annotations.md
+++ b/.changeset/inspect-entity-dialog-non-string-annotations.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Fix the Inspect Entity dialog crashing when an entity carries non-string `metadata.annotations` or `metadata.labels` values (for example a `null` value set by a programmatic catalog provider). Such values now render as their JSON-stringified form instead of throwing `TypeError: Cannot read properties of null (reading 'match')`.

--- a/.changeset/inspect-entity-dialog-non-string-annotations.md
+++ b/.changeset/inspect-entity-dialog-non-string-annotations.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-react': patch
 ---
 
-Fix the Inspect Entity dialog crashing when an entity carries non-string `metadata.annotations` or `metadata.labels` values (for example a `null` value set by a programmatic catalog provider). Such values now render as their JSON-stringified form instead of throwing `TypeError: Cannot read properties of null (reading 'match')`.
+Fix the Inspect Entity dialog crashing when an entity carries non-string `metadata.annotations` or `metadata.labels` values (for example a `null` value set by a programmatic catalog provider). Such values now render as their JSON-stringified form, falling back to `String(value)` when stringification throws or is undefined (e.g. `BigInt`, circular references, `Symbol`), instead of throwing `TypeError: Cannot read properties of null (reading 'match')`.

--- a/plugins/catalog-react/src/components/InspectEntityDialog/components/OverviewPage.test.tsx
+++ b/plugins/catalog-react/src/components/InspectEntityDialog/components/OverviewPage.test.tsx
@@ -100,4 +100,29 @@ describe('OverviewPage', () => {
     expect(await screen.findByText('java')).toBeInTheDocument();
     expect(screen.getByText('data')).toBeInTheDocument();
   });
+
+  it('renders without crashing when annotations or labels carry non-string values', async () => {
+    const entityWithNullAnnotation = {
+      ...entity,
+      metadata: {
+        ...entity.metadata,
+        annotations: {
+          ...entity.metadata.annotations,
+          'my-custom-annotation': null,
+        },
+        labels: {
+          ...entity.metadata.labels,
+          'numeric-label': 42,
+        },
+      },
+    } as any;
+
+    await renderInTestApp(<OverviewPage entity={entityWithNullAnnotation} />, {
+      mountedRoutes,
+    });
+
+    const terms = screen.getAllByRole('term').map(el => el.textContent);
+    expect(terms).toContain('my-custom-annotation');
+    expect(terms).toContain('numeric-label');
+  });
 });

--- a/plugins/catalog-react/src/components/InspectEntityDialog/components/OverviewPage.test.tsx
+++ b/plugins/catalog-react/src/components/InspectEntityDialog/components/OverviewPage.test.tsx
@@ -102,6 +102,7 @@ describe('OverviewPage', () => {
   });
 
   it('renders without crashing when annotations or labels carry non-string values', async () => {
+    const bigintValue = BigInt('9007199254740993');
     const entityWithNullAnnotation = {
       ...entity,
       metadata: {
@@ -109,6 +110,8 @@ describe('OverviewPage', () => {
         annotations: {
           ...entity.metadata.annotations,
           'my-custom-annotation': null,
+          // BigInt makes JSON.stringify throw — exercise the catch path.
+          'bigint-annotation': bigintValue,
         },
         labels: {
           ...entity.metadata.labels,
@@ -123,6 +126,15 @@ describe('OverviewPage', () => {
 
     const terms = screen.getAllByRole('term').map(el => el.textContent);
     expect(terms).toContain('my-custom-annotation');
+    expect(terms).toContain('bigint-annotation');
     expect(terms).toContain('numeric-label');
+
+    // Non-string values must still surface to the user, not silently disappear.
+    const definitions = screen
+      .getAllByRole('definition')
+      .map(el => el.textContent);
+    expect(definitions).toContain('null');
+    expect(definitions).toContain('42');
+    expect(definitions).toContain(String(bigintValue));
   });
 });

--- a/plugins/catalog-react/src/components/InspectEntityDialog/components/OverviewPage.test.tsx
+++ b/plugins/catalog-react/src/components/InspectEntityDialog/components/OverviewPage.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import { renderInTestApp } from '@backstage/test-utils';
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import { entityRouteRef } from '../../../routes';
 import { OverviewPage } from './OverviewPage';
 
@@ -124,17 +124,27 @@ describe('OverviewPage', () => {
       mountedRoutes,
     });
 
-    const terms = screen.getAllByRole('term').map(el => el.textContent);
-    expect(terms).toContain('my-custom-annotation');
-    expect(terms).toContain('bigint-annotation');
-    expect(terms).toContain('numeric-label');
-
-    // Non-string values must still surface to the user, not silently disappear.
-    const definitions = screen
+    // Scope assertions to the specific Annotations/Labels lists so unrelated
+    // sections with matching text can't produce false positives.
+    const annotations = within(screen.getByLabelText('Annotations'));
+    const annotationTerms = annotations
+      .getAllByRole('term')
+      .map(el => el.textContent);
+    const annotationValues = annotations
       .getAllByRole('definition')
       .map(el => el.textContent);
-    expect(definitions).toContain('null');
-    expect(definitions).toContain('42');
-    expect(definitions).toContain(String(bigintValue));
+    expect(annotationTerms).toContain('my-custom-annotation');
+    expect(annotationTerms).toContain('bigint-annotation');
+    // Non-string values must still surface to the user, not silently disappear.
+    expect(annotationValues).toContain('null');
+    expect(annotationValues).toContain(String(bigintValue));
+
+    const labels = within(screen.getByLabelText('Labels'));
+    const labelTerms = labels.getAllByRole('term').map(el => el.textContent);
+    const labelValues = labels
+      .getAllByRole('definition')
+      .map(el => el.textContent);
+    expect(labelTerms).toContain('numeric-label');
+    expect(labelValues).toContain('42');
   });
 });

--- a/plugins/catalog-react/src/components/InspectEntityDialog/components/OverviewPage.tsx
+++ b/plugins/catalog-react/src/components/InspectEntityDialog/components/OverviewPage.tsx
@@ -127,7 +127,18 @@ function renderEntryValue(value: unknown): ReactNode {
   if (typeof value === 'string') {
     return value;
   }
-  return JSON.stringify(value);
+  // JSON.stringify can return undefined (e.g. for symbol/function/undefined)
+  // and can throw (BigInt, circular references). Fall back to String() so the
+  // value stays visible and the dialog never crashes.
+  try {
+    const stringified = JSON.stringify(value);
+    if (stringified === undefined) {
+      return String(value);
+    }
+    return stringified;
+  } catch {
+    return String(value);
+  }
 }
 
 function entriesToItems(entries: [string, unknown][]) {

--- a/plugins/catalog-react/src/components/InspectEntityDialog/components/OverviewPage.tsx
+++ b/plugins/catalog-react/src/components/InspectEntityDialog/components/OverviewPage.tsx
@@ -103,7 +103,10 @@ const useStyles = makeStyles({
 });
 
 // Extracts a link from a value, if possible
-function findLink(value: string): string | undefined {
+function findLink(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
   if (value.match(/^url:https?:\/\//)) {
     return value.slice('url:'.length);
   }
@@ -113,14 +116,25 @@ function findLink(value: string): string | undefined {
   return undefined;
 }
 
-function entriesToItems(entries: [string, string][]) {
-  return entries.map(([key, value]) => {
-    const link = findLink(value);
-    return {
-      key,
-      value: link ? <Link to={link}>{value}</Link> : value,
-    };
-  });
+// Renders annotation/label values defensively. Entities created
+// programmatically can carry non-string values (e.g. null), and the inspect
+// dialog must not crash on them.
+function renderEntryValue(value: unknown): ReactNode {
+  const link = findLink(value);
+  if (link) {
+    return <Link to={link}>{String(value)}</Link>;
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  return JSON.stringify(value);
+}
+
+function entriesToItems(entries: [string, unknown][]) {
+  return entries.map(([key, value]) => ({
+    key,
+    value: renderEntryValue(value),
+  }));
 }
 
 function CopyButton({ text, label }: { text: string; label: string }) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Programmatically created entities can carry non-string values in `metadata.annotations` and `metadata.labels` (notably `null`, e.g. when JSON is serialized with explicit null fields). When such an entity is opened in the Inspect Entity dialog, the OverviewPage's `findLink` helper calls `value.match(...)` on those values and crashes the UI with:

```
TypeError: Cannot read properties of null (reading 'match')
```

This PR makes `findLink` and `entriesToItems` defensive about non-string values: `findLink` returns `undefined` unless the value is a string, and non-string values are rendered as their JSON-stringified form so they remain visible in the dialog. The "don't allow null values in the database" half of the issue is left for a separate backend change.

Reproduction is the entity in [#34146](https://github.com/backstage/backstage/issues/34146):

```json
{
  "apiVersion": "backstage.io/v1alpha1",
  "kind": "Resource",
  "metadata": {
    "name": "pekkas-database",
    "annotations": { "my-custom-annotation": null }
  },
  "spec": { "type": "database", "owner": "user:default/pekka" }
}
```

Closes #34146

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.