### PR TITLE
catalog-backend: drive queryEntities ordering from search-by-key

### DIFF
--- a/.changeset/query-entities-inner-join.md
+++ b/.changeset/query-entities-inner-join.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-catalog-backend': minor
+---
+
+**BREAKING**: When paginating entities with an order field via `/entities/by-query`, entities that lack the order field are now excluded from both the result set and the `totalItems` count. Previously these entities appeared at the end of the sorted result via `NULLS LAST`, but cursor-based pagination could not actually reach them past the first page — the count over-reported the number of navigable entities. The new behavior aligns the count with what is actually returned.
+
+This also removes the `DISTINCT` deduplication from the sort-field CTE, which is a prerequisite for the planner to use the `(key, value, entity_id)` index in sort order and short-circuit on `LIMIT`. Installations with duplicate search rows should land the search-table deduplication migration before adopting this change.

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
@@ -1899,27 +1899,28 @@ describe('DefaultEntitiesCatalog', () => {
           stitcher,
         });
 
-        await expect(
-          catalog
-            .queryEntities({
-              orderFields: [{ field: 'metadata.title', order: 'asc' }],
-              credentials: mockCredentials.none(),
-            })
-            .then(r =>
-              entitiesResponseToObjects(r.items).map(e => e!.metadata.name),
-            ),
-        ).resolves.toEqual(['CC', 'BB', 'AA']); // 'AA' has no title, ends up last
+        // Entities without the sort field are excluded — sorting by a field
+        // means "show me entities that have this field, in order." The count
+        // also reflects only the entities that will be returned.
+        const ascResult = await catalog.queryEntities({
+          orderFields: [{ field: 'metadata.title', order: 'asc' }],
+          credentials: mockCredentials.none(),
+        });
+        expect(
+          entitiesResponseToObjects(ascResult.items).map(e => e!.metadata.name),
+        ).toEqual(['CC', 'BB']);
+        expect(ascResult.totalItems).toBe(2);
 
-        await expect(
-          catalog
-            .queryEntities({
-              orderFields: [{ field: 'metadata.title', order: 'desc' }],
-              credentials: mockCredentials.none(),
-            })
-            .then(r =>
-              entitiesResponseToObjects(r.items).map(e => e!.metadata.name),
-            ),
-        ).resolves.toEqual(['BB', 'CC', 'AA']); // 'AA' has no title, ends up last
+        const descResult = await catalog.queryEntities({
+          orderFields: [{ field: 'metadata.title', order: 'desc' }],
+          credentials: mockCredentials.none(),
+        });
+        expect(
+          entitiesResponseToObjects(descResult.items).map(
+            e => e!.metadata.name,
+          ),
+        ).toEqual(['BB', 'CC']);
+        expect(descResult.totalItems).toBe(2);
       },
     );
 

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -273,33 +273,39 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
     const sortField = cursor.orderFields.at(0);
 
     // The first part of the query builder is a subquery that applies all of the
-    // filtering.
+    // filtering. When a sort field is specified, the search table for that key
+    // drives the query via INNER JOIN so that the (key, value, entity_id)
+    // index walks rows in sort order, letting LIMIT short-circuit. Entities
+    // that lack the sort field are excluded from both the result set and the
+    // count — this is a deliberate choice that aligns totalItems with the
+    // number of entities actually reachable through cursor pagination.
     const dbQuery = this.database.with(
       'filtered',
       ['entity_id', 'final_entity', ...(sortField ? ['value'] : [])],
       inner => {
-        inner
-          .from<DbFinalEntitiesRow>('final_entities')
-          .whereNotNull('final_entity');
-
         if (sortField) {
           inner
-            .distinct()
-            .leftOuterJoin('search', qb =>
-              qb
-                .on('search.entity_id', 'final_entities.entity_id')
-                .andOnVal('search.key', sortField.field),
+            .from('search')
+            .innerJoin(
+              'final_entities',
+              'final_entities.entity_id',
+              'search.entity_id',
             )
+            .where('search.key', sortField.field)
+            .whereNotNull('final_entities.final_entity')
             .select({
               entity_id: 'final_entities.entity_id',
               final_entity: 'final_entities.final_entity',
               value: 'search.value',
             });
         } else {
-          inner.select({
-            entity_id: 'final_entities.entity_id',
-            final_entity: 'final_entities.final_entity',
-          });
+          inner
+            .from<DbFinalEntitiesRow>('final_entities')
+            .whereNotNull('final_entity')
+            .select({
+              entity_id: 'final_entities.entity_id',
+              final_entity: 'final_entities.final_entity',
+            });
         }
 
         // Add regular filters and/or predicate query, if given


### PR DESCRIPTION
## Hey, I just made a Pull Request!

> Draft. Demonstrates the INNER JOIN ordering optimization for `/entities/by-query`. Companion to #34162 (which does the same for `/entities`). Intentionally on a separate branch for independent discussion.

### The change

Replace the `LEFT OUTER JOIN search ... DISTINCT` in the `queryEntities` CTE with an `INNER JOIN` that drives from the search table for the sort field's key. Two semantic changes:

1. **Entities without the sort field are excluded** from both results and `totalItems`. Previously they appeared via `NULLS LAST` on the first page but were unreachable via cursor pagination on page 2+ (the cursor seek `WHERE value > X` can't match NULLs — pre-existing bug, confirmed by testing). The count now matches what's actually navigable.

2. **DISTINCT is removed.** The `LEFT OUTER JOIN + DISTINCT` combination forced the planner to materialize the entire filtered set before sorting, which killed the LIMIT short-circuit. Removing DISTINCT is safe only after the search table dedup migration is landed (production currently has ~434k duplicate search rows).

### Measurements (production replica, ~462k entities, ~13.5M search rows, with #34015 covering indices)

All scenarios use `kind=component` filter and `ORDER BY metadata.name ASC` unless noted otherwise. Warm-cache, run 3 of 3.

| Test | Current code | This PR | Speedup |
|---|---:|---:|---:|
| First page (with totalItems count) | 1,231 ms | 924 ms | 1.3× |
| Paginated (cursor seek, no count) | ~1,000 ms | **11 ms** | **~100×** |
| No filter, LIMIT 21 | ~1,000 ms | **0.4 ms** | **~2,500×** |
| Compound AND filter, LIMIT 21 | ~1,000 ms | 177 ms | ~6× |
| OR-of-conjunctions, LIMIT 21 | >60,000 ms | **3.6 ms** | **>16,000×** |
| Narrow filter (kind=template), LIMIT 21 | ~1,000 ms | **4.2 ms** | **~240×** |

### Key observations

**Without the count (page 2+, or `skipTotalItems`):** ~10 ms per page. The INNER JOIN CTE is inlined by PG12+, the planner walks the `(key, value, entity_id)` index in sort order, and LIMIT short-circuits after 21 rows. ~100× faster than the current code.

**With the count (first page):** 924 ms. The `filtered_count AS (SELECT count(*) FROM filtered)` CTE materializes the full filtered set to count it, negating the LIMIT optimization. This is the same materialize-and-count cost as the current code — the count itself is the floor.

**The OR-of-conjunctions pathology is fixed:** 3.6 ms vs the current >60s timeout. The planner can short-circuit on LIMIT when driving from the name index.

**The count is the remaining bottleneck** for first-page loads. Options for the future:
- `skipTotalItems: true` — already supported, reduces first page to ~10ms
- Separate count query without the CTE (estimated ~370ms, not yet implemented)
- Approximate counts via `pg_class.reltuples` for filtered results
- Cached counts maintained by the stitcher

### Prerequisites

1. **Search table dedup migration** — clean up the ~434k duplicate search rows and add a UNIQUE constraint on `(entity_id, key, value)`. The existing `search_entity_key_value_idx` btree can be promoted to UNIQUE via `ALTER TABLE ... ADD CONSTRAINT ... USING INDEX` — no new index needed. Without this, removing DISTINCT causes entities with duplicate search rows to appear multiple times.

2. **#34015 covering indices** — the `search_key_value_entity_idx (key, value, entity_id)` index is what enables the planner to walk in sort order. Without it, the INNER JOIN still wins over LEFT JOIN but doesn't achieve the same LIMIT short-circuit.

### Test status

- 156 of 160 tests pass.
- 4 failures on `should not return duplicate entities when using orderField` — expected, requires the dedup migration as prerequisite.
- `should sort properly for fields that do not exist on all entities` — updated to expect the new "exclude entities without the field" behavior, with `totalItems` assertion confirming count agreement.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes _(4 known failures documented above)_
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.