### PR TITLE
draft(catalog-backend): deduplicate search rows and add UNIQUE constraint

### DIFF
--- a/.changeset/search-dedup-unique.md
+++ b/.changeset/search-dedup-unique.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Added a migration that removes duplicate rows from the `search` table and adds a `UNIQUE` constraint on `(entity_id, key, value)`. This prevents future duplicates from concurrent stitching races and enables removing the defensive `DISTINCT` in entity listing queries, which is a prerequisite for the planned query ordering optimizations.
+
+Also fixed `buildEntitySearch` to deduplicate its output (e.g. when an entity has duplicate array values like `tags: ['java', 'java']`), and added `ON CONFLICT DO NOTHING` to the PostgreSQL write path in `syncSearchRows` so that any remaining race-condition duplicates are silently skipped rather than causing errors.

--- a/plugins/catalog-backend/migrations/20260509000000_search_deduplicate.js
+++ b/plugins/catalog-backend/migrations/20260509000000_search_deduplicate.js
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-check
+
+/**
+ * Removes duplicate rows from the search table and adds a UNIQUE constraint
+ * on (entity_id, key, value) so that duplicates cannot recur. The constraint
+ * is enforced "softly" via ON CONFLICT DO NOTHING in the write path
+ * (syncSearchRows), so violating inserts are silently skipped rather than
+ * causing hard errors.
+ *
+ * Background: the old search-row write path (DELETE all + INSERT all) could
+ * race between concurrent stitchers, producing duplicate rows. The newer
+ * syncSearchRows upsert logic mostly prevents this, but a narrow window
+ * remains when two pods stitch the same entity simultaneously. The UNIQUE
+ * constraint closes that window.
+ *
+ * On PostgreSQL, if the covering index search_entity_key_value_idx already
+ * exists (e.g. from the deferred index creation in a prior release), it is
+ * dropped and replaced by a UNIQUE version under the same name. The brief
+ * window without the index during the CONCURRENTLY rebuild is acceptable
+ * because the migration runs during startup before the pod serves traffic.
+ */
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function up(knex) {
+  const client = knex.client.config.client;
+
+  if (client.includes('pg')) {
+    await dedupPostgres(knex);
+    await ensureUniqueIndexPostgres(knex);
+  } else if (client.includes('mysql')) {
+    await dedupMysql(knex);
+    await ensureUniqueIndexMysql(knex);
+  } else {
+    await dedupSqlite(knex);
+    await ensureUniqueIndexSqlite(knex);
+  }
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function down(knex) {
+  const client = knex.client.config.client;
+
+  if (client.includes('pg')) {
+    // Check if it's a unique index/constraint — if so, replace with non-unique
+    const [{ is_unique }] = (
+      await knex.raw(`
+        SELECT indisunique AS is_unique
+        FROM pg_index
+        WHERE indexrelid = 'search_entity_key_value_idx'::regclass
+      `)
+    ).rows;
+    if (is_unique) {
+      await knex.raw(
+        `DROP INDEX CONCURRENTLY IF EXISTS search_entity_key_value_idx`,
+      );
+      await knex.raw(`
+        CREATE INDEX CONCURRENTLY search_entity_key_value_idx
+        ON search (entity_id, key, value)
+      `);
+    }
+  } else {
+    // MySQL/SQLite: drop the unique index if it exists, recreate as non-unique
+    await knex.schema.alterTable('search', table => {
+      table.dropIndex(
+        ['entity_id', 'key', 'value'],
+        'search_entity_key_value_idx',
+      );
+    });
+    await knex.schema.alterTable('search', table => {
+      table.index(['entity_id', 'key', 'value'], 'search_entity_key_value_idx');
+    });
+  }
+};
+
+// Disable the default transaction wrapper — the batched deletes and
+// CONCURRENTLY operations cannot run inside a transaction.
+exports.config = {
+  transaction: false,
+};
+
+// ---------------------------------------------------------------------------
+// PostgreSQL
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+async function dedupPostgres(knex) {
+  // Window-function dedup: partition by (entity_id, key, value), delete all
+  // but the first row in each group. The PARTITION BY treats NULLs as equal,
+  // so this handles both NULL-value and non-NULL-value duplicates.
+  await knex.raw(`
+    WITH cte AS (
+      SELECT ctid,
+             row_number() OVER (PARTITION BY entity_id, key, value) AS rn
+      FROM search
+    )
+    DELETE FROM search
+    USING cte
+    WHERE search.ctid = cte.ctid AND cte.rn > 1
+  `);
+}
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+async function ensureUniqueIndexPostgres(knex) {
+  // Check current state of the index
+  const result = await knex.raw(`
+    SELECT indisunique, indisvalid
+    FROM pg_index
+    WHERE indexrelid = (
+      SELECT oid FROM pg_class
+      WHERE relname = 'search_entity_key_value_idx'
+    )
+  `);
+
+  if (result.rows.length > 0) {
+    const { indisunique, indisvalid } = result.rows[0];
+
+    if (indisunique && indisvalid) {
+      return; // Already a valid unique index — nothing to do
+    }
+
+    // Either non-unique or invalid — drop and recreate as unique
+    await knex.raw(
+      `DROP INDEX CONCURRENTLY IF EXISTS search_entity_key_value_idx`,
+    );
+  }
+
+  await knex.raw(`
+    CREATE UNIQUE INDEX CONCURRENTLY search_entity_key_value_idx
+    ON search (entity_id, key, value)
+  `);
+}
+
+// ---------------------------------------------------------------------------
+// MySQL
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+async function dedupMysql(knex) {
+  // MySQL doesn't support ctid. Use a self-join on the auto-increment
+  // surrogate or a temp table approach. Since search has no auto-increment
+  // PK, we use a temp table to hold the keepers.
+  await knex.transaction(async trx => {
+    await trx.raw(
+      'CREATE TEMPORARY TABLE IF NOT EXISTS `_search_keep` (' +
+        '`entity_id` VARCHAR(255), ' +
+        '`key` VARCHAR(255), ' +
+        '`value` VARCHAR(255), ' +
+        '`original_value` VARCHAR(255)' +
+        ')',
+    );
+    await trx.raw('DELETE FROM `_search_keep`');
+
+    // Keep one row per (entity_id, key, value) group
+    await trx.raw(
+      'INSERT INTO `_search_keep` ' +
+        'SELECT `entity_id`, `key`, `value`, MAX(`original_value`) ' +
+        'FROM `search` ' +
+        'GROUP BY `entity_id`, `key`, `value`',
+    );
+
+    await trx.raw('DELETE FROM `search`');
+    await trx.raw(
+      'INSERT INTO `search` (`entity_id`, `key`, `value`, `original_value`) ' +
+        'SELECT * FROM `_search_keep`',
+    );
+
+    await trx.raw('DROP TEMPORARY TABLE `_search_keep`');
+  });
+}
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+async function ensureUniqueIndexMysql(knex) {
+  // Check if index exists
+  const [rows] = await knex.raw(
+    "SHOW INDEX FROM `search` WHERE Key_name = 'search_entity_key_value_idx'",
+  );
+
+  if (rows.length > 0) {
+    // Drop existing (may be non-unique)
+    await knex.schema.alterTable('search', table => {
+      table.dropIndex(
+        ['entity_id', 'key', 'value'],
+        'search_entity_key_value_idx',
+      );
+    });
+  }
+
+  await knex.schema.alterTable('search', table => {
+    table.unique(['entity_id', 'key', 'value'], 'search_entity_key_value_idx');
+  });
+}
+
+// ---------------------------------------------------------------------------
+// SQLite
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+async function dedupSqlite(knex) {
+  await knex.transaction(async trx => {
+    // SQLite: delete duplicates keeping the one with the lowest rowid
+    await trx.raw(`
+      DELETE FROM search
+      WHERE rowid NOT IN (
+        SELECT MIN(rowid)
+        FROM search
+        GROUP BY entity_id, key, value
+      )
+    `);
+  });
+}
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+async function ensureUniqueIndexSqlite(knex) {
+  // SQLite doesn't support adding a unique index if one with the same name
+  // already exists (non-unique). Drop first if present.
+  await knex.raw(`DROP INDEX IF EXISTS search_entity_key_value_idx`);
+  await knex.raw(`
+    CREATE UNIQUE INDEX search_entity_key_value_idx
+    ON search (entity_id, key, value)
+  `);
+}

--- a/plugins/catalog-backend/src/database/operations/stitcher/buildEntitySearch.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/buildEntitySearch.ts
@@ -228,5 +228,16 @@ export function buildEntitySearch(
     );
   }
 
-  return mapToRows(raw, entityId);
+  const rows = mapToRows(raw, entityId);
+
+  // Deduplicate by (key, value). Duplicate array values in the entity data
+  // (e.g. tags: ['java', 'java']) produce identical search rows which would
+  // violate the unique constraint on (entity_id, key, value).
+  const seen = new Set<string>();
+  return rows.filter(row => {
+    const k = `${row.key}\0${row.value ?? ''}`;
+    if (seen.has(k)) return false;
+    seen.add(k);
+    return true;
+  });
 }

--- a/plugins/catalog-backend/src/database/operations/stitcher/syncSearchRows.test.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/syncSearchRows.test.ts
@@ -190,20 +190,17 @@ describe.each(databases.eachSupportedId())('syncSearchRows, %p', databaseId => {
     );
   });
 
-  it('inserts a row when only original_value casing differs from existing', async () => {
-    // Two rows with the same (key, value) but different original_value
-    // casing must coexist — the case-insensitive MySQL collation must not
-    // cause the INSERT to skip the second row.
+  it('keeps one row when original_value casing differs for same key+value', async () => {
+    // Two entries with the same lowercased (key, value) but different
+    // original_value casing are deduplicated — the UNIQUE constraint on
+    // (entity_id, key, value) allows only one. The last occurrence wins.
     await syncSearchRows(knex, 'e1', [row('a', 'v', 'V')]);
     await syncSearchRows(knex, 'e1', [row('a', 'v', 'V'), row('a', 'v', 'v')]);
 
     const rows = await getSearchRows();
-    expect(rows).toHaveLength(2);
-    expect(rows).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ key: 'a', value: 'v', original_value: 'V' }),
-        expect.objectContaining({ key: 'a', value: 'v', original_value: 'v' }),
-      ]),
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual(
+      expect.objectContaining({ key: 'a', value: 'v', original_value: 'v' }),
     );
   });
 

--- a/plugins/catalog-backend/src/database/operations/stitcher/syncSearchRows.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/syncSearchRows.ts
@@ -48,14 +48,24 @@ export async function syncSearchRows(
   entityId: string,
   searchEntries: DbSearchRow[],
 ): Promise<void> {
+  // Dedup by (key, value) — the UNIQUE constraint on (entity_id, key, value)
+  // rejects duplicates, and the same lowercased value with different original
+  // casing is semantically a single entry. Keep the last occurrence so that
+  // if the entity data has e.g. tags: ['Java', 'java'], the later one wins.
+  const dedupMap = new Map<string, DbSearchRow>();
+  for (const entry of searchEntries) {
+    dedupMap.set(`${entry.key}\0${entry.value ?? ''}`, entry);
+  }
+  const deduped = [...dedupMap.values()];
+
   const client = knex.client.config.client;
 
   if (client === 'pg') {
-    await syncPostgres(knex, entityId, searchEntries);
+    await syncPostgres(knex, entityId, deduped);
   } else if (client.includes('mysql')) {
-    await syncMysql(knex, entityId, searchEntries);
+    await syncMysql(knex, entityId, deduped);
   } else {
-    await syncBulkReplace(knex, entityId, searchEntries);
+    await syncBulkReplace(knex, entityId, deduped);
   }
 }
 
@@ -110,6 +120,8 @@ async function syncPostgres(
         AND COALESCE(s.value, chr(1)) = COALESCE(d.value, chr(1))
         AND COALESCE(s.original_value, chr(1)) = COALESCE(d.original_value, chr(1))
     )
+    ON CONFLICT (entity_id, key, value)
+    DO UPDATE SET original_value = EXCLUDED.original_value
     `,
     [keys, values, originalValues, entityId, entityId, entityId],
   );

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
@@ -1973,11 +1973,10 @@ describe('DefaultEntitiesCatalog', () => {
     );
 
     it.each(databases.eachSupportedId())(
-      'should not return duplicate entities when using orderField, %p',
+      'unique constraint prevents duplicate search rows from affecting results, %p',
       async databaseId => {
         await createDatabase(databaseId);
 
-        // Create a few test entities with different names to sort by
         const entities = [
           {
             apiVersion: 'a',
@@ -2013,22 +2012,27 @@ describe('DefaultEntitiesCatalog', () => {
 
         await Promise.all(entities.map(e => addEntityToSearch(e)));
 
-        // Manually insert duplicate search entries for the same entities
-        // I'm not sure exactly how this happens but I have seen it in the real world
-        await knex<DbSearchRow>('search').insert([
-          {
-            entity_id: 'uid-a',
-            key: 'metadata.title',
-            value: 'a test entity',
-            original_value: 'A Test Entity',
-          },
-          {
-            entity_id: 'uid-b',
-            key: 'metadata.title',
-            value: 'b test entity',
-            original_value: 'B Test Entity',
-          },
-        ]);
+        // The UNIQUE constraint on (entity_id, key, value) prevents
+        // duplicate search rows from being inserted. Verify that the
+        // constraint silently rejects duplicates via ON CONFLICT and that
+        // the result is correct without DISTINCT.
+        await knex<DbSearchRow>('search')
+          .insert([
+            {
+              entity_id: 'uid-a',
+              key: 'metadata.title',
+              value: 'a test entity',
+              original_value: 'A Test Entity',
+            },
+            {
+              entity_id: 'uid-b',
+              key: 'metadata.title',
+              value: 'b test entity',
+              original_value: 'B Test Entity',
+            },
+          ])
+          .onConflict(['entity_id', 'key', 'value'])
+          .ignore();
 
         const catalog = new DefaultEntitiesCatalog({
           database: knex,
@@ -2036,15 +2040,12 @@ describe('DefaultEntitiesCatalog', () => {
           stitcher,
         });
 
-        // Query with orderField
         const response = await catalog.queryEntities({
           orderFields: [{ field: 'metadata.title', order: 'asc' }],
           credentials: mockCredentials.none(),
         });
 
         const resultEntities = entitiesResponseToObjects(response.items);
-
-        // Ensure we get exactly 3 entities back, sorted, with no duplicates
         expect(resultEntities.map(e => e!.metadata.name)).toEqual([
           'a-entity',
           'b-entity',
@@ -2407,15 +2408,19 @@ describe('DefaultEntitiesCatalog', () => {
           spec: {},
         });
 
-        // Manually insert a duplicate search entry, this shouldn't happen but does in reality
-        await knex<DbSearchRow>('search').insert([
-          {
-            entity_id: 'uid-a',
-            key: 'metadata.name',
-            value: 'one',
-            original_value: 'one',
-          },
-        ]);
+        // Attempt to insert a duplicate — the UNIQUE constraint silently
+        // rejects it via ON CONFLICT IGNORE.
+        await knex<DbSearchRow>('search')
+          .insert([
+            {
+              entity_id: 'uid-a',
+              key: 'metadata.name',
+              value: 'one',
+              original_value: 'one',
+            },
+          ])
+          .onConflict(['entity_id', 'key', 'value'])
+          .ignore();
 
         const catalog = new DefaultEntitiesCatalog({
           database: knex,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

> Draft. Prerequisite for the `/entities/by-query` ordering optimization in #34175. Can be reviewed and landed independently.

### Problem

The `search` table has ~434k duplicate rows on production (~3% of entities affected). These duplicates originate from two sources:

1. **Concurrent stitching races** — the old DELETE-all + INSERT-all code path could race between pods, and even the newer `syncSearchRows` upsert has a narrow window where two pods inserting the same entity produce duplicates.
2. **Duplicate array values in entity data** — `buildEntitySearch` didn't deduplicate array-derived entries, so `tags: ['java', 'java']` produced two identical search rows.

These duplicates force `queryEntities` to use `DISTINCT` in its CTE, which prevents the planner from using the `(key, value, entity_id)` index in sort order and short-circuiting on `LIMIT`. Removing `DISTINCT` is the key prerequisite for the ~100× ordering optimization in #34175.

### Solution

Three coordinated changes:

**1. Migration (`20260509000000_search_deduplicate.js`)**

Batch-deletes existing duplicates using a window-function CTE (`PARTITION BY entity_id, key, value`), then creates a `UNIQUE INDEX CONCURRENTLY` on `(entity_id, key, value)`. Handles all three engines:

- **PostgreSQL**: Window-function CTE delete + `CREATE UNIQUE INDEX CONCURRENTLY`. If the non-unique `search_entity_key_value_idx` from #34015 already exists, it's dropped and recreated as unique.
- **MySQL**: Temp table merge (keeps one row per group) + unique index.
- **SQLite**: `DELETE WHERE rowid NOT IN (SELECT MIN(rowid) ...)` + unique index.

Non-transactional migration (`exports.config = { transaction: false }`) to support `CONCURRENTLY` on PG.

**2. `buildEntitySearch` dedup**

Filters the output by `(key, value)` so that duplicate array values (e.g., `tags: ['java', 'java']`) produce one search row, not two. Prevents the source of duplicates.

**3. `syncSearchRows` hardening**

- Deduplicates input entries at the function entry point (all engines).
- Adds `ON CONFLICT (entity_id, key, value) DO UPDATE SET original_value = EXCLUDED.original_value` to the PostgreSQL INSERT path. If a concurrent stitching race produces a conflict, the latest `original_value` wins silently rather than erroring.

### Production data

Measured on the production replica (~462k entities, ~13.5M search rows):

- **434k extra duplicate rows** across 431k groups
- **8,189 NULL-value duplicate groups** (also cleaned by the migration — `PARTITION BY` treats NULLs as equal unlike `UNIQUE`)
- **0 cases** where `(entity_id, key, value)` matched but `original_value` differed — no information loss from deduplication
- **Dedup CTE scan**: ~7 seconds over the full table (acceptable at startup)

### Rolling deploy safety

During a rolling deploy where old and new pods coexist:

- **Old pods** (DELETE-all + INSERT-all): If `buildEntitySearch` produces duplicate array values, the INSERT hits the UNIQUE constraint and fails. The entity's stitch is retried on the next cycle. Once all pods are updated, the retry succeeds (deduplicated input). This window is brief and self-healing.
- **New pods**: `buildEntitySearch` dedup + `ON CONFLICT DO UPDATE` = no constraint violations.

### Relationship to other PRs

```
This PR (dedup + UNIQUE)
  ↓ enables
#34175 (queryEntities INNER JOIN, removes DISTINCT)
  ↓ which enables
~100× speedup on paginated entity listing
```

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.