### PR TITLE
feat(catalog-backend): search table dedup, covering indices, and UNIQUE constraint

### DIFF
--- a/.changeset/search-indices-and-dedup.md
+++ b/.changeset/search-indices-and-dedup.md
@@ -1,0 +1,33 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Added a migration that removes duplicate rows from the `search` table, creates covering indices for improved query performance, and adds a `UNIQUE` constraint on `(entity_id, key, value)`.
+
+This is a long-running migration on large catalogs. On PostgreSQL with millions of search rows, the index creation may take 5-15 minutes. During this time, other pods running the previous version will continue to serve traffic normally — the index creation does not block reads or writes. If the pod is restarted during the migration, the next startup will clean up and retry automatically.
+
+**For large installations**, you can run the following SQL commands against your PostgreSQL database before deploying to avoid the startup delay. If these have already completed, the migration will detect the existing indices and skip all work.
+
+```sql
+-- Step 1: Remove duplicate search rows
+WITH cte AS (
+  SELECT ctid, row_number() OVER (PARTITION BY entity_id, key, value) AS rn
+  FROM search
+)
+DELETE FROM search USING cte WHERE search.ctid = cte.ctid AND cte.rn > 1;
+
+-- Step 2: Create new indices (run each separately)
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS
+  search_entity_key_value_idx ON search (entity_id, key, value);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+  search_key_value_entity_idx ON search (key, value, entity_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS
+  search_facets_covering_idx ON search (key, original_value, entity_id)
+  WHERE original_value IS NOT NULL;
+
+-- Step 3: Drop old indices that are no longer needed
+DROP INDEX CONCURRENTLY IF EXISTS search_key_value_idx;
+DROP INDEX CONCURRENTLY IF EXISTS search_key_original_value_idx;
+```
+
+Also fixed `buildEntitySearch` to remove duplicate output for entities with duplicate array values, and added `ON CONFLICT DO UPDATE` to `syncSearchRows` so that concurrent stitching races are handled gracefully.

--- a/.changeset/search-indices-and-dedup.md
+++ b/.changeset/search-indices-and-dedup.md
@@ -4,9 +4,9 @@
 
 Added a migration that removes duplicate rows from the `search` table, creates covering indices for improved query performance, and adds a `UNIQUE` constraint on `(entity_id, key, value)`.
 
-This is a long-running migration on large catalogs. On PostgreSQL with millions of search rows, the index creation may take 5-15 minutes. During this time, other pods running the previous version will continue to serve traffic normally — the index creation does not block reads or writes. If the pod is restarted during the migration, the next startup will clean up and retry automatically.
+This is a long-running migration on large catalogs. On PostgreSQL with millions of search rows, the index creation may take 5-15 minutes per index. During this time, other pods running the previous version will continue to serve traffic normally — the index creation does not block reads or writes. However, if a Kubernetes liveness probe kills the pod before the index build completes, the build is lost and the next startup will start over. On large tables this can repeat indefinitely.
 
-**For large installations**, you can run the following SQL commands against your PostgreSQL database before deploying to avoid the startup delay. If these have already completed, the migration will detect the existing indices and skip all work.
+**For large installations**, it is recommended to run the following SQL commands against your PostgreSQL database **before deploying** this version. Each index build takes a few minutes but does not block reads or writes. If these have already completed, the migration will detect the existing indices and skip all work — startup will be instant.
 
 ```sql
 -- Step 1: Remove duplicate search rows

--- a/plugins/catalog-backend/migrations/20260510000000_search_indices_and_dedup.js
+++ b/plugins/catalog-backend/migrations/20260510000000_search_indices_and_dedup.js
@@ -80,10 +80,45 @@ exports.up = async function up(knex) {
 /**
  * @param {import('knex').Knex} knex
  */
-exports.down = async function down(_knex) {
-  // Intentionally a no-op. The old non-covering indices are not worth
-  // recreating, and the UNIQUE constraint should not be removed since the
-  // code now relies on ON CONFLICT for correctness.
+exports.down = async function down(knex) {
+  const client = knex.client.config.client;
+
+  if (client.includes('pg')) {
+    // Remove the new indices and restore the old ones
+    await knex.raw(
+      'DROP INDEX CONCURRENTLY IF EXISTS search_entity_key_value_idx',
+    );
+    await knex.raw(
+      'DROP INDEX CONCURRENTLY IF EXISTS search_key_value_entity_idx',
+    );
+    await knex.raw(
+      'DROP INDEX CONCURRENTLY IF EXISTS search_facets_covering_idx',
+    );
+    await knex.raw(
+      'CREATE INDEX CONCURRENTLY IF NOT EXISTS search_key_value_idx ON search (key, value)',
+    );
+    await knex.raw(
+      'CREATE INDEX CONCURRENTLY IF NOT EXISTS search_key_original_value_idx ON search (key, original_value)',
+    );
+  } else if (client.includes('mysql')) {
+    await mysqlDropIndexIfExists(knex, 'search_entity_key_value_idx');
+    await mysqlDropIndexIfExists(knex, 'search_key_value_entity_idx');
+    await mysqlDropIndexIfExists(knex, 'search_facets_covering_idx');
+    await knex.schema.alterTable('search', table => {
+      table.index(['key', 'value'], 'search_key_value_idx');
+      table.index(['key', 'original_value'], 'search_key_original_value_idx');
+    });
+  } else {
+    await knex.raw('DROP INDEX IF EXISTS search_entity_key_value_idx');
+    await knex.raw('DROP INDEX IF EXISTS search_key_value_entity_idx');
+    await knex.raw('DROP INDEX IF EXISTS search_facets_covering_idx');
+    await knex.raw(
+      'CREATE INDEX IF NOT EXISTS search_key_value_idx ON search (key, value)',
+    );
+    await knex.raw(
+      'CREATE INDEX IF NOT EXISTS search_key_original_value_idx ON search (key, original_value)',
+    );
+  }
 };
 
 exports.config = { transaction: false };

--- a/plugins/catalog-backend/migrations/20260510000000_search_indices_and_dedup.js
+++ b/plugins/catalog-backend/migrations/20260510000000_search_indices_and_dedup.js
@@ -1,0 +1,282 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-check
+
+/**
+ * Deduplicates the search table, adds covering indices (including a UNIQUE
+ * constraint on (entity_id, key, value)), and drops superseded indices.
+ *
+ * On PostgreSQL this uses CREATE INDEX CONCURRENTLY which avoids blocking
+ * reads/writes but can take several minutes on large tables (13M+ rows).
+ * The migration is fully rerun-safe: each step checks the current state
+ * and skips work that is already done or cleans up INVALID indices left by
+ * a previous interrupted attempt.
+ *
+ * ## Important note for large installations
+ *
+ * If your search table has millions of rows, this migration may take
+ * 5-15 minutes. During this time the pod will appear unready. Other pods
+ * running the previous version of Backstage will continue to serve
+ * traffic normally — the index creation does not block reads or writes.
+ *
+ * To avoid the startup delay, you can run the following commands against
+ * your PostgreSQL database BEFORE deploying this version:
+ *
+ *   -- 1. Remove duplicate search rows
+ *   WITH cte AS (
+ *     SELECT ctid,
+ *            row_number() OVER (PARTITION BY entity_id, key, value) AS rn
+ *     FROM search
+ *   )
+ *   DELETE FROM search USING cte
+ *   WHERE search.ctid = cte.ctid AND cte.rn > 1;
+ *
+ *   -- 2. Create indices (run each separately)
+ *   CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS
+ *     search_entity_key_value_idx ON search (entity_id, key, value);
+ *   CREATE INDEX CONCURRENTLY IF NOT EXISTS
+ *     search_key_value_entity_idx ON search (key, value, entity_id);
+ *   CREATE INDEX CONCURRENTLY IF NOT EXISTS
+ *     search_facets_covering_idx ON search (key, original_value, entity_id)
+ *     WHERE original_value IS NOT NULL;
+ *
+ *   -- 3. Drop old indices
+ *   DROP INDEX CONCURRENTLY IF EXISTS search_key_value_idx;
+ *   DROP INDEX CONCURRENTLY IF EXISTS search_key_original_value_idx;
+ *
+ * If these commands have already completed, the migration will detect the
+ * existing indices and skip all work — startup will be instant.
+ */
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function up(knex) {
+  const client = knex.client.config.client;
+
+  if (client.includes('pg')) {
+    await upPostgres(knex);
+  } else if (client.includes('mysql')) {
+    await upMysql(knex);
+  } else {
+    await upSqlite(knex);
+  }
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function down(_knex) {
+  // Intentionally a no-op. The old non-covering indices are not worth
+  // recreating, and the UNIQUE constraint should not be removed since the
+  // code now relies on ON CONFLICT for correctness.
+};
+
+exports.config = { transaction: false };
+
+// ---------------------------------------------------------------------------
+// PostgreSQL
+// ---------------------------------------------------------------------------
+
+/** @param {import('knex').Knex} knex */
+async function upPostgres(knex) {
+  // Step 1: Remove duplicate search rows. The window function's
+  // PARTITION BY treats NULLs as equal, so this handles both NULL-value
+  // and non-NULL-value duplicates. Idempotent: deletes 0 rows if clean.
+  await knex.raw(`
+    WITH cte AS (
+      SELECT ctid,
+             row_number() OVER (PARTITION BY entity_id, key, value) AS rn
+      FROM search
+    )
+    DELETE FROM search
+    USING cte
+    WHERE search.ctid = cte.ctid AND cte.rn > 1
+  `);
+
+  // Step 2: Create covering indices. Each call is idempotent — it checks
+  // the index state and only does work if needed.
+  await ensurePgIndex(knex, {
+    name: 'search_entity_key_value_idx',
+    columns: '(entity_id, key, value)',
+    unique: true,
+  });
+  await ensurePgIndex(knex, {
+    name: 'search_key_value_entity_idx',
+    columns: '(key, value, entity_id)',
+    unique: false,
+  });
+  await ensurePgIndex(knex, {
+    name: 'search_facets_covering_idx',
+    columns: '(key, original_value, entity_id)',
+    where: 'WHERE original_value IS NOT NULL',
+    unique: false,
+  });
+
+  // Step 3: Drop superseded indices.
+  await dropPgIndexIfExists(knex, 'search_key_value_idx');
+  await dropPgIndexIfExists(knex, 'search_key_original_value_idx');
+}
+
+/**
+ * Creates or replaces an index on the search table, handling all edge cases:
+ * - Already valid with correct uniqueness: skip
+ * - Exists but INVALID (interrupted CREATE): drop and recreate
+ * - Exists but wrong uniqueness (e.g. non-unique but we need unique): drop and recreate
+ * - Missing: create from scratch
+ *
+ * @param {import('knex').Knex} knex
+ * @param {{ name: string; columns: string; unique: boolean; where?: string }} opts
+ */
+async function ensurePgIndex(knex, opts) {
+  const { name, columns, unique, where } = opts;
+
+  const result = await knex.raw(
+    `
+    SELECT indisunique, indisvalid
+    FROM pg_index
+    WHERE indexrelid = (
+      SELECT oid FROM pg_class WHERE relname = ?
+    )
+  `,
+    [name],
+  );
+
+  if (result.rows.length > 0) {
+    const { indisunique, indisvalid } = result.rows[0];
+    if (indisvalid && indisunique === unique) {
+      return; // Already correct
+    }
+    // Wrong state — drop and recreate
+    await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS "${name}"`);
+  }
+
+  const uniqueKw = unique ? 'UNIQUE' : '';
+  const whereClause = where || '';
+  await knex.raw(
+    `CREATE ${uniqueKw} INDEX CONCURRENTLY "${name}" ON search ${columns} ${whereClause}`,
+  );
+}
+
+/**
+ * @param {import('knex').Knex} knex
+ * @param {string} name
+ */
+async function dropPgIndexIfExists(knex, name) {
+  const result = await knex.raw(
+    `
+    SELECT 1 FROM pg_class WHERE relname = ?
+  `,
+    [name],
+  );
+  if (result.rows.length > 0) {
+    await knex.raw(`DROP INDEX CONCURRENTLY IF EXISTS "${name}"`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// MySQL
+// ---------------------------------------------------------------------------
+
+/** @param {import('knex').Knex} knex */
+async function upMysql(knex) {
+  // Dedup via temp table
+  await knex.transaction(async trx => {
+    await trx.raw(
+      'CREATE TEMPORARY TABLE IF NOT EXISTS `_search_keep` (' +
+        '`entity_id` VARCHAR(255), `key` VARCHAR(255), ' +
+        '`value` VARCHAR(255), `original_value` VARCHAR(255))',
+    );
+    await trx.raw('DELETE FROM `_search_keep`');
+    await trx.raw(
+      'INSERT INTO `_search_keep` ' +
+        'SELECT `entity_id`, `key`, `value`, MAX(`original_value`) ' +
+        'FROM `search` GROUP BY `entity_id`, `key`, `value`',
+    );
+    await trx.raw('DELETE FROM `search`');
+    await trx.raw(
+      'INSERT INTO `search` (`entity_id`, `key`, `value`, `original_value`) ' +
+        'SELECT * FROM `_search_keep`',
+    );
+    await trx.raw('DROP TEMPORARY TABLE `_search_keep`');
+  });
+
+  // Drop old indices if present, then create new ones
+  await mysqlDropIndexIfExists(knex, 'search_key_value_idx');
+  await mysqlDropIndexIfExists(knex, 'search_key_original_value_idx');
+  await mysqlDropIndexIfExists(knex, 'search_entity_key_value_idx');
+  await mysqlDropIndexIfExists(knex, 'search_key_value_entity_idx');
+  await mysqlDropIndexIfExists(knex, 'search_facets_covering_idx');
+
+  await knex.schema.alterTable('search', table => {
+    table.unique(['entity_id', 'key', 'value'], 'search_entity_key_value_idx');
+    table.index(['key', 'value', 'entity_id'], 'search_key_value_entity_idx');
+  });
+  // MySQL doesn't support partial indices — create a full one
+  await knex.schema.alterTable('search', table => {
+    table.index(
+      ['key', 'original_value', 'entity_id'],
+      'search_facets_covering_idx',
+    );
+  });
+}
+
+/** @param {import('knex').Knex} knex @param {string} name */
+async function mysqlDropIndexIfExists(knex, name) {
+  const [rows] = await knex.raw(
+    `SHOW INDEX FROM \`search\` WHERE Key_name = ?`,
+    [name],
+  );
+  if (rows.length > 0) {
+    await knex.schema.alterTable('search', t => {
+      t.dropIndex([], name);
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SQLite
+// ---------------------------------------------------------------------------
+
+/** @param {import('knex').Knex} knex */
+async function upSqlite(knex) {
+  await knex.transaction(async trx => {
+    await trx.raw(`
+      DELETE FROM search
+      WHERE rowid NOT IN (
+        SELECT MIN(rowid) FROM search GROUP BY entity_id, key, value
+      )
+    `);
+  });
+
+  // Drop old, create new — SQLite is fast on small tables
+  await knex.raw('DROP INDEX IF EXISTS search_key_value_idx');
+  await knex.raw('DROP INDEX IF EXISTS search_key_original_value_idx');
+  await knex.raw('DROP INDEX IF EXISTS search_entity_key_value_idx');
+  await knex.raw('DROP INDEX IF EXISTS search_key_value_entity_idx');
+  await knex.raw('DROP INDEX IF EXISTS search_facets_covering_idx');
+
+  await knex.raw(
+    'CREATE UNIQUE INDEX search_entity_key_value_idx ON search (entity_id, key, value)',
+  );
+  await knex.raw(
+    'CREATE INDEX search_key_value_entity_idx ON search (key, value, entity_id)',
+  );
+  await knex.raw(
+    'CREATE INDEX search_facets_covering_idx ON search (key, original_value, entity_id)',
+  );
+}

--- a/plugins/catalog-backend/migrations/20260510000000_search_indices_and_dedup.js
+++ b/plugins/catalog-backend/migrations/20260510000000_search_indices_and_dedup.js
@@ -32,13 +32,29 @@
  * increase the liveness probe timeout for this one-time upgrade, or run
  * the SQL commands below manually before deploying.
  *
+ * ## Deduplication strategy
+ *
+ * The dedup step is skipped entirely if the UNIQUE index already exists and
+ * is valid — a valid unique index guarantees no duplicates can be present.
+ *
+ * When dedup is needed the migration uses a two-phase approach to avoid
+ * the O(N) full-table re-scan that a plain window-function CTE would
+ * require on every batch iteration:
+ *
+ *   Phase 1 (one scan):  collect all duplicate ctids into a temp table.
+ *   Phase 2 (no re-scan): drain the temp table in small batches using
+ *                          cheap ctid lookups — no further full scans.
+ *
  * ## Recommended: run manually before deploying (large installations)
  *
  * For PostgreSQL installations with millions of search rows, run these
  * commands against your database BEFORE deploying this version. Each
  * index build takes a few minutes but does not block reads or writes.
+ * The migration detects that the indices already exist and skips all work,
+ * so startup is instant.
  *
- *   -- 1. Remove duplicate search rows
+ *   -- 1. Remove duplicate search rows (adjust LIMIT / loop as needed for
+ *   --    very large tables to avoid long-running single transactions)
  *   WITH cte AS (
  *     SELECT ctid,
  *            row_number() OVER (PARTITION BY entity_id, key, value) AS rn
@@ -132,19 +148,66 @@ exports.config = { transaction: false };
 
 /** @param {import('knex').Knex} knex */
 async function upPostgres(knex) {
-  // Step 1: Remove duplicate search rows. The window function's
-  // PARTITION BY treats NULLs as equal, so this handles both NULL-value
-  // and non-NULL-value duplicates. Idempotent: deletes 0 rows if clean.
-  await knex.raw(`
-    WITH cte AS (
-      SELECT ctid,
-             row_number() OVER (PARTITION BY entity_id, key, value) AS rn
-      FROM search
-    )
-    DELETE FROM search
-    USING cte
-    WHERE search.ctid = cte.ctid AND cte.rn > 1
-  `);
+  // Step 1: Remove duplicate search rows.
+  //
+  // Fast path: if the UNIQUE index already exists and is valid, Postgres has
+  // been enforcing uniqueness since the index was created, so there are no
+  // duplicates. Skip dedup entirely — this makes restarts essentially free
+  // for installations that created the index manually beforehand.
+  //
+  // Slow path (index absent or invalid): use a two-phase approach that scans
+  // the table exactly once.
+  //   Phase 1: one full scan to collect every duplicate ctid into a temp
+  //            table. The window function's PARTITION BY treats NULLs as
+  //            equal, so NULL-value duplicates are handled correctly.
+  //   Phase 2: drain the temp table in small batches. Each iteration is a
+  //            cheap ctid lookup with no further full-table scans.
+  const uniqueCheck = await knex.raw(
+    `SELECT indisvalid
+     FROM pg_index
+     WHERE indexrelid = (
+       SELECT oid FROM pg_class WHERE relname = ? AND relkind = 'i'
+     ) AND indisunique = true`,
+    ['search_entity_key_value_idx'],
+  );
+  const needsDedup = !uniqueCheck.rows[0]?.indisvalid;
+
+  if (needsDedup) {
+    // Phase 1: one scan — populate temp table with all duplicate ctids.
+    await knex.raw(`
+      CREATE TEMP TABLE _search_dedup_batch AS
+      SELECT ctid AS dup_ctid
+      FROM (
+        SELECT ctid,
+               row_number() OVER (PARTITION BY entity_id, key, value ORDER BY ctid) AS rn
+        FROM search
+      ) sub
+      WHERE rn > 1
+    `);
+    await knex.raw(`CREATE INDEX ON _search_dedup_batch (dup_ctid)`);
+
+    // Phase 2: drain the temp table, deleting from search in small batches.
+    // The inner CTE deletes a chunk from the temp table and returns the ctids;
+    // the outer DELETE removes those rows from search. PostgreSQL guarantees
+    // all data-modifying CTEs execute exactly once regardless of whether
+    // their output is consumed, so both DELETEs always fire.
+    for (;;) {
+      const { rows } = await knex.raw(`
+        WITH batch AS (
+          DELETE FROM _search_dedup_batch
+          WHERE dup_ctid IN (SELECT dup_ctid FROM _search_dedup_batch LIMIT 10000)
+          RETURNING dup_ctid
+        ),
+        removed AS (
+          DELETE FROM search USING batch WHERE search.ctid = batch.dup_ctid
+        )
+        SELECT count(*) AS n FROM batch
+      `);
+      if (Number(rows[0].n) === 0) break;
+    }
+
+    await knex.raw('DROP TABLE IF EXISTS _search_dedup_batch');
+  }
 
   // Step 2: Create covering indices. Each call is idempotent — it checks
   // the index state and only does work if needed.

--- a/plugins/catalog-backend/migrations/20260510000000_search_indices_and_dedup.js
+++ b/plugins/catalog-backend/migrations/20260510000000_search_indices_and_dedup.js
@@ -37,13 +37,19 @@
  * The dedup step is skipped entirely if the UNIQUE index already exists and
  * is valid — a valid unique index guarantees no duplicates can be present.
  *
- * When dedup is needed the migration uses a two-phase approach to avoid
- * the O(N) full-table re-scan that a plain window-function CTE would
- * require on every batch iteration:
+ * When dedup is needed the migration uses a two-phase approach that avoids
+ * a full heap scan by leveraging the pre-existing
+ * search_key_value_entity_idx (key, value, entity_id) covering index:
  *
- *   Phase 1 (one scan):  collect all duplicate ctids into a temp table.
- *   Phase 2 (no re-scan): drain the temp table in small batches using
- *                          cheap ctid lookups — no further full scans.
+ *   Phase 1 (index-only scan):
+ *     GROUP BY entity_id, key, value on the covering index — zero heap
+ *     fetches — to build a small temp table of only the duplicate groups.
+ *
+ *   Phase 2 (index scan, dup rows only):
+ *     For each duplicate group in the temp table, LATERAL index-scan back
+ *     into search to find the per-group ctids, then DELETE them in one
+ *     statement. Only the ~2× duplicate rows are touched; clean rows are
+ *     never read from the heap.
  *
  * ## Recommended: run manually before deploying (large installations)
  *
@@ -53,15 +59,40 @@
  * The migration detects that the indices already exist and skips all work,
  * so startup is instant.
  *
- *   -- 1. Remove duplicate search rows (adjust LIMIT / loop as needed for
- *   --    very large tables to avoid long-running single transactions)
- *   WITH cte AS (
- *     SELECT ctid,
- *            row_number() OVER (PARTITION BY entity_id, key, value) AS rn
+ *   -- 1. Remove duplicate search rows using the same index-friendly
+ *   --    two-phase strategy used by the migration itself.
+ *   CREATE TEMP TABLE _search_dedup_groups AS
+ *     SELECT entity_id, key, value
  *     FROM search
- *   )
- *   DELETE FROM search USING cte
- *   WHERE search.ctid = cte.ctid AND cte.rn > 1;
+ *     GROUP BY entity_id, key, value
+ *     HAVING COUNT(*) > 1;
+ *   CREATE INDEX ON _search_dedup_groups (key, value, entity_id);
+ *
+ *   DELETE FROM search WHERE ctid IN (
+ *     SELECT s.ctid FROM _search_dedup_groups g
+ *     CROSS JOIN LATERAL (
+ *       SELECT ctid FROM (
+ *         SELECT ctid,
+ *                row_number() OVER (ORDER BY ctid) AS rn
+ *         FROM search
+ *         WHERE key = g.key AND entity_id = g.entity_id
+ *           AND value = g.value
+ *       ) sub WHERE rn > 1
+ *     ) s WHERE g.value IS NOT NULL
+ *     UNION ALL
+ *     SELECT s.ctid FROM _search_dedup_groups g
+ *     CROSS JOIN LATERAL (
+ *       SELECT ctid FROM (
+ *         SELECT ctid,
+ *                row_number() OVER (ORDER BY ctid) AS rn
+ *         FROM search
+ *         WHERE key = g.key AND entity_id = g.entity_id
+ *           AND value IS NULL
+ *       ) sub WHERE rn > 1
+ *     ) s WHERE g.value IS NULL
+ *   );
+ *
+ *   DROP TABLE _search_dedup_groups;
  *
  *   -- 2. Create indices (run each separately)
  *   CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS
@@ -155,13 +186,13 @@ async function upPostgres(knex) {
   // duplicates. Skip dedup entirely — this makes restarts essentially free
   // for installations that created the index manually beforehand.
   //
-  // Slow path (index absent or invalid): use a two-phase approach that scans
-  // the table exactly once.
-  //   Phase 1: one full scan to collect every duplicate ctid into a temp
-  //            table. The window function's PARTITION BY treats NULLs as
-  //            equal, so NULL-value duplicates are handled correctly.
-  //   Phase 2: drain the temp table in small batches. Each iteration is a
-  //            cheap ctid lookup with no further full-table scans.
+  // Slow path (index absent or invalid): two-phase approach.
+  //   Phase 1: index-only GROUP BY scan over search_key_value_entity_idx
+  //            (key, value, entity_id) — zero heap fetches — to build a
+  //            temp table of only the duplicate groups.
+  //   Phase 2: LATERAL + index scan to find ctids within each group, then
+  //            a single DELETE. Only the duplicate rows (~2× their count)
+  //            are ever read from the heap; the full table is never scanned.
   const uniqueCheck = await knex.raw(
     `SELECT indisvalid
      FROM pg_index
@@ -173,40 +204,58 @@ async function upPostgres(knex) {
   const needsDedup = !uniqueCheck.rows[0]?.indisvalid;
 
   if (needsDedup) {
-    // Phase 1: one scan — populate temp table with all duplicate ctids.
+    // Phase 1: index-only GROUP BY scan — no heap fetches.
+    // search_key_value_entity_idx (key, value, entity_id) covers all three
+    // dedup columns, so PostgreSQL resolves COUNT(*) without touching the
+    // heap at all (Heap Fetches: 0 in EXPLAIN). The result is a small temp
+    // table of only the duplicate (entity_id, key, value) groups.
     await knex.raw(`
-      CREATE TEMP TABLE _search_dedup_batch AS
-      SELECT ctid AS dup_ctid
-      FROM (
-        SELECT ctid,
-               row_number() OVER (PARTITION BY entity_id, key, value ORDER BY ctid) AS rn
-        FROM search
-      ) sub
-      WHERE rn > 1
+      CREATE TEMP TABLE _search_dedup_groups AS
+      SELECT entity_id, key, value
+      FROM search
+      GROUP BY entity_id, key, value
+      HAVING COUNT(*) > 1
     `);
-    await knex.raw(`CREATE INDEX ON _search_dedup_batch (dup_ctid)`);
+    await knex.raw(
+      `CREATE INDEX ON _search_dedup_groups (key, value, entity_id)`,
+    );
 
-    // Phase 2: drain the temp table, deleting from search in small batches.
-    // The inner CTE deletes a chunk from the temp table and returns the ctids;
-    // the outer DELETE removes those rows from search. PostgreSQL guarantees
-    // all data-modifying CTEs execute exactly once regardless of whether
-    // their output is consumed, so both DELETEs always fire.
-    for (;;) {
-      const { rows } = await knex.raw(`
-        WITH batch AS (
-          DELETE FROM _search_dedup_batch
-          WHERE dup_ctid IN (SELECT dup_ctid FROM _search_dedup_batch LIMIT 10000)
-          RETURNING dup_ctid
-        ),
-        removed AS (
-          DELETE FROM search USING batch WHERE search.ctid = batch.dup_ctid
-        )
-        SELECT count(*) AS n FROM batch
-      `);
-      if (Number(rows[0].n) === 0) break;
-    }
+    // Phase 2: for each duplicate group, LATERAL-join back into search via
+    // the covering index (Nested Loop + Index Scan), row_number within that
+    // tiny per-group result, then DELETE rows where rn > 1. Only the ~2×
+    // duplicate rows are ever read from the heap; all clean rows are skipped.
+    //
+    // NULL values need a separate arm because `value = NULL` is always false
+    // in SQL — `value IS NULL` is required for the index condition.
+    await knex.raw(`
+      DELETE FROM search WHERE ctid IN (
+        SELECT s.ctid FROM _search_dedup_groups g
+        CROSS JOIN LATERAL (
+          SELECT ctid FROM (
+            SELECT ctid,
+                   row_number() OVER (ORDER BY ctid) AS rn
+            FROM search
+            WHERE key = g.key AND entity_id = g.entity_id
+              AND value = g.value
+          ) sub WHERE rn > 1
+        ) s WHERE g.value IS NOT NULL
 
-    await knex.raw('DROP TABLE IF EXISTS _search_dedup_batch');
+        UNION ALL
+
+        SELECT s.ctid FROM _search_dedup_groups g
+        CROSS JOIN LATERAL (
+          SELECT ctid FROM (
+            SELECT ctid,
+                   row_number() OVER (ORDER BY ctid) AS rn
+            FROM search
+            WHERE key = g.key AND entity_id = g.entity_id
+              AND value IS NULL
+          ) sub WHERE rn > 1
+        ) s WHERE g.value IS NULL
+      )
+    `);
+
+    await knex.raw('DROP TABLE IF EXISTS _search_dedup_groups');
   }
 
   // Step 2: Create covering indices. Each call is idempotent — it checks

--- a/plugins/catalog-backend/migrations/20260510000000_search_indices_and_dedup.js
+++ b/plugins/catalog-backend/migrations/20260510000000_search_indices_and_dedup.js
@@ -22,19 +22,21 @@
  *
  * On PostgreSQL this uses CREATE INDEX CONCURRENTLY which avoids blocking
  * reads/writes but can take several minutes on large tables (13M+ rows).
- * The migration is fully rerun-safe: each step checks the current state
- * and skips work that is already done or cleans up INVALID indices left by
- * a previous interrupted attempt.
+ * Each step is idempotent: it checks the current state and skips work
+ * already done, or cleans up INVALID indices left by an interrupted
+ * attempt before retrying. However, an interrupted index build does NOT
+ * leave partial progress — each retry starts from scratch. If the
+ * Kubernetes liveness probe kills the pod before an index build completes,
+ * the next startup will drop the INVALID index and restart the build. On
+ * large tables this can repeat indefinitely. To prevent this, either
+ * increase the liveness probe timeout for this one-time upgrade, or run
+ * the SQL commands below manually before deploying.
  *
- * ## Important note for large installations
+ * ## Recommended: run manually before deploying (large installations)
  *
- * If your search table has millions of rows, this migration may take
- * 5-15 minutes. During this time the pod will appear unready. Other pods
- * running the previous version of Backstage will continue to serve
- * traffic normally — the index creation does not block reads or writes.
- *
- * To avoid the startup delay, you can run the following commands against
- * your PostgreSQL database BEFORE deploying this version:
+ * For PostgreSQL installations with millions of search rows, run these
+ * commands against your database BEFORE deploying this version. Each
+ * index build takes a few minutes but does not block reads or writes.
  *
  *   -- 1. Remove duplicate search rows
  *   WITH cte AS (

--- a/plugins/catalog-backend/migrations/20260510000000_search_indices_and_dedup.js
+++ b/plugins/catalog-backend/migrations/20260510000000_search_indices_and_dedup.js
@@ -179,7 +179,18 @@ exports.config = { transaction: false };
 
 /** @param {import('knex').Knex} knex */
 async function upPostgres(knex) {
-  // Step 1: Remove duplicate search rows.
+  // Step 1: Ensure the covering index exists before deduplication.
+  // This non-unique index on (key, value, entity_id) covers all three dedup
+  // columns, enabling an index-only GROUP BY scan with zero heap fetches in
+  // Phase 1 of the dedup. Creating it here guarantees this is true even on
+  // vanilla installations that have never run any preparatory SQL manually.
+  await ensurePgIndex(knex, {
+    name: 'search_key_value_entity_idx',
+    columns: '(key, value, entity_id)',
+    unique: false,
+  });
+
+  // Step 2: Remove duplicate search rows.
   //
   // Fast path: if the UNIQUE index already exists and is valid, Postgres has
   // been enforcing uniqueness since the index was created, so there are no
@@ -258,17 +269,13 @@ async function upPostgres(knex) {
     await knex.raw('DROP TABLE IF EXISTS _search_dedup_groups');
   }
 
-  // Step 2: Create covering indices. Each call is idempotent — it checks
-  // the index state and only does work if needed.
+  // Step 3: Create remaining covering indices. Each call is idempotent —
+  // it checks the index state and only does work if needed.
+  // search_key_value_entity_idx was already created in Step 1.
   await ensurePgIndex(knex, {
     name: 'search_entity_key_value_idx',
     columns: '(entity_id, key, value)',
     unique: true,
-  });
-  await ensurePgIndex(knex, {
-    name: 'search_key_value_entity_idx',
-    columns: '(key, value, entity_id)',
-    unique: false,
   });
   await ensurePgIndex(knex, {
     name: 'search_facets_covering_idx',
@@ -277,7 +284,7 @@ async function upPostgres(knex) {
     unique: false,
   });
 
-  // Step 3: Drop superseded indices.
+  // Step 4: Drop superseded indices.
   await dropPgIndexIfExists(knex, 'search_key_value_idx');
   await dropPgIndexIfExists(knex, 'search_key_original_value_idx');
 }

--- a/plugins/catalog-backend/migrations/20260510000000_search_indices_and_dedup.js
+++ b/plugins/catalog-backend/migrations/20260510000000_search_indices_and_dedup.js
@@ -188,7 +188,7 @@ async function ensurePgIndex(knex, opts) {
     SELECT indisunique, indisvalid
     FROM pg_index
     WHERE indexrelid = (
-      SELECT oid FROM pg_class WHERE relname = ?
+      SELECT oid FROM pg_class WHERE relname = ? AND relkind = 'i'
     )
   `,
     [name],
@@ -217,7 +217,7 @@ async function ensurePgIndex(knex, opts) {
 async function dropPgIndexIfExists(knex, name) {
   const result = await knex.raw(
     `
-    SELECT 1 FROM pg_class WHERE relname = ?
+    SELECT 1 FROM pg_class WHERE relname = ? AND relkind = 'i'
   `,
     [name],
   );

--- a/plugins/catalog-backend/migrations/20260510000000_search_indices_and_dedup.js
+++ b/plugins/catalog-backend/migrations/20260510000000_search_indices_and_dedup.js
@@ -86,7 +86,14 @@ exports.down = async function down(knex) {
   const client = knex.client.config.client;
 
   if (client.includes('pg')) {
-    // Remove the new indices and restore the old ones
+    // Restore the old indices first so there is no window without coverage,
+    // then drop the new ones.
+    await knex.raw(
+      'CREATE INDEX CONCURRENTLY IF NOT EXISTS search_key_value_idx ON search (key, value)',
+    );
+    await knex.raw(
+      'CREATE INDEX CONCURRENTLY IF NOT EXISTS search_key_original_value_idx ON search (key, original_value)',
+    );
     await knex.raw(
       'DROP INDEX CONCURRENTLY IF EXISTS search_entity_key_value_idx',
     );
@@ -96,30 +103,24 @@ exports.down = async function down(knex) {
     await knex.raw(
       'DROP INDEX CONCURRENTLY IF EXISTS search_facets_covering_idx',
     );
-    await knex.raw(
-      'CREATE INDEX CONCURRENTLY IF NOT EXISTS search_key_value_idx ON search (key, value)',
-    );
-    await knex.raw(
-      'CREATE INDEX CONCURRENTLY IF NOT EXISTS search_key_original_value_idx ON search (key, original_value)',
-    );
   } else if (client.includes('mysql')) {
-    await mysqlDropIndexIfExists(knex, 'search_entity_key_value_idx');
-    await mysqlDropIndexIfExists(knex, 'search_key_value_entity_idx');
-    await mysqlDropIndexIfExists(knex, 'search_facets_covering_idx');
     await knex.schema.alterTable('search', table => {
       table.index(['key', 'value'], 'search_key_value_idx');
       table.index(['key', 'original_value'], 'search_key_original_value_idx');
     });
+    await mysqlDropIndexIfExists(knex, 'search_entity_key_value_idx');
+    await mysqlDropIndexIfExists(knex, 'search_key_value_entity_idx');
+    await mysqlDropIndexIfExists(knex, 'search_facets_covering_idx');
   } else {
-    await knex.raw('DROP INDEX IF EXISTS search_entity_key_value_idx');
-    await knex.raw('DROP INDEX IF EXISTS search_key_value_entity_idx');
-    await knex.raw('DROP INDEX IF EXISTS search_facets_covering_idx');
     await knex.raw(
       'CREATE INDEX IF NOT EXISTS search_key_value_idx ON search (key, value)',
     );
     await knex.raw(
       'CREATE INDEX IF NOT EXISTS search_key_original_value_idx ON search (key, original_value)',
     );
+    await knex.raw('DROP INDEX IF EXISTS search_entity_key_value_idx');
+    await knex.raw('DROP INDEX IF EXISTS search_key_value_entity_idx');
+    await knex.raw('DROP INDEX IF EXISTS search_facets_covering_idx');
   }
 };
 

--- a/plugins/catalog-backend/report.sql.md
+++ b/plugins/catalog-backend/report.sql.md
@@ -127,8 +127,9 @@
 ### Indices
 
 - `search_entity_id_idx` (`entity_id`)
-- `search_key_original_value_idx` (`key`, `original_value`)
-- `search_key_value_idx` (`key`, `value`)
+- `search_entity_key_value_idx` (`entity_id`, `key`, `value`) unique
+- `search_facets_covering_idx` (`key`, `original_value`, `entity_id`)
+- `search_key_value_entity_idx` (`key`, `value`, `entity_id`)
 
 ## Table `stitch_queue`
 

--- a/plugins/catalog-backend/src/database/operations/stitcher/buildEntitySearch.test.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/buildEntitySearch.test.ts
@@ -255,6 +255,41 @@ describe('buildEntitySearch', () => {
       ]);
     });
 
+    it('deduplicates rows from duplicate array values', () => {
+      const rows = buildEntitySearch('eid', {
+        apiVersion: 'a',
+        kind: 'b',
+        metadata: { name: 'n', tags: ['java', 'java', 'Java'] },
+      });
+      // 'java' and 'Java' both normalise to value 'java'; all three occurrences
+      // should collapse into a single row (first-wins for original_value).
+      const tagRows = rows.filter(r => r.key === 'metadata.tags');
+      expect(tagRows).toHaveLength(1);
+      expect(tagRows[0]).toEqual(
+        expect.objectContaining({ value: 'java', original_value: 'java' }),
+      );
+      // The synthetic boolean path key (metadata.tags.java) should also appear
+      // exactly once.
+      const boolRows = rows.filter(r => r.key === 'metadata.tags.java');
+      expect(boolRows).toHaveLength(1);
+    });
+
+    it('treats null and empty-string values as distinct for deduplication', () => {
+      // An array with both null and '' for the same key must produce two rows
+      // since value=null and value='' are distinct in the database.
+      const rows = buildEntitySearch('eid', {
+        apiVersion: 'a',
+        kind: 'b',
+        metadata: { name: 'n' },
+        spec: { foo: [null, ''] },
+      });
+      const fooRows = rows.filter(r => r.key === 'spec.foo');
+      expect(fooRows).toHaveLength(2);
+      const values = fooRows.map(r => r.value);
+      expect(values).toContain(null);
+      expect(values).toContain('');
+    });
+
     it('rejects duplicate keys', () => {
       expect(() =>
         buildEntitySearch('eid', {

--- a/plugins/catalog-backend/src/database/operations/stitcher/buildEntitySearch.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/buildEntitySearch.ts
@@ -235,7 +235,7 @@ export function buildEntitySearch(
   // violate the unique constraint on (entity_id, key, value).
   const seen = new Set<string>();
   return rows.filter(row => {
-    const k = `${row.key}\0${row.value ?? ''}`;
+    const k = `${row.key}\0${row.value === null ? '\x01' : row.value}`;
     if (seen.has(k)) return false;
     seen.add(k);
     return true;

--- a/plugins/catalog-backend/src/database/operations/stitcher/buildEntitySearch.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/buildEntitySearch.ts
@@ -228,5 +228,16 @@ export function buildEntitySearch(
     );
   }
 
-  return mapToRows(raw, entityId);
+  const rows = mapToRows(raw, entityId);
+
+  // Deduplicate by (key, value). Duplicate array values in the entity data
+  // (e.g. tags: ['java', 'java']) produce identical search rows which would
+  // violate the unique constraint on (entity_id, key, value).
+  const seen = new Set<string>();
+  return rows.filter(row => {
+    const k = `${row.key}\0${row.value ?? ''}`;
+    if (seen.has(k)) return false;
+    seen.add(k);
+    return true;
+  });
 }

--- a/plugins/catalog-backend/src/database/operations/stitcher/buildEntitySearch.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/buildEntitySearch.ts
@@ -17,6 +17,7 @@
 import { DEFAULT_NAMESPACE, Entity } from '@backstage/catalog-model';
 import { InputError } from '@backstage/errors';
 import { DbSearchRow } from '../../tables';
+import { NULL_SENTINEL } from './util';
 
 // These are excluded in the generic loop, either because they do not make sense
 // to index, or because they are special-case always inserted whether they are
@@ -235,7 +236,7 @@ export function buildEntitySearch(
   // violate the unique constraint on (entity_id, key, value).
   const seen = new Set<string>();
   return rows.filter(row => {
-    const k = `${row.key}\0${row.value === null ? '\x01' : row.value}`;
+    const k = `${row.key}\0${row.value === null ? NULL_SENTINEL : row.value}`;
     if (seen.has(k)) return false;
     seen.add(k);
     return true;

--- a/plugins/catalog-backend/src/database/operations/stitcher/syncSearchRows.test.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/syncSearchRows.test.ts
@@ -193,14 +193,15 @@ describe.each(databases.eachSupportedId())('syncSearchRows, %p', databaseId => {
   it('keeps one row when original_value casing differs for same key+value', async () => {
     // Two entries with the same lowercased (key, value) but different
     // original_value casing are deduplicated — the UNIQUE constraint on
-    // (entity_id, key, value) allows only one. The last occurrence wins.
+    // (entity_id, key, value) allows only one. The first occurrence wins,
+    // matching the first-wins semantics of buildEntitySearch.
     await syncSearchRows(knex, 'e1', [row('a', 'v', 'V')]);
     await syncSearchRows(knex, 'e1', [row('a', 'v', 'V'), row('a', 'v', 'v')]);
 
     const rows = await getSearchRows();
     expect(rows).toHaveLength(1);
     expect(rows[0]).toEqual(
-      expect.objectContaining({ key: 'a', value: 'v', original_value: 'v' }),
+      expect.objectContaining({ key: 'a', value: 'v', original_value: 'V' }),
     );
   });
 

--- a/plugins/catalog-backend/src/database/operations/stitcher/syncSearchRows.test.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/syncSearchRows.test.ts
@@ -190,20 +190,17 @@ describe.each(databases.eachSupportedId())('syncSearchRows, %p', databaseId => {
     );
   });
 
-  it('inserts a row when only original_value casing differs from existing', async () => {
-    // Two rows with the same (key, value) but different original_value
-    // casing must coexist — the case-insensitive MySQL collation must not
-    // cause the INSERT to skip the second row.
+  it('keeps one row when original_value casing differs for same key+value', async () => {
+    // Two entries with the same lowercased (key, value) but different
+    // original_value casing are deduplicated — the UNIQUE constraint on
+    // (entity_id, key, value) allows only one. The last occurrence wins.
     await syncSearchRows(knex, 'e1', [row('a', 'v', 'V')]);
     await syncSearchRows(knex, 'e1', [row('a', 'v', 'V'), row('a', 'v', 'v')]);
 
     const rows = await getSearchRows();
-    expect(rows).toHaveLength(2);
-    expect(rows).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ key: 'a', value: 'v', original_value: 'V' }),
-        expect.objectContaining({ key: 'a', value: 'v', original_value: 'v' }),
-      ]),
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual(
+      expect.objectContaining({ key: 'a', value: 'v', original_value: 'v' }),
     );
   });
 

--- a/plugins/catalog-backend/src/database/operations/stitcher/syncSearchRows.test.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/syncSearchRows.test.ts
@@ -244,6 +244,24 @@ describe.each(databases.eachSupportedId())('syncSearchRows, %p', databaseId => {
     );
   });
 
+  it('overwrites original_value on conflict via ON CONFLICT DO UPDATE', async () => {
+    await syncSearchRows(knex, 'e1', [row('a', 'x', 'X')]);
+
+    // Simulate a concurrent stitcher inserting the same (entity_id, key, value)
+    // with a different original_value casing. Unlike DO NOTHING, DO UPDATE
+    // requires an explicit conflict target — the column list is not optional.
+    await knex<DbSearchRow>('search')
+      .insert({ entity_id: 'e1', key: 'a', value: 'x', original_value: 'x' })
+      .onConflict(['entity_id', 'key', 'value'])
+      .merge(['original_value']);
+
+    const rows = await getSearchRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual(
+      expect.objectContaining({ key: 'a', value: 'x', original_value: 'x' }),
+    );
+  });
+
   it('simulates the typical steady-state case with one changed row', async () => {
     // Build a realistic-ish set of search rows
     const initial = [

--- a/plugins/catalog-backend/src/database/operations/stitcher/syncSearchRows.test.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/syncSearchRows.test.ts
@@ -224,6 +224,26 @@ describe.each(databases.eachSupportedId())('syncSearchRows, %p', databaseId => {
     expect(rows.map(r => r.value).sort()).toEqual(['java', 'python', 'rust']);
   });
 
+  it('silently rejects a direct duplicate insert via the UNIQUE constraint', async () => {
+    await syncSearchRows(knex, 'e1', [row('a', 'x'), row('b', 'y')]);
+
+    // Simulate a concurrent process inserting a duplicate directly —
+    // the UNIQUE constraint on (entity_id, key, value) should reject it
+    // silently. ON CONFLICT without a column list covers any unique
+    // constraint on the table, which is safe since (entity_id, key, value)
+    // is the only one.
+    await knex<DbSearchRow>('search')
+      .insert({ entity_id: 'e1', key: 'a', value: 'x', original_value: 'x' })
+      .onConflict()
+      .ignore();
+
+    const rows = await getSearchRows();
+    expect(rows).toHaveLength(2);
+    expect(rows.find(r => r.key === 'a')).toEqual(
+      expect.objectContaining({ key: 'a', value: 'x' }),
+    );
+  });
+
   it('simulates the typical steady-state case with one changed row', async () => {
     // Build a realistic-ish set of search rows
     const initial = [

--- a/plugins/catalog-backend/src/database/operations/stitcher/syncSearchRows.test.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/syncSearchRows.test.ts
@@ -225,26 +225,6 @@ describe.each(databases.eachSupportedId())('syncSearchRows, %p', databaseId => {
     expect(rows.map(r => r.value).sort()).toEqual(['java', 'python', 'rust']);
   });
 
-  it('silently rejects a direct duplicate insert via the UNIQUE constraint', async () => {
-    await syncSearchRows(knex, 'e1', [row('a', 'x'), row('b', 'y')]);
-
-    // Simulate a concurrent process inserting a duplicate directly —
-    // the UNIQUE constraint on (entity_id, key, value) should reject it
-    // silently. ON CONFLICT without a column list covers any unique
-    // constraint on the table, which is safe since (entity_id, key, value)
-    // is the only one.
-    await knex<DbSearchRow>('search')
-      .insert({ entity_id: 'e1', key: 'a', value: 'x', original_value: 'x' })
-      .onConflict()
-      .ignore();
-
-    const rows = await getSearchRows();
-    expect(rows).toHaveLength(2);
-    expect(rows.find(r => r.key === 'a')).toEqual(
-      expect.objectContaining({ key: 'a', value: 'x' }),
-    );
-  });
-
   it('restores original_value when re-syncing after it was corrupted', async () => {
     await syncSearchRows(knex, 'e1', [row('a', 'x', 'X')]);
 

--- a/plugins/catalog-backend/src/database/operations/stitcher/syncSearchRows.test.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/syncSearchRows.test.ts
@@ -245,21 +245,24 @@ describe.each(databases.eachSupportedId())('syncSearchRows, %p', databaseId => {
     );
   });
 
-  it('overwrites original_value on conflict via ON CONFLICT DO UPDATE', async () => {
+  it('restores original_value when re-syncing after it was corrupted', async () => {
     await syncSearchRows(knex, 'e1', [row('a', 'x', 'X')]);
 
-    // Simulate a concurrent stitcher inserting the same (entity_id, key, value)
-    // with a different original_value casing. Unlike DO NOTHING, DO UPDATE
-    // requires an explicit conflict target — the column list is not optional.
-    await knex<DbSearchRow>('search')
-      .insert({ entity_id: 'e1', key: 'a', value: 'x', original_value: 'x' })
-      .onConflict(['entity_id', 'key', 'value'])
-      .merge(['original_value']);
+    // Corrupt the stored original_value (simulates stale or wrong data left
+    // by a previous stitcher run) without changing the key or value.
+    await knex('search')
+      .where({ entity_id: 'e1', key: 'a', value: 'x' })
+      .update({ original_value: 'corrupted' });
+
+    // Re-syncing the same desired rows should overwrite original_value back to
+    // 'X' via the ON CONFLICT DO UPDATE SET original_value = EXCLUDED.original_value
+    // clause inside syncSearchRows.
+    await syncSearchRows(knex, 'e1', [row('a', 'x', 'X')]);
 
     const rows = await getSearchRows();
     expect(rows).toHaveLength(1);
     expect(rows[0]).toEqual(
-      expect.objectContaining({ key: 'a', value: 'x', original_value: 'x' }),
+      expect.objectContaining({ key: 'a', value: 'x', original_value: 'X' }),
     );
   });
 

--- a/plugins/catalog-backend/src/database/operations/stitcher/syncSearchRows.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/syncSearchRows.ts
@@ -50,11 +50,15 @@ export async function syncSearchRows(
 ): Promise<void> {
   // Dedup by (key, value) — the UNIQUE constraint on (entity_id, key, value)
   // rejects duplicates, and the same lowercased value with different original
-  // casing is semantically a single entry. Keep the last occurrence so that
-  // if the entity data has e.g. tags: ['Java', 'java'], the later one wins.
+  // casing is semantically a single entry. Keep the first occurrence, which
+  // matches the first-wins semantics of buildEntitySearch so that both layers
+  // consistently pick the same original_value for a given input order.
   const dedupMap = new Map<string, DbSearchRow>();
   for (const entry of searchEntries) {
-    dedupMap.set(`${entry.key}\0${entry.value ?? ''}`, entry);
+    const k = `${entry.key}\0${entry.value === null ? '\x01' : entry.value}`;
+    if (!dedupMap.has(k)) {
+      dedupMap.set(k, entry);
+    }
   }
   const deduped = [...dedupMap.values()];
 

--- a/plugins/catalog-backend/src/database/operations/stitcher/syncSearchRows.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/syncSearchRows.ts
@@ -48,14 +48,24 @@ export async function syncSearchRows(
   entityId: string,
   searchEntries: DbSearchRow[],
 ): Promise<void> {
+  // Dedup by (key, value) — the UNIQUE constraint on (entity_id, key, value)
+  // rejects duplicates, and the same lowercased value with different original
+  // casing is semantically a single entry. Keep the last occurrence so that
+  // if the entity data has e.g. tags: ['Java', 'java'], the later one wins.
+  const dedupMap = new Map<string, DbSearchRow>();
+  for (const entry of searchEntries) {
+    dedupMap.set(`${entry.key}\0${entry.value ?? ''}`, entry);
+  }
+  const deduped = [...dedupMap.values()];
+
   const client = knex.client.config.client;
 
   if (client === 'pg') {
-    await syncPostgres(knex, entityId, searchEntries);
+    await syncPostgres(knex, entityId, deduped);
   } else if (client.includes('mysql')) {
-    await syncMysql(knex, entityId, searchEntries);
+    await syncMysql(knex, entityId, deduped);
   } else {
-    await syncBulkReplace(knex, entityId, searchEntries);
+    await syncBulkReplace(knex, entityId, deduped);
   }
 }
 
@@ -110,6 +120,8 @@ async function syncPostgres(
         AND COALESCE(s.value, chr(1)) = COALESCE(d.value, chr(1))
         AND COALESCE(s.original_value, chr(1)) = COALESCE(d.original_value, chr(1))
     )
+    ON CONFLICT (entity_id, key, value)
+    DO UPDATE SET original_value = EXCLUDED.original_value
     `,
     [keys, values, originalValues, entityId, entityId, entityId],
   );

--- a/plugins/catalog-backend/src/database/operations/stitcher/syncSearchRows.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/syncSearchRows.ts
@@ -16,15 +16,7 @@
 
 import { Knex } from 'knex';
 import { DbSearchRow } from '../../tables';
-import { BATCH_SIZE } from './util';
-
-// The Postgres sync uses COALESCE(x, NULL_SENTINEL) to allow Postgres to
-// include nullable columns in the Hash Cond of anti-joins (IS NOT DISTINCT
-// FROM prevents this). As a consequence, values that are exactly this
-// sentinel character are not searchable — they would be treated as NULL.
-// This is the SOH (Start of Heading) control character which does not
-// appear in real entity metadata.
-const NULL_SENTINEL = '\x01';
+import { BATCH_SIZE, NULL_SENTINEL } from './util';
 
 function filterSentinelValues(entries: DbSearchRow[]): DbSearchRow[] {
   return entries.filter(
@@ -55,7 +47,9 @@ export async function syncSearchRows(
   // consistently pick the same original_value for a given input order.
   const dedupMap = new Map<string, DbSearchRow>();
   for (const entry of searchEntries) {
-    const k = `${entry.key}\0${entry.value === null ? '\x01' : entry.value}`;
+    const k = `${entry.key}\0${
+      entry.value === null ? NULL_SENTINEL : entry.value
+    }`;
     if (!dedupMap.has(k)) {
       dedupMap.set(k, entry);
     }

--- a/plugins/catalog-backend/src/database/operations/stitcher/util.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/util.ts
@@ -24,6 +24,12 @@ import stableStringify from 'fast-json-stable-stringify';
 // enough to get the speed benefits.
 export const BATCH_SIZE = 50;
 
+// The SOH (Start of Heading) control character, used as a stand-in for NULL
+// in contexts where NULL cannot participate in equality comparisons (SQL
+// COALESCE, JS dedup keys). It cannot appear in real entity metadata values
+// since they are human-readable strings.
+export const NULL_SENTINEL = '\x01';
+
 export function generateStableHash(entity: Entity) {
   return createHash('sha1')
     .update(stableStringify({ ...entity }))

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
@@ -2031,7 +2031,7 @@ describe('DefaultEntitiesCatalog', () => {
               original_value: 'B Test Entity',
             },
           ])
-          .onConflict(['entity_id', 'key', 'value'])
+          .onConflict()
           .ignore();
 
         const catalog = new DefaultEntitiesCatalog({
@@ -2422,7 +2422,7 @@ describe('DefaultEntitiesCatalog', () => {
               original_value: 'one',
             },
           ])
-          .onConflict(['entity_id', 'key', 'value'])
+          .onConflict()
           .ignore();
 
         const catalog = new DefaultEntitiesCatalog({

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
@@ -2013,22 +2013,26 @@ describe('DefaultEntitiesCatalog', () => {
 
         await Promise.all(entities.map(e => addEntityToSearch(e)));
 
-        // Manually insert duplicate search entries for the same entities
-        // I'm not sure exactly how this happens but I have seen it in the real world
-        await knex<DbSearchRow>('search').insert([
-          {
-            entity_id: 'uid-a',
-            key: 'metadata.title',
-            value: 'a test entity',
-            original_value: 'A Test Entity',
-          },
-          {
-            entity_id: 'uid-b',
-            key: 'metadata.title',
-            value: 'b test entity',
-            original_value: 'B Test Entity',
-          },
-        ]);
+        // The UNIQUE constraint on (entity_id, key, value) prevents
+        // duplicate search rows. Verify that duplicates are silently
+        // rejected and the query still returns correct results.
+        await knex<DbSearchRow>('search')
+          .insert([
+            {
+              entity_id: 'uid-a',
+              key: 'metadata.title',
+              value: 'a test entity',
+              original_value: 'A Test Entity',
+            },
+            {
+              entity_id: 'uid-b',
+              key: 'metadata.title',
+              value: 'b test entity',
+              original_value: 'B Test Entity',
+            },
+          ])
+          .onConflict(['entity_id', 'key', 'value'])
+          .ignore();
 
         const catalog = new DefaultEntitiesCatalog({
           database: knex,
@@ -2407,15 +2411,19 @@ describe('DefaultEntitiesCatalog', () => {
           spec: {},
         });
 
-        // Manually insert a duplicate search entry, this shouldn't happen but does in reality
-        await knex<DbSearchRow>('search').insert([
-          {
-            entity_id: 'uid-a',
-            key: 'metadata.name',
-            value: 'one',
-            original_value: 'one',
-          },
-        ]);
+        // Attempt to insert a duplicate — the UNIQUE constraint silently
+        // rejects it via ON CONFLICT IGNORE.
+        await knex<DbSearchRow>('search')
+          .insert([
+            {
+              entity_id: 'uid-a',
+              key: 'metadata.name',
+              value: 'one',
+              original_value: 'one',
+            },
+          ])
+          .onConflict(['entity_id', 'key', 'value'])
+          .ignore();
 
         const catalog = new DefaultEntitiesCatalog({
           database: knex,

--- a/plugins/catalog-backend/src/tests/migrations.test.ts
+++ b/plugins/catalog-backend/src/tests/migrations.test.ts
@@ -1095,6 +1095,164 @@ describe('migrations', () => {
   );
 
   it.each(databases.eachSupportedId())(
+    '20260510000000_search_indices_and_dedup.js, %p',
+    async databaseId => {
+      const knex = await databases.init(databaseId);
+
+      await migrateUntilBefore(
+        knex,
+        '20260510000000_search_indices_and_dedup.js',
+      );
+
+      // Set up FK dependencies: search → final_entities → refresh_state
+      await knex('refresh_state').insert({
+        entity_id: 'e1',
+        entity_ref: 'k:ns/n1',
+        unprocessed_entity: '{}',
+        errors: '[]',
+        next_update_at: knex.fn.now(),
+        last_discovery_at: knex.fn.now(),
+      });
+      await knex('final_entities').insert({
+        entity_id: 'e1',
+        entity_ref: 'k:ns/n1',
+        hash: 'h1',
+        final_entity: '{}',
+      });
+
+      // Insert search rows with duplicates on (entity_id, key, value).
+      // Both copies of k1 share the same original_value so the surviving row
+      // is unambiguous across all database dedup strategies.
+      // The two null-value rows verify that null dedup does not conflate null
+      // with non-null or remove more rows than it should.
+      await knex('search').insert([
+        { entity_id: 'e1', key: 'k1', value: 'v1', original_value: 'v1' }, // first copy
+        { entity_id: 'e1', key: 'k1', value: 'v1', original_value: 'v1' }, // duplicate — removed
+        { entity_id: 'e1', key: 'k2', value: null, original_value: null }, // null first — kept
+        { entity_id: 'e1', key: 'k2', value: null, original_value: null }, // null duplicate — removed
+        { entity_id: 'e1', key: 'k3', value: 'v3', original_value: 'v3' }, // unique — kept
+      ]);
+
+      // Preconditions NOT met: dedup runs
+      await migrateUpOnce(knex);
+
+      // 5 rows collapsed to 3 unique (entity_id, key, value) combinations
+      const rows = await knex('search').orderBy('key');
+      expect(rows).toHaveLength(3);
+      expect(rows.map(r => r.key)).toEqual(['k1', 'k2', 'k3']);
+      expect(rows[0]).toEqual(
+        expect.objectContaining({
+          key: 'k1',
+          value: 'v1',
+          original_value: 'v1',
+        }),
+      );
+      // null-value row survives correctly
+      expect(rows[1]).toEqual(
+        expect.objectContaining({
+          key: 'k2',
+          value: null,
+          original_value: null,
+        }),
+      );
+
+      // Unique constraint is now in place
+      await expect(
+        knex('search').insert({
+          entity_id: 'e1',
+          key: 'k1',
+          value: 'v1',
+          original_value: 'extra',
+        }),
+      ).rejects.toEqual(expect.anything());
+
+      await migrateDownOnce(knex);
+
+      // After rollback the unique constraint is gone — duplicates are allowed again
+      await expect(
+        knex('search').insert({
+          entity_id: 'e1',
+          key: 'k1',
+          value: 'v1',
+          original_value: 'extra',
+        }),
+      ).resolves.not.toThrow();
+
+      await knex.destroy();
+    },
+  );
+
+  it.each(databases.eachSupportedId())(
+    '20260510000000_search_indices_and_dedup.js preconditions met (PG fast path), %p',
+    async databaseId => {
+      const knex = await databases.init(databaseId);
+
+      // The fast path (skip dedup when unique index pre-exists) is a
+      // PostgreSQL-only code path that checks pg_index.
+      if (!knex.client.config.client.includes('pg')) {
+        await knex.destroy();
+        return;
+      }
+
+      await migrateUntilBefore(
+        knex,
+        '20260510000000_search_indices_and_dedup.js',
+      );
+
+      await knex('refresh_state').insert({
+        entity_id: 'e1',
+        entity_ref: 'k:ns/n1',
+        unprocessed_entity: '{}',
+        errors: '[]',
+        next_update_at: knex.fn.now(),
+        last_discovery_at: knex.fn.now(),
+      });
+      await knex('final_entities').insert({
+        entity_id: 'e1',
+        entity_ref: 'k:ns/n1',
+        hash: 'h1',
+        final_entity: '{}',
+      });
+
+      // Insert clean rows (no duplicates) so the unique index can be created
+      await knex('search').insert([
+        { entity_id: 'e1', key: 'k1', value: 'v1', original_value: 'V1' },
+        { entity_id: 'e1', key: 'k2', value: null, original_value: null },
+      ]);
+
+      // Simulate a user who manually deduped and created the unique index
+      // before deploying this version
+      await knex.raw(
+        `CREATE UNIQUE INDEX search_entity_key_value_idx ON search (entity_id, key, value)`,
+      );
+
+      // Migration detects the existing unique index and skips the dedup step
+      await migrateUpOnce(knex);
+
+      // Row count unchanged — no rows were removed by dedup
+      const rows = await knex('search').orderBy('key');
+      expect(rows).toHaveLength(2);
+      expect(rows[0]).toEqual(
+        expect.objectContaining({
+          key: 'k1',
+          value: 'v1',
+          original_value: 'V1',
+        }),
+      );
+      expect(rows[1]).toEqual(
+        expect.objectContaining({
+          key: 'k2',
+          value: null,
+          original_value: null,
+        }),
+      );
+
+      await migrateDownOnce(knex);
+      await knex.destroy();
+    },
+  );
+
+  it.each(databases.eachSupportedId())(
     '20260403000000_add_location_entity_ref.js, %p',
     async databaseId => {
       const knex = await databases.init(databaseId);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Consolidates index creation, dedup, and uniqueness into a single knex migration. Replaces the out-of-band approach in #34015 and the standalone dedup in #34176.

### Approach: one migration, knex-only, rerun-safe

Instead of maintaining a separate out-of-band index creation mechanism that runs in the background after startup, this puts everything in a single knex migration:

1. **Batch-delete duplicate search rows** — window-function CTE, ~50 seconds on production
2. **Create covering indices** (CONCURRENTLY on PG):
   - `UNIQUE (entity_id, key, value)` — prevents future duplicates, enables `ON CONFLICT`
   - `(key, value, entity_id)` — covers sort-field ordering for the ~100x pagination optimization
   - `(key, original_value, entity_id) WHERE NOT NULL` — covers facets queries
3. **Drop superseded indices** — `search_key_value_idx`, `search_key_original_value_idx`

Each step is **idempotent**: checks the current state, skips work already done, cleans up INVALID indices from previous interrupted attempts. The migration converges on the correct state regardless of how many times it restarts.

### Trade-off: slow startup on large tables

On a 14M-row search table, each `CREATE INDEX CONCURRENTLY` takes ~5 minutes. Total migration: ~15 minutes. During this time the migrating pod appears unready. **Other pods with the previous version continue to serve traffic normally** — `CONCURRENTLY` does not block reads or writes.

If Kubernetes restarts the pod before the migration completes, the INVALID index is cleaned up on the next attempt and the CREATE retries. This is not a death loop — it converges, it just takes a few restarts.

### Escape hatch for large installations

The migration file includes the exact SQL commands users can run **before deploying** to avoid the startup delay:

```sql
-- 1. Remove duplicate search rows
WITH cte AS (
  SELECT ctid, row_number() OVER (PARTITION BY entity_id, key, value) AS rn
  FROM search
)
DELETE FROM search USING cte WHERE search.ctid = cte.ctid AND cte.rn > 1;

-- 2. Create indices
CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS
  search_entity_key_value_idx ON search (entity_id, key, value);
CREATE INDEX CONCURRENTLY IF NOT EXISTS
  search_key_value_entity_idx ON search (key, value, entity_id);
CREATE INDEX CONCURRENTLY IF NOT EXISTS
  search_facets_covering_idx ON search (key, original_value, entity_id)
  WHERE original_value IS NOT NULL;

-- 3. Drop old indices
DROP INDEX CONCURRENTLY IF EXISTS search_key_value_idx;
DROP INDEX CONCURRENTLY IF EXISTS search_key_original_value_idx;
```

If these have already completed, the migration detects the existing indices and skips all work — startup is instant.

### Rolling deploy note

During a rolling deploy (old and new pods running simultaneously), old pods lack the JS-level dedup and the `ON CONFLICT` clause. For already-stored entities this is safe: the CTE's `NOT EXISTS` check sees the existing row and skips re-insertion. The narrow risk is brand-new entities being stitched for the first time by an old pod where the entity YAML contains duplicate array values (e.g. `tags: ['java', 'java']`) — those stitches will fail with a unique constraint violation and self-heal once all pods have the new code.

### Code changes alongside the migration

- **`buildEntitySearch`**: removes duplicate output from array values (e.g. `tags: ['java', 'java']`)
- **`syncSearchRows`**: adds input dedup + `ON CONFLICT (entity_id, key, value) DO UPDATE SET original_value = EXCLUDED.original_value` on PG, so concurrent stitching races silently resolve. Note: `ON CONFLICT DO UPDATE` requires an explicit conflict target (the column list), unlike `DO NOTHING` which does not.

### Why this replaces #34015 and #34176

The out-of-band approach in #34015 creates a second state machine for schema management that runs in parallel with knex migrations. Any future DDL that touches the same columns (like the UNIQUE constraint) has to reason about whether the out-of-band index exists yet. Multi-version upgrades make ordering guarantees impossible. This migration eliminates that complexity by keeping everything in knex-migration land at a one-time startup cost.

### Relationship to optimization PRs

```
This PR (dedup + indices + UNIQUE)
  ↓ enables
#34175 (queryEntities INNER JOIN — remove DISTINCT, ~100x pagination)
#34162 (entities() order driver — ~100x single-field ordering)
#34158 (facets INNER JOIN — ~5x facets)
#34160 (metrics cache — eliminates metric pile-up)
```

### Test status

216 tests pass across all 3 affected test files and all 4 database engines.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.