### PR TITLE
docs(scaffolder): update form decorators docs for promoted API

### DIFF
--- a/docs/features/software-templates/experimental.md
+++ b/docs/features/software-templates/experimental.md
@@ -73,33 +73,18 @@ You don't need to provide any extra configuration, but you have to be sure that 
 
 ## Form Decorators
 
-Form decorators provide the ability to run arbitrary code before the form is submitted along with secrets to the `scaffolder-backend` plugin. They are provided to the `app` using a Utility API.
+Form decorators provide the ability to run arbitrary code before the form is submitted along with secrets to the `scaffolder-backend` plugin.
 
-#### Installation
+#### Configuring templates
 
-To install the Form Decorators, add the following to your `packages/app/src/apis.ts`:
-
-```ts
-  createApiFactory({
-    api: formDecoratorsApiRef,
-    deps: {},
-    factory: () =>
-      DefaultScaffolderFormDecoratorsApi.create({
-        decorators: [
-          // add decorators here
-        ],
-      }),
-  }),
-```
-
-And then you'll also need to define which decorators run in each template using the `EXPERIMENTAL_formDecorators` key in the template's `spec`:
+Define which decorators run in each template using the `formDecorators` key in the template's `spec`:
 
 ```yaml
 kind: Template
 metadata:
   name: my-template
 spec:
-  EXPERIMENTAL_formDecorators:
+  formDecorators:
     - id: myDecorator
       input:
         test: something funky
@@ -108,36 +93,65 @@ spec:
   steps: ...
 ```
 
-#### Creating a Decorator
+:::note
+The legacy `EXPERIMENTAL_formDecorators` field is still supported but deprecated. Migrate to `formDecorators` when possible.
+:::
 
-You can create a decorator using the simple helper method `createScaffolderFormDecorator`:
+#### Creating a decorator
+
+Create a decorator with `createScaffolderFormDecorator` and register it as an extension using `FormDecoratorBlueprint`:
 
 ```ts
-export const mockDecorator = createScaffolderFormDecorator({
-  // give the decorator a name
-  id: 'mockDecorator',
+import { createScaffolderFormDecorator } from '@backstage/plugin-scaffolder-react/alpha';
 
-  // define the schema for the input that can be provided in `template.yaml`
+const mockDecorator = createScaffolderFormDecorator({
+  id: 'mockDecorator',
   schema: {
     input: {
       test: z => z.string(),
     },
   },
   deps: {
-    // define dependencies here
     githubApi: githubAuthApiRef,
   },
   decorator: async (
-    // Context has all the things needed to write simple decorators
     { setSecrets, setFormState, input: { test } },
-    // Depepdencies injected here
     { githubApi },
   ) => {
-    // mutate the form state
     setFormState(state => ({ ...state, test, mock: 'MOCK' }));
-
-    // mutate the form secrets
     setSecrets(state => ({ ...state, GITHUB_TOKEN: 'MOCK_TOKEN' }));
   },
 });
+```
+
+#### Installation (new frontend system)
+
+Register your decorator as an extension using `FormDecoratorBlueprint`:
+
+```ts
+import { FormDecoratorBlueprint } from '@backstage/plugin-scaffolder-react/alpha';
+
+export const myDecoratorExtension = FormDecoratorBlueprint.make({
+  name: 'my-decorator',
+  params: {
+    decorator: mockDecorator,
+  },
+});
+```
+
+Then install the extension in your app or plugin.
+
+#### Installation (legacy frontend system)
+
+For apps using the legacy frontend system, provide decorators through a Utility API in `packages/app/src/apis.ts`:
+
+```ts
+createApiFactory({
+  api: formDecoratorsApiRef,
+  deps: {},
+  factory: () =>
+    DefaultScaffolderFormDecoratorsApi.create({
+      decorators: [mockDecorator],
+    }),
+}),
 ```

--- a/docs/features/software-templates/experimental.md
+++ b/docs/features/software-templates/experimental.md
@@ -80,12 +80,13 @@ Form decorators provide the ability to run arbitrary code before the form is sub
 Define which decorators run in each template using the `formDecorators` key in the template's `spec`:
 
 ```yaml
+apiVersion: scaffolder.backstage.io/v1beta3
 kind: Template
 metadata:
   name: my-template
 spec:
   formDecorators:
-    - id: myDecorator
+    - id: mockDecorator
       input:
         test: something funky
 
@@ -103,6 +104,7 @@ Create a decorator with `createScaffolderFormDecorator` and register it as an ex
 
 ```ts
 import { createScaffolderFormDecorator } from '@backstage/plugin-scaffolder-react/alpha';
+import { githubAuthApiRef } from '@backstage/core-plugin-api';
 
 const mockDecorator = createScaffolderFormDecorator({
   id: 'mockDecorator',
@@ -118,8 +120,9 @@ const mockDecorator = createScaffolderFormDecorator({
     { setSecrets, setFormState, input: { test } },
     { githubApi },
   ) => {
-    setFormState(state => ({ ...state, test, mock: 'MOCK' }));
-    setSecrets(state => ({ ...state, GITHUB_TOKEN: 'MOCK_TOKEN' }));
+    const token = await githubApi.getAccessToken(['repo']);
+    setFormState(state => ({ ...state, test }));
+    setSecrets(state => ({ ...state, GITHUB_TOKEN: token }));
   },
 });
 ```


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updates the form decorators documentation in `docs/features/software-templates/experimental.md` to reflect the changes from #34180:

- Replaced `EXPERIMENTAL_formDecorators` with `formDecorators` in template examples
- Added deprecation note for the legacy field
- Added `FormDecoratorBlueprint` usage for the new frontend system
- Separated installation instructions for new and legacy frontend systems

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages.
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.