### PR TITLE
docs(actions): fix filtering actions docs

### DIFF
--- a/docs/backend-system/core-services/actions.md
+++ b/docs/backend-system/core-services/actions.md
@@ -45,6 +45,8 @@ backend:
 
 In addition to plugin-level restrictions, the Actions Service supports filtering actions using include and exclude rules. This allows fine-grained control over which actions are exposed or runnable in a Backstage instance.
 
+Actions can be filtered by `id` (using glob patterns) or by their attributes (`destructive`, `readOnly`, or `idempotent`).
+
 #### Include specific actions
 
 ```yaml
@@ -52,7 +54,9 @@ backend:
   actions:
     filter:
       include:
-        - 'catalog.*'
+        - id: 'catalog:*'
+        - attributes:
+            destructive: false
 ```
 
 #### Exclude specific actions
@@ -62,7 +66,9 @@ backend:
   actions:
     filter:
       exclude:
-        - 'scaffolder.internal.*'
+        - id: '*:delete-*'
+        - attributes:
+            readOnly: false
 ```
 
 ### Permissions

--- a/docs/backend-system/core-services/actions.md
+++ b/docs/backend-system/core-services/actions.md
@@ -45,7 +45,12 @@ backend:
 
 In addition to plugin-level restrictions, the Actions Service supports filtering actions using include and exclude rules. This allows fine-grained control over which actions are exposed or runnable in a Backstage instance.
 
-Actions can be filtered by `id` (using glob patterns) or by their attributes (`destructive`, `readOnly`, or `idempotent`).
+Actions can be filtered by `id` (using glob patterns) or by their `attributes` (`destructive`, `readOnly`, or `idempotent`).
+
+**How filter rules are evaluated:**
+
+- Within a single rule, `id` and `attributes` are combined with AND logic
+- Multiple rules in the same `include` or `exclude` array are combined with OR logic
 
 #### Include specific actions
 
@@ -54,9 +59,12 @@ backend:
   actions:
     filter:
       include:
+        # Include all catalog actions that are non-destructive
         - id: 'catalog:*'
-        - attributes:
+          attributes:
             destructive: false
+        # OR include all fetch actions from any plugin
+        - id: '*:fetch-*'
 ```
 
 #### Exclude specific actions
@@ -66,9 +74,11 @@ backend:
   actions:
     filter:
       exclude:
+        # Exclude all delete actions from any plugin
         - id: '*:delete-*'
+        # OR exclude all destructive actions
         - attributes:
-            readOnly: false
+            destructive: true
 ```
 
 ### Permissions


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Small fixes on how to filter actions

- it's expected to be an object-array, not a string-array (see [config.d.ts](https://github.com/backstage/backstage/blob/8006acf89a7d892b7eb9724aae2a002c9cafd93f/packages/backend-defaults/config.d.ts))
- action id are `:` separated, not `.`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] ~A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))~
- [X] Added or updated documentation (_obviously yes that's the point of this PR_)
- [X] ~Tests for new functionality and regression tests for bug fixes~
- [X] ~Screenshots attached (for UI changes)~
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
