### PR TITLE
feat(scaffolder): add parameters to form decorator context

### DIFF
--- a/.changeset/scaffolder-form-decorator-parameters.md
+++ b/.changeset/scaffolder-form-decorator-parameters.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-scaffolder-react': minor
+'@backstage/plugin-scaffolder': minor
+---
+
+Form decorators now receive the template's parameter schemas via a new `parameters` property on the decorator context. The value is the array of parameter step schemas as written in the template's `spec.parameters`, allowing decorators to inspect the form's structure when deciding how to mutate state or secrets.

--- a/plugins/scaffolder-react/report-alpha.api.md
+++ b/plugins/scaffolder-react/report-alpha.api.md
@@ -270,6 +270,7 @@ export type ScaffolderFormDecoratorContext<
 > = {
   input: TInput;
   formState: Record<string, JsonValue>;
+  parameters: JsonObject[];
   setFormState: (
     fn: (currentState: Record<string, JsonValue>) => Record<string, JsonValue>,
   ) => void;

--- a/plugins/scaffolder-react/src/next/extensions/createScaffolderFormDecorator.ts
+++ b/plugins/scaffolder-react/src/next/extensions/createScaffolderFormDecorator.ts
@@ -24,6 +24,7 @@ export type ScaffolderFormDecoratorContext<
 > = {
   input: TInput;
   formState: Record<string, JsonValue>;
+  parameters: JsonObject[];
 
   setFormState: (
     fn: (currentState: Record<string, JsonValue>) => Record<string, JsonValue>,

--- a/plugins/scaffolder/src/alpha/hooks/useFormDecorators.test.tsx
+++ b/plugins/scaffolder/src/alpha/hooks/useFormDecorators.test.tsx
@@ -260,6 +260,77 @@ describe('useFormDecorators', () => {
     });
   });
 
+  it('should expose the parameter schemas from the manifest on the context', async () => {
+    const seenParameters = jest.fn();
+    const parametersDecorator = createScaffolderFormDecorator({
+      id: 'parameters',
+      async decorator({ parameters }) {
+        seenParameters(parameters);
+      },
+    });
+
+    const parametersManifest: TemplateParameterSchema = {
+      formDecorators: [{ id: 'parameters' }],
+      steps: [
+        {
+          title: 'First',
+          schema: {
+            title: 'First',
+            properties: { name: { type: 'string' } },
+            required: ['name'],
+          },
+        },
+        {
+          title: 'Second',
+          schema: {
+            title: 'Second',
+            properties: { count: { type: 'number' } },
+          },
+        },
+      ],
+      title: 'test',
+    };
+
+    const renderedHook = renderHook(() => useFormDecorators(), {
+      wrapper: ({ children }) => (
+        <TestApiProvider
+          apis={[
+            [
+              formDecoratorsApiRef,
+              DefaultScaffolderFormDecoratorsApi.create({
+                decorators: [parametersDecorator],
+              }),
+            ],
+            [errorApiRef, { post: () => {} }],
+          ]}
+        >
+          {children}
+        </TestApiProvider>
+      ),
+    });
+
+    await waitFor(async () => {
+      const result = renderedHook.result.current!;
+      await result.run({
+        formState: {},
+        secrets: {},
+        manifest: parametersManifest,
+      });
+
+      expect(seenParameters).toHaveBeenCalledWith([
+        {
+          title: 'First',
+          properties: { name: { type: 'string' } },
+          required: ['name'],
+        },
+        {
+          title: 'Second',
+          properties: { count: { type: 'number' } },
+        },
+      ]);
+    });
+  });
+
   it('should allow merging of existing secrets and formstate', async () => {
     const secretAndFormDataModifier = createScaffolderFormDecorator({
       id: 'test',

--- a/plugins/scaffolder/src/alpha/hooks/useFormDecorators.ts
+++ b/plugins/scaffolder/src/alpha/hooks/useFormDecorators.ts
@@ -138,6 +138,7 @@ export const useFormDecorators = () => {
                 formState = { ...handler(formState) };
               },
               formState,
+              parameters: opts.manifest?.steps.map(step => step.schema) ?? [],
               input: decorator.input ?? {},
             });
           }),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
This adds a further context to scaffolder decorators by providing the original parameters schema.

This would help me with my use-case. I am curious to hear if broadening the context would make sense as well (e.g. exposing the entire `manifest` or `manifest.steps` instead)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
