### PR TITLE
fix(catalog): normalize ancestry graph entity routes

### DIFF
--- a/.changeset/light-heads-cheer.md
+++ b/.changeset/light-heads-cheer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Fixed ancestry graph node links to generate normalized catalog entity URLs.

--- a/plugins/catalog-react/src/components/InspectEntityDialog/components/AncestryPage.test.tsx
+++ b/plugins/catalog-react/src/components/InspectEntityDialog/components/AncestryPage.test.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity } from '@backstage/catalog-model';
+import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useLocation } from 'react-router-dom';
+import { catalogApiRef } from '../../../api';
+import { entityRouteRef } from '../../../routes';
+import { catalogApiMock } from '../../../testUtils';
+import { AncestryPage } from './AncestryPage';
+
+const mountedRoutes = {
+  '/catalog/:namespace/:kind/:name/*': entityRouteRef,
+};
+
+const entity: Entity = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Location',
+  metadata: {
+    namespace: 'Default',
+    name: 'generated-37616cd91ff362d0d5e93176ea63756c41145697',
+  },
+};
+
+const LocationDisplay = () => {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname}</div>;
+};
+
+describe('AncestryPage', () => {
+  const getBBoxDescriptor = Object.getOwnPropertyDescriptor(
+    window.SVGElement.prototype,
+    'getBBox',
+  );
+
+  beforeAll(() => {
+    Object.defineProperty(window.SVGElement.prototype, 'getBBox', {
+      value: () => ({ width: 100, height: 20 }),
+      configurable: true,
+    });
+  });
+
+  afterAll(() => {
+    if (getBBoxDescriptor) {
+      Object.defineProperty(
+        window.SVGElement.prototype,
+        'getBBox',
+        getBBoxDescriptor,
+      );
+    } else {
+      Reflect.deleteProperty(window.SVGElement.prototype, 'getBBox');
+    }
+  });
+
+  it('navigates to normalized entity route params when clicking a graph node', async () => {
+    const user = userEvent.setup();
+    const catalogApi = catalogApiMock.mock({
+      getEntityAncestors: jest.fn().mockResolvedValue({
+        rootEntityRef:
+          'location:default/generated-37616cd91ff362d0d5e93176ea63756c41145697',
+        items: [
+          {
+            entity,
+            parentEntityRefs: [],
+          },
+        ],
+      }),
+    });
+
+    renderInTestApp(
+      <TestApiProvider apis={[[catalogApiRef, catalogApi]]}>
+        <AncestryPage entity={entity} />
+        <LocationDisplay />
+      </TestApiProvider>,
+      { mountedRoutes },
+    );
+
+    await user.click(
+      await screen.findByText(
+        /generated-37616cd91ff362d0d5e93176ea63756c41145697/,
+      ),
+    );
+
+    expect(screen.getByTestId('location')).toHaveTextContent(
+      '/catalog/default/location/generated-37616cd91ff362d0d5e93176ea63756c41145697',
+    );
+  });
+});

--- a/plugins/catalog-react/src/components/InspectEntityDialog/components/AncestryPage.tsx
+++ b/plugins/catalog-react/src/components/InspectEntityDialog/components/AncestryPage.tsx
@@ -14,11 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  Entity,
-  DEFAULT_NAMESPACE,
-  stringifyEntityRef,
-} from '@backstage/catalog-model';
+import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
 import {
   DependencyGraph,
   DependencyGraphTypes,
@@ -34,7 +30,7 @@ import { useLayoutEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import useAsync from 'react-use/esm/useAsync';
 import { catalogApiRef } from '../../../api';
-import { entityRouteRef } from '../../../routes';
+import { entityRouteParams, entityRouteRef } from '../../../routes';
 import { useEntityPresentation } from '../../../apis';
 import { EntityKindIcon } from './EntityKindIcon';
 import { catalogReactTranslationRef } from '../../../translation';
@@ -139,13 +135,7 @@ function CustomNode({ node }: DependencyGraphTypes.RenderNodeProps<NodeType>) {
   const { primaryTitle: displayTitle } = useEntityPresentation(node);
 
   const onClick = () => {
-    navigate(
-      entityRoute({
-        kind: node.kind,
-        namespace: node.metadata.namespace || DEFAULT_NAMESPACE,
-        name: node.metadata.name,
-      }),
-    );
+    navigate(entityRoute(entityRouteParams(node, { encodeParams: true })));
   };
 
   return (


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Summary

Fixes ancestry graph node navigation to use normalized catalog entity route params.

### Details

- Reuses `entityRouteParams` in AncestryPage instead of manually constructing route params.
- Normalizes kind and namespace consistently with `EntityRefLink`.
- Preserves existing route encoding behavior.
- Adds regression coverage for clicking a graph node with uppercase kind / namespace.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
