### PR TITLE
ci: add explicit permissions to pull_request_target workflows

### DIFF
--- a/.github/workflows/sync_dependabot-changesets.yml
+++ b/.github/workflows/sync_dependabot-changesets.yml
@@ -5,6 +5,10 @@ on:
       - '.github/workflows/sync_dependabot-changesets.yml'
       - '**/yarn.lock'
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   generate-changeset:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync_pull-requests-trigger.yml
+++ b/.github/workflows/sync_pull-requests-trigger.yml
@@ -16,6 +16,11 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  actions: none
+  contents: none
+  pull-requests: none
+
 jobs:
   trigger:
     if: >

--- a/.github/workflows/sync_renovate-changesets.yml
+++ b/.github/workflows/sync_renovate-changesets.yml
@@ -5,6 +5,10 @@ on:
       - '.github/workflows/sync_renovate-changesets.yml'
       - '**/yarn.lock'
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   generate-changeset:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Three `pull_request_target` workflows lacked explicit `permissions:` blocks, meaning the `GITHUB_TOKEN` received default permissions (which can be `write-all` depending on org settings). Since `pull_request_target` runs in the base repository context with access to secrets, applying least-privilege scoping reduces blast radius.

### Changes

| Workflow | Added permissions | Rationale |
|---|---|---|
| `sync_renovate-changesets` | `contents: write`, `pull-requests: write` | Pushes changeset commits and approves lock-only PRs |
| `sync_dependabot-changesets` | `contents: write`, `pull-requests: write` | Same — pushes changesets/dedupe and approves lock-only PRs |
| `sync_pull-requests-trigger` | all `none` | Only saves metadata to artifacts; needs no token permissions |

The other five `pull_request_target` workflows already have explicit permissions blocks.

Note: the Renovate and Dependabot workflows primarily use `GH_SERVICE_ACCOUNT_TOKEN` (a PAT secret) rather than `GITHUB_TOKEN` for their authenticated operations, so this change affects the fallback token scope, not the PAT. Still worth scoping for defense in depth.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)