### PR TITLE
devtools: migrate ExternalDependenciesContent to Backstage UI (BUI)

### DIFF
--- a/.changeset/migrate-external-dependencies-to-bui.md
+++ b/.changeset/migrate-external-dependencies-to-bui.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-devtools': patch
+---
+
+Migrated ExternalDependenciesContent to Backstage UI by replacing the legacy Table from @backstage/core-components with the BUI Table, while keeping the existing data and behavior unchanged.

--- a/docs/backend-system/building-backends/01-index.md
+++ b/docs/backend-system/building-backends/01-index.md
@@ -153,3 +153,90 @@ Below is an example of a more elaborate setup where we have three different back
 In this example we have split out the Catalog and Search plugins into one backend deployment. The proxy routes all traffic for `/api/catalog/` and `/api/search/` to this instance. With this separation we're able to scale and deploy these two plugins independently, and they are also isolated from both a performance and security perspective. Likewise the TechDocs and Scaffolder plugins are split out as well, and then we route the rest of the traffic to our instance that contains the App, Auth, and Proxy plugins.
 
 We also see how each of the plugins have their own logical database, but are often set up to share the actual Database Management System (DBMS) instance. This is of course not a requirement, and you can choose to further divide or consolidate the databases as you see fit.
+
+## Startup Configuration
+
+The `backend.startup` configuration block lets you control how the backend behaves when plugins or plugin modules fail to boot during startup. By default, any plugin or module boot failure is fatal and causes the backend to abort. This configuration lets you make specific plugins or modules optional, or flip the default so that all are optional unless explicitly required.
+
+### Plugin Boot Failure Handling
+
+If a plugin fails to boot, the backend aborts startup by default. You can change this per-plugin using `onPluginBootFailure: continue`:
+
+```yaml
+backend:
+  startup:
+    plugins:
+      catalog:
+        onPluginBootFailure: continue
+```
+
+With this configuration, if the `catalog` plugin crashes during startup, the backend will log the error and continue starting up the remaining plugins. This is useful when troubleshooting data-dependent issues, as it allows you to leave a crashing plugin installed while still allowing the rest of the backend to serve requests.
+
+### Plugin Module Boot Failure Handling
+
+You can apply the same control to individual plugin modules using `onPluginModuleBootFailure`:
+
+```yaml
+backend:
+  startup:
+    plugins:
+      catalog:
+        modules:
+          githubEntityProvider:
+            onPluginModuleBootFailure: continue
+```
+
+This allows the `githubEntityProvider` module to fail without bringing down the `catalog` plugin or the rest of the backend.
+
+### Setting a Global Default
+
+Instead of opting each plugin into `continue` mode individually, you can flip the global default so that all plugins continue on failure, and only specific ones are required to succeed:
+
+```yaml
+backend:
+  startup:
+    default:
+      onPluginBootFailure: continue
+    plugins:
+      auth:
+        onPluginBootFailure: abort
+```
+
+In this example, all plugins are optional except `auth`, which is explicitly set to `abort` and is therefore required to start successfully.
+
+The same `default` mechanism works for modules via `onPluginModuleBootFailure`:
+
+```yaml
+backend:
+  startup:
+    default:
+      onPluginModuleBootFailure: continue
+    plugins:
+      catalog:
+        modules:
+          githubEntityProvider:
+            onPluginModuleBootFailure: abort
+```
+
+### Full Configuration Reference
+
+```yaml
+backend:
+  startup:
+    # Global defaults applied when not specified per-plugin or per-module
+    default:
+      # Defaults to 'abort'. Set to 'continue' to make all plugins optional by default.
+      onPluginBootFailure: abort | continue
+      # Defaults to 'abort'. Set to 'continue' to make all plugin modules optional by default.
+      onPluginModuleBootFailure: abort | continue
+
+    # Per-plugin and per-module overrides
+    plugins:
+      <pluginId>:
+        # Override the default boot failure behavior for this specific plugin.
+        onPluginBootFailure: abort | continue
+        modules:
+          <moduleId>:
+            # Override the default boot failure behavior for this specific plugin module.
+            onPluginModuleBootFailure: abort | continue
+```

--- a/docs/backend-system/building-backends/01-index.md
+++ b/docs/backend-system/building-backends/01-index.md
@@ -182,11 +182,11 @@ backend:
     plugins:
       catalog:
         modules:
-          githubEntityProvider:
+          github: # moduleId as declared in createBackendModule({ moduleId: '...' })
             onPluginModuleBootFailure: continue
 ```
 
-This allows the `githubEntityProvider` module to fail without bringing down the `catalog` plugin or the rest of the backend.
+This allows the `github` catalog module to fail without bringing down the `catalog` plugin or the rest of the backend. Note that the key under `modules` is the `moduleId` declared in `createBackendModule`, not the plugin or entity provider name.
 
 ### Setting a Global Default
 
@@ -214,7 +214,7 @@ backend:
     plugins:
       catalog:
         modules:
-          githubEntityProvider:
+          github:
             onPluginModuleBootFailure: abort
 ```
 
@@ -226,17 +226,17 @@ backend:
     # Global defaults applied when not specified per-plugin or per-module
     default:
       # Defaults to 'abort'. Set to 'continue' to make all plugins optional by default.
-      onPluginBootFailure: abort | continue
+      onPluginBootFailure: abort # or continue
       # Defaults to 'abort'. Set to 'continue' to make all plugin modules optional by default.
-      onPluginModuleBootFailure: abort | continue
+      onPluginModuleBootFailure: abort # or continue
 
     # Per-plugin and per-module overrides
     plugins:
       <pluginId>:
         # Override the default boot failure behavior for this specific plugin.
-        onPluginBootFailure: abort | continue
+        onPluginBootFailure: abort # or continue
         modules:
           <moduleId>:
             # Override the default boot failure behavior for this specific plugin module.
-            onPluginModuleBootFailure: abort | continue
+            onPluginModuleBootFailure: abort # or continue
 ```

--- a/plugins/devtools/src/components/Content/ExternalDependenciesContent/ExternalDependenciesContent.module.css
+++ b/plugins/devtools/src/components/Content/ExternalDependenciesContent/ExternalDependenciesContent.module.css
@@ -1,0 +1,4 @@
+.container {
+  border-radius: var(--bui-space-1);
+  box-shadow: var(--bui-shadow);
+}

--- a/plugins/devtools/src/components/Content/ExternalDependenciesContent/ExternalDependenciesContent.tsx
+++ b/plugins/devtools/src/components/Content/ExternalDependenciesContent/ExternalDependenciesContent.tsx
@@ -14,30 +14,30 @@
  * limitations under the License.
  */
 
+import { useCallback, useMemo } from 'react';
 import {
   Progress,
   StatusError,
   StatusOK,
   StatusWarning,
-  Table,
-  TableColumn,
 } from '@backstage/core-components';
 import { ExternalDependency } from '@backstage/plugin-devtools-common';
-import Box from '@material-ui/core/Box';
-import Grid from '@material-ui/core/Grid';
-import Paper from '@material-ui/core/Paper';
+import {
+  Box,
+  CellText,
+  ColumnConfig,
+  Flex,
+  SearchField,
+  SortDescriptor,
+  Table,
+  Text,
+  useTable,
+} from '@backstage/ui';
 import Typography from '@material-ui/core/Typography';
-import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+import Paper from '@material-ui/core/Paper';
 import Alert from '@material-ui/lab/Alert';
 import { useExternalDependencies } from '../../../hooks';
-
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    paperStyle: {
-      padding: theme.spacing(2),
-    },
-  }),
-);
+import styles from './ExternalDependenciesContent.module.css';
 
 export const getExternalDependencyStatus = (
   result: Partial<ExternalDependency> | undefined,
@@ -65,42 +65,104 @@ export const getExternalDependencyStatus = (
   }
 };
 
-const columns: TableColumn[] = [
-  {
-    title: 'Name',
-    width: 'auto',
-    field: 'name',
-  },
-  {
-    title: 'Target',
-    width: 'auto',
-    field: 'target',
-  },
-  {
-    title: 'Type',
-    width: 'auto',
-    field: 'type',
-  },
-  {
-    title: 'Status',
-    width: 'auto',
-    render: (row: Partial<ExternalDependency>) => (
-      <Grid container direction="column">
-        <Grid item>
-          <Typography variant="button">
-            {getExternalDependencyStatus(row)}
-          </Typography>
-        </Grid>
-        <Grid item>{row.error && <Typography>{row.error}</Typography>}</Grid>
-      </Grid>
-    ),
-  },
-];
+interface ExternalDependencyWithId extends ExternalDependency {
+  id: string;
+}
 
 /** @public */
 export const ExternalDependenciesContent = () => {
-  const classes = useStyles();
   const { externalDependencies, loading, error } = useExternalDependencies();
+
+  const dependenciesWithId = useMemo(
+    () =>
+      (externalDependencies ?? []).map(item => ({
+        ...item,
+        id: item.name,
+      })),
+    [externalDependencies],
+  );
+
+  const columns = useMemo<ColumnConfig<ExternalDependencyWithId>[]>(
+    () => [
+      {
+        id: 'name',
+        label: 'Name',
+        width: '25%',
+        isSortable: true,
+        isRowHeader: true,
+        cell: item => <CellText title={item.name} />,
+      },
+      {
+        id: 'target',
+        label: 'Target',
+        width: '25%',
+        isSortable: true,
+        cell: item => <CellText title={item.target ?? ''} />,
+      },
+      {
+        id: 'type',
+        label: 'Type',
+        width: '20%',
+        isSortable: true,
+        cell: item => <CellText title={item.type ?? ''} />,
+      },
+      {
+        id: 'status',
+        label: 'Status',
+        cell: item => (
+          <Flex direction="column">
+            {getExternalDependencyStatus(item)}
+            {item.error && <Text>{item.error}</Text>}
+          </Flex>
+        ),
+      },
+    ],
+    [],
+  );
+
+  const searchFn = useCallback(
+    (items: ExternalDependencyWithId[], query: string) => {
+      const lowerQuery = query.toLowerCase();
+      return items.filter(
+        item =>
+          item.name.toLowerCase().includes(lowerQuery) ||
+          (item.target ?? '').toLowerCase().includes(lowerQuery) ||
+          (item.type ?? '').toLowerCase().includes(lowerQuery) ||
+          (item.status ?? '').toLowerCase().includes(lowerQuery),
+      );
+    },
+    [],
+  );
+
+  const sortFn = useCallback(
+    (
+      items: ExternalDependencyWithId[],
+      { column, direction }: SortDescriptor,
+    ) => {
+      if (column !== 'name' && column !== 'target' && column !== 'type') {
+        return items;
+      }
+      return [...items].sort((a, b) => {
+        const aVal = String(a[column] ?? '');
+        const bVal = String(b[column] ?? '');
+        const cmp = aVal.localeCompare(bVal);
+        return direction === 'descending' ? -cmp : cmp;
+      });
+    },
+    [],
+  );
+
+  const { tableProps, search } = useTable({
+    mode: 'complete',
+    data: dependenciesWithId,
+    initialSort: { column: 'name', direction: 'ascending' },
+    paginationOptions: {
+      pageSize: 20,
+      pageSizeOptions: [20, 50, 100],
+    },
+    searchFn,
+    sortFn,
+  });
 
   if (loading) {
     return <Progress />;
@@ -111,7 +173,7 @@ export const ExternalDependenciesContent = () => {
   if (!externalDependencies || externalDependencies.length === 0) {
     return (
       <Box>
-        <Paper className={classes.paperStyle}>
+        <Paper>
           <Typography>No external dependencies found</Typography>
         </Paper>
       </Box>
@@ -119,17 +181,36 @@ export const ExternalDependenciesContent = () => {
   }
 
   return (
-    <Table
-      title="Status"
-      options={{
-        paging: true,
-        pageSize: 20,
-        pageSizeOptions: [20, 50, 100],
-        loadingType: 'linear',
-        showEmptyDataSourceMessage: !loading,
-      }}
-      columns={columns}
-      data={externalDependencies || []}
-    />
+    <Flex
+      direction="column"
+      gap="2"
+      p="4"
+      bg="neutral"
+      className={styles.container}
+    >
+      <Flex justify="between" align="center">
+        <Text variant="title-small" weight="bold" as="h2">
+          Status
+        </Text>
+        <Box maxWidth="288px" width="100%">
+          <SearchField
+            aria-label="Search"
+            placeholder="Search..."
+            {...search}
+          />
+        </Box>
+      </Flex>
+      <Table
+        columnConfig={columns}
+        {...tableProps}
+        emptyState={
+          search.value ? (
+            <Text>No results match "{search.value}"</Text>
+          ) : (
+            <Text>No external dependencies found.</Text>
+          )
+        }
+      />
+    </Flex>
   );
 };

--- a/plugins/devtools/src/components/Content/ExternalDependenciesContent/ExternalDependenciesContent.tsx
+++ b/plugins/devtools/src/components/Content/ExternalDependenciesContent/ExternalDependenciesContent.tsx
@@ -24,6 +24,7 @@ import {
 import { ExternalDependency } from '@backstage/plugin-devtools-common';
 import {
   Box,
+  Cell,
   CellText,
   ColumnConfig,
   Flex,
@@ -110,10 +111,12 @@ export const ExternalDependenciesContent = () => {
         id: 'status',
         label: 'Status',
         cell: item => (
-          <Flex direction="column">
-            {getExternalDependencyStatus(item)}
-            {item.error && <Text>{item.error}</Text>}
-          </Flex>
+          <Cell>
+            <Flex direction="column">
+              {getExternalDependencyStatus(item)}
+              {item.error && <Text>{item.error}</Text>}
+            </Flex>
+          </Cell>
         ),
       },
     ],
@@ -173,7 +176,7 @@ export const ExternalDependenciesContent = () => {
   if (!externalDependencies || externalDependencies.length === 0) {
     return (
       <Box>
-        <Paper>
+        <Paper style={{ padding: '16px' }}>
           <Typography>No external dependencies found</Typography>
         </Paper>
       </Box>


### PR DESCRIPTION
Fixes #32746

## What this PR does

Migrates the `ExternalDependenciesContent` component from the legacy `Table` in `@backstage/core-components` to the new BUI `Table` from `@backstage/ui`, following the same approach used in #34056 for `InfoDependenciesTable`.

**Changes:**
- Replaced `Table` and `TableColumn` imports from `@backstage/core-components` with BUI equivalents (`Table`, `useTable`, `ColumnConfig`, `CellText`, `Flex`, `SearchField`, `Text`, `Box`, `SortDescriptor`)
- Added search support across all columns (name, target, type, status)
- Added sort support for name, target, and type columns
- Added `ExternalDependenciesContent.module.css` for BUI styling (same as InfoDependenciesTable)
- Added changeset

**Behavior preserved:**
- All existing columns (Name, Target, Type, Status) with same rendering
- `getExternalDependencyStatus` helper function kept unchanged
- Empty state and loading/error handling unchanged
- Pagination defaults kept (20/50/100)

#### Checklist
- [x] A changeset describing the change and affected packages.
- [x] Added or updated documentation (N/A)
- [x] Tests for new functionality and regression tests for bug fixes (no existing tests for this component)
- [x] All commits have a `Signed-off-by` line in the message.