### PR TITLE
fix(backend-defaults): fix flaky TaskWorker initialDelayDuration test

### DIFF
--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.test.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.test.ts
@@ -329,7 +329,7 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
     await new Promise(resolve => setTimeout(resolve, 250));
     expect(fn1).toHaveBeenCalledTimes(0);
     await waitForExpect(() => {
-      expect(fn1.mock.calls.length).toBeGreaterThan(0);
+      expect(fn1.mock).toHaveBeenCalled();
     });
 
     // Start a second worker and make sure it waits but the first worker still works along

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.test.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.test.ts
@@ -328,8 +328,9 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
     expect(fn1).toHaveBeenCalledTimes(0);
     await new Promise(resolve => setTimeout(resolve, 250));
     expect(fn1).toHaveBeenCalledTimes(0);
-    await new Promise(resolve => setTimeout(resolve, 100));
-    expect(fn1.mock.calls.length).toBeGreaterThan(0);
+    await waitForExpect(() => {
+      expect(fn1.mock.calls.length).toBeGreaterThan(0);
+    });
 
     // Start a second worker and make sure it waits but the first worker still works along
     const fn2 = jest.fn();

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.test.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.test.ts
@@ -329,7 +329,7 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
     await new Promise(resolve => setTimeout(resolve, 250));
     expect(fn1).toHaveBeenCalledTimes(0);
     await waitForExpect(() => {
-      expect(fn1.mock).toHaveBeenCalled();
+      expect(fn1).toHaveBeenCalled();
     });
 
     // Start a second worker and make sure it waits but the first worker still works along


### PR DESCRIPTION
## Summary
- The `respects initialDelayDuration per worker` test was flaky because it relied on a fixed 100ms sleep after a 300ms initial delay, giving only ~50ms for the worker to complete DB roundtrips (find task → claim task → execute) before asserting
- Replaced the fixed sleep with `waitForExpect`, which polls until the assertion passes — consistent with all other timing-sensitive assertions in the same test file
- The 250ms sleep + `toHaveBeenCalledTimes(0)` check that validates the delay is respected is unchanged

## Test plan
- [x] Verified the fix is consistent with existing patterns in TaskWorker.test.ts (7 other uses of `waitForExpect`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)