### PR TITLE
chore(deps): sync zod-validation-error between packages

### DIFF
--- a/.changeset/wide-knives-roll.md
+++ b/.changeset/wide-knives-roll.md
@@ -1,0 +1,8 @@
+---
+'@backstage/filter-predicates': patch
+'@backstage/cli-module-new': patch
+'@backstage/plugin-catalog-backend': patch
+'@backstage/plugin-auth-node': patch
+---
+
+Synced zod-validation-error versions between packages

--- a/packages/cli-module-new/package.json
+++ b/packages/cli-module-new/package.json
@@ -48,7 +48,7 @@
     "semver": "^7.5.3",
     "yaml": "^2.0.0",
     "zod": "^3.25.76",
-    "zod-validation-error": "^4.0.2"
+    "zod-validation-error": "^5.0.0"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "workspace:^",

--- a/packages/filter-predicates/package.json
+++ b/packages/filter-predicates/package.json
@@ -40,7 +40,7 @@
     "@backstage/errors": "workspace:^",
     "@backstage/types": "workspace:^",
     "zod": "^3.25.76 || ^4.0.0",
-    "zod-validation-error": "^4.0.2"
+    "zod-validation-error": "^5.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^"

--- a/plugins/auth-node/package.json
+++ b/plugins/auth-node/package.json
@@ -52,7 +52,7 @@
     "passport": "^0.7.0",
     "zod": "^3.25.76 || ^4.0.0",
     "zod-to-json-schema": "^3.25.1",
-    "zod-validation-error": "^4.0.2"
+    "zod-validation-error": "^5.0.0"
   },
   "devDependencies": {
     "@backstage/backend-defaults": "workspace:^",

--- a/plugins/catalog-backend/package.json
+++ b/plugins/catalog-backend/package.json
@@ -97,7 +97,7 @@
     "yaml": "^2.0.0",
     "yn": "^4.0.0",
     "zod": "^3.25.76 || ^4.0.0",
-    "zod-validation-error": "^4.0.2"
+    "zod-validation-error": "^5.0.0"
   },
   "devDependencies": {
     "@backstage/backend-defaults": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2733,7 +2733,7 @@ __metadata:
     semver: "npm:^7.5.3"
     yaml: "npm:^2.0.0"
     zod: "npm:^3.25.76"
-    zod-validation-error: "npm:^4.0.2"
+    zod-validation-error: "npm:^5.0.0"
   bin:
     cli-module-new: bin/backstage-cli-module-new
   languageName: unknown
@@ -3279,7 +3279,7 @@ __metadata:
     "@backstage/errors": "workspace:^"
     "@backstage/types": "workspace:^"
     zod: "npm:^3.25.76 || ^4.0.0"
-    zod-validation-error: "npm:^4.0.2"
+    zod-validation-error: "npm:^5.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4289,7 +4289,7 @@ __metadata:
     supertest: "npm:^7.0.0"
     zod: "npm:^3.25.76 || ^4.0.0"
     zod-to-json-schema: "npm:^3.25.1"
-    zod-validation-error: "npm:^4.0.2"
+    zod-validation-error: "npm:^5.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4843,7 +4843,7 @@ __metadata:
     yaml: "npm:^2.0.0"
     yn: "npm:^4.0.0"
     zod: "npm:^3.25.76 || ^4.0.0"
-    zod-validation-error: "npm:^4.0.2"
+    zod-validation-error: "npm:^5.0.0"
   languageName: unknown
   linkType: soft
 
@@ -48534,15 +48534,6 @@ __metadata:
   peerDependencies:
     zod: ^3.25.28 || ^4
   checksum: 10/7035328654113f1a0b8e4c2d34a06f918c93650ef8a50d4fb30ad8f22e47d5762c163af9c82494756b34776bae3c41c26cfc6945105b0eee7dceb528cc07e665
-  languageName: node
-  linkType: hard
-
-"zod-validation-error@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "zod-validation-error@npm:4.0.2"
-  peerDependencies:
-    zod: ^3.25.0 || ^4.0.0
-  checksum: 10/5e35ca8ebb4602dcb526e122d7e9fca695c4a479bd97535f3400a732d49160f24f7213a9ed64986fc9dc3a2e8a6c4e1241ec0c4d8a4e3e69ea91a0328ded2192
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Synced zod-validation-errors, 5.x has only a wording change no functional changes and is already used elsewhere. No need to have two versions of it installed

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
