### PR TITLE
feat(scaffolder): add GitHub ruleset create action

### DIFF
--- a/.changeset/github-rulesets-arrive.md
+++ b/.changeset/github-rulesets-arrive.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-github': patch
+---
+
+Added a `github:ruleset:create` Scaffolder action for creating GitHub repository rulesets.

--- a/plugins/scaffolder-backend-module-github/report.api.md
+++ b/plugins/scaffolder-backend-module-github/report.api.md
@@ -365,6 +365,50 @@ export function createGithubRepoPushAction(options: {
 >;
 
 // @public
+export function createGithubRulesetCreateAction(options: {
+  integrations: ScmIntegrations;
+  githubCredentialsProvider?: GithubCredentialsProvider;
+}): TemplateAction<
+  {
+    repoUrl: string;
+    name: string;
+    enforcement: 'active' | 'disabled' | 'evaluate';
+    rules: Record<string, any>[];
+    target?: 'push' | 'tag' | 'branch' | undefined;
+    bypassActors?:
+      | {
+          actorType:
+            | 'Team'
+            | 'Integration'
+            | 'User'
+            | 'OrganizationAdmin'
+            | 'RepositoryRole'
+            | 'DeployKey';
+          actorId?: number | null | undefined;
+          bypassMode?: 'always' | 'pull_request' | 'exempt' | undefined;
+        }[]
+      | undefined;
+    conditions?:
+      | {
+          refName?:
+            | {
+                include: string[];
+                exclude: string[];
+              }
+            | undefined;
+        }
+      | undefined;
+    token?: string | undefined;
+  },
+  {
+    rulesetId: number;
+    rulesetName: string;
+    rulesetUrl?: string | undefined;
+  },
+  'v2'
+>;
+
+// @public
 export function createGithubWebhookAction(options: {
   integrations: ScmIntegrationRegistry;
   defaultWebhookSecret?: string;

--- a/plugins/scaffolder-backend-module-github/src/actions/githubRulesetCreate.examples.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubRulesetCreate.examples.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ConfigReader } from '@backstage/config';
+import {
+  DefaultGithubCredentialsProvider,
+  GithubCredentialsProvider,
+  ScmIntegrations,
+} from '@backstage/integration';
+import { TemplateAction } from '@backstage/plugin-scaffolder-node';
+import { createMockActionContext } from '@backstage/plugin-scaffolder-node-test-utils';
+import { createGithubRulesetCreateAction } from './githubRulesetCreate';
+import { examples } from './githubRulesetCreate.examples';
+import yaml from 'yaml';
+
+const mockOctokit = {
+  rest: {
+    repos: {
+      createRepoRuleset: jest.fn(),
+    },
+  },
+};
+jest.mock('octokit', () => ({
+  Octokit: class {
+    constructor() {
+      return mockOctokit;
+    }
+  },
+}));
+
+describe('github:ruleset:create examples', () => {
+  const config = new ConfigReader({
+    integrations: {
+      github: [
+        { host: 'github.com', token: 'tokenlols' },
+        { host: 'ghe.github.com' },
+      ],
+    },
+  });
+
+  const integrations = ScmIntegrations.fromConfig(config);
+  let githubCredentialsProvider: GithubCredentialsProvider;
+  let action: TemplateAction<any, any, any>;
+
+  beforeEach(() => {
+    githubCredentialsProvider =
+      DefaultGithubCredentialsProvider.fromIntegrations(integrations);
+    action = createGithubRulesetCreateAction({
+      integrations,
+      githubCredentialsProvider,
+    });
+    mockOctokit.rest.repos.createRepoRuleset.mockResolvedValue({
+      data: {
+        id: 1,
+        name: 'Require pull requests',
+      },
+    });
+  });
+
+  afterEach(jest.resetAllMocks);
+
+  it.each(examples)('should handle example: $description', async example => {
+    const input = yaml.parse(example.example).steps[0].input;
+
+    await action.handler(
+      createMockActionContext({
+        input,
+      }),
+    );
+
+    expect(mockOctokit.rest.repos.createRepoRuleset).toHaveBeenCalledWith(
+      expect.objectContaining({
+        owner: 'owner',
+        repo: 'repo',
+        name: input.name,
+        target: input.target ?? 'branch',
+        enforcement: input.enforcement,
+        rules: input.rules,
+      }),
+    );
+  });
+});

--- a/plugins/scaffolder-backend-module-github/src/actions/githubRulesetCreate.examples.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubRulesetCreate.examples.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TemplateExample } from '@backstage/plugin-scaffolder-node';
+import yaml from 'yaml';
+
+export const examples: TemplateExample[] = [
+  {
+    description: 'Create a GitHub repository ruleset requiring pull requests.',
+    example: yaml.stringify({
+      steps: [
+        {
+          action: 'github:ruleset:create',
+          name: 'Create a pull request ruleset',
+          input: {
+            repoUrl: 'github.com?repo=repo&owner=owner',
+            name: 'Require pull requests',
+            enforcement: 'active',
+            conditions: {
+              refName: {
+                include: ['~DEFAULT_BRANCH'],
+                exclude: [],
+              },
+            },
+            rules: [
+              {
+                type: 'pull_request',
+                parameters: {
+                  dismiss_stale_reviews_on_push: true,
+                  require_code_owner_review: true,
+                  require_last_push_approval: false,
+                  required_approving_review_count: 1,
+                  required_review_thread_resolution: true,
+                },
+              },
+            ],
+          },
+        },
+      ],
+    }),
+  },
+  {
+    description: 'Create a GitHub repository ruleset requiring status checks.',
+    example: yaml.stringify({
+      steps: [
+        {
+          action: 'github:ruleset:create',
+          name: 'Create a required status checks ruleset',
+          input: {
+            repoUrl: 'github.com?repo=repo&owner=owner',
+            name: 'Require status checks',
+            enforcement: 'active',
+            conditions: {
+              refName: {
+                include: ['~DEFAULT_BRANCH'],
+                exclude: [],
+              },
+            },
+            rules: [
+              {
+                type: 'required_status_checks',
+                parameters: {
+                  required_status_checks: [{ context: 'build' }],
+                  strict_required_status_checks_policy: true,
+                },
+              },
+            ],
+          },
+        },
+      ],
+    }),
+  },
+  {
+    description: 'Create a GitHub repository ruleset with bypass actors.',
+    example: yaml.stringify({
+      steps: [
+        {
+          action: 'github:ruleset:create',
+          name: 'Create a ruleset with bypass actors',
+          input: {
+            repoUrl: 'github.com?repo=repo&owner=owner',
+            name: 'Require pull requests',
+            enforcement: 'active',
+            bypassActors: [
+              {
+                actorId: 1,
+                actorType: 'Team',
+                bypassMode: 'always',
+              },
+            ],
+            conditions: {
+              refName: {
+                include: ['~DEFAULT_BRANCH'],
+                exclude: [],
+              },
+            },
+            rules: [
+              {
+                type: 'pull_request',
+                parameters: {
+                  dismiss_stale_reviews_on_push: false,
+                  require_code_owner_review: false,
+                  require_last_push_approval: false,
+                  required_approving_review_count: 1,
+                  required_review_thread_resolution: false,
+                },
+              },
+            ],
+          },
+        },
+      ],
+    }),
+  },
+  {
+    description: 'Create a GitHub repository tag ruleset.',
+    example: yaml.stringify({
+      steps: [
+        {
+          action: 'github:ruleset:create',
+          name: 'Create a tag ruleset',
+          input: {
+            repoUrl: 'github.com?repo=repo&owner=owner',
+            name: 'Protect release tags',
+            target: 'tag',
+            enforcement: 'active',
+            conditions: {
+              refName: {
+                include: ['refs/tags/v*'],
+                exclude: [],
+              },
+            },
+            rules: [
+              {
+                type: 'deletion',
+              },
+            ],
+          },
+        },
+      ],
+    }),
+  },
+];

--- a/plugins/scaffolder-backend-module-github/src/actions/githubRulesetCreate.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubRulesetCreate.test.ts
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ConfigReader } from '@backstage/config';
+import {
+  DefaultGithubCredentialsProvider,
+  GithubCredentialsProvider,
+  ScmIntegrations,
+} from '@backstage/integration';
+import { TemplateAction } from '@backstage/plugin-scaffolder-node';
+import { createMockActionContext } from '@backstage/plugin-scaffolder-node-test-utils';
+import { createGithubRulesetCreateAction } from './githubRulesetCreate';
+import { Octokit } from 'octokit';
+
+const octokitMock = Octokit as unknown as jest.Mock;
+const mockOctokit = {
+  rest: {
+    repos: {
+      createRepoRuleset: jest.fn(),
+    },
+  },
+};
+jest.mock('octokit', () => ({
+  Octokit: jest.fn(),
+}));
+
+describe('github:ruleset:create', () => {
+  const config = new ConfigReader({
+    integrations: {
+      github: [
+        { host: 'github.com', token: 'tokenlols' },
+        { host: 'ghe.github.com' },
+      ],
+    },
+  });
+
+  const integrations = ScmIntegrations.fromConfig(config);
+  let githubCredentialsProvider: GithubCredentialsProvider;
+  let action: TemplateAction<any, any, any>;
+
+  beforeEach(() => {
+    octokitMock.mockImplementation(() => mockOctokit);
+    githubCredentialsProvider =
+      DefaultGithubCredentialsProvider.fromIntegrations(integrations);
+    action = createGithubRulesetCreateAction({
+      integrations,
+      githubCredentialsProvider,
+    });
+    mockOctokit.rest.repos.createRepoRuleset.mockResolvedValue({
+      data: {
+        id: 1,
+        name: 'Require pull requests',
+        _links: {
+          self: {
+            href: 'https://api.github.com/repos/owner/repo/rulesets/1',
+          },
+        },
+      },
+    });
+  });
+
+  afterEach(jest.resetAllMocks);
+
+  it('should pass context logger to Octokit client', async () => {
+    const mockContext = createMockActionContext({
+      input: {
+        repoUrl: 'github.com?repo=repo&owner=owner',
+        name: 'Require pull requests',
+        enforcement: 'active',
+        rules: [{ type: 'deletion' }],
+      },
+    });
+
+    await action.handler(mockContext);
+
+    expect(octokitMock).toHaveBeenCalledWith(
+      expect.objectContaining({ log: mockContext.logger }),
+    );
+  });
+
+  it('should create a repository ruleset with default target', async () => {
+    const mockContext = createMockActionContext({
+      input: {
+        repoUrl: 'github.com?repo=repo&owner=owner',
+        name: 'Require pull requests',
+        enforcement: 'active',
+        conditions: {
+          refName: {
+            include: ['~DEFAULT_BRANCH'],
+            exclude: [],
+          },
+        },
+        rules: [
+          {
+            type: 'pull_request',
+            parameters: {
+              dismiss_stale_reviews_on_push: true,
+              require_code_owner_review: true,
+              require_last_push_approval: false,
+              required_approving_review_count: 1,
+              required_review_thread_resolution: true,
+            },
+          },
+        ],
+      },
+    });
+
+    await action.handler(mockContext);
+
+    expect(mockOctokit.rest.repos.createRepoRuleset).toHaveBeenCalledWith({
+      owner: 'owner',
+      repo: 'repo',
+      name: 'Require pull requests',
+      target: 'branch',
+      enforcement: 'active',
+      bypass_actors: undefined,
+      conditions: {
+        ref_name: {
+          include: ['~DEFAULT_BRANCH'],
+          exclude: [],
+        },
+      },
+      rules: [
+        {
+          type: 'pull_request',
+          parameters: {
+            dismiss_stale_reviews_on_push: true,
+            require_code_owner_review: true,
+            require_last_push_approval: false,
+            required_approving_review_count: 1,
+            required_review_thread_resolution: true,
+          },
+        },
+      ],
+    });
+    expect(mockContext.output).toHaveBeenCalledWith('rulesetId', 1);
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'rulesetName',
+      'Require pull requests',
+    );
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'rulesetUrl',
+      'https://api.github.com/repos/owner/repo/rulesets/1',
+    );
+  });
+
+  it('should translate bypass actors and explicit tag target', async () => {
+    await action.handler(
+      createMockActionContext({
+        input: {
+          repoUrl: 'github.com?repo=repo&owner=owner',
+          name: 'Protect tags',
+          target: 'tag',
+          enforcement: 'active',
+          bypassActors: [
+            {
+              actorId: 1,
+              actorType: 'Team',
+              bypassMode: 'always',
+            },
+            {
+              actorId: null,
+              actorType: 'DeployKey',
+            },
+            {
+              actorId: 2,
+              actorType: 'User',
+              bypassMode: 'exempt',
+            },
+          ],
+          conditions: {
+            refName: {
+              include: ['refs/tags/v*'],
+              exclude: [],
+            },
+          },
+          rules: [{ type: 'deletion' }],
+        },
+      }),
+    );
+
+    expect(mockOctokit.rest.repos.createRepoRuleset).toHaveBeenCalledWith({
+      owner: 'owner',
+      repo: 'repo',
+      name: 'Protect tags',
+      target: 'tag',
+      enforcement: 'active',
+      bypass_actors: [
+        {
+          actor_id: 1,
+          actor_type: 'Team',
+          bypass_mode: 'always',
+        },
+        {
+          actor_id: null,
+          actor_type: 'DeployKey',
+          bypass_mode: undefined,
+        },
+        {
+          actor_id: 2,
+          actor_type: 'User',
+          bypass_mode: 'exempt',
+        },
+      ],
+      conditions: {
+        ref_name: {
+          include: ['refs/tags/v*'],
+          exclude: [],
+        },
+      },
+      rules: [{ type: 'deletion' }],
+    });
+  });
+
+  it('should create a minimal repository ruleset without optional outputs', async () => {
+    mockOctokit.rest.repos.createRepoRuleset.mockResolvedValueOnce({
+      data: {
+        id: 2,
+        name: 'Block deletions',
+      },
+    });
+    const mockContext = createMockActionContext({
+      input: {
+        repoUrl: 'github.com?repo=repo&owner=owner',
+        name: 'Block deletions',
+        enforcement: 'disabled',
+        rules: [{ type: 'deletion' }],
+      },
+    });
+
+    await action.handler(mockContext);
+
+    expect(mockOctokit.rest.repos.createRepoRuleset).toHaveBeenCalledWith({
+      owner: 'owner',
+      repo: 'repo',
+      name: 'Block deletions',
+      target: 'branch',
+      enforcement: 'disabled',
+      bypass_actors: undefined,
+      conditions: undefined,
+      rules: [{ type: 'deletion' }],
+    });
+    expect(mockContext.output).toHaveBeenCalledWith('rulesetId', 2);
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'rulesetName',
+      'Block deletions',
+    );
+    expect(mockContext.output).not.toHaveBeenCalledWith(
+      'rulesetUrl',
+      expect.anything(),
+    );
+  });
+
+  it('should reject repoUrl without owner', async () => {
+    await expect(
+      action.handler(
+        createMockActionContext({
+          input: {
+            repoUrl: 'github.com?repo=repo',
+            name: 'Require pull requests',
+            enforcement: 'active',
+            rules: [{ type: 'deletion' }],
+          },
+        }),
+      ),
+    ).rejects.toThrow('missing owner');
+  });
+});

--- a/plugins/scaffolder-backend-module-github/src/actions/githubRulesetCreate.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubRulesetCreate.ts
@@ -197,14 +197,18 @@ export function createGithubRulesetCreateAction(options: {
             rules: rules as CreateRepoRulesetParams['rules'],
           });
 
-          return response.data;
+          return {
+            id: response.data.id,
+            name: response.data.name,
+            rulesetUrl: response.data._links?.self?.href,
+          };
         },
       });
 
       ctx.output('rulesetId', ruleset.id);
       ctx.output('rulesetName', ruleset.name);
-      if (ruleset._links?.self?.href) {
-        ctx.output('rulesetUrl', ruleset._links.self.href);
+      if (ruleset.rulesetUrl) {
+        ctx.output('rulesetUrl', ruleset.rulesetUrl);
       }
     },
   });

--- a/plugins/scaffolder-backend-module-github/src/actions/githubRulesetCreate.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubRulesetCreate.ts
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { InputError } from '@backstage/errors';
+import {
+  GithubCredentialsProvider,
+  ScmIntegrations,
+} from '@backstage/integration';
+import {
+  createTemplateAction,
+  parseRepoUrl,
+} from '@backstage/plugin-scaffolder-node';
+import { Octokit } from 'octokit';
+import { getOctokitOptions } from '../util';
+import { examples } from './githubRulesetCreate.examples';
+
+type CreateRepoRulesetParams = NonNullable<
+  Parameters<Octokit['rest']['repos']['createRepoRuleset']>[0]
+>;
+
+/**
+ * Creates a GitHub repository ruleset.
+ *
+ * @public
+ */
+export function createGithubRulesetCreateAction(options: {
+  integrations: ScmIntegrations;
+  githubCredentialsProvider?: GithubCredentialsProvider;
+}) {
+  const { integrations, githubCredentialsProvider } = options;
+
+  return createTemplateAction({
+    id: 'github:ruleset:create',
+    description: 'Creates a GitHub repository ruleset.',
+    examples,
+    schema: {
+      input: {
+        repoUrl: z =>
+          z.string({
+            description:
+              'Accepts the format `github.com?repo=reponame&owner=owner` where `reponame` is the repository name and `owner` is an organization or username',
+          }),
+        name: z =>
+          z.string({
+            description: 'The name of the ruleset.',
+          }),
+        target: z =>
+          z
+            .enum(['branch', 'tag', 'push'], {
+              description:
+                'The target of the ruleset. The default value is `branch`.',
+            })
+            .default('branch')
+            .optional(),
+        enforcement: z =>
+          z.enum(['disabled', 'active', 'evaluate'], {
+            description: 'The enforcement level of the ruleset.',
+          }),
+        bypassActors: z =>
+          z
+            .array(
+              z.object({
+                actorId: z.number().nullable().optional(),
+                actorType: z.enum([
+                  'Integration',
+                  'OrganizationAdmin',
+                  'RepositoryRole',
+                  'Team',
+                  'DeployKey',
+                  'User',
+                ]),
+                bypassMode: z
+                  .enum(['always', 'pull_request', 'exempt'])
+                  .optional(),
+              }),
+              {
+                description:
+                  'Actors that can bypass the rules in this ruleset.',
+              },
+            )
+            .optional(),
+        conditions: z =>
+          z
+            .object(
+              {
+                refName: z
+                  .object({
+                    include: z.array(z.string()),
+                    exclude: z.array(z.string()),
+                  })
+                  .optional(),
+              },
+              {
+                description:
+                  'Conditions for matching refs. Use `~DEFAULT_BRANCH` to include the default branch or `~ALL` to include all branches.',
+              },
+            )
+            .optional(),
+        rules: z =>
+          z.array(z.record(z.any()), {
+            description:
+              'The rules within the ruleset, using the GitHub REST API rule shape.',
+          }),
+        token: z =>
+          z
+            .string({
+              description: 'The token to use for authorization to GitHub',
+            })
+            .optional(),
+      },
+      output: {
+        rulesetId: z =>
+          z.number({
+            description: 'The ID of the created ruleset.',
+          }),
+        rulesetName: z =>
+          z.string({
+            description: 'The name of the created ruleset.',
+          }),
+        rulesetUrl: z =>
+          z
+            .string({
+              description: 'The API URL of the created ruleset.',
+            })
+            .optional(),
+      },
+    },
+    async handler(ctx) {
+      const {
+        repoUrl,
+        name,
+        target = 'branch',
+        enforcement,
+        bypassActors,
+        conditions,
+        rules,
+        token,
+      } = ctx.input;
+
+      const { host, owner, repo } = parseRepoUrl(repoUrl, integrations);
+
+      if (!owner) {
+        throw new InputError('Invalid repository owner provided in repoUrl');
+      }
+
+      const octokitOptions = await getOctokitOptions({
+        integrations,
+        credentialsProvider: githubCredentialsProvider,
+        token,
+        host,
+        owner,
+        repo,
+      });
+      const client = new Octokit({
+        ...octokitOptions,
+        log: ctx.logger,
+      });
+      // GitHub supports User actors and exempt bypass mode for repository
+      // rulesets, but the generated Octokit type in this repo is narrower.
+      const bypassActorsParam = bypassActors?.map(actor => ({
+        actor_id: actor.actorId,
+        actor_type: actor.actorType,
+        bypass_mode: actor.bypassMode,
+      })) as CreateRepoRulesetParams['bypass_actors'];
+
+      const ruleset = await ctx.checkpoint({
+        key: `create.ruleset.${owner}.${repo}.${name}`,
+        fn: async () => {
+          const response = await client.rest.repos.createRepoRuleset({
+            owner,
+            repo,
+            name,
+            target,
+            enforcement,
+            bypass_actors: bypassActorsParam,
+            conditions: conditions?.refName
+              ? {
+                  ref_name: {
+                    include: conditions.refName.include,
+                    exclude: conditions.refName.exclude,
+                  },
+                }
+              : undefined,
+            rules: rules as CreateRepoRulesetParams['rules'],
+          });
+
+          return response.data;
+        },
+      });
+
+      ctx.output('rulesetId', ruleset.id);
+      ctx.output('rulesetName', ruleset.name);
+      if (ruleset._links?.self?.href) {
+        ctx.output('rulesetUrl', ruleset._links.self.href);
+      }
+    },
+  });
+}

--- a/plugins/scaffolder-backend-module-github/src/actions/index.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/index.ts
@@ -19,6 +19,7 @@ export { createGithubIssuesLabelAction } from './githubIssuesLabel';
 export { createGithubIssuesCreateAction } from './githubIssuesCreate';
 export { createGithubRepoCreateAction } from './githubRepoCreate';
 export { createGithubRepoPushAction } from './githubRepoPush';
+export { createGithubRulesetCreateAction } from './githubRulesetCreate';
 export { createGithubWebhookAction } from './githubWebhook';
 export { createGithubDeployKeyAction } from './githubDeployKey';
 export { createGithubEnvironmentAction } from './githubEnvironment';

--- a/plugins/scaffolder-backend-module-github/src/module.ts
+++ b/plugins/scaffolder-backend-module-github/src/module.ts
@@ -32,6 +32,7 @@ import {
   createPublishGithubPullRequestAction,
   createGithubPagesEnableAction,
   createGithubBranchProtectionAction,
+  createGithubRulesetCreateAction,
 } from './actions';
 import {
   DefaultGithubCredentialsProvider,
@@ -90,6 +91,10 @@ export const githubModule = createBackendModule({
             githubCredentialsProvider,
           }),
           createGithubRepoPushAction({ integrations, config }),
+          createGithubRulesetCreateAction({
+            integrations,
+            githubCredentialsProvider,
+          }),
           createGithubWebhookAction({
             integrations,
             githubCredentialsProvider,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds a standalone `github:ruleset:create` Scaffolder action for creating GitHub repository rulesets from templates.

This addresses #32246 by supporting GitHub’s newer rulesets API without adding more top-level options to `github:repo:create`. The action can be composed after repository creation or used against an existing repository.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
