### PR TITLE
permission: cache user info, clean up PolicyQueryUser, drop getPluginRequestToken

### DIFF
--- a/.changeset/permission-backend-drop-token.md
+++ b/.changeset/permission-backend-drop-token.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-permission-backend': patch
+---
+
+The permission backend no longer populates the removed `token` and `identity` fields on `PolicyQueryUser`, and no longer calls `auth.getPluginRequestToken()` during policy evaluation. This removes one internal round-trip per authorize request.

--- a/.changeset/permission-node-optional-deprecated-fields.md
+++ b/.changeset/permission-node-optional-deprecated-fields.md
@@ -1,0 +1,11 @@
+---
+'@backstage/plugin-permission-node': minor
+---
+
+**BREAKING**: Cleaned up the `PolicyQueryUser` type:
+
+- `token` — **Removed.** Was previously deprecated in favor of `credentials` with `coreServices.auth`.
+- `expiresInSeconds` — **Removed.** Was previously deprecated.
+- `identity` — **Removed.** Was previously deprecated in favor of `info`.
+- `info` — **Deprecated.** Still required and populated for now; will be made optional and then removed in a future release.
+- `credentials` — Unchanged.

--- a/.changeset/permission-userinfo-cache.md
+++ b/.changeset/permission-userinfo-cache.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Added a new `CachedUserInfoService` decorator that wraps `DefaultUserInfoService` with a 5-second TTL cache and in-flight request coalescing. The decorator is wired in via `userInfoServiceFactory` using a shared root-level cache. Repeated `getUserInfo()` calls for the same user token within the TTL window return the cached result without making an HTTP call to the auth backend. Note that custom `UserInfoService` implementations registered via their own factory will not benefit from this cache automatically.

--- a/packages/backend-defaults/src/entrypoints/userInfo/CachedUserInfoService.test.ts
+++ b/packages/backend-defaults/src/entrypoints/userInfo/CachedUserInfoService.test.ts
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  BackstageUserInfo,
+  UserInfoService,
+} from '@backstage/backend-plugin-api';
+import { mockCredentials } from '@backstage/backend-test-utils';
+import { CachedUserInfoService } from './CachedUserInfoService';
+
+const aliceInfo: BackstageUserInfo = {
+  userEntityRef: 'user:default/alice',
+  ownershipEntityRefs: ['user:default/alice', 'group:default/team-a'],
+};
+
+describe('CachedUserInfoService', () => {
+  it('delegates to the underlying service on the first call', async () => {
+    const delegate: UserInfoService = {
+      getUserInfo: jest.fn().mockResolvedValue(aliceInfo),
+    };
+    const service = new CachedUserInfoService(delegate);
+
+    const result = await service.getUserInfo(mockCredentials.user());
+
+    expect(result).toEqual(aliceInfo);
+    expect(delegate.getUserInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns the cached result on subsequent calls within TTL', async () => {
+    const delegate: UserInfoService = {
+      getUserInfo: jest.fn().mockResolvedValue(aliceInfo),
+    };
+    const service = new CachedUserInfoService(delegate);
+    const creds = mockCredentials.user();
+
+    await service.getUserInfo(creds);
+    await service.getUserInfo(creds);
+    await service.getUserInfo(creds);
+
+    expect(delegate.getUserInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces concurrent in-flight requests for the same token', async () => {
+    const delegate: UserInfoService = {
+      getUserInfo: jest.fn().mockResolvedValue(aliceInfo),
+    };
+    const service = new CachedUserInfoService(delegate);
+    const creds = mockCredentials.user();
+
+    const [r1, r2, r3] = await Promise.all([
+      service.getUserInfo(creds),
+      service.getUserInfo(creds),
+      service.getUserInfo(creds),
+    ]);
+
+    expect(r1).toEqual(aliceInfo);
+    expect(r2).toEqual(aliceInfo);
+    expect(r3).toEqual(aliceInfo);
+    expect(delegate.getUserInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches different tokens separately', async () => {
+    const delegate: UserInfoService = {
+      getUserInfo: jest.fn().mockResolvedValue(aliceInfo),
+    };
+    const service = new CachedUserInfoService(delegate);
+
+    await service.getUserInfo(mockCredentials.user('user:default/alice'));
+    await service.getUserInfo(mockCredentials.user('user:default/bob'));
+
+    expect(delegate.getUserInfo).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-fetches after the TTL expires', async () => {
+    const delegate: UserInfoService = {
+      getUserInfo: jest.fn().mockResolvedValue(aliceInfo),
+    };
+    const service = new CachedUserInfoService(delegate, { ttlMs: 50 });
+    const creds = mockCredentials.user();
+
+    await service.getUserInfo(creds);
+    expect(delegate.getUserInfo).toHaveBeenCalledTimes(1);
+
+    await new Promise(resolve => setTimeout(resolve, 60));
+
+    await service.getUserInfo(creds);
+    expect(delegate.getUserInfo).toHaveBeenCalledTimes(2);
+  });
+
+  it('evicts the cache entry on rejection and retries on next call', async () => {
+    const delegate: UserInfoService = {
+      getUserInfo: jest
+        .fn()
+        .mockRejectedValueOnce(new Error('auth backend down'))
+        .mockResolvedValueOnce(aliceInfo),
+    };
+    const service = new CachedUserInfoService(delegate);
+    const creds = mockCredentials.user();
+
+    await expect(service.getUserInfo(creds)).rejects.toThrow(
+      'auth backend down',
+    );
+    expect(delegate.getUserInfo).toHaveBeenCalledTimes(1);
+
+    const result = await service.getUserInfo(creds);
+    expect(result).toEqual(aliceInfo);
+    expect(delegate.getUserInfo).toHaveBeenCalledTimes(2);
+  });
+
+  it('evicts eagerly so concurrent waiters see the rejection and the next call retries', async () => {
+    let rejectFirst: (error: Error) => void;
+    const firstCall = new Promise<BackstageUserInfo>((_resolve, reject) => {
+      rejectFirst = reject;
+    });
+
+    const delegate: UserInfoService = {
+      getUserInfo: jest
+        .fn()
+        .mockReturnValueOnce(firstCall)
+        .mockResolvedValueOnce(aliceInfo),
+    };
+    const service = new CachedUserInfoService(delegate);
+    const creds = mockCredentials.user();
+
+    const p1 = service.getUserInfo(creds);
+    const p2 = service.getUserInfo(creds);
+
+    rejectFirst!(new Error('boom'));
+
+    await expect(p1).rejects.toThrow('boom');
+    await expect(p2).rejects.toThrow('boom');
+
+    const result = await service.getUserInfo(creds);
+    expect(result).toEqual(aliceInfo);
+    expect(delegate.getUserInfo).toHaveBeenCalledTimes(2);
+  });
+
+  it('delegates directly when credentials have no token', async () => {
+    const delegate: UserInfoService = {
+      getUserInfo: jest.fn().mockResolvedValue(aliceInfo),
+    };
+    const service = new CachedUserInfoService(delegate);
+
+    await service.getUserInfo(mockCredentials.none());
+    await service.getUserInfo(mockCredentials.none());
+
+    expect(delegate.getUserInfo).toHaveBeenCalledTimes(2);
+  });
+
+  it('shares cache entries across instances when given the same map', async () => {
+    const delegate1: UserInfoService = {
+      getUserInfo: jest.fn().mockResolvedValue(aliceInfo),
+    };
+    const delegate2: UserInfoService = {
+      getUserInfo: jest.fn().mockResolvedValue(aliceInfo),
+    };
+    const entries = new Map();
+    const service1 = new CachedUserInfoService(delegate1, { entries });
+    const service2 = new CachedUserInfoService(delegate2, { entries });
+    const creds = mockCredentials.user();
+
+    await service1.getUserInfo(creds);
+    await service2.getUserInfo(creds);
+
+    expect(delegate1.getUserInfo).toHaveBeenCalledTimes(1);
+    expect(delegate2.getUserInfo).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend-defaults/src/entrypoints/userInfo/CachedUserInfoService.test.ts
+++ b/packages/backend-defaults/src/entrypoints/userInfo/CachedUserInfoService.test.ts
@@ -19,7 +19,10 @@ import {
   UserInfoService,
 } from '@backstage/backend-plugin-api';
 import { mockCredentials } from '@backstage/backend-test-utils';
-import { CachedUserInfoService } from './CachedUserInfoService';
+import {
+  CachedUserInfoService,
+  UserInfoCacheEntry,
+} from './CachedUserInfoService';
 
 const aliceInfo: BackstageUserInfo = {
   userEntityRef: 'user:default/alice',
@@ -85,19 +88,24 @@ describe('CachedUserInfoService', () => {
   });
 
   it('re-fetches after the TTL expires', async () => {
-    const delegate: UserInfoService = {
-      getUserInfo: jest.fn().mockResolvedValue(aliceInfo),
-    };
-    const service = new CachedUserInfoService(delegate, { ttlMs: 50 });
-    const creds = mockCredentials.user();
+    jest.useFakeTimers();
+    try {
+      const delegate: UserInfoService = {
+        getUserInfo: jest.fn().mockResolvedValue(aliceInfo),
+      };
+      const service = new CachedUserInfoService(delegate, { ttlMs: 50 });
+      const creds = mockCredentials.user();
 
-    await service.getUserInfo(creds);
-    expect(delegate.getUserInfo).toHaveBeenCalledTimes(1);
+      await service.getUserInfo(creds);
+      expect(delegate.getUserInfo).toHaveBeenCalledTimes(1);
 
-    await new Promise(resolve => setTimeout(resolve, 60));
+      jest.advanceTimersByTime(60);
 
-    await service.getUserInfo(creds);
-    expect(delegate.getUserInfo).toHaveBeenCalledTimes(2);
+      await service.getUserInfo(creds);
+      expect(delegate.getUserInfo).toHaveBeenCalledTimes(2);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
   it('evicts the cache entry on rejection and retries on next call', async () => {
@@ -167,7 +175,7 @@ describe('CachedUserInfoService', () => {
     const delegate2: UserInfoService = {
       getUserInfo: jest.fn().mockResolvedValue(aliceInfo),
     };
-    const entries = new Map();
+    const entries = new Map<string, UserInfoCacheEntry>();
     const service1 = new CachedUserInfoService(delegate1, { entries });
     const service2 = new CachedUserInfoService(delegate2, { entries });
     const creds = mockCredentials.user();

--- a/packages/backend-defaults/src/entrypoints/userInfo/CachedUserInfoService.ts
+++ b/packages/backend-defaults/src/entrypoints/userInfo/CachedUserInfoService.ts
@@ -58,14 +58,6 @@ export class CachedUserInfoService implements UserInfoService {
 
     const now = Date.now();
 
-    const cached = this.#entries.get(token);
-    if (cached) {
-      if (cached.expiresAt > now) {
-        return cached.promise;
-      }
-      this.#entries.delete(token);
-    }
-
     if (now - this.#lastSweep > SWEEP_INTERVAL_MS) {
       this.#lastSweep = now;
       for (const [key, entry] of this.#entries) {
@@ -73,6 +65,11 @@ export class CachedUserInfoService implements UserInfoService {
           this.#entries.delete(key);
         }
       }
+    }
+
+    const cached = this.#entries.get(token);
+    if (cached && cached.expiresAt > now) {
+      return cached.promise;
     }
 
     const promise = this.#delegate.getUserInfo(credentials).catch(error => {

--- a/packages/backend-defaults/src/entrypoints/userInfo/CachedUserInfoService.ts
+++ b/packages/backend-defaults/src/entrypoints/userInfo/CachedUserInfoService.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  BackstageCredentials,
+  BackstageUserInfo,
+  UserInfoService,
+} from '@backstage/backend-plugin-api';
+import { toInternalBackstageCredentials } from '../auth/helpers';
+
+const DEFAULT_TTL_MS = 5_000;
+const SWEEP_INTERVAL_MS = 30_000;
+
+export type UserInfoCacheEntry = {
+  promise: Promise<BackstageUserInfo>;
+  expiresAt: number;
+};
+
+export class CachedUserInfoService implements UserInfoService {
+  readonly #delegate: UserInfoService;
+  readonly #entries: Map<string, UserInfoCacheEntry>;
+  readonly #ttlMs: number;
+  #lastSweep: number = Date.now();
+
+  constructor(
+    delegate: UserInfoService,
+    options?: {
+      entries?: Map<string, UserInfoCacheEntry>;
+      ttlMs?: number;
+    },
+  ) {
+    this.#delegate = delegate;
+    this.#entries = options?.entries ?? new Map();
+    this.#ttlMs = options?.ttlMs ?? DEFAULT_TTL_MS;
+  }
+
+  async getUserInfo(
+    credentials: BackstageCredentials,
+  ): Promise<BackstageUserInfo> {
+    const internalCredentials = toInternalBackstageCredentials(credentials);
+    const token = internalCredentials.token;
+    if (!token) {
+      return this.#delegate.getUserInfo(credentials);
+    }
+
+    const now = Date.now();
+
+    const cached = this.#entries.get(token);
+    if (cached) {
+      if (cached.expiresAt > now) {
+        return cached.promise;
+      }
+      this.#entries.delete(token);
+    }
+
+    if (now - this.#lastSweep > SWEEP_INTERVAL_MS) {
+      this.#lastSweep = now;
+      for (const [key, entry] of this.#entries) {
+        if (entry.expiresAt <= now) {
+          this.#entries.delete(key);
+        }
+      }
+    }
+
+    const promise = this.#delegate.getUserInfo(credentials).catch(error => {
+      this.#entries.delete(token);
+      throw error;
+    });
+
+    this.#entries.set(token, {
+      promise,
+      expiresAt: now + this.#ttlMs,
+    });
+
+    return promise;
+  }
+}

--- a/packages/backend-defaults/src/entrypoints/userInfo/userInfoServiceFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/userInfo/userInfoServiceFactory.ts
@@ -18,6 +18,10 @@ import {
   coreServices,
   createServiceFactory,
 } from '@backstage/backend-plugin-api';
+import {
+  CachedUserInfoService,
+  UserInfoCacheEntry,
+} from './CachedUserInfoService';
 import { DefaultUserInfoService } from './DefaultUserInfoService';
 
 /**
@@ -34,7 +38,13 @@ export const userInfoServiceFactory = createServiceFactory({
   deps: {
     discovery: coreServices.discovery,
   },
-  async factory({ discovery }) {
-    return new DefaultUserInfoService({ discovery });
+  createRootContext() {
+    return new Map<string, UserInfoCacheEntry>();
+  },
+  async factory({ discovery }, entries) {
+    return new CachedUserInfoService(
+      new DefaultUserInfoService({ discovery }),
+      { entries },
+    );
   },
 });

--- a/plugins/permission-backend/src/service/router.test.ts
+++ b/plugins/permission-backend/src/service/router.test.ts
@@ -270,17 +270,6 @@ describe('createRouter', () => {
           },
         },
         {
-          token: mockCredentials.service.token({
-            onBehalfOf: mockCredentials.user(),
-            targetPluginId: 'catalog',
-          }),
-          identity: {
-            type: 'user',
-            userEntityRef: mockCredentials.user().principal.userEntityRef,
-            ownershipEntityRefs: [
-              mockCredentials.user().principal.userEntityRef,
-            ],
-          },
           info: {
             userEntityRef: mockCredentials.user().principal.userEntityRef,
             ownershipEntityRefs: [

--- a/plugins/permission-backend/src/service/router.ts
+++ b/plugins/permission-backend/src/service/router.ts
@@ -132,17 +132,7 @@ const handleRequest = async (
   let user: PolicyQueryUser | undefined;
   if (auth.isPrincipal(credentials, 'user')) {
     const info = await userInfo.getUserInfo(credentials);
-    const { token } = await auth.getPluginRequestToken({
-      onBehalfOf: credentials,
-      targetPluginId: 'catalog', // TODO: unknown at this point
-    });
     user = {
-      identity: {
-        type: 'user',
-        userEntityRef: credentials.principal.userEntityRef,
-        ownershipEntityRefs: info.ownershipEntityRefs,
-      },
-      token,
       credentials,
       info,
     };

--- a/plugins/permission-node/package.json
+++ b/plugins/permission-node/package.json
@@ -59,7 +59,6 @@
     "@backstage/backend-plugin-api": "workspace:^",
     "@backstage/config": "workspace:^",
     "@backstage/errors": "workspace:^",
-    "@backstage/plugin-auth-node": "workspace:^",
     "@backstage/plugin-permission-common": "workspace:^",
     "@types/express": "^4.17.6",
     "express": "^4.22.0",

--- a/plugins/permission-node/report.api.md
+++ b/plugins/permission-node/report.api.md
@@ -10,7 +10,6 @@ import { AuthorizePermissionResponse } from '@backstage/plugin-permission-common
 import { AuthorizeResult } from '@backstage/plugin-permission-common';
 import { AuthService } from '@backstage/backend-plugin-api';
 import { BackstageCredentials } from '@backstage/backend-plugin-api';
-import { BackstageUserIdentity } from '@backstage/plugin-auth-node';
 import { BackstageUserInfo } from '@backstage/backend-plugin-api';
 import { ConditionalPolicyDecision } from '@backstage/plugin-permission-common';
 import { Config } from '@backstage/config';
@@ -365,9 +364,6 @@ export type PolicyQuery = {
 
 // @public
 export type PolicyQueryUser = {
-  token: string;
-  expiresInSeconds?: number;
-  identity: BackstageUserIdentity;
   credentials: BackstageCredentials;
   info: BackstageUserInfo;
 };

--- a/plugins/permission-node/src/policy/types.ts
+++ b/plugins/permission-node/src/policy/types.ts
@@ -18,7 +18,6 @@ import {
   Permission,
   PolicyDecision,
 } from '@backstage/plugin-permission-common';
-import { BackstageUserIdentity } from '@backstage/plugin-auth-node';
 import {
   BackstageCredentials,
   BackstageUserInfo,
@@ -45,33 +44,14 @@ export type PolicyQuery = {
  */
 export type PolicyQueryUser = {
   /**
-   * The token used to authenticate the user within Backstage.
-   *
-   * @deprecated User the `credentials` field in combination with `coreServices.auth` to generate a request token instead.
-   */
-  token: string;
-
-  /**
-   * The number of seconds until the token expires. If not set, it can be assumed that the token does not expire.
-   *
-   * @deprecated This field is deprecated and will be removed in a future release.
-   */
-  expiresInSeconds?: number;
-
-  /**
-   * A plaintext description of the identity that is encapsulated within the token.
-   *
-   * @deprecated Use the `info` field instead.
-   */
-  identity: BackstageUserIdentity;
-
-  /**
    * The credentials of the user making the request.
    */
   credentials: BackstageCredentials;
 
   /**
    * The information for the user making the request.
+   *
+   * @deprecated This field is deprecated and will be removed in a future release.
    */
   info: BackstageUserInfo;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6498,7 +6498,6 @@ __metadata:
     "@backstage/cli": "workspace:^"
     "@backstage/config": "workspace:^"
     "@backstage/errors": "workspace:^"
-    "@backstage/plugin-auth-node": "workspace:^"
     "@backstage/plugin-permission-common": "workspace:^"
     "@types/express": "npm:^4.17.6"
     "@types/supertest": "npm:^2.0.8"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Problem

The permission backend resolves `userInfo.getUserInfo()` and `auth.getPluginRequestToken()` sequentially for every authorize request with user credentials — even when the same user makes many requests in quick succession. This adds unnecessary latency to every permissioned endpoint.

### Changes

**1. Cache user info lookups** (`@backstage/backend-defaults`)

New `CachedUserInfoService` decorator with a 5-second TTL cache keyed on the raw token. Concurrent calls for the same token coalesce into a single in-flight request. Rejections evict the cache entry so the next call retries. A periodic sweep (every 30s) removes expired entries from tokens that are never requested again. The cache is created once at root level and shared across all plugin instances via `createRootContext`. Note that custom `UserInfoService` implementations registered via their own factory will not benefit from this cache automatically.

**2. Clean up `PolicyQueryUser`** (`@backstage/plugin-permission-node`)

**BREAKING** — removed previously-deprecated fields:

- `token` — **Removed.** Was deprecated in favor of `credentials` with `coreServices.auth`.
- `expiresInSeconds` — **Removed.** Was deprecated.
- `identity` — **Removed.** Was deprecated in favor of `info`.
- `info` — **Deprecated.** Still required and populated for now; will be made optional and then removed in a future release.
- `credentials` — Unchanged.

**3. Drop `getPluginRequestToken` call** (`@backstage/plugin-permission-backend`)

The permission backend no longer calls `auth.getPluginRequestToken()` during policy evaluation (the `token` field it populated was removed). This eliminates one internal round-trip per authorize request.

### Test plan

- [x] Permission-backend router tests pass (25 tests)
- [x] DefaultUserInfoService tests pass (3 tests)
- [x] CachedUserInfoService tests pass (9 tests) — covers caching, TTL expiry, request coalescing, error eviction + retry, shared entries across instances
- [x] Type checker passes
- [x] API reports updated

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)