### PR TITLE
feat(ui): add 'number' to TextField type prop

### DIFF
--- a/.changeset/textfield-add-number-type.md
+++ b/.changeset/textfield-add-number-type.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Added `number` to the `TextField` `type` prop union, allowing numeric inputs without type assertion workarounds.

--- a/packages/ui/report.api.md
+++ b/packages/ui/report.api.md
@@ -3444,7 +3444,7 @@ export type TextFieldOwnProps = {
 export interface TextFieldProps
   extends Omit<TextFieldProps_2, 'className' | 'description'>,
     TextFieldOwnProps {
-  type?: 'text' | 'email' | 'tel' | 'url';
+  type?: 'text' | 'email' | 'tel' | 'url' | 'number';
 }
 
 // @public (undocumented)

--- a/packages/ui/src/components/TextField/types.ts
+++ b/packages/ui/src/components/TextField/types.ts
@@ -55,5 +55,5 @@ export interface TextFieldProps
    * Use `SearchField` for
    * search inputs and `PasswordField` for password inputs.
    */
-  type?: 'text' | 'email' | 'tel' | 'url';
+  type?: 'text' | 'email' | 'tel' | 'url' | 'number';
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The TextField component wraps React Aria's AriaTextField which already passes the type prop through to the HTML <Input> element. Adding 'number' to the type union removes the need for `@ts-expect-error` workarounds when using TextField for numeric inputs.

This adds 'number' to the type union.

  Changes

  - packages/ui/src/components/TextField/types.ts — added 'number' to the type prop union
  - packages/ui/report.api.md — updated API report
  
#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
