### PR TITLE
fix(ui): allow fields to grow in flex layouts

### DIFF
--- a/.changeset/fix-ui-field-flex.md
+++ b/.changeset/fix-ui-field-flex.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Updated field components to grow within flex layouts instead of forcing their width to remain fixed.

--- a/packages/ui/src/components/Combobox/Combobox.module.css
+++ b/packages/ui/src/components/Combobox/Combobox.module.css
@@ -28,6 +28,13 @@
     }
   }
 
+  .bui-Combobox {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    flex: 1;
+  }
+
   .bui-ComboboxPopover {
     min-width: var(--trigger-width);
 

--- a/packages/ui/src/components/DatePicker/DatePicker.module.css
+++ b/packages/ui/src/components/DatePicker/DatePicker.module.css
@@ -26,7 +26,7 @@
     flex-direction: column;
     font-family: var(--bui-font-regular);
     width: 100%;
-    flex-shrink: 0;
+    flex: 1;
   }
 
   /* ============================================================

--- a/packages/ui/src/components/DateRangePicker/DateRangePicker.module.css
+++ b/packages/ui/src/components/DateRangePicker/DateRangePicker.module.css
@@ -26,7 +26,7 @@
     flex-direction: column;
     font-family: var(--bui-font-regular);
     width: 100%;
-    flex-shrink: 0;
+    flex: 1;
   }
 
   /* ============================================================

--- a/packages/ui/src/components/PasswordField/PasswordField.module.css
+++ b/packages/ui/src/components/PasswordField/PasswordField.module.css
@@ -22,7 +22,7 @@
     flex-direction: column;
     font-family: var(--bui-font-regular);
     width: 100%;
-    flex-shrink: 0;
+    flex: 1;
 
     &[data-size='small'] {
       --password-field-item-height: 2rem;

--- a/packages/ui/src/components/SearchField/SearchField.module.css
+++ b/packages/ui/src/components/SearchField/SearchField.module.css
@@ -23,7 +23,6 @@
     font-family: var(--bui-font-regular);
     width: 100%;
     flex: 1;
-    flex-shrink: 0;
 
     &[data-size='small'] {
       --search-field-item-height: 2rem;

--- a/packages/ui/src/components/Select/Select.module.css
+++ b/packages/ui/src/components/Select/Select.module.css
@@ -28,6 +28,13 @@
     }
   }
 
+  .bui-Select {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    flex: 1;
+  }
+
   .bui-SelectPopover {
     min-width: var(--trigger-width);
   }

--- a/packages/ui/src/components/TextField/TextField.module.css
+++ b/packages/ui/src/components/TextField/TextField.module.css
@@ -22,7 +22,7 @@
     flex-direction: column;
     font-family: var(--bui-font-regular);
     width: 100%;
-    flex-shrink: 0;
+    flex: 1;
 
     &[data-on-bg='neutral-1'] .bui-Input {
       background-color: var(--bui-bg-neutral-2);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updated Backstage UI field components so their root containers grow within flex layouts using `flex: 1`, removing the conflicting root-level shrink behavior where it existed.

This covers TextField, SearchField, PasswordField, DatePicker, DateRangePicker, Select, and Combobox, and includes a patch changeset for `@backstage/ui`.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))