### PR TITLE
fix(auth-backend): harden default allowed patterns for CIMD and DCR

### DIFF
--- a/.changeset/harden-oidc-defaults.md
+++ b/.changeset/harden-oidc-defaults.md
@@ -1,0 +1,37 @@
+---
+'@backstage/plugin-auth-backend': minor
+---
+
+Hardened the default allowed patterns for CIMD and DCR to replace the previous permissive `['*']` wildcards with specific defaults for known MCP clients.
+
+**CIMD (`experimentalClientIdMetadataDocuments`):**
+
+- `allowedClientIdPatterns` now defaults to Claude, VS Code, and the built-in Backstage CLI instead of `['*']`
+- `allowedRedirectUriPatterns` now defaults to loopback addresses (localhost, 127.0.0.1, [::1]) instead of `['*']`
+
+**DCR (`experimentalDynamicClientRegistration`):**
+
+- `allowedRedirectUriPatterns` now defaults to Cursor and loopback addresses instead of `['*']`
+
+If you need to allow additional clients or redirect URIs, you can override these defaults in your `app-config.yaml`:
+
+```yaml
+auth:
+  experimentalClientIdMetadataDocuments:
+    enabled: true
+    allowedClientIdPatterns:
+      - 'https://claude.ai/*'
+      - 'https://vscode.dev/*'
+      - 'https://my-custom-client.example.com/*'
+    allowedRedirectUriPatterns:
+      - 'http://localhost:*'
+      - 'http://127.0.0.1:*'
+      - 'https://my-app.example.com/callback'
+  experimentalDynamicClientRegistration:
+    enabled: true
+    allowedRedirectUriPatterns:
+      - 'cursor://*'
+      - 'http://localhost:*'
+      - 'http://127.0.0.1:*'
+      - 'myapp://*'
+```

--- a/.changeset/harden-oidc-defaults.md
+++ b/.changeset/harden-oidc-defaults.md
@@ -2,7 +2,7 @@
 '@backstage/plugin-auth-backend': minor
 ---
 
-Hardened the default allowed patterns for CIMD and DCR to replace the previous permissive `['*']` wildcards with specific defaults for known MCP clients.
+**BREAKING**: Hardened the default allowed patterns for CIMD and DCR to replace the previous permissive `['*']` wildcards with specific defaults for known MCP clients. If you previously relied on the default `['*']` patterns, you will need to explicitly configure the patterns you need in your `app-config.yaml`.
 
 **CIMD (`experimentalClientIdMetadataDocuments`):**
 

--- a/.github/vale/config/vocabularies/Backstage/accept.txt
+++ b/.github/vale/config/vocabularies/Backstage/accept.txt
@@ -258,6 +258,7 @@ LocalStack
 lockdown
 lockfile
 lockfiles
+loopback
 lookbehind
 lookup
 lookups

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -355,15 +355,8 @@ scaffolder:
 auth:
   experimentalDynamicClientRegistration:
     enabled: true
-    allowedRedirectUriPatterns:
-      - cursor://*
-      - http://localhost:*
-      - http://127.0.0.1:*
   experimentalClientIdMetadataDocuments:
     enabled: true
-    allowedRedirectUriPatterns:
-      - http://127.0.0.1:*
-      - http://localhost:*
 
   ### Add auth.keyStore.provider to more granularly control how to store JWK data when running
   # the auth-backend.

--- a/docs/ai/mcp-actions.md
+++ b/docs/ai/mcp-actions.md
@@ -200,14 +200,18 @@ This can be enabled in the `auth-backend` plugin by using the `auth.experimental
 auth:
   experimentalClientIdMetadataDocuments:
     enabled: true
-    # Optional: restrict which `client_id` URLs are allowed (defaults to ['*'])
-    allowedClientIdPatterns:
-      - 'https://example.com/*'
-      - 'https://*.trusted-domain.com/*'
-    # Optional: restrict which redirect URIs are allowed (defaults to ['*'])
-    allowedRedirectUriPatterns:
-      - 'http://localhost:*'
-      - 'https://*.example.com/*'
+    # Optional: override which client_id URLs are allowed.
+    # Defaults to Claude, VS Code, and the built-in Backstage CLI.
+    # Note: setting this replaces the defaults entirely.
+    # allowedClientIdPatterns:
+    #   - 'https://claude.ai/*'
+    #   - 'https://vscode.dev/*'
+    #   - 'https://my-custom-client.example.com/*'
+    # Optional: override which redirect URIs are allowed.
+    # Defaults to loopback addresses (localhost, 127.0.0.1, [::1]).
+    # allowedRedirectUriPatterns:
+    #   - 'http://localhost:*'
+    #   - 'http://127.0.0.1:*'
 ```
 
 #### Dynamic Client Registration
@@ -224,10 +228,12 @@ This can be enabled in the `auth-backend` plugin by using the `auth.experimental
 auth:
   experimentalDynamicClientRegistration:
     enabled: true
-
-    # Optional: limit valid callback URLs for added security
-    allowedRedirectUriPatterns:
-      - cursor://*
+    # Optional: restrict which redirect URIs are allowed.
+    # Defaults to Cursor, localhost, and 127.0.0.1.
+    # allowedRedirectUriPatterns:
+    #   - 'cursor://*'
+    #   - 'http://localhost:*'
+    #   - 'http://127.0.0.1:*'
 ```
 
 ## Configuring MCP Clients

--- a/docs/ai/mcp-actions.md
+++ b/docs/ai/mcp-actions.md
@@ -206,12 +206,14 @@ auth:
     # allowedClientIdPatterns:
     #   - 'https://claude.ai/*'
     #   - 'https://vscode.dev/*'
+    #   - 'http://localhost:7007/.well-known/oauth-client/cli.json'
     #   - 'https://my-custom-client.example.com/*'
     # Optional: override which redirect URIs are allowed.
     # Defaults to loopback addresses (localhost, 127.0.0.1, [::1]).
     # allowedRedirectUriPatterns:
     #   - 'http://localhost:*'
     #   - 'http://127.0.0.1:*'
+    #   - 'http://[::1]:*'
 ```
 
 #### Dynamic Client Registration
@@ -229,11 +231,12 @@ auth:
   experimentalDynamicClientRegistration:
     enabled: true
     # Optional: restrict which redirect URIs are allowed.
-    # Defaults to Cursor, localhost, and 127.0.0.1.
+    # Defaults to Cursor and loopback addresses (localhost, 127.0.0.1, [::1]).
     # allowedRedirectUriPatterns:
     #   - 'cursor://*'
     #   - 'http://localhost:*'
     #   - 'http://127.0.0.1:*'
+    #   - 'http://[::1]:*'
 ```
 
 ## Configuring MCP Clients

--- a/docs/ai/mcp-actions.md
+++ b/docs/ai/mcp-actions.md
@@ -202,11 +202,12 @@ auth:
     enabled: true
     # Optional: override which client_id URLs are allowed.
     # Defaults to Claude, VS Code, and the built-in Backstage CLI.
-    # Note: setting this replaces the defaults entirely.
+    # Note: setting this replaces the defaults entirely. The built-in
+    # CLI pattern is derived from your auth backend's base URL and
+    # must be re-added manually if you override this list.
     # allowedClientIdPatterns:
     #   - 'https://claude.ai/*'
     #   - 'https://vscode.dev/*'
-    #   - '${backend.baseUrl}/.well-known/oauth-client/cli.json'
     #   - 'https://my-custom-client.example.com/*'
     # Optional: override which redirect URIs are allowed.
     # Defaults to loopback addresses (localhost, 127.0.0.1, [::1]).

--- a/docs/ai/mcp-actions.md
+++ b/docs/ai/mcp-actions.md
@@ -206,7 +206,7 @@ auth:
     # allowedClientIdPatterns:
     #   - 'https://claude.ai/*'
     #   - 'https://vscode.dev/*'
-    #   - 'http://localhost:7007/.well-known/oauth-client/cli.json'
+    #   - '${backend.baseUrl}/.well-known/oauth-client/cli.json'
     #   - 'https://my-custom-client.example.com/*'
     # Optional: override which redirect URIs are allowed.
     # Defaults to loopback addresses (localhost, 127.0.0.1, [::1]).

--- a/plugins/auth-backend/config.d.ts
+++ b/plugins/auth-backend/config.d.ts
@@ -163,7 +163,8 @@ export interface Config {
 
       /**
        * A list of allowed URI patterns to use for redirect URIs during
-       * dynamic client registration. Defaults to '[*]' which allows any redirect URI.
+       * dynamic client registration.
+       * Defaults to Cursor and loopback addresses (localhost, 127.0.0.1, [::1]).
        */
       allowedRedirectUriPatterns?: string[];
     };
@@ -183,7 +184,8 @@ export interface Config {
       /**
        * A list of allowed URI patterns for client_id URLs.
        * Uses glob-style pattern matching where `*` matches any characters.
-       * Defaults to ['*'] which allows any client_id URL.
+       * Defaults to `['https://claude.ai/*', 'https://vscode.dev/*', '{baseUrl}/.well-known/oauth-client/*']`
+       * where `{baseUrl}` is the auth backend's base URL.
        *
        * @example ['https://example.com/*', 'https://*.trusted-domain.com/*']
        */
@@ -192,7 +194,7 @@ export interface Config {
       /**
        * A list of allowed URI patterns for redirect URIs.
        * Uses glob-style pattern matching where `*` matches any characters.
-       * Defaults to ['*'] which allows any redirect URI.
+       * Defaults to loopback addresses (localhost, 127.0.0.1, [::1]).
        *
        * @example ['http://localhost:*', 'http://127.0.0.1:*\/callback']
        */

--- a/plugins/auth-backend/config.d.ts
+++ b/plugins/auth-backend/config.d.ts
@@ -184,7 +184,7 @@ export interface Config {
       /**
        * A list of allowed URI patterns for client_id URLs.
        * Uses glob-style pattern matching where `*` matches any characters.
-       * Defaults to `['https://claude.ai/*', 'https://vscode.dev/*', '{baseUrl}/.well-known/oauth-client/*']`
+       * Defaults to `['https://claude.ai/*', 'https://vscode.dev/*', '{baseUrl}/.well-known/oauth-client/cli.json']`
        * where `{baseUrl}` is the auth backend's base URL.
        *
        * @example ['https://example.com/*', 'https://*.trusted-domain.com/*']

--- a/plugins/auth-backend/src/service/OidcRouter.test.ts
+++ b/plugins/auth-backend/src/service/OidcRouter.test.ts
@@ -98,6 +98,7 @@ describe('OidcRouter', () => {
         auth: {
           experimentalDynamicClientRegistration: {
             enabled: true,
+            allowedRedirectUriPatterns: ['*'],
           },
         },
       },
@@ -182,6 +183,7 @@ describe('OidcRouter', () => {
         auth: {
           experimentalDynamicClientRegistration: {
             enabled: true,
+            allowedRedirectUriPatterns: ['*'],
           },
           experimentalRefreshToken: {
             enabled: true,
@@ -1349,6 +1351,8 @@ describe('OidcRouter', () => {
               auth: {
                 experimentalClientIdMetadataDocuments: {
                   enabled: true,
+                  allowedClientIdPatterns: ['*'],
+                  allowedRedirectUriPatterns: ['*'],
                 },
               },
             },
@@ -1441,6 +1445,8 @@ describe('OidcRouter', () => {
             auth: {
               experimentalClientIdMetadataDocuments: {
                 enabled: true,
+                allowedClientIdPatterns: ['*'],
+                allowedRedirectUriPatterns: ['*'],
               },
               // DCR is NOT enabled
             },

--- a/plugins/auth-backend/src/service/OidcService.test.ts
+++ b/plugins/auth-backend/src/service/OidcService.test.ts
@@ -224,7 +224,7 @@ describe('OidcService', () => {
 
         const client = await service.registerClient({
           clientName: 'Test Client',
-          redirectUris: ['https://example.com/callback'],
+          redirectUris: ['http://localhost:8080/callback'],
           responseTypes: ['code'],
           grantTypes: ['authorization_code'],
           scope: 'openid',
@@ -233,7 +233,7 @@ describe('OidcService', () => {
         expect(client).toEqual(
           expect.objectContaining({
             clientName: 'Test Client',
-            redirectUris: ['https://example.com/callback'],
+            redirectUris: ['http://localhost:8080/callback'],
             responseTypes: ['code'],
             grantTypes: ['authorization_code'],
             scope: 'openid',
@@ -365,12 +365,12 @@ describe('OidcService', () => {
 
         const client = await service.registerClient({
           clientName: 'Test Client',
-          redirectUris: ['https://example.com/callback'],
+          redirectUris: ['http://localhost:8080/callback'],
         });
 
         const authSession = await service.createAuthorizationSession({
           clientId: client.clientId,
-          redirectUri: 'https://example.com/callback',
+          redirectUri: 'http://localhost:8080/callback',
           responseType: 'code',
           scope: 'openid',
           state: 'test-state',
@@ -380,7 +380,7 @@ describe('OidcService', () => {
           id: expect.any(String),
           clientName: 'Test Client',
           scope: 'openid',
-          redirectUri: 'https://example.com/callback',
+          redirectUri: 'http://localhost:8080/callback',
         });
       });
 
@@ -390,7 +390,7 @@ describe('OidcService', () => {
         await expect(
           service.createAuthorizationSession({
             clientId: 'invalid-client',
-            redirectUri: 'https://example.com/callback',
+            redirectUri: 'http://localhost:8080/callback',
             responseType: 'code',
           }),
         ).rejects.toThrow('Invalid client_id');
@@ -401,7 +401,7 @@ describe('OidcService', () => {
 
         const client = await service.registerClient({
           clientName: 'Test Client',
-          redirectUris: ['https://example.com/callback'],
+          redirectUris: ['http://localhost:8080/callback'],
         });
 
         await expect(
@@ -418,13 +418,13 @@ describe('OidcService', () => {
 
         const client = await service.registerClient({
           clientName: 'Test Client',
-          redirectUris: ['https://example.com/callback'],
+          redirectUris: ['http://localhost:8080/callback'],
         });
 
         await expect(
           service.createAuthorizationSession({
             clientId: client.clientId,
-            redirectUri: 'https://example.com/callback',
+            redirectUri: 'http://localhost:8080/callback',
             responseType: 'token',
           }),
         ).rejects.toThrow('Only authorization code flow is supported');
@@ -435,12 +435,12 @@ describe('OidcService', () => {
 
         const client = await service.registerClient({
           clientName: 'Test Client',
-          redirectUris: ['https://example.com/callback'],
+          redirectUris: ['http://localhost:8080/callback'],
         });
 
         const authSession = await service.createAuthorizationSession({
           clientId: client.clientId,
-          redirectUri: 'https://example.com/callback',
+          redirectUri: 'http://localhost:8080/callback',
           responseType: 'code',
           codeChallenge: 'test-challenge',
           codeChallengeMethod: 'S256',
@@ -454,13 +454,13 @@ describe('OidcService', () => {
 
         const client = await service.registerClient({
           clientName: 'Test Client',
-          redirectUris: ['https://example.com/callback'],
+          redirectUris: ['http://localhost:8080/callback'],
         });
 
         await expect(
           service.createAuthorizationSession({
             clientId: client.clientId,
-            redirectUri: 'https://example.com/callback',
+            redirectUri: 'http://localhost:8080/callback',
             responseType: 'code',
             codeChallenge: 'test-challenge',
             codeChallengeMethod: 'invalid',
@@ -475,12 +475,12 @@ describe('OidcService', () => {
 
         const client = await service.registerClient({
           clientName: 'Test Client',
-          redirectUris: ['https://example.com/callback'],
+          redirectUris: ['http://localhost:8080/callback'],
         });
 
         const authSession = await service.createAuthorizationSession({
           clientId: client.clientId,
-          redirectUri: 'https://example.com/callback',
+          redirectUri: 'http://localhost:8080/callback',
           responseType: 'code',
           state: 'test-state',
         });
@@ -491,7 +491,7 @@ describe('OidcService', () => {
         });
 
         expect(result.redirectUrl).toMatch(
-          /^https:\/\/example\.com\/callback\?code=.+&state=test-state$/,
+          /^http:\/\/localhost:8080\/callback\?code=.+&state=test-state$/,
         );
       });
 
@@ -511,12 +511,12 @@ describe('OidcService', () => {
 
         const client = await service.registerClient({
           clientName: 'Test Client',
-          redirectUris: ['https://example.com/callback'],
+          redirectUris: ['http://localhost:8080/callback'],
         });
 
         const authSession = await service.createAuthorizationSession({
           clientId: client.clientId,
-          redirectUri: 'https://example.com/callback',
+          redirectUri: 'http://localhost:8080/callback',
           responseType: 'code',
         });
 
@@ -538,12 +538,12 @@ describe('OidcService', () => {
 
         const client = await service.registerClient({
           clientName: 'Test Client',
-          redirectUris: ['https://example.com/callback'],
+          redirectUris: ['http://localhost:8080/callback'],
         });
 
         const authSession = await service.createAuthorizationSession({
           clientId: client.clientId,
-          redirectUri: 'https://example.com/callback',
+          redirectUri: 'http://localhost:8080/callback',
           responseType: 'code',
         });
 
@@ -567,12 +567,12 @@ describe('OidcService', () => {
 
         const client = await service.registerClient({
           clientName: 'Test Client',
-          redirectUris: ['https://example.com/callback'],
+          redirectUris: ['http://localhost:8080/callback'],
         });
 
         const authSession = await service.createAuthorizationSession({
           clientId: client.clientId,
-          redirectUri: 'https://example.com/callback',
+          redirectUri: 'http://localhost:8080/callback',
           responseType: 'code',
           scope: 'openid',
           state: 'test-state',
@@ -587,7 +587,7 @@ describe('OidcService', () => {
             id: authSession.id,
             clientId: client.clientId,
             clientName: 'Test Client',
-            redirectUri: 'https://example.com/callback',
+            redirectUri: 'http://localhost:8080/callback',
             scope: 'openid',
             state: 'test-state',
             responseType: 'code',
@@ -600,12 +600,12 @@ describe('OidcService', () => {
 
         const client = await service.registerClient({
           clientName: 'Test Client',
-          redirectUris: ['https://example.com/callback'],
+          redirectUris: ['http://localhost:8080/callback'],
         });
 
         const authSession = await service.createAuthorizationSession({
           clientId: client.clientId,
-          redirectUri: 'https://example.com/callback',
+          redirectUri: 'http://localhost:8080/callback',
           responseType: 'code',
         });
 
@@ -626,12 +626,12 @@ describe('OidcService', () => {
 
         const client = await service.registerClient({
           clientName: 'Test Client',
-          redirectUris: ['https://example.com/callback'],
+          redirectUris: ['http://localhost:8080/callback'],
         });
 
         const authSession = await service.createAuthorizationSession({
           clientId: client.clientId,
-          redirectUri: 'https://example.com/callback',
+          redirectUri: 'http://localhost:8080/callback',
           responseType: 'code',
         });
 
@@ -654,12 +654,12 @@ describe('OidcService', () => {
 
         const client = await service.registerClient({
           clientName: 'Test Client',
-          redirectUris: ['https://example.com/callback'],
+          redirectUris: ['http://localhost:8080/callback'],
         });
 
         const authSession = await service.createAuthorizationSession({
           clientId: client.clientId,
-          redirectUri: 'https://example.com/callback',
+          redirectUri: 'http://localhost:8080/callback',
           responseType: 'code',
         });
 
@@ -691,12 +691,12 @@ describe('OidcService', () => {
 
         const client = await service.registerClient({
           clientName: 'Test Client',
-          redirectUris: ['https://example.com/callback'],
+          redirectUris: ['http://localhost:8080/callback'],
         });
 
         const authSession = await service.createAuthorizationSession({
           clientId: client.clientId,
-          redirectUri: 'https://example.com/callback',
+          redirectUri: 'http://localhost:8080/callback',
           responseType: 'code',
         });
 
@@ -718,12 +718,12 @@ describe('OidcService', () => {
 
         const client = await service.registerClient({
           clientName: 'Test Client',
-          redirectUris: ['https://example.com/callback'],
+          redirectUris: ['http://localhost:8080/callback'],
         });
 
         const authSession = await service.createAuthorizationSession({
           clientId: client.clientId,
-          redirectUri: 'https://example.com/callback',
+          redirectUri: 'http://localhost:8080/callback',
           responseType: 'code',
         });
 
@@ -749,12 +749,12 @@ describe('OidcService', () => {
 
         const client = await service.registerClient({
           clientName: 'Test Client',
-          redirectUris: ['https://example.com/callback'],
+          redirectUris: ['http://localhost:8080/callback'],
         });
 
         const authSession = await service.createAuthorizationSession({
           clientId: client.clientId,
-          redirectUri: 'https://example.com/callback',
+          redirectUri: 'http://localhost:8080/callback',
           responseType: 'code',
           scope: 'openid',
         });
@@ -768,7 +768,7 @@ describe('OidcService', () => {
 
         const tokenResult = await service.exchangeCodeForToken({
           code,
-          redirectUri: 'https://example.com/callback',
+          redirectUri: 'http://localhost:8080/callback',
           grantType: 'authorization_code',
         });
 
@@ -787,7 +787,7 @@ describe('OidcService', () => {
         await expect(
           service.exchangeCodeForToken({
             code: 'test-code',
-            redirectUri: 'https://example.com/callback',
+            redirectUri: 'http://localhost:8080/callback',
             grantType: 'client_credentials',
           }),
         ).rejects.toThrow('Unsupported grant type');
@@ -800,7 +800,7 @@ describe('OidcService', () => {
 
         const client = await service.registerClient({
           clientName: 'Test Client',
-          redirectUris: ['https://example.com/callback'],
+          redirectUris: ['http://localhost:8080/callback'],
         });
 
         const codeVerifier = 'test-code-verifier';
@@ -811,7 +811,7 @@ describe('OidcService', () => {
 
         const authSession = await service.createAuthorizationSession({
           clientId: client.clientId,
-          redirectUri: 'https://example.com/callback',
+          redirectUri: 'http://localhost:8080/callback',
           responseType: 'code',
           codeChallenge,
           codeChallengeMethod: 'S256',
@@ -826,7 +826,7 @@ describe('OidcService', () => {
 
         const tokenResult = await service.exchangeCodeForToken({
           code,
-          redirectUri: 'https://example.com/callback',
+          redirectUri: 'http://localhost:8080/callback',
           grantType: 'authorization_code',
           codeVerifier,
         });
@@ -839,13 +839,13 @@ describe('OidcService', () => {
 
         const client = await service.registerClient({
           clientName: 'Test Client',
-          redirectUris: ['https://example.com/callback'],
+          redirectUris: ['http://localhost:8080/callback'],
         });
 
         const codeChallenge = 'test-challenge';
         const authSession = await service.createAuthorizationSession({
           clientId: client.clientId,
-          redirectUri: 'https://example.com/callback',
+          redirectUri: 'http://localhost:8080/callback',
           responseType: 'code',
           codeChallenge,
           codeChallengeMethod: 'S256',
@@ -861,7 +861,7 @@ describe('OidcService', () => {
         await expect(
           service.exchangeCodeForToken({
             code,
-            redirectUri: 'https://example.com/callback',
+            redirectUri: 'http://localhost:8080/callback',
             grantType: 'authorization_code',
             codeVerifier: 'invalid-verifier',
           }),
@@ -884,12 +884,12 @@ describe('OidcService', () => {
 
         const client = await service.registerClient({
           clientName: 'Test Client',
-          redirectUris: ['https://example.com/callback'],
+          redirectUris: ['http://localhost:8080/callback'],
         });
 
         const authSession = await service.createAuthorizationSession({
           clientId: client.clientId,
-          redirectUri: 'https://example.com/callback',
+          redirectUri: 'http://localhost:8080/callback',
           responseType: 'code',
           scope: 'openid offline_access',
         });
@@ -903,7 +903,7 @@ describe('OidcService', () => {
 
         const tokenResult = await service.exchangeCodeForToken({
           code,
-          redirectUri: 'https://example.com/callback',
+          redirectUri: 'http://localhost:8080/callback',
           grantType: 'authorization_code',
         });
 
@@ -1515,13 +1515,13 @@ describe('OidcService', () => {
           // Register a DCR client
           const dcrClient = await service.registerClient({
             clientName: 'DCR Client',
-            redirectUris: ['https://example.com/callback'],
+            redirectUris: ['http://localhost:8080/callback'],
           });
 
           // Create session with DCR client
           const authSession = await service.createAuthorizationSession({
             clientId: dcrClient.clientId,
-            redirectUri: 'https://example.com/callback',
+            redirectUri: 'http://localhost:8080/callback',
             responseType: 'code',
           });
 

--- a/plugins/auth-backend/src/service/OidcService.test.ts
+++ b/plugins/auth-backend/src/service/OidcService.test.ts
@@ -314,6 +314,47 @@ describe('OidcService', () => {
         );
       });
 
+      it('should accept loopback redirect URIs with default patterns', async () => {
+        const { service } = await createOidcService({ databaseId });
+
+        const client = await service.registerClient({
+          clientName: 'Test Client',
+          redirectUris: ['http://localhost:3000/callback'],
+        });
+
+        expect(client).toEqual(
+          expect.objectContaining({
+            redirectUris: ['http://localhost:3000/callback'],
+          }),
+        );
+      });
+
+      it('should accept cursor redirect URIs with default patterns', async () => {
+        const { service } = await createOidcService({ databaseId });
+
+        const client = await service.registerClient({
+          clientName: 'Test Client',
+          redirectUris: ['cursor://callback'],
+        });
+
+        expect(client).toEqual(
+          expect.objectContaining({
+            redirectUris: ['cursor://callback'],
+          }),
+        );
+      });
+
+      it('should reject non-loopback redirect URIs with default patterns', async () => {
+        const { service } = await createOidcService({ databaseId });
+
+        await expect(
+          service.registerClient({
+            clientName: 'Test Client',
+            redirectUris: ['https://example.com/callback'],
+          }),
+        ).rejects.toThrow('Invalid redirect_uri');
+      });
+
       it('should reject redirect URIs containing userinfo', async () => {
         const { service } = await createOidcService({
           databaseId,
@@ -981,6 +1022,58 @@ describe('OidcService', () => {
       });
 
       describe('createAuthorizationSession with CIMD', () => {
+        it('should accept loopback redirect URIs with default CIMD patterns', async () => {
+          const { service } = await createOidcService({
+            databaseId,
+            config: {
+              auth: {
+                experimentalClientIdMetadataDocuments: {
+                  enabled: true,
+                  allowedClientIdPatterns: ['*'],
+                },
+              },
+            },
+          });
+
+          const authSession = await service.createAuthorizationSession({
+            clientId: cimdClientId,
+            redirectUri: 'http://localhost:8080/callback',
+            responseType: 'code',
+            scope: 'openid',
+            ...pkceParams,
+          });
+
+          expect(authSession).toEqual({
+            id: expect.any(String),
+            clientName: 'CIMD Test Client',
+            scope: 'openid',
+            redirectUri: 'http://localhost:8080/callback',
+          });
+        });
+
+        it('should reject non-loopback redirect URIs with default CIMD patterns', async () => {
+          const { service } = await createOidcService({
+            databaseId,
+            config: {
+              auth: {
+                experimentalClientIdMetadataDocuments: {
+                  enabled: true,
+                  allowedClientIdPatterns: ['*'],
+                },
+              },
+            },
+          });
+
+          await expect(
+            service.createAuthorizationSession({
+              clientId: cimdClientId,
+              redirectUri: 'https://example.com/callback',
+              responseType: 'code',
+              ...pkceParams,
+            }),
+          ).rejects.toThrow('Invalid redirect_uri');
+        });
+
         it('should create authorization session for CIMD client', async () => {
           const { service } = await createOidcService({
             databaseId,

--- a/plugins/auth-backend/src/service/OidcService.test.ts
+++ b/plugins/auth-backend/src/service/OidcService.test.ts
@@ -287,6 +287,33 @@ describe('OidcService', () => {
         );
       });
 
+      it('should accept IPv6 loopback redirect URI', async () => {
+        const { service } = await createOidcService({
+          databaseId,
+          config: {
+            auth: {
+              experimentalDynamicClientRegistration: {
+                allowedRedirectUriPatterns: [
+                  'http://[::1]:*',
+                  'http://[::1]/*',
+                ],
+              },
+            },
+          },
+        });
+
+        const client = await service.registerClient({
+          clientName: 'Test Client',
+          redirectUris: ['http://[::1]:3000/callback'],
+        });
+
+        expect(client).toEqual(
+          expect.objectContaining({
+            redirectUris: ['http://[::1]:3000/callback'],
+          }),
+        );
+      });
+
       it('should reject redirect URIs containing userinfo', async () => {
         const { service } = await createOidcService({
           databaseId,
@@ -1165,6 +1192,82 @@ describe('OidcService', () => {
               ...pkceParams,
             }),
           ).rejects.toThrow('Redirect URI not registered');
+        });
+
+        it('should accept IPv6 loopback redirect_uri with a different port per RFC 8252', async () => {
+          mockFetchCimdMetadata.mockResolvedValue({
+            ...cimdMetadata,
+            redirectUris: ['http://[::1]/callback'],
+          });
+
+          const { service } = await createOidcService({
+            databaseId,
+            config: {
+              auth: {
+                experimentalClientIdMetadataDocuments: {
+                  enabled: true,
+                  allowedClientIdPatterns: ['*'],
+                  allowedRedirectUriPatterns: [
+                    'http://[::1]:*',
+                    'http://[::1]/*',
+                  ],
+                },
+              },
+            },
+          });
+
+          const authSession = await service.createAuthorizationSession({
+            clientId: cimdClientId,
+            redirectUri: 'http://[::1]:54321/callback',
+            responseType: 'code',
+            scope: 'openid',
+            ...pkceParams,
+          });
+
+          expect(authSession).toEqual({
+            id: expect.any(String),
+            clientName: 'CIMD Test Client',
+            scope: 'openid',
+            redirectUri: 'http://[::1]:54321/callback',
+          });
+        });
+
+        it('should accept 127.0.0.1 loopback redirect_uri with a different port per RFC 8252', async () => {
+          mockFetchCimdMetadata.mockResolvedValue({
+            ...cimdMetadata,
+            redirectUris: ['http://127.0.0.1/callback'],
+          });
+
+          const { service } = await createOidcService({
+            databaseId,
+            config: {
+              auth: {
+                experimentalClientIdMetadataDocuments: {
+                  enabled: true,
+                  allowedClientIdPatterns: ['*'],
+                  allowedRedirectUriPatterns: [
+                    'http://127.0.0.1:*',
+                    'http://127.0.0.1/*',
+                  ],
+                },
+              },
+            },
+          });
+
+          const authSession = await service.createAuthorizationSession({
+            clientId: cimdClientId,
+            redirectUri: 'http://127.0.0.1:54321/callback',
+            responseType: 'code',
+            scope: 'openid',
+            ...pkceParams,
+          });
+
+          expect(authSession).toEqual({
+            id: expect.any(String),
+            clientName: 'CIMD Test Client',
+            scope: 'openid',
+            redirectUri: 'http://127.0.0.1:54321/callback',
+          });
         });
 
         it('should reject redirect_uri when CIMD metadata uses wildcard patterns', async () => {

--- a/plugins/auth-backend/src/service/OidcService.test.ts
+++ b/plugins/auth-backend/src/service/OidcService.test.ts
@@ -921,7 +921,11 @@ describe('OidcService', () => {
             databaseId,
             config: {
               auth: {
-                experimentalClientIdMetadataDocuments: { enabled: true },
+                experimentalClientIdMetadataDocuments: {
+                  enabled: true,
+                  allowedClientIdPatterns: ['*'],
+                  allowedRedirectUriPatterns: ['*'],
+                },
               },
             },
           });
@@ -955,7 +959,11 @@ describe('OidcService', () => {
             databaseId,
             config: {
               auth: {
-                experimentalClientIdMetadataDocuments: { enabled: true },
+                experimentalClientIdMetadataDocuments: {
+                  enabled: true,
+                  allowedClientIdPatterns: ['*'],
+                  allowedRedirectUriPatterns: ['*'],
+                },
               },
             },
           });
@@ -1054,7 +1062,11 @@ describe('OidcService', () => {
             databaseId,
             config: {
               auth: {
-                experimentalClientIdMetadataDocuments: { enabled: true },
+                experimentalClientIdMetadataDocuments: {
+                  enabled: true,
+                  allowedClientIdPatterns: ['*'],
+                  allowedRedirectUriPatterns: ['*'],
+                },
               },
             },
           });
@@ -1075,6 +1087,7 @@ describe('OidcService', () => {
               auth: {
                 experimentalClientIdMetadataDocuments: {
                   enabled: true,
+                  allowedClientIdPatterns: ['*'],
                   allowedRedirectUriPatterns: ['https://*.example.com/*'],
                 },
               },
@@ -1100,7 +1113,11 @@ describe('OidcService', () => {
             databaseId,
             config: {
               auth: {
-                experimentalClientIdMetadataDocuments: { enabled: true },
+                experimentalClientIdMetadataDocuments: {
+                  enabled: true,
+                  allowedClientIdPatterns: ['*'],
+                  allowedRedirectUriPatterns: ['*'],
+                },
               },
             },
           });
@@ -1131,7 +1148,11 @@ describe('OidcService', () => {
             databaseId,
             config: {
               auth: {
-                experimentalClientIdMetadataDocuments: { enabled: true },
+                experimentalClientIdMetadataDocuments: {
+                  enabled: true,
+                  allowedClientIdPatterns: ['*'],
+                  allowedRedirectUriPatterns: ['*'],
+                },
               },
             },
           });
@@ -1158,6 +1179,7 @@ describe('OidcService', () => {
               auth: {
                 experimentalClientIdMetadataDocuments: {
                   enabled: true,
+                  allowedClientIdPatterns: ['*'],
                   allowedRedirectUriPatterns: ['http://localhost:*'],
                 },
               },
@@ -1181,6 +1203,7 @@ describe('OidcService', () => {
               auth: {
                 experimentalClientIdMetadataDocuments: {
                   enabled: true,
+                  allowedClientIdPatterns: ['*'],
                   allowedRedirectUriPatterns: ['http://localhost:*'],
                 },
               },
@@ -1202,7 +1225,11 @@ describe('OidcService', () => {
             databaseId,
             config: {
               auth: {
-                experimentalClientIdMetadataDocuments: { enabled: true },
+                experimentalClientIdMetadataDocuments: {
+                  enabled: true,
+                  allowedClientIdPatterns: ['*'],
+                  allowedRedirectUriPatterns: ['*'],
+                },
               },
             },
           });
@@ -1223,7 +1250,11 @@ describe('OidcService', () => {
             databaseId,
             config: {
               auth: {
-                experimentalClientIdMetadataDocuments: { enabled: true },
+                experimentalClientIdMetadataDocuments: {
+                  enabled: true,
+                  allowedClientIdPatterns: ['*'],
+                  allowedRedirectUriPatterns: ['*'],
+                },
               },
             },
           });
@@ -1260,7 +1291,11 @@ describe('OidcService', () => {
             databaseId,
             config: {
               auth: {
-                experimentalClientIdMetadataDocuments: { enabled: true },
+                experimentalClientIdMetadataDocuments: {
+                  enabled: true,
+                  allowedClientIdPatterns: ['*'],
+                  allowedRedirectUriPatterns: ['*'],
+                },
               },
             },
           });
@@ -1308,7 +1343,11 @@ describe('OidcService', () => {
             databaseId,
             config: {
               auth: {
-                experimentalClientIdMetadataDocuments: { enabled: true },
+                experimentalClientIdMetadataDocuments: {
+                  enabled: true,
+                  allowedClientIdPatterns: ['*'],
+                  allowedRedirectUriPatterns: ['*'],
+                },
               },
             },
           });
@@ -1357,8 +1396,15 @@ describe('OidcService', () => {
             databaseId,
             config: {
               auth: {
-                experimentalClientIdMetadataDocuments: { enabled: true },
-                experimentalDynamicClientRegistration: { enabled: true },
+                experimentalClientIdMetadataDocuments: {
+                  enabled: true,
+                  allowedClientIdPatterns: ['*'],
+                  allowedRedirectUriPatterns: ['*'],
+                },
+                experimentalDynamicClientRegistration: {
+                  enabled: true,
+                  allowedRedirectUriPatterns: ['*'],
+                },
               },
             },
           });
@@ -1385,8 +1431,15 @@ describe('OidcService', () => {
             databaseId,
             config: {
               auth: {
-                experimentalClientIdMetadataDocuments: { enabled: true },
-                experimentalDynamicClientRegistration: { enabled: true },
+                experimentalClientIdMetadataDocuments: {
+                  enabled: true,
+                  allowedClientIdPatterns: ['*'],
+                  allowedRedirectUriPatterns: ['*'],
+                },
+                experimentalDynamicClientRegistration: {
+                  enabled: true,
+                  allowedRedirectUriPatterns: ['*'],
+                },
               },
             },
           });

--- a/plugins/auth-backend/src/service/OidcService.ts
+++ b/plugins/auth-backend/src/service/OidcService.ts
@@ -219,14 +219,9 @@ export class OidcService {
     const generatedClientId = crypto.randomUUID();
     const generatedClientSecret = crypto.randomUUID();
 
-    const dcrEnabled =
-      this.config.getOptionalBoolean(
-        'auth.experimentalDynamicClientRegistration.enabled',
-      ) ?? false;
-    const allowedRedirectUriPatterns =
-      this.config.getOptionalStringArray(
-        'auth.experimentalDynamicClientRegistration.allowedRedirectUriPatterns',
-      ) ?? (dcrEnabled ? ['cursor://*', ...LOOPBACK_REDIRECT_PATTERNS] : ['*']);
+    const allowedRedirectUriPatterns = this.config.getOptionalStringArray(
+      'auth.experimentalDynamicClientRegistration.allowedRedirectUriPatterns',
+    ) ?? ['cursor://*', ...LOOPBACK_REDIRECT_PATTERNS];
 
     for (const redirectUri of opts.redirectUris ?? []) {
       validateRedirectUri(redirectUri, allowedRedirectUriPatterns);
@@ -322,17 +317,13 @@ export class OidcService {
 
     return {
       enabled,
-      allowedClientIdPatterns:
-        this.config.getOptionalStringArray(
-          'auth.experimentalClientIdMetadataDocuments.allowedClientIdPatterns',
-        ) ??
-        (enabled
-          ? ['https://claude.ai/*', 'https://vscode.dev/*', cliClientId]
-          : ['*']),
+      allowedClientIdPatterns: this.config.getOptionalStringArray(
+        'auth.experimentalClientIdMetadataDocuments.allowedClientIdPatterns',
+      ) ?? ['https://claude.ai/*', 'https://vscode.dev/*', cliClientId],
       allowedRedirectUriPatterns:
         this.config.getOptionalStringArray(
           'auth.experimentalClientIdMetadataDocuments.allowedRedirectUriPatterns',
-        ) ?? (enabled ? LOOPBACK_REDIRECT_PATTERNS : ['*']),
+        ) ?? LOOPBACK_REDIRECT_PATTERNS,
     };
   }
 

--- a/plugins/auth-backend/src/service/OidcService.ts
+++ b/plugins/auth-backend/src/service/OidcService.ts
@@ -46,6 +46,14 @@ function validateRedirectUri(
 }
 
 const LOOPBACK_HOSTS = ['localhost', '127.0.0.1', '[::1]'];
+const LOOPBACK_REDIRECT_PATTERNS = [
+  'http://localhost:*',
+  'http://localhost/*',
+  'http://127.0.0.1:*',
+  'http://127.0.0.1/*',
+  'http://[::1]:*',
+  'http://[::1]/*',
+];
 
 /**
  * RFC 8252 Section 7.3: For loopback redirect URIs, the authorization server
@@ -211,9 +219,14 @@ export class OidcService {
     const generatedClientId = crypto.randomUUID();
     const generatedClientSecret = crypto.randomUUID();
 
-    const allowedRedirectUriPatterns = this.config.getOptionalStringArray(
-      'auth.experimentalDynamicClientRegistration.allowedRedirectUriPatterns',
-    ) ?? ['*'];
+    const dcrEnabled =
+      this.config.getOptionalBoolean(
+        'auth.experimentalDynamicClientRegistration.enabled',
+      ) ?? false;
+    const allowedRedirectUriPatterns =
+      this.config.getOptionalStringArray(
+        'auth.experimentalDynamicClientRegistration.allowedRedirectUriPatterns',
+      ) ?? (dcrEnabled ? ['cursor://*', ...LOOPBACK_REDIRECT_PATTERNS] : ['*']);
 
     for (const redirectUri of opts.redirectUris ?? []) {
       validateRedirectUri(redirectUri, allowedRedirectUriPatterns);
@@ -297,17 +310,26 @@ export class OidcService {
   }
 
   private getCimdConfig() {
+    const enabled =
+      this.config.getOptionalBoolean(
+        'auth.experimentalClientIdMetadataDocuments.enabled',
+      ) ?? false;
+
+    const cliClientId = `${this.baseUrl}/.well-known/oauth-client/*`;
+
     return {
-      enabled:
-        this.config.getOptionalBoolean(
-          'auth.experimentalClientIdMetadataDocuments.enabled',
-        ) ?? false,
-      allowedClientIdPatterns: this.config.getOptionalStringArray(
-        'auth.experimentalClientIdMetadataDocuments.allowedClientIdPatterns',
-      ) ?? ['*'],
-      allowedRedirectUriPatterns: this.config.getOptionalStringArray(
-        'auth.experimentalClientIdMetadataDocuments.allowedRedirectUriPatterns',
-      ) ?? ['*'],
+      enabled,
+      allowedClientIdPatterns:
+        this.config.getOptionalStringArray(
+          'auth.experimentalClientIdMetadataDocuments.allowedClientIdPatterns',
+        ) ??
+        (enabled
+          ? ['https://claude.ai/*', 'https://vscode.dev/*', cliClientId]
+          : ['*']),
+      allowedRedirectUriPatterns:
+        this.config.getOptionalStringArray(
+          'auth.experimentalClientIdMetadataDocuments.allowedRedirectUriPatterns',
+        ) ?? (enabled ? LOOPBACK_REDIRECT_PATTERNS : ['*']),
     };
   }
 

--- a/plugins/auth-backend/src/service/OidcService.ts
+++ b/plugins/auth-backend/src/service/OidcService.ts
@@ -310,10 +310,7 @@ export class OidcService {
         'auth.experimentalClientIdMetadataDocuments.enabled',
       ) ?? false;
 
-    const cliClientId = new URL(
-      '/.well-known/oauth-client/cli.json',
-      this.baseUrl,
-    ).toString();
+    const cliClientId = `${this.baseUrl}/.well-known/oauth-client/cli.json`;
 
     return {
       enabled,

--- a/plugins/auth-backend/src/service/OidcService.ts
+++ b/plugins/auth-backend/src/service/OidcService.ts
@@ -310,10 +310,10 @@ export class OidcService {
         'auth.experimentalClientIdMetadataDocuments.enabled',
       ) ?? false;
 
-    const cliClientId = `${this.baseUrl.replace(
-      /\/$/,
-      '',
-    )}/.well-known/oauth-client/cli.json`;
+    const cliClientId = new URL(
+      '/.well-known/oauth-client/cli.json',
+      this.baseUrl,
+    ).toString();
 
     return {
       enabled,

--- a/plugins/auth-backend/src/service/OidcService.ts
+++ b/plugins/auth-backend/src/service/OidcService.ts
@@ -315,7 +315,10 @@ export class OidcService {
         'auth.experimentalClientIdMetadataDocuments.enabled',
       ) ?? false;
 
-    const cliClientId = `${this.baseUrl}/.well-known/oauth-client/*`;
+    const cliClientId = `${this.baseUrl.replace(
+      /\/$/,
+      '',
+    )}/.well-known/oauth-client/cli.json`;
 
     return {
       enabled,


### PR DESCRIPTION
## Summary

- Replaced permissive `['*']` wildcard defaults for CIMD and DCR with specific patterns for known MCP clients
- **CIMD** `allowedClientIdPatterns` now defaults to Claude, VS Code, and the built-in Backstage CLI
- **CIMD** `allowedRedirectUriPatterns` now defaults to `localhost` and `127.0.0.1`
- **DCR** `allowedRedirectUriPatterns` now defaults to Cursor, `localhost`, and `127.0.0.1`
- Restrictive defaults only apply when the feature is explicitly enabled
- Updated docs and example config

## Test plan

- [x] All 196 OidcService tests pass
- [x] `yarn tsc` passes
- [x] Config docs updated to reflect new defaults