### PR TITLE
confluenceToMarkdown action now supports repositories with no mkdocs.yml file

### DIFF
--- a/.changeset/grumpy-trams-rest.md
+++ b/.changeset/grumpy-trams-rest.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-confluence-to-markdown': minor
+---
+
+confluenceToMarkdown action now supports repositories with no mkdocs.yml files

--- a/plugins/scaffolder-backend-module-confluence-to-markdown/src/actions/confluence/confluenceToMarkdown.test.ts
+++ b/plugins/scaffolder-backend-module-confluence-to-markdown/src/actions/confluence/confluenceToMarkdown.test.ts
@@ -26,6 +26,7 @@ import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { createMockActionContext } from '@backstage/plugin-scaffolder-node-test-utils';
 import { UrlReaderService } from '@backstage/backend-plugin-api';
+import fs from 'fs-extra';
 
 describe('confluence:transform:markdown', () => {
   const baseUrl = `https://nodomain.confluence.com`;
@@ -240,6 +241,57 @@ describe('confluence:transform:markdown', () => {
     }).rejects.toThrow(
       'Could not find document https://nodomain.confluence.com/display/testing/mkdocs. Please check your input.',
     );
+  });
+
+  it('should create a default mkdocs.yml when repoUrl does not point to a mkdocs.yml file', async () => {
+    await fs.remove(`${workspacePath}/mkdocs.yml`);
+    const noMkdocsContext = createMockActionContext({
+      input: {
+        confluenceUrls: [
+          'https://nodomain.confluence.com/display/testing/mkdocs',
+        ],
+        repoUrl: 'https://notreal.github.com/space/backstage/blob/main',
+      },
+      workspacePath,
+    });
+    jest.spyOn(noMkdocsContext.logger, 'info');
+
+    const options = { reader, integrations, config };
+    const responseBody = {
+      results: [
+        {
+          id: '4444444',
+          type: 'page',
+          title: 'Testing',
+          body: {
+            export_view: {
+              value: '<p>hello world</p>',
+            },
+          },
+        },
+      ],
+    };
+    const responseBodyTwo = { results: [] };
+
+    worker.use(
+      rest.get(`${baseUrl}/rest/api/content`, (_, res, ctx) =>
+        res(ctx.status(200, 'OK'), ctx.json(responseBody)),
+      ),
+      rest.get(
+        `${baseUrl}/rest/api/content/4444444/child/attachment`,
+        (_, res, ctx) => res(ctx.status(200, 'OK'), ctx.json(responseBodyTwo)),
+      ),
+    );
+
+    const action = createConfluenceToMarkdownAction(options);
+    await action.handler(noMkdocsContext);
+
+    expect(noMkdocsContext.logger.info).toHaveBeenCalledWith(
+      `mkdocs.yml not found at ${workspacePath}/mkdocs.yml, creating a default`,
+    );
+    expect(mockDir.content({ path: 'workspace/docs' })).toEqual({
+      'mkdocs.md': 'hello world',
+    });
   });
 
   it('should fail on the second fetch call to confluence', async () => {

--- a/plugins/scaffolder-backend-module-confluence-to-markdown/src/actions/confluence/confluenceToMarkdown.ts
+++ b/plugins/scaffolder-backend-module-confluence-to-markdown/src/actions/confluence/confluenceToMarkdown.ts
@@ -14,26 +14,26 @@
  * limitations under the License.
  */
 
+import { UrlReaderService } from '@backstage/backend-plugin-api';
 import { Config } from '@backstage/config';
+import { ConflictError, InputError } from '@backstage/errors';
 import { ScmIntegrations } from '@backstage/integration';
 import {
   createTemplateAction,
   fetchContents,
 } from '@backstage/plugin-scaffolder-node';
-import { InputError, ConflictError } from '@backstage/errors';
-import { NodeHtmlMarkdown } from 'node-html-markdown';
 import fs from 'fs-extra';
 import parseGitUrl from 'git-url-parse';
+import { NodeHtmlMarkdown } from 'node-html-markdown';
 import YAML from 'yaml';
+import { examples } from './confluenceToMarkdown.examples';
 import {
-  readFileAsString,
+  createConfluenceVariables,
   fetchConfluence,
   getAndWriteAttachments,
-  createConfluenceVariables,
   getConfluenceConfig,
+  readFileAsString,
 } from './helpers';
-import { examples } from './confluenceToMarkdown.examples';
-import { UrlReaderService } from '@backstage/backend-plugin-api';
 
 /**
  * @public
@@ -63,7 +63,7 @@ export const createConfluenceToMarkdownAction = (options: {
         repoUrl: z =>
           z.string({
             description:
-              'mkdocs.yml file location inside the github repo you want to store the document',
+              'mkdocs.yml file location inside the github/bitbucket repo you want to store the documentation on. In case no mkdocs.yml is present it will create a default one.',
           }),
       },
       output: {
@@ -85,12 +85,13 @@ export const createConfluenceToMarkdownAction = (options: {
       const confluenceConfig = getConfluenceConfig(config);
       const { confluenceUrls, repoUrl } = ctx.input;
       const parsedRepoUrl = parseGitUrl(repoUrl);
-      const filePathToMkdocs = parsedRepoUrl.filepath.substring(
+      const mkdocsFilePath = parsedRepoUrl.filepath || 'mkdocs.yml';
+      const filePathToMkdocs = mkdocsFilePath.substring(
         0,
-        parsedRepoUrl.filepath.lastIndexOf('/') + 1,
+        mkdocsFilePath.lastIndexOf('/') + 1,
       );
       const dirPath = ctx.workspacePath;
-      const repoFileDir = `${dirPath}/${parsedRepoUrl.filepath}`;
+      const repoFileDir = `${dirPath}/${mkdocsFilePath}`;
       let productArray: string[][] = [];
 
       ctx.logger.info(`Fetching the mkdocs.yml catalog from ${repoUrl}`);
@@ -103,6 +104,16 @@ export const createConfluenceToMarkdownAction = (options: {
         fetchUrl: `https://${parsedRepoUrl.resource}/${parsedRepoUrl.owner}/${parsedRepoUrl.name}`,
         outputPath: ctx.workspacePath,
       });
+
+      if (!(await fs.pathExists(repoFileDir))) {
+        ctx.logger.info(
+          `mkdocs.yml not found at ${repoFileDir}, creating a default`,
+        );
+        await fs.outputFile(
+          repoFileDir,
+          YAML.stringify({ site_name: 'Documentation', nav: [] }),
+        );
+      }
 
       for (const url of confluenceUrls) {
         const { spacekey, title, titleWithSpaces } =


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Previously you had to to put in link to mkdocs.yml file inside a git repository. Now you have the option to link to the root of the git repository instead. In case the mkdocs.yml file is not found it will generate a default one

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
