### PR TITLE
Add regression test for sidebar sub-path selection

### DIFF
--- a/packages/core-components/src/layout/Sidebar/Items.test.tsx
+++ b/packages/core-components/src/layout/Sidebar/Items.test.tsx
@@ -129,6 +129,22 @@ describe('Items', () => {
       );
       expect(analyticsApiMock.captureEvent).not.toHaveBeenCalled();
     });
+
+    it('should not highlight parent sidebar item when child route is active and end is set', async () => {
+      await renderInTestApp(
+        <Sidebar>
+          <SidebarItem text="Test" icon={HomeIcon} to="/test" end />
+          <SidebarItem text="Test Again" icon={HomeIcon} to="/test/again" />
+        </Sidebar>,
+        { routeEntries: ['/test/again'] },
+      );
+
+      const parentItem = await screen.findByRole('link', { name: 'Test' });
+      const childItem = await screen.findByRole('link', { name: 'Test Again' });
+
+      expect(parentItem.className).not.toContain('selected');
+      expect(childItem.className).toContain('selected');
+    });
   });
 
   describe('SidebarSearchField', () => {


### PR DESCRIPTION
Description
Adds regression test coverage for sidebar item selection when routes share a parent/child path structure.

This verifies that when a parent sidebar item uses `end`, navigating to a child route does not incorrectly mark the parent item as selected.

Fixes #33302

Test
```bash
yarn test packages/core-components/src/layout/Sidebar/Items.test.tsx --watch=false
