### PR TITLE
feat(techdocs): add TechDocs generator pullOptions support for private registry image pull

### DIFF
--- a/.changeset/techdocs-docker-private-registry.md
+++ b/.changeset/techdocs-docker-private-registry.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-techdocs-backend': minor
+'@backstage/plugin-techdocs-node': minor
+---
+
+Added support for `techdocs.generator.pullOptions` when pulling the TechDocs generator Docker image from private registries that require authentication.

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -307,6 +307,8 @@ techdocs:
     runIn: 'docker'
     # dockerImage: my-org/techdocs # use a custom docker image
     # pullImage: true # or false to disable automatic pulling of image (e.g. if custom docker login is required)
+    # https://github.com/apocas/dockerode?tab=readme-ov-file#pull-from-private-repos
+    # pullOptions: # credentials for private registries, if dockerImage is set and pullImage is true
   publisher:
     type: 'local' # Alternatives - 'googleGcs' or 'awsS3' or 'azureBlobStorage' or 'openStackSwift'. Read documentation for using alternatives.
 

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -228,6 +228,8 @@ techdocs:
     runIn: 'docker'
     # dockerImage: my-org/techdocs # use a custom docker image
     # pullImage: true # or false to disable automatic pulling of image (e.g. if custom docker login is required)
+    # https://github.com/apocas/dockerode?tab=readme-ov-file#pull-from-private-repos
+    # pullOptions: # credentials for private registries, if dockerImage is set and pullImage is true
   publisher:
     type: 'local' # Alternatives - 'googleGcs' or 'awsS3' or 'azureBlobStorage' or 'openStackSwift'. Read documentation for using alternatives.
 

--- a/docs/features/techdocs/configuration.md
+++ b/docs/features/techdocs/configuration.md
@@ -63,6 +63,29 @@ techdocs:
     pullImage: false
 ```
 
+### Pull Options
+
+`techdocs.generator.pullOptions`
+
+(Optional) This can be used to pass auth options when pulling the docker image. This is useful when `techdocs.generator.dockerImage` is set and `techdocs.generator.pullImage` is `true` (or unset, which uses the default pull behavior) and the image is hosted in a private registry.
+
+You can set `authconfig` to provide registry credentials. For supported fields and more examples, see the [Dockerode docs for pulling from private repos](https://github.com/apocas/dockerode?tab=readme-ov-file#pull-from-private-repos).
+
+**Example:**
+
+```yaml
+techdocs:
+  generator:
+    runIn: 'docker'
+    dockerImage: 'custom-registry/techdocs'
+    pullImage: true
+    pullOptions:
+      authconfig:
+        username: ${REGISTRY_USERNAME}
+        password: ${REGISTRY_PASSWORD}
+        serveraddress: 'https://index.docker.io/v1'
+```
+
 ### MkDocs Configuration
 
 #### Omit TechDocs Core Plugin

--- a/plugins/techdocs-backend/config.d.ts
+++ b/plugins/techdocs-backend/config.d.ts
@@ -16,6 +16,8 @@
 
 import { HumanDuration } from '@backstage/types';
 
+import { ContainerRunnerPullOptions } from '@backstage/plugin-techdocs-node';
+
 export interface Config {
   /**
    * Configuration options for the techdocs-backend plugin
@@ -46,6 +48,12 @@ export interface Config {
        * Pull the latest docker image
        */
       pullImage?: boolean;
+
+      /**
+       * Credentials for private registries
+       * @visibility secret
+       */
+      pullOptions?: ContainerRunnerPullOptions;
 
       /**
        * Override behavior specific to mkdocs.

--- a/plugins/techdocs-backend/config.d.ts
+++ b/plugins/techdocs-backend/config.d.ts
@@ -16,6 +16,8 @@
 
 import { HumanDuration } from '@backstage/types';
 
+import { ContainerRunnerPullOptions } from '@backstage/plugin-techdocs-node';
+
 export interface Config {
   /**
    * Configuration options for the techdocs-backend plugin
@@ -46,6 +48,11 @@ export interface Config {
        * Pull the latest docker image
        */
       pullImage?: boolean;
+
+      /**
+       * Credentials for private registries
+       */
+      pullOptions?: ContainerRunnerPullOptions;
 
       /**
        * Override behavior specific to mkdocs.

--- a/plugins/techdocs-node/report.api.md
+++ b/plugins/techdocs-node/report.api.md
@@ -19,6 +19,19 @@ import * as winston from 'winston';
 import { Writable } from 'node:stream';
 
 // @public
+export type ContainerRunnerPullOptions = {
+  authconfig?: {
+    username?: string;
+    password?: string;
+    auth?: string;
+    email?: string;
+    serveraddress?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+};
+
+// @public
 export class DirectoryPreparer implements PreparerBase {
   static fromConfig(config: Config, options: PreparerConfig): DirectoryPreparer;
   prepare(entity: Entity, options?: PreparerOptions): Promise<PreparerResponse>;
@@ -277,17 +290,7 @@ export interface TechDocsContainerRunner {
     envVars?: Record<string, string>;
     pullImage?: boolean;
     defaultUser?: boolean;
-    pullOptions?: {
-      authconfig?: {
-        username?: string;
-        password?: string;
-        auth?: string;
-        email?: string;
-        serveraddress?: string;
-        [key: string]: unknown;
-      };
-      [key: string]: unknown;
-    };
+    pullOptions?: ContainerRunnerPullOptions;
   }): Promise<void>;
 }
 

--- a/plugins/techdocs-node/src/stages/generate/DockerContainerRunner.test.ts
+++ b/plugins/techdocs-node/src/stages/generate/DockerContainerRunner.test.ts
@@ -98,6 +98,51 @@ describe('DockerContainerRunner', () => {
     expect(mockRun).toHaveBeenCalled();
   });
 
+  it('should pass pull options to the docker client when pullImage is not set', async () => {
+    const pullOptions = {
+      authconfig: {
+        username: 'user',
+        password: 'pass',
+      },
+    };
+
+    await containerTaskApi.runContainer({
+      imageName,
+      args,
+      pullOptions,
+    });
+
+    expect(mockPull).toHaveBeenCalledWith(
+      imageName,
+      pullOptions,
+      expect.any(Function),
+    );
+    expect(mockRun).toHaveBeenCalled();
+  });
+
+  it('should pass pull options to the docker client when pullImage is true', async () => {
+    const pullOptions = {
+      authconfig: {
+        username: 'user',
+        password: 'pass',
+      },
+    };
+
+    await containerTaskApi.runContainer({
+      imageName,
+      args,
+      pullImage: true,
+      pullOptions,
+    });
+
+    expect(mockPull).toHaveBeenCalledWith(
+      imageName,
+      pullOptions,
+      expect.any(Function),
+    );
+    expect(mockRun).toHaveBeenCalled();
+  });
+
   it('should call the dockerClient run command with the correct arguments passed through', async () => {
     await containerTaskApi.runContainer({
       imageName,

--- a/plugins/techdocs-node/src/stages/generate/DockerContainerRunner.ts
+++ b/plugins/techdocs-node/src/stages/generate/DockerContainerRunner.ts
@@ -20,7 +20,7 @@ import { ForwardedError } from '@backstage/errors';
 import { PassThrough } from 'node:stream';
 import { pipeline as pipelineStream } from 'node:stream';
 import { promisify } from 'node:util';
-import { TechDocsContainerRunner } from './types';
+import { ContainerRunnerPullOptions, TechDocsContainerRunner } from './types';
 import { Writable } from 'node:stream';
 
 const pipeline = promisify(pipelineStream);
@@ -48,6 +48,7 @@ export class DockerContainerRunner implements TechDocsContainerRunner {
     workingDir?: string;
     envVars?: Record<string, string>;
     pullImage?: boolean;
+    pullOptions?: ContainerRunnerPullOptions;
     defaultUser?: boolean;
   }) {
     const {
@@ -59,6 +60,7 @@ export class DockerContainerRunner implements TechDocsContainerRunner {
       workingDir,
       envVars = {},
       pullImage = true,
+      pullOptions = {},
       defaultUser = false,
     } = options;
 
@@ -74,7 +76,7 @@ export class DockerContainerRunner implements TechDocsContainerRunner {
 
     if (pullImage) {
       await new Promise<void>((resolve, reject) => {
-        this.dockerClient.pull(imageName, {}, (err, stream) => {
+        this.dockerClient.pull(imageName, pullOptions, (err, stream) => {
           if (err) {
             reject(err);
           } else if (!stream) {

--- a/plugins/techdocs-node/src/stages/generate/index.ts
+++ b/plugins/techdocs-node/src/stages/generate/index.ts
@@ -22,6 +22,7 @@ export type {
   GeneratorBuilder,
   GeneratorRunOptions,
   SupportedGeneratorKey,
+  ContainerRunnerPullOptions,
   TechDocsContainerRunner,
 } from './types';
 import { getMkdocsYml } from './helpers';

--- a/plugins/techdocs-node/src/stages/generate/techdocs.test.ts
+++ b/plugins/techdocs-node/src/stages/generate/techdocs.test.ts
@@ -104,6 +104,29 @@ describe('readGeneratorConfig', () => {
     });
   });
 
+  it('should read pull options config', () => {
+    const pullOptions = {
+      authconfig: {
+        username: 'user',
+        password: 'pass',
+      },
+    };
+
+    const config = new ConfigReader({
+      techdocs: {
+        generator: {
+          runIn: 'docker',
+          pullOptions,
+        },
+      },
+    });
+
+    expect(readGeneratorConfig(config, logger)).toEqual({
+      runIn: 'docker',
+      pullOptions,
+    });
+  });
+
   describe('with legacy techdocs.generators.techdocs config', () => {
     it('should read legacy docker option', () => {
       const config = new ConfigReader({

--- a/plugins/techdocs-node/src/stages/generate/techdocs.ts
+++ b/plugins/techdocs-node/src/stages/generate/techdocs.ts
@@ -37,6 +37,7 @@ import {
   sanitizeMkdocsYml,
 } from './mkdocsPatchers';
 import {
+  ContainerRunnerPullOptions,
   GeneratorBase,
   GeneratorConfig,
   GeneratorOptions,
@@ -191,6 +192,7 @@ export class TechdocsGenerator implements GeneratorBase {
             // write to, otherwise they will just fail trying to write to /
             envVars: { HOME: '/tmp' },
             pullImage: this.options.pullImage,
+            pullOptions: this.options.pullOptions,
             defaultUser: runAsDefaultUser,
           });
           childLogger.info(
@@ -257,6 +259,9 @@ export function readGeneratorConfig(
       'docker',
     dockerImage: config.getOptionalString('techdocs.generator.dockerImage'),
     pullImage: config.getOptionalBoolean('techdocs.generator.pullImage'),
+    pullOptions: config.getOptional<ContainerRunnerPullOptions>(
+      'techdocs.generator.pullOptions',
+    ),
     omitTechdocsCoreMkdocsPlugin: config.getOptionalBoolean(
       'techdocs.generator.mkdocs.omitTechdocsCorePlugin',
     ),

--- a/plugins/techdocs-node/src/stages/generate/types.ts
+++ b/plugins/techdocs-node/src/stages/generate/types.ts
@@ -36,12 +36,30 @@ export type GeneratorOptions = {
 };
 
 /**
+ * TechDocs container runner pull options, which can be used to specify registry credentials for pulling private images.
+ * {@link https://github.com/apocas/dockerode?tab=readme-ov-file#pull-from-private-repos}
+ * @public
+ */
+export type ContainerRunnerPullOptions = {
+  authconfig?: {
+    username?: string;
+    password?: string;
+    auth?: string;
+    email?: string;
+    serveraddress?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+};
+
+/**
  * The techdocs generator configurations options.
  */
 export type GeneratorConfig = {
   runIn: GeneratorRunInType;
   dockerImage?: string;
   pullImage?: boolean;
+  pullOptions?: ContainerRunnerPullOptions;
   omitTechdocsCoreMkdocsPlugin?: boolean;
   legacyCopyReadmeMdToIndexMd?: boolean;
   defaultPlugins?: string[];
@@ -127,16 +145,6 @@ export interface TechDocsContainerRunner {
     envVars?: Record<string, string>;
     pullImage?: boolean;
     defaultUser?: boolean;
-    pullOptions?: {
-      authconfig?: {
-        username?: string;
-        password?: string;
-        auth?: string;
-        email?: string;
-        serveraddress?: string;
-        [key: string]: unknown;
-      };
-      [key: string]: unknown;
-    };
+    pullOptions?: ContainerRunnerPullOptions;
   }): Promise<void>;
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds support for passing `techdocs.generator.pullOptions` from `app-config.yaml` to the TechDocs Docker image pull.

This makes it possible to authenticate against private registries when using a custom TechDocs generator image with `techdocs.generator.runIn: docker`, `dockerImage: <custom-image>`, and `pullImage: true` (or unset).

### What changed
- Added support for `techdocs.generator.pullOptions` in config
- Passed `pullOptions` through to `dockerode` `dockerClient.pull`
- Updated TechDocs backend config schema to reflect the new option in config
- Updated docs, added config examples for private registry authentication
- Added tests covering config parsing and Docker pull behavior

### Example
```yaml
techdocs:
  generator:
    runIn: 'docker'
    dockerImage: 'custom-registry/techdocs'
    pullImage: true
    pullOptions:
      authconfig:
        username: ${REGISTRY_USERNAME}
        password: ${REGISTRY_PASSWORD}
```


#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
