### PR TITLE
catalog-model: add addKindVersion and updateKindVersion to builder

### DIFF
--- a/.changeset/catalog-model-kind-version-methods.md
+++ b/.changeset/catalog-model-kind-version-methods.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': minor
+---
+
+Added `addKindVersion` and `updateKindVersion` methods to `CatalogModelLayerBuilder`, allowing plugins to declare new versions or modify existing versions of a kind without having to re-declare the kind itself. The `versions` array on `updateKind` is now deprecated in favor of these dedicated methods.

--- a/packages/catalog-model/report-alpha.api.md
+++ b/packages/catalog-model/report-alpha.api.md
@@ -163,12 +163,30 @@ export interface CatalogModelKindSummary {
 }
 
 // @alpha
+export interface CatalogModelKindVersionAddition {
+  kind: string;
+  version: CatalogModelKindVersionDefinition;
+}
+
+// @alpha
 export interface CatalogModelKindVersionDefinition {
   description?: string;
   name: string | string[];
   relationFields?: CatalogModelKindRelationFieldDefinition[];
   // (undocumented)
   schema: {
+    jsonSchema: JsonObject;
+  };
+  specType?: string | string[];
+}
+
+// @alpha
+export interface CatalogModelKindVersionUpdate {
+  description?: string;
+  kind: string;
+  name: string | string[];
+  relationFields?: CatalogModelKindRelationFieldDefinition[];
+  schema?: {
     jsonSchema: JsonObject;
   };
   specType?: string | string[];
@@ -202,6 +220,7 @@ export interface CatalogModelLayer {
 export interface CatalogModelLayerBuilder {
   addAnnotation(annotation: CatalogModelAnnotationDefinition): void;
   addKind(kind: CatalogModelKindDefinition): void;
+  addKindVersion(addition: CatalogModelKindVersionAddition): void;
   addLabel(label: CatalogModelLabelDefinition): void;
   addRelationPair(relation: CatalogModelRelationPairDefinition): void;
   addTag(tag: CatalogModelTagDefinition): void;
@@ -212,6 +231,7 @@ export interface CatalogModelLayerBuilder {
   removeTag(tag: CatalogModelRemoveTagDefinition): void;
   updateAnnotation(annotation: CatalogModelUpdateAnnotationDefinition): void;
   updateKind(kind: CatalogModelUpdateKindDefinition): void;
+  updateKindVersion(update: CatalogModelKindVersionUpdate): void;
   updateLabel(label: CatalogModelUpdateLabelDefinition): void;
   updateRelationPair(relation: CatalogModelUpdateRelationPairDefinition): void;
   updateTag(tag: CatalogModelUpdateTagDefinition): void;
@@ -333,6 +353,7 @@ export interface CatalogModelUpdateKindDefinition {
     singular?: string;
     plural?: string;
   };
+  // @deprecated
   versions?: CatalogModelUpdateKindVersionDefinition[];
 }
 

--- a/packages/catalog-model/src/model/compileCatalogModel.test.ts
+++ b/packages/catalog-model/src/model/compileCatalogModel.test.ts
@@ -136,6 +136,254 @@ describe('compileCatalogModel', () => {
       model.getKind({ kind: 'Unknown', apiVersion: 'example.com/v1alpha1' }),
     ).toBeUndefined();
   });
+
+  it('should support adding a new version to an existing kind via addKindVersion', () => {
+    const baseLayer = createCatalogModelLayer({
+      layerId: 'Base',
+      builder: model => {
+        model.addKind({
+          group: 'example.com',
+          names: { kind: 'Widget', singular: 'widget', plural: 'widgets' },
+          description: 'A widget',
+          versions: [
+            {
+              name: 'v1alpha1',
+              schema: {
+                jsonSchema: {
+                  type: 'object',
+                  properties: {
+                    spec: {
+                      type: 'object',
+                      properties: { size: { type: 'number' } },
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        });
+      },
+    });
+
+    const extensionLayer = createCatalogModelLayer({
+      layerId: 'Extension',
+      builder: model => {
+        model.addKindVersion({
+          kind: 'Widget',
+          version: {
+            name: 'v1beta1',
+            schema: {
+              jsonSchema: {
+                type: 'object',
+                properties: {
+                  spec: {
+                    type: 'object',
+                    required: ['color'],
+                    properties: { color: { type: 'string' } },
+                  },
+                },
+              },
+            },
+          },
+        });
+      },
+    });
+
+    const model = compileCatalogModel([baseLayer, extensionLayer]);
+
+    const v1alpha1 = model.getKind({
+      kind: 'Widget',
+      apiVersion: 'example.com/v1alpha1',
+    });
+    expect(v1alpha1).toBeDefined();
+
+    const v1beta1 = model.getKind({
+      kind: 'Widget',
+      apiVersion: 'example.com/v1beta1',
+    });
+    expect(v1beta1).toBeDefined();
+
+    const ajv = new Ajv({ allowUnionTypes: true, allErrors: true });
+    const validate = ajv.compile(v1beta1!.jsonSchema);
+    expect(
+      validate({
+        apiVersion: 'example.com/v1beta1',
+        kind: 'Widget',
+        metadata: { name: 'my-widget' },
+        spec: { color: 'red' },
+      }),
+    ).toBe(true);
+    expect(
+      validate({
+        apiVersion: 'example.com/v1beta1',
+        kind: 'Widget',
+        metadata: { name: 'my-widget' },
+        spec: {},
+      }),
+    ).toBe(false);
+  });
+
+  it('should support updating an existing version via updateKindVersion', () => {
+    const baseLayer = createCatalogModelLayer({
+      layerId: 'Base',
+      builder: model => {
+        model.addKind({
+          group: 'example.com',
+          names: { kind: 'Widget', singular: 'widget', plural: 'widgets' },
+          description: 'A widget',
+          versions: [
+            {
+              name: 'v1alpha1',
+              schema: {
+                jsonSchema: {
+                  type: 'object',
+                  properties: {
+                    spec: {
+                      type: 'object',
+                      properties: { size: { type: 'number' } },
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        });
+      },
+    });
+
+    const updateLayer = createCatalogModelLayer({
+      layerId: 'Update',
+      builder: model => {
+        model.updateKindVersion({
+          kind: 'Widget',
+          name: 'v1alpha1',
+          schema: {
+            jsonSchema: {
+              type: 'object',
+              properties: {
+                spec: {
+                  type: 'object',
+                  properties: { weight: { type: 'number' } },
+                },
+              },
+            },
+          },
+        });
+      },
+    });
+
+    const model = compileCatalogModel([baseLayer, updateLayer]);
+    const kind = model.getKind({
+      kind: 'Widget',
+      apiVersion: 'example.com/v1alpha1',
+    });
+    expect(kind).toBeDefined();
+
+    const ajv = new Ajv({ allowUnionTypes: true, allErrors: true });
+    const validate = ajv.compile(kind!.jsonSchema);
+
+    // Original field still works
+    expect(
+      validate({
+        apiVersion: 'example.com/v1alpha1',
+        kind: 'Widget',
+        metadata: { name: 'w' },
+        spec: { size: 42 },
+      }),
+    ).toBe(true);
+
+    // Merged field also works
+    expect(
+      validate({
+        apiVersion: 'example.com/v1alpha1',
+        kind: 'Widget',
+        metadata: { name: 'w' },
+        spec: { size: 42, weight: 10 },
+      }),
+    ).toBe(true);
+
+    // Wrong type for merged field fails
+    expect(
+      validate({
+        apiVersion: 'example.com/v1alpha1',
+        kind: 'Widget',
+        metadata: { name: 'w' },
+        spec: { size: 42, weight: 'heavy' },
+      }),
+    ).toBe(false);
+  });
+
+  it('should support adding a spec type variant via addKindVersion', () => {
+    const baseLayer = createCatalogModelLayer({
+      layerId: 'Base',
+      builder: model => {
+        model.addKind({
+          group: 'example.com',
+          names: { kind: 'Widget', singular: 'widget', plural: 'widgets' },
+          description: 'A widget',
+          versions: [
+            {
+              name: 'v1alpha1',
+              specType: 'basic',
+              schema: {
+                jsonSchema: {
+                  type: 'object',
+                  properties: {
+                    spec: {
+                      type: 'object',
+                      properties: { size: { type: 'number' } },
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        });
+      },
+    });
+
+    const variantLayer = createCatalogModelLayer({
+      layerId: 'Variant',
+      builder: model => {
+        model.addKindVersion({
+          kind: 'Widget',
+          version: {
+            name: 'v1alpha1',
+            specType: 'fancy',
+            schema: {
+              jsonSchema: {
+                type: 'object',
+                properties: {
+                  spec: {
+                    type: 'object',
+                    required: ['sparkle'],
+                    properties: { sparkle: { type: 'boolean' } },
+                  },
+                },
+              },
+            },
+          },
+        });
+      },
+    });
+
+    const model = compileCatalogModel([baseLayer, variantLayer]);
+
+    const basic = model.getKind({
+      kind: 'Widget',
+      apiVersion: 'example.com/v1alpha1',
+      spec: { type: 'basic' },
+    });
+    const fancy = model.getKind({
+      kind: 'Widget',
+      apiVersion: 'example.com/v1alpha1',
+      spec: { type: 'fancy' },
+    });
+
+    expect(basic).toBeDefined();
+    expect(fancy).toBeDefined();
+    expect(basic!.jsonSchema).not.toEqual(fancy!.jsonSchema);
+  });
 });
 
 describe('compileCatalogModel specType', () => {

--- a/packages/catalog-model/src/model/createCatalogModelLayerBuilder.ts
+++ b/packages/catalog-model/src/model/createCatalogModelLayerBuilder.ts
@@ -23,6 +23,10 @@ import {
   opsFromCatalogModelKind,
 } from './modelActions/addKind';
 import {
+  type CatalogModelKindVersionAddition,
+  opsFromCatalogModelKindVersion,
+} from './modelActions/addKindVersion';
+import {
   type CatalogModelLabelDefinition,
   opsFromCatalogModelLabel,
 } from './modelActions/addLabel';
@@ -59,6 +63,10 @@ import {
   opsFromCatalogModelUpdateKind,
 } from './modelActions/updateKind';
 import {
+  type CatalogModelKindVersionUpdate,
+  opsFromCatalogModelUpdateKindVersion,
+} from './modelActions/updateKindVersion';
+import {
   type CatalogModelUpdateLabelDefinition,
   opsFromCatalogModelUpdateLabel,
 } from './modelActions/updateLabel';
@@ -88,9 +96,17 @@ export interface CatalogModelLayerBuilder {
    */
   addKind(kind: CatalogModelKindDefinition): void;
   /**
+   * Adds a new version to an existing kind.
+   */
+  addKindVersion(addition: CatalogModelKindVersionAddition): void;
+  /**
    * Updates an existing kind in the model.
    */
   updateKind(kind: CatalogModelUpdateKindDefinition): void;
+  /**
+   * Updates an existing version of a kind in the model.
+   */
+  updateKindVersion(update: CatalogModelKindVersionUpdate): void;
   /**
    * Removes a kind entirely from the model.
    */
@@ -169,8 +185,18 @@ export class DefaultCatalogModelLayerBuilder
     this.#ops.push(...ops);
   }
 
+  addKindVersion(addition: CatalogModelKindVersionAddition): void {
+    const ops = opsFromCatalogModelKindVersion(addition);
+    this.#ops.push(...ops);
+  }
+
   updateKind(kind: CatalogModelUpdateKindDefinition): void {
     const ops = opsFromCatalogModelUpdateKind(kind);
+    this.#ops.push(...ops);
+  }
+
+  updateKindVersion(update: CatalogModelKindVersionUpdate): void {
+    const ops = opsFromCatalogModelUpdateKindVersion(update);
     this.#ops.push(...ops);
   }
 

--- a/packages/catalog-model/src/model/modelActions/addKindVersion.test.ts
+++ b/packages/catalog-model/src/model/modelActions/addKindVersion.test.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { opsFromCatalogModelKindVersion } from './addKindVersion';
+
+describe('opsFromCatalogModelKindVersion', () => {
+  it('should produce a single declareKindVersion op', () => {
+    const ops = opsFromCatalogModelKindVersion({
+      kind: 'Component',
+      version: {
+        name: 'v1beta1',
+        specType: 'service',
+        description: 'A service component',
+        schema: {
+          jsonSchema: {
+            type: 'object',
+            properties: {
+              spec: {
+                type: 'object',
+                properties: {
+                  owner: { type: 'string' },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(ops).toEqual([
+      expect.objectContaining({
+        op: 'declareKindVersion.v1',
+        kind: 'Component',
+        name: 'v1beta1',
+        specType: 'service',
+      }),
+    ]);
+  });
+
+  it('should expand multiple version names', () => {
+    const ops = opsFromCatalogModelKindVersion({
+      kind: 'Component',
+      version: {
+        name: ['v1alpha1', 'v1beta1'],
+        schema: {
+          jsonSchema: {
+            type: 'object',
+            properties: {
+              spec: { type: 'object' },
+            },
+          },
+        },
+      },
+    });
+
+    expect(ops).toHaveLength(2);
+    expect(ops[0]).toEqual(
+      expect.objectContaining({ name: 'v1alpha1', specType: undefined }),
+    );
+    expect(ops[1]).toEqual(
+      expect.objectContaining({ name: 'v1beta1', specType: undefined }),
+    );
+  });
+
+  it('should expand multiple spec types', () => {
+    const ops = opsFromCatalogModelKindVersion({
+      kind: 'Resource',
+      version: {
+        name: 'v1alpha1',
+        specType: ['database', 'cache'],
+        schema: {
+          jsonSchema: {
+            type: 'object',
+            properties: {
+              spec: { type: 'object' },
+            },
+          },
+        },
+      },
+    });
+
+    expect(ops).toHaveLength(2);
+    expect(ops[0]).toEqual(expect.objectContaining({ specType: 'database' }));
+    expect(ops[1]).toEqual(expect.objectContaining({ specType: 'cache' }));
+  });
+
+  it('should include relation fields in properties', () => {
+    const ops = opsFromCatalogModelKindVersion({
+      kind: 'Component',
+      version: {
+        name: 'v1alpha1',
+        relationFields: [
+          {
+            selector: { path: 'spec.owner' },
+            relation: 'ownedBy',
+            defaultKind: 'Group',
+          },
+        ],
+        schema: {
+          jsonSchema: {
+            type: 'object',
+            properties: {
+              spec: {
+                type: 'object',
+                properties: {
+                  owner: { type: 'string' },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(ops[0]).toEqual(
+      expect.objectContaining({
+        properties: expect.objectContaining({
+          relationFields: [
+            expect.objectContaining({
+              relation: 'ownedBy',
+              selector: { path: 'spec.owner' },
+            }),
+          ],
+        }),
+      }),
+    );
+  });
+});

--- a/packages/catalog-model/src/model/modelActions/addKindVersion.ts
+++ b/packages/catalog-model/src/model/modelActions/addKindVersion.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { reduceKindSchema } from '../jsonSchema/reduceKindSchema';
+import { validateKindRootSchemaSemantics } from '../jsonSchema/validateKindRootSchemaSemantics';
+import { validateMetaSchema } from '../jsonSchema/validateMetaSchema';
+import { CatalogModelOp } from '../operations';
+import { createDeclareKindVersionOp } from '../operations/declareKindVersion';
+import { CatalogModelKindVersionDefinition } from './addKind';
+
+/**
+ * The definition needed to add a single version to an existing kind.
+ *
+ * @alpha
+ */
+export interface CatalogModelKindVersionAddition {
+  /**
+   * The kind to add the version to, e.g. "Component".
+   */
+  kind: string;
+
+  /**
+   * The version definition to add.
+   */
+  version: CatalogModelKindVersionDefinition;
+}
+
+export function opsFromCatalogModelKindVersion(
+  addition: CatalogModelKindVersionAddition,
+): CatalogModelOp[] {
+  const { kind, version } = addition;
+  const ops: CatalogModelOp[] = [];
+
+  const jsonSchema = reduceKindSchema(version.schema.jsonSchema);
+  validateMetaSchema(jsonSchema);
+  validateKindRootSchemaSemantics(jsonSchema);
+
+  const names = Array.isArray(version.name) ? version.name : [version.name];
+  for (const name of names) {
+    const specTypes = version.specType
+      ? [version.specType].flat()
+      : [undefined];
+    for (const specType of specTypes) {
+      ops.push(
+        createDeclareKindVersionOp({
+          kind,
+          name,
+          specType,
+          properties: {
+            description: version.description,
+            relationFields: version.relationFields,
+            schema: {
+              jsonSchema: jsonSchema as any,
+            },
+          },
+        }),
+      );
+    }
+  }
+
+  return ops;
+}

--- a/packages/catalog-model/src/model/modelActions/index.ts
+++ b/packages/catalog-model/src/model/modelActions/index.ts
@@ -20,6 +20,7 @@ export {
   type CatalogModelKindRelationFieldDefinition,
   type CatalogModelKindVersionDefinition,
 } from './addKind';
+export { type CatalogModelKindVersionAddition } from './addKindVersion';
 export { type CatalogModelLabelDefinition } from './addLabel';
 export { type CatalogModelRelationPairDefinition } from './addRelationPair';
 export { type CatalogModelRemoveAnnotationDefinition } from './removeAnnotation';
@@ -32,6 +33,7 @@ export {
   type CatalogModelUpdateKindDefinition,
   type CatalogModelUpdateKindVersionDefinition,
 } from './updateKind';
+export { type CatalogModelKindVersionUpdate } from './updateKindVersion';
 export { type CatalogModelUpdateLabelDefinition } from './updateLabel';
 export { type CatalogModelUpdateRelationPairDefinition } from './updateRelationPair';
 export { type CatalogModelUpdateTagDefinition } from './updateTag';

--- a/packages/catalog-model/src/model/modelActions/updateKind.ts
+++ b/packages/catalog-model/src/model/modelActions/updateKind.ts
@@ -58,6 +58,10 @@ export interface CatalogModelUpdateKindDefinition {
 
   /**
    * Update one or more versions of the kind's actual schema shape.
+   *
+   * @deprecated Use the separate `addKindVersion` and `updateKindVersion`
+   * methods on the builder instead. This field will be removed in a future
+   * release.
    */
   versions?: CatalogModelUpdateKindVersionDefinition[];
 }

--- a/packages/catalog-model/src/model/modelActions/updateKindVersion.test.ts
+++ b/packages/catalog-model/src/model/modelActions/updateKindVersion.test.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { opsFromCatalogModelUpdateKindVersion } from './updateKindVersion';
+
+describe('opsFromCatalogModelUpdateKindVersion', () => {
+  it('should produce a single updateKindVersion op', () => {
+    const ops = opsFromCatalogModelUpdateKindVersion({
+      kind: 'Component',
+      name: 'v1alpha1',
+      specType: 'service',
+      description: 'Updated description',
+      schema: {
+        jsonSchema: {
+          type: 'object',
+          properties: {
+            spec: {
+              type: 'object',
+              properties: {
+                newField: { type: 'string' },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(ops).toEqual([
+      expect.objectContaining({
+        op: 'updateKindVersion.v1',
+        kind: 'Component',
+        name: 'v1alpha1',
+        specType: 'service',
+        properties: expect.objectContaining({
+          description: 'Updated description',
+        }),
+      }),
+    ]);
+  });
+
+  it('should expand multiple version names', () => {
+    const ops = opsFromCatalogModelUpdateKindVersion({
+      kind: 'Component',
+      name: ['v1alpha1', 'v1beta1'],
+      description: 'Shared update',
+    });
+
+    expect(ops).toHaveLength(2);
+    expect(ops[0]).toEqual(
+      expect.objectContaining({ name: 'v1alpha1', specType: undefined }),
+    );
+    expect(ops[1]).toEqual(
+      expect.objectContaining({ name: 'v1beta1', specType: undefined }),
+    );
+  });
+
+  it('should expand multiple spec types', () => {
+    const ops = opsFromCatalogModelUpdateKindVersion({
+      kind: 'Resource',
+      name: 'v1alpha1',
+      specType: ['database', 'cache'],
+      description: 'Updated',
+    });
+
+    expect(ops).toHaveLength(2);
+    expect(ops[0]).toEqual(expect.objectContaining({ specType: 'database' }));
+    expect(ops[1]).toEqual(expect.objectContaining({ specType: 'cache' }));
+  });
+
+  it('should work without schema', () => {
+    const ops = opsFromCatalogModelUpdateKindVersion({
+      kind: 'Component',
+      name: 'v1alpha1',
+      relationFields: [
+        {
+          selector: { path: 'spec.owner' },
+          relation: 'ownedBy',
+        },
+      ],
+    });
+
+    expect(ops).toHaveLength(1);
+    expect(ops[0]).toEqual(
+      expect.objectContaining({
+        properties: expect.objectContaining({
+          relationFields: [expect.objectContaining({ relation: 'ownedBy' })],
+          schema: undefined,
+        }),
+      }),
+    );
+  });
+});

--- a/packages/catalog-model/src/model/modelActions/updateKindVersion.ts
+++ b/packages/catalog-model/src/model/modelActions/updateKindVersion.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { JsonObject } from '@backstage/types';
+import { reduceKindSchema } from '../jsonSchema/reduceKindSchema';
+import { validateMetaSchema } from '../jsonSchema/validateMetaSchema';
+import { CatalogModelOp } from '../operations';
+import { createUpdateKindVersionOp } from '../operations/updateKindVersion';
+import { CatalogModelKindRelationFieldDefinition } from './addKind';
+
+/**
+ * The definition needed to update a single version of an existing kind.
+ *
+ * @alpha
+ */
+export interface CatalogModelKindVersionUpdate {
+  /**
+   * The kind to update the version on, e.g. "Component".
+   */
+  kind: string;
+
+  /**
+   * The specific version name or names to update, e.g. "v1alpha1" or
+   * ["v1alpha1", "v1beta1"].
+   */
+  name: string | string[];
+
+  /**
+   * The spec type or types that this version update applies to.
+   */
+  specType?: string | string[];
+
+  /**
+   * A short description of this particular version (and type, where
+   * applicable). Specify this if you want to override the default value.
+   */
+  description?: string;
+
+  /**
+   * The fields that shall be used to generate relations, if any. Specify this
+   * if you want to override the default value.
+   */
+  relationFields?: CatalogModelKindRelationFieldDefinition[];
+
+  /**
+   * The JSON schema to deep merge with the existing schema for this version.
+   */
+  schema?: {
+    jsonSchema: JsonObject;
+  };
+}
+
+export function opsFromCatalogModelUpdateKindVersion(
+  update: CatalogModelKindVersionUpdate,
+): CatalogModelOp[] {
+  const ops: CatalogModelOp[] = [];
+
+  const jsonSchema = update.schema
+    ? reduceKindSchema(update.schema.jsonSchema)
+    : undefined;
+  if (jsonSchema) {
+    validateMetaSchema(jsonSchema);
+  }
+
+  const names = Array.isArray(update.name) ? update.name : [update.name];
+  for (const name of names) {
+    const specTypes = update.specType ? [update.specType].flat() : [undefined];
+    for (const specType of specTypes) {
+      ops.push(
+        createUpdateKindVersionOp({
+          kind: update.kind,
+          name,
+          specType,
+          properties: {
+            description: update.description,
+            relationFields: update.relationFields,
+            schema: jsonSchema ? { jsonSchema: jsonSchema as any } : undefined,
+          },
+        }),
+      );
+    }
+  }
+
+  return ops;
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Problem

`CatalogModelLayerBuilder` had no way to add a single new version to an existing kind without re-declaring the kind itself. The `updateKind` method accepted a `versions` array, but it could only modify versions that already existed — it couldn't add new ones.

### Changes

**New methods on `CatalogModelLayerBuilder`:**

- **`addKindVersion`** — declares a new (version, specType) slot on an existing kind. Creates the version name if it doesn't exist yet. Fails if the (version, specType) combination is already declared.

- **`updateKindVersion`** — modifies an existing (version, specType) slot (description, relation fields, schema merge). Strict: both the version name and the specType must already exist.

**Deprecation:**

The `versions` array on `updateKind` is deprecated in favor of `addKindVersion` and `updateKindVersion`. It continues to work for backward compatibility.

### Test coverage

- Unit tests for `opsFromCatalogModelKindVersion` (4 tests): single version, multiple names, multiple spec types, relation fields
- Unit tests for `opsFromCatalogModelUpdateKindVersion` (4 tests): single version, multiple names, multiple spec types, schema-less update
- Compiler flow tests (3 tests):
  - Adding a new version (`v1beta1`) to an existing kind, validating the new schema
  - Updating an existing version with a schema merge, verifying both original and merged fields
  - Adding a new spec type variant (`fancy`) alongside an existing one (`basic`)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)