### PR TITLE
config: add optional onChange callbacks to Config methods

### DIFF
--- a/.changeset/config-onchange-callbacks.md
+++ b/.changeset/config-onchange-callbacks.md
@@ -1,0 +1,7 @@
+---
+'@backstage/config': minor
+---
+
+Added an optional `onChange` callback parameter to all data-reading methods on
+the `Config` type. This allows consumers to register interest in config value
+changes and signal whether the update was accepted via the return value.

--- a/packages/config/report.api.md
+++ b/packages/config/report.api.md
@@ -25,22 +25,49 @@ export type Config = {
   subscribe?(onChange: () => void): {
     unsubscribe: () => void;
   };
-  has(key: string): boolean;
-  keys(): string[];
-  get<T = JsonValue_2>(key?: string): T;
-  getOptional<T = JsonValue_2>(key?: string): T | undefined;
-  getConfig(key: string): Config;
-  getOptionalConfig(key: string): Config | undefined;
-  getConfigArray(key: string): Config[];
-  getOptionalConfigArray(key: string): Config[] | undefined;
-  getNumber(key: string): number;
-  getOptionalNumber(key: string): number | undefined;
-  getBoolean(key: string): boolean;
-  getOptionalBoolean(key: string): boolean | undefined;
-  getString(key: string): string;
-  getOptionalString(key: string): string | undefined;
-  getStringArray(key: string): string[];
-  getOptionalStringArray(key: string): string[] | undefined;
+  has(key: string, onChange?: ConfigUpdateCallback<boolean>): boolean;
+  keys(onChange?: ConfigUpdateCallback<string[]>): string[];
+  get<T = JsonValue_2>(key?: string, onChange?: ConfigUpdateCallback<T>): T;
+  getOptional<T = JsonValue_2>(
+    key?: string,
+    onChange?: ConfigUpdateCallback<T | undefined>,
+  ): T | undefined;
+  getConfig(key: string, onChange?: ConfigUpdateCallback<Config>): Config;
+  getOptionalConfig(
+    key: string,
+    onChange?: ConfigUpdateCallback<Config | undefined>,
+  ): Config | undefined;
+  getConfigArray(
+    key: string,
+    onChange?: ConfigUpdateCallback<Config[]>,
+  ): Config[];
+  getOptionalConfigArray(
+    key: string,
+    onChange?: ConfigUpdateCallback<Config[] | undefined>,
+  ): Config[] | undefined;
+  getNumber(key: string, onChange?: ConfigUpdateCallback<number>): number;
+  getOptionalNumber(
+    key: string,
+    onChange?: ConfigUpdateCallback<number | undefined>,
+  ): number | undefined;
+  getBoolean(key: string, onChange?: ConfigUpdateCallback<boolean>): boolean;
+  getOptionalBoolean(
+    key: string,
+    onChange?: ConfigUpdateCallback<boolean | undefined>,
+  ): boolean | undefined;
+  getString(key: string, onChange?: ConfigUpdateCallback<string>): string;
+  getOptionalString(
+    key: string,
+    onChange?: ConfigUpdateCallback<string | undefined>,
+  ): string | undefined;
+  getStringArray(
+    key: string,
+    onChange?: ConfigUpdateCallback<string[]>,
+  ): string[];
+  getOptionalStringArray(
+    key: string,
+    onChange?: ConfigUpdateCallback<string[] | undefined>,
+  ): string[] | undefined;
 };
 
 // @public
@@ -69,6 +96,15 @@ export class ConfigReader implements Config {
   has(key: string): boolean;
   keys(): string[];
 }
+
+// @public
+export type ConfigUpdateCallback<T> = (newValue: T) => ConfigUpdateResult;
+
+// @public
+export type ConfigUpdateResult = {
+  accepted: boolean;
+  stop?: boolean;
+};
 
 // @public @deprecated
 export type JsonArray = JsonArray_2;

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -28,4 +28,9 @@ export type {
 } from './deprecatedTypes';
 export { readDurationFromConfig } from './readDurationFromConfig';
 export { ConfigReader } from './reader';
-export type { AppConfig, Config } from './types';
+export type {
+  AppConfig,
+  Config,
+  ConfigUpdateCallback,
+  ConfigUpdateResult,
+} from './types';

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -17,6 +17,29 @@
 import { JsonObject, JsonValue } from '@backstage/types';
 
 /**
+ * Result returned by a config update callback.
+ *
+ * @public
+ */
+export type ConfigUpdateResult = {
+  /**
+   * Whether this consumer applied the update.
+   */
+  accepted: boolean;
+  /**
+   * If true, this callback will not be invoked for future updates.
+   */
+  stop?: boolean;
+};
+
+/**
+ * Callback invoked when a config value changes.
+ *
+ * @public
+ */
+export type ConfigUpdateCallback<T> = (newValue: T) => ConfigUpdateResult;
+
+/**
  * A serialized form of configuration data that carries additional context.
  *
  * @public
@@ -64,17 +87,17 @@ export type Config = {
   /**
    * Checks whether the given key is present.
    */
-  has(key: string): boolean;
+  has(key: string, onChange?: ConfigUpdateCallback<boolean>): boolean;
 
   /**
    * Lists all available configuration keys.
    */
-  keys(): string[];
+  keys(onChange?: ConfigUpdateCallback<string[]>): string[];
 
   /**
    * Same as `getOptional`, but will throw an error if there's no value for the given key.
    */
-  get<T = JsonValue>(key?: string): T;
+  get<T = JsonValue>(key?: string, onChange?: ConfigUpdateCallback<T>): T;
 
   /**
    * Read out all configuration data for the given key.
@@ -84,67 +107,94 @@ export type Config = {
    * the type of a configuration value in the case where there are multiple possible
    * shapes of the configuration.
    */
-  getOptional<T = JsonValue>(key?: string): T | undefined;
+  getOptional<T = JsonValue>(
+    key?: string,
+    onChange?: ConfigUpdateCallback<T | undefined>,
+  ): T | undefined;
 
   /**
    * Same as `getOptionalConfig`, but will throw an error if there's no value for the given key.
    */
-  getConfig(key: string): Config;
+  getConfig(key: string, onChange?: ConfigUpdateCallback<Config>): Config;
 
   /**
    * Creates a sub-view of the configuration object.
    * The configuration value at the position of the provided key must be an object.
    */
-  getOptionalConfig(key: string): Config | undefined;
+  getOptionalConfig(
+    key: string,
+    onChange?: ConfigUpdateCallback<Config | undefined>,
+  ): Config | undefined;
 
   /**
    * Same as `getOptionalConfigArray`, but will throw an error if there's no value for the given key.
    */
-  getConfigArray(key: string): Config[];
+  getConfigArray(
+    key: string,
+    onChange?: ConfigUpdateCallback<Config[]>,
+  ): Config[];
 
   /**
    * Creates a sub-view of an array of configuration objects.
    * The configuration value at the position of the provided key must be an array of objects.
    */
-  getOptionalConfigArray(key: string): Config[] | undefined;
+  getOptionalConfigArray(
+    key: string,
+    onChange?: ConfigUpdateCallback<Config[] | undefined>,
+  ): Config[] | undefined;
 
   /**
    * Same as `getOptionalNumber`, but will throw an error if there's no value for the given key.
    */
-  getNumber(key: string): number;
+  getNumber(key: string, onChange?: ConfigUpdateCallback<number>): number;
 
   /**
    * Reads a configuration value at the given key, expecting it to be a number.
    */
-  getOptionalNumber(key: string): number | undefined;
+  getOptionalNumber(
+    key: string,
+    onChange?: ConfigUpdateCallback<number | undefined>,
+  ): number | undefined;
 
   /**
    * Same as `getOptionalBoolean`, but will throw an error if there's no value for the given key.
    */
-  getBoolean(key: string): boolean;
+  getBoolean(key: string, onChange?: ConfigUpdateCallback<boolean>): boolean;
 
   /**
    * Reads a configuration value at the given key, expecting it to be a boolean.
    */
-  getOptionalBoolean(key: string): boolean | undefined;
+  getOptionalBoolean(
+    key: string,
+    onChange?: ConfigUpdateCallback<boolean | undefined>,
+  ): boolean | undefined;
 
   /**
    * Same as `getOptionalString`, but will throw an error if there's no value for the given key.
    */
-  getString(key: string): string;
+  getString(key: string, onChange?: ConfigUpdateCallback<string>): string;
 
   /**
    * Reads a configuration value at the given key, expecting it to be a string.
    */
-  getOptionalString(key: string): string | undefined;
+  getOptionalString(
+    key: string,
+    onChange?: ConfigUpdateCallback<string | undefined>,
+  ): string | undefined;
 
   /**
    * Same as `getOptionalStringArray`, but will throw an error if there's no value for the given key.
    */
-  getStringArray(key: string): string[];
+  getStringArray(
+    key: string,
+    onChange?: ConfigUpdateCallback<string[]>,
+  ): string[];
 
   /**
    * Reads a configuration value at the given key, expecting it to be an array of strings.
    */
-  getOptionalStringArray(key: string): string[] | undefined;
+  getOptionalStringArray(
+    key: string,
+    onChange?: ConfigUpdateCallback<string[] | undefined>,
+  ): string[] | undefined;
 };


### PR DESCRIPTION


## Hey, I just made a Pull Request!

This change adds an optional onChange callback to all methods of the Config type that return some form of configuration. This allows callers to signal that they're able to process updates to configuration. It's entirely optional - both callers of Config methods and implementations themselves are free to ignore the parameter entirely.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
