### PR TITLE
fix(catalog-backend): move generateStableHash out of shared util to fix Storybook build

### DIFF
--- a/.changeset/fix-storybook-crypto-import.md
+++ b/.changeset/fix-storybook-crypto-import.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Moved `generateStableHash` out of shared utility file to avoid pulling `node:crypto` into browser bundles

--- a/plugins/catalog-backend/src/database/operations/stitcher/performStitching.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/performStitching.ts
@@ -18,11 +18,14 @@ import { ENTITY_STATUS_CATALOG_PROCESSING_TYPE } from '@backstage/catalog-client
 import {
   ANNOTATION_EDIT_URL,
   ANNOTATION_VIEW_URL,
+  Entity,
   EntityRelation,
 } from '@backstage/catalog-model';
 import { AlphaEntity, EntityStatusItem } from '@backstage/catalog-model/alpha';
 import { SerializedError } from '@backstage/errors';
 import { Knex } from 'knex';
+import { createHash } from 'node:crypto';
+import stableStringify from 'fast-json-stable-stringify';
 import { StitchingStrategy } from '../../../stitching/types';
 import {
   DbFinalEntitiesRow,
@@ -32,11 +35,16 @@ import {
 import { buildEntitySearch } from './buildEntitySearch';
 import { markDeferredStitchCompleted } from './markDeferredStitchCompleted';
 import { syncSearchRows } from './syncSearchRows';
-import { generateStableHash } from './util';
 import {
   LoggerService,
   isDatabaseConflictError,
 } from '@backstage/backend-plugin-api';
+
+function generateStableHash(entity: Entity) {
+  return createHash('sha1')
+    .update(stableStringify({ ...entity }))
+    .digest('hex');
+}
 
 // See https://github.com/facebook/react/blob/f0cf832e1d0c8544c36aa8b310960885a11a847c/packages/react-dom-bindings/src/shared/sanitizeURL.js
 const scriptProtocolPattern =

--- a/plugins/catalog-backend/src/database/operations/stitcher/util.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/util.ts
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-import { Entity } from '@backstage/catalog-model';
-import { createHash } from 'node:crypto';
-import stableStringify from 'fast-json-stable-stringify';
-
 // The number of items that are sent per batch to the database layer, when
 // doing .batchInsert calls to knex. This needs to be low enough to not cause
 // errors in the underlying engine due to exceeding query limits, but large
@@ -29,9 +25,3 @@ export const BATCH_SIZE = 50;
 // COALESCE, JS dedup keys). It cannot appear in real entity metadata values
 // since they are human-readable strings.
 export const NULL_SENTINEL = '\x01';
-
-export function generateStableHash(entity: Entity) {
-  return createHash('sha1')
-    .update(stableStringify({ ...entity }))
-    .digest('hex');
-}


### PR DESCRIPTION
## Summary

- Moved `generateStableHash` (and its `node:crypto` dependency) from `util.ts` into `performStitching.ts`, its only consumer
- `util.ts` now only contains pure constants (`BATCH_SIZE`, `NULL_SENTINEL`) with no Node.js dependencies

The Storybook build was failing because `InMemoryCatalogClient` in `catalog-client` reaches into `catalog-backend`'s `buildEntitySearch.ts` via a relative cross-package import. That file imports `NULL_SENTINEL` from `util.ts`, which also contained `generateStableHash` using `createHash` from `node:crypto`. Vite couldn't resolve `node:crypto` for the browser bundle, causing the build to fail.

## Test plan

- [x] `yarn build-storybook` completes successfully
- [x] `yarn tsc` passes
- [x] All 94 stitcher tests pass (`CI=1 yarn test plugins/catalog-backend/src/database/operations/stitcher/`)