### PR TITLE
feat(cli): add catalog-processor-module template

### DIFF
--- a/.changeset/catalog-processor-module-template.md
+++ b/.changeset/catalog-processor-module-template.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli-module-new': patch
+---
+
+Added a new `catalog-processor-module` template for scaffolding catalog processor modules via `backstage-cli new`.

--- a/docs/tooling/cli/04-templates.md
+++ b/docs/tooling/cli/04-templates.md
@@ -4,9 +4,35 @@ title: CLI Templates
 description: Overview of the new CLI Declarative Templates
 ---
 
-The behavior of the `backstage-cli new` command is configurable through your root `package.json`, and you can also create and add custom CLI templates to suit your needs.
+The `backstage-cli new` command (typically run as `yarn new` in a Backstage workspace) scaffolds new plugins, modules, and library packages. It presents a list of available templates and walks you through a short set of prompts before generating the package, wiring up dependencies, and registering it in the workspace.
 
-## Basic Configuration
+## Built-in templates
+
+The following templates are included out of the box:
+
+| Template                            | Description                                                                                 |
+| :---------------------------------- | :------------------------------------------------------------------------------------------ |
+| `frontend-plugin`                   | A new frontend plugin                                                                       |
+| `frontend-plugin-module`            | A new frontend module that extends an existing frontend plugin                              |
+| `legacy-frontend-plugin`            | A new frontend plugin (legacy system)                                                       |
+| `backend-plugin`                    | A new backend plugin                                                                        |
+| `backend-plugin-module`             | A new backend module that extends an existing backend plugin                                |
+| `plugin-web-library`                | A new web library plugin package                                                            |
+| `plugin-node-library`               | A new Node.js library plugin package                                                        |
+| `plugin-common-library`             | A new isomorphic common plugin package                                                      |
+| `web-library`                       | A library package, exporting shared functionality for web environments                      |
+| `node-library`                      | A library package, exporting shared functionality for Node.js environments                  |
+| `cli-module`                        | A CLI module that adds commands to the Backstage CLI                                        |
+| `catalog-processor-module`          | A Processor module for the Software Catalog                                                 |
+| `catalog-provider-module`           | An Entity Provider module for the Software Catalog                                          |
+| `scaffolder-backend-module`         | A module exporting custom actions for @backstage/plugin-scaffolder-backend                  |
+| `scaffolder-field-extension-module` | A custom field extension for the Backstage Scaffolder                                       |
+| `permission-policy-module`          | A backend module that provides a custom permission policy for the permission-backend plugin |
+| `search-collator-module`            | A Search Collator module for Backstage Search                                               |
+
+## Configuration
+
+The behavior of `yarn new` is configurable through your root `package.json`:
 
 ```json
 {
@@ -93,8 +119,12 @@ When defining the `templates` array it will override the default set of template
           "@backstage/cli-module-new/templates/web-library",
           "@backstage/cli-module-new/templates/node-library",
           "@backstage/cli-module-new/templates/cli-module",
+          "@backstage/cli-module-new/templates/catalog-processor-module",
           "@backstage/cli-module-new/templates/catalog-provider-module",
-          "@backstage/cli-module-new/templates/scaffolder-backend-module"
+          "@backstage/cli-module-new/templates/scaffolder-backend-module",
+          "@backstage/cli-module-new/templates/scaffolder-field-extension-module",
+          "@backstage/cli-module-new/templates/permission-policy-module",
+          "@backstage/cli-module-new/templates/search-collator-module"
         ]
       }
     }

--- a/packages/cli-module-new/src/lib/defaultTemplates.ts
+++ b/packages/cli-module-new/src/lib/defaultTemplates.ts
@@ -26,6 +26,7 @@ export const defaultTemplates = [
   '@backstage/cli-module-new/templates/web-library',
   '@backstage/cli-module-new/templates/node-library',
   '@backstage/cli-module-new/templates/cli-module',
+  '@backstage/cli-module-new/templates/catalog-processor-module',
   '@backstage/cli-module-new/templates/catalog-provider-module',
   '@backstage/cli-module-new/templates/scaffolder-backend-module',
   '@backstage/cli-module-new/templates/scaffolder-field-extension-module',

--- a/packages/cli-module-new/src/lib/version.ts
+++ b/packages/cli-module-new/src/lib/version.ts
@@ -35,6 +35,7 @@ import { version as backendDefaults } from '../../../backend-defaults/package.js
 import { version as backendPluginApi } from '../../../backend-plugin-api/package.json';
 import { version as backendTestUtils } from '../../../backend-test-utils/package.json';
 import { version as catalogClient } from '../../../catalog-client/package.json';
+import { version as catalogModel } from '../../../catalog-model/package.json';
 import { version as cli } from '../../../cli/package.json';
 import { version as config } from '../../../config/package.json';
 import { version as coreAppApi } from '../../../core-app-api/package.json';
@@ -61,6 +62,7 @@ export const packageVersions: Record<string, string> = {
   '@backstage/backend-plugin-api': backendPluginApi,
   '@backstage/backend-test-utils': backendTestUtils,
   '@backstage/catalog-client': catalogClient,
+  '@backstage/catalog-model': catalogModel,
   '@backstage/cli': cli,
   '@backstage/config': config,
   '@backstage/core-app-api': coreAppApi,

--- a/packages/cli-module-new/templates/catalog-processor-module/.eslintrc.js.hbs
+++ b/packages/cli-module-new/templates/catalog-processor-module/.eslintrc.js.hbs
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/packages/cli-module-new/templates/catalog-processor-module/README.md.hbs
+++ b/packages/cli-module-new/templates/catalog-processor-module/README.md.hbs
@@ -1,0 +1,5 @@
+# {{packageName}}
+
+The {{fullModuleId}} module for [@backstage/plugin-catalog-backend](https://www.npmjs.com/package/@backstage/plugin-catalog-backend).
+
+_This plugin was created through the Backstage CLI_

--- a/packages/cli-module-new/templates/catalog-processor-module/package.json.hbs
+++ b/packages/cli-module-new/templates/catalog-processor-module/package.json.hbs
@@ -25,6 +25,7 @@
   "dependencies": {
     "@backstage/backend-plugin-api": "{{versionQuery '@backstage/backend-plugin-api'}}",
     "@backstage/catalog-model": "{{versionQuery '@backstage/catalog-model'}}",
+    "@backstage/config": "{{versionQuery '@backstage/config'}}",
     "@backstage/plugin-catalog-node": "{{versionQuery '@backstage/plugin-catalog-node'}}"
   },
   "devDependencies": {

--- a/packages/cli-module-new/templates/catalog-processor-module/package.json.hbs
+++ b/packages/cli-module-new/templates/catalog-processor-module/package.json.hbs
@@ -1,0 +1,37 @@
+{
+  "name": "{{packageName}}",
+  "description": "The {{fullModuleId}} module for @backstage/plugin-catalog-backend",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.cjs.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "backend-plugin-module",
+    "pluginId": "catalog",
+    "pluginPackage": "@backstage/plugin-catalog-backend"
+  },
+  "scripts": {
+    "start": "backstage-cli package start",
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test",
+    "clean": "backstage-cli package clean",
+    "prepack": "backstage-cli package prepack",
+    "postpack": "backstage-cli package postpack"
+  },
+  "dependencies": {
+    "@backstage/backend-plugin-api": "{{versionQuery '@backstage/backend-plugin-api'}}",
+    "@backstage/catalog-model": "{{versionQuery '@backstage/catalog-model'}}",
+    "@backstage/plugin-catalog-node": "{{versionQuery '@backstage/plugin-catalog-node'}}"
+  },
+  "devDependencies": {
+    "@backstage/cli": "{{versionQuery '@backstage/cli'}}",
+    "@backstage/backend-test-utils": "{{versionQuery '@backstage/backend-test-utils'}}"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/cli-module-new/templates/catalog-processor-module/portable-template.yaml
+++ b/packages/cli-module-new/templates/catalog-processor-module/portable-template.yaml
@@ -1,0 +1,9 @@
+name: catalog-processor-module
+role: backend-plugin-module
+description: A Processor module for the Software Catalog
+values:
+  pluginId: catalog
+  fullModuleId: '{{ moduleId }}-processor'
+  moduleVar: '{{ camelCase pluginId }}Module{{ upperFirst ( camelCase moduleId ) }}'
+  processorVar: '{{ camelCase moduleId }}Processor'
+  processorClass: '{{ upperFirst ( camelCase moduleId ) }}Processor'

--- a/packages/cli-module-new/templates/catalog-processor-module/portable-template.yaml
+++ b/packages/cli-module-new/templates/catalog-processor-module/portable-template.yaml
@@ -5,5 +5,4 @@ values:
   pluginId: catalog
   fullModuleId: '{{ moduleId }}-processor'
   moduleVar: '{{ camelCase pluginId }}Module{{ upperFirst ( camelCase moduleId ) }}'
-  processorVar: '{{ camelCase moduleId }}Processor'
   processorClass: '{{ upperFirst ( camelCase moduleId ) }}Processor'

--- a/packages/cli-module-new/templates/catalog-processor-module/src/index.ts.hbs
+++ b/packages/cli-module-new/templates/catalog-processor-module/src/index.ts.hbs
@@ -1,0 +1,8 @@
+/***/
+/**
+ * The {{fullModuleId}} module for @backstage/plugin-catalog-backend
+ *
+ * @packageDocumentation
+ */
+
+export { {{moduleVar}} as default } from './module';

--- a/packages/cli-module-new/templates/catalog-processor-module/src/module.ts.hbs
+++ b/packages/cli-module-new/templates/catalog-processor-module/src/module.ts.hbs
@@ -1,0 +1,22 @@
+import {
+  coreServices,
+  createBackendModule,
+} from '@backstage/backend-plugin-api';
+import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node';
+import { {{processorClass}} } from './processor/{{processorClass}}';
+
+export const {{moduleVar}} = createBackendModule({
+  pluginId: '{{pluginId}}',
+  moduleId: '{{fullModuleId}}',
+  register({ registerInit }) {
+    registerInit({
+      deps: {
+        config: coreServices.rootConfig,
+        catalog: catalogProcessingExtensionPoint,
+      },
+      async init({ catalog, config }) {
+        catalog.addProcessor({{processorClass}}.fromConfig(config));
+      },
+    });
+  },
+});

--- a/packages/cli-module-new/templates/catalog-processor-module/src/processor/{{processorClass}}.test.ts.hbs
+++ b/packages/cli-module-new/templates/catalog-processor-module/src/processor/{{processorClass}}.test.ts.hbs
@@ -1,0 +1,29 @@
+import { {{processorClass}} } from './{{processorClass}}';
+
+describe('{{processorClass}}', () => {
+  it('should return the processor name', () => {
+    const processor = {{processorClass}}.fromConfig({} as any);
+
+    expect(processor.getProcessorName()).toBe('{{processorClass}}');
+  });
+
+  it('should pre-process an entity', async () => {
+    const processor = {{processorClass}}.fromConfig({} as any);
+
+    const entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: { name: 'my-component' },
+      spec: { type: 'service', lifecycle: 'production', owner: 'my-team' },
+    };
+
+    const result = await processor.preProcessEntity(
+      entity as any,
+      { type: 'url', target: 'https://example.com' },
+      jest.fn(),
+      { type: 'url', target: 'https://example.com' },
+    );
+
+    expect(result).toEqual(entity);
+  });
+});

--- a/packages/cli-module-new/templates/catalog-processor-module/src/processor/{{processorClass}}.ts.hbs
+++ b/packages/cli-module-new/templates/catalog-processor-module/src/processor/{{processorClass}}.ts.hbs
@@ -1,0 +1,45 @@
+import { Config } from '@backstage/config';
+import { Entity } from '@backstage/catalog-model';
+import {
+  CatalogProcessor,
+  CatalogProcessorEmit,
+  LocationSpec,
+} from '@backstage/plugin-catalog-node';
+
+export class {{processorClass}} implements CatalogProcessor {
+  static fromConfig(_config: Config): {{processorClass}} {
+    return new {{processorClass}}();
+  }
+
+  getProcessorName(): string {
+    return '{{processorClass}}';
+  }
+
+  async preProcessEntity(
+    entity: Entity,
+    _location: LocationSpec,
+    _emit: CatalogProcessorEmit,
+    _originLocation: LocationSpec,
+  ): Promise<Entity> {
+    // TODO: Implement entity pre-processing logic, for example:
+    // entity.metadata.annotations = {
+    //   ...entity.metadata.annotations,
+    //   'example.com/my-annotation': 'my-value',
+    // };
+    return entity;
+  }
+
+  // Uncomment if you need to validate entities of a specific kind:
+  // async validateEntityKind(entity: Entity): Promise<boolean> {
+  //   return entity.kind === 'MyKind';
+  // }
+
+  // Uncomment if you need to enrich or mutate entities after validation:
+  // async postProcessEntity(
+  //   entity: Entity,
+  //   _location: LocationSpec,
+  //   _emit: CatalogProcessorEmit,
+  // ): Promise<Entity> {
+  //   return entity;
+  // }
+}

--- a/packages/cli-module-new/templates/catalog-processor-module/src/processor/{{processorClass}}.ts.hbs
+++ b/packages/cli-module-new/templates/catalog-processor-module/src/processor/{{processorClass}}.ts.hbs
@@ -6,6 +6,9 @@ import {
   LocationSpec,
 } from '@backstage/plugin-catalog-node';
 
+/**
+ * @see https://backstage.io/docs/features/software-catalog/extending-the-model
+ */
 export class {{processorClass}} implements CatalogProcessor {
   static fromConfig(_config: Config): {{processorClass}} {
     return new {{processorClass}}();


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added a new `catalog-processor-module` template for scaffolding catalog processor modules via `backstage-cli new`.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))