### PR TITLE
feat(cli-module-new): add scaffolder-field-extension-module CLI template

### DIFF
--- a/.changeset/add-scaffolder-field-extension-template.md
+++ b/.changeset/add-scaffolder-field-extension-template.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli-module-new': patch
+---
+
+Added a new `scaffolder-field-extension-module` template for scaffolding custom Scaffolder form field extensions via `backstage-cli new`.

--- a/packages/cli-module-new/src/lib/defaultTemplates.ts
+++ b/packages/cli-module-new/src/lib/defaultTemplates.ts
@@ -28,4 +28,5 @@ export const defaultTemplates = [
   '@backstage/cli-module-new/templates/cli-module',
   '@backstage/cli-module-new/templates/catalog-provider-module',
   '@backstage/cli-module-new/templates/scaffolder-backend-module',
+  '@backstage/cli-module-new/templates/scaffolder-field-extension-module',
 ];

--- a/packages/cli-module-new/templates/scaffolder-field-extension-module/.eslintrc.js.hbs
+++ b/packages/cli-module-new/templates/scaffolder-field-extension-module/.eslintrc.js.hbs
@@ -1,0 +1,1 @@
+module.exports = require('@backstage/cli/config/eslint-factory')(__dirname);

--- a/packages/cli-module-new/templates/scaffolder-field-extension-module/README.md.hbs
+++ b/packages/cli-module-new/templates/scaffolder-field-extension-module/README.md.hbs
@@ -1,0 +1,17 @@
+# {{packageName}}
+
+The {{moduleId}} field extension module for the Backstage Scaffolder.
+
+## Usage
+
+To use this field in a Scaffolder template, reference it in the template spec:
+
+```yaml
+properties:
+  myField:
+    title: My Field
+    type: string
+    ui:field: {{kebabCase moduleId}}
+```
+
+_This plugin was created through the Backstage CLI_

--- a/packages/cli-module-new/templates/scaffolder-field-extension-module/package.json.hbs
+++ b/packages/cli-module-new/templates/scaffolder-field-extension-module/package.json.hbs
@@ -1,0 +1,43 @@
+{
+  "name": "{{packageName}}",
+  "description": "The {{moduleId}} field extension module for the Backstage Scaffolder.",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.cjs.js",
+    "module": "dist/index.esm.js",
+    "types": "dist/index.d.ts"
+  },
+  "backstage": {
+    "role": "frontend-plugin-module",
+    "pluginId": "{{pluginId}}",
+    "pluginPackage": "{{pluginPackage}}"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "build": "backstage-cli package build",
+    "lint": "backstage-cli package lint",
+    "test": "backstage-cli package test",
+    "clean": "backstage-cli package clean",
+    "prepack": "backstage-cli package prepack",
+    "postpack": "backstage-cli package postpack"
+  },
+  "dependencies": {
+    "@backstage/frontend-plugin-api": "{{versionQuery '@backstage/frontend-plugin-api'}}",
+    "@backstage/plugin-scaffolder-react": "{{versionQuery '@backstage/plugin-scaffolder-react'}}"
+  },
+  "devDependencies": {
+    "@backstage/cli": "{{versionQuery '@backstage/cli'}}",
+    "@testing-library/jest-dom": "{{versionQuery '@testing-library/jest-dom' '6.0.0'}}",
+    "@testing-library/react": "{{versionQuery '@testing-library/react' '16.0.0'}}",
+    "@testing-library/user-event": "{{versionQuery '@testing-library/user-event' '14.0.0'}}",
+    "react": "{{versionQuery 'react' '18.0.0'}}"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0"
+  },
+  "files": [
+    "dist"
+  ]
+}

--- a/packages/cli-module-new/templates/scaffolder-field-extension-module/package.json.hbs
+++ b/packages/cli-module-new/templates/scaffolder-field-extension-module/package.json.hbs
@@ -35,7 +35,7 @@
     "react": "{{versionQuery 'react' '18.0.0'}}"
   },
   "peerDependencies": {
-    "react": "^18.0.0 || ^19.0.0"
+    "react": "^17.0.0 || ^18.0.0"
   },
   "files": [
     "dist"

--- a/packages/cli-module-new/templates/scaffolder-field-extension-module/portable-template.yaml
+++ b/packages/cli-module-new/templates/scaffolder-field-extension-module/portable-template.yaml
@@ -1,0 +1,8 @@
+name: scaffolder-field-extension-module
+role: frontend-plugin-module
+description: A custom field extension for the Backstage Scaffolder
+values:
+  pluginId: scaffolder
+  moduleVar: '{{ camelCase pluginId }}Module{{ upperFirst ( camelCase moduleId ) }}'
+  extensionName: '{{ upperFirst ( camelCase moduleId ) }}FieldExtension'
+  extensionComponent: '{{ upperFirst ( camelCase moduleId ) }}Field'

--- a/packages/cli-module-new/templates/scaffolder-field-extension-module/src/extensions/{{extensionName}}.test.tsx.hbs
+++ b/packages/cli-module-new/templates/scaffolder-field-extension-module/src/extensions/{{extensionName}}.test.tsx.hbs
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { {{ extensionComponent }} } from './{{ extensionName }}';
+
+describe('{{ extensionComponent }}', () => {
+  it('should render the field and handle changes', async () => {
+    const onChange = jest.fn();
+
+    render(
+      <{{ extensionComponent }}
+        onChange={onChange}
+        rawErrors={[]}
+        required={false}
+        formData=""
+      />,
+    );
+
+    const input = screen.getByRole('textbox');
+    await userEvent.type(input, 'test');
+
+    expect(onChange).toHaveBeenCalled();
+  });
+});

--- a/packages/cli-module-new/templates/scaffolder-field-extension-module/src/extensions/{{extensionName}}.test.tsx.hbs
+++ b/packages/cli-module-new/templates/scaffolder-field-extension-module/src/extensions/{{extensionName}}.test.tsx.hbs
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { {{ extensionComponent }} } from './{{ extensionName }}';

--- a/packages/cli-module-new/templates/scaffolder-field-extension-module/src/extensions/{{extensionName}}.tsx.hbs
+++ b/packages/cli-module-new/templates/scaffolder-field-extension-module/src/extensions/{{extensionName}}.tsx.hbs
@@ -1,0 +1,43 @@
+import React from 'react';
+import {
+  FormFieldBlueprint,
+  createFormField,
+} from '@backstage/plugin-scaffolder-react/alpha';
+import { FieldExtensionComponentProps } from '@backstage/plugin-scaffolder-react';
+
+export const {{ extensionComponent }} = ({
+  onChange,
+  rawErrors,
+  required,
+  formData,
+}: FieldExtensionComponentProps<string>) => {
+  // TODO: Replace with your custom field component
+  return (
+    <input
+      type="text"
+      onChange={e => onChange(e.target.value)}
+      value={formData ?? ''}
+      required={required}
+    />
+  );
+};
+
+export const {{ extensionName }} = FormFieldBlueprint.make({
+  name: '{{ kebabCase moduleId }}',
+  params: {
+    field: async () =>
+      createFormField({
+        name: '{{ extensionComponent }}',
+        component: {{ extensionComponent }},
+        // Uncomment to add validation:
+        // validation: async (value, validation, { apiHolder }) => {
+        //   if (!value) validation.addError('Field is required');
+        // },
+        // Uncomment to define schema for the Custom Field Explorer preview:
+        // schema: {
+        //   uiOptions: { type: 'object', properties: {} },
+        //   returnValue: { type: 'string' },
+        // },
+      }),
+  },
+});

--- a/packages/cli-module-new/templates/scaffolder-field-extension-module/src/extensions/{{extensionName}}.tsx.hbs
+++ b/packages/cli-module-new/templates/scaffolder-field-extension-module/src/extensions/{{extensionName}}.tsx.hbs
@@ -1,13 +1,14 @@
-import React from 'react';
 import {
   FormFieldBlueprint,
   createFormField,
 } from '@backstage/plugin-scaffolder-react/alpha';
-import { FieldExtensionComponentProps } from '@backstage/plugin-scaffolder-react';
+import {
+  FieldExtensionComponentProps,
+  makeFieldSchema,
+} from '@backstage/plugin-scaffolder-react';
 
 export const {{ extensionComponent }} = ({
   onChange,
-  rawErrors,
   required,
   formData,
 }: FieldExtensionComponentProps<string>) => {
@@ -34,10 +35,9 @@ export const {{ extensionName }} = FormFieldBlueprint.make({
         //   if (!value) validation.addError('Field is required');
         // },
         // Uncomment to define schema for the Custom Field Explorer preview:
-        // schema: {
-        //   uiOptions: { type: 'object', properties: {} },
-        //   returnValue: { type: 'string' },
-        // },
+        // schema: makeFieldSchema({
+        //   output: z => z.string(),
+        // }),
       }),
   },
 });

--- a/packages/cli-module-new/templates/scaffolder-field-extension-module/src/index.ts.hbs
+++ b/packages/cli-module-new/templates/scaffolder-field-extension-module/src/index.ts.hbs
@@ -1,0 +1,1 @@
+export { {{ moduleVar }} as default } from './module';

--- a/packages/cli-module-new/templates/scaffolder-field-extension-module/src/module.tsx.hbs
+++ b/packages/cli-module-new/templates/scaffolder-field-extension-module/src/module.tsx.hbs
@@ -1,0 +1,7 @@
+import { createFrontendModule } from '@backstage/frontend-plugin-api';
+import { {{ extensionName }} } from './extensions/{{ extensionName }}';
+
+export const {{ moduleVar }} = createFrontendModule({
+  pluginId: '{{ pluginId }}',
+  extensions: [{{ extensionName }}],
+});

--- a/packages/cli-module-new/templates/scaffolder-field-extension-module/src/setupTests.ts
+++ b/packages/cli-module-new/templates/scaffolder-field-extension-module/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added a new `scaffolder-field-extension-module` template for scaffolding custom Scaffolder form field extensions via `backstage-cli new`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))