### PR TITLE
fix(scaffolder-node): add retry with exponential backoff to Git push

### DIFF
--- a/.changeset/add-retry-to-git-operations.md
+++ b/.changeset/add-retry-to-git-operations.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-node': patch
+---
+
+Added retry with exponential back off to `Git.push()`. Scaffolder template actions that create a repository and immediately push to it (e.g., `publish:github`) can encounter transient failures when the repository is not yet fully provisioned. The push is now retried up to 5 times with increasing delays before failing. Authentication and permission errors (401, 403) fail immediately without retrying.

--- a/plugins/scaffolder-node/src/scm/git.test.ts
+++ b/plugins/scaffolder-node/src/scm/git.test.ts
@@ -545,26 +545,32 @@ describe('Git', () => {
     });
 
     it('should propagate the data from the error handler', async () => {
-      const remote = 'origin';
-      const dir = '/some/mock/dir';
-      const auth = {
-        username: 'blob',
-        password: 'hunter2',
-      };
-      const git = Git.fromAuth(auth);
-      const remoteRef = 'master';
-      const force = true;
+      jest.useFakeTimers();
+      try {
+        const remote = 'origin';
+        const dir = '/some/mock/dir';
+        const auth = {
+          username: 'blob',
+          password: 'hunter2',
+        };
+        const git = Git.fromAuth(auth);
+        const remoteRef = 'master';
+        const force = true;
 
-      (isomorphic.push as jest.Mock).mockImplementation(() => {
-        const error: Error & { data?: unknown } = new Error('mock error');
-        error.data = { some: 'more information here' };
+        (isomorphic.push as jest.Mock).mockImplementation(() => {
+          const error: Error & { data?: unknown } = new Error('mock error');
+          error.data = { some: 'more information here' };
 
-        throw error;
-      });
+          throw error;
+        });
 
-      await expect(git.push({ remote, dir, remoteRef, force })).rejects.toThrow(
-        'more information here',
-      );
+        const promise = git.push({ remote, dir, remoteRef, force });
+        promise.catch(() => {});
+        await jest.runAllTimersAsync();
+        await expect(promise).rejects.toThrow('more information here');
+      } finally {
+        jest.useRealTimers();
+      }
     });
   });
 
@@ -616,6 +622,118 @@ describe('Git', () => {
         dir,
         ref,
       });
+    });
+  });
+
+  describe('retry on transient errors', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('should retry push on transient error and succeed', async () => {
+      const git = Git.fromAuth({
+        username: 'blob',
+        password: 'hunter2',
+      });
+
+      (isomorphic.push as jest.Mock)
+        .mockRejectedValueOnce(new Error('ECONNRESET'))
+        .mockRejectedValueOnce(new Error('socket hang up'))
+        .mockResolvedValueOnce(undefined);
+
+      const promise = git.push({
+        dir: '/mock',
+        remote: 'origin',
+      });
+      await jest.runAllTimersAsync();
+      await promise;
+
+      expect(isomorphic.push).toHaveBeenCalledTimes(3);
+    });
+
+    it('should not retry on authentication errors', async () => {
+      const git = Git.fromAuth({
+        username: 'blob',
+        password: 'hunter2',
+      });
+
+      (isomorphic.push as jest.Mock).mockImplementation(() => {
+        throw new Error('HTTP Error: 401 Unauthorized');
+      });
+
+      await expect(
+        git.push({ dir: '/mock', remote: 'origin' }),
+      ).rejects.toThrow('401 Unauthorized');
+
+      expect(isomorphic.push).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not retry on permission errors', async () => {
+      const git = Git.fromAuth({
+        username: 'blob',
+        password: 'hunter2',
+      });
+
+      (isomorphic.push as jest.Mock).mockImplementation(() => {
+        throw new Error('HTTP Error: 403 Forbidden');
+      });
+
+      await expect(
+        git.push({ dir: '/mock', remote: 'origin' }),
+      ).rejects.toThrow('403 Forbidden');
+
+      expect(isomorphic.push).toHaveBeenCalledTimes(1);
+    });
+
+    it('should throw after exhausting all retries', async () => {
+      const git = Git.fromAuth({
+        username: 'blob',
+        password: 'hunter2',
+      });
+
+      (isomorphic.push as jest.Mock).mockImplementation(() => {
+        throw new Error('ECONNRESET');
+      });
+
+      const promise = git.push({ dir: '/mock', remote: 'origin' });
+      // Silence unhandled rejection while timers flush
+      promise.catch(() => {});
+      await jest.runAllTimersAsync();
+      await expect(promise).rejects.toThrow('ECONNRESET');
+
+      // 1 initial attempt + 5 retries = 6 total calls
+      expect(isomorphic.push).toHaveBeenCalledTimes(6);
+    });
+
+    it('should log warnings on retry attempts', async () => {
+      const logger = {
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        debug: jest.fn(),
+        child: jest.fn(),
+      };
+      const git = Git.fromAuth({
+        username: 'blob',
+        password: 'hunter2',
+        logger: logger as any,
+      });
+
+      (isomorphic.push as jest.Mock)
+        .mockRejectedValueOnce(new Error('ECONNRESET'))
+        .mockResolvedValueOnce(undefined);
+
+      const promise = git.push({ dir: '/mock', remote: 'origin' });
+      await jest.runAllTimersAsync();
+      await promise;
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Git push failed (attempt 1/6)'),
+      );
     });
   });
 });

--- a/plugins/scaffolder-node/src/scm/git.ts
+++ b/plugins/scaffolder-node/src/scm/git.ts
@@ -23,6 +23,7 @@ import git, {
 import http from 'isomorphic-git/http/node';
 import fs from 'fs-extra';
 import { LoggerService } from '@backstage/backend-plugin-api';
+import { isError } from '@backstage/errors';
 // @ts-ignore
 import { pgp } from '@isomorphic-git/pgp-plugin';
 
@@ -289,25 +290,35 @@ export class Git {
       `Pushing directory to remote {dir=${dir},remote=${remote}}`,
     );
     try {
-      return await git.push({
-        fs,
-        dir,
-        http,
-        onProgress: this.onProgressHandler(),
-        remoteRef,
-        force,
-        headers: this.headers,
-        remote,
-        url,
-        onAuth: this.onAuth,
-        corsProxy: '',
+      return await this.retryOnTransientError({
+        name: 'Git push',
+        fn: () =>
+          git.push({
+            fs,
+            dir,
+            http,
+            onProgress: this.onProgressHandler(),
+            remoteRef,
+            force,
+            headers: this.headers,
+            remote,
+            url,
+            onAuth: this.onAuth,
+            corsProxy: '',
+          }),
       });
     } catch (ex) {
       this.config.logger?.error(
         `Failed to push to repo {dir=${dir}, remote=${remote}}`,
       );
-      if (ex.data) {
-        throw new Error(`${ex.message} {data=${JSON.stringify(ex.data)}}`);
+      if (isError(ex) && 'data' in ex) {
+        let serializedData: string;
+        try {
+          serializedData = JSON.stringify(ex.data);
+        } catch {
+          serializedData = '[unserializable data]';
+        }
+        throw new Error(`${ex.message} {data=${serializedData}}`);
       }
       throw ex;
     }
@@ -351,6 +362,63 @@ export class Git {
   }
 
   private onAuth: AuthCallback;
+
+  private static readonly nonTransientPatterns = [
+    /auth/i,
+    /permission/i,
+    /forbidden/i,
+    /401/,
+    /403/,
+  ];
+
+  private async retryOnTransientError<T>(operation: {
+    /** The name of the operation */
+    name: string;
+    /** The operation to be executed */
+    fn: () => Promise<T>;
+  }): Promise<T> {
+    const maxRetries = 5;
+    const baseDelayMs = 2000;
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        return await operation.fn();
+      } catch (ex) {
+        const errorMsg = isError(ex) ? ex.message : String(ex);
+        let errorData = '';
+        if (isError(ex) && 'data' in ex) {
+          try {
+            errorData = JSON.stringify(ex.data);
+          } catch {
+            errorData = '[unserializable data]';
+          }
+        }
+        const fullError = `${errorMsg} ${errorData}`;
+        const isNonTransient = Git.nonTransientPatterns.some(p =>
+          p.test(fullError),
+        );
+
+        if (isNonTransient || attempt >= maxRetries) {
+          throw ex;
+        }
+
+        const delayMs = baseDelayMs * Math.pow(2, attempt);
+        const jitterMs = Math.floor(
+          Math.random() * Math.max(1, Math.floor(delayMs * 0.1)),
+        );
+        this.config.logger?.warn(
+          `${operation.name} failed (attempt ${attempt + 1}/${
+            maxRetries + 1
+          }), retrying in ${delayMs + jitterMs}ms: ${errorMsg}`,
+        );
+        await new Promise(resolve => setTimeout(resolve, delayMs + jitterMs));
+      }
+    }
+
+    throw new Error(
+      `${operation.name} failed after ${maxRetries + 1} attempts`,
+    );
+  }
 
   private onProgressHandler = (): ProgressCallback => {
     let currentPhase = '';


### PR DESCRIPTION
## What

Adds retry with exponential backoff and jitter to `Git.push()` in `@backstage/plugin-scaffolder-node`.

## Why

Scaffolder template actions that create a repository and immediately push to it (e.g., `publish:github`) can encounter transient failures—most commonly HTTP 404 errors—when the repository is not yet fully provisioned on the remote. This is a known issue in GitHub's infrastructure where the repository creation API returns success before the Git endpoint is ready to accept pushes.

**GitHub's own availability data confirms this is a systemic issue, not an edge case.** GitHub has acknowledged ongoing reliability challenges driven by exponential growth in agentic development workflows since late 2025. In an [April 2026 blog post](https://github.blog/news-insights/company-news/an-update-on-github-availability/), GitHub's leadership stated:

> This exponential growth does not stress one system at a time. A pull request can touch Git storage, mergeability checks, branch protection, GitHub Actions, search, notifications, permissions, webhooks, APIs, background jobs, caches, and databases. At high scale, small inefficiencies compound: queues deepen, cache misses become database load, indexes fall behind, retries amplify traffic, and one slow dependency can affect several product experiences.

The [April 2026 availability report](https://github.blog/news-insights/company-news/github-availability-report-april-2026/) documents **10 incidents in a single month**, including Git operations errors (April 23, ~2% of git operations affected), DNS-related cascading failures, and search infrastructure saturation from botnet traffic. Notably, the April 23 incident caused "5–7% of overall traffic" to fail, with Git operations averaging 1.25% errors and peaking at 2.07%. Independent tracking at [mrshu.github.io/github-statuses](https://mrshu.github.io/github-statuses/) provides a community-maintained view of these recurring incidents, built because GitHub itself stopped publishing aggregate uptime numbers.

This makes retry logic especially important for the scaffolder's "create-then-push" pattern, where the push happens seconds after repository creation—right in the window where transient failures are most likely.

### Why this fix belongs here

1. **Scaffolder-specific pattern**: The "create then immediately push" workflow is unique to the scaffolder's publish actions. Outside of scaffolder templates, a 404 on push typically indicates a genuinely non-existent repository.
2. **`isomorphic-git` likely won't add retry**: As a pure JavaScript Git client, `isomorphic-git` implements the Git protocol faithfully. Retry/backoff logic is an application-level concern that doesn't belong in a transport library. There is no retry / backoff logic in the library today.
3. **Proven in production**: This approach has been running successfully at my company via a Yarn patch for months, eliminating transient push failures in scaffolder template runs.

## How

- `Git.push()` now wraps the `isomorphic-git` call in a retry loop
- Up to 5 retries with exponential backoff (2s, 4s, 8s, 16s, 32s) plus 10% jitter
- Authentication and permission errors (401, 403) fail immediately without retrying
- Warnings are logged on each retry attempt with the attempt number and delay

The retry is intentionally scoped to `push()` only. `clone()` and `fetch()` operate on repositories that are already known to exist and are not subject to the same provisioning race condition.

Open to suggestions on if we should make these retry values configurable or not via public interface. Intentionally trying to keep initial PR small.

## Checklist

- [x] Added unit tests covering retry success, non-transient fast-fail, retry exhaustion, and logging
- [x] Added changeset
- [x] Signed off commits (DCO)

Fixes #33746