### PR TITLE
fix(create-app): remove disabled nav-item config that breaks custom sidebar

### DIFF
--- a/packages/create-app/templates/default-app/app-config.yaml.hbs
+++ b/packages/create-app/templates/default-app/app-config.yaml.hbs
@@ -6,12 +6,6 @@ app:
   packages: all
 
   extensions:
-    # Disable the nav items that we're manually rendering in packages/app/src/modules/nav/Sidebar.tsx
-    - nav-item:search: false
-    - nav-item:user-settings: false
-    - nav-item:catalog: false
-    - nav-item:scaffolder: false
-
     # Configure the catalog index page to be the root page, this is normally mounted on /catalog
     - page:catalog:
         config:


### PR DESCRIPTION
The `nav-item` extensions were disabled in the template config to prevent duplicate rendering, but the custom sidebar already handles this via `nav.take()`. After #33788 added filtering of disabled nav items from page discovery, disabling them causes `nav.take('page:catalog')` to return nothing, breaking the sidebar navigation.
