### PR TITLE
fix: correct changeset bump level for scaffolder-backend

### DIFF
--- a/.changeset/bitter-files-flash.md
+++ b/.changeset/bitter-files-flash.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-scaffolder-backend': major
+'@backstage/plugin-scaffolder-backend': patch
 ---
 
 Add explicit memory management to SecureTemplater usage


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The changeset `bitter-files-flash.md` for `@backstage/plugin-scaffolder-backend` was incorrectly marked as `major` when it should be `patch`. This fixes the bump level.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))