### PR TITLE
Reduce scheduler polling with batched readiness checks

### DIFF
--- a/.changeset/shared-task-poller.md
+++ b/.changeset/shared-task-poller.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Reduced scheduler database polling overhead by introducing a shared `TaskStatePoller` that batches per-task readiness checks into a single query per poll cycle. Previously, each scheduled task independently queried the database every few seconds; now all tasks registered by a plugin share one poll query.

--- a/.changeset/shared-task-poller.md
+++ b/.changeset/shared-task-poller.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Reduced scheduler database polling overhead by batching readiness checks for global tasks registered by each plugin into one query per poll cycle on each backend instance.

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/PluginTaskSchedulerImpl.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/PluginTaskSchedulerImpl.ts
@@ -159,7 +159,6 @@ export class PluginTaskSchedulerImpl implements SchedulerService {
         this.instrumentedFunction(task, scope),
         knex,
         this.logger.child({ task: task.id }),
-        undefined,
         this.poller,
       );
       await worker.start(settings, { signal: abortController.signal });

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/PluginTaskSchedulerImpl.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/PluginTaskSchedulerImpl.ts
@@ -147,11 +147,11 @@ export class PluginTaskSchedulerImpl implements SchedulerService {
       if (!this.poller) {
         this.pollerSignal = new AbortController();
         this.shutdownInitiated.then(() => this.pollerSignal!.abort());
-        this.poller = new TaskStatePoller(
+        this.poller = new TaskStatePoller({
           knex,
-          Duration.fromObject({ seconds: 5 }),
-          this.logger.child({ type: 'taskStatePoller' }),
-        );
+          pollInterval: Duration.fromObject({ seconds: 5 }),
+          logger: this.logger.child({ type: 'taskStatePoller' }),
+        });
         this.poller.start(this.pollerSignal.signal);
       }
 

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/PluginTaskSchedulerImpl.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/PluginTaskSchedulerImpl.ts
@@ -36,6 +36,7 @@ import { Duration } from 'luxon';
 import express from 'express';
 import Router from 'express-promise-router';
 import { LocalTaskWorker } from './LocalTaskWorker';
+import { TaskStatePoller } from './TaskStatePoller';
 import { TaskWorker } from './TaskWorker';
 import { TaskSettingsV2, TaskApiTasksResponse } from './types';
 import { delegateAbortController, TRACER_ID, validateId } from './util';
@@ -59,6 +60,8 @@ export class PluginTaskSchedulerImpl implements SchedulerService {
   private readonly pluginId: string;
   private readonly databaseFactory: () => Promise<Knex>;
   private readonly logger: LoggerService;
+  private poller?: TaskStatePoller;
+  private pollerSignal?: AbortController;
 
   constructor(
     pluginId: string,
@@ -140,11 +143,25 @@ export class PluginTaskSchedulerImpl implements SchedulerService {
 
     if (scope === 'global') {
       const knex = await this.databaseFactory();
+
+      if (!this.poller) {
+        this.pollerSignal = new AbortController();
+        this.shutdownInitiated.then(() => this.pollerSignal!.abort());
+        this.poller = new TaskStatePoller(
+          knex,
+          Duration.fromObject({ seconds: 5 }),
+          this.logger.child({ type: 'taskStatePoller' }),
+        );
+        this.poller.start(this.pollerSignal.signal);
+      }
+
       const worker = new TaskWorker(
         task.id,
         this.instrumentedFunction(task, scope),
         knex,
         this.logger.child({ task: task.id }),
+        undefined,
+        this.poller,
       );
       await worker.start(settings, { signal: abortController.signal });
       this.globalWorkersById.set(task.id, worker);

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/PluginTaskSchedulerImpl.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/PluginTaskSchedulerImpl.ts
@@ -61,7 +61,6 @@ export class PluginTaskSchedulerImpl implements SchedulerService {
   private readonly databaseFactory: () => Promise<Knex>;
   private readonly logger: LoggerService;
   private poller?: TaskStatePoller;
-  private pollerSignal?: AbortController;
 
   constructor(
     pluginId: string,
@@ -145,14 +144,14 @@ export class PluginTaskSchedulerImpl implements SchedulerService {
       const knex = await this.databaseFactory();
 
       if (!this.poller) {
-        this.pollerSignal = new AbortController();
-        this.shutdownInitiated.then(() => this.pollerSignal!.abort());
+        const pollerAbort = new AbortController();
+        this.shutdownInitiated.then(() => pollerAbort.abort());
         this.poller = new TaskStatePoller({
           knex,
           pollInterval: Duration.fromObject({ seconds: 5 }),
           logger: this.logger.child({ type: 'taskStatePoller' }),
         });
-        this.poller.start(this.pollerSignal.signal);
+        this.poller.start(pollerAbort.signal);
       }
 
       const worker = new TaskWorker(

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/PluginTaskSchedulerImpl.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/PluginTaskSchedulerImpl.ts
@@ -36,6 +36,7 @@ import { Duration } from 'luxon';
 import express from 'express';
 import Router from 'express-promise-router';
 import { LocalTaskWorker } from './LocalTaskWorker';
+import { TaskStatePoller } from './TaskStatePoller';
 import { TaskWorker } from './TaskWorker';
 import { TaskSettingsV2, TaskApiTasksResponse } from './types';
 import { delegateAbortController, TRACER_ID, validateId } from './util';
@@ -59,6 +60,7 @@ export class PluginTaskSchedulerImpl implements SchedulerService {
   private readonly pluginId: string;
   private readonly databaseFactory: () => Promise<Knex>;
   private readonly logger: LoggerService;
+  private poller?: TaskStatePoller;
 
   constructor(
     pluginId: string,
@@ -140,11 +142,20 @@ export class PluginTaskSchedulerImpl implements SchedulerService {
 
     if (scope === 'global') {
       const knex = await this.databaseFactory();
+
+      if (!this.poller) {
+        this.poller = new TaskStatePoller({
+          knex,
+          logger: this.logger.child({ type: 'taskStatePoller' }),
+        });
+      }
+
       const worker = new TaskWorker(
         task.id,
         this.instrumentedFunction(task, scope),
         knex,
         this.logger.child({ task: task.id }),
+        this.poller,
       );
       await worker.start(settings, { signal: abortController.signal });
       this.globalWorkersById.set(task.id, worker);

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskStatePoller.test.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskStatePoller.test.ts
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestDatabases, mockServices } from '@backstage/backend-test-utils';
+import { Duration } from 'luxon';
+import { migrateBackendTasks } from '../database/migrateBackendTasks';
+import { DB_TASKS_TABLE, DbTasksRow } from '../database/tables';
+import { TaskStatePoller } from './TaskStatePoller';
+import { nowPlus } from './util';
+import { Knex } from 'knex';
+
+jest.setTimeout(60_000);
+
+const databases = TestDatabases.create({
+  ids: ['POSTGRES_18', 'POSTGRES_14', 'SQLITE_3'],
+});
+
+describe.each(databases.eachSupportedId())(
+  'TaskStatePoller, %p',
+  databaseId => {
+    let knex: Knex;
+
+    beforeAll(async () => {
+      await databases.init(databaseId);
+      jest.useFakeTimers();
+    }, 60_000);
+
+    afterAll(() => {
+      jest.useRealTimers();
+    });
+
+    beforeEach(async () => {
+      knex = await databases.init(databaseId);
+      await migrateBackendTasks(knex);
+    });
+
+    afterEach(async () => {
+      await knex.destroy();
+    });
+
+    const defaultSettings = {
+      version: 2,
+      cadence: 'PT5S',
+      timeoutAfterDuration: 'PT30S',
+    };
+
+    async function insertTask(id: string, opts: { ready?: boolean } = {}) {
+      await knex<DbTasksRow>(DB_TASKS_TABLE).insert({
+        id,
+        settings_json: JSON.stringify(defaultSettings),
+        next_run_start_at: opts.ready
+          ? nowPlus(Duration.fromObject({ minutes: -1 }), knex)
+          : nowPlus(Duration.fromObject({ hours: 1 }), knex),
+      });
+    }
+
+    function createPoller(signal: AbortSignal) {
+      const poller = new TaskStatePoller(
+        knex,
+        Duration.fromMillis(100),
+        mockServices.logger.mock(),
+      );
+      poller.start(signal);
+      return poller;
+    }
+
+    it('resolves with ready when a task is ready to run', async () => {
+      await insertTask('task-a', { ready: true });
+
+      const ac = new AbortController();
+      const poller = createPoller(ac.signal);
+
+      const promise = poller.waitForReady('task-a', ac.signal);
+      await jest.advanceTimersByTimeAsync(200);
+      const result = await promise;
+
+      expect(result).toMatchObject({
+        result: 'ready',
+        settings: expect.objectContaining({ version: 2 }),
+      });
+
+      ac.abort();
+    });
+
+    it('waits until the task becomes ready', async () => {
+      await insertTask('task-b', { ready: false });
+
+      const ac = new AbortController();
+      const poller = createPoller(ac.signal);
+
+      let resolved = false;
+      const promise = poller.waitForReady('task-b', ac.signal).then(r => {
+        resolved = true;
+        return r;
+      });
+
+      await jest.advanceTimersByTimeAsync(300);
+      expect(resolved).toBe(false);
+
+      // Make the task ready
+      await knex<DbTasksRow>(DB_TASKS_TABLE)
+        .where('id', 'task-b')
+        .update({
+          next_run_start_at: nowPlus(
+            Duration.fromObject({ minutes: -1 }),
+            knex,
+          ),
+        });
+
+      await jest.advanceTimersByTimeAsync(200);
+      const result = await promise;
+
+      expect(result.result).toBe('ready');
+      ac.abort();
+    });
+
+    it('resolves with abort when a task disappears from the database', async () => {
+      await insertTask('task-c', { ready: false });
+
+      const ac = new AbortController();
+      const poller = createPoller(ac.signal);
+
+      const promise = poller.waitForReady('task-c', ac.signal);
+
+      await jest.advanceTimersByTimeAsync(50);
+      await knex<DbTasksRow>(DB_TASKS_TABLE).where('id', 'task-c').delete();
+      await jest.advanceTimersByTimeAsync(200);
+
+      const result = await promise;
+      expect(result.result).toBe('abort');
+      ac.abort();
+    });
+
+    it('resolves with not-ready-yet when abort signal fires', async () => {
+      await insertTask('task-d', { ready: false });
+
+      const pollerAc = new AbortController();
+      const poller = createPoller(pollerAc.signal);
+
+      const waiterAc = new AbortController();
+      const promise = poller.waitForReady('task-d', waiterAc.signal);
+
+      waiterAc.abort();
+      const result = await promise;
+
+      expect(result.result).toBe('not-ready-yet');
+      pollerAc.abort();
+    });
+
+    it('batches multiple tasks into a single poll cycle', async () => {
+      await insertTask('task-e1', { ready: true });
+      await insertTask('task-e2', { ready: true });
+      await insertTask('task-e3', { ready: false });
+
+      const ac = new AbortController();
+      const poller = createPoller(ac.signal);
+
+      const p1 = poller.waitForReady('task-e1', ac.signal);
+      const p2 = poller.waitForReady('task-e2', ac.signal);
+
+      await jest.advanceTimersByTimeAsync(200);
+
+      const [r1, r2] = await Promise.all([p1, p2]);
+      expect(r1.result).toBe('ready');
+      expect(r2.result).toBe('ready');
+
+      ac.abort();
+    });
+
+    it('does not resolve for tasks that are currently running', async () => {
+      await insertTask('task-f', { ready: true });
+      await knex<DbTasksRow>(DB_TASKS_TABLE)
+        .where('id', 'task-f')
+        .update({ current_run_ticket: 'some-ticket' });
+
+      const ac = new AbortController();
+      const poller = createPoller(ac.signal);
+
+      let resolved = false;
+      poller.waitForReady('task-f', ac.signal).then(() => {
+        resolved = true;
+      });
+
+      await jest.advanceTimersByTimeAsync(500);
+      expect(resolved).toBe(false);
+
+      ac.abort();
+    });
+  },
+);

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskStatePoller.test.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskStatePoller.test.ts
@@ -187,17 +187,19 @@ describe.each(databases.eachSupportedId())(
       const poller = createPoller(ac.signal);
 
       let resolved = false;
-      poller
+      const promise = poller
         .setupListener('task-f')
         .waitForReady()
         .then(() => {
           resolved = true;
-        });
+        })
+        .catch(() => {});
 
       await jest.advanceTimersByTimeAsync(500);
       expect(resolved).toBe(false);
 
       ac.abort();
+      await promise;
     });
   },
 );

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskStatePoller.test.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskStatePoller.test.ts
@@ -24,9 +24,7 @@ import { Knex } from 'knex';
 
 jest.setTimeout(60_000);
 
-const databases = TestDatabases.create({
-  ids: ['POSTGRES_18', 'POSTGRES_14', 'SQLITE_3'],
-});
+const databases = TestDatabases.create();
 
 describe.each(databases.eachSupportedId())(
   'TaskStatePoller, %p',

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskStatePoller.test.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskStatePoller.test.ts
@@ -66,11 +66,11 @@ describe.each(databases.eachSupportedId())(
     }
 
     function createPoller(signal: AbortSignal) {
-      const poller = new TaskStatePoller(
+      const poller = new TaskStatePoller({
         knex,
-        Duration.fromMillis(100),
-        mockServices.logger.mock(),
-      );
+        pollInterval: Duration.fromMillis(100),
+        logger: mockServices.logger.mock(),
+      });
       poller.start(signal);
       return poller;
     }

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskStatePoller.test.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskStatePoller.test.ts
@@ -81,7 +81,7 @@ describe.each(databases.eachSupportedId())(
       const ac = new AbortController();
       const poller = createPoller(ac.signal);
 
-      const promise = poller.waitForReady('task-a', ac.signal);
+      const promise = poller.setupListener('task-a').waitForReady();
       await jest.advanceTimersByTimeAsync(200);
       const result = await promise;
 
@@ -100,10 +100,13 @@ describe.each(databases.eachSupportedId())(
       const poller = createPoller(ac.signal);
 
       let resolved = false;
-      const promise = poller.waitForReady('task-b', ac.signal).then(r => {
-        resolved = true;
-        return r;
-      });
+      const promise = poller
+        .setupListener('task-b')
+        .waitForReady()
+        .then(r => {
+          resolved = true;
+          return r;
+        });
 
       await jest.advanceTimersByTimeAsync(300);
       expect(resolved).toBe(false);
@@ -131,7 +134,7 @@ describe.each(databases.eachSupportedId())(
       const ac = new AbortController();
       const poller = createPoller(ac.signal);
 
-      const promise = poller.waitForReady('task-c', ac.signal);
+      const promise = poller.setupListener('task-c').waitForReady();
 
       await jest.advanceTimersByTimeAsync(50);
       await knex<DbTasksRow>(DB_TASKS_TABLE).where('id', 'task-c').delete();
@@ -142,20 +145,16 @@ describe.each(databases.eachSupportedId())(
       ac.abort();
     });
 
-    it('resolves with not-ready-yet when abort signal fires', async () => {
+    it('rejects when the poller is shut down', async () => {
       await insertTask('task-d', { ready: false });
 
-      const pollerAc = new AbortController();
-      const poller = createPoller(pollerAc.signal);
+      const ac = new AbortController();
+      const poller = createPoller(ac.signal);
 
-      const waiterAc = new AbortController();
-      const promise = poller.waitForReady('task-d', waiterAc.signal);
+      const promise = poller.setupListener('task-d').waitForReady();
 
-      waiterAc.abort();
-      const result = await promise;
-
-      expect(result.result).toBe('not-ready-yet');
-      pollerAc.abort();
+      ac.abort();
+      await expect(promise).rejects.toThrow('Poller has been shut down');
     });
 
     it('batches multiple tasks into a single poll cycle', async () => {
@@ -166,8 +165,8 @@ describe.each(databases.eachSupportedId())(
       const ac = new AbortController();
       const poller = createPoller(ac.signal);
 
-      const p1 = poller.waitForReady('task-e1', ac.signal);
-      const p2 = poller.waitForReady('task-e2', ac.signal);
+      const p1 = poller.setupListener('task-e1').waitForReady();
+      const p2 = poller.setupListener('task-e2').waitForReady();
 
       await jest.advanceTimersByTimeAsync(200);
 
@@ -188,9 +187,12 @@ describe.each(databases.eachSupportedId())(
       const poller = createPoller(ac.signal);
 
       let resolved = false;
-      poller.waitForReady('task-f', ac.signal).then(() => {
-        resolved = true;
-      });
+      poller
+        .setupListener('task-f')
+        .waitForReady()
+        .then(() => {
+          resolved = true;
+        });
 
       await jest.advanceTimersByTimeAsync(500);
       expect(resolved).toBe(false);

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskStatePoller.test.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskStatePoller.test.ts
@@ -1,0 +1,505 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestDatabases, mockServices } from '@backstage/backend-test-utils';
+import { getEventListeners } from 'node:events';
+import { Knex } from 'knex';
+import { Duration } from 'luxon';
+import { migrateBackendTasks } from '../database/migrateBackendTasks';
+import { DB_TASKS_TABLE, DbTasksRow } from '../database/tables';
+import { TaskStatePoller } from './TaskStatePoller';
+import { nowPlus } from './util';
+
+jest.setTimeout(60_000);
+
+const databases = TestDatabases.create();
+
+describe.each(databases.eachSupportedId())(
+  'TaskStatePoller, %p',
+  databaseId => {
+    const pollInterval = Duration.fromMillis(100);
+    let knex: Knex;
+
+    beforeEach(async () => {
+      knex = await databases.init(databaseId);
+      await migrateBackendTasks(knex);
+    });
+
+    const defaultSettings = {
+      version: 2,
+      cadence: 'PT5S',
+      timeoutAfterDuration: 'PT30S',
+    };
+
+    async function insertTask(id: string, opts: { ready?: boolean } = {}) {
+      await knex<DbTasksRow>(DB_TASKS_TABLE).insert({
+        id,
+        settings_json: JSON.stringify(defaultSettings),
+        next_run_start_at: opts.ready
+          ? nowPlus(Duration.fromObject({ minutes: -1 }), knex)
+          : nowPlus(Duration.fromObject({ hours: 1 }), knex),
+      });
+    }
+
+    function createPoller(logger = mockServices.logger.mock()) {
+      return new TaskStatePoller({ knex, logger });
+    }
+
+    function waitForTask(
+      poller: TaskStatePoller,
+      taskId: string,
+      controller: AbortController,
+      interval = pollInterval,
+    ) {
+      return poller.waitForTask(taskId, {
+        signal: controller.signal,
+        pollInterval: interval,
+      });
+    }
+
+    function waitForNextReadinessQuery() {
+      return new Promise<void>(resolve => {
+        const onQueryResponse = (
+          _response: unknown,
+          query: { sql: string },
+        ) => {
+          if (
+            query.sql.includes(DB_TASKS_TABLE) &&
+            query.sql.toLowerCase().startsWith('select')
+          ) {
+            knex.off('query-response', onQueryResponse);
+            resolve();
+          }
+        };
+        knex.on('query-response', onQueryResponse);
+      });
+    }
+
+    it('batches task outcomes into one query and preserves diagnostics', async () => {
+      await insertTask('task-ready', { ready: true });
+      await insertTask('task-invalid', { ready: true });
+      await knex<DbTasksRow>(DB_TASKS_TABLE)
+        .where('id', 'task-invalid')
+        .update({ settings_json: '{}' });
+
+      const logger = mockServices.logger.mock();
+      const poller = createPoller(logger);
+      const readyController = new AbortController();
+      const invalidController = new AbortController();
+      const missingController = new AbortController();
+      const readinessQueries: string[] = [];
+      const onQuery = (query: { sql: string }) => {
+        if (
+          query.sql.includes(DB_TASKS_TABLE) &&
+          query.sql.toLowerCase().startsWith('select')
+        ) {
+          readinessQueries.push(query.sql);
+        }
+      };
+      knex.on('query', onQuery);
+
+      try {
+        const results = Promise.all([
+          waitForTask(poller, 'task-ready', readyController),
+          waitForTask(poller, 'task-invalid', invalidController),
+          waitForTask(poller, 'task-missing', missingController),
+        ]);
+        await expect(results).resolves.toEqual([
+          {
+            result: 'ready',
+            settings: defaultSettings,
+          },
+          { result: 'abort' },
+          { result: 'abort' },
+        ]);
+        expect(readinessQueries).toHaveLength(1);
+        expect(logger.info).toHaveBeenCalledWith(
+          expect.stringContaining(
+            'Task "task-invalid" is no longer able to parse task settings',
+          ),
+        );
+        expect(logger.info).toHaveBeenCalledWith(
+          expect.stringContaining('No longer able to find task "task-missing"'),
+        );
+      } finally {
+        knex.off('query', onQuery);
+      }
+    });
+
+    it('logs query failures with error details and retries', async () => {
+      await insertTask('task-query-retry', { ready: true });
+      const unavailableTable = `${DB_TASKS_TABLE}_unavailable`;
+      await knex.schema.renameTable(DB_TASKS_TABLE, unavailableTable);
+
+      const logger = mockServices.logger.mock();
+      const warning = new Promise<[string, unknown]>(resolve => {
+        logger.warn.mockImplementation((message, error) => {
+          resolve([message, error]);
+        });
+      });
+      const poller = createPoller(logger);
+      const controller = new AbortController();
+      let tableRestored = false;
+
+      try {
+        const promise = waitForTask(poller, 'task-query-retry', controller);
+        const [message, error] = await warning;
+        await knex.schema.renameTable(unavailableTable, DB_TASKS_TABLE);
+        tableRestored = true;
+
+        expect(message).toBe('Task state poll failed');
+        expect(error).toEqual(
+          expect.objectContaining({
+            message: expect.any(String),
+            stack: expect.any(String),
+          }),
+        );
+        await expect(promise).resolves.toMatchObject({ result: 'ready' });
+      } finally {
+        controller.abort();
+        if (!tableRestored) {
+          await knex.schema.renameTable(unavailableTable, DB_TASKS_TABLE);
+        }
+      }
+    });
+
+    it('keeps waiting until tasks become ready and idle', async () => {
+      await insertTask('task-future', { ready: false });
+      await insertTask('task-running', { ready: true });
+      await knex<DbTasksRow>(DB_TASKS_TABLE)
+        .where('id', 'task-running')
+        .update({ current_run_ticket: 'some-ticket' });
+
+      const poller = createPoller();
+      const futureController = new AbortController();
+      const runningController = new AbortController();
+      const firstPoll = waitForNextReadinessQuery();
+      let futureResolved = false;
+      let runningResolved = false;
+      const futurePromise = waitForTask(
+        poller,
+        'task-future',
+        futureController,
+      ).then(result => {
+        futureResolved = true;
+        return result;
+      });
+      const runningPromise = waitForTask(
+        poller,
+        'task-running',
+        runningController,
+      ).then(result => {
+        runningResolved = true;
+        return result;
+      });
+
+      await firstPoll;
+      expect(futureResolved).toBe(false);
+      expect(runningResolved).toBe(false);
+
+      await knex<DbTasksRow>(DB_TASKS_TABLE)
+        .where('id', 'task-future')
+        .update({
+          next_run_start_at: nowPlus(
+            Duration.fromObject({ minutes: -1 }),
+            knex,
+          ),
+        });
+      await knex<DbTasksRow>(DB_TASKS_TABLE)
+        .where('id', 'task-running')
+        .update({ current_run_ticket: knex.raw('null') });
+      const readyPoll = waitForNextReadinessQuery();
+      await readyPoll;
+
+      await expect(
+        Promise.all([futurePromise, runningPromise]),
+      ).resolves.toEqual([
+        { result: 'ready', settings: defaultSettings },
+        { result: 'ready', settings: defaultSettings },
+      ]);
+    });
+
+    it('cleans up waits and timers when workers stop', async () => {
+      const stoppedController = new AbortController();
+      stoppedController.abort();
+      await expect(
+        waitForTask(createPoller(), 'task-stopped', stoppedController),
+      ).resolves.toEqual({ result: 'abort' });
+      expect(getEventListeners(stoppedController.signal, 'abort')).toHaveLength(
+        0,
+      );
+
+      await insertTask('task-aborted-before-poll', { ready: false });
+      await insertTask('task-after-early-abort', { ready: true });
+      const reusablePoller = createPoller();
+      const earlyController = new AbortController();
+      const earlyPromise = waitForTask(
+        reusablePoller,
+        'task-aborted-before-poll',
+        earlyController,
+      );
+      earlyController.abort();
+      await expect(earlyPromise).resolves.toEqual({ result: 'abort' });
+      await Promise.resolve();
+
+      const nextController = new AbortController();
+      const nextPoll = waitForNextReadinessQuery();
+      const nextPromise = waitForTask(
+        reusablePoller,
+        'task-after-early-abort',
+        nextController,
+      );
+      await nextPoll;
+      await expect(nextPromise).resolves.toMatchObject({ result: 'ready' });
+
+      await insertTask('task-pending', { ready: false });
+      const pendingController = new AbortController();
+      const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+      const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+      try {
+        const pendingPoll = waitForNextReadinessQuery();
+        const pendingPromise = waitForTask(
+          createPoller(),
+          'task-pending',
+          pendingController,
+        );
+        await pendingPoll;
+        await new Promise(resolve => setImmediate(resolve));
+        const pollTimers = setTimeoutSpy.mock.results
+          .filter(
+            (_, index) =>
+              setTimeoutSpy.mock.calls[index][1] ===
+              pollInterval.as('milliseconds'),
+          )
+          .map(result => result.value);
+
+        pendingController.abort();
+
+        await expect(pendingPromise).resolves.toEqual({ result: 'abort' });
+        expect(
+          getEventListeners(pendingController.signal, 'abort'),
+        ).toHaveLength(0);
+        expect(pollTimers).not.toHaveLength(0);
+        expect(
+          pollTimers.some(timer =>
+            clearTimeoutSpy.mock.calls.some(([value]) => value === timer),
+          ),
+        ).toBe(true);
+      } finally {
+        pendingController.abort();
+        setTimeoutSpy.mockRestore();
+        clearTimeoutSpy.mockRestore();
+      }
+    });
+
+    it('rejects invalid polling intervals without registering a waiter', () => {
+      const controller = new AbortController();
+      const poller = createPoller();
+
+      for (const interval of [
+        Duration.fromMillis(0),
+        Duration.fromMillis(-1),
+      ]) {
+        expect(() =>
+          waitForTask(poller, 'task-invalid-interval', controller, interval),
+        ).toThrow('pollInterval must be a finite positive duration');
+      }
+
+      expect(getEventListeners(controller.signal, 'abort')).toHaveLength(0);
+    });
+
+    it('does not poll more often than every 100 milliseconds', async () => {
+      await insertTask('task-minimum-poll-interval', { ready: false });
+      const controller = new AbortController();
+      const readinessQueries: string[] = [];
+      const onQuery = (query: { sql: string }) => {
+        if (
+          query.sql.includes(DB_TASKS_TABLE) &&
+          query.sql.toLowerCase().startsWith('select')
+        ) {
+          readinessQueries.push(query.sql);
+        }
+      };
+      knex.on('query', onQuery);
+      jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate'] });
+
+      try {
+        const firstPoll = waitForNextReadinessQuery();
+        const promise = waitForTask(
+          createPoller(),
+          'task-minimum-poll-interval',
+          controller,
+          Duration.fromMillis(1),
+        );
+        await firstPoll;
+        await new Promise(resolve => setImmediate(resolve));
+        expect(readinessQueries).toHaveLength(1);
+
+        jest.advanceTimersByTime(99);
+        await new Promise(resolve => setImmediate(resolve));
+        expect(readinessQueries).toHaveLength(1);
+
+        jest.advanceTimersByTime(1);
+        await new Promise(resolve => setImmediate(resolve));
+        expect(readinessQueries).toHaveLength(2);
+
+        controller.abort();
+        await expect(promise).resolves.toEqual({ result: 'abort' });
+      } finally {
+        controller.abort();
+        knex.off('query', onQuery);
+        jest.useRealTimers();
+      }
+    });
+
+    it('uses a task requested interval while waiting', async () => {
+      await insertTask('task-fast-poll', { ready: false });
+      const controller = new AbortController();
+      const poller = createPoller();
+      const firstPoll = waitForNextReadinessQuery();
+      const promise = waitForTask(poller, 'task-fast-poll', controller);
+
+      await firstPoll;
+      await knex<DbTasksRow>(DB_TASKS_TABLE)
+        .where('id', 'task-fast-poll')
+        .update({
+          next_run_start_at: nowPlus(
+            Duration.fromObject({ minutes: -1 }),
+            knex,
+          ),
+        });
+      const readyPoll = waitForNextReadinessQuery();
+      const waitStartedAt = Date.now();
+      await readyPoll;
+
+      expect(Date.now() - waitStartedAt).toBeLessThan(4_000);
+      await expect(promise).resolves.toMatchObject({ result: 'ready' });
+    });
+
+    it('waits one interval before polling again after a ready result', async () => {
+      await insertTask('task-ready-cooldown', { ready: true });
+      const controller = new AbortController();
+      const interval = Duration.fromObject({ seconds: 5 });
+      const readinessQueries: string[] = [];
+      const onQuery = (query: { sql: string }) => {
+        if (
+          query.sql.includes(DB_TASKS_TABLE) &&
+          query.sql.toLowerCase().startsWith('select')
+        ) {
+          readinessQueries.push(query.sql);
+        }
+      };
+      knex.on('query', onQuery);
+      jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate'] });
+
+      try {
+        const poller = createPoller();
+        const firstPromise = waitForTask(
+          poller,
+          'task-ready-cooldown',
+          controller,
+          interval,
+        );
+        await firstPromise;
+        await new Promise(resolve => setImmediate(resolve));
+        expect(readinessQueries).toHaveLength(1);
+
+        let secondResolved = false;
+        const secondPromise = waitForTask(
+          poller,
+          'task-ready-cooldown',
+          controller,
+          interval,
+        ).then(result => {
+          secondResolved = true;
+          return result;
+        });
+
+        await new Promise(resolve => setImmediate(resolve));
+        jest.advanceTimersByTime(4_999);
+        expect(secondResolved).toBe(false);
+        expect(readinessQueries).toHaveLength(1);
+
+        jest.advanceTimersByTime(1);
+        await new Promise(resolve => setImmediate(resolve));
+        expect(readinessQueries).toHaveLength(2);
+        await expect(secondPromise).resolves.toMatchObject({ result: 'ready' });
+      } finally {
+        controller.abort();
+        knex.off('query', onQuery);
+        jest.useRealTimers();
+      }
+    });
+
+    it('pulls a scheduled poll forward for a faster waiter', async () => {
+      await insertTask('task-slow-poll', { ready: false });
+      await insertTask('task-fast-late-poll', { ready: true });
+      const slowController = new AbortController();
+      const fastController = new AbortController();
+      const readinessQueries: string[] = [];
+      const onQuery = (query: { sql: string }) => {
+        if (
+          query.sql.includes(DB_TASKS_TABLE) &&
+          query.sql.toLowerCase().startsWith('select')
+        ) {
+          readinessQueries.push(query.sql);
+        }
+      };
+      knex.on('query', onQuery);
+      jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate'] });
+
+      try {
+        const poller = createPoller();
+        const firstPoll = waitForNextReadinessQuery();
+        const slowPromise = waitForTask(
+          poller,
+          'task-slow-poll',
+          slowController,
+          Duration.fromObject({ seconds: 50 }),
+        );
+        await firstPoll;
+        await new Promise(resolve => setImmediate(resolve));
+
+        const fastPromise = waitForTask(
+          poller,
+          'task-fast-late-poll',
+          fastController,
+          Duration.fromObject({ seconds: 5 }),
+        );
+
+        jest.advanceTimersByTime(4_999);
+        expect(readinessQueries).toHaveLength(1);
+
+        jest.advanceTimersByTime(1);
+        await new Promise(resolve => setImmediate(resolve));
+        expect(readinessQueries).toHaveLength(2);
+        await expect(fastPromise).resolves.toMatchObject({ result: 'ready' });
+        await new Promise(resolve => setImmediate(resolve));
+
+        jest.advanceTimersByTime(49_999);
+        expect(readinessQueries).toHaveLength(2);
+
+        slowController.abort();
+        await slowPromise;
+      } finally {
+        slowController.abort();
+        fastController.abort();
+        knex.off('query', onQuery);
+        jest.useRealTimers();
+      }
+    });
+  },
+);

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskStatePoller.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskStatePoller.ts
@@ -44,16 +44,19 @@ interface PendingWaiter {
  * promises when tasks become ready.
  */
 export class TaskStatePoller {
-  private readonly waiters = new Map<string, PendingWaiter[]>();
-  private pollTimer: ReturnType<typeof setTimeout> | undefined;
-  private pollCycleRunning = false;
-  private signal?: AbortSignal;
+  readonly #knex: Knex;
+  readonly #pollInterval: Duration;
+  readonly #logger: LoggerService;
+  readonly #waiters = new Map<string, PendingWaiter[]>();
+  #pollTimer: ReturnType<typeof setTimeout> | undefined;
+  #pollCycleRunning = false;
+  #signal?: AbortSignal;
 
-  constructor(
-    private readonly knex: Knex,
-    private readonly pollInterval: Duration,
-    private readonly logger: LoggerService,
-  ) {}
+  constructor(knex: Knex, pollInterval: Duration, logger: LoggerService) {
+    this.#knex = knex;
+    this.#pollInterval = pollInterval;
+    this.#logger = logger;
+  }
 
   /**
    * Register a listener for a task. The returned object's `waitForReady()`
@@ -64,30 +67,30 @@ export class TaskStatePoller {
   setupListener(taskId: string): TaskListener {
     return {
       waitForReady: () => {
-        if (this.signal?.aborted) {
+        if (this.#signal?.aborted) {
           return Promise.reject(new Error('Poller has been shut down'));
         }
 
         return new Promise<TaskPollResult>((resolve, reject) => {
           const waiter: PendingWaiter = { taskId, resolve };
 
-          let list = this.waiters.get(taskId);
+          let list = this.#waiters.get(taskId);
           if (!list) {
             list = [];
-            this.waiters.set(taskId, list);
+            this.#waiters.set(taskId, list);
           }
           list.push(waiter);
 
-          this.signal?.addEventListener(
+          this.#signal?.addEventListener(
             'abort',
             () => {
-              this.removeWaiter(waiter);
+              this.#removeWaiter(waiter);
               reject(new Error('Poller has been shut down'));
             },
             { once: true },
           );
 
-          this.ensurePolling();
+          this.#ensurePolling();
         });
       },
     };
@@ -98,59 +101,59 @@ export class TaskStatePoller {
    * only runs when there are active waiters; it idles otherwise.
    */
   start(signal: AbortSignal): void {
-    this.signal = signal;
+    this.#signal = signal;
     signal.addEventListener('abort', () => {
-      if (this.pollTimer) {
-        clearTimeout(this.pollTimer);
-        this.pollTimer = undefined;
+      if (this.#pollTimer) {
+        clearTimeout(this.#pollTimer);
+        this.#pollTimer = undefined;
       }
     });
   }
 
-  private ensurePolling(): void {
-    if (this.pollCycleRunning || this.pollTimer || this.signal?.aborted) {
+  #ensurePolling(): void {
+    if (this.#pollCycleRunning || this.#pollTimer || this.#signal?.aborted) {
       return;
     }
     // Use a microtask for the initial poll so it fires immediately even
     // under fake timers (setTimeout(fn, 0) requires timer advancement).
-    this.pollCycleRunning = true;
-    Promise.resolve().then(() => this.runPollCycle());
+    this.#pollCycleRunning = true;
+    Promise.resolve().then(() => this.#runPollCycle());
   }
 
-  private async runPollCycle(): Promise<void> {
+  async #runPollCycle(): Promise<void> {
     try {
-      await this.poll();
+      await this.#poll();
     } catch (e) {
-      this.logger.warn(`Task state poll failed: ${e}`);
+      this.#logger.warn(`Task state poll failed: ${e}`);
     }
-    this.pollCycleRunning = false;
+    this.#pollCycleRunning = false;
 
-    if (this.waiters.size > 0 && !this.signal?.aborted) {
-      this.pollTimer = setTimeout(() => {
-        this.pollTimer = undefined;
-        this.pollCycleRunning = true;
-        this.runPollCycle();
-      }, this.pollInterval.as('milliseconds'));
+    if (this.#waiters.size > 0 && !this.#signal?.aborted) {
+      this.#pollTimer = setTimeout(() => {
+        this.#pollTimer = undefined;
+        this.#pollCycleRunning = true;
+        this.#runPollCycle();
+      }, this.#pollInterval.as('milliseconds'));
     }
   }
 
-  private async poll(): Promise<void> {
-    const taskIds = [...this.waiters.keys()];
+  async #poll(): Promise<void> {
+    const taskIds = [...this.#waiters.keys()];
     if (taskIds.length === 0) {
       return;
     }
 
-    const rows = await this.knex<DbTasksRow>(DB_TASKS_TABLE)
+    const rows = await this.#knex<DbTasksRow>(DB_TASKS_TABLE)
       .whereIn('id', taskIds)
       .select({
         id: 'id',
         settingsJson: 'settings_json',
-        ready: this.knex.raw(
+        ready: this.#knex.raw(
           `CASE
             WHEN next_run_start_at <= ? AND current_run_ticket IS NULL THEN TRUE
             ELSE FALSE
           END`,
-          [this.knex.fn.now()],
+          [this.#knex.fn.now()],
         ),
       });
 
@@ -163,7 +166,7 @@ export class TaskStatePoller {
         continue;
       }
 
-      const waiters = this.waiters.get(row.id);
+      const waiters = this.#waiters.get(row.id);
       if (!waiters || waiters.length === 0) {
         continue;
       }
@@ -172,34 +175,34 @@ export class TaskStatePoller {
       try {
         settings = taskSettingsV2Schema.parse(JSON.parse(row.settingsJson));
       } catch {
-        this.resolveAll(row.id, { result: 'abort' });
+        this.#resolveAll(row.id, { result: 'abort' });
         continue;
       }
 
-      this.resolveAll(row.id, { result: 'ready', settings });
+      this.#resolveAll(row.id, { result: 'ready', settings });
     }
 
     for (const taskId of taskIds) {
       if (!foundIds.has(taskId)) {
-        this.resolveAll(taskId, { result: 'abort' });
+        this.#resolveAll(taskId, { result: 'abort' });
       }
     }
   }
 
-  private resolveAll(taskId: string, result: TaskPollResult): void {
-    const waiters = this.waiters.get(taskId);
+  #resolveAll(taskId: string, result: TaskPollResult): void {
+    const waiters = this.#waiters.get(taskId);
     if (!waiters) {
       return;
     }
-    this.waiters.delete(taskId);
+    this.#waiters.delete(taskId);
 
     for (const waiter of waiters) {
       waiter.resolve(result);
     }
   }
 
-  private removeWaiter(waiter: PendingWaiter): void {
-    const list = this.waiters.get(waiter.taskId);
+  #removeWaiter(waiter: PendingWaiter): void {
+    const list = this.#waiters.get(waiter.taskId);
     if (!list) {
       return;
     }
@@ -208,7 +211,7 @@ export class TaskStatePoller {
       list.splice(idx, 1);
     }
     if (list.length === 0) {
-      this.waiters.delete(waiter.taskId);
+      this.#waiters.delete(waiter.taskId);
     }
   }
 }

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskStatePoller.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskStatePoller.ts
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LoggerService } from '@backstage/backend-plugin-api';
+import { Knex } from 'knex';
+import { Duration } from 'luxon';
+import { DB_TASKS_TABLE, DbTasksRow } from '../database/tables';
+import { TaskSettingsV2, taskSettingsV2Schema } from './types';
+
+export type TaskPollResult =
+  | { result: 'not-ready-yet' }
+  | { result: 'abort' }
+  | { result: 'ready'; settings: TaskSettingsV2 };
+
+interface PendingWaiter {
+  taskId: string;
+  resolve: (result: TaskPollResult) => void;
+  cleanup: () => void;
+}
+
+/**
+ * Shared poller that batches per-task readiness checks into a single query.
+ *
+ * Instead of each TaskWorker independently querying the database every few
+ * seconds, workers call `waitForReady` which returns a Promise. The poller
+ * runs one query per cycle covering all waiting tasks, and resolves the
+ * relevant promises when tasks become ready.
+ */
+export class TaskStatePoller {
+  private readonly waiters = new Map<string, PendingWaiter[]>();
+  private pollTimer: ReturnType<typeof setTimeout> | undefined;
+  private pollCycleRunning = false;
+  private signal?: AbortSignal;
+
+  constructor(
+    private readonly knex: Knex,
+    private readonly pollInterval: Duration,
+    private readonly logger: LoggerService,
+  ) {}
+
+  /**
+   * Returns a Promise that resolves when the given task is detected as ready
+   * to run, or when the task disappears from the database (abort), or when
+   * the signal fires.
+   */
+  waitForReady(taskId: string, signal: AbortSignal): Promise<TaskPollResult> {
+    if (signal.aborted) {
+      return Promise.resolve({ result: 'not-ready-yet' });
+    }
+
+    return new Promise<TaskPollResult>(resolve => {
+      const waiter: PendingWaiter = {
+        taskId,
+        resolve,
+        cleanup: () => {},
+      };
+
+      const onAbort = () => {
+        this.removeWaiter(waiter);
+        resolve({ result: 'not-ready-yet' });
+      };
+
+      waiter.cleanup = () => {
+        signal.removeEventListener('abort', onAbort);
+      };
+
+      signal.addEventListener('abort', onAbort, { once: true });
+
+      let list = this.waiters.get(taskId);
+      if (!list) {
+        list = [];
+        this.waiters.set(taskId, list);
+      }
+      list.push(waiter);
+
+      this.ensurePolling();
+    });
+  }
+
+  /**
+   * Start the poller. Must be called before `waitForReady`. The poller only
+   * runs when there are active waiters; it idles otherwise.
+   */
+  start(signal: AbortSignal): void {
+    this.signal = signal;
+    signal.addEventListener('abort', () => {
+      if (this.pollTimer) {
+        clearTimeout(this.pollTimer);
+        this.pollTimer = undefined;
+      }
+    });
+  }
+
+  private ensurePolling(): void {
+    if (this.pollCycleRunning || this.pollTimer || this.signal?.aborted) {
+      return;
+    }
+    // Use a microtask for the initial poll so it fires immediately even
+    // under fake timers (setTimeout(fn, 0) requires timer advancement).
+    this.pollCycleRunning = true;
+    Promise.resolve().then(() => this.runPollCycle());
+  }
+
+  private async runPollCycle(): Promise<void> {
+    try {
+      await this.poll();
+    } catch (e) {
+      this.logger.warn(`Task state poll failed: ${e}`);
+    }
+    this.pollCycleRunning = false;
+
+    if (this.waiters.size > 0 && !this.signal?.aborted) {
+      this.pollTimer = setTimeout(() => {
+        this.pollTimer = undefined;
+        this.pollCycleRunning = true;
+        this.runPollCycle();
+      }, this.pollInterval.as('milliseconds'));
+    }
+  }
+
+  private async poll(): Promise<void> {
+    const taskIds = [...this.waiters.keys()];
+    if (taskIds.length === 0) {
+      return;
+    }
+
+    const rows = await this.knex<DbTasksRow>(DB_TASKS_TABLE)
+      .whereIn('id', taskIds)
+      .select({
+        id: 'id',
+        settingsJson: 'settings_json',
+        ready: this.knex.raw(
+          `CASE
+            WHEN next_run_start_at <= ? AND current_run_ticket IS NULL THEN TRUE
+            ELSE FALSE
+          END`,
+          [this.knex.fn.now()],
+        ),
+      });
+
+    const foundIds = new Set<string>();
+
+    for (const row of rows) {
+      foundIds.add(row.id);
+
+      if (!row.ready) {
+        continue;
+      }
+
+      const waiters = this.waiters.get(row.id);
+      if (!waiters || waiters.length === 0) {
+        continue;
+      }
+
+      let settings: TaskSettingsV2;
+      try {
+        settings = taskSettingsV2Schema.parse(JSON.parse(row.settingsJson));
+      } catch {
+        this.resolveAll(row.id, { result: 'abort' });
+        continue;
+      }
+
+      this.resolveAll(row.id, { result: 'ready', settings });
+    }
+
+    for (const taskId of taskIds) {
+      if (!foundIds.has(taskId)) {
+        this.resolveAll(taskId, { result: 'abort' });
+      }
+    }
+  }
+
+  private resolveAll(taskId: string, result: TaskPollResult): void {
+    const waiters = this.waiters.get(taskId);
+    if (!waiters) {
+      return;
+    }
+    this.waiters.delete(taskId);
+
+    for (const waiter of waiters) {
+      waiter.cleanup();
+      waiter.resolve(result);
+    }
+  }
+
+  private removeWaiter(waiter: PendingWaiter): void {
+    const list = this.waiters.get(waiter.taskId);
+    if (!list) {
+      return;
+    }
+    const idx = list.indexOf(waiter);
+    if (idx >= 0) {
+      list.splice(idx, 1);
+    }
+    if (list.length === 0) {
+      this.waiters.delete(waiter.taskId);
+    }
+  }
+}

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskStatePoller.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskStatePoller.ts
@@ -52,10 +52,14 @@ export class TaskStatePoller {
   #pollCycleRunning = false;
   #signal?: AbortSignal;
 
-  constructor(knex: Knex, pollInterval: Duration, logger: LoggerService) {
-    this.#knex = knex;
-    this.#pollInterval = pollInterval;
-    this.#logger = logger;
+  constructor(options: {
+    knex: Knex;
+    pollInterval: Duration;
+    logger: LoggerService;
+  }) {
+    this.#knex = options.knex;
+    this.#pollInterval = options.pollInterval;
+    this.#logger = options.logger;
   }
 
   /**

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskStatePoller.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskStatePoller.ts
@@ -22,7 +22,6 @@ import { DB_TASKS_TABLE, DbTasksRow } from '../database/tables';
 import { TaskSettingsV2, taskSettingsV2Schema } from './types';
 
 export type TaskPollResult =
-  | { result: 'not-ready-yet' }
   | { result: 'abort' }
   | { result: 'ready'; settings: TaskSettingsV2 };
 

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskStatePoller.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskStatePoller.ts
@@ -25,19 +25,23 @@ export type TaskPollResult =
   | { result: 'abort' }
   | { result: 'ready'; settings: TaskSettingsV2 };
 
+export interface TaskListener {
+  waitForReady(): Promise<TaskPollResult>;
+}
+
 interface PendingWaiter {
   taskId: string;
   resolve: (result: TaskPollResult) => void;
-  cleanup: () => void;
 }
 
 /**
  * Shared poller that batches per-task readiness checks into a single query.
  *
  * Instead of each TaskWorker independently querying the database every few
- * seconds, workers call `waitForReady` which returns a Promise. The poller
- * runs one query per cycle covering all waiting tasks, and resolves the
- * relevant promises when tasks become ready.
+ * seconds, workers call `setupListener` once at startup, then call
+ * `waitForReady()` on the returned listener in a loop. The poller runs one
+ * query per cycle covering all waiting tasks, and resolves the relevant
+ * promises when tasks become ready.
  */
 export class TaskStatePoller {
   private readonly waiters = new Map<string, PendingWaiter[]>();
@@ -52,47 +56,46 @@ export class TaskStatePoller {
   ) {}
 
   /**
-   * Returns a Promise that resolves when the given task is detected as ready
-   * to run, or when the task disappears from the database (abort), or when
-   * the signal fires.
+   * Register a listener for a task. The returned object's `waitForReady()`
+   * returns a Promise that resolves when the task is detected as ready to
+   * run, when the task disappears from the database (abort), or rejects
+   * when the poller is shut down.
    */
-  waitForReady(taskId: string, signal: AbortSignal): Promise<TaskPollResult> {
-    if (signal.aborted) {
-      return Promise.resolve({ result: 'not-ready-yet' });
-    }
+  setupListener(taskId: string): TaskListener {
+    return {
+      waitForReady: () => {
+        if (this.signal?.aborted) {
+          return Promise.reject(new Error('Poller has been shut down'));
+        }
 
-    return new Promise<TaskPollResult>(resolve => {
-      const waiter: PendingWaiter = {
-        taskId,
-        resolve,
-        cleanup: () => {},
-      };
+        return new Promise<TaskPollResult>((resolve, reject) => {
+          const waiter: PendingWaiter = { taskId, resolve };
 
-      const onAbort = () => {
-        this.removeWaiter(waiter);
-        resolve({ result: 'not-ready-yet' });
-      };
+          let list = this.waiters.get(taskId);
+          if (!list) {
+            list = [];
+            this.waiters.set(taskId, list);
+          }
+          list.push(waiter);
 
-      waiter.cleanup = () => {
-        signal.removeEventListener('abort', onAbort);
-      };
+          this.signal?.addEventListener(
+            'abort',
+            () => {
+              this.removeWaiter(waiter);
+              reject(new Error('Poller has been shut down'));
+            },
+            { once: true },
+          );
 
-      signal.addEventListener('abort', onAbort, { once: true });
-
-      let list = this.waiters.get(taskId);
-      if (!list) {
-        list = [];
-        this.waiters.set(taskId, list);
-      }
-      list.push(waiter);
-
-      this.ensurePolling();
-    });
+          this.ensurePolling();
+        });
+      },
+    };
   }
 
   /**
-   * Start the poller. Must be called before `waitForReady`. The poller only
-   * runs when there are active waiters; it idles otherwise.
+   * Start the poller. Must be called before `setupListener`. The poller
+   * only runs when there are active waiters; it idles otherwise.
    */
   start(signal: AbortSignal): void {
     this.signal = signal;
@@ -191,7 +194,6 @@ export class TaskStatePoller {
     this.waiters.delete(taskId);
 
     for (const waiter of waiters) {
-      waiter.cleanup();
       waiter.resolve(result);
     }
   }

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskStatePoller.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskStatePoller.ts
@@ -15,6 +15,7 @@
  */
 
 import { LoggerService } from '@backstage/backend-plugin-api';
+import { createDeferred, DeferredPromise } from '@backstage/types';
 import { Knex } from 'knex';
 import { Duration } from 'luxon';
 import { DB_TASKS_TABLE, DbTasksRow } from '../database/tables';
@@ -31,7 +32,7 @@ export interface TaskListener {
 
 interface PendingWaiter {
   taskId: string;
-  resolve: (result: TaskPollResult) => void;
+  deferred: DeferredPromise<TaskPollResult>;
 }
 
 /**
@@ -75,27 +76,28 @@ export class TaskStatePoller {
           return Promise.reject(new Error('Poller has been shut down'));
         }
 
-        return new Promise<TaskPollResult>((resolve, reject) => {
-          const waiter: PendingWaiter = { taskId, resolve };
+        const deferred = createDeferred<TaskPollResult>();
+        const waiter: PendingWaiter = { taskId, deferred };
 
-          let list = this.#waiters.get(taskId);
-          if (!list) {
-            list = [];
-            this.#waiters.set(taskId, list);
-          }
-          list.push(waiter);
+        let list = this.#waiters.get(taskId);
+        if (!list) {
+          list = [];
+          this.#waiters.set(taskId, list);
+        }
+        list.push(waiter);
 
-          this.#signal?.addEventListener(
-            'abort',
-            () => {
-              this.#removeWaiter(waiter);
-              reject(new Error('Poller has been shut down'));
-            },
-            { once: true },
-          );
+        this.#signal?.addEventListener(
+          'abort',
+          () => {
+            this.#removeWaiter(waiter);
+            deferred.reject(new Error('Poller has been shut down'));
+          },
+          { once: true },
+        );
 
-          this.#ensurePolling();
-        });
+        this.#ensurePolling();
+
+        return deferred;
       },
     };
   }
@@ -118,8 +120,6 @@ export class TaskStatePoller {
     if (this.#pollCycleRunning || this.#pollTimer || this.#signal?.aborted) {
       return;
     }
-    // Use a microtask for the initial poll so it fires immediately even
-    // under fake timers (setTimeout(fn, 0) requires timer advancement).
     this.#pollCycleRunning = true;
     Promise.resolve().then(() => this.#runPollCycle());
   }
@@ -201,7 +201,7 @@ export class TaskStatePoller {
     this.#waiters.delete(taskId);
 
     for (const waiter of waiters) {
-      waiter.resolve(result);
+      waiter.deferred.resolve(result);
     }
   }
 

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskStatePoller.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskStatePoller.ts
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LoggerService } from '@backstage/backend-plugin-api';
+import { createDeferred, DeferredPromise } from '@backstage/types';
+import { Knex } from 'knex';
+import { Duration } from 'luxon';
+import { DB_TASKS_TABLE, DbTasksRow } from '../database/tables';
+import { TaskSettingsV2, taskSettingsV2Schema } from './types';
+
+type TaskPollResult =
+  | { result: 'abort' }
+  | { result: 'ready'; settings: TaskSettingsV2 };
+
+interface PendingWaiter {
+  taskId: string;
+  deferred: DeferredPromise<TaskPollResult>;
+  pollIntervalMs: number;
+  signal: AbortSignal;
+  abortHandler: () => void;
+}
+
+const MIN_POLL_INTERVAL_MS = 100;
+
+/**
+ * Batches readiness checks for all waiting tasks of a plugin.
+ */
+export class TaskStatePoller {
+  readonly #knex: Knex;
+  readonly #logger: LoggerService;
+  readonly #waiters = new Map<string, Set<PendingWaiter>>();
+  #pollTimer: ReturnType<typeof setTimeout> | undefined;
+  #pollTimerDueAt: number | undefined;
+  #nextPollAllowedAt: number | undefined;
+  #pollCycleRunning = false;
+
+  constructor(options: { knex: Knex; logger: LoggerService }) {
+    this.#knex = options.knex;
+    this.#logger = options.logger;
+  }
+
+  waitForTask(
+    taskId: string,
+    options: { signal: AbortSignal; pollInterval: Duration },
+  ): Promise<TaskPollResult> {
+    if (options.signal.aborted) {
+      return Promise.resolve({ result: 'abort' });
+    }
+
+    const requestedPollIntervalMs = options.pollInterval.as('milliseconds');
+    if (
+      !Number.isFinite(requestedPollIntervalMs) ||
+      requestedPollIntervalMs <= 0
+    ) {
+      throw new TypeError('pollInterval must be a finite positive duration');
+    }
+    const pollIntervalMs = Math.max(
+      requestedPollIntervalMs,
+      MIN_POLL_INTERVAL_MS,
+    );
+
+    const deferred = createDeferred<TaskPollResult>();
+    const waiter: PendingWaiter = {
+      taskId,
+      deferred,
+      pollIntervalMs,
+      signal: options.signal,
+      abortHandler: () => {
+        this.#removeWaiter(waiter);
+        deferred.resolve({ result: 'abort' });
+      },
+    };
+
+    let waiters = this.#waiters.get(taskId);
+    if (!waiters) {
+      waiters = new Set();
+      this.#waiters.set(taskId, waiters);
+    }
+    waiters.add(waiter);
+    options.signal.addEventListener('abort', waiter.abortHandler, {
+      once: true,
+    });
+
+    this.#ensurePolling();
+    this.#rescheduleFor(waiter);
+    return deferred;
+  }
+
+  #ensurePolling(): void {
+    if (this.#pollCycleRunning || this.#pollTimer) {
+      return;
+    }
+
+    const delayMs = (this.#nextPollAllowedAt ?? 0) - Date.now();
+    if (delayMs > 0) {
+      this.#schedulePoll(delayMs);
+      return;
+    }
+
+    this.#pollCycleRunning = true;
+    Promise.resolve().then(() => this.#runPollCycle());
+  }
+
+  async #runPollCycle(): Promise<void> {
+    const cyclePollIntervalMs = this.#nextPollIntervalMs();
+    if (!Number.isFinite(cyclePollIntervalMs)) {
+      this.#pollCycleRunning = false;
+      this.#nextPollAllowedAt = undefined;
+      return;
+    }
+
+    try {
+      await this.#poll();
+    } catch (error) {
+      this.#logger.warn('Task state poll failed', error);
+    }
+    this.#pollCycleRunning = false;
+
+    const currentPollIntervalMs = this.#nextPollIntervalMs();
+    const nextPollCooldownMs = Math.min(
+      cyclePollIntervalMs,
+      currentPollIntervalMs,
+    );
+    this.#nextPollAllowedAt = Date.now() + nextPollCooldownMs;
+    if (this.#waiters.size > 0) {
+      this.#schedulePoll(currentPollIntervalMs);
+    }
+  }
+
+  #schedulePoll(delayMs: number): void {
+    this.#pollTimerDueAt = Date.now() + delayMs;
+    this.#pollTimer = setTimeout(() => {
+      this.#pollTimer = undefined;
+      this.#pollTimerDueAt = undefined;
+      if (this.#waiters.size === 0) {
+        return;
+      }
+      this.#pollCycleRunning = true;
+      this.#runPollCycle();
+    }, delayMs);
+  }
+
+  #rescheduleFor(waiter: PendingWaiter): void {
+    if (!this.#pollTimer || this.#pollTimerDueAt === undefined) {
+      return;
+    }
+
+    const desiredPollAt = Date.now() + waiter.pollIntervalMs;
+    if (desiredPollAt >= this.#pollTimerDueAt) {
+      return;
+    }
+
+    clearTimeout(this.#pollTimer);
+    this.#schedulePoll(waiter.pollIntervalMs);
+  }
+
+  #nextPollIntervalMs(): number {
+    let intervalMs = Infinity;
+    for (const waiters of this.#waiters.values()) {
+      for (const waiter of waiters) {
+        intervalMs = Math.min(intervalMs, waiter.pollIntervalMs);
+      }
+    }
+    return intervalMs;
+  }
+
+  async #poll(): Promise<void> {
+    const taskIds = [...this.#waiters.keys()];
+    if (taskIds.length === 0) {
+      return;
+    }
+
+    const rows = await this.#knex<DbTasksRow>(DB_TASKS_TABLE)
+      .whereIn('id', taskIds)
+      .select({
+        id: 'id',
+        settingsJson: 'settings_json',
+        ready: this.#knex.raw(
+          `CASE
+            WHEN next_run_start_at <= ? AND current_run_ticket IS NULL THEN TRUE
+            ELSE FALSE
+          END`,
+          [this.#knex.fn.now()],
+        ),
+      });
+
+    const foundIds = new Set<string>();
+
+    for (const row of rows) {
+      foundIds.add(row.id);
+
+      if (!row.ready) {
+        continue;
+      }
+
+      try {
+        const settings = taskSettingsV2Schema.parse(
+          JSON.parse(row.settingsJson),
+        );
+        this.#resolveAll(row.id, { result: 'ready', settings });
+      } catch (error) {
+        this.#logger.info(
+          `Task "${row.id}" is no longer able to parse task settings; aborting and assuming that a newer version of the task has been issued and is being handled by other workers, ${error}`,
+        );
+        this.#resolveAll(row.id, { result: 'abort' });
+      }
+    }
+
+    for (const taskId of taskIds) {
+      if (!foundIds.has(taskId)) {
+        this.#logger.info(
+          `No longer able to find task "${taskId}"; aborting and assuming that it has been unregistered or expired`,
+        );
+        this.#resolveAll(taskId, { result: 'abort' });
+      }
+    }
+  }
+
+  #resolveAll(taskId: string, result: TaskPollResult): void {
+    const waiters = this.#waiters.get(taskId);
+    if (!waiters) {
+      return;
+    }
+    this.#waiters.delete(taskId);
+
+    for (const waiter of waiters) {
+      this.#cleanupWaiter(waiter);
+      waiter.deferred.resolve(result);
+    }
+  }
+
+  #removeWaiter(waiter: PendingWaiter): void {
+    const waiters = this.#waiters.get(waiter.taskId);
+    if (!waiters) {
+      return;
+    }
+    waiters.delete(waiter);
+    this.#cleanupWaiter(waiter);
+    if (waiters.size === 0) {
+      this.#waiters.delete(waiter.taskId);
+    }
+    if (this.#waiters.size === 0 && this.#pollTimer) {
+      clearTimeout(this.#pollTimer);
+      this.#pollTimer = undefined;
+      this.#pollTimerDueAt = undefined;
+      this.#nextPollAllowedAt = undefined;
+    }
+  }
+
+  #cleanupWaiter(waiter: PendingWaiter): void {
+    waiter.signal.removeEventListener('abort', waiter.abortHandler);
+  }
+}

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.test.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.test.ts
@@ -66,7 +66,7 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       timeoutAfterDuration: Duration.fromObject({ minutes: 1 }).toISO()!,
     };
 
-    const worker = new TaskWorker('task1', fn, knex, logger, undefined, poller);
+    const worker = new TaskWorker('task1', fn, knex, logger, poller);
     await worker.persistTask(settings);
 
     let row = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
@@ -179,15 +179,7 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       cadence: '* * * * * *',
       timeoutAfterDuration: Duration.fromMillis(60000).toISO()!,
     };
-    const checkFrequency = Duration.fromObject({ milliseconds: 100 });
-    const worker = new TaskWorker(
-      'task1',
-      fn,
-      knex,
-      logger,
-      checkFrequency,
-      poller,
-    );
+    const worker = new TaskWorker('task1', fn, knex, logger, poller);
     worker.start(settings, { signal: testScopedSignal() });
 
     await waitForExpect(async () => {
@@ -216,15 +208,7 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       cadence: '* * * * * *',
       timeoutAfterDuration: Duration.fromMillis(60000).toISO()!,
     };
-    const checkFrequency = Duration.fromObject({ milliseconds: 100 });
-    const worker = new TaskWorker(
-      'task1',
-      fn,
-      knex,
-      logger,
-      checkFrequency,
-      poller,
-    );
+    const worker = new TaskWorker('task1', fn, knex, logger, poller);
     worker.start(settings, { signal: testScopedSignal() });
 
     await waitForExpect(() => {
@@ -243,7 +227,7 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       timeoutAfterDuration: Duration.fromMillis(60000).toISO()!,
     };
 
-    const worker = new TaskWorker('task1', fn, knex, logger, undefined, poller);
+    const worker = new TaskWorker('task1', fn, knex, logger, poller);
     await worker.persistTask(settings);
 
     await waitForExpect(async () => {
@@ -293,28 +277,14 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       timeoutAfterDuration: Duration.fromMillis(60000).toISO()!,
     };
 
-    const worker1 = new TaskWorker(
-      'task1',
-      fn,
-      knex,
-      logger,
-      undefined,
-      poller,
-    );
+    const worker1 = new TaskWorker('task1', fn, knex, logger, poller);
     await worker1.persistTask(settings);
     await knex<DbTasksRow>(DB_TASKS_TABLE).where('id', '=', 'task1').delete();
     await expect(worker1.findReadyTask()).resolves.toEqual({
       result: 'abort',
     });
 
-    const worker2 = new TaskWorker(
-      'task2',
-      fn,
-      knex,
-      logger,
-      undefined,
-      poller,
-    );
+    const worker2 = new TaskWorker('task2', fn, knex, logger, poller);
     await worker2.persistTask(settings);
 
     await waitForExpect(async () => {
@@ -327,14 +297,7 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
     await knex<DbTasksRow>(DB_TASKS_TABLE).where('id', '=', 'task2').delete();
     await expect(worker2.tryClaimTask('ticket', settings)).resolves.toBe(false);
 
-    const worker3 = new TaskWorker(
-      'task3',
-      fn,
-      knex,
-      logger,
-      undefined,
-      poller,
-    );
+    const worker3 = new TaskWorker('task3', fn, knex, logger, poller);
     await worker3.persistTask(settings);
 
     await waitForExpect(async () => {
@@ -362,14 +325,7 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
 
     // Start a single worker and make sure it waits and then goes to work
     const fn1 = jest.fn(async () => {});
-    const worker1 = new TaskWorker(
-      'task1',
-      fn1,
-      knex,
-      logger,
-      Duration.fromMillis(10),
-      poller,
-    );
+    const worker1 = new TaskWorker('task1', fn1, knex, logger, poller);
     await worker1.start(settings, { signal: abortFirst.signal });
 
     expect(fn1).toHaveBeenCalledTimes(0);
@@ -382,14 +338,7 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
     // Start a second worker and make sure it waits but the first worker still works along
     const fn2 = jest.fn();
     const promise2 = new Promise(resolve => fn2.mockImplementation(resolve));
-    const worker2 = new TaskWorker(
-      'task1',
-      fn2,
-      knex,
-      logger,
-      Duration.fromMillis(10),
-      poller,
-    );
+    const worker2 = new TaskWorker('task1', fn2, knex, logger, poller);
     await worker2.start(settings, { signal: testScopedSignal() });
 
     // We eventually abort the first worker just to make sure that the second
@@ -412,14 +361,7 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       timeoutAfterDuration: 'PT1M',
     };
 
-    const worker = new TaskWorker(
-      'task99',
-      fn,
-      knex,
-      logger,
-      undefined,
-      poller,
-    );
+    const worker = new TaskWorker('task99', fn, knex, logger, poller);
     await worker.persistTask(settings);
     const row1 = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
 
@@ -458,14 +400,7 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       timeoutAfterDuration: 'PT1M',
     };
 
-    const worker = new TaskWorker(
-      'task99',
-      fn,
-      knex,
-      logger,
-      undefined,
-      poller,
-    );
+    const worker = new TaskWorker('task99', fn, knex, logger, poller);
     await worker.persistTask(initialSettings);
     // replicate task running, sets next_run_start_at based on cadence
     await worker.tryClaimTask('ticket', initialSettings);
@@ -517,14 +452,7 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       timeoutAfterDuration: 'PT1M',
     };
 
-    const worker = new TaskWorker(
-      'task99',
-      fn,
-      knex,
-      logger,
-      undefined,
-      poller,
-    );
+    const worker = new TaskWorker('task99', fn, knex, logger, poller);
     await worker.persistTask(initialSettings);
     // replicate task running, sets next_run_start_at based on cadence
     await worker.tryClaimTask('ticket', initialSettings);
@@ -575,14 +503,7 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       timeoutAfterDuration: 'PT1M',
     };
 
-    const worker = new TaskWorker(
-      'task99',
-      fn,
-      knex,
-      logger,
-      undefined,
-      poller,
-    );
+    const worker = new TaskWorker('task99', fn, knex, logger, poller);
     await worker.persistTask(initialSettings);
     await worker.tryClaimTask('ticket', initialSettings);
     await worker.tryReleaseTask('ticket', initialSettings);
@@ -600,7 +521,7 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       timeoutAfterDuration: Duration.fromObject({ minutes: 1 }).toISO()!,
     };
 
-    const worker = new TaskWorker('task1', fn, knex, logger, undefined, poller);
+    const worker = new TaskWorker('task1', fn, knex, logger, poller);
     await worker.persistTask(settings);
     await worker.tryClaimTask('ticket', settings);
 
@@ -634,7 +555,7 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       timeoutAfterDuration: Duration.fromObject({ minutes: 1 }).toISO()!,
     };
 
-    const worker = new TaskWorker('task1', fn, knex, logger, undefined, poller);
+    const worker = new TaskWorker('task1', fn, knex, logger, poller);
     await worker.persistTask(settings);
 
     await expect(TaskWorker.cancel(knex, 'task1')).rejects.toThrow(

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.test.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.test.ts
@@ -35,19 +35,23 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
 
   let knex: Awaited<ReturnType<typeof databases.init>>;
   let poller: TaskStatePoller;
+  let pollerAbort: AbortController;
 
   beforeEach(async () => {
     knex = await databases.init(databaseId);
     await migrateBackendTasks(knex);
+    pollerAbort = new AbortController();
     poller = new TaskStatePoller(
       knex,
-      Duration.fromObject({ seconds: 1 }),
+      Duration.fromObject({ milliseconds: 100 }),
       logger,
     );
+    poller.start(pollerAbort.signal);
     jest.resetAllMocks();
   });
 
   afterEach(async () => {
+    pollerAbort.abort();
     await knex?.destroy();
   });
 

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.test.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.test.ts
@@ -41,11 +41,11 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
     knex = await databases.init(databaseId);
     await migrateBackendTasks(knex);
     pollerAbort = new AbortController();
-    poller = new TaskStatePoller(
+    poller = new TaskStatePoller({
       knex,
-      Duration.fromObject({ milliseconds: 100 }),
+      pollInterval: Duration.fromObject({ milliseconds: 100 }),
       logger,
-    );
+    });
     poller.start(pollerAbort.signal);
     jest.resetAllMocks();
   });

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.test.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.test.ts
@@ -21,6 +21,7 @@ import waitForExpect from 'wait-for-expect';
 import { migrateBackendTasks } from '../database/migrateBackendTasks';
 import { DB_TASKS_TABLE, DbTasksRow } from '../database/tables';
 import { TaskWorker } from './TaskWorker';
+import { TaskStatePoller } from './TaskStatePoller';
 import { createTestScopedSignal } from './__testUtils__/createTestScopedSignal';
 import { TaskSettingsV2 } from './types';
 
@@ -33,10 +34,16 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
   const testScopedSignal = createTestScopedSignal();
 
   let knex: Awaited<ReturnType<typeof databases.init>>;
+  let poller: TaskStatePoller;
 
   beforeEach(async () => {
     knex = await databases.init(databaseId);
     await migrateBackendTasks(knex);
+    poller = new TaskStatePoller(
+      knex,
+      Duration.fromObject({ seconds: 1 }),
+      logger,
+    );
     jest.resetAllMocks();
   });
 
@@ -55,7 +62,7 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       timeoutAfterDuration: Duration.fromObject({ minutes: 1 }).toISO()!,
     };
 
-    const worker = new TaskWorker('task1', fn, knex, logger);
+    const worker = new TaskWorker('task1', fn, knex, logger, undefined, poller);
     await worker.persistTask(settings);
 
     let row = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
@@ -169,7 +176,14 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       timeoutAfterDuration: Duration.fromMillis(60000).toISO()!,
     };
     const checkFrequency = Duration.fromObject({ milliseconds: 100 });
-    const worker = new TaskWorker('task1', fn, knex, logger, checkFrequency);
+    const worker = new TaskWorker(
+      'task1',
+      fn,
+      knex,
+      logger,
+      checkFrequency,
+      poller,
+    );
     worker.start(settings, { signal: testScopedSignal() });
 
     await waitForExpect(async () => {
@@ -199,7 +213,14 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       timeoutAfterDuration: Duration.fromMillis(60000).toISO()!,
     };
     const checkFrequency = Duration.fromObject({ milliseconds: 100 });
-    const worker = new TaskWorker('task1', fn, knex, logger, checkFrequency);
+    const worker = new TaskWorker(
+      'task1',
+      fn,
+      knex,
+      logger,
+      checkFrequency,
+      poller,
+    );
     worker.start(settings, { signal: testScopedSignal() });
 
     await waitForExpect(() => {
@@ -218,7 +239,7 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       timeoutAfterDuration: Duration.fromMillis(60000).toISO()!,
     };
 
-    const worker = new TaskWorker('task1', fn, knex, logger);
+    const worker = new TaskWorker('task1', fn, knex, logger, undefined, poller);
     await worker.persistTask(settings);
 
     await waitForExpect(async () => {
@@ -268,14 +289,28 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       timeoutAfterDuration: Duration.fromMillis(60000).toISO()!,
     };
 
-    const worker1 = new TaskWorker('task1', fn, knex, logger);
+    const worker1 = new TaskWorker(
+      'task1',
+      fn,
+      knex,
+      logger,
+      undefined,
+      poller,
+    );
     await worker1.persistTask(settings);
     await knex<DbTasksRow>(DB_TASKS_TABLE).where('id', '=', 'task1').delete();
     await expect(worker1.findReadyTask()).resolves.toEqual({
       result: 'abort',
     });
 
-    const worker2 = new TaskWorker('task2', fn, knex, logger);
+    const worker2 = new TaskWorker(
+      'task2',
+      fn,
+      knex,
+      logger,
+      undefined,
+      poller,
+    );
     await worker2.persistTask(settings);
 
     await waitForExpect(async () => {
@@ -288,7 +323,14 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
     await knex<DbTasksRow>(DB_TASKS_TABLE).where('id', '=', 'task2').delete();
     await expect(worker2.tryClaimTask('ticket', settings)).resolves.toBe(false);
 
-    const worker3 = new TaskWorker('task3', fn, knex, logger);
+    const worker3 = new TaskWorker(
+      'task3',
+      fn,
+      knex,
+      logger,
+      undefined,
+      poller,
+    );
     await worker3.persistTask(settings);
 
     await waitForExpect(async () => {
@@ -322,6 +364,7 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       knex,
       logger,
       Duration.fromMillis(10),
+      poller,
     );
     await worker1.start(settings, { signal: abortFirst.signal });
 
@@ -341,6 +384,7 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       knex,
       logger,
       Duration.fromMillis(10),
+      poller,
     );
     await worker2.start(settings, { signal: testScopedSignal() });
 
@@ -364,7 +408,14 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       timeoutAfterDuration: 'PT1M',
     };
 
-    const worker = new TaskWorker('task99', fn, knex, logger);
+    const worker = new TaskWorker(
+      'task99',
+      fn,
+      knex,
+      logger,
+      undefined,
+      poller,
+    );
     await worker.persistTask(settings);
     const row1 = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
 
@@ -403,7 +454,14 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       timeoutAfterDuration: 'PT1M',
     };
 
-    const worker = new TaskWorker('task99', fn, knex, logger);
+    const worker = new TaskWorker(
+      'task99',
+      fn,
+      knex,
+      logger,
+      undefined,
+      poller,
+    );
     await worker.persistTask(initialSettings);
     // replicate task running, sets next_run_start_at based on cadence
     await worker.tryClaimTask('ticket', initialSettings);
@@ -455,7 +513,14 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       timeoutAfterDuration: 'PT1M',
     };
 
-    const worker = new TaskWorker('task99', fn, knex, logger);
+    const worker = new TaskWorker(
+      'task99',
+      fn,
+      knex,
+      logger,
+      undefined,
+      poller,
+    );
     await worker.persistTask(initialSettings);
     // replicate task running, sets next_run_start_at based on cadence
     await worker.tryClaimTask('ticket', initialSettings);
@@ -506,7 +571,14 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       timeoutAfterDuration: 'PT1M',
     };
 
-    const worker = new TaskWorker('task99', fn, knex, logger);
+    const worker = new TaskWorker(
+      'task99',
+      fn,
+      knex,
+      logger,
+      undefined,
+      poller,
+    );
     await worker.persistTask(initialSettings);
     await worker.tryClaimTask('ticket', initialSettings);
     await worker.tryReleaseTask('ticket', initialSettings);
@@ -524,7 +596,7 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       timeoutAfterDuration: Duration.fromObject({ minutes: 1 }).toISO()!,
     };
 
-    const worker = new TaskWorker('task1', fn, knex, logger);
+    const worker = new TaskWorker('task1', fn, knex, logger, undefined, poller);
     await worker.persistTask(settings);
     await worker.tryClaimTask('ticket', settings);
 
@@ -558,7 +630,7 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       timeoutAfterDuration: Duration.fromObject({ minutes: 1 }).toISO()!,
     };
 
-    const worker = new TaskWorker('task1', fn, knex, logger);
+    const worker = new TaskWorker('task1', fn, knex, logger, undefined, poller);
     await worker.persistTask(settings);
 
     await expect(TaskWorker.cancel(knex, 'task1')).rejects.toThrow(

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.test.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.test.ts
@@ -21,6 +21,7 @@ import waitForExpect from 'wait-for-expect';
 import { migrateBackendTasks } from '../database/migrateBackendTasks';
 import { DB_TASKS_TABLE, DbTasksRow } from '../database/tables';
 import { TaskWorker } from './TaskWorker';
+import { TaskStatePoller } from './TaskStatePoller';
 import { createTestScopedSignal } from './__testUtils__/createTestScopedSignal';
 import { TaskSettingsV2 } from './types';
 
@@ -33,10 +34,15 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
   const testScopedSignal = createTestScopedSignal();
 
   let knex: Awaited<ReturnType<typeof databases.init>>;
+  let poller: TaskStatePoller;
 
   beforeEach(async () => {
     knex = await databases.init(databaseId);
     await migrateBackendTasks(knex);
+    poller = new TaskStatePoller({
+      knex,
+      logger,
+    });
     jest.resetAllMocks();
   });
 
@@ -51,7 +57,7 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       timeoutAfterDuration: Duration.fromObject({ minutes: 1 }).toISO()!,
     };
 
-    const worker = new TaskWorker('task1', fn, knex, logger);
+    const worker = new TaskWorker('task1', fn, knex, logger, poller);
     await worker.persistTask(settings);
 
     let row = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
@@ -80,21 +86,6 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
         ],
       ]),
     );
-
-    // Note that this is timing sensitive - if things take too long between
-    // persistTask and findReadyTask, this test will fail. We set some margin
-    // of initialDelayDuration to cover for this, but if this turns out to be
-    // flaky, we may have to revisit how this test is written.
-    await expect(worker.findReadyTask()).resolves.toEqual({
-      result: 'not-ready-yet',
-    });
-
-    await waitForExpect(async () => {
-      await expect(worker.findReadyTask()).resolves.toEqual({
-        result: 'ready',
-        settings,
-      });
-    });
 
     row = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
     expect(row).toEqual(
@@ -164,8 +155,7 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       cadence: '* * * * * *',
       timeoutAfterDuration: Duration.fromMillis(60000).toISO()!,
     };
-    const checkFrequency = Duration.fromObject({ milliseconds: 100 });
-    const worker = new TaskWorker('task1', fn, knex, logger, checkFrequency);
+    const worker = new TaskWorker('task1', fn, knex, logger, poller);
     worker.start(settings, { signal: testScopedSignal() });
 
     await waitForExpect(async () => {
@@ -194,8 +184,14 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       cadence: '* * * * * *',
       timeoutAfterDuration: Duration.fromMillis(60000).toISO()!,
     };
-    const checkFrequency = Duration.fromObject({ milliseconds: 100 });
-    const worker = new TaskWorker('task1', fn, knex, logger, checkFrequency);
+    const worker = new TaskWorker(
+      'task1',
+      fn,
+      knex,
+      logger,
+      poller,
+      Duration.fromMillis(100),
+    );
     worker.start(settings, { signal: testScopedSignal() });
 
     await waitForExpect(() => {
@@ -212,8 +208,7 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       cadence: '* * * * * *',
       timeoutAfterDuration: Duration.fromMillis(60000).toISO()!,
     };
-    const checkFrequency = Duration.fromObject({ milliseconds: 50 });
-    const worker = new TaskWorker('task1', fn, knex, logger, checkFrequency);
+    const worker = new TaskWorker('task1', fn, knex, logger, poller);
     worker.start(settings, { signal: controller.signal });
 
     await waitForExpect(() => {
@@ -227,6 +222,55 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
     expect(fn.mock.calls.length).toBe(callsBeforeAbort);
   });
 
+  it.each(['PT0.01S', 'PT0S'])(
+    'does not use the %s task cadence for liveness checks',
+    async cadence => {
+      const controller = new AbortController();
+      let finishTask!: () => void;
+      const taskFinished = new Promise<void>(resolve => {
+        finishTask = resolve;
+      });
+      const fn = jest.fn(() => taskFinished);
+      const settings: TaskSettingsV2 = {
+        version: 2,
+        cadence,
+        timeoutAfterDuration: 'PT10S',
+      };
+      const livenessQueries: string[] = [];
+      const onQuery = (query: { sql: string }) => {
+        if (
+          query.sql.toLowerCase().startsWith('select') &&
+          query.sql.includes('current_run_ticket') &&
+          !query.sql.includes('next_run_start_at')
+        ) {
+          livenessQueries.push(query.sql);
+        }
+      };
+      knex.on('query', onQuery);
+
+      const worker = new TaskWorker(
+        'task1',
+        fn,
+        knex,
+        logger,
+        poller,
+        Duration.fromMillis(500),
+      );
+
+      try {
+        worker.start(settings, { signal: controller.signal });
+        await waitForExpect(() => expect(fn).toHaveBeenCalledTimes(1));
+        await new Promise(resolve => setTimeout(resolve, 150));
+
+        expect(livenessQueries).toHaveLength(0);
+      } finally {
+        controller.abort();
+        finishTask();
+        knex.off('query', onQuery);
+      }
+    },
+  );
+
   it('does not clobber ticket lock when stolen', async () => {
     const fn = jest.fn(
       async () => new Promise<void>(resolve => setTimeout(resolve, 50)),
@@ -238,15 +282,8 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       timeoutAfterDuration: Duration.fromMillis(60000).toISO()!,
     };
 
-    const worker = new TaskWorker('task1', fn, knex, logger);
+    const worker = new TaskWorker('task1', fn, knex, logger, poller);
     await worker.persistTask(settings);
-
-    await waitForExpect(async () => {
-      await expect(worker.findReadyTask()).resolves.toEqual({
-        result: 'ready',
-        settings,
-      });
-    });
 
     await expect(worker.tryClaimTask('ticket', settings)).resolves.toBe(true);
 
@@ -288,35 +325,14 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       timeoutAfterDuration: Duration.fromMillis(60000).toISO()!,
     };
 
-    const worker1 = new TaskWorker('task1', fn, knex, logger);
-    await worker1.persistTask(settings);
-    await knex<DbTasksRow>(DB_TASKS_TABLE).where('id', '=', 'task1').delete();
-    await expect(worker1.findReadyTask()).resolves.toEqual({
-      result: 'abort',
-    });
-
-    const worker2 = new TaskWorker('task2', fn, knex, logger);
+    const worker2 = new TaskWorker('task2', fn, knex, logger, poller);
     await worker2.persistTask(settings);
-
-    await waitForExpect(async () => {
-      await expect(worker2.findReadyTask()).resolves.toEqual({
-        result: 'ready',
-        settings,
-      });
-    });
 
     await knex<DbTasksRow>(DB_TASKS_TABLE).where('id', '=', 'task2').delete();
     await expect(worker2.tryClaimTask('ticket', settings)).resolves.toBe(false);
 
-    const worker3 = new TaskWorker('task3', fn, knex, logger);
+    const worker3 = new TaskWorker('task3', fn, knex, logger, poller);
     await worker3.persistTask(settings);
-
-    await waitForExpect(async () => {
-      await expect(worker3.findReadyTask()).resolves.toEqual({
-        result: 'ready',
-        settings,
-      });
-    });
 
     await expect(worker3.tryClaimTask('ticket', settings)).resolves.toBe(true);
     await knex<DbTasksRow>(DB_TASKS_TABLE).where('id', '=', 'task3').delete();
@@ -341,6 +357,7 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       fn1,
       knex,
       logger,
+      poller,
       Duration.fromMillis(10),
     );
     await worker1.start(settings, { signal: abortFirst.signal });
@@ -360,6 +377,7 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       fn2,
       knex,
       logger,
+      poller,
       Duration.fromMillis(10),
     );
     await worker2.start(settings, { signal: testScopedSignal() });
@@ -384,7 +402,7 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       timeoutAfterDuration: 'PT1M',
     };
 
-    const worker = new TaskWorker('task99', fn, knex, logger);
+    const worker = new TaskWorker('task99', fn, knex, logger, poller);
     await worker.persistTask(settings);
     const row1 = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
 
@@ -423,7 +441,7 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       timeoutAfterDuration: 'PT1M',
     };
 
-    const worker = new TaskWorker('task99', fn, knex, logger);
+    const worker = new TaskWorker('task99', fn, knex, logger, poller);
     await worker.persistTask(initialSettings);
     // replicate task running, sets next_run_start_at based on cadence
     await worker.tryClaimTask('ticket', initialSettings);
@@ -475,7 +493,7 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       timeoutAfterDuration: 'PT1M',
     };
 
-    const worker = new TaskWorker('task99', fn, knex, logger);
+    const worker = new TaskWorker('task99', fn, knex, logger, poller);
     await worker.persistTask(initialSettings);
     // replicate task running, sets next_run_start_at based on cadence
     await worker.tryClaimTask('ticket', initialSettings);
@@ -526,7 +544,7 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       timeoutAfterDuration: 'PT1M',
     };
 
-    const worker = new TaskWorker('task99', fn, knex, logger);
+    const worker = new TaskWorker('task99', fn, knex, logger, poller);
     await worker.persistTask(initialSettings);
     await worker.tryClaimTask('ticket', initialSettings);
     await worker.tryReleaseTask('ticket', initialSettings);
@@ -544,7 +562,7 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       timeoutAfterDuration: Duration.fromObject({ minutes: 1 }).toISO()!,
     };
 
-    const worker = new TaskWorker('task1', fn, knex, logger);
+    const worker = new TaskWorker('task1', fn, knex, logger, poller);
     await worker.persistTask(settings);
     await worker.tryClaimTask('ticket', settings);
 
@@ -578,7 +596,7 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       timeoutAfterDuration: Duration.fromObject({ minutes: 1 }).toISO()!,
     };
 
-    const worker = new TaskWorker('task1', fn, knex, logger);
+    const worker = new TaskWorker('task1', fn, knex, logger, poller);
     await worker.persistTask(settings);
 
     await expect(TaskWorker.cancel(knex, 'task1')).rejects.toThrow(
@@ -597,7 +615,7 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       timeoutAfterDuration: 'PT1M',
     };
 
-    const worker = new TaskWorker('task99', fn, knex, logger);
+    const worker = new TaskWorker('task99', fn, knex, logger, poller);
     await worker.persistTask(manualSettings);
 
     const rowBeforeTransition = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
@@ -632,7 +650,7 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       timeoutAfterDuration: 'PT1M',
     };
 
-    const worker = new TaskWorker('task99', fn, knex, logger);
+    const worker = new TaskWorker('task99', fn, knex, logger, poller);
     await worker.persistTask(manualSettings);
 
     const rowBeforeTransition = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.ts
@@ -34,11 +34,7 @@ import {
   serializeError,
 } from './util';
 import { SchedulerServiceTaskFunction } from '@backstage/backend-plugin-api';
-import {
-  TaskListener,
-  TaskPollResult,
-  TaskStatePoller,
-} from './TaskStatePoller';
+import { TaskListener, TaskStatePoller } from './TaskStatePoller';
 
 const DEFAULT_WORK_CHECK_FREQUENCY = Duration.fromObject({ seconds: 5 });
 
@@ -236,16 +232,13 @@ export class TaskWorker {
     listener: TaskListener,
     signal: AbortSignal,
   ): Promise<
-    | { result: 'not-ready-yet' }
     | { result: 'abort' }
+    | { result: 'claim-lost' }
     | { result: 'failed' }
     | { result: 'completed' }
   > {
-    const findResult: TaskPollResult = await listener.waitForReady();
-    if (
-      findResult.result === 'not-ready-yet' ||
-      findResult.result === 'abort'
-    ) {
+    const findResult = await listener.waitForReady();
+    if (findResult.result === 'abort') {
       return findResult;
     }
     return this.claimAndRun(findResult.settings, signal);
@@ -255,13 +248,13 @@ export class TaskWorker {
     taskSettings: TaskSettingsV2,
     signal: AbortSignal,
   ): Promise<
-    { result: 'not-ready-yet' } | { result: 'failed' } | { result: 'completed' }
+    { result: 'claim-lost' } | { result: 'failed' } | { result: 'completed' }
   > {
     const ticket = uuid();
 
     const claimed = await this.tryClaimTask(ticket, taskSettings);
     if (!claimed) {
-      return { result: 'not-ready-yet' };
+      return { result: 'claim-lost' };
     }
 
     // Abort the task execution either if the worker is stopped, or if the

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.ts
@@ -36,7 +36,7 @@ import {
 import { SchedulerServiceTaskFunction } from '@backstage/backend-plugin-api';
 import { TaskListener, TaskStatePoller } from './TaskStatePoller';
 
-const DEFAULT_WORK_CHECK_FREQUENCY = Duration.fromObject({ seconds: 5 });
+const LIVENESS_CHECK_INTERVAL = Duration.fromObject({ seconds: 5 });
 
 /**
  * Implements tasks that run across worker hosts, with collaborative locking.
@@ -51,7 +51,6 @@ export class TaskWorker {
   private readonly fn: SchedulerServiceTaskFunction;
   private readonly knex: Knex;
   private readonly logger: LoggerService;
-  private readonly workCheckFrequency: Duration;
   private readonly poller: TaskStatePoller;
 
   constructor(
@@ -59,14 +58,12 @@ export class TaskWorker {
     fn: SchedulerServiceTaskFunction,
     knex: Knex,
     logger: LoggerService,
-    workCheckFrequency: Duration = DEFAULT_WORK_CHECK_FREQUENCY,
     poller: TaskStatePoller,
   ) {
     this.taskId = taskId;
     this.fn = fn;
     this.knex = knex;
     this.logger = logger;
-    this.workCheckFrequency = workCheckFrequency;
     this.poller = poller;
   }
 
@@ -271,7 +268,7 @@ export class TaskWorker {
         if (!taskAbortController.signal.aborted) {
           scheduleLivenessCheck();
         }
-      }, this.workCheckFrequency.as('milliseconds'));
+      }, LIVENESS_CHECK_INTERVAL.as('milliseconds'));
     };
     scheduleLivenessCheck();
 

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.ts
@@ -52,6 +52,7 @@ export class TaskWorker {
   private readonly knex: Knex;
   private readonly logger: LoggerService;
   private readonly workCheckFrequency: Duration;
+  private readonly poller: TaskStatePoller;
 
   constructor(
     taskId: string,
@@ -59,13 +60,14 @@ export class TaskWorker {
     knex: Knex,
     logger: LoggerService,
     workCheckFrequency: Duration = DEFAULT_WORK_CHECK_FREQUENCY,
-    private readonly poller?: TaskStatePoller,
+    poller: TaskStatePoller,
   ) {
     this.taskId = taskId;
     this.fn = fn;
     this.knex = knex;
     this.logger = logger;
     this.workCheckFrequency = workCheckFrequency;
+    this.poller = poller;
   }
 
   async start(settings: TaskSettingsV2, options: { signal: AbortSignal }) {
@@ -79,15 +81,6 @@ export class TaskWorker {
       `Registered scheduled task: ${this.taskId}, ${JSON.stringify(settings)}`,
     );
 
-    let workCheckFrequency = this.workCheckFrequency;
-    const isDuration = settings?.cadence.startsWith('P');
-    if (isDuration) {
-      const cadence = Duration.fromISO(settings.cadence);
-      if (cadence < workCheckFrequency) {
-        workCheckFrequency = cadence;
-      }
-    }
-
     (async () => {
       let attemptNum = 1;
       for (;;) {
@@ -95,14 +88,9 @@ export class TaskWorker {
           await this.performInitialWait(settings, options.signal);
 
           while (!options.signal.aborted) {
-            const runResult = this.poller
-              ? await this.runOnceViaPoller(options.signal)
-              : await this.runOnce(options.signal);
+            const runResult = await this.runOnceViaPoller(options.signal);
             if (runResult.result === 'abort') {
               break;
-            }
-            if (!this.poller) {
-              await sleep(workCheckFrequency, options.signal);
             }
           }
 
@@ -235,30 +223,8 @@ export class TaskWorker {
 
   /**
    * Makes a single attempt at running the task to completion, if ready.
-   * Uses direct DB query to check readiness.
-   */
-  private async runOnce(
-    signal: AbortSignal,
-  ): Promise<
-    | { result: 'not-ready-yet' }
-    | { result: 'abort' }
-    | { result: 'failed' }
-    | { result: 'completed' }
-  > {
-    const findResult = await this.findReadyTask();
-    if (
-      findResult.result === 'not-ready-yet' ||
-      findResult.result === 'abort'
-    ) {
-      return findResult;
-    }
-    return this.claimAndRun(findResult.settings, signal);
-  }
-
-  /**
-   * Like runOnce, but waits for the shared poller to signal readiness instead
-   * of querying the database directly. The poller's poll interval replaces
-   * the caller's sleep.
+   * Waits for the shared poller to signal readiness instead of querying
+   * the database directly.
    */
   private async runOnceViaPoller(
     signal: AbortSignal,
@@ -268,7 +234,7 @@ export class TaskWorker {
     | { result: 'failed' }
     | { result: 'completed' }
   > {
-    const findResult: TaskPollResult = await this.poller!.waitForReady(
+    const findResult: TaskPollResult = await this.poller.waitForReady(
       this.taskId,
       signal,
     );

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.ts
@@ -34,7 +34,11 @@ import {
   serializeError,
 } from './util';
 import { SchedulerServiceTaskFunction } from '@backstage/backend-plugin-api';
-import { TaskPollResult, TaskStatePoller } from './TaskStatePoller';
+import {
+  TaskListener,
+  TaskPollResult,
+  TaskStatePoller,
+} from './TaskStatePoller';
 
 const DEFAULT_WORK_CHECK_FREQUENCY = Duration.fromObject({ seconds: 5 });
 
@@ -81,6 +85,8 @@ export class TaskWorker {
       `Registered scheduled task: ${this.taskId}, ${JSON.stringify(settings)}`,
     );
 
+    const listener = this.poller.setupListener(this.taskId);
+
     (async () => {
       let attemptNum = 1;
       for (;;) {
@@ -88,7 +94,7 @@ export class TaskWorker {
           await this.performInitialWait(settings, options.signal);
 
           while (!options.signal.aborted) {
-            const runResult = await this.runOnce(options.signal);
+            const runResult = await this.runOnce(listener, options.signal);
             if (runResult.result === 'abort') {
               break;
             }
@@ -227,6 +233,7 @@ export class TaskWorker {
    * the database directly.
    */
   private async runOnce(
+    listener: TaskListener,
     signal: AbortSignal,
   ): Promise<
     | { result: 'not-ready-yet' }
@@ -234,10 +241,7 @@ export class TaskWorker {
     | { result: 'failed' }
     | { result: 'completed' }
   > {
-    const findResult: TaskPollResult = await this.poller.waitForReady(
-      this.taskId,
-      signal,
-    );
+    const findResult: TaskPollResult = await listener.waitForReady();
     if (
       findResult.result === 'not-ready-yet' ||
       findResult.result === 'abort'

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.ts
@@ -34,6 +34,7 @@ import {
   serializeError,
 } from './util';
 import { SchedulerServiceTaskFunction } from '@backstage/backend-plugin-api';
+import { TaskPollResult, TaskStatePoller } from './TaskStatePoller';
 
 const DEFAULT_WORK_CHECK_FREQUENCY = Duration.fromObject({ seconds: 5 });
 
@@ -58,6 +59,7 @@ export class TaskWorker {
     knex: Knex,
     logger: LoggerService,
     workCheckFrequency: Duration = DEFAULT_WORK_CHECK_FREQUENCY,
+    private readonly poller?: TaskStatePoller,
   ) {
     this.taskId = taskId;
     this.fn = fn;
@@ -93,11 +95,15 @@ export class TaskWorker {
           await this.performInitialWait(settings, options.signal);
 
           while (!options.signal.aborted) {
-            const runResult = await this.runOnce(options.signal);
+            const runResult = this.poller
+              ? await this.runOnceViaPoller(options.signal)
+              : await this.runOnce(options.signal);
             if (runResult.result === 'abort') {
               break;
             }
-            await sleep(workCheckFrequency, options.signal);
+            if (!this.poller) {
+              await sleep(workCheckFrequency, options.signal);
+            }
           }
 
           this.logger.info(`Task worker finished: ${this.taskId}`);
@@ -229,8 +235,7 @@ export class TaskWorker {
 
   /**
    * Makes a single attempt at running the task to completion, if ready.
-   *
-   * @returns The outcome of the attempt
+   * Uses direct DB query to check readiness.
    */
   private async runOnce(
     signal: AbortSignal,
@@ -247,8 +252,41 @@ export class TaskWorker {
     ) {
       return findResult;
     }
+    return this.claimAndRun(findResult.settings, signal);
+  }
 
-    const taskSettings = findResult.settings;
+  /**
+   * Like runOnce, but waits for the shared poller to signal readiness instead
+   * of querying the database directly. The poller's poll interval replaces
+   * the caller's sleep.
+   */
+  private async runOnceViaPoller(
+    signal: AbortSignal,
+  ): Promise<
+    | { result: 'not-ready-yet' }
+    | { result: 'abort' }
+    | { result: 'failed' }
+    | { result: 'completed' }
+  > {
+    const findResult: TaskPollResult = await this.poller!.waitForReady(
+      this.taskId,
+      signal,
+    );
+    if (
+      findResult.result === 'not-ready-yet' ||
+      findResult.result === 'abort'
+    ) {
+      return findResult;
+    }
+    return this.claimAndRun(findResult.settings, signal);
+  }
+
+  private async claimAndRun(
+    taskSettings: TaskSettingsV2,
+    signal: AbortSignal,
+  ): Promise<
+    { result: 'not-ready-yet' } | { result: 'failed' } | { result: 'completed' }
+  > {
     const ticket = uuid();
 
     const claimed = await this.tryClaimTask(ticket, taskSettings);

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.ts
@@ -88,7 +88,7 @@ export class TaskWorker {
           await this.performInitialWait(settings, options.signal);
 
           while (!options.signal.aborted) {
-            const runResult = await this.runOnceViaPoller(options.signal);
+            const runResult = await this.runOnce(options.signal);
             if (runResult.result === 'abort') {
               break;
             }
@@ -226,7 +226,7 @@ export class TaskWorker {
    * Waits for the shared poller to signal readiness instead of querying
    * the database directly.
    */
-  private async runOnceViaPoller(
+  private async runOnce(
     signal: AbortSignal,
   ): Promise<
     | { result: 'not-ready-yet' }

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.ts
@@ -34,6 +34,7 @@ import {
   serializeError,
 } from './util';
 import { SchedulerServiceTaskFunction } from '@backstage/backend-plugin-api';
+import { TaskStatePoller } from './TaskStatePoller';
 
 const DEFAULT_WORK_CHECK_FREQUENCY = Duration.fromObject({ seconds: 5 });
 
@@ -50,6 +51,7 @@ export class TaskWorker {
   private readonly fn: SchedulerServiceTaskFunction;
   private readonly knex: Knex;
   private readonly logger: LoggerService;
+  private readonly poller: TaskStatePoller;
   private readonly workCheckFrequency: Duration;
 
   constructor(
@@ -57,12 +59,14 @@ export class TaskWorker {
     fn: SchedulerServiceTaskFunction,
     knex: Knex,
     logger: LoggerService,
+    poller: TaskStatePoller,
     workCheckFrequency: Duration = DEFAULT_WORK_CHECK_FREQUENCY,
   ) {
     this.taskId = taskId;
     this.fn = fn;
     this.knex = knex;
     this.logger = logger;
+    this.poller = poller;
     this.workCheckFrequency = workCheckFrequency;
   }
 
@@ -78,10 +82,10 @@ export class TaskWorker {
     );
 
     let workCheckFrequency = this.workCheckFrequency;
-    const isDuration = settings?.cadence.startsWith('P');
+    const isDuration = settings.cadence.startsWith('P');
     if (isDuration) {
       const cadence = Duration.fromISO(settings.cadence);
-      if (cadence < workCheckFrequency) {
+      if (cadence.as('milliseconds') > 0 && cadence < workCheckFrequency) {
         workCheckFrequency = cadence;
       }
     }
@@ -93,11 +97,13 @@ export class TaskWorker {
           await this.performInitialWait(settings, options.signal);
 
           while (!options.signal.aborted) {
-            const runResult = await this.runOnce(options.signal);
+            const runResult = await this.runOnce(
+              options.signal,
+              workCheckFrequency,
+            );
             if (runResult.result === 'abort') {
               break;
             }
-            await sleep(workCheckFrequency, options.signal);
           }
 
           this.logger.info(`Task worker finished: ${this.taskId}`);
@@ -232,31 +238,39 @@ export class TaskWorker {
 
   /**
    * Makes a single attempt at running the task to completion, if ready.
-   *
-   * @returns The outcome of the attempt
+   * Waits for the shared poller to signal readiness instead of querying
+   * the database directly.
    */
   private async runOnce(
     signal: AbortSignal,
+    workCheckFrequency: Duration,
   ): Promise<
-    | { result: 'not-ready-yet' }
     | { result: 'abort' }
+    | { result: 'claim-lost' }
     | { result: 'failed' }
     | { result: 'completed' }
   > {
-    const findResult = await this.findReadyTask();
-    if (
-      findResult.result === 'not-ready-yet' ||
-      findResult.result === 'abort'
-    ) {
+    const findResult = await this.poller.waitForTask(this.taskId, {
+      signal,
+      pollInterval: workCheckFrequency,
+    });
+    if (findResult.result === 'abort') {
       return findResult;
     }
+    return this.claimAndRun(findResult.settings, signal);
+  }
 
-    const taskSettings = findResult.settings;
+  private async claimAndRun(
+    taskSettings: TaskSettingsV2,
+    signal: AbortSignal,
+  ): Promise<
+    { result: 'claim-lost' } | { result: 'failed' } | { result: 'completed' }
+  > {
     const ticket = uuid();
 
     const claimed = await this.tryClaimTask(ticket, taskSettings);
     if (!claimed) {
-      return { result: 'not-ready-yet' };
+      return { result: 'claim-lost' };
     }
 
     // Abort the task execution either if the worker is stopped, or if the
@@ -405,49 +419,6 @@ export class TaskWorker {
       this.logger.warn(
         `Failed to check liveness for task "${this.taskId}", ${e}`,
       );
-    }
-  }
-
-  /**
-   * Check if the task is ready to run
-   */
-  async findReadyTask(): Promise<
-    | { result: 'not-ready-yet' }
-    | { result: 'abort' }
-    | { result: 'ready'; settings: TaskSettingsV2 }
-  > {
-    const [row] = await this.knex<DbTasksRow>(DB_TASKS_TABLE)
-      .where('id', '=', this.taskId)
-      .select({
-        settingsJson: 'settings_json',
-        ready: this.knex.raw(
-          `CASE
-            WHEN next_run_start_at <= ? AND current_run_ticket IS NULL THEN TRUE
-            ELSE FALSE
-          END`,
-          [this.knex.fn.now()],
-        ),
-      });
-
-    if (!row) {
-      this.logger.info(
-        'No longer able to find task; aborting and assuming that it has been unregistered or expired',
-      );
-      return { result: 'abort' };
-    } else if (!row.ready) {
-      return { result: 'not-ready-yet' };
-    }
-
-    try {
-      const obj = JSON.parse(row.settingsJson);
-      const settings = taskSettingsV2Schema.parse(obj);
-      return { result: 'ready', settings };
-    } catch (e) {
-      this.logger.info(
-        `Task "${this.taskId}" is no longer able to parse task settings; aborting and assuming that a ` +
-          `newer version of the task has been issued and being handled by other workers, ${e}`,
-      );
-      return { result: 'abort' };
     }
   }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

## Summary

Global scheduler workers previously queried the task table independently while waiting for work. This adds an internal task-state poller shared by the global tasks registered by each plugin on a backend instance.

- Batches all currently waiting task IDs into one readiness query per plugin poll cycle
- Preserves task-specific polling cadence and liveness-check timing, including sub-five-second duration schedules
- Keeps cancellation scoped to each worker and cleans up its abort listener and timer state
- Polls only while tasks are waiting, without an immediate repoll after a ready or lost-claim result

There are no public API changes.

## Test plan

- Added database-backed coverage for batched query counts, ready/running/missing/invalid tasks, mixed polling cadences, cancellation cleanup, and post-readiness cooldown
- `BACKSTAGE_TEST_DISABLE_DOCKER=1 CI=1 yarn test packages/backend-defaults/src/entrypoints/scheduler/lib/TaskStatePoller.test.ts packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.test.ts packages/backend-defaults/src/entrypoints/scheduler/lib/PluginTaskSchedulerImpl.test.ts`
- `yarn tsc`
- `yarn lint --fix`
- `yarn build:api-reports`

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation (not applicable; this changes no public API or configuration)
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (not applicable; no UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
