### PR TITLE
Fix cache eviction race in CachedUserInfoService

### DIFF
--- a/.changeset/cached-service-cleanup.md
+++ b/.changeset/cached-service-cleanup.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Fixed a race condition in `CachedUserInfoService` where a failed request could incorrectly evict a newer cache entry for the same token. The error handler now verifies the map entry is still the same promise before deleting it.

--- a/packages/backend-defaults/src/entrypoints/userInfo/CachedUserInfoService.test.ts
+++ b/packages/backend-defaults/src/entrypoints/userInfo/CachedUserInfoService.test.ts
@@ -19,6 +19,7 @@ import {
   UserInfoService,
 } from '@backstage/backend-plugin-api';
 import { mockCredentials } from '@backstage/backend-test-utils';
+import { createDeferred } from '@backstage/types';
 import {
   CachedUserInfoService,
   UserInfoCacheEntry,
@@ -129,10 +130,8 @@ describe('CachedUserInfoService', () => {
   });
 
   it('evicts eagerly so concurrent waiters see the rejection and the next call retries', async () => {
-    let rejectFirst: (error: Error) => void;
-    const firstCall = new Promise<BackstageUserInfo>((_resolve, reject) => {
-      rejectFirst = reject;
-    });
+    const firstCall = createDeferred<BackstageUserInfo>();
+    firstCall.catch(() => {});
 
     const delegate: UserInfoService = {
       getUserInfo: jest
@@ -146,7 +145,7 @@ describe('CachedUserInfoService', () => {
     const p1 = service.getUserInfo(creds);
     const p2 = service.getUserInfo(creds);
 
-    rejectFirst!(new Error('boom'));
+    firstCall.reject(new Error('boom'));
 
     await expect(p1).rejects.toThrow('boom');
     await expect(p2).rejects.toThrow('boom');

--- a/packages/backend-defaults/src/entrypoints/userInfo/CachedUserInfoService.ts
+++ b/packages/backend-defaults/src/entrypoints/userInfo/CachedUserInfoService.ts
@@ -73,7 +73,9 @@ export class CachedUserInfoService implements UserInfoService {
     }
 
     const promise = this.#delegate.getUserInfo(credentials).catch(error => {
-      this.#entries.delete(token);
+      if (this.#entries.get(token)?.promise === promise) {
+        this.#entries.delete(token);
+      }
       throw error;
     });
 


### PR DESCRIPTION
## Summary

- Guard the error-path `delete` in `CachedUserInfoService` so it only removes the entry if the map still holds the same promise. This prevents a stale rejection from evicting a newer cache entry for the same token.
- Switch the concurrent-rejection test to `createDeferred` from `@backstage/types` for readability.

Followup to #34252.

## Test plan

- [x] All 9 existing `CachedUserInfoService` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)