### PR TITLE
Add more details to the events support section in GitLab Discovery and Org docs

### DIFF
--- a/docs/integrations/gitlab/discovery.md
+++ b/docs/integrations/gitlab/discovery.md
@@ -37,17 +37,189 @@ Then add the following to your backend initialization:
 backend.add(import('@backstage/plugin-catalog-backend-module-gitlab'));
 ```
 
-You need to decide how you want to receive events from external sources like
+## Events Support
 
-- [via HTTP endpoint](https://github.com/backstage/backstage/blob/master/plugins/events-backend/README.md#configuration)
-- [via an AWS SQS queue](https://github.com/backstage/backstage/tree/master/plugins/events-backend-module-aws-sqs/README.md)
-- [via Google Pub/Sub](https://github.com/backstage/backstage/tree/master/plugins/events-backend-module-google-pubsub/README.md)
-- [via a Kafka topic](https://github.com/backstage/backstage/tree/master/plugins/events-backend-module-kafka/README.md)
+The catalog module for GitLab comes with events support enabled. This will make it subscribe to its relevant topics (`gitlab.push`) and expects these events to be published via the `EventsService`.
 
-Further documentation:
+### Prerequisites
 
-- [Events Plugin](https://github.com/backstage/backstage/tree/master/plugins/events-backend/README.md)
-- [GitLab Module for the Events Plugin](https://github.com/backstage/backstage/blob/master/plugins/events-backend-module-gitlab/README.md)
+There are two Prerequisites to use the builtin events support:
+
+1. Creating a group level or project level webhook in GitLab
+2. Installing and configuring `@backstage/plugin-events-backend-module-gitlab`
+
+#### Configure Webhooks in GitLab
+
+You can either configure group level webhooks or project level webhooks. Refer to the official docs on [how to configure them](https://docs.gitlab.com/user/project/integrations/webhooks/).
+
+The webhook(s) will need to be configured to react to `push` events.
+
+When creating the webhook in GitLab, the "URL" will look something like: `https://<your-instance-name>/api/events/http/gitlab`.
+
+#### Install and Configure GitLab Events Module
+
+In order to use the built-in events support you'll need to install and configure `@backstage/plugin-events-backend-module-gitlab`. This module will route received events from the generic topic `gitlab` to more specific ones based on the event type (e.g., `gitlab.push`). These more specific events are what the builtin events support is expecting.
+
+First we need to add the package:
+
+```bash title="from your Backstage root directory"
+yarn --cwd packages/backend add @backstage/plugin-events-backend-module-gitlab
+```
+
+Then we need to add it to your backend:
+
+```ts title="in packages/backend/src/index.ts"
+backend.add(import('@backstage/plugin-events-backend'));
+/* highlight-add-start */
+backend.add(import('@backstage/plugin-events-backend-module-gitlab'));
+/* highlight-add-end */
+```
+
+Finally you will want to configure it:
+
+```yaml title="app-config.yaml
+events:
+  modules:
+    gitlab:
+      webhookSecret: ${GITLAB_WEBHOOK_SECRET}
+```
+
+Though this last step is technically optional, you'll want to include it to be sure the events being received are from GitLab and not from an external bad actor.
+
+The value of `${GITLAB_WEBHOOK_SECRET}` in this example would be the same that you used when creating the webhook on GitLab.
+
+### Events Setup using HTTP endpoint
+
+Using the HTTP endpoint for events just requires adding some additional configuration to your `app-config.yaml` as it is a built in feature of the Events backend, here's what that would look like:
+
+```yaml title="app-config.yaml
+events:
+  http:
+    topics:
+      - gitlab
+```
+
+This will then expose an endpoint like this: <http://localhost/api/events/http/gitlab>
+
+### Events Setup using AWS SQS module
+
+Alternatively to using the HTTP endpoint you can use the AWS SQS module, here's how.
+
+First we need to add the package:
+
+```bash title="from your Backstage root directory"
+yarn --cwd packages/backend add @backstage/plugins-events-backend-module-aws-sqs
+```
+
+Then we need to add it to your backend:
+
+```ts title="in packages/backend/src/index.ts"
+backend.add(import('@backstage/plugin-events-backend'));
+backend.add(import('@backstage/plugin-events-backend-module-gitlab'));
+/* highlight-add-start */
+backend.add(import('@backstage/plugins-events-backend-module-aws-sqs'));
+/* highlight-add-end */
+```
+
+Finally you will want to configure it:
+
+```yaml title="app-config.yaml
+events:
+  modules:
+    awsSqs:
+      awsSqsConsumingEventPublisher:
+        topics:
+          gitlab:
+            queue:
+              url: 'https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue'
+              region: us-east-2
+```
+
+The [AWS SQS module `README`](https://github.com/backstage/backstage/blob/master/plugins/events-backend-module-aws-sqs/README.md#configuration) has more details on the configuration options, the example above includes only the required options.
+
+### Events Setup using Google Pub/Sub module
+
+Alternatively to using the HTTP endpoint you can use the Google Pub/Sub module, here's how.
+
+First we need to add the package:
+
+```bash title="from your Backstage root directory"
+yarn --cwd packages/backend add @backstage/plugin-events-backend-module-google-pubsub
+```
+
+Then we need to add it to your backend:
+
+```ts title="in packages/backend/src/index.ts"
+backend.add(import('@backstage/plugin-events-backend'));
+backend.add(import('@backstage/plugin-events-backend-module-gitlab'));
+/* highlight-add-start */
+backend.add(import('@backstage/plugin-events-backend-module-google-pubsub'));
+/* highlight-add-end */
+```
+
+Finally you will want to configure it:
+
+```yaml title="app-config.yaml
+events:
+  modules:
+    googlePubSub:
+      googlePubSubConsumingEventPublisher:
+        subscriptions:
+          # A unique key for your subscription, to be used in logging and metrics
+          mySubscription:
+            # The fully qualified name of the subscription
+            subscriptionName: 'projects/my-google-project/subscriptions/gitlab-events'
+            # The event system topic to transfer to. This can also be just a plain string
+            targetTopic: 'gitlab.{{ event.attributes.x-gitlab-event }}'
+```
+
+The [Google Pub/Sub module `README`](https://github.com/backstage/backstage/blob/master/plugins/events-backend-module-google-pubsub/README.md#configuration) has more details on the configuration options, the example above includes only the required options.
+
+### Events Setup using Kafka module
+
+Alternatively to using the HTTP endpoint you can use the Kafka module, here's how.
+
+First we need to add the package:
+
+```bash title="from your Backstage root directory"
+yarn --cwd packages/backend add @backstage/plugin-events-backend-module-kafka
+```
+
+Then we need to add it to your backend:
+
+```ts title="in packages/backend/src/index.ts"
+backend.add(import('@backstage/plugin-events-backend'));
+backend.add(import('@backstage/plugin-events-backend-module-gitlab'));
+/* highlight-add-start */
+backend.add(import('@backstage/plugin-events-backend-module-kafka'));
+/* highlight-add-end */
+```
+
+Finally you will want to configure it:
+
+```yaml title="app-config.yaml
+events:
+  modules:
+    kafka:
+      kafkaConsumingEventPublisher:
+        # Client ID used by Backstage to identify when connecting to the Kafka cluster.
+        clientId: your-client-id
+        # List of brokers in the Kafka cluster to connect to.
+        brokers:
+          - broker1
+          - broker2
+        topics:
+          # Replace with actual topic name as expected by subscribers
+          - topic: 'backstage.topic'
+            kafka:
+              # The Kafka topics to subscribe to.
+              topics:
+                - topic1
+              # The GroupId to be used by the topic consumers.
+              groupId: your-group-id
+```
+
+The [Kafka module `README`](https://github.com/backstage/backstage/blob/master/plugins/events-backend-module-kafka/README.md#configuration) has more details on the configuration options, the example above includes only the required options.
 
 ## Configuration
 

--- a/docs/integrations/gitlab/discovery.md
+++ b/docs/integrations/gitlab/discovery.md
@@ -60,29 +60,29 @@ When creating the webhook in GitLab, the "URL" will look something like: `https:
 
 In order to use the built-in events support you'll need to install and configure `@backstage/plugin-events-backend-module-gitlab`. This module will route received events from the generic topic `gitlab` to more specific ones based on the event type (e.g., `gitlab.push`). These more specific events are what the builtin events support is expecting.
 
-First we need to add the package:
+1. Add the GitLab events package:
 
-```bash title="from your Backstage root directory"
-yarn --cwd packages/backend add @backstage/plugin-events-backend-module-gitlab
-```
+   ```bash title="from your Backstage root directory"
+   yarn --cwd packages/backend add @backstage/plugin-events-backend-module-gitlab
+   ```
 
-Then we need to add it to your backend:
+2. Add the GitLab events module to your Backstage backend:
 
-```ts title="in packages/backend/src/index.ts"
-backend.add(import('@backstage/plugin-events-backend'));
-/* highlight-add-start */
-backend.add(import('@backstage/plugin-events-backend-module-gitlab'));
-/* highlight-add-end */
-```
+   ```ts title="in packages/backend/src/index.ts"
+   backend.add(import('@backstage/plugin-events-backend'));
+   /* highlight-add-start */
+   backend.add(import('@backstage/plugin-events-backend-module-gitlab'));
+   /* highlight-add-end */
+   ```
 
-Finally you will want to configure it:
+3. Configure the GitLab events module:
 
-```yaml title="app-config.yaml
-events:
-  modules:
-    gitlab:
-      webhookSecret: ${GITLAB_WEBHOOK_SECRET}
-```
+   ```yaml title="app-config.yaml"
+   events:
+     modules:
+       gitlab:
+         webhookSecret: ${GITLAB_WEBHOOK_SECRET}
+   ```
 
 Though this last step is technically optional, you'll want to include it to be sure the events being received are from GitLab and not from an external bad actor.
 
@@ -92,7 +92,7 @@ The value of `${GITLAB_WEBHOOK_SECRET}` in this example would be the same that y
 
 Using the HTTP endpoint for events just requires adding some additional configuration to your `app-config.yaml` as it is a built in feature of the Events backend, here's what that would look like:
 
-```yaml title="app-config.yaml
+```yaml title="app-config.yaml"
 events:
   http:
     topics:
@@ -105,35 +105,35 @@ This will then expose an endpoint like this: <http://localhost/api/events/http/g
 
 Alternatively to using the HTTP endpoint you can use the AWS SQS module, here's how.
 
-First we need to add the package:
+1. Add the AWS SQS events package:
 
-```bash title="from your Backstage root directory"
-yarn --cwd packages/backend add @backstage/plugins-events-backend-module-aws-sqs
-```
+   ```bash title="from your Backstage root directory"
+   yarn --cwd packages/backend add @backstage/plugins-events-backend-module-aws-sqs
+   ```
 
-Then we need to add it to your backend:
+2. Add the AWS SQS events module to your Backstage backend:
 
-```ts title="in packages/backend/src/index.ts"
-backend.add(import('@backstage/plugin-events-backend'));
-backend.add(import('@backstage/plugin-events-backend-module-gitlab'));
-/* highlight-add-start */
-backend.add(import('@backstage/plugins-events-backend-module-aws-sqs'));
-/* highlight-add-end */
-```
+   ```ts title="in packages/backend/src/index.ts"
+   backend.add(import('@backstage/plugin-events-backend'));
+   backend.add(import('@backstage/plugin-events-backend-module-gitlab'));
+   /* highlight-add-start */
+   backend.add(import('@backstage/plugins-events-backend-module-aws-sqs'));
+   /* highlight-add-end */
+   ```
 
-Finally you will want to configure it:
+3. Configure the AWS SQS events module:
 
-```yaml title="app-config.yaml
-events:
-  modules:
-    awsSqs:
-      awsSqsConsumingEventPublisher:
-        topics:
-          gitlab:
-            queue:
-              url: 'https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue'
-              region: us-east-2
-```
+   ```yaml title="app-config.yaml"
+   events:
+     modules:
+       awsSqs:
+         awsSqsConsumingEventPublisher:
+           topics:
+             gitlab:
+               queue:
+                 url: 'https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue'
+                 region: us-east-2
+   ```
 
 The [AWS SQS module `README`](https://github.com/backstage/backstage/blob/master/plugins/events-backend-module-aws-sqs/README.md#configuration) has more details on the configuration options, the example above includes only the required options.
 
@@ -141,37 +141,37 @@ The [AWS SQS module `README`](https://github.com/backstage/backstage/blob/master
 
 Alternatively to using the HTTP endpoint you can use the Google Pub/Sub module, here's how.
 
-First we need to add the package:
+1. Add the Google Pub/Sub events package:
 
-```bash title="from your Backstage root directory"
-yarn --cwd packages/backend add @backstage/plugin-events-backend-module-google-pubsub
-```
+   ```bash title="from your Backstage root directory"
+   yarn --cwd packages/backend add @backstage/plugin-events-backend-module-google-pubsub
+   ```
 
-Then we need to add it to your backend:
+2. Add the Google Pub/Sub events module to your Backstage backend:
 
-```ts title="in packages/backend/src/index.ts"
-backend.add(import('@backstage/plugin-events-backend'));
-backend.add(import('@backstage/plugin-events-backend-module-gitlab'));
-/* highlight-add-start */
-backend.add(import('@backstage/plugin-events-backend-module-google-pubsub'));
-/* highlight-add-end */
-```
+   ```ts title="in packages/backend/src/index.ts"
+   backend.add(import('@backstage/plugin-events-backend'));
+   backend.add(import('@backstage/plugin-events-backend-module-gitlab'));
+   /* highlight-add-start */
+   backend.add(import('@backstage/plugin-events-backend-module-google-pubsub'));
+   /* highlight-add-end */
+   ```
 
-Finally you will want to configure it:
+3. Configure the Google Pub/Sub events module:
 
-```yaml title="app-config.yaml
-events:
-  modules:
-    googlePubSub:
-      googlePubSubConsumingEventPublisher:
-        subscriptions:
-          # A unique key for your subscription, to be used in logging and metrics
-          mySubscription:
-            # The fully qualified name of the subscription
-            subscriptionName: 'projects/my-google-project/subscriptions/gitlab-events'
-            # The event system topic to transfer to. This can also be just a plain string
-            targetTopic: 'gitlab.{{ event.attributes.x-gitlab-event }}'
-```
+   ```yaml title="app-config.yaml"
+   events:
+     modules:
+       googlePubSub:
+         googlePubSubConsumingEventPublisher:
+           subscriptions:
+             # A unique key for your subscription, to be used in logging and metrics
+             mySubscription:
+               # The fully qualified name of the subscription
+               subscriptionName: 'projects/my-google-project/subscriptions/gitlab-events'
+               # The event system topic to transfer to. This can also be just a plain string
+               targetTopic: 'gitlab.{{ event.attributes.x-gitlab-event }}'
+   ```
 
 The [Google Pub/Sub module `README`](https://github.com/backstage/backstage/blob/master/plugins/events-backend-module-google-pubsub/README.md#configuration) has more details on the configuration options, the example above includes only the required options.
 
@@ -179,45 +179,45 @@ The [Google Pub/Sub module `README`](https://github.com/backstage/backstage/blob
 
 Alternatively to using the HTTP endpoint you can use the Kafka module, here's how.
 
-First we need to add the package:
+1. Add the Kafka events package:
 
-```bash title="from your Backstage root directory"
-yarn --cwd packages/backend add @backstage/plugin-events-backend-module-kafka
-```
+   ```bash title="from your Backstage root directory"
+   yarn --cwd packages/backend add @backstage/plugin-events-backend-module-kafka
+   ```
 
-Then we need to add it to your backend:
+2. Add the Kafka events module to your Backstage backend:
 
-```ts title="in packages/backend/src/index.ts"
-backend.add(import('@backstage/plugin-events-backend'));
-backend.add(import('@backstage/plugin-events-backend-module-gitlab'));
-/* highlight-add-start */
-backend.add(import('@backstage/plugin-events-backend-module-kafka'));
-/* highlight-add-end */
-```
+   ```ts title="in packages/backend/src/index.ts"
+   backend.add(import('@backstage/plugin-events-backend'));
+   backend.add(import('@backstage/plugin-events-backend-module-gitlab'));
+   /* highlight-add-start */
+   backend.add(import('@backstage/plugin-events-backend-module-kafka'));
+   /* highlight-add-end */
+   ```
 
-Finally you will want to configure it:
+3. Configure the Kafka events module:
 
-```yaml title="app-config.yaml
-events:
-  modules:
-    kafka:
-      kafkaConsumingEventPublisher:
-        # Client ID used by Backstage to identify when connecting to the Kafka cluster.
-        clientId: your-client-id
-        # List of brokers in the Kafka cluster to connect to.
-        brokers:
-          - broker1
-          - broker2
-        topics:
-          # Replace with actual topic name as expected by subscribers
-          - topic: 'backstage.topic'
-            kafka:
-              # The Kafka topics to subscribe to.
-              topics:
-                - topic1
-              # The GroupId to be used by the topic consumers.
-              groupId: your-group-id
-```
+   ```yaml title="app-config.yaml"
+   events:
+     modules:
+       kafka:
+         kafkaConsumingEventPublisher:
+           # Client ID used by Backstage to identify when connecting to the Kafka cluster.
+           clientId: your-client-id
+           # List of brokers in the Kafka cluster to connect to.
+           brokers:
+             - broker1
+             - broker2
+           topics:
+             # Replace with actual topic name as expected by subscribers
+             - topic: 'backstage.topic'
+               kafka:
+                 # The Kafka topics to subscribe to.
+                 topics:
+                   - topic1
+                 # The GroupId to be used by the topic consumers.
+                 groupId: your-group-id
+   ```
 
 The [Kafka module `README`](https://github.com/backstage/backstage/blob/master/plugins/events-backend-module-kafka/README.md#configuration) has more details on the configuration options, the example above includes only the required options.
 

--- a/docs/integrations/gitlab/org.md
+++ b/docs/integrations/gitlab/org.md
@@ -66,7 +66,7 @@ Install and configure `@backstage/plugin-events-backend-module-gitlab` as descri
 
 ### Receiving events in Backstage
 
-Set up how your backstage instance recieves these events using one of the options below:
+Set up how your backstage instance receives these events using one of the options below:
 
 - [Events Setup using HTTP endpoint](./discovery.md#events-setup-using-http-endpoint)
 - [Events Setup using AWS SQS module](./discovery.md#events-setup-using-aws-sqs-module)

--- a/docs/integrations/gitlab/org.md
+++ b/docs/integrations/gitlab/org.md
@@ -66,7 +66,7 @@ Install and configure `@backstage/plugin-events-backend-module-gitlab` as descri
 
 ### Receiving events in Backstage
 
-Set up how your backstage instance receives these events using one of the options below:
+Set up how your Backstage instance receives these events using one of the options below:
 
 - [Events Setup using HTTP endpoint](./discovery.md#events-setup-using-http-endpoint)
 - [Events Setup using AWS SQS module](./discovery.md#events-setup-using-aws-sqs-module)

--- a/docs/integrations/gitlab/org.md
+++ b/docs/integrations/gitlab/org.md
@@ -11,16 +11,6 @@ groups -- directly from GitLab. The result is a hierarchy of
 [`Group`](../../features/software-catalog/descriptor-format.md#kind-group)
 entities that mirrors your org setup.
 
-This provider can also be configured to ingest GitLab data based on [GitLab System hooks](https://docs.gitlab.com/ee/administration/system_hooks.html). The events currently accepted are:
-
-- `group_create`
-- `group_destroy`
-- `group_rename`
-- `user_create`
-- `user_destroy`
-- `user_add_to_group`
-- `user_remove_from_group`
-
 ## Installation
 
 As this provider is not one of the default providers, you will first need to install the Gitlab provider plugin:
@@ -31,7 +21,7 @@ yarn --cwd packages/backend add @backstage/plugin-catalog-backend-module-gitlab 
 
 Then add the following to your backend initialization:
 
-```ts title="packages/backend/src/index.ts
+```ts title="packages/backend/src/index.ts"
 // optional if you want HTTP endpoints to receive external events
 // backend.add(import('@backstage/plugin-events-backend'));
 // optional if you want to use AWS SQS instead of HTTP endpoints to receive external events
@@ -43,18 +33,45 @@ Then add the following to your backend initialization:
 backend.add(import('@backstage/plugin-catalog-backend-module-gitlab-org'));
 ```
 
-You need to decide how you want to receive events from external sources like
+## Events Support
 
-- [via HTTP endpoint](https://github.com/backstage/backstage/blob/master/plugins/events-backend/README.md#configuration)
-- [via an AWS SQS queue](https://github.com/backstage/backstage/tree/master/plugins/events-backend-module-aws-sqs/README.md)
-- [via Google Pub/Sub](https://github.com/backstage/backstage/tree/master/plugins/events-backend-module-google-pubsub/README.md)
-- [via a Kafka topic](https://github.com/backstage/backstage/tree/master/plugins/events-backend-module-kafka/README.md)
+The catalog module for GitLab Org comes with events support enabled. This will make it subscribe to its relevant topics and expects these events to be published via the `EventsService`.
 
-Further documentation:
+The provider subscribes to the following topics:
 
-- [GitLab System hooks](https://docs.gitlab.com/ee/administration/system_hooks.html)
-- [Events Plugin](https://github.com/backstage/backstage/tree/master/plugins/events-backend/README.md)
-- [GitLab Module for the Events Plugin](https://github.com/backstage/backstage/blob/master/plugins/events-backend-module-gitlab/README.md)
+- `gitlab.group_create`
+- `gitlab.group_destroy`
+- `gitlab.group_rename`
+- `gitlab.user_create`
+- `gitlab.user_destroy`
+- `gitlab.user_add_to_group`
+- `gitlab.user_remove_from_group`
+
+### Prerequisites
+
+There are two prerequisites to use the builtin events support:
+
+1. Creating a system hook in GitLab
+2. Installing and configuring `@backstage/plugin-events-backend-module-gitlab`
+
+#### Configure a system hook in GitLab
+
+Refer to the official docs to [configure system hooks](https://docs.gitlab.com/ee/administration/system_hooks.html).
+
+The webhook(s) will need to be configured to react to `group_create`, `group_destroy`, `group_rename`, `user_create`, `user_destroy`, `user_add_to_group`, and `user_remove_from_group` events.
+
+#### Install and Configure GitLab Events Module
+
+Install and configure `@backstage/plugin-events-backend-module-gitlab` as described in [GitLab Discovery — Install and Configure GitLab Events Module](./discovery.md#install-and-configure-gitlab-events-module). The [gitlab events module](https://github.com/backstage/backstage/tree/master/plugins/events-backend-module-gitlab/README.md) routes received events from the generic topic `gitlab` to more specific ones based on the event type (for example, `gitlab.user_add_to_group`). These more specific events are what the builtin org events support expects.
+
+### Receiving events in Backstage
+
+Set up how your backstage instance recieves these events using one of the options below:
+
+- [Events Setup using HTTP endpoint](./discovery.md#events-setup-using-http-endpoint)
+- [Events Setup using AWS SQS module](./discovery.md#events-setup-using-aws-sqs-module)
+- [Events Setup using Google Pub/Sub module](./discovery.md#events-setup-using-google-pubsub-module)
+- [Events Setup using Kafka module](./discovery.md#events-setup-using-kafka-module)
 
 ## Configuration
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added some more details on how to setup events support for Gitlab Discovery and Org Data, which covers:

- Install and Configure GitHub Events Module
- Events Setup using HTTP endpoint, AWS SQS module, Google Pub/Sub module, Kafka module

I tried to keep the structure as close as possible to the events support section under GitHub Discovery

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
