### PR TITLE
Fix stitch queue race: wrap claim in transaction

### DIFF
--- a/.changeset/stitch-claim-transaction.md
+++ b/.changeset/stitch-claim-transaction.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Fixed a race condition in the stitch queue claim logic where the `SELECT FOR UPDATE SKIP LOCKED` row locks were released before the `next_stitch_at` bump, allowing multiple workers to claim the same entity. Both statements now run inside a single transaction.

--- a/.changeset/stitch-claim-transaction.md
+++ b/.changeset/stitch-claim-transaction.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend': patch
 ---
 
-Fixed a race condition in the stitch queue claim logic where the `SELECT FOR UPDATE SKIP LOCKED` row locks were released before the `next_stitch_at` bump, allowing multiple workers to claim the same entity. Both statements now run inside a single transaction.
+Fixed a race condition in the stitch queue and entity processing claim logic where `SELECT FOR UPDATE SKIP LOCKED` row locks were released before the subsequent timestamp bump, allowing multiple workers to claim the same rows. Both the select and update now run inside a single transaction for MySQL and PostgreSQL.

--- a/plugins/catalog-backend/src/database/DefaultProcessingDatabase.ts
+++ b/plugins/catalog-backend/src/database/DefaultProcessingDatabase.ts
@@ -229,7 +229,7 @@ export class DefaultProcessingDatabase implements ProcessingDatabase {
     // single transaction so that the row locks persist until
     // next_update_at has been bumped.
     const run = async (tx: Knex | Knex.Transaction) => {
-      const items = await tx<DbRefreshStateRow>('refresh_state')
+      const items: DbRefreshStateRow[] = await tx('refresh_state')
         .select([
           'entity_id',
           'entity_ref',
@@ -250,7 +250,7 @@ export class DefaultProcessingDatabase implements ProcessingDatabase {
         });
 
       if (items.length > 0) {
-        await tx<DbRefreshStateRow>('refresh_state')
+        await tx('refresh_state')
           .whereIn(
             'entity_ref',
             items.map(i => i.entity_ref),

--- a/plugins/catalog-backend/src/database/DefaultProcessingDatabase.ts
+++ b/plugins/catalog-backend/src/database/DefaultProcessingDatabase.ts
@@ -207,49 +207,65 @@ export class DefaultProcessingDatabase implements ProcessingDatabase {
     request: { processBatchSize: number },
   ): Promise<GetProcessableEntitiesResult> {
     const knex = maybeTx as Knex.Transaction | Knex;
-
-    let itemsQuery = knex<DbRefreshStateRow>('refresh_state').select([
-      'entity_id',
-      'entity_ref',
-      'unprocessed_entity',
-      'result_hash',
-      'cache',
-      'errors',
-      'location_key',
-      'next_update_at',
-    ]);
-
-    // This avoids duplication of work because of race conditions and is
-    // also fast because locked rows are ignored rather than blocking.
-    // It's only available in MySQL and PostgreSQL
-    if (['mysql', 'mysql2', 'pg'].includes(knex.client.config.client)) {
-      itemsQuery = itemsQuery.forUpdate().skipLocked();
-    }
-
-    const items = await itemsQuery
-      .where('next_update_at', '<=', knex.fn.now())
-      .limit(request.processBatchSize)
-      .orderBy('next_update_at', 'asc');
+    const useLocking = ['mysql', 'mysql2', 'pg'].includes(
+      knex.client.config.client,
+    );
 
     const interval = this.options.refreshInterval();
 
-    const nextUpdateAt = (refreshInterval: number) => {
-      if (knex.client.config.client.includes('sqlite3')) {
-        return knex.raw(`datetime('now', ?)`, [`${refreshInterval} seconds`]);
-      } else if (knex.client.config.client.includes('mysql')) {
-        return knex.raw(`now() + interval ${refreshInterval} second`);
+    const nextUpdateAt = (
+      tx: Knex | Knex.Transaction,
+      refreshInterval: number,
+    ) => {
+      if (tx.client.config.client.includes('sqlite3')) {
+        return tx.raw(`datetime('now', ?)`, [`${refreshInterval} seconds`]);
+      } else if (tx.client.config.client.includes('mysql')) {
+        return tx.raw(`now() + interval ${refreshInterval} second`);
       }
-      return knex.raw(`now() + interval '${refreshInterval} seconds'`);
+      return tx.raw(`now() + interval '${refreshInterval} seconds'`);
     };
 
-    await knex<DbRefreshStateRow>('refresh_state')
-      .whereIn(
-        'entity_ref',
-        items.map(i => i.entity_ref),
-      )
-      .update({
-        next_update_at: nextUpdateAt(interval),
-      });
+    // The SELECT FOR UPDATE SKIP LOCKED + UPDATE must run inside a
+    // single transaction so that the row locks persist until
+    // next_update_at has been bumped.
+    const run = async (tx: Knex | Knex.Transaction) => {
+      const items = await tx<DbRefreshStateRow>('refresh_state')
+        .select([
+          'entity_id',
+          'entity_ref',
+          'unprocessed_entity',
+          'result_hash',
+          'cache',
+          'errors',
+          'location_key',
+          'next_update_at',
+        ])
+        .where('next_update_at', '<=', tx.fn.now())
+        .limit(request.processBatchSize)
+        .orderBy('next_update_at', 'asc')
+        .modify(qb => {
+          if (useLocking) {
+            qb.forUpdate().skipLocked();
+          }
+        });
+
+      if (items.length > 0) {
+        await tx<DbRefreshStateRow>('refresh_state')
+          .whereIn(
+            'entity_ref',
+            items.map(i => i.entity_ref),
+          )
+          .update({
+            next_update_at: nextUpdateAt(tx, interval),
+          });
+      }
+
+      return items;
+    };
+
+    const items = knex.isTransaction
+      ? await run(knex)
+      : await knex.transaction(run);
 
     return {
       items: items.map(

--- a/plugins/catalog-backend/src/database/DefaultProcessingDatabase.ts
+++ b/plugins/catalog-backend/src/database/DefaultProcessingDatabase.ts
@@ -263,9 +263,10 @@ export class DefaultProcessingDatabase implements ProcessingDatabase {
       return items;
     };
 
-    const items = knex.isTransaction
-      ? await run(knex)
-      : await knex.transaction(run);
+    const items =
+      knex.isTransaction || !useLocking
+        ? await run(knex)
+        : await knex.transaction(run);
 
     return {
       items: items.map(

--- a/plugins/catalog-backend/src/database/operations/stitcher/getDeferredStitchableEntities.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/getDeferredStitchableEntities.ts
@@ -92,10 +92,9 @@ export async function getDeferredStitchableEntities(options: {
     }));
   };
 
-  if (knex.isTransaction || !useLocking) {
-    return run(knex);
-  }
-  return knex.transaction(run);
+  return knex.isTransaction || !useLocking
+    ? await run(knex)
+    : await knex.transaction(run);
 }
 
 function nowPlus(knex: Knex, duration: HumanDuration): Knex.Raw {

--- a/plugins/catalog-backend/src/database/operations/stitcher/getDeferredStitchableEntities.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/getDeferredStitchableEntities.ts
@@ -61,7 +61,7 @@ export async function getDeferredStitchableEntities(options: {
   // are released after the SELECT auto-commits, and another worker can
   // claim the same rows before the UPDATE runs.
   const run = async (tx: Knex | Knex.Transaction) => {
-    const items = await tx<DbStitchQueueRow>('stitch_queue')
+    const items: DbStitchQueueRow[] = await tx('stitch_queue')
       .select('entity_ref', 'next_stitch_at', 'stitch_ticket')
       .where('next_stitch_at', '<=', tx.fn.now())
       .orderBy('next_stitch_at', 'asc')
@@ -76,7 +76,7 @@ export async function getDeferredStitchableEntities(options: {
       return [];
     }
 
-    await tx<DbStitchQueueRow>('stitch_queue')
+    await tx('stitch_queue')
       .whereIn(
         'entity_ref',
         items.map(i => i.entity_ref),

--- a/plugins/catalog-backend/src/database/operations/stitcher/getDeferredStitchableEntities.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/getDeferredStitchableEntities.ts
@@ -60,7 +60,7 @@ export async function getDeferredStitchableEntities(options: {
   // next_stitch_at has been bumped. Without the transaction the locks
   // are released after the SELECT auto-commits, and another worker can
   // claim the same rows before the UPDATE runs.
-  return knex.transaction(async tx => {
+  const run = async (tx: Knex | Knex.Transaction) => {
     let itemsQuery = tx<DbStitchQueueRow>('stitch_queue').select(
       'entity_ref',
       'next_stitch_at',
@@ -94,7 +94,12 @@ export async function getDeferredStitchableEntities(options: {
       stitchTicket: i.stitch_ticket,
       stitchRequestedAt: timestampToDateTime(i.next_stitch_at),
     }));
-  });
+  };
+
+  if (knex.isTransaction) {
+    return run(knex);
+  }
+  return knex.transaction(run);
 }
 
 function nowPlus(knex: Knex, duration: HumanDuration): Knex.Raw {

--- a/plugins/catalog-backend/src/database/operations/stitcher/getDeferredStitchableEntities.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/getDeferredStitchableEntities.ts
@@ -61,20 +61,16 @@ export async function getDeferredStitchableEntities(options: {
   // are released after the SELECT auto-commits, and another worker can
   // claim the same rows before the UPDATE runs.
   const run = async (tx: Knex | Knex.Transaction) => {
-    let itemsQuery = tx<DbStitchQueueRow>('stitch_queue').select(
-      'entity_ref',
-      'next_stitch_at',
-      'stitch_ticket',
-    );
-
-    if (useLocking) {
-      itemsQuery = itemsQuery.forUpdate().skipLocked();
-    }
-
-    const items = await itemsQuery
+    const items = await tx<DbStitchQueueRow>('stitch_queue')
+      .select('entity_ref', 'next_stitch_at', 'stitch_ticket')
       .where('next_stitch_at', '<=', tx.fn.now())
       .orderBy('next_stitch_at', 'asc')
-      .limit(batchSize);
+      .limit(batchSize)
+      .modify(qb => {
+        if (useLocking) {
+          qb.forUpdate().skipLocked();
+        }
+      });
 
     if (!items.length) {
       return [];

--- a/plugins/catalog-backend/src/database/operations/stitcher/getDeferredStitchableEntities.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/getDeferredStitchableEntities.ts
@@ -51,43 +51,50 @@ export async function getDeferredStitchableEntities(options: {
   }>
 > {
   const { knex, batchSize, stitchTimeout } = options;
-
-  let itemsQuery = knex<DbStitchQueueRow>('stitch_queue').select(
-    'entity_ref',
-    'next_stitch_at',
-    'stitch_ticket',
+  const useLocking = ['mysql', 'mysql2', 'pg'].includes(
+    knex.client.config.client,
   );
 
-  // This avoids duplication of work because of race conditions and is
-  // also fast because locked rows are ignored rather than blocking.
-  // It's only available in MySQL and PostgreSQL
-  if (['mysql', 'mysql2', 'pg'].includes(knex.client.config.client)) {
-    itemsQuery = itemsQuery.forUpdate().skipLocked();
-  }
-
-  const items = await itemsQuery
-    .where('next_stitch_at', '<=', knex.fn.now())
-    .orderBy('next_stitch_at', 'asc')
-    .limit(batchSize);
-
-  if (!items.length) {
-    return [];
-  }
-
-  await knex<DbStitchQueueRow>('stitch_queue')
-    .whereIn(
+  // The SELECT FOR UPDATE SKIP LOCKED + UPDATE must run inside a single
+  // transaction so that the row locks held by FOR UPDATE persist until
+  // next_stitch_at has been bumped. Without the transaction the locks
+  // are released after the SELECT auto-commits, and another worker can
+  // claim the same rows before the UPDATE runs.
+  return knex.transaction(async tx => {
+    let itemsQuery = tx<DbStitchQueueRow>('stitch_queue').select(
       'entity_ref',
-      items.map(i => i.entity_ref),
-    )
-    .update({
-      next_stitch_at: nowPlus(knex, stitchTimeout),
-    });
+      'next_stitch_at',
+      'stitch_ticket',
+    );
 
-  return items.map(i => ({
-    entityRef: i.entity_ref,
-    stitchTicket: i.stitch_ticket,
-    stitchRequestedAt: timestampToDateTime(i.next_stitch_at),
-  }));
+    if (useLocking) {
+      itemsQuery = itemsQuery.forUpdate().skipLocked();
+    }
+
+    const items = await itemsQuery
+      .where('next_stitch_at', '<=', tx.fn.now())
+      .orderBy('next_stitch_at', 'asc')
+      .limit(batchSize);
+
+    if (!items.length) {
+      return [];
+    }
+
+    await tx<DbStitchQueueRow>('stitch_queue')
+      .whereIn(
+        'entity_ref',
+        items.map(i => i.entity_ref),
+      )
+      .update({
+        next_stitch_at: nowPlus(tx, stitchTimeout),
+      });
+
+    return items.map(i => ({
+      entityRef: i.entity_ref,
+      stitchTicket: i.stitch_ticket,
+      stitchRequestedAt: timestampToDateTime(i.next_stitch_at),
+    }));
+  });
 }
 
 function nowPlus(knex: Knex, duration: HumanDuration): Knex.Raw {

--- a/plugins/catalog-backend/src/database/operations/stitcher/getDeferredStitchableEntities.ts
+++ b/plugins/catalog-backend/src/database/operations/stitcher/getDeferredStitchableEntities.ts
@@ -92,7 +92,7 @@ export async function getDeferredStitchableEntities(options: {
     }));
   };
 
-  if (knex.isTransaction) {
+  if (knex.isTransaction || !useLocking) {
     return run(knex);
   }
   return knex.transaction(run);


### PR DESCRIPTION
## Summary

- Wraps `SELECT FOR UPDATE SKIP LOCKED` + timestamp bump inside a single transaction in both `getDeferredStitchableEntities` (stitch queue) and `getProcessableEntities` (refresh state)
- Previously, the row locks from `FOR UPDATE` were released when the SELECT auto-committed, allowing another worker to claim the same rows before the UPDATE ran
- The transaction is only created for MySQL and PostgreSQL where `FOR UPDATE SKIP LOCKED` is used — sqlite3 skips the wrapping to avoid unnecessary overhead
- If the caller already provides a transaction, it is reused instead of creating a nested one

## Test plan

- [x] All 4 `getDeferredStitchableEntities` tests pass (MySQL 8, Postgres 18, Postgres 14, SQLite 3)
- [x] All 48 `DefaultProcessingDatabase` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)