### PR TITLE
fix(catalog): fix flaky entity page test

### DIFF
--- a/.changeset/fix-test-route-matching.md
+++ b/.changeset/fix-test-route-matching.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-test-utils': patch
+---
+
+Fixed `renderInTestApp` to set up React Router route matching when `mountedRoutes` are provided. Previously, mounted routes only fed the route resolution API for link generation (`useRouteRef`), but did not create `<Route>` elements for param extraction (`useParams`). This meant that `initialRouteEntries` had no effect on route param availability. The test element is now wrapped in `<Routes>` with a `<Route>` for each mounted path, matching the behavior of the real `AppRoutes` extension.

--- a/.changeset/fix-test-route-matching.md
+++ b/.changeset/fix-test-route-matching.md
@@ -2,4 +2,4 @@
 '@backstage/frontend-test-utils': patch
 ---
 
-Added a `mountPath` option to `renderInTestApp` that controls the route path pattern the test element is rendered at. When set, the element is wrapped in a `<Route>` with the given path, enabling `useParams()` to extract route parameters from the URL. When `mountPath` is set and `initialRouteEntries` is not, the initial route entry defaults to the mount path. This is useful for testing page components that depend on URL parameters, such as entity pages that use `useRouteRefParams`.
+Added a `mountPath` option to `renderInTestApp` that controls the route path pattern the test element is rendered at. When set, the element is wrapped in a `<Route>` with the given path, enabling `useParams()` to extract route parameters from the URL. Use together with `initialRouteEntries` to set a concrete URL that matches the pattern. This is useful for testing page components that depend on URL parameters, such as entity pages that use `useRouteRefParams`.

--- a/.changeset/fix-test-route-matching.md
+++ b/.changeset/fix-test-route-matching.md
@@ -2,4 +2,4 @@
 '@backstage/frontend-test-utils': patch
 ---
 
-Fixed `renderInTestApp` to set up React Router route matching when `mountedRoutes` are provided. Previously, mounted routes only fed the route resolution API for link generation (`useRouteRef`), but did not create `<Route>` elements for param extraction (`useParams`). This meant that `initialRouteEntries` had no effect on route param availability. The test element is now wrapped in `<Routes>` with a `<Route>` for each mounted path, matching the behavior of the real `AppRoutes` extension.
+Added a `mountPath` option to `renderInTestApp` that controls the route path pattern the test element is rendered at. When set, the element is wrapped in a `<Route>` with the given path, enabling `useParams()` to extract route parameters from the URL. When `mountPath` is set and `initialRouteEntries` is not, the initial route entry defaults to the mount path. This is useful for testing page components that depend on URL parameters, such as entity pages that use `useRouteRefParams`.

--- a/packages/frontend-test-utils/report.api.md
+++ b/packages/frontend-test-utils/report.api.md
@@ -478,6 +478,7 @@ export type TestAppOptions<TApiPairs extends any[] = any[]> = {
   };
   config?: JsonObject;
   features?: FrontendFeature[];
+  mountPath?: string;
   initialRouteEntries?: string[];
   apis?: readonly [...TestApiPairs<TApiPairs>];
 };

--- a/packages/frontend-test-utils/src/app/renderInTestApp.tsx
+++ b/packages/frontend-test-utils/src/app/renderInTestApp.tsx
@@ -15,7 +15,7 @@
  */
 
 import { Fragment } from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { prepareSpecializedApp } from '@backstage/frontend-app-api';
 import { RenderResult, render } from '@testing-library/react';
 import { ConfigReader } from '@backstage/config';
@@ -125,11 +125,31 @@ export function renderInTestApp<const TApiPairs extends any[] = any[]>(
   element: JSX.Element,
   options?: TestAppOptions<TApiPairs>,
 ): RenderResult {
+  const mountedPaths = options?.mountedRoutes
+    ? Object.keys(options.mountedRoutes)
+    : [];
+
   const extensions: Array<ExtensionDefinition> = [
     createExtension({
       attachTo: { id: 'app/root', input: 'children' },
       output: [coreExtensionData.reactElement],
       factory: () => {
+        if (mountedPaths.length > 0) {
+          return [
+            coreExtensionData.reactElement(
+              <Routes>
+                {mountedPaths.map(path => (
+                  <Route
+                    key={path}
+                    path={path === '/' ? path : `${path.replace(/\/$/, '')}/*`}
+                    element={element}
+                  />
+                ))}
+                <Route path="*" element={element} />
+              </Routes>,
+            ),
+          ];
+        }
         return [coreExtensionData.reactElement(element)];
       },
     }),

--- a/packages/frontend-test-utils/src/app/renderInTestApp.tsx
+++ b/packages/frontend-test-utils/src/app/renderInTestApp.tsx
@@ -135,6 +135,7 @@ export function renderInTestApp<const TApiPairs extends any[] = any[]>(
       output: [coreExtensionData.reactElement],
       factory: () => {
         let content: JSX.Element = element;
+
         if (mountedPaths.length > 0) {
           content = (
             <Routes>
@@ -142,13 +143,14 @@ export function renderInTestApp<const TApiPairs extends any[] = any[]>(
                 <Route
                   key={path}
                   path={path === '/' ? path : `${path.replace(/\/$/, '')}/*`}
-                  element={element}
+                  element={content}
                 />
               ))}
-              <Route path="*" element={element} />
+              <Route path="*" element={content} />
             </Routes>
           );
         }
+
         return [coreExtensionData.reactElement(content)];
       },
     }),

--- a/packages/frontend-test-utils/src/app/renderInTestApp.tsx
+++ b/packages/frontend-test-utils/src/app/renderInTestApp.tsx
@@ -80,7 +80,28 @@ export type TestAppOptions<TApiPairs extends any[] = any[]> = {
   features?: FrontendFeature[];
 
   /**
-   * Initial route entries to use for the router.
+   * The route path pattern that the test element is rendered at. When set,
+   * the element is wrapped in a `<Route>` with this path, enabling
+   * `useParams()` to extract parameters from the URL. Defaults to `'/'`.
+   *
+   * When `mountPath` is set and `initialRouteEntries` is not, the
+   * initial route entry defaults to `mountPath` (which works for paths
+   * without parameters). For parameterized paths you must also set
+   * `initialRouteEntries` to a concrete URL that matches the pattern.
+   *
+   * @example
+   * ```ts
+   * renderInTestApp(<EntityPage />, {
+   *   mountPath: '/catalog/:namespace/:kind/:name',
+   *   initialRouteEntries: ['/catalog/default/component/my-entity'],
+   * })
+   * ```
+   */
+  mountPath?: string;
+
+  /**
+   * Initial route entries to use for the router. When `mountPath` is set
+   * and this is not, defaults to `[mountPath]`.
    */
   initialRouteEntries?: string[];
 
@@ -125,9 +146,7 @@ export function renderInTestApp<const TApiPairs extends any[] = any[]>(
   element: JSX.Element,
   options?: TestAppOptions<TApiPairs>,
 ): RenderResult {
-  const mountedPaths = options?.mountedRoutes
-    ? Object.keys(options.mountedRoutes)
-    : [];
+  const mountPath = options?.mountPath;
 
   const extensions: Array<ExtensionDefinition> = [
     createExtension({
@@ -136,16 +155,12 @@ export function renderInTestApp<const TApiPairs extends any[] = any[]>(
       factory: () => {
         let content: JSX.Element = element;
 
-        if (mountedPaths.length > 0) {
+        if (mountPath) {
+          const routePath =
+            mountPath === '/' ? mountPath : `${mountPath.replace(/\/$/, '')}/*`;
           content = (
             <Routes>
-              {mountedPaths.map(path => (
-                <Route
-                  key={path}
-                  path={path === '/' ? path : `${path.replace(/\/$/, '')}/*`}
-                  element={content}
-                />
-              ))}
+              <Route path={routePath} element={content} />
               <Route path="*" element={content} />
             </Routes>
           );
@@ -198,7 +213,10 @@ export function renderInTestApp<const TApiPairs extends any[] = any[]>(
           params: {
             component: ({ children }) => (
               <MemoryRouter
-                initialEntries={options?.initialRouteEntries}
+                initialEntries={
+                  options?.initialRouteEntries ??
+                  (mountPath ? [mountPath] : undefined)
+                }
                 future={{
                   v7_relativeSplatPath: false,
                   v7_startTransition: false,

--- a/packages/frontend-test-utils/src/app/renderInTestApp.tsx
+++ b/packages/frontend-test-utils/src/app/renderInTestApp.tsx
@@ -134,23 +134,22 @@ export function renderInTestApp<const TApiPairs extends any[] = any[]>(
       attachTo: { id: 'app/root', input: 'children' },
       output: [coreExtensionData.reactElement],
       factory: () => {
+        let content: JSX.Element = element;
         if (mountedPaths.length > 0) {
-          return [
-            coreExtensionData.reactElement(
-              <Routes>
-                {mountedPaths.map(path => (
-                  <Route
-                    key={path}
-                    path={path === '/' ? path : `${path.replace(/\/$/, '')}/*`}
-                    element={element}
-                  />
-                ))}
-                <Route path="*" element={element} />
-              </Routes>,
-            ),
-          ];
+          content = (
+            <Routes>
+              {mountedPaths.map(path => (
+                <Route
+                  key={path}
+                  path={path === '/' ? path : `${path.replace(/\/$/, '')}/*`}
+                  element={element}
+                />
+              ))}
+              <Route path="*" element={element} />
+            </Routes>
+          );
         }
-        return [coreExtensionData.reactElement(element)];
+        return [coreExtensionData.reactElement(content)];
       },
     }),
   ];

--- a/packages/frontend-test-utils/src/app/renderInTestApp.tsx
+++ b/packages/frontend-test-utils/src/app/renderInTestApp.tsx
@@ -157,11 +157,12 @@ export function renderInTestApp<const TApiPairs extends any[] = any[]>(
 
         if (mountPath) {
           const routePath =
-            mountPath === '/' ? mountPath : `${mountPath.replace(/\/$/, '')}/*`;
+            mountPath === '/' || mountPath.endsWith('/*')
+              ? mountPath
+              : `${mountPath.replace(/\/$/, '')}/*`;
           content = (
             <Routes>
               <Route path={routePath} element={content} />
-              <Route path="*" element={content} />
             </Routes>
           );
         }

--- a/packages/frontend-test-utils/src/app/renderInTestApp.tsx
+++ b/packages/frontend-test-utils/src/app/renderInTestApp.tsx
@@ -82,12 +82,10 @@ export type TestAppOptions<TApiPairs extends any[] = any[]> = {
   /**
    * The route path pattern that the test element is rendered at. When set,
    * the element is wrapped in a `<Route>` with this path, enabling
-   * `useParams()` to extract parameters from the URL. Defaults to `'/'`.
+   * `useParams()` to extract parameters from the URL.
    *
-   * When `mountPath` is set and `initialRouteEntries` is not, the
-   * initial route entry defaults to `mountPath` (which works for paths
-   * without parameters). For parameterized paths you must also set
-   * `initialRouteEntries` to a concrete URL that matches the pattern.
+   * Should be used together with `initialRouteEntries` to set a concrete
+   * URL that matches the pattern.
    *
    * @example
    * ```ts
@@ -100,8 +98,7 @@ export type TestAppOptions<TApiPairs extends any[] = any[]> = {
   mountPath?: string;
 
   /**
-   * Initial route entries to use for the router. When `mountPath` is set
-   * and this is not, defaults to `[mountPath]`.
+   * Initial route entries to use for the router.
    */
   initialRouteEntries?: string[];
 
@@ -214,10 +211,7 @@ export function renderInTestApp<const TApiPairs extends any[] = any[]>(
           params: {
             component: ({ children }) => (
               <MemoryRouter
-                initialEntries={
-                  options?.initialRouteEntries ??
-                  (mountPath ? [mountPath] : undefined)
-                }
+                initialEntries={options?.initialRouteEntries}
                 future={{
                   v7_relativeSplatPath: false,
                   v7_startTransition: false,

--- a/plugins/catalog/src/alpha/pages.test.tsx
+++ b/plugins/catalog/src/alpha/pages.test.tsx
@@ -150,6 +150,7 @@ describe('Entity page', () => {
 
       await renderInTestApp(tester.reactElement(), {
         apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
+        mountPath: '/catalog/:namespace/:kind/:name',
         initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
@@ -201,6 +202,7 @@ describe('Entity page', () => {
 
       await renderInTestApp(tester.reactElement(), {
         apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
+        mountPath: '/catalog/:namespace/:kind/:name',
         initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
@@ -245,6 +247,7 @@ describe('Entity page', () => {
 
       await renderInTestApp(tester.reactElement(), {
         apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
+        mountPath: '/catalog/:namespace/:kind/:name',
         initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
@@ -296,6 +299,7 @@ describe('Entity page', () => {
 
       await renderInTestApp(tester.reactElement(), {
         apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
+        mountPath: '/catalog/:namespace/:kind/:name',
         initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
@@ -341,6 +345,7 @@ describe('Entity page', () => {
 
       await renderInTestApp(tester.reactElement(), {
         apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
+        mountPath: '/catalog/:namespace/:kind/:name',
         initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
@@ -373,6 +378,7 @@ describe('Entity page', () => {
 
       await renderInTestApp(tester.reactElement(), {
         apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
+        mountPath: '/catalog/:namespace/:kind/:name',
         initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
@@ -417,6 +423,7 @@ describe('Entity page', () => {
 
       await renderInTestApp(tester.reactElement(), {
         apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
+        mountPath: '/catalog/:namespace/:kind/:name',
         initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
@@ -457,6 +464,7 @@ describe('Entity page', () => {
 
       await renderInTestApp(tester.reactElement(), {
         apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
+        mountPath: '/catalog/:namespace/:kind/:name',
         initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
@@ -496,6 +504,7 @@ describe('Entity page', () => {
 
       await renderInTestApp(tester.reactElement(), {
         apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
+        mountPath: '/catalog/:namespace/:kind/:name',
         initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
@@ -543,6 +552,7 @@ describe('Entity page', () => {
 
       await renderInTestApp(tester.reactElement(), {
         apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
+        mountPath: '/catalog/:namespace/:kind/:name',
         initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
@@ -590,6 +600,7 @@ describe('Entity page', () => {
 
       await renderInTestApp(tester.reactElement(), {
         apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
+        mountPath: '/catalog/:namespace/:kind/:name',
         initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
@@ -625,6 +636,7 @@ describe('Entity page', () => {
 
       await renderInTestApp(tester.reactElement(), {
         apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
+        mountPath: '/catalog/:namespace/:kind/:name',
         initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
@@ -662,6 +674,7 @@ describe('Entity page', () => {
 
       await renderInTestApp(tester.reactElement(), {
         apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
+        mountPath: '/catalog/:namespace/:kind/:name',
         initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
@@ -719,6 +732,7 @@ describe('Entity page', () => {
 
       await renderInTestApp(tester.reactElement(), {
         apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
+        mountPath: '/catalog/:namespace/:kind/:name',
         initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
@@ -772,6 +786,7 @@ describe('Entity page', () => {
 
       await renderInTestApp(tester.reactElement(), {
         apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
+        mountPath: '/catalog/:namespace/:kind/:name',
         initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
@@ -861,6 +876,7 @@ describe('Entity page', () => {
           .add(filteredMenuItem);
 
         await renderInTestApp(tester.reactElement(), {
+          mountPath: '/catalog/:namespace/:kind/:name',
           initialRouteEntries: ['/catalog/default/component/artist-lookup'],
           config: {
             app: {

--- a/plugins/catalog/src/alpha/pages.test.tsx
+++ b/plugins/catalog/src/alpha/pages.test.tsx
@@ -28,6 +28,7 @@ import {
 } from '@backstage/plugin-catalog-react/alpha';
 import { catalogApiMock } from '@backstage/plugin-catalog-react/testUtils';
 import {
+  catalogApiRef,
   entityRouteRef,
   MockStarredEntitiesApi,
   starredEntitiesApiRef,
@@ -107,8 +108,8 @@ describe('Entity page', () => {
     ],
   };
 
-  const mockCatalogApi = catalogApiMock({
-    entities: [entityMock],
+  const mockCatalogApi = catalogApiMock.mock({
+    getEntityByRef: async () => entityMock,
   });
 
   const mockStarredEntitiesApi = new MockStarredEntitiesApi();
@@ -151,8 +152,10 @@ describe('Entity page', () => {
         .add(apidocsEntityContent);
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
-        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
+        apis: [
+          [catalogApiRef, mockCatalogApi],
+          [starredEntitiesApiRef, mockStarredEntitiesApi],
+        ],
         config: {
           app: {
             title: 'Custom app',
@@ -196,8 +199,10 @@ describe('Entity page', () => {
         .add(apidocsEntityContent);
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
-        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
+        apis: [
+          [catalogApiRef, mockCatalogApi],
+          [starredEntitiesApiRef, mockStarredEntitiesApi],
+        ],
         config: {
           app: {
             title: 'Custom app',
@@ -234,8 +239,10 @@ describe('Entity page', () => {
         });
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
-        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
+        apis: [
+          [catalogApiRef, mockCatalogApi],
+          [starredEntitiesApiRef, mockStarredEntitiesApi],
+        ],
         config: {
           app: {
             title: 'Custom app',
@@ -285,8 +292,10 @@ describe('Entity page', () => {
         });
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
-        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
+        apis: [
+          [catalogApiRef, mockCatalogApi],
+          [starredEntitiesApiRef, mockStarredEntitiesApi],
+        ],
         config: {
           app: {
             title: 'Custom app',
@@ -324,8 +333,10 @@ describe('Entity page', () => {
         });
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
-        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
+        apis: [
+          [catalogApiRef, mockCatalogApi],
+          [starredEntitiesApiRef, mockStarredEntitiesApi],
+        ],
         config: {
           app: {
             title: 'Custom app',
@@ -356,8 +367,10 @@ describe('Entity page', () => {
         .add(overviewEntityContent);
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
-        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
+        apis: [
+          [catalogApiRef, mockCatalogApi],
+          [starredEntitiesApiRef, mockStarredEntitiesApi],
+        ],
         config: {
           app: {
             title: 'Custom app',
@@ -400,8 +413,10 @@ describe('Entity page', () => {
         .add(apidocsEntityContent);
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
-        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
+        apis: [
+          [catalogApiRef, mockCatalogApi],
+          [starredEntitiesApiRef, mockStarredEntitiesApi],
+        ],
         config: {
           app: {
             title: 'Custom app',
@@ -434,8 +449,10 @@ describe('Entity page', () => {
         .add(apidocsEntityContent);
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
-        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
+        apis: [
+          [catalogApiRef, mockCatalogApi],
+          [starredEntitiesApiRef, mockStarredEntitiesApi],
+        ],
         config: {
           app: {
             title: 'Custom app',
@@ -473,8 +490,10 @@ describe('Entity page', () => {
         .add(apidocsEntityContent);
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
-        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
+        apis: [
+          [catalogApiRef, mockCatalogApi],
+          [starredEntitiesApiRef, mockStarredEntitiesApi],
+        ],
         config: {
           app: {
             title: 'Custom app',
@@ -520,8 +539,10 @@ describe('Entity page', () => {
         .add(apidocsEntityContent);
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
-        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
+        apis: [
+          [catalogApiRef, mockCatalogApi],
+          [starredEntitiesApiRef, mockStarredEntitiesApi],
+        ],
         config: {
           app: {
             title: 'Custom app',
@@ -567,8 +588,10 @@ describe('Entity page', () => {
         });
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
-        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
+        apis: [
+          [catalogApiRef, mockCatalogApi],
+          [starredEntitiesApiRef, mockStarredEntitiesApi],
+        ],
         config: {
           app: {
             title: 'Custom app',
@@ -602,8 +625,10 @@ describe('Entity page', () => {
       );
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
-        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
+        apis: [
+          [catalogApiRef, mockCatalogApi],
+          [starredEntitiesApiRef, mockStarredEntitiesApi],
+        ],
         config: {
           app: {
             title: 'Custom app',
@@ -639,8 +664,10 @@ describe('Entity page', () => {
       ).add(customEntityHeader);
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
-        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
+        apis: [
+          [catalogApiRef, mockCatalogApi],
+          [starredEntitiesApiRef, mockStarredEntitiesApi],
+        ],
         config: {
           app: {
             title: 'Custom app',
@@ -696,8 +723,10 @@ describe('Entity page', () => {
       ).add(menuItem);
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
-        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
+        apis: [
+          [catalogApiRef, mockCatalogApi],
+          [starredEntitiesApiRef, mockStarredEntitiesApi],
+        ],
         config: {
           app: {
             title: 'Custom app',
@@ -749,8 +778,10 @@ describe('Entity page', () => {
       ).add(menuItem);
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
-        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
+        apis: [
+          [catalogApiRef, mockCatalogApi],
+          [starredEntitiesApiRef, mockStarredEntitiesApi],
+        ],
         config: {
           app: {
             title: 'Custom app',
@@ -851,10 +882,9 @@ describe('Entity page', () => {
               convertLegacyRouteRef(entityRouteRef),
           },
           apis: [
-            mockCatalogApi,
+            [catalogApiRef, mockCatalogApi],
             [starredEntitiesApiRef, mockStarredEntitiesApi],
           ],
-          initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         });
 
         await userEvent.click(await screen.findByTestId('menu-button'));

--- a/plugins/catalog/src/alpha/pages.test.tsx
+++ b/plugins/catalog/src/alpha/pages.test.tsx
@@ -176,11 +176,17 @@ describe('Entity page', () => {
 
       await expect(
         screen.findByRole('button', { name: /TechDocs/ }),
-      ).resolves.toHaveAttribute('href', '/techdocs');
+      ).resolves.toHaveAttribute(
+        'href',
+        '/catalog/default/component/artist-lookup/techdocs',
+      );
 
       await expect(
         screen.findByRole('button', { name: /ApiDocs/ }),
-      ).resolves.toHaveAttribute('href', '/apidocs');
+      ).resolves.toHaveAttribute(
+        'href',
+        '/catalog/default/component/artist-lookup/apidocs',
+      );
     });
 
     it('Should rename a default group', async () => {
@@ -222,11 +228,17 @@ describe('Entity page', () => {
 
       await expect(
         screen.findByRole('button', { name: /TechDocs/ }),
-      ).resolves.toHaveAttribute('href', '/techdocs');
+      ).resolves.toHaveAttribute(
+        'href',
+        '/catalog/default/component/artist-lookup/techdocs',
+      );
 
       await expect(
         screen.findByRole('button', { name: /ApiDocs/ }),
-      ).resolves.toHaveAttribute('href', '/apidocs');
+      ).resolves.toHaveAttribute(
+        'href',
+        '/catalog/default/component/artist-lookup/apidocs',
+      );
     });
 
     it('Should disassociate a content with a default group', async () => {
@@ -317,11 +329,17 @@ describe('Entity page', () => {
 
       await expect(
         screen.findByRole('button', { name: /TechDocs/ }),
-      ).resolves.toHaveAttribute('href', '/techdocs');
+      ).resolves.toHaveAttribute(
+        'href',
+        '/catalog/default/component/artist-lookup/techdocs',
+      );
 
       await expect(
         screen.findByRole('button', { name: /ApiDocs/ }),
-      ).resolves.toHaveAttribute('href', '/apidocs');
+      ).resolves.toHaveAttribute(
+        'href',
+        '/catalog/default/component/artist-lookup/apidocs',
+      );
     });
 
     it('Should render a single-content groups as a normal tab', async () => {
@@ -441,11 +459,17 @@ describe('Entity page', () => {
 
       await expect(
         screen.findByRole('button', { name: /TechDocs/ }),
-      ).resolves.toHaveAttribute('href', '/techdocs');
+      ).resolves.toHaveAttribute(
+        'href',
+        '/catalog/default/component/artist-lookup/techdocs',
+      );
 
       await expect(
         screen.findByRole('button', { name: /ApiDocs/ }),
-      ).resolves.toHaveAttribute('href', '/apidocs');
+      ).resolves.toHaveAttribute(
+        'href',
+        '/catalog/default/component/artist-lookup/apidocs',
+      );
     });
 
     it('Should sort content by title by default', async () => {
@@ -816,14 +840,14 @@ describe('Entity page', () => {
         screen.findByText(/artist-lookup/),
       ).resolves.toBeInTheDocument();
 
-      await userEvent.click(screen.getByTestId('menu-button'));
+      await userEvent.click(await screen.findByTestId('menu-button'));
 
       await expect(
         screen.findByText('Test Title'),
       ).resolves.toBeInTheDocument();
 
       await expect(screen.findByText('Test Icon')).resolves.toBeInTheDocument();
-      const listItem = screen.getByText('Test Title').closest('li');
+      const listItem = (await screen.findByText('Test Title')).closest('li');
       expect(listItem).toHaveAttribute('aria-disabled', disabled.toString());
       if (!disabled) {
         await userEvent.click(screen.getByText('Test Title'));

--- a/plugins/catalog/src/alpha/pages.test.tsx
+++ b/plugins/catalog/src/alpha/pages.test.tsx
@@ -28,7 +28,6 @@ import {
 } from '@backstage/plugin-catalog-react/alpha';
 import { catalogApiMock } from '@backstage/plugin-catalog-react/testUtils';
 import {
-  catalogApiRef,
   entityRouteRef,
   MockStarredEntitiesApi,
   starredEntitiesApiRef,
@@ -108,8 +107,8 @@ describe('Entity page', () => {
     ],
   };
 
-  const mockCatalogApi = catalogApiMock.mock({
-    getEntityByRef: async () => entityMock,
+  const mockCatalogApi = catalogApiMock({
+    entities: [entityMock as Entity],
   });
 
   const mockStarredEntitiesApi = new MockStarredEntitiesApi();
@@ -152,10 +151,8 @@ describe('Entity page', () => {
         .add(apidocsEntityContent);
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [
-          [catalogApiRef, mockCatalogApi],
-          [starredEntitiesApiRef, mockStarredEntitiesApi],
-        ],
+        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
+        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
             title: 'Custom app',
@@ -199,10 +196,8 @@ describe('Entity page', () => {
         .add(apidocsEntityContent);
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [
-          [catalogApiRef, mockCatalogApi],
-          [starredEntitiesApiRef, mockStarredEntitiesApi],
-        ],
+        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
+        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
             title: 'Custom app',
@@ -239,10 +234,8 @@ describe('Entity page', () => {
         });
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [
-          [catalogApiRef, mockCatalogApi],
-          [starredEntitiesApiRef, mockStarredEntitiesApi],
-        ],
+        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
+        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
             title: 'Custom app',
@@ -292,10 +285,8 @@ describe('Entity page', () => {
         });
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [
-          [catalogApiRef, mockCatalogApi],
-          [starredEntitiesApiRef, mockStarredEntitiesApi],
-        ],
+        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
+        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
             title: 'Custom app',
@@ -333,10 +324,8 @@ describe('Entity page', () => {
         });
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [
-          [catalogApiRef, mockCatalogApi],
-          [starredEntitiesApiRef, mockStarredEntitiesApi],
-        ],
+        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
+        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
             title: 'Custom app',
@@ -367,10 +356,8 @@ describe('Entity page', () => {
         .add(overviewEntityContent);
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [
-          [catalogApiRef, mockCatalogApi],
-          [starredEntitiesApiRef, mockStarredEntitiesApi],
-        ],
+        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
+        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
             title: 'Custom app',
@@ -413,10 +400,8 @@ describe('Entity page', () => {
         .add(apidocsEntityContent);
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [
-          [catalogApiRef, mockCatalogApi],
-          [starredEntitiesApiRef, mockStarredEntitiesApi],
-        ],
+        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
+        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
             title: 'Custom app',
@@ -449,10 +434,8 @@ describe('Entity page', () => {
         .add(apidocsEntityContent);
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [
-          [catalogApiRef, mockCatalogApi],
-          [starredEntitiesApiRef, mockStarredEntitiesApi],
-        ],
+        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
+        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
             title: 'Custom app',
@@ -490,10 +473,8 @@ describe('Entity page', () => {
         .add(apidocsEntityContent);
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [
-          [catalogApiRef, mockCatalogApi],
-          [starredEntitiesApiRef, mockStarredEntitiesApi],
-        ],
+        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
+        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
             title: 'Custom app',
@@ -539,10 +520,8 @@ describe('Entity page', () => {
         .add(apidocsEntityContent);
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [
-          [catalogApiRef, mockCatalogApi],
-          [starredEntitiesApiRef, mockStarredEntitiesApi],
-        ],
+        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
+        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
             title: 'Custom app',
@@ -588,10 +567,8 @@ describe('Entity page', () => {
         });
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [
-          [catalogApiRef, mockCatalogApi],
-          [starredEntitiesApiRef, mockStarredEntitiesApi],
-        ],
+        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
+        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
             title: 'Custom app',
@@ -625,10 +602,8 @@ describe('Entity page', () => {
       );
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [
-          [catalogApiRef, mockCatalogApi],
-          [starredEntitiesApiRef, mockStarredEntitiesApi],
-        ],
+        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
+        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
             title: 'Custom app',
@@ -664,10 +639,8 @@ describe('Entity page', () => {
       ).add(customEntityHeader);
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [
-          [catalogApiRef, mockCatalogApi],
-          [starredEntitiesApiRef, mockStarredEntitiesApi],
-        ],
+        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
+        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
             title: 'Custom app',
@@ -723,10 +696,8 @@ describe('Entity page', () => {
       ).add(menuItem);
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [
-          [catalogApiRef, mockCatalogApi],
-          [starredEntitiesApiRef, mockStarredEntitiesApi],
-        ],
+        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
+        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
             title: 'Custom app',
@@ -778,10 +749,8 @@ describe('Entity page', () => {
       ).add(menuItem);
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [
-          [catalogApiRef, mockCatalogApi],
-          [starredEntitiesApiRef, mockStarredEntitiesApi],
-        ],
+        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
+        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
             title: 'Custom app',
@@ -882,9 +851,10 @@ describe('Entity page', () => {
               convertLegacyRouteRef(entityRouteRef),
           },
           apis: [
-            [catalogApiRef, mockCatalogApi],
+            mockCatalogApi,
             [starredEntitiesApiRef, mockStarredEntitiesApi],
           ],
+          initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         });
 
         await userEvent.click(await screen.findByTestId('menu-button'));

--- a/plugins/catalog/src/alpha/pages.test.tsx
+++ b/plugins/catalog/src/alpha/pages.test.tsx
@@ -39,7 +39,7 @@ import { Entity } from '@backstage/catalog-model';
 jest.setTimeout(30_000);
 
 describe('Entity page', () => {
-  const entityMock = {
+  const entityMock: Entity = {
     metadata: {
       namespace: 'default',
       annotations: {
@@ -108,7 +108,7 @@ describe('Entity page', () => {
   };
 
   const mockCatalogApi = catalogApiMock({
-    entities: [entityMock as Entity],
+    entities: [entityMock],
   });
 
   const mockStarredEntitiesApi = new MockStarredEntitiesApi();

--- a/plugins/catalog/src/alpha/pages.test.tsx
+++ b/plugins/catalog/src/alpha/pages.test.tsx
@@ -107,6 +107,8 @@ describe('Entity page', () => {
     ],
   };
 
+  const entityPath = '/catalog/default/component/artist-lookup';
+
   const mockCatalogApi = catalogApiMock({ entities: [entityMock] });
 
   const mockStarredEntitiesApi = new MockStarredEntitiesApi();
@@ -151,7 +153,7 @@ describe('Entity page', () => {
       await renderInTestApp(tester.reactElement(), {
         apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
         mountPath: '/catalog/:namespace/:kind/:name',
-        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
+        initialRouteEntries: [entityPath],
         config: {
           app: {
             title: 'Custom app',
@@ -171,17 +173,11 @@ describe('Entity page', () => {
 
       await expect(
         screen.findByRole('button', { name: /TechDocs/ }),
-      ).resolves.toHaveAttribute(
-        'href',
-        '/catalog/default/component/artist-lookup/techdocs',
-      );
+      ).resolves.toHaveAttribute('href', `${entityPath}/techdocs`);
 
       await expect(
         screen.findByRole('button', { name: /ApiDocs/ }),
-      ).resolves.toHaveAttribute(
-        'href',
-        '/catalog/default/component/artist-lookup/apidocs',
-      );
+      ).resolves.toHaveAttribute('href', `${entityPath}/apidocs`);
     });
 
     it('Should rename a default group', async () => {
@@ -203,7 +199,7 @@ describe('Entity page', () => {
       await renderInTestApp(tester.reactElement(), {
         apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
         mountPath: '/catalog/:namespace/:kind/:name',
-        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
+        initialRouteEntries: [entityPath],
         config: {
           app: {
             title: 'Custom app',
@@ -221,17 +217,11 @@ describe('Entity page', () => {
 
       await expect(
         screen.findByRole('button', { name: /TechDocs/ }),
-      ).resolves.toHaveAttribute(
-        'href',
-        '/catalog/default/component/artist-lookup/techdocs',
-      );
+      ).resolves.toHaveAttribute('href', `${entityPath}/techdocs`);
 
       await expect(
         screen.findByRole('button', { name: /ApiDocs/ }),
-      ).resolves.toHaveAttribute(
-        'href',
-        '/catalog/default/component/artist-lookup/apidocs',
-      );
+      ).resolves.toHaveAttribute('href', `${entityPath}/apidocs`);
     });
 
     it('Should disassociate a content with a default group', async () => {
@@ -248,7 +238,7 @@ describe('Entity page', () => {
       await renderInTestApp(tester.reactElement(), {
         apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
         mountPath: '/catalog/:namespace/:kind/:name',
-        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
+        initialRouteEntries: [entityPath],
         config: {
           app: {
             title: 'Custom app',
@@ -300,7 +290,7 @@ describe('Entity page', () => {
       await renderInTestApp(tester.reactElement(), {
         apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
         mountPath: '/catalog/:namespace/:kind/:name',
-        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
+        initialRouteEntries: [entityPath],
         config: {
           app: {
             title: 'Custom app',
@@ -318,17 +308,11 @@ describe('Entity page', () => {
 
       await expect(
         screen.findByRole('button', { name: /TechDocs/ }),
-      ).resolves.toHaveAttribute(
-        'href',
-        '/catalog/default/component/artist-lookup/techdocs',
-      );
+      ).resolves.toHaveAttribute('href', `${entityPath}/techdocs`);
 
       await expect(
         screen.findByRole('button', { name: /ApiDocs/ }),
-      ).resolves.toHaveAttribute(
-        'href',
-        '/catalog/default/component/artist-lookup/apidocs',
-      );
+      ).resolves.toHaveAttribute('href', `${entityPath}/apidocs`);
     });
 
     it('Should render a single-content groups as a normal tab', async () => {
@@ -346,7 +330,7 @@ describe('Entity page', () => {
       await renderInTestApp(tester.reactElement(), {
         apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
         mountPath: '/catalog/:namespace/:kind/:name',
-        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
+        initialRouteEntries: [entityPath],
         config: {
           app: {
             title: 'Custom app',
@@ -379,7 +363,7 @@ describe('Entity page', () => {
       await renderInTestApp(tester.reactElement(), {
         apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
         mountPath: '/catalog/:namespace/:kind/:name',
-        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
+        initialRouteEntries: [entityPath],
         config: {
           app: {
             title: 'Custom app',
@@ -424,7 +408,7 @@ describe('Entity page', () => {
       await renderInTestApp(tester.reactElement(), {
         apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
         mountPath: '/catalog/:namespace/:kind/:name',
-        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
+        initialRouteEntries: [entityPath],
         config: {
           app: {
             title: 'Custom app',
@@ -442,17 +426,11 @@ describe('Entity page', () => {
 
       await expect(
         screen.findByRole('button', { name: /TechDocs/ }),
-      ).resolves.toHaveAttribute(
-        'href',
-        '/catalog/default/component/artist-lookup/techdocs',
-      );
+      ).resolves.toHaveAttribute('href', `${entityPath}/techdocs`);
 
       await expect(
         screen.findByRole('button', { name: /ApiDocs/ }),
-      ).resolves.toHaveAttribute(
-        'href',
-        '/catalog/default/component/artist-lookup/apidocs',
-      );
+      ).resolves.toHaveAttribute('href', `${entityPath}/apidocs`);
     });
 
     it('Should sort content by title by default', async () => {
@@ -465,7 +443,7 @@ describe('Entity page', () => {
       await renderInTestApp(tester.reactElement(), {
         apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
         mountPath: '/catalog/:namespace/:kind/:name',
-        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
+        initialRouteEntries: [entityPath],
         config: {
           app: {
             title: 'Custom app',
@@ -505,7 +483,7 @@ describe('Entity page', () => {
       await renderInTestApp(tester.reactElement(), {
         apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
         mountPath: '/catalog/:namespace/:kind/:name',
-        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
+        initialRouteEntries: [entityPath],
         config: {
           app: {
             title: 'Custom app',
@@ -553,7 +531,7 @@ describe('Entity page', () => {
       await renderInTestApp(tester.reactElement(), {
         apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
         mountPath: '/catalog/:namespace/:kind/:name',
-        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
+        initialRouteEntries: [entityPath],
         config: {
           app: {
             title: 'Custom app',
@@ -601,7 +579,7 @@ describe('Entity page', () => {
       await renderInTestApp(tester.reactElement(), {
         apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
         mountPath: '/catalog/:namespace/:kind/:name',
-        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
+        initialRouteEntries: [entityPath],
         config: {
           app: {
             title: 'Custom app',
@@ -637,7 +615,7 @@ describe('Entity page', () => {
       await renderInTestApp(tester.reactElement(), {
         apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
         mountPath: '/catalog/:namespace/:kind/:name',
-        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
+        initialRouteEntries: [entityPath],
         config: {
           app: {
             title: 'Custom app',
@@ -675,7 +653,7 @@ describe('Entity page', () => {
       await renderInTestApp(tester.reactElement(), {
         apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
         mountPath: '/catalog/:namespace/:kind/:name',
-        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
+        initialRouteEntries: [entityPath],
         config: {
           app: {
             title: 'Custom app',
@@ -733,7 +711,7 @@ describe('Entity page', () => {
       await renderInTestApp(tester.reactElement(), {
         apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
         mountPath: '/catalog/:namespace/:kind/:name',
-        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
+        initialRouteEntries: [entityPath],
         config: {
           app: {
             title: 'Custom app',
@@ -787,7 +765,7 @@ describe('Entity page', () => {
       await renderInTestApp(tester.reactElement(), {
         apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
         mountPath: '/catalog/:namespace/:kind/:name',
-        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
+        initialRouteEntries: [entityPath],
         config: {
           app: {
             title: 'Custom app',
@@ -877,7 +855,7 @@ describe('Entity page', () => {
 
         await renderInTestApp(tester.reactElement(), {
           mountPath: '/catalog/:namespace/:kind/:name',
-          initialRouteEntries: ['/catalog/default/component/artist-lookup'],
+          initialRouteEntries: [entityPath],
           config: {
             app: {
               title: 'Custom app',

--- a/plugins/catalog/src/alpha/pages.test.tsx
+++ b/plugins/catalog/src/alpha/pages.test.tsx
@@ -156,6 +156,7 @@ describe('Entity page', () => {
           [catalogApiRef, mockCatalogApi],
           [starredEntitiesApiRef, mockStarredEntitiesApi],
         ],
+        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
             title: 'Custom app',
@@ -203,6 +204,7 @@ describe('Entity page', () => {
           [catalogApiRef, mockCatalogApi],
           [starredEntitiesApiRef, mockStarredEntitiesApi],
         ],
+        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
             title: 'Custom app',
@@ -243,6 +245,7 @@ describe('Entity page', () => {
           [catalogApiRef, mockCatalogApi],
           [starredEntitiesApiRef, mockStarredEntitiesApi],
         ],
+        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
             title: 'Custom app',
@@ -296,6 +299,7 @@ describe('Entity page', () => {
           [catalogApiRef, mockCatalogApi],
           [starredEntitiesApiRef, mockStarredEntitiesApi],
         ],
+        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
             title: 'Custom app',
@@ -337,6 +341,7 @@ describe('Entity page', () => {
           [catalogApiRef, mockCatalogApi],
           [starredEntitiesApiRef, mockStarredEntitiesApi],
         ],
+        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
             title: 'Custom app',
@@ -371,6 +376,7 @@ describe('Entity page', () => {
           [catalogApiRef, mockCatalogApi],
           [starredEntitiesApiRef, mockStarredEntitiesApi],
         ],
+        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
             title: 'Custom app',
@@ -417,6 +423,7 @@ describe('Entity page', () => {
           [catalogApiRef, mockCatalogApi],
           [starredEntitiesApiRef, mockStarredEntitiesApi],
         ],
+        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
             title: 'Custom app',
@@ -453,6 +460,7 @@ describe('Entity page', () => {
           [catalogApiRef, mockCatalogApi],
           [starredEntitiesApiRef, mockStarredEntitiesApi],
         ],
+        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
             title: 'Custom app',
@@ -494,6 +502,7 @@ describe('Entity page', () => {
           [catalogApiRef, mockCatalogApi],
           [starredEntitiesApiRef, mockStarredEntitiesApi],
         ],
+        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
             title: 'Custom app',
@@ -543,6 +552,7 @@ describe('Entity page', () => {
           [catalogApiRef, mockCatalogApi],
           [starredEntitiesApiRef, mockStarredEntitiesApi],
         ],
+        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
             title: 'Custom app',
@@ -592,6 +602,7 @@ describe('Entity page', () => {
           [catalogApiRef, mockCatalogApi],
           [starredEntitiesApiRef, mockStarredEntitiesApi],
         ],
+        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
             title: 'Custom app',
@@ -629,6 +640,7 @@ describe('Entity page', () => {
           [catalogApiRef, mockCatalogApi],
           [starredEntitiesApiRef, mockStarredEntitiesApi],
         ],
+        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
             title: 'Custom app',
@@ -668,6 +680,7 @@ describe('Entity page', () => {
           [catalogApiRef, mockCatalogApi],
           [starredEntitiesApiRef, mockStarredEntitiesApi],
         ],
+        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
             title: 'Custom app',
@@ -727,6 +740,7 @@ describe('Entity page', () => {
           [catalogApiRef, mockCatalogApi],
           [starredEntitiesApiRef, mockStarredEntitiesApi],
         ],
+        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
             title: 'Custom app',
@@ -782,6 +796,7 @@ describe('Entity page', () => {
           [catalogApiRef, mockCatalogApi],
           [starredEntitiesApiRef, mockStarredEntitiesApi],
         ],
+        initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
             title: 'Custom app',

--- a/plugins/catalog/src/alpha/pages.test.tsx
+++ b/plugins/catalog/src/alpha/pages.test.tsx
@@ -28,7 +28,6 @@ import {
 } from '@backstage/plugin-catalog-react/alpha';
 import { catalogApiMock } from '@backstage/plugin-catalog-react/testUtils';
 import {
-  catalogApiRef,
   entityRouteRef,
   MockStarredEntitiesApi,
   starredEntitiesApiRef,
@@ -108,9 +107,7 @@ describe('Entity page', () => {
     ],
   };
 
-  const mockCatalogApi = catalogApiMock.mock({
-    getEntityByRef: async () => entityMock,
-  });
+  const mockCatalogApi = catalogApiMock({ entities: [entityMock] });
 
   const mockStarredEntitiesApi = new MockStarredEntitiesApi();
 
@@ -152,10 +149,7 @@ describe('Entity page', () => {
         .add(apidocsEntityContent);
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [
-          [catalogApiRef, mockCatalogApi],
-          [starredEntitiesApiRef, mockStarredEntitiesApi],
-        ],
+        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
         initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
@@ -206,10 +200,7 @@ describe('Entity page', () => {
         .add(apidocsEntityContent);
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [
-          [catalogApiRef, mockCatalogApi],
-          [starredEntitiesApiRef, mockStarredEntitiesApi],
-        ],
+        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
         initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
@@ -253,10 +244,7 @@ describe('Entity page', () => {
         });
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [
-          [catalogApiRef, mockCatalogApi],
-          [starredEntitiesApiRef, mockStarredEntitiesApi],
-        ],
+        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
         initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
@@ -307,10 +295,7 @@ describe('Entity page', () => {
         });
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [
-          [catalogApiRef, mockCatalogApi],
-          [starredEntitiesApiRef, mockStarredEntitiesApi],
-        ],
+        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
         initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
@@ -355,10 +340,7 @@ describe('Entity page', () => {
         });
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [
-          [catalogApiRef, mockCatalogApi],
-          [starredEntitiesApiRef, mockStarredEntitiesApi],
-        ],
+        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
         initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
@@ -390,10 +372,7 @@ describe('Entity page', () => {
         .add(overviewEntityContent);
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [
-          [catalogApiRef, mockCatalogApi],
-          [starredEntitiesApiRef, mockStarredEntitiesApi],
-        ],
+        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
         initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
@@ -437,10 +416,7 @@ describe('Entity page', () => {
         .add(apidocsEntityContent);
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [
-          [catalogApiRef, mockCatalogApi],
-          [starredEntitiesApiRef, mockStarredEntitiesApi],
-        ],
+        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
         initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
@@ -480,10 +456,7 @@ describe('Entity page', () => {
         .add(apidocsEntityContent);
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [
-          [catalogApiRef, mockCatalogApi],
-          [starredEntitiesApiRef, mockStarredEntitiesApi],
-        ],
+        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
         initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
@@ -522,10 +495,7 @@ describe('Entity page', () => {
         .add(apidocsEntityContent);
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [
-          [catalogApiRef, mockCatalogApi],
-          [starredEntitiesApiRef, mockStarredEntitiesApi],
-        ],
+        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
         initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
@@ -572,10 +542,7 @@ describe('Entity page', () => {
         .add(apidocsEntityContent);
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [
-          [catalogApiRef, mockCatalogApi],
-          [starredEntitiesApiRef, mockStarredEntitiesApi],
-        ],
+        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
         initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
@@ -622,10 +589,7 @@ describe('Entity page', () => {
         });
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [
-          [catalogApiRef, mockCatalogApi],
-          [starredEntitiesApiRef, mockStarredEntitiesApi],
-        ],
+        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
         initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
@@ -660,10 +624,7 @@ describe('Entity page', () => {
       );
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [
-          [catalogApiRef, mockCatalogApi],
-          [starredEntitiesApiRef, mockStarredEntitiesApi],
-        ],
+        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
         initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
@@ -700,10 +661,7 @@ describe('Entity page', () => {
       ).add(customEntityHeader);
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [
-          [catalogApiRef, mockCatalogApi],
-          [starredEntitiesApiRef, mockStarredEntitiesApi],
-        ],
+        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
         initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
@@ -760,10 +718,7 @@ describe('Entity page', () => {
       ).add(menuItem);
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [
-          [catalogApiRef, mockCatalogApi],
-          [starredEntitiesApiRef, mockStarredEntitiesApi],
-        ],
+        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
         initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
@@ -816,10 +771,7 @@ describe('Entity page', () => {
       ).add(menuItem);
 
       await renderInTestApp(tester.reactElement(), {
-        apis: [
-          [catalogApiRef, mockCatalogApi],
-          [starredEntitiesApiRef, mockStarredEntitiesApi],
-        ],
+        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
         initialRouteEntries: ['/catalog/default/component/artist-lookup'],
         config: {
           app: {
@@ -909,6 +861,7 @@ describe('Entity page', () => {
           .add(filteredMenuItem);
 
         await renderInTestApp(tester.reactElement(), {
+          initialRouteEntries: ['/catalog/default/component/artist-lookup'],
           config: {
             app: {
               title: 'Custom app',
@@ -921,7 +874,7 @@ describe('Entity page', () => {
               convertLegacyRouteRef(entityRouteRef),
           },
           apis: [
-            [catalogApiRef, mockCatalogApi],
+            mockCatalogApi,
             [starredEntitiesApiRef, mockStarredEntitiesApi],
           ],
         });


### PR DESCRIPTION
## Summary

The `pages.test.tsx` entity page test was flaky because `renderInTestApp` never set up React Router `<Route>` matching for the test element. `useParams()` always returned `{}`, so `useEntityFromUrl` got no route params and posted a "No name provided!" error. The test passed or failed depending on a race between the error effect and the tab render.

### Fix

**`renderInTestApp`**: Add a `mountPath` option that wraps the test element in a `<Route>` with the given path pattern, enabling `useParams()` to extract parameters from the URL. This mirrors what the real `AppRoutes` extension does via `useRoutes()`. Use together with `initialRouteEntries` to set a concrete URL matching the pattern.

**`pages.test.tsx`**: Use `mountPath` + `initialRouteEntries` + the in-memory `catalogApiMock({ entities: [...] })` so the test does real end-to-end routing: URL → params → entity lookup. Href expectations updated to match production behavior (sub-route links resolve relative to the matched parent Route).

### Test plan

- [x] All 20 entity page tests pass
- [x] All `renderInTestApp` tests pass
- [x] All `convertLegacyPageExtension` and `catalog-react/alpha/converters` tests pass
- [x] API report updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)