### PR TITLE
fix(catalog-backend): split queryEntities list and count queries

### DIFF
--- a/.changeset/split-query-entities-count.md
+++ b/.changeset/split-query-entities-count.md
@@ -3,3 +3,5 @@
 ---
 
 Split the `queryEntities` list and count into separate queries instead of a multi-reference CTE. When the `filtered` CTE was referenced twice (once for the count, once for the data), PostgreSQL refused to inline it, forcing full materialization of the filtered set before applying `LIMIT`. By running the count as a standalone query, the list CTE is only referenced once, allowing the planner to short-circuit on `LIMIT` and return the first page in milliseconds instead of waiting for the full filtered set to materialize.
+
+The standalone count query also fixes a pre-existing bug where `totalItems` was inflated for entities with multi-valued sort fields (e.g. tags). The old CTE-based count counted search rows, so an entity with 3 tags would be counted 3 times. The new count uses `EXISTS` to count distinct entities, aligning `totalItems` with the number of entities actually reachable through cursor pagination.

--- a/.changeset/split-query-entities-count.md
+++ b/.changeset/split-query-entities-count.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Split the `queryEntities` list and count into separate queries instead of a multi-reference CTE. When the `filtered` CTE was referenced twice (once for the count, once for the data), PostgreSQL refused to inline it, forcing full materialization of the filtered set before applying `LIMIT`. By running the count as a standalone query, the list CTE is only referenced once, allowing the planner to short-circuit on `LIMIT` and return the first page in milliseconds instead of waiting for the full filtered set to materialize.

--- a/.patches/pr-33721.txt
+++ b/.patches/pr-33721.txt
@@ -1,1 +1,0 @@
-Fix home page widgets not being draggable or resizable after the first save 

--- a/.patches/pr-34001.txt
+++ b/.patches/pr-34001.txt
@@ -1,1 +1,0 @@
-Fix facets endpoint performance regression when filters or permissions are applied

--- a/.patches/pr-34004.txt
+++ b/.patches/pr-34004.txt
@@ -1,1 +1,0 @@
-Preserve external hrefs in BUI link components under non-root base path

--- a/.patches/pr-34323.txt
+++ b/.patches/pr-34323.txt
@@ -1,0 +1,1 @@
+Split queryEntities list and count queries to fix CTE materialization bottleneck

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -484,22 +484,9 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
       },
     );
 
-    // Only pay the cost of counting the number of items if needed
-    if (shouldComputeTotalItems) {
-      // Note the intentional cross join here. The filtered_count dataset is
-      // always exactly one row, so it won't grow the result unnecessarily. But
-      // it's also important that there IS at least one row, because even if the
-      // filtered dataset is empty, we still want to know the total number of
-      // items.
-      dbQuery
-        .with('filtered_count', ['count'], inner =>
-          inner.from('filtered').count('*', { as: 'count' }),
-        )
-        .fromRaw('filtered_count, filtered')
-        .select('count', 'filtered.*');
-    } else {
-      dbQuery.from('filtered').select('*');
-    }
+    // The list query always references the 'filtered' CTE exactly once,
+    // allowing Postgres 12+ to inline it and short-circuit on LIMIT.
+    dbQuery.from('filtered').select('*');
 
     const isOrderingDescending = sortField?.order === 'desc';
 
@@ -585,15 +572,69 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
     // fetch an extra item to check if there are more items.
     dbQuery.limit(isFetchingBackwards ? limit : limit + 1);
 
-    const rows = shouldComputeTotalItems || limit > 0 ? await dbQuery : [];
+    // Build a standalone count query that reproduces the same filtering as
+    // the 'filtered' CTE. Running it separately ensures the list CTE is
+    // only referenced once, letting Postgres 12+ inline it and
+    // short-circuit on LIMIT.
+    let countQuery: Knex.QueryBuilder | undefined;
+    if (shouldComputeTotalItems) {
+      countQuery = this.database('final_entities')
+        .whereNotNull('final_entities.final_entity')
+        .count('*', { as: 'count' });
+
+      if (sortField) {
+        countQuery.whereExists(
+          this.database('search')
+            .select(this.database.raw(1))
+            .whereRaw('search.entity_id = final_entities.entity_id')
+            .where('search.key', sortField.field),
+        );
+      }
+
+      if (cursor.filter || cursor.query) {
+        applyEntityFilterToQuery({
+          filter: cursor.filter,
+          query: cursor.query,
+          targetQuery: countQuery,
+          onEntityIdField: 'final_entities.entity_id',
+          knex: this.database,
+        });
+      }
+
+      const normalizedFullTextFilterTerm = cursor.fullTextFilter?.term?.trim();
+      if (normalizedFullTextFilterTerm) {
+        const textFilterFields = cursor.fullTextFilter?.fields ?? [
+          sortField?.field || 'metadata.uid',
+        ];
+        const matchQuery = this.database<DbSearchRow>('search')
+          .select('search.entity_id')
+          .whereIn(
+            'search.key',
+            textFilterFields.map(field => field.toLocaleLowerCase('en-US')),
+          )
+          .andWhere(function keyFilter() {
+            this.andWhereRaw(
+              'search.value like ?',
+              `%${normalizedFullTextFilterTerm.toLocaleLowerCase('en-US')}%`,
+            );
+          });
+        countQuery.andWhere('final_entities.entity_id', 'in', matchQuery);
+      }
+    }
+
+    // Run list and count queries concurrently
+    const [rows, countResult] = await Promise.all([
+      limit > 0 ? dbQuery : Promise.resolve([]),
+      countQuery ?? Promise.resolve(undefined),
+    ]);
 
     let totalItems: number;
     if (cursor.totalItems !== undefined) {
       totalItems = cursor.totalItems;
     } else if (cursor.skipTotalItems) {
       totalItems = 0;
-    } else if (rows.length) {
-      totalItems = Number(rows[0].count);
+    } else if (countResult?.[0]) {
+      totalItems = Number(countResult[0].count);
     } else {
       totalItems = 0;
     }

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -398,13 +398,63 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
 
     const sortField = cursor.orderFields.at(0);
 
-    // The first part of the query builder is a subquery that applies all of the
-    // filtering. When a sort field is specified, the search table for that key
-    // drives the query via INNER JOIN so that the (key, value, entity_id)
-    // index walks rows in sort order, letting LIMIT short-circuit. Entities
-    // that lack the sort field are excluded from both the result set and the
-    // count — this is a deliberate choice that aligns totalItems with the
-    // number of entities actually reachable through cursor pagination.
+    const normalizedFullTextFilterTerm = cursor.fullTextFilter?.term?.trim();
+    const textFilterFields = cursor.fullTextFilter?.fields ?? [
+      sortField?.field || 'metadata.uid',
+    ];
+
+    // Shared predicate logic applied to both the list CTE and the
+    // standalone count query so they stay in sync. The `searchInScope`
+    // flag indicates whether a `search` table is already joined in the
+    // target query (true for the list CTE when a sort field is set),
+    // enabling a fast-path LIKE on the already-joined row.
+    const applyPredicates = (
+      q: Knex.QueryBuilder,
+      options?: { searchInScope?: boolean },
+    ) => {
+      if (cursor.filter || cursor.query) {
+        applyEntityFilterToQuery({
+          filter: cursor.filter,
+          query: cursor.query,
+          targetQuery: q,
+          onEntityIdField: 'final_entities.entity_id',
+          knex: this.database,
+        });
+      }
+
+      if (normalizedFullTextFilterTerm) {
+        if (
+          options?.searchInScope &&
+          textFilterFields.length === 1 &&
+          textFilterFields[0] === sortField?.field
+        ) {
+          q.andWhereRaw(
+            'search.value like ?',
+            `%${normalizedFullTextFilterTerm.toLocaleLowerCase('en-US')}%`,
+          );
+        } else {
+          const matchQuery = this.database<DbSearchRow>('search')
+            .select('search.entity_id')
+            .whereIn(
+              'search.key',
+              textFilterFields.map(field => field.toLocaleLowerCase('en-US')),
+            )
+            .andWhere(function keyFilter() {
+              this.andWhereRaw(
+                'search.value like ?',
+                `%${normalizedFullTextFilterTerm.toLocaleLowerCase('en-US')}%`,
+              );
+            });
+          q.andWhere('final_entities.entity_id', 'in', matchQuery);
+        }
+      }
+    };
+
+    // The list CTE. When a sort field is specified, the search table for
+    // that key drives the query via INNER JOIN so that the covering index
+    // walks rows in sort order, letting LIMIT short-circuit. Entities
+    // that lack the sort field are excluded — this aligns totalItems with
+    // the set reachable through cursor pagination.
     const dbQuery = this.database.with(
       'filtered',
       ['entity_id', 'final_entity', ...(sortField ? ['value'] : [])],
@@ -434,59 +484,33 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
             });
         }
 
-        // Add regular filters and/or predicate query, if given
-        if (cursor.filter || cursor.query) {
-          applyEntityFilterToQuery({
-            filter: cursor.filter,
-            query: cursor.query,
-            targetQuery: inner,
-            onEntityIdField: 'final_entities.entity_id',
-            knex: this.database,
-          });
-        }
-
-        // Add full text search filters, if given
-        const normalizedFullTextFilterTerm =
-          cursor.fullTextFilter?.term?.trim();
-        const textFilterFields = cursor.fullTextFilter?.fields ?? [
-          sortField?.field || 'metadata.uid',
-        ];
-        if (normalizedFullTextFilterTerm) {
-          if (
-            textFilterFields.length === 1 &&
-            textFilterFields[0] === sortField?.field
-          ) {
-            // If there is one item, apply the like query to the top level query which is already
-            //   filtered based on the singular sortField.
-            inner.andWhereRaw(
-              'search.value like ?',
-              `%${normalizedFullTextFilterTerm.toLocaleLowerCase('en-US')}%`,
-            );
-          } else {
-            const matchQuery = this.database<DbSearchRow>('search')
-              .select('search.entity_id')
-              // textFilterFields must be lowercased to match searchable keys in database, i.e. spec.profile.displayName -> spec.profile.displayname
-              .whereIn(
-                'search.key',
-                textFilterFields.map(field => field.toLocaleLowerCase('en-US')),
-              )
-              .andWhere(function keyFilter() {
-                this.andWhereRaw(
-                  'search.value like ?',
-                  `%${normalizedFullTextFilterTerm.toLocaleLowerCase(
-                    'en-US',
-                  )}%`,
-                );
-              });
-            inner.andWhere('final_entities.entity_id', 'in', matchQuery);
-          }
-        }
+        applyPredicates(inner, { searchInScope: !!sortField });
       },
     );
 
-    // The list query always references the 'filtered' CTE exactly once,
-    // allowing Postgres 12+ to inline it and short-circuit on LIMIT.
+    // The list query references the CTE exactly once, allowing Postgres
+    // 12+ to inline it and short-circuit on LIMIT.
     dbQuery.from('filtered').select('*');
+
+    // Standalone count query — runs concurrently with the list so the
+    // CTE stays single-referenced and inlineable.
+    let countQuery: Knex.QueryBuilder | undefined;
+    if (shouldComputeTotalItems) {
+      countQuery = this.database('final_entities')
+        .whereNotNull('final_entities.final_entity')
+        .count('*', { as: 'count' });
+
+      if (sortField) {
+        countQuery.whereExists(
+          this.database('search')
+            .select(this.database.raw(1))
+            .whereRaw('search.entity_id = final_entities.entity_id')
+            .where('search.key', sortField.field),
+        );
+      }
+
+      applyPredicates(countQuery);
+    }
 
     const isOrderingDescending = sortField?.order === 'desc';
 
@@ -571,56 +595,6 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
     }
     // fetch an extra item to check if there are more items.
     dbQuery.limit(isFetchingBackwards ? limit : limit + 1);
-
-    // Build a standalone count query that reproduces the same filtering as
-    // the 'filtered' CTE. Running it separately ensures the list CTE is
-    // only referenced once, letting Postgres 12+ inline it and
-    // short-circuit on LIMIT.
-    let countQuery: Knex.QueryBuilder | undefined;
-    if (shouldComputeTotalItems) {
-      countQuery = this.database('final_entities')
-        .whereNotNull('final_entities.final_entity')
-        .count('*', { as: 'count' });
-
-      if (sortField) {
-        countQuery.whereExists(
-          this.database('search')
-            .select(this.database.raw(1))
-            .whereRaw('search.entity_id = final_entities.entity_id')
-            .where('search.key', sortField.field),
-        );
-      }
-
-      if (cursor.filter || cursor.query) {
-        applyEntityFilterToQuery({
-          filter: cursor.filter,
-          query: cursor.query,
-          targetQuery: countQuery,
-          onEntityIdField: 'final_entities.entity_id',
-          knex: this.database,
-        });
-      }
-
-      const normalizedFullTextFilterTerm = cursor.fullTextFilter?.term?.trim();
-      if (normalizedFullTextFilterTerm) {
-        const textFilterFields = cursor.fullTextFilter?.fields ?? [
-          sortField?.field || 'metadata.uid',
-        ];
-        const matchQuery = this.database<DbSearchRow>('search')
-          .select('search.entity_id')
-          .whereIn(
-            'search.key',
-            textFilterFields.map(field => field.toLocaleLowerCase('en-US')),
-          )
-          .andWhere(function keyFilter() {
-            this.andWhereRaw(
-              'search.value like ?',
-              `%${normalizedFullTextFilterTerm.toLocaleLowerCase('en-US')}%`,
-            );
-          });
-        countQuery.andWhere('final_entities.entity_id', 'in', matchQuery);
-      }
-    }
 
     // Run list and count queries concurrently
     const [rows, countResult] = await Promise.all([

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -505,7 +505,8 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
           this.database('search')
             .select(this.database.raw(1))
             .whereRaw('search.entity_id = final_entities.entity_id')
-            .where('search.key', sortField.field),
+            .where('search.key', sortField.field)
+            .whereNotNull('search.value'),
         );
       }
 


### PR DESCRIPTION
## Summary

- Split the `queryEntities` list and count into two separate queries run via `Promise.all`, instead of the current multi-reference CTE that forces full materialization before `LIMIT` can short-circuit.

This is a minimal cherry-pick of the core performance fix from #34214, isolated so it can be merged and deployed as a patch without the larger API surface changes in that PR.

### Problem

The current query wraps the filtered set in a CTE (`filtered`) that is referenced **twice** — once by `filtered_count` and once by the outer `SELECT`. PostgreSQL 12+ refuses to inline a multi-referenced CTE, so it materializes the entire filtered set (e.g. all ~46K components), spills to temp, and only *then* applies `LIMIT 21`. The covering index can't help — the query shape itself prevents short-circuiting.

### Fix

Always reference the `filtered` CTE exactly once (for the list query). Run the count as a standalone query via `Promise.all`. Since the CTE is now single-referenced, Postgres inlines it and the planner can drive directly from the index with `LIMIT` short-circuit.

### Evidence

_All timings from `EXPLAIN ANALYZE` on a staging replica (~462K entities, ~13.2M search rows)._

| Scenario | Before (fused CTE) | After: list query | After: count query | After: wall clock (`Promise.all`) |
|---|---:|---:|---:|---:|
| `kind=component`, page 1, LIMIT 21 | **2,660 ms** | **1.6 ms** | 1,048 ms | **~1,048 ms** |
| No filter, page 1, LIMIT 21 | **7,715 ms** | **0.5 ms** | 5,471 ms | **~5,471 ms** |
| `kind=template` (narrow), page 1 | 1.1 ms | 0.6 ms | 0.4 ms | ~0.6 ms |
| Cursor page 2+ (`kind=component`) | 23 ms | 23 ms | n/a (skipped) | ~23 ms |

**Key takeaways:**

- **The common first-page load (`kind=component`)** drops from **2.7s to ~1s** wall clock — the list query returns in 1.6 ms instead of waiting for 2.7s of CTE materialization. The wall clock is bounded by the count (1s), but row data is available almost immediately.
- **No-filter first page** drops from **7.7s to ~5.5s** — the list returns in 0.5 ms. The count is expensive (5.5s scanning all entities) but runs concurrently with the now-instant list.
- **Narrow filters and cursor pages** are already fast and stay fast — no regression.
- A follow-up (`totalItems: 'exclude'` from #34214) can skip the count entirely, bringing page 1 to **<2 ms** for all filter shapes.

## Test plan

- [x] All 172 `DefaultEntitiesCatalog` tests pass
- [x] Type check passes (no new errors)
- [x] `EXPLAIN ANALYZE` verified on staging replica (timings above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)