### PR TITLE
feat(create-app): add CI workflow to default app template

### DIFF
--- a/.changeset/create-app-ci-workflow.md
+++ b/.changeset/create-app-ci-workflow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Added a GitHub Actions CI workflow to the default app template. New Backstage instances created with `create-app` now include a `.github/workflows/ci.yml` that runs lint, type checking, tests, configuration validation, and a Docker image build on every pull request.

--- a/docs/getting-started/ci.md
+++ b/docs/getting-started/ci.md
@@ -1,0 +1,271 @@
+---
+id: ci
+title: Setting up CI
+sidebar_label: Setting up CI
+description: Configure continuous integration checks for your Backstage instance.
+---
+
+Audience: Developers and Admins
+
+## Why CI matters for Backstage
+
+A Backstage instance is a living project. As you add plugins, customize
+configuration, and update dependencies, things can break in subtle ways: a
+TypeScript error in one package, a config typo that prevents the backend
+from starting, or a Docker image that no longer builds. Continuous
+Integration (CI) catches these problems on every pull request, before they
+reach production.
+
+A good CI pipeline for Backstage verifies that:
+
+- Code compiles and passes lint checks
+- Tests pass across all packages in the monorepo
+- Configuration files are valid
+- The deployment artifact (typically a Docker image) builds successfully
+
+## What to check
+
+These checks apply regardless of which CI system you use. Most map to
+commands provided by the Backstage CLI.
+
+### Lint
+
+```shell
+yarn backstage-cli repo lint
+```
+
+Runs ESLint across all packages in the monorepo. This catches code quality
+issues, unused imports, and style violations. See
+[repo lint](../tooling/cli/03-commands.md#repo-lint) for available options.
+
+### Type checking
+
+```shell
+yarn tsc:full
+```
+
+Runs the TypeScript compiler with `--skipLibCheck false` and
+`--incremental false`, performing a complete type check across the entire
+project. This is stricter than the default `yarn tsc` and catches type
+errors that incremental builds might miss.
+
+### Tests
+
+```shell
+yarn backstage-cli repo test
+```
+
+Runs the test suite for all packages. The Backstage CLI automatically
+detects which test runner to use and handles monorepo-specific
+configuration. See
+[repo test](../tooling/cli/03-commands.md#repo-test) for available
+options.
+
+### Deprecated API usage
+
+```shell
+yarn backstage-cli repo list-deprecations
+```
+
+Scans your code for usage of deprecated Backstage APIs. This is especially
+useful when preparing for version upgrades, but running it in CI ensures
+new code doesn't introduce deprecated patterns. See
+[repo list-deprecations](../tooling/cli/03-commands.md#repo-list-deprecations)
+for available options.
+
+### Build
+
+```shell
+yarn build:all
+```
+
+Builds all packages in the monorepo, including the backend bundle that the
+Dockerfile needs. Running the build in CI catches compilation errors,
+missing dependencies, and broken imports that type checking alone might
+not surface. See
+[repo build](../tooling/cli/03-commands.md#repo-build) for available
+options.
+
+### Configuration validation
+
+```shell
+yarn backstage-cli config:check --lax --strict
+```
+
+Validates your `app-config.yaml` against the configuration schema. The
+`--lax` flag allows environment variables to remain unresolved (useful in
+CI where production secrets aren't available), while `--strict` ensures
+the config structure matches the schema. See
+[config:check](../tooling/cli/03-commands.md#configcheck) for available
+options.
+
+To validate your production configuration as well:
+
+```shell
+yarn backstage-cli config:check --lax --strict \
+  --config app-config.yaml \
+  --config app-config.production.yaml
+```
+
+### Docker build
+
+```shell
+yarn build-image
+```
+
+Verifies that the Docker image builds successfully. This script runs
+`docker build` with the correct build context and Dockerfile path. It
+catches issues like incompatible dependencies that only surface at
+packaging time. This step expects pre-built backend bundles from
+`yarn build:all`.
+
+## GitHub Actions
+
+If you created your Backstage instance with `create-app`, a GitHub Actions
+workflow is included at `.github/workflows/ci.yml`. It runs all of the
+checks above on every pull request.
+
+Here's what the workflow does, step by step:
+
+### Node.js and Yarn setup
+
+The workflow installs Node.js 24.x and caches both `node_modules` and the
+global Yarn cache. On subsequent runs, `yarn install --immutable` finishes
+in seconds when the lockfile hasn't changed.
+
+### CI steps
+
+The pipeline runs these steps in order:
+
+1. **Lint** -- checks code quality across all packages
+2. **Deprecations** -- flags deprecated API usage
+3. **Type checking** -- full TypeScript compilation
+4. **Build** -- builds all packages (`yarn build:all`)
+5. **Tests** -- runs the full test suite
+6. **Config check** -- validates both default and production configuration
+7. **Docker build** -- verifies the container image builds
+
+Build runs before tests because some test setups depend on generated
+artifacts, and it runs before the Docker build because the Dockerfile
+expects pre-built backend bundles.
+
+### Customizing the workflow
+
+Common modifications:
+
+- **Add a matrix strategy** to test on multiple Node.js versions (the
+  template supports Node.js 22 and 24).
+- **Add a deploy step** that pushes the Docker image to a registry when
+  merging to your default branch.
+- **Add end-to-end tests** using the included Playwright configuration
+  (`yarn test:e2e`).
+
+## Other CI systems
+
+The same checks work in any CI system -- only the pipeline syntax changes.
+
+### GitLab CI
+
+```yaml
+stages:
+  - validate
+  - build
+  - test
+
+lint:
+  stage: validate
+  script:
+    - yarn install --immutable
+    - yarn backstage-cli repo lint
+
+type-check:
+  stage: validate
+  script:
+    - yarn install --immutable
+    - yarn tsc:full
+
+build:
+  stage: build
+  script:
+    - yarn install --immutable
+    - yarn build:all
+
+test:
+  stage: test
+  script:
+    - yarn install --immutable
+    - yarn backstage-cli repo test
+```
+
+### Jenkins
+
+```groovy
+pipeline {
+  agent {
+    docker {
+      image 'node:24-slim'
+    }
+  }
+  environment {
+    CI = 'true'
+    NODE_OPTIONS = '--max-old-space-size=4096'
+  }
+  stages {
+    stage('Install') {
+      steps {
+        sh 'yarn install --immutable'
+      }
+    }
+    stage('Lint') {
+      steps {
+        sh 'yarn backstage-cli repo lint'
+      }
+    }
+    stage('Type check') {
+      steps {
+        sh 'yarn tsc:full'
+      }
+    }
+    stage('Build') {
+      steps {
+        sh 'yarn build:all'
+      }
+    }
+    stage('Test') {
+      steps {
+        sh 'yarn backstage-cli repo test'
+      }
+    }
+    stage('Config check') {
+      steps {
+        sh 'yarn backstage-cli config:check --lax --strict'
+      }
+    }
+  }
+}
+```
+
+### Key differences from GitHub Actions
+
+- **Caching**: GitHub Actions has built-in cache actions. Other systems
+  require you to configure cache paths and keys manually.
+- **Docker-in-Docker**: Some CI systems require extra configuration to run
+  `docker build` inside a pipeline. Check your platform's documentation
+  for Docker support.
+- **Environment variables**: Set `CI=true` and
+  `NODE_OPTIONS=--max-old-space-size=4096` in your pipeline environment.
+  The `CI` variable ensures deterministic behavior in tools like Jest, and
+  the memory limit is explained below.
+
+## Environment variables
+
+Two environment variables are set in the generated workflow:
+
+- **`CI=true`** -- Enables CI-specific behavior in tools like Jest (for
+  example, running all tests instead of only changed ones) and prevents
+  interactive prompts.
+- **`NODE_OPTIONS=--max-old-space-size=4096`** -- Increases the Node.js
+  heap memory limit to 4 GB. TypeScript compilation and bundling across a
+  monorepo can exceed the default memory limit, especially as you add
+  plugins. This setting prevents out-of-memory crashes during
+  `yarn tsc:full` and `yarn build:all`.

--- a/docs/getting-started/ci.md
+++ b/docs/getting-started/ci.md
@@ -36,7 +36,7 @@ yarn backstage-cli repo lint
 
 Runs ESLint across all packages in the monorepo. This catches code quality
 issues, unused imports, and style violations. See
-[repo lint](../tooling/cli/03-commands.md#repo-lint) for available options.
+[repo lint](../tooling/cli/module-lint.md#repo-lint) for available options.
 
 ### Type checking
 
@@ -58,7 +58,7 @@ yarn backstage-cli repo test
 Runs the test suite for all packages. The Backstage CLI automatically
 detects which test runner to use and handles monorepo-specific
 configuration. See
-[repo test](../tooling/cli/03-commands.md#repo-test) for available
+[repo test](../tooling/cli/module-test.md#repo-test) for available
 options.
 
 ### Deprecated API usage
@@ -70,7 +70,7 @@ yarn backstage-cli repo list-deprecations
 Scans your code for usage of deprecated Backstage APIs. This is especially
 useful when preparing for version upgrades, but running it in CI ensures
 new code doesn't introduce deprecated patterns. See
-[repo list-deprecations](../tooling/cli/03-commands.md#repo-list-deprecations)
+[repo list-deprecations](../tooling/cli/module-maintenance.md#repo-list-deprecations)
 for available options.
 
 ### Build
@@ -83,23 +83,10 @@ Builds all packages in the monorepo, including the backend bundle that the
 Dockerfile needs. Running the build in CI catches compilation errors,
 missing dependencies, and broken imports that type checking alone might
 not surface. See
-[repo build](../tooling/cli/03-commands.md#repo-build) for available
+[repo build](../tooling/cli/module-build.md#repo-build) for available
 options.
 
 ### Configuration validation
-
-```shell
-yarn backstage-cli config:check --lax --strict
-```
-
-Validates your `app-config.yaml` against the configuration schema. The
-`--lax` flag allows environment variables to remain unresolved (useful in
-CI where production secrets aren't available), while `--strict` ensures
-the config structure matches the schema. See
-[config:check](../tooling/cli/03-commands.md#configcheck) for available
-options.
-
-To validate your production configuration as well:
 
 ```shell
 yarn backstage-cli config:check --lax --strict \
@@ -107,7 +94,16 @@ yarn backstage-cli config:check --lax --strict \
   --config app-config.production.yaml
 ```
 
-### Docker build
+Validates your configuration files against the configuration schema. The
+`--lax` flag allows environment variables to remain unresolved (useful in
+CI where production secrets aren't available), while `--strict` ensures
+the config structure matches the schema. Passing multiple `--config`
+flags lets you validate your production configuration alongside the
+default. See
+[config:check](../tooling/cli/module-config.md#configcheck) for available
+options.
+
+### Docker build (optional)
 
 ```shell
 yarn build-image
@@ -118,6 +114,10 @@ Verifies that the Docker image builds successfully. This script runs
 catches issues like incompatible dependencies that only surface at
 packaging time. This step expects pre-built backend bundles from
 `yarn build:all`.
+
+This step is optional. Docker builds can be slow, so some teams prefer to
+run them only on merges to the default branch or on a scheduled basis
+rather than on every pull request.
 
 ## GitHub Actions
 
@@ -138,11 +138,11 @@ in seconds when the lockfile hasn't changed.
 The pipeline runs these steps in order:
 
 1. **Lint** -- checks code quality across all packages
-2. **Deprecations** -- flags deprecated API usage
-3. **Type checking** -- full TypeScript compilation
+2. **Type checking** -- full TypeScript compilation
+3. **Deprecations** -- flags deprecated API usage
 4. **Build** -- builds all packages (`yarn build:all`)
 5. **Tests** -- runs the full test suite
-6. **Config check** -- validates both default and production configuration
+6. **Config check** -- validates default and production configuration together
 7. **Docker build** -- verifies the container image builds
 
 Build runs before tests because some test setups depend on generated
@@ -238,11 +238,52 @@ pipeline {
     }
     stage('Config check') {
       steps {
-        sh 'yarn backstage-cli config:check --lax --strict'
+        sh 'yarn backstage-cli config:check --lax --strict --config app-config.yaml --config app-config.production.yaml'
       }
     }
   }
 }
+```
+
+### Azure DevOps
+
+```yaml
+trigger:
+  - main
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+variables:
+  CI: 'true'
+  NODE_OPTIONS: '--max-old-space-size=4096'
+
+steps:
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '24.x'
+    displayName: use node.js
+
+  - script: yarn install --immutable
+    displayName: yarn install
+
+  - script: yarn backstage-cli repo lint
+    displayName: lint
+
+  - script: yarn tsc:full
+    displayName: type checking
+
+  - script: yarn backstage-cli repo list-deprecations
+    displayName: deprecations
+
+  - script: yarn build:all
+    displayName: build
+
+  - script: yarn backstage-cli repo test
+    displayName: tests
+
+  - script: yarn backstage-cli config:check --lax --strict --config app-config.yaml --config app-config.production.yaml
+    displayName: config check
 ```
 
 ### Key differences from GitHub Actions

--- a/docs/getting-started/ci.md
+++ b/docs/getting-started/ci.md
@@ -140,13 +140,13 @@ The pipeline runs these steps in order:
 1. **Lint** -- checks code quality across all packages
 2. **Type checking** -- full TypeScript compilation
 3. **Deprecations** -- flags deprecated API usage
-4. **Build** -- builds all packages (`yarn build:all`)
-5. **Tests** -- runs the full test suite
+4. **Tests** -- runs the full test suite
+5. **Build** -- builds all packages (`yarn build:all`)
 6. **Config check** -- validates default and production configuration together
 7. **Docker build** -- verifies the container image builds
 
-Build runs before tests because some test setups depend on generated
-artifacts, and it runs before the Docker build because the Dockerfile
+Tests run before the full build to give faster feedback on the most common
+failure mode. Build runs before the Docker build because the Dockerfile
 expects pre-built backend bundles.
 
 ### Customizing the workflow
@@ -171,6 +171,19 @@ stages:
   - validate
   - build
   - test
+
+default:
+  cache:
+    key:
+      files:
+        - yarn.lock
+    paths:
+      - node_modules/
+      - .yarn/cache/
+
+variables:
+  CI: 'true'
+  NODE_OPTIONS: '--max-old-space-size=8192'
 
 lint:
   stage: validate
@@ -208,7 +221,7 @@ pipeline {
   }
   environment {
     CI = 'true'
-    NODE_OPTIONS = '--max-old-space-size=4096'
+    NODE_OPTIONS = '--max-old-space-size=8192'
   }
   stages {
     stage('Install') {
@@ -247,6 +260,11 @@ pipeline {
 
 ### Azure DevOps
 
+> **Note:** YAML `pr:` triggers only work when your repo is hosted on
+> GitHub or Bitbucket Cloud. If you use Azure Repos Git, configure a
+> [branch policy for build validation](https://learn.microsoft.com/en-us/azure/devops/repos/git/branch-policies#build-validation)
+> to run this pipeline on pull requests.
+
 ```yaml
 trigger:
   - main
@@ -256,7 +274,7 @@ pool:
 
 variables:
   CI: 'true'
-  NODE_OPTIONS: '--max-old-space-size=4096'
+  NODE_OPTIONS: '--max-old-space-size=8192'
 
 steps:
   - task: NodeTool@0
@@ -294,7 +312,7 @@ steps:
   `docker build` inside a pipeline. Check your platform's documentation
   for Docker support.
 - **Environment variables**: Set `CI=true` and
-  `NODE_OPTIONS=--max-old-space-size=4096` in your pipeline environment.
+  `NODE_OPTIONS=--max-old-space-size=8192` in your pipeline environment.
   The `CI` variable ensures deterministic behavior in tools like Jest, and
   the memory limit is explained below.
 
@@ -305,8 +323,8 @@ Two environment variables are set in the generated workflow:
 - **`CI=true`** -- Enables CI-specific behavior in tools like Jest (for
   example, running all tests instead of only changed ones) and prevents
   interactive prompts.
-- **`NODE_OPTIONS=--max-old-space-size=4096`** -- Increases the Node.js
-  heap memory limit to 4 GB. TypeScript compilation and bundling across a
+- **`NODE_OPTIONS=--max-old-space-size=8192`** -- Increases the Node.js
+  heap memory limit to 8 GB. TypeScript compilation and bundling across a
   monorepo can exceed the default memory limit, especially as you add
   plugins. This setting prevents out-of-memory crashes during
   `yarn tsc:full` and `yarn build:all`.

--- a/docs/tooling/cli/03-commands.md
+++ b/docs/tooling/cli/03-commands.md
@@ -36,107 +36,693 @@ info                                           Show helpful information for debu
 help [command]                                 display help for command
 ```
 
-## Commands by Module
+The `package` command category, `yarn backstage-cli package --help`:
 
-### [Auth Module](./module-auth.md)
+```text
+start [options]                  Start a package for local development
+build [options]                  Build a package for production deployment or publishing
+lint [options] [directories...]  Lint a package
+test                             Run tests, forwarding args to Jest, defaulting to watch mode
+clean                            Delete cache directories
+prepack                          Prepares a package for packaging before publishing
+postpack                         Restores the changes made by the prepack command
+help [command]                   display help for command
+```
 
-| Command            | Description                               |
-| ------------------ | ----------------------------------------- |
-| `auth login`       | Log in the CLI to a Backstage instance    |
-| `auth logout`      | Log out and clear stored credentials      |
-| `auth show`        | Show details of an authenticated instance |
-| `auth list`        | List authenticated instances              |
-| `auth print-token` | Print an access token to stdout           |
-| `auth select`      | Select the default instance               |
+The `repo` command category, `yarn backstage-cli repo --help`:
 
-### [Actions Module](./module-actions.md)
+```text
+start [options] [packageName...]  Starts packages in the repo for local development
+build [options]                   Build packages in the project, excluding bundled app and backend packages.
+test [options]                    Run tests, forwarding args to Jest, defaulting to watch mode
+lint [options]                    Lint all packages in the project
+fix [options]                     Automatically fix packages in the project
+clean                             Delete cache and output directories
+list-deprecations [options]       List deprecations
+help [command]                    display help for command
+```
 
-| Command                  | Description                                           |
-| ------------------------ | ----------------------------------------------------- |
-| `actions list`           | List available actions from configured plugin sources |
-| `actions execute`        | Execute an action                                     |
-| `actions sources add`    | Add a plugin source for action discovery              |
-| `actions sources list`   | List configured plugin sources                        |
-| `actions sources remove` | Remove a plugin source                                |
+The `migrate` command category, `yarn backstage-cli migrate --help`:
 
-### [Build Module](./module-build.md)
+```text
+package-roles         Add package role field to packages that don't have it
+package-scripts       Set package scripts according to each package role
+package-exports       Synchronize package subpath export definitions
+package-lint-configs  Migrates all packages to use @backstage/cli/config/eslint-factory
+react-router-deps     Migrates the react-router dependencies for all packages to be peer dependencies
+help [command]        display help for command
+```
 
-| Command            | Description                                             |
-| ------------------ | ------------------------------------------------------- |
-| `repo start`       | Start packages for local development                    |
-| `repo build`       | Build packages in the project                           |
-| `repo clean`       | Delete cache and output directories across the project  |
-| `package start`    | Start a package for local development                   |
-| `package build`    | Build a package for production deployment or publishing |
-| `package bundle`   | Bundle a plugin for dynamic loading (experimental)      |
-| `package clean`    | Delete cache directories                                |
-| `package prepack`  | Prepare a package for packaging before publishing       |
-| `package postpack` | Restore changes made by prepack                         |
-| `build-workspace`  | Build a temporary dist workspace from provided packages |
+## repo start
 
-### [Config Module](./module-config.md)
+Start a set of packages in the project for local development. If no explicit packages are listed via arguments or options, packages will instead be selected based on their [package role](./02-build-system.md#package-roles). If a single set of frontend and/or backend packages are found, they will be started. If there are multiple matches the directories 'packages/app' and 'packages/backend' will be preferred. If no matches are found the command will fall back to expecting a single plugin frontend and/or backend package to start instead.
 
-| Command         | Description                                          |
-| --------------- | ---------------------------------------------------- |
-| `config:docs`   | Browse the configuration reference documentation     |
-| `config:print`  | Print the app configuration                          |
-| `config:check`  | Validate that configuration loads and matches schema |
-| `config:schema` | Print the configuration schema                       |
+Any `--config` options in the `start` script in `package.json` of the selected packages will be picked up and used, unless a `--config` option is provided to this command, in which case it will be used instead.
 
-### [GitHub Module](./module-github.md)
+Any `--require` option in the `start` script in `package.json` of the selected backend package will be picked up and used.
 
-| Command             | Description                                  |
-| ------------------- | -------------------------------------------- |
-| `create-github-app` | Create a new GitHub App in your organization |
+```text
+Usage: backstage-cli repo start [options] [packageNameOrPath...]
 
-### [Info Module](./module-info.md)
+Starts packages in the repo for local development
 
-| Command | Description                                               |
-| ------- | --------------------------------------------------------- |
-| `info`  | Show helpful information for debugging and reporting bugs |
+Arguments:
+  packageNameOrPath     Run the specified packages instead of the defaults.
 
-### [Lint Module](./module-lint.md)
+Options:
+  --plugin <pluginId>   Start the dev entry-point for any matching plugin package in the repo (default: [])
+  --config <path>       Config files to load instead of app-config.yaml (default: [])
+  --inspect [host]      Enable debugger in Node.js environments. Applies to backend package only
+  --inspect-brk [host]  Enable debugger in Node.js environments, breaking before code starts. Applies to backend package only
+  --require <path...>   Add a --require argument to the node process. Applies to backend package only
+  --link <path>         Link an external workspace for module resolution
+```
 
-| Command        | Description                      |
-| -------------- | -------------------------------- |
-| `package lint` | Lint a package                   |
-| `repo lint`    | Lint all packages in the project |
+## repo build
 
-### [Maintenance Module](./module-maintenance.md)
+Builds all packages in the project, excluding bundled packages by default, i.e. ones
+with the role `'frontend'` or `'backend'`.
 
-| Command                  | Description                               |
-| ------------------------ | ----------------------------------------- |
-| `repo fix`               | Automatically fix packages in the project |
-| `repo list-deprecations` | List deprecations                         |
+```text
+Usage: backstage-cli repo build [options]
 
-### [Migrate Module](./module-migrate.md)
+Build packages in the project, excluding bundled app and backend packages.
 
-| Command                        | Description                                            |
-| ------------------------------ | ------------------------------------------------------ |
-| `versions:bump`                | Bump Backstage packages to the latest versions         |
-| `versions:migrate`             | Migrate plugins to the @backstage-community namespace  |
-| `migrate package-roles`        | Add package role field to packages                     |
-| `migrate package-scripts`      | Set package scripts according to each package role     |
-| `migrate package-exports`      | Synchronize package subpath export definitions         |
-| `migrate package-lint-configs` | Migrate to @backstage/cli/config/eslint-factory        |
-| `migrate react-router-deps`    | Migrate react-router dependencies to peer dependencies |
+Options:
+  --all          Build all packages, including bundled app and backend packages.
+  --since <ref>  Only build packages and their dev dependents that changed since the specified ref
+```
 
-### [New Module](./module-new.md)
+## repo lint
 
-| Command | Description                                                  |
-| ------- | ------------------------------------------------------------ |
-| `new`   | Open an interactive guide to creating new things in your app |
+Lint all packages in the project.
 
-### [Test Module](./module-test.md)
+```text
+Usage: backstage-cli repo lint [options]
 
-| Command        | Description                    |
-| -------------- | ------------------------------ |
-| `repo test`    | Run tests across the project   |
-| `package test` | Run tests for a single package |
+Lint all packages in the project
 
-### [Translations Module](./module-translations.md)
+Options:
+  --format <format>           Lint report output format (default: "eslint-formatter-friendly")
+  --since <ref>               Only lint packages that changed since the specified ref
+  --success-cache             Enable success caching, which skips running lint for unchanged packages that were successful in the previous run
+  --success-cache-dir <path>  Set the success cache location, (default: node_modules/.cache/backstage-cli)
+  --fix                       Attempt to automatically fix violations
+```
 
-| Command               | Description                               |
-| --------------------- | ----------------------------------------- |
-| `translations export` | Export translation messages to JSON files |
-| `translations import` | Generate translation resource wiring code |
+## repo list-deprecations
+
+Scan all packages in the project for usage of deprecated Backstage APIs and
+report them. This is useful for tracking migration progress when upgrading
+Backstage versions.
+
+```text
+Usage: backstage-cli repo list-deprecations [options]
+
+List deprecations found across all packages in the project
+
+Options:
+  --json        Output as JSON
+```
+
+## repo test
+
+Test packages in the project. It is recommended to have this command be used as the `test` script in the root `package.json` in your project:
+
+```json title="package.json in the root of your project"
+{
+  ...
+  "scripts": {
+    ...
+    "test": "backstage-cli repo test"
+  }
+}
+```
+
+If run without any arguments it will default to running changed tests in watch mode, unless the `CI` environment flag is set, in which case it will run all tests without watching:
+
+```sh title="Run changes tests from repo root"
+yarn test
+```
+
+If arguments are provided, they will be forwarded to Jest and used to filter test to execute. If full paths to tests are provided, only those tests will be included, for example:
+
+```sh title="Run specific tests from repo root"
+yarn test packages/app/src/App.test.tsx
+```
+
+If you want to avoid re-running tests that have not changed since the last successful run in CI, you can use the `--success-cache` flag. By default this cache is stored in `node_modules/.cache/backstage-cli`, but you can choose a different directory with the `--success-cache-dir <path>`.
+
+```text
+Usage: backstage-cli repo test [options]
+
+Run tests, forwarding args to Jest, defaulting to watch mode
+
+Options:
+  --since <ref>               Only test packages that changed since the specified ref
+  --success-cache             Enable success caching, which skips running tests for unchanged packages that were successful in the previous run
+  --success-cache-dir <path>  Set the success cache location, (default: node_modules/.cache/backstage-cli)
+  --jest-help                 Show help for Jest CLI options, which are passed through
+  -h, --help                  display help for command
+```
+
+## package start
+
+Starts the package for local development. See the frontend and backend development parts in the build system [bundling](./02-build-system.md#bundling) section for more details.
+
+```text
+Usage: backstage-cli package start [options]
+
+Start a package for local development
+
+Options:
+  --config <path>     Config files to load instead of app-config.yaml (default: [])
+  --role <name>       Run the command with an explicit package role
+  --check             Enable type checking and linting if available
+  --inspect           Enable debugger in Node.js environments
+  --inspect-brk       Enable debugger in Node.js environments, breaking before code starts
+  --entrypoint <path> Entry directory path (uses index file) or entry file path (without extension). Defaults to "dev"
+```
+
+## package build
+
+Build an individual package based on its role. See the build system [building](./02-build-system.md#building) and [bundling](./02-build-system.md#bundling) sections for more details.
+
+```text
+Usage: backstage-cli package build [options]
+
+Build a package for production deployment or publishing
+
+Options:
+  --role <name>              Run the command with an explicit package role
+  --minify                   Minify the generated code. Does not apply to app package (app is minified by default).
+  --skip-build-dependencies  Skip the automatic building of local dependencies. Applies to backend packages only.
+  --stats                    If bundle stats are available, write them to the output directory. Applies to app packages only.
+  --config <path>            Config files to load instead of app-config.yaml. Applies to app packages only. (default: [])
+  --module-federation        Build a package as a module federation remote. Applies to frontend plugin packages only.
+```
+
+## package bundle
+
+:::caution Experimental
+This command is experimental and may receive breaking changes in future releases
+without a deprecation period. It is hidden from the main `--help` output.
+:::
+
+Bundle a plugin for dynamic loading. This creates a self-contained plugin
+package that can be deployed independently and loaded dynamically by a Backstage
+application. Supports both backend and frontend plugins.
+
+Unlike regular builds, the bundle command:
+
+- Creates a fully self-contained plugin deliverable
+
+- Produces module federation assets (frontend) or includes plugin dependencies in the plugin's private `node_modules`, building and packing (with `yarn pack`) the local `workspace:^` dependencies first (backend).
+- Generates a config schema from plugin-related packages only.
+- Validates that the plugin exports valid dynamic loading entry points (backend only)
+
+### Usage
+
+```bash
+# Bundle the current package (output: ./bundle/)
+yarn backstage-cli package bundle
+
+# Bundle to a specific directory (output: ../dynamic-plugins/<mangled-package-name>/)
+yarn backstage-cli package bundle --output-destination ../dynamic-plugins
+
+# Override the bundle subdirectory name
+yarn backstage-cli package bundle --output-name my-plugin-bundle
+
+# Clean output before bundling
+yarn backstage-cli package bundle --clean
+
+# Skip building for the plugin and its local dependencies
+yarn backstage-cli package bundle --no-build
+
+# Skip dependency installation and entrypoint validation
+yarn backstage-cli package bundle --no-install
+
+# Stream detailed output from build, pack, and install steps
+yarn backstage-cli package bundle --verbose
+
+# Use a pre-built dist workspace for batch bundling.
+# First, create the workspace with:
+#   backstage-cli build-workspace <output-dir> [packages...] --alwaysPack
+# Then pass <output-dir> as --pre-packed-dir:
+yarn backstage-cli package bundle --pre-packed-dir ../dist-workspace
+```
+
+### Options
+
+```text
+Usage: backstage-cli package bundle [options]
+
+Bundle a plugin for dynamic loading
+
+Options:
+  --output-destination <dir>  Directory in which the bundle subdirectory is created.
+                              Defaults to the current package directory.
+  --output-name <name>        Name of the bundle subdirectory. Defaults to "bundle" when
+                              output stays in the package directory, or to the mangled
+                              package name (e.g. myorg-plugin-foo) when
+                              --output-destination is specified.
+  --clean                     Clean the output directory before bundling
+  --no-build                  Skip building packages (assumes they are already built)
+  --no-install                Skip dependency installation and entrypoint validation.
+  --verbose                   Stream detailed output from internal steps (build, pack,
+                              install) to the console. Without this flag, output is
+                              captured to per-step log files and only shown on error.
+  --pre-packed-dir <dir>      Path to a pre-built dist workspace (from
+                              build-workspace --alwaysPack). Skips local dependency
+                              packing and uses pre-packed packages directly. For frontend
+                              plugins, this also enables yarn.lock generation for SBOM.
+```
+
+### Output Contract
+
+The bundle output is a directory that can be deployed as a standalone unit.
+Consumers of the bundle (such as `@backstage/backend-dynamic-feature-service`
+or `@backstage/frontend-dynamic-feature-loader`) can rely on the following
+guarantees:
+
+**All bundles:**
+
+- A `package.json` at the bundle root with entry points configured for dynamic
+  loading. The `backstage.role` and `files` fields are preserved from the source package.
+- A `dist/` directory containing the built plugin code.
+- A `dist/.config-schema.json` file (when any config schemas apply) containing
+  gathered schemas from the plugin, its local workspace dependencies, and
+  third-party dependencies. Schemas from unrelated Backstage packages are excluded.
+- No `scripts` or `devDependencies` in `package.json`.
+
+**Backend plugins** (`backend-plugin`, `backend-plugin-module`):
+
+- A `node_modules/` directory with all production dependencies (including local
+  workspace dependencies), pinned to their exact versions from the source lockfile.
+- `bundleDependencies` is set to `true` in `package.json`.
+
+**Frontend plugins** (`frontend-plugin`, `frontend-plugin-module`):
+
+- `main` points to `dist/remoteEntry.js` (the Module Federation remote entry).
+- `types` points to `dist/@mf-types/index.d.ts` when type declarations are
+  available.
+- No embedded `node_modules/` directory.
+
+### Environment Variables
+
+The bundle command supports the same environment variables as the Backstage yarn plugin
+for resolving `backstage:^` version specifiers:
+
+- `BACKSTAGE_MANIFEST_FILE`: Path to a local manifest file (for offline usage)
+- `BACKSTAGE_VERSIONS_BASE_URL`: Custom base URL for fetching release manifests
+
+### Supported Package Roles
+
+The bundle command supports packages with the following roles:
+
+- `backend-plugin`
+- `backend-plugin-module`
+- `frontend-plugin`
+- `frontend-plugin-module`
+
+## package lint
+
+Lint a package. In addition to the default `eslint` behavior, this command will
+include TypeScript files, treat warnings as errors, and default to linting the
+entire directory if no specific files are listed. For more information, see the
+build system [linting](./02-build-system.md#linting) section.
+
+```text
+Usage: backstage-cli package lint [options]
+
+Lint a package
+
+Options:
+  --format <format>        Lint report output format (default: "eslint-formatter-friendly")
+  --fix                    Attempt to automatically fix violations
+  --max-warnings <number>  Fail if more than this number of warnings. -1 allows warnings. (default: -1)
+```
+
+## package test
+
+Run tests, forwarding all unknown options to Jest, and defaulting to watch mode.
+When executing the tests, `process.env.NODE_ENV` will be set to `"test"`.
+
+This command uses a default Jest configuration that is included in the CLI,
+which is set up with similar goals for speed, scale, and working within a
+monorepo. The configuration sets the `src` as the root directory, enforces the
+`.test.` infix for tests, and uses `src/setupTests.ts` as the test setup
+location. The included configuration also supports test execution at the root of
+a yarn workspaces monorepo by automatically creating one grouped configuration
+that includes all packages that have `backstage-cli test` in their package
+`test` script.
+
+For more information about configuration overrides and editor support, see the [Jest Configuration section](./02-build-system.md#jest-configuration) in the build system documentation.
+
+```text
+Usage: backstage-cli package test [options]
+
+Run tests, forwarding args to Jest, defaulting to watch mode
+
+Options:
+  --backstage-cli-help    display help for command
+```
+
+## package clean
+
+Remove cache and output directories.
+
+```text
+Usage: backstage-cli package clean [options]
+
+Delete cache directories
+```
+
+## package prepack
+
+This command should be added as `scripts.prepack` in all packages. It enables
+packaging- and publish-time overrides for fields inside `packages.json`.
+For more details, see the build system [publishing](./02-build-system.md#publishing) section.
+
+```text
+Usage: backstage-cli package prepack [options]
+
+Prepares a package for packaging before publishing
+```
+
+## package postpack
+
+This should be added as `scripts.postpack` in all packages. It restores
+`package.json` to what it looked like before calling the `prepack` command.
+
+```text
+Usage: backstage-cli package postpack [options]
+
+Restores the changes made by the prepack command
+```
+
+## new
+
+The `new` command opens up an interactive guide for you to create new things
+in your app. If you do not pass in any options it is completely interactive, but
+it is possible to pre-select what you want to create using the `--select` flag,
+and provide options using `--option`, for example:
+
+```bash
+backstage-cli new --select frontend-plugin --option pluginId=foo
+```
+
+This command is typically added as script in the root `package.json` to be
+executed with `yarn new`. For example you may have it set up like this:
+
+```json
+{
+  "scripts": {
+    "new": "backstage-cli new"
+  }
+}
+```
+
+The `new` command comes with a default collection of plugins/packages, however,
+you can customize this list and even create your own CLI templates. For more
+information see [CLI Templates](./04-templates.md).
+
+```text
+Usage: backstage-cli new
+
+Options:
+  -h, --help               display help for command
+```
+
+## config\:docs
+
+This commands opens up the reference documentation of your apps local
+configuration schema in the browser. This is useful to get an overview of what
+configuration values are available to use, a description of what they do and
+their format, and where they get sent.
+
+```text
+Usage: backstage-cli config:docs [options]
+
+Browse the configuration reference documentation
+
+Options:
+  --package <name>  Only include the schema that applies to the given package
+  -h, --help        display help for command
+```
+
+## config\:print
+
+Print the static configuration, defaulting to reading `app-config.yaml` in the
+repo root, using schema collected from all local packages in the repo.
+
+For example, to validate that a given configuration value is visible in the
+frontend when building the `my-app` package, you can use the following:
+
+```bash
+yarn backstage-cli config:print --frontend --package my-app
+```
+
+```text
+Usage: backstage-cli config:print [options]
+
+Options:
+  --package <name>   Only load config schema that applies to the given package
+  --lax              Do not require environment variables to be set
+  --frontend         Print only the frontend configuration
+  --with-secrets     Include secrets in the printed configuration
+  --format <format>  Format to print the configuration in, either json or yaml [yaml]
+  --config <path>    Config files to load instead of app-config.yaml (default: [])
+  -h, --help         display help for command
+```
+
+## config\:check
+
+Validate that static configuration loads and matches schema, defaulting to
+reading `app-config.yaml` in the repo root and using schema collected from all
+local packages in the repo.
+
+```text
+Usage: backstage-cli config:check [options]
+
+Options:
+  --package <name>  Only load config schema that applies to the given package
+  --lax             Do not require environment variables to be set
+  --frontend        Only validate the frontend configuration
+  --deprecated      Output deprecated configuration settings
+  --strict          Ensure that the provided config(s) has no errors and does not contain keys not in the schema.
+  --config <path>   Config files to load instead of app-config.yaml (default: [])
+  -h, --help        display help for command
+```
+
+## config\:schema
+
+Dump the configuration schema that was collected from all local packages in the
+repo.
+
+Note: when run by `yarn`, supply the yarn option `--silent` if you are using the
+output in a command line pipe to avoid non schema output in the pipeline.
+
+```text
+Usage: backstage-cli config:schema [options]
+
+Print configuration schema
+
+Options:
+  --package <name>   Only output config schema that applies to the given package
+  --format <format>  Format to print the schema in, either json or yaml [yaml]
+  -h, --help         display help for command
+```
+
+## versions\:bump
+
+Bump all `@backstage` packages to the latest versions. This checks for updates
+in the package registry, and will update entries `package.json` files when necessary. See more how this command can be configured and used [for keeping Backstage updated](../../getting-started/keeping-backstage-updated.md).
+
+```text
+Usage: backstage-cli versions:bump [options]
+
+Options:
+  -h, --help        display help for command
+  --pattern <glob>  Override glob for matching packages to upgrade
+  --release <version|next|main> Bump to a specific Backstage release line or version (default: "main")
+```
+
+## build-workspace
+
+Builds a mirror of the workspace using the packaged production version of each
+package. This essentially calls `yarn pack` in each included package and unpacks
+the resulting archive in the target `workspace-dir`.
+
+```text
+Usage: backstage-cli build-workspace [options] <workspace-dir> [packages...]
+
+Options:
+  --alwaysPack  Force workspace output to be a result of running `yarn pack` on
+                each package (warning: very slow)
+```
+
+When `--alwaysPack` is used, the output directory can be passed to
+`backstage-cli package bundle --pre-packed-dir` to speed up batch bundling of
+multiple plugins from the same monorepo.
+
+## create-github-app
+
+Creates a GitHub App in your GitHub organization. This is an alternative to
+token-based [GitHub integration](../../integrations/github/locations.md). See
+[GitHub Apps for Backstage Authentication](../../integrations/github/github-apps.md).
+
+Launches a browser to create the App through GitHub and saves the result as a
+YAML file that can be referenced in the GitHub integration configuration.
+
+```text
+Usage: backstage-cli create-github-app <github-org>
+```
+
+## translations export
+
+Export translation messages from an app and all of its frontend plugins to JSON
+files. This command must be run from within a package directory (e.g.
+`packages/app`), not from the repository root.
+
+The command discovers all `TranslationRef` definitions in the dependency tree,
+extracts their default messages using the TypeScript type system, and writes
+them as JSON files along with a manifest.
+
+For more details on the translation workflow, see the
+[Internationalization](../../plugins/internationalization.md) documentation.
+
+```text
+Usage: backstage-cli translations export [options]
+
+Options:
+  --output <dir>       Output directory for exported messages and manifest (default: "translations")
+  --pattern <pattern>  File path pattern for message files relative to the output
+                       directory, with {id} and {lang} placeholders
+                       (default: "messages/{id}.{lang}.json")
+  -h, --help           display help for command
+```
+
+### Examples
+
+Export translations with default settings:
+
+```bash
+cd packages/app
+yarn backstage-cli translations export
+```
+
+Export with language-based directory grouping:
+
+```bash
+yarn backstage-cli translations export --pattern '{lang}/{id}.json'
+```
+
+## translations import
+
+Generate translation resource wiring code from translated JSON files. Reads the
+manifest and translated message files produced by `translations export`, and
+generates a TypeScript module that creates `TranslationResource` objects for each
+translated ref.
+
+The file pattern used during export is stored in the manifest and automatically
+used by the import command.
+
+```text
+Usage: backstage-cli translations import [options]
+
+Options:
+  --input <dir>    Input directory containing the manifest and translated message files (default: "translations")
+  --output <path>  Output path for the generated wiring module (default: "src/translations/resources.ts")
+  -h, --help       display help for command
+```
+
+### Examples
+
+Generate wiring code with default settings:
+
+```bash
+cd packages/app
+yarn backstage-cli translations import
+```
+
+## info
+
+Outputs debug information which is useful when opening an issue. Outputs system
+information, node.js and npm versions, CLI version and type (inside backstage
+repo or a created app), all `@backstage/*` package dependency versions, and any
+packages that contain a `backstage` field in their `package.json`.
+
+The command distinguishes between installed packages (from npm) and local
+workspace packages, making it easier to understand your Backstage setup.
+
+```text
+Usage: backstage-cli info [options]
+
+Options:
+  --include <patterns...>  Glob patterns for additional packages to include
+                           (e.g., @mycompany/backstage-*)
+  --format <text|json>     Output format (default: text)
+  -h, --help               display help for command
+```
+
+### Examples
+
+Output debug information to the console:
+
+```bash
+yarn backstage-cli info
+```
+
+Include additional packages matching a glob pattern:
+
+```bash
+yarn backstage-cli info --include "@mycompany/*"
+```
+
+Output as JSON:
+
+```bash
+yarn backstage-cli info --format json
+```
+
+Export JSON to a file for further processing:
+
+```bash
+yarn backstage-cli info --format json > backstage-info.json
+```
+
+Combine options to include custom packages and export to JSON:
+
+```bash
+yarn backstage-cli info --include "@mycompany/backstage-*" --include "@internal/*" --format json > debug-info.json
+```
+
+Export text output to a file:
+
+```bash
+yarn backstage-cli info --format text > backstage-info.txt
+```
+
+### JSON Output Format
+
+When using `--format json`, the output is structured as follows:
+
+```json
+{
+  "system": {
+    "os": "Darwin 23.0.0 - darwin/arm64",
+    "node": "v18.17.0",
+    "yarn": "3.6.0",
+    "cli": { "version": "0.27.0", "local": false },
+    "backstage": "1.20.0"
+  },
+  "dependencies": {
+    "@backstage/core-plugin-api": "1.8.0",
+    "@backstage/plugin-catalog": "1.15.0"
+  },
+  "local": {
+    "@mycompany/backstage-plugin-custom": "0.1.0"
+  }
+}
+```

--- a/docs/tooling/cli/03-commands.md
+++ b/docs/tooling/cli/03-commands.md
@@ -36,693 +36,107 @@ info                                           Show helpful information for debu
 help [command]                                 display help for command
 ```
 
-The `package` command category, `yarn backstage-cli package --help`:
-
-```text
-start [options]                  Start a package for local development
-build [options]                  Build a package for production deployment or publishing
-lint [options] [directories...]  Lint a package
-test                             Run tests, forwarding args to Jest, defaulting to watch mode
-clean                            Delete cache directories
-prepack                          Prepares a package for packaging before publishing
-postpack                         Restores the changes made by the prepack command
-help [command]                   display help for command
-```
-
-The `repo` command category, `yarn backstage-cli repo --help`:
-
-```text
-start [options] [packageName...]  Starts packages in the repo for local development
-build [options]                   Build packages in the project, excluding bundled app and backend packages.
-test [options]                    Run tests, forwarding args to Jest, defaulting to watch mode
-lint [options]                    Lint all packages in the project
-fix [options]                     Automatically fix packages in the project
-clean                             Delete cache and output directories
-list-deprecations [options]       List deprecations
-help [command]                    display help for command
-```
-
-The `migrate` command category, `yarn backstage-cli migrate --help`:
-
-```text
-package-roles         Add package role field to packages that don't have it
-package-scripts       Set package scripts according to each package role
-package-exports       Synchronize package subpath export definitions
-package-lint-configs  Migrates all packages to use @backstage/cli/config/eslint-factory
-react-router-deps     Migrates the react-router dependencies for all packages to be peer dependencies
-help [command]        display help for command
-```
-
-## repo start
-
-Start a set of packages in the project for local development. If no explicit packages are listed via arguments or options, packages will instead be selected based on their [package role](./02-build-system.md#package-roles). If a single set of frontend and/or backend packages are found, they will be started. If there are multiple matches the directories 'packages/app' and 'packages/backend' will be preferred. If no matches are found the command will fall back to expecting a single plugin frontend and/or backend package to start instead.
-
-Any `--config` options in the `start` script in `package.json` of the selected packages will be picked up and used, unless a `--config` option is provided to this command, in which case it will be used instead.
-
-Any `--require` option in the `start` script in `package.json` of the selected backend package will be picked up and used.
-
-```text
-Usage: backstage-cli repo start [options] [packageNameOrPath...]
-
-Starts packages in the repo for local development
-
-Arguments:
-  packageNameOrPath     Run the specified packages instead of the defaults.
-
-Options:
-  --plugin <pluginId>   Start the dev entry-point for any matching plugin package in the repo (default: [])
-  --config <path>       Config files to load instead of app-config.yaml (default: [])
-  --inspect [host]      Enable debugger in Node.js environments. Applies to backend package only
-  --inspect-brk [host]  Enable debugger in Node.js environments, breaking before code starts. Applies to backend package only
-  --require <path...>   Add a --require argument to the node process. Applies to backend package only
-  --link <path>         Link an external workspace for module resolution
-```
-
-## repo build
-
-Builds all packages in the project, excluding bundled packages by default, i.e. ones
-with the role `'frontend'` or `'backend'`.
-
-```text
-Usage: backstage-cli repo build [options]
-
-Build packages in the project, excluding bundled app and backend packages.
-
-Options:
-  --all          Build all packages, including bundled app and backend packages.
-  --since <ref>  Only build packages and their dev dependents that changed since the specified ref
-```
-
-## repo lint
-
-Lint all packages in the project.
-
-```text
-Usage: backstage-cli repo lint [options]
-
-Lint all packages in the project
-
-Options:
-  --format <format>           Lint report output format (default: "eslint-formatter-friendly")
-  --since <ref>               Only lint packages that changed since the specified ref
-  --success-cache             Enable success caching, which skips running lint for unchanged packages that were successful in the previous run
-  --success-cache-dir <path>  Set the success cache location, (default: node_modules/.cache/backstage-cli)
-  --fix                       Attempt to automatically fix violations
-```
-
-## repo list-deprecations
-
-Scan all packages in the project for usage of deprecated Backstage APIs and
-report them. This is useful for tracking migration progress when upgrading
-Backstage versions.
-
-```text
-Usage: backstage-cli repo list-deprecations [options]
-
-List deprecations found across all packages in the project
-
-Options:
-  --json        Output as JSON
-```
-
-## repo test
-
-Test packages in the project. It is recommended to have this command be used as the `test` script in the root `package.json` in your project:
-
-```json title="package.json in the root of your project"
-{
-  ...
-  "scripts": {
-    ...
-    "test": "backstage-cli repo test"
-  }
-}
-```
-
-If run without any arguments it will default to running changed tests in watch mode, unless the `CI` environment flag is set, in which case it will run all tests without watching:
-
-```sh title="Run changes tests from repo root"
-yarn test
-```
-
-If arguments are provided, they will be forwarded to Jest and used to filter test to execute. If full paths to tests are provided, only those tests will be included, for example:
-
-```sh title="Run specific tests from repo root"
-yarn test packages/app/src/App.test.tsx
-```
-
-If you want to avoid re-running tests that have not changed since the last successful run in CI, you can use the `--success-cache` flag. By default this cache is stored in `node_modules/.cache/backstage-cli`, but you can choose a different directory with the `--success-cache-dir <path>`.
-
-```text
-Usage: backstage-cli repo test [options]
-
-Run tests, forwarding args to Jest, defaulting to watch mode
-
-Options:
-  --since <ref>               Only test packages that changed since the specified ref
-  --success-cache             Enable success caching, which skips running tests for unchanged packages that were successful in the previous run
-  --success-cache-dir <path>  Set the success cache location, (default: node_modules/.cache/backstage-cli)
-  --jest-help                 Show help for Jest CLI options, which are passed through
-  -h, --help                  display help for command
-```
-
-## package start
-
-Starts the package for local development. See the frontend and backend development parts in the build system [bundling](./02-build-system.md#bundling) section for more details.
-
-```text
-Usage: backstage-cli package start [options]
-
-Start a package for local development
-
-Options:
-  --config <path>     Config files to load instead of app-config.yaml (default: [])
-  --role <name>       Run the command with an explicit package role
-  --check             Enable type checking and linting if available
-  --inspect           Enable debugger in Node.js environments
-  --inspect-brk       Enable debugger in Node.js environments, breaking before code starts
-  --entrypoint <path> Entry directory path (uses index file) or entry file path (without extension). Defaults to "dev"
-```
-
-## package build
-
-Build an individual package based on its role. See the build system [building](./02-build-system.md#building) and [bundling](./02-build-system.md#bundling) sections for more details.
-
-```text
-Usage: backstage-cli package build [options]
-
-Build a package for production deployment or publishing
-
-Options:
-  --role <name>              Run the command with an explicit package role
-  --minify                   Minify the generated code. Does not apply to app package (app is minified by default).
-  --skip-build-dependencies  Skip the automatic building of local dependencies. Applies to backend packages only.
-  --stats                    If bundle stats are available, write them to the output directory. Applies to app packages only.
-  --config <path>            Config files to load instead of app-config.yaml. Applies to app packages only. (default: [])
-  --module-federation        Build a package as a module federation remote. Applies to frontend plugin packages only.
-```
-
-## package bundle
-
-:::caution Experimental
-This command is experimental and may receive breaking changes in future releases
-without a deprecation period. It is hidden from the main `--help` output.
-:::
-
-Bundle a plugin for dynamic loading. This creates a self-contained plugin
-package that can be deployed independently and loaded dynamically by a Backstage
-application. Supports both backend and frontend plugins.
-
-Unlike regular builds, the bundle command:
-
-- Creates a fully self-contained plugin deliverable
-
-- Produces module federation assets (frontend) or includes plugin dependencies in the plugin's private `node_modules`, building and packing (with `yarn pack`) the local `workspace:^` dependencies first (backend).
-- Generates a config schema from plugin-related packages only.
-- Validates that the plugin exports valid dynamic loading entry points (backend only)
-
-### Usage
-
-```bash
-# Bundle the current package (output: ./bundle/)
-yarn backstage-cli package bundle
-
-# Bundle to a specific directory (output: ../dynamic-plugins/<mangled-package-name>/)
-yarn backstage-cli package bundle --output-destination ../dynamic-plugins
-
-# Override the bundle subdirectory name
-yarn backstage-cli package bundle --output-name my-plugin-bundle
-
-# Clean output before bundling
-yarn backstage-cli package bundle --clean
-
-# Skip building for the plugin and its local dependencies
-yarn backstage-cli package bundle --no-build
-
-# Skip dependency installation and entrypoint validation
-yarn backstage-cli package bundle --no-install
-
-# Stream detailed output from build, pack, and install steps
-yarn backstage-cli package bundle --verbose
-
-# Use a pre-built dist workspace for batch bundling.
-# First, create the workspace with:
-#   backstage-cli build-workspace <output-dir> [packages...] --alwaysPack
-# Then pass <output-dir> as --pre-packed-dir:
-yarn backstage-cli package bundle --pre-packed-dir ../dist-workspace
-```
-
-### Options
-
-```text
-Usage: backstage-cli package bundle [options]
-
-Bundle a plugin for dynamic loading
-
-Options:
-  --output-destination <dir>  Directory in which the bundle subdirectory is created.
-                              Defaults to the current package directory.
-  --output-name <name>        Name of the bundle subdirectory. Defaults to "bundle" when
-                              output stays in the package directory, or to the mangled
-                              package name (e.g. myorg-plugin-foo) when
-                              --output-destination is specified.
-  --clean                     Clean the output directory before bundling
-  --no-build                  Skip building packages (assumes they are already built)
-  --no-install                Skip dependency installation and entrypoint validation.
-  --verbose                   Stream detailed output from internal steps (build, pack,
-                              install) to the console. Without this flag, output is
-                              captured to per-step log files and only shown on error.
-  --pre-packed-dir <dir>      Path to a pre-built dist workspace (from
-                              build-workspace --alwaysPack). Skips local dependency
-                              packing and uses pre-packed packages directly. For frontend
-                              plugins, this also enables yarn.lock generation for SBOM.
-```
-
-### Output Contract
-
-The bundle output is a directory that can be deployed as a standalone unit.
-Consumers of the bundle (such as `@backstage/backend-dynamic-feature-service`
-or `@backstage/frontend-dynamic-feature-loader`) can rely on the following
-guarantees:
-
-**All bundles:**
-
-- A `package.json` at the bundle root with entry points configured for dynamic
-  loading. The `backstage.role` and `files` fields are preserved from the source package.
-- A `dist/` directory containing the built plugin code.
-- A `dist/.config-schema.json` file (when any config schemas apply) containing
-  gathered schemas from the plugin, its local workspace dependencies, and
-  third-party dependencies. Schemas from unrelated Backstage packages are excluded.
-- No `scripts` or `devDependencies` in `package.json`.
-
-**Backend plugins** (`backend-plugin`, `backend-plugin-module`):
-
-- A `node_modules/` directory with all production dependencies (including local
-  workspace dependencies), pinned to their exact versions from the source lockfile.
-- `bundleDependencies` is set to `true` in `package.json`.
-
-**Frontend plugins** (`frontend-plugin`, `frontend-plugin-module`):
-
-- `main` points to `dist/remoteEntry.js` (the Module Federation remote entry).
-- `types` points to `dist/@mf-types/index.d.ts` when type declarations are
-  available.
-- No embedded `node_modules/` directory.
-
-### Environment Variables
-
-The bundle command supports the same environment variables as the Backstage yarn plugin
-for resolving `backstage:^` version specifiers:
-
-- `BACKSTAGE_MANIFEST_FILE`: Path to a local manifest file (for offline usage)
-- `BACKSTAGE_VERSIONS_BASE_URL`: Custom base URL for fetching release manifests
-
-### Supported Package Roles
-
-The bundle command supports packages with the following roles:
-
-- `backend-plugin`
-- `backend-plugin-module`
-- `frontend-plugin`
-- `frontend-plugin-module`
-
-## package lint
-
-Lint a package. In addition to the default `eslint` behavior, this command will
-include TypeScript files, treat warnings as errors, and default to linting the
-entire directory if no specific files are listed. For more information, see the
-build system [linting](./02-build-system.md#linting) section.
-
-```text
-Usage: backstage-cli package lint [options]
-
-Lint a package
-
-Options:
-  --format <format>        Lint report output format (default: "eslint-formatter-friendly")
-  --fix                    Attempt to automatically fix violations
-  --max-warnings <number>  Fail if more than this number of warnings. -1 allows warnings. (default: -1)
-```
-
-## package test
-
-Run tests, forwarding all unknown options to Jest, and defaulting to watch mode.
-When executing the tests, `process.env.NODE_ENV` will be set to `"test"`.
-
-This command uses a default Jest configuration that is included in the CLI,
-which is set up with similar goals for speed, scale, and working within a
-monorepo. The configuration sets the `src` as the root directory, enforces the
-`.test.` infix for tests, and uses `src/setupTests.ts` as the test setup
-location. The included configuration also supports test execution at the root of
-a yarn workspaces monorepo by automatically creating one grouped configuration
-that includes all packages that have `backstage-cli test` in their package
-`test` script.
-
-For more information about configuration overrides and editor support, see the [Jest Configuration section](./02-build-system.md#jest-configuration) in the build system documentation.
-
-```text
-Usage: backstage-cli package test [options]
-
-Run tests, forwarding args to Jest, defaulting to watch mode
-
-Options:
-  --backstage-cli-help    display help for command
-```
-
-## package clean
-
-Remove cache and output directories.
-
-```text
-Usage: backstage-cli package clean [options]
-
-Delete cache directories
-```
-
-## package prepack
-
-This command should be added as `scripts.prepack` in all packages. It enables
-packaging- and publish-time overrides for fields inside `packages.json`.
-For more details, see the build system [publishing](./02-build-system.md#publishing) section.
-
-```text
-Usage: backstage-cli package prepack [options]
-
-Prepares a package for packaging before publishing
-```
-
-## package postpack
-
-This should be added as `scripts.postpack` in all packages. It restores
-`package.json` to what it looked like before calling the `prepack` command.
-
-```text
-Usage: backstage-cli package postpack [options]
-
-Restores the changes made by the prepack command
-```
-
-## new
-
-The `new` command opens up an interactive guide for you to create new things
-in your app. If you do not pass in any options it is completely interactive, but
-it is possible to pre-select what you want to create using the `--select` flag,
-and provide options using `--option`, for example:
-
-```bash
-backstage-cli new --select frontend-plugin --option pluginId=foo
-```
-
-This command is typically added as script in the root `package.json` to be
-executed with `yarn new`. For example you may have it set up like this:
-
-```json
-{
-  "scripts": {
-    "new": "backstage-cli new"
-  }
-}
-```
-
-The `new` command comes with a default collection of plugins/packages, however,
-you can customize this list and even create your own CLI templates. For more
-information see [CLI Templates](./04-templates.md).
-
-```text
-Usage: backstage-cli new
-
-Options:
-  -h, --help               display help for command
-```
-
-## config\:docs
-
-This commands opens up the reference documentation of your apps local
-configuration schema in the browser. This is useful to get an overview of what
-configuration values are available to use, a description of what they do and
-their format, and where they get sent.
-
-```text
-Usage: backstage-cli config:docs [options]
-
-Browse the configuration reference documentation
-
-Options:
-  --package <name>  Only include the schema that applies to the given package
-  -h, --help        display help for command
-```
-
-## config\:print
-
-Print the static configuration, defaulting to reading `app-config.yaml` in the
-repo root, using schema collected from all local packages in the repo.
-
-For example, to validate that a given configuration value is visible in the
-frontend when building the `my-app` package, you can use the following:
-
-```bash
-yarn backstage-cli config:print --frontend --package my-app
-```
-
-```text
-Usage: backstage-cli config:print [options]
-
-Options:
-  --package <name>   Only load config schema that applies to the given package
-  --lax              Do not require environment variables to be set
-  --frontend         Print only the frontend configuration
-  --with-secrets     Include secrets in the printed configuration
-  --format <format>  Format to print the configuration in, either json or yaml [yaml]
-  --config <path>    Config files to load instead of app-config.yaml (default: [])
-  -h, --help         display help for command
-```
-
-## config\:check
-
-Validate that static configuration loads and matches schema, defaulting to
-reading `app-config.yaml` in the repo root and using schema collected from all
-local packages in the repo.
-
-```text
-Usage: backstage-cli config:check [options]
-
-Options:
-  --package <name>  Only load config schema that applies to the given package
-  --lax             Do not require environment variables to be set
-  --frontend        Only validate the frontend configuration
-  --deprecated      Output deprecated configuration settings
-  --strict          Ensure that the provided config(s) has no errors and does not contain keys not in the schema.
-  --config <path>   Config files to load instead of app-config.yaml (default: [])
-  -h, --help        display help for command
-```
-
-## config\:schema
-
-Dump the configuration schema that was collected from all local packages in the
-repo.
-
-Note: when run by `yarn`, supply the yarn option `--silent` if you are using the
-output in a command line pipe to avoid non schema output in the pipeline.
-
-```text
-Usage: backstage-cli config:schema [options]
-
-Print configuration schema
-
-Options:
-  --package <name>   Only output config schema that applies to the given package
-  --format <format>  Format to print the schema in, either json or yaml [yaml]
-  -h, --help         display help for command
-```
-
-## versions\:bump
-
-Bump all `@backstage` packages to the latest versions. This checks for updates
-in the package registry, and will update entries `package.json` files when necessary. See more how this command can be configured and used [for keeping Backstage updated](../../getting-started/keeping-backstage-updated.md).
-
-```text
-Usage: backstage-cli versions:bump [options]
-
-Options:
-  -h, --help        display help for command
-  --pattern <glob>  Override glob for matching packages to upgrade
-  --release <version|next|main> Bump to a specific Backstage release line or version (default: "main")
-```
-
-## build-workspace
-
-Builds a mirror of the workspace using the packaged production version of each
-package. This essentially calls `yarn pack` in each included package and unpacks
-the resulting archive in the target `workspace-dir`.
-
-```text
-Usage: backstage-cli build-workspace [options] <workspace-dir> [packages...]
-
-Options:
-  --alwaysPack  Force workspace output to be a result of running `yarn pack` on
-                each package (warning: very slow)
-```
-
-When `--alwaysPack` is used, the output directory can be passed to
-`backstage-cli package bundle --pre-packed-dir` to speed up batch bundling of
-multiple plugins from the same monorepo.
-
-## create-github-app
-
-Creates a GitHub App in your GitHub organization. This is an alternative to
-token-based [GitHub integration](../../integrations/github/locations.md). See
-[GitHub Apps for Backstage Authentication](../../integrations/github/github-apps.md).
-
-Launches a browser to create the App through GitHub and saves the result as a
-YAML file that can be referenced in the GitHub integration configuration.
-
-```text
-Usage: backstage-cli create-github-app <github-org>
-```
-
-## translations export
-
-Export translation messages from an app and all of its frontend plugins to JSON
-files. This command must be run from within a package directory (e.g.
-`packages/app`), not from the repository root.
-
-The command discovers all `TranslationRef` definitions in the dependency tree,
-extracts their default messages using the TypeScript type system, and writes
-them as JSON files along with a manifest.
-
-For more details on the translation workflow, see the
-[Internationalization](../../plugins/internationalization.md) documentation.
-
-```text
-Usage: backstage-cli translations export [options]
-
-Options:
-  --output <dir>       Output directory for exported messages and manifest (default: "translations")
-  --pattern <pattern>  File path pattern for message files relative to the output
-                       directory, with {id} and {lang} placeholders
-                       (default: "messages/{id}.{lang}.json")
-  -h, --help           display help for command
-```
-
-### Examples
-
-Export translations with default settings:
-
-```bash
-cd packages/app
-yarn backstage-cli translations export
-```
-
-Export with language-based directory grouping:
-
-```bash
-yarn backstage-cli translations export --pattern '{lang}/{id}.json'
-```
-
-## translations import
-
-Generate translation resource wiring code from translated JSON files. Reads the
-manifest and translated message files produced by `translations export`, and
-generates a TypeScript module that creates `TranslationResource` objects for each
-translated ref.
-
-The file pattern used during export is stored in the manifest and automatically
-used by the import command.
-
-```text
-Usage: backstage-cli translations import [options]
-
-Options:
-  --input <dir>    Input directory containing the manifest and translated message files (default: "translations")
-  --output <path>  Output path for the generated wiring module (default: "src/translations/resources.ts")
-  -h, --help       display help for command
-```
-
-### Examples
-
-Generate wiring code with default settings:
-
-```bash
-cd packages/app
-yarn backstage-cli translations import
-```
-
-## info
-
-Outputs debug information which is useful when opening an issue. Outputs system
-information, node.js and npm versions, CLI version and type (inside backstage
-repo or a created app), all `@backstage/*` package dependency versions, and any
-packages that contain a `backstage` field in their `package.json`.
-
-The command distinguishes between installed packages (from npm) and local
-workspace packages, making it easier to understand your Backstage setup.
-
-```text
-Usage: backstage-cli info [options]
-
-Options:
-  --include <patterns...>  Glob patterns for additional packages to include
-                           (e.g., @mycompany/backstage-*)
-  --format <text|json>     Output format (default: text)
-  -h, --help               display help for command
-```
-
-### Examples
-
-Output debug information to the console:
-
-```bash
-yarn backstage-cli info
-```
-
-Include additional packages matching a glob pattern:
-
-```bash
-yarn backstage-cli info --include "@mycompany/*"
-```
-
-Output as JSON:
-
-```bash
-yarn backstage-cli info --format json
-```
-
-Export JSON to a file for further processing:
-
-```bash
-yarn backstage-cli info --format json > backstage-info.json
-```
-
-Combine options to include custom packages and export to JSON:
-
-```bash
-yarn backstage-cli info --include "@mycompany/backstage-*" --include "@internal/*" --format json > debug-info.json
-```
-
-Export text output to a file:
-
-```bash
-yarn backstage-cli info --format text > backstage-info.txt
-```
-
-### JSON Output Format
-
-When using `--format json`, the output is structured as follows:
-
-```json
-{
-  "system": {
-    "os": "Darwin 23.0.0 - darwin/arm64",
-    "node": "v18.17.0",
-    "yarn": "3.6.0",
-    "cli": { "version": "0.27.0", "local": false },
-    "backstage": "1.20.0"
-  },
-  "dependencies": {
-    "@backstage/core-plugin-api": "1.8.0",
-    "@backstage/plugin-catalog": "1.15.0"
-  },
-  "local": {
-    "@mycompany/backstage-plugin-custom": "0.1.0"
-  }
-}
-```
+## Commands by Module
+
+### [Auth Module](./module-auth.md)
+
+| Command            | Description                               |
+| ------------------ | ----------------------------------------- |
+| `auth login`       | Log in the CLI to a Backstage instance    |
+| `auth logout`      | Log out and clear stored credentials      |
+| `auth show`        | Show details of an authenticated instance |
+| `auth list`        | List authenticated instances              |
+| `auth print-token` | Print an access token to stdout           |
+| `auth select`      | Select the default instance               |
+
+### [Actions Module](./module-actions.md)
+
+| Command                  | Description                                           |
+| ------------------------ | ----------------------------------------------------- |
+| `actions list`           | List available actions from configured plugin sources |
+| `actions execute`        | Execute an action                                     |
+| `actions sources add`    | Add a plugin source for action discovery              |
+| `actions sources list`   | List configured plugin sources                        |
+| `actions sources remove` | Remove a plugin source                                |
+
+### [Build Module](./module-build.md)
+
+| Command            | Description                                             |
+| ------------------ | ------------------------------------------------------- |
+| `repo start`       | Start packages for local development                    |
+| `repo build`       | Build packages in the project                           |
+| `repo clean`       | Delete cache and output directories across the project  |
+| `package start`    | Start a package for local development                   |
+| `package build`    | Build a package for production deployment or publishing |
+| `package bundle`   | Bundle a plugin for dynamic loading (experimental)      |
+| `package clean`    | Delete cache directories                                |
+| `package prepack`  | Prepare a package for packaging before publishing       |
+| `package postpack` | Restore changes made by prepack                         |
+| `build-workspace`  | Build a temporary dist workspace from provided packages |
+
+### [Config Module](./module-config.md)
+
+| Command         | Description                                          |
+| --------------- | ---------------------------------------------------- |
+| `config:docs`   | Browse the configuration reference documentation     |
+| `config:print`  | Print the app configuration                          |
+| `config:check`  | Validate that configuration loads and matches schema |
+| `config:schema` | Print the configuration schema                       |
+
+### [GitHub Module](./module-github.md)
+
+| Command             | Description                                  |
+| ------------------- | -------------------------------------------- |
+| `create-github-app` | Create a new GitHub App in your organization |
+
+### [Info Module](./module-info.md)
+
+| Command | Description                                               |
+| ------- | --------------------------------------------------------- |
+| `info`  | Show helpful information for debugging and reporting bugs |
+
+### [Lint Module](./module-lint.md)
+
+| Command        | Description                      |
+| -------------- | -------------------------------- |
+| `package lint` | Lint a package                   |
+| `repo lint`    | Lint all packages in the project |
+
+### [Maintenance Module](./module-maintenance.md)
+
+| Command                  | Description                               |
+| ------------------------ | ----------------------------------------- |
+| `repo fix`               | Automatically fix packages in the project |
+| `repo list-deprecations` | List deprecations                         |
+
+### [Migrate Module](./module-migrate.md)
+
+| Command                        | Description                                            |
+| ------------------------------ | ------------------------------------------------------ |
+| `versions:bump`                | Bump Backstage packages to the latest versions         |
+| `versions:migrate`             | Migrate plugins to the @backstage-community namespace  |
+| `migrate package-roles`        | Add package role field to packages                     |
+| `migrate package-scripts`      | Set package scripts according to each package role     |
+| `migrate package-exports`      | Synchronize package subpath export definitions         |
+| `migrate package-lint-configs` | Migrate to @backstage/cli/config/eslint-factory        |
+| `migrate react-router-deps`    | Migrate react-router dependencies to peer dependencies |
+
+### [New Module](./module-new.md)
+
+| Command | Description                                                  |
+| ------- | ------------------------------------------------------------ |
+| `new`   | Open an interactive guide to creating new things in your app |
+
+### [Test Module](./module-test.md)
+
+| Command        | Description                    |
+| -------------- | ------------------------------ |
+| `repo test`    | Run tests across the project   |
+| `package test` | Run tests for a single package |
+
+### [Translations Module](./module-translations.md)
+
+| Command               | Description                               |
+| --------------------- | ----------------------------------------- |
+| `translations export` | Export translation messages to JSON files |
+| `translations import` | Generate translation resource wiring code |

--- a/microsite/sidebars.ts
+++ b/microsite/sidebars.ts
@@ -62,6 +62,7 @@ export default {
         'getting-started/configure-app-with-plugins',
         'getting-started/homepage',
       ]),
+      'getting-started/ci',
       sidebarElementWithIndex({ label: 'Deploying Backstage' }, [
         'deployment/index',
         'deployment/scaling',

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,7 @@ nav:
           - Configuring App with plugins: 'getting-started/configure-app-with-plugins.md'
           - Customize the look-and-feel of your App: 'conf/user-interface/index.md'
           - Customizing your Homepage: 'getting-started/homepage.md'
+      - Setting up CI: 'getting-started/ci.md'
       - Deployment:
           - Deploying Backstage: 'deployment/index.md'
           - Scaling: 'deployment/scaling.md'

--- a/packages/create-app/templates/default-app/.github/workflows/ci.yml
+++ b/packages/create-app/templates/default-app/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+# Documentation: https://backstage.io/docs/getting-started/ci
+name: PR CI build
+
+on:
+  pull_request: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    env:
+      CI: true
+      NODE_OPTIONS: --max-old-space-size=4096
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      # Beginning of yarn setup
+      - name: use node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24.x
+          registry-url: https://registry.npmjs.org/
+      - name: cache all node_modules
+        id: cache-modules
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-node_modules-${{ hashFiles('yarn.lock', '**/package.json') }}
+      - name: find location of global yarn cache
+        id: yarn-cache
+        if: steps.cache-modules.outputs.cache-hit != 'true'
+        run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+      - name: cache global yarn cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        if: steps.cache-modules.outputs.cache-hit != 'true'
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: yarn install
+        run: yarn install --immutable
+      # End of yarn setup
+
+      - name: lint
+        run: yarn backstage-cli repo lint
+
+      - name: deprecations
+        run: yarn backstage-cli repo list-deprecations
+
+      - name: type checking and declarations
+        run: yarn tsc:full
+
+      - name: build
+        run: yarn build:all
+
+      - name: tests
+        run: yarn backstage-cli repo test
+
+      - name: config check
+        run: |
+          yarn backstage-cli config:check --lax --strict
+          yarn backstage-cli config:check --lax --strict --config app-config.yaml --config app-config.production.yaml
+
+      - name: docker build
+        env:
+          DOCKER_BUILDKIT: 1
+        run: yarn build-image

--- a/packages/create-app/templates/default-app/.github/workflows/ci.yml
+++ b/packages/create-app/templates/default-app/.github/workflows/ci.yml
@@ -1,8 +1,12 @@
 # Documentation: https://backstage.io/docs/getting-started/ci
+# Other CI systems: https://backstage.io/docs/getting-started/ci#other-ci-systems
 name: PR CI build
 
 on:
   pull_request: {}
+
+permissions:
+  contents: read
 
 jobs:
   build:
@@ -46,11 +50,11 @@ jobs:
       - name: lint
         run: yarn backstage-cli repo lint
 
-      - name: deprecations
-        run: yarn backstage-cli repo list-deprecations
-
       - name: type checking and declarations
         run: yarn tsc:full
+
+      - name: deprecations
+        run: yarn backstage-cli repo list-deprecations
 
       - name: build
         run: yarn build:all
@@ -59,10 +63,10 @@ jobs:
         run: yarn backstage-cli repo test
 
       - name: config check
-        run: |
-          yarn backstage-cli config:check --lax --strict
-          yarn backstage-cli config:check --lax --strict --config app-config.yaml --config app-config.production.yaml
+        run: yarn backstage-cli config:check --lax --strict --config app-config.yaml --config app-config.production.yaml
 
+      # Optional: Docker builds can be slow. Consider moving this to a merge
+      # or scheduled workflow if it slows down your pull request feedback loop.
       - name: docker build
         env:
           DOCKER_BUILDKIT: 1

--- a/packages/create-app/templates/default-app/.github/workflows/ci.yml
+++ b/packages/create-app/templates/default-app/.github/workflows/ci.yml
@@ -8,26 +8,34 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
 
     env:
       CI: true
-      NODE_OPTIONS: --max-old-space-size=4096
+      NODE_OPTIONS: --max-old-space-size=8192
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@v6
 
       # Beginning of yarn setup
       - name: use node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@v6
         with:
           node-version: 24.x
           registry-url: https://registry.npmjs.org/
+      - name: install and enable corepack
+        run: |
+          npm install -g corepack
+          corepack enable
       - name: cache all node_modules
         id: cache-modules
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: actions/cache@v5
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-node_modules-${{ hashFiles('yarn.lock', '**/package.json') }}
@@ -36,7 +44,7 @@ jobs:
         if: steps.cache-modules.outputs.cache-hit != 'true'
         run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
       - name: cache global yarn cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: actions/cache@v5
         if: steps.cache-modules.outputs.cache-hit != 'true'
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
@@ -56,11 +64,11 @@ jobs:
       - name: deprecations
         run: yarn backstage-cli repo list-deprecations
 
-      - name: build
-        run: yarn build:all
-
       - name: tests
         run: yarn backstage-cli repo test
+
+      - name: build
+        run: yarn build:all
 
       - name: config check
         run: yarn backstage-cli config:check --lax --strict --config app-config.yaml --config app-config.production.yaml


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added a GitHub Actions CI workflow to the default app template. New Backstage instances created with `create-app` now include a `.github/workflows/ci.yml` that runs lint, type checking, tests, configuration validation, and a Docker image build on every pull request.

Also adds a getting-started docs page covering CI setup (GitHub Actions, GitLab CI, Jenkins) and documents the `repo list-deprecations` CLI command.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))