### PR TITLE
feat(catalog): add skills endpoint

### DIFF
--- a/.changeset/skills-well-known-endpoint.md
+++ b/.changeset/skills-well-known-endpoint.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-catalog-backend-module-ai-model': patch
+---
+
+Added a well-known skills endpoint at `/.well-known/skills/` that serves skill metadata and
+content for use with `npx skills`. The endpoint discovers catalog entities of kind `AiResource`
+with `spec.type: skill` and serves their content from the source location.
+Results are cached for 5 minutes.

--- a/plugins/catalog-backend-module-ai-model/README.md
+++ b/plugins/catalog-backend-module-ai-model/README.md
@@ -43,3 +43,34 @@ Any other `type` value is accepted with the base spec fields: `type`, `lifecycle
 ## Accessing skill and rule content
 
 The actual content of skills and rules is not stored in the entity spec. Instead, the source file is referenced via the standard `backstage.io/source-location` annotation, consistent with how other Backstage entities reference their source files. Entity providers that generate `AiResource` entities from `SKILL.md` or rule files should set this annotation to point to the source file.
+
+## Skills endpoint for `npx skills`
+
+This module exposes a [`/.well-known/skills/`](https://www.skills.sh/docs/cli) endpoint on the root HTTP router, making skills registered in the catalog discoverable by the [`npx skills`](https://www.skills.sh/) CLI tool.
+
+When a Backstage instance has this module installed, you can install skills from it using:
+
+```sh
+npx skills add https://your-backstage.example.com
+```
+
+### Endpoint details
+
+| Path                                 | Description                                  |
+| ------------------------------------ | -------------------------------------------- |
+| `/.well-known/skills/index.json`     | Returns a JSON index of all available skills |
+| `/.well-known/skills/:name/SKILL.md` | Returns the content of a specific skill      |
+
+The index only includes `AiResource` entities with `spec.type: skill` that have a valid `backstage.io/source-location` annotation pointing to a reachable URL. Skills whose content cannot be retrieved are silently excluded from the index.
+
+### Caching
+
+Skill content and the index are cached for 5 minutes using the Backstage cache service. This avoids repeated fetches of the underlying source files on every request.
+
+### Requirements
+
+For skills to appear in the endpoint:
+
+1. The entity must be of kind `AiResource` with `spec.type: skill`
+2. The entity must have a `backstage.io/source-location` annotation of type `url:` pointing to the SKILL.md file
+3. The URL must be readable by the configured URL reader (i.e. included in `integrations` or `reading.allow` configuration)

--- a/plugins/catalog-backend-module-ai-model/package.json
+++ b/plugins/catalog-backend-module-ai-model/package.json
@@ -44,10 +44,14 @@
   "dependencies": {
     "@backstage/backend-plugin-api": "workspace:^",
     "@backstage/catalog-model": "workspace:^",
-    "@backstage/plugin-catalog-node": "workspace:^"
+    "@backstage/plugin-catalog-node": "workspace:^",
+    "express": "^4.21.0"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "workspace:^",
-    "@backstage/cli": "workspace:^"
+    "@backstage/cli": "workspace:^",
+    "@types/express": "^4.17.6",
+    "@types/supertest": "^2.0.8",
+    "supertest": "^7.0.0"
   }
 }

--- a/plugins/catalog-backend-module-ai-model/src/SkillsRouter.test.ts
+++ b/plugins/catalog-backend-module-ai-model/src/SkillsRouter.test.ts
@@ -1,0 +1,390 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import express from 'express';
+import request from 'supertest';
+import { createSkillsRouter } from './SkillsRouter';
+import { mockCredentials, mockServices } from '@backstage/backend-test-utils';
+import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
+
+describe('createSkillsRouter', () => {
+  const mockCatalog = catalogServiceMock.mock();
+
+  const mockReader = mockServices.urlReader.mock();
+  const mockCache = mockServices.cache.mock();
+  const mockAuth = mockServices.auth.mock();
+  const mockLogger = mockServices.logger.mock();
+
+  let app: express.Express;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockCache.get.mockResolvedValue(undefined);
+    mockCache.set.mockResolvedValue(undefined);
+    mockAuth.getOwnServiceCredentials.mockResolvedValue(
+      mockCredentials.service(),
+    );
+
+    const router = createSkillsRouter({
+      catalog: mockCatalog as any,
+      auth: mockAuth,
+      reader: mockReader,
+      cache: mockCache,
+      logger: mockLogger,
+    });
+
+    app = express();
+    app.use('/.well-known/skills', router);
+  });
+
+  describe('GET /.well-known/skills/index.json', () => {
+    it('returns an index of available skills', async () => {
+      mockCatalog.getEntities.mockResolvedValue({
+        items: [
+          {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'AiResource',
+            metadata: {
+              name: 'frontend-design',
+              namespace: 'default',
+              description: 'A skill for frontend design',
+              annotations: {
+                'backstage.io/source-location':
+                  'url:https://github.com/org/repo/blob/main/skills/frontend-design/SKILL.md',
+              },
+            },
+            spec: { type: 'skill', lifecycle: 'production', owner: 'team-a' },
+          },
+          {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'AiResource',
+            metadata: {
+              name: 'testing-patterns',
+              namespace: 'default',
+              description: 'Skill for testing patterns',
+              annotations: {
+                'backstage.io/source-location':
+                  'url:https://github.com/org/repo/blob/main/skills/testing/SKILL.md',
+              },
+            },
+            spec: { type: 'skill', lifecycle: 'production', owner: 'team-b' },
+          },
+          {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'AiResource',
+            metadata: {
+              name: 'custom-skill',
+              namespace: 'custom-ns',
+              description: 'A skill in a custom namespace',
+              annotations: {
+                'backstage.io/source-location':
+                  'url:https://github.com/org/repo/blob/main/skills/custom/SKILL.md',
+              },
+            },
+            spec: { type: 'skill', lifecycle: 'production', owner: 'team-c' },
+          },
+        ],
+      });
+
+      const response = await request(app).get('/.well-known/skills/index.json');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        skills: [
+          {
+            name: 'frontend-design',
+            description: 'A skill for frontend design',
+            files: ['SKILL.md'],
+          },
+          {
+            name: 'testing-patterns',
+            description: 'Skill for testing patterns',
+            files: ['SKILL.md'],
+          },
+          {
+            name: 'custom-ns/custom-skill',
+            description: 'A skill in a custom namespace',
+            files: ['SKILL.md'],
+          },
+        ],
+      });
+    });
+
+    it('returns cached index when available', async () => {
+      const cachedIndex = {
+        skills: [
+          {
+            name: 'cached-skill',
+            description: 'From cache',
+            files: ['SKILL.md'],
+          },
+        ],
+      };
+      mockCache.get.mockResolvedValue(cachedIndex);
+
+      const response = await request(app).get('/.well-known/skills/index.json');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual(cachedIndex);
+      expect(mockCatalog.getEntities).not.toHaveBeenCalled();
+    });
+
+    it('skips skills without source-location annotation', async () => {
+      mockCatalog.getEntities.mockResolvedValue({
+        items: [
+          {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'AiResource',
+            metadata: {
+              name: 'no-source',
+              namespace: 'default',
+              description: 'Missing source location',
+              annotations: {},
+            },
+            spec: { type: 'skill', lifecycle: 'production', owner: 'team-a' },
+          },
+        ],
+      });
+
+      const response = await request(app).get('/.well-known/skills/index.json');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ skills: [] });
+    });
+
+    it('includes skills with valid url source location without fetching content', async () => {
+      mockCatalog.getEntities.mockResolvedValue({
+        items: [
+          {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'AiResource',
+            metadata: {
+              name: 'unreachable-skill',
+              namespace: 'default',
+              description: 'Cannot fetch',
+              annotations: {
+                'backstage.io/source-location':
+                  'url:https://github.com/org/repo/blob/main/skills/broken/SKILL.md',
+              },
+            },
+            spec: { type: 'skill', lifecycle: 'production', owner: 'team-a' },
+          },
+        ],
+      });
+
+      const response = await request(app).get('/.well-known/skills/index.json');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({
+        skills: [
+          {
+            name: 'unreachable-skill',
+            description: 'Cannot fetch',
+            files: ['SKILL.md'],
+          },
+        ],
+      });
+      expect(mockReader.readUrl).not.toHaveBeenCalled();
+    });
+
+    it('skips skills with non-url source location type', async () => {
+      mockCatalog.getEntities.mockResolvedValue({
+        items: [
+          {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'AiResource',
+            metadata: {
+              name: 'file-based',
+              namespace: 'default',
+              description: 'File source',
+              annotations: {
+                'backstage.io/source-location': 'file:/local/path/SKILL.md',
+              },
+            },
+            spec: { type: 'skill', lifecycle: 'production', owner: 'team-a' },
+          },
+        ],
+      });
+
+      const response = await request(app).get('/.well-known/skills/index.json');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ skills: [] });
+    });
+  });
+
+  describe('GET /.well-known/skills/:skillName/SKILL.md', () => {
+    it('returns skill content from cache', async () => {
+      mockCache.get.mockResolvedValue('# Cached Skill Content');
+      mockCatalog.getEntityByRef.mockResolvedValue({
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'AiResource',
+        metadata: {
+          name: 'frontend-design',
+          namespace: 'default',
+          description: 'A skill for frontend design',
+          annotations: {
+            'backstage.io/source-location':
+              'url:https://github.com/org/repo/blob/main/skills/frontend-design/SKILL.md',
+          },
+        },
+        spec: { type: 'skill', lifecycle: 'production', owner: 'team-a' },
+      });
+
+      const response = await request(app).get(
+        '/.well-known/skills/frontend-design/SKILL.md',
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.type).toBe('text/markdown');
+      expect(response.text).toBe('# Cached Skill Content');
+    });
+
+    it('fetches and caches skill content when not in cache', async () => {
+      mockCache.get.mockResolvedValue(undefined);
+      mockCatalog.getEntityByRef.mockResolvedValue({
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'AiResource',
+        metadata: {
+          name: 'frontend-design',
+          namespace: 'default',
+          description: 'A skill for frontend design',
+          annotations: {
+            'backstage.io/source-location':
+              'url:https://github.com/org/repo/blob/main/skills/frontend-design/SKILL.md',
+          },
+        },
+        spec: { type: 'skill', lifecycle: 'production', owner: 'team-a' },
+      });
+
+      mockReader.readUrl.mockResolvedValue({
+        buffer: async () => Buffer.from('# Fresh Skill Content'),
+        etag: 'abc123',
+      });
+
+      const response = await request(app).get(
+        '/.well-known/skills/frontend-design/SKILL.md',
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.type).toBe('text/markdown');
+      expect(response.text).toBe('# Fresh Skill Content');
+      expect(mockCache.set).toHaveBeenCalledWith(
+        'skills-content:airesource:default/frontend-design',
+        '# Fresh Skill Content',
+        { ttl: { minutes: 5 } },
+      );
+    });
+
+    it('returns 404 when skill entity is not found', async () => {
+      mockCache.get.mockResolvedValue(undefined);
+      mockCatalog.getEntityByRef.mockResolvedValue(undefined);
+
+      const response = await request(app).get(
+        '/.well-known/skills/nonexistent/SKILL.md',
+      );
+
+      expect(response.status).toBe(404);
+      expect(response.body).toEqual({ error: 'Skill not found' });
+    });
+
+    it('returns 404 when entity is not a skill type', async () => {
+      mockCache.get.mockResolvedValue(undefined);
+      mockCatalog.getEntityByRef.mockResolvedValue({
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'AiResource',
+        metadata: {
+          name: 'some-rule',
+          namespace: 'default',
+          description: 'A rule',
+          annotations: {
+            'backstage.io/source-location': 'url:https://example.com/rule.md',
+          },
+        },
+        spec: { type: 'rule', lifecycle: 'production', owner: 'team-a' },
+      });
+
+      const response = await request(app).get(
+        '/.well-known/skills/some-rule/SKILL.md',
+      );
+
+      expect(response.status).toBe(404);
+      expect(response.body).toEqual({ error: 'Skill not found' });
+    });
+
+    it('returns 404 when skill content cannot be fetched', async () => {
+      mockCache.get.mockResolvedValue(undefined);
+      mockCatalog.getEntityByRef.mockResolvedValue({
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'AiResource',
+        metadata: {
+          name: 'broken-skill',
+          namespace: 'default',
+          description: 'Broken',
+          annotations: {
+            'backstage.io/source-location':
+              'url:https://github.com/org/repo/blob/main/skills/broken/SKILL.md',
+          },
+        },
+        spec: { type: 'skill', lifecycle: 'production', owner: 'team-a' },
+      });
+
+      mockReader.readUrl.mockRejectedValue(new Error('Not found'));
+
+      const response = await request(app).get(
+        '/.well-known/skills/broken-skill/SKILL.md',
+      );
+
+      expect(response.status).toBe(404);
+      expect(response.body).toEqual({ error: 'Skill content not available' });
+    });
+
+    it('resolves skills from non-default namespace', async () => {
+      mockCache.get.mockResolvedValue(undefined);
+      mockCatalog.getEntityByRef.mockResolvedValue({
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'AiResource',
+        metadata: {
+          name: 'custom-skill',
+          namespace: 'custom-ns',
+          description: 'A custom namespace skill',
+          annotations: {
+            'backstage.io/source-location':
+              'url:https://github.com/org/repo/blob/main/skills/custom/SKILL.md',
+          },
+        },
+        spec: { type: 'skill', lifecycle: 'production', owner: 'team-c' },
+      });
+
+      mockReader.readUrl.mockResolvedValue({
+        buffer: async () => Buffer.from('# Custom NS Skill'),
+        etag: 'def456',
+      });
+
+      const response = await request(app).get(
+        '/.well-known/skills/custom-ns/custom-skill/SKILL.md',
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.text).toBe('# Custom NS Skill');
+      expect(mockCatalog.getEntityByRef).toHaveBeenCalledWith(
+        'airesource:custom-ns/custom-skill',
+        expect.anything(),
+      );
+    });
+  });
+});

--- a/plugins/catalog-backend-module-ai-model/src/SkillsRouter.ts
+++ b/plugins/catalog-backend-module-ai-model/src/SkillsRouter.ts
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Response, Router } from 'express';
+import {
+  AuthService,
+  CacheService,
+  LoggerService,
+  UrlReaderService,
+} from '@backstage/backend-plugin-api';
+import { CatalogService } from '@backstage/plugin-catalog-node';
+import {
+  ANNOTATION_SOURCE_LOCATION,
+  Entity,
+  getEntitySourceLocation,
+  stringifyEntityRef,
+} from '@backstage/catalog-model';
+
+/** @internal */
+export type SkillsRouterOptions = {
+  catalog: CatalogService;
+  auth: AuthService;
+  reader: UrlReaderService;
+  cache: CacheService;
+  logger: LoggerService;
+};
+
+type SkillIndexEntry = {
+  name: string;
+  description: string;
+  files: string[];
+};
+
+type CachedSkillIndex = {
+  skills: SkillIndexEntry[];
+};
+
+const CACHE_KEY_INDEX = 'skills-index';
+const CACHE_KEY_PREFIX_CONTENT = 'skills-content:';
+const CACHE_TTL = { minutes: 5 };
+
+/** @internal */
+export function createSkillsRouter(options: SkillsRouterOptions): Router {
+  const { catalog, auth, reader, cache, logger } = options;
+
+  const router = Router();
+
+  function skillDisplayName(entity: Entity): string {
+    const ns = entity.metadata.namespace ?? 'default';
+    if (ns === 'default') {
+      return entity.metadata.name;
+    }
+    return `${ns}/${entity.metadata.name}`;
+  }
+
+  async function getSkillEntities(): Promise<Entity[]> {
+    const response = await catalog.getEntities(
+      {
+        filter: { kind: 'AiResource', 'spec.type': 'skill' },
+        fields: [
+          'metadata.name',
+          'metadata.description',
+          'metadata.namespace',
+          'metadata.annotations',
+          'kind',
+          'apiVersion',
+          'spec.type',
+        ],
+      },
+      { credentials: await auth.getOwnServiceCredentials() },
+    );
+
+    return response.items;
+  }
+
+  function hasValidSourceLocation(entity: Entity): boolean {
+    const annotation =
+      entity.metadata.annotations?.[ANNOTATION_SOURCE_LOCATION];
+    if (!annotation) {
+      return false;
+    }
+    try {
+      const sourceLocation = getEntitySourceLocation(entity);
+      return sourceLocation.type === 'url';
+    } catch {
+      return false;
+    }
+  }
+
+  async function fetchSkillContent(
+    entity: Entity,
+  ): Promise<string | undefined> {
+    const cacheKey = `${CACHE_KEY_PREFIX_CONTENT}${stringifyEntityRef(entity)}`;
+    try {
+      const cached = await cache.get<string | null>(cacheKey);
+      if (cached !== undefined) {
+        return cached ?? undefined;
+      }
+
+      const sourceLocation = getEntitySourceLocation(entity);
+      if (sourceLocation.type !== 'url') {
+        await cache.set(cacheKey, null, { ttl: CACHE_TTL });
+        return undefined;
+      }
+
+      const response = await reader.readUrl(sourceLocation.target);
+      const buffer = await response.buffer();
+      const content = buffer.toString('utf-8');
+
+      await cache.set(cacheKey, content, { ttl: CACHE_TTL });
+      return content;
+    } catch (error) {
+      logger.debug(
+        `Failed to fetch skill content for ${entity.metadata.name}: ${error}`,
+      );
+      await cache.set(cacheKey, null, { ttl: CACHE_TTL });
+      return undefined;
+    }
+  }
+
+  async function buildSkillIndex(): Promise<CachedSkillIndex> {
+    const cached = await cache.get<CachedSkillIndex>(CACHE_KEY_INDEX);
+    if (cached) {
+      return cached;
+    }
+
+    const entities = await getSkillEntities();
+    const skills: SkillIndexEntry[] = [];
+
+    for (const entity of entities) {
+      if (!hasValidSourceLocation(entity)) {
+        continue;
+      }
+
+      skills.push({
+        name: skillDisplayName(entity),
+        description: entity.metadata.description ?? '',
+        files: ['SKILL.md'],
+      });
+    }
+
+    const index: CachedSkillIndex = { skills };
+    await cache.set(CACHE_KEY_INDEX, index, { ttl: CACHE_TTL });
+    return index;
+  }
+
+  router.get('/index.json', async (_req, res) => {
+    try {
+      const index = await buildSkillIndex();
+      res.json(index);
+    } catch (error) {
+      logger.error(`Failed to build skills index: ${error}`);
+      res.status(500).json({ error: 'Failed to build skills index' });
+    }
+  });
+
+  async function handleSkillContent(
+    namespace: string,
+    name: string,
+    res: Response,
+  ) {
+    try {
+      const entity = await catalog.getEntityByRef(
+        `airesource:${namespace}/${name}`,
+        { credentials: await auth.getOwnServiceCredentials() },
+      );
+
+      if (!entity || entity.spec?.type !== 'skill') {
+        res.status(404).json({ error: 'Skill not found' });
+        return;
+      }
+
+      const content = await fetchSkillContent(entity);
+      if (content === undefined) {
+        res.status(404).json({ error: 'Skill content not available' });
+        return;
+      }
+
+      res.type('text/markdown').send(content);
+    } catch (error) {
+      logger.error(
+        `Failed to fetch skill content for ${namespace}/${name}: ${error}`,
+      );
+      res.status(500).json({ error: 'Failed to fetch skill content' });
+    }
+  }
+
+  // Non-default namespace: /<namespace>/<name>/SKILL.md
+  router.get('/:namespace/:skillName/SKILL.md', async (req, res) => {
+    await handleSkillContent(req.params.namespace, req.params.skillName, res);
+  });
+
+  // Default namespace: /<name>/SKILL.md
+  router.get('/:skillName/SKILL.md', async (req, res) => {
+    await handleSkillContent('default', req.params.skillName, res);
+  });
+
+  return router;
+}

--- a/plugins/catalog-backend-module-ai-model/src/module.test.ts
+++ b/plugins/catalog-backend-module-ai-model/src/module.test.ts
@@ -16,21 +16,39 @@
 
 import { startTestBackend } from '@backstage/backend-test-utils';
 import { catalogModelExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
+import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
 import { catalogModuleAiResourceEntityModel } from './module';
 
 describe('catalogModuleAiResourceEntityModel', () => {
-  it('should register the model source', async () => {
+  it('should register the model source and serve skills endpoint', async () => {
     const extensionPoint = {
       setFieldValidators: jest.fn(),
       setEntityDataParser: jest.fn(),
       addModelSource: jest.fn(),
     };
 
-    await startTestBackend({
-      extensionPoints: [[catalogModelExtensionPoint, extensionPoint]],
-      features: [catalogModuleAiResourceEntityModel],
+    const mockCatalog = catalogServiceMock.mock({
+      getEntities: jest.fn().mockResolvedValue({ items: [] }),
     });
 
-    expect(extensionPoint.addModelSource).toHaveBeenCalledTimes(1);
+    const backend = await startTestBackend({
+      extensionPoints: [[catalogModelExtensionPoint, extensionPoint]],
+      features: [catalogModuleAiResourceEntityModel, mockCatalog.factory],
+    });
+
+    try {
+      expect(extensionPoint.addModelSource).toHaveBeenCalledTimes(1);
+
+      // Verify the skills endpoint is reachable
+      const port = backend.server.port();
+      const response = await fetch(
+        `http://localhost:${port}/.well-known/skills/index.json`,
+      );
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body).toEqual({ skills: [] });
+    } finally {
+      await backend.stop();
+    }
   });
 });

--- a/plugins/catalog-backend-module-ai-model/src/module.ts
+++ b/plugins/catalog-backend-module-ai-model/src/module.ts
@@ -14,13 +14,18 @@
  * limitations under the License.
  */
 
-import { createBackendModule } from '@backstage/backend-plugin-api';
 import {
-  CatalogModelSources,
+  coreServices,
+  createBackendModule,
+} from '@backstage/backend-plugin-api';
+import {
   aiResourceEntityModel,
+  CatalogModelSources,
   mcpServerApiEntityModel,
 } from '@backstage/catalog-model/alpha';
 import { catalogModelExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
+import { catalogServiceRef } from '@backstage/plugin-catalog-node';
+import { createSkillsRouter } from './SkillsRouter';
 
 /**
  * Registers support for the AiResource entity kind in the catalog.
@@ -34,14 +39,38 @@ export const catalogModuleAiResourceEntityModel = createBackendModule({
     reg.registerInit({
       deps: {
         model: catalogModelExtensionPoint,
+        rootHttpRouter: coreServices.rootHttpRouter,
+        catalog: catalogServiceRef,
+        auth: coreServices.auth,
+        reader: coreServices.urlReader,
+        cache: coreServices.cache,
+        logger: coreServices.logger,
       },
-      async init({ model }) {
+      async init({
+        model,
+        rootHttpRouter,
+        catalog,
+        auth,
+        reader,
+        cache,
+        logger,
+      }) {
         model.addModelSource(
           CatalogModelSources.static([
             aiResourceEntityModel,
             mcpServerApiEntityModel,
           ]),
         );
+
+        const skillsRouter = createSkillsRouter({
+          catalog,
+          auth,
+          reader,
+          cache,
+          logger,
+        });
+
+        rootHttpRouter.use('/.well-known/skills', skillsRouter);
       },
     });
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4769,6 +4769,10 @@ __metadata:
     "@backstage/catalog-model": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/plugin-catalog-node": "workspace:^"
+    "@types/express": "npm:^4.17.6"
+    "@types/supertest": "npm:^2.0.8"
+    express: "npm:^4.21.0"
+    supertest: "npm:^7.0.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

add well-known endpoint to fetch skills from the catalog using `npx skills` cli tool the same way backstage.io provides it's skills.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
