### PR TITLE
Fix Redis keepalive logic

### DIFF
--- a/.changeset/stupid-pants-start.md
+++ b/.changeset/stupid-pants-start.md
@@ -2,4 +2,4 @@
 '@backstage/backend-defaults': patch
 ---
 
-The `connection` config option for the Redis cache store now accepts either a string URL or an object with additional connection options that are passed directly to the underlying client. This allows configuring options like `pingInterval` without needing dedicated config fields. For clustered Redis, the connection object properties are merged into cluster defaults. Fixes https://github.com/backstage/backstage/issues/31813, https://github.com/backstage/backstage/issues/31742.
+The `connection` config option for the Redis cache store now accepts either a string URL or an object with additional connection options that are passed directly to the underlying client. The object form is only supported when `backend.cache.store` is `redis`; other stores require a plain string. This allows configuring options like `pingInterval` without needing dedicated config fields. For clustered Redis, the connection object properties are merged into cluster defaults. Fixes https://github.com/backstage/backstage/issues/31813, https://github.com/backstage/backstage/issues/31742.

--- a/.changeset/stupid-pants-start.md
+++ b/.changeset/stupid-pants-start.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Added a `pingInterval` config option for the Redis cache store to keep connections alive in environments where idle connections are silently dropped. Works with both standalone and clustered Redis. Fixes https://github.com/backstage/backstage/issues/31813, https://github.com/backstage/backstage/issues/31742.

--- a/.changeset/stupid-pants-start.md
+++ b/.changeset/stupid-pants-start.md
@@ -2,4 +2,4 @@
 '@backstage/backend-defaults': patch
 ---
 
-Added a `pingInterval` config option for the Redis cache store to keep connections alive in environments where idle connections are silently dropped. Works with both standalone and clustered Redis. Fixes https://github.com/backstage/backstage/issues/31813, https://github.com/backstage/backstage/issues/31742.
+The `connection` config option for the Redis cache store now accepts either a string URL or an object with additional connection options that are passed directly to the underlying client. This allows configuring options like `pingInterval` without needing dedicated config fields. For clustered Redis, the connection object properties are merged into cluster defaults. Fixes https://github.com/backstage/backstage/issues/31813, https://github.com/backstage/backstage/issues/31742.

--- a/docs/backend-system/core-services/cache.md
+++ b/docs/backend-system/core-services/cache.md
@@ -34,7 +34,12 @@ backend:
 backend:
   cache:
     store: redis
+    # Connection can be a simple URL string:
     connection: redis://localhost:6379
+    # Or an object with additional options passed to the underlying client:
+    # connection:
+    #   url: redis://localhost:6379
+    #   pingInterval: 60000
 
     # Store-specific configuration (optional)
     redis:
@@ -43,9 +48,6 @@ backend:
         namespace: 'my-app'
         # Separator used between namespace and plugin ID (default: ':')
         keyPrefixSeparator: ':'
-        # Send PING commands at this interval to keep the connection alive
-        # When cluster mode is enabled, this is applied to all cluster node connections via cluster defaults
-        pingInterval: 60000
         # Other Redis-specific options...
         clearBatchSize: 1000
         useUnlink: false

--- a/docs/backend-system/core-services/cache.md
+++ b/docs/backend-system/core-services/cache.md
@@ -36,7 +36,8 @@ backend:
     store: redis
     # Connection can be a simple URL string:
     connection: redis://localhost:6379
-    # Or an object with additional options passed to the underlying client:
+    # Or an object with additional options passed to the underlying client
+    # (only supported for the Redis store):
     # connection:
     #   url: redis://localhost:6379
     #   pingInterval: 60000

--- a/docs/backend-system/core-services/cache.md
+++ b/docs/backend-system/core-services/cache.md
@@ -43,6 +43,9 @@ backend:
         namespace: 'my-app'
         # Separator used between namespace and plugin ID (default: ':')
         keyPrefixSeparator: ':'
+        # Send PING commands at this interval to keep the connection alive
+        # When cluster mode is enabled, this is applied to all cluster node connections via cluster defaults
+        pingInterval: 60000
         # Other Redis-specific options...
         clearBatchSize: 1000
         useUnlink: false

--- a/packages/backend-defaults/config.d.ts
+++ b/packages/backend-defaults/config.d.ts
@@ -784,10 +784,23 @@ export interface Config {
       | {
           store: 'redis';
           /**
-           * A redis connection string in the form `redis://user:pass@host:port`.
+           * A redis connection string in the form `redis://user:pass@host:port`,
+           * or an object with connection options passed directly to the underlying
+           * client (e.g. `{ url: 'redis://localhost:6379', pingInterval: 60000 }`).
            * @visibility secret
            */
-          connection: string;
+          connection:
+            | string
+            | {
+                /**
+                 * The Redis connection URL.
+                 */
+                url: string;
+                /**
+                 * Other connection settings
+                 */
+                [key: string]: unknown;
+              };
           /** An optional default TTL (in milliseconds, if given as a number). */
           defaultTtl?: number | HumanDuration | string;
           redis?: {
@@ -817,12 +830,6 @@ export interface Config {
                * Defaults to `false`.
                */
               noNamespaceAffectsAll?: boolean;
-              /**
-               * Send `PING` command at interval. Supports a number in milliseconds
-               * or a human duration string like '10s'. Useful for environments
-               * with idle connection timeouts.
-               */
-              pingInterval?: number | HumanDuration | string;
             };
             /**
              * An optional Redis cluster configuration.

--- a/packages/backend-defaults/config.d.ts
+++ b/packages/backend-defaults/config.d.ts
@@ -817,6 +817,12 @@ export interface Config {
                * Defaults to `false`.
                */
               noNamespaceAffectsAll?: boolean;
+              /**
+               * Send `PING` command at interval. Supports a number in milliseconds
+               * or a human duration string like '10s'. Useful for environments
+               * with idle connection timeouts.
+               */
+              pingInterval?: number | HumanDuration | string;
             };
             /**
              * An optional Redis cluster configuration.

--- a/packages/backend-defaults/config.d.ts
+++ b/packages/backend-defaults/config.d.ts
@@ -787,6 +787,7 @@ export interface Config {
            * A redis connection string in the form `redis://user:pass@host:port`,
            * or an object with connection options passed directly to the underlying
            * client (e.g. `{ url: 'redis://localhost:6379', pingInterval: 60000 }`).
+           * The object form is only supported for the Redis store.
            * @visibility secret
            */
           connection:

--- a/packages/backend-defaults/report-cache.api.md
+++ b/packages/backend-defaults/report-cache.api.md
@@ -4,7 +4,7 @@
 
 ```ts
 import { CacheService } from '@backstage/backend-plugin-api';
-import { LoggerService } from '@backstage/backend-plugin-api';
+import type { LoggerService } from '@backstage/backend-plugin-api';
 import { RootConfigService } from '@backstage/backend-plugin-api';
 import { ServiceFactory } from '@backstage/backend-plugin-api';
 

--- a/packages/backend-defaults/src/entrypoints/cache/CacheManager.test.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/CacheManager.test.ts
@@ -511,6 +511,68 @@ describe('CacheManager store options', () => {
     });
   });
 
+  it('passes pingInterval to Redis client in non-clustered mode', () => {
+    const manager = CacheManager.fromConfig(
+      mockServices.rootConfig({
+        data: {
+          backend: {
+            cache: {
+              store: 'redis',
+              connection: 'redis://localhost:6379',
+              redis: {
+                client: {
+                  pingInterval: 15000,
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+    manager.forPlugin('p1');
+
+    expect(KeyvRedis).toHaveBeenCalledWith(
+      { url: 'redis://localhost:6379', pingInterval: 15000 },
+      { keyPrefixSeparator: ':' },
+    );
+  });
+
+  it('merges pingInterval into cluster defaults when configured', () => {
+    const clusterInstance = { fake: 'cluster' };
+    (createCluster as jest.Mock).mockReturnValue(clusterInstance);
+
+    const manager = CacheManager.fromConfig(
+      mockServices.rootConfig({
+        data: {
+          backend: {
+            cache: {
+              store: 'redis',
+              connection: 'redis://localhost:6379',
+              redis: {
+                client: {
+                  pingInterval: 10000,
+                },
+                cluster: {
+                  rootNodes: [{ url: 'redis://localhost:6379' }],
+                  defaults: { password: 'secret' },
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+    manager.forPlugin('p1');
+
+    expect(createCluster).toHaveBeenCalledWith({
+      rootNodes: [{ url: 'redis://localhost:6379' }],
+      defaults: { password: 'secret', pingInterval: 10000 },
+    });
+    expect(KeyvRedis).toHaveBeenCalledWith(clusterInstance, {
+      keyPrefixSeparator: ':',
+    });
+  });
+
   describe('Namespace construction', () => {
     it('returns pluginId when no store options are provided', () => {
       const result = (CacheManager as any).constructNamespace(

--- a/packages/backend-defaults/src/entrypoints/cache/CacheManager.test.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/CacheManager.test.ts
@@ -532,8 +532,11 @@ describe('CacheManager store options', () => {
     manager.forPlugin('p1');
 
     expect(KeyvRedis).toHaveBeenCalledWith(
-      { url: 'redis://localhost:6379', pingInterval: 15000 },
-      { keyPrefixSeparator: ':' },
+      expect.objectContaining({
+        url: 'redis://localhost:6379',
+        pingInterval: 15000,
+      }),
+      expect.objectContaining({ keyPrefixSeparator: ':' }),
     );
   });
 
@@ -564,13 +567,19 @@ describe('CacheManager store options', () => {
     );
     manager.forPlugin('p1');
 
-    expect(createCluster).toHaveBeenCalledWith({
-      rootNodes: [{ url: 'redis://localhost:6379' }],
-      defaults: { password: 'secret', pingInterval: 10000 },
-    });
-    expect(KeyvRedis).toHaveBeenCalledWith(clusterInstance, {
-      keyPrefixSeparator: ':',
-    });
+    expect(createCluster).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rootNodes: [{ url: 'redis://localhost:6379' }],
+        defaults: expect.objectContaining({
+          password: 'secret',
+          pingInterval: 10000,
+        }),
+      }),
+    );
+    expect(KeyvRedis).toHaveBeenCalledWith(
+      clusterInstance,
+      expect.objectContaining({ keyPrefixSeparator: ':' }),
+    );
   });
 
   describe('Namespace construction', () => {

--- a/packages/backend-defaults/src/entrypoints/cache/CacheManager.test.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/CacheManager.test.ts
@@ -570,9 +570,13 @@ describe('CacheManager store options', () => {
         rootNodes: [{ url: 'redis://localhost:6379' }],
         defaults: expect.objectContaining({
           password: 'secret',
-          url: 'redis://localhost:6379',
           pingInterval: 10000,
         }),
+      }),
+    );
+    expect(createCluster).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaults: expect.not.objectContaining({ url: expect.anything() }),
       }),
     );
     expect(KeyvRedis).toHaveBeenCalledWith(
@@ -635,6 +639,31 @@ describe('CacheManager store options', () => {
       ),
     ).toThrow('backend.cache.connection must be a string or object');
   });
+
+  it.each(['valkey', 'memcache', 'memory'])(
+    'rejects connection object for non-redis store %s',
+    store => {
+      expect(() =>
+        CacheManager.fromConfig(
+          mockServices.rootConfig({
+            data: {
+              backend: {
+                cache: {
+                  store,
+                  connection: {
+                    url: 'redis://localhost:6379',
+                    pingInterval: 15000,
+                  },
+                },
+              },
+            },
+          }),
+        ),
+      ).toThrow(
+        "backend.cache.connection object form is only supported when backend.cache.store is 'redis'",
+      );
+    },
+  );
 
   describe('Namespace construction', () => {
     it('returns pluginId when no store options are provided', () => {

--- a/packages/backend-defaults/src/entrypoints/cache/CacheManager.test.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/CacheManager.test.ts
@@ -581,6 +581,61 @@ describe('CacheManager store options', () => {
     );
   });
 
+  it('rejects connection object without a url', () => {
+    expect(() =>
+      CacheManager.fromConfig(
+        mockServices.rootConfig({
+          data: {
+            backend: {
+              cache: {
+                store: 'redis',
+                connection: { pingInterval: 15000 },
+              },
+            },
+          },
+        }),
+      ),
+    ).toThrow(
+      "backend.cache.connection object must include a non-empty 'url' string",
+    );
+  });
+
+  it('rejects connection object with empty url', () => {
+    expect(() =>
+      CacheManager.fromConfig(
+        mockServices.rootConfig({
+          data: {
+            backend: {
+              cache: {
+                store: 'redis',
+                connection: { url: '' },
+              },
+            },
+          },
+        }),
+      ),
+    ).toThrow(
+      "backend.cache.connection object must include a non-empty 'url' string",
+    );
+  });
+
+  it('rejects connection as an array', () => {
+    expect(() =>
+      CacheManager.fromConfig(
+        mockServices.rootConfig({
+          data: {
+            backend: {
+              cache: {
+                store: 'redis',
+                connection: ['redis://localhost:6379'],
+              },
+            },
+          },
+        }),
+      ),
+    ).toThrow('backend.cache.connection must be a string or object');
+  });
+
   describe('Namespace construction', () => {
     it('returns pluginId when no store options are provided', () => {
       const result = (CacheManager as any).constructNamespace(

--- a/packages/backend-defaults/src/entrypoints/cache/CacheManager.test.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/CacheManager.test.ts
@@ -511,18 +511,16 @@ describe('CacheManager store options', () => {
     });
   });
 
-  it('passes pingInterval to Redis client in non-clustered mode', () => {
+  it('passes connection object directly to Redis client in non-clustered mode', () => {
     const manager = CacheManager.fromConfig(
       mockServices.rootConfig({
         data: {
           backend: {
             cache: {
               store: 'redis',
-              connection: 'redis://localhost:6379',
-              redis: {
-                client: {
-                  pingInterval: 15000,
-                },
+              connection: {
+                url: 'redis://localhost:6379',
+                pingInterval: 15000,
               },
             },
           },
@@ -540,7 +538,7 @@ describe('CacheManager store options', () => {
     );
   });
 
-  it('merges pingInterval into cluster defaults when configured', () => {
+  it('merges connection object into cluster defaults when configured', () => {
     const clusterInstance = { fake: 'cluster' };
     (createCluster as jest.Mock).mockReturnValue(clusterInstance);
 
@@ -550,11 +548,11 @@ describe('CacheManager store options', () => {
           backend: {
             cache: {
               store: 'redis',
-              connection: 'redis://localhost:6379',
+              connection: {
+                url: 'redis://localhost:6379',
+                pingInterval: 10000,
+              },
               redis: {
-                client: {
-                  pingInterval: 10000,
-                },
                 cluster: {
                   rootNodes: [{ url: 'redis://localhost:6379' }],
                   defaults: { password: 'secret' },
@@ -572,6 +570,7 @@ describe('CacheManager store options', () => {
         rootNodes: [{ url: 'redis://localhost:6379' }],
         defaults: expect.objectContaining({
           password: 'secret',
+          url: 'redis://localhost:6379',
           pingInterval: 10000,
         }),
       }),

--- a/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
@@ -27,6 +27,7 @@ import {
   ttlToMilliseconds,
   CacheStoreOptions,
   CacheStoreConnection,
+  CacheStoreConnectionObject,
   CacheStoreConfiguration,
   CacheStoreDeps,
   RedisCacheStoreConfiguration,
@@ -157,7 +158,7 @@ export class CacheManager {
         );
       }
 
-      return raw as Record<string, unknown>;
+      return raw as CacheStoreConnectionObject;
     }
 
     if (raw !== undefined && typeof raw !== 'string') {
@@ -253,8 +254,7 @@ export class CacheManager {
         clusterConfig.getOptional('defaults');
 
       if (typeof config.connection === 'object') {
-        const { url: _url, ...connectionDefaults } =
-          config.connection as Record<string, unknown>;
+        const { url: _url, ...connectionDefaults } = config.connection;
         defaults = { ...defaults, ...connectionDefaults };
       }
 

--- a/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
@@ -28,6 +28,7 @@ import {
   CacheStoreOptions,
   CacheStoreConnection,
   CacheStoreConfiguration,
+  CacheStoreDeps,
   RedisCacheStoreConfiguration,
   RedisCacheStoreOptions,
   InfinispanClientBehaviorOptions,
@@ -190,22 +191,21 @@ export class CacheManager {
       );
     }
 
-    const parseOptions: CacheStoreConfiguration = {
-      storeConfigPath,
-      config,
-      logger,
-    };
+    const deps = { config, logger };
 
     switch (store) {
       case 'redis':
-        return CacheManager.parseRedisOptions({
-          ...parseOptions,
-          connection,
-        });
+        return CacheManager.parseRedisOptions(
+          { storeConfigPath, connection },
+          deps,
+        );
       case 'valkey':
-        return CacheManager.parseValkeyOptions(parseOptions);
+        return CacheManager.parseValkeyOptions({ storeConfigPath }, deps);
       case 'infinispan':
-        return InfinispanOptionsMapper.parseInfinispanOptions(parseOptions);
+        return InfinispanOptionsMapper.parseInfinispanOptions(
+          { storeConfigPath },
+          deps,
+        );
       default:
         return undefined;
     }
@@ -214,18 +214,17 @@ export class CacheManager {
   /**
    * Parse Redis-specific options from configuration.
    */
-  private static parseRedisOptions({
-    storeConfigPath,
-    connection,
-    config,
-    logger,
-  }: RedisCacheStoreConfiguration): RedisCacheStoreOptions {
+  private static parseRedisOptions(
+    config: RedisCacheStoreConfiguration,
+    deps: CacheStoreDeps,
+  ): RedisCacheStoreOptions {
     const redisOptions: RedisCacheStoreOptions = {
       type: 'redis',
     };
 
     const redisConfig =
-      config.getOptionalConfig(storeConfigPath) ?? new ConfigReader({});
+      deps.config.getOptionalConfig(config.storeConfigPath) ??
+      new ConfigReader({});
 
     redisOptions.client = {
       namespace: redisConfig.getOptionalString('client.namespace'),
@@ -242,7 +241,7 @@ export class CacheManager {
       const clusterConfig = redisConfig.getConfig('cluster');
 
       if (!clusterConfig.has('rootNodes')) {
-        logger?.warn(
+        deps.logger?.warn(
           `Redis cluster config has no 'rootNodes' key, defaulting to non-clustered mode`,
         );
         return redisOptions;
@@ -253,11 +252,9 @@ export class CacheManager {
       let defaults: RedisClusterOptions['defaults'] =
         clusterConfig.getOptional('defaults');
 
-      if (typeof connection === 'object') {
-        const { url: _url, ...connectionDefaults } = connection as Record<
-          string,
-          unknown
-        >;
+      if (typeof config.connection === 'object') {
+        const { url: _url, ...connectionDefaults } =
+          config.connection as Record<string, unknown>;
         defaults = { ...defaults, ...connectionDefaults };
       }
 
@@ -280,17 +277,17 @@ export class CacheManager {
   /**
    * Parse Valkey-specific options from configuration.
    */
-  private static parseValkeyOptions({
-    storeConfigPath,
-    config,
-    logger,
-  }: CacheStoreConfiguration): ValkeyCacheStoreOptions {
+  private static parseValkeyOptions(
+    config: CacheStoreConfiguration,
+    deps: CacheStoreDeps,
+  ): ValkeyCacheStoreOptions {
     const valkeyOptions: ValkeyCacheStoreOptions = {
       type: 'valkey',
     };
 
     const valkeyConfig =
-      config.getOptionalConfig(storeConfigPath) ?? new ConfigReader({});
+      deps.config.getOptionalConfig(config.storeConfigPath) ??
+      new ConfigReader({});
 
     valkeyOptions.client = {
       keyPrefix: valkeyConfig.getOptionalString('client.keyPrefix'),
@@ -300,7 +297,7 @@ export class CacheManager {
       const clusterConfig = valkeyConfig.getConfig('cluster');
 
       if (!clusterConfig.has('rootNodes')) {
-        logger?.warn(
+        deps.logger?.warn(
           `Valkey cluster config has no 'rootNodes' key, defaulting to non-clustered mode`,
         );
         return valkeyOptions;

--- a/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
@@ -135,7 +135,7 @@ export class CacheManager {
    * passed through to the underlying store client.
    *
    * @param config - The configuration service
-   * @return The parsed connection config, either a string or an object depending on how it was configured
+   * @returns The parsed connection config, either a string or an object depending on how it was configured
    */
   private static parseConnection(
     config: RootConfigService,

--- a/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
@@ -142,8 +142,20 @@ export class CacheManager {
   ): CacheStoreConnection {
     const raw = config.getOptional('backend.cache.connection');
 
-    if (typeof raw === 'object' && raw !== null) {
+    if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+      const url = (raw as { url?: unknown }).url;
+      if (typeof url !== 'string' || url.length === 0) {
+        throw new Error(
+          "backend.cache.connection object must include a non-empty 'url' string",
+        );
+      }
       return raw as Record<string, unknown>;
+    }
+
+    if (raw !== undefined && typeof raw !== 'string') {
+      throw new Error(
+        `backend.cache.connection must be a string or object, got ${typeof raw}`,
+      );
     }
 
     return config.getOptionalString('backend.cache.connection') ?? '';

--- a/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
@@ -42,7 +42,6 @@ import {
   InfinispanKeyvStore,
 } from './providers/infinispan/InfinispanKeyvStore';
 import type { KeyvRedisOptions, RedisClusterOptions } from '@keyv/redis';
-import type KeyvRedisClass from '@keyv/redis';
 
 type StoreFactory = (pluginId: string, defaultTtl: number | undefined) => Keyv;
 
@@ -386,10 +385,10 @@ export class CacheManager {
   }
 
   private createRedisStoreFactory(): StoreFactory {
-    const KeyvRedis = require('@keyv/redis').default as typeof KeyvRedisClass;
-    const { createCluster } =
-      require('@keyv/redis') as typeof import('@keyv/redis');
-    const stores: Record<string, KeyvRedisClass<unknown>> = {};
+    const keyvRedis = require('@keyv/redis') as typeof import('@keyv/redis');
+    const KeyvRedis = keyvRedis.default;
+    const { createCluster } = keyvRedis;
+    const stores: Record<string, InstanceType<typeof KeyvRedis>> = {};
 
     return (pluginId, defaultTtl) => {
       if (this.storeOptions?.type !== 'redis') {

--- a/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
@@ -26,6 +26,9 @@ import {
   CacheManagerOptions,
   ttlToMilliseconds,
   CacheStoreOptions,
+  CacheStoreConnection,
+  CacheStoreConfiguration,
+  RedisCacheStoreConfiguration,
   RedisCacheStoreOptions,
   InfinispanClientBehaviorOptions,
   InfinispanServerConfig,
@@ -38,7 +41,7 @@ import {
   InfinispanClientCacheInterface,
   InfinispanKeyvStore,
 } from './providers/infinispan/InfinispanKeyvStore';
-import type { KeyvRedisOptions } from '@keyv/redis';
+import type { KeyvRedisOptions, RedisClusterOptions } from '@keyv/redis';
 import type KeyvRedisClass from '@keyv/redis';
 
 type StoreFactory = (pluginId: string, defaultTtl: number | undefined) => Keyv;
@@ -65,7 +68,7 @@ export class CacheManager {
 
   private readonly logger?: LoggerService;
   private readonly store: keyof CacheManager['storeFactories'];
-  private readonly connection: string;
+  private readonly connection: CacheStoreConnection;
   private readonly errorHandler: CacheManagerOptions['onError'];
   private readonly defaultTtl?: number;
   private readonly storeOptions?: CacheStoreOptions;
@@ -86,8 +89,7 @@ export class CacheManager {
     // with an in-memory cache client.
     const store = config.getOptionalString('backend.cache.store') || 'memory';
     const defaultTtlConfig = config.getOptional('backend.cache.defaultTtl');
-    const connectionString =
-      config.getOptionalString('backend.cache.connection') || '';
+    const connection = CacheManager.parseConnection(config);
     const logger = options.logger?.child({
       type: 'cacheManager',
     });
@@ -110,16 +112,41 @@ export class CacheManager {
     }
 
     // Read store-specific options from config
-    const storeOptions = CacheManager.parseStoreOptions(store, config, logger);
+    const storeOptions = CacheManager.parseStoreOptions(
+      store,
+      connection,
+      config,
+      logger,
+    );
 
     return new CacheManager(
       store,
-      connectionString,
+      connection,
       options.onError,
       logger,
       defaultTtl,
       storeOptions,
     );
+  }
+
+  /**
+   * Parse the connection config, which can be either a plain URL string
+   * or an object with connection options (e.g. `{ url, pingInterval }`)
+   * passed through to the underlying store client.
+   *
+   * @param config - The configuration service
+   * @return The parsed connection config, either a string or an object depending on how it was configured
+   */
+  private static parseConnection(
+    config: RootConfigService,
+  ): CacheStoreConnection {
+    const raw = config.getOptional('backend.cache.connection');
+
+    if (typeof raw === 'object' && raw !== null) {
+      return raw as Record<string, unknown>;
+    }
+
+    return config.getOptionalString('backend.cache.connection') ?? '';
   }
 
   /**
@@ -132,6 +159,7 @@ export class CacheManager {
    */
   private static parseStoreOptions(
     store: string,
+    connection: CacheStoreConnection,
     config: RootConfigService,
     logger?: LoggerService,
   ): CacheStoreOptions | undefined {
@@ -143,17 +171,22 @@ export class CacheManager {
       );
     }
 
+    const parseOptions: CacheStoreConfiguration = {
+      storeConfigPath,
+      config,
+      logger,
+    };
+
     switch (store) {
       case 'redis':
-        return CacheManager.parseRedisOptions(storeConfigPath, config, logger);
+        return CacheManager.parseRedisOptions({
+          ...parseOptions,
+          connection,
+        });
       case 'valkey':
-        return CacheManager.parseValkeyOptions(storeConfigPath, config, logger);
+        return CacheManager.parseValkeyOptions(parseOptions);
       case 'infinispan':
-        return InfinispanOptionsMapper.parseInfinispanOptions(
-          storeConfigPath,
-          config,
-          logger,
-        );
+        return InfinispanOptionsMapper.parseInfinispanOptions(parseOptions);
       default:
         return undefined;
     }
@@ -162,11 +195,12 @@ export class CacheManager {
   /**
    * Parse Redis-specific options from configuration.
    */
-  private static parseRedisOptions(
-    storeConfigPath: string,
-    config: RootConfigService,
-    logger?: LoggerService,
-  ): RedisCacheStoreOptions {
+  private static parseRedisOptions({
+    storeConfigPath,
+    connection,
+    config,
+    logger,
+  }: RedisCacheStoreConfiguration): RedisCacheStoreOptions {
     const redisOptions: RedisCacheStoreOptions = {
       type: 'redis',
     };
@@ -185,19 +219,6 @@ export class CacheManager {
       ),
     };
 
-    const pingIntervalConfig = redisConfig.getOptional('client.pingInterval');
-    if (pingIntervalConfig !== undefined) {
-      if (typeof pingIntervalConfig === 'number') {
-        redisOptions.pingInterval = pingIntervalConfig;
-      } else {
-        redisOptions.pingInterval = durationToMilliseconds(
-          readDurationFromConfig(redisConfig, {
-            key: 'client.pingInterval',
-          }),
-        );
-      }
-    }
-
     if (redisConfig.has('cluster')) {
       const clusterConfig = redisConfig.getConfig('cluster');
 
@@ -208,9 +229,18 @@ export class CacheManager {
         return redisOptions;
       }
 
+      // When connection is an object, merge its properties into cluster
+      // defaults so every node inherits those options (e.g. pingInterval).
+      let defaults: RedisClusterOptions['defaults'] =
+        clusterConfig.getOptional('defaults');
+
+      if (typeof connection === 'object') {
+        defaults = { ...defaults, ...connection };
+      }
+
       redisOptions.cluster = {
         rootNodes: clusterConfig.get('rootNodes'),
-        defaults: clusterConfig.getOptional('defaults'),
+        defaults,
         minimizeConnections: clusterConfig.getOptionalBoolean(
           'minimizeConnections',
         ),
@@ -227,11 +257,11 @@ export class CacheManager {
   /**
    * Parse Valkey-specific options from configuration.
    */
-  private static parseValkeyOptions(
-    storeConfigPath: string,
-    config: RootConfigService,
-    logger?: LoggerService,
-  ): ValkeyCacheStoreOptions {
+  private static parseValkeyOptions({
+    storeConfigPath,
+    config,
+    logger,
+  }: CacheStoreConfiguration): ValkeyCacheStoreOptions {
     const valkeyOptions: ValkeyCacheStoreOptions = {
       type: 'valkey',
     };
@@ -304,7 +334,7 @@ export class CacheManager {
   /** @internal */
   constructor(
     store: string,
-    connectionString: string,
+    connection: CacheStoreConnection,
     errorHandler: CacheManagerOptions['onError'],
     logger?: LoggerService,
     defaultTtl?: number,
@@ -315,7 +345,7 @@ export class CacheManager {
     }
     this.logger = logger;
     this.store = store as keyof CacheManager['storeFactories'];
-    this.connection = connectionString;
+    this.connection = connection;
     this.errorHandler = errorHandler;
     this.defaultTtl = defaultTtl;
     this.storeOptions = storeOptions;
@@ -360,25 +390,12 @@ export class CacheManager {
           keyPrefixSeparator: ':',
         };
         if (this.storeOptions?.cluster) {
-          // Create a Redis cluster, merging pingInterval into defaults if configured
-          const clusterOpts = { ...this.storeOptions.cluster };
-          if (this.storeOptions.pingInterval) {
-            clusterOpts.defaults = {
-              ...clusterOpts.defaults,
-              pingInterval: this.storeOptions.pingInterval,
-            };
-          }
-          const cluster = createCluster(clusterOpts);
+          // Create a Redis cluster
+          const cluster = createCluster(this.storeOptions.cluster);
           stores[pluginId] = new KeyvRedis(cluster, redisOptions);
         } else {
           // Create a regular Redis connection
-          const connectionOptions = this.storeOptions?.pingInterval
-            ? {
-                url: this.connection,
-                pingInterval: this.storeOptions.pingInterval,
-              }
-            : this.connection;
-          stores[pluginId] = new KeyvRedis(connectionOptions, redisOptions);
+          stores[pluginId] = new KeyvRedis(this.connection, redisOptions);
         }
 
         // Always provide an error handler to avoid stopping the process

--- a/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
@@ -114,10 +114,8 @@ export class CacheManager {
 
     // Read store-specific options from config
     const storeOptions = CacheManager.parseStoreOptions(
-      store,
-      connection,
-      config,
-      logger,
+      { store, connection },
+      { config, logger },
     );
 
     return new CacheManager(
@@ -179,20 +177,17 @@ export class CacheManager {
    * @returns The parsed store options
    */
   private static parseStoreOptions(
-    store: string,
-    connection: CacheStoreConnection,
-    config: RootConfigService,
-    logger?: LoggerService,
+    config: { store: string; connection: CacheStoreConnection },
+    deps: CacheStoreDeps,
   ): CacheStoreOptions | undefined {
+    const { store, connection } = config;
     const storeConfigPath = `backend.cache.${store}`;
 
-    if (store !== 'memory' && !config.has(storeConfigPath)) {
-      logger?.warn(
+    if (store !== 'memory' && !deps.config.has(storeConfigPath)) {
+      deps.logger?.warn(
         `No configuration found for cache store '${store}' at '${storeConfigPath}'.`,
       );
     }
-
-    const deps = { config, logger };
 
     switch (store) {
       case 'redis':

--- a/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
@@ -38,6 +38,8 @@ import {
   InfinispanClientCacheInterface,
   InfinispanKeyvStore,
 } from './providers/infinispan/InfinispanKeyvStore';
+import type { KeyvRedisOptions } from '@keyv/redis';
+import type KeyvRedisClass from '@keyv/redis';
 
 type StoreFactory = (pluginId: string, defaultTtl: number | undefined) => Keyv;
 
@@ -182,6 +184,19 @@ export class CacheManager {
         'client.noNamespaceAffectsAll',
       ),
     };
+
+    const pingIntervalConfig = redisConfig.getOptional('client.pingInterval');
+    if (pingIntervalConfig !== undefined) {
+      if (typeof pingIntervalConfig === 'number') {
+        redisOptions.pingInterval = pingIntervalConfig;
+      } else {
+        redisOptions.pingInterval = durationToMilliseconds(
+          readDurationFromConfig(redisConfig, {
+            key: 'client.pingInterval',
+          }),
+        );
+      }
+    }
 
     if (redisConfig.has('cluster')) {
       const clusterConfig = redisConfig.getConfig('cluster');
@@ -329,9 +344,10 @@ export class CacheManager {
   }
 
   private createRedisStoreFactory(): StoreFactory {
-    const KeyvRedis = require('@keyv/redis').default;
-    const { createCluster } = require('@keyv/redis');
-    const stores: Record<string, typeof KeyvRedis> = {};
+    const KeyvRedis = require('@keyv/redis').default as typeof KeyvRedisClass;
+    const { createCluster } =
+      require('@keyv/redis') as typeof import('@keyv/redis');
+    const stores: Record<string, KeyvRedisClass<unknown>> = {};
 
     return (pluginId, defaultTtl) => {
       if (this.storeOptions?.type !== 'redis') {
@@ -340,16 +356,29 @@ export class CacheManager {
         );
       }
       if (!stores[pluginId]) {
-        const redisOptions = this.storeOptions?.client || {
+        const redisOptions: KeyvRedisOptions = this.storeOptions?.client || {
           keyPrefixSeparator: ':',
         };
         if (this.storeOptions?.cluster) {
-          // Create a Redis cluster
-          const cluster = createCluster(this.storeOptions?.cluster);
+          // Create a Redis cluster, merging pingInterval into defaults if configured
+          const clusterOpts = { ...this.storeOptions.cluster };
+          if (this.storeOptions.pingInterval) {
+            clusterOpts.defaults = {
+              ...clusterOpts.defaults,
+              pingInterval: this.storeOptions.pingInterval,
+            };
+          }
+          const cluster = createCluster(clusterOpts);
           stores[pluginId] = new KeyvRedis(cluster, redisOptions);
         } else {
           // Create a regular Redis connection
-          stores[pluginId] = new KeyvRedis(this.connection, redisOptions);
+          const connectionOptions = this.storeOptions?.pingInterval
+            ? {
+                url: this.connection,
+                pingInterval: this.storeOptions.pingInterval,
+              }
+            : this.connection;
+          stores[pluginId] = new KeyvRedis(connectionOptions, redisOptions);
         }
 
         // Always provide an error handler to avoid stopping the process

--- a/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/CacheManager.ts
@@ -140,14 +140,22 @@ export class CacheManager {
     config: RootConfigService,
   ): CacheStoreConnection {
     const raw = config.getOptional('backend.cache.connection');
+    const store = config.getOptionalString('backend.cache.store') || 'memory';
 
     if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+      if (store !== 'redis') {
+        throw new Error(
+          "backend.cache.connection object form is only supported when backend.cache.store is 'redis'",
+        );
+      }
+
       const url = (raw as { url?: unknown }).url;
       if (typeof url !== 'string' || url.length === 0) {
         throw new Error(
           "backend.cache.connection object must include a non-empty 'url' string",
         );
       }
+
       return raw as Record<string, unknown>;
     }
 
@@ -246,7 +254,11 @@ export class CacheManager {
         clusterConfig.getOptional('defaults');
 
       if (typeof connection === 'object') {
-        defaults = { ...defaults, ...connection };
+        const { url: _url, ...connectionDefaults } = connection as Record<
+          string,
+          unknown
+        >;
+        defaults = { ...defaults, ...connectionDefaults };
       }
 
       redisOptions.cluster = {

--- a/packages/backend-defaults/src/entrypoints/cache/providers/infinispan/InfinispanOptionsMapper.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/providers/infinispan/InfinispanOptionsMapper.ts
@@ -15,10 +15,7 @@
  */
 
 import {
-  LoggerService,
-  RootConfigService,
-} from '@backstage/backend-plugin-api';
-import {
+  CacheStoreConfiguration,
   DataFormatOptions,
   InfinispanAuthOptions,
   InfinispanCacheStoreOptions,
@@ -33,16 +30,14 @@ export class InfinispanOptionsMapper {
   /**
    * Parses Infinispan options from the provided configuration path.
    *
-   * @param storeConfigPath - The configuration path for the Infinispan store.
-   * @param config - The root configuration service to retrieve the Infinispan configuration.
-   * @param logger - An optional logger service for logging errors and warnings.
+   * @param options - Common store parse options.
    * @returns Parsed Infinispan cache store options.
    */
-  public static parseInfinispanOptions(
-    storeConfigPath: string,
-    config: RootConfigService,
-    logger?: LoggerService,
-  ): InfinispanCacheStoreOptions {
+  public static parseInfinispanOptions({
+    storeConfigPath,
+    config,
+    logger,
+  }: CacheStoreConfiguration): InfinispanCacheStoreOptions {
     const infinispanConfig = config.getConfig(storeConfigPath);
     const parsedOptions: Partial<InfinispanCacheStoreOptions> = {
       type: 'infinispan',

--- a/packages/backend-defaults/src/entrypoints/cache/providers/infinispan/InfinispanOptionsMapper.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/providers/infinispan/InfinispanOptionsMapper.ts
@@ -16,6 +16,7 @@
 
 import {
   CacheStoreConfiguration,
+  CacheStoreDeps,
   DataFormatOptions,
   InfinispanAuthOptions,
   InfinispanCacheStoreOptions,
@@ -30,15 +31,15 @@ export class InfinispanOptionsMapper {
   /**
    * Parses Infinispan options from the provided configuration path.
    *
-   * @param options - Common store parse options.
+   * @param config - The store configuration.
+   * @param deps - Service dependencies.
    * @returns Parsed Infinispan cache store options.
    */
-  public static parseInfinispanOptions({
-    storeConfigPath,
-    config,
-    logger,
-  }: CacheStoreConfiguration): InfinispanCacheStoreOptions {
-    const infinispanConfig = config.getConfig(storeConfigPath);
+  public static parseInfinispanOptions(
+    config: CacheStoreConfiguration,
+    deps: CacheStoreDeps,
+  ): InfinispanCacheStoreOptions {
+    const infinispanConfig = deps.config.getConfig(config.storeConfigPath);
     const parsedOptions: Partial<InfinispanCacheStoreOptions> = {
       type: 'infinispan',
     };
@@ -62,12 +63,12 @@ export class InfinispanOptionsMapper {
         } as InfinispanServerConfig;
       } else {
         throw new Error(
-          `Infinispan 'servers' configuration at ${storeConfigPath} is invalid, must be an object or an array.`,
+          `Infinispan 'servers' configuration at ${config.storeConfigPath} is invalid, must be an object or an array.`,
         );
       }
     } else {
-      logger?.warn(
-        `Infinispan configuration at ${storeConfigPath} is missing the 'servers' definition, will use client defaults.`,
+      deps.logger?.warn(
+        `Infinispan configuration at ${config.storeConfigPath} is missing the 'servers' definition, will use client defaults.`,
       );
     }
 
@@ -98,8 +99,8 @@ export class InfinispanOptionsMapper {
     ) {
       behaviorOptions.version = clientVersion;
     } else if (clientVersion !== null && clientVersion !== undefined) {
-      logger?.warn(
-        `Invalid Infinispan client version "${clientVersion}" in config at ${storeConfigPath}.version. Must be "2.9", "2.5", or "2.2". It will be ignored, and the client may use a default or fail.`,
+      deps.logger?.warn(
+        `Invalid Infinispan client version "${clientVersion}" in config at ${config.storeConfigPath}.version. Must be "2.9", "2.5", or "2.2". It will be ignored, and the client may use a default or fail.`,
       );
     }
 
@@ -110,8 +111,8 @@ export class InfinispanOptionsMapper {
     if (mediaType === 'text/plain' || mediaType === 'application/json') {
       behaviorOptions.mediaType = mediaType;
     } else if (mediaType !== null && mediaType !== undefined) {
-      logger?.warn(
-        `Invalid Infinispan mediaType "${mediaType}" in config at ${storeConfigPath}.mediaType. Must be "text/plain" | "application/json". It will be ignored, and the client may use a default or fail.`,
+      deps.logger?.warn(
+        `Invalid Infinispan mediaType "${mediaType}" in config at ${config.storeConfigPath}.mediaType. Must be "text/plain" | "application/json". It will be ignored, and the client may use a default or fail.`,
       );
     }
 
@@ -173,25 +174,25 @@ export class InfinispanOptionsMapper {
     if (keyType === 'text/plain' || keyType === 'application/json') {
       dataFormatOpts.keyType = keyType;
     } else if (keyType !== null && keyType !== undefined) {
-      logger?.warn(
-        `Invalid Infinispan dataFormat.keyType "${keyType}" in config at ${storeConfigPath}.dataFormat.keyType. Must be "text/plain" | "application/json". Not mapped, client will use default 'text/plain'.`,
+      deps.logger?.warn(
+        `Invalid Infinispan dataFormat.keyType "${keyType}" in config at ${config.storeConfigPath}.dataFormat.keyType. Must be "text/plain" | "application/json". Not mapped, client will use default 'text/plain'.`,
       );
     }
 
     if (valueType === 'text/plain' || valueType === 'application/json') {
       dataFormatOpts.valueType = valueType;
     } else if (valueType !== null && valueType !== undefined) {
-      logger?.warn(
-        `Invalid Infinispan dataFormat.valueType "${valueType}" in config at ${storeConfigPath}.dataFormat.valueType. Must be "text/plain" | "application/json". Not mapped, client will use default 'text/plain'.`,
+      deps.logger?.warn(
+        `Invalid Infinispan dataFormat.valueType "${valueType}" in config at ${config.storeConfigPath}.dataFormat.valueType. Must be "text/plain" | "application/json". Not mapped, client will use default 'text/plain'.`,
       );
     }
     behaviorOptions.dataFormat = dataFormatOpts as DataFormatOptions;
     parsedOptions.options = behaviorOptions as InfinispanClientBehaviorOptions;
 
-    logger?.debug(
-      `Parsed Infinispan options from config at ${storeConfigPath}: ${JSON.stringify(
-        parsedOptions,
-      )}`,
+    deps.logger?.debug(
+      `Parsed Infinispan options from config at ${
+        config.storeConfigPath
+      }: ${JSON.stringify(parsedOptions)}`,
     );
     return parsedOptions as InfinispanCacheStoreOptions;
   }

--- a/packages/backend-defaults/src/entrypoints/cache/types.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/types.ts
@@ -29,6 +29,7 @@ export type RedisCacheStoreOptions = {
   type: 'redis';
   client?: KeyvRedisOptions;
   cluster?: RedisClusterOptions;
+  pingInterval?: number;
 };
 
 /**

--- a/packages/backend-defaults/src/entrypoints/cache/types.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/types.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import {
+import type {
   LoggerService,
   RootConfigService,
 } from '@backstage/backend-plugin-api';
-import { HumanDuration, durationToMilliseconds } from '@backstage/types';
-import { RedisClusterOptions, KeyvRedisOptions } from '@keyv/redis';
-import { KeyvValkeyOptions } from '@keyv/valkey';
-import { ClusterNode, ClusterOptions } from 'iovalkey';
+import { durationToMilliseconds, type HumanDuration } from '@backstage/types';
+import type { RedisClusterOptions, KeyvRedisOptions } from '@keyv/redis';
+import type { KeyvValkeyOptions } from '@keyv/valkey';
+import type { ClusterNode, ClusterOptions } from 'iovalkey';
 
 /**
  * A cache store connection, either a URL string or an object with

--- a/packages/backend-defaults/src/entrypoints/cache/types.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/types.ts
@@ -24,12 +24,23 @@ import type { KeyvValkeyOptions } from '@keyv/valkey';
 import type { ClusterNode, ClusterOptions } from 'iovalkey';
 
 /**
+ * An object form of a cache store connection, with a URL and additional
+ * connection options passed through to the underlying client.
+ *
+ * @public
+ */
+export type CacheStoreConnectionObject = { url: string } & Record<
+  string,
+  unknown
+>;
+
+/**
  * A cache store connection, either a URL string or an object with
  * connection options passed through to the underlying client.
  *
  * @public
  */
-export type CacheStoreConnection = string | Record<string, unknown>;
+export type CacheStoreConnection = string | CacheStoreConnectionObject;
 
 /**
  * Common config options passed to store-specific config parsers.

--- a/packages/backend-defaults/src/entrypoints/cache/types.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/types.ts
@@ -32,12 +32,20 @@ import type { ClusterNode, ClusterOptions } from 'iovalkey';
 export type CacheStoreConnection = string | Record<string, unknown>;
 
 /**
- * Common options passed to store-specific config parsers.
+ * Common config options passed to store-specific config parsers.
  *
  * @public
  */
 export type CacheStoreConfiguration = {
   storeConfigPath: string;
+};
+
+/**
+ * Service dependencies required by cache store config parsers.
+ *
+ * @public
+ */
+export type CacheStoreDeps = {
   config: RootConfigService;
   logger?: LoggerService;
 };

--- a/packages/backend-defaults/src/entrypoints/cache/types.ts
+++ b/packages/backend-defaults/src/entrypoints/cache/types.ts
@@ -14,11 +14,42 @@
  * limitations under the License.
  */
 
-import { LoggerService } from '@backstage/backend-plugin-api';
+import {
+  LoggerService,
+  RootConfigService,
+} from '@backstage/backend-plugin-api';
 import { HumanDuration, durationToMilliseconds } from '@backstage/types';
 import { RedisClusterOptions, KeyvRedisOptions } from '@keyv/redis';
 import { KeyvValkeyOptions } from '@keyv/valkey';
 import { ClusterNode, ClusterOptions } from 'iovalkey';
+
+/**
+ * A cache store connection, either a URL string or an object with
+ * connection options passed through to the underlying client.
+ *
+ * @public
+ */
+export type CacheStoreConnection = string | Record<string, unknown>;
+
+/**
+ * Common options passed to store-specific config parsers.
+ *
+ * @public
+ */
+export type CacheStoreConfiguration = {
+  storeConfigPath: string;
+  config: RootConfigService;
+  logger?: LoggerService;
+};
+
+/**
+ * Parse options for the Redis cache store
+ *
+ * @public
+ */
+export type RedisCacheStoreConfiguration = CacheStoreConfiguration & {
+  connection: CacheStoreConnection;
+};
 
 /**
  * Options for Redis cache store.
@@ -29,7 +60,6 @@ export type RedisCacheStoreOptions = {
   type: 'redis';
   client?: KeyvRedisOptions;
   cluster?: RedisClusterOptions;
-  pingInterval?: number;
 };
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Allows the Redis cache store's `connection` config to accept either a plain URL string or an object with additional connection options passed directly to the underlying client. This enables configuring options like `pingInterval` (to keep connections alive and prevent silent drops by load balancers or NAT gateways) without needing dedicated config fields for each option.

The object form is only supported when `backend.cache.store` is `redis` — other stores will throw an error if an object is provided.

I took some inspiration from this [PR](https://github.com/backstage/backstage/pull/32559) by @matthewadowns. I wanted to make a contribution against their PR, but I think that my PR has a more focused, minimal take.

This PR should fix:

- #31813 
- #31742 

### Example config:

```yaml
backend:
  cache:
    store: redis
    # Connection can be a simple URL string:
    connection: redis://localhost:6379
    # Or an object with additional options passed to the underlying client
    # (only supported for the Redis store):
    # connection:
    #   url: redis://localhost:6379
    #   pingInterval: 60000
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
