### PR TITLE
chore: group @opentelemetry/* packages in Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -38,6 +38,11 @@
       rangeStrategy: 'replace',
       matchSourceUrls: ['https://github.com/module-federation/core{/,}**'],
     },
+    {
+      groupName: 'OpenTelemetry packages',
+      rangeStrategy: 'replace',
+      matchPackagePatterns: ['^@opentelemetry/'],
+    },
     // We update yarn packages manually as it's gzip'd and we don't want to pollute the repository too much.
     {
       matchSourceUrls: ['https://github.com/yarnpkg/berry'],


### PR DESCRIPTION
## Summary

- Group all `@opentelemetry/*` packages so they get upgraded together in a single PR, matching how other monorepo package families (Rush Stack, Module Federation, etc.) are already grouped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)