### PR TITLE
golden-path: add docs for integrations

### DIFF
--- a/.github/vale/config/vocabularies/Backstage/accept.txt
+++ b/.github/vale/config/vocabularies/Backstage/accept.txt
@@ -47,6 +47,7 @@ BUIProvider
 builtins
 bundler
 bundlers
+backpressures
 bursty
 callout
 callouts
@@ -384,6 +385,7 @@ pubsub
 Pulumi
 pygments
 pymdownx
+queryable
 rankdir
 readme
 readmes

--- a/docs/golden-path/plugins/integrations/001-catalog.md
+++ b/docs/golden-path/plugins/integrations/001-catalog.md
@@ -9,16 +9,402 @@ description: How to integrate your plugin with the Backstage Software Catalog
 
 ### What is the Software Catalog?
 
-<!--TODO-->
+The [Software Catalog](../../../features/software-catalog/index.md) is the
+graph of typed entities that sits at the center of every Backstage instance.
+Components, APIs, Resources, Systems, Users, Groups — anything an organization
+wants to model and reason about — live in the catalog and are related to each
+other through a small set of well-known relations.
+
+Each entity is identified by its `apiVersion`, `kind`, and `metadata.name`
+(scoped by `metadata.namespace`). The catalog backend ingests entity
+descriptors from one or more _sources_, validates them against a schema, runs
+them through a pipeline of _processors_, stitches the resulting relations
+together, and exposes the final state through a queryable API that the
+frontend and other plugins consume.
+
+For your plugin, the catalog is the place you go when you want a stable,
+shared answer to "which thing is this, who owns it, and how does it relate to
+everything else?" — rather than maintaining your own list of services, owners,
+or resources.
 
 ### Integration Points
 
-<!--TODO-->
+There are three main places where a plugin can plug into the catalog. Pick the
+one that matches the question you are trying to answer.
+
+**Entity providers** push entities into the catalog. They run on a schedule,
+fetch data from an external system, and emit a full or delta set of entities
+that the catalog should know about. Use a provider when your plugin owns a
+source of truth that should appear in the catalog — todos discovered in a
+backing store, for example.
+
+**Catalog processors** transform entities as they flow through the ingestion
+pipeline. They can read annotations, mutate spec fields, emit additional
+entities, or attach extra relations. Use a processor when you want to react to
+existing entities or annotations rather than provide a brand-new source.
+
+**The catalog model** controls which kinds, versions, and spec types are
+considered valid. Extending the model lets you introduce a new first-class
+kind — `Todo`, for example — with its own schema, relations, and type guards.
+Use a model extension when your data does not fit comfortably into any of the
+built-in kinds.
+
+A typical plugin uses one or two of these together: a provider plus a model
+extension to introduce a new kind, or a processor that reads an annotation off
+existing entities to expose plugin-specific data.
 
 ## Adding a new `backstage.io/todo` annotation
 
-<!--TODO-->
+The lightest-weight integration is to attach to entities that already live in
+the catalog. Adopters add an annotation to their `catalog-info.yaml`, and your
+plugin reacts to it. There is no new kind, no new provider, and the source of
+truth stays in the adopter's repository.
+
+### Reserve the annotation name
+
+Annotations are namespaced strings, and the `backstage.io/` prefix is
+reserved for annotations defined by the project. For a plugin you ship
+yourself, pick a namespace you control — for example
+`todo.backstage.io/source` — and document it. For the rest of this guide we
+will pretend our plugin is shipped by the Backstage project and use
+`backstage.io/todo-source`.
+
+Add a constant in your common package so backend, frontend, and any policies
+reference the same string:
+
+```ts
+// plugins/todo-common/src/annotations.ts
+export const TODO_SOURCE_ANNOTATION = 'backstage.io/todo-source';
+```
+
+### Read the annotation in the backend
+
+Inside a route handler, look the entity up through the catalog client and
+read the annotation off `metadata.annotations`:
+
+```ts
+// plugins/todo-backend/src/service/router.ts
+import { CatalogService } from '@backstage/plugin-catalog-node';
+import { TODO_SOURCE_ANNOTATION } from '@internal/plugin-todo-common';
+
+router.get('/todos/by-entity/:ref', async (req, res) => {
+  const credentials = await httpAuth.credentials(req, { allow: ['user'] });
+  const entity = await catalog.getEntityByRef(req.params.ref, { credentials });
+
+  const source = entity?.metadata.annotations?.[TODO_SOURCE_ANNOTATION];
+  if (!source) {
+    res.json({ items: [] });
+    return;
+  }
+
+  const items = await todoList.listTodosForSource(source);
+  res.json({ items });
+});
+```
+
+The annotation is just a hint; the actual todo data still comes from your
+plugin's own store. The catalog is the index, not the database.
+
+### Surface the annotation on the entity page
+
+On the frontend, use the standard helpers to check for the annotation before
+showing your card. This keeps the UI clean for entities that have not opted
+in:
+
+```tsx
+// plugins/todo/src/components/EntityTodoContent.tsx
+import { useEntity } from '@backstage/plugin-catalog-react';
+import { TODO_SOURCE_ANNOTATION } from '@internal/plugin-todo-common';
+
+export const isTodoAvailable = (entity: Entity) =>
+  Boolean(entity.metadata.annotations?.[TODO_SOURCE_ANNOTATION]);
+
+export const EntityTodoContent = () => {
+  const { entity } = useEntity();
+  if (!isTodoAvailable(entity)) {
+    return <MissingAnnotationEmptyState annotation={TODO_SOURCE_ANNOTATION} />;
+  }
+  return <TodoListForEntity entityRef={stringifyEntityRef(entity)} />;
+};
+```
+
+`MissingAnnotationEmptyState` is the conventional way to nudge adopters
+towards adding the annotation, and it links straight to your plugin's docs.
+
+### Validate the annotation with a processor
+
+If you want to fail fast when somebody types the annotation wrong, register
+a catalog processor that validates it during ingestion. Processors run as
+part of the catalog pipeline, so a bad annotation surfaces as a refresh error
+on the entity rather than as a confusing empty state in the UI:
+
+```ts
+// plugins/catalog-backend-module-todo/src/TodoAnnotationProcessor.ts
+import { CatalogProcessor } from '@backstage/plugin-catalog-node';
+import { TODO_SOURCE_ANNOTATION } from '@internal/plugin-todo-common';
+
+export class TodoAnnotationProcessor implements CatalogProcessor {
+  getProcessorName() {
+    return 'TodoAnnotationProcessor';
+  }
+
+  async preProcessEntity(entity: Entity) {
+    const value = entity.metadata.annotations?.[TODO_SOURCE_ANNOTATION];
+    if (value !== undefined && !/^[a-z0-9-/]+$/.test(value)) {
+      throw new Error(
+        `Invalid value for annotation ${TODO_SOURCE_ANNOTATION}: ${value}`,
+      );
+    }
+    return entity;
+  }
+}
+```
+
+Wire the processor into a catalog backend module:
+
+```ts
+// plugins/catalog-backend-module-todo/src/module.ts
+import { createBackendModule } from '@backstage/backend-plugin-api';
+import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node';
+import { TodoAnnotationProcessor } from './TodoAnnotationProcessor';
+
+export const catalogModuleTodoAnnotation = createBackendModule({
+  pluginId: 'catalog',
+  moduleId: 'todo-annotation',
+  register(env) {
+    env.registerInit({
+      deps: { catalog: catalogProcessingExtensionPoint },
+      async init({ catalog }) {
+        catalog.addProcessor(new TodoAnnotationProcessor());
+      },
+    });
+  },
+});
+```
+
+Adopters install the module alongside the catalog backend, and the annotation
+is now part of their ingestion pipeline.
 
 ## Custom TODO Entity Kind
 
-<!--TODO-->
+Annotations are a good fit when todos belong to something else in the
+catalog. When todos themselves are first-class objects — with their own
+owners, lifecycles, and relations — model them as a new kind instead.
+
+### Define the kind
+
+Custom kinds live in a common package so they can be imported from frontend,
+backend, and any code that writes a `catalog-info.yaml`. Define the entity
+shape and a type guard:
+
+```ts
+// plugins/todo-common/src/TodoEntityV1alpha1.ts
+import type { Entity } from '@backstage/catalog-model';
+
+export interface TodoEntityV1alpha1 extends Entity {
+  apiVersion: 'todo.backstage.io/v1alpha1';
+  kind: 'Todo';
+  spec: {
+    owner: string;
+    status: 'open' | 'in-progress' | 'done';
+    dueDate?: string;
+  };
+}
+
+export const isTodoEntity = (entity: Entity): entity is TodoEntityV1alpha1 =>
+  entity.apiVersion === 'todo.backstage.io/v1alpha1' && entity.kind === 'Todo';
+```
+
+Pair the type with a JSON Schema. The schema is what the catalog uses to
+reject malformed entries at ingestion time, and it is also what powers
+auto-completion in `catalog-info.yaml` files:
+
+```json
+// plugins/todo-common/src/schema/Todo.v1alpha1.schema.json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["apiVersion", "kind", "metadata", "spec"],
+  "properties": {
+    "apiVersion": { "const": "todo.backstage.io/v1alpha1" },
+    "kind": { "const": "Todo" },
+    "spec": {
+      "type": "object",
+      "required": ["owner", "status"],
+      "properties": {
+        "owner": { "type": "string", "minLength": 1 },
+        "status": { "enum": ["open", "in-progress", "done"] },
+        "dueDate": { "type": "string", "format": "date-time" }
+      }
+    }
+  }
+}
+```
+
+### Register the kind with the catalog model
+
+The catalog model extension point is how new kinds enter the validation
+pipeline. Build a model layer that describes the kind, its versions, and the
+relations it produces:
+
+```ts
+// plugins/todo-common/src/todoEntityModel.ts
+import { createCatalogModelLayer } from '@backstage/catalog-model/alpha';
+import todoJsonSchema from './schema/Todo.v1alpha1.schema.json';
+import type { JsonObject } from '@backstage/types';
+
+export const todoEntityModel = createCatalogModelLayer({
+  layerId: 'todo.backstage.io/kind-todo',
+  builder: model => {
+    model.addKind({
+      group: 'todo.backstage.io',
+      names: { kind: 'Todo', singular: 'todo', plural: 'todos' },
+      description: 'A unit of work tracked by the Todo plugin.',
+      versions: [
+        {
+          name: 'v1alpha1',
+          relationFields: [
+            {
+              selector: { path: 'spec.owner' },
+              relation: 'ownedBy',
+              defaultKind: 'Group',
+              defaultNamespace: 'inherit',
+              allowedKinds: ['Group', 'User'],
+            },
+          ],
+          schema: {
+            jsonSchema: todoJsonSchema as JsonObject,
+          },
+        },
+      ],
+    });
+  },
+});
+```
+
+Wire the model layer into a catalog backend module so adopters can install it
+with a one-line module reference:
+
+```ts
+// plugins/catalog-backend-module-todo/src/todoEntityModule.ts
+import { createBackendModule } from '@backstage/backend-plugin-api';
+import { CatalogModelSources } from '@backstage/catalog-model/alpha';
+import { catalogModelExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
+import { todoEntityModel } from '@internal/plugin-todo-common';
+
+export const catalogModuleTodoEntityModel = createBackendModule({
+  pluginId: 'catalog',
+  moduleId: 'todo-entity-model',
+  register(env) {
+    env.registerInit({
+      deps: { model: catalogModelExtensionPoint },
+      async init({ model }) {
+        model.addModelSource(CatalogModelSources.static([todoEntityModel]));
+      },
+    });
+  },
+});
+```
+
+With the module installed, an adopter can drop a `catalog-info.yaml` into
+their repository and have the catalog accept it as a `Todo`:
+
+```yaml
+apiVersion: todo.backstage.io/v1alpha1
+kind: Todo
+metadata:
+  name: write-golden-path-docs
+  description: Finish the integrations chapter of the golden path
+spec:
+  owner: group:default/platform
+  status: in-progress
+  dueDate: 2026-06-01T00:00:00Z
+```
+
+### Push todos in from your own backend
+
+When the source of truth is your plugin's database rather than a YAML file in
+a repo, expose the same entities through an entity provider. The catalog will
+keep your provider's view in sync with everything else it knows about:
+
+```ts
+// plugins/catalog-backend-module-todo/src/TodoEntityProvider.ts
+import {
+  EntityProvider,
+  EntityProviderConnection,
+} from '@backstage/plugin-catalog-node';
+import type { TodoListService } from './services';
+
+export class TodoEntityProvider implements EntityProvider {
+  private connection?: EntityProviderConnection;
+
+  constructor(
+    private readonly todoList: TodoListService,
+    private readonly scheduler: SchedulerService,
+  ) {}
+
+  getProviderName() {
+    return 'todo-entity-provider';
+  }
+
+  async connect(connection: EntityProviderConnection) {
+    this.connection = connection;
+    await this.scheduler.scheduleTask({
+      id: 'todo-entity-provider-refresh',
+      frequency: { minutes: 5 },
+      timeout: { minutes: 2 },
+      fn: () => this.refresh(),
+    });
+  }
+
+  private async refresh() {
+    if (!this.connection) return;
+    const todos = await this.todoList.listTodos();
+
+    await this.connection.applyMutation({
+      type: 'full',
+      entities: todos.map(todo => ({
+        locationKey: `todo:${todo.id}`,
+        entity: {
+          apiVersion: 'todo.backstage.io/v1alpha1',
+          kind: 'Todo',
+          metadata: {
+            name: todo.id,
+            annotations: {
+              'backstage.io/managed-by-location': `todo:${todo.id}`,
+              'backstage.io/managed-by-origin-location': `todo:${todo.id}`,
+            },
+          },
+          spec: {
+            owner: todo.owner,
+            status: todo.status,
+            dueDate: todo.dueDate,
+          },
+        },
+      })),
+    });
+  }
+}
+```
+
+Register the provider via the catalog processing extension point:
+
+```ts
+import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node';
+
+env.registerInit({
+  deps: {
+    catalog: catalogProcessingExtensionPoint,
+    scheduler: coreServices.scheduler,
+    todoList: todoListServiceRef,
+  },
+  async init({ catalog, scheduler, todoList }) {
+    catalog.addEntityProvider(new TodoEntityProvider(todoList, scheduler));
+  },
+});
+```
+
+The `locationKey` is what ties an emitted entity back to the provider, so
+deleting a todo in your backend cleanly removes it from the catalog on the
+next refresh. The `managed-by-location` annotations tell adopters where a
+given entity came from when they inspect it in the UI.

--- a/docs/golden-path/plugins/integrations/002-search.md
+++ b/docs/golden-path/plugins/integrations/002-search.md
@@ -9,7 +9,7 @@ description: How to integrate your plugin with Backstage Search
 
 ### What is Backstage Search?
 
-[Backstage Search](../../../features/search/index.md) is the federated search
+[Backstage Search](../../../features/search/README.md) is the federated search
 layer that sits in front of every other plugin. It periodically indexes
 documents from contributing plugins into a single search engine, exposes a
 unified query API, and renders the results behind one search box on the

--- a/docs/golden-path/plugins/integrations/002-search.md
+++ b/docs/golden-path/plugins/integrations/002-search.md
@@ -9,12 +9,239 @@ description: How to integrate your plugin with Backstage Search
 
 ### What is Backstage Search?
 
-<!--TODO-->
+[Backstage Search](../../../features/search/index.md) is the federated search
+layer that sits in front of every other plugin. It periodically indexes
+documents from contributing plugins into a single search engine, exposes a
+unified query API, and renders the results behind one search box on the
+frontend. Adopters get a consistent search experience without each plugin
+having to ship its own.
+
+The pieces fit together like this:
+
+- **Collators** read documents out of a source (the catalog, TechDocs, your
+  plugin's database) and stream them into the index on a schedule.
+- **Decorators** sit between collators and the engine, transforming or
+  filtering documents on the way through — adding fields, dropping
+  unauthorized entries, etc.
+- A **search engine** (Lunr in-process by default, Postgres or Elasticsearch
+  in production) stores the index and answers queries.
+- The **frontend** issues queries through the search API and renders matches
+  using per-document-type **result item components**.
+
+For your plugin, this means search work splits cleanly into two questions:
+"how do I get my data into the index?" (a backend collator), and "how should
+matches look in the results list?" (a frontend extension).
 
 ### Common integration points
 
-<!--TODO-->
+Most plugins need one or both of the following:
+
+**A collator on the backend** that turns your domain objects into
+`IndexableDocument`s and emits them on a schedule. Use a collator when you own
+data that other Backstage users would benefit from searching across.
+
+**A result item component on the frontend** that renders matches for your
+document type in the global search modal and on the search page. Use this
+when the default rendering does not carry enough information for users to
+recognize a match.
+
+A small number of plugins also ship a **decorator** — for example, to attach
+ownership data to documents from another collator — but a collator plus a
+result item is the common case.
 
 ## Creating a custom TODO collator
 
-<!--TODO-->
+The goal is to make every todo in your plugin's store appear in global
+search, scored alongside catalog entities and TechDocs pages.
+
+### Define the document type
+
+A collator emits documents that implement `IndexableDocument`. The base type
+already includes `title`, `text`, and `location`; extend it with the fields
+you want to search on or display:
+
+```ts
+// plugins/todo-common/src/TodoSearchDocument.ts
+import type { IndexableDocument } from '@backstage/plugin-search-common';
+
+export interface TodoSearchDocument extends IndexableDocument {
+  status: 'open' | 'in-progress' | 'done';
+  owner: string;
+  dueDate?: string;
+}
+
+export const TODO_SEARCH_TYPE = 'todo';
+```
+
+Export the document type and the `TODO_SEARCH_TYPE` string from your common
+package. The frontend will key its result item off the same string, so
+sharing it through `todo-common` prevents drift.
+
+### Build the collator factory
+
+Implement `DocumentCollatorFactory`. The `type` field is the document type
+the engine indexes against; `getCollator` returns a `Readable` stream of your
+documents. Yield them from an async generator so the factory backpressures
+naturally for large todo sets:
+
+```ts
+// plugins/search-backend-module-todo/src/TodoCollatorFactory.ts
+import { Readable } from 'stream';
+import {
+  DocumentCollatorFactory,
+  IndexableDocument,
+} from '@backstage/plugin-search-common';
+import {
+  TODO_SEARCH_TYPE,
+  TodoSearchDocument,
+} from '@internal/plugin-todo-common';
+import type { TodoListService } from './services';
+
+export class TodoCollatorFactory implements DocumentCollatorFactory {
+  public readonly type = TODO_SEARCH_TYPE;
+
+  constructor(
+    private readonly todoList: TodoListService,
+    private readonly locationTemplate = '/todo/:namespace/:id',
+  ) {}
+
+  async getCollator(): Promise<Readable> {
+    return Readable.from(this.execute());
+  }
+
+  private async *execute(): AsyncGenerator<TodoSearchDocument> {
+    let cursor: string | undefined;
+    do {
+      const { items, nextCursor } = await this.todoList.listTodos({
+        cursor,
+        limit: 200,
+      });
+      cursor = nextCursor;
+
+      for (const todo of items) {
+        yield {
+          title: todo.title,
+          text: todo.description ?? '',
+          location: this.locationTemplate
+            .replace(':namespace', encodeURIComponent(todo.namespace))
+            .replace(':id', encodeURIComponent(todo.id)),
+          status: todo.status,
+          owner: todo.owner,
+          dueDate: todo.dueDate,
+        };
+      }
+    } while (cursor);
+  }
+}
+```
+
+The `location` field is what users click on in the result list, so make sure
+it routes to the page on your frontend that actually shows the todo.
+
+### Register the collator with the search backend
+
+Wire the factory into a `search` backend module, scheduled however often you
+want the index refreshed. Most plugins re-index every 10 minutes in
+development and once an hour in production:
+
+```ts
+// plugins/search-backend-module-todo/src/module.ts
+import {
+  coreServices,
+  createBackendModule,
+} from '@backstage/backend-plugin-api';
+import { searchIndexRegistryExtensionPoint } from '@backstage/plugin-search-backend-node/alpha';
+import { todoListServiceRef } from '@internal/plugin-todo-backend';
+import { TodoCollatorFactory } from './TodoCollatorFactory';
+
+export const searchModuleTodoCollator = createBackendModule({
+  pluginId: 'search',
+  moduleId: 'todo-collator',
+  register(env) {
+    env.registerInit({
+      deps: {
+        scheduler: coreServices.scheduler,
+        indexRegistry: searchIndexRegistryExtensionPoint,
+        todoList: todoListServiceRef,
+      },
+      async init({ scheduler, indexRegistry, todoList }) {
+        indexRegistry.addCollator({
+          schedule: scheduler.createScheduledTaskRunner({
+            frequency: { minutes: 10 },
+            timeout: { minutes: 5 },
+            initialDelay: { seconds: 30 },
+          }),
+          factory: new TodoCollatorFactory(todoList),
+        });
+      },
+    });
+  },
+});
+```
+
+Adopters install the module the same way they install any other backend
+module — one `backend.add(...)` call in their `packages/backend/src/index.ts`.
+
+### Respect permissions during indexing
+
+If you defined a `todo.read` resource permission in the
+[permissions chapter](003-permissions.md), reuse it here so users only see
+matches they are actually allowed to read. Set `visibilityPermission` on the
+factory and emit an `authorization` block on each document:
+
+```ts
+import { todoReadPermission } from '@internal/plugin-todo-common';
+
+export class TodoCollatorFactory implements DocumentCollatorFactory {
+  public readonly type = TODO_SEARCH_TYPE;
+  public readonly visibilityPermission = todoReadPermission;
+
+  // ...
+
+  private async *execute(): AsyncGenerator<TodoSearchDocument> {
+    for await (const todo of /* ... */) {
+      yield {
+        // ...other fields
+        authorization: { resourceRef: todo.id },
+      };
+    }
+  }
+}
+```
+
+When the search engine returns a hit, the search backend will call your
+permission policy with `todoReadPermission` and the `resourceRef`, dropping
+results the user is not allowed to see before they ever reach the UI.
+
+### Render todo results on the frontend
+
+Finally, register a result item component for the new document type. The
+search result list resolves each hit against the registered components and
+falls back to a generic renderer when none matches:
+
+```tsx
+// plugins/todo/src/plugin.ts
+import {
+  createPlugin,
+  createSearchResultListItemExtension,
+} from '@backstage/plugin-search-react';
+import { TODO_SEARCH_TYPE } from '@internal/plugin-todo-common';
+
+export const todoPlugin = createPlugin({ id: 'todo' /* ... */ });
+
+export const TodoSearchResultListItem = todoPlugin.provide(
+  createSearchResultListItemExtension({
+    name: 'TodoSearchResultListItem',
+    predicate: result => result.type === TODO_SEARCH_TYPE,
+    component: () =>
+      import('./components/TodoSearchResultListItem').then(
+        m => m.TodoSearchResultListItem,
+      ),
+  }),
+);
+```
+
+Adopters drop `<TodoSearchResultListItem />` inside their search result list,
+and matches against the `todo` document type now render with whatever rich
+display you want — status pill, owner avatar, due date — instead of a
+generic title and snippet.

--- a/docs/golden-path/plugins/integrations/004-notifications.md
+++ b/docs/golden-path/plugins/integrations/004-notifications.md
@@ -9,16 +9,206 @@ description: How to integrate your plugin with Backstage Notifications
 
 ### What are Backstage Notifications?
 
-<!--TODO-->
+[Backstage Notifications](../../../notifications/index.md) is the shared
+mechanism for telling a user that something happened. A plugin emits a
+notification, the notifications backend stores it and surfaces it in the
+in-app inbox, and optional processors fan the same notification out to
+external channels like email or Slack. The end user sees a single, unified
+inbox no matter which plugin sent the message.
+
+The flow looks like this:
+
+1. Your plugin calls `notificationService.send` with a payload and a set of
+   recipients (user entity refs, or `broadcast` for everyone).
+2. The notifications backend runs the payload through any registered
+   `processOptions` hooks, resolves entity refs into individual users, runs
+   the per-recipient `preProcess` hooks, and writes the notification to the
+   database.
+3. The user sees the notification in the Backstage UI; in parallel,
+   `postProcess` hooks deliver it to email, Slack, or whatever else the
+   adopter has wired up.
+
+Your plugin's job is to send the notification well. How it is delivered is up
+to the adopter and the modules they install.
 
 ### Common integration points
 
-<!--TODO-->
+Most plugins only ever touch one part of the system:
+
+**Sending notifications** from your backend by depending on
+`notificationService` and calling `send` when something interesting happens.
+This is the integration point for plugins that produce events.
+
+A smaller number of plugins ship a **notification processor** through
+`notificationsProcessingExtensionPoint`. That is for plugins that _deliver_
+notifications somewhere (a new channel), not for plugins that produce them.
+If your plugin sends todos and reminders, you want the sending path, not a
+processor.
 
 ## TODO with an alarm
 
-<!--TODO-->
+The goal is to let users set a due time on a todo and receive a notification
+when the alarm fires. The alarm is just a timestamp; the scheduler service
+fires us up to look for due todos, and the notifications service delivers
+the message.
+
+### Persist the alarm
+
+Store the alarm time on the todo and the user who should be notified:
+
+```ts
+// plugins/todo-backend/src/database/migrations/20260520000000_todo_alarms.ts
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('todos', table => {
+    table.timestamp('alarm_at').nullable();
+    table.string('alarm_user_ref').nullable();
+    table.timestamp('alarm_fired_at').nullable();
+  });
+}
+```
+
+`alarm_fired_at` is what stops you from sending the same notification twice
+when the scheduled task runs again. Compare against it in your query rather
+than tracking state in memory.
+
+### Add the notification service to the plugin
+
+Depend on `notificationService` from `@backstage/plugin-notifications-node`
+alongside your other services:
+
+```ts
+// plugins/todo-backend/src/plugin.ts
+import { notificationService } from '@backstage/plugin-notifications-node';
+
+env.registerInit({
+  deps: {
+    scheduler: coreServices.scheduler,
+    notifications: notificationService,
+    todoList: todoListServiceRef,
+  },
+  async init({ scheduler, notifications, todoList }) {
+    await scheduler.scheduleTask({
+      id: 'todo-alarm-fanout',
+      frequency: { minutes: 1 },
+      timeout: { minutes: 1 },
+      fn: () => fireDueTodoAlarms({ notifications, todoList }),
+    });
+
+    // ...register the rest of the plugin
+  },
+});
+```
+
+A one-minute cadence is fine here; the worst case is a one-minute lag on a
+user-set alarm, which is well below what users perceive as missed.
+
+### Send the notification when an alarm is due
+
+The task itself queries for todos whose alarm has passed but has not yet
+been delivered, sends a notification per todo, and marks them as fired:
+
+```ts
+// plugins/todo-backend/src/alarms/fireDueTodoAlarms.ts
+import type { NotificationService } from '@backstage/plugin-notifications-node';
+import type { TodoListService } from '../services';
+
+export async function fireDueTodoAlarms(opts: {
+  notifications: NotificationService;
+  todoList: TodoListService;
+}) {
+  const due = await opts.todoList.findDueAlarms({ now: new Date() });
+
+  for (const todo of due) {
+    await opts.notifications.send({
+      recipients: { type: 'entity', entityRef: todo.alarmUserRef },
+      payload: {
+        title: `Reminder: ${todo.title}`,
+        description: todo.description,
+        link: `/todo/${encodeURIComponent(todo.namespace)}/${encodeURIComponent(
+          todo.id,
+        )}`,
+        severity: 'normal',
+        topic: 'todo.alarm',
+        scope: `todo.alarm:${todo.id}`,
+        icon: 'clock',
+      },
+    });
+
+    await opts.todoList.markAlarmFired(todo.id);
+  }
+}
+```
+
+Two payload fields deserve attention. `topic` groups related notifications
+together so users can mute the whole class — "Todo alarms" — without muting
+your whole plugin. `scope`, combined with the same `origin`, causes a
+repeated send for the same key to update the existing notification rather
+than create a new one; this is what saves a user's inbox when an alarm fires
+on a flapping condition.
+
+Wrap the send in a try/catch only if you want the loop to continue on
+individual failures. Logging the error and moving on is usually the right
+call — a one-minute retry is already built in by the scheduler.
 
 ## Create TODOs for other people and notify them
 
-<!--TODO-->
+When a user creates a todo on behalf of someone else, that person should
+hear about it. The pattern is the same as the alarm above, just triggered
+from the create handler and with the recipient pulled off the request.
+
+### Send on create
+
+Inside the `POST /todos` handler, after the new todo has been written to the
+database, send a notification to its owner:
+
+```ts
+// plugins/todo-backend/src/service/router.ts
+router.post('/todos', async (req, res) => {
+  const credentials = await httpAuth.credentials(req, { allow: ['user'] });
+  const userInfo = await userInfoService.getUserInfo(credentials);
+  const todo = await todoList.createTodo(parsed.data, { credentials });
+
+  if (todo.owner && todo.owner !== userInfo.userEntityRef) {
+    await notifications.send({
+      recipients: {
+        type: 'entity',
+        entityRef: todo.owner,
+        excludeEntityRef: userInfo.userEntityRef,
+      },
+      payload: {
+        title: `${userInfo.userEntityRef} assigned you a todo`,
+        description: todo.title,
+        link: `/todo/${encodeURIComponent(todo.namespace)}/${encodeURIComponent(
+          todo.id,
+        )}`,
+        severity: 'normal',
+        topic: 'todo.assigned',
+        scope: `todo.assigned:${todo.id}`,
+      },
+    });
+  }
+
+  res.status(201).json(todo);
+});
+```
+
+Three things to notice:
+
+- The recipient is an entity ref, not a user. If `todo.owner` is a `Group`,
+  the notifications backend resolves it to the underlying user members for
+  you — you do not need to walk the catalog yourself.
+- `excludeEntityRef` keeps a user from notifying themselves when they create
+  a todo with themselves as the owner. It is also the right place to pass
+  the requesting user when the recipient is a group that the requester is a
+  member of.
+- The `scope` includes the todo id, so re-assigning the same todo updates
+  the existing notification instead of stacking duplicates in the inbox.
+
+### Let users opt out
+
+Users can mute notifications per topic from their user settings. The
+`topic` field you set on the payload (`todo.assigned`, `todo.alarm`) is the
+key they see in that UI, so pick names that read well to a human, and
+document them in your plugin's README. There is nothing else to wire up;
+the notifications backend honors the user setting before persisting or
+fanning out.


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Replaces the TODO stubs in the catalog, search, and notifications chapters of the plugins golden path with full walkthroughs:

- Catalog: explains the catalog as a typed entity graph and walks through the three main integration points (annotations + processor, custom kind via the catalog model, and entity provider sync).
- Search: explains collators/decorators and walks through building a custom todo collator with `searchIndexRegistryExtensionPoint`, permission-aware indexing, and a frontend result item.
- Notifications: explains the in-app + external delivery model and walks through sending notifications from a scheduled task (alarm fanout) and from the create handler (assign-on-create), with notes on topics, scope, and group recipients.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
