### PR TITLE
feat: add secrets schema support to ActionsRegistry

### DIFF
--- a/.changeset/secrets-backend-defaults.md
+++ b/.changeset/secrets-backend-defaults.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Updated `DefaultActionsRegistryService` to validate and forward secrets to action handlers. The invoke endpoint now accepts a wrapped body format `{ input, secrets }` with an `X-Actions-Body-Version: 2` header while maintaining backward compatibility with the raw input format. Updated `DefaultActionsService` to include secrets in the invoke request body.

--- a/.changeset/secrets-backend-defaults.md
+++ b/.changeset/secrets-backend-defaults.md
@@ -2,4 +2,4 @@
 '@backstage/backend-defaults': patch
 ---
 
-Updated `DefaultActionsRegistryService` to validate and forward secrets to action handlers. The invoke endpoint now accepts a wrapped body format `{ input, secrets }` while maintaining backward compatibility with the raw input format. Updated `DefaultActionsService` to include secrets in the invoke request body.
+Added a new `v2` invoke endpoint (`/.backstage/actions/v2/actions/:id/invoke`) that accepts a wrapped body format `{ input, secrets }` with secrets validation. The existing `v1` invoke endpoint remains unchanged for backward compatibility. Updated `DefaultActionsService` to use the `v2` endpoint. Updated `DefaultActionsRegistryService` to expose secrets schema in the actions list response and validate secrets on invocation.

--- a/.changeset/secrets-backend-defaults.md
+++ b/.changeset/secrets-backend-defaults.md
@@ -2,4 +2,4 @@
 '@backstage/backend-defaults': patch
 ---
 
-Updated `DefaultActionsRegistryService` to validate and forward secrets to action handlers. The invoke endpoint now accepts a wrapped body format `{ input, secrets }` with an `X-Actions-Body-Version: 2` header while maintaining backward compatibility with the raw input format. Updated `DefaultActionsService` to include secrets in the invoke request body.
+Updated `DefaultActionsRegistryService` to validate and forward secrets to action handlers. The invoke endpoint now accepts a wrapped body format `{ input, secrets }` while maintaining backward compatibility with the raw input format. Updated `DefaultActionsService` to include secrets in the invoke request body.

--- a/.changeset/secrets-backend-plugin-api.md
+++ b/.changeset/secrets-backend-plugin-api.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-plugin-api': patch
+---
+
+Added optional `secrets` schema support to `ActionsRegistryActionOptions` and `ActionsRegistryActionContext`. Actions can now declare a Zod secrets schema separate from the input schema, enabling surfaces to collect sensitive credentials independently from tool arguments. Added optional `secrets` field to `ActionsServiceAction` metadata and `ActionsService.invoke()` parameters.

--- a/.changeset/secrets-backend-test-utils.md
+++ b/.changeset/secrets-backend-test-utils.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-test-utils': patch
+---
+
+Updated `MockActionsRegistry` to support the new secrets schema. The mock now validates secrets against the declared schema, rejects missing secrets for actions that require them, and forwards secrets to the action handler.

--- a/docs/backend-system/core-services/actions-registry.md
+++ b/docs/backend-system/core-services/actions-registry.md
@@ -18,9 +18,10 @@ Each action registered with the service must conform to the `ActionsRegistryActi
 - **`name`:** A unique identifier for the action (string)
 - **`title`:** A human-readable title for the action (string)
 - **`description`:** A detailed description of what the action does (string)
-- **`schema`:** Object containing input and output schema definitions
+- **`schema`:** Object containing schema definitions
   - **`input`:** Function that returns a Zod schema for validating input
   - **`output`:** Function that returns a Zod schema for validating output
+  - **`secrets`:** (optional) Function that returns a Zod schema for validating secrets. See [Secrets](#secrets) below.
 - **`action`:** The async function that executes the action logic
 
 ### Optional Properties
@@ -36,6 +37,7 @@ Each action registered with the service must conform to the `ActionsRegistryActi
 When an action is executed, it receives a context object (`ActionsRegistryActionContext`) containing:
 
 - **`input`:** The validated input data matching the defined input schema
+- **`secrets`:** The validated secrets data matching the defined secrets schema, or `undefined` if no secrets schema is declared
 - **`logger`:** A LoggerService instance for logging within the action
 - **`credentials`:** BackstageCredentials for authentication and authorization
 
@@ -194,6 +196,63 @@ actionsRegistry.register({
 ```
 
 Actions without a `visibilityPermission` field remain visible and accessible by all callers, preserving backwards compatibility.
+
+## Secrets
+
+Actions can declare a `secrets` schema to request external credentials from the end user, such as API tokens, personal access tokens, or other sensitive values that are not part of Backstage's own authentication system. Secrets are kept separate from the input schema so they never appear in tool definitions or LLM context when actions are exposed as MCP tools.
+
+### Declaring a Secrets Schema
+
+Add a `secrets` function to the `schema` object alongside `input` and `output`. It works the same way as the input schema, receiving the Zod instance and returning a Zod object schema:
+
+```typescript
+actionsRegistry.register({
+  name: 'create-issue',
+  title: 'Create GitHub Issue',
+  description: 'Creates an issue in a GitHub repository',
+  schema: {
+    input: z =>
+      z.object({
+        repo: z.string(),
+        title: z.string(),
+        body: z.string().optional(),
+      }),
+    output: z =>
+      z.object({
+        issueUrl: z.string(),
+      }),
+    secrets: z =>
+      z.object({
+        githubToken: z
+          .string()
+          .describe('GitHub Personal Access Token with repo scope'),
+      }),
+  },
+  attributes: {
+    destructive: false,
+  },
+  action: async ({ input, secrets, credentials }) => {
+    const octokit = new Octokit({ auth: secrets.githubToken });
+
+    const { data } = await octokit.issues.create({
+      owner: input.repo.split('/')[0],
+      repo: input.repo.split('/')[1],
+      title: input.title,
+      body: input.body,
+    });
+
+    return { output: { issueUrl: data.html_url } };
+  },
+});
+```
+
+The `secrets` field in the action context is fully typed based on the declared schema. Actions without a `secrets` schema receive `undefined` for the `secrets` field.
+
+### How Secrets Flow Through the System
+
+Secrets are validated against the Zod schema the same way input is validated. If secrets are required but not provided, or if they fail validation, the action returns an `InputError`. If secrets are provided to an action that does not declare a secrets schema, the request is also rejected.
+
+The secrets schema is included in the action metadata returned by the list endpoint, so callers can discover which secrets an action requires before invoking it.
 
 ## Best Practices
 

--- a/docs/backend-system/core-services/actions.md
+++ b/docs/backend-system/core-services/actions.md
@@ -13,8 +13,8 @@ The Actions Service is a core service that provides a standardized interface for
 
 The Actions Service implements the `ActionsService` interface, which provides two primary methods:
 
-- **`list()`:** Retrieves all available actions with their complete metadata
-- **`invoke()`:** Executes a specific action by ID with provided input data
+- **`list()`:** Retrieves all available actions with their complete metadata, including any declared secrets schema
+- **`invoke()`:** Executes a specific action by ID with provided input data and optional secrets
 
 The service works in conjunction with the [Actions Registry Service](./actions-registry.md), where actions are registered by plugins and then made available for discovery and execution through this service.
 
@@ -119,11 +119,13 @@ export async function executeAction(
   actionId: string,
   input: JsonObject,
   credentials: BackstageCredentials,
+  secrets?: JsonObject,
 ) {
   try {
     const { output } = await actionsService.invoke({
       id: actionId,
       input,
+      secrets,
       credentials,
     });
 
@@ -155,6 +157,29 @@ async function fetchUserInfo(
   return output;
 }
 ```
+
+## Invoking Actions with Secrets
+
+Some actions declare a `secrets` schema for external credentials they need from the end user. You can discover which actions require secrets by inspecting the `schema.secrets` field in the action metadata returned by `list()`. When invoking an action that requires secrets, pass them alongside the input:
+
+```typescript
+const { actions } = await actionsService.list({ credentials });
+const action = actions.find(a => a.id === 'my-plugin:create-issue');
+
+if (action?.schema.secrets) {
+  // This action needs secrets — collect them from the user first
+  const { output } = await actionsService.invoke({
+    id: action.id,
+    input: { repo: 'backstage/backstage', title: 'My issue' },
+    secrets: { githubToken: collectedToken },
+    credentials,
+  });
+}
+```
+
+If you provide secrets to an action that does not declare a secrets schema, the invocation is rejected with an `InputError`. Similarly, omitting required secrets results in an `InputError`.
+
+For more details on how to declare secrets in an action, see the [Actions Registry Secrets](./actions-registry.md#secrets) documentation.
 
 ## Best Practices
 

--- a/packages/backend-defaults/src/alpha/entrypoints/actions/DefaultActionsService.ts
+++ b/packages/backend-defaults/src/alpha/entrypoints/actions/DefaultActionsService.ts
@@ -98,6 +98,7 @@ export class DefaultActionsService implements ActionsService {
     credentials: BackstageCredentials;
   }) {
     const pluginId = this.pluginIdFromActionId(opts.id);
+    // Deprecated: remove v1 fallback once all registries support v2
     const version = opts.secrets ? 'v2' : 'v1';
     const body =
       version === 'v2'

--- a/packages/backend-defaults/src/alpha/entrypoints/actions/DefaultActionsService.ts
+++ b/packages/backend-defaults/src/alpha/entrypoints/actions/DefaultActionsService.ts
@@ -94,6 +94,7 @@ export class DefaultActionsService implements ActionsService {
   async invoke(opts: {
     id: string;
     input?: JsonObject;
+    secrets?: JsonObject;
     credentials: BackstageCredentials;
   }) {
     const pluginId = this.pluginIdFromActionId(opts.id);
@@ -105,9 +106,10 @@ export class DefaultActionsService implements ActionsService {
       credentials: opts.credentials,
       options: {
         method: 'POST',
-        body: JSON.stringify(opts.input),
+        body: JSON.stringify({ input: opts.input, secrets: opts.secrets }),
         headers: {
           'Content-Type': 'application/json',
+          'X-Actions-Body-Version': '2',
         },
       },
     });

--- a/packages/backend-defaults/src/alpha/entrypoints/actions/DefaultActionsService.ts
+++ b/packages/backend-defaults/src/alpha/entrypoints/actions/DefaultActionsService.ts
@@ -98,15 +98,21 @@ export class DefaultActionsService implements ActionsService {
     credentials: BackstageCredentials;
   }) {
     const pluginId = this.pluginIdFromActionId(opts.id);
+    const version = opts.secrets ? 'v2' : 'v1';
+    const body =
+      version === 'v2'
+        ? JSON.stringify({ input: opts.input, secrets: opts.secrets })
+        : JSON.stringify(opts.input);
+
     const response = await this.makeRequest({
-      path: `/.backstage/actions/v2/actions/${encodeURIComponent(
+      path: `/.backstage/actions/${version}/actions/${encodeURIComponent(
         opts.id,
       )}/invoke`,
       pluginId,
       credentials: opts.credentials,
       options: {
         method: 'POST',
-        body: JSON.stringify({ input: opts.input, secrets: opts.secrets }),
+        body,
         headers: {
           'Content-Type': 'application/json',
         },

--- a/packages/backend-defaults/src/alpha/entrypoints/actions/DefaultActionsService.ts
+++ b/packages/backend-defaults/src/alpha/entrypoints/actions/DefaultActionsService.ts
@@ -99,7 +99,7 @@ export class DefaultActionsService implements ActionsService {
   }) {
     const pluginId = this.pluginIdFromActionId(opts.id);
     const response = await this.makeRequest({
-      path: `/.backstage/actions/v1/actions/${encodeURIComponent(
+      path: `/.backstage/actions/v2/actions/${encodeURIComponent(
         opts.id,
       )}/invoke`,
       pluginId,
@@ -109,7 +109,6 @@ export class DefaultActionsService implements ActionsService {
         body: JSON.stringify({ input: opts.input, secrets: opts.secrets }),
         headers: {
           'Content-Type': 'application/json',
-          'X-Actions-Body-Version': '2',
         },
       },
     });

--- a/packages/backend-defaults/src/alpha/entrypoints/actions/actionsServiceFactory.test.ts
+++ b/packages/backend-defaults/src/alpha/entrypoints/actions/actionsServiceFactory.test.ts
@@ -592,7 +592,7 @@ describe('actionsServiceFactory', () => {
       it('should invoke the action and return the output', async () => {
         server.use(
           rest.post(
-            'http://localhost:0/api/my-plugin/.backstage/actions/v1/actions/my-plugin:test/invoke',
+            'http://localhost:0/api/my-plugin/.backstage/actions/v2/actions/my-plugin:test/invoke',
             (_req, res, ctx) => res(ctx.json({ output: { ok: true } })),
           ),
         );
@@ -611,7 +611,7 @@ describe('actionsServiceFactory', () => {
       it('should throw a 404 if the action does not exist', async () => {
         server.use(
           rest.post(
-            'http://localhost:0/api/my-plugin/.backstage/actions/v1/actions/my-plugin:test/invoke',
+            'http://localhost:0/api/my-plugin/.backstage/actions/v2/actions/my-plugin:test/invoke',
             (_req, res, ctx) => res(ctx.status(404)),
           ),
         );
@@ -631,7 +631,7 @@ describe('actionsServiceFactory', () => {
       it('should throw a 400 if the action returns an invalid input', async () => {
         server.use(
           rest.post(
-            'http://localhost:0/api/my-plugin/.backstage/actions/v1/actions/my-plugin:test/invoke',
+            'http://localhost:0/api/my-plugin/.backstage/actions/v2/actions/my-plugin:test/invoke',
             (_req, res, ctx) => res(ctx.status(400)),
           ),
         );

--- a/packages/backend-defaults/src/alpha/entrypoints/actions/actionsServiceFactory.test.ts
+++ b/packages/backend-defaults/src/alpha/entrypoints/actions/actionsServiceFactory.test.ts
@@ -592,7 +592,7 @@ describe('actionsServiceFactory', () => {
       it('should invoke the action and return the output', async () => {
         server.use(
           rest.post(
-            'http://localhost:0/api/my-plugin/.backstage/actions/v2/actions/my-plugin:test/invoke',
+            'http://localhost:0/api/my-plugin/.backstage/actions/v1/actions/my-plugin:test/invoke',
             (_req, res, ctx) => res(ctx.json({ output: { ok: true } })),
           ),
         );
@@ -611,7 +611,7 @@ describe('actionsServiceFactory', () => {
       it('should throw a 404 if the action does not exist', async () => {
         server.use(
           rest.post(
-            'http://localhost:0/api/my-plugin/.backstage/actions/v2/actions/my-plugin:test/invoke',
+            'http://localhost:0/api/my-plugin/.backstage/actions/v1/actions/my-plugin:test/invoke',
             (_req, res, ctx) => res(ctx.status(404)),
           ),
         );
@@ -631,7 +631,7 @@ describe('actionsServiceFactory', () => {
       it('should throw a 400 if the action returns an invalid input', async () => {
         server.use(
           rest.post(
-            'http://localhost:0/api/my-plugin/.backstage/actions/v2/actions/my-plugin:test/invoke',
+            'http://localhost:0/api/my-plugin/.backstage/actions/v1/actions/my-plugin:test/invoke',
             (_req, res, ctx) => res(ctx.status(400)),
           ),
         );

--- a/packages/backend-defaults/src/alpha/entrypoints/actionsRegistry/DefaultActionsRegistryService.ts
+++ b/packages/backend-defaults/src/alpha/entrypoints/actionsRegistry/DefaultActionsRegistryService.ts
@@ -34,10 +34,10 @@ import {
 import { InputError, NotAllowedError, NotFoundError } from '@backstage/errors';
 import { AuthorizeResult } from '@backstage/plugin-permission-common';
 
-type ActionEntry = [string, ActionsRegistryActionOptions<any, any>];
+type ActionEntry = [string, ActionsRegistryActionOptions<any, any, any>];
 
 export class DefaultActionsRegistryService implements ActionsRegistryService {
-  private actions: Map<string, ActionsRegistryActionOptions<any, any>> =
+  private actions: Map<string, ActionsRegistryActionOptions<any, any, any>> =
     new Map();
 
   private readonly logger: LoggerService;
@@ -123,6 +123,9 @@ export class DefaultActionsRegistryService implements ActionsRegistryService {
             output: action.schema?.output
               ? zodToJsonSchema(action.schema.output(z))
               : zodToJsonSchema(z.object({})),
+            ...(action.schema?.secrets && {
+              secrets: zodToJsonSchema(action.schema.secrets(z)),
+            }),
           },
         })),
       });
@@ -156,8 +159,12 @@ export class DefaultActionsRegistryService implements ActionsRegistryService {
           }
         }
 
+        const isWrapped = req.headers['x-actions-body-version'] === '2';
+        const rawInput = isWrapped ? req.body.input : req.body;
+        const rawSecrets = isWrapped ? req.body.secrets : undefined;
+
         const input = action.schema?.input
-          ? action.schema.input(z).safeParse(req.body)
+          ? action.schema.input(z).safeParse(rawInput)
           : ({ success: true, data: undefined } as const);
 
         if (!input.success) {
@@ -167,8 +174,26 @@ export class DefaultActionsRegistryService implements ActionsRegistryService {
           );
         }
 
+        if (action.schema?.secrets && !rawSecrets) {
+          throw new InputError(
+            `Action "${req.params.actionId}" requires secrets but none were provided`,
+          );
+        }
+
+        const secrets = action.schema?.secrets
+          ? action.schema.secrets(z).safeParse(rawSecrets)
+          : ({ success: true, data: undefined } as const);
+
+        if (!secrets.success) {
+          throw new InputError(
+            `Invalid secrets for action "${req.params.actionId}"`,
+            secrets.error,
+          );
+        }
+
         const result = await action.action({
           input: input.data,
+          secrets: secrets.data,
           credentials,
           logger: this.logger,
         });
@@ -193,7 +218,14 @@ export class DefaultActionsRegistryService implements ActionsRegistryService {
   register<
     TInputSchema extends AnyZodObject,
     TOutputSchema extends AnyZodObject,
-  >(options: ActionsRegistryActionOptions<TInputSchema, TOutputSchema>): void {
+    TSecretsSchema extends AnyZodObject | undefined = undefined,
+  >(
+    options: ActionsRegistryActionOptions<
+      TInputSchema,
+      TOutputSchema,
+      TSecretsSchema
+    >,
+  ): void {
     const id = `${this.metadata.getId()}:${options.name}`;
 
     if (this.actions.has(id)) {

--- a/packages/backend-defaults/src/alpha/entrypoints/actionsRegistry/DefaultActionsRegistryService.ts
+++ b/packages/backend-defaults/src/alpha/entrypoints/actionsRegistry/DefaultActionsRegistryService.ts
@@ -131,9 +131,12 @@ export class DefaultActionsRegistryService implements ActionsRegistryService {
       });
     });
 
-    router.post(
-      '/.backstage/actions/v1/actions/:actionId/invoke',
-      async (req, res) => {
+    const invokeHandler =
+      (opts: { wrapped: boolean }) =>
+      async (
+        req: import('express').Request,
+        res: import('express').Response,
+      ) => {
         const credentials = await this.httpAuth.credentials(req);
         if (this.auth.isPrincipal(credentials, 'none')) {
           throw new NotAllowedError(
@@ -159,9 +162,8 @@ export class DefaultActionsRegistryService implements ActionsRegistryService {
           }
         }
 
-        const isWrapped = req.headers['x-actions-body-version'] === '2';
-        const rawInput = isWrapped ? req.body.input : req.body;
-        const rawSecrets = isWrapped ? req.body.secrets : undefined;
+        const rawInput = opts.wrapped ? req.body.input : req.body;
+        const rawSecrets = opts.wrapped ? req.body.secrets : undefined;
 
         const input = action.schema?.input
           ? action.schema.input(z).safeParse(rawInput)
@@ -216,8 +218,18 @@ export class DefaultActionsRegistryService implements ActionsRegistryService {
         }
 
         res.json({ output: output.data });
-      },
+      };
+
+    router.post(
+      '/.backstage/actions/v1/actions/:actionId/invoke',
+      invokeHandler({ wrapped: false }),
     );
+
+    router.post(
+      '/.backstage/actions/v2/actions/:actionId/invoke',
+      invokeHandler({ wrapped: true }),
+    );
+
     return router;
   }
 

--- a/packages/backend-defaults/src/alpha/entrypoints/actionsRegistry/DefaultActionsRegistryService.ts
+++ b/packages/backend-defaults/src/alpha/entrypoints/actionsRegistry/DefaultActionsRegistryService.ts
@@ -180,6 +180,12 @@ export class DefaultActionsRegistryService implements ActionsRegistryService {
           );
         }
 
+        if (!action.schema?.secrets && rawSecrets) {
+          throw new InputError(
+            `Action "${req.params.actionId}" does not accept secrets`,
+          );
+        }
+
         const secrets = action.schema?.secrets
           ? action.schema.secrets(z).safeParse(rawSecrets)
           : ({ success: true, data: undefined } as const);

--- a/packages/backend-defaults/src/alpha/entrypoints/actionsRegistry/DefaultActionsRegistryService.ts
+++ b/packages/backend-defaults/src/alpha/entrypoints/actionsRegistry/DefaultActionsRegistryService.ts
@@ -220,6 +220,7 @@ export class DefaultActionsRegistryService implements ActionsRegistryService {
         res.json({ output: output.data });
       };
 
+    // Deprecated: remove v1 invoke route once all callers have migrated to v2
     router.post(
       '/.backstage/actions/v1/actions/:actionId/invoke',
       invokeHandler({ wrapped: false }),

--- a/packages/backend-defaults/src/alpha/entrypoints/actionsRegistry/actionsRegistryServiceFactory.test.ts
+++ b/packages/backend-defaults/src/alpha/entrypoints/actionsRegistry/actionsRegistryServiceFactory.test.ts
@@ -825,32 +825,31 @@ describe('actionsRegistryServiceFactory', () => {
       });
     });
 
-    it('should pass secrets to the action handler when using wrapped body format', async () => {
-      const mockSecretAction = jest
-        .fn()
-        .mockResolvedValue({ output: { ok: true } });
+    const mockSecretAction = jest.fn();
+    const pluginWithSecrets = createBackendPlugin({
+      pluginId: 'my-plugin',
+      register(reg) {
+        reg.registerInit({
+          deps: { actionsRegistry: actionsRegistryServiceRef },
+          async init({ actionsRegistry }) {
+            actionsRegistry.register({
+              name: 'secret-action',
+              title: 'Secret Action',
+              description: 'Needs secrets',
+              schema: {
+                input: z => z.object({ repo: z.string() }),
+                output: z => z.object({ ok: z.boolean() }),
+                secrets: z => z.object({ token: z.string() }),
+              },
+              action: mockSecretAction,
+            });
+          },
+        });
+      },
+    });
 
-      const pluginWithSecrets = createBackendPlugin({
-        pluginId: 'my-plugin',
-        register(reg) {
-          reg.registerInit({
-            deps: { actionsRegistry: actionsRegistryServiceRef },
-            async init({ actionsRegistry }) {
-              actionsRegistry.register({
-                name: 'secret-action',
-                title: 'Secret Action',
-                description: 'Needs secrets',
-                schema: {
-                  input: z => z.object({ repo: z.string() }),
-                  output: z => z.object({ ok: z.boolean() }),
-                  secrets: z => z.object({ token: z.string() }),
-                },
-                action: mockSecretAction,
-              });
-            },
-          });
-        },
-      });
+    it('should pass secrets to the action handler when using wrapped body format', async () => {
+      mockSecretAction.mockResolvedValue({ output: { ok: true } });
 
       const { server } = await startTestBackend({
         features: [pluginWithSecrets, ...defaultServices],
@@ -873,27 +872,7 @@ describe('actionsRegistryServiceFactory', () => {
     });
 
     it('should return 400 when action requires secrets but none provided', async () => {
-      const pluginWithSecrets = createBackendPlugin({
-        pluginId: 'my-plugin',
-        register(reg) {
-          reg.registerInit({
-            deps: { actionsRegistry: actionsRegistryServiceRef },
-            async init({ actionsRegistry }) {
-              actionsRegistry.register({
-                name: 'secret-action',
-                title: 'Secret Action',
-                description: 'Needs secrets',
-                schema: {
-                  input: z => z.object({ repo: z.string() }),
-                  output: z => z.object({ ok: z.boolean() }),
-                  secrets: z => z.object({ token: z.string() }),
-                },
-                action: async () => ({ output: { ok: true } }),
-              });
-            },
-          });
-        },
-      });
+      mockSecretAction.mockResolvedValue({ output: { ok: true } });
 
       const { server } = await startTestBackend({
         features: [pluginWithSecrets, ...defaultServices],
@@ -911,27 +890,7 @@ describe('actionsRegistryServiceFactory', () => {
     });
 
     it('should validate secrets against the schema', async () => {
-      const pluginWithSecrets = createBackendPlugin({
-        pluginId: 'my-plugin',
-        register(reg) {
-          reg.registerInit({
-            deps: { actionsRegistry: actionsRegistryServiceRef },
-            async init({ actionsRegistry }) {
-              actionsRegistry.register({
-                name: 'secret-action',
-                title: 'Secret Action',
-                description: 'Needs secrets',
-                schema: {
-                  input: z => z.object({ repo: z.string() }),
-                  output: z => z.object({ ok: z.boolean() }),
-                  secrets: z => z.object({ token: z.string() }),
-                },
-                action: async () => ({ output: { ok: true } }),
-              });
-            },
-          });
-        },
-      });
+      mockSecretAction.mockResolvedValue({ output: { ok: true } });
 
       const { server } = await startTestBackend({
         features: [pluginWithSecrets, ...defaultServices],
@@ -945,6 +904,24 @@ describe('actionsRegistryServiceFactory', () => {
         .send({ input: { repo: 'test' }, secrets: { token: 123 } });
 
       expect(status).toBe(400);
+    });
+
+    it('should return 400 when secrets are sent to an action that does not accept them', async () => {
+      mockAction.mockResolvedValue({ output: { ok: true } });
+
+      const { server } = await startTestBackend({
+        features: [pluginSubject, ...defaultServices],
+      });
+
+      const { status, body } = await request(server)
+        .post(
+          '/api/my-plugin/.backstage/actions/v1/actions/my-plugin:test/invoke',
+        )
+        .set('X-Actions-Body-Version', '2')
+        .send({ input: { name: 'test' }, secrets: { token: 'unexpected' } });
+
+      expect(status).toBe(400);
+      expect(body.error.message).toMatch(/does not accept secrets/);
     });
 
     it('should still accept raw body format for backward compatibility', async () => {

--- a/packages/backend-defaults/src/alpha/entrypoints/actionsRegistry/actionsRegistryServiceFactory.test.ts
+++ b/packages/backend-defaults/src/alpha/entrypoints/actionsRegistry/actionsRegistryServiceFactory.test.ts
@@ -857,9 +857,8 @@ describe('actionsRegistryServiceFactory', () => {
 
       const { status } = await request(server)
         .post(
-          '/api/my-plugin/.backstage/actions/v1/actions/my-plugin:secret-action/invoke',
+          '/api/my-plugin/.backstage/actions/v2/actions/my-plugin:secret-action/invoke',
         )
-        .set('X-Actions-Body-Version', '2')
         .send({ input: { repo: 'test' }, secrets: { token: 'my-secret' } });
 
       expect(status).toBe(200);
@@ -880,9 +879,8 @@ describe('actionsRegistryServiceFactory', () => {
 
       const { status, body } = await request(server)
         .post(
-          '/api/my-plugin/.backstage/actions/v1/actions/my-plugin:secret-action/invoke',
+          '/api/my-plugin/.backstage/actions/v2/actions/my-plugin:secret-action/invoke',
         )
-        .set('X-Actions-Body-Version', '2')
         .send({ input: { repo: 'test' } });
 
       expect(status).toBe(400);
@@ -898,9 +896,8 @@ describe('actionsRegistryServiceFactory', () => {
 
       const { status } = await request(server)
         .post(
-          '/api/my-plugin/.backstage/actions/v1/actions/my-plugin:secret-action/invoke',
+          '/api/my-plugin/.backstage/actions/v2/actions/my-plugin:secret-action/invoke',
         )
-        .set('X-Actions-Body-Version', '2')
         .send({ input: { repo: 'test' }, secrets: { token: 123 } });
 
       expect(status).toBe(400);
@@ -915,9 +912,8 @@ describe('actionsRegistryServiceFactory', () => {
 
       const { status, body } = await request(server)
         .post(
-          '/api/my-plugin/.backstage/actions/v1/actions/my-plugin:test/invoke',
+          '/api/my-plugin/.backstage/actions/v2/actions/my-plugin:test/invoke',
         )
-        .set('X-Actions-Body-Version', '2')
         .send({ input: { name: 'test' }, secrets: { token: 'unexpected' } });
 
       expect(status).toBe(400);

--- a/packages/backend-defaults/src/alpha/entrypoints/actionsRegistry/actionsRegistryServiceFactory.test.ts
+++ b/packages/backend-defaults/src/alpha/entrypoints/actionsRegistry/actionsRegistryServiceFactory.test.ts
@@ -162,6 +162,67 @@ describe('actionsRegistryServiceFactory', () => {
 
       expect(true).toBe(true);
     });
+
+    it('should properly infer the secrets types', () => {
+      createBackendPlugin({
+        pluginId: 'my-plugin',
+        register(reg) {
+          reg.registerInit({
+            deps: {
+              actionsRegistry: actionsRegistryServiceRef,
+            },
+            async init({ actionsRegistry }) {
+              actionsRegistry.register({
+                name: 'test',
+                title: 'Test',
+                description: 'Test',
+                schema: {
+                  input: z => z.object({ test: z.string() }),
+                  output: z => z.object({ ok: z.boolean() }),
+                  secrets: z => z.object({ token: z.string() }),
+                },
+                action: async ({ secrets: { token } }) => {
+                  // @ts-expect-error - token is not a boolean
+                  const _t: boolean = token;
+                  return { output: { ok: true } };
+                },
+              });
+            },
+          });
+        },
+      });
+
+      expect(true).toBe(true);
+    });
+
+    it('should allow actions without secrets schema', () => {
+      createBackendPlugin({
+        pluginId: 'my-plugin',
+        register(reg) {
+          reg.registerInit({
+            deps: {
+              actionsRegistry: actionsRegistryServiceRef,
+            },
+            async init({ actionsRegistry }) {
+              actionsRegistry.register({
+                name: 'test',
+                title: 'Test',
+                description: 'Test',
+                schema: {
+                  input: z => z.object({ test: z.string() }),
+                  output: z => z.object({ ok: z.boolean() }),
+                },
+                action: async () => {
+                  return { output: { ok: true } };
+                },
+              });
+            },
+          });
+        },
+      });
+
+      expect(true).toBe(true);
+    });
   });
 
   describe('/.backstage/actions/v1/actions', () => {
@@ -461,6 +522,87 @@ describe('actionsRegistryServiceFactory', () => {
         ],
       });
     });
+
+    it('should return secrets schema in action list when declared', async () => {
+      const pluginSubject = createBackendPlugin({
+        pluginId: 'my-plugin',
+        register(reg) {
+          reg.registerInit({
+            deps: {
+              actionsRegistry: actionsRegistryServiceRef,
+            },
+            async init({ actionsRegistry }) {
+              actionsRegistry.register({
+                name: 'test',
+                title: 'Test',
+                description: 'Test',
+                schema: {
+                  input: z => z.object({}),
+                  output: z => z.object({}),
+                  secrets: z =>
+                    z.object({
+                      token: z.string(),
+                    }),
+                },
+                action: async () => ({ output: {} }),
+              });
+            },
+          });
+        },
+      });
+
+      const { server } = await startTestBackend({
+        features: [pluginSubject, ...defaultServices],
+      });
+
+      const { body, status } = await request(server).get(
+        '/api/my-plugin/.backstage/actions/v1/actions',
+      );
+
+      expect(status).toBe(200);
+      expect(body.actions[0].schema.secrets).toMatchObject({
+        type: 'object',
+        properties: {
+          token: { type: 'string' },
+        },
+      });
+    });
+
+    it('should not include secrets schema when not declared', async () => {
+      const pluginSubject = createBackendPlugin({
+        pluginId: 'my-plugin',
+        register(reg) {
+          reg.registerInit({
+            deps: {
+              actionsRegistry: actionsRegistryServiceRef,
+            },
+            async init({ actionsRegistry }) {
+              actionsRegistry.register({
+                name: 'test',
+                title: 'Test',
+                description: 'Test',
+                schema: {
+                  input: z => z.object({}),
+                  output: z => z.object({}),
+                },
+                action: async () => ({ output: {} }),
+              });
+            },
+          });
+        },
+      });
+
+      const { server } = await startTestBackend({
+        features: [pluginSubject, ...defaultServices],
+      });
+
+      const { body, status } = await request(server).get(
+        '/api/my-plugin/.backstage/actions/v1/actions',
+      );
+
+      expect(status).toBe(200);
+      expect(body.actions[0].schema.secrets).toBeUndefined();
+    });
   });
 
   describe('/.backstage/actions/v1/actions/:actionId/invoke', () => {
@@ -681,6 +823,147 @@ describe('actionsRegistryServiceFactory', () => {
           message: 'entity not found',
         },
       });
+    });
+
+    it('should pass secrets to the action handler when using wrapped body format', async () => {
+      const mockSecretAction = jest
+        .fn()
+        .mockResolvedValue({ output: { ok: true } });
+
+      const pluginWithSecrets = createBackendPlugin({
+        pluginId: 'my-plugin',
+        register(reg) {
+          reg.registerInit({
+            deps: { actionsRegistry: actionsRegistryServiceRef },
+            async init({ actionsRegistry }) {
+              actionsRegistry.register({
+                name: 'secret-action',
+                title: 'Secret Action',
+                description: 'Needs secrets',
+                schema: {
+                  input: z => z.object({ repo: z.string() }),
+                  output: z => z.object({ ok: z.boolean() }),
+                  secrets: z => z.object({ token: z.string() }),
+                },
+                action: mockSecretAction,
+              });
+            },
+          });
+        },
+      });
+
+      const { server } = await startTestBackend({
+        features: [pluginWithSecrets, ...defaultServices],
+      });
+
+      const { status } = await request(server)
+        .post(
+          '/api/my-plugin/.backstage/actions/v1/actions/my-plugin:secret-action/invoke',
+        )
+        .set('X-Actions-Body-Version', '2')
+        .send({ input: { repo: 'test' }, secrets: { token: 'my-secret' } });
+
+      expect(status).toBe(200);
+      expect(mockSecretAction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: { repo: 'test' },
+          secrets: { token: 'my-secret' },
+        }),
+      );
+    });
+
+    it('should return 400 when action requires secrets but none provided', async () => {
+      const pluginWithSecrets = createBackendPlugin({
+        pluginId: 'my-plugin',
+        register(reg) {
+          reg.registerInit({
+            deps: { actionsRegistry: actionsRegistryServiceRef },
+            async init({ actionsRegistry }) {
+              actionsRegistry.register({
+                name: 'secret-action',
+                title: 'Secret Action',
+                description: 'Needs secrets',
+                schema: {
+                  input: z => z.object({ repo: z.string() }),
+                  output: z => z.object({ ok: z.boolean() }),
+                  secrets: z => z.object({ token: z.string() }),
+                },
+                action: async () => ({ output: { ok: true } }),
+              });
+            },
+          });
+        },
+      });
+
+      const { server } = await startTestBackend({
+        features: [pluginWithSecrets, ...defaultServices],
+      });
+
+      const { status, body } = await request(server)
+        .post(
+          '/api/my-plugin/.backstage/actions/v1/actions/my-plugin:secret-action/invoke',
+        )
+        .set('X-Actions-Body-Version', '2')
+        .send({ input: { repo: 'test' } });
+
+      expect(status).toBe(400);
+      expect(body.error.message).toMatch(/requires secrets/);
+    });
+
+    it('should validate secrets against the schema', async () => {
+      const pluginWithSecrets = createBackendPlugin({
+        pluginId: 'my-plugin',
+        register(reg) {
+          reg.registerInit({
+            deps: { actionsRegistry: actionsRegistryServiceRef },
+            async init({ actionsRegistry }) {
+              actionsRegistry.register({
+                name: 'secret-action',
+                title: 'Secret Action',
+                description: 'Needs secrets',
+                schema: {
+                  input: z => z.object({ repo: z.string() }),
+                  output: z => z.object({ ok: z.boolean() }),
+                  secrets: z => z.object({ token: z.string() }),
+                },
+                action: async () => ({ output: { ok: true } }),
+              });
+            },
+          });
+        },
+      });
+
+      const { server } = await startTestBackend({
+        features: [pluginWithSecrets, ...defaultServices],
+      });
+
+      const { status } = await request(server)
+        .post(
+          '/api/my-plugin/.backstage/actions/v1/actions/my-plugin:secret-action/invoke',
+        )
+        .set('X-Actions-Body-Version', '2')
+        .send({ input: { repo: 'test' }, secrets: { token: 123 } });
+
+      expect(status).toBe(400);
+    });
+
+    it('should still accept raw body format for backward compatibility', async () => {
+      const { server } = await startTestBackend({
+        features: [pluginSubject, ...defaultServices],
+      });
+
+      const { status } = await request(server)
+        .post(
+          '/api/my-plugin/.backstage/actions/v1/actions/my-plugin:test/invoke',
+        )
+        .send({ name: 'test' });
+
+      expect(status).toBe(200);
+      expect(mockAction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: { name: 'test' },
+        }),
+      );
     });
   });
 

--- a/packages/backend-defaults/src/alpha/entrypoints/actionsRegistry/actionsRegistryServiceFactory.test.ts
+++ b/packages/backend-defaults/src/alpha/entrypoints/actionsRegistry/actionsRegistryServiceFactory.test.ts
@@ -607,8 +607,11 @@ describe('actionsRegistryServiceFactory', () => {
 
   describe('/.backstage/actions/v1/actions/:actionId/invoke', () => {
     const mockAction = jest.fn();
+    const mockSecretAction = jest.fn();
 
     beforeEach(() => {
+      mockAction.mockReset();
+      mockSecretAction.mockReset();
       mockAction.mockResolvedValue({ output: { ok: true } });
     });
 
@@ -825,7 +828,6 @@ describe('actionsRegistryServiceFactory', () => {
       });
     });
 
-    const mockSecretAction = jest.fn();
     const pluginWithSecrets = createBackendPlugin({
       pluginId: 'my-plugin',
       register(reg) {

--- a/packages/backend-plugin-api/report-alpha.api.md
+++ b/packages/backend-plugin-api/report-alpha.api.md
@@ -15,8 +15,14 @@ import { ServiceRef } from '@backstage/backend-plugin-api';
 import { z } from 'zod/v3';
 
 // @alpha (undocumented)
-export type ActionsRegistryActionContext<TInputSchema extends AnyZodObject> = {
+export type ActionsRegistryActionContext<
+  TInputSchema extends AnyZodObject,
+  TSecretsSchema extends AnyZodObject | undefined = undefined,
+> = {
   input: z.infer<TInputSchema>;
+  secrets: TSecretsSchema extends AnyZodObject
+    ? z.infer<TSecretsSchema>
+    : undefined;
   logger: LoggerService;
   credentials: BackstageCredentials;
 };
@@ -36,6 +42,7 @@ export type ActionsRegistryActionExample<
 export type ActionsRegistryActionOptions<
   TInputSchema extends AnyZodObject,
   TOutputSchema extends AnyZodObject,
+  TSecretsSchema extends AnyZodObject | undefined = undefined,
 > = {
   name: string;
   title: string;
@@ -43,6 +50,9 @@ export type ActionsRegistryActionOptions<
   schema: {
     input: (zod: typeof z) => TInputSchema;
     output: (zod: typeof z) => TOutputSchema;
+    secrets?: (
+      zod: typeof z,
+    ) => TSecretsSchema extends AnyZodObject ? TSecretsSchema : never;
   };
   examples?: Array<ActionsRegistryActionExample<TInputSchema, TOutputSchema>>;
   visibilityPermission?: BasicPermission;
@@ -51,7 +61,9 @@ export type ActionsRegistryActionOptions<
     idempotent?: boolean;
     readOnly?: boolean;
   };
-  action: (context: ActionsRegistryActionContext<TInputSchema>) => Promise<
+  action: (
+    context: ActionsRegistryActionContext<TInputSchema, TSecretsSchema>,
+  ) => Promise<
     z.infer<TOutputSchema> extends void
       ? void
       : {
@@ -66,8 +78,13 @@ export interface ActionsRegistryService {
   register<
     TInputSchema extends AnyZodObject,
     TOutputSchema extends AnyZodObject,
+    TSecretsSchema extends AnyZodObject | undefined = undefined,
   >(
-    options: ActionsRegistryActionOptions<TInputSchema, TOutputSchema>,
+    options: ActionsRegistryActionOptions<
+      TInputSchema,
+      TOutputSchema,
+      TSecretsSchema
+    >,
   ): void;
 }
 
@@ -84,6 +101,7 @@ export interface ActionsService {
   invoke(opts: {
     id: string;
     input?: JsonObject;
+    secrets?: JsonObject;
     credentials: BackstageCredentials;
   }): Promise<{
     output: JsonValue;
@@ -104,6 +122,7 @@ export type ActionsServiceAction = {
   schema: {
     input: JSONSchema7;
     output: JSONSchema7;
+    secrets?: JSONSchema7;
   };
   examples?: Array<{
     title: string;

--- a/packages/backend-plugin-api/src/alpha/ActionsRegistryService.ts
+++ b/packages/backend-plugin-api/src/alpha/ActionsRegistryService.ts
@@ -23,8 +23,14 @@ import {
 /**
  * @alpha
  */
-export type ActionsRegistryActionContext<TInputSchema extends AnyZodObject> = {
+export type ActionsRegistryActionContext<
+  TInputSchema extends AnyZodObject,
+  TSecretsSchema extends AnyZodObject | undefined = undefined,
+> = {
   input: z.infer<TInputSchema>;
+  secrets: TSecretsSchema extends AnyZodObject
+    ? z.infer<TSecretsSchema>
+    : undefined;
   logger: LoggerService;
   credentials: BackstageCredentials;
 };
@@ -50,6 +56,7 @@ export type ActionsRegistryActionExample<
 export type ActionsRegistryActionOptions<
   TInputSchema extends AnyZodObject,
   TOutputSchema extends AnyZodObject,
+  TSecretsSchema extends AnyZodObject | undefined = undefined,
 > = {
   name: string;
   title: string;
@@ -57,6 +64,9 @@ export type ActionsRegistryActionOptions<
   schema: {
     input: (zod: typeof z) => TInputSchema;
     output: (zod: typeof z) => TOutputSchema;
+    secrets?: (
+      zod: typeof z,
+    ) => TSecretsSchema extends AnyZodObject ? TSecretsSchema : never;
   };
   examples?: Array<ActionsRegistryActionExample<TInputSchema, TOutputSchema>>;
   visibilityPermission?: BasicPermission;
@@ -66,7 +76,7 @@ export type ActionsRegistryActionOptions<
     readOnly?: boolean;
   };
   action: (
-    context: ActionsRegistryActionContext<TInputSchema>,
+    context: ActionsRegistryActionContext<TInputSchema, TSecretsSchema>,
   ) => Promise<
     z.infer<TOutputSchema> extends void
       ? void
@@ -81,7 +91,12 @@ export interface ActionsRegistryService {
   register<
     TInputSchema extends AnyZodObject,
     TOutputSchema extends AnyZodObject,
+    TSecretsSchema extends AnyZodObject | undefined = undefined,
   >(
-    options: ActionsRegistryActionOptions<TInputSchema, TOutputSchema>,
+    options: ActionsRegistryActionOptions<
+      TInputSchema,
+      TOutputSchema,
+      TSecretsSchema
+    >,
   ): void;
 }

--- a/packages/backend-plugin-api/src/alpha/ActionsService.ts
+++ b/packages/backend-plugin-api/src/alpha/ActionsService.ts
@@ -29,6 +29,7 @@ export type ActionsServiceAction = {
   schema: {
     input: JSONSchema7;
     output: JSONSchema7;
+    secrets?: JSONSchema7;
   };
   examples?: Array<{
     title: string;
@@ -53,6 +54,7 @@ export interface ActionsService {
   invoke(opts: {
     id: string;
     input?: JsonObject;
+    secrets?: JsonObject;
     credentials: BackstageCredentials;
   }): Promise<{ output: JsonValue }>;
 }

--- a/packages/backend-test-utils/report-alpha.api.md
+++ b/packages/backend-test-utils/report-alpha.api.md
@@ -65,13 +65,14 @@ export class MockActionsRegistry
   implements ActionsRegistryService, ActionsService
 {
   // (undocumented)
-  readonly actions: Map<string, ActionsRegistryActionOptions<any, any>>;
+  readonly actions: Map<string, ActionsRegistryActionOptions<any, any, any>>;
   // (undocumented)
   static create(opts: { logger: LoggerService }): MockActionsRegistry;
   // (undocumented)
   invoke(opts: {
     id: string;
     input?: JsonObject;
+    secrets?: JsonObject;
     credentials?: BackstageCredentials;
   }): Promise<{
     output: JsonValue;
@@ -84,7 +85,14 @@ export class MockActionsRegistry
   register<
     TInputSchema extends AnyZodObject,
     TOutputSchema extends AnyZodObject,
-  >(options: ActionsRegistryActionOptions<TInputSchema, TOutputSchema>): void;
+    TSecretsSchema extends AnyZodObject | undefined = undefined,
+  >(
+    options: ActionsRegistryActionOptions<
+      TInputSchema,
+      TOutputSchema,
+      TSecretsSchema
+    >,
+  ): void;
 }
 
 // @alpha

--- a/packages/backend-test-utils/src/alpha/services/MockActionsRegistry.ts
+++ b/packages/backend-test-utils/src/alpha/services/MockActionsRegistry.ts
@@ -138,6 +138,10 @@ export class MockActionsRegistry
       );
     }
 
+    if (!action.schema?.secrets && opts.secrets) {
+      throw new InputError(`Action "${opts.id}" does not accept secrets`);
+    }
+
     const secrets = action.schema?.secrets
       ? action.schema.secrets(z).safeParse(opts.secrets)
       : ({ success: true, data: undefined } as const);

--- a/packages/backend-test-utils/src/alpha/services/MockActionsRegistry.ts
+++ b/packages/backend-test-utils/src/alpha/services/MockActionsRegistry.ts
@@ -75,7 +75,7 @@ export class MockActionsRegistry
     return new MockActionsRegistry(opts.logger);
   }
 
-  readonly actions: Map<string, ActionsRegistryActionOptions<any, any>> =
+  readonly actions: Map<string, ActionsRegistryActionOptions<any, any, any>> =
     new Map();
 
   async list(): Promise<{ actions: ActionsServiceAction[] }> {
@@ -99,6 +99,9 @@ export class MockActionsRegistry
           output: action.schema?.output
             ? zodToJsonSchema(action.schema.output(z))
             : zodToJsonSchema(z.object({})),
+          ...(action.schema?.secrets && {
+            secrets: zodToJsonSchema(action.schema.secrets(z)),
+          }),
         } as ActionsServiceAction['schema'],
       })),
     };
@@ -107,6 +110,7 @@ export class MockActionsRegistry
   async invoke(opts: {
     id: string;
     input?: JsonObject;
+    secrets?: JsonObject;
     credentials?: BackstageCredentials;
   }): Promise<{ output: JsonValue }> {
     const action = this.actions.get(opts.id);
@@ -128,8 +132,26 @@ export class MockActionsRegistry
       throw new InputError(`Invalid input to action "${opts.id}"`, input.error);
     }
 
+    if (action.schema?.secrets && !opts.secrets) {
+      throw new InputError(
+        `Action "${opts.id}" requires secrets but none were provided`,
+      );
+    }
+
+    const secrets = action.schema?.secrets
+      ? action.schema.secrets(z).safeParse(opts.secrets)
+      : ({ success: true, data: undefined } as const);
+
+    if (!secrets.success) {
+      throw new InputError(
+        `Invalid secrets for action "${opts.id}"`,
+        secrets.error,
+      );
+    }
+
     const result = await action.action({
       input: input.data,
+      secrets: secrets.data,
       credentials: opts.credentials ?? mockCredentials.none(),
       logger: this.logger,
     });
@@ -151,7 +173,14 @@ export class MockActionsRegistry
   register<
     TInputSchema extends AnyZodObject,
     TOutputSchema extends AnyZodObject,
-  >(options: ActionsRegistryActionOptions<TInputSchema, TOutputSchema>): void {
+    TSecretsSchema extends AnyZodObject | undefined = undefined,
+  >(
+    options: ActionsRegistryActionOptions<
+      TInputSchema,
+      TOutputSchema,
+      TSecretsSchema
+    >,
+  ): void {
     // hardcode test: prefix similar to how the default actions registry does it
     // and other places around the testing ecosystem:
     // https://github.com/backstage/backstage/blob/a9219496d5c073aaa0b8caf32ece10455cf65e61/packages/backend-test-utils/src/next/services/mockServices.ts#L321


### PR DESCRIPTION
Adds optional secrets schema support to the ActionsRegistry, allowing plugin authors to declare that an action requires external credentials (API keys, tokens) separate from regular input.

## Changes

- Add `TSecretsSchema` type parameter to `ActionsRegistryActionOptions`, `ActionsRegistryActionContext`, and `ActionsRegistryService.register()`
- Add optional `secrets` field to `ActionsServiceAction` metadata and `ActionsService.invoke()`
- Update `DefaultActionsService` to send wrapped `{ input, secrets }` body
- Update `MockActionsRegistry` to support secrets validation
- Reject unexpected secrets sent to actions without a secrets schema

## Usage

```typescript
actionsRegistry.register({
  name: 'create-issue',
  title: 'Create GitHub Issue',
  description: 'Creates an issue in a GitHub repository',
  schema: {
    input: z => z.object({ repo: z.string(), title: z.string() }),
    output: z => z.object({ issueUrl: z.string() }),
    secrets: z => z.object({
      githubToken: z.string().describe('GitHub PAT with repo scope'),
    }),
  },
  action: async ({ input, credentials, secrets }) => {
    // secrets.githubToken is typed and validated
  },
});
```

Secrets are kept separate from tool input schemas so they never appear in LLM context. Collection of secrets from end users (via MCP elicitation or a frontend plugin) will be handled in follow-up PRs.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.