### PR TITLE
fix(catalog-incremental): use text for ingestions.last_error column type

### DIFF
--- a/.changeset/two-books-sleep.md
+++ b/.changeset/two-books-sleep.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-incremental-ingestion': patch
+---
+
+Alter column type for `ingestions.last_error` to remove the 255-character restriction.

--- a/plugins/catalog-backend-module-incremental-ingestion/migrations/20260522155028_last_error_column.js
+++ b/plugins/catalog-backend-module-incremental-ingestion/migrations/20260522155028_last_error_column.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-check
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function up(knex) {
+  await knex.schema.alterTable('ingestions', table => {
+    table.text('last_error', 'longtext').nullable().alter();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function down(knex) {
+  const oversizedCountResult = await knex('ingestions')
+    .where(knex.raw('LENGTH(last_error) > 255'))
+    .count({ count: '*' })
+    .first();
+  const oversizedCount = Number(oversizedCountResult?.count ?? 0);
+
+  if (oversizedCount > 0) {
+    throw new Error(
+      `Migration aborted: Found ${oversizedCount} ingestion entries with 'last_error' exceeding 255 characters. Manual intervention required.`,
+    );
+  }
+
+  await knex.schema.alterTable('ingestions', table => {
+    table.string('last_error').nullable().alter();
+  });
+};

--- a/plugins/catalog-backend-module-incremental-ingestion/report.sql.md
+++ b/plugins/catalog-backend-module-incremental-ingestion/report.sql.md
@@ -39,7 +39,7 @@
 | `created_at`             | `timestamp with time zone` | false    | -          | `CURRENT_TIMESTAMP` |
 | `id`                     | `uuid`                     | false    | -          | -                   |
 | `ingestion_completed_at` | `timestamp with time zone` | true     | -          | -                   |
-| `last_error`             | `character varying`        | true     | 255        | -                   |
+| `last_error`             | `text`                     | true     | -          | -                   |
 | `next_action`            | `character varying`        | false    | 255        | -                   |
 | `next_action_at`         | `timestamp with time zone` | false    | -          | `CURRENT_TIMESTAMP` |
 | `provider_name`          | `character varying`        | false    | 255        | -                   |

--- a/plugins/catalog-backend-module-incremental-ingestion/src/database/IncrementalIngestionDatabaseManager.test.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/database/IncrementalIngestionDatabaseManager.test.ts
@@ -15,9 +15,9 @@
  */
 
 import { TestDatabases } from '@backstage/backend-test-utils';
-import { IncrementalIngestionDatabaseManager } from './IncrementalIngestionDatabaseManager';
-import { randomUUID as uuid } from 'node:crypto';
 import { DeferredEntity } from '@backstage/plugin-catalog-node';
+import { randomUUID as uuid } from 'node:crypto';
+import { IncrementalIngestionDatabaseManager } from './IncrementalIngestionDatabaseManager';
 
 const migrationsDir = `${__dirname}/../../migrations`;
 
@@ -239,6 +239,29 @@ describe.each(databases.eachSupportedId())(
       const remaining = await knex('ingestion_mark_entities').select('ref');
       expect(remaining).toHaveLength(1);
       expect(remaining[0].ref).toBe('component:default/y');
+    });
+
+    it('updateIngestionRecordById with long last_error value', async () => {
+      const knex = await databases.init(databaseId);
+      await knex.migrate.latest({ directory: migrationsDir });
+
+      const manager = new IncrementalIngestionDatabaseManager({ client: knex });
+      const { ingestionId } = (await manager.createProviderIngestionRecord(
+        'testLastErrorProvider',
+      ))!;
+      const expectedLastError = 'a'.repeat(256);
+
+      await manager.updateIngestionRecordById({
+        ingestionId,
+        update: {
+          last_error: expectedLastError,
+        },
+      });
+      const { last_error } = (await manager.getCurrentIngestionRecord(
+        'testLastErrorProvider',
+      ))!;
+
+      expect(last_error).toEqual(expectedLastError);
     });
   },
 );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When an incremental entity provider fails with an error message longer than 255 characters, the ingestion engine gets stuck in a loop trying to update the `ingestions` record:

> error: update "ingestions" set "next_action" = $1, "attempts" = $2, "last_error" = $3, "next_action_at" = $4, "status" = $5 where "id" = $6 - value too long for type character varying(255)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
