### PR TITLE
fix(ui): keep BUI Header title and actions aligned on wide viewports

### DIFF
--- a/.changeset/fix-bui-header-wide-viewport-alignment.md
+++ b/.changeset/fix-bui-header-wide-viewport-alignment.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed `Header` so its title and `customActions` stay aligned with the page edges on very wide viewports. Previously, on screens wider than 1920px the header content was centered with empty gutters on either side, making it appear shifted inward relative to the page body below.

--- a/packages/ui/src/components/Header/Header.module.css
+++ b/packages/ui/src/components/Header/Header.module.css
@@ -23,6 +23,16 @@
     margin-bottom: 0;
   }
 
+  /* The Header acts as page chrome and should span the full available width
+     rather than inheriting Container's 120rem cap, which would shift the
+     title and customActions inward on very wide viewports. */
+  .bui-HeaderTop.bui-HeaderTop,
+  .bui-HeaderContent.bui-HeaderContent,
+  .bui-HeaderBottom.bui-HeaderBottom {
+    max-width: none;
+    margin-inline: 0;
+  }
+
   .bui-HeaderBottom {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #34346

The BUI `Header` wraps each of its three sections (`headerTop`, `content`, `headerBottom`) in the shared `Container` component, which has `max-width: 120rem` (1920px) and `margin-inline: auto`. On viewports wider than 1920px this centers the header content and leaves empty gutters on either side, while the page body below it (e.g. the catalog table) extends to the full available width. The result is that the title and `customActions` visibly shift inward relative to the rest of the page.

This change adds a scoped override in `Header.module.css` that drops `max-width` and `margin-inline` for the three Header wrappers only, using the same doubled-class specificity pattern already in that file. The shared `Container` cap is unchanged, so other consumers (`SearchField`, `Table`, `PluginHeader`, etc.) keep the readability constraint.

Padding-inline from `Container` is preserved, so the header still has consistent page-level side padding — it just spans the full available width now, with the title flush to the left and `customActions` flush to the right.

  <!-- Add a before/after screenshot of demo.backstage.io/catalog at >1920px viewport here. -->

#### :heavy_check_mark: Checklist
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

## Screenshot
**Before** 
<img width="3440" height="700" alt="before-ultrawide-3440" src="https://github.com/user-attachments/assets/98ac2adc-f09e-4f10-9b51-34ac81d762d6" />
<img width="1440" height="600" alt="before-narrow-1440" src="https://github.com/user-attachments/assets/55d82337-07f1-4a2f-88f3-ea6b13da8d79" />
<img width="2400" height="600" alt="before-wide-2400" src="https://github.com/user-attachments/assets/1aadd595-690a-4ebc-abc7-cde996ca08e1" />

**After**
<img width="1440" height="600" alt="after-narrow-1440" src="https://github.com/user-attachments/assets/c7e4ccde-92e4-4ed6-b5ea-7ed2431fc674" />
<img width="3440" height="700" alt="after-ultrawide-3440" src="https://github.com/user-attachments/assets/12f136f8-8d18-4c9f-9b73-997441af9990" />
<img width="2400" height="600" alt="after-wide-2400" src="https://github.com/user-attachments/assets/f4aa4e83-8a78-4391-9d07-9257096d4b4f" />
