### PR TITLE
Add AWS Controller plugin to plugin directory

### DIFF
--- a/microsite/data/plugins/aws-controller.yaml
+++ b/microsite/data/plugins/aws-controller.yaml
@@ -1,0 +1,11 @@
+---
+title: AWS Controller
+author: AWS Forge Contributors
+authorUrl: https://github.com/refaelb
+category: Services
+description: Bring AWS S3, RDS and EC2 visibility into Backstage Catalog entities.
+documentation: https://github.com/refaelb/backstage-plugin-aws-controller#readme
+iconUrl: /img/logo-gradient-on-dark.svg
+npmPackageName: '@aws-forge/backstage-plugin-aws-controller'
+addedDate: '2026-05-24'
+status: active


### PR DESCRIPTION
Adds plugin directory entry for @aws-forge/backstage-plugin-aws-controller
Backend companion package: @aws-forge/backstage-plugin-aws-controller-backend
Documentation: https://github.com/aws-forge/backstage-plugin-aws-control#readme
Status: active