### PR TITLE
fix(frontend-plugin-api): honor noHeader on all PageBlueprint pages

### DIFF
--- a/.changeset/page-blueprint-no-header.md
+++ b/.changeset/page-blueprint-no-header.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+Fixed the `noHeader` option on pages created with `PageBlueprint` only taking effect for pages that use a `loader`. The option is now also honored by pages that render sub-pages with tabs and by pages without a loader, and the default page layout now hides its header when the option is set.

--- a/packages/frontend-plugin-api/src/blueprints/PageBlueprint.test.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/PageBlueprint.test.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { ReactNode } from 'react';
 import { createRouteRef } from '../routing';
 import { PageBlueprint } from './PageBlueprint';
 import {
@@ -25,6 +26,27 @@ import {
   createExtensionInput,
 } from '../wiring';
 import { waitFor } from '@testing-library/react';
+
+// Replace the swappable page layout with a probe so we can assert which props
+// the blueprint forwards to it, independent of how a layout chooses to render.
+// `createElement` is used instead of JSX to keep the mock factory free of
+// references that Jest is not allowed to hoist.
+jest.mock('../components', () => {
+  const actual = jest.requireActual('../components');
+  const { createElement } = jest.requireActual('react');
+  return {
+    ...actual,
+    PageLayout: (props: { noHeader?: boolean; children?: ReactNode }) =>
+      createElement(
+        'div',
+        {
+          'data-testid': 'page-layout-probe',
+          'data-no-header': String(Boolean(props.noHeader)),
+        },
+        props.children,
+      ),
+  };
+});
 
 describe('PageBlueprint', () => {
   const mockRouteRef = createRouteRef();
@@ -162,6 +184,64 @@ describe('PageBlueprint', () => {
     const { getByTestId } = renderInTestApp(tester.reactElement());
 
     await waitFor(() => expect(getByTestId('test')).toBeInTheDocument());
+  });
+
+  it('forwards the noHeader option to the page layout for pages without a loader', async () => {
+    const withHeader = renderInTestApp(
+      createExtensionTester(
+        PageBlueprint.make({
+          name: 'with-header',
+          params: { path: '/test', title: 'Test' },
+        }),
+      ).reactElement(),
+    );
+    expect(await withHeader.findByTestId('page-layout-probe')).toHaveAttribute(
+      'data-no-header',
+      'false',
+    );
+    withHeader.unmount();
+
+    const withoutHeader = renderInTestApp(
+      createExtensionTester(
+        PageBlueprint.make({
+          name: 'without-header',
+          params: { path: '/test', title: 'Test', noHeader: true },
+        }),
+      ).reactElement(),
+    );
+    expect(
+      await withoutHeader.findByTestId('page-layout-probe'),
+    ).toHaveAttribute('data-no-header', 'true');
+  });
+
+  it('forwards the noHeader option to the page layout for pages with sub-pages', async () => {
+    const SubPageBlueprint = createExtensionBlueprint({
+      kind: 'sub-page',
+      attachTo: { id: 'page:parent-page', input: 'pages' },
+      output: [coreExtensionData.routePath, coreExtensionData.reactElement],
+      factory() {
+        return [
+          coreExtensionData.routePath('/sub'),
+          coreExtensionData.reactElement(<div>sub page</div>),
+        ];
+      },
+    });
+
+    const parentPage = PageBlueprint.make({
+      name: 'parent-page',
+      params: { path: '/test', title: 'Test', noHeader: true },
+    });
+
+    const tester = createExtensionTester(parentPage).add(
+      SubPageBlueprint.make({ name: 'sub', params: {} }),
+    );
+
+    const { findByTestId } = renderInTestApp(tester.reactElement());
+
+    expect(await findByTestId('page-layout-probe')).toHaveAttribute(
+      'data-no-header',
+      'true',
+    );
   });
 
   it('should allow defining additional inputs to the extension', async () => {

--- a/packages/frontend-plugin-api/src/blueprints/PageBlueprint.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/PageBlueprint.tsx
@@ -145,6 +145,7 @@ export const PageBlueprint = createExtensionBlueprint({
           <PageLayout
             title={resolvedTitle}
             icon={resolvedIcon}
+            noHeader={noHeader}
             tabs={tabs}
             titleLink={titleLink}
             headerActions={headerActions}
@@ -179,6 +180,7 @@ export const PageBlueprint = createExtensionBlueprint({
           <PageLayout
             title={resolvedTitle}
             icon={resolvedIcon}
+            noHeader={noHeader}
             titleLink={titleLink}
             headerActions={headerActions}
           />

--- a/packages/frontend-plugin-api/src/components/PageLayout.test.tsx
+++ b/packages/frontend-plugin-api/src/components/PageLayout.test.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { PageLayout } from './PageLayout';
+
+describe('PageLayout', () => {
+  const tabs = [{ id: 'one', label: 'Tab One', href: '/one' }];
+
+  it('renders the header with the title and tabs by default', async () => {
+    render(
+      <PageLayout title="My Title" tabs={tabs}>
+        <div>Page content</div>
+      </PageLayout>,
+    );
+
+    expect(await screen.findByText('Page content')).toBeInTheDocument();
+    expect(screen.getByText('My Title')).toBeInTheDocument();
+    expect(screen.getByText('Tab One')).toBeInTheDocument();
+  });
+
+  it('hides the header, title and tabs when noHeader is set', async () => {
+    render(
+      <PageLayout title="My Title" tabs={tabs} noHeader>
+        <div>Page content</div>
+      </PageLayout>,
+    );
+
+    expect(await screen.findByText('Page content')).toBeInTheDocument();
+    expect(screen.queryByText('My Title')).not.toBeInTheDocument();
+    expect(screen.queryByText('Tab One')).not.toBeInTheDocument();
+  });
+});

--- a/packages/frontend-plugin-api/src/components/PageLayout.tsx
+++ b/packages/frontend-plugin-api/src/components/PageLayout.tsx
@@ -53,7 +53,7 @@ export interface PageLayoutProps {
  * Default implementation of PageLayout using plain HTML elements
  */
 function DefaultPageLayout(props: PageLayoutProps): JSX.Element {
-  const { title, icon, headerActions, tabs, children } = props;
+  const { title, icon, noHeader, headerActions, tabs, children } = props;
 
   return (
     <div
@@ -65,7 +65,7 @@ function DefaultPageLayout(props: PageLayoutProps): JSX.Element {
         minHeight: 0,
       }}
     >
-      {(title || tabs) && (
+      {!noHeader && (title || tabs) && (
         <header
           style={{
             borderBottom: '1px solid #ddd',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `noHeader` option on pages created with `PageBlueprint` only took effect for pages defined with a `loader`. Pages that render sub-pages with tabs, and pages without a loader, ignored the option and always rendered the plugin header, so overriding a page with `noHeader: true` had no effect for many plugins.

This forwards `noHeader` to the page layout in those cases as well, and makes the default page layout skip rendering its header when the option is set, so the page can fill all available space.

The change is covered by tests for both `PageBlueprint` and the default `PageLayout`.

Fixes #34051

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
