### PR TITLE
fix(techdocs-react): stop retry loop on failed metadata request

### DIFF
--- a/.changeset/techdocs-metadata-retry-loop.md
+++ b/.changeset/techdocs-metadata-retry-loop.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-react': patch
+---
+
+Fixed the TechDocs reader requesting the documentation metadata in a tight loop when the request fails permanently (for example when the metadata returns a 404). The reader now stops after a failed request, which previously flooded the backend with requests and caused the page to flicker.

--- a/plugins/techdocs-react/src/context.test.tsx
+++ b/plugins/techdocs-react/src/context.test.tsx
@@ -130,6 +130,38 @@ describe('useTechDocsReaderPage', () => {
     );
   });
 
+  it('does not retry metadata loading after a permanent error', async () => {
+    techdocsApiMock.getTechDocsMetadata.mockRejectedValue(
+      new Error('Not Found'),
+    );
+
+    try {
+      const { result } = renderHook(() => useTechDocsReaderPage(), { wrapper });
+
+      // Wait for the initial metadata request to fail.
+      await waitFor(() => {
+        expect(result.current.metadata.error).toBeDefined();
+      });
+      const callsAfterInitialError =
+        techdocsApiMock.getTechDocsMetadata.mock.calls.length;
+
+      // Attaching the shadow root previously re-triggered the metadata fetch on
+      // every render, causing an unbounded retry loop while the request kept
+      // failing. Setting it must not start retrying a permanently failed load.
+      await act(async () => result.current.setShadowRoot(mockShadowRoot()));
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      expect(techdocsApiMock.getTechDocsMetadata).toHaveBeenCalledTimes(
+        callsAfterInitialError,
+      );
+      expect(result.current.metadata.error).toBeDefined();
+    } finally {
+      techdocsApiMock.getTechDocsMetadata.mockResolvedValue(
+        mockTechDocsMetadata,
+      );
+    }
+  });
+
   it('should set entityRef as lowercase when legacyUseCaseSensitiveTripletPaths is false', async () => {
     const lowercaseEntityRef = {
       kind: mockEntityMetadata.kind.toLocaleLowerCase(),

--- a/plugins/techdocs-react/src/context.tsx
+++ b/plugins/techdocs-react/src/context.tsx
@@ -135,16 +135,26 @@ export const TechDocsReaderPageProvider = memo(
       defaultTechDocsReaderPageValue.shadowRoot,
     );
 
+    const {
+      value: metadataValue,
+      loading: metadataLoading,
+      error: metadataError,
+      retry: retryMetadata,
+    } = metadata;
+
     useEffect(() => {
-      if (shadowRoot && !metadata.value && !metadata.loading) {
-        metadata.retry();
+      // Retry once the shadow root is attached, but only while the request has
+      // not yet produced a value or failed. Checking the error state is what
+      // stops a permanently failing request (e.g. a 404) from retrying forever.
+      if (shadowRoot && !metadataValue && !metadataLoading && !metadataError) {
+        retryMetadata();
       }
     }, [
-      metadata.value,
-      metadata.loading,
       shadowRoot,
-      metadata.retry,
-      metadata,
+      metadataValue,
+      metadataLoading,
+      metadataError,
+      retryMetadata,
     ]);
 
     const value: TechDocsReaderPageValue = {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`TechDocsReaderPageProvider` re-ran the documentation metadata request whenever the shadow root was attached and no value had loaded yet, and it included the whole async state object in the effect's dependencies. When the request failed permanently (for example, a 404 from `getTechDocsMetadata`), every failed attempt produced a new state object that re-triggered the effect, resulting in an unbounded retry loop. This flooded the backend with requests and made the page flicker.

The effect now skips retrying once the request has errored, and depends on the individual async state fields instead of the whole state object.

Fixes #33615

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
