### PR TITLE
Auth: skip sign-in resolver on refresh when user profile is unavailable

### DIFF
--- a/.changeset/puny-pets-design.md
+++ b/.changeset/puny-pets-design.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-auth-backend-module-vmware-cloud-provider': patch
+'@backstage/plugin-auth-backend-module-microsoft-provider': patch
+'@backstage/plugin-auth-backend-module-oidc-provider': patch
+---
+
+Updated the authenticator to use the new `OAuthAuthenticatorResponse` type for `authenticate` and `refresh` return values, allowing the user profile to be optional when the access token targets a different resource.

--- a/.changeset/rude-items-notice.md
+++ b/.changeset/rude-items-notice.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-node': patch
+---
+
+Fixed an issue where the sign-in resolver was invoked during token refresh even when the authenticator did not provide a user profile, such as when refreshing resource-scoped tokens in the Microsoft provider. The resolver is now skipped in this case and no Backstage identity token is issued in the response.

--- a/.changeset/rude-items-notice.md
+++ b/.changeset/rude-items-notice.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-auth-node': patch
+'@backstage/plugin-auth-node': minor
 ---
 
 Fixed an issue where the sign-in resolver was invoked during token refresh even when the authenticator did not provide a user profile, such as when refreshing resource-scoped tokens in the Microsoft provider. The resolver is now skipped in this case and no Backstage identity token is issued in the response.

--- a/.changeset/rude-items-notice.md
+++ b/.changeset/rude-items-notice.md
@@ -3,3 +3,5 @@
 ---
 
 Fixed an issue where the sign-in resolver was invoked during token refresh even when the authenticator did not provide a user profile, such as when refreshing resource-scoped tokens in the Microsoft provider. The resolver is now skipped in this case and no Backstage identity token is issued in the response.
+
+Custom `profileTransform` implementations may need to be updated to handle an optional `fullProfile` field, for example by using optional chaining (`input.fullProfile?.email`).

--- a/.changeset/rude-items-notice.md
+++ b/.changeset/rude-items-notice.md
@@ -5,3 +5,5 @@
 Fixed an issue where the sign-in resolver was invoked during token refresh even when the authenticator did not provide a user profile, such as when refreshing resource-scoped tokens in the Microsoft provider. The resolver is now skipped in this case and no Backstage identity token is issued in the response.
 
 Custom `profileTransform` implementations may need to be updated to handle an optional `fullProfile` field, for example by using optional chaining (`input.fullProfile?.email`).
+
+The `fullProfile` field in `PassportOAuthResult` is now optional, reflecting the fact that passport strategies can skip loading a profile at runtime.

--- a/plugins/auth-backend-module-microsoft-provider/src/authenticator.test.ts
+++ b/plugins/auth-backend-module-microsoft-provider/src/authenticator.test.ts
@@ -171,14 +171,15 @@ describe('microsoftAuthenticator', () => {
       );
 
       const profile = authenticateResponse.fullProfile;
-      expect(profile.displayName).toBe('Conrad');
-      expect(profile.emails).toStrictEqual([
+      expect(profile).toBeDefined();
+      expect(profile!.displayName).toBe('Conrad');
+      expect(profile!.emails).toStrictEqual([
         {
           type: 'work',
           value: 'conrad@example.com',
         },
       ]);
-      expect(profile.photos).toStrictEqual([{ value: photo }]);
+      expect(profile!.photos).toStrictEqual([{ value: photo }]);
     });
 
     it('returns access token for non-microsoft graph scope', async () => {
@@ -220,14 +221,15 @@ describe('microsoftAuthenticator', () => {
       );
 
       const profile = authenticateResponse.fullProfile;
-      expect(profile.displayName).toBe('Conrad');
-      expect(profile.emails).toStrictEqual([
+      expect(profile).toBeDefined();
+      expect(profile!.displayName).toBe('Conrad');
+      expect(profile!.emails).toStrictEqual([
         {
           type: 'work',
           value: 'conrad@example.com',
         },
       ]);
-      expect(profile.photos).toBeUndefined();
+      expect(profile!.photos).toBeUndefined();
     });
   });
 
@@ -249,14 +251,15 @@ describe('microsoftAuthenticator', () => {
       );
 
       const profile = refreshResponse.fullProfile;
-      expect(profile.displayName).toBe('Conrad');
-      expect(profile.emails).toStrictEqual([
+      expect(profile).toBeDefined();
+      expect(profile!.displayName).toBe('Conrad');
+      expect(profile!.emails).toStrictEqual([
         {
           type: 'work',
           value: 'conrad@example.com',
         },
       ]);
-      expect(profile.photos).toStrictEqual([{ value: photo }]);
+      expect(profile!.photos).toStrictEqual([{ value: photo }]);
     });
 
     it('returns access token for non-microsoft graph scope', async () => {

--- a/plugins/auth-backend-module-oidc-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-oidc-provider/src/authenticator.ts
@@ -26,7 +26,7 @@ import {
 } from 'openid-client';
 import {
   createOAuthAuthenticator,
-  OAuthAuthenticatorResult,
+  OAuthAuthenticatorResponse,
   PassportDoneCallback,
   PassportHelpers,
   PassportOAuthAuthenticatorHelper,
@@ -58,12 +58,12 @@ export type OidcAuthResult = {
 /** @public */
 export const oidcAuthenticator = createOAuthAuthenticator({
   defaultProfileTransform: async (
-    input: OAuthAuthenticatorResult<OidcAuthResult>,
+    input: OAuthAuthenticatorResponse<OidcAuthResult>,
   ) => ({
     profile: {
-      email: input.fullProfile.userinfo.email,
-      picture: input.fullProfile.userinfo.picture,
-      displayName: input.fullProfile.userinfo.name,
+      email: input.fullProfile?.userinfo.email,
+      picture: input.fullProfile?.userinfo.picture,
+      displayName: input.fullProfile?.userinfo.name,
     },
   }),
   scopes: {
@@ -174,7 +174,7 @@ export const oidcAuthenticator = createOAuthAuthenticator({
   async authenticate(
     input,
     ctx,
-  ): Promise<OAuthAuthenticatorResult<OidcAuthResult>> {
+  ): Promise<OAuthAuthenticatorResponse<OidcAuthResult>> {
     const { strategy } = await ctx.promise;
     const { result, privateInfo } =
       await PassportHelpers.executeFrameHandlerStrategy<

--- a/plugins/auth-backend-module-vmware-cloud-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-vmware-cloud-provider/src/authenticator.ts
@@ -85,7 +85,7 @@ export const vmwareCloudAuthenticator = createOAuthAuthenticator<
       string
     >;
 
-    if (context_name !== input.fullProfile.organizationId) {
+    if (context_name !== input.fullProfile?.organizationId) {
       throw new Error(`ID token organizationId mismatch`);
     }
 

--- a/plugins/auth-backend-module-vmware-cloud-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-vmware-cloud-provider/src/authenticator.ts
@@ -85,7 +85,10 @@ export const vmwareCloudAuthenticator = createOAuthAuthenticator<
       string
     >;
 
-    if (context_name !== input.fullProfile?.organizationId) {
+    if (
+      !input.fullProfile ||
+      context_name !== input.fullProfile.organizationId
+    ) {
       throw new Error(`ID token organizationId mismatch`);
     }
 

--- a/plugins/auth-node/report.api.md
+++ b/plugins/auth-node/report.api.md
@@ -194,7 +194,7 @@ export function createOAuthProviderFactory<TProfile>(options: {
   authenticator: OAuthAuthenticator<unknown, TProfile>;
   additionalScopes?: string[];
   stateTransform?: OAuthStateTransform;
-  profileTransform?: ProfileTransform<OAuthAuthenticatorResult<TProfile>>;
+  profileTransform?: ProfileTransform<OAuthAuthenticatorResponse<TProfile>>;
   signInResolver?: SignInResolver<OAuthAuthenticatorResult<TProfile>>;
   signInResolverFactories?: {
     [name in string]: SignInResolverFactory;
@@ -287,9 +287,11 @@ export interface OAuthAuthenticator<TContext, TProfile> {
   authenticate(
     input: OAuthAuthenticatorAuthenticateInput,
     ctx: TContext,
-  ): Promise<OAuthAuthenticatorResult<TProfile>>;
+  ): Promise<OAuthAuthenticatorResponse<TProfile>>;
   // (undocumented)
-  defaultProfileTransform: ProfileTransform<OAuthAuthenticatorResult<TProfile>>;
+  defaultProfileTransform: ProfileTransform<
+    OAuthAuthenticatorResponse<TProfile>
+  >;
   // (undocumented)
   initialize(ctx: { callbackUrl: string; config: Config }): TContext;
   // (undocumented)
@@ -301,7 +303,7 @@ export interface OAuthAuthenticator<TContext, TProfile> {
   refresh(
     input: OAuthAuthenticatorRefreshInput,
     ctx: TContext,
-  ): Promise<OAuthAuthenticatorResult<TProfile>>;
+  ): Promise<OAuthAuthenticatorResponse<TProfile>>;
   // (undocumented)
   scopes?: OAuthAuthenticatorScopeOptions;
   // @deprecated (undocumented)
@@ -346,6 +348,14 @@ export interface OAuthAuthenticatorRefreshInput {
   // (undocumented)
   scope: string;
   scopeAlreadyGranted?: boolean;
+}
+
+// @public
+export interface OAuthAuthenticatorResponse<TProfile> {
+  // (undocumented)
+  fullProfile?: TProfile;
+  // (undocumented)
+  session: OAuthSession;
 }
 
 // @public (undocumented)
@@ -416,7 +426,7 @@ export interface OAuthRouteHandlersOptions<TProfile> {
   // (undocumented)
   isOriginAllowed: (origin: string) => boolean;
   // (undocumented)
-  profileTransform?: ProfileTransform<OAuthAuthenticatorResult<TProfile>>;
+  profileTransform?: ProfileTransform<OAuthAuthenticatorResponse<TProfile>>;
   // (undocumented)
   providerId: string;
   // (undocumented)
@@ -521,10 +531,10 @@ export class PassportOAuthAuthenticatorHelper {
   authenticate(
     input: OAuthAuthenticatorAuthenticateInput,
     options?: Record<string, string>,
-  ): Promise<OAuthAuthenticatorResult<PassportProfile>>;
+  ): Promise<OAuthAuthenticatorResponse<PassportProfile>>;
   // (undocumented)
   static defaultProfileTransform: ProfileTransform<
-    OAuthAuthenticatorResult<PassportProfile>
+    OAuthAuthenticatorResponse<PassportProfile>
   >;
   // (undocumented)
   fetchProfile(accessToken: string): Promise<PassportProfile>;
@@ -533,7 +543,7 @@ export class PassportOAuthAuthenticatorHelper {
   // (undocumented)
   refresh(
     input: OAuthAuthenticatorRefreshInput,
-  ): Promise<OAuthAuthenticatorResult<PassportProfile>>;
+  ): Promise<OAuthAuthenticatorResponse<PassportProfile>>;
   // (undocumented)
   start(
     input: OAuthAuthenticatorStartInput,

--- a/plugins/auth-node/report.api.md
+++ b/plugins/auth-node/report.api.md
@@ -567,7 +567,7 @@ export type PassportOAuthPrivateInfo = {
 
 // @public (undocumented)
 export type PassportOAuthResult = {
-  fullProfile: PassportProfile;
+  fullProfile?: PassportProfile;
   params: {
     id_token?: string;
     scope: string;

--- a/plugins/auth-node/src/oauth/CookieScopeManager.ts
+++ b/plugins/auth-node/src/oauth/CookieScopeManager.ts
@@ -17,7 +17,7 @@
 import express from 'express';
 import {
   OAuthAuthenticator,
-  OAuthAuthenticatorResult,
+  OAuthAuthenticatorResponse,
   OAuthAuthenticatorScopeOptions,
 } from './types';
 import { OAuthCookieManager } from './OAuthCookieManager';
@@ -117,7 +117,7 @@ export class CookieScopeManager {
   async handleCallback(
     req: express.Request,
     ctx: {
-      result: OAuthAuthenticatorResult<any>;
+      result: OAuthAuthenticatorResponse<any>;
       state: OAuthState;
       origin?: string;
     },
@@ -148,7 +148,7 @@ export class CookieScopeManager {
   async refresh(req: express.Request): Promise<{
     scope: string;
     scopeAlreadyGranted?: boolean;
-    commit(result: OAuthAuthenticatorResult<any>): Promise<string>;
+    commit(result: OAuthAuthenticatorResponse<any>): Promise<string>;
   }> {
     const requestScope = splitScope(req.query.scope?.toString());
     const grantedScope = splitScope(this.cookieManager?.getGrantedScopes(req));

--- a/plugins/auth-node/src/oauth/PassportOAuthAuthenticatorHelper.ts
+++ b/plugins/auth-node/src/oauth/PassportOAuthAuthenticatorHelper.ts
@@ -24,7 +24,7 @@ import { ProfileTransform } from '../types';
 import {
   OAuthAuthenticatorAuthenticateInput,
   OAuthAuthenticatorRefreshInput,
-  OAuthAuthenticatorResult,
+  OAuthAuthenticatorResponse,
   OAuthAuthenticatorStartInput,
 } from './types';
 
@@ -54,10 +54,10 @@ export type PassportOAuthDoneCallback = PassportDoneCallback<
 /** @public */
 export class PassportOAuthAuthenticatorHelper {
   static defaultProfileTransform: ProfileTransform<
-    OAuthAuthenticatorResult<PassportProfile>
+    OAuthAuthenticatorResponse<PassportProfile>
   > = async input => ({
     profile: PassportHelpers.transformProfile(
-      input.fullProfile ?? {},
+      (input.fullProfile ?? {}) as PassportProfile,
       input.session.idToken,
     ),
   });
@@ -86,7 +86,7 @@ export class PassportOAuthAuthenticatorHelper {
   async authenticate(
     input: OAuthAuthenticatorAuthenticateInput,
     options?: Record<string, string>,
-  ): Promise<OAuthAuthenticatorResult<PassportProfile>> {
+  ): Promise<OAuthAuthenticatorResponse<PassportProfile>> {
     const { result, privateInfo } =
       await PassportHelpers.executeFrameHandlerStrategy<
         PassportOAuthResult,
@@ -94,7 +94,7 @@ export class PassportOAuthAuthenticatorHelper {
       >(input.req, this.#strategy, options);
 
     return {
-      fullProfile: result.fullProfile as PassportProfile,
+      fullProfile: result.fullProfile,
       session: {
         accessToken: result.accessToken,
         tokenType: result.params.token_type ?? 'bearer',
@@ -108,7 +108,7 @@ export class PassportOAuthAuthenticatorHelper {
 
   async refresh(
     input: OAuthAuthenticatorRefreshInput,
-  ): Promise<OAuthAuthenticatorResult<PassportProfile>> {
+  ): Promise<OAuthAuthenticatorResponse<PassportProfile>> {
     const result = await PassportHelpers.executeRefreshTokenStrategy(
       this.#strategy,
       input.refreshToken,

--- a/plugins/auth-node/src/oauth/PassportOAuthAuthenticatorHelper.ts
+++ b/plugins/auth-node/src/oauth/PassportOAuthAuthenticatorHelper.ts
@@ -30,7 +30,7 @@ import {
 
 /** @public */
 export type PassportOAuthResult = {
-  fullProfile: PassportProfile;
+  fullProfile?: PassportProfile;
   params: {
     id_token?: string;
     scope: string;

--- a/plugins/auth-node/src/oauth/createOAuthProviderFactory.ts
+++ b/plugins/auth-node/src/oauth/createOAuthProviderFactory.ts
@@ -23,7 +23,11 @@ import {
 import { OAuthEnvironmentHandler } from './OAuthEnvironmentHandler';
 import { createOAuthRouteHandlers } from './createOAuthRouteHandlers';
 import { OAuthStateTransform } from './state';
-import { OAuthAuthenticator, OAuthAuthenticatorResult } from './types';
+import {
+  OAuthAuthenticator,
+  OAuthAuthenticatorResponse,
+  OAuthAuthenticatorResult,
+} from './types';
 import { SignInResolverFactory } from '../sign-in/createSignInResolverFactory';
 
 /** @public */
@@ -31,7 +35,7 @@ export function createOAuthProviderFactory<TProfile>(options: {
   authenticator: OAuthAuthenticator<unknown, TProfile>;
   additionalScopes?: string[];
   stateTransform?: OAuthStateTransform;
-  profileTransform?: ProfileTransform<OAuthAuthenticatorResult<TProfile>>;
+  profileTransform?: ProfileTransform<OAuthAuthenticatorResponse<TProfile>>;
   signInResolver?: SignInResolver<OAuthAuthenticatorResult<TProfile>>;
   signInResolverFactories?: {
     [name in string]: SignInResolverFactory;

--- a/plugins/auth-node/src/oauth/createOAuthRouteHandlers.test.ts
+++ b/plugins/auth-node/src/oauth/createOAuthRouteHandlers.test.ts
@@ -1127,6 +1127,51 @@ describe('createOAuthRouteHandlers', () => {
       expect(getRefreshTokenCookie(agent).value).toBe('new-refresh-token');
     });
 
+    it('should skip sign-in resolver when fullProfile is not available', async () => {
+      const signInResolver = jest.fn(async () => ({
+        token: mockBackstageToken,
+      }));
+
+      const agent = request.agent(
+        wrapInApp(
+          createOAuthRouteHandlers({
+            ...baseConfig,
+            profileTransform: async () => ({ profile: { email: 'em@i.l' } }),
+            signInResolver,
+          }),
+        ),
+      );
+
+      agent.jar.setCookie(
+        'my-provider-refresh-token=refresh-token',
+        '127.0.0.1',
+        '/my-provider',
+      );
+
+      mockAuthenticator.refresh.mockImplementation(async ({ scope }) => ({
+        fullProfile: undefined as any,
+        session: { ...mockSession, scope },
+      }));
+
+      const res = await agent
+        .post('/my-provider/refresh')
+        .set('X-Requested-With', 'XMLHttpRequest')
+        .query({ scope: 'my-scope' });
+
+      expect(res.status).toBe(200);
+      expect(signInResolver).not.toHaveBeenCalled();
+      expect(res.body).toEqual({
+        profile: { email: 'em@i.l' },
+        providerInfo: {
+          accessToken: 'access-token',
+          expiresInSeconds: 3,
+          idToken: 'id-token',
+          scope: 'my-scope',
+        },
+      });
+      expect(res.body.backstageIdentity).toBeUndefined();
+    });
+
     it('should forward errors', async () => {
       const agent = request.agent(
         wrapInApp(createOAuthRouteHandlers(baseConfig)),

--- a/plugins/auth-node/src/oauth/createOAuthRouteHandlers.test.ts
+++ b/plugins/auth-node/src/oauth/createOAuthRouteHandlers.test.ts
@@ -777,6 +777,54 @@ describe('createOAuthRouteHandlers', () => {
       );
     });
 
+    it('should fail initial auth when sign-in resolver is configured but fullProfile is missing', async () => {
+      const signInResolver = jest.fn(async () => ({
+        token: mockBackstageToken,
+      }));
+
+      const agent = request.agent(
+        wrapInApp(
+          createOAuthRouteHandlers({
+            ...baseConfig,
+            profileTransform: async () => ({ profile: { email: 'em@i.l' } }),
+            signInResolver,
+          }),
+        ),
+      );
+
+      agent.jar.setCookie(
+        'my-provider-nonce=123',
+        '127.0.0.1',
+        '/my-provider/handler',
+      );
+
+      mockAuthenticator.authenticate.mockResolvedValue({
+        fullProfile: undefined,
+        session: mockSession,
+      });
+
+      const res = await agent.get('/my-provider/handler/frame').query({
+        state: encodeOAuthState({
+          env: 'development',
+          nonce: '123',
+          scope: 'my-scope',
+        } as OAuthState),
+      });
+
+      expect(res.status).toBe(200);
+      expect(signInResolver).not.toHaveBeenCalled();
+      const parsed = parseWebMessageResponse(res.text);
+      expect(parsed.response).toEqual(
+        expect.objectContaining({
+          type: 'authorization_response',
+          error: expect.objectContaining({
+            name: 'Error',
+            message: expect.stringContaining('Sign-in requires a user profile'),
+          }),
+        }),
+      );
+    });
+
     it('should redirect with persisted scope', async () => {
       const agent = request.agent(
         wrapInApp(
@@ -1149,7 +1197,7 @@ describe('createOAuthRouteHandlers', () => {
       );
 
       mockAuthenticator.refresh.mockImplementation(async ({ scope }) => ({
-        fullProfile: undefined as any,
+        fullProfile: undefined,
         session: { ...mockSession, scope },
       }));
 

--- a/plugins/auth-node/src/oauth/createOAuthRouteHandlers.ts
+++ b/plugins/auth-node/src/oauth/createOAuthRouteHandlers.ts
@@ -42,6 +42,7 @@ import {
 import {
   OAuthAuthenticator,
   OAuthAuthenticatorLogoutResult,
+  OAuthAuthenticatorResponse,
   OAuthAuthenticatorResult,
 } from './types';
 import { Config, readDurationFromConfig } from '@backstage/config';
@@ -58,7 +59,7 @@ export interface OAuthRouteHandlersOptions<TProfile> {
   resolverContext: AuthResolverContext;
   additionalScopes?: string[];
   stateTransform?: OAuthStateTransform;
-  profileTransform?: ProfileTransform<OAuthAuthenticatorResult<TProfile>>;
+  profileTransform?: ProfileTransform<OAuthAuthenticatorResponse<TProfile>>;
   cookieConfigurer?: CookieConfigurer;
   signInResolver?: SignInResolver<OAuthAuthenticatorResult<TProfile>>;
 }
@@ -217,6 +218,7 @@ export function createOAuthRouteHandlers<TProfile>(
 
         const signInResult =
           signInResolver &&
+          hasFullProfile(result) &&
           (await signInResolver({ profile, result }, resolverContext));
 
         const grantedScopes = await scopeManager.handleCallback(req, {
@@ -386,7 +388,7 @@ export function createOAuthRouteHandlers<TProfile>(
           },
         };
 
-        if (signInResolver && result.fullProfile) {
+        if (signInResolver && hasFullProfile(result)) {
           const identity = await signInResolver(
             { profile, result },
             resolverContext,
@@ -401,4 +403,10 @@ export function createOAuthRouteHandlers<TProfile>(
       }
     },
   };
+}
+
+function hasFullProfile<TProfile>(
+  result: OAuthAuthenticatorResponse<TProfile>,
+): result is OAuthAuthenticatorResult<TProfile> {
+  return !!result.fullProfile;
 }

--- a/plugins/auth-node/src/oauth/createOAuthRouteHandlers.ts
+++ b/plugins/auth-node/src/oauth/createOAuthRouteHandlers.ts
@@ -216,10 +216,18 @@ export function createOAuthRouteHandlers<TProfile>(
         );
         const { profile } = await profileTransform(result, resolverContext);
 
-        const signInResult =
-          signInResolver &&
-          hasFullProfile(result) &&
-          (await signInResolver({ profile, result }, resolverContext));
+        let signInResult: { token: string } | false | undefined;
+        if (signInResolver) {
+          if (!hasFullProfile(result)) {
+            throw new Error(
+              'Sign-in requires a user profile, but the authenticator did not provide one',
+            );
+          }
+          signInResult = await signInResolver(
+            { profile, result },
+            resolverContext,
+          );
+        }
 
         const grantedScopes = await scopeManager.handleCallback(req, {
           result,
@@ -408,5 +416,5 @@ export function createOAuthRouteHandlers<TProfile>(
 function hasFullProfile<TProfile>(
   result: OAuthAuthenticatorResponse<TProfile>,
 ): result is OAuthAuthenticatorResult<TProfile> {
-  return !!result.fullProfile;
+  return result.fullProfile !== undefined;
 }

--- a/plugins/auth-node/src/oauth/createOAuthRouteHandlers.ts
+++ b/plugins/auth-node/src/oauth/createOAuthRouteHandlers.ts
@@ -386,7 +386,7 @@ export function createOAuthRouteHandlers<TProfile>(
           },
         };
 
-        if (signInResolver) {
+        if (signInResolver && result.fullProfile) {
           const identity = await signInResolver(
             { profile, result },
             resolverContext,

--- a/plugins/auth-node/src/oauth/index.ts
+++ b/plugins/auth-node/src/oauth/index.ts
@@ -39,6 +39,7 @@ export {
   type OAuthAuthenticatorLogoutInput,
   type OAuthAuthenticatorLogoutResult,
   type OAuthAuthenticatorRefreshInput,
+  type OAuthAuthenticatorResponse,
   type OAuthAuthenticatorResult,
   type OAuthAuthenticatorScopeOptions,
   type OAuthAuthenticatorStartInput,

--- a/plugins/auth-node/src/oauth/types.ts
+++ b/plugins/auth-node/src/oauth/types.ts
@@ -92,9 +92,26 @@ export interface OAuthAuthenticatorResult<TProfile> {
   session: OAuthSession;
 }
 
+/**
+ * Similar to {@link OAuthAuthenticatorResult}, but with an optional
+ * `fullProfile`. This is used as the return type for `authenticate` and
+ * `refresh` in {@link OAuthAuthenticator} to allow providers to skip
+ * fetching a user profile, for example when the access token targets
+ * a different resource and cannot be used to call the provider's user
+ * info endpoint.
+ *
+ * @public
+ */
+export interface OAuthAuthenticatorResponse<TProfile> {
+  fullProfile?: TProfile;
+  session: OAuthSession;
+}
+
 /** @public */
 export interface OAuthAuthenticator<TContext, TProfile> {
-  defaultProfileTransform: ProfileTransform<OAuthAuthenticatorResult<TProfile>>;
+  defaultProfileTransform: ProfileTransform<
+    OAuthAuthenticatorResponse<TProfile>
+  >;
   /** @deprecated use `scopes.persist` instead */
   shouldPersistScopes?: boolean;
   scopes?: OAuthAuthenticatorScopeOptions;
@@ -106,11 +123,11 @@ export interface OAuthAuthenticator<TContext, TProfile> {
   authenticate(
     input: OAuthAuthenticatorAuthenticateInput,
     ctx: TContext,
-  ): Promise<OAuthAuthenticatorResult<TProfile>>;
+  ): Promise<OAuthAuthenticatorResponse<TProfile>>;
   refresh(
     input: OAuthAuthenticatorRefreshInput,
     ctx: TContext,
-  ): Promise<OAuthAuthenticatorResult<TProfile>>;
+  ): Promise<OAuthAuthenticatorResponse<TProfile>>;
   logout?(
     input: OAuthAuthenticatorLogoutInput,
     ctx: TContext,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When an OAuth provider skips fetching the user profile during a token refresh (e.g. because the access token targets a different resource like Azure Management API), the sign-in resolver was still invoked and would fail trying to read from an undefined profile.

The framework now skips the sign-in resolver when `fullProfile` is not present, returning only the provider access token without a Backstage identity. This is safe because the identity was already established during the initial sign-in.

This fix relies on the authenticator implicitly signaling that identity resolution should be skipped (by not returning a profile). For the future a more explicit approach could let the frontend opt out of identity resolution.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
