### PR TITLE
Add config to disable experimental public entry point

### DIFF
--- a/.changeset/disable-experimental-public-entrypoint.md
+++ b/.changeset/disable-experimental-public-entrypoint.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-app-backend': patch
 ---
 
-Added a new `app.disableExperimentalPublicEntryPoint` config option that allows you to opt out of the automatic public sign-in entry point. When set to `true`, the app backend will skip serving the public entry point to unauthenticated users, even if the app was bundled with an `index-public-experimental` entry point.
+Added a new `app.disablePublicEntryPoint` config option that allows you to opt out of the automatic public sign-in entry point. When set to `true`, the app backend will skip serving the public entry point to unauthenticated users, even if the app was bundled with an `index-public-experimental` entry point.

--- a/.changeset/disable-experimental-public-entrypoint.md
+++ b/.changeset/disable-experimental-public-entrypoint.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-app-backend': patch
+---
+
+Added a new `app.disableExperimentalPublicEntryPoint` config option that allows you to opt out of the automatic public sign-in entry point. When set to `true`, the app backend will skip serving the public entry point to unauthenticated users, even if the app was bundled with an `index-public-experimental` entry point.

--- a/plugins/app-backend/config.d.ts
+++ b/plugins/app-backend/config.d.ts
@@ -44,12 +44,12 @@ export interface Config {
     disableStaticFallbackCache?: boolean;
 
     /**
-     * Disables the experimental public entry point used for unauthenticated
-     * sign-in pages. When the app is bundled with an
-     * `index-public-experimental` entry point, the app backend will
-     * automatically serve it to unauthenticated users. Set this to `true` to
-     * skip that behavior and always serve the main entry point instead.
+     * Disables the public entry point used for unauthenticated sign-in pages.
+     * When the app is bundled with an `index-public-experimental` entry point,
+     * the app backend will automatically serve it to unauthenticated users.
+     * Set this to `true` to skip that behavior and always serve the main
+     * entry point instead.
      */
-    disableExperimentalPublicEntryPoint?: boolean;
+    disablePublicEntryPoint?: boolean;
   };
 }

--- a/plugins/app-backend/config.d.ts
+++ b/plugins/app-backend/config.d.ts
@@ -42,5 +42,14 @@ export interface Config {
      * If you disable this, it is recommended to set a `staticFallbackHandler` instead.
      */
     disableStaticFallbackCache?: boolean;
+
+    /**
+     * Disables the experimental public entry point used for unauthenticated
+     * sign-in pages. When the app is bundled with an
+     * `index-public-experimental` entry point, the app backend will
+     * automatically serve it to unauthenticated users. Set this to `true` to
+     * skip that behavior and always serve the main entry point instead.
+     */
+    disableExperimentalPublicEntryPoint?: boolean;
   };
 }

--- a/plugins/app-backend/src/service/__fixtures__/app-dir/dist/public/index.html
+++ b/plugins/app-backend/src/service/__fixtures__/app-dir/dist/public/index.html
@@ -1,0 +1,1 @@
+this is public index.html

--- a/plugins/app-backend/src/service/__fixtures__/app-dir/dist/public/static/main.txt
+++ b/plugins/app-backend/src/service/__fixtures__/app-dir/dist/public/static/main.txt
@@ -1,0 +1,1 @@
+this is public main.txt

--- a/plugins/app-backend/src/service/router.test.ts
+++ b/plugins/app-backend/src/service/router.test.ts
@@ -21,7 +21,11 @@ import { resolve as resolvePath } from 'node:path';
 import request from 'supertest';
 import { createRouter } from './router';
 import { loadConfigSchema } from '@backstage/config-loader';
-import { mockServices, TestDatabases } from '@backstage/backend-test-utils';
+import {
+  mockCredentials,
+  mockServices,
+  TestDatabases,
+} from '@backstage/backend-test-utils';
 
 jest.mock('../lib/config', () => ({
   injectConfig: jest.fn(),
@@ -133,6 +137,104 @@ describe('createRouter with static fallback handler', () => {
 
     const response3 = await request(app).get('/static/missing.txt');
     expect(response3.status).toBe(404);
+  });
+});
+
+describe('createRouter with public entry point', () => {
+  let app: express.Express;
+
+  beforeAll(async () => {
+    const router = await createRouter({
+      logger: mockServices.logger.mock(),
+      database: mockServices.database.mock(),
+      auth: mockServices.auth(),
+      httpAuth: mockServices.httpAuth({
+        defaultCredentials: mockCredentials.none(),
+      }),
+      config: mockServices.rootConfig({
+        data: {
+          app: { disableStaticFallbackCache: true },
+        },
+      }),
+      appPackageName: 'example-app',
+    });
+    app = express().use(router);
+  });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('serves the public entry point to unauthenticated users', async () => {
+    const response = await request(app).get('/index.html');
+
+    expect(response.status).toBe(200);
+    expect(response.text.trim()).toBe('this is public index.html');
+  });
+
+  it('serves the main entry point to authenticated users', async () => {
+    const response = await request(app)
+      .get('/index.html')
+      .set('Cookie', mockCredentials.limitedUser.cookie());
+
+    expect(response.status).toBe(200);
+    expect(response.text.trim()).toBe('this is index.html');
+  });
+
+  it('handles sign-in and issues a user cookie', async () => {
+    const response = await request(app)
+      .post('/')
+      .set('Content-Type', 'application/x-www-form-urlencoded')
+      .send(`type=sign-in&token=${mockCredentials.user.token()}`);
+
+    expect(response.status).toBe(200);
+    expect(response.headers['set-cookie']).toBeDefined();
+    expect(response.text.trim()).toBe('this is index.html');
+  });
+
+  it('rejects POST requests without a sign-in type', async () => {
+    const response = await request(app)
+      .post('/')
+      .set('Content-Type', 'application/x-www-form-urlencoded')
+      .send('type=something-else');
+
+    expect(response.status).toBeGreaterThanOrEqual(400);
+  });
+});
+
+describe('createRouter with disablePublicEntryPoint', () => {
+  let app: express.Express;
+
+  beforeAll(async () => {
+    const router = await createRouter({
+      logger: mockServices.logger.mock(),
+      database: mockServices.database.mock(),
+      auth: mockServices.auth(),
+      httpAuth: mockServices.httpAuth({
+        defaultCredentials: mockCredentials.none(),
+      }),
+      config: mockServices.rootConfig({
+        data: {
+          app: {
+            disableStaticFallbackCache: true,
+            disablePublicEntryPoint: true,
+          },
+        },
+      }),
+      appPackageName: 'example-app',
+    });
+    app = express().use(router);
+  });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('serves the main entry point to unauthenticated users', async () => {
+    const response = await request(app).get('/index.html');
+
+    expect(response.status).toBe(200);
+    expect(response.text.trim()).toBe('this is index.html');
   });
 });
 

--- a/plugins/app-backend/src/service/router.test.ts
+++ b/plugins/app-backend/src/service/router.test.ts
@@ -188,7 +188,7 @@ describe('createRouter with public entry point', () => {
       .send(`type=sign-in&token=${mockCredentials.user.token()}`);
 
     expect(response.status).toBe(200);
-    expect(response.headers['set-cookie']).toBeDefined();
+    expect(response.header['set-cookie']).toBeDefined();
     expect(response.text.trim()).toBe('this is index.html');
   });
 
@@ -198,7 +198,7 @@ describe('createRouter with public entry point', () => {
       .set('Content-Type', 'application/x-www-form-urlencoded')
       .send('type=something-else');
 
-    expect(response.status).toBeGreaterThanOrEqual(400);
+    expect(response.status).toBe(500);
   });
 });
 

--- a/plugins/app-backend/src/service/router.ts
+++ b/plugins/app-backend/src/service/router.ts
@@ -153,12 +153,11 @@ export async function createRouter(
 
   const publicDistDir = resolvePath(appDistDir, 'public');
 
-  const disableExperimentalPublicEntryPoint = config.getOptionalBoolean(
-    'app.disableExperimentalPublicEntryPoint',
+  const disablePublicEntryPoint = config.getOptionalBoolean(
+    'app.disablePublicEntryPoint',
   );
   const enablePublicEntryPoint =
-    !disableExperimentalPublicEntryPoint &&
-    (await fs.pathExists(publicDistDir));
+    !disablePublicEntryPoint && (await fs.pathExists(publicDistDir));
 
   if (enablePublicEntryPoint) {
     logger.info(

--- a/plugins/app-backend/src/service/router.ts
+++ b/plugins/app-backend/src/service/router.ts
@@ -153,7 +153,12 @@ export async function createRouter(
 
   const publicDistDir = resolvePath(appDistDir, 'public');
 
-  const enablePublicEntryPoint = await fs.pathExists(publicDistDir);
+  const disableExperimentalPublicEntryPoint = config.getOptionalBoolean(
+    'app.disableExperimentalPublicEntryPoint',
+  );
+  const enablePublicEntryPoint =
+    !disableExperimentalPublicEntryPoint &&
+    (await fs.pathExists(publicDistDir));
 
   if (enablePublicEntryPoint) {
     logger.info(


### PR DESCRIPTION
Adds an `app.disablePublicEntryPoint` config option to the app-backend plugin. When set to `true`, the backend skips serving the public entry point to unauthenticated users even if the app bundle includes a `dist/public` directory from an `index-public-experimental` entry point.

This lets adopters explicitly opt out of the automatic public sign-in page behavior.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))