### PR TITLE
feat(catalog): Add CatalogColumnBlueprint for config-driven catalog table column customization

### DIFF
--- a/.changeset/catalog-column-blueprint.md
+++ b/.changeset/catalog-column-blueprint.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': minor
+---
+
+Added `CatalogColumnBlueprint` for creating catalog table column extensions that attach to the catalog page. This enables adopters to customize, reorder, and extend catalog table columns using the existing `app.extensions` mechanism in `app-config.yaml`. The blueprint also supports a `filter` config option using the standard filter predicate format to control column visibility per entity kind.

--- a/.changeset/catalog-column-extensions.md
+++ b/.changeset/catalog-column-extensions.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': minor
+---
+
+Added default catalog table column extensions using `CatalogColumnBlueprint`. The catalog page now accepts column extensions via a `columns` input, allowing adopters to reorder, disable, or add custom columns through `app.extensions` in `app-config.yaml`.

--- a/docs/features/software-catalog/catalog-customization.md
+++ b/docs/features/software-catalog/catalog-customization.md
@@ -213,12 +213,143 @@ app:
     - catalog-filter:catalog/processing-status: false
 ```
 
-## Customizing columns, actions, and table options
+## Customizing catalog table columns
 
-In the old frontend system, customizing the catalog table columns, row actions,
-and table options was done by passing props directly to the `CatalogIndexPage`
-component. In the new frontend system, these customizations are done by
-overriding the `page:catalog` extension.
+The catalog table ships with a set of built-in columns: Name, System, Owner, Type, Lifecycle, Description, and Tags. Each column is a separate extension using `CatalogColumnBlueprint`, and can be customized, reordered, disabled, or extended using `app-config.yaml`.
+
+The built-in column extension IDs are:
+
+- `catalog-column:catalog/name`
+- `catalog-column:catalog/system`
+- `catalog-column:catalog/owner`
+- `catalog-column:catalog/type`
+- `catalog-column:catalog/lifecycle`
+- `catalog-column:catalog/description`
+- `catalog-column:catalog/tags`
+
+### Disabling columns
+
+To hide specific columns from the catalog table, disable them in config:
+
+```yaml title="app-config.yaml"
+app:
+  extensions:
+    - catalog-column:catalog/tags: false
+    - catalog-column:catalog/lifecycle: false
+```
+
+### Reordering columns
+
+The order in which columns appear in the config determines their order in the table:
+
+```yaml title="app-config.yaml"
+app:
+  extensions:
+    - catalog-column:catalog/owner
+    - catalog-column:catalog/name
+    - catalog-column:catalog/type
+    - catalog-column:catalog/description
+    - catalog-column:catalog/system
+    - catalog-column:catalog/tags
+    - catalog-column:catalog/lifecycle
+```
+
+### Filtering columns per entity kind
+
+Each column extension accepts a `filter` config option that controls when the column is visible based on the currently selected entity kind or type. The filter uses the standard [entity predicate query](#entity-predicate-queries) format.
+
+Show a column only for a specific kind:
+
+```yaml title="app-config.yaml"
+app:
+  extensions:
+    - catalog-column:catalog/type:
+        config:
+          filter:
+            kind: component
+```
+
+Show a column for multiple kinds:
+
+```yaml title="app-config.yaml"
+app:
+  extensions:
+    - catalog-column:catalog/system:
+        config:
+          filter:
+            kind:
+              $in: [component, api, resource]
+```
+
+Hide a column for specific kinds:
+
+```yaml title="app-config.yaml"
+app:
+  extensions:
+    - catalog-column:catalog/description:
+        config:
+          filter:
+            $not:
+              kind:
+                $in: [user, group, location]
+```
+
+The config filter is combined with the column's built-in code filter using a logical AND. This means config can further restrict which kinds a column appears for, but it cannot override the built-in defaults to make a column appear for kinds where it is hidden by default.
+
+### Adding custom columns
+
+To add a custom column, create a column extension using `CatalogColumnBlueprint` in your app or plugin:
+
+```tsx title="packages/app/src/catalog/columns.tsx"
+import { CatalogColumnBlueprint } from '@backstage/plugin-catalog-react/alpha';
+
+const qualityScoreColumn = CatalogColumnBlueprint.make({
+  name: 'quality-score',
+  params: {
+    column: {
+      title: 'Quality Score',
+      field: 'metadata.annotations.quality-score',
+    },
+    filter: ({ kind }) => kind === 'component',
+  },
+});
+
+export default qualityScoreColumn;
+```
+
+Then register the column as a plugin extension or install it directly in the app. The column will automatically attach to the catalog page's `columns` input. You can then control its position via config:
+
+```yaml title="app-config.yaml"
+app:
+  extensions:
+    - catalog-column:catalog/name
+    - catalog-column:default/quality-score
+    - catalog-column:catalog/owner
+```
+
+### Combining customizations
+
+You can combine reordering, disabling, filtering, and custom columns:
+
+```yaml title="app-config.yaml"
+app:
+  extensions:
+    - catalog-column:catalog/name
+    - catalog-column:catalog/owner:
+        config:
+          filter:
+            kind:
+              $in: [component, api, resource]
+    - catalog-column:catalog/type
+    - catalog-column:catalog/description
+    - catalog-column:catalog/system: false
+    - catalog-column:catalog/lifecycle: false
+    - catalog-column:catalog/tags: false
+```
+
+### Advanced column customization
+
+If you need full control over the catalog page including columns, actions, and table options, you can override the entire `page:catalog` extension. This approach replaces the default catalog page with a fully custom implementation.
 
 For example, to customize the catalog index page with custom columns or actions,
 you can override the page extension using a frontend module:

--- a/docs/frontend-system/building-plugins/03-common-extension-blueprints.md
+++ b/docs/frontend-system/building-plugins/03-common-extension-blueprints.md
@@ -71,6 +71,25 @@ Router extensions allow you to replace the router component used by the app. The
 
 These are the [extension blueprints](../architecture/23-extension-blueprints.md) provided by the Catalog plugin.
 
+### CatalogColumn - [Example](https://github.com/backstage/backstage/blob/master/plugins/catalog/src/alpha/columns.tsx)
+
+Creates catalog table columns for the catalog index page. Exported as `CatalogColumnBlueprint`.
+
+Each column extension attaches to the `page:catalog` extension's `columns` input. The blueprint accepts a `column` param (the `TableColumn` definition) and an optional `filter` param (a function that controls visibility based on the currently selected entity kind or type).
+
+Columns support a `filter` config option using the standard [entity predicate query](../../features/software-catalog/catalog-customization.md#entity-predicate-queries) format, allowing adopters to control column visibility per entity kind from `app-config.yaml`:
+
+```yaml
+app:
+  extensions:
+    - catalog-column:catalog/type:
+        config:
+          filter:
+            kind: component
+```
+
+Columns can also be disabled, reordered, or extended via config. See the [catalog customization guide](../../features/software-catalog/catalog-customization.md#customizing-catalog-table-columns) for full details.
+
 ### EntityCard - [Example](https://github.com/backstage/backstage/blob/75e79518eafc6e6eb55585f166667418419662de/plugins/org/src/alpha.tsx#L27-L36)
 
 Creates entity cards to be displayed on the entity pages of the catalog plugin. Exported as `EntityCardBlueprint`.

--- a/docs/getting-started/viewing-catalog.md
+++ b/docs/getting-started/viewing-catalog.md
@@ -55,7 +55,7 @@ For each kind of entity, a set of columns display information regarding the enti
 - `Tags` - an optional field that can be used for searching
 - `Actions` - see [Catalog Actions](#catalog-actions)
 
-You can modify the columns associated with each kind of entity, following the instructions in [Customizing columns, actions, and table options](../features/software-catalog/catalog-customization.md#customizing-columns-actions-and-table-options).
+You can modify the columns associated with each kind of entity, following the instructions in [Customizing catalog table columns](../features/software-catalog/catalog-customization.md#customizing-catalog-table-columns).
 
 ## Catalog Actions
 
@@ -69,7 +69,7 @@ From left to right, the actions are:
 - Edit - Edit the `catalog-info.yaml` file that defines the entity. See [Updating a Component](../getting-started/update-a-component.md)
 - Star - Designate the entity as a favorite. You can [filter](../getting-started/filter-catalog.md) the catalog for starred entities.
 
-[Customizing columns, actions, and table options](../features/software-catalog/catalog-customization.md#customizing-columns-actions-and-table-options) describes how you can modify the actions that are displayed.
+[Customizing catalog table columns](../features/software-catalog/catalog-customization.md#customizing-catalog-table-columns) describes how you can modify the actions that are displayed.
 
 ## Viewing entity details
 

--- a/docs/getting-started/viewing-catalog.md
+++ b/docs/getting-started/viewing-catalog.md
@@ -69,7 +69,7 @@ From left to right, the actions are:
 - Edit - Edit the `catalog-info.yaml` file that defines the entity. See [Updating a Component](../getting-started/update-a-component.md)
 - Star - Designate the entity as a favorite. You can [filter](../getting-started/filter-catalog.md) the catalog for starred entities.
 
-[Customizing catalog table columns](../features/software-catalog/catalog-customization.md#customizing-catalog-table-columns) describes how you can modify the actions that are displayed.
+See [Customizing catalog table columns](../features/software-catalog/catalog-customization.md#customizing-catalog-table-columns) for further customization of the catalog table.
 
 ## Viewing entity details
 

--- a/plugins/catalog-react/report-alpha.api.md
+++ b/plugins/catalog-react/report-alpha.api.md
@@ -29,11 +29,11 @@ import { TranslationRef } from '@backstage/frontend-plugin-api';
 export const CatalogColumnBlueprint: ExtensionBlueprint<{
   kind: 'catalog-column';
   params: {
-    column: TableColumn<any>;
+    column: TableColumn<{}>;
     filter?: CatalogColumnFilterFn;
   };
   output:
-    | ExtensionDataRef<TableColumn<any>, 'catalog.table-column', {}>
+    | ExtensionDataRef<TableColumn<{}>, 'catalog.table-column', {}>
     | ExtensionDataRef<
         CatalogColumnFilterFn,
         'catalog.table-column-filter',
@@ -50,7 +50,7 @@ export const CatalogColumnBlueprint: ExtensionBlueprint<{
   };
   dataRefs: {
     column: ConfigurableExtensionDataRef<
-      TableColumn<any>,
+      TableColumn<{}>,
       'catalog.table-column',
       {}
     >;

--- a/plugins/catalog-react/report-alpha.api.md
+++ b/plugins/catalog-react/report-alpha.api.md
@@ -69,7 +69,7 @@ export interface CatalogColumnFilterContext {
   // (undocumented)
   kind?: string;
   // (undocumented)
-  type?: string;
+  type?: string | string[];
 }
 
 // @alpha

--- a/plugins/catalog-react/report-alpha.api.md
+++ b/plugins/catalog-react/report-alpha.api.md
@@ -21,8 +21,61 @@ import { ReactElement } from 'react';
 import { ReactNode } from 'react';
 import { ResourcePermission } from '@backstage/plugin-permission-common';
 import { RouteRef } from '@backstage/frontend-plugin-api';
+import { TableColumn } from '@backstage/core-components';
 import { TableItem } from '@backstage/ui';
 import { TranslationRef } from '@backstage/frontend-plugin-api';
+
+// @alpha
+export const CatalogColumnBlueprint: ExtensionBlueprint<{
+  kind: 'catalog-column';
+  params: {
+    column: TableColumn<any>;
+    filter?: CatalogColumnFilterFn;
+  };
+  output:
+    | ExtensionDataRef<TableColumn<any>, 'catalog.table-column', {}>
+    | ExtensionDataRef<
+        CatalogColumnFilterFn,
+        'catalog.table-column-filter',
+        {
+          optional: true;
+        }
+      >;
+  inputs: {};
+  config: {
+    filter: FilterPredicate | undefined;
+  };
+  configInput: {
+    filter?: FilterPredicate | undefined;
+  };
+  dataRefs: {
+    column: ConfigurableExtensionDataRef<
+      TableColumn<any>,
+      'catalog.table-column',
+      {}
+    >;
+    filter: ConfigurableExtensionDataRef<
+      CatalogColumnFilterFn,
+      'catalog.table-column-filter',
+      {}
+    >;
+  };
+}>;
+
+// @alpha
+export interface CatalogColumnFilterContext {
+  // (undocumented)
+  entities: Entity[];
+  // (undocumented)
+  kind?: string;
+  // (undocumented)
+  type?: string;
+}
+
+// @alpha
+export type CatalogColumnFilterFn = (
+  context: CatalogColumnFilterContext,
+) => boolean;
 
 // @alpha
 export const CatalogFilterBlueprint: ExtensionBlueprint<{

--- a/plugins/catalog-react/src/alpha/blueprints/CatalogColumnBlueprint.test.tsx
+++ b/plugins/catalog-react/src/alpha/blueprints/CatalogColumnBlueprint.test.tsx
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  CatalogColumnBlueprint,
+  type CatalogColumnFilterContext,
+} from './CatalogColumnBlueprint';
+import { createExtensionTester } from '@backstage/frontend-test-utils';
+
+describe('CatalogColumnBlueprint', () => {
+  const mockColumn = { title: 'Test', field: 'metadata.name' };
+  const ctx = (kind?: string): CatalogColumnFilterContext => ({
+    kind,
+    entities: [],
+  });
+
+  it('should return an extension with sensible defaults', () => {
+    const extension = CatalogColumnBlueprint.make({
+      name: 'test',
+      params: { column: mockColumn },
+    });
+
+    expect(extension).toMatchInlineSnapshot(`
+      {
+        "$$type": "@backstage/ExtensionDefinition",
+        "T": undefined,
+        "attachTo": {
+          "id": "page:catalog",
+          "input": "columns",
+        },
+        "configSchema": {
+          "parse": [Function],
+          "schema": [Function],
+        },
+        "disabled": false,
+        "factory": [Function],
+        "if": undefined,
+        "inputs": {},
+        "kind": "catalog-column",
+        "name": "test",
+        "output": [
+          [Function],
+          {
+            "$$type": "@backstage/ExtensionDataRef",
+            "config": {
+              "optional": true,
+            },
+            "id": "catalog.table-column-filter",
+            "optional": [Function],
+            "toString": [Function],
+          },
+        ],
+        "override": [Function],
+        "toString": [Function],
+        "version": "v2",
+      }
+    `);
+  });
+
+  it('should output the column data ref', () => {
+    const tester = createExtensionTester(
+      CatalogColumnBlueprint.make({
+        name: 'test',
+        params: { column: mockColumn },
+      }),
+    );
+
+    expect(tester.get(CatalogColumnBlueprint.dataRefs.column)).toBe(mockColumn);
+  });
+
+  it('should output the code filter when provided in params', () => {
+    const mockFilter = (_ctx: CatalogColumnFilterContext) => true;
+
+    const tester = createExtensionTester(
+      CatalogColumnBlueprint.make({
+        name: 'test',
+        params: { column: mockColumn, filter: mockFilter },
+      }),
+    );
+
+    expect(tester.get(CatalogColumnBlueprint.dataRefs.filter)).toBe(mockFilter);
+  });
+
+  it('should not output a filter when none is provided', () => {
+    const tester = createExtensionTester(
+      CatalogColumnBlueprint.make({
+        name: 'test',
+        params: { column: mockColumn },
+      }),
+    );
+
+    expect(tester.get(CatalogColumnBlueprint.dataRefs.filter)).toBeUndefined();
+  });
+
+  it('should resolve a config filter predicate object', () => {
+    const tester = createExtensionTester(
+      CatalogColumnBlueprint.make({
+        name: 'test',
+        params: { column: mockColumn },
+      }),
+      { config: { filter: { kind: 'component' } } },
+    );
+
+    const filterFn = tester.get(CatalogColumnBlueprint.dataRefs.filter)!;
+    expect(filterFn(ctx('component'))).toBe(true);
+    expect(filterFn(ctx('user'))).toBe(false);
+    expect(filterFn(ctx(undefined))).toBe(false);
+  });
+
+  it('should support $in operator in config filter', () => {
+    const tester = createExtensionTester(
+      CatalogColumnBlueprint.make({
+        name: 'test',
+        params: { column: mockColumn },
+      }),
+      { config: { filter: { kind: { $in: ['component', 'api'] } } } },
+    );
+
+    const filterFn = tester.get(CatalogColumnBlueprint.dataRefs.filter)!;
+    expect(filterFn(ctx('component'))).toBe(true);
+    expect(filterFn(ctx('api'))).toBe(true);
+    expect(filterFn(ctx('user'))).toBe(false);
+  });
+
+  it('should support $not operator in config filter', () => {
+    const tester = createExtensionTester(
+      CatalogColumnBlueprint.make({
+        name: 'test',
+        params: { column: mockColumn },
+      }),
+      { config: { filter: { $not: { kind: 'user' } } } },
+    );
+
+    const filterFn = tester.get(CatalogColumnBlueprint.dataRefs.filter)!;
+    expect(filterFn(ctx('component'))).toBe(true);
+    expect(filterFn(ctx('user'))).toBe(false);
+  });
+
+  it('should AND config filter with code filter', () => {
+    const codeFilter = (c: CatalogColumnFilterContext) => c.kind !== 'group';
+
+    const tester = createExtensionTester(
+      CatalogColumnBlueprint.make({
+        name: 'test',
+        params: { column: mockColumn, filter: codeFilter },
+      }),
+      { config: { filter: { kind: { $in: ['component', 'group'] } } } },
+    );
+
+    const filterFn = tester.get(CatalogColumnBlueprint.dataRefs.filter)!;
+    // config allows component+group, code blocks group => only component passes
+    expect(filterFn(ctx('component'))).toBe(true);
+    expect(filterFn(ctx('group'))).toBe(false);
+    // config blocks user
+    expect(filterFn(ctx('user'))).toBe(false);
+  });
+
+  it('should ignore string config filter and log deprecation warning', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    const tester = createExtensionTester(
+      CatalogColumnBlueprint.make({
+        name: 'test',
+        params: { column: mockColumn },
+      }),
+      { config: { filter: 'some-string' } },
+    );
+
+    // Access a data ref to trigger factory execution
+    tester.get(CatalogColumnBlueprint.dataRefs.column);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('DEPRECATION WARNING'),
+    );
+    expect(tester.get(CatalogColumnBlueprint.dataRefs.filter)).toBeUndefined();
+
+    warnSpy.mockRestore();
+  });
+});

--- a/plugins/catalog-react/src/alpha/blueprints/CatalogColumnBlueprint.test.tsx
+++ b/plugins/catalog-react/src/alpha/blueprints/CatalogColumnBlueprint.test.tsx
@@ -166,26 +166,4 @@ describe('CatalogColumnBlueprint', () => {
     // config blocks user
     expect(filterFn(ctx('user'))).toBe(false);
   });
-
-  it('should ignore string config filter and log deprecation warning', () => {
-    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
-
-    const tester = createExtensionTester(
-      CatalogColumnBlueprint.make({
-        name: 'test',
-        params: { column: mockColumn },
-      }),
-      { config: { filter: 'some-string' } },
-    );
-
-    // Access a data ref to trigger factory execution
-    tester.get(CatalogColumnBlueprint.dataRefs.column);
-
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('DEPRECATION WARNING'),
-    );
-    expect(tester.get(CatalogColumnBlueprint.dataRefs.filter)).toBeUndefined();
-
-    warnSpy.mockRestore();
-  });
 });

--- a/plugins/catalog-react/src/alpha/blueprints/CatalogColumnBlueprint.ts
+++ b/plugins/catalog-react/src/alpha/blueprints/CatalogColumnBlueprint.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2026 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/catalog-react/src/alpha/blueprints/CatalogColumnBlueprint.ts
+++ b/plugins/catalog-react/src/alpha/blueprints/CatalogColumnBlueprint.ts
@@ -21,11 +21,10 @@ import {
 import { TableColumn } from '@backstage/core-components';
 import { Entity } from '@backstage/catalog-model';
 import {
-  FilterPredicate,
   createZodV4FilterPredicateSchema,
   filterPredicateToFilterFunction,
+  type FilterPredicate,
 } from '@backstage/filter-predicates';
-import { z } from 'zod/v4';
 
 /**
  * Context passed to catalog column filter functions to determine visibility.
@@ -48,7 +47,7 @@ export type CatalogColumnFilterFn = (
 
 /** @alpha */
 export const catalogColumnDataRef = createExtensionDataRef<
-  TableColumn<any>
+  TableColumn<{}>
 >().with({ id: 'catalog.table-column' });
 
 /** @alpha */
@@ -58,21 +57,12 @@ export const catalogColumnFilterDataRef =
   });
 
 function resolveConfigFilter(config: {
-  filter?: FilterPredicate | string;
+  filter?: FilterPredicate;
 }): CatalogColumnFilterFn | undefined {
-  if (typeof config.filter === 'string') {
-    // eslint-disable-next-line no-console
-    console.warn(
-      `DEPRECATION WARNING: Using a string-based filter in the catalog column configuration is deprecated. Use a filter predicate object instead.`,
-    );
-    return undefined;
-  }
   if (config.filter) {
-    const predicateFn =
-      filterPredicateToFilterFunction<CatalogColumnFilterContext>(
-        config.filter,
-      );
-    return predicateFn;
+    return filterPredicateToFilterFunction<CatalogColumnFilterContext>(
+      config.filter,
+    );
   }
   return undefined;
 }
@@ -90,13 +80,11 @@ export const CatalogColumnBlueprint = createExtensionBlueprint({
     filter: catalogColumnFilterDataRef,
   },
   configSchema: {
-    filter: z
-      .union([z.string(), createZodV4FilterPredicateSchema()])
-      .optional(),
+    filter: createZodV4FilterPredicateSchema().optional(),
   },
   *factory(
     params: {
-      column: TableColumn<any>;
+      column: TableColumn<{}>;
       filter?: CatalogColumnFilterFn;
     },
     { config },

--- a/plugins/catalog-react/src/alpha/blueprints/CatalogColumnBlueprint.ts
+++ b/plugins/catalog-react/src/alpha/blueprints/CatalogColumnBlueprint.ts
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  createExtensionBlueprint,
+  createExtensionDataRef,
+} from '@backstage/frontend-plugin-api';
+import { TableColumn } from '@backstage/core-components';
+import { Entity } from '@backstage/catalog-model';
+import {
+  FilterPredicate,
+  createZodV4FilterPredicateSchema,
+  filterPredicateToFilterFunction,
+} from '@backstage/filter-predicates';
+import { z } from 'zod/v4';
+
+/**
+ * Context passed to catalog column filter functions to determine visibility.
+ * @alpha
+ */
+export interface CatalogColumnFilterContext {
+  kind?: string;
+  type?: string;
+  entities: Entity[];
+}
+
+/**
+ * A function that determines whether a column should be visible
+ * given the current catalog table context.
+ * @alpha
+ */
+export type CatalogColumnFilterFn = (
+  context: CatalogColumnFilterContext,
+) => boolean;
+
+/** @alpha */
+export const catalogColumnDataRef = createExtensionDataRef<
+  TableColumn<any>
+>().with({ id: 'catalog.table-column' });
+
+/** @alpha */
+export const catalogColumnFilterDataRef =
+  createExtensionDataRef<CatalogColumnFilterFn>().with({
+    id: 'catalog.table-column-filter',
+  });
+
+function resolveConfigFilter(config: {
+  filter?: FilterPredicate | string;
+}): CatalogColumnFilterFn | undefined {
+  if (typeof config.filter === 'string') {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `DEPRECATION WARNING: Using a string-based filter in the catalog column configuration is deprecated. Use a filter predicate object instead.`,
+    );
+    return undefined;
+  }
+  if (config.filter) {
+    const predicateFn =
+      filterPredicateToFilterFunction<CatalogColumnFilterContext>(
+        config.filter,
+      );
+    return predicateFn;
+  }
+  return undefined;
+}
+
+/**
+ * Creates Catalog Column Extensions for the catalog table.
+ * @alpha
+ */
+export const CatalogColumnBlueprint = createExtensionBlueprint({
+  kind: 'catalog-column',
+  attachTo: { id: 'page:catalog', input: 'columns' },
+  output: [catalogColumnDataRef, catalogColumnFilterDataRef.optional()],
+  dataRefs: {
+    column: catalogColumnDataRef,
+    filter: catalogColumnFilterDataRef,
+  },
+  configSchema: {
+    filter: z
+      .union([z.string(), createZodV4FilterPredicateSchema()])
+      .optional(),
+  },
+  *factory(
+    params: {
+      column: TableColumn<any>;
+      filter?: CatalogColumnFilterFn;
+    },
+    { config },
+  ) {
+    yield catalogColumnDataRef(params.column);
+
+    const configFilter = resolveConfigFilter(config);
+    const combinedFilter = configFilter
+      ? (ctx: CatalogColumnFilterContext) =>
+          configFilter(ctx) && (params.filter ? params.filter(ctx) : true)
+      : params.filter;
+
+    if (combinedFilter) {
+      yield catalogColumnFilterDataRef(combinedFilter);
+    }
+  },
+});

--- a/plugins/catalog-react/src/alpha/blueprints/CatalogColumnBlueprint.ts
+++ b/plugins/catalog-react/src/alpha/blueprints/CatalogColumnBlueprint.ts
@@ -32,7 +32,7 @@ import {
  */
 export interface CatalogColumnFilterContext {
   kind?: string;
-  type?: string;
+  type?: string | string[];
   entities: Entity[];
 }
 

--- a/plugins/catalog-react/src/alpha/blueprints/index.ts
+++ b/plugins/catalog-react/src/alpha/blueprints/index.ts
@@ -13,6 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+export {
+  CatalogColumnBlueprint,
+  type CatalogColumnFilterContext,
+  type CatalogColumnFilterFn,
+} from './CatalogColumnBlueprint';
 export { CatalogFilterBlueprint } from './CatalogFilterBlueprint';
 export { EntityCardBlueprint } from './EntityCardBlueprint';
 export { EntityContentBlueprint } from './EntityContentBlueprint';

--- a/plugins/catalog/report-alpha.api.md
+++ b/plugins/catalog/report-alpha.api.md
@@ -7,6 +7,7 @@ import { AnyApiFactory } from '@backstage/frontend-plugin-api';
 import { AnyRouteRefParams } from '@backstage/frontend-plugin-api';
 import { ApiFactory } from '@backstage/frontend-plugin-api';
 import { ApiHolder } from '@backstage/core-plugin-api';
+import { CatalogColumnFilterFn } from '@backstage/plugin-catalog-react/alpha';
 import { CompoundEntityRef } from '@backstage/catalog-model';
 import { ConfigurableExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { defaultEntityContentGroups } from '@backstage/plugin-catalog-react/alpha';
@@ -331,6 +332,174 @@ const _default: OverridableFrontendPlugin<
       >(
         params: ApiFactory<TApi, TImpl, TDeps>,
       ) => ExtensionBlueprintParams<AnyApiFactory>;
+    }>;
+    'catalog-column:catalog/description': OverridableExtensionDefinition<{
+      kind: 'catalog-column';
+      name: 'description';
+      config: {
+        filter: FilterPredicate | undefined;
+      };
+      configInput: {
+        filter?: FilterPredicate | undefined;
+      };
+      output:
+        | ExtensionDataRef<TableColumn<any>, 'catalog.table-column', {}>
+        | ExtensionDataRef<
+            CatalogColumnFilterFn,
+            'catalog.table-column-filter',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+      params: {
+        column: TableColumn<any>;
+        filter?: CatalogColumnFilterFn;
+      };
+    }>;
+    'catalog-column:catalog/lifecycle': OverridableExtensionDefinition<{
+      kind: 'catalog-column';
+      name: 'lifecycle';
+      config: {
+        filter: FilterPredicate | undefined;
+      };
+      configInput: {
+        filter?: FilterPredicate | undefined;
+      };
+      output:
+        | ExtensionDataRef<TableColumn<any>, 'catalog.table-column', {}>
+        | ExtensionDataRef<
+            CatalogColumnFilterFn,
+            'catalog.table-column-filter',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+      params: {
+        column: TableColumn<any>;
+        filter?: CatalogColumnFilterFn;
+      };
+    }>;
+    'catalog-column:catalog/name': OverridableExtensionDefinition<{
+      kind: 'catalog-column';
+      name: 'name';
+      config: {
+        filter: FilterPredicate | undefined;
+      };
+      configInput: {
+        filter?: FilterPredicate | undefined;
+      };
+      output:
+        | ExtensionDataRef<TableColumn<any>, 'catalog.table-column', {}>
+        | ExtensionDataRef<
+            CatalogColumnFilterFn,
+            'catalog.table-column-filter',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+      params: {
+        column: TableColumn<any>;
+        filter?: CatalogColumnFilterFn;
+      };
+    }>;
+    'catalog-column:catalog/owner': OverridableExtensionDefinition<{
+      kind: 'catalog-column';
+      name: 'owner';
+      config: {
+        filter: FilterPredicate | undefined;
+      };
+      configInput: {
+        filter?: FilterPredicate | undefined;
+      };
+      output:
+        | ExtensionDataRef<TableColumn<any>, 'catalog.table-column', {}>
+        | ExtensionDataRef<
+            CatalogColumnFilterFn,
+            'catalog.table-column-filter',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+      params: {
+        column: TableColumn<any>;
+        filter?: CatalogColumnFilterFn;
+      };
+    }>;
+    'catalog-column:catalog/system': OverridableExtensionDefinition<{
+      kind: 'catalog-column';
+      name: 'system';
+      config: {
+        filter: FilterPredicate | undefined;
+      };
+      configInput: {
+        filter?: FilterPredicate | undefined;
+      };
+      output:
+        | ExtensionDataRef<TableColumn<any>, 'catalog.table-column', {}>
+        | ExtensionDataRef<
+            CatalogColumnFilterFn,
+            'catalog.table-column-filter',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+      params: {
+        column: TableColumn<any>;
+        filter?: CatalogColumnFilterFn;
+      };
+    }>;
+    'catalog-column:catalog/tags': OverridableExtensionDefinition<{
+      kind: 'catalog-column';
+      name: 'tags';
+      config: {
+        filter: FilterPredicate | undefined;
+      };
+      configInput: {
+        filter?: FilterPredicate | undefined;
+      };
+      output:
+        | ExtensionDataRef<TableColumn<any>, 'catalog.table-column', {}>
+        | ExtensionDataRef<
+            CatalogColumnFilterFn,
+            'catalog.table-column-filter',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+      params: {
+        column: TableColumn<any>;
+        filter?: CatalogColumnFilterFn;
+      };
+    }>;
+    'catalog-column:catalog/type': OverridableExtensionDefinition<{
+      kind: 'catalog-column';
+      name: 'type';
+      config: {
+        filter: FilterPredicate | undefined;
+      };
+      configInput: {
+        filter?: FilterPredicate | undefined;
+      };
+      output:
+        | ExtensionDataRef<TableColumn<any>, 'catalog.table-column', {}>
+        | ExtensionDataRef<
+            CatalogColumnFilterFn,
+            'catalog.table-column-filter',
+            {
+              optional: true;
+            }
+          >;
+      inputs: {};
+      params: {
+        column: TableColumn<any>;
+        filter?: CatalogColumnFilterFn;
+      };
     }>;
     'catalog-filter:catalog/kind': OverridableExtensionDefinition<{
       config: {
@@ -1190,6 +1359,25 @@ const _default: OverridableFrontendPlugin<
         >;
         filters: ExtensionInput<
           ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>,
+          {
+            singleton: false;
+            optional: false;
+            internal: false;
+          }
+        >;
+        columns: ExtensionInput<
+          | ConfigurableExtensionDataRef<
+              TableColumn<any>,
+              'catalog.table-column',
+              {}
+            >
+          | ConfigurableExtensionDataRef<
+              CatalogColumnFilterFn,
+              'catalog.table-column-filter',
+              {
+                optional: true;
+              }
+            >,
           {
             singleton: false;
             optional: false;

--- a/plugins/catalog/report-alpha.api.md
+++ b/plugins/catalog/report-alpha.api.md
@@ -343,7 +343,7 @@ const _default: OverridableFrontendPlugin<
         filter?: FilterPredicate | undefined;
       };
       output:
-        | ExtensionDataRef<TableColumn<any>, 'catalog.table-column', {}>
+        | ExtensionDataRef<TableColumn<{}>, 'catalog.table-column', {}>
         | ExtensionDataRef<
             CatalogColumnFilterFn,
             'catalog.table-column-filter',
@@ -353,7 +353,7 @@ const _default: OverridableFrontendPlugin<
           >;
       inputs: {};
       params: {
-        column: TableColumn<any>;
+        column: TableColumn<{}>;
         filter?: CatalogColumnFilterFn;
       };
     }>;
@@ -367,7 +367,7 @@ const _default: OverridableFrontendPlugin<
         filter?: FilterPredicate | undefined;
       };
       output:
-        | ExtensionDataRef<TableColumn<any>, 'catalog.table-column', {}>
+        | ExtensionDataRef<TableColumn<{}>, 'catalog.table-column', {}>
         | ExtensionDataRef<
             CatalogColumnFilterFn,
             'catalog.table-column-filter',
@@ -377,7 +377,7 @@ const _default: OverridableFrontendPlugin<
           >;
       inputs: {};
       params: {
-        column: TableColumn<any>;
+        column: TableColumn<{}>;
         filter?: CatalogColumnFilterFn;
       };
     }>;
@@ -391,7 +391,7 @@ const _default: OverridableFrontendPlugin<
         filter?: FilterPredicate | undefined;
       };
       output:
-        | ExtensionDataRef<TableColumn<any>, 'catalog.table-column', {}>
+        | ExtensionDataRef<TableColumn<{}>, 'catalog.table-column', {}>
         | ExtensionDataRef<
             CatalogColumnFilterFn,
             'catalog.table-column-filter',
@@ -401,7 +401,7 @@ const _default: OverridableFrontendPlugin<
           >;
       inputs: {};
       params: {
-        column: TableColumn<any>;
+        column: TableColumn<{}>;
         filter?: CatalogColumnFilterFn;
       };
     }>;
@@ -415,7 +415,7 @@ const _default: OverridableFrontendPlugin<
         filter?: FilterPredicate | undefined;
       };
       output:
-        | ExtensionDataRef<TableColumn<any>, 'catalog.table-column', {}>
+        | ExtensionDataRef<TableColumn<{}>, 'catalog.table-column', {}>
         | ExtensionDataRef<
             CatalogColumnFilterFn,
             'catalog.table-column-filter',
@@ -425,7 +425,7 @@ const _default: OverridableFrontendPlugin<
           >;
       inputs: {};
       params: {
-        column: TableColumn<any>;
+        column: TableColumn<{}>;
         filter?: CatalogColumnFilterFn;
       };
     }>;
@@ -439,7 +439,7 @@ const _default: OverridableFrontendPlugin<
         filter?: FilterPredicate | undefined;
       };
       output:
-        | ExtensionDataRef<TableColumn<any>, 'catalog.table-column', {}>
+        | ExtensionDataRef<TableColumn<{}>, 'catalog.table-column', {}>
         | ExtensionDataRef<
             CatalogColumnFilterFn,
             'catalog.table-column-filter',
@@ -449,7 +449,7 @@ const _default: OverridableFrontendPlugin<
           >;
       inputs: {};
       params: {
-        column: TableColumn<any>;
+        column: TableColumn<{}>;
         filter?: CatalogColumnFilterFn;
       };
     }>;
@@ -463,7 +463,7 @@ const _default: OverridableFrontendPlugin<
         filter?: FilterPredicate | undefined;
       };
       output:
-        | ExtensionDataRef<TableColumn<any>, 'catalog.table-column', {}>
+        | ExtensionDataRef<TableColumn<{}>, 'catalog.table-column', {}>
         | ExtensionDataRef<
             CatalogColumnFilterFn,
             'catalog.table-column-filter',
@@ -473,7 +473,7 @@ const _default: OverridableFrontendPlugin<
           >;
       inputs: {};
       params: {
-        column: TableColumn<any>;
+        column: TableColumn<{}>;
         filter?: CatalogColumnFilterFn;
       };
     }>;
@@ -487,7 +487,7 @@ const _default: OverridableFrontendPlugin<
         filter?: FilterPredicate | undefined;
       };
       output:
-        | ExtensionDataRef<TableColumn<any>, 'catalog.table-column', {}>
+        | ExtensionDataRef<TableColumn<{}>, 'catalog.table-column', {}>
         | ExtensionDataRef<
             CatalogColumnFilterFn,
             'catalog.table-column-filter',
@@ -497,7 +497,7 @@ const _default: OverridableFrontendPlugin<
           >;
       inputs: {};
       params: {
-        column: TableColumn<any>;
+        column: TableColumn<{}>;
         filter?: CatalogColumnFilterFn;
       };
     }>;
@@ -1367,7 +1367,7 @@ const _default: OverridableFrontendPlugin<
         >;
         columns: ExtensionInput<
           | ConfigurableExtensionDataRef<
-              TableColumn<any>,
+              TableColumn<{}>,
               'catalog.table-column',
               {}
             >

--- a/plugins/catalog/src/alpha/columns.test.tsx
+++ b/plugins/catalog/src/alpha/columns.test.tsx
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  CatalogColumnBlueprint,
+  type CatalogColumnFilterContext,
+  type CatalogColumnFilterFn,
+} from '@backstage/plugin-catalog-react/alpha';
+import { createExtensionTester } from '@backstage/frontend-test-utils';
+import columns from './columns';
+
+const ctx = (kind?: string): CatalogColumnFilterContext => ({
+  kind,
+  entities: [],
+});
+
+function getFilter(extension: any): CatalogColumnFilterFn | undefined {
+  return createExtensionTester(extension).get(
+    CatalogColumnBlueprint.dataRefs.filter,
+  );
+}
+
+describe('default catalog columns', () => {
+  it('should export seven columns', () => {
+    expect(columns).toHaveLength(7);
+  });
+
+  it('should show name column for all kinds', () => {
+    const filter = getFilter(columns[0]);
+    expect(filter).toBeUndefined();
+  });
+
+  it('should hide system column for user, domain, system, group, template, and location kinds', () => {
+    const filter = getFilter(columns[1])!;
+    expect(filter).toBeDefined();
+
+    expect(filter(ctx('component'))).toBe(true);
+    expect(filter(ctx('api'))).toBe(true);
+    expect(filter(ctx(undefined))).toBe(true);
+
+    expect(filter(ctx('user'))).toBe(false);
+    expect(filter(ctx('domain'))).toBe(false);
+    expect(filter(ctx('system'))).toBe(false);
+    expect(filter(ctx('group'))).toBe(false);
+    expect(filter(ctx('template'))).toBe(false);
+    expect(filter(ctx('location'))).toBe(false);
+  });
+
+  it('should hide owner column for user, group, template, and location kinds', () => {
+    const filter = getFilter(columns[2])!;
+    expect(filter).toBeDefined();
+
+    expect(filter(ctx('component'))).toBe(true);
+    expect(filter(ctx('api'))).toBe(true);
+    expect(filter(ctx('domain'))).toBe(true);
+
+    expect(filter(ctx('user'))).toBe(false);
+    expect(filter(ctx('group'))).toBe(false);
+    expect(filter(ctx('template'))).toBe(false);
+    expect(filter(ctx('location'))).toBe(false);
+  });
+
+  it('should hide type column only for user kind', () => {
+    const filter = getFilter(columns[3])!;
+    expect(filter).toBeDefined();
+
+    expect(filter(ctx('component'))).toBe(true);
+    expect(filter(ctx('api'))).toBe(true);
+    expect(filter(ctx('group'))).toBe(true);
+    expect(filter(ctx(undefined))).toBe(true);
+
+    expect(filter(ctx('user'))).toBe(false);
+  });
+
+  it('should hide lifecycle column for user, domain, system, group, template, and location kinds', () => {
+    const filter = getFilter(columns[4])!;
+    expect(filter).toBeDefined();
+
+    expect(filter(ctx('component'))).toBe(true);
+    expect(filter(ctx('api'))).toBe(true);
+
+    expect(filter(ctx('user'))).toBe(false);
+    expect(filter(ctx('domain'))).toBe(false);
+    expect(filter(ctx('system'))).toBe(false);
+    expect(filter(ctx('group'))).toBe(false);
+    expect(filter(ctx('template'))).toBe(false);
+    expect(filter(ctx('location'))).toBe(false);
+  });
+
+  it('should hide description column only for location kind', () => {
+    const filter = getFilter(columns[5])!;
+    expect(filter).toBeDefined();
+
+    expect(filter(ctx('component'))).toBe(true);
+    expect(filter(ctx('user'))).toBe(true);
+    expect(filter(ctx(undefined))).toBe(true);
+
+    expect(filter(ctx('location'))).toBe(false);
+  });
+
+  it('should hide tags column only for location kind', () => {
+    const filter = getFilter(columns[6])!;
+    expect(filter).toBeDefined();
+
+    expect(filter(ctx('component'))).toBe(true);
+    expect(filter(ctx('user'))).toBe(true);
+    expect(filter(ctx(undefined))).toBe(true);
+
+    expect(filter(ctx('location'))).toBe(false);
+  });
+
+  it('should handle case-insensitive kind matching', () => {
+    const systemFilter = getFilter(columns[1])!;
+    expect(systemFilter(ctx('User'))).toBe(false);
+    expect(systemFilter(ctx('USER'))).toBe(false);
+    expect(systemFilter(ctx('Component'))).toBe(true);
+  });
+});

--- a/plugins/catalog/src/alpha/columns.test.tsx
+++ b/plugins/catalog/src/alpha/columns.test.tsx
@@ -29,7 +29,7 @@ const ctx = (kind?: string): CatalogColumnFilterContext => ({
 
 function getFilter(extension: any): CatalogColumnFilterFn | undefined {
   return createExtensionTester(extension).get(
-    CatalogColumnBlueprint.dataRefs.filter,
+    CatalogColumnBlueprint.dataRefs.filter.optional(),
   );
 }
 

--- a/plugins/catalog/src/alpha/columns.tsx
+++ b/plugins/catalog/src/alpha/columns.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Backstage Authors
+ * Copyright 2026 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/catalog/src/alpha/columns.tsx
+++ b/plugins/catalog/src/alpha/columns.tsx
@@ -18,7 +18,10 @@ import {
   CatalogColumnBlueprint,
   type CatalogColumnFilterContext,
 } from '@backstage/plugin-catalog-react/alpha';
+import { type TableColumn } from '@backstage/core-components';
 import { columnFactories } from '../components/CatalogTable/columns';
+
+const col = (c: TableColumn<any>): TableColumn<{}> => c;
 
 const kindsWithoutSystem = [
   'user',
@@ -46,14 +49,14 @@ function hideForKinds(kinds: string[]) {
 const catalogNameColumn = CatalogColumnBlueprint.make({
   name: 'name',
   params: {
-    column: columnFactories.createNameColumn(),
+    column: col(columnFactories.createNameColumn()),
   },
 });
 
 const catalogSystemColumn = CatalogColumnBlueprint.make({
   name: 'system',
   params: {
-    column: columnFactories.createSystemColumn(),
+    column: col(columnFactories.createSystemColumn()),
     filter: hideForKinds(kindsWithoutSystem),
   },
 });
@@ -61,7 +64,7 @@ const catalogSystemColumn = CatalogColumnBlueprint.make({
 const catalogOwnerColumn = CatalogColumnBlueprint.make({
   name: 'owner',
   params: {
-    column: columnFactories.createOwnerColumn(),
+    column: col(columnFactories.createOwnerColumn()),
     filter: hideForKinds(kindsWithoutOwner),
   },
 });
@@ -69,7 +72,7 @@ const catalogOwnerColumn = CatalogColumnBlueprint.make({
 const catalogTypeColumn = CatalogColumnBlueprint.make({
   name: 'type',
   params: {
-    column: columnFactories.createSpecTypeColumn(),
+    column: col(columnFactories.createSpecTypeColumn()),
     filter: ({ kind }) => {
       if (!kind) return true;
       const k = kind.toLocaleLowerCase('en-US');
@@ -81,7 +84,7 @@ const catalogTypeColumn = CatalogColumnBlueprint.make({
 const catalogLifecycleColumn = CatalogColumnBlueprint.make({
   name: 'lifecycle',
   params: {
-    column: columnFactories.createSpecLifecycleColumn(),
+    column: col(columnFactories.createSpecLifecycleColumn()),
     filter: hideForKinds(kindsWithoutLifecycle),
   },
 });
@@ -89,7 +92,7 @@ const catalogLifecycleColumn = CatalogColumnBlueprint.make({
 const catalogDescriptionColumn = CatalogColumnBlueprint.make({
   name: 'description',
   params: {
-    column: columnFactories.createMetadataDescriptionColumn(),
+    column: col(columnFactories.createMetadataDescriptionColumn()),
     filter: ({ kind }) => {
       if (!kind) return true;
       return kind.toLocaleLowerCase('en-US') !== 'location';
@@ -100,7 +103,7 @@ const catalogDescriptionColumn = CatalogColumnBlueprint.make({
 const catalogTagsColumn = CatalogColumnBlueprint.make({
   name: 'tags',
   params: {
-    column: columnFactories.createTagsColumn(),
+    column: col(columnFactories.createTagsColumn()),
     filter: ({ kind }) => {
       if (!kind) return true;
       return kind.toLocaleLowerCase('en-US') !== 'location';

--- a/plugins/catalog/src/alpha/columns.tsx
+++ b/plugins/catalog/src/alpha/columns.tsx
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  CatalogColumnBlueprint,
+  type CatalogColumnFilterContext,
+} from '@backstage/plugin-catalog-react/alpha';
+import { columnFactories } from '../components/CatalogTable/columns';
+
+const kindsWithoutSystem = [
+  'user',
+  'domain',
+  'system',
+  'group',
+  'template',
+  'location',
+];
+const kindsWithoutLifecycle = [
+  'user',
+  'domain',
+  'system',
+  'group',
+  'template',
+  'location',
+];
+const kindsWithoutOwner = ['user', 'group', 'template', 'location'];
+
+function hideForKinds(kinds: string[]) {
+  return ({ kind }: CatalogColumnFilterContext) =>
+    !kind || !kinds.includes(kind.toLocaleLowerCase('en-US'));
+}
+
+const catalogNameColumn = CatalogColumnBlueprint.make({
+  name: 'name',
+  params: {
+    column: columnFactories.createNameColumn(),
+  },
+});
+
+const catalogSystemColumn = CatalogColumnBlueprint.make({
+  name: 'system',
+  params: {
+    column: columnFactories.createSystemColumn(),
+    filter: hideForKinds(kindsWithoutSystem),
+  },
+});
+
+const catalogOwnerColumn = CatalogColumnBlueprint.make({
+  name: 'owner',
+  params: {
+    column: columnFactories.createOwnerColumn(),
+    filter: hideForKinds(kindsWithoutOwner),
+  },
+});
+
+const catalogTypeColumn = CatalogColumnBlueprint.make({
+  name: 'type',
+  params: {
+    column: columnFactories.createSpecTypeColumn(),
+    filter: ({ kind }) => {
+      if (!kind) return true;
+      const k = kind.toLocaleLowerCase('en-US');
+      return k !== 'user';
+    },
+  },
+});
+
+const catalogLifecycleColumn = CatalogColumnBlueprint.make({
+  name: 'lifecycle',
+  params: {
+    column: columnFactories.createSpecLifecycleColumn(),
+    filter: hideForKinds(kindsWithoutLifecycle),
+  },
+});
+
+const catalogDescriptionColumn = CatalogColumnBlueprint.make({
+  name: 'description',
+  params: {
+    column: columnFactories.createMetadataDescriptionColumn(),
+    filter: ({ kind }) => {
+      if (!kind) return true;
+      return kind.toLocaleLowerCase('en-US') !== 'location';
+    },
+  },
+});
+
+const catalogTagsColumn = CatalogColumnBlueprint.make({
+  name: 'tags',
+  params: {
+    column: columnFactories.createTagsColumn(),
+    filter: ({ kind }) => {
+      if (!kind) return true;
+      return kind.toLocaleLowerCase('en-US') !== 'location';
+    },
+  },
+});
+
+export default [
+  catalogNameColumn,
+  catalogSystemColumn,
+  catalogOwnerColumn,
+  catalogTypeColumn,
+  catalogLifecycleColumn,
+  catalogDescriptionColumn,
+  catalogTagsColumn,
+];

--- a/plugins/catalog/src/alpha/pages.tsx
+++ b/plugins/catalog/src/alpha/pages.tsx
@@ -34,12 +34,18 @@ import {
   EntityContextMenuItemBlueprint,
   EntityHeaderBlueprint,
   EntityContentGroupDefinitions,
+  type CatalogColumnFilterContext,
 } from '@backstage/plugin-catalog-react/alpha';
 import CategoryIcon from '@material-ui/icons/Category';
 import { rootRouteRef } from '../routes';
 import { useEntityFromUrl } from '../components/CatalogEntityPage/useEntityFromUrl';
 import { buildFilterFn } from './filter/FilterWrapper';
 import type { CatalogExportSettings } from '../components/CatalogExportButton';
+import { type TableColumn } from '@backstage/core-components';
+import type {
+  CatalogTableColumnsFunc,
+  CatalogTableRow,
+} from '../components/CatalogTable/types';
 
 const catalogExportConfigDataRef = createExtensionDataRef<{
   exporters?: CatalogExportSettings['exporters'];
@@ -119,19 +125,22 @@ export const catalogPage = PageBlueprint.makeWithOverrides({
           filter: col.get(CatalogColumnBlueprint.dataRefs.filter),
         }));
 
-        const columnsFunc =
-          columnEntries.length > 0
-            ? ({ filters: entityFilters, entities }: any) => {
-                const context = {
-                  kind: entityFilters.kind?.value,
-                  type: entityFilters.type?.value,
-                  entities,
-                };
-                return columnEntries
-                  .filter(entry => !entry.filter || entry.filter(context))
-                  .map(entry => entry.column);
-              }
-            : undefined;
+        const columnsFunc: CatalogTableColumnsFunc = ({
+          filters: entityFilters,
+          entities,
+        }) => {
+          const typeValue = entityFilters.type?.value;
+          const context: CatalogColumnFilterContext = {
+            kind: entityFilters.kind?.value,
+            type: Array.isArray(typeValue) ? typeValue[0] : typeValue,
+            entities,
+          };
+          return columnEntries
+            .filter(entry => !entry.filter || entry.filter(context))
+            .map(
+              entry => entry.column,
+            ) as unknown as TableColumn<CatalogTableRow>[];
+        };
 
         // Merge export customizers from all attached extensions
         const mergedExportSettings: CatalogExportSettings = {

--- a/plugins/catalog/src/alpha/pages.tsx
+++ b/plugins/catalog/src/alpha/pages.tsx
@@ -129,10 +129,9 @@ export const catalogPage = PageBlueprint.makeWithOverrides({
           filters: entityFilters,
           entities,
         }) => {
-          const typeValue = entityFilters.type?.value;
           const context: CatalogColumnFilterContext = {
             kind: entityFilters.kind?.value,
-            type: Array.isArray(typeValue) ? typeValue[0] : typeValue,
+            type: entityFilters.type?.value,
             entities,
           };
           return columnEntries

--- a/plugins/catalog/src/alpha/pages.tsx
+++ b/plugins/catalog/src/alpha/pages.tsx
@@ -28,6 +28,7 @@ import {
   entityRouteRef,
 } from '@backstage/plugin-catalog-react';
 import {
+  CatalogColumnBlueprint,
   defaultEntityContentGroupDefinitions,
   EntityContentBlueprint,
   EntityContextMenuItemBlueprint,
@@ -70,6 +71,10 @@ export const CatalogExportConfigBlueprint = createExtensionBlueprint({
 export const catalogPage = PageBlueprint.makeWithOverrides({
   inputs: {
     filters: createExtensionInput([coreExtensionData.reactElement]),
+    columns: createExtensionInput([
+      CatalogColumnBlueprint.dataRefs.column,
+      CatalogColumnBlueprint.dataRefs.filter.optional(),
+    ]),
     exportConfig: createExtensionInput([catalogExportConfigDataRef.optional()]),
   },
   configSchema: {
@@ -109,6 +114,25 @@ export const catalogPage = PageBlueprint.makeWithOverrides({
           filter.get(coreExtensionData.reactElement),
         );
 
+        const columnEntries = inputs.columns.map(col => ({
+          column: col.get(CatalogColumnBlueprint.dataRefs.column),
+          filter: col.get(CatalogColumnBlueprint.dataRefs.filter),
+        }));
+
+        const columnsFunc =
+          columnEntries.length > 0
+            ? ({ filters: entityFilters, entities }: any) => {
+                const context = {
+                  kind: entityFilters.kind?.value,
+                  type: entityFilters.type?.value,
+                  entities,
+                };
+                return columnEntries
+                  .filter(entry => !entry.filter || entry.filter(context))
+                  .map(entry => entry.column);
+              }
+            : undefined;
+
         // Merge export customizers from all attached extensions
         const mergedExportSettings: CatalogExportSettings = {
           ...config.exportSettings,
@@ -138,6 +162,7 @@ export const catalogPage = PageBlueprint.makeWithOverrides({
         return (
           <NfsDefaultCatalogPage
             filters={<>{filters}</>}
+            columns={columnsFunc}
             pagination={config.pagination}
             exportSettings={
               mergedExportSettings.enabled ? mergedExportSettings : undefined

--- a/plugins/catalog/src/alpha/plugin.tsx
+++ b/plugins/catalog/src/alpha/plugin.tsx
@@ -28,6 +28,7 @@ import {
 
 import apis from './apis';
 import pages from './pages';
+import columns from './columns';
 import filters from './filters';
 import entityCards from './entityCards';
 import entityContents from './entityContents';
@@ -56,6 +57,7 @@ export default createFrontendPlugin({
   extensions: [
     ...apis,
     ...pages,
+    ...columns,
     ...filters,
     ...entityCards,
     ...entityContents,


### PR DESCRIPTION
## Description

This PR introduces `CatalogColumnBlueprint` in `@backstage/plugin-catalog-react`, enabling catalog table columns to be defined as individual frontend extensions. The catalog page now accepts column extensions via a `columns` input, allowing adopters to customize the catalog table entirely through `app-config.yaml`.

### What's included

**`@backstage/plugin-catalog-react`**
- New `CatalogColumnBlueprint` for creating catalog table column extensions
- Supports a `filter` config option using the standard filter predicate format to control column visibility per entity kind
- Exports `CatalogColumnFilterContext` and `CatalogColumnFilterFn` types

**`@backstage/plugin-catalog`**
- Built-in columns (Name, System, Owner, Type, Lifecycle, Description, Tags) are now defined as individual `CatalogColumnBlueprint` extensions
- The catalog page accepts column extensions via a new `columns` input
- Default per-kind visibility is preserved (e.g., System/Lifecycle hidden for User/Group kinds)

**Documentation**
- Added "Customizing catalog table columns" section to catalog customization docs
- Added `CatalogColumn` entry to common extension blueprints reference

### Built-in column extension IDs

- `catalog-column:catalog/name`
- `catalog-column:catalog/system`
- `catalog-column:catalog/owner`
- `catalog-column:catalog/type`
- `catalog-column:catalog/lifecycle`
- `catalog-column:catalog/description`
- `catalog-column:catalog/tags`

### Configuration use cases

#### 1. Disabling columns

Hide columns you don't need:

~~~yaml
app:
  extensions:
    - catalog-column:catalog/tags: false
    - catalog-column:catalog/lifecycle: false
~~~
<img width="2560" height="1440" alt="Screenshot 2026-05-26 at 5 02 43 PM (2)" src="https://github.com/user-attachments/assets/d47a5e4a-cab7-4530-b2b3-2ac5dcd25f18" />

#### 2. Reordering columns

The order in config determines the order in the table:

~~~yaml
app:
  extensions:
    - catalog-column:catalog/owner
    - catalog-column:catalog/name
    - catalog-column:catalog/type
    - catalog-column:catalog/description
    - catalog-column:catalog/system
    - catalog-column:catalog/tags
    - catalog-column:catalog/lifecycle
~~~
<img width="2560" height="1440" alt="Screenshot 2026-05-26 at 5 05 20 PM (2)" src="https://github.com/user-attachments/assets/73fffeef-dd95-45ef-b4a8-09964c2abbc8" />

#### 3. Show a column only for a specific kind

~~~yaml
app:
  extensions:
    - catalog-column:catalog/type:
        config:
          filter:
            kind: component
~~~

https://github.com/user-attachments/assets/90e4e0f5-fa2c-4983-9e45-b3861f1e2cb3


#### 4. Show a column for multiple kinds using `$in`

~~~yaml
app:
  extensions:
    - catalog-column:catalog/system:
        config:
          filter:
            kind:
              $in: [component, api, resource]
~~~

https://github.com/user-attachments/assets/9b9c31e6-6131-466c-aac1-da0949e13040


#### 5. Hide a column for specific kinds using `$not`

~~~yaml
app:
  extensions:
    - catalog-column:catalog/description:
        config:
          filter:
            $not:
              kind:
                $in: [user, group, location]
~~~

https://github.com/user-attachments/assets/c45a5c1f-b391-4c82-8fb6-12e8327c6a7a


#### 6. Adding a custom column (code + config) ( [test commit](https://github.com/its-mitesh-kumar/backstage/pull/4/changes/589b0e32589d68d63c602ad59b28d2ffd433f294) )

Define a custom column extension in code:

~~~tsx
import { CatalogColumnBlueprint } from '@backstage/plugin-catalog-react/alpha';

const namespaceColumn = CatalogColumnBlueprint.make({
  name: 'namespace',
  params: {
    column: {
      title: 'Namespace',
      field: 'metadata.namespace',
      render: (entity: any) =>{
        return entity?.entity?.metadata?.namespace ?? 'N/A'
      }
    },
    // filter: ({ kind }) => kind === 'component',
  },
});

export default namespaceColumn;

~~~

Then position it alongside built-in columns via config:

~~~yaml
app:
  extensions:
    - catalog-column:catalog/name
    - catalog-column:catalog/namespace
    - catalog-column:catalog/owner
    - catalog-column:catalog/type
    - catalog-column:catalog/system
    - catalog-column:catalog/lifecycle
    - catalog-column:catalog/description
    - catalog-column:catalog/tags
~~~

https://github.com/user-attachments/assets/06a7d01c-0b58-4e32-83e7-29a3636b6320


#### 7. Combining all customizations together

Reorder, disable, filter, and add custom columns in a single config:

~~~yaml
app:
  extensions:
    - catalog-column:catalog/name
    - catalog-column:catalog/owner:
        config:
          filter:
            kind:
              $in: [component, api, resource]
    - catalog-column:catalog/type
    - catalog-column:catalog/description
    - catalog-column:catalog/system: false
    - catalog-column:catalog/lifecycle: false
    - catalog-column:catalog/tags: false
~~~

### How config filters interact with code filters

The config `filter` is combined with the column's built-in code filter using a logical AND. This means:
- Config can **further restrict** which kinds a column appears for
- Config **cannot override** built-in defaults to make a column appear for kinds where it is hidden by code

For example, if a column's code hides it for `user` and `group` kinds, a config filter of `{ kind: user }` would result in the column not being shown at all (both filters must pass).

### Without any config

When no column configuration is specified in `app-config.yaml`, the catalog table behaves exactly as before — all built-in columns are shown with their default per-kind visibility rules (e.g., System and Lifecycle columns are hidden for User/Group/Location kinds).

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.
<!--- Please include the following in your Pull Request when applicable: -->

