### PR TITLE
Bitbucket username should not be treated as a secret

### DIFF
--- a/.changeset/fix-visibility-for-bitbucket-config-parameter.md
+++ b/.changeset/fix-visibility-for-bitbucket-config-parameter.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Changed visibility of Bitbucket username as it is not a secret.

--- a/packages/integration/config.d.ts
+++ b/packages/integration/config.d.ts
@@ -115,7 +115,6 @@ export interface Config {
     bitbucketCloud?: Array<{
       /**
        * The username to use for authenticated requests.
-       * @visibility secret
        */
       username?: string;
       /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The username field in the Bitbucket integration shows up masked, i.e. "*****". This PR updates that to be shown as clear text.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
