### PR TITLE
feat(ui): add controlled input and loading state for server-side filtering

### DIFF
--- a/.changeset/server-side-filter-support.md
+++ b/.changeset/server-side-filter-support.md
@@ -1,0 +1,7 @@
+---
+'@backstage/ui': patch
+---
+
+Added controlled input and loading-state props to `Combobox`, `Select`, `MenuAutocomplete`, and `MenuAutocompleteListbox` so that server-side / async filtering can be wired up without reimplementing the components. When the controlled input value is set, the built-in client-side filter is disabled and the parent is expected to supply the filtered options. A new `isLoading` prop shows a "Searching..." indicator while results are being fetched.
+
+**Affected components:** Combobox, Select, MenuAutocomplete, MenuAutocompleteListbox

--- a/docs-ui/src/app/components/combobox/components.tsx
+++ b/docs-ui/src/app/components/combobox/components.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { Combobox } from '../../../../../packages/ui/src/components/Combobox/Combobox';
 import { Flex } from '../../../../../packages/ui/src/components/Flex/Flex';
 import { RiCloudLine } from '@remixicon/react';
@@ -139,6 +140,47 @@ export const DisabledOption = () => (
     style={{ width: 300 }}
   />
 );
+
+export const ServerSideFiltering = () => {
+  const [inputValue, setInputValue] = useState('');
+  const [options, setOptions] = useState(countries);
+  const [isLoading, setIsLoading] = useState(false);
+  const abortRef = useRef<AbortController>();
+
+  const handleInputChange = useCallback((value: string) => {
+    setInputValue(value);
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setIsLoading(true);
+    const timer = setTimeout(() => {
+      if (!controller.signal.aborted) {
+        setOptions(
+          countries.filter(c =>
+            c.label.toLowerCase().includes(value.toLowerCase()),
+          ),
+        );
+        setIsLoading(false);
+      }
+    }, 500);
+    controller.signal.addEventListener('abort', () => clearTimeout(timer));
+  }, []);
+
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  return (
+    <Combobox
+      label="Country"
+      name="country"
+      placeholder="Search countries..."
+      inputValue={inputValue}
+      onInputChange={handleInputChange}
+      options={options}
+      isLoading={isLoading}
+      style={{ width: 300 }}
+    />
+  );
+};
 
 export const WithSections = () => (
   <Combobox

--- a/docs-ui/src/app/components/combobox/page.mdx
+++ b/docs-ui/src/app/components/combobox/page.mdx
@@ -11,6 +11,7 @@ import {
   DisabledOption,
   AllowsCustomValue,
   WithSections,
+  ServerSideFiltering,
 } from './components';
 import { comboboxPropDefs } from './props-definition';
 import {
@@ -28,6 +29,7 @@ import {
   comboboxDisabledOptionsSnippet,
   comboboxCustomValueSnippet,
   comboboxSectionsSnippet,
+  comboboxServerSideSnippet,
 } from './snippets';
 import { PageTitle } from '@/components/PageTitle';
 import { Theming } from '@/components/Theming';
@@ -140,6 +142,19 @@ nested `options` array.
   open
   preview={<WithSections />}
   code={comboboxSectionsSnippet}
+/>
+
+### Server-side filtering
+
+Control the input value and supply pre-filtered options from a server or async
+source. When `inputValue` is set the built-in client-side filter is disabled.
+Use `isLoading` to show a loading indicator while results are being fetched.
+
+<Snippet
+  layout="side-by-side"
+  open
+  preview={<ServerSideFiltering />}
+  code={comboboxServerSideSnippet}
 />
 
 ### Responsive

--- a/docs-ui/src/app/components/combobox/props-definition.tsx
+++ b/docs-ui/src/app/components/combobox/props-definition.tsx
@@ -47,7 +47,13 @@ export const comboboxPropDefs: Record<string, PropDef> = {
   onInputChange: {
     type: 'enum',
     values: ['(value: string) => void'],
-    description: 'Called when the input text changes.',
+    description:
+      'Called when the input text changes. When both inputValue and onInputChange are set, the built-in client-side filter is disabled so you can supply server-filtered options.',
+  },
+  isLoading: {
+    type: 'boolean',
+    description:
+      'Whether results are currently loading. Shows a loading indicator in the dropdown and dims existing items.',
   },
   label: {
     type: 'string',

--- a/docs-ui/src/app/components/combobox/snippets.ts
+++ b/docs-ui/src/app/components/combobox/snippets.ts
@@ -90,6 +90,31 @@ export const comboboxCustomValueSnippet = `<Combobox
   ]}
 />`;
 
+export const comboboxServerSideSnippet = `import { Combobox } from '@backstage/ui';
+import { useAsyncList } from 'react-aria-components';
+
+function ServerSideCombobox() {
+  const list = useAsyncList({
+    async load({ filterText, signal }) {
+      const res = await fetch(\`/api/items?q=\${filterText}\`, { signal });
+      const items = await res.json();
+      return { items };
+    },
+  });
+
+  return (
+    <Combobox
+      label="Country"
+      name="country"
+      placeholder="Search countries..."
+      inputValue={list.filterText}
+      onInputChange={list.setFilterText}
+      options={list.items}
+      isLoading={list.isLoading}
+    />
+  );
+}`;
+
 export const comboboxSectionsSnippet = `<Combobox
   name="font"
   label="Font Family"

--- a/docs-ui/src/app/components/menu/components.tsx
+++ b/docs-ui/src/app/components/menu/components.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState, useEffect, useRef, useCallback } from 'react';
 import {
   MenuTrigger,
   Menu,
@@ -138,6 +139,66 @@ export const PreviewAutocompleteMenu = () => (
     </MenuTrigger>
   </MemoryRouter>
 );
+
+const autocompleteOptions = [
+  { value: 'apple', label: 'Apple' },
+  { value: 'banana', label: 'Banana' },
+  { value: 'cherry', label: 'Cherry' },
+  { value: 'grape', label: 'Grape' },
+  { value: 'mango', label: 'Mango' },
+  { value: 'orange', label: 'Orange' },
+  { value: 'peach', label: 'Peach' },
+  { value: 'pear', label: 'Pear' },
+  { value: 'strawberry', label: 'Strawberry' },
+];
+
+export const PreviewAutocompleteServerSide = () => {
+  const [inputValue, setInputValue] = useState('');
+  const [items, setItems] = useState(autocompleteOptions);
+  const [isLoading, setIsLoading] = useState(false);
+  const abortRef = useRef<AbortController>();
+
+  const handleInputChange = useCallback((value: string) => {
+    setInputValue(value);
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setIsLoading(true);
+    const timer = setTimeout(() => {
+      if (!controller.signal.aborted) {
+        setItems(
+          autocompleteOptions.filter(o =>
+            o.label.toLowerCase().includes(value.toLowerCase()),
+          ),
+        );
+        setIsLoading(false);
+      }
+    }, 500);
+    controller.signal.addEventListener('abort', () => clearTimeout(timer));
+  }, []);
+
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  return (
+    <MemoryRouter>
+      <MenuTrigger>
+        <Button variant="secondary">Search</Button>
+        <MenuAutocomplete
+          placeholder="Type to search..."
+          inputValue={inputValue}
+          onInputChange={handleInputChange}
+          isLoading={isLoading}
+        >
+          {items.map(option => (
+            <MenuItem key={option.value} id={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </MenuAutocomplete>
+      </MenuTrigger>
+    </MemoryRouter>
+  );
+};
 
 export const PreviewAutocompleteListbox = () => (
   <MemoryRouter>

--- a/docs-ui/src/app/components/menu/page.mdx
+++ b/docs-ui/src/app/components/menu/page.mdx
@@ -11,6 +11,7 @@ import {
   PreviewAutocompleteMenu,
   PreviewAutocompleteListbox,
   PreviewAutocompleteListboxMultiple,
+  PreviewAutocompleteServerSide,
 } from './components';
 import {
   menuTriggerPropDefs,
@@ -35,6 +36,7 @@ import {
   autocomplete,
   autocompleteListbox,
   autocompleteListboxMultiple,
+  autocompleteServerSide,
 } from './snippets';
 import { PageTitle } from '@/components/PageTitle';
 import { Theming } from '@/components/Theming';
@@ -202,6 +204,21 @@ The `href` prop works with both internal and external links.
   open
   preview={<PreviewAutocompleteMenu />}
   code={autocomplete}
+/>
+
+### Server-side autocomplete
+
+Control the search input value and supply pre-filtered items from a server or
+async source. When `inputValue` is set the built-in client-side filter is
+disabled. Use `isLoading` to show a loading indicator while results are being
+fetched. This pattern works for both `MenuAutocomplete` and
+`MenuAutocompleteListbox`.
+
+<Snippet
+  layout="side-by-side"
+  open
+  preview={<PreviewAutocompleteServerSide />}
+  code={autocompleteServerSide}
 />
 
 ### With list box

--- a/docs-ui/src/app/components/menu/props-definition.tsx
+++ b/docs-ui/src/app/components/menu/props-definition.tsx
@@ -151,6 +151,21 @@ export const menuAutocompletePropDefs: Record<string, PropDef> = {
     type: 'string',
     description: 'Placeholder text for the search input.',
   },
+  inputValue: {
+    type: 'string',
+    description:
+      'Controlled search input value. When set, disables the built-in client-side filter so you can supply server-filtered items.',
+  },
+  onInputChange: {
+    type: 'enum',
+    values: ['(value: string) => void'],
+    description: 'Called when the search input value changes.',
+  },
+  isLoading: {
+    type: 'boolean',
+    description:
+      'Whether results are currently loading. Shows a loading indicator and dims existing items.',
+  },
   placement: {
     type: 'enum',
     values: [
@@ -220,6 +235,21 @@ export const menuAutocompleteListboxPropDefs: Record<string, PropDef> = {
   placeholder: {
     type: 'string',
     description: 'Placeholder text for the search input.',
+  },
+  inputValue: {
+    type: 'string',
+    description:
+      'Controlled search input value. When set, disables the built-in client-side filter so you can supply server-filtered items.',
+  },
+  onInputChange: {
+    type: 'enum',
+    values: ['(value: string) => void'],
+    description: 'Called when the search input value changes.',
+  },
+  isLoading: {
+    type: 'boolean',
+    description:
+      'Whether results are currently loading. Shows a loading indicator and dims existing items.',
   },
   placement: {
     type: 'enum',

--- a/docs-ui/src/app/components/menu/snippets.ts
+++ b/docs-ui/src/app/components/menu/snippets.ts
@@ -106,6 +106,36 @@ export const autocompleteListbox = `<MenuTrigger>
   </MenuAutocompleteListbox>
 </MenuTrigger>`;
 
+export const autocompleteServerSide = `import { useAsyncList } from 'react-aria-components';
+
+function ServerSideMenu() {
+  const list = useAsyncList({
+    async load({ filterText, signal }) {
+      const res = await fetch(\`/api/items?q=\${filterText}\`, { signal });
+      const items = await res.json();
+      return { items };
+    },
+  });
+
+  return (
+    <MenuTrigger>
+      <Button>Search</Button>
+      <MenuAutocomplete
+        placeholder="Type to search..."
+        inputValue={list.filterText}
+        onInputChange={list.setFilterText}
+        isLoading={list.isLoading}
+      >
+        {list.items.map(item => (
+          <MenuItem key={item.value} id={item.value}>
+            {item.label}
+          </MenuItem>
+        ))}
+      </MenuAutocomplete>
+    </MenuTrigger>
+  );
+}`;
+
 export const autocompleteListboxMultiple = `<MenuTrigger>
   <Button variant="secondary">Multi-select</Button>
   <MenuAutocompleteListbox

--- a/docs-ui/src/app/components/select/components.tsx
+++ b/docs-ui/src/app/components/select/components.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { Select } from '../../../../../packages/ui/src/components/Select/Select';
 import { Flex } from '../../../../../packages/ui/src/components/Flex/Flex';
 import { RiCloudLine } from '@remixicon/react';
@@ -184,6 +185,48 @@ export const WithSections = () => (
     style={{ width: 300 }}
   />
 );
+
+export const SearchableServerSide = () => {
+  const [searchValue, setSearchValue] = useState('');
+  const [options, setOptions] = useState(countries);
+  const [isLoading, setIsLoading] = useState(false);
+  const abortRef = useRef<AbortController>();
+
+  const handleSearchChange = useCallback((value: string) => {
+    setSearchValue(value);
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setIsLoading(true);
+    const timer = setTimeout(() => {
+      if (!controller.signal.aborted) {
+        setOptions(
+          countries.filter(c =>
+            c.label.toLowerCase().includes(value.toLowerCase()),
+          ),
+        );
+        setIsLoading(false);
+      }
+    }, 500);
+    controller.signal.addEventListener('abort', () => clearTimeout(timer));
+  }, []);
+
+  useEffect(() => () => abortRef.current?.abort(), []);
+
+  return (
+    <Select
+      label="Country"
+      name="country"
+      searchable
+      searchPlaceholder="Search countries..."
+      searchValue={searchValue}
+      onSearchChange={handleSearchChange}
+      options={options}
+      isLoading={isLoading}
+      style={{ width: 300 }}
+    />
+  );
+};
 
 export const SearchableWithSections = () => (
   <Select

--- a/docs-ui/src/app/components/select/page.mdx
+++ b/docs-ui/src/app/components/select/page.mdx
@@ -14,6 +14,7 @@ import {
   SearchableMultiple,
   WithSections,
   SearchableWithSections,
+  SearchableServerSide,
 } from './components';
 import {
   selectPropDefs,
@@ -34,6 +35,7 @@ import {
   selectDisabledOptionsSnippet,
   selectSectionsSnippet,
   selectSearchableSectionsSnippet,
+  selectServerSideSnippet,
 } from './snippets';
 import { PageTitle } from '@/components/PageTitle';
 import { Theming } from '@/components/Theming';
@@ -154,6 +156,19 @@ Combine search and multiple selection.
   open
   preview={<SearchableMultiple />}
   code={selectSearchableMultipleSnippet}
+/>
+
+### Server-side search
+
+Control the search value and supply pre-filtered options from a server or async
+source. When `searchValue` is set the built-in client-side filter is disabled.
+Use `isLoading` to show a loading indicator while results are being fetched.
+
+<Snippet
+  layout="side-by-side"
+  open
+  preview={<SearchableServerSide />}
+  code={selectServerSideSnippet}
 />
 
 ### With sections

--- a/docs-ui/src/app/components/select/props-definition.tsx
+++ b/docs-ui/src/app/components/select/props-definition.tsx
@@ -116,6 +116,21 @@ export const selectPropDefs: Record<string, PropDef> = {
     description:
       'Placeholder text for the search input when searchable is true.',
   },
+  searchValue: {
+    type: 'string',
+    description:
+      'Controlled search input value. When set, disables the built-in client-side filter so you can supply server-filtered options.',
+  },
+  onSearchChange: {
+    type: 'enum',
+    values: ['(value: string) => void'],
+    description: 'Called when the search input value changes.',
+  },
+  isLoading: {
+    type: 'boolean',
+    description:
+      'Whether results are currently loading. Shows a loading indicator in the dropdown and dims existing items.',
+  },
   isOpen: {
     type: 'boolean',
     description: 'Controlled open state. Use with onOpenChange.',

--- a/docs-ui/src/app/components/select/snippets.ts
+++ b/docs-ui/src/app/components/select/snippets.ts
@@ -134,6 +134,32 @@ export const selectSectionsSnippet = `<Select
   ]}
 />`;
 
+export const selectServerSideSnippet = `import { Select } from '@backstage/ui';
+import { useAsyncList } from 'react-aria-components';
+
+function ServerSideSelect() {
+  const list = useAsyncList({
+    async load({ filterText, signal }) {
+      const res = await fetch(\`/api/items?q=\${filterText}\`, { signal });
+      const items = await res.json();
+      return { items };
+    },
+  });
+
+  return (
+    <Select
+      label="Country"
+      name="country"
+      searchable
+      searchPlaceholder="Search countries..."
+      searchValue={list.filterText}
+      onSearchChange={list.setFilterText}
+      options={list.items}
+      isLoading={list.isLoading}
+    />
+  );
+}`;
+
 export const selectSearchableSectionsSnippet = `<Select
   name="font"
   label="Font Family"

--- a/packages/ui/report.api.md
+++ b/packages/ui/report.api.md
@@ -1036,6 +1036,7 @@ export const ComboboxDefinition: {
     readonly description: {};
     readonly isRequired: {};
     readonly className: {};
+    readonly isLoading: {};
   };
 };
 
@@ -1065,9 +1066,10 @@ export const ComboboxListBoxDefinition: {
   readonly classNames: {
     readonly root: 'bui-ComboboxList';
     readonly noResults: 'bui-ComboboxNoResults';
+    readonly loadingState: 'bui-ComboboxLoadingState';
   };
   readonly propDefs: {
-    readonly options: {};
+    readonly isLoading: {};
   };
 };
 
@@ -1090,6 +1092,7 @@ export type ComboboxOwnProps = {
   size?: 'small' | 'medium' | Partial<Record<Breakpoint, 'small' | 'medium'>>;
   options?: Array<Option_2 | OptionSection>;
   placeholder?: string;
+  isLoading?: boolean;
   label?: FieldLabelProps['label'];
   secondaryLabel?: FieldLabelProps['secondaryLabel'];
   description?: FieldLabelProps['description'];
@@ -1100,7 +1103,10 @@ export type ComboboxOwnProps = {
 // @public (undocumented)
 export interface ComboboxProps
   extends ComboboxOwnProps,
-    Omit<ComboBoxProps<Option_2>, keyof ComboboxOwnProps> {}
+    Omit<
+      ComboBoxProps<Option_2>,
+      keyof ComboboxOwnProps | 'items' | 'defaultItems'
+    > {}
 
 // @public
 export const ComboboxSectionDefinition: {
@@ -2110,6 +2116,9 @@ export const MenuAutocompleteListbox: (
 // @public (undocumented)
 export type MenuAutocompleteListBoxOwnProps = MenuPopoverOwnProps & {
   placeholder?: string;
+  inputValue?: string;
+  onInputChange?: (value: string) => void;
+  isLoading?: boolean;
   selectionMode?: ListBoxProps<object>['selectionMode'];
 };
 
@@ -2121,6 +2130,9 @@ export interface MenuAutocompleteListBoxProps<T>
 // @public (undocumented)
 export type MenuAutocompleteOwnProps = MenuPopoverOwnProps & {
   placeholder?: string;
+  inputValue?: string;
+  onInputChange?: (value: string) => void;
+  isLoading?: boolean;
 };
 
 // @public (undocumented)
@@ -2767,6 +2779,9 @@ export const SelectDefinition: {
     readonly options: {};
     readonly searchable: {};
     readonly searchPlaceholder: {};
+    readonly searchValue: {};
+    readonly onSearchChange: {};
+    readonly isLoading: {};
     readonly label: {};
     readonly secondaryLabel: {};
     readonly description: {};
@@ -2782,6 +2797,9 @@ export type SelectOwnProps = {
   options?: Array<Option_2 | OptionSection>;
   searchable?: boolean;
   searchPlaceholder?: string;
+  searchValue?: string;
+  onSearchChange?: (value: string) => void;
+  isLoading?: boolean;
   label?: FieldLabelProps['label'];
   secondaryLabel?: FieldLabelProps['secondaryLabel'];
   description?: FieldLabelProps['description'];

--- a/packages/ui/src/components/Combobox/Combobox.module.css
+++ b/packages/ui/src/components/Combobox/Combobox.module.css
@@ -195,6 +195,10 @@
     outline: none;
     border-radius: var(--bui-radius-2);
 
+    [data-stale] & {
+      opacity: 0.6;
+    }
+
     &[data-focused] {
       background-color: var(--bui-bg-neutral-2);
     }
@@ -227,6 +231,10 @@
     &:first-child .bui-ComboboxSectionHeader {
       padding-top: 0;
     }
+
+    [data-stale] & {
+      opacity: 0.6;
+    }
   }
 
   .bui-ComboboxSectionHeader {
@@ -242,6 +250,7 @@
     text-transform: uppercase;
   }
 
+  .bui-ComboboxLoadingState,
   .bui-ComboboxNoResults {
     padding-inline: var(--bui-space-3);
     padding-block: var(--bui-space-2);

--- a/packages/ui/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/ui/src/components/Combobox/Combobox.stories.tsx
@@ -19,8 +19,9 @@ import { Combobox } from './Combobox';
 import { Flex } from '../Flex';
 import { Box } from '../Box';
 import { Text } from '../Text';
-import { Form } from 'react-aria-components';
+import { Form, useAsyncList } from 'react-aria-components';
 import { RiCloudLine } from '@remixicon/react';
+import { fn } from 'storybook/test';
 
 const meta = preview.meta({
   title: 'Backstage UI/Combobox',
@@ -86,6 +87,7 @@ export const Default = meta.story({
     options: fontOptions,
     placeholder: 'Pick a font',
     name: 'font',
+    onChange: fn(),
   },
 });
 
@@ -98,15 +100,14 @@ export const WithIcon = meta.story({
 
 export const WithSections = meta.story({
   args: {
-    label: 'Font Family',
+    ...Default.input.args,
     options: sectionedOptions,
-    placeholder: 'Pick a font',
-    name: 'font',
   },
 });
 
 export const AllowsCustomValue = meta.story({
   args: {
+    ...Default.input.args,
     label: 'Country',
     options: countries,
     placeholder: 'Type any country',
@@ -197,6 +198,7 @@ export const WithError = meta.story({
 
 export const WithLongNames = meta.story({
   args: {
+    ...Default.input.args,
     label: 'Document Template',
     options: [
       {
@@ -233,6 +235,41 @@ export const WithLongNamesAndPadding = meta.story({
       </div>
     ),
   ],
+});
+
+export const ServerSideFiltering = meta.story({
+  args: {
+    ...Default.input.args,
+    label: 'Country',
+    placeholder: 'Search countries...',
+    name: 'country',
+  },
+  render: function Render(args) {
+    const list = useAsyncList<(typeof countries)[0]>({
+      async load({ filterText, signal }) {
+        await new Promise(resolve => setTimeout(resolve, 500));
+        signal.throwIfAborted();
+        const filtered = countries
+          .filter(c =>
+            c.label
+              .toLocaleLowerCase('en-US')
+              .includes((filterText ?? '').toLocaleLowerCase('en-US')),
+          )
+          .map(c => ({ value: c.value, label: c.label }));
+        return { items: filtered };
+      },
+    });
+
+    return (
+      <Combobox
+        {...args}
+        inputValue={list.filterText}
+        onInputChange={list.setFilterText}
+        options={list.items}
+        isLoading={list.isLoading}
+      />
+    );
+  },
 });
 
 export const AutoBg = meta.story({

--- a/packages/ui/src/components/Combobox/Combobox.tsx
+++ b/packages/ui/src/components/Combobox/Combobox.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { forwardRef, useEffect } from 'react';
+import { forwardRef, useEffect, useMemo } from 'react';
 import { ComboBox as AriaComboBox } from 'react-aria-components';
 import { useFilter } from 'react-aria';
 import { ComboboxProps } from './types';
@@ -25,6 +25,41 @@ import { FieldLabel } from '../FieldLabel';
 import { FieldError } from '../FieldError';
 import { ComboboxInput } from './ComboboxInput';
 import { ComboboxListBox } from './ComboboxListBox';
+import type {
+  Option,
+  OptionSection,
+  OptionWithId,
+  OptionSectionWithId,
+} from '../Select/types';
+
+function addIds(
+  options: Array<Option | OptionSection> | undefined,
+): Array<OptionWithId | OptionSectionWithId> | undefined {
+  return (
+    options?.map(item => {
+      if ('options' in item) {
+        return {
+          ...item,
+          id: item.title,
+          options: item.options.map(o => ({ ...o, id: o.value })),
+        };
+      }
+      return { ...item, id: item.value };
+    }) ?? []
+  );
+}
+
+function disabledKeysFromOptions(
+  options: Array<Option | OptionSection> | undefined,
+): Iterable<string> | undefined {
+  return options?.flatMap(o =>
+    'options' in o
+      ? o.options.filter(o => o.disabled).map(o => o.value)
+      : o.disabled
+      ? [o.value]
+      : [],
+  );
+}
 
 /**
  * A text input combined with a dropdown list of options. The user can type to filter
@@ -49,10 +84,18 @@ export const Combobox = forwardRef<HTMLDivElement, ComboboxProps>(
       placeholder,
       isRequired,
       secondaryLabel,
+      isLoading,
     } = ownProps;
 
     const ariaLabel = restProps['aria-label'];
     const ariaLabelledBy = restProps['aria-labelledby'];
+
+    const isControlled = restProps.inputValue !== undefined;
+    const itemsWithIds = useMemo(() => addIds(options), [options]);
+    const disabledKeys = useMemo(
+      () => disabledKeysFromOptions(options),
+      [options],
+    );
 
     useEffect(() => {
       if (!label && !ariaLabel && !ariaLabelledBy) {
@@ -66,9 +109,13 @@ export const Combobox = forwardRef<HTMLDivElement, ComboboxProps>(
       secondaryLabel || (isRequired ? 'Required' : null);
 
     return (
-      <AriaComboBox
+      <AriaComboBox<OptionWithId | OptionSectionWithId>
         className={classes.root}
         defaultFilter={contains}
+        allowsEmptyCollection
+        items={isControlled ? itemsWithIds : undefined}
+        defaultItems={!isControlled ? itemsWithIds : undefined}
+        disabledKeys={disabledKeys}
         {...dataAttributes}
         ref={ref}
         {...restProps}
@@ -82,7 +129,7 @@ export const Combobox = forwardRef<HTMLDivElement, ComboboxProps>(
         <ComboboxInput icon={icon} placeholder={placeholder} />
         <FieldError />
         <Popover className={classes.popover} hideArrow {...dataAttributes}>
-          <ComboboxListBox options={options} />
+          <ComboboxListBox isLoading={isLoading} />
         </Popover>
       </AriaComboBox>
     );

--- a/packages/ui/src/components/Combobox/ComboboxListBox.tsx
+++ b/packages/ui/src/components/Combobox/ComboboxListBox.tsx
@@ -28,7 +28,15 @@ import {
   ComboboxListBoxItemDefinition,
   ComboboxSectionDefinition,
 } from './definition';
-import type { Option, OptionSection, ComboboxListBoxOwnProps } from './types';
+import type { ComboboxListBoxOwnProps } from './types';
+import type { OptionWithId, OptionSectionWithId } from '../Select/types';
+
+const LoadingState = () => {
+  const { ownProps } = useDefinition(ComboboxListBoxDefinition, {});
+  const { classes } = ownProps;
+
+  return <div className={classes.loadingState}>Searching...</div>;
+};
 
 const NoResults = () => {
   const { ownProps } = useDefinition(ComboboxListBoxDefinition, {});
@@ -37,16 +45,15 @@ const NoResults = () => {
   return <div className={classes.noResults}>No results found.</div>;
 };
 
-function ComboboxItem({ option }: { option: Option }) {
+function ComboboxItem({ option }: { option: OptionWithId }) {
   const { ownProps } = useDefinition(ComboboxListBoxItemDefinition, {});
   const { classes } = ownProps;
 
   return (
     <ListBoxItem
-      id={option.value}
+      id={option.id}
       textValue={option.label}
       className={classes.root}
-      isDisabled={option.disabled}
     >
       <div className={classes.indicator}>
         <RiCheckLine aria-hidden="true" />
@@ -58,7 +65,7 @@ function ComboboxItem({ option }: { option: Option }) {
   );
 }
 
-function ComboboxSectionItems({ section }: { section: OptionSection }) {
+function ComboboxSectionItems({ section }: { section: OptionSectionWithId }) {
   const { ownProps } = useDefinition(ComboboxSectionDefinition, {});
   const { classes } = ownProps;
 
@@ -66,7 +73,7 @@ function ComboboxSectionItems({ section }: { section: OptionSection }) {
     <ListBoxSection className={classes.root}>
       <Header className={classes.header}>{section.title}</Header>
       {section.options.map(option => (
-        <ComboboxItem key={option.value} option={option} />
+        <ComboboxItem option={option} />
       ))}
     </ListBoxSection>
   );
@@ -74,17 +81,22 @@ function ComboboxSectionItems({ section }: { section: OptionSection }) {
 
 export function ComboboxListBox(props: ComboboxListBoxOwnProps) {
   const { ownProps } = useDefinition(ComboboxListBoxDefinition, props);
-  const { classes, options } = ownProps;
+  const { classes, isLoading } = ownProps;
 
   return (
-    <ListBox className={classes.root} renderEmptyState={() => <NoResults />}>
-      {options?.map(item =>
+    <ListBox<OptionWithId | OptionSectionWithId>
+      className={classes.root}
+      aria-busy={isLoading || undefined}
+      data-stale={isLoading || undefined}
+      renderEmptyState={() => (isLoading ? <LoadingState /> : <NoResults />)}
+    >
+      {item =>
         'options' in item ? (
-          <ComboboxSectionItems key={item.title} section={item} />
+          <ComboboxSectionItems key={item.id} section={item} />
         ) : (
-          <ComboboxItem key={item.value} option={item} />
-        ),
-      )}
+          <ComboboxItem key={item.id} option={item} />
+        )
+      }
     </ListBox>
   );
 }

--- a/packages/ui/src/components/Combobox/definition.ts
+++ b/packages/ui/src/components/Combobox/definition.ts
@@ -44,6 +44,7 @@ export const ComboboxDefinition = defineComponent<ComboboxOwnProps>()({
     description: {},
     isRequired: {},
     className: {},
+    isLoading: {},
   },
 });
 
@@ -78,9 +79,10 @@ export const ComboboxListBoxDefinition =
     classNames: {
       root: 'bui-ComboboxList',
       noResults: 'bui-ComboboxNoResults',
+      loadingState: 'bui-ComboboxLoadingState',
     },
     propDefs: {
-      options: {},
+      isLoading: {},
     },
   });
 

--- a/packages/ui/src/components/Combobox/types.ts
+++ b/packages/ui/src/components/Combobox/types.ts
@@ -46,6 +46,12 @@ export type ComboboxOwnProps = {
    */
   placeholder?: string;
 
+  /**
+   * Whether results are currently loading. Shows a loading indicator in the
+   * dropdown and keeps the popover open while items are being fetched.
+   */
+  isLoading?: boolean;
+
   label?: FieldLabelProps['label'];
   secondaryLabel?: FieldLabelProps['secondaryLabel'];
   description?: FieldLabelProps['description'];
@@ -56,7 +62,10 @@ export type ComboboxOwnProps = {
 /** @public */
 export interface ComboboxProps
   extends ComboboxOwnProps,
-    Omit<AriaComboBoxProps<Option>, keyof ComboboxOwnProps> {}
+    Omit<
+      AriaComboBoxProps<Option>,
+      keyof ComboboxOwnProps | 'items' | 'defaultItems'
+    > {}
 
 /** @internal */
 export interface ComboboxInputOwnProps {
@@ -66,7 +75,7 @@ export interface ComboboxInputOwnProps {
 
 /** @internal */
 export interface ComboboxListBoxOwnProps {
-  options?: ComboboxOwnProps['options'];
+  isLoading?: boolean;
 }
 
 /** @internal */

--- a/packages/ui/src/components/Menu/Menu.module.css
+++ b/packages/ui/src/components/Menu/Menu.module.css
@@ -116,6 +116,10 @@
         display: block;
       }
     }
+
+    [data-stale] & {
+      opacity: 0.6;
+    }
   }
 
   .bui-MenuItemListBox {
@@ -187,6 +191,10 @@
   .bui-MenuSection {
     &:first-child .bui-MenuSectionHeader {
       padding-top: 0;
+    }
+
+    [data-stale] & {
+      opacity: 0.6;
     }
   }
 
@@ -281,6 +289,7 @@
     }
   }
 
+  .bui-MenuLoadingState,
   .bui-MenuEmptyState {
     padding-inline: var(--bui-space-3);
     padding-block: var(--bui-space-2);

--- a/packages/ui/src/components/Menu/Menu.tsx
+++ b/packages/ui/src/components/Menu/Menu.tsx
@@ -44,6 +44,7 @@ import {
   MenuSectionDefinition,
   MenuSeparatorDefinition,
   MenuEmptyStateDefinition,
+  MenuLoadingStateDefinition,
 } from './definition';
 import type {
   MenuTriggerProps,
@@ -69,6 +70,12 @@ import { BgReset } from '../../hooks/useBg';
 
 // The height will be used for virtualized menus. It should match the size set in CSS for each menu item.
 const rowHeight = 32;
+
+const MenuLoadingState = () => {
+  const { ownProps } = useDefinition(MenuLoadingStateDefinition, {});
+
+  return <div className={ownProps.classes.root}>Searching...</div>;
+};
 
 const MenuEmptyState = () => {
   const { ownProps } = useDefinition(MenuEmptyStateDefinition, {});
@@ -188,14 +195,22 @@ export const MenuAutocomplete = (props: MenuAutocompleteProps<object>) => {
     maxHeight,
     style,
     placeholder,
+    inputValue,
+    isLoading,
+    onInputChange,
   } = ownProps;
   const { contains } = useFilter({ sensitivity: 'base' });
   let newMaxWidth = maxWidth || (virtualized ? '260px' : 'undefined');
+  const isControlled = inputValue !== undefined;
 
   const menuContent = (
     <RAMenu
       className={classes.content}
-      renderEmptyState={() => <MenuEmptyState />}
+      renderEmptyState={() =>
+        isLoading ? <MenuLoadingState /> : <MenuEmptyState />
+      }
+      aria-busy={isLoading || undefined}
+      data-stale={isLoading || undefined}
       style={{ width: newMaxWidth, maxHeight, ...style }}
       {...restProps}
     />
@@ -205,7 +220,11 @@ export const MenuAutocomplete = (props: MenuAutocompleteProps<object>) => {
     <RAPopover className={classes.root} placement={placement}>
       <BgReset>
         <Box bg="neutral" className={classes.inner}>
-          <RAAutocomplete filter={contains}>
+          <RAAutocomplete
+            filter={isControlled ? undefined : contains}
+            inputValue={isControlled ? inputValue : undefined}
+            onInputChange={isControlled ? onInputChange : undefined}
+          >
             <RASearchField
               className={classes.searchField}
               aria-label={placeholder || 'Search'}
@@ -254,14 +273,22 @@ export const MenuAutocompleteListbox = (
     maxHeight,
     style,
     placeholder,
+    inputValue,
+    isLoading,
+    onInputChange,
   } = ownProps;
   const { contains } = useFilter({ sensitivity: 'base' });
   let newMaxWidth = maxWidth || (virtualized ? '260px' : 'undefined');
+  const isControlled = inputValue !== undefined;
 
   const listBoxContent = (
     <RAListBox
       className={classes.content}
-      renderEmptyState={() => <MenuEmptyState />}
+      renderEmptyState={() =>
+        isLoading ? <MenuLoadingState /> : <MenuEmptyState />
+      }
+      aria-busy={isLoading || undefined}
+      data-stale={isLoading || undefined}
       selectionMode={selectionMode}
       style={{ width: newMaxWidth, maxHeight, ...style }}
       {...restProps}
@@ -272,7 +299,11 @@ export const MenuAutocompleteListbox = (
     <RAPopover className={classes.root} placement={placement}>
       <BgReset>
         <Box bg="neutral" className={classes.inner}>
-          <RAAutocomplete filter={contains}>
+          <RAAutocomplete
+            filter={isControlled ? undefined : contains}
+            inputValue={isControlled ? inputValue : undefined}
+            onInputChange={isControlled ? onInputChange : undefined}
+          >
             <RASearchField
               className={classes.searchField}
               aria-label={placeholder || 'Search'}

--- a/packages/ui/src/components/Menu/MenuAutocomplete.stories.tsx
+++ b/packages/ui/src/components/Menu/MenuAutocomplete.stories.tsx
@@ -24,6 +24,7 @@ import {
 } from './index';
 import { Button } from '../..';
 import { useState, useEffect } from 'react';
+import { useAsyncList } from 'react-aria-components';
 import { MemoryRouter } from 'react-router-dom';
 import { BUIProvider } from '../../provider';
 
@@ -93,6 +94,44 @@ export const PreviewAutocompleteMenu = meta.story({
       </MenuAutocomplete>
     </MenuTrigger>
   ),
+});
+
+export const ServerSideFiltering = meta.story({
+  args: {
+    ...Default.input.args,
+  },
+  render: () => {
+    const list = useAsyncList<(typeof options)[0]>({
+      async load({ filterText, signal }) {
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        signal.throwIfAborted();
+        const filtered = options.filter(o =>
+          o.label
+            .toLocaleLowerCase('en-US')
+            .includes((filterText ?? '').toLocaleLowerCase('en-US')),
+        );
+        return { items: filtered };
+      },
+    });
+
+    return (
+      <MenuTrigger isOpen>
+        <Button aria-label="Menu">Menu</Button>
+        <MenuAutocomplete
+          placeholder="Search fruits..."
+          inputValue={list.filterText}
+          onInputChange={list.setFilterText}
+          isLoading={list.isLoading}
+        >
+          {list.items.map(option => (
+            <MenuItem key={option.value} id={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </MenuAutocomplete>
+      </MenuTrigger>
+    );
+  },
 });
 
 export const Virtualized = meta.story({

--- a/packages/ui/src/components/Menu/MenuAutocompleteListBox.stories.tsx
+++ b/packages/ui/src/components/Menu/MenuAutocompleteListBox.stories.tsx
@@ -25,7 +25,7 @@ import {
 } from './index';
 import { Button, Flex, Text } from '../..';
 import { useEffect, useState } from 'react';
-import { Selection } from 'react-aria-components';
+import { Selection, useAsyncList } from 'react-aria-components';
 import { MemoryRouter } from 'react-router-dom';
 import { BUIProvider } from '../../provider';
 
@@ -178,6 +178,52 @@ export const Submenu = meta.story({
               </MenuAutocompleteListbox>
             </SubmenuTrigger>
           </Menu>
+        </MenuTrigger>
+      </Flex>
+    );
+  },
+});
+
+export const ServerSideFiltering = meta.story({
+  args: {
+    ...Default.input.args,
+  },
+  render: () => {
+    const list = useAsyncList<(typeof options)[0]>({
+      async load({ filterText, signal }) {
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        signal.throwIfAborted();
+        const filtered = options.filter(o =>
+          o.label
+            .toLocaleLowerCase('en-US')
+            .includes((filterText ?? '').toLocaleLowerCase('en-US')),
+        );
+        return { items: filtered };
+      },
+    });
+    const [selected, setSelected] = useState<Selection>(
+      new Set([options[2].value]),
+    );
+
+    return (
+      <Flex direction="column" gap="2" align="start">
+        <Text>Selected: {Array.from(selected).join(', ')}</Text>
+        <MenuTrigger isOpen>
+          <Button aria-label="Menu">Menu</Button>
+          <MenuAutocompleteListbox
+            placeholder="Search fruits..."
+            inputValue={list.filterText}
+            onInputChange={list.setFilterText}
+            isLoading={list.isLoading}
+            selectedKeys={selected}
+            onSelectionChange={setSelected}
+          >
+            {list.items.map(option => (
+              <MenuListBoxItem key={option.value} id={option.value}>
+                {option.label}
+              </MenuListBoxItem>
+            ))}
+          </MenuAutocompleteListbox>
         </MenuTrigger>
       </Flex>
     );

--- a/packages/ui/src/components/Menu/definition.ts
+++ b/packages/ui/src/components/Menu/definition.ts
@@ -80,6 +80,9 @@ export const MenuAutocompleteDefinition =
     propDefs: {
       ...menuPopoverPropDefs,
       placeholder: {},
+      inputValue: {},
+      onInputChange: {},
+      isLoading: {},
     },
   });
 
@@ -91,6 +94,9 @@ export const MenuAutocompleteListboxDefinition =
     propDefs: {
       ...menuPopoverPropDefs,
       placeholder: {},
+      inputValue: {},
+      onInputChange: {},
+      isLoading: {},
       selectionMode: { default: 'single' },
     },
   });
@@ -155,6 +161,15 @@ export const MenuSeparatorDefinition = defineComponent<MenuSeparatorOwnProps>()(
     },
   },
 );
+
+/** @internal */
+export const MenuLoadingStateDefinition = defineComponent<{}>()({
+  styles,
+  classNames: {
+    root: 'bui-MenuLoadingState',
+  },
+  propDefs: {},
+});
 
 /** @internal */
 export const MenuEmptyStateDefinition = defineComponent<{}>()({

--- a/packages/ui/src/components/Menu/types.ts
+++ b/packages/ui/src/components/Menu/types.ts
@@ -67,6 +67,23 @@ export interface MenuListBoxProps<T>
 /** @public */
 export type MenuAutocompleteOwnProps = MenuPopoverOwnProps & {
   placeholder?: string;
+
+  /**
+   * The current search input value (controlled). When set, disables the
+   * built-in client-side filter so the parent can supply server-filtered items.
+   */
+  inputValue?: string;
+
+  /**
+   * Handler called when the search input value changes.
+   */
+  onInputChange?: (value: string) => void;
+
+  /**
+   * Whether results are currently loading. Shows a loading indicator
+   * in the menu.
+   */
+  isLoading?: boolean;
 };
 
 /** @public */
@@ -77,6 +94,24 @@ export interface MenuAutocompleteProps<T>
 /** @public */
 export type MenuAutocompleteListBoxOwnProps = MenuPopoverOwnProps & {
   placeholder?: string;
+
+  /**
+   * The current search input value (controlled). When set, disables the
+   * built-in client-side filter so the parent can supply server-filtered items.
+   */
+  inputValue?: string;
+
+  /**
+   * Handler called when the search input value changes.
+   */
+  onInputChange?: (value: string) => void;
+
+  /**
+   * Whether results are currently loading. Shows a loading indicator
+   * in the list.
+   */
+  isLoading?: boolean;
+
   selectionMode?: RAListBoxProps<object>['selectionMode'];
 };
 

--- a/packages/ui/src/components/SearchAutocomplete/SearchAutocomplete.module.css
+++ b/packages/ui/src/components/SearchAutocomplete/SearchAutocomplete.module.css
@@ -174,10 +174,6 @@
     min-width: 150px;
     outline: none;
     padding-block: var(--bui-space-1);
-
-    &[data-stale] {
-      opacity: 0.6;
-    }
   }
 
   .bui-SearchAutocompleteItem {
@@ -197,6 +193,10 @@
     &[data-hovered] .bui-SearchAutocompleteItemContent {
       background: var(--bui-bg-neutral-2);
       color: var(--bui-fg-primary);
+    }
+
+    [data-stale] & {
+      opacity: 0.6;
     }
   }
 

--- a/packages/ui/src/components/Select/Select.module.css
+++ b/packages/ui/src/components/Select/Select.module.css
@@ -175,6 +175,10 @@
     &[data-selected] .bui-SelectItemIndicator {
       opacity: 1;
     }
+
+    [data-stale] & {
+      opacity: 0.6;
+    }
   }
 
   .bui-SelectItemIndicator {
@@ -255,6 +259,10 @@
     &:first-child .bui-SelectSectionHeader {
       padding-top: 0;
     }
+
+    [data-stale] & {
+      opacity: 0.6;
+    }
   }
 
   .bui-SelectSectionHeader {
@@ -270,6 +278,7 @@
     text-transform: uppercase;
   }
 
+  .bui-SelectLoadingState,
   .bui-SelectNoResults {
     padding-inline: var(--bui-space-3);
     padding-block: var(--bui-space-2);

--- a/packages/ui/src/components/Select/Select.stories.tsx
+++ b/packages/ui/src/components/Select/Select.stories.tsx
@@ -19,7 +19,7 @@ import { Select } from './Select';
 import { Flex } from '../Flex';
 import { Box } from '../Box';
 import { Text } from '../Text';
-import { Form } from 'react-aria-components';
+import { Form, useAsyncList } from 'react-aria-components';
 import { RiCloudLine } from '@remixicon/react';
 
 const meta = preview.meta({
@@ -137,6 +137,38 @@ export const WithSections = meta.story({
     label: 'Font Family',
     options: sectionedOptions,
     name: 'font',
+  },
+});
+
+export const SearchableServerSide = meta.story({
+  args: {
+    label: 'Country',
+    searchable: true,
+    searchPlaceholder: 'Search countries...',
+  },
+  render: function Render(args) {
+    const list = useAsyncList<(typeof countries)[0]>({
+      async load({ filterText, signal }) {
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        signal.throwIfAborted();
+        const filtered = countries.filter(c =>
+          c.label
+            .toLocaleLowerCase('en-US')
+            .includes((filterText ?? '').toLocaleLowerCase('en-US')),
+        );
+        return { items: filtered };
+      },
+    });
+
+    return (
+      <Select
+        {...args}
+        searchValue={list.filterText}
+        onSearchChange={list.setFilterText}
+        options={list.items.map(i => ({ value: i.value, label: i.label }))}
+        isLoading={list.isLoading}
+      />
+    );
   },
 });
 

--- a/packages/ui/src/components/Select/Select.tsx
+++ b/packages/ui/src/components/Select/Select.tsx
@@ -52,6 +52,9 @@ export const Select = forwardRef<
     icon,
     searchable,
     searchPlaceholder,
+    searchValue,
+    onSearchChange,
+    isLoading,
     isRequired,
     secondaryLabel,
   } = ownProps;
@@ -91,7 +94,10 @@ export const Select = forwardRef<
         <SelectContent
           searchable={searchable}
           searchPlaceholder={searchPlaceholder}
+          searchValue={searchValue}
+          isLoading={isLoading}
           options={options}
+          onSearchChange={onSearchChange}
         />
       </Popover>
     </AriaSelect>

--- a/packages/ui/src/components/Select/SelectContent.tsx
+++ b/packages/ui/src/components/Select/SelectContent.tsx
@@ -30,20 +30,37 @@ import type { SelectOwnProps } from './types';
 interface SelectContentProps {
   searchable?: boolean;
   searchPlaceholder?: string;
+  searchValue?: string;
+  onSearchChange?: (value: string) => void;
+  isLoading?: boolean;
   options?: SelectOwnProps['options'];
 }
 
 export function SelectContent(props: SelectContentProps) {
   const { contains } = useFilter({ sensitivity: 'base' });
   const { ownProps } = useDefinition(SelectContentDefinition, props);
-  const { classes, searchable, searchPlaceholder, options } = ownProps;
+  const {
+    classes,
+    searchable,
+    searchPlaceholder,
+    searchValue,
+    onSearchChange,
+    isLoading,
+    options,
+  } = ownProps;
 
   if (!searchable) {
-    return <SelectListBox options={options} />;
+    return <SelectListBox options={options} isLoading={isLoading} />;
   }
 
+  const isControlled = searchValue !== undefined;
+
   return (
-    <Autocomplete filter={contains}>
+    <Autocomplete
+      filter={isControlled ? undefined : contains}
+      inputValue={isControlled ? searchValue : undefined}
+      onInputChange={isControlled ? onSearchChange : undefined}
+    >
       <SearchField
         autoFocus
         className={classes.root}
@@ -54,7 +71,7 @@ export function SelectContent(props: SelectContentProps) {
           <RiCloseCircleLine />
         </Button>
       </SearchField>
-      <SelectListBox options={options} />
+      <SelectListBox options={options} isLoading={isLoading} />
     </Autocomplete>
   );
 }

--- a/packages/ui/src/components/Select/SelectListBox.tsx
+++ b/packages/ui/src/components/Select/SelectListBox.tsx
@@ -32,7 +32,15 @@ import type { Option, OptionSection, SelectOwnProps } from './types';
 
 interface SelectListBoxProps {
   options?: SelectOwnProps['options'];
+  isLoading?: boolean;
 }
+
+const LoadingState = () => {
+  const { ownProps } = useDefinition(SelectListBoxDefinition, {});
+  const { classes } = ownProps;
+
+  return <div className={classes.loadingState}>Searching...</div>;
+};
 
 const NoResults = () => {
   const { ownProps } = useDefinition(SelectListBoxDefinition, {});
@@ -78,10 +86,15 @@ function SelectSectionItems({ section }: { section: OptionSection }) {
 
 export function SelectListBox(props: SelectListBoxProps) {
   const { ownProps } = useDefinition(SelectListBoxDefinition, props);
-  const { classes, options } = ownProps;
+  const { classes, options, isLoading } = ownProps;
 
   return (
-    <ListBox className={classes.root} renderEmptyState={() => <NoResults />}>
+    <ListBox
+      className={classes.root}
+      aria-busy={isLoading || undefined}
+      data-stale={isLoading || undefined}
+      renderEmptyState={() => (isLoading ? <LoadingState /> : <NoResults />)}
+    >
       {options?.map(item =>
         'options' in item ? (
           <SelectSectionItems key={item.title} section={item} />

--- a/packages/ui/src/components/Select/definition.ts
+++ b/packages/ui/src/components/Select/definition.ts
@@ -41,6 +41,9 @@ export const SelectDefinition = defineComponent<SelectOwnProps>()({
     options: {},
     searchable: {},
     searchPlaceholder: {},
+    searchValue: {},
+    onSearchChange: {},
+    isLoading: {},
     label: {},
     secondaryLabel: {},
     description: {},
@@ -79,10 +82,14 @@ export const SelectContentDefinition = defineComponent<SelectContentOwnProps>()(
       root: 'bui-SelectSearchWrapper',
       search: 'bui-SelectSearch',
       searchClear: 'bui-SelectSearchClear',
+      loadingState: 'bui-SelectLoadingState',
     },
     propDefs: {
       searchable: {},
       searchPlaceholder: { default: 'Search...' },
+      searchValue: {},
+      onSearchChange: {},
+      isLoading: {},
       options: {},
     },
   },
@@ -98,9 +105,11 @@ export const SelectListBoxDefinition = defineComponent<SelectListBoxOwnProps>()(
     classNames: {
       root: 'bui-SelectList',
       noResults: 'bui-SelectNoResults',
+      loadingState: 'bui-SelectLoadingState',
     },
     propDefs: {
       options: {},
+      isLoading: {},
     },
   },
 );

--- a/packages/ui/src/components/Select/types.ts
+++ b/packages/ui/src/components/Select/types.ts
@@ -22,8 +22,17 @@ import type { FieldLabelProps } from '../FieldLabel/types';
 /** @public */
 export type Option = { value: string; label: string; disabled?: boolean };
 
+/** @internal */
+export type OptionWithId = Option & { id: string };
+
 /** @public */
 export type OptionSection = { title: string; options: Option[] };
+
+/** @internal */
+export type OptionSectionWithId = Omit<OptionSection, 'options'> & {
+  id: string;
+  options: OptionWithId[];
+};
 
 /** @public */
 export type SelectOwnProps = {
@@ -57,6 +66,23 @@ export type SelectOwnProps = {
    */
   searchPlaceholder?: string;
 
+  /**
+   * The current search input value (controlled). When set, disables the
+   * built-in client-side filter so the parent can supply server-filtered options.
+   */
+  searchValue?: string;
+
+  /**
+   * Handler called when the search input value changes.
+   */
+  onSearchChange?: (value: string) => void;
+
+  /**
+   * Whether results are currently loading. Shows a loading indicator
+   * in the dropdown list.
+   */
+  isLoading?: boolean;
+
   label?: FieldLabelProps['label'];
   secondaryLabel?: FieldLabelProps['secondaryLabel'];
   description?: FieldLabelProps['description'];
@@ -84,12 +110,16 @@ export interface SelectTriggerOwnProps {
 export interface SelectContentOwnProps {
   searchable?: boolean;
   searchPlaceholder?: string;
+  searchValue?: string;
+  onSearchChange?: (value: string) => void;
+  isLoading?: boolean;
   options?: SelectOwnProps['options'];
 }
 
 /** @internal */
 export interface SelectListBoxOwnProps {
   options?: SelectOwnProps['options'];
+  isLoading?: boolean;
 }
 
 /** @internal */


### PR DESCRIPTION
## Controlled Autocompletes and Comboboxes

Adds controlled input/search value and loading-state props to **Combobox**, **Select**, **MenuAutocomplete**, and **MenuAutocompleteListbox** so that async / server-side filtering can be wired up without reimplementing these components.

### What changed

- **Combobox** — new `inputValue`, `onInputChange`, and `isLoading` props. When `inputValue` is set the built-in client-side filter is bypassed; the parent provides pre-filtered `options`. Internally the component now uses React Aria's `items`/`defaultItems` pattern with stable `id` keys so the collection updates correctly when items change externally.
- **Select** — new `searchValue`, `onSearchChange`, and `isLoading` props (only relevant when `searchable` is enabled). Same controlled/uncontrolled split.
- **MenuAutocomplete / MenuAutocompleteListbox** — new `inputValue`, `onInputChange`, and `isLoading` props with the same semantics.
- **Loading indicator** — all four components show a "Searching…" empty-state and dim existing items (`data-stale` + `aria-busy`) while `isLoading` is true.
- **SearchAutocomplete CSS** — moved `data-stale` opacity from the listbox root to individual items for consistency with the other components.

### Non-breaking

All new props are optional and default to `undefined`, preserving the existing uncontrolled behavior. No existing prop signatures or DOM contracts changed. `items` and `defaultItems` are now explicitly omitted from `ComboboxProps` to prevent conflicts with the internal collection management, but these were not part of the documented API surface.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

🤖 Generated with [Claude Code](https://claude.com/claude-code)