### PR TITLE
fix: remove stale stitcher reference from catalog test

### DIFF
--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
@@ -2190,7 +2190,6 @@ describe.each(databases.eachSupportedId())(
         const catalog = new DefaultEntitiesCatalog({
           database: knex,
           logger: mockServices.logger.mock(),
-          stitcher,
         });
 
         const filter = { key: 'spec.should_include_this' };
@@ -2252,7 +2251,6 @@ describe.each(databases.eachSupportedId())(
         const catalog = new DefaultEntitiesCatalog({
           database: knex,
           logger: mockServices.logger.mock(),
-          stitcher,
         });
 
         const response = await catalog.queryEntities({


### PR DESCRIPTION
## Summary

The stitching refactor removed `stitcher` from `DefaultEntitiesCatalog`'s constructor, but two tests added by the query split PR (#34323) still pass it. This causes `yarn tsc` to fail on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)