### PR TITLE
fix: restore runtime dependencies incorrectly demoted to devDependencies

### DIFF
--- a/.changeset/fix-missing-runtime-deps.md
+++ b/.changeset/fix-missing-runtime-deps.md
@@ -1,0 +1,6 @@
+---
+'@backstage/catalog-client': patch
+'@backstage/frontend-plugin-api': patch
+---
+
+Moved dependencies that are re-exported in the public API from `devDependencies` to `dependencies`. These were incorrectly demoted in #33936 because the source code only uses type imports, but the types still appear in the published API surface and need to be resolvable by consumers at build time.

--- a/.patches/pr-34416.txt
+++ b/.patches/pr-34416.txt
@@ -1,0 +1,1 @@
+Restore runtime dependencies incorrectly demoted to devDependencies

--- a/packages/catalog-client/package.json
+++ b/packages/catalog-client/package.json
@@ -51,13 +51,13 @@
     "@backstage/catalog-model": "workspace:^",
     "@backstage/errors": "workspace:^",
     "@backstage/filter-predicates": "workspace:^",
+    "@backstage/plugin-catalog-common": "workspace:^",
     "cross-fetch": "^4.0.0",
     "lodash": "^4.17.21",
     "uri-template": "^2.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",
-    "@backstage/plugin-catalog-common": "workspace:^",
     "@types/lodash": "^4.14.151",
     "msw": "^1.0.0"
   }

--- a/packages/frontend-plugin-api/package.json
+++ b/packages/frontend-plugin-api/package.json
@@ -44,6 +44,7 @@
     "test": "backstage-cli package test"
   },
   "dependencies": {
+    "@backstage/config": "workspace:^",
     "@backstage/errors": "workspace:^",
     "@backstage/filter-predicates": "workspace:^",
     "@backstage/types": "workspace:^",
@@ -54,7 +55,6 @@
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",
-    "@backstage/config": "workspace:^",
     "@backstage/frontend-app-api": "workspace:^",
     "@backstage/frontend-test-utils": "workspace:^",
     "@backstage/test-utils": "workspace:^",


### PR DESCRIPTION
## Summary

PR #33936 removed duplicate `dependencies`/`devDependencies` entries, but two packages had dependencies incorrectly left only in `devDependencies` when they should be runtime dependencies. These packages re-export types from the demoted deps in their published API surface, making them required at build time for consumers.

**Fixed packages:**

| Package | Dependency | Why it's needed at runtime |
|---------|-----------|---------------------------|
| `@backstage/catalog-client` | `@backstage/plugin-catalog-common` | `AnalyzeLocationRequest` and `AnalyzeLocationResponse` types are re-exported in both `report.api.md` and `report-testUtils.api.md` |
| `@backstage/frontend-plugin-api` | `@backstage/config` | `Config` type is re-exported in `report.api.md` |

**How this was found:** scanned all `report*.api.md` files for import statements referencing packages that are only in `devDependencies` (not in `dependencies` or `peerDependencies`).

## Test plan

- [x] `yarn tsc` clean
- [x] No API report changes needed (the types were already in the reports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)