### PR TITLE
Redesign CatalogFilterBlueprint to model-based API

### DIFF
--- a/.changeset/catalog-filter-blueprint-redesign.md
+++ b/.changeset/catalog-filter-blueprint-redesign.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-catalog-react': minor
+---
+
+Redesigned the `CatalogFilterBlueprint` alpha API from a component-rendering model to a declarative, model-based approach. Filters can now be declared as facet-based (providing a label, entity path, and selection mode) or options-based (providing static options with a `toFilter` function and API dependency injection). The old `loader`-based API is deprecated but still supported for custom filter components.
+
+Added new exported types: `CatalogFilterDescriptor`, `CatalogFacetFilterDescriptor`, `CatalogOptionsFilterDescriptor`, `CatalogCustomFilterDescriptor`.

--- a/.changeset/catalog-filter-bui-pickers.md
+++ b/.changeset/catalog-filter-bui-pickers.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': minor
+---
+
+Updated catalog page filters to use the new model-based `CatalogFilterBlueprint` API. The built-in kind, type, tags, lifecycle, and namespace filters are now declared as facet models, and the processing status filter uses the new options model with a custom `toFilter` function. Model-based filters are rendered using Backstage UI `Select` components.

--- a/plugins/catalog-react/src/alpha/blueprints/CatalogFilterBlueprint.test.tsx
+++ b/plugins/catalog-react/src/alpha/blueprints/CatalogFilterBlueprint.test.tsx
@@ -37,6 +37,7 @@ describe('CatalogFilterBlueprint', () => {
     expect(descriptor).toEqual({
       type: 'facet',
       label: 'Test',
+      filterKey: 'metadata.test',
       path: 'metadata.test',
       mode: 'multi',
       defaultValue: ['a', 'b'],
@@ -61,6 +62,7 @@ describe('CatalogFilterBlueprint', () => {
     expect(descriptor).toEqual({
       type: 'facet',
       label: 'Kind',
+      filterKey: 'kind',
       path: 'kind',
       mode: 'single',
       defaultValue: undefined,
@@ -113,6 +115,7 @@ describe('CatalogFilterBlueprint', () => {
     expect(descriptor).toMatchObject({
       type: 'options',
       label: 'Status',
+      filterKey: 'Status',
       mode: 'multi',
       deps: {},
       options: [
@@ -156,6 +159,7 @@ describe('CatalogFilterBlueprint', () => {
     expect(descriptor).toEqual({
       type: 'facet',
       label: 'Kind',
+      filterKey: 'kind',
       path: 'kind',
       mode: 'single',
       defaultValue: 'component',

--- a/plugins/catalog-react/src/alpha/blueprints/CatalogFilterBlueprint.test.tsx
+++ b/plugins/catalog-react/src/alpha/blueprints/CatalogFilterBlueprint.test.tsx
@@ -14,96 +14,151 @@
  * limitations under the License.
  */
 import { CatalogFilterBlueprint } from './CatalogFilterBlueprint';
-import {
-  coreExtensionData,
-  createExtension,
-  createExtensionInput,
-} from '@backstage/frontend-plugin-api';
-import {
-  createExtensionTester,
-  renderInTestApp,
-} from '@backstage/frontend-test-utils';
-import { waitFor, screen } from '@testing-library/react';
+import { createExtensionTester } from '@backstage/frontend-test-utils';
+import { z } from 'zod/v4';
 
 describe('CatalogFilterBlueprint', () => {
-  it('should create an extension with sane defaults', () => {
+  it('should create a facet filter descriptor from model-based params', () => {
     const extension = CatalogFilterBlueprint.make({
+      name: 'test',
       params: {
-        loader: async () => <div />,
+        label: 'Test',
+        path: 'metadata.test',
+        mode: 'multi',
+        defaultValue: ['a', 'b'],
       },
     });
-    expect(extension).toMatchInlineSnapshot(`
-      {
-        "$$type": "@backstage/ExtensionDefinition",
-        "T": undefined,
-        "attachTo": {
-          "id": "page:catalog",
-          "input": "filters",
-        },
-        "configSchema": undefined,
-        "disabled": false,
-        "factory": [Function],
-        "if": undefined,
-        "inputs": {},
-        "kind": "catalog-filter",
-        "name": undefined,
-        "output": [
-          [Function],
-        ],
-        "override": [Function],
-        "toString": [Function],
-        "version": "v2",
-      }
-    `);
+
+    const tester = createExtensionTester(extension);
+    const descriptor = tester.get(
+      CatalogFilterBlueprint.dataRefs.filterDescriptor,
+    );
+
+    expect(descriptor).toEqual({
+      type: 'facet',
+      label: 'Test',
+      path: 'metadata.test',
+      mode: 'multi',
+      defaultValue: ['a', 'b'],
+    });
   });
 
-  it('should allow overriding of inputs and config', async () => {
+  it('should create a facet filter descriptor with single mode and no default', () => {
+    const extension = CatalogFilterBlueprint.make({
+      name: 'kind',
+      params: {
+        label: 'Kind',
+        path: 'kind',
+        mode: 'single',
+      },
+    });
+
+    const tester = createExtensionTester(extension);
+    const descriptor = tester.get(
+      CatalogFilterBlueprint.dataRefs.filterDescriptor,
+    );
+
+    expect(descriptor).toEqual({
+      type: 'facet',
+      label: 'Kind',
+      path: 'kind',
+      mode: 'single',
+      defaultValue: undefined,
+    });
+  });
+
+  it('should create a custom filter descriptor from deprecated loader params', () => {
+    const extension = CatalogFilterBlueprint.make({
+      name: 'custom',
+      params: {
+        loader: async () => <div>custom filter</div>,
+      },
+    });
+
+    const tester = createExtensionTester(extension);
+    const descriptor = tester.get(
+      CatalogFilterBlueprint.dataRefs.filterDescriptor,
+    );
+
+    expect(descriptor.type).toBe('custom');
+    expect(descriptor).toHaveProperty('element');
+  });
+
+  it('should create an options filter descriptor with static options and toFilter', () => {
+    const toFilter = jest.fn((selected: string[]) => {
+      if (!selected.length) return undefined;
+      return {
+        getCatalogFilters: () => ({ status: selected }),
+      };
+    });
+
+    const extension = CatalogFilterBlueprint.make({
+      name: 'status',
+      params: {
+        label: 'Status',
+        mode: 'multi',
+        options: [
+          { label: 'Active', value: 'active' },
+          { label: 'Inactive', value: 'inactive' },
+        ],
+        toFilter,
+      },
+    });
+
+    const tester = createExtensionTester(extension);
+    const descriptor = tester.get(
+      CatalogFilterBlueprint.dataRefs.filterDescriptor,
+    );
+
+    expect(descriptor).toMatchObject({
+      type: 'options',
+      label: 'Status',
+      mode: 'multi',
+      deps: {},
+      options: [
+        { label: 'Active', value: 'active' },
+        { label: 'Inactive', value: 'inactive' },
+      ],
+    });
+
+    const optionsDescriptor = descriptor as Extract<
+      typeof descriptor,
+      { type: 'options' }
+    >;
+    const filter = optionsDescriptor.toFilter(['active'], {});
+    expect(toFilter).toHaveBeenCalledWith(['active'], {});
+    expect(filter).toEqual({
+      getCatalogFilters: expect.any(Function),
+    });
+  });
+
+  it('should support makeWithOverrides to inject config into model params', () => {
     const extension = CatalogFilterBlueprint.makeWithOverrides({
-      name: 'test-name',
-      inputs: {
-        mock: createExtensionInput([coreExtensionData.reactElement]),
+      name: 'with-config',
+      configSchema: {
+        initialFilter: z.string().default('component'),
       },
-      config: {
-        schema: {
-          test: z => z.string(),
-        },
-      },
-      factory(originalFactory, { config, inputs }) {
+      factory(originalFactory, { config }) {
         return originalFactory({
-          loader: async () => (
-            <div data-testid="test">
-              config: {config.test}
-              <div data-testid="contents">
-                {inputs.mock.map((i, k) => (
-                  <div key={k}>{i.get(coreExtensionData.reactElement)}</div>
-                ))}
-              </div>
-            </div>
-          ),
+          label: 'Kind',
+          path: 'kind',
+          mode: 'single',
+          defaultValue: config.initialFilter,
         });
       },
     });
 
-    const mockExtension = createExtension({
-      attachTo: { id: 'catalog-filter:test-name', input: 'mock' },
-      output: [coreExtensionData.reactElement],
-      factory() {
-        return [coreExtensionData.reactElement(<div>im a mock</div>)];
-      },
-    });
-
-    renderInTestApp(
-      createExtensionTester(extension, { config: { test: 'mock test config' } })
-        .add(mockExtension)
-        .reactElement(),
+    const tester = createExtensionTester(extension);
+    const descriptor = tester.get(
+      CatalogFilterBlueprint.dataRefs.filterDescriptor,
     );
 
-    await waitFor(() => {
-      expect(screen.getByTestId('test')).toBeInTheDocument();
-      expect(screen.getByTestId('test')).toHaveTextContent(
-        'config: mock test config',
-      );
-      expect(screen.getByTestId('contents')).toHaveTextContent('im a mock');
+    expect(descriptor).toEqual({
+      type: 'facet',
+      label: 'Kind',
+      path: 'kind',
+      mode: 'single',
+      defaultValue: 'component',
     });
   });
 });

--- a/plugins/catalog-react/src/alpha/blueprints/CatalogFilterBlueprint.ts
+++ b/plugins/catalog-react/src/alpha/blueprints/CatalogFilterBlueprint.ts
@@ -31,6 +31,7 @@ import { EntityFilter } from '../../types';
 export interface CatalogFacetFilterDescriptor {
   type: 'facet';
   label: string;
+  filterKey: string;
   path: string;
   mode: 'single' | 'multi';
   defaultValue?: string | string[];
@@ -45,6 +46,7 @@ export interface CatalogFacetFilterDescriptor {
 export interface CatalogOptionsFilterDescriptor {
   type: 'options';
   label: string;
+  filterKey: string;
   mode: 'single' | 'multi';
   defaultValue?: string | string[];
   options: Array<{ label: string; value: string }>;
@@ -100,12 +102,14 @@ export const CatalogFilterBlueprint = createExtensionBlueprint({
     params:
       | {
           label: string;
+          filterKey?: string;
           path: string;
           mode: 'single' | 'multi';
           defaultValue?: string | string[];
         }
       | {
           label: string;
+          filterKey?: string;
           mode: 'single' | 'multi';
           defaultValue?: string | string[];
           options: Array<{ label: string; value: string }>;
@@ -134,6 +138,7 @@ export const CatalogFilterBlueprint = createExtensionBlueprint({
         catalogFilterDescriptorDataRef({
           type: 'options',
           label: params.label,
+          filterKey: params.filterKey ?? params.label,
           mode: params.mode,
           defaultValue: params.defaultValue,
           options: params.options,
@@ -146,6 +151,7 @@ export const CatalogFilterBlueprint = createExtensionBlueprint({
       catalogFilterDescriptorDataRef({
         type: 'facet',
         label: params.label,
+        filterKey: params.filterKey ?? params.path,
         path: params.path,
         mode: params.mode,
         defaultValue: params.defaultValue,

--- a/plugins/catalog-react/src/alpha/blueprints/CatalogFilterBlueprint.ts
+++ b/plugins/catalog-react/src/alpha/blueprints/CatalogFilterBlueprint.ts
@@ -16,23 +16,140 @@
 
 import {
   ExtensionBoundary,
-  coreExtensionData,
   createExtensionBlueprint,
+  createExtensionDataRef,
 } from '@backstage/frontend-plugin-api';
+import { ApiRef } from '@backstage/core-plugin-api';
+import { EntityFilter } from '../../types';
 
 /**
- * Creates Catalog Filter Extensions
+ * Describes a facet-based catalog filter rendered by the catalog page controller.
+ * The available options are fetched from catalog facets using the given path,
+ * and selections map directly to catalog backend filters.
+ * @alpha
+ */
+export interface CatalogFacetFilterDescriptor {
+  type: 'facet';
+  label: string;
+  path: string;
+  mode: 'single' | 'multi';
+  defaultValue?: string | string[];
+}
+
+/**
+ * Describes a catalog filter with static options and a custom filter factory.
+ * The options are defined upfront, and a toFilter function maps selections
+ * to an EntityFilter using injected API dependencies.
+ * @alpha
+ */
+export interface CatalogOptionsFilterDescriptor {
+  type: 'options';
+  label: string;
+  mode: 'single' | 'multi';
+  defaultValue?: string | string[];
+  options: Array<{ label: string; value: string }>;
+  deps: Record<string, ApiRef<unknown>>;
+  toFilter(
+    selected: string[],
+    deps: Record<string, unknown>,
+  ): EntityFilter | undefined | Promise<EntityFilter | undefined>;
+}
+
+/**
+ * Describes a catalog filter that provides its own rendering.
+ * @alpha
+ */
+export interface CatalogCustomFilterDescriptor {
+  type: 'custom';
+  element: JSX.Element;
+}
+
+/**
+ * @alpha
+ */
+export type CatalogFilterDescriptor =
+  | CatalogFacetFilterDescriptor
+  | CatalogOptionsFilterDescriptor
+  | CatalogCustomFilterDescriptor;
+
+const catalogFilterDescriptorDataRef =
+  createExtensionDataRef<CatalogFilterDescriptor>().with({
+    id: 'catalog.filter-descriptor',
+  });
+
+/**
+ * Creates catalog filter extensions.
+ *
+ * Supports three styles:
+ * - Facet-based: provide a label, entity path, and selection mode. The catalog
+ *   page fetches available values and renders the picker.
+ * - Options-based: provide static options with a toFilter function that maps
+ *   selections to EntityFilter objects, with API dependencies injected.
+ * - Custom component (deprecated): provide a loader that returns JSX.
+ *
  * @alpha
  */
 export const CatalogFilterBlueprint = createExtensionBlueprint({
   kind: 'catalog-filter',
   attachTo: { id: 'page:catalog', input: 'filters' },
-  output: [coreExtensionData.reactElement],
-  factory(params: { loader: () => Promise<JSX.Element> }, { node }) {
+  output: [catalogFilterDescriptorDataRef],
+  dataRefs: {
+    filterDescriptor: catalogFilterDescriptorDataRef,
+  },
+  factory(
+    params:
+      | {
+          label: string;
+          path: string;
+          mode: 'single' | 'multi';
+          defaultValue?: string | string[];
+        }
+      | {
+          label: string;
+          mode: 'single' | 'multi';
+          defaultValue?: string | string[];
+          options: Array<{ label: string; value: string }>;
+          deps?: Record<string, ApiRef<unknown>>;
+          toFilter(
+            selected: string[],
+            deps: Record<string, unknown>,
+          ): EntityFilter | undefined | Promise<EntityFilter | undefined>;
+        }
+      | {
+          /** @deprecated Use the model-based params instead. */
+          loader: () => Promise<JSX.Element>;
+        },
+    { node },
+  ) {
+    if ('loader' in params) {
+      return [
+        catalogFilterDescriptorDataRef({
+          type: 'custom',
+          element: ExtensionBoundary.lazy(node, params.loader),
+        }),
+      ];
+    }
+    if ('options' in params) {
+      return [
+        catalogFilterDescriptorDataRef({
+          type: 'options',
+          label: params.label,
+          mode: params.mode,
+          defaultValue: params.defaultValue,
+          options: params.options,
+          deps: params.deps ?? {},
+          toFilter: params.toFilter,
+        }),
+      ];
+    }
     return [
-      coreExtensionData.reactElement(
-        ExtensionBoundary.lazy(node, params.loader),
-      ),
+      catalogFilterDescriptorDataRef({
+        type: 'facet',
+        label: params.label,
+        path: params.path,
+        mode: params.mode,
+        defaultValue: params.defaultValue,
+      }),
     ];
   },
 });

--- a/plugins/catalog-react/src/alpha/blueprints/index.ts
+++ b/plugins/catalog-react/src/alpha/blueprints/index.ts
@@ -13,7 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { CatalogFilterBlueprint } from './CatalogFilterBlueprint';
+export {
+  CatalogFilterBlueprint,
+  type CatalogFilterDescriptor,
+  type CatalogFacetFilterDescriptor,
+  type CatalogOptionsFilterDescriptor,
+  type CatalogCustomFilterDescriptor,
+} from './CatalogFilterBlueprint';
 export { EntityCardBlueprint } from './EntityCardBlueprint';
 export { EntityContentBlueprint } from './EntityContentBlueprint';
 export {

--- a/plugins/catalog/src/alpha/components/FacetFilterPicker.tsx
+++ b/plugins/catalog/src/alpha/components/FacetFilterPicker.tsx
@@ -33,18 +33,23 @@ type DynamicEntityFilters = DefaultEntityFilters & {
 };
 
 class FacetEntityFilter implements EntityFilter {
-  constructor(readonly path: string, readonly values: string[]) {}
+  readonly value: string;
+
+  constructor(readonly path: string, readonly values: string[]) {
+    this.value = values[0];
+  }
 
   getCatalogFilters(): Record<string, string | string[]> {
     return { [this.path]: this.values };
   }
 
   filterEntity(entity: Entity): boolean {
-    const value = this.resolve(entity, this.path);
-    if (Array.isArray(value)) {
-      return this.values.some(v => value.includes(v));
+    const resolved = this.resolve(entity, this.path);
+    if (Array.isArray(resolved)) {
+      return this.values.every(v => resolved.includes(v));
     }
-    return this.values.includes(String(value));
+    if (resolved === null || resolved === undefined) return false;
+    return this.values.includes(String(resolved));
   }
 
   toQueryValue(): string | string[] {

--- a/plugins/catalog/src/alpha/components/FacetFilterPicker.tsx
+++ b/plugins/catalog/src/alpha/components/FacetFilterPicker.tsx
@@ -15,30 +15,27 @@
  */
 
 import { useEffect, useMemo, useState } from 'react';
-import { useApi } from '@backstage/core-plugin-api';
+import { alertApiRef, useApi } from '@backstage/core-plugin-api';
 import { Select } from '@backstage/ui';
 import useAsync from 'react-use/esm/useAsync';
 import { Entity } from '@backstage/catalog-model';
-import {
-  catalogApiRef,
-  useEntityList,
-  type DefaultEntityFilters,
-} from '@backstage/plugin-catalog-react';
+import { catalogApiRef, useEntityList } from '@backstage/plugin-catalog-react';
 import type { CatalogFacetFilterDescriptor } from '@backstage/plugin-catalog-react/alpha';
 import type { EntityFilter } from '@backstage/plugin-catalog-react';
 import { multiSelectProps } from './multiSelectProps';
+import type { DynamicEntityFilters } from './types';
 
-type DynamicEntityFilters = DefaultEntityFilters & {
-  [key: string]: EntityFilter | undefined;
-};
+function titleCase(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
 
 class FacetEntityFilter implements EntityFilter {
   readonly value: string;
   readonly label: string;
 
   constructor(readonly path: string, readonly values: string[]) {
-    this.value = values[0];
-    this.label = values[0];
+    this.value = values[0] ?? '';
+    this.label = titleCase(values[0] ?? '');
   }
 
   getCatalogFilters(): Record<string, string | string[]> {
@@ -67,6 +64,7 @@ class FacetEntityFilter implements EntityFilter {
 export function FacetFilterPicker(props: CatalogFacetFilterDescriptor) {
   const { label, filterKey, path, mode, defaultValue } = props;
   const catalogApi = useApi(catalogApiRef);
+  const alertApi = useApi(alertApiRef);
   const { updateFilters, queryParameters } =
     useEntityList<DynamicEntityFilters>();
 
@@ -94,7 +92,7 @@ export function FacetFilterPicker(props: CatalogFacetFilterDescriptor) {
     }
   }, [queryParam]);
 
-  const { value: availableValues = [] } = useAsync(async () => {
+  const { value: availableValues = [], error } = useAsync(async () => {
     const { facets } = await catalogApi.getEntityFacets({
       facets: [path],
     });
@@ -108,15 +106,28 @@ export function FacetFilterPicker(props: CatalogFacetFilterDescriptor) {
   }, [path, catalogApi]);
 
   useEffect(() => {
+    if (error) {
+      alertApi.post({
+        message: `Failed to load filter values for ${label}.`,
+        severity: 'error',
+      });
+    }
+  }, [error, alertApi, label]);
+
+  useEffect(() => {
     updateFilters({
       [filterKey]: selected.length
         ? new FacetEntityFilter(path, selected)
         : undefined,
     });
+  }, [selected, filterKey, path, updateFilters]);
+
+  useEffect(() => {
     return () => {
       updateFilters({ [filterKey]: undefined });
     };
-  }, [selected, filterKey, path, updateFilters]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const options = availableValues.map(v => ({ label: v, value: v }));
 
@@ -139,7 +150,7 @@ export function FacetFilterPicker(props: CatalogFacetFilterDescriptor) {
       selectionMode="multiple"
       searchable
       options={options}
-      {...multiSelectProps(selected, setSelected)}
+      {...multiSelectProps(selected, setSelected, availableValues)}
     />
   );
 }

--- a/plugins/catalog/src/alpha/components/FacetFilterPicker.tsx
+++ b/plugins/catalog/src/alpha/components/FacetFilterPicker.tsx
@@ -34,9 +34,11 @@ type DynamicEntityFilters = DefaultEntityFilters & {
 
 class FacetEntityFilter implements EntityFilter {
   readonly value: string;
+  readonly label: string;
 
   constructor(readonly path: string, readonly values: string[]) {
     this.value = values[0];
+    this.label = values[0];
   }
 
   getCatalogFilters(): Record<string, string | string[]> {
@@ -62,10 +64,8 @@ class FacetEntityFilter implements EntityFilter {
 }
 
 /** @internal */
-export function FacetFilterPicker(
-  props: CatalogFacetFilterDescriptor & { filterKey: string },
-) {
-  const { label, path, mode, defaultValue, filterKey } = props;
+export function FacetFilterPicker(props: CatalogFacetFilterDescriptor) {
+  const { label, filterKey, path, mode, defaultValue } = props;
   const catalogApi = useApi(catalogApiRef);
   const { updateFilters, queryParameters } =
     useEntityList<DynamicEntityFilters>();
@@ -105,7 +105,7 @@ export function FacetFilterPicker(
           .toLocaleLowerCase('en-US')
           .localeCompare(b.toLocaleLowerCase('en-US')),
       );
-  }, [path]);
+  }, [path, catalogApi]);
 
   useEffect(() => {
     updateFilters({
@@ -113,6 +113,9 @@ export function FacetFilterPicker(
         ? new FacetEntityFilter(path, selected)
         : undefined,
     });
+    return () => {
+      updateFilters({ [filterKey]: undefined });
+    };
   }, [selected, filterKey, path, updateFilters]);
 
   const options = availableValues.map(v => ({ label: v, value: v }));

--- a/plugins/catalog/src/alpha/components/FacetFilterPicker.tsx
+++ b/plugins/catalog/src/alpha/components/FacetFilterPicker.tsx
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { useApi } from '@backstage/core-plugin-api';
+import { Select } from '@backstage/ui';
+import useAsync from 'react-use/esm/useAsync';
+import { Entity } from '@backstage/catalog-model';
+import {
+  catalogApiRef,
+  useEntityList,
+  type DefaultEntityFilters,
+} from '@backstage/plugin-catalog-react';
+import type { CatalogFacetFilterDescriptor } from '@backstage/plugin-catalog-react/alpha';
+import type { EntityFilter } from '@backstage/plugin-catalog-react';
+import { multiSelectProps } from './multiSelectProps';
+
+type DynamicEntityFilters = DefaultEntityFilters & {
+  [key: string]: EntityFilter | undefined;
+};
+
+class FacetEntityFilter implements EntityFilter {
+  constructor(readonly path: string, readonly values: string[]) {}
+
+  getCatalogFilters(): Record<string, string | string[]> {
+    return { [this.path]: this.values };
+  }
+
+  filterEntity(entity: Entity): boolean {
+    const value = this.resolve(entity, this.path);
+    if (Array.isArray(value)) {
+      return this.values.some(v => value.includes(v));
+    }
+    return this.values.includes(String(value));
+  }
+
+  toQueryValue(): string | string[] {
+    return this.values.length === 1 ? this.values[0] : this.values;
+  }
+
+  private resolve(obj: any, path: string): unknown {
+    return path.split('.').reduce((o, key) => o?.[key], obj);
+  }
+}
+
+/** @internal */
+export function FacetFilterPicker(
+  props: CatalogFacetFilterDescriptor & { filterKey: string },
+) {
+  const { label, path, mode, defaultValue, filterKey } = props;
+  const catalogApi = useApi(catalogApiRef);
+  const { updateFilters, queryParameters } =
+    useEntityList<DynamicEntityFilters>();
+
+  const queryParam = useMemo(
+    () =>
+      [queryParameters[filterKey as keyof typeof queryParameters]]
+        .flat()
+        .filter(Boolean) as string[],
+    [queryParameters, filterKey],
+  );
+
+  const initial = useMemo(() => {
+    if (queryParam.length) return queryParam;
+    if (defaultValue) {
+      return Array.isArray(defaultValue) ? defaultValue : [defaultValue];
+    }
+    return [];
+  }, [queryParam, defaultValue]);
+
+  const [selected, setSelected] = useState<string[]>(initial);
+
+  useEffect(() => {
+    if (queryParam.length) {
+      setSelected(queryParam);
+    }
+  }, [queryParam]);
+
+  const { value: availableValues = [] } = useAsync(async () => {
+    const { facets } = await catalogApi.getEntityFacets({
+      facets: [path],
+    });
+    return (facets[path] ?? [])
+      .map(f => f.value)
+      .sort((a, b) =>
+        a
+          .toLocaleLowerCase('en-US')
+          .localeCompare(b.toLocaleLowerCase('en-US')),
+      );
+  }, [path]);
+
+  useEffect(() => {
+    updateFilters({
+      [filterKey]: selected.length
+        ? new FacetEntityFilter(path, selected)
+        : undefined,
+    });
+  }, [selected, filterKey, path, updateFilters]);
+
+  const options = availableValues.map(v => ({ label: v, value: v }));
+
+  if (mode === 'single') {
+    return (
+      <Select
+        label={label}
+        selectionMode="single"
+        searchable={options.length > 10}
+        options={options}
+        selectedKey={selected[0] ?? null}
+        onSelectionChange={key => setSelected(key ? [String(key)] : [])}
+      />
+    );
+  }
+
+  return (
+    <Select
+      label={label}
+      selectionMode="multiple"
+      searchable
+      options={options}
+      {...multiSelectProps(selected, setSelected)}
+    />
+  );
+}

--- a/plugins/catalog/src/alpha/components/OptionsFilterPicker.tsx
+++ b/plugins/catalog/src/alpha/components/OptionsFilterPicker.tsx
@@ -17,17 +17,11 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useApiHolder } from '@backstage/core-plugin-api';
 import { Select } from '@backstage/ui';
-import {
-  useEntityList,
-  type DefaultEntityFilters,
-} from '@backstage/plugin-catalog-react';
+import { useEntityList } from '@backstage/plugin-catalog-react';
 import type { CatalogOptionsFilterDescriptor } from '@backstage/plugin-catalog-react/alpha';
 import type { EntityFilter } from '@backstage/plugin-catalog-react';
 import { multiSelectProps } from './multiSelectProps';
-
-type DynamicEntityFilters = DefaultEntityFilters & {
-  [key: string]: EntityFilter | undefined;
-};
+import type { DynamicEntityFilters } from './types';
 
 /** @internal */
 export function OptionsFilterPicker(props: CatalogOptionsFilterDescriptor) {
@@ -37,13 +31,19 @@ export function OptionsFilterPicker(props: CatalogOptionsFilterDescriptor) {
   const { updateFilters, queryParameters } =
     useEntityList<DynamicEntityFilters>();
 
-  const resolvedDeps = useMemo(
-    () =>
-      Object.fromEntries(
-        Object.entries(deps).map(([key, ref]) => [key, apiHolder.get(ref)]),
-      ),
-    [deps, apiHolder],
-  );
+  const resolvedDeps = useMemo(() => {
+    const resolved: Record<string, unknown> = {};
+    for (const [key, ref] of Object.entries(deps)) {
+      const api = apiHolder.get(ref);
+      if (!api) {
+        throw new Error(
+          `Missing API dependency '${key}' for filter '${filterKey}'`,
+        );
+      }
+      resolved[key] = api;
+    }
+    return resolved;
+  }, [deps, apiHolder, filterKey]);
 
   const queryParam = useMemo(
     () =>
@@ -103,9 +103,15 @@ export function OptionsFilterPicker(props: CatalogOptionsFilterDescriptor) {
 
     return () => {
       cancelled = true;
-      updateFilters({ [filterKey]: undefined });
     };
   }, [selected, filterKey, toFilter, resolvedDeps, updateFilters]);
+
+  useEffect(() => {
+    return () => {
+      updateFilters({ [filterKey]: undefined });
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const selectOptions = options.map(o => ({ label: o.label, value: o.value }));
 
@@ -126,7 +132,11 @@ export function OptionsFilterPicker(props: CatalogOptionsFilterDescriptor) {
       label={label}
       selectionMode="multiple"
       options={selectOptions}
-      {...multiSelectProps(selected, setSelected)}
+      {...multiSelectProps(
+        selected,
+        setSelected,
+        options.map(o => o.value),
+      )}
     />
   );
 }

--- a/plugins/catalog/src/alpha/components/OptionsFilterPicker.tsx
+++ b/plugins/catalog/src/alpha/components/OptionsFilterPicker.tsx
@@ -30,10 +30,8 @@ type DynamicEntityFilters = DefaultEntityFilters & {
 };
 
 /** @internal */
-export function OptionsFilterPicker(
-  props: CatalogOptionsFilterDescriptor & { filterKey: string },
-) {
-  const { label, mode, defaultValue, options, deps, toFilter, filterKey } =
+export function OptionsFilterPicker(props: CatalogOptionsFilterDescriptor) {
+  const { label, filterKey, mode, defaultValue, options, deps, toFilter } =
     props;
   const apiHolder = useApiHolder();
   const { updateFilters, queryParameters } =
@@ -76,15 +74,20 @@ export function OptionsFilterPicker(
 
     if (!selected.length) {
       updateFilters({ [filterKey]: undefined });
-      return undefined;
+      return () => {
+        cancelled = true;
+      };
     }
 
     const applyFilter = (filter: EntityFilter | undefined) => {
       if (cancelled) return;
-      if (filter && !filter.toQueryValue) {
-        filter.toQueryValue = () => selected;
-      }
-      updateFilters({ [filterKey]: filter });
+      const withQueryValue = filter
+        ? {
+            ...filter,
+            toQueryValue: filter.toQueryValue ?? (() => selected),
+          }
+        : undefined;
+      updateFilters({ [filterKey]: withQueryValue });
     };
 
     const result = toFilter(selected, resolvedDeps);
@@ -100,6 +103,7 @@ export function OptionsFilterPicker(
 
     return () => {
       cancelled = true;
+      updateFilters({ [filterKey]: undefined });
     };
   }, [selected, filterKey, toFilter, resolvedDeps, updateFilters]);
 

--- a/plugins/catalog/src/alpha/components/OptionsFilterPicker.tsx
+++ b/plugins/catalog/src/alpha/components/OptionsFilterPicker.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { useApiHolder } from '@backstage/core-plugin-api';
+import { Select } from '@backstage/ui';
+import {
+  useEntityList,
+  type DefaultEntityFilters,
+} from '@backstage/plugin-catalog-react';
+import type { EntityFilter } from '@backstage/plugin-catalog-react';
+import type { CatalogOptionsFilterDescriptor } from '@backstage/plugin-catalog-react/alpha';
+import { multiSelectProps } from './multiSelectProps';
+
+type DynamicEntityFilters = DefaultEntityFilters & {
+  [key: string]: EntityFilter | undefined;
+};
+
+/** @internal */
+export function OptionsFilterPicker(
+  props: CatalogOptionsFilterDescriptor & { filterKey: string },
+) {
+  const { label, mode, defaultValue, options, deps, toFilter, filterKey } =
+    props;
+  const apiHolder = useApiHolder();
+  const { updateFilters, queryParameters } =
+    useEntityList<DynamicEntityFilters>();
+
+  const resolvedDeps = useMemo(
+    () =>
+      Object.fromEntries(
+        Object.entries(deps).map(([key, ref]) => [key, apiHolder.get(ref)]),
+      ),
+    [deps, apiHolder],
+  );
+
+  const queryParam = useMemo(
+    () =>
+      [queryParameters[filterKey as keyof typeof queryParameters]]
+        .flat()
+        .filter(Boolean) as string[],
+    [queryParameters, filterKey],
+  );
+
+  const initial = useMemo(() => {
+    if (queryParam.length) return queryParam;
+    if (defaultValue) {
+      return Array.isArray(defaultValue) ? defaultValue : [defaultValue];
+    }
+    return [];
+  }, [queryParam, defaultValue]);
+
+  const [selected, setSelected] = useState<string[]>(initial);
+
+  useEffect(() => {
+    if (queryParam.length) {
+      setSelected(queryParam);
+    }
+  }, [queryParam]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!selected.length) {
+      updateFilters({ [filterKey]: undefined });
+      return undefined;
+    }
+
+    const result = toFilter(selected, resolvedDeps);
+    if (result instanceof Promise) {
+      result.then(filter => {
+        if (!cancelled) {
+          updateFilters({ [filterKey]: filter });
+        }
+      });
+    } else {
+      updateFilters({ [filterKey]: result });
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selected, filterKey, toFilter, resolvedDeps, updateFilters]);
+
+  const selectOptions = options.map(o => ({ label: o.label, value: o.value }));
+
+  if (mode === 'single') {
+    return (
+      <Select
+        label={label}
+        selectionMode="single"
+        options={selectOptions}
+        selectedKey={selected[0] ?? null}
+        onSelectionChange={key => setSelected(key ? [String(key)] : [])}
+      />
+    );
+  }
+
+  return (
+    <Select
+      label={label}
+      selectionMode="multiple"
+      options={selectOptions}
+      {...multiSelectProps(selected, setSelected)}
+    />
+  );
+}

--- a/plugins/catalog/src/alpha/components/OptionsFilterPicker.tsx
+++ b/plugins/catalog/src/alpha/components/OptionsFilterPicker.tsx
@@ -21,8 +21,8 @@ import {
   useEntityList,
   type DefaultEntityFilters,
 } from '@backstage/plugin-catalog-react';
-import type { EntityFilter } from '@backstage/plugin-catalog-react';
 import type { CatalogOptionsFilterDescriptor } from '@backstage/plugin-catalog-react/alpha';
+import type { EntityFilter } from '@backstage/plugin-catalog-react';
 import { multiSelectProps } from './multiSelectProps';
 
 type DynamicEntityFilters = DefaultEntityFilters & {
@@ -79,15 +79,23 @@ export function OptionsFilterPicker(
       return undefined;
     }
 
+    const applyFilter = (filter: EntityFilter | undefined) => {
+      if (cancelled) return;
+      if (filter && !filter.toQueryValue) {
+        filter.toQueryValue = () => selected;
+      }
+      updateFilters({ [filterKey]: filter });
+    };
+
     const result = toFilter(selected, resolvedDeps);
     if (result instanceof Promise) {
-      result.then(filter => {
+      result.then(applyFilter, () => {
         if (!cancelled) {
-          updateFilters({ [filterKey]: filter });
+          updateFilters({ [filterKey]: undefined });
         }
       });
     } else {
-      updateFilters({ [filterKey]: result });
+      applyFilter(result);
     }
 
     return () => {

--- a/plugins/catalog/src/alpha/components/multiSelectProps.ts
+++ b/plugins/catalog/src/alpha/components/multiSelectProps.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// The BUI Select component supports selectionMode="multiple" at runtime,
+// but the TypeScript types don't expose the controlled multi-select props
+// (selectedKeys, onSelectionChange with Set) because react-aria's Select
+// type is inherently single-select. This helper provides the props in a
+// type-safe way until the BUI types are fixed.
+export function multiSelectProps(
+  selected: string[],
+  setSelected: (values: string[]) => void,
+): Record<string, unknown> {
+  return {
+    selectedKeys: new Set(selected),
+    onSelectionChange: (keys: Set<string> | 'all') => {
+      if (keys !== 'all') {
+        setSelected([...keys].map(String));
+      }
+    },
+  };
+}

--- a/plugins/catalog/src/alpha/components/multiSelectProps.ts
+++ b/plugins/catalog/src/alpha/components/multiSelectProps.ts
@@ -22,11 +22,14 @@
 export function multiSelectProps(
   selected: string[],
   setSelected: (values: string[]) => void,
+  allOptions?: string[],
 ): Record<string, unknown> {
   return {
     selectedKeys: new Set(selected),
     onSelectionChange: (keys: Set<string> | 'all') => {
-      if (keys !== 'all') {
+      if (keys === 'all') {
+        setSelected(allOptions ?? []);
+      } else {
         setSelected([...keys].map(String));
       }
     },

--- a/plugins/catalog/src/alpha/components/types.ts
+++ b/plugins/catalog/src/alpha/components/types.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DefaultEntityFilters } from '@backstage/plugin-catalog-react';
+import type { EntityFilter } from '@backstage/plugin-catalog-react';
+
+export type DynamicEntityFilters = DefaultEntityFilters & {
+  [key: string]: EntityFilter | undefined;
+};

--- a/plugins/catalog/src/alpha/filters.tsx
+++ b/plugins/catalog/src/alpha/filters.tsx
@@ -115,9 +115,6 @@ const catalogProcessingStatusCatalogFilter = CatalogFilterBlueprint.make({
           }
           return true;
         },
-        toQueryValue() {
-          return selected;
-        },
       };
     },
   },

--- a/plugins/catalog/src/alpha/filters.tsx
+++ b/plugins/catalog/src/alpha/filters.tsx
@@ -17,18 +17,6 @@
 import { CatalogFilterBlueprint } from '@backstage/plugin-catalog-react/alpha';
 import { z } from 'zod/v4';
 
-const catalogTagCatalogFilter = CatalogFilterBlueprint.make({
-  name: 'tag',
-  params: {
-    loader: async () => {
-      const { EntityTagPicker } = await import(
-        '@backstage/plugin-catalog-react'
-      );
-      return <EntityTagPicker />;
-    },
-  },
-});
-
 const catalogKindCatalogFilter = CatalogFilterBlueprint.makeWithOverrides({
   name: 'kind',
   configSchema: {
@@ -36,12 +24,10 @@ const catalogKindCatalogFilter = CatalogFilterBlueprint.makeWithOverrides({
   },
   factory(originalFactory, { config }) {
     return originalFactory({
-      loader: async () => {
-        const { EntityKindPicker } = await import(
-          '@backstage/plugin-catalog-react'
-        );
-        return <EntityKindPicker initialFilter={config.initialFilter} />;
-      },
+      label: 'Kind',
+      path: 'kind',
+      mode: 'single',
+      defaultValue: config.initialFilter,
     });
   },
 });
@@ -49,12 +35,36 @@ const catalogKindCatalogFilter = CatalogFilterBlueprint.makeWithOverrides({
 const catalogTypeCatalogFilter = CatalogFilterBlueprint.make({
   name: 'type',
   params: {
-    loader: async () => {
-      const { EntityTypePicker } = await import(
-        '@backstage/plugin-catalog-react'
-      );
-      return <EntityTypePicker />;
-    },
+    label: 'Type',
+    path: 'spec.type',
+    mode: 'single',
+  },
+});
+
+const catalogTagCatalogFilter = CatalogFilterBlueprint.make({
+  name: 'tag',
+  params: {
+    label: 'Tags',
+    path: 'metadata.tags',
+    mode: 'multi',
+  },
+});
+
+const catalogLifecycleCatalogFilter = CatalogFilterBlueprint.make({
+  name: 'lifecycle',
+  params: {
+    label: 'Lifecycle',
+    path: 'spec.lifecycle',
+    mode: 'multi',
+  },
+});
+
+const catalogNamespaceCatalogFilter = CatalogFilterBlueprint.make({
+  name: 'namespace',
+  params: {
+    label: 'Namespace',
+    path: 'metadata.namespace',
+    mode: 'multi',
   },
 });
 
@@ -75,38 +85,40 @@ const catalogModeCatalogFilter = CatalogFilterBlueprint.makeWithOverrides({
   },
 });
 
-const catalogNamespaceCatalogFilter = CatalogFilterBlueprint.make({
-  name: 'namespace',
-  params: {
-    loader: async () => {
-      const { EntityNamespacePicker } = await import(
-        '@backstage/plugin-catalog-react'
-      );
-      return <EntityNamespacePicker />;
-    },
-  },
-});
-
-const catalogLifecycleCatalogFilter = CatalogFilterBlueprint.make({
-  name: 'lifecycle',
-  params: {
-    loader: async () => {
-      const { EntityLifecyclePicker } = await import(
-        '@backstage/plugin-catalog-react'
-      );
-      return <EntityLifecyclePicker />;
-    },
-  },
-});
-
 const catalogProcessingStatusCatalogFilter = CatalogFilterBlueprint.make({
   name: 'processing-status',
   params: {
-    loader: async () => {
-      const { EntityProcessingStatusPicker } = await import(
-        '@backstage/plugin-catalog-react'
-      );
-      return <EntityProcessingStatusPicker />;
+    label: 'Processing Status',
+    mode: 'multi',
+    options: [
+      { label: 'Is Orphan', value: 'orphan' },
+      { label: 'Has Error', value: 'error' },
+    ],
+    toFilter(selected) {
+      if (!selected.length) return undefined;
+      return {
+        getCatalogFilters() {
+          const filters: Record<string, string | string[]> = {};
+          if (selected.includes('orphan')) {
+            filters['metadata.annotations.backstage.io/orphan'] = 'true';
+          }
+          return filters;
+        },
+        filterEntity(entity) {
+          if (selected.includes('orphan')) {
+            const orphan = entity.metadata.annotations?.['backstage.io/orphan'];
+            if (orphan !== 'true') return false;
+          }
+          if (selected.includes('error')) {
+            const status = (entity as any)?.status?.items;
+            if (!status || status.length === 0) return false;
+          }
+          return true;
+        },
+        toQueryValue() {
+          return selected;
+        },
+      };
     },
   },
 });
@@ -128,7 +140,7 @@ const catalogListCatalogFilter = CatalogFilterBlueprint.makeWithOverrides({
   },
 });
 
-// this is the default order that the filters will be applied in
+// the default order that the filters will be applied in
 export default [
   catalogKindCatalogFilter,
   catalogTypeCatalogFilter,

--- a/plugins/catalog/src/alpha/filters.tsx
+++ b/plugins/catalog/src/alpha/filters.tsx
@@ -25,6 +25,7 @@ const catalogKindCatalogFilter = CatalogFilterBlueprint.makeWithOverrides({
   factory(originalFactory, { config }) {
     return originalFactory({
       label: 'Kind',
+      filterKey: 'kind',
       path: 'kind',
       mode: 'single',
       defaultValue: config.initialFilter,
@@ -36,6 +37,7 @@ const catalogTypeCatalogFilter = CatalogFilterBlueprint.make({
   name: 'type',
   params: {
     label: 'Type',
+    filterKey: 'type',
     path: 'spec.type',
     mode: 'single',
   },
@@ -45,6 +47,7 @@ const catalogTagCatalogFilter = CatalogFilterBlueprint.make({
   name: 'tag',
   params: {
     label: 'Tags',
+    filterKey: 'tags',
     path: 'metadata.tags',
     mode: 'multi',
   },
@@ -54,6 +57,7 @@ const catalogLifecycleCatalogFilter = CatalogFilterBlueprint.make({
   name: 'lifecycle',
   params: {
     label: 'Lifecycle',
+    filterKey: 'lifecycles',
     path: 'spec.lifecycle',
     mode: 'multi',
   },
@@ -63,6 +67,7 @@ const catalogNamespaceCatalogFilter = CatalogFilterBlueprint.make({
   name: 'namespace',
   params: {
     label: 'Namespace',
+    filterKey: 'namespace',
     path: 'metadata.namespace',
     mode: 'multi',
   },
@@ -89,6 +94,7 @@ const catalogProcessingStatusCatalogFilter = CatalogFilterBlueprint.make({
   name: 'processing-status',
   params: {
     label: 'Processing Status',
+    filterKey: 'processing-status',
     mode: 'multi',
     options: [
       { label: 'Is Orphan', value: 'orphan' },

--- a/plugins/catalog/src/alpha/pages.tsx
+++ b/plugins/catalog/src/alpha/pages.tsx
@@ -139,12 +139,13 @@ export const catalogPage = PageBlueprint.makeWithOverrides({
                   />
                 );
               case 'custom':
-              default:
                 return (
                   <Fragment key={`custom-${keyCounter++}`}>
                     {descriptor.element}
                   </Fragment>
                 );
+              default:
+                return null;
             }
           }
           const element = filter.get(coreExtensionData.reactElement);

--- a/plugins/catalog/src/alpha/pages.tsx
+++ b/plugins/catalog/src/alpha/pages.tsx
@@ -127,16 +127,14 @@ export const catalogPage = PageBlueprint.makeWithOverrides({
               case 'options':
                 return (
                   <OptionsFilterPicker
-                    key={descriptor.label}
-                    filterKey={descriptor.label}
+                    key={descriptor.filterKey}
                     {...descriptor}
                   />
                 );
               case 'facet':
                 return (
                   <FacetFilterPicker
-                    key={descriptor.path}
-                    filterKey={descriptor.path}
+                    key={descriptor.filterKey}
                     {...descriptor}
                   />
                 );

--- a/plugins/catalog/src/alpha/pages.tsx
+++ b/plugins/catalog/src/alpha/pages.tsx
@@ -35,6 +35,7 @@ import {
   EntityHeaderBlueprint,
   EntityContentGroupDefinitions,
 } from '@backstage/plugin-catalog-react/alpha';
+import { Fragment } from 'react';
 import CategoryIcon from '@material-ui/icons/Category';
 import { rootRouteRef } from '../routes';
 import { useEntityFromUrl } from '../components/CatalogEntityPage/useEntityFromUrl';
@@ -71,7 +72,8 @@ export const CatalogExportConfigBlueprint = createExtensionBlueprint({
 export const catalogPage = PageBlueprint.makeWithOverrides({
   inputs: {
     filters: createExtensionInput([
-      CatalogFilterBlueprint.dataRefs.filterDescriptor,
+      CatalogFilterBlueprint.dataRefs.filterDescriptor.optional(),
+      coreExtensionData.reactElement.optional(),
     ]),
     exportConfig: createExtensionInput([catalogExportConfigDataRef.optional()]),
   },
@@ -115,33 +117,45 @@ export const catalogPage = PageBlueprint.makeWithOverrides({
           './components/OptionsFilterPicker'
         );
 
-        const descriptors = inputs.filters.map(filter =>
-          filter.get(CatalogFilterBlueprint.dataRefs.filterDescriptor),
-        );
-
-        const filterElements = descriptors.map(descriptor => {
-          switch (descriptor.type) {
-            case 'custom':
-              return descriptor.element;
-            case 'options':
-              return (
-                <OptionsFilterPicker
-                  key={descriptor.label}
-                  filterKey={descriptor.label}
-                  {...descriptor}
-                />
-              );
-            case 'facet':
-              return (
-                <FacetFilterPicker
-                  key={descriptor.path}
-                  filterKey={descriptor.path}
-                  {...descriptor}
-                />
-              );
-            default:
-              return null;
+        let keyCounter = 0;
+        const filterElements = inputs.filters.map(filter => {
+          const descriptor = filter.get(
+            CatalogFilterBlueprint.dataRefs.filterDescriptor,
+          );
+          if (descriptor) {
+            switch (descriptor.type) {
+              case 'options':
+                return (
+                  <OptionsFilterPicker
+                    key={descriptor.label}
+                    filterKey={descriptor.label}
+                    {...descriptor}
+                  />
+                );
+              case 'facet':
+                return (
+                  <FacetFilterPicker
+                    key={descriptor.path}
+                    filterKey={descriptor.path}
+                    {...descriptor}
+                  />
+                );
+              case 'custom':
+              default:
+                return (
+                  <Fragment key={`custom-${keyCounter++}`}>
+                    {descriptor.element}
+                  </Fragment>
+                );
+            }
           }
+          const element = filter.get(coreExtensionData.reactElement);
+          if (element) {
+            return (
+              <Fragment key={`legacy-${keyCounter++}`}>{element}</Fragment>
+            );
+          }
+          return null;
         });
 
         // Merge export customizers from all attached extensions

--- a/plugins/catalog/src/alpha/pages.tsx
+++ b/plugins/catalog/src/alpha/pages.tsx
@@ -28,6 +28,7 @@ import {
   entityRouteRef,
 } from '@backstage/plugin-catalog-react';
 import {
+  CatalogFilterBlueprint,
   defaultEntityContentGroupDefinitions,
   EntityContentBlueprint,
   EntityContextMenuItemBlueprint,
@@ -69,7 +70,9 @@ export const CatalogExportConfigBlueprint = createExtensionBlueprint({
 
 export const catalogPage = PageBlueprint.makeWithOverrides({
   inputs: {
-    filters: createExtensionInput([coreExtensionData.reactElement]),
+    filters: createExtensionInput([
+      CatalogFilterBlueprint.dataRefs.filterDescriptor,
+    ]),
     exportConfig: createExtensionInput([catalogExportConfigDataRef.optional()]),
   },
   configSchema: {
@@ -105,9 +108,41 @@ export const catalogPage = PageBlueprint.makeWithOverrides({
         const { NfsDefaultCatalogPage } = await import(
           '../components/CatalogPage/DefaultCatalogPage'
         );
-        const filters = inputs.filters.map(filter =>
-          filter.get(coreExtensionData.reactElement),
+        const { FacetFilterPicker } = await import(
+          './components/FacetFilterPicker'
         );
+        const { OptionsFilterPicker } = await import(
+          './components/OptionsFilterPicker'
+        );
+
+        const descriptors = inputs.filters.map(filter =>
+          filter.get(CatalogFilterBlueprint.dataRefs.filterDescriptor),
+        );
+
+        const filterElements = descriptors.map(descriptor => {
+          switch (descriptor.type) {
+            case 'custom':
+              return descriptor.element;
+            case 'options':
+              return (
+                <OptionsFilterPicker
+                  key={descriptor.label}
+                  filterKey={descriptor.label}
+                  {...descriptor}
+                />
+              );
+            case 'facet':
+              return (
+                <FacetFilterPicker
+                  key={descriptor.path}
+                  filterKey={descriptor.path}
+                  {...descriptor}
+                />
+              );
+            default:
+              return null;
+          }
+        });
 
         // Merge export customizers from all attached extensions
         const mergedExportSettings: CatalogExportSettings = {
@@ -137,7 +172,7 @@ export const catalogPage = PageBlueprint.makeWithOverrides({
 
         return (
           <NfsDefaultCatalogPage
-            filters={<>{filters}</>}
+            filters={<>{filterElements}</>}
             pagination={config.pagination}
             exportSettings={
               mergedExportSettings.enabled ? mergedExportSettings : undefined


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Redesigns the `CatalogFilterBlueprint` alpha API from a component-rendering model to a declarative, model-based approach. Instead of each filter extension providing its own React component via a `loader`, filters now describe themselves as data and the catalog page controller handles rendering using Backstage UI components.

### Three filter param variants

**Facet-based** — provide a label, entity path, and selection mode. The catalog page fetches available values via catalog facets and renders a BUI `Select`:
```ts
CatalogFilterBlueprint.make({
  name: 'tag',
  params: { label: 'Tags', path: 'metadata.tags', mode: 'multi' },
});
```

**Options-based** — provide static options with a `toFilter` function and optional API dependency injection:
```ts
CatalogFilterBlueprint.make({
  name: 'processing-status',
  params: {
    label: 'Processing Status',
    mode: 'multi',
    options: [
      { label: 'Is Orphan', value: 'orphan' },
      { label: 'Has Error', value: 'error' },
    ],
    toFilter(selected) {
      return {
        getCatalogFilters() { return { ... }; },
        filterEntity(entity) { return ...; },
      };
    },
  },
});
```

**Deprecated loader** — the old component-based escape hatch for filters that don't fit a declarative model (e.g. `UserListPicker`, `EntityOwnerPicker`):
```ts
CatalogFilterBlueprint.make({
  name: 'list',
  params: { loader: async () => <UserListPicker /> },
});
```

### What changed

- `@backstage/plugin-catalog-react`: New blueprint API with `filterDescriptor` data ref and exported descriptor types
- `@backstage/plugin-catalog`: Catalog page reads descriptors and renders `FacetFilterPicker` / `OptionsFilterPicker` using BUI `Select`, or passes through custom elements
- 5 filters converted to facet model (kind, type, tags, lifecycle, namespace)
- 1 filter converted to options model (processing-status)
- 2 filters remain as deprecated loader (owner, user-list)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.