### PR TITLE
fix(backend-test-utils): increase MySQL connect and pool timeouts

### DIFF
--- a/.changeset/mysql-test-timeout.md
+++ b/.changeset/mysql-test-timeout.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-test-utils': patch
+---
+
+Increased MySQL connection and pool timeouts to reduce flaky `connect ETIMEDOUT` failures in CI. The test MySQL container now also uses `mysql_native_password` for cheaper connection handshakes and disables binary logging.

--- a/packages/backend-test-utils/src/database/mysql.ts
+++ b/packages/backend-test-utils/src/database/mysql.ts
@@ -176,6 +176,7 @@ export class MysqlEngine implements Engine {
         connection: {
           ...this.#connection,
           database: databaseName,
+          connectTimeout: 30_000,
         },
         ...LARGER_POOL_CONFIG,
       });

--- a/packages/backend-test-utils/src/database/mysql.ts
+++ b/packages/backend-test-utils/src/database/mysql.ts
@@ -56,6 +56,10 @@ export async function startMysqlContainer(image: string): Promise<{
     .withExposedPorts(3306)
     .withEnvironment({ MYSQL_ROOT_PASSWORD: password })
     .withTmpFs({ '/var/lib/mysql': 'rw' })
+    .withCommand([
+      '--default-authentication-plugin=mysql_native_password',
+      '--skip-log-bin',
+    ])
     .start();
 
   const host = container.getHost();

--- a/packages/backend-test-utils/src/database/types.ts
+++ b/packages/backend-test-utils/src/database/types.ts
@@ -129,5 +129,7 @@ export const LARGER_POOL_CONFIG = {
   pool: {
     min: 0,
     max: 50,
+    acquireTimeoutMillis: 30_000,
+    createTimeoutMillis: 30_000,
   },
 };


### PR DESCRIPTION
## Summary

MySQL tests intermittently fail with `connect ETIMEDOUT` in CI when many test suites share a single MySQL container. The `mysql2` driver defaults to a 10-second connect timeout, which is too short under load.

### Changes

- Add `connectTimeout: 30_000` to the MySQL connection config in `createDatabaseInstance` (mysql2-specific, ignored by pg)
- Add `acquireTimeoutMillis: 30_000` and `createTimeoutMillis: 30_000` to the shared `LARGER_POOL_CONFIG`

### Why this should help

The `connect ETIMEDOUT` error is at the TCP level — the MySQL container cant accept a new connection within 10 seconds. Under CI load with dozens of test suites creating/destroying connections concurrently, this is a realistic bottleneck. Tripling the timeout gives the container more breathing room.

🤖 Generated with [Claude Code](https://claude.com/claude-code)