### PR TITLE
docs(microsite): add Kapa AI chatbot widget

### DIFF
--- a/microsite/docusaurus.config.ts
+++ b/microsite/docusaurus.config.ts
@@ -123,28 +123,6 @@ const config: Config = {
         },
       }),
     },
-    {
-      tagName: 'script',
-      attributes: {},
-      innerHTML: `
-        (function () {
-          function mount() {
-            if (document.querySelector('.kapa-ask-ai-mobile-trigger')) return;
-            var btn = document.createElement('button');
-            btn.type = 'button';
-            btn.className = 'kapa-ask-ai-trigger kapa-ask-ai-mobile-trigger';
-            btn.setAttribute('aria-label', 'Ask AI');
-            btn.textContent = '✨';
-            document.body.appendChild(btn);
-          }
-          if (document.readyState === 'loading') {
-            document.addEventListener('DOMContentLoaded', mount);
-          } else {
-            mount();
-          }
-        })();
-      `,
-    },
   ],
   organizationName: 'Spotify',
   projectName: 'backstage',
@@ -160,9 +138,11 @@ const config: Config = {
       'data-project-name': 'Backstage',
       'data-project-color': '#36baa2',
       'data-project-logo': 'https://backstage.io/img/favicon.svg',
-      'data-button-hide': 'true',
-      'data-modal-override-open-class': 'kapa-ask-ai-trigger',
-      'data-modal-z-index': '2147483000',
+      'data-launcher-button-image': 'https://backstage.io/img/favicon.svg',
+      'data-button-position-bottom': '4rem',
+      'data-button-position-right': '0.75rem',
+      'data-color-scheme-selector': "[data-theme='dark']",
+      'data-example-questions': 'What is Backstage?,How do I get started?',
       async: true,
     },
   ],
@@ -571,13 +551,6 @@ const config: Config = {
           to: '/community',
           label: 'Community',
           position: 'left',
-        },
-        {
-          type: 'html',
-          position: 'right',
-          className: 'navbar-ask-ai-item',
-          value:
-            '<button class="kapa-ask-ai-trigger navbar-ask-ai-button" type="button" aria-label="Ask AI">Ask AI</button>',
         },
         {
           href: 'https://github.com/backstage/backstage',

--- a/microsite/docusaurus.config.ts
+++ b/microsite/docusaurus.config.ts
@@ -123,6 +123,28 @@ const config: Config = {
         },
       }),
     },
+    {
+      tagName: 'script',
+      attributes: {},
+      innerHTML: `
+        (function () {
+          function mount() {
+            if (document.querySelector('.kapa-ask-ai-mobile-trigger')) return;
+            var btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'kapa-ask-ai-trigger kapa-ask-ai-mobile-trigger';
+            btn.setAttribute('aria-label', 'Ask AI');
+            btn.textContent = '✨';
+            document.body.appendChild(btn);
+          }
+          if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', mount);
+          } else {
+            mount();
+          }
+        })();
+      `,
+    },
   ],
   organizationName: 'Spotify',
   projectName: 'backstage',
@@ -132,6 +154,17 @@ const config: Config = {
     '/js/medium-zoom.js',
     '/js/dismissable-banner.js',
     '/js/scroll-nav-to-view-in-docs.js',
+    {
+      src: 'https://widget.kapa.ai/kapa-widget.bundle.js',
+      'data-website-id': '4f3b7b51-4ea6-4a5b-aede-44fbe128c0f2',
+      'data-project-name': 'Backstage',
+      'data-project-color': '#36baa2',
+      'data-project-logo': 'https://backstage.io/img/favicon.svg',
+      'data-button-hide': 'true',
+      'data-modal-override-open-class': 'kapa-ask-ai-trigger',
+      'data-modal-z-index': '2147483000',
+      async: true,
+    },
   ],
   stylesheets: [
     'https://fonts.googleapis.com/css?family=IBM+Plex+Mono:500,700&display=swap',
@@ -538,6 +571,13 @@ const config: Config = {
           to: '/community',
           label: 'Community',
           position: 'left',
+        },
+        {
+          type: 'html',
+          position: 'right',
+          className: 'navbar-ask-ai-item',
+          value:
+            '<button class="kapa-ask-ai-trigger navbar-ask-ai-button" type="button" aria-label="Ask AI">Ask AI</button>',
         },
         {
           href: 'https://github.com/backstage/backstage',

--- a/microsite/src/theme/customTheme.scss
+++ b/microsite/src/theme/customTheme.scss
@@ -264,7 +264,6 @@ html.plugin-docs feedback-button {
   }
 }
 
-
 .header-github-link::before,
 .header-discord-link::before {
   content: '';

--- a/microsite/src/theme/customTheme.scss
+++ b/microsite/src/theme/customTheme.scss
@@ -207,6 +207,64 @@ html.plugin-docs feedback-button {
   opacity: 0.6;
 }
 
+/* Navbar "Ask AI" trigger for the Kapa widget */
+.navbar-ask-ai-button {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.75rem;
+  margin: 0 0.25rem;
+  font: inherit;
+  font-weight: var(--ifm-font-weight-semibold);
+  color: var(--ifm-navbar-link-color);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+
+  &:hover {
+    color: var(--ifm-navbar-link-hover-color);
+    opacity: 0.8;
+  }
+}
+
+/* Show floating launcher on mobile only, navbar trigger on desktop only */
+@media (max-width: 996px) {
+  .navbar-ask-ai-item {
+    display: none;
+  }
+}
+
+.kapa-ask-ai-mobile-trigger {
+  display: none;
+  position: fixed;
+  bottom: 10px;
+  left: 10px;
+  width: 2.75rem;
+  height: 2.75rem;
+  padding: 0;
+  font-size: 1.25rem;
+  line-height: 1;
+  color: var(--ifm-color-black);
+  background: var(--ifm-color-primary);
+  border: none;
+  border-radius: 999px;
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+  cursor: pointer;
+  z-index: 200;
+
+  &:hover {
+    background: var(--ifm-color-primary-dark);
+  }
+}
+@media (max-width: 996px) {
+  .kapa-ask-ai-mobile-trigger {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+}
+
+
 .header-github-link::before,
 .header-discord-link::before {
   content: '';

--- a/microsite/src/theme/customTheme.scss
+++ b/microsite/src/theme/customTheme.scss
@@ -207,63 +207,6 @@ html.plugin-docs feedback-button {
   opacity: 0.6;
 }
 
-/* Navbar "Ask AI" trigger for the Kapa widget */
-.navbar-ask-ai-button {
-  display: inline-flex;
-  align-items: center;
-  padding: 0.25rem 0.75rem;
-  margin: 0 0.25rem;
-  font: inherit;
-  font-weight: var(--ifm-font-weight-semibold);
-  color: var(--ifm-navbar-link-color);
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  transition: opacity 0.15s ease;
-
-  &:hover {
-    color: var(--ifm-navbar-link-hover-color);
-    opacity: 0.8;
-  }
-}
-
-/* Show floating launcher on mobile only, navbar trigger on desktop only */
-@media (max-width: 996px) {
-  .navbar-ask-ai-item {
-    display: none;
-  }
-}
-
-.kapa-ask-ai-mobile-trigger {
-  display: none;
-  position: fixed;
-  bottom: 10px;
-  left: 10px;
-  width: 2.75rem;
-  height: 2.75rem;
-  padding: 0;
-  font-size: 1.25rem;
-  line-height: 1;
-  color: var(--ifm-color-black);
-  background: var(--ifm-color-primary);
-  border: none;
-  border-radius: 999px;
-  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
-  cursor: pointer;
-  z-index: 200;
-
-  &:hover {
-    background: var(--ifm-color-primary-dark);
-  }
-}
-@media (max-width: 996px) {
-  .kapa-ask-ai-mobile-trigger {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-  }
-}
-
 .header-github-link::before,
 .header-discord-link::before {
   content: '';


### PR DESCRIPTION
Summary

Adds the Kapa AI (https://www.kapa.ai/) assistant to the Docusaurus microsite (microsite/) so visitors can ask natural-language questions about Backstage directly from the docs.

The integration uses Kapa's native floating launcher, configured entirely through the widget's data-* attributes on the script tag in microsite/docusaurus.config.ts:

- Launcher: bottom-right, positioned 4rem from the bottom so it sits above the existing pushfeedback button. Skinned with the Backstage "B" mark.
- Theme aware: data-color-scheme-selector ties the modal's color scheme to the microsite's data-theme, so it follows dark/light mode.
- Branding: project name, color, and logo set to match Backstage.
- Example questions: shown in the modal to help first-time users get started.

<img width="1362" height="1254" alt="image" src="https://github.com/user-attachments/assets/23558631-f56c-47cf-8a06-7a1f7b504a9c" />

<img width="1108" height="991" alt="image" src="https://github.com/user-attachments/assets/d13b7ab3-29ee-4345-a344-27ca0df56bf4" />


Test plan

- [x] cd microsite && yarn install && yarn start
- [x] A floating launcher appears in the bottom-right, above the feedback button (no overlap).
- [x] Clicking it opens the Kapa modal and answers a question.
- [x] Toggling the site between dark and light mode updates the modal's color scheme to match.
- [x] The launcher and modal show the Backstage "B" logo.