### PR TITLE
fix(frontend-plugin-api): restore deprecated NavItemBlueprint export

### DIFF
--- a/.changeset/restore-nav-item-blueprint.md
+++ b/.changeset/restore-nav-item-blueprint.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+Restored the deprecated `NavItemBlueprint` export. While nav items are now automatically inferred from `PageBlueprint` extensions, removing the export was a breaking change for adopters with in-repo plugins that still reference it. The blueprint remains deprecated and will be removed in a future major version.

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -1821,6 +1821,43 @@ export const microsoftAuthApiRef: ApiRef_2<
   readonly $$type: '@backstage/ApiRef';
 };
 
+// @public @deprecated
+export const NavItemBlueprint: ExtensionBlueprint_2<{
+  kind: 'nav-item';
+  params: {
+    title: string;
+    icon: IconComponent;
+    routeRef: RouteRef<undefined>;
+  };
+  output: ExtensionDataRef_2<
+    {
+      title: string;
+      icon: IconComponent;
+      routeRef: RouteRef<undefined>;
+    },
+    'core.nav-item.target',
+    {}
+  >;
+  inputs: {};
+  config: {
+    title: string | undefined;
+  };
+  configInput: {
+    title?: string | undefined;
+  };
+  dataRefs: {
+    target: ConfigurableExtensionDataRef_2<
+      {
+        title: string;
+        icon: IconComponent;
+        routeRef: RouteRef<undefined>;
+      },
+      'core.nav-item.target',
+      {}
+    >;
+  };
+}>;
+
 // @public (undocumented)
 export const NotFoundErrorPage: {
   (props: NotFoundErrorPageProps): JSX.Element | null;

--- a/packages/frontend-plugin-api/src/blueprints/NavItemBlueprint.ts
+++ b/packages/frontend-plugin-api/src/blueprints/NavItemBlueprint.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { z } from 'zod/v4';
+import { IconComponent } from '../icons/types';
+import { RouteRef } from '../routing';
+import { createExtensionBlueprint, createExtensionDataRef } from '../wiring';
+
+const targetDataRef = createExtensionDataRef<{
+  title: string;
+  icon: IconComponent;
+  routeRef: RouteRef<undefined>;
+}>().with({ id: 'core.nav-item.target' });
+
+/**
+ * Creates extensions that make up the items of the nav bar.
+ *
+ * @public
+ * @deprecated Nav items are now automatically inferred from `PageBlueprint`
+ * extensions based on their `title` and `icon` params. You can remove your
+ * `NavItemBlueprint` usage and instead pass `title` and `icon` directly to
+ * the `PageBlueprint`.
+ */
+export const NavItemBlueprint = createExtensionBlueprint({
+  kind: 'nav-item',
+  attachTo: { id: 'app/nav', input: 'items' },
+  output: [targetDataRef],
+  dataRefs: {
+    target: targetDataRef,
+  },
+  factory: (
+    {
+      icon,
+      routeRef,
+      title,
+    }: {
+      title: string;
+      icon: IconComponent;
+      routeRef: RouteRef<undefined>;
+    },
+    { config },
+  ) => [
+    targetDataRef({
+      title: config.title ?? title,
+      icon,
+      routeRef,
+    }),
+  ],
+  configSchema: {
+    title: z.string().optional(),
+  },
+});

--- a/packages/frontend-plugin-api/src/blueprints/index.ts
+++ b/packages/frontend-plugin-api/src/blueprints/index.ts
@@ -19,6 +19,7 @@ export {
   type AnalyticsImplementationFactory,
 } from './AnalyticsImplementationBlueprint';
 export { ApiBlueprint } from './ApiBlueprint';
+export { NavItemBlueprint } from './NavItemBlueprint';
 export { AppRootElementBlueprint } from './AppRootElementBlueprint';
 export { PageBlueprint } from './PageBlueprint';
 export { SubPageBlueprint } from './SubPageBlueprint';


### PR DESCRIPTION
## Summary

Restores the `NavItemBlueprint` export that was removed in #34299. The removal was intended to complete the migration to page-based nav discovery, but it was a **compile-time breaking change** for adopters with in-repo plugins that still import `NavItemBlueprint`.

### Why the runtime backward compat worked but people still broke

The `AppNav` extension correctly handles legacy nav items via an internal `legacyNavItemTargetDataRef` with the same data ref ID (`core.nav-item.target`). The framework's `getData()` matches by string ID, not object identity ([`instantiateAppNodeTree.ts:528`](https://github.com/backstage/backstage/blob/master/packages/frontend-app-api/src/tree/instantiateAppNodeTree.ts#L528)). So **pre-compiled plugins** (e.g. from npm) continued to work fine.

The issue: **in-repo plugins** that `import { NavItemBlueprint } from '@backstage/frontend-plugin-api'` fail to compile after upgrading, because the export no longer exists. This is the common Backstage adopter pattern — custom plugins that live alongside the framework and get recompiled on every upgrade.

### What this PR does

Re-adds `NavItemBlueprint` with its original implementation and `@deprecated` annotation. The deprecation message guides adopters toward `PageBlueprint` title/icon. No changes to `AppNav` or other plugins are needed — the existing `legacyNavItemTargetDataRef` path handles everything.

## Test plan

- [x] `yarn tsc` clean
- [x] `yarn build:api-reports` — NavItemBlueprint re-appears in `report.api.md`
- [x] Data ref ID `core.nav-item.target` matches between the restored blueprint and `AppNav`'s legacy input

🤖 Generated with [Claude Code](https://claude.com/claude-code)