### PR TITLE
fix(catalog-backend-module-backstage-openapi): Remove extra quote in example config

### DIFF
--- a/plugins/catalog-backend-module-backstage-openapi/README.md
+++ b/plugins/catalog-backend-module-backstage-openapi/README.md
@@ -28,7 +28,7 @@ catalog:
         - catalog
         - events
         - search
-      definitionFormat: 'yaml"' # Optional, defaults to 'json'
+      definitionFormat: 'yaml' # Optional, defaults to 'json'
       entityOverrides: # All optional
         metadata:
           name: 'my-name'


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix the readme for catalog-backend-module-backstage-openapi to not have the rogue double quote in the example.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
