### PR TITLE
Allow service factories to return falsy value

### DIFF
--- a/.changeset/cyan-seals-hammer.md
+++ b/.changeset/cyan-seals-hammer.md
@@ -1,0 +1,6 @@
+---
+'@backstage/backend-test-utils': patch
+'@backstage/backend-app-api': patch
+---
+
+Allow service factories to return falsy value

--- a/packages/backend-app-api/src/wiring/BackendInitializer.test.ts
+++ b/packages/backend-app-api/src/wiring/BackendInitializer.test.ts
@@ -49,6 +49,18 @@ function mkNoopFactory(ref: ServiceRef<{}, 'plugin'>) {
   );
 }
 
+function mkFalsyFactory(ref: ServiceRef<undefined, 'plugin'>) {
+  const fn = jest.fn().mockReturnValue(undefined);
+  return Object.assign(
+    fn,
+    createServiceFactory({
+      service: ref,
+      deps: {},
+      factory: fn,
+    }),
+  );
+}
+
 const testPlugin = createBackendPlugin({
   pluginId: 'test',
   register(reg) {
@@ -1285,6 +1297,26 @@ describe('BackendInitializer', () => {
     await expect(init.start()).rejects.toThrow(
       "Service or extension point dependencies of module 'test-mod' for plugin 'test' are missing for the following ref(s): serviceRef{a}",
     );
+  });
+
+  it('should allow modules with dependencies that return a falsy value', async () => {
+    const ref = createServiceRef<undefined>({ id: 'falsy' });
+    const factory = mkFalsyFactory(ref);
+
+    const init = new BackendInitializer([...baseFactories, factory]);
+    init.add(
+      createBackendPlugin({
+        pluginId: 'tester',
+        register(reg) {
+          reg.registerInit({
+            deps: { ref },
+            async init() {},
+          });
+        },
+      }),
+    );
+
+    await expect(init.start()).resolves.not.toThrow();
   });
 
   it('should properly load double-default CJS modules', async () => {

--- a/packages/backend-app-api/src/wiring/BackendInitializer.ts
+++ b/packages/backend-app-api/src/wiring/BackendInitializer.ts
@@ -218,12 +218,12 @@ export class BackendInitializer {
         }
         result.set(name, epImpl);
       } else {
-        const [impl, ok] = this.#serviceRegistry.get(
+        const [ok, impl] = await this.#serviceRegistry.get(
           ref as ServiceRef<unknown>,
           pluginId,
         );
         if (ok) {
-          result.set(name, await impl);
+          result.set(name, impl);
         } else {
           missingRefs.add(ref);
         }
@@ -299,11 +299,10 @@ export class BackendInitializer {
     // backend instances, each instance will log the error, because we can't
     // determine which instance the error came from.
     if (process.env.NODE_ENV !== 'test') {
-      const [rootLoggerPromise] = this.#serviceRegistry.get(
+      const [, rootLogger] = await this.#serviceRegistry.get(
         coreServices.rootLogger,
         'root',
       );
-      const rootLogger = await rootLoggerPromise;
       this.#unhandledRejectionHandler = (reason: Error) => {
         rootLogger
           ?.child({ type: 'unhandledRejection' })
@@ -321,16 +320,14 @@ export class BackendInitializer {
     // Initialize all root scoped services
     await this.#serviceRegistry.initializeEagerServicesWithScope('root');
 
-    const [rootConfigPromise] = this.#serviceRegistry.get(
+    const [, rootConfig] = await this.#serviceRegistry.get(
       coreServices.rootConfig,
       'root',
     );
-    const rootConfig = await rootConfigPromise;
-    const [rootLoggerPromise] = this.#serviceRegistry.get(
+    const [, rootLogger] = await this.#serviceRegistry.get(
       coreServices.rootLogger,
       'root',
     );
-    const rootLogger = await rootLoggerPromise;
 
     const allRegistrations = this.#registrations.flatMap(f =>
       f.getRegistrations(),
@@ -610,11 +607,10 @@ export class BackendInitializer {
       shutdown(): Promise<void>;
     }
   > {
-    const [lifecycleServicePromise] = this.#serviceRegistry.get(
+    const [, lifecycleService] = await this.#serviceRegistry.get(
       coreServices.rootLifecycle,
       'root',
     );
-    const lifecycleService = await lifecycleServicePromise;
 
     const service = lifecycleService as any;
     if (
@@ -633,11 +629,10 @@ export class BackendInitializer {
   ): Promise<
     LifecycleService & { startup(): Promise<void>; shutdown(): Promise<void> }
   > {
-    const [lifecycleServicePromise] = this.#serviceRegistry.get(
+    const [, lifecycleService] = await this.#serviceRegistry.get(
       coreServices.lifecycle,
       pluginId,
     );
-    const lifecycleService = await lifecycleServicePromise;
 
     const service = lifecycleService as any;
     if (
@@ -667,12 +662,12 @@ export class BackendInitializer {
             `Feature loaders can only depend on root scoped services, but '${name}' is scoped to '${ref.scope}'. Offending loader is ${loader.description}`,
           );
         }
-        const [implPromise, ok] = this.#serviceRegistry.get(
+        const [ok, impl] = await this.#serviceRegistry.get(
           ref as ServiceRef<unknown>,
           'root',
         );
         if (ok) {
-          deps.set(name, await implPromise);
+          deps.set(name, impl);
         } else {
           missingRefs.add(ref);
         }

--- a/packages/backend-app-api/src/wiring/BackendInitializer.ts
+++ b/packages/backend-app-api/src/wiring/BackendInitializer.ts
@@ -218,12 +218,12 @@ export class BackendInitializer {
         }
         result.set(name, epImpl);
       } else {
-        const impl = await this.#serviceRegistry.get(
+        const [impl, ok] = this.#serviceRegistry.get(
           ref as ServiceRef<unknown>,
           pluginId,
         );
-        if (impl) {
-          result.set(name, impl);
+        if (ok) {
+          result.set(name, await impl);
         } else {
           missingRefs.add(ref);
         }
@@ -299,10 +299,11 @@ export class BackendInitializer {
     // backend instances, each instance will log the error, because we can't
     // determine which instance the error came from.
     if (process.env.NODE_ENV !== 'test') {
-      const rootLogger = await this.#serviceRegistry.get(
+      const [rootLoggerPromise] = this.#serviceRegistry.get(
         coreServices.rootLogger,
         'root',
       );
+      const rootLogger = await rootLoggerPromise;
       this.#unhandledRejectionHandler = (reason: Error) => {
         rootLogger
           ?.child({ type: 'unhandledRejection' })
@@ -320,14 +321,16 @@ export class BackendInitializer {
     // Initialize all root scoped services
     await this.#serviceRegistry.initializeEagerServicesWithScope('root');
 
-    const rootConfig = await this.#serviceRegistry.get(
+    const [rootConfigPromise] = this.#serviceRegistry.get(
       coreServices.rootConfig,
       'root',
     );
-    const rootLogger = await this.#serviceRegistry.get(
+    const rootConfig = await rootConfigPromise;
+    const [rootLoggerPromise] = this.#serviceRegistry.get(
       coreServices.rootLogger,
       'root',
     );
+    const rootLogger = await rootLoggerPromise;
 
     const allRegistrations = this.#registrations.flatMap(f =>
       f.getRegistrations(),
@@ -607,10 +610,11 @@ export class BackendInitializer {
       shutdown(): Promise<void>;
     }
   > {
-    const lifecycleService = await this.#serviceRegistry.get(
+    const [lifecycleServicePromise] = this.#serviceRegistry.get(
       coreServices.rootLifecycle,
       'root',
     );
+    const lifecycleService = await lifecycleServicePromise;
 
     const service = lifecycleService as any;
     if (
@@ -629,10 +633,11 @@ export class BackendInitializer {
   ): Promise<
     LifecycleService & { startup(): Promise<void>; shutdown(): Promise<void> }
   > {
-    const lifecycleService = await this.#serviceRegistry.get(
+    const [lifecycleServicePromise] = this.#serviceRegistry.get(
       coreServices.lifecycle,
       pluginId,
     );
+    const lifecycleService = await lifecycleServicePromise;
 
     const service = lifecycleService as any;
     if (
@@ -662,12 +667,12 @@ export class BackendInitializer {
             `Feature loaders can only depend on root scoped services, but '${name}' is scoped to '${ref.scope}'. Offending loader is ${loader.description}`,
           );
         }
-        const impl = await this.#serviceRegistry.get(
+        const [implPromise, ok] = this.#serviceRegistry.get(
           ref as ServiceRef<unknown>,
           'root',
         );
-        if (impl) {
-          deps.set(name, impl);
+        if (ok) {
+          deps.set(name, await implPromise);
         } else {
           missingRefs.add(ref);
         }

--- a/packages/backend-app-api/src/wiring/ServiceRegistry.test.ts
+++ b/packages/backend-app-api/src/wiring/ServiceRegistry.test.ts
@@ -91,35 +91,37 @@ const refDefault2b = createServiceRef<{ x: number }>({
 describe('ServiceRegistry', () => {
   it('should return undefined if there is no factory defined', async () => {
     const registry = ServiceRegistry.create([]);
-    expect(registry.get(ref1, 'catalog')).toBe(undefined);
+    expect(registry.get(ref1, 'catalog')[0]).toBe(undefined);
   });
 
   it('should return an implementation for a registered ref', async () => {
     const registry = ServiceRegistry.create([sf1]);
-    await expect(registry.get(ref1, 'catalog')).resolves.toEqual({ x: 1 });
-    await expect(registry.get(ref1, 'scaffolder')).resolves.toEqual({ x: 1 });
-    expect(await registry.get(ref1, 'catalog')).toBe(
-      await registry.get(ref1, 'catalog'),
+    await expect(registry.get(ref1, 'catalog')[0]).resolves.toEqual({ x: 1 });
+    await expect(registry.get(ref1, 'scaffolder')[0]).resolves.toEqual({
+      x: 1,
+    });
+    expect(await registry.get(ref1, 'catalog')[0]).toBe(
+      await registry.get(ref1, 'catalog')[0],
     );
-    expect(await registry.get(ref1, 'scaffolder')).toBe(
-      await registry.get(ref1, 'scaffolder'),
+    expect(await registry.get(ref1, 'scaffolder')[0]).toBe(
+      await registry.get(ref1, 'scaffolder')[0],
     );
-    expect(await registry.get(ref1, 'catalog')).not.toBe(
-      await registry.get(ref1, 'scaffolder'),
+    expect(await registry.get(ref1, 'catalog')[0]).not.toBe(
+      await registry.get(ref1, 'scaffolder')[0],
     );
   });
 
   it('should handle multiple factories with different serviceRefs', async () => {
     const registry = ServiceRegistry.create([sf1, sf2]);
 
-    await expect(registry.get(ref1, 'catalog')).resolves.toEqual({
+    await expect(registry.get(ref1, 'catalog')[0]).resolves.toEqual({
       x: 1,
     });
-    await expect(registry.get(ref2, 'catalog')).resolves.toEqual({
+    await expect(registry.get(ref2, 'catalog')[0]).resolves.toEqual({
       x: 2,
     });
-    expect(await registry.get(ref1, 'catalog')).not.toBe(
-      await registry.get(ref2, 'catalog'),
+    expect(await registry.get(ref1, 'catalog')[0]).not.toBe(
+      await registry.get(ref2, 'catalog')[0],
     );
   });
 
@@ -133,7 +135,7 @@ describe('ServiceRegistry', () => {
       },
     });
     const registry = ServiceRegistry.create([factory, sf1]);
-    await expect(registry.get(ref2, 'catalog')).rejects.toThrow(
+    await expect(registry.get(ref2, 'catalog')[0]).rejects.toThrow(
       "Failed to instantiate 'root' scoped service '2' because it depends on 'plugin' scoped service '1'.",
     );
   });
@@ -147,7 +149,7 @@ describe('ServiceRegistry', () => {
       },
     });
     const registry = ServiceRegistry.create([factory, sf2]);
-    await expect(registry.get(ref1, 'catalog')).resolves.toEqual({
+    await expect(registry.get(ref1, 'catalog')[0]).resolves.toEqual({
       x: 2,
     });
   });
@@ -162,7 +164,7 @@ describe('ServiceRegistry', () => {
       },
     });
     const registry = ServiceRegistry.create([factory, sf2]);
-    await expect(registry.get(ref, 'catalog')).resolves.toEqual({
+    await expect(registry.get(ref, 'catalog')[0]).resolves.toEqual({
       x: 2,
     });
   });
@@ -177,14 +179,14 @@ describe('ServiceRegistry', () => {
       },
     });
     const registry = ServiceRegistry.create([factory]);
-    await expect(registry.get(ref, 'catalog')).resolves.toEqual({
+    await expect(registry.get(ref, 'catalog')[0]).resolves.toEqual({
       pluginId: 'catalog',
     });
   });
 
   it('should use the last factory for each ref', async () => {
     const registry = ServiceRegistry.create([sf2, sf2b]);
-    await expect(registry.get(ref2, 'catalog')).resolves.toEqual({
+    await expect(registry.get(ref2, 'catalog')[0]).resolves.toEqual({
       x: 22,
     });
   });
@@ -192,14 +194,14 @@ describe('ServiceRegistry', () => {
   it('should use added service factories for each ref', async () => {
     const registry = ServiceRegistry.create([sf2]);
     registry.add(sf2b);
-    await expect(registry.get(ref2, 'catalog')).resolves.toEqual({
+    await expect(registry.get(ref2, 'catalog')[0]).resolves.toEqual({
       x: 22,
     });
   });
 
   it('should not allow factories to be added after instantiation', async () => {
     const registry = ServiceRegistry.create([sf2]);
-    await expect(registry.get(ref2, 'catalog')).resolves.toEqual({
+    await expect(registry.get(ref2, 'catalog')[0]).resolves.toEqual({
       x: 2,
     });
     expect(() => registry.add(sf2b)).toThrow(
@@ -217,34 +219,34 @@ describe('ServiceRegistry', () => {
 
   it('should use the defaultFactory from the ref if not provided to the registry', async () => {
     const registry = ServiceRegistry.create([]);
-    await expect(registry.get(refDefault1, 'catalog')).resolves.toEqual({
+    await expect(registry.get(refDefault1, 'catalog')[0]).resolves.toEqual({
       x: 10,
     });
   });
 
   it('should not use the defaultFactory from the ref if provided to the registry', async () => {
     const registry = ServiceRegistry.create([sf1]);
-    await expect(registry.get(refDefault1, 'catalog')).resolves.toEqual({
+    await expect(registry.get(refDefault1, 'catalog')[0]).resolves.toEqual({
       x: 1,
     });
   });
 
   it('should handle duplicate defaultFactories by duplicating the implementations', async () => {
     const registry = ServiceRegistry.create([]);
-    await expect(registry.get(refDefault2a, 'catalog')).resolves.toEqual({
+    await expect(registry.get(refDefault2a, 'catalog')[0]).resolves.toEqual({
       x: 20,
     });
-    await expect(registry.get(refDefault2b, 'catalog')).resolves.toEqual({
+    await expect(registry.get(refDefault2b, 'catalog')[0]).resolves.toEqual({
       x: 220,
     });
-    expect(await registry.get(refDefault2a, 'catalog')).toBe(
-      await registry.get(refDefault2a, 'catalog'),
+    expect(await registry.get(refDefault2a, 'catalog')[0]).toBe(
+      await registry.get(refDefault2a, 'catalog')[0],
     );
-    expect(await registry.get(refDefault2b, 'catalog')).toBe(
-      await registry.get(refDefault2b, 'catalog'),
+    expect(await registry.get(refDefault2b, 'catalog')[0]).toBe(
+      await registry.get(refDefault2b, 'catalog')[0],
     );
-    expect(await registry.get(refDefault2a, 'catalog')).not.toBe(
-      await registry.get(refDefault2b, 'catalog'),
+    expect(await registry.get(refDefault2a, 'catalog')[0]).not.toBe(
+      await registry.get(refDefault2b, 'catalog')[0],
     );
   });
 
@@ -263,8 +265,8 @@ describe('ServiceRegistry', () => {
 
     const registry = ServiceRegistry.create([]);
     await Promise.all([
-      expect(registry.get(ref, 'catalog')).resolves.toBeUndefined(),
-      expect(registry.get(ref, 'catalog')).resolves.toBeUndefined(),
+      expect(registry.get(ref, 'catalog')[0]).resolves.toBeUndefined(),
+      expect(registry.get(ref, 'catalog')[0]).resolves.toBeUndefined(),
     ]);
     expect(factoryLoader).toHaveBeenCalledTimes(1);
   });
@@ -282,11 +284,11 @@ describe('ServiceRegistry', () => {
     const registry = ServiceRegistry.create([myFactory]);
 
     await Promise.all([
-      registry.get(ref1, 'catalog')!,
-      registry.get(ref1, 'catalog')!,
-      registry.get(ref1, 'catalog')!,
-      registry.get(ref1, 'scaffolder')!,
-      registry.get(ref1, 'scaffolder')!,
+      registry.get(ref1, 'catalog')[0]!,
+      registry.get(ref1, 'catalog')[0]!,
+      registry.get(ref1, 'catalog')[0]!,
+      registry.get(ref1, 'scaffolder')[0]!,
+      registry.get(ref1, 'scaffolder')[0]!,
     ]);
 
     expect(createRootContext).toHaveBeenCalledTimes(1);
@@ -304,11 +306,11 @@ describe('ServiceRegistry', () => {
     const registry = ServiceRegistry.create([myFactory]);
 
     await Promise.all([
-      registry.get(ref1, 'catalog')!,
-      registry.get(ref1, 'catalog')!,
-      registry.get(ref1, 'catalog')!,
-      registry.get(ref1, 'scaffolder')!,
-      registry.get(ref1, 'scaffolder')!,
+      registry.get(ref1, 'catalog')[0]!,
+      registry.get(ref1, 'catalog')[0]!,
+      registry.get(ref1, 'catalog')[0]!,
+      registry.get(ref1, 'scaffolder')[0]!,
+      registry.get(ref1, 'scaffolder')[0]!,
     ]);
 
     expect(factory).toHaveBeenCalledTimes(2);
@@ -325,7 +327,7 @@ describe('ServiceRegistry', () => {
 
     const registry = ServiceRegistry.create([myFactory]);
 
-    await expect(registry.get(ref1, 'catalog')).rejects.toThrow(
+    await expect(registry.get(ref1, 'catalog')[0]).rejects.toThrow(
       "Failed to instantiate service '1' for 'catalog' because the following dependent services are missing: '2'",
     );
   });
@@ -352,7 +354,7 @@ describe('ServiceRegistry', () => {
 
     const registry = ServiceRegistry.create([factoryA, factoryB]);
 
-    await expect(registry.get(refA, 'catalog')).rejects.toThrow(
+    await expect(registry.get(refA, 'catalog')[0]).rejects.toThrow(
       "Failed to instantiate service 'a' for 'catalog' because the factory function threw an error, Error: Failed to instantiate service 'b' for 'catalog' because the following dependent services are missing: 'c', 'd'",
     );
   });
@@ -565,7 +567,7 @@ describe('ServiceRegistry', () => {
 
     const registry = ServiceRegistry.create([myFactory]);
 
-    await expect(registry.get(ref1, 'catalog')).rejects.toThrow(
+    await expect(registry.get(ref1, 'catalog')[0]).rejects.toThrow(
       "Failed to instantiate service '1' because createRootContext threw an error, Error: top-level error",
     );
   });
@@ -581,7 +583,7 @@ describe('ServiceRegistry', () => {
 
     const registry = ServiceRegistry.create([myFactory]);
 
-    await expect(registry.get(ref1, 'catalog')).rejects.toThrow(
+    await expect(registry.get(ref1, 'catalog')[0]).rejects.toThrow(
       "Failed to instantiate service '1' for 'catalog' because the factory function threw an error, Error: error in plugin",
     );
   });
@@ -596,7 +598,7 @@ describe('ServiceRegistry', () => {
 
     const registry = ServiceRegistry.create([]);
 
-    await expect(registry.get(ref, 'catalog')).rejects.toThrow(
+    await expect(registry.get(ref, 'catalog')[0]).rejects.toThrow(
       "Failed to instantiate service '1' because the default factory loader threw an error, Error: default factory error",
     );
   });

--- a/packages/backend-app-api/src/wiring/ServiceRegistry.test.ts
+++ b/packages/backend-app-api/src/wiring/ServiceRegistry.test.ts
@@ -89,39 +89,45 @@ const refDefault2b = createServiceRef<{ x: number }>({
 });
 
 describe('ServiceRegistry', () => {
-  it('should return undefined if there is no factory defined', async () => {
+  it('should return [false] if there is no factory defined', async () => {
     const registry = ServiceRegistry.create([]);
-    expect(registry.get(ref1, 'catalog')[0]).toBe(undefined);
+    await expect(registry.get(ref1, 'catalog')).resolves.toEqual([false]);
   });
 
   it('should return an implementation for a registered ref', async () => {
     const registry = ServiceRegistry.create([sf1]);
-    await expect(registry.get(ref1, 'catalog')[0]).resolves.toEqual({ x: 1 });
-    await expect(registry.get(ref1, 'scaffolder')[0]).resolves.toEqual({
-      x: 1,
-    });
-    expect(await registry.get(ref1, 'catalog')[0]).toBe(
-      await registry.get(ref1, 'catalog')[0],
+    await expect(registry.get(ref1, 'catalog')).resolves.toEqual([
+      true,
+      { x: 1 },
+    ]);
+    await expect(registry.get(ref1, 'scaffolder')).resolves.toEqual([
+      true,
+      { x: 1 },
+    ]);
+    expect(await registry.get(ref1, 'catalog')).toEqual(
+      await registry.get(ref1, 'catalog'),
     );
-    expect(await registry.get(ref1, 'scaffolder')[0]).toBe(
-      await registry.get(ref1, 'scaffolder')[0],
+    expect((await registry.get(ref1, 'scaffolder'))[1]).toBe(
+      (await registry.get(ref1, 'scaffolder'))[1],
     );
-    expect(await registry.get(ref1, 'catalog')[0]).not.toBe(
-      await registry.get(ref1, 'scaffolder')[0],
+    expect((await registry.get(ref1, 'catalog'))[1]).not.toBe(
+      (await registry.get(ref1, 'scaffolder'))[1],
     );
   });
 
   it('should handle multiple factories with different serviceRefs', async () => {
     const registry = ServiceRegistry.create([sf1, sf2]);
 
-    await expect(registry.get(ref1, 'catalog')[0]).resolves.toEqual({
-      x: 1,
-    });
-    await expect(registry.get(ref2, 'catalog')[0]).resolves.toEqual({
-      x: 2,
-    });
-    expect(await registry.get(ref1, 'catalog')[0]).not.toBe(
-      await registry.get(ref2, 'catalog')[0],
+    await expect(registry.get(ref1, 'catalog')).resolves.toEqual([
+      true,
+      { x: 1 },
+    ]);
+    await expect(registry.get(ref2, 'catalog')).resolves.toEqual([
+      true,
+      { x: 2 },
+    ]);
+    expect((await registry.get(ref1, 'catalog'))[1]).not.toBe(
+      (await registry.get(ref2, 'catalog'))[1],
     );
   });
 
@@ -135,7 +141,7 @@ describe('ServiceRegistry', () => {
       },
     });
     const registry = ServiceRegistry.create([factory, sf1]);
-    await expect(registry.get(ref2, 'catalog')[0]).rejects.toThrow(
+    await expect(registry.get(ref2, 'catalog')).rejects.toThrow(
       "Failed to instantiate 'root' scoped service '2' because it depends on 'plugin' scoped service '1'.",
     );
   });
@@ -149,9 +155,10 @@ describe('ServiceRegistry', () => {
       },
     });
     const registry = ServiceRegistry.create([factory, sf2]);
-    await expect(registry.get(ref1, 'catalog')[0]).resolves.toEqual({
-      x: 2,
-    });
+    await expect(registry.get(ref1, 'catalog')).resolves.toEqual([
+      true,
+      { x: 2 },
+    ]);
   });
 
   it('should be possible for root scoped services to depend on root scoped services', async () => {
@@ -164,9 +171,10 @@ describe('ServiceRegistry', () => {
       },
     });
     const registry = ServiceRegistry.create([factory, sf2]);
-    await expect(registry.get(ref, 'catalog')[0]).resolves.toEqual({
-      x: 2,
-    });
+    await expect(registry.get(ref, 'catalog')).resolves.toEqual([
+      true,
+      { x: 2 },
+    ]);
   });
 
   it('should return the pluginId from the pluginMetadata service', async () => {
@@ -179,31 +187,35 @@ describe('ServiceRegistry', () => {
       },
     });
     const registry = ServiceRegistry.create([factory]);
-    await expect(registry.get(ref, 'catalog')[0]).resolves.toEqual({
-      pluginId: 'catalog',
-    });
+    await expect(registry.get(ref, 'catalog')).resolves.toEqual([
+      true,
+      { pluginId: 'catalog' },
+    ]);
   });
 
   it('should use the last factory for each ref', async () => {
     const registry = ServiceRegistry.create([sf2, sf2b]);
-    await expect(registry.get(ref2, 'catalog')[0]).resolves.toEqual({
-      x: 22,
-    });
+    await expect(registry.get(ref2, 'catalog')).resolves.toEqual([
+      true,
+      { x: 22 },
+    ]);
   });
 
   it('should use added service factories for each ref', async () => {
     const registry = ServiceRegistry.create([sf2]);
     registry.add(sf2b);
-    await expect(registry.get(ref2, 'catalog')[0]).resolves.toEqual({
-      x: 22,
-    });
+    await expect(registry.get(ref2, 'catalog')).resolves.toEqual([
+      true,
+      { x: 22 },
+    ]);
   });
 
   it('should not allow factories to be added after instantiation', async () => {
     const registry = ServiceRegistry.create([sf2]);
-    await expect(registry.get(ref2, 'catalog')[0]).resolves.toEqual({
-      x: 2,
-    });
+    await expect(registry.get(ref2, 'catalog')).resolves.toEqual([
+      true,
+      { x: 2 },
+    ]);
     expect(() => registry.add(sf2b)).toThrow(
       'Unable to set service factory with id 2, service has already been instantiated',
     );
@@ -219,34 +231,38 @@ describe('ServiceRegistry', () => {
 
   it('should use the defaultFactory from the ref if not provided to the registry', async () => {
     const registry = ServiceRegistry.create([]);
-    await expect(registry.get(refDefault1, 'catalog')[0]).resolves.toEqual({
-      x: 10,
-    });
+    await expect(registry.get(refDefault1, 'catalog')).resolves.toEqual([
+      true,
+      { x: 10 },
+    ]);
   });
 
   it('should not use the defaultFactory from the ref if provided to the registry', async () => {
     const registry = ServiceRegistry.create([sf1]);
-    await expect(registry.get(refDefault1, 'catalog')[0]).resolves.toEqual({
-      x: 1,
-    });
+    await expect(registry.get(refDefault1, 'catalog')).resolves.toEqual([
+      true,
+      { x: 1 },
+    ]);
   });
 
   it('should handle duplicate defaultFactories by duplicating the implementations', async () => {
     const registry = ServiceRegistry.create([]);
-    await expect(registry.get(refDefault2a, 'catalog')[0]).resolves.toEqual({
-      x: 20,
-    });
-    await expect(registry.get(refDefault2b, 'catalog')[0]).resolves.toEqual({
-      x: 220,
-    });
-    expect(await registry.get(refDefault2a, 'catalog')[0]).toBe(
-      await registry.get(refDefault2a, 'catalog')[0],
+    await expect(registry.get(refDefault2a, 'catalog')).resolves.toEqual([
+      true,
+      { x: 20 },
+    ]);
+    await expect(registry.get(refDefault2b, 'catalog')).resolves.toEqual([
+      true,
+      { x: 220 },
+    ]);
+    expect((await registry.get(refDefault2a, 'catalog'))[1]).toBe(
+      (await registry.get(refDefault2a, 'catalog'))[1],
     );
-    expect(await registry.get(refDefault2b, 'catalog')[0]).toBe(
-      await registry.get(refDefault2b, 'catalog')[0],
+    expect((await registry.get(refDefault2b, 'catalog'))[1]).toBe(
+      (await registry.get(refDefault2b, 'catalog'))[1],
     );
-    expect(await registry.get(refDefault2a, 'catalog')[0]).not.toBe(
-      await registry.get(refDefault2b, 'catalog')[0],
+    expect((await registry.get(refDefault2a, 'catalog'))[1]).not.toBe(
+      (await registry.get(refDefault2b, 'catalog'))[1],
     );
   });
 
@@ -265,8 +281,8 @@ describe('ServiceRegistry', () => {
 
     const registry = ServiceRegistry.create([]);
     await Promise.all([
-      expect(registry.get(ref, 'catalog')[0]).resolves.toBeUndefined(),
-      expect(registry.get(ref, 'catalog')[0]).resolves.toBeUndefined(),
+      expect(registry.get(ref, 'catalog')).resolves.toEqual([true, undefined]),
+      expect(registry.get(ref, 'catalog')).resolves.toEqual([true, undefined]),
     ]);
     expect(factoryLoader).toHaveBeenCalledTimes(1);
   });
@@ -284,11 +300,11 @@ describe('ServiceRegistry', () => {
     const registry = ServiceRegistry.create([myFactory]);
 
     await Promise.all([
-      registry.get(ref1, 'catalog')[0]!,
-      registry.get(ref1, 'catalog')[0]!,
-      registry.get(ref1, 'catalog')[0]!,
-      registry.get(ref1, 'scaffolder')[0]!,
-      registry.get(ref1, 'scaffolder')[0]!,
+      registry.get(ref1, 'catalog'),
+      registry.get(ref1, 'catalog'),
+      registry.get(ref1, 'catalog'),
+      registry.get(ref1, 'scaffolder'),
+      registry.get(ref1, 'scaffolder'),
     ]);
 
     expect(createRootContext).toHaveBeenCalledTimes(1);
@@ -306,11 +322,11 @@ describe('ServiceRegistry', () => {
     const registry = ServiceRegistry.create([myFactory]);
 
     await Promise.all([
-      registry.get(ref1, 'catalog')[0]!,
-      registry.get(ref1, 'catalog')[0]!,
-      registry.get(ref1, 'catalog')[0]!,
-      registry.get(ref1, 'scaffolder')[0]!,
-      registry.get(ref1, 'scaffolder')[0]!,
+      registry.get(ref1, 'catalog'),
+      registry.get(ref1, 'catalog'),
+      registry.get(ref1, 'catalog'),
+      registry.get(ref1, 'scaffolder'),
+      registry.get(ref1, 'scaffolder'),
     ]);
 
     expect(factory).toHaveBeenCalledTimes(2);
@@ -327,7 +343,7 @@ describe('ServiceRegistry', () => {
 
     const registry = ServiceRegistry.create([myFactory]);
 
-    await expect(registry.get(ref1, 'catalog')[0]).rejects.toThrow(
+    await expect(registry.get(ref1, 'catalog')).rejects.toThrow(
       "Failed to instantiate service '1' for 'catalog' because the following dependent services are missing: '2'",
     );
   });
@@ -354,7 +370,7 @@ describe('ServiceRegistry', () => {
 
     const registry = ServiceRegistry.create([factoryA, factoryB]);
 
-    await expect(registry.get(refA, 'catalog')[0]).rejects.toThrow(
+    await expect(registry.get(refA, 'catalog')).rejects.toThrow(
       "Failed to instantiate service 'a' for 'catalog' because the factory function threw an error, Error: Failed to instantiate service 'b' for 'catalog' because the following dependent services are missing: 'c', 'd'",
     );
   });
@@ -567,7 +583,7 @@ describe('ServiceRegistry', () => {
 
     const registry = ServiceRegistry.create([myFactory]);
 
-    await expect(registry.get(ref1, 'catalog')[0]).rejects.toThrow(
+    await expect(registry.get(ref1, 'catalog')).rejects.toThrow(
       "Failed to instantiate service '1' because createRootContext threw an error, Error: top-level error",
     );
   });
@@ -583,7 +599,7 @@ describe('ServiceRegistry', () => {
 
     const registry = ServiceRegistry.create([myFactory]);
 
-    await expect(registry.get(ref1, 'catalog')[0]).rejects.toThrow(
+    await expect(registry.get(ref1, 'catalog')).rejects.toThrow(
       "Failed to instantiate service '1' for 'catalog' because the factory function threw an error, Error: error in plugin",
     );
   });
@@ -598,7 +614,7 @@ describe('ServiceRegistry', () => {
 
     const registry = ServiceRegistry.create([]);
 
-    await expect(registry.get(ref, 'catalog')[0]).rejects.toThrow(
+    await expect(registry.get(ref, 'catalog')).rejects.toThrow(
       "Failed to instantiate service '1' because the default factory loader threw an error, Error: default factory error",
     );
   });

--- a/packages/backend-app-api/src/wiring/ServiceRegistry.ts
+++ b/packages/backend-app-api/src/wiring/ServiceRegistry.ts
@@ -252,15 +252,20 @@ export class ServiceRegistry {
   get<T, TInstances extends 'singleton' | 'multiton'>(
     ref: ServiceRef<T, 'plugin' | 'root', TInstances>,
     pluginId: string,
-  ):
-    | [Promise<TInstances extends 'multiton' ? T[] : T>, true]
-    | [undefined, false] {
+  ): [Promise<TInstances extends 'multiton' ? T[] : T> | undefined, boolean] {
     this.#instantiatedFactories.add(ref.id);
 
     const resolvedFactory = this.#resolveFactory(ref, pluginId);
 
     if (!resolvedFactory) {
-      return [undefined, false];
+      return [
+        ref.multiton
+          ? (Promise.resolve([]) as
+              | Promise<TInstances extends 'multiton' ? T[] : T>
+              | undefined)
+          : undefined,
+        false,
+      ];
     }
 
     const resultPromise = resolvedFactory

--- a/packages/backend-app-api/src/wiring/ServiceRegistry.ts
+++ b/packages/backend-app-api/src/wiring/ServiceRegistry.ts
@@ -239,9 +239,11 @@ export class ServiceRegistry {
       if (factory.service.scope === scope) {
         // Root-scoped services are eager by default, plugin-scoped are lazy by default
         if (scope === 'root' && factory.initialization !== 'lazy') {
-          await this.get(factory.service, pluginId);
+          const [promise] = this.get(factory.service, pluginId);
+          await promise;
         } else if (scope === 'plugin' && factory.initialization === 'always') {
-          await this.get(factory.service, pluginId);
+          const [promise] = this.get(factory.service, pluginId);
+          await promise;
         }
       }
     }
@@ -250,20 +252,18 @@ export class ServiceRegistry {
   get<T, TInstances extends 'singleton' | 'multiton'>(
     ref: ServiceRef<T, 'plugin' | 'root', TInstances>,
     pluginId: string,
-  ): Promise<TInstances extends 'multiton' ? T[] : T> | undefined {
+  ):
+    | [Promise<TInstances extends 'multiton' ? T[] : T>, true]
+    | [undefined, false] {
     this.#instantiatedFactories.add(ref.id);
 
     const resolvedFactory = this.#resolveFactory(ref, pluginId);
 
     if (!resolvedFactory) {
-      return ref.multiton
-        ? (Promise.resolve([]) as
-            | Promise<TInstances extends 'multiton' ? T[] : T>
-            | undefined)
-        : undefined;
+      return [undefined, false];
     }
 
-    return resolvedFactory
+    const resultPromise = resolvedFactory
       .then(factories => {
         return Promise.all(
           factories.map(factory => {
@@ -281,8 +281,8 @@ export class ServiceRegistry {
                       `Failed to instantiate 'root' scoped service '${ref.id}' because it depends on '${serviceRef.scope}' scoped service '${serviceRef.id}'.`,
                     );
                   }
-                  const target = this.get(serviceRef, pluginId)!;
-                  rootDeps.push(target.then(impl => [name, impl]));
+                  const [target, _] = this.get(serviceRef, pluginId);
+                  rootDeps.push(target!.then(impl => [name, impl]));
                 }
 
                 existing = Promise.all(rootDeps).then(entries =>
@@ -302,8 +302,8 @@ export class ServiceRegistry {
 
               for (const [name, serviceRef] of Object.entries(factory.deps)) {
                 if (serviceRef.scope === 'root') {
-                  const target = this.get(serviceRef, pluginId)!;
-                  rootDeps.push(target.then(impl => [name, impl]));
+                  const [target, _] = this.get(serviceRef, pluginId);
+                  rootDeps.push(target!.then(impl => [name, impl]));
                 }
               }
 
@@ -331,8 +331,8 @@ export class ServiceRegistry {
               >();
 
               for (const [name, serviceRef] of Object.entries(factory.deps)) {
-                const target = this.get(serviceRef, pluginId)!;
-                allDeps.push(target.then(impl => [name, impl]));
+                const [target, _] = this.get(serviceRef, pluginId);
+                allDeps.push(target!.then(impl => [name, impl]));
               }
 
               result = implementation.context
@@ -354,5 +354,10 @@ export class ServiceRegistry {
         );
       })
       .then(results => (ref.multiton ? results : results[0]));
+
+    return [
+      resultPromise as Promise<TInstances extends 'multiton' ? T[] : T>,
+      true,
+    ];
   }
 }

--- a/packages/backend-app-api/src/wiring/ServiceRegistry.ts
+++ b/packages/backend-app-api/src/wiring/ServiceRegistry.ts
@@ -251,15 +251,14 @@ export class ServiceRegistry {
     ref: ServiceRef<T, 'plugin' | 'root', TInstances>,
     pluginId: string,
   ): Promise<
-    | [ok: false, instance: [] | undefined]
-    | [ok: true, instance: TInstances extends 'multiton' ? T[] : T]
+    [ok: false] | [ok: true, instance: TInstances extends 'multiton' ? T[] : T]
   > {
     this.#instantiatedFactories.add(ref.id);
 
     const resolvedFactory = this.#resolveFactory(ref, pluginId);
 
     if (!resolvedFactory) {
-      return Promise.resolve([false, ref.multiton ? [] : undefined]);
+      return Promise.resolve([false]);
     }
 
     return resolvedFactory

--- a/packages/backend-app-api/src/wiring/ServiceRegistry.ts
+++ b/packages/backend-app-api/src/wiring/ServiceRegistry.ts
@@ -239,11 +239,9 @@ export class ServiceRegistry {
       if (factory.service.scope === scope) {
         // Root-scoped services are eager by default, plugin-scoped are lazy by default
         if (scope === 'root' && factory.initialization !== 'lazy') {
-          const [promise] = this.get(factory.service, pluginId);
-          await promise;
+          await this.get(factory.service, pluginId);
         } else if (scope === 'plugin' && factory.initialization === 'always') {
-          const [promise] = this.get(factory.service, pluginId);
-          await promise;
+          await this.get(factory.service, pluginId);
         }
       }
     }
@@ -252,23 +250,18 @@ export class ServiceRegistry {
   get<T, TInstances extends 'singleton' | 'multiton'>(
     ref: ServiceRef<T, 'plugin' | 'root', TInstances>,
     pluginId: string,
-  ): [Promise<TInstances extends 'multiton' ? T[] : T> | undefined, boolean] {
+  ): Promise<
+    [ok: false] | [ok: true, instance: TInstances extends 'multiton' ? T[] : T]
+  > {
     this.#instantiatedFactories.add(ref.id);
 
     const resolvedFactory = this.#resolveFactory(ref, pluginId);
 
     if (!resolvedFactory) {
-      return [
-        ref.multiton
-          ? (Promise.resolve([]) as
-              | Promise<TInstances extends 'multiton' ? T[] : T>
-              | undefined)
-          : undefined,
-        false,
-      ];
+      return Promise.resolve([false]);
     }
 
-    const resultPromise = resolvedFactory
+    return resolvedFactory
       .then(factories => {
         return Promise.all(
           factories.map(factory => {
@@ -286,8 +279,12 @@ export class ServiceRegistry {
                       `Failed to instantiate 'root' scoped service '${ref.id}' because it depends on '${serviceRef.scope}' scoped service '${serviceRef.id}'.`,
                     );
                   }
-                  const [target, _] = this.get(serviceRef, pluginId);
-                  rootDeps.push(target!.then(impl => [name, impl]));
+                  rootDeps.push(
+                    this.get(serviceRef, pluginId).then(([, impl]) => [
+                      name,
+                      impl,
+                    ]),
+                  );
                 }
 
                 existing = Promise.all(rootDeps).then(entries =>
@@ -307,8 +304,12 @@ export class ServiceRegistry {
 
               for (const [name, serviceRef] of Object.entries(factory.deps)) {
                 if (serviceRef.scope === 'root') {
-                  const [target, _] = this.get(serviceRef, pluginId);
-                  rootDeps.push(target!.then(impl => [name, impl]));
+                  rootDeps.push(
+                    this.get(serviceRef, pluginId).then(([, impl]) => [
+                      name,
+                      impl,
+                    ]),
+                  );
                 }
               }
 
@@ -336,8 +337,12 @@ export class ServiceRegistry {
               >();
 
               for (const [name, serviceRef] of Object.entries(factory.deps)) {
-                const [target, _] = this.get(serviceRef, pluginId);
-                allDeps.push(target!.then(impl => [name, impl]));
+                allDeps.push(
+                  this.get(serviceRef, pluginId).then(([, impl]) => [
+                    name,
+                    impl,
+                  ]),
+                );
               }
 
               result = implementation.context
@@ -358,11 +363,11 @@ export class ServiceRegistry {
           }),
         );
       })
-      .then(results => (ref.multiton ? results : results[0]));
-
-    return [
-      resultPromise as Promise<TInstances extends 'multiton' ? T[] : T>,
-      true,
-    ];
+      .then(results => [
+        true,
+        (ref.multiton ? results : results[0]) as TInstances extends 'multiton'
+          ? T[]
+          : T,
+      ]);
   }
 }

--- a/packages/backend-app-api/src/wiring/ServiceRegistry.ts
+++ b/packages/backend-app-api/src/wiring/ServiceRegistry.ts
@@ -251,14 +251,15 @@ export class ServiceRegistry {
     ref: ServiceRef<T, 'plugin' | 'root', TInstances>,
     pluginId: string,
   ): Promise<
-    [ok: false] | [ok: true, instance: TInstances extends 'multiton' ? T[] : T]
+    | [ok: false, instance: [] | undefined]
+    | [ok: true, instance: TInstances extends 'multiton' ? T[] : T]
   > {
     this.#instantiatedFactories.add(ref.id);
 
     const resolvedFactory = this.#resolveFactory(ref, pluginId);
 
     if (!resolvedFactory) {
-      return Promise.resolve([false]);
+      return Promise.resolve([false, ref.multiton ? [] : undefined]);
     }
 
     return resolvedFactory

--- a/packages/backend-test-utils/src/wiring/ServiceFactoryTester.ts
+++ b/packages/backend-test-utils/src/wiring/ServiceFactoryTester.ts
@@ -96,7 +96,11 @@ export class ServiceFactoryTester<
     ...args: 'root' extends TScope ? [] : [pluginId?: string]
   ): Promise<TInstances extends 'multiton' ? TService[] : TService> {
     const [pluginId] = args;
-    const instance = this.#registry.get(this.#subject, pluginId ?? 'test')!;
+    const [instancePromise, _] = this.#registry.get(
+      this.#subject,
+      pluginId ?? 'test',
+    );
+    const instance = await instancePromise!;
     return instance;
   }
 
@@ -116,7 +120,11 @@ export class ServiceFactoryTester<
     ...args: 'root' extends TGetScope ? [] : [pluginId?: string]
   ): Promise<TGetInstances extends 'multiton' ? TGetService[] : TGetService> {
     const [pluginId] = args;
-    const instance = await this.#registry.get(service, pluginId ?? 'test');
+    const [instancePromise, _] = await this.#registry.get(
+      service,
+      pluginId ?? 'test',
+    );
+    const instance = await instancePromise;
     if (instance === undefined) {
       throw new Error(`Service '${service.id}' not found`);
     }

--- a/packages/backend-test-utils/src/wiring/ServiceFactoryTester.ts
+++ b/packages/backend-test-utils/src/wiring/ServiceFactoryTester.ts
@@ -96,12 +96,11 @@ export class ServiceFactoryTester<
     ...args: 'root' extends TScope ? [] : [pluginId?: string]
   ): Promise<TInstances extends 'multiton' ? TService[] : TService> {
     const [pluginId] = args;
-    const [instancePromise, _] = this.#registry.get(
+    const [, instance] = await this.#registry.get(
       this.#subject,
       pluginId ?? 'test',
     );
-    const instance = await instancePromise!;
-    return instance;
+    return instance!;
   }
 
   /**
@@ -120,12 +119,11 @@ export class ServiceFactoryTester<
     ...args: 'root' extends TGetScope ? [] : [pluginId?: string]
   ): Promise<TGetInstances extends 'multiton' ? TGetService[] : TGetService> {
     const [pluginId] = args;
-    const [instancePromise, _] = await this.#registry.get(
+    const [ok, instance] = await this.#registry.get(
       service,
       pluginId ?? 'test',
     );
-    const instance = await instancePromise;
-    if (instance === undefined) {
+    if (!ok) {
       throw new Error(`Service '${service.id}' not found`);
     }
     return instance;


### PR DESCRIPTION
When you initialize a backend referencing a service factory that does not exist, an error is correctly thrown:

```
Service or extension point dependencies of module 'test-mod' for plugin 'test' are missing for the following ref(s): serviceRef{a}
```

However, if a service factory _does_ exist but its implementation returns a falsy value, that same error is incorrectly thrown.

These changes allow Backstage to differentiate between a service factory that does not exist, and one whose implementation returns a falsy value, continuing to throw the same error in the former case but allowing the factory result to be used in the latter case.

To do this, we change the signature of the `ServiceRegistry#get()` function to return both the service factory's return value (which could be falsy), _as well as_ a boolean indicating whether the service factory exists or not.

Subsequently, when the `BackendInitializer` checks to see if a service factory exists, it relies on the value of the boolean instead of the falsiness of the service factory's return value.

All calls to `ServiceRegistry#get()` have been updated to reflect the new call signature, and a single test has been added to `BackendInitializer.test.ts` to reflect this new behavior. All existing tests remain unchanged except for the call signatures, reflecting that these changes _should_ be backwards compatible.

## Motivation

Backstage offers [Feature Loaders](https://backstage.io/docs/backend-system/architecture/feature-loaders/) which can be used to achieve much of the same desired result. However, in practice these loaders do not scale well across multiple plugins and/or multiple service factories.

Take for example a service factory which returns an API client. This client may or may not be instantiated based on the existence of some access token in the Backstage configuration.

You _could_ use feature loaders to gate the loading of all plugins that depend on the API client, and thus require the access token to be set:

```ts
export default createBackendFeatureLoader({
  deps: {
    config: coreServices.rootConfig,
  },
  *loader({ config }) {
    if (config.getOptionalString('foo.token')) {
      yield import('@backstage/plugin-that-requires-foo-client');
    }
  },
});
```

This pattern works well enough in the simple case, but falls apart in more complex scenarios:

- Plugins that require combinations of API clients
- Plugins that require some clients but where others are optional
- Plugins whose logic conditionally changes based on the existence of the API client (i.e. some logic can continue to run, instead of it being "all or nothing")

You can imagine how the complexity of the feature loader will balloon in these cases. And in some cases, it may not be possible to achieve the desired outcome using feature loaders alone.

The better approach is to allow the service factory to inform its consumers whether the desired API client (i.e. service) is available. The consumer can evaluate the falsiness of the service factory's returned value on its own, and decide how to change its behavior based on the result.

This also has the added benefit of only the service factory needing to know about where things like access tokens live in Backstage's configuration. If you were to use feature loaders, both the feature loader _and_ the service factory would need to know the path at which this configuration lives, thereby duplicating this information across the code base and not following the DRY principle.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] ~Screenshots attached (for UI changes)~ N/A
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
