### PR TITLE
fix(core): sidebar submenu text clipping

### DIFF
--- a/.changeset/sweet-planets-burn.md
+++ b/.changeset/sweet-planets-burn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Fixed text clipping in SidebarSubmenuItem by correcting line-height from 1 to 1.5

--- a/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
@@ -74,7 +74,7 @@ const useStyles = makeStyles(
       whiteSpace: 'nowrap',
       overflow: 'hidden',
       'text-overflow': 'ellipsis',
-      lineHeight: 1,
+      lineHeight: 1.5,
     },
     subtitle: {
       fontSize: 10,


### PR DESCRIPTION
## Fix text clipping in SidebarSubmenuItem

Fixed a bug where characters with descenders (g, y, p, j) were being vertically clipped in the SidebarSubmenuItem label. This affected the "My Squads" section and the Catalog sidebar submenu.

The root cause was `lineHeight: 1` combined with `overflow: hidden` in the `label` style of `SidebarSubmenuItem.tsx`. Changed `lineHeight` from `1` to `1.5` (Material UI default) to give descenders enough room to render.

Fixes #33937

## Before
<img width="500" height="400" alt="Before-MySquad" src="https://github.com/user-attachments/assets/cdb61710-3621-4e91-9192-988cae71eb7f" />
<img width="500" height="400" alt="Before-Catalog" src="https://github.com/user-attachments/assets/28f6e062-2fa0-479a-bd0b-54c1af41a1b1" />

## After
<img width="500" height="400" alt="After-MySquad" src="https://github.com/user-attachments/assets/78950420-6c4a-41ef-8572-2d951f5c43b4" />
<img width="500" height="400" alt="After-Catalog" src="https://github.com/user-attachments/assets/a498df03-b107-4d76-a90c-00d00fbab608" />

#### :heavy_check_mark: Checklist
- [x] A changeset describing the change and affected packages.
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes