### PR TITLE
Add allowlist mitigation for kubernetes-backend catalog locator SSRF

### DIFF
--- a/.changeset/fix-kubernetes-backend-catalog-ssrf.md
+++ b/.changeset/fix-kubernetes-backend-catalog-ssrf.md
@@ -1,0 +1,37 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+**SECURITY**: Added an opt-in mitigation for a Server-Side Request Forgery
+(SSRF) vulnerability in the catalog-based Kubernetes cluster locator
+(`clusterLocatorMethods: [{ type: 'catalog' }]`).
+
+The `kubernetes.io/api-server` annotation on a catalog `kubernetes-cluster`
+Resource is the URL the backend sends credentials to when it talks to the
+cluster. Because catalog entities can be created by any actor with catalog
+write access, that URL is untrusted: an attacker can register a malicious
+entity and exfiltrate the backend's cluster credentials (AWS STS bearer
+tokens, Azure / GCP tokens, or a user's OIDC token).
+
+The catalog cluster locator now accepts an explicit allowlist of trusted
+cluster API server origins (scheme + host + optional port):
+
+```yaml
+kubernetes:
+  clusterLocatorMethods:
+    - type: catalog
+      allowedClusterUrls:
+        - https://my-cluster.example.com
+        - https://eks-cluster.us-east-1.eks.amazonaws.com
+```
+
+When `allowedClusterUrls` is configured, catalog entities whose api-server
+origin does not match an entry are filtered out (with a warning log).
+
+For backwards compatibility, the locator still falls back to the previous
+behaviour of trusting any URL supplied via catalog annotations when no
+allowlist is configured, but it now logs a loud deprecation warning the
+first time it does so. **A future release will switch this default to
+deny-all**; configure `allowedClusterUrls` now to avoid the upcoming
+breaking change. Adopters who consciously accept the risk in the meantime
+can silence the warning with `allowUnsafeClusterUrls: true`.

--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -185,6 +185,53 @@ spec:
   owner: user:guest
 ```
 
+##### Trusting catalog-supplied cluster URLs
+
+The `kubernetes.io/api-server` annotation on a catalog Resource is the URL the
+backend will send credentials to when it talks to the cluster. Because catalog
+entities can in general be created by any actor with catalog write access,
+that URL must be treated as untrusted. If left unchecked, an attacker can
+register a malicious `kubernetes-cluster` Resource pointing at a server they
+control and exfiltrate the backend's cluster credentials (AWS STS bearer
+tokens, Azure / GCP tokens, or a user's OIDC token).
+
+To prevent this, the catalog cluster locator accepts an allowlist of trusted
+cluster API server origins (scheme + host + optional port). Only entities
+whose api-server annotation matches one of these origins are returned:
+
+```yaml
+kubernetes:
+  clusterLocatorMethods:
+    - type: catalog
+      allowedClusterUrls:
+        - https://my-cluster.example.com
+        - https://eks-cluster.us-east-1.eks.amazonaws.com
+        - https://10.0.0.5:6443
+```
+
+> **Deprecation notice**
+>
+> If `allowedClusterUrls` is not configured the catalog locator currently
+> falls back to its legacy behaviour of trusting every URL supplied via
+> catalog annotations, with a loud deprecation warning. **A future release
+> will switch this default to deny-all** and `allowedClusterUrls` will
+> become required for the catalog locator to return any clusters. Configure
+> it now to avoid the upcoming breaking change.
+>
+> Adopters who consciously accept the risk in the meantime can silence the
+> warning by explicitly opting in:
+>
+> ```yaml
+> kubernetes:
+>   clusterLocatorMethods:
+>     - type: catalog
+>       allowUnsafeClusterUrls: true # NOT RECOMMENDED - retains SSRF
+> ```
+>
+> `allowUnsafeClusterUrls: true` does not protect against the upcoming
+> change of default to deny-all; configure `allowedClusterUrls` for real
+> protection.
+
 Note that it is insecure to store a Kubernetes service account token in an
 annotation on a catalog entity (where it could easily be accidentally revealed
 by the catalog API) -- therefore there is no annotation corresponding to the

--- a/plugins/kubernetes-backend/config.d.ts
+++ b/plugins/kubernetes-backend/config.d.ts
@@ -72,6 +72,33 @@ export interface Config {
       | {
           /** @visibility frontend */
           type: 'catalog';
+          /**
+           * Allowlist of trusted cluster API server origins (scheme + host +
+           * optional port). The `kubernetes.io/api-server` annotation of a
+           * catalog `kubernetes-cluster` Resource must match one of these
+           * origins for the entity to be returned by the locator.
+           *
+           * This protects against an SSRF / credential exfiltration attack in
+           * which an actor with catalog write access registers a malicious
+           * cluster entity that causes the backend to send server-side
+           * credentials (AWS / Azure / GCP / OIDC tokens) to an arbitrary URL.
+           *
+           * If this option is omitted, the catalog locator returns no clusters
+           * (default-deny). Set `allowUnsafeClusterUrls: true` to temporarily
+           * restore the previous, unsafe behaviour.
+           *
+           * @visibility frontend
+           */
+          allowedClusterUrls?: string[];
+          /**
+           * Restores the pre-fix behaviour of trusting any URL supplied via
+           * catalog annotations. Enabling this re-introduces the SSRF that
+           * `allowedClusterUrls` is designed to prevent and should only be
+           * used as a short term migration aid.
+           *
+           * @visibility frontend
+           */
+          allowUnsafeClusterUrls?: boolean;
         }
       | {
           /** @visibility frontend */

--- a/plugins/kubernetes-backend/src/cluster-locator/CatalogClusterLocator.test.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/CatalogClusterLocator.test.ts
@@ -71,12 +71,15 @@ const entities: Entity[] = [
   },
 ];
 
+const allowedClusterUrls = ['https://apiserver.com'];
+
 describe('CatalogClusterLocator', () => {
   it('returns empty cluster details when the cluster is empty', async () => {
     const credentials = mockCredentials.user();
     const clusterSupplier = CatalogClusterLocator.fromConfig(
       catalogServiceMock({ entities: [] }),
       mockServices.auth(),
+      { allowedClusterUrls },
     );
 
     const result = await clusterSupplier.getClusters({ credentials });
@@ -89,6 +92,7 @@ describe('CatalogClusterLocator', () => {
     const clusterSupplier = CatalogClusterLocator.fromConfig(
       catalogServiceMock({ entities }),
       mockServices.auth(),
+      { allowedClusterUrls },
     );
 
     const result = await clusterSupplier.getClusters({ credentials });
@@ -101,10 +105,163 @@ describe('CatalogClusterLocator', () => {
     const clusterSupplier = CatalogClusterLocator.fromConfig(
       catalogServiceMock({ entities }),
       mockServices.auth(),
+      { allowedClusterUrls },
     );
 
     const result = await clusterSupplier.getClusters({ credentials });
     expect(result).toHaveLength(2);
     expect(result[1]).toMatchSnapshot();
+  });
+
+  describe('URL allowlist', () => {
+    it('falls back to the legacy (unsafe) behaviour and logs a deprecation warning when no allowlist is configured', async () => {
+      const credentials = mockCredentials.user();
+      const logger = mockServices.logger.mock();
+      const warnSpy = jest.spyOn(logger, 'warn');
+      const clusterSupplier = CatalogClusterLocator.fromConfig(
+        catalogServiceMock({ entities }),
+        mockServices.auth(),
+        { logger },
+      );
+
+      const result = await clusterSupplier.getClusters({ credentials });
+      expect(result).toHaveLength(2);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toMatch(/allowedClusterUrls/);
+
+      // The warning must only be logged once per process, not on every call.
+      await clusterSupplier.getClusters({ credentials });
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not log the deprecation warning when allowUnsafeClusterUrls is acknowledged', async () => {
+      const credentials = mockCredentials.user();
+      const logger = mockServices.logger.mock();
+      const warnSpy = jest.spyOn(logger, 'warn');
+      const clusterSupplier = CatalogClusterLocator.fromConfig(
+        catalogServiceMock({ entities }),
+        mockServices.auth(),
+        { allowUnsafeClusterUrls: true, logger },
+      );
+
+      const result = await clusterSupplier.getClusters({ credentials });
+      expect(result).toHaveLength(2);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('filters out entities whose api-server origin is not in the allowlist', async () => {
+      const credentials = mockCredentials.user();
+      const logger = mockServices.logger.mock();
+      const warnSpy = jest.spyOn(logger, 'warn');
+      const clusterSupplier = CatalogClusterLocator.fromConfig(
+        catalogServiceMock({
+          entities: [
+            ...entities,
+            {
+              apiVersion: 'backstage.io/v1alpha1',
+              kind: 'Resource',
+              metadata: {
+                annotations: {
+                  'kubernetes.io/api-server': 'https://attacker.example.com',
+                  'kubernetes.io/api-server-certificate-authority': 'caData',
+                  [ANNOTATION_KUBERNETES_AUTH_PROVIDER]: 'aws',
+                },
+                name: 'evil',
+                namespace: 'default',
+              },
+              spec: {
+                type: 'kubernetes-cluster',
+              },
+            },
+          ],
+        }),
+        mockServices.auth(),
+        { allowedClusterUrls, logger },
+      );
+
+      const result = await clusterSupplier.getClusters({ credentials });
+
+      expect(result).toHaveLength(2);
+      expect(result.map(c => c.name)).toEqual(['owned', 'owned']);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /Ignoring catalog Kubernetes cluster 'evil'.*allowedClusterUrls/s,
+        ),
+      );
+    });
+
+    it('matches origins regardless of path/query suffix', async () => {
+      const credentials = mockCredentials.user();
+      const clusterSupplier = CatalogClusterLocator.fromConfig(
+        catalogServiceMock({
+          entities: [
+            {
+              apiVersion: 'backstage.io/v1alpha1',
+              kind: 'Resource',
+              metadata: {
+                annotations: {
+                  'kubernetes.io/api-server':
+                    'https://apiserver.com:6443/api?x=y',
+                  'kubernetes.io/api-server-certificate-authority': 'caData',
+                  [ANNOTATION_KUBERNETES_AUTH_PROVIDER]: 'aws',
+                },
+                name: 'with-port-and-path',
+                namespace: 'default',
+              },
+              spec: {
+                type: 'kubernetes-cluster',
+              },
+            },
+          ],
+        }),
+        mockServices.auth(),
+        { allowedClusterUrls: ['https://apiserver.com:6443/anything'] },
+      );
+
+      const result = await clusterSupplier.getClusters({ credentials });
+      expect(result).toHaveLength(1);
+      expect(result[0].url).toEqual('https://apiserver.com:6443/api?x=y');
+    });
+
+    it('treats different ports as different origins', async () => {
+      const credentials = mockCredentials.user();
+      const clusterSupplier = CatalogClusterLocator.fromConfig(
+        catalogServiceMock({
+          entities: [
+            {
+              apiVersion: 'backstage.io/v1alpha1',
+              kind: 'Resource',
+              metadata: {
+                annotations: {
+                  'kubernetes.io/api-server': 'https://apiserver.com:8443',
+                  'kubernetes.io/api-server-certificate-authority': 'caData',
+                  [ANNOTATION_KUBERNETES_AUTH_PROVIDER]: 'aws',
+                },
+                name: 'wrong-port',
+                namespace: 'default',
+              },
+              spec: {
+                type: 'kubernetes-cluster',
+              },
+            },
+          ],
+        }),
+        mockServices.auth(),
+        { allowedClusterUrls: ['https://apiserver.com'] },
+      );
+
+      const result = await clusterSupplier.getClusters({ credentials });
+      expect(result).toEqual([]);
+    });
+
+    it('rejects malformed allowlist entries up-front', () => {
+      expect(() =>
+        CatalogClusterLocator.fromConfig(
+          catalogServiceMock({ entities }),
+          mockServices.auth(),
+          { allowedClusterUrls: ['not-a-url'] },
+        ),
+      ).toThrow(/allowedClusterUrls/);
+    });
   });
 });

--- a/plugins/kubernetes-backend/src/cluster-locator/CatalogClusterLocator.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/CatalogClusterLocator.ts
@@ -17,6 +17,7 @@
 import {
   AuthService,
   BackstageCredentials,
+  LoggerService,
 } from '@backstage/backend-plugin-api';
 import {
   ClusterDetails,
@@ -40,20 +41,79 @@ function isObject(obj: unknown): obj is JsonObject {
   return typeof obj === 'object' && obj !== null && !Array.isArray(obj);
 }
 
-export class CatalogClusterLocator implements KubernetesClustersSupplier {
-  private catalogService: CatalogService;
-  private auth: AuthService;
+/**
+ * Options that govern how catalog-sourced Kubernetes cluster entities are
+ * trusted at runtime.
+ *
+ * Catalog entities are user-controlled (anyone with catalog write access can
+ * create them), so the URL they declare via the
+ * {@link ANNOTATION_KUBERNETES_API_SERVER} annotation must be treated as
+ * untrusted. Without an allowlist, an attacker who can register a malicious
+ * `kubernetes-cluster` Resource can cause the backend to send its server-side
+ * credentials (e.g. AWS STS bearer tokens, Azure / GCP tokens, user OIDC
+ * tokens) to an arbitrary URL of their choosing.
+ */
+export interface CatalogClusterLocatorOptions {
+  /**
+   * Allowlist of origins (scheme + host + optional port) that catalog-sourced
+   * clusters may target. The `kubernetes.io/api-server` annotation of an
+   * entity must parse to one of these origins for the entity to be returned.
+   *
+   * Each entry must be an absolute URL (only the origin is used for the
+   * comparison). For example, `https://my-cluster.example.com` will match an
+   * entity whose api-server is `https://my-cluster.example.com/some/path`.
+   *
+   * If unset, the locator currently falls back to its legacy behaviour of
+   * trusting any URL supplied via the annotation, with a loud deprecation
+   * warning logged on first use. A future release will switch the default to
+   * deny-all so that this option becomes required for the catalog locator to
+   * return clusters. Configure it now to avoid the upcoming breaking change.
+   */
+  allowedClusterUrls?: string[];
 
-  constructor(catalogService: CatalogService, auth: AuthService) {
+  /**
+   * Acknowledges that the catalog locator is intentionally being run without
+   * an `allowedClusterUrls` allowlist and suppresses the deprecation warning.
+   *
+   * Setting this to `true` keeps the pre-fix behaviour of trusting any URL
+   * supplied via catalog annotations. It reintroduces (or rather, retains)
+   * the SSRF that `allowedClusterUrls` is designed to prevent and should
+   * only be used as a short term migration aid; it does not protect against
+   * the upcoming change of default to deny-all.
+   *
+   * @defaultValue false
+   */
+  allowUnsafeClusterUrls?: boolean;
+}
+
+export class CatalogClusterLocator implements KubernetesClustersSupplier {
+  private readonly catalogService: CatalogService;
+  private readonly auth: AuthService;
+  private readonly logger: LoggerService | undefined;
+  private readonly allowedOrigins: Set<string> | undefined;
+  private readonly allowUnsafeClusterUrls: boolean;
+  private hasLoggedDeprecation = false;
+
+  constructor(
+    catalogService: CatalogService,
+    auth: AuthService,
+    options?: CatalogClusterLocatorOptions & { logger?: LoggerService },
+  ) {
     this.catalogService = catalogService;
     this.auth = auth;
+    this.logger = options?.logger;
+    this.allowUnsafeClusterUrls = options?.allowUnsafeClusterUrls === true;
+    this.allowedOrigins = CatalogClusterLocator.parseAllowedOrigins(
+      options?.allowedClusterUrls,
+    );
   }
 
   static fromConfig(
     catalogApi: CatalogService,
     auth: AuthService,
+    options?: CatalogClusterLocatorOptions & { logger?: LoggerService },
   ): CatalogClusterLocator {
-    return new CatalogClusterLocator(catalogApi, auth);
+    return new CatalogClusterLocator(catalogApi, auth, options);
   }
 
   async getClusters(options?: {
@@ -80,25 +140,115 @@ export class CatalogClusterLocator implements KubernetesClustersSupplier {
           options?.credentials ?? (await this.auth.getNoneCredentials()),
       },
     );
-    return clusters.items.map(entity => {
-      const annotations = entity.metadata.annotations!;
-      const clusterDetails: ClusterDetails = {
-        name: entity.metadata.name,
-        title: entity.metadata.title,
-        url: annotations[ANNOTATION_KUBERNETES_API_SERVER],
-        authMetadata: annotations,
-        caData: annotations[ANNOTATION_KUBERNETES_API_SERVER_CA],
-        skipMetricsLookup:
-          annotations[ANNOTATION_KUBERNETES_SKIP_METRICS_LOOKUP] === 'true',
-        skipTLSVerify:
-          annotations[ANNOTATION_KUBERNETES_SKIP_TLS_VERIFY] === 'true',
-        dashboardUrl: annotations[ANNOTATION_KUBERNETES_DASHBOARD_URL],
-        dashboardApp: annotations[ANNOTATION_KUBERNETES_DASHBOARD_APP],
-        dashboardParameters: this.getDashboardParameters(annotations),
-      };
 
-      return clusterDetails;
-    });
+    const allowlistConfigured = (this.allowedOrigins?.size ?? 0) > 0;
+
+    // When no allowlist is configured we currently fall back to the legacy
+    // behaviour of trusting every URL supplied via catalog annotations. A
+    // future release will switch this default to deny-all in order to fully
+    // close the SSRF; until then we log a loud deprecation warning to nudge
+    // operators to opt in to the allowlist (or to explicitly acknowledge the
+    // risk with `allowUnsafeClusterUrls: true`).
+    if (
+      !allowlistConfigured &&
+      !this.allowUnsafeClusterUrls &&
+      !this.hasLoggedDeprecation
+    ) {
+      this.hasLoggedDeprecation = true;
+      this.logger?.warn(
+        'The catalog Kubernetes cluster locator is being used without ' +
+          "'allowedClusterUrls'. Any actor with catalog write access can " +
+          'currently register a `kubernetes-cluster` Resource that causes ' +
+          'the backend to send its cluster credentials (AWS / Azure / GCP / ' +
+          'OIDC tokens) to an arbitrary URL. Configure ' +
+          "'kubernetes.clusterLocatorMethods[].allowedClusterUrls' with the " +
+          'origins (scheme://host[:port]) of trusted cluster API servers to ' +
+          'enforce a safe allowlist. A future release will switch the ' +
+          'default to deny-all and this option will become required. To ' +
+          'explicitly acknowledge the risk and silence this warning, set ' +
+          "'allowUnsafeClusterUrls: true'.",
+      );
+    }
+
+    return clusters.items
+      .map(entity => {
+        const annotations = entity.metadata.annotations!;
+        const url = annotations[ANNOTATION_KUBERNETES_API_SERVER];
+
+        if (allowlistConfigured && !this.isUrlAllowed(url)) {
+          this.logger?.warn(
+            `Ignoring catalog Kubernetes cluster '${entity.metadata.name}' ` +
+              `because its '${ANNOTATION_KUBERNETES_API_SERVER}' annotation ` +
+              `('${url}') does not match any entry in 'allowedClusterUrls'.`,
+          );
+          return undefined;
+        }
+
+        const clusterDetails: ClusterDetails = {
+          name: entity.metadata.name,
+          title: entity.metadata.title,
+          url,
+          authMetadata: annotations,
+          caData: annotations[ANNOTATION_KUBERNETES_API_SERVER_CA],
+          skipMetricsLookup:
+            annotations[ANNOTATION_KUBERNETES_SKIP_METRICS_LOOKUP] === 'true',
+          skipTLSVerify:
+            annotations[ANNOTATION_KUBERNETES_SKIP_TLS_VERIFY] === 'true',
+          dashboardUrl: annotations[ANNOTATION_KUBERNETES_DASHBOARD_URL],
+          dashboardApp: annotations[ANNOTATION_KUBERNETES_DASHBOARD_APP],
+          dashboardParameters: this.getDashboardParameters(annotations),
+        };
+
+        return clusterDetails;
+      })
+      .filter((c): c is ClusterDetails => c !== undefined);
+  }
+
+  private isUrlAllowed(rawUrl: string | undefined): boolean {
+    if (!rawUrl || !this.allowedOrigins) {
+      return false;
+    }
+    let origin: string;
+    try {
+      origin = new URL(rawUrl).origin;
+    } catch {
+      return false;
+    }
+    if (origin === 'null') {
+      // URLs without a hostname (e.g. `file:`, opaque schemes) parse to the
+      // string literal 'null'. Reject them rather than silently accept.
+      return false;
+    }
+    return this.allowedOrigins.has(origin);
+  }
+
+  private static parseAllowedOrigins(
+    allowedUrls: string[] | undefined,
+  ): Set<string> | undefined {
+    if (!allowedUrls || allowedUrls.length === 0) {
+      return undefined;
+    }
+    const origins = new Set<string>();
+    for (const entry of allowedUrls) {
+      let origin: string;
+      try {
+        origin = new URL(entry).origin;
+      } catch {
+        throw new Error(
+          `Invalid entry in 'allowedClusterUrls': '${entry}' is not a valid ` +
+            'absolute URL (expected something like ' +
+            "'https://my-cluster.example.com').",
+        );
+      }
+      if (origin === 'null') {
+        throw new Error(
+          `Invalid entry in 'allowedClusterUrls': '${entry}' does not have ` +
+            'a usable origin (scheme + host).',
+        );
+      }
+      origins.add(origin);
+    }
+    return origins;
   }
 
   private getDashboardParameters(

--- a/plugins/kubernetes-backend/src/cluster-locator/index.test.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/index.test.ts
@@ -132,7 +132,7 @@ describe('getCombinedClusterSupplier', () => {
                 { name: 'cluster', url: 'url', authProvider: 'authProvider' },
               ],
             },
-            { type: 'catalog' },
+            { type: 'catalog', allowUnsafeClusterUrls: true },
           ],
         },
       },

--- a/plugins/kubernetes-backend/src/cluster-locator/index.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/index.ts
@@ -86,7 +86,15 @@ export const getCombinedClusterSupplier = (
       const type = clusterLocatorMethod.getString('type');
       switch (type) {
         case 'catalog':
-          return CatalogClusterLocator.fromConfig(catalogService, auth);
+          return CatalogClusterLocator.fromConfig(catalogService, auth, {
+            logger,
+            allowedClusterUrls:
+              clusterLocatorMethod.getOptionalStringArray('allowedClusterUrls'),
+            allowUnsafeClusterUrls:
+              clusterLocatorMethod.getOptionalBoolean(
+                'allowUnsafeClusterUrls',
+              ) ?? false,
+          });
         case 'localKubectlProxy':
           return new LocalKubectlProxyClusterLocator();
         case 'config':


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Summary

Adds an opt-in mitigation for a Server-Side Request Forgery (SSRF) / credential exfiltration vulnerability in the catalog-based Kubernetes cluster locator (`@backstage/plugin-kubernetes-backend`, `clusterLocatorMethods: [{ type: 'catalog' }]`).

The locator previously used the `kubernetes.io/api-server` annotation of a catalog `kubernetes-cluster` Resource directly as the outbound request URL, without any validation. Because any authenticated actor with catalog write access can register such a Resource, this allows an attacker to cause the backend to send server-side credentials (AWS STS bearer tokens, Azure / GCP tokens, or a user's OIDC bearer token) to a URL of their choosing.

> [!WARNING]
> This may warrant the private security advisory flow documented in [`SECURITY.md`](https://github.com/backstage/backstage/blob/master/SECURITY.md) rather than a public PR. Happy to move this into a private fork on a draft GHSA if maintainers prefer.

### Fix

The catalog cluster locator now accepts an explicit allowlist of trusted cluster API server origins (scheme + host + optional port):

```yaml
kubernetes:
  clusterLocatorMethods:
    - type: catalog
      allowedClusterUrls:
        - https://my-cluster.example.com
        - https://eks-cluster.us-east-1.eks.amazonaws.com
        - https://10.0.0.5:6443
```

Catalog entities whose `kubernetes.io/api-server` origin does not match an entry in `allowedClusterUrls` are filtered out (with a warning log).

### Two-phase rollout (no immediate breakage for adopters)

To avoid breaking adopters on upgrade, this PR ships the safer behavior as **opt-in** with a deprecation runway:

- `allowedClusterUrls` **configured** → strict allowlist enforcement (the real fix).
- `allowedClusterUrls` **not configured** (default) → falls back to the legacy behavior of trusting any catalog-supplied URL, but logs a loud deprecation warning the first time it does so.
- `allowUnsafeClusterUrls: true` → explicitly acknowledges the risk and silences the deprecation warning (no behavior change vs. today).

The deprecation warning announces that a future release will flip the default to deny-all, making `allowedClusterUrls` effectively required for the catalog locator to return any clusters. That breaking change should be a separate, follow-up PR once adopters have had a release cycle to migrate.

### Breaking change considerations

Nothing changes for adopters by default on this release — they only see a new deprecation warning in logs. The version bump is `patch`.

### Test plan

New `CatalogClusterLocator` unit tests cover:

- Default fallback (no allowlist, no opt-out) logs the deprecation warning once and still returns clusters.
- `allowUnsafeClusterUrls: true` returns clusters with no warning logged.
- With an allowlist configured, entities outside the allowlist are filtered out and warned about.
- URL match is on origin only (path/query suffix ignored).
- Different ports are different origins.
- Malformed allowlist entries throw at construction time.

Existing snapshot tests updated to pass an allowlist. Unrelated regression tests in `index.test.ts` use `allowUnsafeClusterUrls: true` to keep their semantics.

Verified locally:

```bash
CI=1 yarn test plugins/kubernetes-backend/src/cluster-locator
# Test Suites: 4 passed, 4 total
# Tests:       44 passed, 44 total
yarn tsc      # passes
yarn lint plugins/kubernetes-backend  # passes
yarn build:api-reports plugins/kubernetes-backend  # no public-API diff
```

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a \`Signed-off-by\` line in the message.