### PR TITLE
Enforce RepoUrlPicker ui:options allowlists server-side

### DIFF
--- a/.changeset/fix-scaffolder-backend-repourlpicker-bypass.md
+++ b/.changeset/fix-scaffolder-backend-repourlpicker-bypass.md
@@ -1,0 +1,28 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+**SECURITY**: The scaffolder backend now enforces the `RepoUrlPicker` field
+extension's `allowedHosts`, `allowedOwners`, `allowedRepos`,
+`allowedOrganizations`, and `allowedProjects` `ui:options` server-side when a
+task is created via `POST /api/scaffolder/v2/tasks` and during template
+dry-runs.
+
+Previously these allowlists were only applied in the browser by the
+`RepoUrlPicker` field. A caller posting directly to the API could submit a
+`repoUrl` referencing any host / owner / repo, and the scaffolder backend
+would execute the template's actions against it using its configured SCM
+integration credentials. This allowed an authenticated user with API access
+to bypass template-author-declared boundaries and create repositories in
+organizations outside the intended scope.
+
+The backend now parses the submitted `repoUrl` for any parameter whose
+`ui:field` is `RepoUrlPicker`, and rejects the task with a `400` containing a
+`ValidationError` whenever the parsed `host`, `owner`, `repo`, `organization`,
+or `project` is not present in the corresponding `allowed*` list on that
+field. Fields without any `allowed*` lists (or with an empty list) continue
+to accept any value, matching the previous behaviour.
+
+Templates that intentionally allowed broader values than their `ui:options`
+declared via direct API access will need to relax those `ui:options` to
+reflect the actual policy, or stop bypassing the picker.

--- a/docs/features/software-templates/ui-options-examples.md
+++ b/docs/features/software-templates/ui-options-examples.md
@@ -367,6 +367,17 @@ owner:
 
 The input props that can be specified under `ui:options` for the `RepoUrlPicker` field extension.
 
+> **Security note**
+>
+> The `allowedHosts`, `allowedOwners`, `allowedRepos`, `allowedOrganizations`,
+> and `allowedProjects` options below are enforced both in the browser (by
+> the `RepoUrlPicker` field) and on the scaffolder backend when a task is
+> created via `POST /api/scaffolder/v2/tasks`. The backend rejects any
+> `repoUrl` value whose parsed `host` / `owner` / `repo` / `organization` /
+> `project` is not in the corresponding allowlist, so these settings can be
+> treated as a real policy boundary - not just a UI affordance. Fields
+> without any `allowed*` lists (or with an empty list) accept any value.
+
 ### `allowedHosts`
 
 The `allowedHosts` part should be set to where you wish to enable this template

--- a/plugins/scaffolder-backend/src/service/router.test.ts
+++ b/plugins/scaffolder-backend/src/service/router.test.ts
@@ -176,6 +176,7 @@ const createTestRouter = async (
     autocompleteHandlers?: Record<string, AutocompleteHandler>;
     actionsRegistry?: ActionsService;
     entities?: any[];
+    config?: ConfigReader;
   } = {},
 ) => {
   const logger = mockServices.logger.mock({
@@ -207,7 +208,7 @@ const createTestRouter = async (
   const permissionsRegistry = mockServices.permissionsRegistry.mock();
   const router = await createRouter({
     logger,
-    config: new ConfigReader({}),
+    config: overrides.config ?? new ConfigReader({}),
     database: createDatabase(),
     catalog,
     taskBroker,
@@ -1032,6 +1033,126 @@ describe('scaffolder router', () => {
           },
         }),
       );
+    });
+
+    describe('RepoUrlPicker ui:options enforcement', () => {
+      const repoUrlPickerTemplate = generateMockTemplate({
+        parameters: [
+          {
+            type: 'object',
+            required: ['repoUrl'],
+            properties: {
+              repoUrl: {
+                type: 'string',
+                title: 'Repository Location',
+                'ui:field': 'RepoUrlPicker',
+                'ui:options': {
+                  allowedHosts: ['github.com'],
+                  allowedOwners: ['trusted-org'],
+                },
+              },
+            },
+          },
+        ],
+      });
+
+      const integrationsConfig = new ConfigReader({
+        integrations: {
+          github: [{ host: 'github.com', token: 'irrelevant' }],
+          gitlab: [{ host: 'gitlab.com', token: 'irrelevant' }],
+        },
+      });
+
+      it('accepts a repoUrl whose owner is in allowedOwners', async () => {
+        const { router, taskBroker } = await createTestRouter({
+          entities: [repoUrlPickerTemplate, mockUser],
+          config: integrationsConfig,
+        });
+        const broker =
+          taskBroker.dispatch as jest.Mocked<TaskBroker>['dispatch'];
+        broker.mockResolvedValue({ taskId: 'task-1' });
+
+        const response = await request(router)
+          .post('/v2/tasks')
+          .send({
+            templateRef: stringifyEntityRef({
+              kind: 'template',
+              name: 'create-react-app-template',
+            }),
+            values: {
+              repoUrl: 'github.com?owner=trusted-org&repo=my-repo',
+            },
+          });
+
+        expect(response.status).toEqual(201);
+        expect(broker).toHaveBeenCalled();
+      });
+
+      it('rejects a repoUrl whose owner is not in allowedOwners and does not dispatch the task', async () => {
+        const { router, taskBroker } = await createTestRouter({
+          entities: [repoUrlPickerTemplate, mockUser],
+          config: integrationsConfig,
+        });
+        const broker =
+          taskBroker.dispatch as jest.Mocked<TaskBroker>['dispatch'];
+
+        const response = await request(router)
+          .post('/v2/tasks')
+          .send({
+            templateRef: stringifyEntityRef({
+              kind: 'template',
+              name: 'create-react-app-template',
+            }),
+            values: {
+              repoUrl: 'github.com?owner=attacker-org&repo=my-repo',
+            },
+          });
+
+        expect(response.status).toEqual(400);
+        expect(response.body.errors).toEqual([
+          expect.objectContaining({
+            property: 'instance.repoUrl',
+            message: expect.stringMatching(
+              /owner 'attacker-org' is not in the allowed list/,
+            ),
+          }),
+        ]);
+        expect(broker).not.toHaveBeenCalled();
+      });
+
+      it('rejects a repoUrl whose host is not in allowedHosts and does not dispatch the task', async () => {
+        const { router, taskBroker } = await createTestRouter({
+          entities: [repoUrlPickerTemplate, mockUser],
+          config: integrationsConfig,
+        });
+        const broker =
+          taskBroker.dispatch as jest.Mocked<TaskBroker>['dispatch'];
+
+        const response = await request(router)
+          .post('/v2/tasks')
+          .send({
+            templateRef: stringifyEntityRef({
+              kind: 'template',
+              name: 'create-react-app-template',
+            }),
+            values: {
+              repoUrl: 'gitlab.com?owner=trusted-org&repo=my-repo',
+            },
+          });
+
+        expect(response.status).toEqual(400);
+        expect(response.body.errors).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              property: 'instance.repoUrl',
+              message: expect.stringMatching(
+                /host 'gitlab.com' is not in the allowed list/,
+              ),
+            }),
+          ]),
+        );
+        expect(broker).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -106,6 +106,7 @@ import {
   getWorkingDirectory,
   parseStringsParam,
 } from './helpers';
+import { validateRepoUrlPickerOptions } from './validateRepoUrlPickerOptions';
 
 import {
   convertFiltersToRecord,
@@ -577,6 +578,23 @@ export async function createRouter(
             });
 
             res.status(400).json({ errors: result.errors });
+            return;
+          }
+
+          const repoUrlPickerErrors = validateRepoUrlPickerOptions(
+            values,
+            parameters,
+            integrations,
+          );
+          if (repoUrlPickerErrors.length > 0) {
+            await auditorEvent?.fail({
+              error: new InputError(
+                `RepoUrlPicker allowlist violation: ${repoUrlPickerErrors
+                  .map(e => e.message)
+                  .join('; ')}`,
+              ),
+            });
+            res.status(400).json({ errors: repoUrlPickerErrors });
             return;
           }
         }
@@ -1058,6 +1076,26 @@ export async function createRouter(
             });
 
             res.status(400).json({ errors: result.errors });
+            return;
+          }
+
+          const repoUrlPickerErrors = validateRepoUrlPickerOptions(
+            body.values,
+            parameters,
+            integrations,
+          );
+          if (repoUrlPickerErrors.length > 0) {
+            await auditorEvent?.fail({
+              error: new InputError(
+                `RepoUrlPicker allowlist violation: ${repoUrlPickerErrors
+                  .map(e => e.message)
+                  .join('; ')}`,
+              ),
+              meta: {
+                templateRef: templateRef,
+              },
+            });
+            res.status(400).json({ errors: repoUrlPickerErrors });
             return;
           }
         }

--- a/plugins/scaffolder-backend/src/service/validateRepoUrlPickerOptions.test.ts
+++ b/plugins/scaffolder-backend/src/service/validateRepoUrlPickerOptions.test.ts
@@ -1,0 +1,311 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ConfigReader } from '@backstage/config';
+import { ScmIntegrations } from '@backstage/integration';
+import { validateRepoUrlPickerOptions } from './validateRepoUrlPickerOptions';
+
+const integrations = ScmIntegrations.fromConfig(
+  new ConfigReader({
+    integrations: {
+      github: [{ host: 'github.com', token: 'irrelevant' }],
+      gitlab: [{ host: 'gitlab.com', token: 'irrelevant' }],
+      bitbucketCloud: [
+        { host: 'bitbucket.org', username: 'u', appPassword: 'p' },
+      ],
+      azure: [
+        { host: 'dev.azure.com', credentials: [{ personalAccessToken: 'p' }] },
+      ],
+    },
+  }),
+);
+
+describe('validateRepoUrlPickerOptions', () => {
+  const githubPickerParameters = {
+    type: 'object',
+    properties: {
+      repoUrl: {
+        type: 'string',
+        'ui:field': 'RepoUrlPicker',
+        'ui:options': {
+          allowedHosts: ['github.com'],
+          allowedOwners: ['trusted-org', 'other-trusted-org'],
+        },
+      },
+    },
+  };
+
+  it('returns no errors when the value matches every allowlist', () => {
+    const errors = validateRepoUrlPickerOptions(
+      { repoUrl: 'github.com?owner=trusted-org&repo=my-repo' },
+      githubPickerParameters,
+      integrations,
+    );
+    expect(errors).toEqual([]);
+  });
+
+  it('returns an error when the owner is not in allowedOwners', () => {
+    const errors = validateRepoUrlPickerOptions(
+      { repoUrl: 'github.com?owner=attacker-org&repo=my-repo' },
+      githubPickerParameters,
+      integrations,
+    );
+    expect(errors).toEqual([
+      {
+        path: [],
+        property: 'instance.repoUrl',
+        message: expect.stringMatching(
+          /owner 'attacker-org' is not in the allowed list.*allowedOwners.*trusted-org/,
+        ),
+        schema: {},
+        instance: {},
+        name: 'allowedOwners',
+        argument: { allowed: ['trusted-org', 'other-trusted-org'] },
+        stack: expect.stringContaining('instance.repoUrl'),
+      },
+    ]);
+  });
+
+  it('returns an error when the host is not in allowedHosts', () => {
+    const errors = validateRepoUrlPickerOptions(
+      { repoUrl: 'gitlab.com?owner=trusted-org&repo=my-repo' },
+      githubPickerParameters,
+      integrations,
+    );
+    expect(errors).toEqual([
+      expect.objectContaining({
+        property: 'instance.repoUrl',
+        message: expect.stringMatching(
+          /host 'gitlab.com' is not in the allowed list.*allowedHosts/,
+        ),
+      }),
+    ]);
+  });
+
+  it('reports both host and owner violations independently', () => {
+    const errors = validateRepoUrlPickerOptions(
+      { repoUrl: 'gitlab.com?owner=attacker-org&repo=my-repo' },
+      githubPickerParameters,
+      integrations,
+    );
+    expect(errors).toHaveLength(2);
+    expect(errors.map(e => e.message).join(' ')).toMatch(/host 'gitlab.com'/);
+    expect(errors.map(e => e.message).join(' ')).toMatch(
+      /owner 'attacker-org'/,
+    );
+  });
+
+  it('passes through when the field has no allowlists configured', () => {
+    const parameters = {
+      type: 'object',
+      properties: {
+        repoUrl: {
+          type: 'string',
+          'ui:field': 'RepoUrlPicker',
+          'ui:options': {},
+        },
+      },
+    };
+    const errors = validateRepoUrlPickerOptions(
+      { repoUrl: 'github.com?owner=attacker-org&repo=my-repo' },
+      parameters,
+      integrations,
+    );
+    expect(errors).toEqual([]);
+  });
+
+  it('ignores empty-array allowlists (treated as not configured)', () => {
+    const parameters = {
+      type: 'object',
+      properties: {
+        repoUrl: {
+          type: 'string',
+          'ui:field': 'RepoUrlPicker',
+          'ui:options': {
+            allowedOwners: [],
+          },
+        },
+      },
+    };
+    const errors = validateRepoUrlPickerOptions(
+      { repoUrl: 'github.com?owner=anyone&repo=my-repo' },
+      parameters,
+      integrations,
+    );
+    expect(errors).toEqual([]);
+  });
+
+  it('walks nested object properties', () => {
+    const parameters = {
+      type: 'object',
+      properties: {
+        repository: {
+          type: 'object',
+          properties: {
+            url: {
+              type: 'string',
+              'ui:field': 'RepoUrlPicker',
+              'ui:options': {
+                allowedOwners: ['trusted-org'],
+              },
+            },
+          },
+        },
+      },
+    };
+    const errors = validateRepoUrlPickerOptions(
+      {
+        repository: {
+          url: 'github.com?owner=attacker-org&repo=my-repo',
+        },
+      },
+      parameters,
+      integrations,
+    );
+    expect(errors).toEqual([
+      expect.objectContaining({
+        property: 'instance.repository.url',
+        message: expect.stringMatching(/attacker-org/),
+      }),
+    ]);
+  });
+
+  it('walks schema composition (anyOf/oneOf/allOf)', () => {
+    const parameters = {
+      type: 'object',
+      properties: {
+        repoUrl: {
+          allOf: [
+            {
+              type: 'string',
+              'ui:field': 'RepoUrlPicker',
+              'ui:options': {
+                allowedOwners: ['trusted-org'],
+              },
+            },
+          ],
+        },
+      },
+    };
+    const errors = validateRepoUrlPickerOptions(
+      { repoUrl: 'github.com?owner=attacker-org&repo=my-repo' },
+      parameters,
+      integrations,
+    );
+    expect(errors).toEqual([
+      expect.objectContaining({
+        property: 'instance.repoUrl',
+        message: expect.stringMatching(/attacker-org/),
+      }),
+    ]);
+  });
+
+  it('validates against allowedProjects and allowedRepos for Bitbucket', () => {
+    const parameters = {
+      type: 'object',
+      properties: {
+        repoUrl: {
+          type: 'string',
+          'ui:field': 'RepoUrlPicker',
+          'ui:options': {
+            allowedOwners: ['my-workspace'],
+            allowedProjects: ['TRUSTED-PROJECT'],
+            allowedRepos: ['allowed-repo'],
+          },
+        },
+      },
+    };
+    const ok = validateRepoUrlPickerOptions(
+      {
+        repoUrl:
+          'bitbucket.org?workspace=my-workspace&owner=my-workspace&project=TRUSTED-PROJECT&repo=allowed-repo',
+      },
+      parameters,
+      integrations,
+    );
+    expect(ok).toEqual([]);
+
+    const bad = validateRepoUrlPickerOptions(
+      {
+        repoUrl:
+          'bitbucket.org?workspace=my-workspace&owner=my-workspace&project=OTHER-PROJECT&repo=allowed-repo',
+      },
+      parameters,
+      integrations,
+    );
+    expect(bad).toEqual([
+      expect.objectContaining({
+        message: expect.stringMatching(/project 'OTHER-PROJECT'/),
+      }),
+    ]);
+  });
+
+  it('reports a parse error against the field when the value is malformed', () => {
+    const parameters = {
+      type: 'object',
+      properties: {
+        repoUrl: {
+          type: 'string',
+          'ui:field': 'RepoUrlPicker',
+          'ui:options': {
+            allowedOwners: ['trusted-org'],
+          },
+        },
+      },
+    };
+    const errors = validateRepoUrlPickerOptions(
+      { repoUrl: 'not a url at all' },
+      parameters,
+      integrations,
+    );
+    expect(errors).toEqual([
+      expect.objectContaining({
+        property: 'instance.repoUrl',
+        message: expect.stringMatching(/not a valid repository URL/),
+      }),
+    ]);
+  });
+
+  it('ignores non-string values (handled by JSON Schema)', () => {
+    const errors = validateRepoUrlPickerOptions(
+      { repoUrl: 42 },
+      githubPickerParameters,
+      integrations,
+    );
+    expect(errors).toEqual([]);
+  });
+
+  it('ignores fields that are not RepoUrlPicker', () => {
+    const parameters = {
+      type: 'object',
+      properties: {
+        unrelated: {
+          type: 'string',
+          'ui:field': 'EntityPicker',
+          'ui:options': {
+            allowedOwners: ['trusted-org'],
+          },
+        },
+      },
+    };
+    const errors = validateRepoUrlPickerOptions(
+      { unrelated: 'whatever' },
+      parameters,
+      integrations,
+    );
+    expect(errors).toEqual([]);
+  });
+});

--- a/plugins/scaffolder-backend/src/service/validateRepoUrlPickerOptions.ts
+++ b/plugins/scaffolder-backend/src/service/validateRepoUrlPickerOptions.ts
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ScmIntegrationRegistry } from '@backstage/integration';
+import { parseRepoUrl } from '@backstage/plugin-scaffolder-node';
+
+/**
+ * Errors produced by {@link validateRepoUrlPickerOptions}. The shape mirrors
+ * the `ValidationError` declared in the scaffolder OpenAPI schema so that
+ * the existing `{ errors: [...] }` 400 response envelope can be reused.
+ */
+export type RepoUrlPickerValidationError = {
+  path: Array<string | number>;
+  property: string;
+  message: string;
+  schema: Record<string, unknown>;
+  instance: Record<string, unknown>;
+  name: string;
+  argument: string | number | boolean | Record<string, unknown>;
+  stack: string;
+};
+
+type JsonRecord = { [key: string]: unknown };
+
+const REPO_URL_PICKER_FIELD = 'RepoUrlPicker';
+
+const ALLOWED_OPTION_TO_PARSED_FIELD = {
+  allowedHosts: 'host',
+  allowedOwners: 'owner',
+  allowedRepos: 'repo',
+  allowedOrganizations: 'organization',
+  allowedProjects: 'project',
+} as const;
+
+type AllowedOption = keyof typeof ALLOWED_OPTION_TO_PARSED_FIELD;
+
+const ALLOWED_OPTIONS: AllowedOption[] = Object.keys(
+  ALLOWED_OPTION_TO_PARSED_FIELD,
+) as AllowedOption[];
+
+/**
+ * Server-side enforcement of `RepoUrlPicker` `ui:options` allowlists declared
+ * in a template's `spec.parameters` JSON Schema.
+ *
+ * These constraints (`allowedHosts`, `allowedOwners`, `allowedRepos`,
+ * `allowedOrganizations`, `allowedProjects`) are filtered into UI controls by
+ * the React `RepoUrlPicker` field extension, but the standard JSON Schema
+ * validator the scaffolder backend runs against incoming `values` ignores
+ * them. Without this check, a caller that posts directly to
+ * `POST /api/scaffolder/v2/tasks` can submit any `repoUrl` they want and the
+ * backend will execute the template's actions against it using its configured
+ * SCM integration credentials.
+ *
+ * @param values - The submitted form values (the `values` field of the
+ *   `POST /v2/tasks` request body).
+ * @param parameters - One of the entries in `template.spec.parameters` — i.e.
+ *   either a single schema object or one wizard step's schema.
+ * @param integrations - The plugin's SCM integration registry, used to parse
+ *   `repoUrl` strings into `{ host, owner, repo, ... }` the same way the
+ *   downstream actions will.
+ *
+ * @returns The list of validation errors, one per disallowed value. Empty
+ *   when the values comply with the template's declared allowlists (or when
+ *   the template does not use `RepoUrlPicker`).
+ */
+export function validateRepoUrlPickerOptions(
+  values: unknown,
+  parameters: unknown,
+  integrations: ScmIntegrationRegistry,
+): RepoUrlPickerValidationError[] {
+  if (!isJsonRecord(values) || !isJsonRecord(parameters)) {
+    return [];
+  }
+  const errors: RepoUrlPickerValidationError[] = [];
+  walkSchema(parameters, values, 'instance', integrations, errors);
+  return errors;
+}
+
+function walkSchema(
+  schema: JsonRecord,
+  value: unknown,
+  path: string,
+  integrations: ScmIntegrationRegistry,
+  errors: RepoUrlPickerValidationError[],
+): void {
+  // Composition keywords - walk each sub-schema against the same value.
+  for (const key of ['allOf', 'anyOf', 'oneOf'] as const) {
+    const subs = schema[key];
+    if (Array.isArray(subs)) {
+      for (const sub of subs) {
+        if (isJsonRecord(sub)) {
+          walkSchema(sub, value, path, integrations, errors);
+        }
+      }
+    }
+  }
+
+  if (
+    schema['ui:field'] === REPO_URL_PICKER_FIELD &&
+    typeof value === 'string'
+  ) {
+    validateRepoUrlValue(
+      value,
+      schema['ui:options'],
+      path,
+      integrations,
+      errors,
+    );
+    // A RepoUrlPicker terminal field is always a string; no need to recurse.
+    return;
+  }
+
+  const properties = schema.properties;
+  if (isJsonRecord(properties) && isJsonRecord(value)) {
+    for (const [propName, propSchema] of Object.entries(properties)) {
+      if (!isJsonRecord(propSchema)) {
+        continue;
+      }
+      if (Object.prototype.hasOwnProperty.call(value, propName)) {
+        walkSchema(
+          propSchema,
+          value[propName],
+          `${path}.${propName}`,
+          integrations,
+          errors,
+        );
+      }
+    }
+  }
+}
+
+function validateRepoUrlValue(
+  value: string,
+  rawOptions: unknown,
+  path: string,
+  integrations: ScmIntegrationRegistry,
+  errors: RepoUrlPickerValidationError[],
+): void {
+  // No allowlist on the field means nothing to enforce.
+  const options = isJsonRecord(rawOptions) ? rawOptions : {};
+  const allowlists: Partial<Record<AllowedOption, string[]>> = {};
+  let hasAnyAllowlist = false;
+  for (const option of ALLOWED_OPTIONS) {
+    const entries = options[option];
+    if (Array.isArray(entries) && entries.length > 0) {
+      const stringEntries = entries.filter(
+        (e): e is string => typeof e === 'string',
+      );
+      if (stringEntries.length > 0) {
+        allowlists[option] = stringEntries;
+        hasAnyAllowlist = true;
+      }
+    }
+  }
+  if (!hasAnyAllowlist) {
+    return;
+  }
+
+  let parsed: ReturnType<typeof parseRepoUrl>;
+  try {
+    parsed = parseRepoUrl(value, integrations);
+  } catch (err) {
+    // Surface the parse error against this field rather than 500ing the
+    // request - the JSON Schema validator only enforces `type: string`, so a
+    // malformed value can legitimately reach this point.
+    const message = `is not a valid repository URL: ${
+      err instanceof Error ? err.message : String(err)
+    }`;
+    errors.push(
+      buildError({
+        path,
+        message,
+        name: 'repoUrl',
+        argument: value,
+      }),
+    );
+    return;
+  }
+
+  for (const option of ALLOWED_OPTIONS) {
+    const allowed = allowlists[option];
+    if (!allowed) {
+      continue;
+    }
+    const parsedField = ALLOWED_OPTION_TO_PARSED_FIELD[option];
+    const actual = parsed[parsedField];
+    // Skip fields the picker didn't fill in for this integration type - if
+    // the value is required for the downstream action, parseRepoUrl will
+    // have already thrown above.
+    if (actual === undefined || actual === '') {
+      continue;
+    }
+    if (!allowed.includes(actual)) {
+      const message =
+        `${parsedField} '${actual}' is not in the allowed list for this ` +
+        `field (${option}: ${JSON.stringify(allowed)}). The template ` +
+        'restricts which values may be submitted for this RepoUrlPicker.';
+      errors.push(
+        buildError({
+          path,
+          message,
+          name: option,
+          argument: allowed,
+        }),
+      );
+    }
+  }
+}
+
+function buildError(args: {
+  path: string;
+  message: string;
+  name: string;
+  argument: unknown;
+}): RepoUrlPickerValidationError {
+  const { path, message, name, argument } = args;
+  // The scaffolder OpenAPI ValidationError schema requires `argument` to be
+  // one of boolean / number / object / string - never an array - so wrap
+  // arrays in a `{ allowed: [...] }` object for transport.
+  const normalisedArgument: RepoUrlPickerValidationError['argument'] =
+    Array.isArray(argument)
+      ? { allowed: argument }
+      : (argument as RepoUrlPickerValidationError['argument']);
+  return {
+    path: [],
+    property: path,
+    message,
+    schema: {},
+    instance: {},
+    name,
+    argument: normalisedArgument,
+    stack: `${path} ${message}`,
+  };
+}
+
+function isJsonRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Summary

Fixes a server-side enforcement gap in `@backstage/plugin-scaffolder-backend`. The `RepoUrlPicker` field extension's `allowedHosts`, `allowedOwners`, `allowedRepos`, `allowedOrganizations`, and `allowedProjects` `ui:options` were previously enforced only in the browser. A caller that posted directly to `POST /api/scaffolder/v2/tasks` could submit any `repoUrl` and the scaffolder backend would execute the template against it using its configured SCM integration credentials, bypassing the boundary the template author intended.

> [!WARNING]
> This may warrant the private security advisory flow documented in [`SECURITY.md`](https://github.com/backstage/backstage/blob/master/SECURITY.md) rather than a public PR. Happy to move this into a private fork on a draft GHSA if maintainers prefer.

### Fix

A new internal helper `validateRepoUrlPickerOptions` walks a template's parameter schema looking for `ui:field: RepoUrlPicker` properties, parses the submitted value with the same `parseRepoUrl` utility downstream actions use, and rejects the task with a `400 ValidationError` whenever any of the parsed `host` / `owner` / `repo` / `organization` / `project` is not in the corresponding `allowed*` list. The schema walker handles nested objects and \`allOf\`/\`anyOf\`/\`oneOf\` composition.

The same enforcement is applied to the dry-run endpoint (\`POST /v2/dry-run\`).

Fields without any `allowed*` lists (or with an empty list) continue to accept any value, matching today's behaviour.

### Compatibility

This is a behavioural change for adopters whose templates currently declare `allowed*` `ui:options` *but* expect API callers to be able to bypass them. Those callers will now receive `400` with a `ValidationError` for the offending field. The version bump is `patch` because:

- The `allowed*` options are already documented as template-defined policy boundaries.
- The package is \`>= 1.0.0\` but the behaviour change matches the documented intent.

The errors are emitted in the same shape as existing JSON Schema validation errors (the OpenAPI `ValidationError` schema), so existing 400 handlers do not need to change.

### Test plan

New \`validateRepoUrlPickerOptions\` unit tests (\`plugins/scaffolder-backend/src/service/validateRepoUrlPickerOptions.test.ts\`) cover:

- Happy path with multiple matching allowlists
- \`allowedOwners\` violation (matches the report's exact PoC)
- \`allowedHosts\` violation
- Multiple simultaneous violations on the same field
- Empty / missing allowlist = accept anything (back-compat)
- Schema walking into nested object properties
- Schema walking into \`allOf\` / \`anyOf\` / \`oneOf\`
- Bitbucket \`allowedProjects\` + \`allowedRepos\`
- Malformed \`repoUrl\` reported as a validation error against the field (not a 500)
- Non-string values ignored (delegated to JSON Schema)
- Non-RepoUrlPicker fields ignored

New router-level tests (\`router.test.ts\` › \`POST /v2/tasks\` › \`RepoUrlPicker ui:options enforcement\`):

- Accepts \`owner=trusted-org\` and dispatches the task
- Rejects \`owner=attacker-org\` with \`400\` and does **not** dispatch the task
- Rejects \`host=gitlab.com\` with \`400\` and does **not** dispatch the task

Verified locally:

\`\`\`bash
CI=1 yarn test plugins/scaffolder-backend/src/service
# Test Suites: 4 passed, 4 total
# Tests:       175 passed, 175 total
yarn tsc     # passes
yarn lint plugins/scaffolder-backend  # passes
yarn build:api-reports plugins/scaffolder-backend  # no public-API diff
\`\`\`

The full router suite passes with no regressions.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a \`Signed-off-by\` line in the message.


Made with [Cursor](https://cursor.com)