### PR TITLE
refactor(devtools): migrate InfoDependenciesTable to Backstage UI

### DIFF
--- a/.changeset/devtools-info-dependencies-table-bui.md
+++ b/.changeset/devtools-info-dependencies-table-bui.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-devtools': patch
+---
+
+Migrated the `InfoDependenciesTable` component from Material UI / `@backstage/core-components` `Table` to the new Backstage UI library. Behavior is preserved: name/versions columns, name-ascending initial sort, page sizes of 15/30/100, and substring filtering across both columns.

--- a/plugins/devtools/src/components/Content/InfoContent/InfoDependenciesTable.tsx
+++ b/plugins/devtools/src/components/Content/InfoContent/InfoDependenciesTable.tsx
@@ -50,7 +50,7 @@ export const InfoDependenciesTable = ({
   infoDependencies: PackageDependency[] | undefined;
 }) => {
   const rows = useMemo<Row[] | undefined>(
-    () => infoDependencies?.map(d => ({ ...d, id: d.name })),
+    () => infoDependencies?.map((d, i) => ({ ...d, id: `${d.name}-${i}` })),
     [infoDependencies],
   );
 

--- a/plugins/devtools/src/components/Content/InfoContent/InfoDependenciesTable.tsx
+++ b/plugins/devtools/src/components/Content/InfoContent/InfoDependenciesTable.tsx
@@ -14,20 +14,33 @@
  * limitations under the License.
  */
 
-import { Table, TableColumn } from '@backstage/core-components';
+import { useMemo } from 'react';
+import {
+  Box,
+  CellText,
+  Flex,
+  SearchField,
+  Table,
+  Text,
+  useTable,
+  type ColumnConfig,
+} from '@backstage/ui';
 import { PackageDependency } from '@backstage/plugin-devtools-common';
 
-const columns: TableColumn[] = [
+type Row = PackageDependency & { id: string };
+
+const columns: ColumnConfig<Row>[] = [
   {
-    title: 'Name',
-    width: 'auto',
-    field: 'name',
-    defaultSort: 'asc',
+    id: 'name',
+    label: 'Name',
+    isRowHeader: true,
+    isSortable: true,
+    cell: item => <CellText title={item.name} />,
   },
   {
-    title: 'Versions',
-    width: 'auto',
-    field: 'versions',
+    id: 'versions',
+    label: 'Versions',
+    cell: item => <CellText title={item.versions} />,
   },
 ];
 
@@ -36,18 +49,46 @@ export const InfoDependenciesTable = ({
 }: {
   infoDependencies: PackageDependency[] | undefined;
 }) => {
+  const rows = useMemo<Row[] | undefined>(
+    () => infoDependencies?.map(d => ({ ...d, id: d.name })),
+    [infoDependencies],
+  );
+
+  const { tableProps, search } = useTable({
+    mode: 'complete',
+    data: rows,
+    paginationOptions: {
+      pageSize: 15,
+      pageSizeOptions: [15, 30, 100],
+    },
+    initialSort: { column: 'name', direction: 'ascending' },
+    sortFn: (items, { column, direction }) => {
+      return [...items].sort((a, b) => {
+        const aVal = column === 'name' ? a.name : a.versions;
+        const bVal = column === 'name' ? b.name : b.versions;
+        const cmp = aVal.localeCompare(bVal);
+        return direction === 'descending' ? -cmp : cmp;
+      });
+    },
+    searchFn: (items, query) => {
+      const lowerQuery = query.toLowerCase();
+      return items.filter(
+        item =>
+          item.name.toLowerCase().includes(lowerQuery) ||
+          item.versions.toLowerCase().includes(lowerQuery),
+      );
+    },
+  });
+
   return (
-    <Table
-      title="Package Dependencies"
-      options={{
-        paging: true,
-        pageSize: 15,
-        pageSizeOptions: [15, 30, 100],
-        loadingType: 'linear',
-        padding: 'dense',
-      }}
-      columns={columns}
-      data={infoDependencies || []}
-    />
+    <Box>
+      <Flex justify="between" align="center" pb="2">
+        <Text variant="title-medium" weight="bold">
+          Package Dependencies
+        </Text>
+        <SearchField aria-label="Filter" placeholder="Filter" {...search} />
+      </Flex>
+      <Table columnConfig={columns} {...tableProps} />
+    </Box>
   );
 };


### PR DESCRIPTION
Fixes #32748

## Summary

Migrates `InfoDependenciesTable` (the Package Dependencies table on the DevTools `/devtools/info` page) from Material UI + `@backstage/core-components` `Table` to the new Backstage UI library.

## What's changing

- **Imports**: `Table` / `TableColumn` from `@backstage/core-components` → `Table`, `CellText`, `useTable`, `ColumnConfig` from `@backstage/ui`; added `Box`, `Flex`, `SearchField`, `Text` for the heading row.
- **Column config**: legacy `TableColumn[]` with `title` / `field` → `ColumnConfig<Row>[]` with `id`, `label`, `isRowHeader`, `isSortable`, and a `cell` renderer using `<CellText title={...} />`.
- **Row identity**: introduced a local `Row = PackageDependency & { id: string }` and a memoized `rows` array that maps `{ ...d, id: d.name }`, satisfying BUI's `TableItem` constraint (package names are unique).
- **Pagination, sort, search**: handled via `useTable({ mode: 'complete', data, paginationOptions, initialSort, sortFn, searchFn })` instead of the legacy table's built-in options.
- **Heading + filter**: rendered as a `<Flex justify="between" align="center">` row above the table — `<Text variant="title-medium" weight="bold">Package Dependencies</Text>` on the left, `<SearchField {...search} />` on the right.

## Behavior preserved

- Name + Versions columns
- Initial sort: name ascending
- Page size 15 (default), with 15 / 30 / 100 options
- Substring filter across both name and versions

`InfoDependenciesTable`'s public prop signature is unchanged, so `InfoContent` does not need any edits.

## Test plan

- [x] Local `yarn start` smoke test on `/devtools/info`: Package Dependencies table renders all rows, sorts by name ascending, filter narrows results live, pagination cycles correctly with 15/30/100 page sizes
- [ ] CI: lint, typecheck, tests, changeset verification

No tests exist for `InfoDependenciesTable` today; happy to add one if maintainers prefer.