### PR TITLE
feat(catalog-backend): add refresh-catalog-entity action

### DIFF
--- a/.changeset/catalog-refresh-entity-mcp-action.md
+++ b/.changeset/catalog-refresh-entity-mcp-action.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': minor
+---
+
+Added a new `refresh-catalog-entity` action to the catalog backend's `ActionsRegistryService`. The action triggers a refresh of a single entity identified by `kind` / `namespace` / `name` (kind defaults to `Component`, namespace defaults to `default`). It performs an existence check via `getEntityByRef` first and throws `NotFoundError` for missing entities. Exposed automatically as an MCP tool by `@backstage/plugin-mcp-actions-backend`.

--- a/.changeset/catalog-refresh-entity-mcp-action.md
+++ b/.changeset/catalog-refresh-entity-mcp-action.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend': minor
 ---
 
-Added a `refresh-catalog-entity` action so agents and MCP clients can requeue a single entity for processing after creating or updating it — useful for reading back fresh data immediately after a scaffolder run without waiting for the next scheduled processing loop.
+Added a `refresh-catalog-entity` action so agents and MCP clients can re-queue a single entity for processing after creating or updating it — useful for reading back fresh data immediately after a scaffolder run without waiting for the next scheduled processing loop.

--- a/.changeset/catalog-refresh-entity-mcp-action.md
+++ b/.changeset/catalog-refresh-entity-mcp-action.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend': minor
 ---
 
-Added a new `refresh-catalog-entity` action to the catalog backend's `ActionsRegistryService`. The action triggers a refresh of a single entity identified by `kind` / `namespace` / `name` (kind defaults to `Component`, namespace defaults to `default`). It performs an existence check via `getEntityByRef` first and throws `NotFoundError` for missing entities. Exposed automatically as an MCP tool by `@backstage/plugin-mcp-actions-backend`.
+Added a `refresh-catalog-entity` action so agents and MCP clients can requeue a single entity for processing after creating or updating it — useful for reading back fresh data immediately after a scaffolder run without waiting for the next scheduled processing loop.

--- a/plugins/catalog-backend/src/actions/createRefreshCatalogEntityAction.test.ts
+++ b/plugins/catalog-backend/src/actions/createRefreshCatalogEntityAction.test.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { createRefreshCatalogEntityAction } from './createRefreshCatalogEntityAction';
+import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
+import { actionsRegistryServiceMock } from '@backstage/backend-test-utils/alpha';
+
+describe('createRefreshCatalogEntityAction', () => {
+  const mockEntity = {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Component',
+    metadata: { name: 'example-website', namespace: 'default' },
+  };
+
+  it('refreshes an entity using explicit kind, namespace, and name', async () => {
+    const mockActionsRegistry = actionsRegistryServiceMock();
+    const mockCatalog = catalogServiceMock();
+
+    mockCatalog.getEntityByRef = jest.fn().mockResolvedValue(mockEntity);
+    mockCatalog.refreshEntity = jest.fn().mockResolvedValue(undefined);
+
+    createRefreshCatalogEntityAction({
+      catalog: mockCatalog,
+      actionsRegistry: mockActionsRegistry,
+    });
+
+    const result = await mockActionsRegistry.invoke({
+      id: 'test:refresh-catalog-entity',
+      input: { kind: 'API', namespace: 'payments', name: 'orders-api' },
+    });
+
+    const expectedRef = 'api:payments/orders-api';
+    expect(result.output).toEqual({ entityRef: expectedRef });
+    expect(mockCatalog.refreshEntity).toHaveBeenCalledWith(
+      expectedRef,
+      expect.objectContaining({ credentials: expect.any(Object) }),
+    );
+  });
+
+  it('defaults kind to "Component" and namespace to "default" when omitted', async () => {
+    const mockActionsRegistry = actionsRegistryServiceMock();
+    const mockCatalog = catalogServiceMock();
+
+    mockCatalog.getEntityByRef = jest.fn().mockResolvedValue(mockEntity);
+    mockCatalog.refreshEntity = jest.fn().mockResolvedValue(undefined);
+
+    createRefreshCatalogEntityAction({
+      catalog: mockCatalog,
+      actionsRegistry: mockActionsRegistry,
+    });
+
+    const result = await mockActionsRegistry.invoke({
+      id: 'test:refresh-catalog-entity',
+      input: { name: 'example-website' },
+    });
+
+    const expectedRef = 'component:default/example-website';
+    expect(result.output).toEqual({ entityRef: expectedRef });
+    expect(mockCatalog.refreshEntity).toHaveBeenCalledWith(
+      expectedRef,
+      expect.objectContaining({ credentials: expect.any(Object) }),
+    );
+  });
+
+  it('throws NotFoundError when the entity does not exist', async () => {
+    const mockActionsRegistry = actionsRegistryServiceMock();
+    const mockCatalog = catalogServiceMock();
+
+    mockCatalog.getEntityByRef = jest.fn().mockResolvedValue(undefined);
+    mockCatalog.refreshEntity = jest.fn();
+
+    createRefreshCatalogEntityAction({
+      catalog: mockCatalog,
+      actionsRegistry: mockActionsRegistry,
+    });
+
+    await expect(
+      mockActionsRegistry.invoke({
+        id: 'test:refresh-catalog-entity',
+        input: { name: 'missing-entity' },
+      }),
+    ).rejects.toMatchObject({
+      name: 'NotFoundError',
+      message: `Entity 'component:default/missing-entity' not found`,
+    });
+
+    expect(mockCatalog.refreshEntity).not.toHaveBeenCalled();
+  });
+
+  it('surfaces errors from catalog.refreshEntity to the caller', async () => {
+    const mockActionsRegistry = actionsRegistryServiceMock();
+    const mockCatalog = catalogServiceMock();
+
+    mockCatalog.getEntityByRef = jest.fn().mockResolvedValue(mockEntity);
+    mockCatalog.refreshEntity = jest
+      .fn()
+      .mockRejectedValue(new Error('processor unavailable'));
+
+    createRefreshCatalogEntityAction({
+      catalog: mockCatalog,
+      actionsRegistry: mockActionsRegistry,
+    });
+
+    await expect(
+      mockActionsRegistry.invoke({
+        id: 'test:refresh-catalog-entity',
+        input: { name: 'example-website' },
+      }),
+    ).rejects.toThrow('processor unavailable');
+  });
+});

--- a/plugins/catalog-backend/src/actions/createRefreshCatalogEntityAction.test.ts
+++ b/plugins/catalog-backend/src/actions/createRefreshCatalogEntityAction.test.ts
@@ -18,18 +18,79 @@ import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
 import { actionsRegistryServiceMock } from '@backstage/backend-test-utils/alpha';
 
 describe('createRefreshCatalogEntityAction', () => {
-  const mockEntity = {
+  const componentEntity = {
     apiVersion: 'backstage.io/v1alpha1',
     kind: 'Component',
-    metadata: { name: 'example-website', namespace: 'default' },
+    metadata: { name: 'orders-api', namespace: 'default' },
+    spec: { type: 'service' },
   };
 
-  it('refreshes an entity using explicit kind, namespace, and name', async () => {
-    const mockActionsRegistry = actionsRegistryServiceMock();
-    const mockCatalog = catalogServiceMock();
+  const apiEntity = {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'API',
+    metadata: { name: 'orders-api', namespace: 'default' },
+  };
 
-    mockCatalog.getEntityByRef = jest.fn().mockResolvedValue(mockEntity);
-    mockCatalog.refreshEntity = jest.fn().mockResolvedValue(undefined);
+  const paymentsApiEntity = {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'API',
+    metadata: { name: 'orders-api', namespace: 'payments' },
+  };
+
+  it('resolves an entity by name alone (single match) and refreshes it', async () => {
+    const mockActionsRegistry = actionsRegistryServiceMock();
+    const mockCatalog = catalogServiceMock({ entities: [componentEntity] });
+    const refreshSpy = jest.spyOn(mockCatalog, 'refreshEntity');
+
+    createRefreshCatalogEntityAction({
+      catalog: mockCatalog,
+      actionsRegistry: mockActionsRegistry,
+    });
+
+    const result = await mockActionsRegistry.invoke({
+      id: 'test:refresh-catalog-entity',
+      input: { name: 'orders-api' },
+    });
+
+    expect(result.output).toEqual({
+      entityRef: 'component:default/orders-api',
+    });
+    expect(refreshSpy).toHaveBeenCalledWith(
+      'component:default/orders-api',
+      expect.objectContaining({ credentials: expect.any(Object) }),
+    );
+  });
+
+  it('disambiguates via kind when multiple entities share a name', async () => {
+    const mockActionsRegistry = actionsRegistryServiceMock();
+    const mockCatalog = catalogServiceMock({
+      entities: [componentEntity, apiEntity],
+    });
+    const refreshSpy = jest.spyOn(mockCatalog, 'refreshEntity');
+
+    createRefreshCatalogEntityAction({
+      catalog: mockCatalog,
+      actionsRegistry: mockActionsRegistry,
+    });
+
+    const result = await mockActionsRegistry.invoke({
+      id: 'test:refresh-catalog-entity',
+      input: { kind: 'API', name: 'orders-api' },
+    });
+
+    expect(result.output).toEqual({ entityRef: 'api:default/orders-api' });
+    expect(refreshSpy).toHaveBeenCalledWith(
+      'api:default/orders-api',
+      expect.objectContaining({ credentials: expect.any(Object) }),
+    );
+  });
+
+  it('disambiguates via kind + namespace when multiple entities share a name', async () => {
+    const mockActionsRegistry = actionsRegistryServiceMock();
+    const mockCatalog = catalogServiceMock({
+      entities: [apiEntity, paymentsApiEntity],
+    });
+    const refreshSpy = jest.spyOn(mockCatalog, 'refreshEntity');
 
     createRefreshCatalogEntityAction({
       catalog: mockCatalog,
@@ -41,53 +102,17 @@ describe('createRefreshCatalogEntityAction', () => {
       input: { kind: 'API', namespace: 'payments', name: 'orders-api' },
     });
 
-    const expectedRef = 'api:payments/orders-api';
-    expect(result.output).toEqual({ entityRef: expectedRef });
-    expect(mockCatalog.getEntityByRef).toHaveBeenCalledWith(
-      expectedRef,
-      expect.objectContaining({ credentials: expect.any(Object) }),
-    );
-    expect(mockCatalog.refreshEntity).toHaveBeenCalledWith(
-      expectedRef,
+    expect(result.output).toEqual({ entityRef: 'api:payments/orders-api' });
+    expect(refreshSpy).toHaveBeenCalledWith(
+      'api:payments/orders-api',
       expect.objectContaining({ credentials: expect.any(Object) }),
     );
   });
 
-  it('defaults kind to "Component" and namespace to "default" when omitted', async () => {
+  it('throws when no entity matches the name', async () => {
     const mockActionsRegistry = actionsRegistryServiceMock();
-    const mockCatalog = catalogServiceMock();
-
-    mockCatalog.getEntityByRef = jest.fn().mockResolvedValue(mockEntity);
-    mockCatalog.refreshEntity = jest.fn().mockResolvedValue(undefined);
-
-    createRefreshCatalogEntityAction({
-      catalog: mockCatalog,
-      actionsRegistry: mockActionsRegistry,
-    });
-
-    const result = await mockActionsRegistry.invoke({
-      id: 'test:refresh-catalog-entity',
-      input: { name: 'example-website' },
-    });
-
-    const expectedRef = 'component:default/example-website';
-    expect(result.output).toEqual({ entityRef: expectedRef });
-    expect(mockCatalog.getEntityByRef).toHaveBeenCalledWith(
-      expectedRef,
-      expect.objectContaining({ credentials: expect.any(Object) }),
-    );
-    expect(mockCatalog.refreshEntity).toHaveBeenCalledWith(
-      expectedRef,
-      expect.objectContaining({ credentials: expect.any(Object) }),
-    );
-  });
-
-  it('throws NotFoundError when the entity does not exist', async () => {
-    const mockActionsRegistry = actionsRegistryServiceMock();
-    const mockCatalog = catalogServiceMock();
-
-    mockCatalog.getEntityByRef = jest.fn().mockResolvedValue(undefined);
-    mockCatalog.refreshEntity = jest.fn();
+    const mockCatalog = catalogServiceMock({ entities: [] });
+    const refreshSpy = jest.spyOn(mockCatalog, 'refreshEntity');
 
     createRefreshCatalogEntityAction({
       catalog: mockCatalog,
@@ -99,21 +124,40 @@ describe('createRefreshCatalogEntityAction', () => {
         id: 'test:refresh-catalog-entity',
         input: { name: 'missing-entity' },
       }),
-    ).rejects.toMatchObject({
-      name: 'NotFoundError',
-      message: `Entity 'component:default/missing-entity' not found`,
+    ).rejects.toThrow(`No entity found with name "missing-entity"`);
+
+    expect(refreshSpy).not.toHaveBeenCalled();
+  });
+
+  it('throws when a name matches multiple entities, listing the candidates', async () => {
+    const mockActionsRegistry = actionsRegistryServiceMock();
+    const mockCatalog = catalogServiceMock({
+      entities: [componentEntity, apiEntity],
+    });
+    const refreshSpy = jest.spyOn(mockCatalog, 'refreshEntity');
+
+    createRefreshCatalogEntityAction({
+      catalog: mockCatalog,
+      actionsRegistry: mockActionsRegistry,
     });
 
-    expect(mockCatalog.refreshEntity).not.toHaveBeenCalled();
+    await expect(
+      mockActionsRegistry.invoke({
+        id: 'test:refresh-catalog-entity',
+        input: { name: 'orders-api' },
+      }),
+    ).rejects.toThrow(
+      `Multiple entities found with name "orders-api", please provide more specific filters. Entities found: "component:default/orders-api", "api:default/orders-api"`,
+    );
+
+    expect(refreshSpy).not.toHaveBeenCalled();
   });
 
   it('surfaces errors from catalog.refreshEntity to the caller', async () => {
     const mockActionsRegistry = actionsRegistryServiceMock();
-    const mockCatalog = catalogServiceMock();
-
-    mockCatalog.getEntityByRef = jest.fn().mockResolvedValue(mockEntity);
-    mockCatalog.refreshEntity = jest
-      .fn()
+    const mockCatalog = catalogServiceMock({ entities: [componentEntity] });
+    jest
+      .spyOn(mockCatalog, 'refreshEntity')
       .mockRejectedValue(new Error('processor unavailable'));
 
     createRefreshCatalogEntityAction({
@@ -124,7 +168,7 @@ describe('createRefreshCatalogEntityAction', () => {
     await expect(
       mockActionsRegistry.invoke({
         id: 'test:refresh-catalog-entity',
-        input: { name: 'example-website' },
+        input: { name: 'orders-api' },
       }),
     ).rejects.toThrow('processor unavailable');
   });

--- a/plugins/catalog-backend/src/actions/createRefreshCatalogEntityAction.test.ts
+++ b/plugins/catalog-backend/src/actions/createRefreshCatalogEntityAction.test.ts
@@ -43,6 +43,10 @@ describe('createRefreshCatalogEntityAction', () => {
 
     const expectedRef = 'api:payments/orders-api';
     expect(result.output).toEqual({ entityRef: expectedRef });
+    expect(mockCatalog.getEntityByRef).toHaveBeenCalledWith(
+      expectedRef,
+      expect.objectContaining({ credentials: expect.any(Object) }),
+    );
     expect(mockCatalog.refreshEntity).toHaveBeenCalledWith(
       expectedRef,
       expect.objectContaining({ credentials: expect.any(Object) }),
@@ -68,6 +72,10 @@ describe('createRefreshCatalogEntityAction', () => {
 
     const expectedRef = 'component:default/example-website';
     expect(result.output).toEqual({ entityRef: expectedRef });
+    expect(mockCatalog.getEntityByRef).toHaveBeenCalledWith(
+      expectedRef,
+      expect.objectContaining({ credentials: expect.any(Object) }),
+    );
     expect(mockCatalog.refreshEntity).toHaveBeenCalledWith(
       expectedRef,
       expect.objectContaining({ credentials: expect.any(Object) }),

--- a/plugins/catalog-backend/src/actions/createRefreshCatalogEntityAction.ts
+++ b/plugins/catalog-backend/src/actions/createRefreshCatalogEntityAction.ts
@@ -15,7 +15,7 @@
  */
 import type { ActionsRegistryService } from '@backstage/backend-plugin-api/alpha';
 import { stringifyEntityRef } from '@backstage/catalog-model';
-import { NotFoundError } from '@backstage/errors';
+import { ConflictError, InputError } from '@backstage/errors';
 import type { CatalogService } from '@backstage/plugin-catalog-node';
 
 export const createRefreshCatalogEntityAction = ({
@@ -33,11 +33,11 @@ export const createRefreshCatalogEntityAction = ({
       readOnly: false,
       idempotent: true,
     },
-    description: `Triggers a refresh of a single entity in the Backstage software catalog, requeuing it for processing.
-
-This is useful immediately after creating or updating an entity (for example, via a scaffolder template invoked by an MCP client) when the new data must be visible in the catalog before subsequent actions can read it.
-
-Each entity is identified by its kind, namespace, and name. The default kind is "Component" and the default namespace is "default".`,
+    description: `
+This allows you to trigger a refresh of a single entity in the software catalog, requeuing it for processing.
+This is useful immediately after creating or updating an entity (for example via a scaffolder template invoked by an MCP client) so the new data becomes visible before subsequent actions read it.
+Each entity in the software catalog has a unique name, kind, and namespace. If the name alone matches multiple entities, provide the kind (and namespace) to disambiguate.
+    `,
     schema: {
       input: z =>
         z.object({
@@ -45,14 +45,14 @@ Each entity is identified by its kind, namespace, and name. The default kind is 
             .string()
             .min(1)
             .describe(
-              `The kind of the entity to refresh, e.g. "Component", "API", "System". Defaults to "Component" if omitted.`,
+              'The kind of the entity to refresh, e.g. "Component", "API", "System". If the kind is unknown it can be omitted.',
             )
             .optional(),
           namespace: z
             .string()
             .min(1)
             .describe(
-              `The namespace of the entity to refresh. Defaults to "default" if omitted.`,
+              'The namespace of the entity to refresh. If the namespace is unknown it can be omitted.',
             )
             .optional(),
           name: z
@@ -69,16 +69,36 @@ Each entity is identified by its kind, namespace, and name. The default kind is 
         }),
     },
     action: async ({ input, credentials }) => {
-      const entityRef = stringifyEntityRef({
-        kind: input.kind ?? 'Component',
-        namespace: input.namespace ?? 'default',
-        name: input.name,
-      });
+      const filter: Record<string, string> = { 'metadata.name': input.name };
 
-      const entity = await catalog.getEntityByRef(entityRef, { credentials });
-      if (!entity) {
-        throw new NotFoundError(`Entity '${entityRef}' not found`);
+      if (input.kind) {
+        filter.kind = input.kind;
       }
+
+      if (input.namespace) {
+        filter['metadata.namespace'] = input.namespace;
+      }
+
+      const { items } = await catalog.queryEntities(
+        { filter },
+        { credentials },
+      );
+
+      if (items.length === 0) {
+        throw new InputError(`No entity found with name "${input.name}"`);
+      }
+
+      if (items.length > 1) {
+        throw new ConflictError(
+          `Multiple entities found with name "${
+            input.name
+          }", please provide more specific filters. Entities found: ${items
+            .map(item => `"${stringifyEntityRef(item)}"`)
+            .join(', ')}`,
+        );
+      }
+
+      const entityRef = stringifyEntityRef(items[0]);
 
       await catalog.refreshEntity(entityRef, { credentials });
 

--- a/plugins/catalog-backend/src/actions/createRefreshCatalogEntityAction.ts
+++ b/plugins/catalog-backend/src/actions/createRefreshCatalogEntityAction.ts
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ActionsRegistryService } from '@backstage/backend-plugin-api/alpha';
+import type { ActionsRegistryService } from '@backstage/backend-plugin-api/alpha';
 import { stringifyEntityRef } from '@backstage/catalog-model';
 import { NotFoundError } from '@backstage/errors';
-import { CatalogService } from '@backstage/plugin-catalog-node';
+import type { CatalogService } from '@backstage/plugin-catalog-node';
 
 export const createRefreshCatalogEntityAction = ({
   catalog,
@@ -33,7 +33,7 @@ export const createRefreshCatalogEntityAction = ({
       readOnly: false,
       idempotent: true,
     },
-    description: `Triggers a refresh of a single entity in the Backstage software catalog, requeueing it for processing.
+    description: `Triggers a refresh of a single entity in the Backstage software catalog, requeuing it for processing.
 
 This is useful immediately after creating or updating an entity (for example, via a scaffolder template invoked by an MCP client) when the new data must be visible in the catalog before subsequent actions can read it.
 
@@ -43,17 +43,23 @@ Each entity is identified by its kind, namespace, and name. The default kind is 
         z.object({
           kind: z
             .string()
+            .min(1)
             .describe(
               `The kind of the entity to refresh, e.g. "Component", "API", "System". Defaults to "Component" if omitted.`,
             )
             .optional(),
           namespace: z
             .string()
+            .min(1)
             .describe(
               `The namespace of the entity to refresh. Defaults to "default" if omitted.`,
             )
             .optional(),
-          name: z.string().describe('The name of the entity to refresh.'),
+          name: z
+            .string()
+            .trim()
+            .min(1)
+            .describe('The name of the entity to refresh.'),
         }),
       output: z =>
         z.object({

--- a/plugins/catalog-backend/src/actions/createRefreshCatalogEntityAction.ts
+++ b/plugins/catalog-backend/src/actions/createRefreshCatalogEntityAction.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ActionsRegistryService } from '@backstage/backend-plugin-api/alpha';
+import { stringifyEntityRef } from '@backstage/catalog-model';
+import { NotFoundError } from '@backstage/errors';
+import { CatalogService } from '@backstage/plugin-catalog-node';
+
+export const createRefreshCatalogEntityAction = ({
+  catalog,
+  actionsRegistry,
+}: {
+  catalog: CatalogService;
+  actionsRegistry: ActionsRegistryService;
+}) => {
+  actionsRegistry.register({
+    name: 'refresh-catalog-entity',
+    title: 'Refresh Catalog Entity',
+    attributes: {
+      destructive: false,
+      readOnly: false,
+      idempotent: true,
+    },
+    description: `Triggers a refresh of a single entity in the Backstage software catalog, requeueing it for processing.
+
+This is useful immediately after creating or updating an entity (for example, via a scaffolder template invoked by an MCP client) when the new data must be visible in the catalog before subsequent actions can read it.
+
+Each entity is identified by its kind, namespace, and name. The default kind is "Component" and the default namespace is "default".`,
+    schema: {
+      input: z =>
+        z.object({
+          kind: z
+            .string()
+            .describe(
+              `The kind of the entity to refresh, e.g. "Component", "API", "System". Defaults to "Component" if omitted.`,
+            )
+            .optional(),
+          namespace: z
+            .string()
+            .describe(
+              `The namespace of the entity to refresh. Defaults to "default" if omitted.`,
+            )
+            .optional(),
+          name: z.string().describe('The name of the entity to refresh.'),
+        }),
+      output: z =>
+        z.object({
+          entityRef: z
+            .string()
+            .describe('The canonical entity reference that was refreshed.'),
+        }),
+    },
+    action: async ({ input, credentials }) => {
+      const entityRef = stringifyEntityRef({
+        kind: input.kind ?? 'Component',
+        namespace: input.namespace ?? 'default',
+        name: input.name,
+      });
+
+      const entity = await catalog.getEntityByRef(entityRef, { credentials });
+      if (!entity) {
+        throw new NotFoundError(`Entity '${entityRef}' not found`);
+      }
+
+      await catalog.refreshEntity(entityRef, { credentials });
+
+      return {
+        output: { entityRef },
+      };
+    },
+  });
+};

--- a/plugins/catalog-backend/src/actions/index.ts
+++ b/plugins/catalog-backend/src/actions/index.ts
@@ -23,6 +23,7 @@ import { createValidateEntityAction } from './createValidateEntityAction.ts';
 import { createRegisterCatalogEntitiesAction } from './createRegisterCatalogEntitiesAction.ts';
 import { createUnregisterCatalogEntitiesAction } from './createUnregisterCatalogEntitiesAction.ts';
 import { createQueryCatalogEntitiesAction } from './createQueryCatalogEntitiesAction.ts';
+import { createRefreshCatalogEntityAction } from './createRefreshCatalogEntityAction.ts';
 
 export const createCatalogActions = (options: {
   actionsRegistry: ActionsRegistryService;
@@ -36,4 +37,5 @@ export const createCatalogActions = (options: {
   createRegisterCatalogEntitiesAction(options);
   createUnregisterCatalogEntitiesAction(options);
   createQueryCatalogEntitiesAction(options);
+  createRefreshCatalogEntityAction(options);
 };


### PR DESCRIPTION
Fixes #33729

## Summary

Registers a new `refresh-catalog-entity` action with the `ActionsRegistryService` in `plugins/catalog-backend`. `@backstage/plugin-mcp-actions-backend` auto-exposes any registered action as an MCP tool, so this becomes callable by MCP clients — e.g. an LLM agent invoking a Backstage scaffolder template can now requeue the resulting entity for processing before reading it back.

## Resolution model

Mirrors the existing `get-catalog-entity` action so LLM clients can move between them without kind gymnastics:

- `name` is required; `kind` and `namespace` are optional with no defaults.
- `CatalogService.queryEntities` filters on `metadata.name` plus any `kind`/`namespace` the caller supplied.
- `InputError` when no entity matches; `ConflictError` listing candidate `entityRef`s when a name matches multiple entities.
- `catalog.refreshEntity(stringifyEntityRef(items[0]))` is then called for the resolved entity.

The output drops the always-true `refreshed: boolean` from the original proposal — success is signalled by the promise resolving, and the returned canonical `entityRef` is the useful piece for the caller.

## Surface area

| File | Change |
|---|---|
| `plugins/catalog-backend/src/actions/createRefreshCatalogEntityAction.ts` | New action — `{ name, kind?, namespace? }` → `{ entityRef }`. |
| `plugins/catalog-backend/src/actions/index.ts` | Registers the new action in `createCatalogActions`. |
| `plugins/catalog-backend/src/actions/createRefreshCatalogEntityAction.test.ts` | Six unit tests: single-match, disambiguation by kind, disambiguation by kind+namespace, no match, multiple matches, error propagation. |
| `.changeset/catalog-refresh-entity-mcp-action.md` | `@backstage/plugin-catalog-backend` — minor. |

## Action attributes

- `destructive: false` — refresh does not delete data
- `readOnly: false` — it mutates catalog state (requeues processing)
- `idempotent: true` — refreshing twice is safe

## Test plan

- [x] Unit tests covering happy path, name-only resolution, disambiguation, no match, ambiguous match, and downstream error propagation.
- [ ] CI: lint, typecheck, tests, changeset verification.