### PR TITLE
fix(ui): preserve Header breadcrumb typography

### DIFF
--- a/.changeset/ui-header-breadcrumb-specificity.md
+++ b/.changeset/ui-header-breadcrumb-specificity.md
@@ -1,0 +1,7 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed Header breadcrumb typography so it remains consistent when component styles are loaded in different orders.
+
+**Affected components:** Header

--- a/packages/ui/src/components/Header/Header.module.css
+++ b/packages/ui/src/components/Header/Header.module.css
@@ -128,8 +128,13 @@
     gap: var(--bui-space-1);
   }
 
-  .bui-HeaderBreadcrumbs .bui-HeaderBreadcrumbLink,
-  .bui-HeaderBreadcrumbsSmall .bui-HeaderBreadcrumbLinkSmall {
+  /*
+   * Link variant defaults have the same specificity as these contextual styles.
+   * Repeat the slot class so the Header styles win regardless of stylesheet order.
+   */
+  .bui-HeaderBreadcrumbs .bui-HeaderBreadcrumbLink.bui-HeaderBreadcrumbLink,
+  .bui-HeaderBreadcrumbsSmall
+    .bui-HeaderBreadcrumbLinkSmall.bui-HeaderBreadcrumbLinkSmall {
     max-width: 240px;
     overflow: hidden;
     font-family: var(--bui-font-regular);
@@ -139,11 +144,12 @@
     white-space: nowrap;
   }
 
-  .bui-HeaderBreadcrumbs .bui-HeaderBreadcrumbLink {
+  .bui-HeaderBreadcrumbs .bui-HeaderBreadcrumbLink.bui-HeaderBreadcrumbLink {
     font-size: inherit;
   }
 
-  .bui-HeaderBreadcrumbsSmall .bui-HeaderBreadcrumbLinkSmall {
+  .bui-HeaderBreadcrumbsSmall
+    .bui-HeaderBreadcrumbLinkSmall.bui-HeaderBreadcrumbLinkSmall {
     font-size: var(--bui-font-size-4);
   }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes an issue where the default `Link` typography styles could override
the contextual Header breadcrumb styles when component stylesheets were loaded
in a different order.

The Header breadcrumb selectors now have sufficient specificity to consistently
apply the intended typography.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))