### PR TITLE
fix(catalog): pre-warm dynamic import to fix flaky entity page test

### DIFF
--- a/plugins/catalog/src/alpha/pages.test.tsx
+++ b/plugins/catalog/src/alpha/pages.test.tsx
@@ -38,6 +38,15 @@ import { Entity } from '@backstage/catalog-model';
 
 jest.setTimeout(30_000);
 
+// The entity page extension uses React.lazy (via ExtensionBoundary.lazy) to
+// dynamically import EntityLayout and its large dependency tree. Pre-warming
+// this import ensures Jest's module cache is populated before the first test,
+// so the Suspense fallback resolves quickly instead of waiting for cold module
+// resolution under CI load.
+beforeAll(async () => {
+  await import('./components/EntityLayout');
+});
+
 describe('Entity page', () => {
   const entityMock: Entity = {
     metadata: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `catalogEntityPage` extension uses `React.lazy` (via `ExtensionBoundary.lazy`) to dynamically import `EntityLayout` and its large transitive dependency tree. Under CI load, the first test in the suite paid a cold-start module resolution cost that exceeded `findByRole`'s 1000ms default timeout, causing the `Suspense` fallback (`<Progress />`) to remain visible and the test to fail.

Previous fix attempts addressed route params, mock API setup, and `waitFor` antipatterns — but the bottleneck was always the `React.lazy` Suspense boundary waiting for Jest to cold-resolve the module graph.

The fix pre-warms the dynamic import in `beforeAll` so `React.lazy` hits Jest's module cache.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)