### PR TITLE
feat(scaffolder-backend-module-gerrit): make description parameter optional

### DIFF
--- a/.changeset/sour-sites-stick.md
+++ b/.changeset/sour-sites-stick.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gerrit': patch
+---
+
+Made `description` parameter optional in `publish:gerrit` action.

--- a/plugins/scaffolder-backend-module-gerrit/report.api.md
+++ b/plugins/scaffolder-backend-module-gerrit/report.api.md
@@ -15,7 +15,7 @@ export function createPublishGerritAction(options: {
 }): TemplateAction<
   {
     repoUrl: string;
-    description: string;
+    description?: string | undefined;
     defaultBranch?: string | undefined;
     gitCommitMessage?: string | undefined;
     gitAuthorName?: string | undefined;

--- a/plugins/scaffolder-backend-module-gerrit/src/actions/gerrit.test.ts
+++ b/plugins/scaffolder-backend-module-gerrit/src/actions/gerrit.test.ts
@@ -291,6 +291,55 @@ describe('publish:gerrit', () => {
     );
   });
 
+  it('can correctly create a new project without description', async () => {
+    expect.assertions(5);
+    server.use(
+      rest.put('https://gerrithost.org/a/projects/repo', (req, res, ctx) => {
+        expect(req.headers.get('Authorization')).toBe(
+          'Basic Z2Vycml0dXNlcjp1c2VydG9rZW4=',
+        );
+        expect(req.body).toEqual({
+          branches: ['master'],
+          create_empty_commit: false,
+          owners: [],
+          parent: 'workspace',
+        });
+        return res(
+          ctx.status(201),
+          ctx.set('Content-Type', 'application/json'),
+          ctx.json({}),
+        );
+      }),
+    );
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        repoUrl: 'gerrithost.org?workspace=workspace&repo=repo',
+        sourcePath: 'repository/',
+      },
+    });
+
+    expect(initRepoAndPush).toHaveBeenCalledWith({
+      dir: `${mockContext.workspacePath}${path.sep}repository${path.sep}`,
+      remoteUrl: 'https://gerrithost.org/a/repo',
+      defaultBranch: 'master',
+      auth: { username: 'gerrituser', password: 'usertoken' },
+      logger: mockContext.logger,
+      commitMessage: expect.stringContaining('initial commit\n\nChange-Id:'),
+      gitAuthorInfo: {},
+    });
+
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'remoteUrl',
+      'https://gerrithost.org/a/repo',
+    );
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'repoContentsUrl',
+      'https://gerrithost.org/gitiles/repo/+/refs/heads/master',
+    );
+  });
+
   it('should not create new projects on dryRun', async () => {
     await action.handler({
       ...mockContext,

--- a/plugins/scaffolder-backend-module-gerrit/src/actions/gerrit.ts
+++ b/plugins/scaffolder-backend-module-gerrit/src/actions/gerrit.ts
@@ -36,7 +36,7 @@ const createGerritProject = async (
     projectName: string;
     parent: string;
     owner?: string;
-    description: string;
+    description?: string;
     defaultBranch: string;
   },
 ): Promise<void> => {
@@ -104,9 +104,11 @@ export function createPublishGerritAction(options: {
             description: 'Repository Location',
           }),
         description: z =>
-          z.string({
-            description: 'Repository Description',
-          }),
+          z
+            .string({
+              description: 'Repository Description',
+            })
+            .optional(),
         defaultBranch: z =>
           z
             .string({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `description` parameter in the [Create Project Gerrit API](https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#create-project) is optional and can be omitted.

#### :heavy_check_mark: Checklist

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] ~Screenshots attached (for UI changes)~
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
