### PR TITLE
fix(ui): update Switch to respond to parent bg context

### DIFF
--- a/.changeset/switch-bg-consumer.md
+++ b/.changeset/switch-bg-consumer.md
@@ -1,0 +1,7 @@
+---
+'@backstage/ui': patch
+---
+
+Switch now adapts its track and thumb colors based on the background context of its parent container, and uses the accent token family when selected.
+
+**Affected components:** Switch

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -165,8 +165,8 @@ export default definePreview({
                   height: isFullscreen
                     ? 'calc(100vh - (var(--bui-space-4) * 2))'
                     : undefined,
-                  overflow: 'auto',
-                  overscrollBehavior: 'none',
+                  overflow: isFullscreen ? 'auto' : undefined,
+                  overscrollBehavior: isFullscreen ? 'none' : undefined,
                 }}
               >
                 <Story />

--- a/packages/ui/report.api.md
+++ b/packages/ui/report.api.md
@@ -3066,6 +3066,7 @@ export const SwitchDefinition: {
     readonly root: 'bui-Switch';
     readonly indicator: 'bui-SwitchIndicator';
   };
+  readonly bg: 'consumer';
   readonly propDefs: {
     readonly label: {};
     readonly className: {};

--- a/packages/ui/src/components/Switch/Switch.module.css
+++ b/packages/ui/src/components/Switch/Switch.module.css
@@ -18,6 +18,24 @@
 
 @layer components {
   .bui-Switch {
+    --switch-indicator-bg: var(--bui-gray-4);
+
+    &[data-on-bg='neutral-1'] {
+      --switch-indicator-bg: var(--bui-gray-3);
+    }
+
+    &[data-on-bg='neutral-2'] {
+      --switch-indicator-bg: var(--bui-gray-4);
+    }
+
+    &[data-on-bg='neutral-3'] {
+      --switch-indicator-bg: var(--bui-gray-3);
+    }
+
+    [data-theme-mode='dark'] & {
+      --switch-indicator-bg: var(--bui-gray-6);
+    }
+
     display: flex;
     /* This is needed so the HiddenInput is positioned correctly */
     position: relative;
@@ -28,22 +46,34 @@
     cursor: pointer;
 
     &[data-disabled] {
+      --switch-thumb-bg: var(--bui-gray-3);
+
+      &[data-on-bg='neutral-1'] {
+        --switch-thumb-bg: var(--bui-gray-2);
+      }
+
+      &[data-on-bg='neutral-2'] {
+        --switch-thumb-bg: var(--bui-gray-3);
+      }
+
+      &[data-on-bg='neutral-3'] {
+        --switch-thumb-bg: var(--bui-gray-2);
+      }
+
       cursor: not-allowed;
       color: var(--bui-fg-disabled);
     }
 
-    &[data-pressed] .bui-SwitchIndicator {
-      &:before {
-        background: var(--bui-fg-solid);
-      }
+    [data-theme-mode='dark'] &[data-disabled] {
+      --switch-thumb-bg: var(--bui-gray-5);
     }
 
     &[data-selected] {
       .bui-SwitchIndicator {
-        background: var(--bui-bg-solid);
+        background: var(--bui-accent-bg);
 
         &:before {
-          background: var(--bui-fg-solid);
+          background: var(--bui-accent-fg);
           transform: translateX(100%);
         }
       }
@@ -65,7 +95,7 @@
     width: 2rem;
     height: 1.143rem;
     border: 2px;
-    background: var(--bui-bg-neutral-3);
+    background: var(--switch-indicator-bg);
     border-radius: 1.143rem;
     transition: all 200ms;
 
@@ -75,7 +105,7 @@
       margin: 0.143rem;
       width: 0.857rem;
       height: 0.857rem;
-      background: var(--bui-fg-solid);
+      background: var(--switch-thumb-bg, var(--bui-accent-fg));
       border-radius: 16px;
       transition: all 200ms;
     }

--- a/packages/ui/src/components/Switch/Switch.module.css
+++ b/packages/ui/src/components/Switch/Switch.module.css
@@ -20,18 +20,6 @@
   .bui-Switch {
     --switch-indicator-bg: var(--bui-gray-4);
 
-    &[data-on-bg='neutral-1'] {
-      --switch-indicator-bg: var(--bui-gray-3);
-    }
-
-    &[data-on-bg='neutral-2'] {
-      --switch-indicator-bg: var(--bui-gray-4);
-    }
-
-    &[data-on-bg='neutral-3'] {
-      --switch-indicator-bg: var(--bui-gray-3);
-    }
-
     [data-theme-mode='dark'] & {
       --switch-indicator-bg: var(--bui-gray-6);
     }

--- a/packages/ui/src/components/Switch/Switch.module.css
+++ b/packages/ui/src/components/Switch/Switch.module.css
@@ -78,6 +78,16 @@
         }
       }
 
+      &[data-disabled] {
+        .bui-SwitchIndicator {
+          background: var(--bui-accent-bg-disabled);
+
+          &:before {
+            background: var(--bui-accent-fg-disabled);
+          }
+        }
+      }
+
       &[data-pressed] {
         .indicator {
           background: var(--bui-bg-neutral-3);

--- a/packages/ui/src/components/Switch/Switch.stories.tsx
+++ b/packages/ui/src/components/Switch/Switch.stories.tsx
@@ -15,6 +15,9 @@
  */
 import preview from '../../../../../.storybook/preview';
 import { Switch } from './Switch';
+import { Box } from '../Box';
+import { Flex } from '../Flex';
+import { Text } from '../Text';
 
 const meta = preview.meta({
   title: 'Backstage UI/Switch',
@@ -30,6 +33,47 @@ export const Default = meta.story({
 export const Disabled = meta.story({
   args: {
     ...Default.input.args,
+    isDisabled: true,
+  },
+});
+
+export const AutoBg = meta.story({
+  args: {
+    label: 'Label',
+  },
+  render: args => (
+    <Box bg="neutral" p="4">
+      <Flex direction="column" gap="4">
+        <Text>Neutral 1 container</Text>
+        <Flex gap="4">
+          <Switch {...args} />
+          <Switch {...args} isSelected />
+        </Flex>
+      </Flex>
+      <Box bg="neutral" p="4" mt="4">
+        <Flex direction="column" gap="4">
+          <Text>Neutral 2 container</Text>
+          <Flex gap="4">
+            <Switch {...args} />
+            <Switch {...args} isSelected />
+          </Flex>
+        </Flex>
+        <Box bg="neutral" p="4" mt="4">
+          <Flex direction="column" gap="4">
+            <Text>Neutral 3 container</Text>
+            <Flex gap="4">
+              <Switch {...args} />
+              <Switch {...args} isSelected />
+            </Flex>
+          </Flex>
+        </Box>
+      </Box>
+    </Box>
+  ),
+});
+
+export const AutoBgDisabled = AutoBg.extend({
+  args: {
     isDisabled: true,
   },
 });

--- a/packages/ui/src/components/Switch/Switch.tsx
+++ b/packages/ui/src/components/Switch/Switch.tsx
@@ -27,11 +27,19 @@ import { SwitchDefinition } from './definition';
  */
 export const Switch = forwardRef<HTMLLabelElement, SwitchProps>(
   (props, ref) => {
-    const { ownProps, restProps } = useDefinition(SwitchDefinition, props);
+    const { ownProps, restProps, dataAttributes } = useDefinition(
+      SwitchDefinition,
+      props,
+    );
     const { classes, label } = ownProps;
 
     return (
-      <AriaSwitch className={classes.root} ref={ref} {...restProps}>
+      <AriaSwitch
+        className={classes.root}
+        ref={ref}
+        {...dataAttributes}
+        {...restProps}
+      >
         <div className={classes.indicator} />
         {label}
       </AriaSwitch>

--- a/packages/ui/src/components/Switch/definition.ts
+++ b/packages/ui/src/components/Switch/definition.ts
@@ -28,6 +28,7 @@ export const SwitchDefinition = defineComponent<SwitchOwnProps>()({
     root: 'bui-Switch',
     indicator: 'bui-SwitchIndicator',
   },
+  bg: 'consumer',
   propDefs: {
     label: {},
     className: {},

--- a/packages/ui/src/css/tokens.css
+++ b/packages/ui/src/css/tokens.css
@@ -224,7 +224,7 @@
     /* Foreground colors */
     --bui-fg-primary: var(--bui-white);
     --bui-fg-secondary: #a3a3a3;
-    --bui-fg-disabled: var(--bui-white);
+    --bui-fg-disabled: #707070;
     --bui-fg-positive: #21b656;
     --bui-fg-negative: #ee3a4c;
     --bui-fg-warning: #f18900;


### PR DESCRIPTION
## Summary

- Switch now reads its parent background context (`bg: 'consumer'`) and sets `data-on-bg` on the root element
- Indicator track and disabled thumb colors vary per neutral bg level in light mode (gray 4/3/4/3 and 3/2/3/2)
- Dark mode uses gray-6 for the track and gray-5 for the disabled thumb across all contexts
- Selected state migrated from deprecated `--bui-bg-solid`/`--bui-fg-solid` to `--bui-accent-bg`/`--bui-accent-fg`
- Fixed dark mode `--bui-fg-disabled` token value
- Added `AutoBg` and `AutoBgDisabled` stories to visually verify bg context behaviour
- Fixed Storybook preview overflow/scroll in non-fullscreen mode

## Test plan

- [ ] Open the `AutoBg` story and verify the Switch indicator changes shade at each nesting level
- [ ] Open the `AutoBgDisabled` story and verify the thumb color changes shade at each nesting level
- [ ] Toggle dark mode and verify all contexts show gray-6 track and gray-5 disabled thumb
- [ ] Verify the selected state uses the accent colour in both light and dark mode