### PR TITLE
ci: add yarn lock changes workflow

### DIFF
--- a/.github/workflows/automate_yarn-lock-changes.yml
+++ b/.github/workflows/automate_yarn-lock-changes.yml
@@ -5,6 +5,7 @@ jobs:
   yarn-lock-changes:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - name: Harden Runner

--- a/.github/workflows/automate_yarn-lock-changes.yml
+++ b/.github/workflows/automate_yarn-lock-changes.yml
@@ -1,0 +1,21 @@
+name: Yarn Lock Changes
+on: [pull_request]
+
+jobs:
+  yarn-lock-changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Yarn Lock Changes
+        uses: Simek/yarn-lock-changes@59f47ee499424d2c2437c5aebf863b5c6d50a5bc # v0.14.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a workflow that posts a comment on pull requests summarizing changes to `yarn.lock`, including added, removed, and updated packages (both direct and transitive).

Large lockfile diffs are difficult to review manually. This makes it easier for reviewers to understand the dependency impact of a PR at a glance -- for example, whether a seemingly small change pulls in dozens of new transitive dependencies, or whether a dependency removal actually cleans up the tree.

Uses [Simek/yarn-lock-changes](https://github.com/Simek/yarn-lock-changes). Example output: https://github.com/jonkoops/backstage/pull/1.