### PR TITLE
catalog-backend-module-bitbucket-server: add SCM event handling

### DIFF
--- a/.changeset/bitbucket-server-scm-events.md
+++ b/.changeset/bitbucket-server-scm-events.md
@@ -1,0 +1,15 @@
+---
+'@backstage/plugin-catalog-backend-module-bitbucket-server': minor
+---
+
+Added SCM event handling for Bitbucket Server. The new
+`BitbucketServerScmEventsBridge` subscribes to the `bitbucketServer` topic
+and translates incoming webhook events into catalog SCM events:
+
+- `repo:refs_changed` (branch/tag push) → `repository.updated`
+- `repo:modified` (repository renamed) → `repository.moved` or `repository.updated`
+- `repo:deleted` → `repository.deleted`
+
+This enables instant catalog refresh when entities change in Bitbucket Server,
+consistent with the equivalent implementations for GitHub, GitLab, and
+Bitbucket Cloud.

--- a/plugins/catalog-backend-module-bitbucket-server/src/events/BitbucketServerScmEventsBridge.ts
+++ b/plugins/catalog-backend-module-bitbucket-server/src/events/BitbucketServerScmEventsBridge.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LoggerService } from '@backstage/backend-plugin-api';
+import { CatalogScmEventsService } from '@backstage/plugin-catalog-node/alpha';
+import { EventParams, EventsService } from '@backstage/plugin-events-node';
+import { analyzeBitbucketServerWebhookEvent } from './analyzeBitbucketServerWebhookEvent';
+
+/**
+ * Takes Bitbucket Server webhook events, analyzes them, and publishes them as
+ * catalog SCM events that entity providers and others can subscribe to.
+ *
+ * @alpha
+ */
+export class BitbucketServerScmEventsBridge {
+  readonly #logger: LoggerService;
+  readonly #events: EventsService;
+  readonly #catalogScmEvents: CatalogScmEventsService;
+  #shuttingDown: boolean;
+  #pendingPublish: Promise<void> | undefined;
+
+  constructor(options: {
+    logger: LoggerService;
+    events: EventsService;
+    catalogScmEvents: CatalogScmEventsService;
+  }) {
+    this.#logger = options.logger;
+    this.#events = options.events;
+    this.#catalogScmEvents = options.catalogScmEvents;
+    this.#shuttingDown = false;
+  }
+
+  async start() {
+    await this.#events.subscribe({
+      id: 'catalog-bitbucket-server-scm-events-bridge',
+      topics: ['bitbucketServer'],
+      onEvent: this.#onEvent.bind(this),
+    });
+  }
+
+  async stop() {
+    this.#shuttingDown = true;
+    await this.#pendingPublish;
+  }
+
+  async #onEvent(params: EventParams): Promise<void> {
+    const eventType = params.metadata?.['x-event-key'] as string | undefined;
+    if (!eventType || !params.eventPayload) {
+      return;
+    }
+
+    if (this.#shuttingDown) {
+      this.#logger.warn(
+        `Skipping Bitbucket Server webhook event of type "${eventType}" on topic "${params.topic}" because the bridge is shutting down`,
+      );
+      return;
+    }
+
+    const previous = this.#pendingPublish ?? Promise.resolve();
+    const current = previous.then(async () => {
+      try {
+        const output = await analyzeBitbucketServerWebhookEvent(
+          eventType,
+          params.eventPayload,
+        );
+
+        if (output.result === 'ok') {
+          await this.#catalogScmEvents.publish(output.events);
+        } else if (output.result === 'ignored') {
+          this.#logger.debug(
+            `Skipping Bitbucket Server webhook event of type "${eventType}" on topic "${params.topic}" because it is ignored: ${output.reason}`,
+          );
+        } else if (output.result === 'aborted') {
+          this.#logger.warn(
+            `Skipping Bitbucket Server webhook event of type "${eventType}" on topic "${params.topic}" because it is aborted: ${output.reason}`,
+          );
+        } else if (output.result === 'unsupported-event') {
+          this.#logger.debug(
+            `Skipping Bitbucket Server webhook event of type "${eventType}" on topic "${params.topic}" because it is unsupported: ${output.event}`,
+          );
+        }
+      } catch (error) {
+        this.#logger.warn(
+          `Failed to handle Bitbucket Server webhook event of type "${eventType}"`,
+          error,
+        );
+      }
+    });
+    this.#pendingPublish = current;
+    await current;
+  }
+}

--- a/plugins/catalog-backend-module-bitbucket-server/src/events/analyzeBitbucketServerWebhookEvent.ts
+++ b/plugins/catalog-backend-module-bitbucket-server/src/events/analyzeBitbucketServerWebhookEvent.ts
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { InputError } from '@backstage/errors';
+import { CatalogScmEvent } from '@backstage/plugin-catalog-node/alpha';
+
+/**
+ * The result of analyzing a Bitbucket Server webhook event.
+ *
+ * - `ok` — one or more catalog SCM events were produced.
+ * - `ignored` — the event was valid but not relevant.
+ * - `aborted` — the event could not be fully processed due to missing data.
+ * - `unsupported-event` — the event type is not handled by this analyzer.
+ *
+ * @alpha
+ */
+export type AnalyzeBitbucketServerWebhookEventResult =
+  | {
+      result: 'unsupported-event';
+      event: string;
+    }
+  | {
+      result: 'ignored';
+      reason: string;
+    }
+  | {
+      result: 'aborted';
+      reason: string;
+    }
+  | {
+      result: 'ok';
+      events: CatalogScmEvent[];
+    };
+
+type JsonObject = Record<string, unknown>;
+
+function asObject(value: unknown): JsonObject | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as JsonObject;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+/**
+ * Builds the repository URL from a Bitbucket Server webhook payload.
+ *
+ * Bitbucket Server includes repository links in the payload under
+ * `repository.links.self[0].href`, e.g.:
+ * https://bitbucket.example.com/projects/PROJ/repos/my-repo/browse
+ *
+ * We normalise this to the repo root by stripping trailing `/browse`.
+ */
+function getRepositoryUrl(payload: JsonObject): string | undefined {
+  const repository = asObject(payload.repository);
+  if (!repository) {
+    return undefined;
+  }
+
+  const links = asObject(repository.links);
+  const selfLinks = links?.self;
+  if (Array.isArray(selfLinks) && selfLinks.length > 0) {
+    const href = asString(asObject(selfLinks[0])?.href);
+    if (href) {
+      return href.replace(/\/browse$/, '');
+    }
+  }
+
+  // Fallback: construct URL from project key and repo slug
+  const projectKey = asString(asObject(repository.project)?.key);
+  const slug = asString(repository.slug);
+  if (projectKey && slug) {
+    // We cannot know the base URL without more context, so abort
+    return undefined;
+  }
+
+  return undefined;
+}
+
+/**
+ * Handles `repo:refs_changed` events (branch push / tag push).
+ *
+ * Bitbucket Server does not include file-level diff information in the webhook
+ * payload, so we emit a `repository.updated` event for the repository to
+ * trigger a full re-ingestion of catalog-info.yaml files.
+ */
+async function onRefsChangedEvent(
+  payload: JsonObject,
+): Promise<AnalyzeBitbucketServerWebhookEventResult> {
+  const repositoryUrl = getRepositoryUrl(payload);
+
+  if (!repositoryUrl) {
+    return {
+      result: 'aborted',
+      reason:
+        'Bitbucket Server repo:refs_changed event did not include a resolvable repository URL',
+    };
+  }
+
+  return {
+    result: 'ok',
+    events: [{ type: 'repository.updated', url: repositoryUrl }],
+  };
+}
+
+/**
+ * Handles `repo:modified` events (repository renamed or description changed).
+ *
+ * When a repository is renamed, Bitbucket Server provides both `old` and `new`
+ * repository objects in the payload. We emit a `repository.moved` event so
+ * that the catalog can update location URLs accordingly.
+ */
+async function onRepoModifiedEvent(
+  payload: JsonObject,
+): Promise<AnalyzeBitbucketServerWebhookEventResult> {
+  const newRepo = asObject(payload.new);
+  const oldRepo = asObject(payload.old);
+
+  const newLinks = asObject(newRepo?.links);
+  const newSelfLinks = newLinks?.self;
+  let newUrl: string | undefined;
+  if (Array.isArray(newSelfLinks) && newSelfLinks.length > 0) {
+    const href = asString(asObject(newSelfLinks[0])?.href);
+    if (href) {
+      newUrl = href.replace(/\/browse$/, '');
+    }
+  }
+
+  const oldLinks = asObject(oldRepo?.links);
+  const oldSelfLinks = oldLinks?.self;
+  let oldUrl: string | undefined;
+  if (Array.isArray(oldSelfLinks) && oldSelfLinks.length > 0) {
+    const href = asString(asObject(oldSelfLinks[0])?.href);
+    if (href) {
+      oldUrl = href.replace(/\/browse$/, '');
+    }
+  }
+
+  if (!newUrl) {
+    return {
+      result: 'aborted',
+      reason:
+        'Bitbucket Server repo:modified event did not include a resolvable new repository URL',
+    };
+  }
+
+  if (oldUrl && oldUrl !== newUrl) {
+    return {
+      result: 'ok',
+      events: [
+        {
+          type: 'repository.moved',
+          fromUrl: oldUrl,
+          toUrl: newUrl,
+        },
+      ],
+    };
+  }
+
+  return {
+    result: 'ok',
+    events: [{ type: 'repository.updated', url: newUrl }],
+  };
+}
+
+/**
+ * Handles `repo:deleted` events.
+ */
+async function onRepoDeletedEvent(
+  payload: JsonObject,
+): Promise<AnalyzeBitbucketServerWebhookEventResult> {
+  const repositoryUrl = getRepositoryUrl(payload);
+
+  if (!repositoryUrl) {
+    return {
+      result: 'aborted',
+      reason:
+        'Bitbucket Server repo:deleted event did not include a resolvable repository URL',
+    };
+  }
+
+  return {
+    result: 'ok',
+    events: [{ type: 'repository.deleted', url: repositoryUrl }],
+  };
+}
+
+/**
+ * Analyzes a Bitbucket Server webhook event and translates it into zero or
+ * more catalog SCM events that entity providers can act on.
+ *
+ * Supported event types (matching the `x-event-key` header set by Bitbucket
+ * Server and routed by `BitbucketServerEventRouter`):
+ *
+ * - `repo:refs_changed` — emits `repository.updated` to trigger catalog
+ *   refresh when a branch or tag is pushed.
+ * - `repo:modified` — emits `repository.moved` when a repository is renamed,
+ *   or `repository.updated` for other metadata changes.
+ * - `repo:deleted` — emits `repository.deleted` to remove stale locations.
+ *
+ * @alpha
+ */
+export async function analyzeBitbucketServerWebhookEvent(
+  eventType: string,
+  eventPayload: unknown,
+): Promise<AnalyzeBitbucketServerWebhookEventResult> {
+  const payload = asObject(eventPayload);
+  if (!payload) {
+    throw new InputError(
+      'Bitbucket Server webhook event payload is not an object',
+    );
+  }
+
+  switch (eventType) {
+    case 'repo:refs_changed':
+      return onRefsChangedEvent(payload);
+    case 'repo:modified':
+      return onRepoModifiedEvent(payload);
+    case 'repo:deleted':
+      return onRepoDeletedEvent(payload);
+    default:
+      return { result: 'unsupported-event', event: eventType };
+  }
+}

--- a/plugins/catalog-backend-module-bitbucket-server/src/module/catalogModuleBitbucketServerEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-bitbucket-server/src/module/catalogModuleBitbucketServerEntityProvider.test.ts
@@ -93,8 +93,13 @@ describe('catalogModuleBitbucketServerEntityProvider', () => {
       'bitbucketServer-provider:default',
     );
     await provider.connect(connection);
-    expect(events.subscribed).toHaveLength(1);
-    expect(events.subscribed[0].id).toEqual('bitbucketServer-provider:default');
+    expect(events.subscribed).toHaveLength(2);
+    expect(events.subscribed.map(s => s.id)).toContain(
+      'bitbucketServer-provider:default',
+    );
+    expect(events.subscribed.map(s => s.id)).toContain(
+      'catalog-bitbucket-server-scm-events-bridge',
+    );
     expect(runner).toHaveBeenCalledTimes(1);
   });
 });

--- a/plugins/catalog-backend-module-bitbucket-server/src/module/catalogModuleBitbucketServerEntityProvider.ts
+++ b/plugins/catalog-backend-module-bitbucket-server/src/module/catalogModuleBitbucketServerEntityProvider.ts
@@ -20,8 +20,10 @@ import {
 } from '@backstage/backend-plugin-api';
 import { catalogServiceRef } from '@backstage/plugin-catalog-node';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node';
+import { catalogScmEventsServiceRef } from '@backstage/plugin-catalog-node/alpha';
 import { eventsServiceRef } from '@backstage/plugin-events-node';
 import { BitbucketServerEntityProvider } from '../providers/BitbucketServerEntityProvider';
+import { BitbucketServerScmEventsBridge } from '../events/BitbucketServerScmEventsBridge';
 
 /**
  * @public
@@ -39,6 +41,8 @@ export const catalogModuleBitbucketServerEntityProvider = createBackendModule({
         logger: coreServices.logger,
         scheduler: coreServices.scheduler,
         auth: coreServices.auth,
+        catalogScmEvents: catalogScmEventsServiceRef,
+        lifecycle: coreServices.lifecycle,
       },
       async init({
         catalog,
@@ -48,6 +52,8 @@ export const catalogModuleBitbucketServerEntityProvider = createBackendModule({
         logger,
         scheduler,
         auth,
+        catalogScmEvents,
+        lifecycle,
       }) {
         const providers = BitbucketServerEntityProvider.fromConfig(config, {
           catalogApi,
@@ -58,6 +64,18 @@ export const catalogModuleBitbucketServerEntityProvider = createBackendModule({
         });
 
         catalog.addEntityProvider(providers);
+
+        const bridge = new BitbucketServerScmEventsBridge({
+          logger,
+          events,
+          catalogScmEvents,
+        });
+        lifecycle.addStartupHook(async () => {
+          await bridge.start();
+        });
+        lifecycle.addShutdownHook(async () => {
+          await bridge.stop();
+        });
       },
     });
   },


### PR DESCRIPTION
Fixes #32833

## Summary

Adds SCM event handling for Bitbucket Server, completing the set of providers
that support the `catalogScmEventsServiceRef` introduced in v1.48.0 (PR #31745).

GitHub, GitLab, and Bitbucket Cloud already have this capability. This PR
brings Bitbucket Server to parity.

## What this PR does

### New files

**`src/events/analyzeBitbucketServerWebhookEvent.ts`**
Translates raw Bitbucket Server webhook payloads into `CatalogScmEvent`
instances. Supported event types (matching the `x-event-key` header routed by
`BitbucketServerEventRouter`):

| Webhook event | Catalog SCM event |
|---|---|
| `repo:refs_changed` | `repository.updated` |
| `repo:modified` (rename) | `repository.moved` |
| `repo:modified` (other) | `repository.updated` |
| `repo:deleted` | `repository.deleted` |

**`src/events/BitbucketServerScmEventsBridge.ts`**
Subscribes to the `bitbucketServer` topic, calls the analyzer, and publishes
results via `catalogScmEventsServiceRef`. Follows the same pattern as
`BitbucketCloudScmEventsBridge` and `GitLabScmEventsBridge`.

### Modified files

**`src/module/catalogModuleBitbucketServerEntityProvider.ts`**
Registers the bridge at startup and shutdown via `lifecycle`, and adds
`catalogScmEventsServiceRef` as a dependency — same as the Bitbucket Cloud
module.

## Testing

The analyzer follows the same structure as `analyzeBitbucketCloudWebhookEvent`
and `analyzeGitLabWebhookEvent`. Unit tests can be added following the
`analyzeBitbucketCloudWebhookEvent.test.ts` pattern.

## Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation (no existing docs page for this feature)
- [ ] Tests for new functionality (follow-up — matching test structure from Bitbucket Cloud)
- [x] All commits have a `Signed-off-by` line in the message.