### PR TITLE
fix(events): increase events bus request body limit to 5mb

### DIFF
--- a/.changeset/events-backend-large-event-payloads.md
+++ b/.changeset/events-backend-large-event-payloads.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-events-backend': patch
+---
+
+Increased the events bus request body limit to 5mb to allow larger event payloads.

--- a/plugins/events-backend/src/service/EventsPlugin.test.ts
+++ b/plugins/events-backend/src/service/EventsPlugin.test.ts
@@ -187,6 +187,17 @@ describe.each(eventBusDatabases.eachSupportedId())(
         .expect(204); // 204, since there are no subscribers
     });
 
+    it('should accept large published event payloads', async () => {
+      backend = await startTestBackend({
+        features: [eventsPlugin, await mockKnexFactory()],
+      });
+      const helper = new ReqHelper(backend);
+
+      await helper
+        .publish('test', { content: 'a'.repeat(1024 * 1024) })
+        .expect(204); // 204, since there are no subscribers
+    });
+
     it('should be possible to subscribe as a service and receive an event', async () => {
       backend = await startTestBackend({
         features: [eventsPlugin, await mockKnexFactory()],

--- a/plugins/events-backend/src/service/hub/createEventBusRouter.ts
+++ b/plugins/events-backend/src/service/hub/createEventBusRouter.ts
@@ -21,7 +21,7 @@ import {
   LoggerService,
   SchedulerService,
 } from '@backstage/backend-plugin-api';
-import { Handler } from 'express';
+import { Handler, json } from 'express';
 import { createOpenApiRouter } from '../../schema/openapi';
 import { MemoryEventBusStore } from './MemoryEventBusStore';
 import { DatabaseEventBusStore } from './DatabaseEventBusStore';
@@ -150,7 +150,9 @@ export async function createEventBusRouter(options: {
 
   const store = await createEventBusStore(options);
 
-  const apiRouter = await createOpenApiRouter();
+  const apiRouter = await createOpenApiRouter({
+    middleware: [json({ limit: '5mb' })],
+  });
 
   apiRouter.post('/bus/v1/events', async (req, res) => {
     const credentials = await httpAuth.credentials(req, {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #34462 

Increase the events bus JSON request body limit to 5 MB, matching the [existing HTTP ingress limit ](https://github.com/backstage/backstage/blob/e5dfdf1c684d30cd96939ae3ae051cbf8610204c/plugins/events-backend/src/service/http/HttpPostIngressEventPublisher.ts#L101) in the events backend plugin. This fixes large event payloads being rejected with `request entity too large` when publishing to `/bus/v1/events`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
