### PR TITLE
fix(core-components): honor closeDelayMs for sidebar submenus

### DIFF
--- a/.changeset/sidebar-submenu-close-delay.md
+++ b/.changeset/sidebar-submenu-close-delay.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+A `SidebarItem` that contains a `SidebarSubmenu` now honors the `closeDelayMs` prop on `Sidebar`. Previously the expanded menu closed immediately when the pointer left the parent item, so moving the pointer diagonally toward one of its entries often dismissed it before it could be clicked. When `closeDelayMs` is set, the expanded menu stays open for the configured delay after the pointer leaves, and the close is cancelled if the pointer returns. The default is unchanged (`0`, close immediately), so existing behavior is preserved unless `closeDelayMs` is set.

--- a/packages/core-components/src/layout/Sidebar/Bar.test.tsx
+++ b/packages/core-components/src/layout/Sidebar/Bar.test.tsx
@@ -19,7 +19,7 @@ import AcUnitIcon from '@material-ui/icons/AcUnit';
 import CreateComponentIcon from '@material-ui/icons/AddCircleOutline';
 import BuildRoundedIcon from '@material-ui/icons/BuildRounded';
 import MenuBookIcon from '@material-ui/icons/MenuBook';
-import { screen } from '@testing-library/react';
+import { act, fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Sidebar } from './Bar';
 import { SidebarExpandButton, SidebarItem, SidebarSearchField } from './Items';
@@ -133,5 +133,72 @@ describe('Sidebar', () => {
         'https://backstage.io/',
       );
     });
+  });
+});
+
+async function renderSidebarWithCloseDelay(closeDelayMs: number) {
+  await renderInTestApp(
+    <SidebarPinStateProvider
+      value={{
+        isPinned: false,
+        isMobile: false,
+        toggleSidebarPinState: () => {},
+      }}
+    >
+      <Sidebar disableExpandOnHover closeDelayMs={closeDelayMs}>
+        <SidebarItem icon={MenuBookIcon} onClick={() => {}} text="Catalog">
+          <SidebarSubmenu title="Catalog">
+            <SidebarSubmenuItem title="Tools" to="/1" icon={BuildRoundedIcon} />
+          </SidebarSubmenu>
+        </SidebarItem>
+      </Sidebar>
+    </SidebarPinStateProvider>,
+  );
+}
+
+describe('Sidebar submenu close delay', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('keeps the submenu open until closeDelayMs has elapsed after the pointer leaves', async () => {
+    await renderSidebarWithCloseDelay(300);
+
+    fireEvent.mouseEnter(screen.getByTestId('item-with-submenu'));
+    expect(await screen.findByText('Tools')).toBeInTheDocument();
+
+    jest.useFakeTimers();
+    fireEvent.mouseLeave(screen.getByTestId('item-with-submenu'));
+
+    expect(screen.getByText('Tools')).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(299);
+    });
+    expect(screen.getByText('Tools')).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(screen.queryByText('Tools')).not.toBeInTheDocument();
+  });
+
+  it('cancels the scheduled close when the pointer returns before the delay', async () => {
+    await renderSidebarWithCloseDelay(300);
+
+    fireEvent.mouseEnter(screen.getByTestId('item-with-submenu'));
+    expect(await screen.findByText('Tools')).toBeInTheDocument();
+
+    jest.useFakeTimers();
+    fireEvent.mouseLeave(screen.getByTestId('item-with-submenu'));
+    act(() => {
+      jest.advanceTimersByTime(150);
+    });
+    fireEvent.mouseEnter(screen.getByTestId('item-with-submenu'));
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(screen.getByText('Tools')).toBeInTheDocument();
   });
 });

--- a/packages/core-components/src/layout/Sidebar/Bar.tsx
+++ b/packages/core-components/src/layout/Sidebar/Bar.tsx
@@ -232,13 +232,14 @@ const DesktopSidebar = (props: DesktopSidebarProps) => {
  * @public
  */
 export const Sidebar = (props: SidebarProps) => {
+  const { children, disableExpandOnHover, openDelayMs, closeDelayMs } = props;
   const sidebarConfig: SidebarConfig = makeSidebarConfig(
     props.sidebarOptions ?? {},
+    { closeDelayMs },
   );
   const submenuConfig: SubmenuConfig = makeSidebarSubmenuConfig(
     props.submenuOptions ?? {},
   );
-  const { children, disableExpandOnHover, openDelayMs, closeDelayMs } = props;
   const { isMobile } = useSidebarPinState();
 
   return isMobile ? (

--- a/packages/core-components/src/layout/Sidebar/Items.tsx
+++ b/packages/core-components/src/layout/Sidebar/Items.tsx
@@ -45,7 +45,9 @@ import {
   ReactNode,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
+  useRef,
   useState,
   MouseEvent,
   ChangeEvent,
@@ -524,11 +526,31 @@ const SidebarItemWithSubmenu = ({
     theme.breakpoints.down('sm'),
   );
 
+  // Debounced close so the submenu survives diagonal pointer travel from the
+  // parent item into it.
+  const closeTimerRef = useRef<number>();
+  const cancelScheduledClose = () => {
+    if (closeTimerRef.current) {
+      clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = undefined;
+    }
+  };
+  useEffect(() => cancelScheduledClose, []);
+
   const handleMouseEnter = () => {
+    cancelScheduledClose();
     setIsHoveredOn(true);
   };
   const handleMouseLeave = () => {
-    setIsHoveredOn(false);
+    cancelScheduledClose();
+    if (sidebarConfig.defaultCloseDelayMs > 0) {
+      closeTimerRef.current = window.setTimeout(() => {
+        closeTimerRef.current = undefined;
+        setIsHoveredOn(false);
+      }, sidebarConfig.defaultCloseDelayMs);
+    } else {
+      setIsHoveredOn(false);
+    }
   };
 
   const arrowIcon = () => {

--- a/packages/core-components/src/layout/Sidebar/config.ts
+++ b/packages/core-components/src/layout/Sidebar/config.ts
@@ -69,9 +69,13 @@ export const sidebarConfig = {
 
 export const makeSidebarConfig = (
   customSidebarConfig: Partial<SidebarOptions>,
+  overrides?: { closeDelayMs?: number },
 ) => ({
   ...sidebarConfig,
   ...customSidebarConfig,
+  ...(overrides?.closeDelayMs !== undefined
+    ? { defaultCloseDelayMs: overrides.closeDelayMs }
+    : {}),
   iconContainerWidth: sidebarConfig.drawerWidthClosed,
   iconSize: sidebarConfig.drawerWidthClosed - sidebarConfig.iconPadding * 2,
   userBadgeDiameter:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

A sidebar submenu closes the instant the pointer leaves the parent item. If the parent sits low in the rail and the expanded menu opens upward, you have to move almost perfectly horizontally to reach an entry — drift diagonally and the menu disappears before you can click it. I kept losing the menu while dogfooding our internal portal, so I went looking for a knob and found that there mostly already is one.

`defaultCloseDelayMs` already exists and is wired to the main rail's hover-collapse via the `closeDelayMs` prop on `<Sidebar>`. It just never reached the submenu. This change resolves the close delay once in `makeSidebarConfig` and surfaces it through `SidebarConfigContext`, so `SidebarItemWithSubmenu` can honor the same value: the menu stays open for `closeDelayMs` after the pointer leaves, and the pending close is cancelled if the pointer comes back.

The default is unchanged (`0` = close immediately), so nobody who hasn't set `closeDelayMs` sees any difference.

#### Why reuse `closeDelayMs` rather than add a new option

It's already documented as the "delay until the sidebar closes on hover," and a submenu is part of the sidebar, so honoring it there reads to me as fixing an inconsistency rather than adding surface area.

Demo (`closeDelayMs={500}`, exaggerated so it's visible):
<img width="1030" height="1040" alt="sidebar-after" src="https://github.com/user-attachments/assets/b9fd57ec-7195-4e64-b74e-18e8b5d2b5b0" />


#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.

No docs change — this reuses the existing public `closeDelayMs` prop and adds no new public API.
