### PR TITLE
fix(ui): improve Switch track contrast

### DIFF
--- a/.changeset/switch-track-contrast.md
+++ b/.changeset/switch-track-contrast.md
@@ -1,0 +1,7 @@
+---
+'@backstage/ui': patch
+---
+
+Improve the contrast of enabled Switch tracks and handles across themes and neutral backgrounds.
+
+**Affected components:** Switch

--- a/.storybook/themes/spotify.css
+++ b/.storybook/themes/spotify.css
@@ -194,7 +194,7 @@
 
 [data-theme-mode='light'][data-theme-name='spotify'] {
   --bui-ring: rgba(0, 0, 0, 0.2);
-  --bui-accent-bg: #1ed760;
+  --bui-accent-bg: #159542;
   --bui-accent-bg-hover: #3be477;
   --bui-accent-bg-disabled: #0f6c30;
   --bui-accent-fg: var(--bui-black);
@@ -210,6 +210,10 @@
   --bui-border-danger: #f87a7a;
   --bui-border-warning: #e36d05;
   --bui-border-success: #53db83;
+
+  .bui-Switch:not([data-disabled]) {
+    --switch-thumb-bg: var(--bui-white);
+  }
 }
 
 [data-theme-mode='dark'][data-theme-name='spotify'] {

--- a/packages/ui/src/components/Switch/Switch.module.css
+++ b/packages/ui/src/components/Switch/Switch.module.css
@@ -18,10 +18,11 @@
 
 @layer components {
   .bui-Switch {
-    --switch-indicator-bg: var(--bui-gray-4);
+    --switch-indicator-bg: var(--bui-gray-6);
+    --switch-thumb-bg: var(--bui-accent-fg);
 
     [data-theme-mode='dark'] & {
-      --switch-indicator-bg: var(--bui-gray-6);
+      --switch-indicator-bg: var(--bui-gray-5);
     }
 
     display: flex;
@@ -53,7 +54,7 @@
     }
 
     [data-theme-mode='dark'] &[data-disabled] {
-      --switch-thumb-bg: var(--bui-gray-5);
+      --switch-thumb-bg: var(--bui-gray-7);
     }
 
     &[data-selected] {
@@ -61,7 +62,7 @@
         background: var(--bui-accent-bg);
 
         &:before {
-          background: var(--bui-accent-fg);
+          background: var(--switch-thumb-bg);
           transform: translateX(100%);
         }
       }
@@ -103,7 +104,7 @@
       margin: 0.143rem;
       width: 0.857rem;
       height: 0.857rem;
-      background: var(--switch-thumb-bg, var(--bui-accent-fg));
+      background: var(--switch-thumb-bg);
       border-radius: 16px;
       transition: all 200ms;
     }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The Switch track did not consistently meet the WCAG AA `3:1` non-text contrast requirement against the surrounding neutral background or the handle.

This adjusts the existing token usage so that Switches maintain sufficient contrast across the Backstage and Spotify themes in both light and dark modes. The Spotify light accent color is adjusted for selected tracks, with a Switch-specific white handle to preserve its contrast. Dark disabled handles retain a visible distinction from the track.

<!-- Attach light and dark screenshots of the AutoBg story here. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))