### PR TITLE
Fix header tab links with router basenames

### DIFF
--- a/.changeset/header-tabs-respect-basename.md
+++ b/.changeset/header-tabs-respect-basename.md
@@ -2,6 +2,6 @@
 '@backstage/ui': patch
 ---
 
-Fixed header tab links to respect the configured router basename.
+Fixed header tab links to respect the configured router `basename`.
 
 **Affected components:** Header

--- a/.changeset/header-tabs-respect-basename.md
+++ b/.changeset/header-tabs-respect-basename.md
@@ -1,0 +1,7 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed header tab links to respect the configured router basename.
+
+**Affected components:** Header

--- a/packages/ui/src/components/Header/HeaderNav.test.tsx
+++ b/packages/ui/src/components/Header/HeaderNav.test.tsx
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { BUIProvider } from '../../provider';
+import { HeaderNav } from './HeaderNav';
+import type { ComponentProps } from 'react';
+
+function renderHeaderNav(
+  props: ComponentProps<typeof HeaderNav>,
+  initialEntry = '/app/catalog',
+) {
+  return render(
+    <MemoryRouter basename="/app" initialEntries={[initialEntry]}>
+      <BUIProvider>
+        <HeaderNav {...props} />
+      </BUIProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('HeaderNav', () => {
+  it('includes the router basename in flat tab hrefs', () => {
+    renderHeaderNav({
+      tabs: [
+        {
+          id: 'overview',
+          label: 'Overview',
+          href: '/catalog/overview',
+        },
+      ],
+      activeTabId: null,
+    });
+
+    expect(screen.getByRole('link', { name: 'Overview' })).toHaveAttribute(
+      'href',
+      '/app/catalog/overview',
+    );
+  });
+
+  it('automatically detects the active flat tab under a router basename', () => {
+    renderHeaderNav(
+      {
+        tabs: [
+          {
+            id: 'overview',
+            label: 'Overview',
+            href: '/catalog/overview',
+          },
+          {
+            id: 'settings',
+            label: 'Settings',
+            href: '/catalog/settings',
+          },
+        ],
+      },
+      '/app/catalog/overview/details',
+    );
+
+    expect(screen.getByRole('link', { name: 'Overview' })).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+    expect(screen.getByRole('link', { name: 'Settings' })).not.toHaveAttribute(
+      'aria-current',
+    );
+  });
+
+  it('includes the router basename in grouped tab hrefs', async () => {
+    renderHeaderNav({
+      tabs: [
+        {
+          id: 'resources',
+          label: 'Resources',
+          items: [
+            {
+              id: 'docs',
+              label: 'TechDocs',
+              href: '/catalog/docs',
+            },
+          ],
+        },
+      ],
+      activeTabId: null,
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Resources' }));
+
+    expect(
+      await screen.findByRole('menuitemradio', { name: 'TechDocs' }),
+    ).toHaveAttribute('href', '/app/catalog/docs');
+  });
+});

--- a/packages/ui/src/components/Header/HeaderNav.tsx
+++ b/packages/ui/src/components/Header/HeaderNav.tsx
@@ -72,7 +72,6 @@ function HeaderNavLink(props: HeaderNavLinkProps) {
           ).current = el;
           registerRef(id, el);
         }}
-        href={href}
         className={ownProps.classes.root}
         aria-current={active ? 'page' : undefined}
         onClick={handleClick}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Header tab links did not include the configured router basename. This caused copied links and browser-native navigation such as opening a tab in a new window to target the wrong URL when Backstage is hosted below a subpath.

This allows the existing router integration to provide the rendered URL for flat header tabs. Regression coverage verifies flat links, grouped links, and automatic active-tab detection when a basename is configured.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))