### PR TITLE
fix(scaffolder): coerce DatabaseTaskStore totalTasks count to a number

### DIFF
--- a/.changeset/late-snakes-coerce-count.md
+++ b/.changeset/late-snakes-coerce-count.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Fixed `DatabaseTaskStore.list` returning `totalTasks` as a string on PostgreSQL. knex returns a `COUNT(*)` aggregate as a string on PostgreSQL (the column is a bigint) while better-sqlite3 returns a number, so the count is now coerced with `Number(...)`. This in turn fixes the `list-scaffolder-tasks` action, whose output schema declares `totalTasks: z.number()` and previously failed validation in production with `Invalid output ... totalTasks: Expected number, received string`.

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.test.ts
@@ -22,6 +22,7 @@ import { ConflictError } from '@backstage/errors';
 import {
   mockServices,
   createMockDirectory,
+  TestDatabases,
 } from '@backstage/backend-test-utils';
 import fs from 'fs-extra';
 import { EventsService } from '@backstage/plugin-events-node';
@@ -588,3 +589,29 @@ describe('DatabaseTaskStore', () => {
     expect(fs.existsSync(`${workspaceDir.path}/app-config.yaml`)).toBeTruthy();
   });
 });
+
+// Regression coverage for the `totalTasks` count type. The rest of the suite
+// runs on better-sqlite3, where a `COUNT(*)` aggregate is returned as a number,
+// so the PostgreSQL behaviour (where knex returns it as a string) was never
+// exercised. These cases run against every supported database.
+jest.setTimeout(60_000);
+
+const databases = TestDatabases.create();
+
+describe.each(databases.eachSupportedId())(
+  'DatabaseTaskStore, %p',
+  databaseId => {
+    it('returns list() totalTasks as a number', async () => {
+      const knex = await databases.init(databaseId);
+      const store = await DatabaseTaskStore.create({ database: knex });
+
+      await store.createTask({ spec: {} as TaskSpec, createdBy: 'me' });
+      await store.createTask({ spec: {} as TaskSpec, createdBy: 'me' });
+
+      const { totalTasks } = await store.list({});
+
+      expect(typeof totalTasks).toBe('number');
+      expect(totalTasks).toBe(2);
+    });
+  },
+);

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.ts
@@ -322,7 +322,13 @@ export class DatabaseTaskStore implements TaskStore {
       createdAt: parseSqlDateToIsoString(result.created_at),
     }));
 
-    return { tasks, totalTasks: count };
+    // `count` is coerced to a number because knex returns the result of a
+    // `COUNT(*)` aggregate as a string on PostgreSQL (the underlying column is
+    // a bigint), whereas it is a number on better-sqlite3. Without this the
+    // `totalTasks` value would be a string in production, which breaks
+    // consumers that expect a number (e.g. the `list-scaffolder-tasks` action
+    // whose output schema declares `totalTasks: z.number()`).
+    return { tasks, totalTasks: Number(count) };
   }
 
   async getTask(taskId: string): Promise<SerializedTask> {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`DatabaseTaskStore.list()` returns the `COUNT(*)` aggregate directly as `totalTasks`. knex returns that aggregate as a **string** on PostgreSQL (the column is a `bigint`) but as a **number** on `better-sqlite3`, so in production `totalTasks` is a string.

This breaks the `list-scaffolder-tasks` action, whose output schema declares `totalTasks: z.number()`, with:

```
Invalid output from action "scaffolder:list-scaffolder-tasks"; caused by [
  { "code": "invalid_type", "expected": "number", "received": "string", "path": ["totalTasks"] }
]
```

Fixes #34471.

### Changes

- `DatabaseTaskStore.list()` coerces the count with `Number(...)` (with an explanatory comment).
- Added a regression test that runs the store against **every supported database**. The existing `DatabaseTaskStore.test.ts` only used `better-sqlite3` (where the count is already a number), which is why this was never caught — the new `describe.each(databases.eachSupportedId())` case exercises PostgreSQL and asserts `typeof totalTasks === 'number'`.
- Added a changeset (`patch` for `@backstage/plugin-scaffolder-backend`).

### Notes

Opened as a **draft** pending the EasyCLA sign-off. Happy to adjust the test approach (this introduces the first `TestDatabases` usage in `scaffolder-backend`) if maintainers prefer a different placement.

✔️ Checklist
- [x] A changeset describing the change and affected packages.
- [x] Added or updated documentation (n/a — internal fix)
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (n/a)
- [x] All your commits have a `Signed-off-by` line in the message.