### PR TITLE
fix(scaffolder): coerce DatabaseTaskStore totalTasks count to a number

### DIFF
--- a/.changeset/scaffolder-totaltasks-count-number.md
+++ b/.changeset/scaffolder-totaltasks-count-number.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Fixed `DatabaseTaskStore.list` returning `totalTasks` as a string on PostgreSQL. knex returns a `COUNT(*)` aggregate as a string on PostgreSQL (the column is a bigint) while better-sqlite3 returns a number, so the count is now coerced with `Number(...)` and guarded with `Number.isSafeInteger(...)`. This in turn fixes the `list-scaffolder-tasks` action, whose output schema declares `totalTasks: z.number()` and previously failed validation in production with `Invalid output ... totalTasks: Expected number, received string`.

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.test.ts
@@ -22,6 +22,7 @@ import { ConflictError } from '@backstage/errors';
 import {
   mockServices,
   createMockDirectory,
+  TestDatabases,
 } from '@backstage/backend-test-utils';
 import fs from 'fs-extra';
 import { EventsService } from '@backstage/plugin-events-node';
@@ -588,3 +589,33 @@ describe('DatabaseTaskStore', () => {
     expect(fs.existsSync(`${workspaceDir.path}/app-config.yaml`)).toBeTruthy();
   });
 });
+
+// Regression coverage for the `totalTasks` count type. The rest of the suite
+// runs on better-sqlite3, where a `COUNT(*)` aggregate is returned as a number,
+// so the PostgreSQL behaviour (where knex returns it as a string) was never
+// exercised. These cases run against every supported database.
+//
+// `TestDatabases.create()` registers its own `afterAll` hook that shuts the
+// engines down, so no explicit teardown is needed here.
+const databases = TestDatabases.create();
+
+describe.each(databases.eachSupportedId())(
+  'DatabaseTaskStore totalTasks, %p',
+  databaseId => {
+    // The timeout is scoped to this single test (passed as the third argument
+    // to `it`) so the rest of the suite keeps the default timeout; spinning up
+    // a real database engine can take longer than the default.
+    it('returns list() totalTasks as a number', async () => {
+      const knex = await databases.init(databaseId);
+      const store = await DatabaseTaskStore.create({ database: knex });
+
+      await store.createTask({ spec: {} as TaskSpec, createdBy: 'me' });
+      await store.createTask({ spec: {} as TaskSpec, createdBy: 'me' });
+
+      const { totalTasks } = await store.list({});
+
+      expect(typeof totalTasks).toBe('number');
+      expect(totalTasks).toBe(2);
+    }, 60_000);
+  },
+);

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/DatabaseTaskStore.ts
@@ -322,7 +322,22 @@ export class DatabaseTaskStore implements TaskStore {
       createdAt: parseSqlDateToIsoString(result.created_at),
     }));
 
-    return { tasks, totalTasks: count };
+    // `count` is coerced to a number because knex returns the result of a
+    // `COUNT(*)` aggregate as a string on PostgreSQL (the underlying column is
+    // a bigint), whereas it is a number on better-sqlite3. Without this the
+    // `totalTasks` value would be a string in production, which breaks
+    // consumers that expect a number (e.g. the `list-scaffolder-tasks` action
+    // whose output schema declares `totalTasks: z.number()`).
+    const totalTasks = Number(count);
+    if (!Number.isSafeInteger(totalTasks)) {
+      // A bigint count above Number.MAX_SAFE_INTEGER would silently lose
+      // precision when coerced, so fail loudly rather than report a wrong total.
+      throw new Error(
+        `Task count '${count}' exceeds the safe integer range and cannot be represented accurately as 'totalTasks'`,
+      );
+    }
+
+    return { tasks, totalTasks };
   }
 
   async getTask(taskId: string): Promise<SerializedTask> {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`DatabaseTaskStore.list()` returns the `COUNT(*)` aggregate directly as `totalTasks`. knex returns that aggregate as a **string** on PostgreSQL (the column is a `bigint`) but as a **number** on `better-sqlite3`, so in production `totalTasks` is a string.

This breaks the `list-scaffolder-tasks` action, whose output schema declares `totalTasks: z.number()`, with:

```
Invalid output from action "scaffolder:list-scaffolder-tasks"; caused by [
  { "code": "invalid_type", "expected": "number", "received": "string", "path": ["totalTasks"] }
]
```

Fixes #34471. Supersedes #34472 (the previous attempt; its fork/branch was deleted so it could not be reopened — this PR rebases the same fix on current `master` and addresses the automated review feedback below).

### Changes

- `DatabaseTaskStore.list()` coerces the count with `Number(...)` (with an explanatory comment).
- Added a regression test that runs the store against **every supported database**. The existing `DatabaseTaskStore.test.ts` only used `better-sqlite3` (where the count is already a number), which is why this was never caught — the new `describe.each(databases.eachSupportedId())` case exercises PostgreSQL and asserts `typeof totalTasks === 'number'`.
- Added a changeset (`patch` for `@backstage/plugin-scaffolder-backend`).

### Addressing the previous automated review

The Copilot review on #34472 raised three points; this PR resolves them:

1. **Precision of `Number(count)` for large bigint counts.** Added a `Number.isSafeInteger(...)` guard that throws a clear error rather than silently returning an inaccurate total once the count exceeds `Number.MAX_SAFE_INTEGER`.
2. **Module-scope `jest.setTimeout(60_000)`.** Removed it; the longer timeout is now passed as the per-test timeout argument to the single `it(...)`, so the rest of the suite keeps the default timeout.
3. **Test teardown.** No explicit teardown is added because `TestDatabases.create()` already registers its own `afterAll` hook that shuts the engines down (and `shutdown()` is private by design). This matches the established pattern in the repo (e.g. `packages/backend-defaults/src/migrations.test.ts`). A comment in the test notes this.

### Checklist

- [x] A changeset describing the change and affected packages.
- [x] Added or updated documentation (n/a — internal fix)
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (n/a)
- [x] All your commits have a `Signed-off-by` line in the message.
