### PR TITLE
fix(scaffolder-backend-module-gitlab): handle empty actions on push (#34098)

### DIFF
--- a/.changeset/fix-gitlab-repo-push-empty-actions.md
+++ b/.changeset/fix-gitlab-repo-push-empty-actions.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gitlab': patch
+---
+
+Fixed `gitlab:repo:push` failing with `400 Bad request - Provide at least one action` when the workspace has no file changes to commit (e.g. re-running a template against an already up-to-date branch). The action now detects an empty action list, skips the commit API call, and logs a warning. The `commitHash` output is omitted in this no-op case (the output is now declared optional); pass `allowEmpty: true` to retain the previous behavior of forwarding an empty commit to GitLab.

--- a/.changeset/fix-gitlab-repo-push-empty-actions.md
+++ b/.changeset/fix-gitlab-repo-push-empty-actions.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-backend-module-gitlab': patch
 ---
 
-Fixed `gitlab:repo:push` failing with `400 Bad request - Provide at least one action` when the workspace has no file changes to commit (e.g. re-running a template against an already up-to-date branch). The action now detects an empty action list, skips the commit API call, and logs a warning. The `commitHash` output is omitted in this no-op case (the output is now declared optional); pass `allowEmpty: true` to retain the previous behavior of forwarding an empty commit to GitLab.
+Fixed `gitlab:repo:push` failing with `400 Bad request - Provide at least one action` when the workspace has no file changes to commit (e.g. re-running a template against an already up-to-date branch). The action now detects an empty action list, skips the commit API call, and logs a warning whenever `allowEmpty` is not true (covering both the default of unset and an explicit `false`). The `commitHash` output is omitted in this no-op case and is now declared optional. Pass `allowEmpty: true` to retain the previous behavior of forwarding an empty commit to GitLab.

--- a/plugins/scaffolder-backend-module-gitlab/report.api.md
+++ b/plugins/scaffolder-backend-module-gitlab/report.api.md
@@ -160,7 +160,7 @@ export const createGitlabRepoPushAction: (options: {
   {
     projectid: string;
     projectPath: string;
-    commitHash: string;
+    commitHash?: string | undefined;
   },
   'v2'
 >;

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.examples.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.examples.test.ts
@@ -116,10 +116,13 @@ describe('gitlab:repo:push', () => {
   describe('Push changes to gitlab repository with a specific source and target path', () => {
     it(`Should ${examples[1].description}`, async () => {
       const input = yaml.parse(examples[1].example).steps[0].input;
+      // Example uses sourcePath: 'src' and targetPath: 'dest', so the
+      // workspace fixture must place the file inside `src/` for it to be
+      // picked up by the action.
       mockDir.setContent({
         [workspacePath]: {
           'abcd.txt': 'Test message',
-          source: {
+          src: {
             'abcd.txt': 'Test message',
           },
         },
@@ -135,7 +138,7 @@ describe('gitlab:repo:push', () => {
         [
           {
             action: 'create',
-            filePath: 'abcd.txt',
+            filePath: 'dest/abcd.txt',
             content: 'VGVzdCBtZXNzYWdl',
             encoding: 'base64',
             execute_filemode: false,

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.test.ts
@@ -542,5 +542,52 @@ describe('createGitLabCommit', () => {
         { allowEmpty: false },
       );
     });
+
+    it('skips commit and omits commitHash output when there are no file changes', async () => {
+      // The default Branches.show mock from beforeEach resolves successfully
+      // (branch exists), so the no-op path is reached without needing extra setup.
+      mockGitlabClient.Branches.show.mockResolvedValueOnce(undefined);
+
+      const input = {
+        repoUrl: 'gitlab.com?repo=repo&owner=owner',
+        commitMessage: 'No-op',
+        branchName: 'some-branch',
+        commitAction: 'auto',
+      };
+      // Empty workspace -> no file actions to send to GitLab
+      mockDir.setContent({ [workspacePath]: {} });
+
+      const ctx = createMockActionContext({ input, workspacePath });
+      await instance.handler(ctx);
+
+      expect(mockGitlabClient.Commits.create).not.toHaveBeenCalled();
+      expect(ctx.output).toHaveBeenCalledWith('projectid', 'owner/repo');
+      expect(ctx.output).toHaveBeenCalledWith('projectPath', 'owner/repo');
+      expect(ctx.output).not.toHaveBeenCalledWith(
+        'commitHash',
+        expect.anything(),
+      );
+    });
+
+    it('still commits empty changes when allowEmpty is true', async () => {
+      const input = {
+        repoUrl: 'gitlab.com?repo=repo&owner=owner',
+        commitMessage: 'Empty commit',
+        branchName: 'some-branch',
+        allowEmpty: true,
+      };
+      mockDir.setContent({ [workspacePath]: {} });
+
+      const ctx = createMockActionContext({ input, workspacePath });
+      await instance.handler(ctx);
+
+      expect(mockGitlabClient.Commits.create).toHaveBeenCalledWith(
+        'owner/repo',
+        'some-branch',
+        'Empty commit',
+        [],
+        { allowEmpty: true },
+      );
+    });
   });
 });

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.ts
@@ -103,7 +103,7 @@ export const createGitlabRepoPushAction = (options: {
           z
             .string({
               description:
-                'The git commit hash of the commit, or omitted when there were no file changes to commit and `allowEmpty` was not set.',
+                'The git commit hash of the commit, or omitted when there were no file changes to commit and `allowEmpty` is not true (covers both the default of unset and an explicit `false`).',
             })
             .optional(),
       },

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.ts
@@ -100,9 +100,12 @@ export const createGitlabRepoPushAction = (options: {
             description: 'Gitlab Project path',
           }),
         commitHash: z =>
-          z.string({
-            description: 'The git commit hash of the commit',
-          }),
+          z
+            .string({
+              description:
+                'The git commit hash of the commit, or omitted when there were no file changes to commit and `allowEmpty` was not set.',
+            })
+            .optional(),
       },
     },
     async handler(ctx) {
@@ -213,6 +216,15 @@ export const createGitlabRepoPushAction = (options: {
             )}`,
           );
         }
+      }
+
+      if (actions.length === 0 && !allowEmpty) {
+        ctx.logger.warn(
+          `No file changes to commit to ${repoID} on branch '${branchName}'; skipping commit. Set 'allowEmpty: true' to create an empty commit.`,
+        );
+        ctx.output('projectid', repoID);
+        ctx.output('projectPath', repoID);
+        return;
       }
 
       try {


### PR DESCRIPTION
## Summary

Fixes #34098.

When the workspace has no file changes to commit (e.g. re-running a template against an already up-to-date branch), `gitlab:repo:push` was forwarding an empty action list to GitLab, which rejects with `400 Bad request - Provide at least one action, or set allow_empty to true`. The user-facing error pointed at file existence / `commitAction` config instead of the real cause.

This PR detects an empty action list after `getFileAction` resolution. If `allowEmpty` is not set, the action logs a warning, skips the commit API call, and returns. `commitHash` is declared optional in the output schema and omitted in the no-op case. Passing `allowEmpty: true` retains the previous behaviour of forwarding an empty commit to GitLab (also covered by a new test).

Also fixes a latent bug surfaced by the new no-op path in `gitlabRepoPush.examples.test.ts`: the test fixture used `source/` while example #1 declares `sourcePath: 'src'`, so it was actually exercising the empty-actions path. The fixture and `filePath` assertion (now correctly `dest/abcd.txt`) had been masked by Jest mock-call persistence across tests in that file.

### Changes

- `plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.ts` — no-op short-circuit; `commitHash` made optional.
- `plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.test.ts` — new tests: no-op path skips `Commits.create`; `allowEmpty: true` still forwards.
- `plugins/scaffolder-backend-module-gitlab/src/actions/gitlabRepoPush.examples.test.ts` — fixture and assertion corrected.
- `.changeset/fix-gitlab-repo-push-empty-actions.md` — patch.

### Validation

```
yarn workspace @backstage/plugin-scaffolder-backend-module-gitlab lint
yarn workspace @backstage/plugin-scaffolder-backend-module-gitlab test --testPathPatterns gitlabRepoPush
# Test Suites: 2 passed, 2 total
# Tests:       20 passed, 20 total
```

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message.