### PR TITLE
fix(scaffolder-backend): restore user-supplied task secrets in dry-run (#33531)

### DIFF
--- a/.changeset/fix-scaffolder-dryrun-task-secrets.md
+++ b/.changeset/fix-scaffolder-dryrun-task-secrets.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Restored user-supplied task secrets in scaffolder dry-run executions. The previous security fix that stripped secrets from dry-run also removed task secrets passed in the dry-run request body, which broke integration test setups that rely on user-supplied secrets. Environment secrets (server-configured) remain stripped during dry-run; only task secrets supplied by the caller are now forwarded to actions.

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.test.ts
@@ -2188,7 +2188,7 @@ describe('NunjucksWorkflowRunner', () => {
       expect(fakeActionHandler.mock.calls[0][0].step.name).toEqual('name');
     });
 
-    it('should not pass environment secrets or task secrets to action inputs during dry-run', async () => {
+    it('should strip environment secrets but pass user-supplied task secrets to action inputs during dry-run', async () => {
       const dryRunHandler = jest.fn();
       actionRegistry.register(
         createTemplateAction({
@@ -2221,7 +2221,7 @@ describe('NunjucksWorkflowRunner', () => {
 
       const handlerCall = dryRunHandler.mock.calls[0][0];
       expect(handlerCall.input.envSecret).toBeUndefined();
-      expect(handlerCall.input.taskSecret).toBeUndefined();
+      expect(handlerCall.input.taskSecret).toEqual('task-secret-value');
     });
   });
 

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
@@ -400,7 +400,7 @@ export class NunjucksWorkflowRunner implements WorkflowRunner {
           parameters: this.environment?.parameters ?? {},
           secrets: task.isDryRun ? {} : this.environment?.secrets ?? {},
         },
-        secrets: task.isDryRun ? {} : task.secrets ?? {},
+        secrets: task.secrets ?? {},
       };
 
       const resolvedEach =


### PR DESCRIPTION
## Summary

Fixes #33531.

Commit 4f5ed06d stripped both environment secrets and task secrets from scaffolder dry-run executions to prevent server-configured secrets from leaking through the dry-run endpoint. Stripping environment secrets is the right call, but the same change also removed user-supplied task secrets sent in the dry-run request body, breaking integration test suites that rely on caller-provided secrets (as reported in #33531).

This is a partial revert at [NunjucksWorkflowRunner.ts:403](https://github.com/backstage/backstage/blob/master/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts#L403). Environment secrets (line 401) remain stripped during dry-run — the original security win is preserved. Task secrets passed by the caller are restored so dry-run executions can exercise secret-dependent steps.

### Changes

- `plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts` — drop the `task.isDryRun ? {}` ternary on `task.secrets` (1 line).
- `plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.test.ts` — rename and update the dry-run secrets test to assert env secrets are stripped while user-supplied task secrets pass through.
- `.changeset/fix-scaffolder-dryrun-task-secrets.md` — patch.

### Threat model note

The remaining defense against environment-secret leakage during dry-run lives at line 401 (`task.isDryRun ? {} : this.environment?.secrets ?? {}`). Task secrets restored here are by definition supplied by the caller invoking dry-run, so they are not exposed to anyone who could not already provide them.

### Validation

```
yarn workspace @backstage/plugin-scaffolder-backend lint
yarn workspace @backstage/plugin-scaffolder-backend test --testPathPatterns NunjucksWorkflowRunner -t secret
# Test Suites: 1 passed, 1 total
# Tests:       17 passed (67 skipped by -t filter), 84 total
```

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message.