### PR TITLE
docs: Add missing metrics to OTel tutorial

### DIFF
--- a/docs/tutorials/setup-opentelemetry.md
+++ b/docs/tutorials/setup-opentelemetry.md
@@ -184,6 +184,8 @@ The following metrics are available:
 - `scaffolder.step.duration`: Duration of a step runs
 - `backend_tasks.task.runs.count`: Total number of times a task has been run
 - `backend_tasks.task.runs.duration`: Histogram of task run durations
+- `backend_tasks.task.runs.started`: Gauge recording the Unix epoch time (seconds) when each task (`taskId` label) was last started
+- `backend_tasks.task.runs.completed`: Gauge recording the Unix epoch time (seconds) when each task (`taskId` label) was last completed
 
 ## References
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The "Available Metrics" section in the OTel tutorial is missing two `backend_tasks` metrics (`started` and `completed`) that were added in fe87fbff1b but the docs were not updated at that time.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

---

Note: Claude Code assisted with investigating the source code to identify the missing metrics and the relevant commits.