### PR TITLE
Add visibility secret annotation for PRIVATE-TOKEN header

### DIFF
--- a/plugins/proxy-backend/config.d.ts
+++ b/plugins/proxy-backend/config.d.ts
@@ -120,18 +120,18 @@ export interface Config {
            * Object with extra headers to be added to target requests.
            */
           headers?: {
-           /** @visibility secret */
-          Authorization?: string;
-          /** @visibility secret */
-          authorization?: string;
-          /** @visibility secret */
-          'X-Api-Key'?: string;
-          /** @visibility secret */
-          'x-api-key'?: string;
-          /** @visibility secret */
-          'PRIVATE-TOKEN'?: string;
-           [key: string]: string | undefined;
-           };
+            /** @visibility secret */
+            Authorization?: string;
+            /** @visibility secret */
+            authorization?: string;
+            /** @visibility secret */
+            'X-Api-Key'?: string;
+            /** @visibility secret */
+            'x-api-key'?: string;
+            /** @visibility secret */
+            'PRIVATE-TOKEN'?: string;
+            [key: string]: string | undefined;
+          };
           /**
            * Changes the origin of the host header to the target URL. Default: true.
            */

--- a/plugins/proxy-backend/config.d.ts
+++ b/plugins/proxy-backend/config.d.ts
@@ -120,16 +120,18 @@ export interface Config {
            * Object with extra headers to be added to target requests.
            */
           headers?: {
-            /** @visibility secret */
-            Authorization?: string;
-            /** @visibility secret */
-            authorization?: string;
-            /** @visibility secret */
-            'X-Api-Key'?: string;
-            /** @visibility secret */
-            'x-api-key'?: string;
-            [key: string]: string | undefined;
-          };
+           /** @visibility secret */
+          Authorization?: string;
+          /** @visibility secret */
+          authorization?: string;
+          /** @visibility secret */
+          'X-Api-Key'?: string;
+          /** @visibility secret */
+          'x-api-key'?: string;
+          /** @visibility secret */
+          'PRIVATE-TOKEN'?: string;
+           [key: string]: string | undefined;
+           };
           /**
            * Changes the origin of the host header to the target URL. Default: true.
            */


### PR DESCRIPTION
## Description

Adds `@visibility secret` annotation for the `PRIVATE-TOKEN` header in the proxy-backend plugin configuration.

This ensures GitLab personal access tokens configured using the `PRIVATE-TOKEN` header are treated as secrets and hidden from config visibility tooling.

## Changes

- Added `@visibility secret` to `PRIVATE-TOKEN` header in `plugins/proxy-backend/config.d.ts`

## Related Issue

Fixes #34269