### PR TITLE
Migrate the Catalog index page to the new header system

### DIFF
--- a/.changeset/catalog-index-bui-header.md
+++ b/.changeset/catalog-index-bui-header.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Updated the new frontend system Catalog index page to use the current Backstage UI page header and content container.

--- a/plugins/catalog/src/components/CatalogExportButton/CatalogExportButton.test.tsx
+++ b/plugins/catalog/src/components/CatalogExportButton/CatalogExportButton.test.tsx
@@ -36,6 +36,7 @@ const mockExportStream = jest.fn();
 
 const renderComponent = (
   settings?: Parameters<typeof CatalogExportButton>[0]['settings'],
+  iconOnly?: Parameters<typeof CatalogExportButton>[0]['iconOnly'],
 ) =>
   renderInTestApp(
     <TestApiProvider
@@ -45,7 +46,7 @@ const renderComponent = (
       ]}
     >
       <EntityListProvider>
-        <CatalogExportButton settings={settings} />
+        <CatalogExportButton settings={settings} iconOnly={iconOnly} />
       </EntityListProvider>
     </TestApiProvider>,
   );
@@ -68,6 +69,14 @@ describe('CatalogExportButton', () => {
     expect(
       screen.getByRole('button', { name: /Export selection/i }),
     ).toBeInTheDocument();
+  });
+
+  it('renders an accessible icon-only export button', async () => {
+    await renderComponent(undefined, true);
+
+    const button = screen.getByRole('button', { name: /Export selection/i });
+    expect(button).toHaveClass('bui-ButtonIcon');
+    expect(button).not.toHaveTextContent('Export selection');
   });
 
   it('opens and closes the dialog', async () => {

--- a/plugins/catalog/src/components/CatalogExportButton/CatalogExportButton.tsx
+++ b/plugins/catalog/src/components/CatalogExportButton/CatalogExportButton.tsx
@@ -20,6 +20,7 @@ import { useTranslationRef, toastApiRef } from '@backstage/frontend-plugin-api';
 import { catalogTranslationRef } from '../../alpha/translation';
 import {
   Button,
+  ButtonIcon,
   Checkbox,
   Dialog,
   DialogBody,
@@ -122,8 +123,10 @@ const DEFAULT_EXPORT_COLUMNS = [
  */
 export const CatalogExportButton = ({
   settings,
+  iconOnly = false,
 }: {
   settings?: CatalogExportSettings;
+  iconOnly?: boolean;
 }) => {
   const { t } = useTranslationRef(catalogTranslationRef);
   const { exportStream, loading, error } = useStreamingExport();
@@ -221,13 +224,22 @@ export const CatalogExportButton = ({
 
   return (
     <>
-      <Button
-        variant="secondary"
-        iconStart={<RiDownloadLine />}
-        onPress={handleOpenDialog}
-      >
-        {t('catalogExportButton.triggerButtonTitle')}
-      </Button>
+      {iconOnly ? (
+        <ButtonIcon
+          variant="secondary"
+          icon={<RiDownloadLine />}
+          aria-label={t('catalogExportButton.triggerButtonTitle')}
+          onPress={handleOpenDialog}
+        />
+      ) : (
+        <Button
+          variant="secondary"
+          iconStart={<RiDownloadLine />}
+          onPress={handleOpenDialog}
+        >
+          {t('catalogExportButton.triggerButtonTitle')}
+        </Button>
+      )}
 
       <Dialog isOpen={open} onOpenChange={isOpen => !isOpen && setOpen(false)}>
         <DialogHeader>{t('catalogExportButton.dialogTitle')}</DialogHeader>

--- a/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.module.css
+++ b/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.module.css
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+.supportButton {
+  /* Header already provides the spacing that SupportButton adds internally. */
+  display: contents;
+}
+
+.supportButton > :global(.MuiBox-root) {
+  margin-left: 0;
+}

--- a/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.module.css
+++ b/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.module.css
@@ -14,11 +14,7 @@
  * limitations under the License.
  */
 
-.supportButton {
-  /* Header already provides the spacing that SupportButton adds internally. */
-  display: contents;
-}
-
 .supportButton > :global(.MuiBox-root) {
+  /* Header already provides the spacing that SupportButton adds internally. */
   margin-left: 0;
 }

--- a/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx
@@ -24,7 +24,8 @@ import {
   TableProps,
 } from '@backstage/core-components';
 import { configApiRef, useApi, useRouteRef } from '@backstage/core-plugin-api';
-import { HeaderPage } from '@backstage/ui';
+import { ButtonLink, Container, Header } from '@backstage/ui';
+import { RiAddLine } from '@remixicon/react';
 import {
   CatalogFilterLayout,
   DefaultFilters,
@@ -44,6 +45,7 @@ import { usePermission } from '@backstage/plugin-permission-react';
 import { CatalogExportButton } from '../CatalogExportButton/CatalogExportButton';
 import type { CatalogExportSettings } from '../CatalogExportButton';
 import Box from '@material-ui/core/Box';
+import styles from './DefaultCatalogPage.module.css';
 
 /** @internal */
 export type BaseCatalogPageProps = {
@@ -103,11 +105,13 @@ export function BaseCatalogPage(props: BaseCatalogPageProps) {
   );
 }
 
-function NfsBaseCatalogPage(props: BaseCatalogPageProps) {
+/** @internal */
+export function NfsBaseCatalogPage(props: BaseCatalogPageProps) {
   const { pagination, exportSettings } = props;
   const orgName =
     useApi(configApiRef).getOptionalString('organization.name') ?? 'Backstage';
   const createComponentLink = useRouteRef(createComponentRouteRef);
+  const createComponentHref = createComponentLink?.();
   const { t } = useTranslationRef(catalogTranslationRef);
   const { allowed } = usePermission({
     permission: catalogEntityCreatePermission,
@@ -115,28 +119,33 @@ function NfsBaseCatalogPage(props: BaseCatalogPageProps) {
 
   return (
     <EntityListProvider pagination={pagination}>
-      <HeaderPage
+      <Header
         title={t('indexPage.title', { orgName })}
         customActions={
           <>
-            {allowed && (
-              <CreateButton
-                title={t('indexPage.createButtonTitle')}
-                to={createComponentLink && createComponentLink()}
-              />
+            {allowed && createComponentHref && (
+              <ButtonLink
+                variant="primary"
+                href={createComponentHref}
+                iconStart={<RiAddLine />}
+              >
+                {t('indexPage.createButtonTitle')}
+              </ButtonLink>
             )}
             {exportSettings?.enabled && (
-              <Box ml={2}>
-                <CatalogExportButton settings={exportSettings} />
-              </Box>
+              <CatalogExportButton settings={exportSettings} iconOnly />
             )}
-            <SupportButton>{t('indexPage.supportButtonContent')}</SupportButton>
+            <div className={styles.supportButton}>
+              <SupportButton>
+                {t('indexPage.supportButtonContent')}
+              </SupportButton>
+            </div>
           </>
         }
       />
-      <Content>
+      <Container>
         <CatalogPageContent {...props} />
-      </Content>
+      </Container>
     </EntityListProvider>
   );
 }

--- a/plugins/catalog/src/components/CatalogPage/NfsDefaultCatalogPage.test.tsx
+++ b/plugins/catalog/src/components/CatalogPage/NfsDefaultCatalogPage.test.tsx
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { configApiRef } from '@backstage/core-plugin-api';
+import { toastApiRef } from '@backstage/frontend-plugin-api';
+import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
+import { permissionApiRef } from '@backstage/plugin-permission-react';
+import {
+  mockApis,
+  renderInTestApp,
+  TestApiProvider,
+} from '@backstage/test-utils';
+import { screen, waitFor } from '@testing-library/react';
+import { SWRConfig } from 'swr';
+import { createComponentRouteRef } from '../../routes';
+import type { CatalogExportSettings } from '../CatalogExportButton';
+import { NfsBaseCatalogPage } from './DefaultCatalogPage';
+
+const configApi = mockApis.config({
+  data: {
+    organization: {
+      name: 'Spotify',
+    },
+    app: {
+      support: {
+        url: 'https://example.com/support',
+        items: [],
+      },
+    },
+  },
+});
+
+type RenderOptions = {
+  authorize?: AuthorizeResult.ALLOW | AuthorizeResult.DENY;
+  exportSettings?: CatalogExportSettings;
+  mountCreateRoute?: boolean;
+};
+
+const renderPage = async ({
+  authorize = AuthorizeResult.ALLOW,
+  exportSettings,
+  mountCreateRoute = true,
+}: RenderOptions = {}) => {
+  const permissionApi = mockApis.permission({ authorize });
+  jest.spyOn(permissionApi, 'authorize');
+  const rendered = await renderInTestApp(
+    <SWRConfig value={{ provider: () => new Map() }}>
+      <TestApiProvider
+        apis={[
+          [catalogApiRef, {}],
+          [configApiRef, configApi],
+          [permissionApiRef, permissionApi],
+          [toastApiRef, { post: jest.fn() }],
+        ]}
+      >
+        <NfsBaseCatalogPage
+          filters={<div>Filters</div>}
+          content={<div>Injected content</div>}
+          exportSettings={exportSettings}
+        />
+      </TestApiProvider>
+    </SWRConfig>,
+    {
+      mountedRoutes: mountCreateRoute
+        ? { '/create': createComponentRouteRef }
+        : {},
+    },
+  );
+
+  return { ...rendered, permissionApi };
+};
+
+describe('NfsBaseCatalogPage', () => {
+  it('renders the BUI header actions and content container', async () => {
+    await renderPage();
+
+    expect(
+      screen.getByRole('heading', { name: 'Spotify Catalog' }),
+    ).toHaveClass('bui-HeaderTitle');
+    const createLink = await screen.findByRole('link', { name: 'Create' });
+    expect(createLink).toHaveAttribute('href', '/create');
+    expect(createLink.querySelector('svg')).toBeInTheDocument();
+    expect(screen.getByTestId('support-button')).toBeInTheDocument();
+    expect(
+      screen.getByText('Injected content').closest('.bui-Container'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders Export selection inside the entity list provider', async () => {
+    await renderPage({ exportSettings: { enabled: true } });
+
+    const exportButton = screen.getByRole('button', {
+      name: 'Export selection',
+    });
+    expect(exportButton).toHaveClass('bui-ButtonIcon');
+    expect(exportButton).not.toHaveTextContent('Export selection');
+  });
+
+  it('hides Create when permission is denied', async () => {
+    const { permissionApi } = await renderPage({
+      authorize: AuthorizeResult.DENY,
+    });
+
+    await waitFor(() => expect(permissionApi.authorize).toHaveBeenCalled());
+    expect(
+      screen.queryByRole('link', { name: 'Create' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('hides Create when the optional create route is unbound', async () => {
+    const { permissionApi } = await renderPage({ mountCreateRoute: false });
+
+    await waitFor(() => expect(permissionApi.authorize).toHaveBeenCalled());
+    expect(
+      screen.queryByRole('link', { name: 'Create' }),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Migrates the Catalog index page in the new frontend system to use the current BUI `Header` and `Container` components.

- Migrates the Create and Export header actions to BUI controls
- Keeps Support as a page-level action and aligns its spacing with the other actions
- Keeps the old frontend system Catalog page unchanged
- Adds focused tests for the migrated header, actions, route binding, and permission behavior

### Screenshots

#### Before

<img width="1451" height="990" alt="image" src="https://github.com/user-attachments/assets/5b1aef95-7647-4e28-8d13-adc9abca65f9" />

#### After

<img width="1446" height="988" alt="image" src="https://github.com/user-attachments/assets/445d0996-3c77-48cb-bf9e-c5152cdda296" />

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation — not applicable
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))