### PR TITLE
Migrate Catalog entity context menu to BUI

### DIFF
--- a/.changeset/catalog-bui-entity-context-menu.md
+++ b/.changeset/catalog-bui-entity-context-menu.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Migrated the new frontend system Catalog entity context menu to BUI and switched its built-in action icons to Remix icons. The old frontend system Catalog context menu remains unchanged.
+
+The default English value of the `entityContextMenu.moreButtonAriaLabel` translation changed from `more` to `More actions`. If you provide localized Catalog messages, update this label as appropriate for your locale.

--- a/.changeset/catalog-bui-entity-context-menu.md
+++ b/.changeset/catalog-bui-entity-context-menu.md
@@ -4,4 +4,6 @@
 
 Migrated the new frontend system Catalog entity context menu to BUI and switched its built-in action icons to Remix icons. The old frontend system Catalog context menu remains unchanged.
 
+**BREAKING ALPHA**: The new frontend system Catalog entity page now consumes data-driven context menu item extensions. Its `contextMenuItems` input expects the `EntityContextMenuItemBlueprint` data output rather than a rendered React element.
+
 The default English value of the `entityContextMenu.moreButtonAriaLabel` translation changed from `more` to `More actions`. If you provide localized Catalog messages, update this label as appropriate for your locale.

--- a/.changeset/catalog-react-bui-entity-context-menu.md
+++ b/.changeset/catalog-react-bui-entity-context-menu.md
@@ -2,6 +2,8 @@
 '@backstage/plugin-catalog-react': minor
 ---
 
-**BREAKING ALPHA**: The `EntityContextMenuItemBlueprint` factory now renders BUI `MenuItem` instead of MUI `MenuItem`. Menu items close immediately when selected, including while asynchronous actions are pending, and links use the BUI external-link behavior. MUI icons passed via the `icon` parameter are automatically sized to fit, but other icon types may render differently.
+**BREAKING ALPHA**: The `EntityContextMenuItemBlueprint` now outputs menu item data instead of a rendered MUI element. The Catalog entity page consumes this data and renders BUI menu items.
 
-We recommend checking that custom context-menu items look correct and switching to Remix Icon equivalents where appropriate.
+The source-level `icon`, `useProps`, and filter authoring model remains, with `icon` now typed as `IconElement`. We recommend using Remix icons and checking that custom icons follow the standard icon sizing requirements.
+
+Menu items close immediately when selected, including while asynchronous actions are pending.

--- a/.changeset/catalog-react-bui-entity-context-menu.md
+++ b/.changeset/catalog-react-bui-entity-context-menu.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-catalog-react': minor
+---
+
+**BREAKING ALPHA**: The `EntityContextMenuItemBlueprint` factory now renders BUI `MenuItem` instead of MUI `MenuItem`. Menu items close immediately when selected, including while asynchronous actions are pending, and links use the BUI external-link behavior. MUI icons passed via the `icon` parameter are automatically sized to fit, but other icon types may render differently.
+
+We recommend checking that custom context-menu items look correct and switching to Remix Icon equivalents where appropriate.

--- a/plugins/catalog-react/report-alpha.api.md
+++ b/plugins/catalog-react/report-alpha.api.md
@@ -13,6 +13,7 @@ import { ExtensionBlueprint } from '@backstage/frontend-plugin-api';
 import { ExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { ExtensionDefinition } from '@backstage/frontend-plugin-api';
 import { FilterPredicate } from '@backstage/filter-predicates';
+import { IconElement } from '@backstage/frontend-plugin-api';
 import { IconLinkVerticalProps } from '@backstage/core-components';
 import { JSX as JSX_2 } from 'react';
 import { JSX as JSX_3 } from 'react/jsx-runtime';
@@ -454,13 +455,17 @@ export const EntityContextMenuItemBlueprint: ExtensionBlueprint<{
   kind: 'entity-context-menu-item';
   params: EntityContextMenuItemParams;
   output:
-    | ExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
     | ExtensionDataRef<
         (entity: Entity) => boolean,
         'catalog.entity-filter-function',
         {
           optional: true;
         }
+      >
+    | ExtensionDataRef<
+        EntityContextMenuItemData,
+        'catalog.entity-context-menu-item-data',
+        {}
       >;
   inputs: {};
   config: {
@@ -470,6 +475,11 @@ export const EntityContextMenuItemBlueprint: ExtensionBlueprint<{
     filter?: FilterPredicate | undefined;
   };
   dataRefs: {
+    data: ConfigurableExtensionDataRef<
+      EntityContextMenuItemData,
+      'catalog.entity-context-menu-item-data',
+      {}
+    >;
     filterFunction: ConfigurableExtensionDataRef<
       (entity: Entity) => boolean,
       'catalog.entity-filter-function',
@@ -479,9 +489,15 @@ export const EntityContextMenuItemBlueprint: ExtensionBlueprint<{
 }>;
 
 // @alpha (undocumented)
+export type EntityContextMenuItemData = {
+  icon: IconElement;
+  useProps: UseProps;
+};
+
+// @alpha (undocumented)
 export type EntityContextMenuItemParams = {
   useProps: UseProps;
-  icon: JSX_2.Element;
+  icon: IconElement;
   filter?: FilterPredicate | ((entity: Entity) => boolean);
 };
 
@@ -712,6 +728,7 @@ export type UseProps = () =>
   | {
       title: ReactNode;
       href: string;
+      onClick?: () => void | Promise<void>;
       disabled?: boolean;
     }
   | {

--- a/plugins/catalog-react/src/alpha/blueprints/EntityContextMenuItemBlueprint.test.tsx
+++ b/plugins/catalog-react/src/alpha/blueprints/EntityContextMenuItemBlueprint.test.tsx
@@ -17,18 +17,48 @@ import {
   createExtensionTester,
   renderInTestApp,
 } from '@backstage/frontend-test-utils';
-import { EntityContextMenuItemBlueprint } from './EntityContextMenuItemBlueprint';
-import { screen, waitFor } from '@testing-library/react';
+import {
+  EntityContextMenuItemBlueprint,
+  type EntityContextMenuItemParams,
+} from './EntityContextMenuItemBlueprint';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { EntityProvider } from '@backstage/plugin-catalog-react';
 import { Entity } from '@backstage/catalog-model';
-
-jest.mock('../../hooks/useEntityContextMenu', () => ({
-  useEntityContextMenu: () => ({
-    onMenuClose: jest.fn(),
-  }),
-}));
+import { Button, Menu, MenuTrigger } from '@backstage/ui';
+import { useState } from 'react';
 
 describe('EntityContextMenuItemBlueprint', () => {
+  async function findMenuItem(title: string) {
+    const menuItem = (await screen.findByText(title)).closest(
+      '[role="menuitem"]',
+    );
+    expect(menuItem).not.toBeNull();
+    return menuItem!;
+  }
+
+  function renderMenuItem(params: EntityContextMenuItemParams) {
+    const extension = EntityContextMenuItemBlueprint.make({
+      name: 'test',
+      params,
+    });
+
+    renderInTestApp(
+      <EntityProvider
+        entity={{
+          apiVersion: 'v1',
+          kind: 'Component',
+          metadata: { name: 'test' },
+        }}
+      >
+        <MenuTrigger isOpen>
+          <Button>Menu</Button>
+          <Menu>{createExtensionTester(extension).reactElement()}</Menu>
+        </MenuTrigger>
+      </EntityProvider>,
+    );
+  }
+
   const data = [
     {
       icon: <span>Test</span>,
@@ -92,31 +122,92 @@ describe('EntityContextMenuItemBlueprint', () => {
   });
 
   it('should render a menu item', async () => {
-    const extension = EntityContextMenuItemBlueprint.make({
-      name: 'test',
-      params: {
-        icon: <span>Icon</span>,
-        useProps: () => ({
-          title: 'Test',
-          onClick: () => {},
-        }),
+    renderMenuItem({
+      icon: <span>Icon</span>,
+      useProps: () => ({
+        title: 'Test',
+        onClick: () => {},
+      }),
+    });
+
+    expect(await findMenuItem('Test')).toBeInTheDocument();
+  });
+
+  it('should invoke an enabled menu item action', async () => {
+    const onClick = jest.fn();
+    renderMenuItem({
+      icon: <span>Icon</span>,
+      useProps: () => ({ title: 'Test', onClick }),
+    });
+
+    await userEvent.click(await findMenuItem('Test'));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('should disable a menu item', async () => {
+    const onClick = jest.fn();
+    renderMenuItem({
+      icon: <span>Icon</span>,
+      useProps: () => ({ title: 'Test', onClick, disabled: true }),
+    });
+
+    const menuItem = await findMenuItem('Test');
+    expect(menuItem).toHaveAttribute('aria-disabled', 'true');
+
+    await userEvent.click(menuItem);
+
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('should allow useProps to use hooks', async () => {
+    renderMenuItem({
+      icon: <span>Icon</span>,
+      useProps: () => {
+        const [title, setTitle] = useState('Before');
+        return { title, onClick: () => setTitle('After') };
       },
     });
 
-    renderInTestApp(
-      <EntityProvider
-        entity={{
-          apiVersion: 'v1',
-          kind: 'Component',
-          metadata: { name: 'test' },
-        }}
-      >
-        <ul>{createExtensionTester(extension).reactElement()}</ul>
-      </EntityProvider>,
-    );
+    await userEvent.click(await findMenuItem('Before'));
 
-    await waitFor(() => {
-      expect(screen.getByText('Test')).toBeInTheDocument();
+    expect(await findMenuItem('After')).toBeInTheDocument();
+  });
+
+  it('should render a leading icon', async () => {
+    renderMenuItem({
+      icon: <span data-testid="icon">Icon</span>,
+      useProps: () => ({ title: 'Test', onClick: () => {} }),
+    });
+
+    const menuItem = await findMenuItem('Test');
+    expect(menuItem).toContainElement(screen.getByTestId('icon'));
+  });
+
+  it('should render external links with BUI link attributes', async () => {
+    renderMenuItem({
+      icon: <span>Icon</span>,
+      useProps: () => ({ title: 'Test', href: 'https://example.com' }),
+    });
+
+    const menuItem = await findMenuItem('Test');
+    expect(menuItem).toHaveAttribute('href', 'https://example.com');
+    expect(menuItem).toHaveAttribute('target', '_blank');
+    expect(menuItem).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('should size MUI SVG icons for BUI menu items', async () => {
+    renderMenuItem({
+      icon: <svg className="MuiSvgIcon-root" data-testid="icon" />,
+      useProps: () => ({ title: 'Test', onClick: () => {} }),
+    });
+
+    await findMenuItem('Test');
+
+    expect(screen.getByTestId('icon')).toHaveStyle({
+      fontSize: '1rem',
+      width: '1rem',
+      height: '1rem',
     });
   });
 

--- a/plugins/catalog-react/src/alpha/blueprints/EntityContextMenuItemBlueprint.test.tsx
+++ b/plugins/catalog-react/src/alpha/blueprints/EntityContextMenuItemBlueprint.test.tsx
@@ -13,49 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-  createExtensionTester,
-  renderInTestApp,
-} from '@backstage/frontend-test-utils';
+import { createExtensionTester } from '@backstage/frontend-test-utils';
 import {
   EntityContextMenuItemBlueprint,
   type EntityContextMenuItemParams,
 } from './EntityContextMenuItemBlueprint';
-import { screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { EntityProvider } from '@backstage/plugin-catalog-react';
 import { Entity } from '@backstage/catalog-model';
-import { Button, Menu, MenuTrigger } from '@backstage/ui';
-import { useState } from 'react';
 
 describe('EntityContextMenuItemBlueprint', () => {
-  async function findMenuItem(title: string) {
-    const menuItem = (await screen.findByText(title)).closest(
-      '[role="menuitem"]',
-    );
-    expect(menuItem).not.toBeNull();
-    return menuItem!;
-  }
-
-  function renderMenuItem(params: EntityContextMenuItemParams) {
+  function getMenuItemData(params: EntityContextMenuItemParams) {
     const extension = EntityContextMenuItemBlueprint.make({
       name: 'test',
       params,
     });
 
-    renderInTestApp(
-      <EntityProvider
-        entity={{
-          apiVersion: 'v1',
-          kind: 'Component',
-          metadata: { name: 'test' },
-        }}
-      >
-        <MenuTrigger isOpen>
-          <Button>Menu</Button>
-          <Menu>{createExtensionTester(extension).reactElement()}</Menu>
-        </MenuTrigger>
-      </EntityProvider>,
+    return createExtensionTester(extension).get(
+      EntityContextMenuItemBlueprint.dataRefs.data,
     );
   }
 
@@ -121,93 +94,13 @@ describe('EntityContextMenuItemBlueprint', () => {
     `);
   });
 
-  it('should render a menu item', async () => {
-    renderMenuItem({
-      icon: <span>Icon</span>,
-      useProps: () => ({
-        title: 'Test',
-        onClick: () => {},
-      }),
-    });
+  it('should output menu item data', () => {
+    const icon = <span>Icon</span>;
+    const useProps = () => ({ title: 'Test', onClick: () => {} });
 
-    expect(await findMenuItem('Test')).toBeInTheDocument();
-  });
-
-  it('should invoke an enabled menu item action', async () => {
-    const onClick = jest.fn();
-    renderMenuItem({
-      icon: <span>Icon</span>,
-      useProps: () => ({ title: 'Test', onClick }),
-    });
-
-    await userEvent.click(await findMenuItem('Test'));
-
-    expect(onClick).toHaveBeenCalledTimes(1);
-  });
-
-  it('should disable a menu item', async () => {
-    const onClick = jest.fn();
-    renderMenuItem({
-      icon: <span>Icon</span>,
-      useProps: () => ({ title: 'Test', onClick, disabled: true }),
-    });
-
-    const menuItem = await findMenuItem('Test');
-    expect(menuItem).toHaveAttribute('aria-disabled', 'true');
-
-    await userEvent.click(menuItem);
-
-    expect(onClick).not.toHaveBeenCalled();
-  });
-
-  it('should allow useProps to use hooks', async () => {
-    renderMenuItem({
-      icon: <span>Icon</span>,
-      useProps: () => {
-        const [title, setTitle] = useState('Before');
-        return { title, onClick: () => setTitle('After') };
-      },
-    });
-
-    await userEvent.click(await findMenuItem('Before'));
-
-    expect(await findMenuItem('After')).toBeInTheDocument();
-  });
-
-  it('should render a leading icon', async () => {
-    renderMenuItem({
-      icon: <span data-testid="icon">Icon</span>,
-      useProps: () => ({ title: 'Test', onClick: () => {} }),
-    });
-
-    const menuItem = await findMenuItem('Test');
-    expect(menuItem).toContainElement(screen.getByTestId('icon'));
-  });
-
-  it('should render external links with BUI link attributes', async () => {
-    renderMenuItem({
-      icon: <span>Icon</span>,
-      useProps: () => ({ title: 'Test', href: 'https://example.com' }),
-    });
-
-    const menuItem = await findMenuItem('Test');
-    expect(menuItem).toHaveAttribute('href', 'https://example.com');
-    expect(menuItem).toHaveAttribute('target', '_blank');
-    expect(menuItem).toHaveAttribute('rel', 'noopener noreferrer');
-  });
-
-  it('should size MUI SVG icons for BUI menu items', async () => {
-    renderMenuItem({
-      icon: <svg className="MuiSvgIcon-root" data-testid="icon" />,
-      useProps: () => ({ title: 'Test', onClick: () => {} }),
-    });
-
-    await findMenuItem('Test');
-
-    expect(screen.getByTestId('icon')).toHaveStyle({
-      fontSize: '1rem',
-      width: '1rem',
-      height: '1rem',
+    expect(getMenuItemData({ icon, useProps })).toEqual({
+      icon,
+      useProps,
     });
   });
 

--- a/plugins/catalog-react/src/alpha/blueprints/EntityContextMenuItemBlueprint.tsx
+++ b/plugins/catalog-react/src/alpha/blueprints/EntityContextMenuItemBlueprint.tsx
@@ -20,10 +20,8 @@ import {
   createExtensionBlueprint,
   ExtensionBoundary,
 } from '@backstage/frontend-plugin-api';
-import MenuItem from '@material-ui/core/MenuItem';
-import ListItemIcon from '@material-ui/core/ListItemIcon';
-import ListItemText from '@material-ui/core/ListItemText';
-import { useEntityContextMenu } from '../../hooks/useEntityContextMenu';
+import { MenuItem } from '@backstage/ui';
+import { makeStyles } from '@material-ui/core/styles';
 import {
   FilterPredicate,
   filterPredicateToFilterFunction,
@@ -31,6 +29,17 @@ import {
 } from '@backstage/filter-predicates';
 import type { Entity } from '@backstage/catalog-model';
 import { entityFilterFunctionDataRef } from './extensionData';
+
+const useStyles = makeStyles({
+  menuItem: {
+    '& .MuiSvgIcon-root': {
+      fontSize: '1rem',
+      width: '1rem',
+      height: '1rem',
+    },
+  },
+});
+
 /** @alpha */
 export type UseProps = () =>
   | {
@@ -68,25 +77,30 @@ export const EntityContextMenuItemBlueprint = createExtensionBlueprint({
   *factory(params: EntityContextMenuItemParams, { node, config }) {
     const loader = async () => {
       const Component = () => {
-        const { onMenuClose } = useEntityContextMenu();
-        const { title, ...menuItemProps } = params.useProps();
-        let handleClick = undefined;
+        const classes = useStyles();
+        const { title, disabled, ...menuItemProps } = params.useProps();
 
-        if ('onClick' in menuItemProps) {
-          handleClick = () => {
-            const result = menuItemProps.onClick();
-            if (result && 'then' in result) {
-              result.then(onMenuClose, onMenuClose);
-            } else {
-              onMenuClose();
-            }
-          };
+        if ('href' in menuItemProps) {
+          return (
+            <MenuItem
+              className={classes.menuItem}
+              iconStart={params.icon}
+              href={menuItemProps.href}
+              isDisabled={disabled}
+            >
+              {title}
+            </MenuItem>
+          );
         }
 
         return (
-          <MenuItem {...menuItemProps} onClick={handleClick}>
-            <ListItemIcon>{params.icon}</ListItemIcon>
-            <ListItemText primary={title} />
+          <MenuItem
+            className={classes.menuItem}
+            iconStart={params.icon}
+            onAction={menuItemProps.onClick}
+            isDisabled={disabled}
+          >
+            {title}
           </MenuItem>
         );
       };

--- a/plugins/catalog-react/src/alpha/blueprints/EntityContextMenuItemBlueprint.tsx
+++ b/plugins/catalog-react/src/alpha/blueprints/EntityContextMenuItemBlueprint.tsx
@@ -14,49 +14,28 @@
  * limitations under the License.
  */
 
-import { ReactNode, JSX } from 'react';
 import {
-  coreExtensionData,
   createExtensionBlueprint,
-  ExtensionBoundary,
+  type IconElement,
 } from '@backstage/frontend-plugin-api';
-import { MenuItem } from '@backstage/ui';
-import { makeStyles } from '@material-ui/core/styles';
 import {
   FilterPredicate,
   filterPredicateToFilterFunction,
   createZodV4FilterPredicateSchema,
 } from '@backstage/filter-predicates';
 import type { Entity } from '@backstage/catalog-model';
-import { entityFilterFunctionDataRef } from './extensionData';
+import {
+  entityContextMenuItemDataRef,
+  entityFilterFunctionDataRef,
+  type UseProps,
+} from './extensionData';
 
-const useStyles = makeStyles({
-  menuItem: {
-    '& .MuiSvgIcon-root': {
-      fontSize: '1rem',
-      width: '1rem',
-      height: '1rem',
-    },
-  },
-});
-
-/** @alpha */
-export type UseProps = () =>
-  | {
-      title: ReactNode;
-      href: string;
-      disabled?: boolean;
-    }
-  | {
-      title: ReactNode;
-      onClick: () => void | Promise<void>;
-      disabled?: boolean;
-    };
+export type { EntityContextMenuItemData, UseProps } from './extensionData';
 
 /** @alpha */
 export type EntityContextMenuItemParams = {
   useProps: UseProps;
-  icon: JSX.Element;
+  icon: IconElement;
   filter?: FilterPredicate | ((entity: Entity) => boolean);
 };
 
@@ -65,50 +44,21 @@ export const EntityContextMenuItemBlueprint = createExtensionBlueprint({
   kind: 'entity-context-menu-item',
   attachTo: { id: 'page:catalog/entity', input: 'contextMenuItems' },
   output: [
-    coreExtensionData.reactElement,
+    entityContextMenuItemDataRef,
     entityFilterFunctionDataRef.optional(),
   ],
   dataRefs: {
+    data: entityContextMenuItemDataRef,
     filterFunction: entityFilterFunctionDataRef,
   },
   configSchema: {
     filter: createZodV4FilterPredicateSchema().optional(),
   },
-  *factory(params: EntityContextMenuItemParams, { node, config }) {
-    const loader = async () => {
-      const Component = () => {
-        const classes = useStyles();
-        const { title, disabled, ...menuItemProps } = params.useProps();
-
-        if ('href' in menuItemProps) {
-          return (
-            <MenuItem
-              className={classes.menuItem}
-              iconStart={params.icon}
-              href={menuItemProps.href}
-              isDisabled={disabled}
-            >
-              {title}
-            </MenuItem>
-          );
-        }
-
-        return (
-          <MenuItem
-            className={classes.menuItem}
-            iconStart={params.icon}
-            onAction={menuItemProps.onClick}
-            isDisabled={disabled}
-          >
-            {title}
-          </MenuItem>
-        );
-      };
-
-      return <Component />;
-    };
-
-    yield coreExtensionData.reactElement(ExtensionBoundary.lazy(node, loader));
+  *factory(params: EntityContextMenuItemParams, { config }) {
+    yield entityContextMenuItemDataRef({
+      icon: params.icon,
+      useProps: params.useProps,
+    });
 
     if (config.filter) {
       yield entityFilterFunctionDataRef(

--- a/plugins/catalog-react/src/alpha/blueprints/extensionData.tsx
+++ b/plugins/catalog-react/src/alpha/blueprints/extensionData.tsx
@@ -15,8 +15,37 @@
  */
 
 import { Entity } from '@backstage/catalog-model';
-import { createExtensionDataRef } from '@backstage/frontend-plugin-api';
-import { ReactElement } from 'react';
+import {
+  createExtensionDataRef,
+  type IconElement,
+} from '@backstage/frontend-plugin-api';
+import { ReactElement, type ReactNode } from 'react';
+
+/** @alpha */
+export type UseProps = () =>
+  | {
+      title: ReactNode;
+      href: string;
+      onClick?: () => void | Promise<void>;
+      disabled?: boolean;
+    }
+  | {
+      title: ReactNode;
+      onClick: () => void | Promise<void>;
+      disabled?: boolean;
+    };
+
+/** @alpha */
+export type EntityContextMenuItemData = {
+  icon: IconElement;
+  useProps: UseProps;
+};
+
+/** @internal */
+export const entityContextMenuItemDataRef =
+  createExtensionDataRef<EntityContextMenuItemData>().with({
+    id: 'catalog.entity-context-menu-item-data',
+  });
 
 /** @internal */
 export const entityContentTitleDataRef = createExtensionDataRef<string>().with({

--- a/plugins/catalog-react/src/alpha/blueprints/index.ts
+++ b/plugins/catalog-react/src/alpha/blueprints/index.ts
@@ -29,6 +29,7 @@ export {
 export type { EntityCardType } from './extensionData';
 export {
   EntityContextMenuItemBlueprint,
+  type EntityContextMenuItemData,
   type EntityContextMenuItemParams,
   type UseProps,
 } from './EntityContextMenuItemBlueprint';

--- a/plugins/catalog/report-alpha.api.md
+++ b/plugins/catalog/report-alpha.api.md
@@ -211,7 +211,7 @@ export const catalogTranslationRef: TranslationRef<
     readonly 'entityContextMenu.inspectMenuTitle': 'Inspect entity';
     readonly 'entityContextMenu.copyURLMenuTitle': 'Copy entity URL';
     readonly 'entityContextMenu.unregisterMenuTitle': 'Unregister entity';
-    readonly 'entityContextMenu.moreButtonAriaLabel': 'more';
+    readonly 'entityContextMenu.moreButtonAriaLabel': 'More actions';
     readonly 'entityLabelsCard.title': 'Labels';
     readonly 'entityLabelsCard.readMoreButtonTitle': 'Read more';
     readonly 'entityLabelsCard.columnKeyLabel': 'Label';

--- a/plugins/catalog/report-alpha.api.md
+++ b/plugins/catalog/report-alpha.api.md
@@ -13,6 +13,7 @@ import { defaultEntityContentGroups } from '@backstage/plugin-catalog-react/alph
 import { Entity } from '@backstage/catalog-model';
 import { EntityCardType } from '@backstage/plugin-catalog-react/alpha';
 import { EntityContentLayoutProps } from '@backstage/plugin-catalog-react/alpha';
+import { EntityContextMenuItemData } from '@backstage/plugin-catalog-react/alpha';
 import { EntityContextMenuItemParams } from '@backstage/plugin-catalog-react/alpha';
 import { EntityListContextProps } from '@backstage/plugin-catalog-react';
 import { EntityListPagination } from '@backstage/plugin-catalog-react';
@@ -1005,13 +1006,17 @@ const _default: OverridableFrontendPlugin<
         filter?: FilterPredicate | undefined;
       };
       output:
-        | ExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
         | ExtensionDataRef<
             (entity: Entity) => boolean,
             'catalog.entity-filter-function',
             {
               optional: true;
             }
+          >
+        | ExtensionDataRef<
+            EntityContextMenuItemData,
+            'catalog.entity-context-menu-item-data',
+            {}
           >;
       inputs: {};
       params: EntityContextMenuItemParams;
@@ -1026,13 +1031,17 @@ const _default: OverridableFrontendPlugin<
         filter?: FilterPredicate | undefined;
       };
       output:
-        | ExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
         | ExtensionDataRef<
             (entity: Entity) => boolean,
             'catalog.entity-filter-function',
             {
               optional: true;
             }
+          >
+        | ExtensionDataRef<
+            EntityContextMenuItemData,
+            'catalog.entity-context-menu-item-data',
+            {}
           >;
       inputs: {};
       params: EntityContextMenuItemParams;
@@ -1047,13 +1056,17 @@ const _default: OverridableFrontendPlugin<
         filter?: FilterPredicate | undefined;
       };
       output:
-        | ExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
         | ExtensionDataRef<
             (entity: Entity) => boolean,
             'catalog.entity-filter-function',
             {
               optional: true;
             }
+          >
+        | ExtensionDataRef<
+            EntityContextMenuItemData,
+            'catalog.entity-context-menu-item-data',
+            {}
           >;
       inputs: {};
       params: EntityContextMenuItemParams;
@@ -1388,7 +1401,11 @@ const _default: OverridableFrontendPlugin<
           }
         >;
         contextMenuItems: ExtensionInput<
-          | ConfigurableExtensionDataRef<JSX_2.Element, 'core.reactElement', {}>
+          | ConfigurableExtensionDataRef<
+              EntityContextMenuItemData,
+              'catalog.entity-context-menu-item-data',
+              {}
+            >
           | ConfigurableExtensionDataRef<
               (entity: Entity) => boolean,
               'catalog.entity-filter-function',

--- a/plugins/catalog/report.api.md
+++ b/plugins/catalog/report.api.md
@@ -312,7 +312,7 @@ export const catalogTranslationRef: TranslationRef<
     readonly 'entityContextMenu.inspectMenuTitle': 'Inspect entity';
     readonly 'entityContextMenu.copyURLMenuTitle': 'Copy entity URL';
     readonly 'entityContextMenu.unregisterMenuTitle': 'Unregister entity';
-    readonly 'entityContextMenu.moreButtonAriaLabel': 'more';
+    readonly 'entityContextMenu.moreButtonAriaLabel': 'More actions';
     readonly 'entityLabelsCard.title': 'Labels';
     readonly 'entityLabelsCard.readMoreButtonTitle': 'Read more';
     readonly 'entityLabelsCard.columnKeyLabel': 'Label';

--- a/plugins/catalog/src/alpha/components/EntityContextMenu/EntityContextMenu.test.tsx
+++ b/plugins/catalog/src/alpha/components/EntityContextMenu/EntityContextMenu.test.tsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderInTestApp } from '@backstage/frontend-test-utils';
+import { MenuItem } from '@backstage/ui';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { EntityContextMenu } from './EntityContextMenu';
+
+describe('EntityContextMenu', () => {
+  it('renders the trigger and supplied menu items', async () => {
+    await renderInTestApp(
+      <EntityContextMenu
+        contextMenuItems={[<MenuItem key="supplied">Supplied item</MenuItem>]}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'More actions' }));
+
+    expect(
+      await screen.findByRole('menuitem', { name: 'Supplied item' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders extras first with an icon and separator, and handles actions', async () => {
+    const onClick = jest.fn();
+    const Icon = () => <span data-testid="extra-icon" />;
+
+    await renderInTestApp(
+      <EntityContextMenu
+        UNSTABLE_extraContextMenuItems={[
+          { title: 'Extra item', Icon, onClick },
+        ]}
+        contextMenuItems={[<MenuItem key="supplied">Supplied item</MenuItem>]}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'More actions' }));
+
+    expect(screen.getAllByRole('menuitem')).toHaveLength(2);
+    expect(screen.getAllByRole('menuitem')[0]).toHaveTextContent('Extra item');
+    expect(screen.getByTestId('extra-icon')).toBeInTheDocument();
+    expect(screen.getByRole('separator')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('menuitem', { name: 'Extra item' }));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render a separator without extras', async () => {
+    await renderInTestApp(
+      <EntityContextMenu
+        contextMenuItems={[<MenuItem key="supplied">Supplied item</MenuItem>]}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'More actions' }));
+
+    expect(screen.queryByRole('separator')).not.toBeInTheDocument();
+  });
+
+  it('does not render a separator without supplied items', async () => {
+    await renderInTestApp(
+      <EntityContextMenu
+        UNSTABLE_extraContextMenuItems={[
+          { title: 'Extra item', Icon: () => null, onClick: () => {} },
+        ]}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'More actions' }));
+
+    expect(screen.queryByRole('separator')).not.toBeInTheDocument();
+  });
+
+  it('closes immediately when a supplied async action remains pending', async () => {
+    const pendingAction = new Promise<void>(() => {});
+
+    await renderInTestApp(
+      <EntityContextMenu
+        contextMenuItems={[
+          <MenuItem key="pending" onAction={() => pendingAction}>
+            Pending action
+          </MenuItem>,
+        ]}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'More actions' }));
+    await userEvent.click(
+      await screen.findByRole('menuitem', { name: 'Pending action' }),
+    );
+
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+});

--- a/plugins/catalog/src/alpha/components/EntityContextMenu/EntityContextMenu.test.tsx
+++ b/plugins/catalog/src/alpha/components/EntityContextMenu/EntityContextMenu.test.tsx
@@ -14,25 +14,93 @@
  * limitations under the License.
  */
 
-import { renderInTestApp } from '@backstage/frontend-test-utils';
-import { MenuItem } from '@backstage/ui';
+import {
+  createExtensionTester,
+  renderInTestApp,
+} from '@backstage/frontend-test-utils';
+import {
+  EntityContextMenuItemBlueprint,
+  type EntityContextMenuItemParams,
+} from '@backstage/plugin-catalog-react/alpha';
 import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
 import { EntityContextMenu } from './EntityContextMenu';
 
+function createContextMenuItem(params: EntityContextMenuItemParams) {
+  const extension = EntityContextMenuItemBlueprint.make({
+    name: 'test',
+    params,
+  });
+  const tester = createExtensionTester(extension);
+
+  return {
+    data: tester.get(EntityContextMenuItemBlueprint.dataRefs.data),
+    node: tester.query(extension).node,
+  };
+}
+
 describe('EntityContextMenu', () => {
-  it('renders the trigger and supplied menu items', async () => {
+  it('renders menu item data and invokes useProps as a hook', async () => {
+    const onClick = jest.fn();
+
+    function useProps() {
+      const [title] = useState('Supplied item');
+      return { title, onClick };
+    }
+
     await renderInTestApp(
       <EntityContextMenu
-        contextMenuItems={[<MenuItem key="supplied">Supplied item</MenuItem>]}
+        contextMenuItems={[
+          createContextMenuItem({
+            icon: <span data-testid="supplied-icon" />,
+            useProps,
+          }),
+        ]}
       />,
     );
 
     await userEvent.click(screen.getByRole('button', { name: 'More actions' }));
 
-    expect(
-      await screen.findByRole('menuitem', { name: 'Supplied item' }),
-    ).toBeInTheDocument();
+    const item = await screen.findByRole('menuitem', {
+      name: 'Supplied item',
+    });
+    expect(screen.getByTestId('supplied-icon')).toBeInTheDocument();
+
+    await userEvent.click(item);
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('supports an action alongside an internal link', async () => {
+    const onClick = jest.fn();
+
+    await renderInTestApp(
+      <EntityContextMenu
+        contextMenuItems={[
+          createContextMenuItem({
+            icon: <span />,
+            useProps: () => ({
+              title: 'Linked action',
+              href: '/internal',
+              onClick,
+            }),
+          }),
+        ]}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'More actions' }));
+
+    const item = await screen.findByRole('menuitem', {
+      name: 'Linked action',
+    });
+    expect(item).toHaveAttribute('href', '/internal');
+    expect(item).not.toHaveAttribute('target');
+
+    await userEvent.click(item);
+
+    expect(onClick).toHaveBeenCalledTimes(1);
   });
 
   it('renders extras first with an icon and separator, and handles actions', async () => {
@@ -44,7 +112,15 @@ describe('EntityContextMenu', () => {
         UNSTABLE_extraContextMenuItems={[
           { title: 'Extra item', Icon, onClick },
         ]}
-        contextMenuItems={[<MenuItem key="supplied">Supplied item</MenuItem>]}
+        contextMenuItems={[
+          createContextMenuItem({
+            icon: <span />,
+            useProps: () => ({
+              title: 'Supplied item',
+              onClick: () => {},
+            }),
+          }),
+        ]}
       />,
     );
 
@@ -60,10 +136,52 @@ describe('EntityContextMenu', () => {
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
+  it('supports extra items with duplicate titles', async () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation();
+
+    try {
+      await renderInTestApp(
+        <EntityContextMenu
+          UNSTABLE_extraContextMenuItems={[
+            { title: 'Extra item', Icon: () => null, onClick: () => {} },
+            { title: 'Extra item', Icon: () => null, onClick: () => {} },
+          ]}
+        />,
+      );
+
+      await userEvent.click(
+        screen.getByRole('button', { name: 'More actions' }),
+      );
+
+      expect(
+        screen.getAllByRole('menuitem', { name: 'Extra item' }),
+      ).toHaveLength(2);
+      expect(
+        consoleError.mock.calls.some(args =>
+          args.some(
+            arg =>
+              typeof arg === 'string' &&
+              arg.includes('Encountered two children with the same key'),
+          ),
+        ),
+      ).toBe(false);
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   it('does not render a separator without extras', async () => {
     await renderInTestApp(
       <EntityContextMenu
-        contextMenuItems={[<MenuItem key="supplied">Supplied item</MenuItem>]}
+        contextMenuItems={[
+          createContextMenuItem({
+            icon: <span />,
+            useProps: () => ({
+              title: 'Supplied item',
+              onClick: () => {},
+            }),
+          }),
+        ]}
       />,
     );
 
@@ -92,9 +210,13 @@ describe('EntityContextMenu', () => {
     await renderInTestApp(
       <EntityContextMenu
         contextMenuItems={[
-          <MenuItem key="pending" onAction={() => pendingAction}>
-            Pending action
-          </MenuItem>,
+          createContextMenuItem({
+            icon: <span />,
+            useProps: () => ({
+              title: 'Pending action',
+              onClick: () => pendingAction,
+            }),
+          }),
         ]}
       />,
     );

--- a/plugins/catalog/src/alpha/components/EntityContextMenu/EntityContextMenu.test.tsx
+++ b/plugins/catalog/src/alpha/components/EntityContextMenu/EntityContextMenu.test.tsx
@@ -228,4 +228,34 @@ describe('EntityContextMenu', () => {
 
     expect(screen.queryByRole('menu')).not.toBeInTheDocument();
   });
+
+  it('handles rejections from supplied async actions', async () => {
+    let rejectAction: (error: Error) => void = () => {};
+    const action = new Promise<void>((_, reject) => {
+      rejectAction = reject;
+    });
+    const catchSpy = jest.spyOn(action, 'catch');
+
+    await renderInTestApp(
+      <EntityContextMenu
+        contextMenuItems={[
+          createContextMenuItem({
+            icon: <span />,
+            useProps: () => ({
+              title: 'Rejected action',
+              onClick: () => action,
+            }),
+          }),
+        ]}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'More actions' }));
+    await userEvent.click(
+      await screen.findByRole('menuitem', { name: 'Rejected action' }),
+    );
+
+    expect(catchSpy).toHaveBeenCalledWith(expect.any(Function));
+    rejectAction(new Error('Action failed'));
+  });
 });

--- a/plugins/catalog/src/alpha/components/EntityContextMenu/EntityContextMenu.tsx
+++ b/plugins/catalog/src/alpha/components/EntityContextMenu/EntityContextMenu.tsx
@@ -15,9 +15,12 @@
  */
 
 import {
+  type AppNode,
+  ExtensionBoundary,
   IconComponent,
   useTranslationRef,
 } from '@backstage/frontend-plugin-api';
+import type { EntityContextMenuItemData } from '@backstage/plugin-catalog-react/alpha';
 import {
   ButtonIcon,
   Menu,
@@ -28,6 +31,51 @@ import {
 import { RiMore2Line } from '@remixicon/react';
 import { catalogTranslationRef } from '../../translation';
 
+export type EntityContextMenuItemDataWithNode = {
+  data: EntityContextMenuItemData;
+  node: AppNode;
+};
+
+function EntityContextMenuItemContent(props: {
+  data: EntityContextMenuItemData;
+}) {
+  const { icon, useProps } = props.data;
+  const { title, disabled, ...menuItemProps } = useProps();
+
+  if ('href' in menuItemProps) {
+    return (
+      <MenuItem
+        iconStart={icon}
+        href={menuItemProps.href}
+        onAction={menuItemProps.onClick}
+        isDisabled={disabled}
+      >
+        {title}
+      </MenuItem>
+    );
+  }
+
+  return (
+    <MenuItem
+      iconStart={icon}
+      onAction={menuItemProps.onClick}
+      isDisabled={disabled}
+    >
+      {title}
+    </MenuItem>
+  );
+}
+
+function EntityContextMenuItem(props: {
+  item: EntityContextMenuItemDataWithNode;
+}) {
+  return (
+    <ExtensionBoundary node={props.item.node}>
+      <EntityContextMenuItemContent data={props.item.data} />
+    </ExtensionBoundary>
+  );
+}
+
 /** @alpha */
 export function EntityContextMenu(props: {
   UNSTABLE_extraContextMenuItems?: {
@@ -35,7 +83,7 @@ export function EntityContextMenu(props: {
     Icon: IconComponent;
     onClick: () => void;
   }[];
-  contextMenuItems?: React.JSX.Element[];
+  contextMenuItems?: EntityContextMenuItemDataWithNode[];
 }) {
   const { UNSTABLE_extraContextMenuItems, contextMenuItems } = props;
   const { t } = useTranslationRef(catalogTranslationRef);
@@ -48,9 +96,9 @@ export function EntityContextMenu(props: {
         aria-label={t('entityContextMenu.moreButtonAriaLabel')}
       />
       <Menu placement="bottom end">
-        {UNSTABLE_extraContextMenuItems?.map(item => (
+        {UNSTABLE_extraContextMenuItems?.map((item, index) => (
           <MenuItem
-            key={item.title}
+            key={`${item.title}-${index}`}
             iconStart={<item.Icon />}
             onAction={() => item.onClick()}
           >
@@ -60,7 +108,9 @@ export function EntityContextMenu(props: {
         {UNSTABLE_extraContextMenuItems?.length && contextMenuItems?.length ? (
           <MenuSeparator />
         ) : null}
-        {contextMenuItems}
+        {contextMenuItems?.map(item => (
+          <EntityContextMenuItem key={item.node.spec.id} item={item} />
+        ))}
       </Menu>
     </MenuTrigger>
   );

--- a/plugins/catalog/src/alpha/components/EntityContextMenu/EntityContextMenu.tsx
+++ b/plugins/catalog/src/alpha/components/EntityContextMenu/EntityContextMenu.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  IconComponent,
+  useTranslationRef,
+} from '@backstage/frontend-plugin-api';
+import {
+  ButtonIcon,
+  Menu,
+  MenuItem,
+  MenuSeparator,
+  MenuTrigger,
+} from '@backstage/ui';
+import { RiMore2Line } from '@remixicon/react';
+import { catalogTranslationRef } from '../../translation';
+
+/** @alpha */
+export function EntityContextMenu(props: {
+  UNSTABLE_extraContextMenuItems?: {
+    title: string;
+    Icon: IconComponent;
+    onClick: () => void;
+  }[];
+  contextMenuItems?: React.JSX.Element[];
+}) {
+  const { UNSTABLE_extraContextMenuItems, contextMenuItems } = props;
+  const { t } = useTranslationRef(catalogTranslationRef);
+
+  return (
+    <MenuTrigger>
+      <ButtonIcon
+        variant="secondary"
+        icon={<RiMore2Line />}
+        aria-label={t('entityContextMenu.moreButtonAriaLabel')}
+      />
+      <Menu placement="bottom end">
+        {UNSTABLE_extraContextMenuItems?.map(item => (
+          <MenuItem
+            key={item.title}
+            iconStart={<item.Icon />}
+            onAction={() => item.onClick()}
+          >
+            {item.title}
+          </MenuItem>
+        ))}
+        {UNSTABLE_extraContextMenuItems?.length && contextMenuItems?.length ? (
+          <MenuSeparator />
+        ) : null}
+        {contextMenuItems}
+      </Menu>
+    </MenuTrigger>
+  );
+}

--- a/plugins/catalog/src/alpha/components/EntityContextMenu/EntityContextMenu.tsx
+++ b/plugins/catalog/src/alpha/components/EntityContextMenu/EntityContextMenu.tsx
@@ -40,14 +40,23 @@ function EntityContextMenuItemContent(props: {
   data: EntityContextMenuItemData;
 }) {
   const { icon, useProps } = props.data;
-  const { title, disabled, ...menuItemProps } = useProps();
+  const { title, disabled, onClick, ...menuItemProps } = useProps();
+  const onAction = onClick
+    ? () => {
+        const result = onClick();
+        if (result) {
+          // Prevent rejected async actions from becoming unhandled rejections.
+          void result.catch(() => {});
+        }
+      }
+    : undefined;
 
   if ('href' in menuItemProps) {
     return (
       <MenuItem
         iconStart={icon}
         href={menuItemProps.href}
-        onAction={menuItemProps.onClick}
+        onAction={onAction}
         isDisabled={disabled}
       >
         {title}
@@ -56,11 +65,7 @@ function EntityContextMenuItemContent(props: {
   }
 
   return (
-    <MenuItem
-      iconStart={icon}
-      onAction={menuItemProps.onClick}
-      isDisabled={disabled}
-    >
+    <MenuItem iconStart={icon} onAction={onAction} isDisabled={disabled}>
       {title}
     </MenuItem>
   );

--- a/plugins/catalog/src/alpha/components/EntityContextMenu/index.ts
+++ b/plugins/catalog/src/alpha/components/EntityContextMenu/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { EntityContextMenu } from './EntityContextMenu';

--- a/plugins/catalog/src/alpha/components/EntityContextMenu/index.ts
+++ b/plugins/catalog/src/alpha/components/EntityContextMenu/index.ts
@@ -14,4 +14,7 @@
  * limitations under the License.
  */
 
-export { EntityContextMenu } from './EntityContextMenu';
+export {
+  EntityContextMenu,
+  type EntityContextMenuItemDataWithNode,
+} from './EntityContextMenu';

--- a/plugins/catalog/src/alpha/components/EntityHeader/EntityHeader.tsx
+++ b/plugins/catalog/src/alpha/components/EntityHeader/EntityHeader.tsx
@@ -42,7 +42,10 @@ import {
 } from '@backstage/plugin-catalog-react';
 
 import { EntityLabels } from '../EntityLabels';
-import { EntityContextMenu } from '../EntityContextMenu';
+import {
+  EntityContextMenu,
+  type EntityContextMenuItemDataWithNode,
+} from '../EntityContextMenu';
 
 function headerProps(
   paramKind: string | undefined,
@@ -161,7 +164,7 @@ export function EntityHeader(props: {
     Icon: IconComponent;
     onClick: () => void;
   }[];
-  contextMenuItems?: React.JSX.Element[];
+  contextMenuItems?: EntityContextMenuItemDataWithNode[];
   /**
    * An array of relation types used to determine the parent entities in the hierarchy.
    * These relations are prioritized in the order provided, allowing for flexible

--- a/plugins/catalog/src/alpha/components/EntityHeader/EntityHeader.tsx
+++ b/plugins/catalog/src/alpha/components/EntityHeader/EntityHeader.tsx
@@ -14,25 +14,15 @@
  * limitations under the License.
  */
 
-import {
-  useState,
-  useCallback,
-  useEffect,
-  ComponentProps,
-  ReactNode,
-} from 'react';
-import { useNavigate, useLocation, useSearchParams } from 'react-router-dom';
+import { useCallback, ComponentProps, ReactNode } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import useAsync from 'react-use/esm/useAsync';
 
 import { makeStyles } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 
 import { Header, Breadcrumbs } from '@backstage/core-components';
-import {
-  useApi,
-  useRouteRef,
-  useRouteRefParams,
-} from '@backstage/core-plugin-api';
+import { useApi, useRouteRefParams } from '@backstage/core-plugin-api';
 import { IconComponent } from '@backstage/frontend-plugin-api';
 
 import {
@@ -47,14 +37,12 @@ import {
   catalogApiRef,
   EntityRefLink,
   InspectEntityDialog,
-  UnregisterEntityDialog,
   EntityDisplayName,
   FavoriteEntity,
 } from '@backstage/plugin-catalog-react';
 
 import { EntityLabels } from '../EntityLabels';
-import { EntityContextMenu } from '../../../components/EntityContextMenu';
-import { rootRouteRef, unregisterRedirectRouteRef } from '../../../routes';
+import { EntityContextMenu } from '../EntityContextMenu';
 
 function headerProps(
   paramKind: string | undefined,
@@ -173,11 +161,6 @@ export function EntityHeader(props: {
     Icon: IconComponent;
     onClick: () => void;
   }[];
-  // NOTE(blam): Intentionally not exported at this point, since it's part of
-  // unstable context menu option, eg: disable the unregister entity menu
-  UNSTABLE_contextMenuOptions?: {
-    disableUnregister: boolean | 'visible' | 'hidden' | 'disable';
-  };
   contextMenuItems?: React.JSX.Element[];
   /**
    * An array of relation types used to determine the parent entities in the hierarchy.
@@ -195,7 +178,6 @@ export function EntityHeader(props: {
 }) {
   const {
     UNSTABLE_extraContextMenuItems,
-    UNSTABLE_contextMenuOptions,
     contextMenuItems,
     parentEntityRelations,
     title,
@@ -210,52 +192,11 @@ export function EntityHeader(props: {
     entity,
   );
 
-  const location = useLocation();
-  const navigate = useNavigate();
-  const catalogRoute = useRouteRef(rootRouteRef);
-  const unregisterRedirectRoute = useRouteRef(unregisterRedirectRouteRef);
-
-  const [confirmationDialogOpen, setConfirmationDialogOpen] = useState(false);
-
-  const openUnregisterEntityDialog = useCallback(
-    () => setConfirmationDialogOpen(true),
-    [setConfirmationDialogOpen],
-  );
-
-  const closeUnregisterEntityDialog = useCallback(
-    () => setConfirmationDialogOpen(false),
-    [setConfirmationDialogOpen],
-  );
-
-  const cleanUpAfterUnregisterConfirmation = useCallback(async () => {
-    setConfirmationDialogOpen(false);
-    navigate(
-      unregisterRedirectRoute ? unregisterRedirectRoute() : catalogRoute(),
-    );
-  }, [
-    navigate,
-    catalogRoute,
-    unregisterRedirectRoute,
-    setConfirmationDialogOpen,
-  ]);
-
-  // Make sure to close the dialog if the user clicks links in it that navigate
-  // to another entity.
-  useEffect(() => {
-    setConfirmationDialogOpen(false);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [location.pathname]);
-
   const [searchParams, setSearchParams] = useSearchParams();
   const selectedInspectEntityDialogTab = searchParams.get('inspect');
 
   const setInspectEntityDialogTab = useCallback(
     (newTab: string) => setSearchParams(`inspect=${newTab}`),
-    [setSearchParams],
-  );
-
-  const openInspectEntityDialog = useCallback(
-    () => setSearchParams('inspect'),
     [setSearchParams],
   );
 
@@ -282,10 +223,7 @@ export function EntityHeader(props: {
           <EntityLabels entity={entity} />
           <EntityContextMenu
             UNSTABLE_extraContextMenuItems={UNSTABLE_extraContextMenuItems}
-            UNSTABLE_contextMenuOptions={UNSTABLE_contextMenuOptions}
             contextMenuItems={contextMenuItems}
-            onInspectEntity={openInspectEntityDialog}
-            onUnregisterEntity={openUnregisterEntityDialog}
           />
           <InspectEntityDialog
             entity={entity!}
@@ -297,12 +235,6 @@ export function EntityHeader(props: {
             open={inspectDialogOpen}
             onClose={closeInspectEntityDialog}
             onSelect={setInspectEntityDialogTab}
-          />
-          <UnregisterEntityDialog
-            entity={entity!}
-            open={confirmationDialogOpen}
-            onClose={closeUnregisterEntityDialog}
-            onConfirm={cleanUpAfterUnregisterConfirmation}
           />
         </>
       )}

--- a/plugins/catalog/src/alpha/components/EntityLayout/EntityLayout.tsx
+++ b/plugins/catalog/src/alpha/components/EntityLayout/EntityLayout.tsx
@@ -58,9 +58,6 @@ attachComponentData(Route, 'core.gatherMountPoints', true); // This causes all m
 
 /** @public */
 export interface EntityLayoutProps {
-  UNSTABLE_contextMenuOptions?: ComponentProps<
-    typeof EntityHeader
-  >['UNSTABLE_contextMenuOptions'];
   UNSTABLE_extraContextMenuItems?: ComponentProps<
     typeof EntityHeader
   >['UNSTABLE_extraContextMenuItems'];
@@ -104,7 +101,6 @@ export interface EntityLayoutProps {
 export const EntityLayout = (props: EntityLayoutProps) => {
   const {
     UNSTABLE_extraContextMenuItems,
-    UNSTABLE_contextMenuOptions,
     contextMenuItems,
     children,
     header,
@@ -154,7 +150,6 @@ export const EntityLayout = (props: EntityLayoutProps) => {
       {header ?? (
         <EntityHeader
           parentEntityRelations={parentEntityRelations}
-          UNSTABLE_contextMenuOptions={UNSTABLE_contextMenuOptions}
           UNSTABLE_extraContextMenuItems={UNSTABLE_extraContextMenuItems}
           contextMenuItems={contextMenuItems}
         />

--- a/plugins/catalog/src/alpha/contextMenuItems.test.tsx
+++ b/plugins/catalog/src/alpha/contextMenuItems.test.tsx
@@ -27,8 +27,11 @@ import {
 } from '@backstage/frontend-plugin-api';
 import { Entity } from '@backstage/catalog-model';
 import { EntityProvider } from '@backstage/plugin-catalog-react';
+import {
+  EntityContextMenuItemBlueprint,
+  type EntityContextMenuItemData,
+} from '@backstage/plugin-catalog-react/alpha';
 import { AuthorizeResult } from '@backstage/plugin-permission-common';
-import { Button, Menu, MenuTrigger } from '@backstage/ui';
 import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
@@ -41,13 +44,13 @@ import {
   RiFileCopyLine,
   type RemixiconComponentType,
 } from '@remixicon/react';
-import { renderToStaticMarkup } from 'react-dom/server';
 import {
   copyEntityUrlContextMenuItem,
   inspectEntityContextMenuItem,
   unregisterEntityContextMenuItem,
 } from './contextMenuItems';
 import { rootRouteRef, unregisterRedirectRouteRef } from '../routes';
+import { EntityContextMenu } from './components/EntityContextMenu';
 
 const useCopyToClipboard = jest.mocked(useCopyToClipboardUnmocked);
 jest.mock('react-use/esm/useCopyToClipboard', () => jest.fn());
@@ -81,13 +84,16 @@ function renderMenuItem(
   extension: ExtensionDefinition,
   options: TestAppOptions = {},
 ) {
+  const tester = createExtensionTester(extension);
+  const item = {
+    data: tester.get(EntityContextMenuItemBlueprint.dataRefs.data),
+    node: tester.query(extension).node,
+  };
+
   return renderInTestApp(
     <SWRConfig value={{ provider: () => new Map() }}>
       <EntityProvider entity={entity}>
-        <MenuTrigger isOpen>
-          <Button>Menu</Button>
-          <Menu>{createExtensionTester(extension).reactElement()}</Menu>
-        </MenuTrigger>
+        <EntityContextMenu contextMenuItems={[item]} />
         <RouterProbe />
       </EntityProvider>
     </SWRConfig>,
@@ -96,6 +102,7 @@ function renderMenuItem(
 }
 
 async function findMenuItem(name: string) {
+  await userEvent.click(screen.getByRole('button', { name: 'More actions' }));
   return screen.findByRole('menuitem', { name });
 }
 
@@ -107,14 +114,16 @@ function createDialog(close: jest.Mock): DialogApiDialog {
   };
 }
 
-function expectIcon(menuItem: HTMLElement, Icon: RemixiconComponentType) {
-  const container = document.createElement('div');
-  container.innerHTML = renderToStaticMarkup(<Icon size={16} />);
-
-  expect(menuItem.querySelector('svg path')).toHaveAttribute(
-    'd',
-    container.querySelector('svg path')?.getAttribute('d'),
+function expectIcon(
+  extension: ExtensionDefinition,
+  Icon: RemixiconComponentType,
+) {
+  const tester = createExtensionTester(extension);
+  const data: EntityContextMenuItemData = tester.get(
+    EntityContextMenuItemBlueprint.dataRefs.data,
   );
+
+  expect(data.icon?.type).toBe(Icon);
 }
 
 describe('context menu items', () => {
@@ -134,7 +143,7 @@ describe('context menu items', () => {
     });
 
     const menuItem = await findMenuItem('Copy entity URL');
-    expectIcon(menuItem, RiFileCopyLine);
+    expectIcon(copyEntityUrlContextMenuItem, RiFileCopyLine);
     await userEvent.click(menuItem);
 
     expect(copyToClipboard).toHaveBeenCalledWith(window.location.toString());
@@ -163,7 +172,7 @@ describe('context menu items', () => {
     renderMenuItem(inspectEntityContextMenuItem);
 
     const menuItem = await findMenuItem('Inspect entity');
-    expectIcon(menuItem, RiBugLine);
+    expectIcon(inspectEntityContextMenuItem, RiBugLine);
     await userEvent.click(menuItem);
 
     expect(screen.getByLabelText('search params')).toHaveTextContent(
@@ -184,7 +193,7 @@ describe('context menu items', () => {
     });
 
     const menuItem = await findMenuItem('Unregister entity');
-    expectIcon(menuItem, RiDeleteBinLine);
+    expectIcon(unregisterEntityContextMenuItem, RiDeleteBinLine);
     await waitFor(() =>
       expect(menuItem).toHaveAttribute('aria-disabled', 'true'),
     );

--- a/plugins/catalog/src/alpha/contextMenuItems.test.tsx
+++ b/plugins/catalog/src/alpha/contextMenuItems.test.tsx
@@ -1,0 +1,286 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  createExtensionTester,
+  mockApis,
+  renderInTestApp,
+  type TestAppOptions,
+} from '@backstage/frontend-test-utils';
+import {
+  dialogApiRef,
+  type DialogApiDialog,
+  type ExtensionDefinition,
+} from '@backstage/frontend-plugin-api';
+import { Entity } from '@backstage/catalog-model';
+import { EntityProvider } from '@backstage/plugin-catalog-react';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
+import { Button, Menu, MenuTrigger } from '@backstage/ui';
+import { act, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
+import useCopyToClipboardUnmocked from 'react-use/esm/useCopyToClipboard';
+import { SWRConfig } from 'swr';
+import { convertLegacyRouteRef } from '@backstage/core-compat-api';
+import {
+  RiBugLine,
+  RiDeleteBinLine,
+  RiFileCopyLine,
+  type RemixiconComponentType,
+} from '@remixicon/react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import {
+  copyEntityUrlContextMenuItem,
+  inspectEntityContextMenuItem,
+  unregisterEntityContextMenuItem,
+} from './contextMenuItems';
+import { rootRouteRef, unregisterRedirectRouteRef } from '../routes';
+
+const useCopyToClipboard = jest.mocked(useCopyToClipboardUnmocked);
+jest.mock('react-use/esm/useCopyToClipboard', () => jest.fn());
+jest.mock('@backstage/plugin-catalog-react', () => ({
+  ...jest.requireActual('@backstage/plugin-catalog-react'),
+  UnregisterEntityDialog: () => null,
+}));
+
+const entity: Entity = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Component',
+  metadata: { name: 'artist-lookup' },
+};
+
+let navigateTo: ReturnType<typeof useNavigate>;
+
+function RouterProbe() {
+  const { pathname } = useLocation();
+  navigateTo = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  return (
+    <>
+      <output aria-label="pathname">{pathname}</output>
+      <output aria-label="search params">{searchParams.toString()}</output>
+    </>
+  );
+}
+
+function renderMenuItem(
+  extension: ExtensionDefinition,
+  options: TestAppOptions = {},
+) {
+  return renderInTestApp(
+    <SWRConfig value={{ provider: () => new Map() }}>
+      <EntityProvider entity={entity}>
+        <MenuTrigger isOpen>
+          <Button>Menu</Button>
+          <Menu>{createExtensionTester(extension).reactElement()}</Menu>
+        </MenuTrigger>
+        <RouterProbe />
+      </EntityProvider>
+    </SWRConfig>,
+    { initialRouteEntries: ['/entity'], ...options },
+  );
+}
+
+async function findMenuItem(name: string) {
+  return screen.findByRole('menuitem', { name });
+}
+
+function createDialog(close: jest.Mock): DialogApiDialog {
+  return {
+    close,
+    update: jest.fn(),
+    result: jest.fn(),
+  };
+}
+
+function expectIcon(menuItem: HTMLElement, Icon: RemixiconComponentType) {
+  const container = document.createElement('div');
+  container.innerHTML = renderToStaticMarkup(<Icon size={16} />);
+
+  expect(menuItem.querySelector('svg path')).toHaveAttribute(
+    'd',
+    container.querySelector('svg path')?.getAttribute('d'),
+  );
+}
+
+describe('context menu items', () => {
+  const copyToClipboard = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useCopyToClipboard.mockReturnValue([
+      { noUserInteraction: false },
+      copyToClipboard,
+    ]);
+  });
+
+  it('copies the entity URL', async () => {
+    renderMenuItem(copyEntityUrlContextMenuItem, {
+      apis: [mockApis.alert()],
+    });
+
+    const menuItem = await findMenuItem('Copy entity URL');
+    expectIcon(menuItem, RiFileCopyLine);
+    await userEvent.click(menuItem);
+
+    expect(copyToClipboard).toHaveBeenCalledWith(window.location.toString());
+  });
+
+  it('posts a transient alert when the entity URL was copied', async () => {
+    const alertApi = mockApis.alert();
+    useCopyToClipboard.mockReturnValue([
+      { noUserInteraction: false, value: 'copied' },
+      copyToClipboard,
+    ]);
+
+    renderMenuItem(copyEntityUrlContextMenuItem, { apis: [alertApi] });
+
+    await findMenuItem('Copy entity URL');
+    await waitFor(() =>
+      expect(alertApi.getAlerts()).toContainEqual({
+        message: 'Copied!',
+        severity: 'info',
+        display: 'transient',
+      }),
+    );
+  });
+
+  it('opens the inspect dialog through search params', async () => {
+    renderMenuItem(inspectEntityContextMenuItem);
+
+    const menuItem = await findMenuItem('Inspect entity');
+    expectIcon(menuItem, RiBugLine);
+    await userEvent.click(menuItem);
+
+    expect(screen.getByLabelText('search params')).toHaveTextContent(
+      'inspect=',
+    );
+  });
+
+  it('disables unregister when delete permission is denied', async () => {
+    const open = jest.fn();
+    renderMenuItem(unregisterEntityContextMenuItem, {
+      apis: [
+        mockApis.permission({ authorize: AuthorizeResult.DENY }),
+        [dialogApiRef, { open }],
+      ],
+      mountedRoutes: {
+        '/catalog': convertLegacyRouteRef(rootRouteRef),
+      },
+    });
+
+    const menuItem = await findMenuItem('Unregister entity');
+    expectIcon(menuItem, RiDeleteBinLine);
+    await waitFor(() =>
+      expect(menuItem).toHaveAttribute('aria-disabled', 'true'),
+    );
+    await userEvent.click(menuItem);
+
+    expect(open).not.toHaveBeenCalled();
+  });
+
+  it('opens unregister and falls back to the catalog route after confirmation', async () => {
+    const close = jest.fn();
+    const open = jest.fn();
+    renderMenuItem(unregisterEntityContextMenuItem, {
+      apis: [mockApis.permission(), [dialogApiRef, { open }]],
+      mountedRoutes: {
+        '/catalog': convertLegacyRouteRef(rootRouteRef),
+      },
+    });
+
+    const menuItem = await findMenuItem('Unregister entity');
+    await waitFor(() => expect(menuItem).not.toHaveAttribute('aria-disabled'));
+    await userEvent.click(menuItem);
+
+    const renderDialog = open.mock.calls[0][0] as (props: {
+      dialog: DialogApiDialog;
+    }) => JSX.Element;
+    const dialog = renderDialog({ dialog: createDialog(close) });
+    act(() => dialog.props.onConfirm());
+
+    expect(close).toHaveBeenCalledTimes(1);
+    await waitFor(() =>
+      expect(screen.getByLabelText('pathname')).toHaveTextContent('/catalog'),
+    );
+  });
+
+  it('closes unregister when navigating to another entity', async () => {
+    const close = jest.fn();
+    const open = jest.fn();
+    const { unmount } = renderMenuItem(unregisterEntityContextMenuItem, {
+      apis: [mockApis.permission(), [dialogApiRef, { open }]],
+      mountedRoutes: {
+        '/catalog': convertLegacyRouteRef(rootRouteRef),
+      },
+    });
+
+    const menuItem = await findMenuItem('Unregister entity');
+    await waitFor(() => expect(menuItem).not.toHaveAttribute('aria-disabled'));
+    await userEvent.click(menuItem);
+
+    const renderDialog = open.mock.calls[0][0] as (props: {
+      dialog: DialogApiDialog;
+    }) => JSX.Element;
+    const dialog = {
+      close,
+      update: jest.fn(),
+      result: jest.fn(),
+    } satisfies DialogApiDialog;
+    unmount();
+    await renderInTestApp(
+      <>
+        {renderDialog({ dialog })}
+        <RouterProbe />
+      </>,
+      { initialRouteEntries: ['/entity'] },
+    );
+    expect(close).not.toHaveBeenCalled();
+    act(() => navigateTo('/catalog/default/component/other'));
+
+    await waitFor(() => expect(close).toHaveBeenCalledTimes(1));
+  });
+
+  it('prefers the unregister redirect route after confirmation', async () => {
+    const close = jest.fn();
+    const open = jest.fn();
+    renderMenuItem(unregisterEntityContextMenuItem, {
+      apis: [mockApis.permission(), [dialogApiRef, { open }]],
+      mountedRoutes: {
+        '/catalog': convertLegacyRouteRef(rootRouteRef),
+        '/after-unregister': convertLegacyRouteRef(unregisterRedirectRouteRef),
+      },
+    });
+
+    const menuItem = await findMenuItem('Unregister entity');
+    await waitFor(() => expect(menuItem).not.toHaveAttribute('aria-disabled'));
+    await userEvent.click(menuItem);
+
+    const renderDialog = open.mock.calls[0][0] as (props: {
+      dialog: DialogApiDialog;
+    }) => JSX.Element;
+    const dialog = renderDialog({ dialog: createDialog(close) });
+    act(() => dialog.props.onConfirm());
+
+    expect(close).toHaveBeenCalledTimes(1);
+    await waitFor(() =>
+      expect(screen.getByLabelText('pathname')).toHaveTextContent(
+        '/after-unregister',
+      ),
+    );
+  });
+});

--- a/plugins/catalog/src/alpha/contextMenuItems.tsx
+++ b/plugins/catalog/src/alpha/contextMenuItems.tsx
@@ -18,9 +18,7 @@ import {
   EntityContextMenuItemBlueprint,
   useEntityPermission,
 } from '@backstage/plugin-catalog-react/alpha';
-import FileCopyTwoToneIcon from '@material-ui/icons/FileCopyTwoTone';
-import BugReportIcon from '@material-ui/icons/BugReport';
-import CancelIcon from '@material-ui/icons/Cancel';
+import { RiBugLine, RiDeleteBinLine, RiFileCopyLine } from '@remixicon/react';
 import useCopyToClipboard from 'react-use/esm/useCopyToClipboard';
 import { alertApiRef, useApi, useRouteRef } from '@backstage/core-plugin-api';
 import {
@@ -28,20 +26,36 @@ import {
   useTranslationRef,
 } from '@backstage/frontend-plugin-api';
 import { catalogTranslationRef } from './translation';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import {
   UnregisterEntityDialog,
   useEntity,
 } from '@backstage/plugin-catalog-react';
 import { rootRouteRef, unregisterRedirectRouteRef } from '../routes';
 import { catalogEntityDeletePermission } from '@backstage/plugin-catalog-common/alpha';
-import { useEffect } from 'react';
+import { type ComponentProps, useEffect, useRef } from 'react';
+
+function UnregisterEntityDialogWithCloseOnRouteChange(
+  props: ComponentProps<typeof UnregisterEntityDialog>,
+) {
+  const { pathname } = useLocation();
+  const initialPathname = useRef(pathname);
+  const { onClose } = props;
+
+  useEffect(() => {
+    if (pathname !== initialPathname.current) {
+      onClose();
+    }
+  }, [pathname, onClose]);
+
+  return <UnregisterEntityDialog {...props} />;
+}
 
 export const copyEntityUrlContextMenuItem = EntityContextMenuItemBlueprint.make(
   {
     name: 'copy-entity-url',
     params: {
-      icon: <FileCopyTwoToneIcon fontSize="small" />,
+      icon: <RiFileCopyLine size={16} />,
       useProps: () => {
         const [copyState, copyToClipboard] = useCopyToClipboard();
         const alertApi = useApi(alertApiRef);
@@ -72,7 +86,7 @@ export const inspectEntityContextMenuItem = EntityContextMenuItemBlueprint.make(
   {
     name: 'inspect-entity',
     params: {
-      icon: <BugReportIcon fontSize="small" />,
+      icon: <RiBugLine size={16} />,
       useProps: () => {
         const [_, setSearchParams] = useSearchParams();
         const { t } = useTranslationRef(catalogTranslationRef);
@@ -92,7 +106,7 @@ export const unregisterEntityContextMenuItem =
   EntityContextMenuItemBlueprint.make({
     name: 'unregister-entity',
     params: {
-      icon: <CancelIcon fontSize="small" />,
+      icon: <RiDeleteBinLine size={16} />,
       useProps: () => {
         const { entity } = useEntity();
         const dialogApi = useApi(dialogApiRef);
@@ -110,7 +124,7 @@ export const unregisterEntityContextMenuItem =
           disabled: !unregisterPermission.allowed,
           onClick: async () => {
             dialogApi.open(({ dialog }) => (
-              <UnregisterEntityDialog
+              <UnregisterEntityDialogWithCloseOnRouteChange
                 open
                 entity={entity}
                 onClose={() => dialog.close()}

--- a/plugins/catalog/src/alpha/pages.test.tsx
+++ b/plugins/catalog/src/alpha/pages.test.tsx
@@ -35,6 +35,7 @@ import {
 import { convertLegacyRouteRef } from '@backstage/core-compat-api';
 import { rootRouteRef } from '../routes';
 import { Entity } from '@backstage/catalog-model';
+import { useAppNode } from '@backstage/frontend-plugin-api';
 
 jest.setTimeout(30_000);
 
@@ -686,6 +687,48 @@ describe('Entity page', () => {
     const onClickMock = jest.fn();
     beforeEach(() => {
       onClickMock.mockReset();
+    });
+
+    it('should render menu items within their extension boundary', async () => {
+      const useProps = () => ({
+        title: useAppNode()!.spec.id,
+        onClick: onClickMock,
+      });
+      const menuItem = EntityContextMenuItemBlueprint.make({
+        name: 'test-boundary',
+        params: {
+          icon: <span>Test Icon</span>,
+          useProps,
+        },
+      });
+      const tester = createExtensionTester(
+        Object.assign({ namespace: 'catalog' }, catalogEntityPage),
+      ).add(menuItem);
+      const menuItemExtensionId = tester.query(menuItem).node.spec.id;
+
+      await renderInTestApp(tester.reactElement(), {
+        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
+        mountPath: '/catalog/:namespace/:kind/:name',
+        initialRouteEntries: [entityPath],
+        config: {
+          app: {
+            title: 'Custom app',
+          },
+          backend: { baseUrl: 'http://localhost:7000' },
+        },
+        mountedRoutes: {
+          '/catalog': convertLegacyRouteRef(rootRouteRef),
+          '/catalog/:namespace/:kind/:name':
+            convertLegacyRouteRef(entityRouteRef),
+        },
+      });
+
+      await userEvent.click(
+        await screen.findByRole('button', { name: 'More actions' }),
+      );
+
+      const title = await screen.findByText(menuItemExtensionId);
+      expect(title.closest('[role="menuitem"]')).not.toBeNull();
     });
 
     it.each([

--- a/plugins/catalog/src/alpha/pages.test.tsx
+++ b/plugins/catalog/src/alpha/pages.test.tsx
@@ -735,13 +735,19 @@ describe('Entity page', () => {
       });
       const { disabled } = params.useProps();
 
-      await userEvent.click(await screen.findByTestId('menu-button'));
+      await userEvent.click(
+        await screen.findByRole('button', { name: 'More actions' }),
+      );
 
-      const title = await screen.findByText('Test Title');
+      const menuItemElement = (await screen.findByText('Test Title')).closest(
+        '[role="menuitem"]',
+      );
+      expect(menuItemElement).not.toBeNull();
       await expect(screen.findByText('Test Icon')).resolves.toBeInTheDocument();
-      const anchor = title.closest('a');
-      expect(anchor).toHaveAttribute('href', '/somewhere');
-      expect(anchor).toHaveAttribute('aria-disabled', disabled.toString());
+      expect(menuItemElement).toHaveAttribute('href', '/somewhere');
+      expect(menuItemElement?.getAttribute('aria-disabled')).toBe(
+        disabled ? 'true' : null,
+      );
     });
 
     it.each([
@@ -794,17 +800,21 @@ describe('Entity page', () => {
         screen.findByText(/artist-lookup/),
       ).resolves.toBeInTheDocument();
 
-      await userEvent.click(await screen.findByTestId('menu-button'));
+      await userEvent.click(
+        await screen.findByRole('button', { name: 'More actions' }),
+      );
 
-      await expect(
-        screen.findByText('Test Title'),
-      ).resolves.toBeInTheDocument();
+      const menuItemElement = (await screen.findByText('Test Title')).closest(
+        '[role="menuitem"]',
+      );
+      expect(menuItemElement).not.toBeNull();
 
       await expect(screen.findByText('Test Icon')).resolves.toBeInTheDocument();
-      const listItem = (await screen.findByText('Test Title')).closest('li');
-      expect(listItem).toHaveAttribute('aria-disabled', disabled.toString());
+      expect(menuItemElement?.getAttribute('aria-disabled')).toBe(
+        disabled ? 'true' : null,
+      );
       if (!disabled) {
-        await userEvent.click(screen.getByText('Test Title'));
+        await userEvent.click(menuItemElement!);
       }
 
       expect(onClickMock).toHaveBeenCalledTimes(disabled ? 0 : 1);
@@ -882,7 +892,9 @@ describe('Entity page', () => {
           ],
         });
 
-        await userEvent.click(await screen.findByTestId('menu-button'));
+        await userEvent.click(
+          await screen.findByRole('button', { name: 'More actions' }),
+        );
 
         await expect(
           screen.findByText('Should Render'),

--- a/plugins/catalog/src/alpha/pages.tsx
+++ b/plugins/catalog/src/alpha/pages.tsx
@@ -167,7 +167,7 @@ export const catalogEntityPage = PageBlueprint.makeWithOverrides({
       EntityContentBlueprint.dataRefs.icon.optional(),
     ]),
     contextMenuItems: createExtensionInput([
-      coreExtensionData.reactElement,
+      EntityContextMenuItemBlueprint.dataRefs.data,
       EntityContextMenuItemBlueprint.dataRefs.filterFunction.optional(),
     ]),
   },
@@ -207,7 +207,8 @@ export const catalogEntityPage = PageBlueprint.makeWithOverrides({
         const { EntityLayout } = await import('./components/EntityLayout');
 
         const menuItems = inputs.contextMenuItems.map(item => ({
-          element: item.get(coreExtensionData.reactElement),
+          data: item.get(EntityContextMenuItemBlueprint.dataRefs.data),
+          node: item.node,
           filter:
             item.get(EntityContextMenuItemBlueprint.dataRefs.filterFunction) ??
             (() => true),
@@ -237,7 +238,9 @@ export const catalogEntityPage = PageBlueprint.makeWithOverrides({
           const entityFromUrl = useEntityFromUrl();
           const { entity } = entityFromUrl;
           const filteredMenuItems = entity
-            ? menuItems.filter(i => i.filter(entity)).map(i => i.element)
+            ? menuItems
+                .filter(i => i.filter(entity))
+                .map(({ data, node }) => ({ data, node }))
             : [];
 
           const header = headers.find(

--- a/plugins/catalog/src/alpha/translation.ts
+++ b/plugins/catalog/src/alpha/translation.ts
@@ -110,7 +110,7 @@ export const catalogTranslationRef = createTranslationRef({
       inspectMenuTitle: 'Inspect entity',
       copyURLMenuTitle: 'Copy entity URL',
       unregisterMenuTitle: 'Unregister entity',
-      moreButtonAriaLabel: 'more',
+      moreButtonAriaLabel: 'More actions',
     },
     entityLabelsCard: {
       title: 'Labels',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Migrates the Catalog entity page context menu in the new frontend system from MUI to BUI. This is in preparation of a coming PR that aligns the whole entity page with the new BUI header system.

This change:

- Updates `EntityContextMenuItemBlueprint` to render BUI menu items.
- Adds a BUI context menu host for the Catalog entity page.
- Migrates the built-in actions to Remix icons.
- Opens the unregister dialog through `dialogApiRef`.
- Preserves unregister redirects and route-change dialog closing.
- Retains sizing compatibility for custom MUI icons.
- Removes unused new frontend system `UNSTABLE_contextMenuOptions` plumbing.
- Changes the default menu button label from `more` to `More actions`.

The old frontend system Catalog context menu is unchanged.

### Screenshots

#### Before

<img width="1298" height="992" alt="image" src="https://github.com/user-attachments/assets/317c5caf-54db-4967-9542-963cb1c03909" />

<img width="1297" height="991" alt="image" src="https://github.com/user-attachments/assets/e347d26e-35b5-4a32-b0d7-c99e8d22b261" />


#### After

<img width="1297" height="990" alt="image" src="https://github.com/user-attachments/assets/2aac878c-6a84-4c12-9997-325f4814c600" />

<img width="1298" height="992" alt="image" src="https://github.com/user-attachments/assets/f0c2ab2a-55d4-4d01-9ada-a416c1f1a5b3" />

### Verification

- `yarn tsc`
- `yarn lint --fix`
- Focused Catalog and Catalog React context-menu tests
- Legacy Catalog context-menu and entity-layout tests
- `yarn build:api-reports`

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
