### PR TITLE
OpenApiDefinition fixed deepLinking scroll to element

### DIFF
--- a/.changeset/fair-forks-laugh.md
+++ b/.changeset/fair-forks-laugh.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-api-docs': patch
 ---
 
-OpenApi Swagger widget - fixed deep-linking scroll to element
+Fixed deep linking in OpenAPI definition widget.

--- a/.changeset/fair-forks-laugh.md
+++ b/.changeset/fair-forks-laugh.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-api-docs': patch
 ---
 
-OpenApi Swagger widget - fixed deepLinking scroll to element
+OpenApi Swagger widget - fixed deep-linking scroll to element

--- a/.changeset/fair-forks-laugh.md
+++ b/.changeset/fair-forks-laugh.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': patch
+---
+
+OpenApi Swagger widget - fixed deepLinking scroll to element

--- a/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinition.test.tsx
+++ b/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinition.test.tsx
@@ -45,13 +45,8 @@ paths:
           description: Success
     `;
 
-    const requestInterceptor = (req: any) => req;
-
     const { getByText } = await renderInTestApp(
-      <OpenApiDefinition
-        definition={definition}
-        requestInterceptor={requestInterceptor}
-      />,
+      <OpenApiDefinition definition={definition} />,
     );
 
     // swagger-ui loads the documentation asynchronously
@@ -100,13 +95,11 @@ paths:
           description: Success
     `;
 
-    const requestInterceptor = (req: any) => req;
     const supportedSubmitMethods = ['get', 'post', 'put', 'delete'] as const;
 
     const { findByRole, getByRole, getByLabelText } = await renderInTestApp(
       <OpenApiDefinition
         definition={definition}
-        requestInterceptor={requestInterceptor}
         supportedSubmitMethods={supportedSubmitMethods as any}
       />,
     );

--- a/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinition.test.tsx
+++ b/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinition.test.tsx
@@ -52,9 +52,6 @@ paths:
 
     // swagger-ui loads the documentation asynchronously
     await waitFor(() => {
-      expect(
-        document.getElementById('operations-artists-get_artists'),
-      ).toBeInTheDocument();
       expect(getByText(/\/artists/i)).toBeInTheDocument();
       expect(getByText(/List all artists/i)).toBeInTheDocument();
     });

--- a/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinition.test.tsx
+++ b/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinition.test.tsx
@@ -37,6 +37,8 @@ servers:
 paths:
   /artists:
     get:
+      tags:
+        - artists
       summary: List all artists
       responses:
         "200":
@@ -54,6 +56,9 @@ paths:
 
     // swagger-ui loads the documentation asynchronously
     await waitFor(() => {
+      expect(
+        document.getElementById('operations-artists-get_artists'),
+      ).toBeInTheDocument();
       expect(getByText(/\/artists/i)).toBeInTheDocument();
       expect(getByText(/List all artists/i)).toBeInTheDocument();
     });
@@ -146,5 +151,39 @@ paths:
       <OpenApiDefinition definition="" />,
     );
     expect(getByText(/No API definition provided/i)).toBeInTheDocument();
+  });
+
+  it('scrolls to deepLink on page load', async () => {
+    const definition = `
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Artist API
+  license:
+    name: MIT
+servers:
+  - url: http://artist.spotify.net/v1
+paths:
+  /artists:
+    get:
+      summary: List all artists
+      responses:
+        "200":
+          description: Success
+    `;
+
+    window.location.hash = '#/artists/listArtists';
+
+    const scrollIntoViewMock = jest.fn();
+
+    jest.spyOn(document, 'getElementById').mockImplementation(() => {
+      return {
+        scrollIntoView: scrollIntoViewMock,
+      } as any;
+    });
+
+    await renderInTestApp(<OpenApiDefinition definition={definition} />);
+
+    expect(scrollIntoViewMock).toHaveBeenCalled();
   });
 });

--- a/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinition.test.tsx
+++ b/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinition.test.tsx
@@ -159,6 +159,8 @@ servers:
 paths:
   /artists:
     get:
+      tags:
+        - artists    
       summary: List all artists
       responses:
         "200":
@@ -169,14 +171,18 @@ paths:
 
     const scrollIntoViewMock = jest.fn();
 
-    jest.spyOn(document, 'getElementById').mockImplementation(() => {
-      return {
-        scrollIntoView: scrollIntoViewMock,
-      } as any;
+    jest.spyOn(document, 'getElementById').mockImplementation(id => {
+      if (id === 'operations-artists-listArtists') {
+        return {
+          scrollIntoView: scrollIntoViewMock,
+        } as any;
+      }
+      return null;
     });
 
     await renderInTestApp(<OpenApiDefinition definition={definition} />);
 
     expect(scrollIntoViewMock).toHaveBeenCalled();
+    window.location.hash = '';
   });
 });

--- a/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinition.test.tsx
+++ b/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinition.test.tsx
@@ -39,6 +39,7 @@ paths:
     get:
       tags:
         - artists
+      operationId: get_artists
       summary: List all artists
       responses:
         "200":
@@ -160,7 +161,8 @@ paths:
   /artists:
     get:
       tags:
-        - artists    
+        - artists
+      operationId: listArtists
       summary: List all artists
       responses:
         "200":
@@ -171,18 +173,23 @@ paths:
 
     const scrollIntoViewMock = jest.fn();
 
-    jest.spyOn(document, 'getElementById').mockImplementation(id => {
-      if (id === 'operations-artists-listArtists') {
-        return {
-          scrollIntoView: scrollIntoViewMock,
-        } as any;
-      }
-      return null;
-    });
+    const getElementByIdSpy = jest
+      .spyOn(document, 'getElementById')
+      .mockImplementation(id => {
+        if (id === 'operations-artists-listArtists') {
+          return {
+            scrollIntoView: scrollIntoViewMock,
+          } as any;
+        }
+        return null;
+      });
 
-    await renderInTestApp(<OpenApiDefinition definition={definition} />);
-
-    expect(scrollIntoViewMock).toHaveBeenCalled();
-    window.location.hash = '';
+    try {
+      await renderInTestApp(<OpenApiDefinition definition={definition} />);
+      expect(scrollIntoViewMock).toHaveBeenCalled();
+    } finally {
+      window.location.hash = '';
+      getElementByIdSpy.mockRestore();
+    }
   });
 });

--- a/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinition.tsx
+++ b/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinition.tsx
@@ -198,6 +198,7 @@ const scrollToDeepLink = () => {
     return;
   }
   const [tag, operationId] = fragment.split('/');
+  if (!tag) return;
   const elementId = operationId
     ? `operations-${tag}-${operationId}`
     : `operations-tag-${tag}`;

--- a/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinition.tsx
+++ b/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinition.tsx
@@ -189,15 +189,21 @@ const useStyles = makeStyles(theme => ({
 
 const scrollToDeepLink = () => {
   const hash = window.location.hash;
-  if (!hash) return;
-  const fragment = decodeURIComponent(hash.substring(2)); // strip leading "#/"
+  if (!hash || !hash.startsWith('#/')) return;
+
+  let fragment;
+  try {
+    fragment = decodeURIComponent(hash.substring(2)); // strip leading "#/"
+  } catch {
+    return;
+  }
   const [tag, operationId] = fragment.split('/');
   const elementId = operationId
     ? `operations-${tag}-${operationId}`
     : `operations-tag-${tag}`;
   document
     .getElementById(elementId)
-    ?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    ?.scrollIntoView({ behavior: 'auto', block: 'start' });
 };
 
 export type OpenApiDefinitionProps = {

--- a/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinition.tsx
+++ b/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinition.tsx
@@ -187,6 +187,19 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
+const scrollToDeepLink = () => {
+  const hash = window.location.hash;
+  if (!hash) return;
+  const fragment = decodeURIComponent(hash.substring(2)); // strip leading "#/"
+  const [tag, operationId] = fragment.split('/');
+  const elementId = operationId
+    ? `operations-${tag}-${operationId}`
+    : `operations-tag-${tag}`;
+  document
+    .getElementById(elementId)
+    ?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+};
+
 export type OpenApiDefinitionProps = {
   definition: string;
 } & Omit<React.ComponentProps<typeof SwaggerUI>, 'spec'>;
@@ -213,6 +226,7 @@ export const OpenApiDefinition = ({
         url=""
         deepLinking
         oauth2RedirectUrl={`${window.location.protocol}//${window.location.host}/oauth2-redirect.html`}
+        onComplete={scrollToDeepLink}
         {...swaggerUiProps}
       />
     </div>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

DeepLinking will now properly scroll to the selected element in openapi specifications

https://github.com/user-attachments/assets/70e5e51c-dc94-49e4-b16e-ea75edc02370

non working example on https://demo.backstage.io/

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
