### PR TITLE
chore(ui): migrate PageHeader to use new Breadcrumbs component

### DIFF
--- a/.changeset/fancy-radios-shine.md
+++ b/.changeset/fancy-radios-shine.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Migrate PageHeader to use the new Breadcrumbs component

--- a/packages/ui/src/components/Header/Header.module.css
+++ b/packages/ui/src/components/Header/Header.module.css
@@ -56,6 +56,8 @@
 
   .bui-HeaderContent[data-sticky] {
     position: sticky;
+    display: flex;
+    align-items: center;
     top: 0;
     z-index: 10;
     background-color: var(--bui-bg-app);

--- a/packages/ui/src/components/Header/Header.module.css
+++ b/packages/ui/src/components/Header/Header.module.css
@@ -106,71 +106,29 @@
     flex: 1 1 auto;
     height: 1lh;
     min-width: 0;
-    font-size: var(--bui-font-size-6);
     line-height: 140%;
-    overflow: hidden;
   }
 
   .bui-HeaderBreadcrumbs,
   .bui-HeaderBreadcrumbsSmall {
+    --bui-Breadcrumbs-max-width: 240px;
+
     position: absolute;
     inset-inline: 0;
     top: 50%;
     display: flex;
     flex-direction: row;
     align-items: center;
-    gap: var(--bui-space-2);
     min-width: 0;
     transform: translateY(-50%);
   }
 
+  .bui-HeaderBreadcrumbs {
+    --bui-Breadcrumbs-gap: var(--bui-space-2);
+  }
+
   .bui-HeaderBreadcrumbsSmall {
-    gap: var(--bui-space-1);
-  }
-
-  .bui-HeaderBreadcrumbs .bui-HeaderBreadcrumbLink,
-  .bui-HeaderBreadcrumbsSmall .bui-HeaderBreadcrumbLinkSmall {
-    max-width: 240px;
-    overflow: hidden;
-    font-family: var(--bui-font-regular);
-    font-weight: var(--bui-font-weight-bold);
-    line-height: inherit;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .bui-HeaderBreadcrumbs .bui-HeaderBreadcrumbLink {
-    font-size: inherit;
-  }
-
-  .bui-HeaderBreadcrumbsSmall .bui-HeaderBreadcrumbLinkSmall {
-    font-size: var(--bui-font-size-4);
-  }
-
-  .bui-HeaderBreadcrumbSeparator {
-    flex-shrink: 0;
-  }
-
-  .bui-HeaderTitle,
-  .bui-HeaderTitleSmall {
-    margin: 0;
-    padding: 0;
-    flex: 1 1 auto;
-    min-width: 0;
-    font-family: var(--bui-font-regular);
-    font-weight: var(--bui-font-weight-bold);
-    line-height: inherit;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .bui-HeaderTitle {
-    font-size: inherit;
-  }
-
-  .bui-HeaderTitleSmall {
-    font-size: var(--bui-font-size-4);
+    --bui-Breadcrumbs-gap: var(--bui-space-1);
   }
 
   .bui-HeaderTags {

--- a/packages/ui/src/components/Header/Header.tsx
+++ b/packages/ui/src/components/Header/Header.tsx
@@ -23,8 +23,9 @@ import { HeaderDefinition } from './definition';
 import { sanitizeUrl } from '@braintree/sanitize-url';
 import { Lexer } from 'marked';
 import { Link } from '../Link';
-import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Container } from '../Container';
+import { Breadcrumb, Breadcrumbs } from '../Breadcrumbs';
 
 const getScrollParent = (element: HTMLElement | null): Element | null => {
   let parent = element?.parentElement;
@@ -199,51 +200,29 @@ export const Header = (props: HeaderProps) => {
         {...dataAttributes}
       >
         <div className={classes.titleStack}>
-          {isStuck ? (
-            <div className={classes.breadcrumbsSmall}>
-              {breadcrumbs &&
-                breadcrumbs.map(breadcrumb => (
-                  <Fragment key={breadcrumb.label}>
-                    <Link
-                      href={breadcrumb.href}
-                      color="secondary"
-                      className={classes.breadcrumbLinkSmall}
-                      standalone
-                    >
-                      {breadcrumb.label}
-                    </Link>
-                    <RiArrowRightSLine
-                      className={classes.breadcrumbSeparator}
-                      size={16}
-                      color="var(--bui-fg-secondary)"
-                    />
-                  </Fragment>
-                ))}
-              <h2 className={classes.titleSmall}>{title}</h2>
-            </div>
-          ) : (
-            <div className={classes.breadcrumbs}>
-              {breadcrumbs &&
-                breadcrumbs.map(breadcrumb => (
-                  <Fragment key={breadcrumb.label}>
-                    <Link
-                      href={breadcrumb.href}
-                      color="secondary"
-                      className={classes.breadcrumbLink}
-                      standalone
-                    >
-                      {breadcrumb.label}
-                    </Link>
-                    <RiArrowRightSLine
-                      className={classes.breadcrumbSeparator}
-                      size={16}
-                      color="var(--bui-fg-secondary)"
-                    />
-                  </Fragment>
-                ))}
-              <h2 className={classes.title}>{title}</h2>
-            </div>
-          )}
+          <Breadcrumbs
+            className={isStuck ? classes.breadcrumbsSmall : classes.breadcrumbs}
+            color="secondary"
+            weight="bold"
+            variant={isStuck ? 'body-large' : 'title-small'}
+            separator={
+              <RiArrowRightSLine
+                className={classes.breadcrumbSeparator}
+                size={16}
+                color="var(--bui-fg-secondary)"
+              />
+            }
+          >
+            {breadcrumbs &&
+              breadcrumbs.map(breadcrumb => (
+                <Breadcrumb key={breadcrumb.label} href={breadcrumb.href}>
+                  {breadcrumb.label}
+                </Breadcrumb>
+              ))}
+            <Breadcrumb as="h2" color="primary">
+              {title}
+            </Breadcrumb>
+          </Breadcrumbs>
         </div>
         <div className={classes.controls}>{customActions}</div>
       </Container>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

https://github.com/user-attachments/assets/3f1ad5fe-7462-4ad1-a893-e1e36432b06d




#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
