### PR TITLE
fix(catalog-backend-module-msgraph): treat empty userSelect as undefined

### DIFF
--- a/.changeset/fix-msgraph-empty-user-select.md
+++ b/.changeset/fix-msgraph-empty-user-select.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-msgraph': patch
+---
+
+Fixed a bug where setting `user.select` to an empty array would cause all users to be dropped from the catalog instead of using the default set of fields.

--- a/.patches/pr-34505.txt
+++ b/.patches/pr-34505.txt
@@ -1,0 +1,1 @@
+Fix empty userSelect causing all users to be dropped in msgraph module

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/read.test.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/read.test.ts
@@ -364,6 +364,31 @@ describe('read microsoft graph', () => {
         undefined,
       );
     });
+
+    it('should use default fields when userSelect is an empty array', async () => {
+      client.getUsers.mockImplementation(getExampleUsers);
+      client.getUserPhotoWithSizeLimit.mockResolvedValue(undefined);
+
+      await readMicrosoftGraphUsers(client, {
+        userSelect: [],
+        logger: mockServices.logger.mock(),
+      });
+
+      expect(client.getUsers).toHaveBeenCalledWith(
+        {
+          select: expect.arrayContaining([
+            'displayName',
+            'mail',
+            'userPrincipalName',
+            'accountEnabled',
+          ]),
+          top: 999,
+        },
+        undefined,
+        undefined,
+        undefined,
+      );
+    });
   });
 
   describe('readMicrosoftGraphUsersInGroups', () => {
@@ -494,6 +519,33 @@ describe('read microsoft graph', () => {
       expect(client.getGroupUserMembers).toHaveBeenCalledWith(
         'groupid',
         { select: expect.arrayContaining(['accountEnabled']), top: 999 },
+        undefined,
+        undefined,
+      );
+    });
+
+    it('should use default fields when userSelect is an empty array', async () => {
+      client.getGroups.mockImplementation(getExampleGroups);
+      client.getGroupUserMembers.mockImplementation(getExampleUsers);
+      client.getUserPhotoWithSizeLimit.mockResolvedValue(undefined);
+
+      await readMicrosoftGraphUsersInGroups(client, {
+        userGroupMemberFilter: 'securityEnabled eq true',
+        userSelect: [],
+        logger: mockServices.logger.mock(),
+      });
+
+      expect(client.getGroupUserMembers).toHaveBeenCalledWith(
+        'groupid',
+        {
+          select: expect.arrayContaining([
+            'displayName',
+            'mail',
+            'userPrincipalName',
+            'accountEnabled',
+          ]),
+          top: 999,
+        },
         undefined,
         undefined,
       );

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/read.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/read.ts
@@ -65,7 +65,7 @@ const DEFAULT_USER_SELECT = [
 const MINIMUM_USER_SELECT = ['id', 'accountEnabled'];
 
 function ensureMinimumSelect(select: string[] | undefined): string[] {
-  const base = select ?? DEFAULT_USER_SELECT;
+  const base = select?.length ? select : DEFAULT_USER_SELECT;
   const lower = new Set(base.map(s => s.toLocaleLowerCase('en-US')));
   const missing = MINIMUM_USER_SELECT.filter(
     f => !lower.has(f.toLocaleLowerCase('en-US')),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

PR #34425 introduced `ensureMinimumSelect` which uses `??` to fall back to the default field set when `userSelect` is not configured. However, when `userSelect` is set to an empty array `[]` in config, `??` does not trigger (since `[]` is not `null`/`undefined`), so the Graph API receives `$select=id,accountEnabled` — only the minimum required fields.

Without `displayName` in the response, `defaultUserTransformer` returns `undefined` for every user, effectively dropping all users from the catalog.

The fix changes `ensureMinimumSelect` to treat an empty array the same as `undefined`, falling back to the full default field set.

This is restoring the behavior of the org data provider before #34425 - previously, setting `userSelect` to `[]` resulted in the default fields being returned.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))