### PR TITLE
fix(catalog-backend): drop redundant search_entity_id_idx

### DIFF
--- a/.changeset/drop-search-entity-id-idx.md
+++ b/.changeset/drop-search-entity-id-idx.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Dropped the legacy `search_entity_id_idx` index which is now redundant with the covering unique index on `(entity_id, key, value)`. The old index caused the query planner to choose an inefficient scan pattern for catalog list queries with multiple sort fields, leading to severely degraded performance on large catalogs.

--- a/plugins/catalog-backend/migrations/20260609000000_drop_search_entity_id_idx.js
+++ b/plugins/catalog-backend/migrations/20260609000000_drop_search_entity_id_idx.js
@@ -36,8 +36,9 @@
  *
  * ## Cost
  *
- * - **PostgreSQL**: `DROP INDEX CONCURRENTLY` — non-blocking, instant
- *   metadata change. Reclaims ~384 MB on a 490K-entity catalog.
+ * - **PostgreSQL**: `DROP INDEX CONCURRENTLY` — non-blocking for
+ *   reads and writes, but may wait for concurrent transactions to
+ *   finish. Reclaims ~384 MB on a 490K-entity catalog.
  * - **MySQL / SQLite**: standard `DROP INDEX`. Reclaims proportionally
  *   less space on smaller catalogs.
  *

--- a/plugins/catalog-backend/migrations/20260609000000_drop_search_entity_id_idx.js
+++ b/plugins/catalog-backend/migrations/20260609000000_drop_search_entity_id_idx.js
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-check
+
+/**
+ * Drops the legacy `search_entity_id_idx` index on the `search` table.
+ *
+ * This single-column index on `entity_id` was created by the original
+ * migration (20210302150147) and served as the supporting index for the
+ * foreign key on `search.entity_id`. It is now fully redundant: the
+ * UNIQUE index `search_entity_key_value_idx` (entity_id, key, value),
+ * introduced in 20260510000000, has `entity_id` as its leading column
+ * and covers both FK cascade checks and all entity_id lookups.
+ *
+ * Worse, the old index actively harms performance. Because it is 4.4x
+ * smaller than the covering index, the PostgreSQL planner prefers it
+ * for entity_id lookups in correlated EXISTS subqueries. This forces a
+ * read-all-then-filter-by-key pattern (~28 rows per entity) instead of
+ * a direct (entity_id, key) seek on the covering index (1 row). On
+ * catalog list queries with multiple sort-field EXISTS checks, this
+ * causes minutes-long execution times.
+ *
+ * ## Cost
+ *
+ * - **PostgreSQL**: `DROP INDEX CONCURRENTLY` — non-blocking, instant
+ *   metadata change. Reclaims ~384 MB on a 490K-entity catalog.
+ * - **MySQL / SQLite**: standard `DROP INDEX`. Reclaims proportionally
+ *   less space on smaller catalogs.
+ *
+ * This migration is safe to run manually before deploying — the
+ * `IF EXISTS` / idempotent checks ensure it is a no-op if the index
+ * has already been removed.
+ */
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function up(knex) {
+  const client = knex.client.config.client;
+
+  if (client.includes('pg')) {
+    const result = await knex.raw(
+      `SELECT 1 FROM pg_class WHERE relname = 'search_entity_id_idx' AND relkind = 'i'`,
+    );
+    if (result.rows.length > 0) {
+      await knex.raw('DROP INDEX CONCURRENTLY IF EXISTS search_entity_id_idx');
+    }
+  } else if (client.includes('mysql')) {
+    const [rows] = await knex.raw(
+      `SHOW INDEX FROM \`search\` WHERE Key_name = 'search_entity_id_idx'`,
+    );
+    if (rows.length > 0) {
+      await knex.schema.alterTable('search', table => {
+        table.dropIndex([], 'search_entity_id_idx');
+      });
+    }
+  } else {
+    await knex.raw('DROP INDEX IF EXISTS search_entity_id_idx');
+  }
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function down(knex) {
+  const client = knex.client.config.client;
+
+  if (client.includes('pg')) {
+    await knex.raw(
+      'CREATE INDEX CONCURRENTLY IF NOT EXISTS search_entity_id_idx ON search (entity_id)',
+    );
+  } else if (client.includes('mysql')) {
+    const [rows] = await knex.raw(
+      `SHOW INDEX FROM \`search\` WHERE Key_name = 'search_entity_id_idx'`,
+    );
+    if (rows.length === 0) {
+      await knex.schema.alterTable('search', table => {
+        table.index(['entity_id'], 'search_entity_id_idx');
+      });
+    }
+  } else {
+    await knex.raw(
+      'CREATE INDEX IF NOT EXISTS search_entity_id_idx ON search (entity_id)',
+    );
+  }
+};
+
+exports.config = { transaction: false };

--- a/plugins/catalog-backend/report.sql.md
+++ b/plugins/catalog-backend/report.sql.md
@@ -127,7 +127,6 @@
 
 ### Indices
 
-- `search_entity_id_idx` (`entity_id`)
 - `search_entity_key_value_idx` (`entity_id`, `key`, `value`) unique
 - `search_facets_covering_idx` (`key`, `original_value`, `entity_id`)
 - `search_key_value_entity_idx` (`key`, `value`, `entity_id`)

--- a/plugins/catalog-backend/src/tests/migrations.test.ts
+++ b/plugins/catalog-backend/src/tests/migrations.test.ts
@@ -1425,7 +1425,11 @@ describe.each(databases.eachSupportedId())('migrations, %p', databaseId => {
     async function indexExists(): Promise<boolean> {
       if (typeof client === 'string' && client.includes('pg')) {
         const r = await knex.raw(
-          `SELECT 1 FROM pg_class WHERE relname = 'search_entity_id_idx' AND relkind = 'i'`,
+          `SELECT 1 FROM pg_class c
+           JOIN pg_namespace n ON n.oid = c.relnamespace
+           WHERE c.relname = 'search_entity_id_idx'
+             AND c.relkind = 'i'
+             AND n.nspname = current_schema()`,
         );
         return r.rows.length > 0;
       } else if (typeof client === 'string' && client.includes('mysql')) {

--- a/plugins/catalog-backend/src/tests/migrations.test.ts
+++ b/plugins/catalog-backend/src/tests/migrations.test.ts
@@ -1412,4 +1412,42 @@ describe.each(databases.eachSupportedId())('migrations, %p', databaseId => {
 
     await knex.destroy();
   });
+
+  it('20260609000000_drop_search_entity_id_idx.js', async () => {
+    const knex = await databases.init(databaseId);
+    const client = knex.client.config.client;
+
+    await migrateUntilBefore(
+      knex,
+      '20260609000000_drop_search_entity_id_idx.js',
+    );
+
+    async function indexExists(): Promise<boolean> {
+      if (typeof client === 'string' && client.includes('pg')) {
+        const r = await knex.raw(
+          `SELECT 1 FROM pg_class WHERE relname = 'search_entity_id_idx' AND relkind = 'i'`,
+        );
+        return r.rows.length > 0;
+      } else if (typeof client === 'string' && client.includes('mysql')) {
+        const [rows] = await knex.raw(
+          `SHOW INDEX FROM \`search\` WHERE Key_name = 'search_entity_id_idx'`,
+        );
+        return rows.length > 0;
+      }
+      const r = await knex.raw(
+        `SELECT 1 FROM sqlite_master WHERE type = 'index' AND name = 'search_entity_id_idx'`,
+      );
+      return r.length > 0;
+    }
+
+    expect(await indexExists()).toBe(true);
+
+    await migrateUpOnce(knex);
+    expect(await indexExists()).toBe(false);
+
+    await migrateDownOnce(knex);
+    expect(await indexExists()).toBe(true);
+
+    await knex.destroy();
+  });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Drops the legacy `search_entity_id_idx` (single-column on `entity_id`, 384 MB on a 490K-entity catalog). This index is fully redundant with `search_entity_key_value_idx` (UNIQUE on `entity_id, key, value`) which has `entity_id` as its leading column and covers FK cascade checks.

The old index actively harms performance: because it is 4.4x smaller, the PostgreSQL planner prefers it for entity_id lookups in correlated EXISTS subqueries. This forces a read-all-then-filter-by-key pattern (~28 rows read per entity, 27 discarded) instead of a direct `(entity_id, key)` seek on the covering index (1 row). On catalog list queries with multiple sort-field EXISTS checks (e.g. 56K components × 3 semi-joins × 28 rows), this causes minutes-long execution times.

The full query battery (`queries.md`) was run against a production-scale replica with EXPLAIN — zero scenarios use this index. All 11 scenarios use the covering indexes correctly.

The migration uses `IF EXISTS` / idempotent checks so operators can safely run the drop manually before deploying.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))