### PR TITLE
fix(catalog-backend): use ANY(array) for entitiesBatch on PostgreSQL

### DIFF
--- a/.changeset/entities-batch-any-array.md
+++ b/.changeset/entities-batch-any-array.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Optimized `entitiesBatch` on PostgreSQL to use `= ANY(array)` instead of `WHERE IN ($1, $2, ...)`. This produces a single stable query plan regardless of batch size, instead of up to 200 different plans that pollute the query plan cache. On PostgreSQL, batching is no longer needed so all entity refs are fetched in a single query.

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
@@ -918,7 +918,7 @@ describe.each(databases.eachSupportedId())(
         ]);
       });
 
-      it('handles more than 200 refs in a single query on PostgreSQL', async () => {
+      it('handles more than 200 refs without chunking on PostgreSQL', async () => {
         await createDatabase();
 
         const names = Array.from({ length: 250 }, (_, i) => `item-${i}`);

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
@@ -918,6 +918,39 @@ describe.each(databases.eachSupportedId())(
         ]);
       });
 
+      it('handles more than 200 refs in a single query on PostgreSQL', async () => {
+        await createDatabase();
+
+        const names = Array.from({ length: 250 }, (_, i) => `item-${i}`);
+        for (const name of names) {
+          await addEntity(
+            {
+              apiVersion: 'a',
+              kind: 'k',
+              metadata: { name },
+              spec: {},
+              relations: [],
+            },
+            [],
+          );
+        }
+
+        const catalog = new DefaultEntitiesCatalog({
+          database: knex,
+          logger: mockServices.logger.mock(),
+        });
+
+        const refs = names.map(n => `k:default/${n}`);
+        const res = await catalog.entitiesBatch({
+          entityRefs: [...refs, 'k:default/does-not-exist'],
+          credentials: mockCredentials.none(),
+        });
+        const items = entitiesResponseToObjects(res.items);
+
+        expect(items.filter(Boolean)).toHaveLength(250);
+        expect(items[items.length - 1]).toBeNull();
+      });
+
       it('queries for entities by ref, including filtering', async () => {
         await createDatabase();
 

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -338,8 +338,12 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
   async entitiesBatch(
     request: EntitiesBatchRequest,
   ): Promise<EntitiesBatchResponse> {
+    if (request.entityRefs.length === 0) {
+      return { items: processRawEntitiesResult([], request.fields) };
+    }
+
     const lookup = new Map<string, string>();
-    const isPg = this.database.client.config.client.includes('pg');
+    const isPg = this.database.client.config.client === 'pg';
 
     const chunks = isPg
       ? [request.entityRefs]
@@ -352,7 +356,9 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
       });
 
       if (isPg) {
-        query = query.whereRaw('final_entities.entity_ref = ANY(?)', [chunk]);
+        query = query.whereRaw('final_entities.entity_ref = ANY(?::text[])', [
+          chunk,
+        ]);
       } else {
         query = query.whereIn('final_entities.entity_ref', chunk);
       }

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -339,14 +339,23 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
     request: EntitiesBatchRequest,
   ): Promise<EntitiesBatchResponse> {
     const lookup = new Map<string, string>();
+    const isPg = this.database.client.config.client.includes('pg');
 
-    for (const chunk of lodashChunk(request.entityRefs, 200)) {
-      let query = this.database<DbFinalEntitiesRow>('final_entities')
-        .select({
-          entityRef: 'final_entities.entity_ref',
-          entity: 'final_entities.final_entity',
-        })
-        .whereIn('final_entities.entity_ref', chunk);
+    const chunks = isPg
+      ? [request.entityRefs]
+      : lodashChunk(request.entityRefs, 200);
+
+    for (const chunk of chunks) {
+      let query = this.database<DbFinalEntitiesRow>('final_entities').select({
+        entityRef: 'final_entities.entity_ref',
+        entity: 'final_entities.final_entity',
+      });
+
+      if (isPg) {
+        query = query.whereRaw('final_entities.entity_ref = ANY(?)', [chunk]);
+      } else {
+        query = query.whereIn('final_entities.entity_ref', chunk);
+      }
 
       if (request?.filter || request?.query) {
         query = applyEntityFilterToQuery({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Replaces `WHERE entity_ref IN ($1, $2, ..., $200)` with `WHERE entity_ref = ANY($1::text[])` in the `entitiesBatch` query on PostgreSQL. The `IN` expansion produces a different query plan for every distinct batch size (up to 200 variants), polluting the query plan cache. The `ANY(array)` form takes a single array parameter, so PostgreSQL produces one stable plan that gets reused regardless of how many entity refs are requested.

Since array parameters have no practical size limit and the plan is always a simple index scan into `final_entities_entity_ref_uniq` (no combinatorial planning cost), the application-level batching is removed on PostgreSQL — all entity refs are fetched in a single round trip. SQLite retains the existing chunked `WHERE IN` approach.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))