### PR TITLE
Fix task worker retry loop to respect abort signal

### DIFF
--- a/.changeset/fix-task-worker-abort-retry.md
+++ b/.changeset/fix-task-worker-abort-retry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Fixed the task worker retry loop to respect the abort signal. Previously, when a task worker encountered an unexpected error, the retry loop would continue indefinitely even after the worker was signaled to stop. The retry loop now checks the abort signal before retrying and passes it to the retry delay, allowing the worker to shut down gracefully.

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/LocalTaskWorker.test.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/LocalTaskWorker.test.ts
@@ -140,6 +140,31 @@ describe('LocalTaskWorker', () => {
     controller.abort();
   });
 
+  it('stops retrying when the abort signal is triggered', async () => {
+    const fn = jest.fn().mockRejectedValue(new Error('always fails'));
+    const controller = new AbortController();
+
+    const worker = new LocalTaskWorker('a', fn, logger);
+    worker.start(
+      {
+        version: 2,
+        cadence: 'PT0.1S',
+        timeoutAfterDuration: 'PT1S',
+      },
+      { signal: controller.signal },
+    );
+
+    await waitFor(() => {
+      expect(fn).toHaveBeenCalled();
+    });
+
+    const callsBeforeAbort = fn.mock.calls.length;
+    controller.abort();
+
+    await new Promise(r => setTimeout(r, 500));
+    expect(fn.mock.calls.length).toBe(callsBeforeAbort);
+  });
+
   it('cannot cancel a task that is not running', async () => {
     const fn = jest.fn();
     const controller = new AbortController();

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/LocalTaskWorker.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/LocalTaskWorker.ts
@@ -77,11 +77,14 @@ export class LocalTaskWorker {
           attemptNum = 0;
           break;
         } catch (e) {
+          if (options.signal.aborted) {
+            break;
+          }
           attemptNum += 1;
           this.logger.warn(
             `Task worker failed unexpectedly, attempt number ${attemptNum}, ${e}`,
           );
-          await sleep(Duration.fromObject({ seconds: 1 }));
+          await sleep(Duration.fromObject({ seconds: 1 }), options.signal);
         }
       }
     })();

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.test.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.test.ts
@@ -207,6 +207,30 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
     });
   });
 
+  it('stops retrying when the abort signal is triggered', async () => {
+    const controller = new AbortController();
+    const fn = jest.fn().mockRejectedValue(new Error('always fails'));
+    const settings: TaskSettingsV2 = {
+      version: 2,
+      initialDelayDuration: undefined,
+      cadence: '* * * * * *',
+      timeoutAfterDuration: Duration.fromMillis(60000).toISO()!,
+    };
+    const checkFrequency = Duration.fromObject({ milliseconds: 50 });
+    const worker = new TaskWorker('task1', fn, knex, logger, checkFrequency);
+    worker.start(settings, { signal: controller.signal });
+
+    await waitForExpect(() => {
+      expect(fn).toHaveBeenCalled();
+    });
+
+    const callsBeforeAbort = fn.mock.calls.length;
+    controller.abort();
+
+    await new Promise(r => setTimeout(r, 500));
+    expect(fn.mock.calls.length).toBe(callsBeforeAbort);
+  });
+
   it('does not clobber ticket lock when stolen', async () => {
     const fn = jest.fn(
       async () => new Promise<void>(resolve => setTimeout(resolve, 50)),

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.ts
@@ -104,11 +104,14 @@ export class TaskWorker {
           attemptNum = 0;
           break;
         } catch (e) {
+          if (options.signal.aborted) {
+            break;
+          }
           attemptNum += 1;
           this.logger.warn(
             `Task worker failed unexpectedly, attempt number ${attemptNum}, ${e}`,
           );
-          await sleep(Duration.fromObject({ seconds: 1 }));
+          await sleep(Duration.fromObject({ seconds: 1 }), options.signal);
         }
       }
     })();


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The retry loop in both `TaskWorker` and `LocalTaskWorker` would continue retrying indefinitely even after the abort signal was triggered. This happened because the `catch` block in the main worker loop neither checked whether the signal was aborted before retrying, nor passed the signal to the `sleep` call used for the retry delay. This caused workers to never shut down gracefully when encountering repeated errors after being signaled to stop.

The fix adds an abort signal check at the top of the catch block to break out of the retry loop immediately, and passes the signal through to the retry delay `sleep` call so the delay is also interruptible.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))