### PR TITLE
Add eslint plugin bugs metadata

### DIFF
--- a/.changeset/clever-badgers-search.md
+++ b/.changeset/clever-badgers-search.md
@@ -1,0 +1,5 @@
+---
+'@backstage/eslint-plugin': patch
+---
+
+Added package metadata pointing to the issue tracker, so npm users can find where to report bugs.

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -11,6 +11,9 @@
     "url": "https://github.com/backstage/backstage",
     "directory": "packages/eslint-plugin"
   },
+  "bugs": {
+    "url": "https://github.com/backstage/backstage/issues"
+  },
   "license": "Apache-2.0",
   "main": "./index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Add the standard npm `bugs.url` metadata to `@backstage/eslint-plugin`.

The published `@backstage/eslint-plugin@0.3.0` package already exposes `homepage` and `repository`, but it does not expose `bugs`. This PR points npm consumers to the Backstage issue tracker while leaving runtime code, dependencies, scripts, and package entrypoints unchanged.

## Verification

```sh
npm view @backstage/eslint-plugin@0.3.0 name version homepage repository bugs deprecated dist.tarball scripts --json
node package metadata smoke
npm pack --dry-run --ignore-scripts ./packages/eslint-plugin
git diff --check
```

The metadata smoke verified the existing homepage/repository fields and the added `bugs.url` value.
