### PR TITLE
Clairep 357 breadcrumbs in plugin header

### DIFF
--- a/docs-ui/src/app/components/plugin-header/props-definition.tsx
+++ b/docs-ui/src/app/components/plugin-header/props-definition.tsx
@@ -15,6 +15,26 @@ export const headerPropDefs: Record<string, PropDef> = {
     type: 'string',
     description: 'URL the title links to when clicked.',
   },
+  breadcrumbs: {
+    type: 'complex',
+    description:
+      'Breadcrumb entries to display in place of the title. When provided, the title is not rendered.',
+    complexType: {
+      name: 'BreadcrumbEntry[]',
+      properties: {
+        label: {
+          type: 'string',
+          required: true,
+          description: 'Display text for the breadcrumb.',
+        },
+        href: {
+          type: 'string',
+          required: false,
+          description: 'URL to navigate to when the breadcrumb is clicked.',
+        },
+      },
+    },
+  },
   customActions: {
     type: 'enum',
     values: ['ReactNode'],

--- a/docs-ui/src/app/hooks/use-breadcrumbs/page.mdx
+++ b/docs-ui/src/app/hooks/use-breadcrumbs/page.mdx
@@ -1,0 +1,61 @@
+import { PageTitle } from '@/components/PageTitle';
+import { PropsTable } from '@/components/PropsTable';
+import { Snippet } from '@/components/Snippet';
+import { breadcrumbEntryDefs } from './props-definition';
+import {
+  breadcrumbRegistrationSnippet,
+  useBreadcrumbsConsumerSnippet,
+  nestedExampleSnippet,
+  subPageRoutesSnippet,
+  stateBasedSnippet,
+} from './snippets';
+
+<PageTitle
+  title="useBreadcrumbs"
+  description="A shared-store system for building breadcrumb trails across page components."
+/>
+
+## Overview
+
+The breadcrumb system has two parts:
+
+- **`BreadcrumbRegistration`** — a component that registers a breadcrumb entry in a shared store on mount and removes it on unmount. Nesting depth determines order.
+- **`useBreadcrumbs()`** — a hook that returns the current breadcrumb trail as an array of entries, sorted by depth. Call this anywhere you render breadcrumbs (e.g. PluginHeader).
+
+Entries are visible to any `useBreadcrumbs()` consumer in the tree, not just descendants of the registration. This means a header component that is a sibling of the registered route content can still read the full trail.
+
+In the new frontend system, `BreadcrumbRegistration` is called automatically by the swapped `PageLayout` and `SubPageWrapper`, so plugin authors get breadcrumbs for plugin pages and sub-pages for free. For plugin-internal routes, wrap route content with `BreadcrumbRegistration` manually.
+
+## Registering a breadcrumb
+
+Wrap your page content with `BreadcrumbRegistration`. The entry is registered in the shared store and available to any `useBreadcrumbs()` consumer.
+
+<Snippet code={breadcrumbRegistrationSnippet} />
+
+## Consuming breadcrumbs
+
+Call `useBreadcrumbs()` to get the trail and render it with the `Breadcrumbs` component.
+
+<Snippet code={useBreadcrumbsConsumerSnippet} />
+
+## Nested pages
+
+Nesting `BreadcrumbRegistration` components builds the trail in depth order — parent entries come first. Each nesting level increments an internal depth counter used for sorting.
+
+<Snippet code={nestedExampleSnippet} />
+
+## Plugin sub-page routes
+
+Plugin root pages and sub-page tabs are registered automatically by the framework. For routes **inside** a sub-page component, wrap each route's element with `BreadcrumbRegistration`. This is the only manual step plugin maintainers need.
+
+<Snippet code={subPageRoutesSnippet} />
+
+## State-driven views (no routes)
+
+`BreadcrumbRegistration` isn't limited to routes — it works with any state-driven view like tabs, selection panels, or list/detail layouts. The breadcrumb updates reactively when the `label` prop changes.
+
+<Snippet code={stateBasedSnippet} />
+
+## BreadcrumbEntry
+
+<PropsTable data={breadcrumbEntryDefs} isHook />

--- a/docs-ui/src/app/hooks/use-breadcrumbs/props-definition.ts
+++ b/docs-ui/src/app/hooks/use-breadcrumbs/props-definition.ts
@@ -1,0 +1,12 @@
+import { type PropDef } from '@/utils/propDefs';
+
+export const breadcrumbEntryDefs: Record<string, PropDef> = {
+  label: {
+    type: 'string',
+    description: 'Display text for the breadcrumb.',
+  },
+  href: {
+    type: 'string',
+    description: 'Optional URL the breadcrumb links to.',
+  },
+};

--- a/docs-ui/src/app/hooks/use-breadcrumbs/snippets.ts
+++ b/docs-ui/src/app/hooks/use-breadcrumbs/snippets.ts
@@ -1,0 +1,152 @@
+export const breadcrumbRegistrationSnippet = `import { BreadcrumbRegistration } from '@backstage/ui';
+
+function SettingsPage() {
+  return (
+    <BreadcrumbRegistration entry={{ label: 'Settings', href: '/settings' }}>
+      <h1>Settings</h1>
+      {/* "Settings" is now in the breadcrumb trail for any useBreadcrumbs() consumer */}
+    </BreadcrumbRegistration>
+  );
+}`;
+
+export const useBreadcrumbsConsumerSnippet = `import { useBreadcrumbs, Breadcrumbs, Breadcrumb } from '@backstage/ui';
+
+function MyHeader({ title }: { title: string }) {
+  // Returns all registered entries sorted by nesting depth
+  const breadcrumbs = useBreadcrumbs();
+
+  return (
+    <Breadcrumbs>
+      {breadcrumbs.map(entry => (
+        <Breadcrumb key={entry.label} href={entry.href}>
+          {entry.label}
+        </Breadcrumb>
+      ))}
+      <Breadcrumb>{title}</Breadcrumb>
+    </Breadcrumbs>
+  );
+}`;
+
+export const nestedExampleSnippet = `import { BreadcrumbRegistration, useBreadcrumbs } from '@backstage/ui';
+
+// Depth is tracked automatically via nesting.
+// A sibling header can read the full trail — it doesn't need to be
+// a descendant of the registrations.
+function App() {
+  return (
+    <BreadcrumbRegistration entry={{ label: 'Catalog', href: '/catalog' }}>
+      <PageHeader />
+      <BreadcrumbRegistration entry={{ label: 'Entity', href: '/catalog/entity' }}>
+        {/* useBreadcrumbs() anywhere returns:
+            [{ label: 'Catalog', href: '/catalog' },
+             { label: 'Entity', href: '/catalog/entity' }] */}
+        <EntityContent />
+      </BreadcrumbRegistration>
+    </BreadcrumbRegistration>
+  );
+}`;
+
+export const subPageRoutesSnippet = `// --- plugin.tsx ---
+// The plugin root page and sub-page are registered via blueprints.
+// The framework handles their breadcrumbs automatically — no manual
+// BreadcrumbRegistration needed at this level.
+
+import { PageBlueprint, SubPageBlueprint } from '@backstage/frontend-plugin-api';
+
+// Registered automatically as "Create" breadcrumb
+const scaffolderPage = PageBlueprint.make({
+  params: {
+    path: '/create',
+    title: 'Create',
+    // ...
+  },
+});
+
+// Registered automatically as "Tasks" breadcrumb
+const scaffolderTasksSubPage = SubPageBlueprint.make({
+  name: 'tasks',
+  params: {
+    path: 'tasks',
+    title: 'Tasks',
+    loader: () => import('./components/TasksSubPage').then(m => <m.TasksSubPage />),
+  },
+});
+
+// --- TasksSubPage.tsx ---
+// Inside the sub-page component, internal routes need manual
+// BreadcrumbRegistration. The index route doesn't need one since
+// the sub-page breadcrumb ("Tasks") already covers it.
+
+import { Routes, Route, useParams } from 'react-router-dom';
+import { BreadcrumbRegistration } from '@backstage/ui';
+
+// For dynamic route params, extract the param and use it as the label.
+function TaskDetailWithBreadcrumb() {
+  const { taskId } = useParams<{ taskId: string }>();
+  return (
+    <BreadcrumbRegistration
+      entry={{ label: taskId ?? 'Task', href: taskId ?? '' }}
+    >
+      <OngoingTaskBody />
+    </BreadcrumbRegistration>
+  );
+}
+
+// On /create/tasks         → Create > Tasks          (all automatic)
+// On /create/tasks/abc-123 → Create > Tasks > abc-123 (abc-123 is manual)
+function TasksSubPage() {
+  return (
+    <Routes>
+      <Route path=":taskId" element={<TaskDetailWithBreadcrumb />} />
+      // ...
+    </Routes>
+  );
+}`;
+
+export const stateBasedSnippet = `import { useState } from 'react';
+import { BreadcrumbRegistration } from '@backstage/ui';
+
+// BreadcrumbRegistration also works with state-driven views
+// that don't use routes — tabs, selection panels, etc.
+// The breadcrumb updates reactively when the label changes.
+
+function ActionsPage() {
+  const [selectedActionId, setSelectedActionId] = useState<string>();
+
+  const content = (
+    <>
+      <ActionList onSelect={setSelectedActionId} />
+      {selectedActionId && <ActionDetail id={selectedActionId} />}
+    </>
+  );
+
+  // Only register a breadcrumb when an action is selected.
+  // On /create/actions             → Create > Actions
+  // On /create/actions (selected)  → Create > Actions > debug:log
+  if (selectedActionId) {
+    return (
+      <BreadcrumbRegistration entry={{ label: selectedActionId, href: '#' }}>
+        {content}
+      </BreadcrumbRegistration>
+    );
+  }
+
+  return content;
+}
+
+// For tab-based views, register the active tab label.
+// Switching tabs updates the breadcrumb automatically.
+// On /create/templating-extensions → Create > Templating Extensions > Filters
+function TemplatingExtensionsContent() {
+  const [tab, setTab] = useState('filter');
+  const tabLabels = { filter: 'Filters', function: 'Functions', value: 'Values' };
+
+  return (
+    <BreadcrumbRegistration entry={{ label: tabLabels[tab], href: '#' }}>
+      <Tabs value={tab} onChange={setTab}>
+        {/* ... */}
+      </Tabs>
+      {/* tab content */}
+    </BreadcrumbRegistration>
+  );
+}`;

--- a/docs-ui/src/utils/data.ts
+++ b/docs-ui/src/utils/data.ts
@@ -191,4 +191,9 @@ export const hooks: Page[] = [
     slug: 'use-is-truncated',
     status: 'new',
   },
+  {
+    title: 'useBreadcrumbs',
+    slug: 'use-breadcrumbs',
+    status: 'new',
+  },
 ];

--- a/docs/frontend-system/building-plugins/03-common-extension-blueprints.md
+++ b/docs/frontend-system/building-plugins/03-common-extension-blueprints.md
@@ -21,6 +21,26 @@ Page extensions provide content for a particular route in the app. By default pa
 
 To enable sub-pages on a page, you can either omit the `loader` param to use the built-in default implementation that renders sub-pages as tabs, or provide a custom `loader` that explicitly handles the sub-page inputs.
 
+Set `noHeader: true` to hide the default plugin page header, or `noBreadcrumbs: true` to disable automatic breadcrumb registration for the page. When breadcrumbs are enabled (the default), the page title is registered as a breadcrumb entry and sub-page titles are registered automatically via `SubPageBlueprint`.
+
+If a sub-page has internal `<Route>` elements, wrap each route's content with `BreadcrumbRegistration` so it appears in the breadcrumb trail:
+
+```tsx
+import { BreadcrumbRegistration } from '@backstage/ui';
+
+<Routes>
+  <Route index element={<MyListPage />} />
+  <Route
+    path=":id"
+    element={
+      <BreadcrumbRegistration entry={{ label: id, href: id }}>
+        <MyDetailPage />
+      </BreadcrumbRegistration>
+    }
+  />
+</Routes>;
+```
+
 ### SubPage - [Reference](https://backstage.io/api/stable/variables/_backstage_frontend-plugin-api.index.SubPageBlueprint.html)
 
 Sub-page extensions create tabbed content within a parent page. They are attached to a page extension's `pages` input and rendered as tabs in the page header. Each sub-page has a `path` (relative to the parent page), a `title` for the tab, and an optional `icon`. Content is lazy-loaded via a `loader` function.

--- a/packages/app-example-plugin/report.api.md
+++ b/packages/app-example-plugin/report.api.md
@@ -93,6 +93,7 @@ const examplePlugin: OverridableFrontendPlugin<
         loader?: () => Promise<JSX_2.Element>;
         routeRef?: RouteRef;
         noHeader?: boolean;
+        noBreadcrumbs?: boolean;
       };
     }>;
   }

--- a/packages/app/src/examples/pagesPlugin.tsx
+++ b/packages/app/src/examples/pagesPlugin.tsx
@@ -27,6 +27,7 @@ import {
   createExtensionInput,
   coreExtensionData,
 } from '@backstage/frontend-plugin-api';
+import { BreadcrumbRegistration } from '@backstage/ui';
 import { useEffect, useState } from 'react';
 import { Route, Routes } from 'react-router-dom';
 
@@ -160,8 +161,27 @@ const Page1 = PageBlueprint.make({
               Sub-page content:
               <div>
                 <Routes>
-                  <Route path="/" element={<h2>This is also page 1</h2>} />
-                  <Route path="/page2" element={<h2>This is page 2</h2>} />
+                  <Route
+                    path="/"
+                    element={
+                      <BreadcrumbRegistration
+                        entry={{ label: 'Page 1', href: '/' }}
+                      >
+                        <h2>This is also page 1</h2>
+                      </BreadcrumbRegistration>
+                    }
+                  />
+
+                  <Route
+                    path="/page2"
+                    element={
+                      <BreadcrumbRegistration
+                        entry={{ label: 'Page 2', href: '/page2' }}
+                      >
+                        <h2>This is page 2</h2>
+                      </BreadcrumbRegistration>
+                    }
+                  />
                 </Routes>
               </div>
             </div>

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -8,6 +8,7 @@ import { ApiRef as ApiRef_2 } from '@backstage/frontend-plugin-api';
 import { ComponentType } from 'react';
 import type { Config } from '@backstage/config';
 import { ConfigurableExtensionDataRef as ConfigurableExtensionDataRef_2 } from '@backstage/frontend-plugin-api';
+import { Context } from 'react';
 import { Expand } from '@backstage/types';
 import { ExpandRecursive } from '@backstage/types';
 import { ExtensionBlueprint as ExtensionBlueprint_2 } from '@backstage/frontend-plugin-api';
@@ -2163,6 +2164,7 @@ export const PageBlueprint: ExtensionBlueprint_2<{
     loader?: () => Promise<JSX_2.Element>;
     routeRef?: RouteRef;
     noHeader?: boolean;
+    noBreadcrumbs?: boolean;
   };
   output:
     | ExtensionDataRef_2<string, 'core.routing.path', {}>
@@ -2245,6 +2247,8 @@ export interface PageLayoutProps {
   headerActions?: Array<JSX.Element | null>;
   // (undocumented)
   icon?: IconElement;
+  // (undocumented)
+  noBreadcrumbs?: boolean;
   // (undocumented)
   noHeader?: boolean;
   // (undocumented)
@@ -2529,6 +2533,21 @@ export const SubPageBlueprint: ExtensionBlueprint_2<{
   };
   dataRefs: never;
 }>;
+
+// @public
+export const SubPageWrapperContext: Context<
+  ComponentType<SubPageWrapperProps> | undefined
+>;
+
+// @public
+export interface SubPageWrapperProps {
+  // (undocumented)
+  children: ReactNode;
+  // (undocumented)
+  href: string;
+  // (undocumented)
+  label: string;
+}
 
 // @public
 export interface SubRouteRef<

--- a/packages/frontend-plugin-api/src/blueprints/PageBlueprint.tsx
+++ b/packages/frontend-plugin-api/src/blueprints/PageBlueprint.tsx
@@ -25,6 +25,7 @@ import {
   createExtensionInput,
 } from '../wiring';
 import { ExtensionBoundary, PageLayout, PageLayoutTab } from '../components';
+import { useSubPageWrapper } from '../components/SubPageWrapperContext';
 import { useApi } from '../apis/system';
 import { routeResolutionApiRef } from '../apis/definitions/RouteResolutionApi';
 import { pluginHeaderActionsApiRef } from '../apis/definitions/PluginHeaderActionsApi';
@@ -84,6 +85,10 @@ export const PageBlueprint = createExtensionBlueprint({
        * Hide the default plugin page header, making the page fill up all available space.
        */
       noHeader?: boolean;
+      /**
+       * Disable breadcrumb registration for this page.
+       */
+      noBreadcrumbs?: boolean;
     },
     { config, node, inputs },
   ) {
@@ -91,6 +96,7 @@ export const PageBlueprint = createExtensionBlueprint({
     const icon = params.icon;
     const pluginId = node.spec.plugin.pluginId;
     const noHeader = params.noHeader ?? false;
+    const noBreadcrumbs = params.noBreadcrumbs ?? false;
     const resolvedTitle =
       title ?? node.spec.plugin.title ?? node.spec.plugin.pluginId;
     const resolvedIcon = icon ?? node.spec.plugin.icon;
@@ -111,6 +117,7 @@ export const PageBlueprint = createExtensionBlueprint({
             title={resolvedTitle}
             icon={resolvedIcon}
             noHeader={noHeader}
+            noBreadcrumbs={noBreadcrumbs}
             titleLink={titleLink}
             headerActions={headerActions}
           >
@@ -141,10 +148,13 @@ export const PageBlueprint = createExtensionBlueprint({
         const headerActionsApi = useApi(pluginHeaderActionsApiRef);
         const headerActions = headerActionsApi.getPluginHeaderActions(pluginId);
 
+        const SubPageWrapper = useSubPageWrapper();
+
         return (
           <PageLayout
             title={resolvedTitle}
             icon={resolvedIcon}
+            noBreadcrumbs={noBreadcrumbs}
             tabs={tabs}
             titleLink={titleLink}
             headerActions={headerActions}
@@ -158,9 +168,17 @@ export const PageBlueprint = createExtensionBlueprint({
               )}
               {inputs.pages.map((page, index) => {
                 const path = page.get(coreExtensionData.routePath);
+                const tabTitle = page.get(coreExtensionData.title);
                 const element = page.get(coreExtensionData.reactElement);
+                const wrapped = SubPageWrapper ? (
+                  <SubPageWrapper label={tabTitle || path} href={path}>
+                    {element}
+                  </SubPageWrapper>
+                ) : (
+                  element
+                );
                 return (
-                  <Route key={index} path={`${path}/*`} element={element} />
+                  <Route key={index} path={`${path}/*`} element={wrapped} />
                 );
               })}
             </Routes>
@@ -179,6 +197,7 @@ export const PageBlueprint = createExtensionBlueprint({
           <PageLayout
             title={resolvedTitle}
             icon={resolvedIcon}
+            noBreadcrumbs={noBreadcrumbs}
             titleLink={titleLink}
             headerActions={headerActions}
           />

--- a/packages/frontend-plugin-api/src/components/PageLayout.tsx
+++ b/packages/frontend-plugin-api/src/components/PageLayout.tsx
@@ -43,6 +43,7 @@ export interface PageLayoutProps {
   title?: string;
   icon?: IconElement;
   noHeader?: boolean;
+  noBreadcrumbs?: boolean;
   titleLink?: string;
   headerActions?: Array<JSX.Element | null>;
   tabs?: PageLayoutTab[];

--- a/packages/frontend-plugin-api/src/components/SubPageWrapperContext.tsx
+++ b/packages/frontend-plugin-api/src/components/SubPageWrapperContext.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  createContext,
+  useContext,
+  type ComponentType,
+  type ReactNode,
+} from 'react';
+
+/**
+ * Props for a sub-page wrapper component provided via {@link SubPageWrapperContext}.
+ *
+ * @public
+ */
+export interface SubPageWrapperProps {
+  label: string;
+  href: string;
+  children: ReactNode;
+}
+
+/**
+ * Context that allows PageLayout implementations to provide a wrapper component
+ * for sub-page route elements. This enables features like breadcrumb registration
+ * without coupling `frontend-plugin-api` to a specific UI library.
+ *
+ * @public
+ */
+export const SubPageWrapperContext = createContext<
+  ComponentType<SubPageWrapperProps> | undefined
+>(undefined);
+
+/** @internal */
+export function useSubPageWrapper():
+  | ComponentType<SubPageWrapperProps>
+  | undefined {
+  return useContext(SubPageWrapperContext);
+}

--- a/packages/frontend-plugin-api/src/components/index.ts
+++ b/packages/frontend-plugin-api/src/components/index.ts
@@ -31,3 +31,7 @@ export {
   type PageLayoutTab,
   type PageTab,
 } from './PageLayout';
+export {
+  SubPageWrapperContext,
+  type SubPageWrapperProps,
+} from './SubPageWrapperContext';

--- a/packages/ui/report.api.md
+++ b/packages/ui/report.api.md
@@ -511,6 +511,14 @@ export const BreadcrumbDefinition: {
 };
 
 // @public
+export interface BreadcrumbEntry {
+  // (undocumented)
+  href?: string;
+  // (undocumented)
+  label: string;
+}
+
+// @public
 export interface BreadcrumbOwnProps extends BreadcrumbStyleProps {
   // (undocumented)
   as?: TextOwnProps['as'];
@@ -522,6 +530,12 @@ export interface BreadcrumbOwnProps extends BreadcrumbStyleProps {
 
 // @public
 export interface BreadcrumbProps extends BreadcrumbOwnProps {}
+
+// @public
+export function BreadcrumbRegistration(props: {
+  entry: BreadcrumbEntry;
+  children: ReactNode;
+}): JSX_2.Element;
 
 // @public
 export const Breadcrumbs: (props: BreadcrumbsProps) => JSX_2.Element | null;
@@ -567,6 +581,11 @@ export interface BreadcrumbsOwnProps extends BreadcrumbStyleProps {
 
 // @public
 export interface BreadcrumbsProps extends BreadcrumbsOwnProps {}
+
+// @public (undocumented)
+export function BreadcrumbsRegistryProvider(props: {
+  children: ReactNode;
+}): JSX_2.Element;
 
 // @public
 export interface BreadcrumbStyleProps {
@@ -3756,6 +3775,9 @@ export function useBgConsumer(): BgContextValue;
 
 // @public
 export function useBgProvider(bg?: Responsive<ProviderBg>): BgContextValue;
+
+// @public
+export function useBreadcrumbs(): BreadcrumbEntry[];
 
 // @public (undocumented)
 export const useBreakpoint: () => {

--- a/packages/ui/report.api.md
+++ b/packages/ui/report.api.md
@@ -2651,6 +2651,7 @@ export const PluginHeaderDefinition: {
     readonly icon: {};
     readonly title: {};
     readonly titleLink: {};
+    readonly breadcrumbs: {};
     readonly customActions: {};
     readonly tabs: {};
     readonly onTabSelectionChange: {};
@@ -2660,6 +2661,8 @@ export const PluginHeaderDefinition: {
 
 // @public
 export interface PluginHeaderOwnProps {
+  // (undocumented)
+  breadcrumbs?: BreadcrumbEntry[];
   // (undocumented)
   className?: string;
   // (undocumented)

--- a/packages/ui/src/components/PluginHeader/PluginHeader.test.tsx
+++ b/packages/ui/src/components/PluginHeader/PluginHeader.test.tsx
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { type PropsWithChildren } from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { BUIProvider } from '../../provider';
+import { PluginHeader } from './PluginHeader';
+
+const originalWarn = console.warn.bind(console);
+const originalResizeObserver = global.ResizeObserver;
+
+beforeAll(() => {
+  global.ResizeObserver = jest.fn(() => ({
+    observe: jest.fn(),
+    unobserve: jest.fn(),
+    disconnect: jest.fn(),
+  })) as unknown as typeof ResizeObserver;
+
+  jest.spyOn(console, 'warn').mockImplementation((msg: unknown, ...args) => {
+    if (typeof msg === 'string' && msg.includes('<Focusable>')) return;
+    originalWarn(msg, ...args);
+  });
+});
+
+afterAll(() => {
+  global.ResizeObserver = originalResizeObserver;
+  jest.restoreAllMocks();
+});
+
+function Wrapper({ children }: PropsWithChildren) {
+  return (
+    <MemoryRouter>
+      <BUIProvider>{children}</BUIProvider>
+    </MemoryRouter>
+  );
+}
+
+describe('PluginHeader', () => {
+  it('should render the title as a breadcrumb when no breadcrumbs are provided', () => {
+    render(<PluginHeader title="My Plugin" />, { wrapper: Wrapper });
+
+    expect(screen.getByText('My Plugin')).toBeInTheDocument();
+    expect(screen.getAllByRole('listitem')).toHaveLength(1);
+  });
+
+  it('should render a default title when no title is provided', () => {
+    render(<PluginHeader />, { wrapper: Wrapper });
+
+    expect(screen.getByText('Your plugin')).toBeInTheDocument();
+  });
+
+  it('should render breadcrumbs instead of the title when provided', () => {
+    const breadcrumbs = [
+      { label: 'Home', href: '/home' },
+      { label: 'Settings', href: '/settings' },
+    ];
+
+    render(<PluginHeader title="My Plugin" breadcrumbs={breadcrumbs} />, {
+      wrapper: Wrapper,
+    });
+
+    const items = screen.getAllByRole('listitem');
+    expect(items).toHaveLength(2);
+    expect(items[0]).toHaveTextContent('Home');
+    expect(items[1]).toHaveTextContent('Settings');
+    expect(screen.queryByText('My Plugin')).not.toBeInTheDocument();
+  });
+
+  it('should fall back to title when breadcrumbs array is empty', () => {
+    render(<PluginHeader title="My Plugin" breadcrumbs={[]} />, {
+      wrapper: Wrapper,
+    });
+
+    expect(screen.getByText('My Plugin')).toBeInTheDocument();
+    expect(screen.getAllByRole('listitem')).toHaveLength(1);
+  });
+
+  it('should render tabs when provided', () => {
+    const tabs = [
+      { id: 'overview', label: 'Overview', href: '/overview' },
+      { id: 'settings', label: 'Settings', href: '/settings' },
+    ];
+
+    render(<PluginHeader title="My Plugin" tabs={tabs} />, {
+      wrapper: Wrapper,
+    });
+
+    expect(screen.getByText('Overview')).toBeInTheDocument();
+    expect(screen.getByText('Settings')).toBeInTheDocument();
+  });
+
+  it('should render custom actions', () => {
+    render(
+      <PluginHeader
+        title="My Plugin"
+        customActions={<button>Action</button>}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    expect(screen.getByText('Action')).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/PluginHeader/PluginHeader.tsx
+++ b/packages/ui/src/components/PluginHeader/PluginHeader.tsx
@@ -22,9 +22,8 @@ import { type NavigateOptions } from 'react-router-dom';
 import { Children, useMemo, useRef } from 'react';
 import { useIsomorphicLayoutEffect } from '../../hooks/useIsomorphicLayoutEffect';
 import { Box } from '../Box';
-import { Link } from '../Link';
 import { RiShapesLine } from '@remixicon/react';
-import { Text } from '../Text';
+import { Breadcrumb, Breadcrumbs } from '../Breadcrumbs';
 
 declare module 'react-aria-components' {
   interface RouterConfig {
@@ -47,6 +46,7 @@ export const PluginHeader = (props: PluginHeaderProps) => {
     icon,
     title,
     titleLink,
+    breadcrumbs,
     customActions,
     onTabSelectionChange,
   } = ownProps;
@@ -122,6 +122,7 @@ export const PluginHeader = (props: PluginHeaderProps) => {
   }, []);
 
   const titleText = title || 'Your plugin';
+  const hasBreadcrumbs = breadcrumbs && breadcrumbs.length > 0;
 
   return (
     <div ref={rootRef} className={classes.root}>
@@ -131,15 +132,17 @@ export const PluginHeader = (props: PluginHeaderProps) => {
             {icon || <RiShapesLine />}
           </Box>
           <h1 className={classes.toolbarName}>
-            {titleLink ? (
-              <Link href={titleLink} standalone variant="body-medium">
-                {titleText}
-              </Link>
-            ) : (
-              <Text as="span" variant="body-medium">
-                {titleText}
-              </Text>
-            )}
+            <Breadcrumbs variant="body-medium">
+              {hasBreadcrumbs ? (
+                breadcrumbs.map(entry => (
+                  <Breadcrumb key={entry.label} href={entry.href}>
+                    {entry.label}
+                  </Breadcrumb>
+                ))
+              ) : (
+                <Breadcrumb href={titleLink}>{titleText}</Breadcrumb>
+              )}
+            </Breadcrumbs>
           </h1>
         </div>
         <div className={classes.toolbarControls}>{actionChildren}</div>

--- a/packages/ui/src/components/PluginHeader/definition.ts
+++ b/packages/ui/src/components/PluginHeader/definition.ts
@@ -37,6 +37,7 @@ export const PluginHeaderDefinition = defineComponent<PluginHeaderOwnProps>()({
     icon: {},
     title: {},
     titleLink: {},
+    breadcrumbs: {},
     customActions: {},
     tabs: {},
     onTabSelectionChange: {},

--- a/packages/ui/src/components/PluginHeader/types.ts
+++ b/packages/ui/src/components/PluginHeader/types.ts
@@ -16,6 +16,7 @@
 
 import { TabsProps } from 'react-aria-components';
 import { TabMatchStrategy } from '../Tabs';
+import type { BreadcrumbEntry } from '../../hooks/useBreadcrumbs';
 
 /**
  * Own props for the {@link PluginHeader} component.
@@ -26,6 +27,7 @@ export interface PluginHeaderOwnProps {
   icon?: React.ReactNode;
   title?: string;
   titleLink?: string;
+  breadcrumbs?: BreadcrumbEntry[];
   customActions?: React.ReactNode;
   tabs?: HeaderTab[];
   onTabSelectionChange?: TabsProps['onSelectionChange'];

--- a/packages/ui/src/hooks/index.ts
+++ b/packages/ui/src/hooks/index.ts
@@ -16,3 +16,9 @@
 
 export * from './useDefinition';
 export { useIsTruncated } from './useIsTruncated';
+export {
+  useBreadcrumbs,
+  BreadcrumbRegistration,
+  BreadcrumbsRegistryProvider,
+} from './useBreadcrumbs';
+export type { BreadcrumbEntry } from './useBreadcrumbs';

--- a/packages/ui/src/hooks/useBreadcrumbs.test.tsx
+++ b/packages/ui/src/hooks/useBreadcrumbs.test.tsx
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen, act } from '@testing-library/react';
+import { useState } from 'react';
+import {
+  BreadcrumbsRegistryProvider,
+  BreadcrumbRegistration,
+  useBreadcrumbs,
+} from './useBreadcrumbs';
+
+function BreadcrumbDisplay() {
+  const entries = useBreadcrumbs();
+  return (
+    <ul data-testid="breadcrumbs">
+      {entries.map((e, i) => (
+        <li key={i}>
+          {e.label}
+          {e.href && ` (${e.href})`}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+describe('useBreadcrumbs', () => {
+  it('should return an empty array when no breadcrumbs are registered', () => {
+    render(
+      <BreadcrumbsRegistryProvider>
+        <BreadcrumbDisplay />
+      </BreadcrumbsRegistryProvider>,
+    );
+
+    expect(screen.getByTestId('breadcrumbs').children).toHaveLength(0);
+  });
+
+  it('should register a breadcrumb entry and display it', () => {
+    render(
+      <BreadcrumbsRegistryProvider>
+        <BreadcrumbRegistration entry={{ label: 'Home', href: '/home' }}>
+          <BreadcrumbDisplay />
+        </BreadcrumbRegistration>
+      </BreadcrumbsRegistryProvider>,
+    );
+
+    expect(screen.getByText('Home (/home)')).toBeInTheDocument();
+  });
+
+  it('should register multiple breadcrumbs in component tree order', () => {
+    render(
+      <BreadcrumbsRegistryProvider>
+        <BreadcrumbRegistration entry={{ label: 'Home', href: '/home' }}>
+          <BreadcrumbRegistration
+            entry={{ label: 'Settings', href: '/home/settings' }}
+          >
+            <BreadcrumbDisplay />
+          </BreadcrumbRegistration>
+        </BreadcrumbRegistration>
+      </BreadcrumbsRegistryProvider>,
+    );
+
+    const items = screen.getByTestId('breadcrumbs').querySelectorAll('li');
+    expect(items).toHaveLength(2);
+    expect(items[0]).toHaveTextContent('Home (/home)');
+    expect(items[1]).toHaveTextContent('Settings (/home/settings)');
+  });
+
+  it('should remove a breadcrumb when the component unmounts', () => {
+    function Toggle() {
+      const [showChild, setShowChild] = useState(true);
+      return (
+        <BreadcrumbRegistration entry={{ label: 'Home', href: '/home' }}>
+          {showChild && (
+            <BreadcrumbRegistration
+              entry={{ label: 'Settings', href: '/settings' }}
+            >
+              <div />
+            </BreadcrumbRegistration>
+          )}
+          <BreadcrumbDisplay />
+          <button onClick={() => setShowChild(false)}>remove</button>
+        </BreadcrumbRegistration>
+      );
+    }
+
+    render(
+      <BreadcrumbsRegistryProvider>
+        <Toggle />
+      </BreadcrumbsRegistryProvider>,
+    );
+
+    expect(
+      screen.getByTestId('breadcrumbs').querySelectorAll('li'),
+    ).toHaveLength(2);
+
+    act(() => {
+      screen.getByText('remove').click();
+    });
+
+    const items = screen.getByTestId('breadcrumbs').querySelectorAll('li');
+    expect(items).toHaveLength(1);
+    expect(items[0]).toHaveTextContent('Home (/home)');
+  });
+
+  it('should register a breadcrumb without an href', () => {
+    render(
+      <BreadcrumbsRegistryProvider>
+        <BreadcrumbRegistration entry={{ label: 'Current Page' }}>
+          <BreadcrumbDisplay />
+        </BreadcrumbRegistration>
+      </BreadcrumbsRegistryProvider>,
+    );
+
+    expect(screen.getByText('Current Page')).toBeInTheDocument();
+  });
+
+  it('should return an empty array outside of a provider', () => {
+    render(<BreadcrumbDisplay />);
+
+    expect(screen.getByTestId('breadcrumbs').children).toHaveLength(0);
+  });
+});

--- a/packages/ui/src/hooks/useBreadcrumbs.tsx
+++ b/packages/ui/src/hooks/useBreadcrumbs.tsx
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react';
+
+/**
+ * A single breadcrumb entry registered by a page component.
+ *
+ * @public
+ */
+export interface BreadcrumbEntry {
+  label: string;
+  href?: string;
+}
+
+interface InternalEntry extends BreadcrumbEntry {
+  depth: number;
+}
+
+interface BreadcrumbsStore {
+  register(entry: InternalEntry): () => void;
+  subscribe(listener: () => void): () => void;
+  getEntries(): BreadcrumbEntry[];
+}
+
+function createBreadcrumbsStore(): BreadcrumbsStore {
+  const entries: InternalEntry[] = [];
+  const listeners = new Set<() => void>();
+
+  function notify() {
+    listeners.forEach(l => l());
+  }
+
+  return {
+    register(entry: InternalEntry) {
+      entries.push(entry);
+      entries.sort((a, b) => a.depth - b.depth);
+      notify();
+      return () => {
+        const idx = entries.indexOf(entry);
+        if (idx >= 0) {
+          entries.splice(idx, 1);
+          notify();
+        }
+      };
+    },
+    subscribe(listener: () => void) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    getEntries() {
+      return entries.map(({ label, href }) => ({ label, href }));
+    },
+  };
+}
+
+const StoreContext = createContext<BreadcrumbsStore | undefined>(undefined);
+const DepthContext = createContext(0);
+
+/** @public */
+export function BreadcrumbsRegistryProvider(props: { children: ReactNode }) {
+  const [store] = useState(createBreadcrumbsStore);
+  return (
+    <StoreContext.Provider value={store}>
+      {props.children}
+    </StoreContext.Provider>
+  );
+}
+
+/**
+ * Returns the current breadcrumb trail registered by page components anywhere
+ * in the tree. Call this in components that render breadcrumbs (e.g. PluginHeader).
+ *
+ * @public
+ */
+export function useBreadcrumbs(): BreadcrumbEntry[] {
+  const store = useContext(StoreContext);
+  const [entries, setEntries] = useState<BreadcrumbEntry[]>(
+    () => store?.getEntries() ?? [],
+  );
+
+  useEffect(() => {
+    if (!store) return undefined;
+    setEntries(store.getEntries());
+    return store.subscribe(() => {
+      setEntries(store.getEntries());
+    });
+  }, [store]);
+
+  return entries;
+}
+
+/**
+ * Registers a breadcrumb entry for the current page. The entry is added on
+ * mount and removed on unmount. Wraps its children and increments the depth
+ * counter so nested registrations are ordered correctly.
+ *
+ * @public
+ */
+export function BreadcrumbRegistration(props: {
+  entry: BreadcrumbEntry;
+  children: ReactNode;
+}) {
+  const store = useContext(StoreContext);
+  const depth = useContext(DepthContext);
+  const { label, href } = props.entry;
+
+  useEffect(() => {
+    if (!store) return undefined;
+    return store.register({ label, href, depth });
+  }, [store, depth, label, href]);
+
+  return (
+    <DepthContext.Provider value={depth + 1}>
+      {props.children}
+    </DepthContext.Provider>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -78,6 +78,12 @@ export { useBreakpoint } from './hooks/useBreakpoint';
 export { useBgProvider, useBgConsumer, BgProvider } from './hooks/useBg';
 export type { BgContextValue, BgProviderProps } from './hooks/useBg';
 export { useIsTruncated } from './hooks/useIsTruncated';
+export {
+  useBreadcrumbs,
+  BreadcrumbRegistration,
+  BreadcrumbsRegistryProvider,
+} from './hooks/useBreadcrumbs';
+export type { BreadcrumbEntry } from './hooks/useBreadcrumbs';
 
 // Provider
 export { BUIProvider } from './provider';

--- a/packages/ui/src/provider/BUIProvider.tsx
+++ b/packages/ui/src/provider/BUIProvider.tsx
@@ -20,6 +20,7 @@ import { useInRouterContext, useNavigate } from 'react-router-dom';
 import { createVersionedValueMap } from '@backstage/version-bridge';
 import { BUIContext } from '../analytics/useAnalytics';
 import { useResolvedHref } from '../hooks/useResolvedHref';
+import { BreadcrumbsRegistryProvider } from '../hooks/useBreadcrumbs';
 import type { UseAnalyticsFn } from '../analytics/types';
 
 /** @public */
@@ -58,7 +59,9 @@ export function BUIProvider(props: BUIProviderProps) {
   );
 
   const content = (
-    <BUIContext.Provider value={value}>{children}</BUIContext.Provider>
+    <BUIContext.Provider value={value}>
+      <BreadcrumbsRegistryProvider>{children}</BreadcrumbsRegistryProvider>
+    </BUIContext.Provider>
   );
 
   if (useInRouterContext()) {

--- a/plugins/api-docs/report-alpha.api.md
+++ b/plugins/api-docs/report-alpha.api.md
@@ -547,6 +547,7 @@ const _default: OverridableFrontendPlugin<
         loader?: () => Promise<JSX_2.Element>;
         routeRef?: RouteRef_2;
         noHeader?: boolean;
+        noBreadcrumbs?: boolean;
       };
     }>;
   }

--- a/plugins/app-visualizer/report.api.md
+++ b/plugins/app-visualizer/report.api.md
@@ -92,6 +92,7 @@ const visualizerPlugin: OverridableFrontendPlugin<
         loader?: () => Promise<JSX_2.Element>;
         routeRef?: RouteRef;
         noHeader?: boolean;
+        noBreadcrumbs?: boolean;
       };
     }>;
     'plugin-header-action:app-visualizer': OverridableExtensionDefinition<{

--- a/plugins/app/src/extensions/AppRoot.tsx
+++ b/plugins/app/src/extensions/AppRoot.tsx
@@ -32,13 +32,15 @@ import {
   routeResolutionApiRef,
   pluginWrapperApiRef,
   useAnalytics,
+  SubPageWrapperContext,
 } from '@backstage/frontend-plugin-api';
 import {
   AppRootWrapperBlueprint,
   RouterBlueprint,
   SignInPageBlueprint,
 } from '@backstage/plugin-app-react';
-import { BUIProvider } from '@backstage/ui';
+import { BUIProvider, BreadcrumbRegistration } from '@backstage/ui';
+import type { SubPageWrapperProps } from '@backstage/frontend-plugin-api';
 import {
   DiscoveryApi,
   ErrorApi,
@@ -206,6 +208,14 @@ export interface AppRouterProps {
   extraElements?: Array<JSX.Element>;
 }
 
+function BreadcrumbRegistrationWrapper(props: SubPageWrapperProps) {
+  return (
+    <BreadcrumbRegistration entry={{ label: props.label, href: props.href }}>
+      {props.children}
+    </BreadcrumbRegistration>
+  );
+}
+
 function DefaultRouter(props: PropsWithChildren<{}>) {
   const configApi = useApi(configApiRef);
   const basePath = getBasePath(configApi);
@@ -283,9 +293,11 @@ export function AppRouter(props: AppRouterProps) {
     return (
       <RouterComponent>
         <BUIProvider useAnalytics={useAnalytics}>
-          {...extraElements}
-          <RouteTracker routeObjects={routeObjects} />
-          {children}
+          <SubPageWrapperContext.Provider value={BreadcrumbRegistrationWrapper}>
+            {...extraElements}
+            <RouteTracker routeObjects={routeObjects} />
+            {children}
+          </SubPageWrapperContext.Provider>
         </BUIProvider>
       </RouterComponent>
     );
@@ -294,14 +306,16 @@ export function AppRouter(props: AppRouterProps) {
   return (
     <RouterComponent>
       <BUIProvider useAnalytics={useAnalytics}>
-        {...extraElements}
-        <RouteTracker routeObjects={routeObjects} />
-        <SignInPageWrapper
-          component={SignInPageComponent}
-          appIdentityProxy={appIdentityProxy}
-        >
-          {children}
-        </SignInPageWrapper>
+        <SubPageWrapperContext.Provider value={BreadcrumbRegistrationWrapper}>
+          {...extraElements}
+          <RouteTracker routeObjects={routeObjects} />
+          <SignInPageWrapper
+            component={SignInPageComponent}
+            appIdentityProxy={appIdentityProxy}
+          >
+            {children}
+          </SignInPageWrapper>
+        </SubPageWrapperContext.Provider>
       </BUIProvider>
     </RouterComponent>
   );

--- a/plugins/app/src/extensions/components.tsx
+++ b/plugins/app/src/extensions/components.tsx
@@ -26,7 +26,11 @@ import {
   ErrorPanel,
   Progress as ProgressComponent,
 } from '@backstage/core-components';
-import { PluginHeader } from '@backstage/ui';
+import {
+  PluginHeader,
+  BreadcrumbRegistration,
+  useBreadcrumbs,
+} from '@backstage/ui';
 import Button from '@material-ui/core/Button';
 import { useMemo } from 'react';
 import { useResolvedPath } from 'react-router-dom';
@@ -79,6 +83,7 @@ export const PageLayout = SwappableComponentBlueprint.make({
           title,
           icon,
           noHeader,
+          noBreadcrumbs,
           titleLink,
           headerActions,
           tabs,
@@ -98,21 +103,34 @@ export const PageLayout = SwappableComponentBlueprint.make({
           [tabs, parentPath],
         );
 
-        if (noHeader) {
-          return <>{children}</>;
-        }
+        const breadcrumbs = useBreadcrumbs();
 
-        return (
+        const content = noHeader ? (
+          <>{children}</>
+        ) : (
           <>
             <PluginHeader
               title={title}
               icon={icon}
               titleLink={titleLink}
+              breadcrumbs={noBreadcrumbs ? undefined : breadcrumbs}
               tabs={resolvedTabs}
               customActions={headerActions}
             />
             {children}
           </>
+        );
+
+        if (noBreadcrumbs) {
+          return content;
+        }
+
+        return (
+          <BreadcrumbRegistration
+            entry={{ label: title ?? '', href: titleLink }}
+          >
+            {content}
+          </BreadcrumbRegistration>
         );
       },
     }),

--- a/plugins/auth/report.api.md
+++ b/plugins/auth/report.api.md
@@ -94,6 +94,7 @@ const _default: OverridableFrontendPlugin<
         loader?: () => Promise<JSX_2.Element>;
         routeRef?: RouteRef;
         noHeader?: boolean;
+        noBreadcrumbs?: boolean;
       };
     }>;
   }

--- a/plugins/catalog-graph/report-alpha.api.md
+++ b/plugins/catalog-graph/report-alpha.api.md
@@ -248,6 +248,7 @@ const _default: OverridableFrontendPlugin<
         loader?: () => Promise<JSX_2.Element>;
         routeRef?: RouteRef_2;
         noHeader?: boolean;
+        noBreadcrumbs?: boolean;
       };
     }>;
   }

--- a/plugins/catalog-import/report-alpha.api.md
+++ b/plugins/catalog-import/report-alpha.api.md
@@ -187,6 +187,7 @@ const _default: OverridableFrontendPlugin<
         loader?: () => Promise<JSX_2.Element>;
         routeRef?: RouteRef_2;
         noHeader?: boolean;
+        noBreadcrumbs?: boolean;
       };
     }>;
   }

--- a/plugins/catalog-unprocessed-entities/report-alpha.api.md
+++ b/plugins/catalog-unprocessed-entities/report-alpha.api.md
@@ -113,6 +113,7 @@ const _default: OverridableFrontendPlugin<
         loader?: () => Promise<JSX_2.Element>;
         routeRef?: RouteRef_2;
         noHeader?: boolean;
+        noBreadcrumbs?: boolean;
       };
     }>;
     'sub-page:catalog-unprocessed-entities': OverridableExtensionDefinition<{

--- a/plugins/catalog/report-alpha.api.md
+++ b/plugins/catalog/report-alpha.api.md
@@ -1225,6 +1225,7 @@ const _default: OverridableFrontendPlugin<
         loader?: () => Promise<JSX_2.Element>;
         routeRef?: RouteRef_2;
         noHeader?: boolean;
+        noBreadcrumbs?: boolean;
       };
     }>;
     'page:catalog/entity': OverridableExtensionDefinition<{
@@ -1412,6 +1413,7 @@ const _default: OverridableFrontendPlugin<
         loader?: () => Promise<JSX_2.Element>;
         routeRef?: RouteRef_2;
         noHeader?: boolean;
+        noBreadcrumbs?: boolean;
       };
     }>;
     'search-result-list-item:catalog': OverridableExtensionDefinition<{

--- a/plugins/devtools/report-alpha.api.md
+++ b/plugins/devtools/report-alpha.api.md
@@ -113,6 +113,7 @@ const _default: OverridableFrontendPlugin<
         loader?: () => Promise<JSX_2.Element>;
         routeRef?: RouteRef_2;
         noHeader?: boolean;
+        noBreadcrumbs?: boolean;
       };
     }>;
     'sub-page:devtools/config': OverridableExtensionDefinition<{

--- a/plugins/home/report-alpha.api.md
+++ b/plugins/home/report-alpha.api.md
@@ -178,6 +178,7 @@ const _default: OverridableFrontendPlugin<
         loader?: () => Promise<JSX_2.Element>;
         routeRef?: RouteRef;
         noHeader?: boolean;
+        noBreadcrumbs?: boolean;
       };
     }>;
   }

--- a/plugins/kubernetes/report-alpha.api.md
+++ b/plugins/kubernetes/report-alpha.api.md
@@ -234,6 +234,7 @@ const _default: OverridableFrontendPlugin<
         loader?: () => Promise<JSX_2.Element>;
         routeRef?: RouteRef_2;
         noHeader?: boolean;
+        noBreadcrumbs?: boolean;
       };
     }>;
   }

--- a/plugins/mui-to-bui/report.api.md
+++ b/plugins/mui-to-bui/report.api.md
@@ -108,6 +108,7 @@ const _default: OverridableFrontendPlugin<
         loader?: () => Promise<JSX_2.Element>;
         routeRef?: RouteRef_2;
         noHeader?: boolean;
+        noBreadcrumbs?: boolean;
       };
     }>;
   }

--- a/plugins/notifications/report-alpha.api.md
+++ b/plugins/notifications/report-alpha.api.md
@@ -114,6 +114,7 @@ const _default: OverridableFrontendPlugin<
         loader?: () => Promise<JSX_2.Element>;
         routeRef?: RouteRef_2;
         noHeader?: boolean;
+        noBreadcrumbs?: boolean;
       };
     }>;
   }

--- a/plugins/scaffolder/report-alpha.api.md
+++ b/plugins/scaffolder/report-alpha.api.md
@@ -258,6 +258,7 @@ const _default: OverridableFrontendPlugin<
         loader?: () => Promise<JSX_2.Element>;
         routeRef?: RouteRef_2;
         noHeader?: boolean;
+        noBreadcrumbs?: boolean;
       };
     }>;
     'scaffolder-form-field:scaffolder/entity-name-picker': OverridableExtensionDefinition<{

--- a/plugins/scaffolder/src/alpha/components/EditorSubPage.tsx
+++ b/plugins/scaffolder/src/alpha/components/EditorSubPage.tsx
@@ -18,6 +18,7 @@ import { useAsync, useMountEffect } from '@react-hookz/web';
 import { useCallback, useMemo } from 'react';
 import { Routes, Route, useNavigate } from 'react-router-dom';
 import { Content } from '@backstage/core-components';
+import { BreadcrumbRegistration } from '@backstage/ui';
 import { useApi } from '@backstage/core-plugin-api';
 import { makeStyles } from '@material-ui/core/styles';
 import { RequirePermission } from '@backstage/plugin-permission-react';
@@ -167,15 +168,33 @@ export function EditorSubPage() {
           <Route index element={<EditorIntroContent />} />
           <Route
             path="template"
-            element={<EditorContent fieldExtensions={fieldExtensions} />}
+            element={
+              <BreadcrumbRegistration
+                entry={{ label: 'Template Editor', href: 'template' }}
+              >
+                <EditorContent fieldExtensions={fieldExtensions} />
+              </BreadcrumbRegistration>
+            }
           />
           <Route
             path="template-form"
-            element={<FormPreviewContent fieldExtensions={fieldExtensions} />}
+            element={
+              <BreadcrumbRegistration
+                entry={{ label: 'Template Form', href: 'template-form' }}
+              >
+                <FormPreviewContent fieldExtensions={fieldExtensions} />
+              </BreadcrumbRegistration>
+            }
           />
           <Route
             path="custom-fields"
-            element={<CustomFieldsContent fieldExtensions={fieldExtensions} />}
+            element={
+              <BreadcrumbRegistration
+                entry={{ label: 'Custom Fields', href: 'custom-fields' }}
+              >
+                <CustomFieldsContent fieldExtensions={fieldExtensions} />
+              </BreadcrumbRegistration>
+            }
           />
         </Routes>
       </SecretsContextProvider>

--- a/plugins/scaffolder/src/alpha/components/TasksSubPage.tsx
+++ b/plugins/scaffolder/src/alpha/components/TasksSubPage.tsx
@@ -14,10 +14,22 @@
  * limitations under the License.
  */
 
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, useParams } from 'react-router-dom';
 import { Content } from '@backstage/core-components';
+import { BreadcrumbRegistration } from '@backstage/ui';
 import { OngoingTaskBody } from '../../components/OngoingTask';
 import { ListTaskPageContent } from '../../components/ListTasksPage';
+
+function TaskDetailWithBreadcrumb() {
+  const { taskId } = useParams<{ taskId: string }>();
+  return (
+    <BreadcrumbRegistration
+      entry={{ label: taskId ?? 'Task', href: taskId ?? '' }}
+    >
+      <OngoingTaskBody />
+    </BreadcrumbRegistration>
+  );
+}
 
 /**
  * Sub-page for the tasks tab. Renders the task list at the index route
@@ -36,7 +48,7 @@ export function TasksSubPage() {
           </Content>
         }
       />
-      <Route path=":taskId" element={<OngoingTaskBody />} />
+      <Route path=":taskId" element={<TaskDetailWithBreadcrumb />} />
     </Routes>
   );
 }

--- a/plugins/scaffolder/src/alpha/components/TemplatesSubPage.tsx
+++ b/plugins/scaffolder/src/alpha/components/TemplatesSubPage.tsx
@@ -15,7 +15,7 @@
  */
 
 import { useCallback, useMemo } from 'react';
-import { Routes, Route, useNavigate } from 'react-router-dom';
+import { Routes, Route, useNavigate, useParams } from 'react-router-dom';
 import {
   Content,
   ContentHeader,
@@ -41,6 +41,7 @@ import { createGroupsWithOther } from '../lib/createGroupsWithOther';
 import {
   FieldExtensionOptions,
   FormProps,
+  type LayoutOptions,
   SecretsContextProvider,
   TemplateGroupFilter,
   useCustomFieldExtensions,
@@ -60,6 +61,7 @@ import {
 import { scaffolderTranslationRef } from '../../translation';
 import { DEFAULT_SCAFFOLDER_FIELD_EXTENSIONS } from '../../extensions/default';
 import { buildTechDocsURL } from '@backstage/plugin-techdocs-react';
+import { BreadcrumbRegistration } from '@backstage/ui';
 import {
   TECHDOCS_ANNOTATION,
   TECHDOCS_EXTERNAL_ANNOTATION,
@@ -169,6 +171,27 @@ function TemplateListContent({
   );
 }
 
+function TemplateWizardWithBreadcrumb(props: {
+  customFieldExtensions: FieldExtensionOptions[];
+  layouts: LayoutOptions[];
+  formProps?: FormProps;
+}) {
+  const { templateName } = useParams<{ templateName: string }>();
+  return (
+    <BreadcrumbRegistration
+      entry={{ label: templateName ?? 'Template', href: '.' }}
+    >
+      <SecretsContextProvider>
+        <TemplateWizardPageContent
+          customFieldExtensions={props.customFieldExtensions}
+          layouts={props.layouts}
+          formProps={props.formProps}
+        />
+      </SecretsContextProvider>
+    </BreadcrumbRegistration>
+  );
+}
+
 /**
  * Sub-page for the templates tab. Renders the template list at the index route
  * and the template wizard at the parameterized route.
@@ -201,13 +224,11 @@ export function TemplatesSubPage(props: {
       <Route
         path=":namespace/:templateName"
         element={
-          <SecretsContextProvider>
-            <TemplateWizardPageContent
-              customFieldExtensions={fieldExtensions}
-              layouts={customLayouts}
-              formProps={props.formProps}
-            />
-          </SecretsContextProvider>
+          <TemplateWizardWithBreadcrumb
+            customFieldExtensions={fieldExtensions}
+            layouts={customLayouts}
+            formProps={props.formProps}
+          />
         }
       />
     </Routes>

--- a/plugins/scaffolder/src/components/ActionsPage/ActionsPage.tsx
+++ b/plugins/scaffolder/src/components/ActionsPage/ActionsPage.tsx
@@ -26,7 +26,14 @@ import {
   MarkdownContent,
   Page,
 } from '@backstage/core-components';
-import { Flex, List, ListRow, SearchField, Text } from '@backstage/ui';
+import {
+  BreadcrumbRegistration,
+  Flex,
+  List,
+  ListRow,
+  SearchField,
+  Text,
+} from '@backstage/ui';
 import { ScaffolderPageContextMenu } from '@backstage/plugin-scaffolder-react/alpha';
 import { useNavigate } from 'react-router-dom';
 import {
@@ -167,7 +174,7 @@ export const ActionPageContent = () => {
     );
   }
 
-  return (
+  const content = (
     <div
       style={{
         display: 'grid',
@@ -243,6 +250,18 @@ export const ActionPageContent = () => {
       )}
     </div>
   );
+
+  if (selectedActionId) {
+    return (
+      <BreadcrumbRegistration
+        entry={{ label: selectedActionId, href: `#${selectedActionId}` }}
+      >
+        {content}
+      </BreadcrumbRegistration>
+    );
+  }
+
+  return content;
 };
 
 export type ActionsPageProps = {

--- a/plugins/scaffolder/src/components/TemplatingExtensionsPage/TemplatingExtensionsPage.tsx
+++ b/plugins/scaffolder/src/components/TemplatingExtensionsPage/TemplatingExtensionsPage.tsx
@@ -56,6 +56,7 @@ import SearchIcon from '@material-ui/icons/Search';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { BreadcrumbRegistration } from '@backstage/ui';
 import useAsync from 'react-use/esm/useAsync';
 import {
   Extension,
@@ -222,8 +223,10 @@ export const TemplatingExtensionsPageContent = ({
     </Link>
   );
 
+  const activeTabLabel = extensionKinds[tab].label;
+
   return (
-    <>
+    <BreadcrumbRegistration entry={{ label: activeTabLabel, href: `#${tab}` }}>
       <Autocomplete
         renderInput={params => (
           <TextField
@@ -292,7 +295,7 @@ export const TemplatingExtensionsPageContent = ({
           {...{ baseLink, t, classes, selectedItem }}
         />
       )}
-    </>
+    </BreadcrumbRegistration>
   );
 };
 

--- a/plugins/search/report-alpha.api.md
+++ b/plugins/search/report-alpha.api.md
@@ -165,6 +165,7 @@ const _default: OverridableFrontendPlugin<
         loader?: () => Promise<JSX_2.Element>;
         routeRef?: RouteRef;
         noHeader?: boolean;
+        noBreadcrumbs?: boolean;
       };
     }>;
   }
@@ -311,6 +312,7 @@ export const searchPage: OverridableExtensionDefinition<{
     loader?: () => Promise<JSX_2.Element>;
     routeRef?: RouteRef;
     noHeader?: boolean;
+    noBreadcrumbs?: boolean;
   };
 }>;
 

--- a/plugins/techdocs/report-alpha.api.md
+++ b/plugins/techdocs/report-alpha.api.md
@@ -332,6 +332,7 @@ const _default: OverridableFrontendPlugin<
         loader?: () => Promise<JSX_2.Element>;
         routeRef?: RouteRef_2;
         noHeader?: boolean;
+        noBreadcrumbs?: boolean;
       };
     }>;
     'page:techdocs/reader': OverridableExtensionDefinition<{
@@ -424,6 +425,7 @@ const _default: OverridableFrontendPlugin<
         loader?: () => Promise<JSX_2.Element>;
         routeRef?: RouteRef_2;
         noHeader?: boolean;
+        noBreadcrumbs?: boolean;
       };
     }>;
     'plugin-header-action:techdocs': OverridableExtensionDefinition<{

--- a/plugins/user-settings/report-alpha.api.md
+++ b/plugins/user-settings/report-alpha.api.md
@@ -96,6 +96,7 @@ const _default: OverridableFrontendPlugin<
         loader?: () => Promise<JSX_2.Element>;
         routeRef?: RouteRef_2;
         noHeader?: boolean;
+        noBreadcrumbs?: boolean;
       };
     }>;
     'sub-page:user-settings/auth-providers': OverridableExtensionDefinition<{


### PR DESCRIPTION
## Hey, I just made a Pull Request!

https://github.com/user-attachments/assets/f6b31b3e-794c-4243-acb2-ec31b401f3a6

- @backstage/ui: Added useBreadcrumbs hook and
  BreadcrumbsRegistryProvider / BreadcrumbRegistration
  components that provide an imperative, depth-ordered
  breadcrumb trail via React context. Updated
  PluginHeader to accept a breadcrumbs prop and render
  a BUI Breadcrumbs component instead of a plain
  Link/Text title.
  - @backstage/frontend-plugin-api: Wired breadcrumbs
  into PageBlueprint — pages auto-register breadcrumbs
  for the plugin title and sub-page tabs. Added a
  noBreadcrumbs param to opt out. Introduced
  SubPageWrapperContext to allow the app shell to
  inject breadcrumb registration around sub-page routes
  without coupling frontend-plugin-api to BUI.
  - @backstage/plugin-app: AppRoot provides
  BreadcrumbsRegistryProvider and passes
  SubPageWrapperContext so that sub-pages get automatic
  breadcrumb entries. Consumes useBreadcrumbs in the
  page layout to feed entries into PluginHeader.
  - @backstage/plugin-scaffolder: Wrapped internal
  scaffolder routes (Editor, Tasks, Templates, Actions,
  TemplatingExtensions) with BreadcrumbRegistration so
  sub-pages appear in the breadcrumb trail.
  - Example app: Updated pagesPlugin.tsx to demonstrate
  BreadcrumbRegistration usage.
  - docs-ui: Added useBreadcrumbs hook documentation
  page, snippets, and prop definitions. Added
  breadcrumbs to PluginHeader props table.
  - API reports: Regenerated for all affected packages.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
