### PR TITLE
fix(ui): fix Table width in Firefox

### DIFF
--- a/.changeset/fix-table-firefox-width.md
+++ b/.changeset/fix-table-firefox-width.md
@@ -1,0 +1,7 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed the Table component not filling its container width in Firefox by moving `overflow: auto` behind a `data-virtualized` attribute so it only applies to virtualized tables.
+
+Affected components: `Table`, `TableRoot`

--- a/packages/ui/report.api.md
+++ b/packages/ui/report.api.md
@@ -3128,6 +3128,9 @@ export const TableDefinition: {
     readonly loading: {
       readonly dataAttribute: true;
     };
+    readonly virtualized: {
+      readonly dataAttribute: true;
+    };
   };
 };
 
@@ -3255,6 +3258,7 @@ export type TableRootOwnProps = {
   stale?: boolean;
   isPending?: boolean;
   loading?: boolean;
+  virtualized?: boolean;
 };
 
 // @public (undocumented)

--- a/packages/ui/src/components/Table/Table.module.css
+++ b/packages/ui/src/components/Table/Table.module.css
@@ -38,9 +38,12 @@
     border-collapse: collapse;
     table-layout: fixed;
     transition: opacity 0.2s ease-in-out;
-    overflow: auto;
     flex: 1;
     min-height: 0;
+
+    &[data-virtualized='true'] {
+      overflow: auto;
+    }
 
     &[data-stale='true'],
     &[data-ispending='true'] {

--- a/packages/ui/src/components/Table/components/Table.tsx
+++ b/packages/ui/src/components/Table/components/Table.tsx
@@ -205,6 +205,7 @@ export function Table<T extends TableItem>({
             disabledKeys={disabledRows}
             stale={isStale}
             isPending={isInitialLoading}
+            virtualized={!!virtualized}
             aria-describedby={liveRegionId}
           >
             <TableHeader columns={visibleColumns}>

--- a/packages/ui/src/components/Table/definition.ts
+++ b/packages/ui/src/components/Table/definition.ts
@@ -54,6 +54,7 @@ export const TableDefinition = defineComponent<TableRootOwnProps>()({
     stale: { dataAttribute: true },
     isPending: { dataAttribute: true },
     loading: { dataAttribute: true },
+    virtualized: { dataAttribute: true },
   },
 });
 

--- a/packages/ui/src/components/Table/types.ts
+++ b/packages/ui/src/components/Table/types.ts
@@ -45,6 +45,7 @@ export type TableRootOwnProps = {
   isPending?: boolean;
   /** @deprecated Use `isPending` instead. */
   loading?: boolean;
+  virtualized?: boolean;
 };
 
 /** @public */


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Follow up from https://github.com/backstage/backstage/pull/34047

The `overflow: auto` property on the `<table>` element caused it to shrink-wrap in Firefox instead of filling its container width. Moved `overflow: auto` behind a `data-virtualized` attribute so it only applies to virtualized tables, which need it as a scroll container. Non-virtualized tables are unaffected by this change.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))