### PR TITLE
chore: add workflow to clean up released patch files

### DIFF
--- a/.github/workflows/sync_patch-cleanup.yml
+++ b/.github/workflows/sync_patch-cleanup.yml
@@ -6,11 +6,11 @@ on:
   workflow_dispatch: {}
 
 concurrency:
-  group: sync-patch-cleanup
+  group: sync-automation/patch-cleanup
   cancel-in-progress: true
 
 jobs:
-  sync-patch-cleanup:
+  sync-automation/patch-cleanup:
     name: Sync Patch Cleanup
     runs-on: ubuntu-latest
     if: github.repository == 'backstage/backstage'
@@ -108,7 +108,7 @@ jobs:
         env:
           FILES: ${{ steps.find-released.outputs.files }}
         run: |
-          BRANCH="patch-cleanup"
+          BRANCH="automation/patch-cleanup"
           git checkout -B "$BRANCH" master
 
           for file in $(echo "$FILES" | jq -r '.[]'); do
@@ -126,7 +126,7 @@ jobs:
         with:
           github-token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}
           script: |
-            const branchName = 'patch-cleanup';
+            const branchName = 'automation/patch-cleanup';
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const files = JSON.parse(process.env.FILES);
@@ -167,7 +167,7 @@ jobs:
         with:
           github-token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}
           script: |
-            const branchName = 'patch-cleanup';
+            const branchName = 'automation/patch-cleanup';
             const owner = context.repo.owner;
             const repo = context.repo.repo;
 

--- a/.github/workflows/sync_patch-cleanup.yml
+++ b/.github/workflows/sync_patch-cleanup.yml
@@ -80,7 +80,7 @@ jobs:
               // Pass all tags at once so git only walks the history once per patch file.
               try {
                 const log = execSync(
-                  `git log --oneline --max-count=1 --grep="Patch from PR #${prNumber}" ${releaseTags.join(' ')}`,
+                  `git log --oneline --max-count=1 --grep="Patch from PR #${prNumber}$" ${releaseTags.join(' ')}`,
                   { encoding: 'utf8' },
                 ).trim();
                 if (log.length > 0) {
@@ -115,7 +115,7 @@ jobs:
             git rm ".patches/$file"
           done
 
-          git commit -m "chore: clean up released patch files"
+          git commit --signoff -m "chore: clean up released patch files"
           git push origin "$BRANCH" --force
 
       - name: Create or update PR

--- a/.github/workflows/sync_patch-cleanup.yml
+++ b/.github/workflows/sync_patch-cleanup.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Configure Git
         run: |
           git config --global user.email noreply@backstage.io
-          git config --global user.name 'Github patch cleanup workflow'
+          git config --global user.name 'GitHub patch cleanup workflow'
 
       - name: Find released patch files
         id: find-released
@@ -68,7 +68,7 @@ jobs:
               .toString()
               .trim()
               .split('\n')
-              .filter(t => !t.includes('next') && !t.includes('rc'));
+              .filter(t => t && !t.includes('next') && !t.includes('rc'));
 
             const released = [];
             for (const file of patchFiles) {
@@ -76,23 +76,20 @@ jobs:
               if (!match) continue;
               const prNumber = match[1];
 
-              // Check if "Patch from PR #NNNN" appears in any release tag's history
-              const isReleased = releaseTags.some(tag => {
-                try {
-                  const log = execSync(
-                    `git log --oneline ${tag} --grep="Patch from PR #${prNumber}" --max-count=1`,
-                    { encoding: 'utf8' },
-                  ).trim();
-                  return log.length > 0;
-                } catch {
-                  return false;
+              // Check if "Patch from PR #NNNN" appears in any release tag's history.
+              // Pass all tags at once so git only walks the history once per patch file.
+              try {
+                const log = execSync(
+                  `git log --oneline --max-count=1 --grep="Patch from PR #${prNumber}" ${releaseTags.join(' ')}`,
+                  { encoding: 'utf8' },
+                ).trim();
+                if (log.length > 0) {
+                  console.log(`${file} — released, marking for cleanup`);
+                  released.push(file);
+                } else {
+                  console.log(`${file} — not yet released, keeping`);
                 }
-              });
-
-              if (isReleased) {
-                console.log(`${file} — released, marking for cleanup`);
-                released.push(file);
-              } else {
+              } catch {
                 console.log(`${file} — not yet released, keeping`);
               }
             }

--- a/.github/workflows/sync_patch-cleanup.yml
+++ b/.github/workflows/sync_patch-cleanup.yml
@@ -63,12 +63,18 @@ jobs:
               return;
             }
 
-            // Get all release tags (non-next, non-rc)
+            // Get stable release tags only (exclude next, rc, beta, alpha, etc.)
             const releaseTags = execSync('git tag -l "v*.*.*" --sort=-v:refname')
               .toString()
               .trim()
               .split('\n')
-              .filter(t => t && !t.includes('next') && !t.includes('rc'));
+              .filter(t => t && /^v\d+\.\d+\.\d+$/.test(t));
+
+            if (releaseTags.length === 0) {
+              console.log('No stable release tags found');
+              core.setOutput('has_released', 'false');
+              return;
+            }
 
             const released = [];
             for (const file of patchFiles) {
@@ -77,10 +83,11 @@ jobs:
               const prNumber = match[1];
 
               // Check if "Patch from PR #NNNN" appears in any release tag's history.
+              // Anchored to the full subject line to prevent prefix false positives.
               // Pass all tags at once so git only walks the history once per patch file.
               try {
                 const log = execSync(
-                  `git log --oneline --max-count=1 --grep="Patch from PR #${prNumber}$" ${releaseTags.join(' ')}`,
+                  `git log --oneline --max-count=1 --extended-regexp --grep="^Patch from PR #${prNumber}$" ${releaseTags.join(' ')}`,
                   { encoding: 'utf8' },
                 ).trim();
                 if (log.length > 0) {

--- a/.github/workflows/sync_patch-cleanup.yml
+++ b/.github/workflows/sync_patch-cleanup.yml
@@ -78,25 +78,24 @@ jobs:
 
             const released = [];
             for (const file of patchFiles) {
-              const match = file.match(/^pr-(\d+)\.txt$/);
-              if (!match) continue;
-              const prNumber = match[1];
-
-              // Check if "Patch from PR #NNNN" appears in any release tag's history.
-              // Anchored to the full subject line to prevent prefix false positives.
-              // Pass all tags at once so git only walks the history once per patch file.
-              try {
-                const log = execSync(
-                  `git log --oneline --max-count=1 --extended-regexp --grep="^Patch from PR #${prNumber}$" ${releaseTags.join(' ')}`,
-                  { encoding: 'utf8' },
-                ).trim();
-                if (log.length > 0) {
-                  console.log(`${file} — released, marking for cleanup`);
-                  released.push(file);
-                } else {
-                  console.log(`${file} — not yet released, keeping`);
+              // Check if the patch file exists in any release tag's tree.
+              // The patch workflow copies pr-*.txt files into the patch branch,
+              // so if the file is present at a release tag, it was consumed.
+              const wasConsumed = releaseTags.some(tag => {
+                try {
+                  execSync(`git cat-file -e ${tag}:.patches/${file}`, {
+                    stdio: 'ignore',
+                  });
+                  return true;
+                } catch {
+                  return false;
                 }
-              } catch {
+              });
+
+              if (wasConsumed) {
+                console.log(`${file} — found in a release tag, marking for cleanup`);
+                released.push(file);
+              } else {
                 console.log(`${file} — not yet released, keeping`);
               }
             }

--- a/.github/workflows/sync_patch-cleanup.yml
+++ b/.github/workflows/sync_patch-cleanup.yml
@@ -6,11 +6,11 @@ on:
   workflow_dispatch: {}
 
 concurrency:
-  group: sync-automation/patch-cleanup
+  group: sync-patch-cleanup
   cancel-in-progress: true
 
 jobs:
-  sync-automation/patch-cleanup:
+  sync-patch-cleanup:
     name: Sync Patch Cleanup
     runs-on: ubuntu-latest
     if: github.repository == 'backstage/backstage'

--- a/.github/workflows/sync_patch-cleanup.yml
+++ b/.github/workflows/sync_patch-cleanup.yml
@@ -1,0 +1,198 @@
+name: Sync Patch Cleanup
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch: {}
+
+concurrency:
+  group: sync-patch-cleanup
+  cancel-in-progress: true
+
+jobs:
+  sync-patch-cleanup:
+    name: Sync Patch Cleanup
+    runs-on: ubuntu-latest
+    if: github.repository == 'backstage/backstage'
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 20000
+          fetch-tags: true
+          ref: master
+          token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config --global user.email noreply@backstage.io
+          git config --global user.name 'Github patch cleanup workflow'
+
+      - name: Find released patch files
+        id: find-released
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          github-token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}
+          script: |
+            const fs = require('fs').promises;
+            const path = require('path');
+            const { execSync } = require('child_process');
+
+            const patchesDir = path.join(process.cwd(), '.patches');
+            let files = [];
+            try {
+              files = await fs.readdir(patchesDir);
+            } catch (error) {
+              console.log('No .patches directory found');
+              core.setOutput('has_released', 'false');
+              return;
+            }
+
+            const patchFiles = files.filter(f => /^pr-\d+\.txt$/.test(f));
+            if (patchFiles.length === 0) {
+              console.log('No patch files found');
+              core.setOutput('has_released', 'false');
+              return;
+            }
+
+            // Get all release tags (non-next, non-rc)
+            const releaseTags = execSync('git tag -l "v*.*.*" --sort=-v:refname')
+              .toString()
+              .trim()
+              .split('\n')
+              .filter(t => !t.includes('next') && !t.includes('rc'));
+
+            const released = [];
+            for (const file of patchFiles) {
+              const match = file.match(/^pr-(\d+)\.txt$/);
+              if (!match) continue;
+              const prNumber = match[1];
+
+              // Check if "Patch from PR #NNNN" appears in any release tag's history
+              const isReleased = releaseTags.some(tag => {
+                try {
+                  const log = execSync(
+                    `git log --oneline ${tag} --grep="Patch from PR #${prNumber}" --max-count=1`,
+                    { encoding: 'utf8' },
+                  ).trim();
+                  return log.length > 0;
+                } catch {
+                  return false;
+                }
+              });
+
+              if (isReleased) {
+                console.log(`${file} — released, marking for cleanup`);
+                released.push(file);
+              } else {
+                console.log(`${file} — not yet released, keeping`);
+              }
+            }
+
+            if (released.length === 0) {
+              console.log('No released patch files to clean up');
+              core.setOutput('has_released', 'false');
+              return;
+            }
+
+            core.setOutput('has_released', 'true');
+            core.setOutput('files', JSON.stringify(released));
+
+      - name: Create cleanup branch
+        if: steps.find-released.outputs.has_released == 'true'
+        env:
+          FILES: ${{ steps.find-released.outputs.files }}
+        run: |
+          BRANCH="patch-cleanup"
+          git checkout -B "$BRANCH" master
+
+          for file in $(echo "$FILES" | jq -r '.[]'); do
+            git rm ".patches/$file"
+          done
+
+          git commit -m "chore: clean up released patch files"
+          git push origin "$BRANCH" --force
+
+      - name: Create or update PR
+        if: steps.find-released.outputs.has_released == 'true'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          FILES: ${{ steps.find-released.outputs.files }}
+        with:
+          github-token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}
+          script: |
+            const branchName = 'patch-cleanup';
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const files = JSON.parse(process.env.FILES);
+
+            const fileList = files.map(f => `- ${f}`).join('\n');
+            const body = `Removes patch files that have already been included in a release.\n\n${fileList}`;
+
+            const { data: pulls } = await github.rest.pulls.list({
+              owner,
+              repo,
+              head: `${owner}:${branchName}`,
+              state: 'open',
+            });
+
+            if (pulls.length > 0) {
+              console.log(`Updating PR #${pulls[0].number}`);
+              await github.rest.pulls.update({
+                owner,
+                repo,
+                pull_number: pulls[0].number,
+                body,
+              });
+            } else {
+              const { data: pr } = await github.rest.pulls.create({
+                owner,
+                repo,
+                title: 'chore: clean up released patch files',
+                body,
+                head: branchName,
+                base: 'master',
+              });
+              console.log(`Created PR #${pr.number}`);
+            }
+
+      - name: Close PR if nothing to clean
+        if: steps.find-released.outputs.has_released == 'false'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          github-token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}
+          script: |
+            const branchName = 'patch-cleanup';
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const { data: pulls } = await github.rest.pulls.list({
+              owner,
+              repo,
+              head: `${owner}:${branchName}`,
+              state: 'open',
+            });
+
+            if (pulls.length > 0) {
+              console.log(`Closing PR #${pulls[0].number} — no more files to clean`);
+              await github.rest.pulls.update({
+                owner,
+                repo,
+                pull_number: pulls[0].number,
+                state: 'closed',
+              });
+            }
+
+            try {
+              await github.rest.git.deleteRef({ owner, repo, ref: `heads/${branchName}` });
+            } catch (error) {
+              if (error.status !== 422) throw error;
+            }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The patch release workflow creates `.patches/pr-*.txt` files on master but never cleans them up after the patch ships. This causes subsequent patch release PRs to list already-shipped fixes in their body (e.g. #34511 listed 4 fixes from v1.51.1 alongside the one new fix).

This adds `sync_patch-cleanup.yml` which:
1. Triggers on `release: published` and `workflow_dispatch`
2. Checks each `.patches/pr-*.txt` by looking for the file in release tag trees (`git cat-file -e <tag>:.patches/<file>`) — if the file exists in a release tag, it was consumed by that release
3. Creates/updates a cleanup PR on the `automation/patch-cleanup` branch to remove consumed files
4. Closes the PR and deletes the branch when there's nothing left to clean

Merging the cleanup PR is manual, so you can hold off if a release turns out to be broken and needs to be re-patched.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))