### PR TITLE
docs(plugin-directory): add three @theplatformlog AI plugins

### DIFF
--- a/microsite/data/plugins/catalog-assistant-backend.yaml
+++ b/microsite/data/plugins/catalog-assistant-backend.yaml
@@ -1,0 +1,11 @@
+---
+title: Catalog Assistant
+author: Naga15
+authorUrl: https://github.com/Naga15
+category: Catalog
+description: Natural-language Q&A over the Software Catalog. Returns grounded answers with entity-ref citations, backed by an LLM.
+documentation: https://github.com/Naga15/platformlog-plugins/tree/master/packages/catalog-assistant-backend
+iconUrl: https://theplatformlog.dev/favicon.svg
+npmPackageName: '@theplatformlog/catalog-assistant-backend'
+addedDate: '2026-06-10'
+status: active

--- a/microsite/data/plugins/scaffolder-backend-module-mcp.yaml
+++ b/microsite/data/plugins/scaffolder-backend-module-mcp.yaml
@@ -1,0 +1,11 @@
+---
+title: Scaffolder MCP Client
+author: Naga15
+authorUrl: https://github.com/Naga15
+category: Scaffolder
+description: Adds an `mcp:call` scaffolder action so templates can invoke any tool on any configured Model Context Protocol (MCP) server.
+documentation: https://github.com/Naga15/platformlog-plugins/tree/master/packages/scaffolder-backend-module-mcp
+iconUrl: https://theplatformlog.dev/favicon.svg
+npmPackageName: '@theplatformlog/scaffolder-backend-module-mcp'
+addedDate: '2026-06-10'
+status: active

--- a/microsite/data/plugins/template-authoring-backend.yaml
+++ b/microsite/data/plugins/template-authoring-backend.yaml
@@ -1,0 +1,11 @@
+---
+title: Template Authoring
+author: Naga15
+authorUrl: https://github.com/Naga15
+category: Scaffolder
+description: Generates scaffolder Template entities from a natural-language description, schema-constrained so the LLM cannot emit an invalid Template.
+documentation: https://github.com/Naga15/platformlog-plugins/tree/master/packages/template-authoring-backend
+iconUrl: https://theplatformlog.dev/favicon.svg
+npmPackageName: '@theplatformlog/template-authoring-backend'
+addedDate: '2026-06-10'
+status: active


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds Backstage plugin-directory entries for three open-source, Apache-2.0 backend plugins published on npm under the `@theplatformlog` scope.

| Plugin | Category | npm |
|---|---|---|
| Scaffolder MCP Client | Scaffolder | [`@theplatformlog/scaffolder-backend-module-mcp`](https://www.npmjs.com/package/@theplatformlog/scaffolder-backend-module-mcp) |
| Catalog Assistant | Catalog | [`@theplatformlog/catalog-assistant-backend`](https://www.npmjs.com/package/@theplatformlog/catalog-assistant-backend) |
| Template Authoring | Scaffolder | [`@theplatformlog/template-authoring-backend`](https://www.npmjs.com/package/@theplatformlog/template-authoring-backend) |

What they do:
- **Scaffolder MCP Client** — an `mcp:call` scaffolder action that invokes any tool on any configured Model Context Protocol (MCP) server. The inverse of `mcp-actions-backend`.
- **Catalog Assistant** — grounded natural-language Q&A over the Software Catalog; returns answers with entity-ref citations.
- **Template Authoring** — generates scaffolder `Template` entities from a natural-language description, schema-constrained so the model cannot emit an invalid Template.

All three:
- are published and public on npm (Apache-2.0)
- link to documentation in their READMEs
- validate clean against `node ./scripts/verify-plugin-directory.js`

These are also open as net-new plugin draft PRs (#34490, #34491, #34492); the directory entries point at the published `@theplatformlog` packages so they're installable today.

## :heavy_check_mark: Checklist

- [x] A changeset describing the change and affecting one or more packages — N/A (microsite data only, no package changes)
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes — N/A (directory data)
- [x] Screenshots attached — N/A (directory listing)
- [x] All your commits have a Signed-off-by line in the message (DCO)