### PR TITLE
Catalog filter by targets

### DIFF
--- a/.changeset/evil-corners-move.md
+++ b/.changeset/evil-corners-move.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': minor
+---
+
+Allow full text searching of Location target URLs in catalog tables

--- a/plugins/catalog-react/src/filters.test.ts
+++ b/plugins/catalog-react/src/filters.test.ts
@@ -129,6 +129,39 @@ describe('EntityTextFilter', () => {
     expect(filter.filterEntity(users[0])).toBeTruthy();
     expect(filter.filterEntity(users[1])).toBeFalsy();
   });
+
+  it('should search spec.target and spec.targets', () => {
+    const location: Entity = {
+      apiVersion: '1',
+      kind: 'Location',
+      metadata: { name: 'my-location' },
+      spec: {
+        target:
+          'https://github.com/backstage/backstage/blob/main/catalog-info.yaml',
+      },
+    };
+    const locationWithTargets: Entity = {
+      apiVersion: '1',
+      kind: 'Location',
+      metadata: { name: 'multi-location' },
+      spec: {
+        targets: [
+          'https://github.com/backstage/backstage/blob/main/one.yaml',
+          'https://github.com/backstage/backstage/blob/main/two.yaml',
+        ],
+      },
+    };
+
+    expect(
+      new EntityTextFilter('catalog-info').filterEntity(location),
+    ).toBeTruthy();
+    expect(
+      new EntityTextFilter('two.yaml').filterEntity(locationWithTargets),
+    ).toBeTruthy();
+    expect(
+      new EntityTextFilter('nonexistent').filterEntity(location),
+    ).toBeFalsy();
+  });
 });
 
 describe('EntityOrphanFilter', () => {

--- a/plugins/catalog-react/src/filters.ts
+++ b/plugins/catalog-react/src/filters.ts
@@ -114,6 +114,8 @@ export class EntityTextFilter implements EntityFilter {
       entity.metadata.name,
       entity.metadata.title,
       (entity.spec?.profile as { displayName?: string })?.displayName,
+      (entity.spec as { target?: string })?.target,
+      ...((entity.spec as { targets?: string[] })?.targets ?? []),
     ]);
 
     for (const word of words) {
@@ -151,7 +153,7 @@ export class EntityTextFilter implements EntityFilter {
   ): Array<string> {
     return value
       .flat()
-      .filter((m): m is string => Boolean(m))
+      .filter((m): m is string => Boolean(m) && typeof m === 'string')
       .map(m => m.toLocaleUpperCase('en-US'));
   }
 }

--- a/plugins/catalog-react/src/filters.ts
+++ b/plugins/catalog-react/src/filters.ts
@@ -132,7 +132,13 @@ export class EntityTextFilter implements EntityFilter {
     return {
       term: this.value,
       // Update this to be more dynamic based on table columns.
-      fields: ['metadata.name', 'metadata.title', 'spec.profile.displayName'],
+      fields: [
+        'metadata.name',
+        'metadata.title',
+        'spec.profile.displayName',
+        'spec.target',
+        'spec.targets',
+      ],
     };
   }
 

--- a/plugins/catalog-react/src/filters.ts
+++ b/plugins/catalog-react/src/filters.ts
@@ -110,12 +110,13 @@ export class EntityTextFilter implements EntityFilter {
   filterEntity(entity: Entity): boolean {
     const words = this.toUpperArray(this.value.split(/\s/));
     const exactMatch = this.toUpperArray([entity.metadata.tags]);
+    const targets = (entity.spec as { targets?: unknown })?.targets;
     const partialMatch = this.toUpperArray([
       entity.metadata.name,
       entity.metadata.title,
       (entity.spec?.profile as { displayName?: string })?.displayName,
       (entity.spec as { target?: string })?.target,
-      ...((entity.spec as { targets?: string[] })?.targets ?? []),
+      ...(Array.isArray(targets) ? targets : []),
     ]);
 
     for (const word of words) {

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.test.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.test.tsx
@@ -521,6 +521,8 @@ describe('<EntityListProvider pagination />', () => {
             'metadata.name',
             'metadata.title',
             'spec.profile.displayName',
+            'spec.target',
+            'spec.targets',
           ],
         },
       });
@@ -917,6 +919,8 @@ describe(`<EntityListProvider pagination={{ mode: 'offset' }} />`, () => {
             'metadata.name',
             'metadata.title',
             'spec.profile.displayName',
+            'spec.target',
+            'spec.targets',
           ],
         },
       });

--- a/plugins/catalog/src/components/CatalogExportButton/file-download/toStreamRequest.test.ts
+++ b/plugins/catalog/src/components/CatalogExportButton/file-download/toStreamRequest.test.ts
@@ -247,6 +247,8 @@ describe('toStreamRequest', () => {
             'metadata.name',
             'metadata.title',
             'spec.profile.displayName',
+            'spec.target',
+            'spec.targets',
           ],
         },
       });
@@ -318,6 +320,8 @@ describe('toStreamRequest', () => {
             'metadata.name',
             'metadata.title',
             'spec.profile.displayName',
+            'spec.target',
+            'spec.targets',
           ],
         },
         orderFields: [{ field: 'metadata.name', order: 'asc' }],


### PR DESCRIPTION
This helps users unregister old locations - not perfect since it can't handle entirely unprocessed things, but helpful nonetheless for a lot of cases. With this change, the regular `/catalog` page can be switched to the `Location` kind and then the search box at the top can accept a (full or partial) URL to match against. The target column is visible right in front of you - it arguably makes sense that it's searchable for that reason alone.