### PR TITLE
feat(catalog): migrate entity page to the BUI header

### DIFF
--- a/.changeset/catalog-entity-bui-header.md
+++ b/.changeset/catalog-entity-bui-header.md
@@ -2,8 +2,10 @@
 '@backstage/plugin-catalog': patch
 ---
 
-**BREAKING ALPHA**: Migrated the new frontend system Catalog entity page to the automatic Catalog plugin header and a BUI page header with entity tags, title, description, metadata, favorite and context-menu actions, and Catalog-composed navigation.
+**BREAKING ALPHA**: Migrated the new frontend system Catalog entity page to the automatic Catalog plugin header and a BUI page header with entity tags, title, metadata, favorite and context-menu actions, and Catalog-composed navigation.
 
 Existing alpha opaque entity header customizations continue to render through a temporary per-entity legacy fallback with the previous MUI tabs and page shell. Migrate those customizations to the new BUI-ready entity header layout extension point to receive composed tabs and the active tab ID. The new extension point wins when both customization types match an entity.
 
 The default BUI navigation does not render entity-content tab icons because the BUI Header tab API does not expose an icon slot. Legacy fallback pages retain their existing tab-icon behavior.
+
+Added the translation keys `entityLabels.systemLabel`, `entityLabels.domainLabel`, and `entityLabels.partOfLabel`. Apps that provide Catalog translations should add translations for these new messages.

--- a/.changeset/catalog-entity-bui-header.md
+++ b/.changeset/catalog-entity-bui-header.md
@@ -1,0 +1,9 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+**BREAKING ALPHA**: Migrated the new frontend system Catalog entity page to the automatic Catalog plugin header and a BUI page header with entity tags, title, description, metadata, favorite and context-menu actions, and Catalog-composed navigation.
+
+Existing alpha opaque entity header customizations continue to render through a temporary per-entity legacy fallback with the previous MUI tabs and page shell. Migrate those customizations to the new BUI-ready entity header layout extension point to receive composed tabs and the active tab ID. The new extension point wins when both customization types match an entity.
+
+The default BUI navigation does not render entity-content tab icons because the BUI Header tab API does not expose an icon slot. Legacy fallback pages retain their existing tab-icon behavior.

--- a/.changeset/catalog-react-entity-header-layout-blueprint.md
+++ b/.changeset/catalog-react-entity-header-layout-blueprint.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-catalog-react': minor
+---
+
+Added an alpha BUI-ready entity header layout extension point. Its loaded component receives Catalog-composed tabs and the active tab ID, allowing custom entity headers to preserve or customize entity-page navigation.
+
+**DEPRECATED ALPHA**: The existing opaque entity header extension point is deprecated. It continues to work through a temporary Catalog legacy-layout fallback so adopters can migrate custom entity headers incrementally.

--- a/plugins/catalog-react/report-alpha.api.md
+++ b/plugins/catalog-react/report-alpha.api.md
@@ -13,7 +13,6 @@ import { ExtensionBlueprint } from '@backstage/frontend-plugin-api';
 import { ExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { ExtensionDefinition } from '@backstage/frontend-plugin-api';
 import { FilterPredicate } from '@backstage/filter-predicates';
-import { HeaderNavTabItem } from '@backstage/ui';
 import { IconElement } from '@backstage/frontend-plugin-api';
 import { IconLinkVerticalProps } from '@backstage/core-components';
 import { JSX as JSX_2 } from 'react';
@@ -586,11 +585,6 @@ export const EntityHeaderBlueprint: ExtensionBlueprint<{
       'catalog.entity-filter-function',
       {}
     >;
-    filterExpression: ConfigurableExtensionDataRef<
-      string,
-      'catalog.entity-filter-expression',
-      {}
-    >;
     element: ConfigurableExtensionDataRef<
       JSX_2.Element,
       'core.reactElement',
@@ -603,20 +597,13 @@ export const EntityHeaderBlueprint: ExtensionBlueprint<{
 export const EntityHeaderLayoutBlueprint: ExtensionBlueprint<{
   kind: 'entity-header-layout';
   params: {
-    filter?: string | FilterPredicate | ((entity: Entity) => boolean);
+    filter?: FilterPredicate | ((entity: Entity) => boolean);
     loader: () => Promise<(props: EntityHeaderLayoutProps) => JSX_2.Element>;
   };
   output:
     | ExtensionDataRef<
         (entity: Entity) => boolean,
         'catalog.entity-filter-function',
-        {
-          optional: true;
-        }
-      >
-    | ExtensionDataRef<
-        string,
-        'catalog.entity-filter-expression',
         {
           optional: true;
         }
@@ -639,11 +626,6 @@ export const EntityHeaderLayoutBlueprint: ExtensionBlueprint<{
       'catalog.entity-filter-function',
       {}
     >;
-    filterExpression: ConfigurableExtensionDataRef<
-      string,
-      'catalog.entity-filter-expression',
-      {}
-    >;
     component: ConfigurableExtensionDataRef<
       (props: EntityHeaderLayoutProps) => JSX_2.Element,
       'catalog.entity-header-layout.component',
@@ -657,7 +639,22 @@ export interface EntityHeaderLayoutProps {
   // (undocumented)
   activeTabId?: string;
   // (undocumented)
-  tabs: HeaderNavTabItem[];
+  tabs: Array<
+    | {
+        id: string;
+        label: string;
+        href: string;
+      }
+    | {
+        id: string;
+        label: string;
+        items: Array<{
+          id: string;
+          label: string;
+          href: string;
+        }>;
+      }
+  >;
 }
 
 // @alpha (undocumented)

--- a/plugins/catalog-react/report-alpha.api.md
+++ b/plugins/catalog-react/report-alpha.api.md
@@ -13,6 +13,7 @@ import { ExtensionBlueprint } from '@backstage/frontend-plugin-api';
 import { ExtensionDataRef } from '@backstage/frontend-plugin-api';
 import { ExtensionDefinition } from '@backstage/frontend-plugin-api';
 import { FilterPredicate } from '@backstage/filter-predicates';
+import { HeaderNavTabItem } from '@backstage/ui';
 import { IconElement } from '@backstage/frontend-plugin-api';
 import { IconLinkVerticalProps } from '@backstage/core-components';
 import { JSX as JSX_2 } from 'react';
@@ -543,7 +544,7 @@ export interface EntityDataTableProps {
   loading?: boolean;
 }
 
-// @alpha (undocumented)
+// @alpha @deprecated (undocumented)
 export const EntityHeaderBlueprint: ExtensionBlueprint<{
   kind: 'entity-header';
   params: {
@@ -585,6 +586,11 @@ export const EntityHeaderBlueprint: ExtensionBlueprint<{
       'catalog.entity-filter-function',
       {}
     >;
+    filterExpression: ConfigurableExtensionDataRef<
+      string,
+      'catalog.entity-filter-expression',
+      {}
+    >;
     element: ConfigurableExtensionDataRef<
       JSX_2.Element,
       'core.reactElement',
@@ -592,6 +598,67 @@ export const EntityHeaderBlueprint: ExtensionBlueprint<{
     >;
   };
 }>;
+
+// @alpha (undocumented)
+export const EntityHeaderLayoutBlueprint: ExtensionBlueprint<{
+  kind: 'entity-header-layout';
+  params: {
+    filter?: string | FilterPredicate | ((entity: Entity) => boolean);
+    loader: () => Promise<(props: EntityHeaderLayoutProps) => JSX_2.Element>;
+  };
+  output:
+    | ExtensionDataRef<
+        (entity: Entity) => boolean,
+        'catalog.entity-filter-function',
+        {
+          optional: true;
+        }
+      >
+    | ExtensionDataRef<
+        string,
+        'catalog.entity-filter-expression',
+        {
+          optional: true;
+        }
+      >
+    | ExtensionDataRef<
+        (props: EntityHeaderLayoutProps) => JSX_2.Element,
+        'catalog.entity-header-layout.component',
+        {}
+      >;
+  inputs: {};
+  config: {
+    filter: FilterPredicate | undefined;
+  };
+  configInput: {
+    filter?: FilterPredicate | undefined;
+  };
+  dataRefs: {
+    filterFunction: ConfigurableExtensionDataRef<
+      (entity: Entity) => boolean,
+      'catalog.entity-filter-function',
+      {}
+    >;
+    filterExpression: ConfigurableExtensionDataRef<
+      string,
+      'catalog.entity-filter-expression',
+      {}
+    >;
+    component: ConfigurableExtensionDataRef<
+      (props: EntityHeaderLayoutProps) => JSX_2.Element,
+      'catalog.entity-header-layout.component',
+      {}
+    >;
+  };
+}>;
+
+// @alpha (undocumented)
+export interface EntityHeaderLayoutProps {
+  // (undocumented)
+  activeTabId?: string;
+  // (undocumented)
+  tabs: HeaderNavTabItem[];
+}
 
 // @alpha (undocumented)
 export const EntityIconLinkBlueprint: ExtensionBlueprint<{

--- a/plugins/catalog-react/src/alpha/blueprints/EntityHeaderBlueprint.tsx
+++ b/plugins/catalog-react/src/alpha/blueprints/EntityHeaderBlueprint.tsx
@@ -41,7 +41,6 @@ export const EntityHeaderBlueprint = createExtensionBlueprint({
   attachTo: { id: 'page:catalog/entity', input: 'headers' },
   dataRefs: {
     filterFunction: entityFilterFunctionDataRef,
-    filterExpression: entityFilterExpressionDataRef,
     element: coreExtensionData.reactElement,
   },
   configSchema: {

--- a/plugins/catalog-react/src/alpha/blueprints/EntityHeaderBlueprint.tsx
+++ b/plugins/catalog-react/src/alpha/blueprints/EntityHeaderBlueprint.tsx
@@ -30,12 +30,18 @@ import {
   entityFilterFunctionDataRef,
 } from './extensionData';
 
-/** @alpha */
+/**
+ * @alpha
+ * @deprecated Use {@link EntityHeaderLayoutBlueprint} instead. This legacy
+ * blueprint renders an opaque header element through the temporary Catalog
+ * entity-page fallback.
+ */
 export const EntityHeaderBlueprint = createExtensionBlueprint({
   kind: 'entity-header',
   attachTo: { id: 'page:catalog/entity', input: 'headers' },
   dataRefs: {
     filterFunction: entityFilterFunctionDataRef,
+    filterExpression: entityFilterExpressionDataRef,
     element: coreExtensionData.reactElement,
   },
   configSchema: {

--- a/plugins/catalog-react/src/alpha/blueprints/EntityHeaderLayoutBlueprint.test.tsx
+++ b/plugins/catalog-react/src/alpha/blueprints/EntityHeaderLayoutBlueprint.test.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity } from '@backstage/catalog-model';
+import {
+  createExtensionTester,
+  renderInTestApp,
+} from '@backstage/frontend-test-utils';
+import { screen } from '@testing-library/react';
+import { EntityHeaderLayoutBlueprint } from './EntityHeaderLayoutBlueprint';
+
+describe('EntityHeaderLayoutBlueprint', () => {
+  it('emits a lazy component that receives composed tab props', async () => {
+    const extension = EntityHeaderLayoutBlueprint.make({
+      name: 'test',
+      params: {
+        loader: async () => props =>
+          (
+            <div>
+              <span>{props.tabs.map(tab => tab.label).join(',')}</span>
+              <span>{props.activeTabId}</span>
+            </div>
+          ),
+      },
+    });
+    const Component = createExtensionTester(extension).get(
+      EntityHeaderLayoutBlueprint.dataRefs.component,
+    );
+
+    await renderInTestApp(
+      <Component
+        tabs={[{ id: '/overview', label: 'Overview', href: 'overview' }]}
+        activeTabId="/overview"
+      />,
+    );
+
+    expect(await screen.findByText('Overview')).toBeInTheDocument();
+    expect(screen.getByText('/overview')).toBeInTheDocument();
+  });
+
+  it('emits function and expression filters through the established model', () => {
+    const filter = (_entity: Entity) => true;
+
+    expect(
+      createExtensionTester(
+        EntityHeaderLayoutBlueprint.make({
+          name: 'function-filter',
+          params: {
+            filter,
+            loader: async () => () => <div />,
+          },
+        }),
+      ).get(EntityHeaderLayoutBlueprint.dataRefs.filterFunction),
+    ).toBe(filter);
+
+    expect(
+      createExtensionTester(
+        EntityHeaderLayoutBlueprint.make({
+          name: 'expression-filter',
+          params: {
+            loader: async () => () => <div />,
+          },
+        }),
+        { config: { filter: 'kind:component' } },
+      ).get(EntityHeaderLayoutBlueprint.dataRefs.filterExpression),
+    ).toBe('kind:component');
+  });
+});

--- a/plugins/catalog-react/src/alpha/blueprints/EntityHeaderLayoutBlueprint.test.tsx
+++ b/plugins/catalog-react/src/alpha/blueprints/EntityHeaderLayoutBlueprint.test.tsx
@@ -51,7 +51,7 @@ describe('EntityHeaderLayoutBlueprint', () => {
     expect(screen.getByText('/overview')).toBeInTheDocument();
   });
 
-  it('emits function and expression filters through the established model', () => {
+  it('emits function filters for params and configured predicates', () => {
     const filter = (_entity: Entity) => true;
 
     expect(
@@ -66,16 +66,33 @@ describe('EntityHeaderLayoutBlueprint', () => {
       ).get(EntityHeaderLayoutBlueprint.dataRefs.filterFunction),
     ).toBe(filter);
 
+    const configuredFilter = createExtensionTester(
+      EntityHeaderLayoutBlueprint.make({
+        name: 'configured-filter',
+        params: {
+          loader: async () => () => <div />,
+        },
+      }),
+      { config: { filter: { kind: 'component' } } },
+    ).get(EntityHeaderLayoutBlueprint.dataRefs.filterFunction);
+
+    expect(configuredFilter).toBeDefined();
     expect(
-      createExtensionTester(
-        EntityHeaderLayoutBlueprint.make({
-          name: 'expression-filter',
-          params: {
-            loader: async () => () => <div />,
-          },
-        }),
-        { config: { filter: 'kind:component' } },
-      ).get(EntityHeaderLayoutBlueprint.dataRefs.filterExpression),
-    ).toBe('kind:component');
+      configuredFilter!({
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: { name: 'example' },
+      }),
+    ).toBe(true);
+    expect(
+      configuredFilter!({
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'API',
+        metadata: { name: 'example' },
+      }),
+    ).toBe(false);
+    expect(EntityHeaderLayoutBlueprint.dataRefs).not.toHaveProperty(
+      'filterExpression',
+    );
   });
 });

--- a/plugins/catalog-react/src/alpha/blueprints/EntityHeaderLayoutBlueprint.tsx
+++ b/plugins/catalog-react/src/alpha/blueprints/EntityHeaderLayoutBlueprint.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity } from '@backstage/catalog-model';
+import {
+  FilterPredicate,
+  createZodV4FilterPredicateSchema,
+} from '@backstage/filter-predicates';
+import {
+  createExtensionBlueprint,
+  createExtensionDataRef,
+  ExtensionBoundary,
+} from '@backstage/frontend-plugin-api';
+import { type HeaderNavTabItem } from '@backstage/ui';
+import { JSX } from 'react';
+import { z } from 'zod/v4';
+import {
+  entityFilterExpressionDataRef,
+  entityFilterFunctionDataRef,
+} from './extensionData';
+import { resolveEntityFilterData } from './resolveEntityFilterData';
+
+/** @alpha */
+export interface EntityHeaderLayoutProps {
+  tabs: HeaderNavTabItem[];
+  activeTabId?: string;
+}
+
+const entityHeaderLayoutComponentDataRef = createExtensionDataRef<
+  (props: EntityHeaderLayoutProps) => JSX.Element
+>().with({
+  id: 'catalog.entity-header-layout.component',
+});
+
+/** @alpha */
+export const EntityHeaderLayoutBlueprint = createExtensionBlueprint({
+  kind: 'entity-header-layout',
+  attachTo: { id: 'page:catalog/entity', input: 'headerLayouts' },
+  output: [
+    entityFilterFunctionDataRef.optional(),
+    entityFilterExpressionDataRef.optional(),
+    entityHeaderLayoutComponentDataRef,
+  ],
+  dataRefs: {
+    filterFunction: entityFilterFunctionDataRef,
+    filterExpression: entityFilterExpressionDataRef,
+    component: entityHeaderLayoutComponentDataRef,
+  },
+  configSchema: {
+    filter: z
+      .union([z.string(), createZodV4FilterPredicateSchema()])
+      .optional(),
+  },
+  *factory(
+    {
+      loader,
+      filter,
+    }: {
+      filter?: string | FilterPredicate | ((entity: Entity) => boolean);
+      loader: () => Promise<(props: EntityHeaderLayoutProps) => JSX.Element>;
+    },
+    { node, config },
+  ) {
+    yield* resolveEntityFilterData(filter, config, node);
+    yield entityHeaderLayoutComponentDataRef(
+      ExtensionBoundary.lazyComponent(node, loader),
+    );
+  },
+});

--- a/plugins/catalog-react/src/alpha/blueprints/EntityHeaderLayoutBlueprint.tsx
+++ b/plugins/catalog-react/src/alpha/blueprints/EntityHeaderLayoutBlueprint.tsx
@@ -18,24 +18,34 @@ import { Entity } from '@backstage/catalog-model';
 import {
   FilterPredicate,
   createZodV4FilterPredicateSchema,
+  filterPredicateToFilterFunction,
 } from '@backstage/filter-predicates';
 import {
   createExtensionBlueprint,
   createExtensionDataRef,
   ExtensionBoundary,
 } from '@backstage/frontend-plugin-api';
-import { type HeaderNavTabItem } from '@backstage/ui';
 import { JSX } from 'react';
-import { z } from 'zod/v4';
-import {
-  entityFilterExpressionDataRef,
-  entityFilterFunctionDataRef,
-} from './extensionData';
-import { resolveEntityFilterData } from './resolveEntityFilterData';
+import { entityFilterFunctionDataRef } from './extensionData';
 
 /** @alpha */
 export interface EntityHeaderLayoutProps {
-  tabs: HeaderNavTabItem[];
+  tabs: Array<
+    | {
+        id: string;
+        label: string;
+        href: string;
+      }
+    | {
+        id: string;
+        label: string;
+        items: Array<{
+          id: string;
+          label: string;
+          href: string;
+        }>;
+      }
+  >;
   activeTabId?: string;
 }
 
@@ -51,30 +61,36 @@ export const EntityHeaderLayoutBlueprint = createExtensionBlueprint({
   attachTo: { id: 'page:catalog/entity', input: 'headerLayouts' },
   output: [
     entityFilterFunctionDataRef.optional(),
-    entityFilterExpressionDataRef.optional(),
     entityHeaderLayoutComponentDataRef,
   ],
   dataRefs: {
     filterFunction: entityFilterFunctionDataRef,
-    filterExpression: entityFilterExpressionDataRef,
     component: entityHeaderLayoutComponentDataRef,
   },
   configSchema: {
-    filter: z
-      .union([z.string(), createZodV4FilterPredicateSchema()])
-      .optional(),
+    filter: createZodV4FilterPredicateSchema().optional(),
   },
   *factory(
     {
       loader,
       filter,
     }: {
-      filter?: string | FilterPredicate | ((entity: Entity) => boolean);
+      filter?: FilterPredicate | ((entity: Entity) => boolean);
       loader: () => Promise<(props: EntityHeaderLayoutProps) => JSX.Element>;
     },
     { node, config },
   ) {
-    yield* resolveEntityFilterData(filter, config, node);
+    if (config.filter) {
+      yield entityFilterFunctionDataRef(
+        filterPredicateToFilterFunction(config.filter),
+      );
+    } else if (typeof filter === 'function') {
+      yield entityFilterFunctionDataRef(filter);
+    } else if (filter) {
+      yield entityFilterFunctionDataRef(
+        filterPredicateToFilterFunction(filter),
+      );
+    }
     yield entityHeaderLayoutComponentDataRef(
       ExtensionBoundary.lazyComponent(node, loader),
     );

--- a/plugins/catalog-react/src/alpha/blueprints/index.ts
+++ b/plugins/catalog-react/src/alpha/blueprints/index.ts
@@ -22,6 +22,10 @@ export {
 } from './EntityContentLayoutBlueprint';
 export { EntityHeaderBlueprint } from './EntityHeaderBlueprint';
 export {
+  EntityHeaderLayoutBlueprint,
+  type EntityHeaderLayoutProps,
+} from './EntityHeaderLayoutBlueprint';
+export {
   defaultEntityContentGroups,
   defaultEntityContentGroupDefinitions,
   type EntityContentGroupDefinitions,

--- a/plugins/catalog/report-alpha.api.md
+++ b/plugins/catalog/report-alpha.api.md
@@ -15,6 +15,7 @@ import { EntityCardType } from '@backstage/plugin-catalog-react/alpha';
 import { EntityContentLayoutProps } from '@backstage/plugin-catalog-react/alpha';
 import { EntityContextMenuItemData } from '@backstage/plugin-catalog-react/alpha';
 import { EntityContextMenuItemParams } from '@backstage/plugin-catalog-react/alpha';
+import { EntityHeaderLayoutProps } from '@backstage/plugin-catalog-react/alpha';
 import { EntityListContextProps } from '@backstage/plugin-catalog-react';
 import { EntityListPagination } from '@backstage/plugin-catalog-react';
 import { EntityOwnerPickerProps } from '@backstage/plugin-catalog-react';
@@ -221,6 +222,9 @@ export const catalogTranslationRef: TranslationRef<
     readonly 'entityLabels.ownerLabel': 'Owner';
     readonly 'entityLabels.warningPanelTitle': 'Entity not found';
     readonly 'entityLabels.lifecycleLabel': 'Lifecycle';
+    readonly 'entityLabels.systemLabel': 'System';
+    readonly 'entityLabels.domainLabel': 'Domain';
+    readonly 'entityLabels.partOfLabel': 'Part of';
     readonly 'entityLinksCard.title': 'Links';
     readonly 'entityLinksCard.readMoreButtonTitle': 'Read more';
     readonly 'entityLinksCard.emptyDescription': 'No links defined for this entity. You can add links to your entity YAML as shown in the highlighted example below:';
@@ -1330,10 +1334,43 @@ const _default: OverridableFrontendPlugin<
             internal: false;
           }
         >;
+        headerLayouts: ExtensionInput<
+          | ConfigurableExtensionDataRef<
+              (entity: Entity) => boolean,
+              'catalog.entity-filter-function',
+              {
+                optional: true;
+              }
+            >
+          | ConfigurableExtensionDataRef<
+              string,
+              'catalog.entity-filter-expression',
+              {
+                optional: true;
+              }
+            >
+          | ConfigurableExtensionDataRef<
+              (props: EntityHeaderLayoutProps) => JSX_2.Element,
+              'catalog.entity-header-layout.component',
+              {}
+            >,
+          {
+            singleton: false;
+            optional: false;
+            internal: false;
+          }
+        >;
         headers: ExtensionInput<
           | ConfigurableExtensionDataRef<
               (entity: Entity) => boolean,
               'catalog.entity-filter-function',
+              {
+                optional: true;
+              }
+            >
+          | ConfigurableExtensionDataRef<
+              string,
+              'catalog.entity-filter-expression',
               {
                 optional: true;
               }

--- a/plugins/catalog/report-alpha.api.md
+++ b/plugins/catalog/report-alpha.api.md
@@ -1343,13 +1343,6 @@ const _default: OverridableFrontendPlugin<
               }
             >
           | ConfigurableExtensionDataRef<
-              string,
-              'catalog.entity-filter-expression',
-              {
-                optional: true;
-              }
-            >
-          | ConfigurableExtensionDataRef<
               (props: EntityHeaderLayoutProps) => JSX_2.Element,
               'catalog.entity-header-layout.component',
               {}
@@ -1364,13 +1357,6 @@ const _default: OverridableFrontendPlugin<
           | ConfigurableExtensionDataRef<
               (entity: Entity) => boolean,
               'catalog.entity-filter-function',
-              {
-                optional: true;
-              }
-            >
-          | ConfigurableExtensionDataRef<
-              string,
-              'catalog.entity-filter-expression',
               {
                 optional: true;
               }

--- a/plugins/catalog/report.api.md
+++ b/plugins/catalog/report.api.md
@@ -321,6 +321,9 @@ export const catalogTranslationRef: TranslationRef<
     readonly 'entityLabels.ownerLabel': 'Owner';
     readonly 'entityLabels.warningPanelTitle': 'Entity not found';
     readonly 'entityLabels.lifecycleLabel': 'Lifecycle';
+    readonly 'entityLabels.systemLabel': 'System';
+    readonly 'entityLabels.domainLabel': 'Domain';
+    readonly 'entityLabels.partOfLabel': 'Part of';
     readonly 'entityLinksCard.title': 'Links';
     readonly 'entityLinksCard.readMoreButtonTitle': 'Read more';
     readonly 'entityLinksCard.emptyDescription': 'No links defined for this entity. You can add links to your entity YAML as shown in the highlighted example below:';

--- a/plugins/catalog/src/alpha/components/EntityHeader/EntityHeaderBui.test.tsx
+++ b/plugins/catalog/src/alpha/components/EntityHeader/EntityHeaderBui.test.tsx
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, screen } from '@testing-library/react';
+import { renderInTestApp } from '@backstage/frontend-test-utils';
+import {
+  Entity,
+  RELATION_OWNED_BY,
+  RELATION_PART_OF,
+} from '@backstage/catalog-model';
+import {
+  EntityProvider,
+  entityRouteRef,
+  MockStarredEntitiesApi,
+  starredEntitiesApiRef,
+} from '@backstage/plugin-catalog-react';
+import { catalogApiMock } from '@backstage/plugin-catalog-react/testUtils';
+import { EntityHeaderBui } from './EntityHeaderBui';
+
+const componentEntity: Entity = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Component',
+  metadata: {
+    namespace: 'default',
+    name: 'artist-lookup',
+    title: 'Artist Lookup',
+    description: 'Catalog description',
+  },
+  spec: { type: 'service', lifecycle: 'experimental' },
+  relations: [
+    { type: RELATION_OWNED_BY, targetRef: 'group:default/team-a' },
+    {
+      type: RELATION_PART_OF,
+      targetRef: 'system:default/artist-engagement-portal',
+    },
+  ],
+};
+
+const ownerEntity: Entity = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Group',
+  metadata: { namespace: 'default', name: 'team-a', title: 'Team A' },
+  spec: { profile: { picture: 'https://example.com/team-a.png' } },
+};
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(resolver => {
+    resolve = resolver;
+  });
+  return { promise, resolve };
+}
+
+async function renderHeader(options: {
+  entity?: Entity;
+  catalogEntities?: Entity[];
+  catalogApi?: ReturnType<typeof catalogApiMock>;
+}) {
+  return renderInTestApp(
+    <EntityProvider entity={options.entity}>
+      <EntityHeaderBui tabs={[]} contextMenuItems={[]} />
+    </EntityProvider>,
+    {
+      apis: [
+        options.catalogApi ??
+          catalogApiMock({ entities: options.catalogEntities ?? [] }),
+        [starredEntitiesApiRef, new MockStarredEntitiesApi()],
+      ],
+      mountPath: '/catalog/:namespace/:kind/:name',
+      initialRouteEntries: ['/catalog/default/component/artist-lookup'],
+      mountedRoutes: {
+        '/catalog/:namespace/:kind/:name': entityRouteRef,
+      },
+    },
+  );
+}
+
+describe('EntityHeaderBui', () => {
+  it('renders rich entity data from canonical relations', async () => {
+    await renderHeader({
+      entity: componentEntity,
+      catalogEntities: [componentEntity, ownerEntity],
+    });
+
+    expect(
+      await screen.findByRole('heading', { name: 'Artist Lookup' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Component')).toBeInTheDocument();
+    expect(screen.getByText('service')).toBeInTheDocument();
+    expect(screen.getByText('Catalog description')).toBeInTheDocument();
+    expect(screen.getByText('experimental')).toBeInTheDocument();
+    expect(await screen.findByText('Team A')).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'artist-engagement-portal' }),
+    ).toHaveAttribute(
+      'href',
+      '/catalog/default/system/artist-engagement-portal',
+    );
+    expect(
+      screen.getByRole('button', { name: 'Add to favorites' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'More actions' }),
+    ).toBeInTheDocument();
+  });
+
+  it('keeps a useful owner fallback while catalog owner resolution is pending', async () => {
+    const ownerResponse = createDeferred<{ items: Entity[] }>();
+    await renderHeader({
+      entity: componentEntity,
+      catalogApi: catalogApiMock.mock({
+        getEntitiesByRefs: jest.fn(() => ownerResponse.promise),
+      }),
+    });
+
+    expect(await screen.findByText('team-a')).toBeInTheDocument();
+    await act(async () => {
+      ownerResponse.resolve({ items: [ownerEntity] });
+    });
+    expect(await screen.findByText('Team A')).toBeInTheDocument();
+  });
+
+  it('renders a route-ref title while the entity is loading', async () => {
+    await renderHeader({ entity: undefined });
+    expect(
+      screen.getByRole('heading', { name: 'artist-lookup' }),
+    ).toBeInTheDocument();
+  });
+});

--- a/plugins/catalog/src/alpha/components/EntityHeader/EntityHeaderBui.test.tsx
+++ b/plugins/catalog/src/alpha/components/EntityHeader/EntityHeaderBui.test.tsx
@@ -100,7 +100,7 @@ describe('EntityHeaderBui', () => {
     ).toBeInTheDocument();
     expect(screen.getByText('Component')).toBeInTheDocument();
     expect(screen.getByText('service')).toBeInTheDocument();
-    expect(screen.getByText('Catalog description')).toBeInTheDocument();
+    expect(screen.queryByText('Catalog description')).not.toBeInTheDocument();
     expect(screen.getByText('experimental')).toBeInTheDocument();
     expect(await screen.findByText('Team A')).toBeInTheDocument();
     expect(

--- a/plugins/catalog/src/alpha/components/EntityHeader/EntityHeaderBui.test.tsx
+++ b/plugins/catalog/src/alpha/components/EntityHeader/EntityHeaderBui.test.tsx
@@ -37,7 +37,6 @@ const componentEntity: Entity = {
     namespace: 'default',
     name: 'artist-lookup',
     title: 'Artist Lookup',
-    description: 'Catalog description',
   },
   spec: { type: 'service', lifecycle: 'experimental' },
   relations: [
@@ -100,7 +99,6 @@ describe('EntityHeaderBui', () => {
     ).toBeInTheDocument();
     expect(screen.getByText('Component')).toBeInTheDocument();
     expect(screen.getByText('service')).toBeInTheDocument();
-    expect(screen.queryByText('Catalog description')).not.toBeInTheDocument();
     expect(screen.getByText('experimental')).toBeInTheDocument();
     expect(await screen.findByText('Team A')).toBeInTheDocument();
     expect(

--- a/plugins/catalog/src/alpha/components/EntityHeader/EntityHeaderBui.tsx
+++ b/plugins/catalog/src/alpha/components/EntityHeader/EntityHeaderBui.tsx
@@ -91,11 +91,7 @@ function useOwnerUsers(entity: Entity | undefined): HeaderMetadataUser[] {
 function HierarchyLinks(props: { refs: CompoundEntityRef[] }) {
   const entityLink = useEntityRefLink();
   return (
-    <Box
-      as="ul"
-      display="inline"
-      style={{ listStyle: 'none', margin: 0, padding: 0 }}
-    >
+    <Box as="ul" display="inline" m={0} p={0} style={{ listStyle: 'none' }}>
       {props.refs.map((ref, index) => (
         <Box as="li" display="inline" key={stringifyEntityRef(ref)}>
           {index > 0 ? ', ' : null}

--- a/plugins/catalog/src/alpha/components/EntityHeader/EntityHeaderBui.tsx
+++ b/plugins/catalog/src/alpha/components/EntityHeader/EntityHeaderBui.tsx
@@ -196,7 +196,6 @@ export function EntityHeaderBui(props: {
         { label: entity?.kind ?? routeParams.kind },
         ...(type ? [{ label: type }] : []),
       ]}
-      description={entity?.metadata.description}
       metadata={metadata}
       tabs={entity ? props.tabs : undefined}
       activeTabId={props.activeTabId}

--- a/plugins/catalog/src/alpha/components/EntityHeader/EntityHeaderBui.tsx
+++ b/plugins/catalog/src/alpha/components/EntityHeader/EntityHeaderBui.tsx
@@ -47,7 +47,10 @@ import {
 import { RiStarFill, RiStarLine } from '@remixicon/react';
 import useAsync from 'react-use/esm/useAsync';
 import { catalogTranslationRef } from '../../translation';
-import { EntityContextMenu } from '../EntityContextMenu';
+import {
+  EntityContextMenu,
+  type EntityContextMenuItemDataWithNode,
+} from '../EntityContextMenu';
 
 function useOwnerUsers(entity: Entity | undefined): HeaderMetadataUser[] {
   const catalogApi = useApi(catalogApiRef);
@@ -182,7 +185,7 @@ function FavoriteEntityButton(props: { entity: Entity }) {
 export function EntityHeaderBui(props: {
   tabs: HeaderNavTabItem[];
   activeTabId?: string;
-  contextMenuItems?: React.JSX.Element[];
+  contextMenuItems?: EntityContextMenuItemDataWithNode[];
 }) {
   const { entity } = useAsyncEntity();
   const routeParams = useRouteRefParams(entityRouteRef);

--- a/plugins/catalog/src/alpha/components/EntityHeader/EntityHeaderBui.tsx
+++ b/plugins/catalog/src/alpha/components/EntityHeader/EntityHeaderBui.tsx
@@ -16,6 +16,7 @@
 
 import { useMemo } from 'react';
 import {
+  Box,
   ButtonIcon,
   Header,
   HeaderMetadataUsers,
@@ -90,16 +91,20 @@ function useOwnerUsers(entity: Entity | undefined): HeaderMetadataUser[] {
 function HierarchyLinks(props: { refs: CompoundEntityRef[] }) {
   const entityLink = useEntityRefLink();
   return (
-    <>
+    <Box
+      as="ul"
+      display="inline"
+      style={{ listStyle: 'none', margin: 0, padding: 0 }}
+    >
       {props.refs.map((ref, index) => (
-        <span key={stringifyEntityRef(ref)}>
+        <Box as="li" display="inline" key={stringifyEntityRef(ref)}>
           {index > 0 ? ', ' : null}
           <Link href={entityLink(ref)} standalone>
             {ref.name}
           </Link>
-        </span>
+        </Box>
       ))}
-    </>
+    </Box>
   );
 }
 

--- a/plugins/catalog/src/alpha/components/EntityHeader/EntityHeaderBui.tsx
+++ b/plugins/catalog/src/alpha/components/EntityHeader/EntityHeaderBui.tsx
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useMemo } from 'react';
+import {
+  ButtonIcon,
+  Header,
+  HeaderMetadataUsers,
+  Link,
+  type HeaderMetadataItem,
+  type HeaderMetadataUser,
+  type HeaderNavTabItem,
+} from '@backstage/ui';
+import {
+  Entity,
+  RELATION_OWNED_BY,
+  RELATION_PART_OF,
+  stringifyEntityRef,
+  type CompoundEntityRef,
+} from '@backstage/catalog-model';
+import { useApi, useRouteRefParams } from '@backstage/core-plugin-api';
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import {
+  catalogApiRef,
+  catalogReactTranslationRef,
+  entityRouteRef,
+  getEntityRelations,
+  useAsyncEntity,
+  useEntityPresentation,
+  useEntityRefLink,
+  useStarredEntity,
+} from '@backstage/plugin-catalog-react';
+import { RiStarFill, RiStarLine } from '@remixicon/react';
+import useAsync from 'react-use/esm/useAsync';
+import { catalogTranslationRef } from '../../translation';
+import { EntityContextMenu } from '../EntityContextMenu';
+
+function useOwnerUsers(entity: Entity | undefined): HeaderMetadataUser[] {
+  const catalogApi = useApi(catalogApiRef);
+  const entityLink = useEntityRefLink();
+  const ownerRefs = useMemo(
+    () => getEntityRelations(entity, RELATION_OWNED_BY),
+    [entity],
+  );
+  const ownerRefStrings = useMemo(
+    () => ownerRefs.map(ref => stringifyEntityRef(ref)),
+    [ownerRefs],
+  );
+  const { value: ownerEntities } = useAsync(async () => {
+    if (ownerRefStrings.length === 0) return [];
+    return (
+      await catalogApi.getEntitiesByRefs({
+        entityRefs: ownerRefStrings,
+        fields: [
+          'kind',
+          'metadata.name',
+          'metadata.namespace',
+          'metadata.title',
+          'spec.profile',
+        ],
+      })
+    ).items;
+  }, [catalogApi, ownerRefStrings]);
+
+  return ownerRefs.map((ref, index) => {
+    const owner = ownerEntities?.[index];
+    const profile = (owner?.spec as { profile?: { picture?: string } })
+      ?.profile;
+    return {
+      name: owner?.metadata.title ?? owner?.metadata.name ?? ref.name,
+      src: profile?.picture,
+      href: entityLink(ref),
+    };
+  });
+}
+
+function HierarchyLinks(props: { refs: CompoundEntityRef[] }) {
+  const entityLink = useEntityRefLink();
+  return (
+    <>
+      {props.refs.map((ref, index) => (
+        <span key={stringifyEntityRef(ref)}>
+          {index > 0 ? ', ' : null}
+          <Link href={entityLink(ref)} standalone>
+            {ref.name}
+          </Link>
+        </span>
+      ))}
+    </>
+  );
+}
+
+function hierarchyLabel(
+  ref: CompoundEntityRef,
+): 'systemLabel' | 'domainLabel' | 'partOfLabel' {
+  switch (ref.kind.toLocaleLowerCase('en-US')) {
+    case 'system':
+      return 'systemLabel';
+    case 'domain':
+      return 'domainLabel';
+    default:
+      return 'partOfLabel';
+  }
+}
+
+function useMetadata(entity: Entity | undefined): HeaderMetadataItem[] {
+  const owners = useOwnerUsers(entity);
+  const { t } = useTranslationRef(catalogTranslationRef);
+  return useMemo(() => {
+    if (!entity) return [];
+    const metadata: HeaderMetadataItem[] = [];
+    const lifecycle = entity.spec?.lifecycle?.toString();
+    if (lifecycle) {
+      metadata.push({
+        label: t('entityLabels.lifecycleLabel'),
+        value: lifecycle,
+      });
+    }
+    if (owners.length > 0) {
+      metadata.push({
+        label: t('entityLabels.ownerLabel'),
+        value: <HeaderMetadataUsers users={owners} />,
+      });
+    }
+
+    const hierarchy = getEntityRelations(entity, RELATION_PART_OF).reduce(
+      (groups, ref) => {
+        const label = hierarchyLabel(ref);
+        groups[label] = [...(groups[label] ?? []), ref];
+        return groups;
+      },
+      {} as Record<string, CompoundEntityRef[]>,
+    );
+    for (const [label, refs] of Object.entries(hierarchy)) {
+      metadata.push({
+        label: t(
+          `entityLabels.${label}` as
+            | 'entityLabels.systemLabel'
+            | 'entityLabels.domainLabel'
+            | 'entityLabels.partOfLabel',
+        ),
+        value: <HierarchyLinks refs={refs} />,
+      });
+    }
+    return metadata;
+  }, [entity, owners, t]);
+}
+
+function FavoriteEntityButton(props: { entity: Entity }) {
+  const { t } = useTranslationRef(catalogReactTranslationRef);
+  const { isStarredEntity, toggleStarredEntity } = useStarredEntity(
+    props.entity,
+  );
+  return (
+    <ButtonIcon
+      variant="secondary"
+      aria-label={
+        isStarredEntity
+          ? t('favoriteEntity.removeFromFavorites')
+          : t('favoriteEntity.addToFavorites')
+      }
+      icon={isStarredEntity ? <RiStarFill /> : <RiStarLine />}
+      onPress={() => toggleStarredEntity()}
+    />
+  );
+}
+
+export function EntityHeaderBui(props: {
+  tabs: HeaderNavTabItem[];
+  activeTabId?: string;
+  contextMenuItems?: React.JSX.Element[];
+}) {
+  const { entity } = useAsyncEntity();
+  const routeParams = useRouteRefParams(entityRouteRef);
+  const presentation = useEntityPresentation(entity ?? routeParams);
+  const metadata = useMetadata(entity);
+  const type = entity?.spec?.type?.toString();
+
+  return (
+    <Header
+      title={presentation.primaryTitle}
+      tags={[
+        { label: entity?.kind ?? routeParams.kind },
+        ...(type ? [{ label: type }] : []),
+      ]}
+      description={entity?.metadata.description}
+      metadata={metadata}
+      tabs={entity ? props.tabs : undefined}
+      activeTabId={props.activeTabId}
+      customActions={
+        entity ? (
+          <>
+            <FavoriteEntityButton entity={entity} />
+            <EntityContextMenu contextMenuItems={props.contextMenuItems} />
+          </>
+        ) : undefined
+      }
+    />
+  );
+}

--- a/plugins/catalog/src/alpha/components/EntityHeader/EntityHeaderBui.tsx
+++ b/plugins/catalog/src/alpha/components/EntityHeader/EntityHeaderBui.tsx
@@ -91,7 +91,7 @@ function useOwnerUsers(entity: Entity | undefined): HeaderMetadataUser[] {
 function HierarchyLinks(props: { refs: CompoundEntityRef[] }) {
   const entityLink = useEntityRefLink();
   return (
-    <Box as="ul" display="inline" m={0} p={0} style={{ listStyle: 'none' }}>
+    <Box as="ul" display="inline" m="0" p="0" style={{ listStyle: 'none' }}>
       {props.refs.map((ref, index) => (
         <Box as="li" display="inline" key={stringifyEntityRef(ref)}>
           {index > 0 ? ', ' : null}

--- a/plugins/catalog/src/alpha/components/EntityLayout/EntityLayout.tsx
+++ b/plugins/catalog/src/alpha/components/EntityLayout/EntityLayout.tsx
@@ -14,15 +14,11 @@
  * limitations under the License.
  */
 
-import { ComponentProps, ReactNode, ReactElement } from 'react';
+import { ComponentProps, ReactNode } from 'react';
 
 import Alert from '@material-ui/lab/Alert';
 
-import {
-  attachComponentData,
-  useElementFilter,
-  useRouteRefParams,
-} from '@backstage/core-plugin-api';
+import { useRouteRefParams } from '@backstage/core-plugin-api';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import {
   Content,
@@ -31,7 +27,6 @@ import {
   Progress,
   WarningPanel,
 } from '@backstage/core-components';
-import { Entity } from '@backstage/catalog-model';
 import {
   entityRouteRef,
   useAsyncEntity,
@@ -41,20 +36,8 @@ import { catalogTranslationRef } from '../../translation';
 import { EntityHeader } from '../EntityHeader';
 import { EntityTabs } from '../EntityTabs';
 import { EntityContentGroupDefinitions } from '@backstage/plugin-catalog-react/alpha';
-
-export type EntityLayoutRouteProps = {
-  path: string;
-  title: string;
-  group?: string;
-  icon?: string | ReactElement;
-  children: JSX.Element;
-  if?: (entity: Entity) => boolean;
-};
-
-const dataKey = 'plugin.catalog.entityLayoutRoute';
-const Route: (props: EntityLayoutRouteProps) => null = () => null;
-attachComponentData(Route, dataKey, true);
-attachComponentData(Route, 'core.gatherMountPoints', true); // This causes all mount points that are discovered within this route to use the path of the route itself
+import { EntityLayoutRoute, useEntityLayoutRoutes } from './entityLayoutRoutes';
+export type { EntityLayoutRouteProps } from './entityLayoutRoutes';
 
 /** @public */
 export interface EntityLayoutProps {
@@ -113,35 +96,7 @@ export const EntityLayout = (props: EntityLayoutProps) => {
   const { kind } = useRouteRefParams(entityRouteRef);
   const { entity, loading, error } = useAsyncEntity();
 
-  const routes = useElementFilter(
-    children,
-    elements =>
-      elements
-        .selectByComponentData({
-          key: dataKey,
-          withStrictError:
-            'Child of EntityLayout must be an EntityLayout.Route',
-        })
-        .getElements<EntityLayoutRouteProps>() // all nodes, element data, maintain structure or not?
-        .flatMap(({ props: elementProps }) => {
-          if (!entity) {
-            return [];
-          }
-          if (elementProps.if && !elementProps.if(entity)) {
-            return [];
-          }
-          return [
-            {
-              path: elementProps.path,
-              title: elementProps.title,
-              group: elementProps.group,
-              children: elementProps.children,
-              icon: elementProps.icon,
-            },
-          ];
-        }),
-    [entity],
-  );
+  const routes = useEntityLayoutRoutes(children, entity);
 
   const { t } = useTranslationRef(catalogTranslationRef);
 
@@ -194,4 +149,4 @@ export const EntityLayout = (props: EntityLayoutProps) => {
   );
 };
 
-EntityLayout.Route = Route;
+EntityLayout.Route = EntityLayoutRoute;

--- a/plugins/catalog/src/alpha/components/EntityLayout/EntityLayout.tsx
+++ b/plugins/catalog/src/alpha/components/EntityLayout/EntityLayout.tsx
@@ -37,6 +37,7 @@ import { EntityHeader } from '../EntityHeader';
 import { EntityTabs } from '../EntityTabs';
 import { EntityContentGroupDefinitions } from '@backstage/plugin-catalog-react/alpha';
 import { EntityLayoutRoute, useEntityLayoutRoutes } from './entityLayoutRoutes';
+
 export type { EntityLayoutRouteProps } from './entityLayoutRoutes';
 
 /** @public */

--- a/plugins/catalog/src/alpha/components/EntityLayout/EntityLayoutBui.test.tsx
+++ b/plugins/catalog/src/alpha/components/EntityLayout/EntityLayoutBui.test.tsx
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentType } from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import { renderInTestApp } from '@backstage/frontend-test-utils';
+import { Entity } from '@backstage/catalog-model';
+import {
+  AsyncEntityProvider,
+  entityRouteRef,
+  MockStarredEntitiesApi,
+  starredEntitiesApiRef,
+} from '@backstage/plugin-catalog-react';
+import {
+  defaultEntityContentGroupDefinitions,
+  type EntityHeaderLayoutProps,
+} from '@backstage/plugin-catalog-react/alpha';
+import { catalogApiMock } from '@backstage/plugin-catalog-react/testUtils';
+import { EntityLayoutBui } from './EntityLayoutBui';
+import { EntityLayoutRoute } from './entityLayoutRoutes';
+
+const componentEntity: Entity = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Component',
+  metadata: {
+    namespace: 'default',
+    name: 'artist-lookup',
+    title: 'Artist Lookup',
+    description: 'Catalog description',
+  },
+  spec: { type: 'service', lifecycle: 'experimental' },
+};
+
+async function renderLayout(options: {
+  entity?: Entity;
+  loading?: boolean;
+  error?: Error;
+  path?: string;
+  NotFoundComponent?: React.ReactNode;
+  HeaderComponent?: ComponentType<EntityHeaderLayoutProps>;
+}) {
+  return renderInTestApp(
+    <AsyncEntityProvider
+      entity={options.entity}
+      loading={options.loading ?? false}
+      error={options.error}
+    >
+      <EntityLayoutBui
+        groupDefinitions={defaultEntityContentGroupDefinitions}
+        defaultContentOrder="title"
+        contextMenuItems={[]}
+        NotFoundComponent={options.NotFoundComponent}
+        HeaderComponent={options.HeaderComponent}
+      >
+        <EntityLayoutRoute path="/overview" title="Overview">
+          <div>Overview content</div>
+        </EntityLayoutRoute>
+      </EntityLayoutBui>
+    </AsyncEntityProvider>,
+    {
+      apis: [
+        catalogApiMock({ entities: options.entity ? [options.entity] : [] }),
+        [starredEntitiesApiRef, new MockStarredEntitiesApi()],
+      ],
+      config: {
+        app: { title: 'Custom app' },
+        backend: { baseUrl: 'http://localhost:7000' },
+      },
+      mountPath: '/catalog/:namespace/:kind/:name/*',
+      initialRouteEntries: [
+        `/catalog/default/component/artist-lookup${options.path ?? ''}`,
+      ],
+      mountedRoutes: {
+        '/catalog/:namespace/:kind/:name/*': entityRouteRef,
+      },
+    },
+  );
+}
+
+describe('EntityLayoutBui', () => {
+  it('renders loading below the default fallback header', async () => {
+    await renderLayout({ loading: true });
+    expect(
+      screen.getByRole('heading', { name: 'artist-lookup' }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('progress')).toBeInTheDocument();
+  });
+
+  it('renders selected content in a BUI container and composes the document title', async () => {
+    await renderLayout({ entity: componentEntity, path: '/overview' });
+    expect(await screen.findByText('Overview content')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(document.title).toBe('Artist Lookup | Overview | Custom app'),
+    );
+  });
+
+  it('renders unmatched entity content through the not-found page', async () => {
+    await renderLayout({ entity: componentEntity, path: '/missing' });
+    expect(await screen.findByTestId('error')).toBeInTheDocument();
+  });
+
+  it('renders errors and missing entities as BUI alerts', async () => {
+    await renderLayout({ error: new Error('catalog failed') });
+    expect(screen.getByText('Error: catalog failed')).toBeInTheDocument();
+    expect(
+      screen.getByText('Error: catalog failed').closest('[data-status]'),
+    ).toHaveAttribute('data-status', 'danger');
+  });
+
+  it('renders the default and custom missing-entity states', async () => {
+    const first = await renderLayout({});
+    expect(screen.getByText('Entity not found')).toBeInTheDocument();
+    first.unmount();
+
+    await renderLayout({ NotFoundComponent: <div>Custom missing</div> });
+    expect(screen.getByText('Custom missing')).toBeInTheDocument();
+  });
+
+  it('passes composed tabs and the active tab ID to a successor header', async () => {
+    const HeaderComponent = jest.fn((props: EntityHeaderLayoutProps) => (
+      <header>
+        {props.tabs.map(tab => tab.label).join(',')}:{props.activeTabId}
+      </header>
+    ));
+    await renderLayout({
+      entity: componentEntity,
+      path: '/overview',
+      HeaderComponent,
+    });
+    expect(await screen.findByText('Overview:/overview')).toBeInTheDocument();
+  });
+
+  it('hosts the URL-driven Inspect dialog independently of the default header', async () => {
+    await renderLayout({
+      entity: componentEntity,
+      path: '/overview?inspect=json',
+      HeaderComponent: () => <header>Successor header</header>,
+    });
+    expect(await screen.findByText('Entity Inspector')).toBeInTheDocument();
+  });
+});

--- a/plugins/catalog/src/alpha/components/EntityLayout/EntityLayoutBui.tsx
+++ b/plugins/catalog/src/alpha/components/EntityLayout/EntityLayoutBui.tsx
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentProps, ComponentType, ReactNode, useCallback } from 'react';
+import { Helmet } from 'react-helmet';
+import { useSearchParams } from 'react-router-dom';
+import { Alert, Container } from '@backstage/ui';
+import {
+  configApiRef,
+  useApi,
+  useRouteRefParams,
+} from '@backstage/core-plugin-api';
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { Link, Progress } from '@backstage/core-components';
+import { NotFoundErrorPage } from '@backstage/frontend-plugin-api';
+import {
+  entityRouteRef,
+  InspectEntityDialog,
+  useAsyncEntity,
+  useEntityPresentation,
+} from '@backstage/plugin-catalog-react';
+import {
+  type EntityContentGroupDefinitions,
+  type EntityHeaderLayoutProps,
+} from '@backstage/plugin-catalog-react/alpha';
+import { catalogTranslationRef } from '../../translation';
+import { EntityHeaderBui } from '../EntityHeader/EntityHeaderBui';
+import { useEntityTabs } from '../EntityTabs/useEntityTabs';
+import { useEntityLayoutRoutes } from './entityLayoutRoutes';
+
+function EntityDocumentTitle(props: { activeContentTitle?: string }) {
+  const configApi = useApi(configApiRef);
+  const routeParams = useRouteRefParams(entityRouteRef);
+  const { entity } = useAsyncEntity();
+  const presentation = useEntityPresentation(entity ?? routeParams);
+  const appTitle = configApi.getOptionalString('app.title') || 'Backstage';
+  return (
+    <>
+      <Helmet
+        titleTemplate={`${presentation.primaryTitle} | %s | ${appTitle}`}
+        defaultTitle={`${presentation.primaryTitle} | ${appTitle}`}
+      />
+      {props.activeContentTitle && <Helmet title={props.activeContentTitle} />}
+    </>
+  );
+}
+
+function InspectEntityDialogHost() {
+  const { entity } = useAsyncEntity();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const selectedTab = searchParams.get('inspect');
+  const setSelectedTab = useCallback(
+    (tab: string) =>
+      setSearchParams(params => {
+        const next = new URLSearchParams(params);
+        next.set('inspect', tab);
+        return next;
+      }),
+    [setSearchParams],
+  );
+  const close = useCallback(
+    () =>
+      setSearchParams(params => {
+        const next = new URLSearchParams(params);
+        next.delete('inspect');
+        return next;
+      }),
+    [setSearchParams],
+  );
+  if (!entity) return null;
+  return (
+    <InspectEntityDialog
+      entity={entity}
+      initialTab={
+        (selectedTab as ComponentProps<
+          typeof InspectEntityDialog
+        >['initialTab']) || undefined
+      }
+      open={typeof selectedTab === 'string'}
+      onClose={close}
+      onSelect={setSelectedTab}
+    />
+  );
+}
+
+export function EntityLayoutBui(props: {
+  children?: ReactNode;
+  NotFoundComponent?: ReactNode;
+  groupDefinitions: EntityContentGroupDefinitions;
+  defaultContentOrder: 'title' | 'natural';
+  contextMenuItems?: React.JSX.Element[];
+  HeaderComponent?: ComponentType<EntityHeaderLayoutProps>;
+}) {
+  const {
+    children,
+    NotFoundComponent,
+    groupDefinitions,
+    defaultContentOrder,
+    contextMenuItems,
+    HeaderComponent,
+  } = props;
+  const { kind } = useRouteRefParams(entityRouteRef);
+  const { entity, loading, error } = useAsyncEntity();
+  const routes = useEntityLayoutRoutes(children, entity);
+  const tabs = useEntityTabs({ routes, groupDefinitions, defaultContentOrder });
+  const { t } = useTranslationRef(catalogTranslationRef);
+
+  return (
+    <main>
+      <EntityDocumentTitle activeContentTitle={tabs.title} />
+      {HeaderComponent ? (
+        <HeaderComponent tabs={tabs.tabs} activeTabId={tabs.activeTabId} />
+      ) : (
+        <EntityHeaderBui
+          tabs={tabs.tabs}
+          activeTabId={tabs.activeTabId}
+          contextMenuItems={contextMenuItems}
+        />
+      )}
+      {loading && <Progress />}
+      {entity && <Container>{tabs.content ?? <NotFoundErrorPage />}</Container>}
+      {error && (
+        <Container>
+          <Alert status="danger" title={error.toString()} />
+        </Container>
+      )}
+      {!loading && !error && !entity && (
+        <Container>
+          {NotFoundComponent ?? (
+            <Alert
+              status="warning"
+              title={t('entityLabels.warningPanelTitle')}
+              description={t('entityPage.notFoundMessage', {
+                kind,
+                link: (
+                  <Link to="https://backstage.io/docs/features/software-catalog/references">
+                    {t('entityPage.notFoundLinkText')}
+                  </Link>
+                ),
+              })}
+            />
+          )}
+        </Container>
+      )}
+      <InspectEntityDialogHost />
+    </main>
+  );
+}

--- a/plugins/catalog/src/alpha/components/EntityLayout/EntityLayoutBui.tsx
+++ b/plugins/catalog/src/alpha/components/EntityLayout/EntityLayoutBui.tsx
@@ -96,6 +96,47 @@ function InspectEntityDialogHost() {
   );
 }
 
+function EntityLayoutContent(props: {
+  content?: React.JSX.Element;
+  NotFoundComponent?: ReactNode;
+}) {
+  const { kind } = useRouteRefParams(entityRouteRef);
+  const { entity, loading, error } = useAsyncEntity();
+  const { t } = useTranslationRef(catalogTranslationRef);
+
+  if (loading) {
+    return <Progress />;
+  }
+  if (error) {
+    return (
+      <Container>
+        <Alert status="danger" title={error.toString()} />
+      </Container>
+    );
+  }
+  if (!entity) {
+    return (
+      <Container>
+        {props.NotFoundComponent ?? (
+          <Alert
+            status="warning"
+            title={t('entityLabels.warningPanelTitle')}
+            description={t('entityPage.notFoundMessage', {
+              kind,
+              link: (
+                <Link to="https://backstage.io/docs/features/software-catalog/references">
+                  {t('entityPage.notFoundLinkText')}
+                </Link>
+              ),
+            })}
+          />
+        )}
+      </Container>
+    );
+  }
+  return <Container>{props.content ?? <NotFoundErrorPage />}</Container>;
+}
+
 export function EntityLayoutBui(props: {
   children?: ReactNode;
   NotFoundComponent?: ReactNode;
@@ -112,11 +153,9 @@ export function EntityLayoutBui(props: {
     contextMenuItems,
     HeaderComponent,
   } = props;
-  const { kind } = useRouteRefParams(entityRouteRef);
-  const { entity, loading, error } = useAsyncEntity();
+  const { entity } = useAsyncEntity();
   const routes = useEntityLayoutRoutes(children, entity);
   const tabs = useEntityTabs({ routes, groupDefinitions, defaultContentOrder });
-  const { t } = useTranslationRef(catalogTranslationRef);
 
   return (
     <main>
@@ -130,31 +169,10 @@ export function EntityLayoutBui(props: {
           contextMenuItems={contextMenuItems}
         />
       )}
-      {loading && <Progress />}
-      {entity && <Container>{tabs.content ?? <NotFoundErrorPage />}</Container>}
-      {error && (
-        <Container>
-          <Alert status="danger" title={error.toString()} />
-        </Container>
-      )}
-      {!loading && !error && !entity && (
-        <Container>
-          {NotFoundComponent ?? (
-            <Alert
-              status="warning"
-              title={t('entityLabels.warningPanelTitle')}
-              description={t('entityPage.notFoundMessage', {
-                kind,
-                link: (
-                  <Link to="https://backstage.io/docs/features/software-catalog/references">
-                    {t('entityPage.notFoundLinkText')}
-                  </Link>
-                ),
-              })}
-            />
-          )}
-        </Container>
-      )}
+      <EntityLayoutContent
+        content={tabs.content}
+        NotFoundComponent={NotFoundComponent}
+      />
       <InspectEntityDialogHost />
     </main>
   );

--- a/plugins/catalog/src/alpha/components/EntityLayout/EntityLayoutBui.tsx
+++ b/plugins/catalog/src/alpha/components/EntityLayout/EntityLayoutBui.tsx
@@ -104,18 +104,17 @@ function EntityLayoutContent(props: {
   const { entity, loading, error } = useAsyncEntity();
   const { t } = useTranslationRef(catalogTranslationRef);
 
-  if (loading) {
-    return <Progress />;
-  }
+  let content: ReactNode;
   if (error) {
-    return (
+    content = (
       <Container>
         <Alert status="danger" title={error.toString()} />
       </Container>
     );
-  }
-  if (!entity) {
-    return (
+  } else if (entity) {
+    content = <Container>{props.content ?? <NotFoundErrorPage />}</Container>;
+  } else if (!loading) {
+    content = (
       <Container>
         {props.NotFoundComponent ?? (
           <Alert
@@ -134,7 +133,13 @@ function EntityLayoutContent(props: {
       </Container>
     );
   }
-  return <Container>{props.content ?? <NotFoundErrorPage />}</Container>;
+
+  return (
+    <>
+      {loading && <Progress />}
+      {content}
+    </>
+  );
 }
 
 export function EntityLayoutBui(props: {

--- a/plugins/catalog/src/alpha/components/EntityLayout/EntityLayoutBui.tsx
+++ b/plugins/catalog/src/alpha/components/EntityLayout/EntityLayoutBui.tsx
@@ -142,7 +142,7 @@ export function EntityLayoutBui(props: {
   NotFoundComponent?: ReactNode;
   groupDefinitions: EntityContentGroupDefinitions;
   defaultContentOrder: 'title' | 'natural';
-  contextMenuItems?: React.JSX.Element[];
+  contextMenuItems?: ComponentProps<typeof EntityHeaderBui>['contextMenuItems'];
   HeaderComponent?: ComponentType<EntityHeaderLayoutProps>;
 }) {
   const {

--- a/plugins/catalog/src/alpha/components/EntityLayout/entityLayoutRoutes.tsx
+++ b/plugins/catalog/src/alpha/components/EntityLayout/entityLayoutRoutes.tsx
@@ -35,6 +35,7 @@ const dataKey = 'plugin.catalog.entityLayoutRoute';
 export const EntityLayoutRoute: (props: EntityLayoutRouteProps) => null = () =>
   null;
 attachComponentData(EntityLayoutRoute, dataKey, true);
+// Ensures mount points discovered within a route use the route's own path.
 attachComponentData(EntityLayoutRoute, 'core.gatherMountPoints', true);
 
 export function useEntityLayoutRoutes(

--- a/plugins/catalog/src/alpha/components/EntityLayout/entityLayoutRoutes.tsx
+++ b/plugins/catalog/src/alpha/components/EntityLayout/entityLayoutRoutes.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity } from '@backstage/catalog-model';
+import {
+  attachComponentData,
+  useElementFilter,
+} from '@backstage/core-plugin-api';
+import { ReactElement, ReactNode } from 'react';
+
+export type EntityLayoutRouteProps = {
+  path: string;
+  title: string;
+  group?: string;
+  icon?: string | ReactElement;
+  children: JSX.Element;
+  if?: (entity: Entity) => boolean;
+};
+
+const dataKey = 'plugin.catalog.entityLayoutRoute';
+
+export const EntityLayoutRoute: (props: EntityLayoutRouteProps) => null = () =>
+  null;
+attachComponentData(EntityLayoutRoute, dataKey, true);
+attachComponentData(EntityLayoutRoute, 'core.gatherMountPoints', true);
+
+export function useEntityLayoutRoutes(
+  children: ReactNode,
+  entity: Entity | undefined,
+) {
+  return useElementFilter(
+    children,
+    elements =>
+      elements
+        .selectByComponentData({
+          key: dataKey,
+          withStrictError:
+            'Child of EntityLayout must be an EntityLayout.Route',
+        })
+        .getElements<EntityLayoutRouteProps>()
+        .flatMap(({ props }) => {
+          if (!entity || (props.if && !props.if(entity))) return [];
+          return [
+            {
+              path: props.path,
+              title: props.title,
+              group: props.group,
+              icon: props.icon,
+              children: props.children,
+            },
+          ];
+        }),
+    [entity],
+  );
+}

--- a/plugins/catalog/src/alpha/components/EntityTabs/EntityTabs.tsx
+++ b/plugins/catalog/src/alpha/components/EntityTabs/EntityTabs.tsx
@@ -21,7 +21,7 @@ import { EntityTabsPanel } from './EntityTabsPanel';
 import { EntityTabsList } from './EntityTabsList';
 import { EntityContentGroupDefinitions } from '@backstage/plugin-catalog-react/alpha';
 
-type SubRoute = {
+export type SubRoute = {
   group?: string;
   path: string;
   title: string;

--- a/plugins/catalog/src/alpha/components/EntityTabs/useEntityTabs.test.tsx
+++ b/plugins/catalog/src/alpha/components/EntityTabs/useEntityTabs.test.tsx
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { buildHeaderTabs, useEntityTabs } from './useEntityTabs';
+
+describe('buildHeaderTabs', () => {
+  const definitions = {
+    documentation: { title: 'Documentation', aliases: ['docs'] },
+    development: { title: 'Development' },
+  };
+
+  it('preserves group semantics and omits icons', () => {
+    expect(
+      buildHeaderTabs(
+        [
+          {
+            path: '/overview',
+            title: 'Overview',
+            children: <div />,
+            icon: 'x',
+          },
+          {
+            path: '/techdocs',
+            title: 'TechDocs',
+            group: 'docs',
+            children: <div />,
+          },
+          {
+            path: '/apidocs',
+            title: 'ApiDocs',
+            group: 'documentation',
+            children: <div />,
+          },
+          { path: '/ci', title: 'CI', group: 'development', children: <div /> },
+        ],
+        definitions,
+        'title',
+      ),
+    ).toEqual([
+      {
+        id: 'documentation',
+        label: 'Documentation',
+        items: [
+          { id: '/apidocs', label: 'ApiDocs', href: 'apidocs' },
+          { id: '/techdocs', label: 'TechDocs', href: 'techdocs' },
+        ],
+      },
+      { id: '/ci', label: 'CI', href: 'ci' },
+      { id: '/overview', label: 'Overview', href: 'overview' },
+    ]);
+  });
+});
+
+function TestHook() {
+  const result = useEntityTabs({
+    routes: [
+      { path: '/', title: 'Overview', children: <div>Overview content</div> },
+      { path: '/docs/*', title: 'Docs', children: <div>Docs content</div> },
+    ],
+    groupDefinitions: {},
+    defaultContentOrder: 'title',
+  });
+  return (
+    <>
+      <span data-testid="active">{result.activeTabId}</span>
+      <div>{result.content}</div>
+    </>
+  );
+}
+
+it('reuses nested wildcard routing for active content', () => {
+  render(
+    <MemoryRouter initialEntries={['/docs/api/v1']}>
+      <Routes>
+        <Route path="/*" element={<TestHook />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+  expect(screen.getByTestId('active')).toHaveTextContent('/docs/*');
+  expect(screen.getByText('Docs content')).toBeInTheDocument();
+});

--- a/plugins/catalog/src/alpha/components/EntityTabs/useEntityTabs.tsx
+++ b/plugins/catalog/src/alpha/components/EntityTabs/useEntityTabs.tsx
@@ -51,8 +51,8 @@ export function buildHeaderTabs(
   }, {} as Record<string, { group?: EntityContentGroupDefinitions[string]; items: HeaderNavTab[] }>);
   const order = Object.keys(groupDefinitions);
   const entries = Object.entries(groups).sort(([a], [b]) => {
-    const ai = order.indexOf(a),
-      bi = order.indexOf(b);
+    const ai = order.indexOf(a);
+    const bi = order.indexOf(b);
     if (ai !== -1 && bi !== -1) return ai - bi;
     if (ai !== -1) return -1;
     if (bi !== -1) return 1;

--- a/plugins/catalog/src/alpha/components/EntityTabs/useEntityTabs.tsx
+++ b/plugins/catalog/src/alpha/components/EntityTabs/useEntityTabs.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useMemo } from 'react';
+import { type HeaderNavTab, type HeaderNavTabItem } from '@backstage/ui';
+import { type EntityContentGroupDefinitions } from '@backstage/plugin-catalog-react/alpha';
+import { type SubRoute, useSelectedSubRoute } from './EntityTabs';
+
+function tabHrefFromPath(path: string): string {
+  return path.replace(/\/\*$/, '').replace(/^\//, '');
+}
+
+export function buildHeaderTabs(
+  routes: SubRoute[],
+  groupDefinitions: EntityContentGroupDefinitions,
+  defaultContentOrder: 'title' | 'natural',
+): HeaderNavTabItem[] {
+  const aliases = Object.entries(groupDefinitions).reduce(
+    (map, [id, group]) => {
+      for (const alias of group.aliases ?? []) map[alias] = id;
+      return map;
+    },
+    {} as Record<string, string>,
+  );
+  const groups = routes.reduce((result, route) => {
+    const groupId =
+      route.group &&
+      (groupDefinitions[route.group] ? route.group : aliases[route.group]);
+    const group = groupId ? groupDefinitions[groupId] : undefined;
+    const key = groupId && group ? groupId : route.path;
+    result[key] ??= { group, items: [] };
+    result[key].items.push({
+      id: route.path,
+      label: route.title,
+      href: tabHrefFromPath(route.path),
+    });
+    return result;
+  }, {} as Record<string, { group?: EntityContentGroupDefinitions[string]; items: HeaderNavTab[] }>);
+  const order = Object.keys(groupDefinitions);
+  const entries = Object.entries(groups).sort(([a], [b]) => {
+    const ai = order.indexOf(a),
+      bi = order.indexOf(b);
+    if (ai !== -1 && bi !== -1) return ai - bi;
+    if (ai !== -1) return -1;
+    if (bi !== -1) return 1;
+    return 0;
+  });
+  for (const [, group] of entries) {
+    if (
+      group.group &&
+      (group.group.contentOrder ?? defaultContentOrder) === 'title'
+    ) {
+      group.items.sort((a, b) =>
+        a.label.localeCompare(b.label, undefined, { sensitivity: 'base' }),
+      );
+    }
+  }
+  return entries.map(([id, group]) =>
+    group.group && group.items.length > 1
+      ? { id, label: group.group.title, items: group.items }
+      : group.items[0],
+  );
+}
+
+export function useEntityTabs(props: {
+  routes: SubRoute[];
+  groupDefinitions: EntityContentGroupDefinitions;
+  defaultContentOrder: 'title' | 'natural';
+}) {
+  const { routes, groupDefinitions, defaultContentOrder } = props;
+  const { route, element } = useSelectedSubRoute(routes);
+  const tabs = useMemo(
+    () => buildHeaderTabs(routes, groupDefinitions, defaultContentOrder),
+    [routes, groupDefinitions, defaultContentOrder],
+  );
+  return {
+    tabs,
+    activeTabId: route?.path,
+    content: element,
+    title: route?.title,
+  };
+}

--- a/plugins/catalog/src/alpha/pages.test.tsx
+++ b/plugins/catalog/src/alpha/pages.test.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { useEffect } from 'react';
 import { act, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
@@ -32,6 +33,7 @@ import {
   entityRouteRef,
   MockStarredEntitiesApi,
   starredEntitiesApiRef,
+  useAsyncEntity,
 } from '@backstage/plugin-catalog-react';
 import { convertLegacyRouteRef } from '@backstage/core-compat-api';
 import { rootRouteRef } from '../routes';
@@ -630,6 +632,88 @@ describe('Entity page', () => {
   });
 
   describe('Entity Page Headers', () => {
+    it('keeps entity content mounted while refreshing the current entity', async () => {
+      let resolveRefresh!: (entity: Entity | undefined) => void;
+      const refreshResponse = new Promise<Entity | undefined>(resolve => {
+        resolveRefresh = resolve;
+      });
+      const getEntityByRef = jest
+        .fn()
+        .mockResolvedValueOnce(entityMock)
+        .mockReturnValueOnce(refreshResponse);
+      let mounts = 0;
+      let unmounts = 0;
+
+      function RefreshContent() {
+        const { refresh } = useAsyncEntity();
+        useEffect(() => {
+          mounts += 1;
+          return () => {
+            unmounts += 1;
+          };
+        }, []);
+        return <button onClick={refresh}>Refresh entity</button>;
+      }
+
+      const refreshContent = EntityContentBlueprint.make({
+        name: 'refresh',
+        params: {
+          path: '/refresh',
+          title: 'Refresh',
+          loader: async () => <RefreshContent />,
+        },
+      });
+      const refreshHeader = EntityHeaderLayoutBlueprint.make({
+        name: 'refresh',
+        params: {
+          filter: { kind: 'component' },
+          loader: async () => () => <header>Refresh header</header>,
+        },
+      });
+      const tester = createExtensionTester(
+        Object.assign({ namespace: 'catalog' }, catalogEntityPage),
+      )
+        .add(refreshContent)
+        .add(refreshHeader);
+
+      await renderInTestApp(tester.reactElement(), {
+        apis: [
+          catalogApiMock.mock({ getEntityByRef }),
+          [starredEntitiesApiRef, mockStarredEntitiesApi],
+        ],
+        mountPath: '/catalog/:namespace/:kind/:name',
+        initialRouteEntries: [`${entityPath}/refresh`],
+        config: {
+          app: { title: 'Custom app' },
+          backend: { baseUrl: 'http://localhost:7000' },
+        },
+        mountedRoutes: {
+          '/catalog': convertLegacyRouteRef(rootRouteRef),
+          '/catalog/:namespace/:kind/:name':
+            convertLegacyRouteRef(entityRouteRef),
+        },
+      });
+
+      await userEvent.click(
+        await screen.findByRole('button', { name: 'Refresh entity' }),
+      );
+      expect(await screen.findByRole('progressbar')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: 'Refresh entity' }),
+      ).toBeInTheDocument();
+      expect(screen.getByText('Refresh header')).toBeInTheDocument();
+      expect(mounts).toBe(1);
+      expect(unmounts).toBe(0);
+
+      await act(async () => resolveRefresh(entityMock));
+      expect(
+        await screen.findByRole('button', { name: 'Refresh entity' }),
+      ).toBeInTheDocument();
+      expect(screen.getByText('Refresh header')).toBeInTheDocument();
+      expect(mounts).toBe(1);
+      expect(unmounts).toBe(0);
+    });
+
     it('Should use the default header', async () => {
       const tester = createExtensionTester(
         Object.assign({ namespace: 'catalog' }, catalogEntityPage),

--- a/plugins/catalog/src/alpha/pages.test.tsx
+++ b/plugins/catalog/src/alpha/pages.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { screen } from '@testing-library/react';
+import { act, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {
   createExtensionTester,
@@ -25,6 +25,7 @@ import {
   EntityContentBlueprint,
   EntityContextMenuItemBlueprint,
   EntityHeaderBlueprint,
+  EntityHeaderLayoutBlueprint,
 } from '@backstage/plugin-catalog-react/alpha';
 import { catalogApiMock } from '@backstage/plugin-catalog-react/testUtils';
 import {
@@ -178,15 +179,15 @@ describe('Entity page', () => {
       });
 
       await userEvent.click(
-        await screen.findByRole('tab', { name: /Documentation/ }),
+        await screen.findByRole('button', { name: /Documentation/ }),
       );
 
       await expect(
-        screen.findByRole('button', { name: /TechDocs/ }),
+        screen.findByRole('menuitemradio', { name: /TechDocs/ }),
       ).resolves.toHaveAttribute('href', `${entityPath}/techdocs`);
 
       await expect(
-        screen.findByRole('button', { name: /ApiDocs/ }),
+        screen.findByRole('menuitemradio', { name: /ApiDocs/ }),
       ).resolves.toHaveAttribute('href', `${entityPath}/apidocs`);
     });
 
@@ -223,14 +224,16 @@ describe('Entity page', () => {
         },
       });
 
-      await userEvent.click(await screen.findByRole('tab', { name: /Docs/ }));
+      await userEvent.click(
+        await screen.findByRole('button', { name: /Docs/ }),
+      );
 
       await expect(
-        screen.findByRole('button', { name: /TechDocs/ }),
+        screen.findByRole('menuitemradio', { name: /TechDocs/ }),
       ).resolves.toHaveAttribute('href', `${entityPath}/techdocs`);
 
       await expect(
-        screen.findByRole('button', { name: /ApiDocs/ }),
+        screen.findByRole('menuitemradio', { name: /ApiDocs/ }),
       ).resolves.toHaveAttribute('href', `${entityPath}/apidocs`);
     });
 
@@ -263,13 +266,13 @@ describe('Entity page', () => {
       });
 
       await expect(
-        screen.findByRole('tab', { name: /TechDocs/ }),
+        screen.findByRole('link', { name: /TechDocs/ }),
       ).resolves.toBeInTheDocument();
       await expect(
-        screen.findByRole('tab', { name: /ApiDocs/ }),
+        screen.findByRole('link', { name: /ApiDocs/ }),
       ).resolves.toBeInTheDocument();
       expect(
-        screen.queryByRole('tab', { name: /Documentation/ }),
+        screen.queryByRole('button', { name: /Documentation/ }),
       ).not.toBeInTheDocument();
     });
 
@@ -314,14 +317,16 @@ describe('Entity page', () => {
         },
       });
 
-      await userEvent.click(await screen.findByRole('tab', { name: /Docs/ }));
+      await userEvent.click(
+        await screen.findByRole('button', { name: /Docs/ }),
+      );
 
       await expect(
-        screen.findByRole('button', { name: /TechDocs/ }),
+        screen.findByRole('menuitemradio', { name: /TechDocs/ }),
       ).resolves.toHaveAttribute('href', `${entityPath}/techdocs`);
 
       await expect(
-        screen.findByRole('button', { name: /ApiDocs/ }),
+        screen.findByRole('menuitemradio', { name: /ApiDocs/ }),
       ).resolves.toHaveAttribute('href', `${entityPath}/apidocs`);
     });
 
@@ -355,10 +360,10 @@ describe('Entity page', () => {
       });
 
       await expect(
-        screen.findByRole('tab', { name: /Overview/ }),
+        screen.findByRole('link', { name: /Overview/ }),
       ).resolves.toBeInTheDocument();
       expect(
-        screen.queryByRole('tab', { name: /Development/ }),
+        screen.queryByRole('button', { name: /Development/ }),
       ).not.toBeInTheDocument();
     });
 
@@ -388,15 +393,18 @@ describe('Entity page', () => {
       });
 
       await expect(
-        screen.findByRole('tab', { name: /Documentation/ }),
+        screen.findByRole('button', { name: /Documentation/ }),
       ).resolves.toBeInTheDocument();
       await expect(
-        screen.findByRole('tab', { name: /Overview/ }),
+        screen.findByRole('link', { name: /Overview/ }),
       ).resolves.toBeInTheDocument();
-      const tabs = screen.getAllByRole('tab');
-      expect(tabs).toHaveLength(2);
-      expect(tabs[0]).toHaveTextContent('Documentation');
-      expect(tabs[1]).toHaveTextContent('Overview');
+      const nav = screen.getByRole('navigation', {
+        name: 'Content navigation',
+      });
+      const items = within(nav).getByRole('list').children;
+      expect(items).toHaveLength(2);
+      expect(items[0]).toHaveTextContent('Documentation');
+      expect(items[1]).toHaveTextContent('Overview');
     });
 
     it('Should resolve group aliases', async () => {
@@ -432,14 +440,16 @@ describe('Entity page', () => {
         },
       });
 
-      await userEvent.click(await screen.findByRole('tab', { name: /Docs/ }));
+      await userEvent.click(
+        await screen.findByRole('button', { name: /Docs/ }),
+      );
 
       await expect(
-        screen.findByRole('button', { name: /TechDocs/ }),
+        screen.findByRole('menuitemradio', { name: /TechDocs/ }),
       ).resolves.toHaveAttribute('href', `${entityPath}/techdocs`);
 
       await expect(
-        screen.findByRole('button', { name: /ApiDocs/ }),
+        screen.findByRole('menuitemradio', { name: /ApiDocs/ }),
       ).resolves.toHaveAttribute('href', `${entityPath}/apidocs`);
     });
 
@@ -468,10 +478,10 @@ describe('Entity page', () => {
       });
 
       await userEvent.click(
-        await screen.findByRole('tab', { name: /Documentation/ }),
+        await screen.findByRole('button', { name: /Documentation/ }),
       );
 
-      const buttons = await screen.findAllByRole('button', {
+      const buttons = await screen.findAllByRole('menuitemradio', {
         name: /Docs/,
       });
       expect(buttons[0]).toHaveTextContent('ApiDocs');
@@ -508,10 +518,10 @@ describe('Entity page', () => {
       });
 
       await userEvent.click(
-        await screen.findByRole('tab', { name: /Documentation/ }),
+        await screen.findByRole('button', { name: /Documentation/ }),
       );
 
-      const buttons = await screen.findAllByRole('button', {
+      const buttons = await screen.findAllByRole('menuitemradio', {
         name: /Docs/,
       });
       expect(buttons[0]).toHaveTextContent('TechDocs');
@@ -556,10 +566,10 @@ describe('Entity page', () => {
       });
 
       await userEvent.click(
-        await screen.findByRole('tab', { name: /Documentation/ }),
+        await screen.findByRole('button', { name: /Documentation/ }),
       );
 
-      const buttons = await screen.findAllByRole('button', {
+      const buttons = await screen.findAllByRole('menuitemradio', {
         name: /Docs/,
       });
       expect(buttons[0]).toHaveTextContent('TechDocs');
@@ -604,15 +614,18 @@ describe('Entity page', () => {
       });
 
       await expect(
-        screen.findByRole('tab', { name: /Overview/ }),
+        screen.findByRole('link', { name: /Overview/ }),
       ).resolves.toBeInTheDocument();
       await expect(
-        screen.findByRole('tab', { name: /Documentation/ }),
+        screen.findByRole('button', { name: /Documentation/ }),
       ).resolves.toBeInTheDocument();
-      const tabs = screen.getAllByRole('tab');
-      expect(tabs).toHaveLength(2);
-      expect(tabs[0]).toHaveTextContent('Overview');
-      expect(tabs[1]).toHaveTextContent('Documentation');
+      const nav = screen.getByRole('navigation', {
+        name: 'Content navigation',
+      });
+      const items = within(nav).getByRole('list').children;
+      expect(items).toHaveLength(2);
+      expect(items[0]).toHaveTextContent('Overview');
+      expect(items[1]).toHaveTextContent('Documentation');
     });
   });
 
@@ -658,7 +671,9 @@ describe('Entity page', () => {
 
       const tester = createExtensionTester(
         Object.assign({ namespace: 'catalog' }, catalogEntityPage),
-      ).add(customEntityHeader);
+      )
+        .add(customEntityHeader)
+        .add(overviewEntityContent);
 
       await renderInTestApp(tester.reactElement(), {
         apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
@@ -680,6 +695,100 @@ describe('Entity page', () => {
       await expect(
         screen.findByRole('heading', { name: /Custom header/ }),
       ).resolves.toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: 'Overview' })).toBeInTheDocument();
+    });
+
+    it('prefers a filtered successor layout over legacy headers', async () => {
+      const successor = EntityHeaderLayoutBlueprint.make({
+        name: 'successor',
+        params: {
+          filter: { kind: 'component' },
+          loader: async () => props =>
+            (
+              <header>
+                Successor header
+                <span>{props.activeTabId}</span>
+              </header>
+            ),
+        },
+      });
+      const legacy = EntityHeaderBlueprint.make({
+        name: 'legacy',
+        params: {
+          loader: async () => <header>Legacy header</header>,
+        },
+      });
+      const tester = createExtensionTester(
+        Object.assign({ namespace: 'catalog' }, catalogEntityPage),
+      )
+        .add(overviewEntityContent)
+        .add(legacy)
+        .add(successor);
+
+      await renderInTestApp(tester.reactElement(), {
+        apis: [mockCatalogApi, [starredEntitiesApiRef, mockStarredEntitiesApi]],
+        mountPath: '/catalog/:namespace/:kind/:name',
+        initialRouteEntries: [`${entityPath}/overview`],
+        config: {
+          app: { title: 'Custom app' },
+          backend: { baseUrl: 'http://localhost:7000' },
+        },
+        mountedRoutes: {
+          '/catalog': convertLegacyRouteRef(rootRouteRef),
+          '/catalog/:namespace/:kind/:name':
+            convertLegacyRouteRef(entityRouteRef),
+        },
+      });
+
+      expect(await screen.findByText('Successor header')).toBeInTheDocument();
+      expect(screen.getByText('/overview')).toBeInTheDocument();
+      expect(screen.queryByText('Legacy header')).not.toBeInTheDocument();
+    });
+
+    it('does not evaluate header predicates before the entity loads', async () => {
+      let resolveEntity!: (entity: Entity | undefined) => void;
+      const entityPromise = new Promise<Entity | undefined>(resolve => {
+        resolveEntity = resolve;
+      });
+      const filter = jest.fn(() => true);
+      const successor = EntityHeaderLayoutBlueprint.make({
+        name: 'delayed',
+        params: {
+          filter,
+          loader: async () => () => <header>Delayed successor</header>,
+        },
+      });
+      const tester = createExtensionTester(
+        Object.assign({ namespace: 'catalog' }, catalogEntityPage),
+      ).add(successor);
+
+      await renderInTestApp(tester.reactElement(), {
+        apis: [
+          catalogApiMock.mock({
+            getEntityByRef: jest.fn(() => entityPromise),
+          }),
+          [starredEntitiesApiRef, mockStarredEntitiesApi],
+        ],
+        mountPath: '/catalog/:namespace/:kind/:name',
+        initialRouteEntries: [entityPath],
+        config: {
+          app: { title: 'Custom app' },
+          backend: { baseUrl: 'http://localhost:7000' },
+        },
+        mountedRoutes: {
+          '/catalog': convertLegacyRouteRef(rootRouteRef),
+          '/catalog/:namespace/:kind/:name':
+            convertLegacyRouteRef(entityRouteRef),
+        },
+      });
+
+      expect(
+        await screen.findByRole('heading', { name: 'artist-lookup' }),
+      ).toBeInTheDocument();
+      expect(filter).not.toHaveBeenCalled();
+      await act(async () => resolveEntity(entityMock));
+      expect(await screen.findByText('Delayed successor')).toBeInTheDocument();
+      expect(filter).toHaveBeenCalledWith(entityMock);
     });
   });
 

--- a/plugins/catalog/src/alpha/pages.tsx
+++ b/plugins/catalog/src/alpha/pages.tsx
@@ -32,6 +32,7 @@ import {
   EntityContentBlueprint,
   EntityContextMenuItemBlueprint,
   EntityHeaderBlueprint,
+  EntityHeaderLayoutBlueprint,
   EntityContentGroupDefinitions,
 } from '@backstage/plugin-catalog-react/alpha';
 import CategoryIcon from '@material-ui/icons/Category';
@@ -152,9 +153,15 @@ export const catalogPage = PageBlueprint.makeWithOverrides({
 export const catalogEntityPage = PageBlueprint.makeWithOverrides({
   name: 'entity',
   inputs: {
+    headerLayouts: createExtensionInput([
+      EntityHeaderLayoutBlueprint.dataRefs.component,
+      EntityHeaderLayoutBlueprint.dataRefs.filterFunction.optional(),
+      EntityHeaderLayoutBlueprint.dataRefs.filterExpression.optional(),
+    ]),
     headers: createExtensionInput([
       EntityHeaderBlueprint.dataRefs.element.optional(),
       EntityHeaderBlueprint.dataRefs.filterFunction.optional(),
+      EntityHeaderBlueprint.dataRefs.filterExpression.optional(),
     ]),
     contents: createExtensionInput([
       coreExtensionData.reactElement,
@@ -194,8 +201,6 @@ export const catalogEntityPage = PageBlueprint.makeWithOverrides({
   factory(originalFactory, { config, inputs }) {
     return originalFactory({
       path: '/catalog/:namespace/:kind/:name',
-      noHeader: true,
-      title: 'Catalog Entity',
       // NOTE: The `convertLegacyRouteRef` call here ensures that this route ref
       // is mutated to support the new frontend system. Removing this conversion
       // is a potentially breaking change since this is a singleton and the
@@ -204,7 +209,10 @@ export const catalogEntityPage = PageBlueprint.makeWithOverrides({
       // `core-compat-api` package.
       routeRef: convertLegacyRouteRef(entityRouteRef), // READ THE ABOVE
       loader: async () => {
-        const { EntityLayout } = await import('./components/EntityLayout');
+        const [{ EntityLayout }, { EntityLayoutBui }] = await Promise.all([
+          import('./components/EntityLayout'),
+          import('./components/EntityLayout/EntityLayoutBui'),
+        ]);
 
         const menuItems = inputs.contextMenuItems.map(item => ({
           data: item.get(EntityContextMenuItemBlueprint.dataRefs.data),
@@ -214,25 +222,61 @@ export const catalogEntityPage = PageBlueprint.makeWithOverrides({
             (() => true),
         }));
 
-        // Get available headers, sorted by if they have a filter function or not.
-        // TODO(blam): we should really have priority or some specificity here which can be used to sort the headers.
-        // That can be done with embedding the priority in the dataRef alongside the filter function.
+        const headerLayouts = inputs.headerLayouts
+          .map(layout => {
+            const filterFunction = layout.get(
+              EntityHeaderLayoutBlueprint.dataRefs.filterFunction,
+            );
+            const filterExpression = layout.get(
+              EntityHeaderLayoutBlueprint.dataRefs.filterExpression,
+            );
+            return {
+              Component: layout.get(
+                EntityHeaderLayoutBlueprint.dataRefs.component,
+              ),
+              filter: buildFilterFn(filterFunction, filterExpression),
+              hasFilter: Boolean(filterFunction || filterExpression),
+            };
+          })
+          .sort((a, b) => Number(b.hasFilter) - Number(a.hasFilter));
+
         const headers = inputs.headers
-          .map(header => ({
-            element: header.get(EntityHeaderBlueprint.dataRefs.element),
-            filter: header.get(EntityHeaderBlueprint.dataRefs.filterFunction),
-          }))
-          .sort((a, b) => {
-            if (a.filter && !b.filter) return -1;
-            if (!a.filter && b.filter) return 1;
-            return 0;
-          });
+          .map(header => {
+            const filterFunction = header.get(
+              EntityHeaderBlueprint.dataRefs.filterFunction,
+            );
+            const filterExpression = header.get(
+              EntityHeaderBlueprint.dataRefs.filterExpression,
+            );
+            return {
+              element: header.get(EntityHeaderBlueprint.dataRefs.element),
+              filter: buildFilterFn(filterFunction, filterExpression),
+              hasFilter: Boolean(filterFunction || filterExpression),
+            };
+          })
+          .sort((a, b) => Number(b.hasFilter) - Number(a.hasFilter));
 
         const groupDefinitions =
           config.groups?.reduce(
             (rest, group) => ({ ...rest, ...group }),
             {} as EntityContentGroupDefinitions,
           ) ?? defaultEntityContentGroupDefinitions;
+
+        const routes = inputs.contents.map(output => (
+          <EntityLayout.Route
+            group={output.get(EntityContentBlueprint.dataRefs.group)}
+            key={output.get(coreExtensionData.routePath)}
+            path={output.get(coreExtensionData.routePath)}
+            title={output.get(EntityContentBlueprint.dataRefs.title)}
+            icon={output.get(EntityContentBlueprint.dataRefs.icon)}
+            if={buildFilterFn(
+              output.get(EntityContentBlueprint.dataRefs.filterFunction),
+              output.get(EntityContentBlueprint.dataRefs.filterExpression),
+            )}
+          >
+            {output.get(coreExtensionData.reactElement)}
+          </EntityLayout.Route>
+        ));
 
         const Component = () => {
           const entityFromUrl = useEntityFromUrl();
@@ -243,39 +287,38 @@ export const catalogEntityPage = PageBlueprint.makeWithOverrides({
                 .map(({ data, node }) => ({ data, node }))
             : [];
 
-          const header = headers.find(
-            h => !h.filter || h.filter(entity!),
-          )?.element;
+          const HeaderComponent = entity
+            ? headerLayouts.find(layout => layout.filter(entity))?.Component
+            : undefined;
+          const legacyHeader = entity
+            ? headers.find(header => header.filter(entity))?.element
+            : undefined;
 
-          return (
-            <AsyncEntityProvider {...entityFromUrl}>
+          const layout =
+            HeaderComponent || !legacyHeader ? (
+              <EntityLayoutBui
+                HeaderComponent={HeaderComponent}
+                contextMenuItems={filteredMenuItems}
+                groupDefinitions={groupDefinitions}
+                defaultContentOrder={config.defaultContentOrder}
+              >
+                {routes}
+              </EntityLayoutBui>
+            ) : (
               <EntityLayout
-                header={header}
+                header={legacyHeader}
                 contextMenuItems={filteredMenuItems}
                 groupDefinitions={groupDefinitions}
                 defaultContentOrder={config.defaultContentOrder}
                 showNavItemIcons={config.showNavItemIcons}
               >
-                {inputs.contents.map(output => (
-                  <EntityLayout.Route
-                    group={output.get(EntityContentBlueprint.dataRefs.group)}
-                    key={output.get(coreExtensionData.routePath)}
-                    path={output.get(coreExtensionData.routePath)}
-                    title={output.get(EntityContentBlueprint.dataRefs.title)}
-                    icon={output.get(EntityContentBlueprint.dataRefs.icon)}
-                    if={buildFilterFn(
-                      output.get(
-                        EntityContentBlueprint.dataRefs.filterFunction,
-                      ),
-                      output.get(
-                        EntityContentBlueprint.dataRefs.filterExpression,
-                      ),
-                    )}
-                  >
-                    {output.get(coreExtensionData.reactElement)}
-                  </EntityLayout.Route>
-                ))}
+                {routes}
               </EntityLayout>
+            );
+
+          return (
+            <AsyncEntityProvider {...entityFromUrl}>
+              {layout}
             </AsyncEntityProvider>
           );
         };

--- a/plugins/catalog/src/alpha/pages.tsx
+++ b/plugins/catalog/src/alpha/pages.tsx
@@ -280,7 +280,10 @@ export const catalogEntityPage = PageBlueprint.makeWithOverrides({
 
         const Component = () => {
           const entityFromUrl = useEntityFromUrl();
-          const { entity } = entityFromUrl;
+          const entity = entityFromUrl.loading
+            ? undefined
+            : entityFromUrl.entity;
+          const entityProviderProps = { ...entityFromUrl, entity };
           const filteredMenuItems = entity
             ? menuItems
                 .filter(i => i.filter(entity))
@@ -317,7 +320,7 @@ export const catalogEntityPage = PageBlueprint.makeWithOverrides({
             );
 
           return (
-            <AsyncEntityProvider {...entityFromUrl}>
+            <AsyncEntityProvider {...entityProviderProps}>
               {layout}
             </AsyncEntityProvider>
           );

--- a/plugins/catalog/src/alpha/pages.tsx
+++ b/plugins/catalog/src/alpha/pages.tsx
@@ -156,12 +156,10 @@ export const catalogEntityPage = PageBlueprint.makeWithOverrides({
     headerLayouts: createExtensionInput([
       EntityHeaderLayoutBlueprint.dataRefs.component,
       EntityHeaderLayoutBlueprint.dataRefs.filterFunction.optional(),
-      EntityHeaderLayoutBlueprint.dataRefs.filterExpression.optional(),
     ]),
     headers: createExtensionInput([
       EntityHeaderBlueprint.dataRefs.element.optional(),
       EntityHeaderBlueprint.dataRefs.filterFunction.optional(),
-      EntityHeaderBlueprint.dataRefs.filterExpression.optional(),
     ]),
     contents: createExtensionInput([
       coreExtensionData.reactElement,
@@ -230,15 +228,12 @@ export const catalogEntityPage = PageBlueprint.makeWithOverrides({
             const filterFunction = layout.get(
               EntityHeaderLayoutBlueprint.dataRefs.filterFunction,
             );
-            const filterExpression = layout.get(
-              EntityHeaderLayoutBlueprint.dataRefs.filterExpression,
-            );
             return {
               Component: layout.get(
                 EntityHeaderLayoutBlueprint.dataRefs.component,
               ),
-              filter: buildFilterFn(filterFunction, filterExpression),
-              hasFilter: Boolean(filterFunction || filterExpression),
+              filter: filterFunction ?? (() => true),
+              hasFilter: Boolean(filterFunction),
             };
           })
           .sort((a, b) => Number(b.hasFilter) - Number(a.hasFilter));
@@ -248,13 +243,10 @@ export const catalogEntityPage = PageBlueprint.makeWithOverrides({
             const filterFunction = header.get(
               EntityHeaderBlueprint.dataRefs.filterFunction,
             );
-            const filterExpression = header.get(
-              EntityHeaderBlueprint.dataRefs.filterExpression,
-            );
             return {
               element: header.get(EntityHeaderBlueprint.dataRefs.element),
-              filter: buildFilterFn(filterFunction, filterExpression),
-              hasFilter: Boolean(filterFunction || filterExpression),
+              filter: filterFunction ?? (() => true),
+              hasFilter: Boolean(filterFunction),
             };
           })
           .sort((a, b) => Number(b.hasFilter) - Number(a.hasFilter));

--- a/plugins/catalog/src/alpha/pages.tsx
+++ b/plugins/catalog/src/alpha/pages.tsx
@@ -222,6 +222,8 @@ export const catalogEntityPage = PageBlueprint.makeWithOverrides({
             (() => true),
         }));
 
+        // Prefer filtered contributions within each header family. A future
+        // priority or specificity value could provide more precise ordering.
         const headerLayouts = inputs.headerLayouts
           .map(layout => {
             const filterFunction = layout.get(

--- a/plugins/catalog/src/alpha/pages.tsx
+++ b/plugins/catalog/src/alpha/pages.tsx
@@ -222,8 +222,9 @@ export const catalogEntityPage = PageBlueprint.makeWithOverrides({
             (() => true),
         }));
 
-        // Prefer filtered contributions within each header family. A future
-        // priority or specificity value could provide more precise ordering.
+        // Get available headers, sorted by if they have a filter function or not.
+        // TODO(blam): we should really have priority or some specificity here which can be used to sort the headers.
+        // That can be done with embedding the priority in the dataRef alongside the filter function.
         const headerLayouts = inputs.headerLayouts
           .map(layout => {
             const filterFunction = layout.get(

--- a/plugins/catalog/src/alpha/pages.tsx
+++ b/plugins/catalog/src/alpha/pages.tsx
@@ -15,6 +15,8 @@
  */
 
 import { convertLegacyRouteRef } from '@backstage/core-compat-api';
+import { stringifyEntityRef } from '@backstage/catalog-model';
+import { useRouteRefParams } from '@backstage/core-plugin-api';
 import {
   coreExtensionData,
   createExtensionInput,
@@ -274,10 +276,14 @@ export const catalogEntityPage = PageBlueprint.makeWithOverrides({
         ));
 
         const Component = () => {
+          const routeParams = useRouteRefParams(entityRouteRef);
           const entityFromUrl = useEntityFromUrl();
-          const entity = entityFromUrl.loading
-            ? undefined
-            : entityFromUrl.entity;
+          const entity =
+            entityFromUrl.entity &&
+            stringifyEntityRef(entityFromUrl.entity) ===
+              stringifyEntityRef(routeParams)
+              ? entityFromUrl.entity
+              : undefined;
           const entityProviderProps = { ...entityFromUrl, entity };
           const filteredMenuItems = entity
             ? menuItems

--- a/plugins/catalog/src/alpha/translation.ts
+++ b/plugins/catalog/src/alpha/translation.ts
@@ -124,6 +124,9 @@ export const catalogTranslationRef = createTranslationRef({
       warningPanelTitle: 'Entity not found',
       ownerLabel: 'Owner',
       lifecycleLabel: 'Lifecycle',
+      systemLabel: 'System',
+      domainLabel: 'Domain',
+      partOfLabel: 'Part of',
     },
     entityLinksCard: {
       title: 'Links',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Migrates the new frontend system Catalog entity page to the automatic plugin header and BUI `Header`.

This adds:

- A BUI entity header with entity kind/type tags, lifecycle, owners, hierarchy, favorite action, context menu, and navigation.
- Catalog-composed BUI tabs that preserve content grouping and ordering.
- A new alpha entity header layout extension point for custom BUI headers.
- A temporary legacy-layout fallback for existing `EntityHeaderBlueprint` customizations.
- Predictable precedence where a matching new header layout wins over a matching legacy header.
- Loading, error, not-found, inspect-dialog, and document-title handling in the BUI layout.

### Why a new blueprint?

The existing `EntityHeaderBlueprint` contributes an opaque React element. Catalog therefore cannot provide a custom header with the composed tabs or active tab, preventing it from participating fully in the BUI header system.

The new entity header layout blueprint loads a component that receives the Catalog-composed tabs and active tab ID. This lets adopters customize the entity header while retaining BUI navigation and the surrounding entity-page layout.

### Alpha migration notes

This introduces two alpha behavior changes:

- The default entity page now uses the BUI header and page layout.
- `EntityHeaderBlueprint` is deprecated in favor of the new BUI-ready entity header layout extension point.

The default switches directly to BUI so that uncustomized Catalog pages adopt the standard header system without additional configuration. Existing `EntityHeaderBlueprint` contributions continue to work through a temporary legacy fallback, giving adopters a grace period in which to migrate.

When both extension types match an entity, the new header layout takes precedence.

BUI header tabs do not currently support entity-content icons. Icons remain available on pages using the legacy fallback.

This PR is stacked on the Catalog entity context-menu BUI migration and should be rebased once that PR lands.

### Before

<img width="1301" height="989" alt="image" src="https://github.com/user-attachments/assets/ceb56efb-16cd-4603-9343-ac907d37e7b2" />

<img width="1296" height="988" alt="image" src="https://github.com/user-attachments/assets/8a261152-893c-44cf-91e3-49b21e781dfc" />


### After

<img width="1297" height="992" alt="image" src="https://github.com/user-attachments/assets/29a07914-1d08-48a0-8441-90560a32514e" />

<img width="1298" height="991" alt="image" src="https://github.com/user-attachments/assets/07e5a376-856a-4914-9557-8b296277408f" />


#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
