### PR TITLE
plugin-app: use FrontendHostDiscovery as default discovery API

### DIFF
--- a/.changeset/default-frontend-discovery-api.md
+++ b/.changeset/default-frontend-discovery-api.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-app': patch
+'@backstage/plugin-app': minor
 ---
 
-Changed the default discovery API implementation to use `FrontendHostDiscovery`, which supports the `discovery.endpoints` configuration for per-plugin endpoint overrides. This aligns the new frontend system with the old frontend system's default behavior.
+Changed the default discovery API implementation to use `FrontendHostDiscovery`, which supports the `discovery.endpoints` configuration for per-plugin endpoint overrides. Note that this will start honoring `discovery.endpoints` (including string `target` values), so if you currently use internal-only targets there, update them to the object form and set `target.external` (or omit `external`) to avoid routing the frontend to internal URLs.

--- a/.changeset/default-frontend-discovery-api.md
+++ b/.changeset/default-frontend-discovery-api.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-app': minor
 ---
 
-**BREAKING** Changed the default discovery API implementation to use `FrontendHostDiscovery`, which supports the `discovery.endpoints` configuration for per-plugin endpoint overrides. Note that this will start honoring `discovery.endpoints` (including string `target` values), so if you currently use internal-only targets there, update them to the object form and set `target.external` (or omit `external`) to avoid routing the frontend to internal URLs.
+**BREAKING** Changed the default discovery API implementation to use `FrontendHostDiscovery`, which supports the `discovery.endpoints` configuration for per-plugin endpoint overrides. Note that this will start honoring `discovery.endpoints` (including string `target` values), so if you currently use internal-only targets there, update them to the object form and move the internal URL to `target.internal`, omitting `target.external` (or setting it to a browser-reachable URL) to avoid routing the frontend to internal URLs.

--- a/.changeset/default-frontend-discovery-api.md
+++ b/.changeset/default-frontend-discovery-api.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-app': minor
 ---
 
-Changed the default discovery API implementation to use `FrontendHostDiscovery`, which supports the `discovery.endpoints` configuration for per-plugin endpoint overrides. Note that this will start honoring `discovery.endpoints` (including string `target` values), so if you currently use internal-only targets there, update them to the object form and set `target.external` (or omit `external`) to avoid routing the frontend to internal URLs.
+**BREAKING** Changed the default discovery API implementation to use `FrontendHostDiscovery`, which supports the `discovery.endpoints` configuration for per-plugin endpoint overrides. Note that this will start honoring `discovery.endpoints` (including string `target` values), so if you currently use internal-only targets there, update them to the object form and set `target.external` (or omit `external`) to avoid routing the frontend to internal URLs.

--- a/.changeset/default-frontend-discovery-api.md
+++ b/.changeset/default-frontend-discovery-api.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-app': patch
+---
+
+Changed the default discovery API implementation to use `FrontendHostDiscovery`, which supports the `discovery.endpoints` configuration for per-plugin endpoint overrides. This aligns the new frontend system with the old frontend system's default behavior.

--- a/plugins/app/src/defaultApis.ts
+++ b/plugins/app/src/defaultApis.ts
@@ -19,6 +19,7 @@ import {
   AlertApiForwarder,
   ErrorApiForwarder,
   ErrorAlerter,
+  FrontendHostDiscovery,
   GoogleAuth,
   GithubAuth,
   OktaAuth,
@@ -28,7 +29,6 @@ import {
   BitbucketServerAuth,
   OAuthRequestManager,
   WebStorage,
-  UrlPatternDiscovery,
   OneLoginAuth,
   UnhandledErrorForwarder,
   AtlassianAuth,
@@ -93,10 +93,7 @@ export const apis = [
       defineParams({
         api: discoveryApiRef,
         deps: { configApi: configApiRef },
-        factory: ({ configApi }) =>
-          UrlPatternDiscovery.compile(
-            `${configApi.getString('backend.baseUrl')}/api/{{ pluginId }}`,
-          ),
+        factory: ({ configApi }) => FrontendHostDiscovery.fromConfig(configApi),
       }),
   }),
   ApiBlueprint.make({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This changes the default discovery API implementation in the new frontend system from `UrlPatternDiscovery` to `FrontendHostDiscovery`. The old frontend system already used `FrontendHostDiscovery`, so this aligns the two. The practical difference is that `FrontendHostDiscovery` supports the `discovery.endpoints` config section for per-plugin endpoint overrides, which `UrlPatternDiscovery` does not.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))