### PR TITLE
docs: rename Azure sidebar label to Azure DevOps

### DIFF
--- a/microsite/sidebars.ts
+++ b/microsite/sidebars.ts
@@ -395,7 +395,7 @@ export default {
           'integrations/azure-blobStorage/locations',
           'integrations/azure-blobStorage/discovery',
         ]),
-        sidebarElementWithIndex({ label: 'Azure' }, [
+        sidebarElementWithIndex({ label: 'Azure DevOps' }, [
           'integrations/azure/locations',
           'integrations/azure/discovery',
           'integrations/azure/org',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The sidebar item labeled **"Azure"** under Integrations actually links to Azure DevOps pages (`integrations/azure/locations`, `integrations/azure/discovery`, `integrations/azure/org`). The generic "Azure" label is misleading since there is already a separate **"Azure Blob Storage"** item right above it.

This renames the label to **"Azure DevOps"** to match the page titles and descriptions.

Closes #31542

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. *(not required — change is in `microsite/` only, not a published package)*
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes *(N/A — docs-only change)*
- [x] All your commits have a `Signed-off-by` line in the message.