### PR TITLE
feat(ui): add server-side filtering to menu autocomplete

### DIFF
--- a/.changeset/menu-server-side-filtering.md
+++ b/.changeset/menu-server-side-filtering.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Added support for server-side filtering of items in `MenuAutocomplete` and `MenuAutocompleteListbox`. Pass `filter={null}` to disable the built-in client-side filtering when items are already filtered server-side, or pass a custom filter function to change how items are matched against the search input. The search input can now also be observed and controlled with the new `onInputChange`, `inputValue`, and `defaultInputValue` props.

--- a/docs-ui/src/app/components/menu/components.tsx
+++ b/docs-ui/src/app/components/menu/components.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../../../../packages/ui/src/components/Menu/Menu';
 import { Button } from '../../../../../packages/ui/src/components/Button/Button';
 import { MemoryRouter } from 'react-router-dom';
+import { useState } from 'react';
 import {
   RiChat1Line,
   RiFileLine,
@@ -151,6 +152,37 @@ export const PreviewAutocompleteListbox = () => (
     </MenuTrigger>
   </MemoryRouter>
 );
+
+const serverOptions = ['Apple', 'Banana', 'Blueberry', 'Cherry', 'Grape'];
+
+export const PreviewServerSideFiltering = () => {
+  const [items, setItems] = useState(serverOptions);
+
+  // Simulates fetching items that match the search from a server.
+  const handleInputChange = (value: string) => {
+    const search = value.toLowerCase();
+    setItems(serverOptions.filter(item => item.toLowerCase().includes(search)));
+  };
+
+  return (
+    <MemoryRouter>
+      <MenuTrigger>
+        <Button variant="secondary">Search</Button>
+        <MenuAutocomplete
+          filter={null}
+          onInputChange={handleInputChange}
+          placeholder="Search fruits..."
+        >
+          {items.map(item => (
+            <MenuItem key={item} id={item}>
+              {item}
+            </MenuItem>
+          ))}
+        </MenuAutocomplete>
+      </MenuTrigger>
+    </MemoryRouter>
+  );
+};
 
 export const PreviewAutocompleteListboxMultiple = () => (
   <MemoryRouter>

--- a/docs-ui/src/app/components/menu/page.mdx
+++ b/docs-ui/src/app/components/menu/page.mdx
@@ -11,6 +11,7 @@ import {
   PreviewAutocompleteMenu,
   PreviewAutocompleteListbox,
   PreviewAutocompleteListboxMultiple,
+  PreviewServerSideFiltering,
 } from './components';
 import {
   menuTriggerPropDefs,
@@ -35,6 +36,7 @@ import {
   autocomplete,
   autocompleteListbox,
   autocompleteListboxMultiple,
+  serverSideFiltering,
 } from './snippets';
 import { PageTitle } from '@/components/PageTitle';
 import { Theming } from '@/components/Theming';
@@ -202,6 +204,19 @@ The `href` prop works with both internal and external links.
   open
   preview={<PreviewAutocompleteMenu />}
   code={autocomplete}
+/>
+
+### Server-side filtering
+
+By default, autocomplete menus filter items client-side as the user types.
+Pass `filter={null}` to disable the built-in filtering and use `onInputChange`
+to fetch matching items from a server instead.
+
+<Snippet
+  layout="side-by-side"
+  open
+  preview={<PreviewServerSideFiltering />}
+  code={serverSideFiltering}
 />
 
 ### With list box

--- a/docs-ui/src/app/components/menu/props-definition.tsx
+++ b/docs-ui/src/app/components/menu/props-definition.tsx
@@ -151,6 +151,30 @@ export const menuAutocompletePropDefs: Record<string, PropDef> = {
     type: 'string',
     description: 'Placeholder text for the search input.',
   },
+  filter: {
+    type: 'enum',
+    values: ['(textValue: string, inputValue: string) => boolean', 'null'],
+    description: (
+      <>
+        Filter function used to match items against the search input. Defaults
+        to a case-insensitive substring match. Pass <Chip>null</Chip> to disable
+        client-side filtering, e.g. when items are filtered server-side.
+      </>
+    ),
+  },
+  inputValue: {
+    type: 'string',
+    description: 'Controlled value of the search input.',
+  },
+  defaultInputValue: {
+    type: 'string',
+    description: 'Default value of the search input (uncontrolled).',
+  },
+  onInputChange: {
+    type: 'enum',
+    values: ['(value: string) => void'],
+    description: 'Handler called when the search input value changes.',
+  },
   placement: {
     type: 'enum',
     values: [
@@ -220,6 +244,30 @@ export const menuAutocompleteListboxPropDefs: Record<string, PropDef> = {
   placeholder: {
     type: 'string',
     description: 'Placeholder text for the search input.',
+  },
+  filter: {
+    type: 'enum',
+    values: ['(textValue: string, inputValue: string) => boolean', 'null'],
+    description: (
+      <>
+        Filter function used to match items against the search input. Defaults
+        to a case-insensitive substring match. Pass <Chip>null</Chip> to disable
+        client-side filtering, e.g. when items are filtered server-side.
+      </>
+    ),
+  },
+  inputValue: {
+    type: 'string',
+    description: 'Controlled value of the search input.',
+  },
+  defaultInputValue: {
+    type: 'string',
+    description: 'Default value of the search input (uncontrolled).',
+  },
+  onInputChange: {
+    type: 'enum',
+    values: ['(value: string) => void'],
+    description: 'Handler called when the search input value changes.',
   },
   placement: {
     type: 'enum',

--- a/docs-ui/src/app/components/menu/snippets.ts
+++ b/docs-ui/src/app/components/menu/snippets.ts
@@ -106,6 +106,28 @@ export const autocompleteListbox = `<MenuTrigger>
   </MenuAutocompleteListbox>
 </MenuTrigger>`;
 
+export const serverSideFiltering = `const [items, setItems] = useState<Fruit[]>([]);
+
+// Fetch items that match the search from a server.
+const handleInputChange = (value: string) => {
+  fetchFruits(value).then(setItems);
+};
+
+<MenuTrigger>
+  <Button variant="secondary">Search</Button>
+  <MenuAutocomplete
+    filter={null}
+    onInputChange={handleInputChange}
+    placeholder="Search fruits..."
+  >
+    {items.map(item => (
+      <MenuItem key={item.id} id={item.id}>
+        {item.name}
+      </MenuItem>
+    ))}
+  </MenuAutocomplete>
+</MenuTrigger>`;
+
 export const autocompleteListboxMultiple = `<MenuTrigger>
   <Button variant="secondary">Multi-select</Button>
   <MenuAutocompleteListbox

--- a/packages/ui/report.api.md
+++ b/packages/ui/report.api.md
@@ -2183,10 +2183,10 @@ export const MenuAutocompleteListbox: (
 ) => JSX_2.Element;
 
 // @public (undocumented)
-export type MenuAutocompleteListBoxOwnProps = MenuPopoverOwnProps & {
-  placeholder?: string;
-  selectionMode?: ListBoxProps<object>['selectionMode'];
-};
+export type MenuAutocompleteListBoxOwnProps = MenuPopoverOwnProps &
+  MenuAutocompleteSearchOwnProps & {
+    selectionMode?: ListBoxProps<object>['selectionMode'];
+  };
 
 // @public (undocumented)
 export interface MenuAutocompleteListBoxProps<T>
@@ -2194,14 +2194,22 @@ export interface MenuAutocompleteListBoxProps<T>
     Omit<ListBoxProps<T>, keyof MenuAutocompleteListBoxOwnProps> {}
 
 // @public (undocumented)
-export type MenuAutocompleteOwnProps = MenuPopoverOwnProps & {
-  placeholder?: string;
-};
+export type MenuAutocompleteOwnProps = MenuPopoverOwnProps &
+  MenuAutocompleteSearchOwnProps;
 
 // @public (undocumented)
 export interface MenuAutocompleteProps<T>
   extends MenuAutocompleteOwnProps,
     Omit<MenuProps_2<T>, keyof MenuAutocompleteOwnProps> {}
+
+// @public
+export type MenuAutocompleteSearchOwnProps = {
+  placeholder?: string;
+  filter?: ((textValue: string, inputValue: string) => boolean) | null;
+  inputValue?: string;
+  defaultInputValue?: string;
+  onInputChange?: (value: string) => void;
+};
 
 // @public
 export const MenuDefinition: {

--- a/packages/ui/src/components/Menu/Menu.test.tsx
+++ b/packages/ui/src/components/Menu/Menu.test.tsx
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { BUIProvider } from '../../provider';
+import { Button } from '../Button';
+import {
+  MenuTrigger,
+  MenuAutocomplete,
+  MenuAutocompleteListbox,
+  MenuItem,
+  MenuListBoxItem,
+} from './index';
+import type { MenuAutocompleteProps } from './types';
+
+const fruits = ['Apple', 'Banana', 'Cherry'];
+
+function renderMenuAutocomplete(props: Partial<MenuAutocompleteProps<object>>) {
+  return render(
+    <MemoryRouter>
+      <BUIProvider>
+        <MenuTrigger isOpen>
+          <Button aria-label="Menu">Menu</Button>
+          <MenuAutocomplete {...props}>
+            {fruits.map(fruit => (
+              <MenuItem key={fruit} id={fruit}>
+                {fruit}
+              </MenuItem>
+            ))}
+          </MenuAutocomplete>
+        </MenuTrigger>
+      </BUIProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('MenuAutocomplete', () => {
+  it('filters items client-side by default', async () => {
+    const onInputChange = jest.fn();
+    renderMenuAutocomplete({ onInputChange });
+
+    fireEvent.change(await screen.findByRole('searchbox'), {
+      target: { value: 'app' },
+    });
+
+    expect(
+      await screen.findByRole('menuitem', { name: 'Apple' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('menuitem', { name: 'Banana' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('menuitem', { name: 'Cherry' }),
+    ).not.toBeInTheDocument();
+    expect(onInputChange).toHaveBeenCalledWith('app');
+  });
+
+  it('filters items with a custom filter function', async () => {
+    const filter = jest.fn(
+      (textValue: string, inputValue: string) => textValue === inputValue,
+    );
+    renderMenuAutocomplete({ filter });
+
+    fireEvent.change(await screen.findByRole('searchbox'), {
+      target: { value: 'Banana' },
+    });
+
+    expect(
+      await screen.findByRole('menuitem', { name: 'Banana' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('menuitem', { name: 'Apple' }),
+    ).not.toBeInTheDocument();
+    expect(filter).toHaveBeenCalledWith(
+      expect.any(String),
+      'Banana',
+      expect.anything(),
+    );
+  });
+
+  it('shows all items regardless of input when filter is null', async () => {
+    const onInputChange = jest.fn();
+    renderMenuAutocomplete({ filter: null, onInputChange });
+
+    fireEvent.change(await screen.findByRole('searchbox'), {
+      target: { value: 'no match' },
+    });
+
+    expect(
+      await screen.findByRole('menuitem', { name: 'Apple' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('menuitem', { name: 'Banana' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('menuitem', { name: 'Cherry' }),
+    ).toBeInTheDocument();
+    expect(onInputChange).toHaveBeenCalledWith('no match');
+  });
+});
+
+describe('MenuAutocompleteListbox', () => {
+  it('shows all items regardless of input when filter is null', async () => {
+    const onInputChange = jest.fn();
+    render(
+      <MemoryRouter>
+        <BUIProvider>
+          <MenuTrigger isOpen>
+            <Button aria-label="Menu">Menu</Button>
+            <MenuAutocompleteListbox
+              filter={null}
+              onInputChange={onInputChange}
+            >
+              {fruits.map(fruit => (
+                <MenuListBoxItem key={fruit} id={fruit}>
+                  {fruit}
+                </MenuListBoxItem>
+              ))}
+            </MenuAutocompleteListbox>
+          </MenuTrigger>
+        </BUIProvider>
+      </MemoryRouter>,
+    );
+
+    fireEvent.change(await screen.findByRole('searchbox'), {
+      target: { value: 'no match' },
+    });
+
+    expect(
+      await screen.findByRole('option', { name: 'Apple' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Banana' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Cherry' })).toBeInTheDocument();
+    expect(onInputChange).toHaveBeenCalledWith('no match');
+  });
+});

--- a/packages/ui/src/components/Menu/Menu.tsx
+++ b/packages/ui/src/components/Menu/Menu.tsx
@@ -188,8 +188,14 @@ export const MenuAutocomplete = (props: MenuAutocompleteProps<object>) => {
     maxHeight,
     style,
     placeholder,
+    inputValue,
+    defaultInputValue,
+    onInputChange,
   } = ownProps;
   const { contains } = useFilter({ sensitivity: 'base' });
+  // Read from the raw props since `ownProps` does not preserve `null`, which
+  // disables client-side filtering for server-filtered items.
+  const filter = props.filter === undefined ? contains : props.filter;
   let newMaxWidth = maxWidth || (virtualized ? '260px' : 'undefined');
 
   const menuContent = (
@@ -205,7 +211,12 @@ export const MenuAutocomplete = (props: MenuAutocompleteProps<object>) => {
     <RAPopover className={classes.root} placement={placement}>
       <BgReset>
         <Box bg="neutral" className={classes.inner}>
-          <RAAutocomplete filter={contains}>
+          <RAAutocomplete
+            filter={filter ?? undefined}
+            inputValue={inputValue}
+            defaultInputValue={defaultInputValue}
+            onInputChange={onInputChange}
+          >
             <RASearchField
               className={classes.searchField}
               aria-label={placeholder || 'Search'}
@@ -254,8 +265,14 @@ export const MenuAutocompleteListbox = (
     maxHeight,
     style,
     placeholder,
+    inputValue,
+    defaultInputValue,
+    onInputChange,
   } = ownProps;
   const { contains } = useFilter({ sensitivity: 'base' });
+  // Read from the raw props since `ownProps` does not preserve `null`, which
+  // disables client-side filtering for server-filtered items.
+  const filter = props.filter === undefined ? contains : props.filter;
   let newMaxWidth = maxWidth || (virtualized ? '260px' : 'undefined');
 
   const listBoxContent = (
@@ -272,7 +289,12 @@ export const MenuAutocompleteListbox = (
     <RAPopover className={classes.root} placement={placement}>
       <BgReset>
         <Box bg="neutral" className={classes.inner}>
-          <RAAutocomplete filter={contains}>
+          <RAAutocomplete
+            filter={filter ?? undefined}
+            inputValue={inputValue}
+            defaultInputValue={defaultInputValue}
+            onInputChange={onInputChange}
+          >
             <RASearchField
               className={classes.searchField}
               aria-label={placeholder || 'Search'}

--- a/packages/ui/src/components/Menu/MenuAutocomplete.stories.tsx
+++ b/packages/ui/src/components/Menu/MenuAutocomplete.stories.tsx
@@ -198,3 +198,39 @@ export const Submenu = meta.story({
     </MenuTrigger>
   ),
 });
+
+export const ServerSideFiltering = meta.story({
+  args: {
+    ...Default.input.args,
+  },
+  render: () => {
+    const [items, setItems] = useState(options);
+
+    // Simulates fetching items that match the search from a server.
+    const handleInputChange = (value: string) => {
+      const search = value.toLocaleLowerCase('en-US');
+      setItems(
+        options.filter(option =>
+          option.label.toLocaleLowerCase('en-US').includes(search),
+        ),
+      );
+    };
+
+    return (
+      <MenuTrigger isOpen>
+        <Button aria-label="Menu">Menu</Button>
+        <MenuAutocomplete
+          filter={null}
+          onInputChange={handleInputChange}
+          placeholder="Search fruits..."
+        >
+          {items.map(option => (
+            <MenuItem key={option.value} id={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </MenuAutocomplete>
+      </MenuTrigger>
+    );
+  },
+});

--- a/packages/ui/src/components/Menu/MenuAutocompleteListBox.stories.tsx
+++ b/packages/ui/src/components/Menu/MenuAutocompleteListBox.stories.tsx
@@ -184,6 +184,50 @@ export const Submenu = meta.story({
   },
 });
 
+export const ServerSideFiltering = meta.story({
+  args: {
+    ...Default.input.args,
+  },
+  render: () => {
+    const [selected, setSelected] = useState<Selection>(
+      new Set([options[2].value]),
+    );
+    const [items, setItems] = useState(options);
+
+    // Simulates fetching items that match the search from a server.
+    const handleInputChange = (value: string) => {
+      const search = value.toLocaleLowerCase('en-US');
+      setItems(
+        options.filter(option =>
+          option.label.toLocaleLowerCase('en-US').includes(search),
+        ),
+      );
+    };
+
+    return (
+      <Flex direction="column" gap="2" align="start">
+        <Text>Selected: {Array.from(selected).join(', ')}</Text>
+        <MenuTrigger isOpen>
+          <Button aria-label="Menu">Menu</Button>
+          <MenuAutocompleteListbox
+            filter={null}
+            onInputChange={handleInputChange}
+            selectedKeys={selected}
+            onSelectionChange={setSelected}
+            placeholder="Search fruits..."
+          >
+            {items.map(option => (
+              <MenuListBoxItem key={option.value} id={option.value}>
+                {option.label}
+              </MenuListBoxItem>
+            ))}
+          </MenuAutocompleteListbox>
+        </MenuTrigger>
+      </Flex>
+    );
+  },
+});
+
 export const Virtualized = meta.story({
   args: {
     ...Default.input.args,

--- a/packages/ui/src/components/Menu/definition.ts
+++ b/packages/ui/src/components/Menu/definition.ts
@@ -52,6 +52,15 @@ const menuPopoverPropDefs = {
   className: {},
 } as const;
 
+// Shared propDefs for autocomplete menu variants
+const menuAutocompleteSearchPropDefs = {
+  placeholder: {},
+  filter: {},
+  inputValue: {},
+  defaultInputValue: {},
+  onInputChange: {},
+} as const;
+
 /**
  * Component definition for Menu
  * @public
@@ -79,7 +88,7 @@ export const MenuAutocompleteDefinition =
     classNames: menuAutocompleteClassNames,
     propDefs: {
       ...menuPopoverPropDefs,
-      placeholder: {},
+      ...menuAutocompleteSearchPropDefs,
     },
   });
 
@@ -90,7 +99,7 @@ export const MenuAutocompleteListboxDefinition =
     classNames: menuAutocompleteClassNames,
     propDefs: {
       ...menuPopoverPropDefs,
-      placeholder: {},
+      ...menuAutocompleteSearchPropDefs,
       selectionMode: { default: 'single' },
     },
   });

--- a/packages/ui/src/components/Menu/index.ts
+++ b/packages/ui/src/components/Menu/index.ts
@@ -37,6 +37,7 @@ export type {
   MenuListBoxOwnProps,
   MenuAutocompleteProps,
   MenuAutocompleteOwnProps,
+  MenuAutocompleteSearchOwnProps,
   MenuAutocompleteListBoxProps,
   MenuAutocompleteListBoxOwnProps,
   MenuItemProps,

--- a/packages/ui/src/components/Menu/types.ts
+++ b/packages/ui/src/components/Menu/types.ts
@@ -64,10 +64,31 @@ export interface MenuListBoxProps<T>
   extends MenuListBoxOwnProps,
     Omit<RAListBoxProps<T>, keyof MenuListBoxOwnProps> {}
 
-/** @public */
-export type MenuAutocompleteOwnProps = MenuPopoverOwnProps & {
+/**
+ * Common own props shared by all autocomplete menu variants.
+ *
+ * @public
+ */
+export type MenuAutocompleteSearchOwnProps = {
   placeholder?: string;
+  /**
+   * Filter function used to match items against the search input value.
+   * Defaults to a case-insensitive substring match of each item's text value.
+   * Pass `null` to disable client-side filtering, e.g. when the items are
+   * already filtered server-side.
+   */
+  filter?: ((textValue: string, inputValue: string) => boolean) | null;
+  /** The value of the search input (controlled). */
+  inputValue?: string;
+  /** The default value of the search input (uncontrolled). */
+  defaultInputValue?: string;
+  /** Handler that is called when the search input value changes. */
+  onInputChange?: (value: string) => void;
 };
+
+/** @public */
+export type MenuAutocompleteOwnProps = MenuPopoverOwnProps &
+  MenuAutocompleteSearchOwnProps;
 
 /** @public */
 export interface MenuAutocompleteProps<T>
@@ -75,10 +96,10 @@ export interface MenuAutocompleteProps<T>
     Omit<RAMenuProps<T>, keyof MenuAutocompleteOwnProps> {}
 
 /** @public */
-export type MenuAutocompleteListBoxOwnProps = MenuPopoverOwnProps & {
-  placeholder?: string;
-  selectionMode?: RAListBoxProps<object>['selectionMode'];
-};
+export type MenuAutocompleteListBoxOwnProps = MenuPopoverOwnProps &
+  MenuAutocompleteSearchOwnProps & {
+    selectionMode?: RAListBoxProps<object>['selectionMode'];
+  };
 
 /** @public */
 export interface MenuAutocompleteListBoxProps<T>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

## What

`MenuAutocomplete` and `MenuAutocompleteListbox` now support server-side filtering. Both components accept a new `filter` prop where `null` disables the built-in client-side filtering, plus `inputValue`, `defaultInputValue` and `onInputChange` to observe or control the search input. Omitting `filter` keeps the current behavior, so existing usage is unaffected.

```tsx
<MenuAutocomplete filter={null} onInputChange={search => fetchItems(search)}>
  {items.map(item => (
    <MenuItem key={item.id} id={item.id}>
      {item.name}
    </MenuItem>
  ))}
</MenuAutocomplete>
```

## Why

Currently both autocomplete menus hardcode a client-side `contains` filter on the underlying react-aria `Autocomplete`, so there is no way to use them with items that are filtered server-side — the menu filters the already-filtered results again against the search input. This has come up as a blocker for plugins that fetch their menu options from an API.

To test, run `yarn test packages/ui/src/components/Menu`, or open the new `ServerSideFiltering` stories for `MenuAutocomplete` and `MenuAutocompleteListBox` in storybook.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
