### PR TITLE
fix(backend-dynamic-feature-service): fall back to main from alpha

### DIFF
--- a/.changeset/fix-dynamic-plugin-alpha-fallback.md
+++ b/.changeset/fix-dynamic-plugin-alpha-fallback.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-dynamic-feature-service': patch
+---
+
+Fixed dynamic backend plugin loading to fall back to the main package export when an alpha `package.json` is present but does not provide a plugin entrypoint. Previously, plugins whose alpha export only exposed supplementary APIs (such as permissions) could fail to load even though the main export was valid. The loader now tries the alpha entry first and uses the main export when the alpha module does not export a `BackendFeature`, `BackendFeatureFactory`, or `dynamicPluginInstaller`.

--- a/packages/backend-dynamic-feature-service/src/features/__fixtures__/dynamic-plugins-root-for-alpha-fallback/test-backend-alpha-fallback-dynamic/alpha/package.json
+++ b/packages/backend-dynamic-feature-service/src/features/__fixtures__/dynamic-plugins-root-for-alpha-fallback/test-backend-alpha-fallback-dynamic/alpha/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "plugin-test-backend-alpha-fallback-dynamic__alpha",
+  "version": "0.0.0",
+  "main": "../dist/alpha.cjs.js"
+}

--- a/packages/backend-dynamic-feature-service/src/features/__fixtures__/dynamic-plugins-root-for-alpha-fallback/test-backend-alpha-fallback-dynamic/dist/alpha.cjs.js
+++ b/packages/backend-dynamic-feature-service/src/features/__fixtures__/dynamic-plugins-root-for-alpha-fallback/test-backend-alpha-fallback-dynamic/dist/alpha.cjs.js
@@ -1,0 +1,7 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+exports.supplementaryExport = {
+  some: 'api',
+};

--- a/packages/backend-dynamic-feature-service/src/features/__fixtures__/dynamic-plugins-root-for-alpha-fallback/test-backend-alpha-fallback-dynamic/dist/index.cjs.js
+++ b/packages/backend-dynamic-feature-service/src/features/__fixtures__/dynamic-plugins-root-for-alpha-fallback/test-backend-alpha-fallback-dynamic/dist/index.cjs.js
@@ -1,0 +1,23 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+var backendPluginApi = require('@backstage/backend-plugin-api');
+
+const testAlphaFallbackPlugin = backendPluginApi.createBackendPlugin({
+  pluginId: 'test-alpha-fallback',
+  register(env) {
+    env.registerInit({
+      deps: {
+        logger: backendPluginApi.coreServices.rootLogger,
+      },
+      async init({ logger }) {
+        logger.info(
+          'This plugin has been loaded from the main export after alpha fallback.',
+        );
+      },
+    });
+  },
+});
+
+exports.default = testAlphaFallbackPlugin;

--- a/packages/backend-dynamic-feature-service/src/features/__fixtures__/dynamic-plugins-root-for-alpha-fallback/test-backend-alpha-fallback-dynamic/package.json
+++ b/packages/backend-dynamic-feature-service/src/features/__fixtures__/dynamic-plugins-root-for-alpha-fallback/test-backend-alpha-fallback-dynamic/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "plugin-test-backend-alpha-fallback-dynamic",
+  "version": "0.0.0",
+  "description": "A test dynamic backend plugin whose alpha export only exposes supplementary APIs.",
+  "backstage": {
+    "role": "backend-plugin",
+    "pluginId": "test-alpha-fallback",
+    "pluginPackages": [
+      "plugin-test-backend-alpha-fallback"
+    ]
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "backstage",
+    "dynamic"
+  ],
+  "exports": {
+    ".": {
+      "require": "./dist/index.cjs.js",
+      "default": "./dist/index.cjs.js"
+    },
+    "./alpha": {
+      "require": "./dist/alpha.cjs.js",
+      "default": "./dist/alpha.cjs.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/index.cjs.js",
+  "files": [
+    "dist",
+    "alpha"
+  ],
+  "bundleDependencies": true
+}

--- a/packages/backend-dynamic-feature-service/src/features/features.test.ts
+++ b/packages/backend-dynamic-feature-service/src/features/features.test.ts
@@ -112,7 +112,7 @@ describe('dynamicPluginsFeatureLoader', () => {
   // This test demonstrates how, without the skipping logic implemented in the {@link CommonJSModelLoader},
   // this dummy package would be loaded by the backend dynamic plugins instead of the one of the backstage root.
   it('should fail because the model loader is not skipping modules living in unexpected locations.', async () => {
-    const dynamicPLuginsLister = new DynamicPluginLister();
+    const dynamicPluginsLister = new DynamicPluginLister();
     const mockedTransport = new MockedTransport();
     await startTestBackend({
       features: [
@@ -137,7 +137,7 @@ describe('dynamicPluginsFeatureLoader', () => {
             format: winston.format.simple(),
           }),
         }),
-        dynamicPLuginsLister.feature(),
+        dynamicPluginsLister.feature(),
       ],
     });
     expect(mockedTransport.logs).toContainEqual(
@@ -145,7 +145,7 @@ describe('dynamicPluginsFeatureLoader', () => {
         "error: an error occurred while loading dynamic backend plugin 'plugin-test-backend-dynamic' from '.*/packages/backend-dynamic-feature-service/src/features/__fixtures__/dynamic-plugins-root/test-backend-dynamic",
       ),
     );
-    expect(dynamicPLuginsLister.loadedPlugins).toMatchObject([
+    expect(dynamicPluginsLister.loadedPlugins).toMatchObject([
       {
         name: 'plugin-test-backend-dynamic',
         platform: 'node',
@@ -159,7 +159,7 @@ describe('dynamicPluginsFeatureLoader', () => {
   });
 
   it('should fail on resolvePackagePath because -dynamic suffix is not allowed for dynamic plugin packages.', async () => {
-    const dynamicPLuginsLister = new DynamicPluginLister();
+    const dynamicPluginsLister = new DynamicPluginLister();
     const mockedTransport = new MockedTransport();
     await startTestBackend({
       features: [
@@ -184,7 +184,7 @@ describe('dynamicPluginsFeatureLoader', () => {
             format: winston.format.simple(),
           }),
         }),
-        dynamicPLuginsLister.feature(),
+        dynamicPluginsLister.feature(),
       ],
     });
     expect(mockedTransport.logs).toContainEqual(
@@ -192,7 +192,7 @@ describe('dynamicPluginsFeatureLoader', () => {
         "error: an error occurred while loading dynamic backend plugin 'plugin-test-backend-dynamic' from '.*/packages/backend-dynamic-feature-service/src/features/__fixtures__/dynamic-plugins-root/test-backend-dynamic",
       ),
     );
-    expect(dynamicPLuginsLister.loadedPlugins).toMatchObject([
+    expect(dynamicPluginsLister.loadedPlugins).toMatchObject([
       {
         name: 'plugin-test-backend-dynamic',
         platform: 'node',
@@ -213,7 +213,7 @@ Require stack:
   });
 
   it('should load and show the 2 dynamic plugins in a list of dynamic plugins returned by a static backend plugin', async () => {
-    const dynamicPLuginsLister = new DynamicPluginLister();
+    const dynamicPluginsLister = new DynamicPluginLister();
     await startTestBackend({
       features: [
         mockServices.rootConfig.factory({
@@ -230,11 +230,11 @@ Require stack:
           moduleLoader: logger =>
             jestFreeTypescriptAwareModuleLoader({ logger }),
         }),
-        dynamicPLuginsLister.feature(),
+        dynamicPluginsLister.feature(),
       ],
     });
 
-    expect(dynamicPLuginsLister.loadedPlugins).toMatchObject([
+    expect(dynamicPluginsLister.loadedPlugins).toMatchObject([
       {
         installer: {
           kind: 'new',
@@ -394,7 +394,7 @@ Require stack:
   });
 
   it('should load a backend plugin from the alpha package first', async () => {
-    const dynamicPLuginsLister = new DynamicPluginLister();
+    const dynamicPluginsLister = new DynamicPluginLister();
     const mockedTransport = new MockedTransport();
     const dynamicPluginsRootForAlpha = resolvePath(
       __dirname,
@@ -420,7 +420,7 @@ Require stack:
             format: winston.format.simple(),
           }),
         }),
-        dynamicPLuginsLister.feature(),
+        dynamicPluginsLister.feature(),
       ],
     });
 
@@ -428,7 +428,7 @@ Require stack:
       'info: This plugin has been loaded from the alpha package. {"service":"backstage"}',
     );
 
-    const loadedPlugins = dynamicPLuginsLister.loadedPlugins;
+    const loadedPlugins = dynamicPluginsLister.loadedPlugins;
     expect(loadedPlugins).toMatchObject([
       {
         installer: {
@@ -441,7 +441,7 @@ Require stack:
       },
     ]);
     expect(
-      dynamicPLuginsLister.getScannedPackage?.(loadedPlugins[0]),
+      dynamicPluginsLister.getScannedPackage?.(loadedPlugins[0]),
     ).toMatchObject({
       location: url.pathToFileURL(
         path.resolve(dynamicPluginsRootForAlpha, 'test-backend-alpha-dynamic'),
@@ -459,6 +459,93 @@ Require stack:
       },
       alphaManifest: {
         name: 'plugin-test-backend-alpha-dynamic__alpha',
+        version: '0.0.0',
+        main: '../dist/alpha.cjs.js',
+      },
+    });
+  });
+
+  it('should fall back to the main export when alpha only exposes supplementary APIs', async () => {
+    const dynamicPluginsLister = new DynamicPluginLister();
+    const mockedTransport = new MockedTransport();
+    const dynamicPluginsRootForAlphaFallback = resolvePath(
+      __dirname,
+      '__fixtures__/dynamic-plugins-root-for-alpha-fallback',
+    );
+    await startTestBackend({
+      features: [
+        mockServices.rootConfig.factory({
+          data: {
+            dynamicPlugins: {
+              rootDirectory: dynamicPluginsRootForAlphaFallback,
+            },
+            backend: {
+              baseUrl: `http://localhost:0`,
+            },
+          },
+        }),
+        dynamicPluginsFeatureLoader({
+          moduleLoader: logger =>
+            jestFreeTypescriptAwareModuleLoader({ logger }),
+          logger: () => ({
+            transports: [mockedTransport],
+            format: winston.format.simple(),
+          }),
+        }),
+        dynamicPluginsLister.feature(),
+      ],
+    });
+
+    expect(mockedTransport.logs).toContainEqual(
+      'info: This plugin has been loaded from the main export after alpha fallback. {"service":"backstage"}',
+    );
+    expect(mockedTransport.logs).toContainEqual(
+      expect.stringMatching(
+        "info: loaded dynamic backend plugin 'plugin-test-backend-alpha-fallback-dynamic' from 'file://.*/test-backend-alpha-fallback-dynamic'",
+      ),
+    );
+    expect(mockedTransport.logs).not.toContainEqual(
+      expect.stringMatching(
+        "info: loaded dynamic backend plugin 'plugin-test-backend-alpha-fallback-dynamic' from 'file://.*/test-backend-alpha-fallback-dynamic/alpha'",
+      ),
+    );
+
+    const loadedPlugins = dynamicPluginsLister.loadedPlugins;
+    expect(loadedPlugins).toMatchObject([
+      {
+        installer: {
+          kind: 'new',
+        },
+        name: 'plugin-test-backend-alpha-fallback-dynamic',
+        platform: 'node',
+        role: 'backend-plugin',
+        version: '0.0.0',
+      },
+    ]);
+    expect(loadedPlugins[0].failure).toBeUndefined();
+    expect(
+      dynamicPluginsLister.getScannedPackage?.(loadedPlugins[0]),
+    ).toMatchObject({
+      location: url.pathToFileURL(
+        path.resolve(
+          dynamicPluginsRootForAlphaFallback,
+          'test-backend-alpha-fallback-dynamic',
+        ),
+      ),
+      manifest: {
+        name: 'plugin-test-backend-alpha-fallback-dynamic',
+        version: '0.0.0',
+        description:
+          'A test dynamic backend plugin whose alpha export only exposes supplementary APIs.',
+        backstage: {
+          role: 'backend-plugin',
+          pluginId: 'test-alpha-fallback',
+          pluginPackages: ['plugin-test-backend-alpha-fallback'],
+        },
+        keywords: ['backstage', 'dynamic'],
+      },
+      alphaManifest: {
+        name: 'plugin-test-backend-alpha-fallback-dynamic__alpha',
         version: '0.0.0',
         main: '../dist/alpha.cjs.js',
       },

--- a/packages/backend-dynamic-feature-service/src/manager/plugin-manager.test.ts
+++ b/packages/backend-dynamic-feature-service/src/manager/plugin-manager.test.ts
@@ -217,6 +217,60 @@ describe('backend-dynamic-feature-service', () => {
         },
       },
       {
+        name: 'should fall back to main export when alpha does not provide a plugin entrypoint',
+        packageManifest: {
+          name: 'backend-dynamic-plugin-test',
+          version: '0.0.0',
+          backstage: {
+            role: 'backend-plugin',
+          },
+          main: 'dist/index.cjs.js',
+        },
+        indexFile: {
+          relativePath: ['dist', 'index.cjs.js'],
+          content: `const plugin = { $$type: '@backstage/BackendFeature' }; exports["default"] = plugin;`,
+        },
+        alpha: {
+          packageManifest: {
+            name: 'backend-dynamic-plugin-test',
+            version: '0.0.0',
+            main: '../dist/alpha.cjs.js',
+          },
+          indexFile: {
+            relativePath: ['dist', 'alpha.cjs.js'],
+            content: `exports.supplementaryExport = {};`,
+          },
+        },
+        expectedLogs(location) {
+          return {
+            infos: [
+              {
+                message: `loaded dynamic backend plugin 'backend-dynamic-plugin-test' from '${location}'`,
+              },
+            ],
+          };
+        },
+        checkLoadedPlugins(plugins) {
+          expect(plugins).toMatchObject([
+            {
+              name: 'backend-dynamic-plugin-test',
+              version: '0.0.0',
+              role: 'backend-plugin',
+              platform: 'node',
+              installer: {
+                kind: 'new',
+              },
+            },
+          ]);
+          const installer: NewBackendPluginInstaller = (
+            plugins[0] as BackendDynamicPlugin
+          ).installer as NewBackendPluginInstaller;
+          expect((installer.install() as BackendFeature).$$type).toEqual(
+            '@backstage/BackendFeature',
+          );
+        },
+      },
+      {
         name: 'should successfully load a new backend plugin by the default BackendFeatureFactory',
         packageManifest: {
           name: 'backend-dynamic-plugin-test',

--- a/packages/backend-dynamic-feature-service/src/manager/plugin-manager.ts
+++ b/packages/backend-dynamic-feature-service/src/manager/plugin-manager.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { Config } from '@backstage/config';
+import { toError } from '@backstage/errors';
 import {
   DynamicPluginProvider,
   BackendDynamicPlugin,
@@ -25,6 +26,7 @@ import { ScannedPluginPackage } from '../scanner';
 import { PluginScanner } from '../scanner/plugin-scanner';
 import { ModuleLoader } from '../loader';
 import { CommonJSModuleLoader } from '../loader/CommonJSModuleLoader';
+import path from 'node:path';
 import * as url from 'node:url';
 import {
   BackendFeature,
@@ -168,14 +170,6 @@ export class DynamicPluginManager implements DynamicPluginProvider {
   private async loadBackendPlugin(
     plugin: ScannedPluginPackage,
   ): Promise<BackendDynamicPlugin> {
-    const usedPluginManifest =
-      plugin.alphaManifest?.main ?? plugin.manifest.main;
-    const usedPluginLocation = plugin.alphaManifest?.main
-      ? `${plugin.location}/alpha`
-      : plugin.location;
-    const packagePath = url.fileURLToPath(
-      `${usedPluginLocation}/${usedPluginManifest}`,
-    );
     const dynamicPlugin: BackendDynamicPlugin = {
       name: plugin.manifest.name,
       version: plugin.manifest.version,
@@ -183,47 +177,63 @@ export class DynamicPluginManager implements DynamicPluginProvider {
       role: plugin.manifest.backstage.role,
     };
 
-    try {
-      const pluginModule = await this.moduleLoader.load(packagePath);
+    const entryPoints: Array<{ location: URL; manifest: string }> = [
+      ...(plugin.alphaManifest?.main
+        ? [
+            {
+              location: new URL('alpha', `${plugin.location}/`),
+              manifest: plugin.alphaManifest.main,
+            },
+          ]
+        : []),
+      {
+        location: plugin.location,
+        manifest: plugin.manifest.main,
+      },
+    ];
 
-      if (isBackendFeature(pluginModule.default)) {
-        dynamicPlugin.installer = {
-          kind: 'new',
-          install: () => pluginModule.default,
-        };
-      } else if (isBackendFeatureFactory(pluginModule.default)) {
-        dynamicPlugin.installer = {
-          kind: 'new',
-          install: pluginModule.default,
-        };
-      } else if (
-        isBackendDynamicPluginInstaller(pluginModule.dynamicPluginInstaller)
-      ) {
-        dynamicPlugin.installer = pluginModule.dynamicPluginInstaller;
-      }
-      if (dynamicPlugin.installer) {
+    if (entryPoints.length === 0) {
+      throw new Error(
+        `Failed to load dynamic backend plugin '${plugin.manifest.name}': no entry points to load`,
+      );
+    }
+
+    for (const [index, { location, manifest }] of entryPoints.entries()) {
+      const loadResult = await tryLoadBackendPluginEntry(
+        this.moduleLoader,
+        location,
+        manifest,
+      );
+
+      if (loadResult.installer) {
+        dynamicPlugin.installer = loadResult.installer;
         this.logger.info(
-          `loaded dynamic backend plugin '${plugin.manifest.name}' from '${usedPluginLocation}'`,
+          `loaded dynamic backend plugin '${plugin.manifest.name}' from '${location}'`,
         );
-      } else {
-        dynamicPlugin.failure = `the module should either export a 'BackendFeature' or 'BackendFeatureFactory' as default export, or export a 'const dynamicPluginInstaller: BackendDynamicPluginInstaller' field as dynamic loading entrypoint.`;
-        this.logger.error(
-          `dynamic backend plugin '${plugin.manifest.name}' could not be loaded from '${usedPluginLocation}': ${dynamicPlugin.failure}`,
-        );
+        return dynamicPlugin;
       }
-      return dynamicPlugin;
-    } catch (error) {
-      const typedError =
-        typeof error === 'object' && 'message' in error && 'name' in error
-          ? error
-          : new Error(error);
-      dynamicPlugin.failure = `${typedError.name}: ${typedError.message}`;
+
+      if (!loadResult.error && index < entryPoints.length - 1) {
+        continue;
+      }
+
+      if (loadResult.error) {
+        dynamicPlugin.failure = `${loadResult.error.name}: ${loadResult.error.message}`;
+        this.logger.error(
+          `an error occurred while loading dynamic backend plugin '${plugin.manifest.name}' from '${location}'`,
+          loadResult.error,
+        );
+        return dynamicPlugin;
+      }
+
+      dynamicPlugin.failure = `the module should either export a 'BackendFeature' or 'BackendFeatureFactory' as default export, or export a 'const dynamicPluginInstaller: BackendDynamicPluginInstaller' field as dynamic loading entrypoint.`;
       this.logger.error(
-        `an error occurred while loading dynamic backend plugin '${plugin.manifest.name}' from '${usedPluginLocation}'`,
-        typedError,
+        `dynamic backend plugin '${plugin.manifest.name}' could not be loaded from '${location}': ${dynamicPlugin.failure}`,
       );
       return dynamicPlugin;
     }
+
+    return dynamicPlugin;
   }
 
   backendPlugins(options?: {
@@ -351,6 +361,44 @@ export const dynamicPluginsFeatureDiscoveryLoader = createBackendFeatureLoader({
     return features;
   },
 });
+
+async function tryLoadBackendPluginEntry(
+  moduleLoader: ModuleLoader,
+  location: URL,
+  manifest: string,
+): Promise<{
+  installer?: BackendDynamicPlugin['installer'];
+  error?: Error;
+}> {
+  try {
+    const packagePath = path.resolve(url.fileURLToPath(location), manifest);
+    const pluginModule = await moduleLoader.load(packagePath);
+    return { installer: resolveInstallerFromModule(pluginModule) };
+  } catch (error) {
+    return { error: toError(error) };
+  }
+}
+
+function resolveInstallerFromModule(
+  pluginModule: Record<string, unknown>,
+): BackendDynamicPlugin['installer'] | undefined {
+  if (isBackendFeature(pluginModule.default)) {
+    return {
+      kind: 'new',
+      install: () => pluginModule.default as BackendFeature,
+    };
+  }
+  if (isBackendFeatureFactory(pluginModule.default)) {
+    return {
+      kind: 'new',
+      install: pluginModule.default as () => BackendFeature,
+    };
+  }
+  if (isBackendDynamicPluginInstaller(pluginModule.dynamicPluginInstaller)) {
+    return pluginModule.dynamicPluginInstaller;
+  }
+  return undefined;
+}
 
 function isBackendFeature(value: unknown): value is BackendFeature {
   return (


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Dynamic backend plugins with an alpha package.json failed to load when the alpha export only exposed supplementary APIs, even if the main export was valid. The loader now tries the alpha entry first and falls back to the main export when no valid plugin installer is found.

Without this fix, attempting to load plugins such as catalog-backend using the backend dynamic feature service will currently fail with an error similar to following message:

```
dynamic backend plugin '@backstage/plugin-catalog-backend-dynamic' could not be loaded from 'file:///opt/app-root/src/dynamic-plugins-root/backstage-plugin-catalog-backend/alpha': the module should either export a 'BackendFeature' or 'BackendFeatureFactory' as default export, or export a 'const dynamicPluginInstaller: BackendDynamicPluginInstaller' field as dynamic loading entrypoint.
```

Assisted-By: Cursor Desktop

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
