### PR TITLE
feat(ui): add FieldLabel support to Checkbox

### DIFF
--- a/.changeset/checkbox-field-label.md
+++ b/.changeset/checkbox-field-label.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+The `Checkbox` component now accepts `label`, `secondaryLabel`, and `description` props, rendering a field label above the checkbox for visual consistency with other form components such as `TextField`. The existing inline label passed via `children` continues to work.

--- a/docs-ui/src/app/components/checkbox/components.tsx
+++ b/docs-ui/src/app/components/checkbox/components.tsx
@@ -19,3 +19,15 @@ export const AllVariants = () => {
     </Flex>
   );
 };
+
+export const WithLabel = () => {
+  return (
+    <Checkbox
+      label="Email notifications"
+      secondaryLabel="Optional"
+      description="We will only email you about important account activity."
+    >
+      Send me product updates
+    </Checkbox>
+  );
+};

--- a/docs-ui/src/app/components/checkbox/page.mdx
+++ b/docs-ui/src/app/components/checkbox/page.mdx
@@ -6,8 +6,9 @@ import {
   checkboxUsageSnippet,
   defaultSnippet,
   allVariantsSnippet,
+  withLabelSnippet,
 } from './snippets';
-import { Default, AllVariants } from './components';
+import { Default, AllVariants, WithLabel } from './components';
 import { PageTitle } from '@/components/PageTitle';
 import { Theming } from '@/components/Theming';
 import { CheckboxDefinition } from '../../../utils/definitions';
@@ -36,6 +37,20 @@ export const reactAriaUrls = {
 <ReactAriaLink component="Checkbox" href={reactAriaUrls.checkbox} />
 
 ## Examples
+
+### With label
+
+Use the `label`, `secondaryLabel`, and `description` props to render a field
+label above the checkbox, consistent with other form components like
+`TextField`.
+
+<Snippet
+  align="center"
+  py={4}
+  open
+  preview={<WithLabel />}
+  code={withLabelSnippet}
+/>
 
 ### All variants
 

--- a/docs-ui/src/app/components/checkbox/props-definition.ts
+++ b/docs-ui/src/app/components/checkbox/props-definition.ts
@@ -8,8 +8,20 @@ export const checkboxPropDefs: Record<string, PropDef> = {
   children: {
     type: 'enum',
     values: ['ReactNode'],
-    required: true,
-    description: 'Label displayed next to the checkbox.',
+    description: 'Inline label displayed next to the checkbox.',
+  },
+  label: {
+    type: 'string',
+    description: 'Visible label displayed above the checkbox.',
+  },
+  secondaryLabel: {
+    type: 'string',
+    description:
+      'Secondary text shown next to the label. If not provided and isRequired is true, displays "Required".',
+  },
+  description: {
+    type: 'string',
+    description: 'Help text displayed below the label.',
   },
   isSelected: {
     type: 'boolean',

--- a/docs-ui/src/app/components/checkbox/snippets.ts
+++ b/docs-ui/src/app/components/checkbox/snippets.ts
@@ -10,3 +10,11 @@ export const allVariantsSnippet = `<Flex direction="column" gap="2">
   <Checkbox isDisabled>Disabled</Checkbox>
   <Checkbox isSelected isDisabled>Checked & Disabled</Checkbox>
 </Flex>`;
+
+export const withLabelSnippet = `<Checkbox
+  label="Email notifications"
+  secondaryLabel="Optional"
+  description="We will only email you about important account activity."
+>
+  Send me product updates
+</Checkbox>`;

--- a/packages/ui/report.api.md
+++ b/packages/ui/report.api.md
@@ -895,12 +895,16 @@ export const CheckboxDefinition: {
     readonly [key: string]: string;
   };
   readonly classNames: {
-    readonly root: 'bui-Checkbox';
+    readonly root: 'bui-CheckboxField';
+    readonly checkbox: 'bui-Checkbox';
     readonly indicator: 'bui-CheckboxIndicator';
   };
   readonly propDefs: {
     readonly children: {};
     readonly className: {};
+    readonly label: {};
+    readonly description: {};
+    readonly secondaryLabel: {};
   };
 };
 
@@ -949,6 +953,9 @@ export interface CheckboxGroupProps
 export type CheckboxOwnProps = {
   children?: React.ReactNode;
   className?: string;
+  label?: FieldLabelProps['label'];
+  description?: FieldLabelProps['description'];
+  secondaryLabel?: FieldLabelProps['secondaryLabel'];
 };
 
 // @public (undocumented)

--- a/packages/ui/src/components/Checkbox/Checkbox.module.css
+++ b/packages/ui/src/components/Checkbox/Checkbox.module.css
@@ -17,6 +17,12 @@
 @layer tokens, base, components, utilities;
 
 @layer components {
+  .bui-CheckboxField {
+    display: flex;
+    flex-direction: column;
+    color: var(--bui-fg-primary);
+  }
+
   .bui-Checkbox {
     display: flex;
     flex-direction: row;

--- a/packages/ui/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/ui/src/components/Checkbox/Checkbox.stories.tsx
@@ -68,6 +68,37 @@ export const Invalid = Default.extend({
   },
 });
 
+export const WithLabel = meta.story({
+  args: {
+    label: 'Email notifications',
+    children: 'Send me product updates',
+  },
+});
+
+export const WithSecondaryLabel = meta.story({
+  args: {
+    label: 'Email notifications',
+    secondaryLabel: 'Optional',
+    children: 'Send me product updates',
+  },
+});
+
+export const WithDescription = meta.story({
+  args: {
+    label: 'Email notifications',
+    description: 'We will only email you about important account activity.',
+    children: 'Send me product updates',
+  },
+});
+
+export const Required = meta.story({
+  args: {
+    label: 'Terms and conditions',
+    isRequired: true,
+    children: 'I accept the terms and conditions',
+  },
+});
+
 export const AllVariants = meta.story({
   ...Default.input,
   render: () => (

--- a/packages/ui/src/components/Checkbox/Checkbox.tsx
+++ b/packages/ui/src/components/Checkbox/Checkbox.tsx
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-import { forwardRef, useEffect } from 'react';
+import { forwardRef, useEffect, useId } from 'react';
 import { Checkbox as RACheckbox } from 'react-aria-components';
 import type { CheckboxProps } from './types';
 import { useDefinition } from '../../hooks/useDefinition';
 import { CheckboxDefinition } from './definition';
+import { FieldLabel } from '../FieldLabel';
 import { RiCheckLine, RiSubtractLine } from '@remixicon/react';
 
 /**
@@ -32,38 +33,57 @@ export const Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(
       CheckboxDefinition,
       props,
     );
-    const { classes, children } = ownProps;
+    const { classes, children, label, secondaryLabel, description } = ownProps;
     const ariaLabel = restProps['aria-label'];
     const ariaLabelledBy = restProps['aria-labelledby'];
 
+    const generatedLabelId = useId();
+    const generatedDescriptionId = useId();
+    const labelId = label ? generatedLabelId : undefined;
+    const descriptionId = description ? generatedDescriptionId : undefined;
+
     useEffect(() => {
-      if (!children && !ariaLabel && !ariaLabelledBy) {
+      if (!label && !children && !ariaLabel && !ariaLabelledBy) {
         console.warn(
           'Checkbox requires either a visible label, aria-label, or aria-labelledby for accessibility',
         );
       }
-    }, [children, ariaLabel, ariaLabelledBy]);
+    }, [label, children, ariaLabel, ariaLabelledBy]);
+
+    // If a secondary label is provided, use it. Otherwise, use 'Required' if the field is required.
+    const secondaryLabelText =
+      secondaryLabel || (restProps.isRequired ? 'Required' : null);
 
     return (
-      <RACheckbox
-        ref={ref}
-        className={classes.root}
-        {...dataAttributes}
-        {...restProps}
-      >
-        {({ isIndeterminate }) => (
-          <>
-            <div className={classes.indicator} aria-hidden="true">
-              {isIndeterminate ? (
-                <RiSubtractLine size={12} />
-              ) : (
-                <RiCheckLine size={12} />
-              )}
-            </div>
-            {children != null && <div>{children}</div>}
-          </>
-        )}
-      </RACheckbox>
+      <div className={classes.root} {...dataAttributes}>
+        <FieldLabel
+          id={labelId}
+          label={label}
+          secondaryLabel={secondaryLabelText}
+          description={description}
+          descriptionId={descriptionId}
+        />
+        <RACheckbox
+          ref={ref}
+          className={classes.checkbox}
+          {...restProps}
+          aria-labelledby={labelId ?? ariaLabelledBy}
+          aria-describedby={descriptionId ?? restProps['aria-describedby']}
+        >
+          {({ isIndeterminate }) => (
+            <>
+              <div className={classes.indicator} aria-hidden="true">
+                {isIndeterminate ? (
+                  <RiSubtractLine size={12} />
+                ) : (
+                  <RiCheckLine size={12} />
+                )}
+              </div>
+              {children != null && <div>{children}</div>}
+            </>
+          )}
+        </RACheckbox>
+      </div>
     );
   },
 );

--- a/packages/ui/src/components/Checkbox/definition.ts
+++ b/packages/ui/src/components/Checkbox/definition.ts
@@ -25,11 +25,15 @@ import styles from './Checkbox.module.css';
 export const CheckboxDefinition = defineComponent<CheckboxOwnProps>()({
   styles,
   classNames: {
-    root: 'bui-Checkbox',
+    root: 'bui-CheckboxField',
+    checkbox: 'bui-Checkbox',
     indicator: 'bui-CheckboxIndicator',
   },
   propDefs: {
     children: {},
     className: {},
+    label: {},
+    description: {},
+    secondaryLabel: {},
   },
 });

--- a/packages/ui/src/components/Checkbox/types.ts
+++ b/packages/ui/src/components/Checkbox/types.ts
@@ -14,11 +14,19 @@
  * limitations under the License.
  */
 import type { CheckboxProps as RACheckboxProps } from 'react-aria-components';
+import type { FieldLabelProps } from '../FieldLabel/types';
 
 /** @public */
 export type CheckboxOwnProps = {
+  /**
+   * The inline label rendered next to the checkbox.
+   */
   children?: React.ReactNode;
   className?: string;
+
+  label?: FieldLabelProps['label'];
+  description?: FieldLabelProps['description'];
+  secondaryLabel?: FieldLabelProps['secondaryLabel'];
 };
 
 /** @public */


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds `label`, `secondaryLabel`, and `description` props to the `Checkbox` component so it can render a field label, optional secondary label, and help text consistently with other form components like `TextField` and `CheckboxGroup`.

### What changed
- `Checkbox` now accepts `label`, `secondaryLabel`, and `description` props, rendered above the control via the shared `FieldLabel` component.
- The existing inline label passed as `children` continues to work (non-breaking); when both are present, the field `label` provides the accessible name via `aria-labelledby`, and `description` is wired up via `aria-describedby`.
- Consistent with `TextField`/`CheckboxGroup`, a `Required` secondary label is shown automatically when `isRequired` is set and no `secondaryLabel` is provided.
- Storybook stories and the `docs-ui` Checkbox page (props table, snippet, and live example) updated to document the new props.
- Added a changeset (`patch` for `@backstage/ui`) and updated the API report.



<img width="1221" height="804" alt="BUI-Checkbox" src="https://github.com/user-attachments/assets/4d2059e0-b1ec-4126-b3da-f2d4e8d14fd9" />

Documentation Before:
<img width="1699" height="1216" alt="Screenshot 2026-06-10 at 16 28 27" src="https://github.com/user-attachments/assets/e5a04df3-88ff-451d-9213-1fa4f7edbf82" />

Documentation After: 
<img width="1699" height="1276" alt="Screenshot 2026-06-10 at 16 29 05" src="https://github.com/user-attachments/assets/34f856ea-7a13-43df-acc5-e443eacaa15c" />

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
