### PR TITLE
Fix Table component not filling container width in Firefox

### DIFF
--- a/.changeset/fix-table-firefox-width.md
+++ b/.changeset/fix-table-firefox-width.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed the Table component not filling its container width in Firefox. The `overflow` style is now applied to a wrapper element instead of the `<table>` element directly, which avoids a Firefox behavior where non-visible overflow on tables causes them to shrink-wrap to content size.

--- a/packages/ui/src/components/Table/Table.module.css
+++ b/packages/ui/src/components/Table/Table.module.css
@@ -30,6 +30,12 @@
     overflow: hidden;
   }
 
+  .bui-TableScrollContainer {
+    overflow: auto;
+    flex: 1;
+    min-height: 0;
+  }
+
   .bui-Table {
     /* Establishes containing block for react-aria's absolutely positioned hidden checkbox inputs, preventing them from escaping to a distant ancestor and creating phantom scroll height. */
     position: relative;
@@ -38,9 +44,6 @@
     border-collapse: collapse;
     table-layout: fixed;
     transition: opacity 0.2s ease-in-out;
-    overflow: auto;
-    flex: 1;
-    min-height: 0;
 
     &[data-stale='true'],
     &[data-ispending='true'] {

--- a/packages/ui/src/components/Table/components/Table.tsx
+++ b/packages/ui/src/components/Table/components/Table.tsx
@@ -184,86 +184,94 @@ export function Table<T extends TableItem>({
       elem
     );
 
+  const wrapScrollContainer = (elem: React.ReactNode) => (
+    <div className={classes.scrollContainer}>{elem}</div>
+  );
+
   return (
     <div className={classes.root} style={style}>
       <VisuallyHidden aria-live="polite" id={liveRegionId}>
         {liveRegionLabel}
       </VisuallyHidden>
       {wrapResizable(
-        wrapVirtualized(
-          <TableRoot
-            {...(isInitialLoading
-              ? {}
-              : {
-                  selectionMode,
-                  selectionBehavior,
-                  selectedKeys,
-                  onSelectionChange,
-                })}
-            sortDescriptor={sort?.descriptor ?? undefined}
-            onSortChange={sort?.onSortChange}
-            disabledKeys={disabledRows}
-            stale={isStale}
-            isPending={isInitialLoading}
-            aria-describedby={liveRegionId}
-          >
-            <TableHeader columns={visibleColumns}>
-              {column =>
-                column.header ? (
-                  column.header()
-                ) : (
-                  <Column
-                    id={column.id}
-                    isRowHeader={column.isRowHeader}
-                    allowsSorting={column.isSortable}
-                    width={column.width}
-                    defaultWidth={column.defaultWidth}
-                    minWidth={column.minWidth}
-                    maxWidth={column.maxWidth}
-                  >
-                    {column.label}
-                  </Column>
-                )
-              }
-            </TableHeader>
-            {isInitialLoading ? (
-              <TableBodySkeleton columns={visibleColumns} />
-            ) : (
-              <TableBody
-                items={data}
-                dependencies={[visibleColumns]}
-                renderEmptyState={
-                  emptyState ? () => <Flex p="3">{emptyState}</Flex> : undefined
-                }
-              >
-                {item => {
-                  const itemIndex = data?.indexOf(item) ?? -1;
-
-                  if (isRowRenderFn(rowConfig)) {
-                    return rowConfig({
-                      item,
-                      index: itemIndex,
-                    });
-                  }
-
-                  return (
-                    <Row
-                      id={String(item.id)}
-                      columns={visibleColumns}
-                      href={rowConfig?.getHref?.(item)}
-                      onAction={
-                        rowConfig?.onClick
-                          ? () => rowConfig?.onClick?.(item)
-                          : undefined
-                      }
+        wrapScrollContainer(
+          wrapVirtualized(
+            <TableRoot
+              {...(isInitialLoading
+                ? {}
+                : {
+                    selectionMode,
+                    selectionBehavior,
+                    selectedKeys,
+                    onSelectionChange,
+                  })}
+              sortDescriptor={sort?.descriptor ?? undefined}
+              onSortChange={sort?.onSortChange}
+              disabledKeys={disabledRows}
+              stale={isStale}
+              isPending={isInitialLoading}
+              aria-describedby={liveRegionId}
+            >
+              <TableHeader columns={visibleColumns}>
+                {column =>
+                  column.header ? (
+                    column.header()
+                  ) : (
+                    <Column
+                      id={column.id}
+                      isRowHeader={column.isRowHeader}
+                      allowsSorting={column.isSortable}
+                      width={column.width}
+                      defaultWidth={column.defaultWidth}
+                      minWidth={column.minWidth}
+                      maxWidth={column.maxWidth}
                     >
-                      {column => column.cell(item)}
-                    </Row>
-                  );
-                }}
-              </TableBody>
-            )}
-          </TableRoot>,
+                      {column.label}
+                    </Column>
+                  )
+                }
+              </TableHeader>
+              {isInitialLoading ? (
+                <TableBodySkeleton columns={visibleColumns} />
+              ) : (
+                <TableBody
+                  items={data}
+                  dependencies={[visibleColumns]}
+                  renderEmptyState={
+                    emptyState
+                      ? () => <Flex p="3">{emptyState}</Flex>
+                      : undefined
+                  }
+                >
+                  {item => {
+                    const itemIndex = data?.indexOf(item) ?? -1;
+
+                    if (isRowRenderFn(rowConfig)) {
+                      return rowConfig({
+                        item,
+                        index: itemIndex,
+                      });
+                    }
+
+                    return (
+                      <Row
+                        id={String(item.id)}
+                        columns={visibleColumns}
+                        href={rowConfig?.getHref?.(item)}
+                        onAction={
+                          rowConfig?.onClick
+                            ? () => rowConfig?.onClick?.(item)
+                            : undefined
+                        }
+                      >
+                        {column => column.cell(item)}
+                      </Row>
+                    );
+                  }}
+                </TableBody>
+              )}
+            </TableRoot>,
+          ),
         ),
       )}
       {pagination.type === 'page' && (

--- a/packages/ui/src/components/Table/definition.ts
+++ b/packages/ui/src/components/Table/definition.ts
@@ -35,6 +35,7 @@ export const TableWrapperDefinition = defineComponent<{
   classNames: {
     root: 'bui-TableWrapper',
     resizableContainer: 'bui-TableResizableContainer',
+    scrollContainer: 'bui-TableScrollContainer',
   },
   propDefs: {
     className: {},


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixed the `Table` component not filling its container width in Firefox by moving `overflow: auto` from the `<table>` element to a wrapper `<div>`.

Firefox creates an anonymous wrapper box around `<table>` elements with non-visible overflow (per CSS spec), causing them to shrink-wrap to content size instead of filling available width. Chrome and Safari are more lenient and ignore overflow on table elements.

This is an alternative approach to #34524 & #34047. That PR conditionally re-applies `overflow: auto` on the `<table>` via a `data-virtualized` attribute, which still hits the Firefox bug for virtualized tables. This PR moves `overflow: auto` to a `<div>` wrapper so it works correctly in all browsers regardless of virtualization mode.

Tested on my machine with Firefox 151.0.3 (aarch64), with the UI changes from https://github.com/backstage/backstage/pull/34350. 
<img width="1711" height="533" alt="firefox-broken" src="https://github.com/user-attachments/assets/9f3985e9-47a9-41a4-86f5-77ad73bbd4ef" />
<img width="1710" height="510" alt="firefox-fix" src="https://github.com/user-attachments/assets/b6da22cf-2238-4633-87f0-1b5684b3e722" />


#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.