### PR TITLE
cli: use cleye's built-in usage generation for command help

### DIFF
--- a/.changeset/cli-command-help-usage.md
+++ b/.changeset/cli-command-help-usage.md
@@ -1,0 +1,16 @@
+---
+'@backstage/cli-module-actions': patch
+'@backstage/cli-module-auth': patch
+'@backstage/cli-module-build': patch
+'@backstage/cli-module-config': patch
+'@backstage/cli-module-github': patch
+'@backstage/cli-module-info': patch
+'@backstage/cli-module-lint': patch
+'@backstage/cli-module-maintenance': patch
+'@backstage/cli-module-migrate': patch
+'@backstage/cli-module-new': patch
+'@backstage/cli-module-test-jest': patch
+'@backstage/cli-module-translations': patch
+---
+
+The `--help` output for commands now shows a generated usage line that lists the available flags and any positional arguments the command accepts.

--- a/packages/cli-module-actions/cli-report.md
+++ b/packages/cli-module-actions/cli-report.md
@@ -34,7 +34,7 @@ Commands:
 ### `backstage-cli-module-actions actions execute`
 
 ```
-Usage: @backstage/cli-module-actions actions execute
+Usage: @backstage/cli-module-actions actions execute [flags...] <action-id>
 
 Options:
   --instance <string>
@@ -44,7 +44,7 @@ Options:
 ### `backstage-cli-module-actions actions list`
 
 ```
-Usage: @backstage/cli-module-actions actions list
+Usage: @backstage/cli-module-actions actions list [flags...]
 
 Options:
   --instance <string>
@@ -69,7 +69,7 @@ Commands:
 ### `backstage-cli-module-actions actions sources add`
 
 ```
-Usage: @backstage/cli-module-actions actions sources add
+Usage: @backstage/cli-module-actions actions sources add [flags...] <plugin-ids...>
 
 Options:
   -h, --help
@@ -78,7 +78,7 @@ Options:
 ### `backstage-cli-module-actions actions sources list`
 
 ```
-Usage: @backstage/cli-module-actions actions sources list
+Usage: @backstage/cli-module-actions actions sources list [flags...]
 
 Options:
   -h, --help
@@ -87,7 +87,7 @@ Options:
 ### `backstage-cli-module-actions actions sources remove`
 
 ```
-Usage: @backstage/cli-module-actions actions sources remove
+Usage: @backstage/cli-module-actions actions sources remove [flags...] <plugin-ids...>
 
 Options:
   -h, --help

--- a/packages/cli-module-actions/package.json
+++ b/packages/cli-module-actions/package.json
@@ -36,7 +36,7 @@
     "@backstage/cli-node": "workspace:^",
     "@backstage/errors": "workspace:^",
     "chalk": "^4.0.0",
-    "cleye": "^2.3.0",
+    "cleye": "^2.6.0",
     "marked": "^15.0.12",
     "marked-terminal": "^7.3.0",
     "strip-ansi": "^7.1.0",

--- a/packages/cli-module-actions/src/commands/execute.ts
+++ b/packages/cli-module-actions/src/commands/execute.ts
@@ -52,7 +52,7 @@ function showGenericHelp(
 ): void {
   cli(
     {
-      help: info,
+      name: info.usage,
       parameters: ['<action-id>'],
       flags: {
         instance: {
@@ -140,7 +140,7 @@ export default async ({ args, info }: CliCommandContext) => {
 
   const { flags } = cli(
     {
-      help: info,
+      name: info.usage,
       flags: {
         ...schemaFlags,
         instance: {

--- a/packages/cli-module-actions/src/commands/list.ts
+++ b/packages/cli-module-actions/src/commands/list.ts
@@ -25,7 +25,7 @@ export default async ({ args, info }: CliCommandContext) => {
     flags: { instance: instanceFlag },
   } = cli(
     {
-      help: info,
+      name: info.usage,
       flags: {
         instance: {
           type: String,

--- a/packages/cli-module-actions/src/commands/sourcesAdd.ts
+++ b/packages/cli-module-actions/src/commands/sourcesAdd.ts
@@ -21,7 +21,7 @@ import { pluginSourcesSchema } from '../lib/pluginSources';
 export default async ({ args, info }: CliCommandContext) => {
   const parsed = cli(
     {
-      help: info,
+      name: info.usage,
       parameters: ['<plugin-ids...>'],
     },
     undefined,

--- a/packages/cli-module-actions/src/commands/sourcesList.ts
+++ b/packages/cli-module-actions/src/commands/sourcesList.ts
@@ -19,7 +19,7 @@ import { CliAuth, type CliCommandContext } from '@backstage/cli-node';
 import { pluginSourcesSchema } from '../lib/pluginSources';
 
 export default async ({ args, info }: CliCommandContext) => {
-  cli({ help: info }, undefined, args);
+  cli({ name: info.usage }, undefined, args);
 
   const auth = await CliAuth.create();
   const sources = pluginSourcesSchema.parse(

--- a/packages/cli-module-actions/src/commands/sourcesRemove.ts
+++ b/packages/cli-module-actions/src/commands/sourcesRemove.ts
@@ -21,7 +21,7 @@ import { pluginSourcesSchema } from '../lib/pluginSources';
 export default async ({ args, info }: CliCommandContext) => {
   const parsed = cli(
     {
-      help: info,
+      name: info.usage,
       parameters: ['<plugin-ids...>'],
     },
     undefined,

--- a/packages/cli-module-auth/cli-report.md
+++ b/packages/cli-module-auth/cli-report.md
@@ -37,7 +37,7 @@ Commands:
 ### `backstage-cli-module-auth auth list`
 
 ```
-Usage: @backstage/cli-module-auth auth list
+Usage: @backstage/cli-module-auth auth list [flags...]
 
 Options:
   -h, --help
@@ -46,7 +46,7 @@ Options:
 ### `backstage-cli-module-auth auth login`
 
 ```
-Usage: @backstage/cli-module-auth auth login
+Usage: @backstage/cli-module-auth auth login [flags...]
 
 Options:
   --backend-url <string>
@@ -58,7 +58,7 @@ Options:
 ### `backstage-cli-module-auth auth logout`
 
 ```
-Usage: @backstage/cli-module-auth auth logout
+Usage: @backstage/cli-module-auth auth logout [flags...]
 
 Options:
   --instance <string>
@@ -68,7 +68,7 @@ Options:
 ### `backstage-cli-module-auth auth print-token`
 
 ```
-Usage: @backstage/cli-module-auth auth print-token
+Usage: @backstage/cli-module-auth auth print-token [flags...]
 
 Options:
   --instance <string>
@@ -78,7 +78,7 @@ Options:
 ### `backstage-cli-module-auth auth select`
 
 ```
-Usage: @backstage/cli-module-auth auth select
+Usage: @backstage/cli-module-auth auth select [flags...]
 
 Options:
   --instance <string>
@@ -88,7 +88,7 @@ Options:
 ### `backstage-cli-module-auth auth show`
 
 ```
-Usage: @backstage/cli-module-auth auth show
+Usage: @backstage/cli-module-auth auth show [flags...]
 
 Options:
   --instance <string>

--- a/packages/cli-module-auth/package.json
+++ b/packages/cli-module-auth/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@backstage/cli-node": "workspace:^",
     "@backstage/errors": "workspace:^",
-    "cleye": "^2.3.0",
+    "cleye": "^2.6.0",
     "fs-extra": "^11.2.0",
     "glob": "^13.0.0",
     "inquirer": "^8.2.0",

--- a/packages/cli-module-auth/src/commands/list.ts
+++ b/packages/cli-module-auth/src/commands/list.ts
@@ -19,7 +19,7 @@ import type { CliCommandContext } from '@backstage/cli-node';
 import { getAllInstances } from '../lib/storage';
 
 export default async ({ args, info }: CliCommandContext) => {
-  cli({ help: info }, undefined, args);
+  cli({ name: info.usage }, undefined, args);
 
   const { instances, selected } = await getAllInstances();
   if (!instances.length) {

--- a/packages/cli-module-auth/src/commands/login.ts
+++ b/packages/cli-module-auth/src/commands/login.ts
@@ -42,7 +42,7 @@ export default async ({ args, info }: CliCommandContext) => {
     flags: { backendUrl, noBrowser, instance: instanceFlag },
   } = cli(
     {
-      help: info,
+      name: info.usage,
       flags: {
         backendUrl: { type: String, description: 'Backend base URL' },
         noBrowser: {

--- a/packages/cli-module-auth/src/commands/logout.ts
+++ b/packages/cli-module-auth/src/commands/logout.ts
@@ -30,7 +30,7 @@ export default async ({ args, info }: CliCommandContext) => {
     flags: { instance: instanceFlag },
   } = cli(
     {
-      help: info,
+      name: info.usage,
       flags: {
         instance: {
           type: String,

--- a/packages/cli-module-auth/src/commands/printToken.ts
+++ b/packages/cli-module-auth/src/commands/printToken.ts
@@ -22,7 +22,7 @@ export default async ({ args, info }: CliCommandContext) => {
     flags: { instance: instanceFlag },
   } = cli(
     {
-      help: info,
+      name: info.usage,
       flags: {
         instance: {
           type: String,

--- a/packages/cli-module-auth/src/commands/select.ts
+++ b/packages/cli-module-auth/src/commands/select.ts
@@ -24,7 +24,7 @@ export default async ({ args, info }: CliCommandContext) => {
     flags: { instance: instanceFlag },
   } = cli(
     {
-      help: info,
+      name: info.usage,
       flags: {
         instance: {
           type: String,

--- a/packages/cli-module-auth/src/commands/show.ts
+++ b/packages/cli-module-auth/src/commands/show.ts
@@ -23,7 +23,7 @@ export default async ({ args, info }: CliCommandContext) => {
     flags: { instance: instanceFlag },
   } = cli(
     {
-      help: info,
+      name: info.usage,
       flags: {
         instance: {
           type: String,

--- a/packages/cli-module-build/cli-report.md
+++ b/packages/cli-module-build/cli-report.md
@@ -21,7 +21,7 @@ Commands:
 ### `backstage-cli-module-build build-workspace`
 
 ```
-Usage: @backstage/cli-module-build build-workspace <workspace-dir> [packages...]
+Usage: @backstage/cli-module-build build-workspace [flags...] <workspace-dir> [packages...]
 
 Options:
   --always-pack
@@ -48,7 +48,7 @@ Commands:
 ### `backstage-cli-module-build package build`
 
 ```
-Usage: @backstage/cli-module-build package build
+Usage: @backstage/cli-module-build package build [flags...]
 
 Options:
   --config <string>
@@ -63,7 +63,7 @@ Options:
 ### `backstage-cli-module-build package clean`
 
 ```
-Usage: @backstage/cli-module-build package clean
+Usage: @backstage/cli-module-build package clean [flags...]
 
 Options:
   -h, --help
@@ -72,7 +72,7 @@ Options:
 ### `backstage-cli-module-build package postpack`
 
 ```
-Usage: @backstage/cli-module-build package postpack
+Usage: @backstage/cli-module-build package postpack [flags...]
 
 Options:
   -h, --help
@@ -81,7 +81,7 @@ Options:
 ### `backstage-cli-module-build package prepack`
 
 ```
-Usage: @backstage/cli-module-build package prepack
+Usage: @backstage/cli-module-build package prepack [flags...]
 
 Options:
   -h, --help
@@ -90,7 +90,7 @@ Options:
 ### `backstage-cli-module-build package start`
 
 ```
-Usage: @backstage/cli-module-build package start
+Usage: @backstage/cli-module-build package start [flags...]
 
 Options:
   --check
@@ -122,7 +122,7 @@ Commands:
 ### `backstage-cli-module-build repo build`
 
 ```
-Usage: @backstage/cli-module-build repo build
+Usage: @backstage/cli-module-build repo build [flags...]
 
 Options:
   --all
@@ -134,7 +134,7 @@ Options:
 ### `backstage-cli-module-build repo clean`
 
 ```
-Usage: @backstage/cli-module-build repo clean
+Usage: @backstage/cli-module-build repo clean [flags...]
 
 Options:
   -h, --help
@@ -143,7 +143,7 @@ Options:
 ### `backstage-cli-module-build repo start`
 
 ```
-Usage: @backstage/cli-module-build repo start [packages...]
+Usage: @backstage/cli-module-build repo start [flags...] [packages...]
 
 Options:
   --config <string>

--- a/packages/cli-module-build/package.json
+++ b/packages/cli-module-build/package.json
@@ -61,7 +61,7 @@
     "buffer": "^6.0.3",
     "chalk": "^4.0.0",
     "chokidar": "^3.3.1",
-    "cleye": "^2.3.0",
+    "cleye": "^2.6.0",
     "cross-spawn": "^7.0.3",
     "css-loader": "^6.5.1",
     "ctrlc-windows": "^2.1.0",

--- a/packages/cli-module-build/src/commands/buildWorkspace.ts
+++ b/packages/cli-module-build/src/commands/buildWorkspace.ts
@@ -37,7 +37,7 @@ export default async ({ args, info }: CliCommandContext) => {
     _: positionals,
   } = cli(
     {
-      help: { ...info, usage: `${info.usage} <workspace-dir> [packages...]` },
+      name: info.usage,
       booleanFlagNegation: true,
       parameters: ['<workspace-dir>', '[packages...]'],
       flags: {

--- a/packages/cli-module-build/src/commands/package/build/command.ts
+++ b/packages/cli-module-build/src/commands/package/build/command.ts
@@ -43,7 +43,7 @@ export default async ({ args, info }: CliCommandContext) => {
     },
   } = cli(
     {
-      help: info,
+      name: info.usage,
       booleanFlagNegation: true,
       flags: {
         role: {

--- a/packages/cli-module-build/src/commands/package/bundle/command.ts
+++ b/packages/cli-module-build/src/commands/package/bundle/command.ts
@@ -918,7 +918,7 @@ export default async ({ args, info }: CliCommandContext) => {
     },
   } = cli(
     {
-      help: info,
+      name: info.usage,
       flags: {
         outputDestination: {
           type: String,

--- a/packages/cli-module-build/src/commands/package/clean.ts
+++ b/packages/cli-module-build/src/commands/package/clean.ts
@@ -20,7 +20,7 @@ import { targetPaths } from '@backstage/cli-common';
 import type { CliCommandContext } from '@backstage/cli-node';
 
 export default async ({ args, info }: CliCommandContext) => {
-  cli({ help: info, booleanFlagNegation: true }, undefined, args);
+  cli({ name: info.usage, booleanFlagNegation: true }, undefined, args);
   await fs.remove(targetPaths.resolve('dist'));
   await fs.remove(targetPaths.resolve('dist-types'));
   await fs.remove(targetPaths.resolve('coverage'));

--- a/packages/cli-module-build/src/commands/package/postpack.ts
+++ b/packages/cli-module-build/src/commands/package/postpack.ts
@@ -20,6 +20,6 @@ import { revertProductionPack } from '../../lib/packager/productionPack';
 import type { CliCommandContext } from '@backstage/cli-node';
 
 export default async ({ args, info }: CliCommandContext) => {
-  cli({ help: info, booleanFlagNegation: true }, undefined, args);
+  cli({ name: info.usage, booleanFlagNegation: true }, undefined, args);
   await revertProductionPack(targetPaths.dir);
 };

--- a/packages/cli-module-build/src/commands/package/prepack.ts
+++ b/packages/cli-module-build/src/commands/package/prepack.ts
@@ -23,7 +23,7 @@ import { createTypeDistProject } from '../../lib/typeDistProject';
 import type { CliCommandContext } from '@backstage/cli-node';
 
 export default async ({ args, info }: CliCommandContext) => {
-  cli({ help: info, booleanFlagNegation: true }, undefined, args);
+  cli({ name: info.usage, booleanFlagNegation: true }, undefined, args);
 
   publishPreflightCheck({
     dir: targetPaths.dir,

--- a/packages/cli-module-build/src/commands/package/start/command.ts
+++ b/packages/cli-module-build/src/commands/package/start/command.ts
@@ -35,7 +35,7 @@ export default async ({ args, info }: CliCommandContext) => {
     },
   } = cli(
     {
-      help: info,
+      name: info.usage,
       booleanFlagNegation: true,
       flags: {
         config: {

--- a/packages/cli-module-build/src/commands/repo/build.ts
+++ b/packages/cli-module-build/src/commands/repo/build.ts
@@ -36,7 +36,7 @@ export default async ({ args, info }: CliCommandContext) => {
     flags: { all, since, minify },
   } = cli(
     {
-      help: info,
+      name: info.usage,
       booleanFlagNegation: true,
       flags: {
         all: {

--- a/packages/cli-module-build/src/commands/repo/clean.ts
+++ b/packages/cli-module-build/src/commands/repo/clean.ts
@@ -22,7 +22,7 @@ import { run, targetPaths } from '@backstage/cli-common';
 import type { CliCommandContext } from '@backstage/cli-node';
 
 export default async ({ args, info }: CliCommandContext) => {
-  cli({ help: info, booleanFlagNegation: true }, undefined, args);
+  cli({ name: info.usage, booleanFlagNegation: true }, undefined, args);
   const packages = await PackageGraph.listTargetPackages();
 
   await fs.remove(targetPaths.resolveRoot('dist'));

--- a/packages/cli-module-build/src/commands/repo/start.ts
+++ b/packages/cli-module-build/src/commands/repo/start.ts
@@ -41,7 +41,7 @@ export default async ({ args, info }: CliCommandContext) => {
     _: namesOrPaths,
   } = cli(
     {
-      help: { ...info, usage: `${info.usage} [packages...]` },
+      name: info.usage,
       booleanFlagNegation: true,
       parameters: ['[packages...]'],
       flags: {

--- a/packages/cli-module-config/cli-report.md
+++ b/packages/cli-module-config/cli-report.md
@@ -37,7 +37,7 @@ Commands:
 ### `backstage-cli-module-config config docs`
 
 ```
-Usage: @backstage/cli-module-config config docs
+Usage: @backstage/cli-module-config config docs [flags...]
 
 Options:
   --package <string>
@@ -47,7 +47,7 @@ Options:
 ### `backstage-cli-module-config config schema`
 
 ```
-Usage: @backstage/cli-module-config config schema
+Usage: @backstage/cli-module-config config schema [flags...]
 
 Options:
   --format <string>
@@ -59,7 +59,7 @@ Options:
 ### `backstage-cli-module-config config:check`
 
 ```
-Usage: @backstage/cli-module-config config:check
+Usage: @backstage/cli-module-config config:check [flags...]
 
 Options:
   --config <string>
@@ -74,7 +74,7 @@ Options:
 ### `backstage-cli-module-config config:docs`
 
 ```
-Usage: @backstage/cli-module-config config:docs
+Usage: @backstage/cli-module-config config:docs [flags...]
 
 Options:
   --package <string>
@@ -84,7 +84,7 @@ Options:
 ### `backstage-cli-module-config config:print`
 
 ```
-Usage: @backstage/cli-module-config config:print
+Usage: @backstage/cli-module-config config:print [flags...]
 
 Options:
   --config <string>
@@ -99,7 +99,7 @@ Options:
 ### `backstage-cli-module-config config:schema`
 
 ```
-Usage: @backstage/cli-module-config config:schema
+Usage: @backstage/cli-module-config config:schema [flags...]
 
 Options:
   --format <string>

--- a/packages/cli-module-config/package.json
+++ b/packages/cli-module-config/package.json
@@ -40,7 +40,7 @@
     "@backstage/types": "workspace:^",
     "@manypkg/get-packages": "^1.1.3",
     "chalk": "^4.0.0",
-    "cleye": "^2.3.0",
+    "cleye": "^2.6.0",
     "json-schema": "^0.4.0",
     "react-dev-utils": "^12.0.0-next.60",
     "yaml": "^2.0.0"

--- a/packages/cli-module-config/src/commands/docs.ts
+++ b/packages/cli-module-config/src/commands/docs.ts
@@ -30,7 +30,7 @@ export default async ({ args, info }: CliCommandContext) => {
     flags: { package: pkg },
   } = cli(
     {
-      help: info,
+      name: info.usage,
       booleanFlagNegation: true,
       flags: {
         package: {

--- a/packages/cli-module-config/src/commands/print.ts
+++ b/packages/cli-module-config/src/commands/print.ts
@@ -26,7 +26,7 @@ export default async ({ args, info }: CliCommandContext) => {
     flags: { config, lax, frontend, withSecrets, format, package: pkg },
   } = cli(
     {
-      help: info,
+      name: info.usage,
       booleanFlagNegation: true,
       flags: {
         package: { type: String, description: 'Package to print config for' },

--- a/packages/cli-module-config/src/commands/schema.ts
+++ b/packages/cli-module-config/src/commands/schema.ts
@@ -27,7 +27,7 @@ export default async ({ args, info }: CliCommandContext) => {
     flags: { merge, format, package: pkg },
   } = cli(
     {
-      help: info,
+      name: info.usage,
       booleanFlagNegation: true,
       flags: {
         package: { type: String, description: 'Package to print schema for' },

--- a/packages/cli-module-config/src/commands/validate.ts
+++ b/packages/cli-module-config/src/commands/validate.ts
@@ -23,7 +23,7 @@ export default async ({ args, info }: CliCommandContext) => {
     flags: { config, lax, frontend, deprecated, strict, package: pkg },
   } = cli(
     {
-      help: info,
+      name: info.usage,
       booleanFlagNegation: true,
       flags: {
         package: {

--- a/packages/cli-module-github/cli-report.md
+++ b/packages/cli-module-github/cli-report.md
@@ -19,7 +19,7 @@ Commands:
 ### `backstage-cli-module-github create-github-app`
 
 ```
-Usage: @backstage/cli-module-github create-github-app <github-org>
+Usage: @backstage/cli-module-github create-github-app [flags...] <github-org>
 
 Options:
   -h, --help

--- a/packages/cli-module-github/package.json
+++ b/packages/cli-module-github/package.json
@@ -37,7 +37,7 @@
     "@backstage/cli-node": "workspace:^",
     "@octokit/request": "^8.0.0",
     "chalk": "^4.0.0",
-    "cleye": "^2.3.0",
+    "cleye": "^2.6.0",
     "express": "^4.22.0",
     "fs-extra": "^11.2.0",
     "inquirer": "^8.2.0",

--- a/packages/cli-module-github/src/commands/create-github-app/index.ts
+++ b/packages/cli-module-github/src/commands/create-github-app/index.ts
@@ -31,7 +31,7 @@ import type { CliCommandContext } from '@backstage/cli-node';
 export default async ({ args, info }: CliCommandContext) => {
   const { _: positionals } = cli(
     {
-      help: { ...info, usage: `${info.usage} <github-org>` },
+      name: info.usage,
       booleanFlagNegation: true,
       parameters: ['<github-org>'],
     },

--- a/packages/cli-module-info/cli-report.md
+++ b/packages/cli-module-info/cli-report.md
@@ -19,7 +19,7 @@ Commands:
 ### `backstage-cli-module-info info`
 
 ```
-Usage: @backstage/cli-module-info info
+Usage: @backstage/cli-module-info info [flags...]
 
 Options:
   --format <string>

--- a/packages/cli-module-info/package.json
+++ b/packages/cli-module-info/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@backstage/cli-common": "workspace:^",
     "@backstage/cli-node": "workspace:^",
-    "cleye": "^2.3.0",
+    "cleye": "^2.6.0",
     "fs-extra": "^11.2.0",
     "minimatch": "^10.2.1"
   },

--- a/packages/cli-module-info/src/commands/info.ts
+++ b/packages/cli-module-info/src/commands/info.ts
@@ -57,7 +57,7 @@ export default async ({ args, info }: CliCommandContext) => {
     flags: { include, format },
   } = cli(
     {
-      help: info,
+      name: info.usage,
       booleanFlagNegation: true,
       flags: {
         include: {

--- a/packages/cli-module-lint/cli-report.md
+++ b/packages/cli-module-lint/cli-report.md
@@ -33,7 +33,7 @@ Commands:
 ### `backstage-cli-module-lint package lint`
 
 ```
-Usage: @backstage/cli-module-lint package lint [directories...]
+Usage: @backstage/cli-module-lint package lint [flags...] [directories...]
 
 Options:
   --fix
@@ -59,7 +59,7 @@ Commands:
 ### `backstage-cli-module-lint repo lint`
 
 ```
-Usage: @backstage/cli-module-lint repo lint
+Usage: @backstage/cli-module-lint repo lint [flags...]
 
 Options:
   --fix

--- a/packages/cli-module-lint/package.json
+++ b/packages/cli-module-lint/package.json
@@ -36,7 +36,7 @@
     "@backstage/cli-common": "workspace:^",
     "@backstage/cli-node": "workspace:^",
     "chalk": "^4.0.0",
-    "cleye": "^2.3.0",
+    "cleye": "^2.6.0",
     "eslint": "^8.6.0",
     "eslint-formatter-friendly": "^7.0.0",
     "fs-extra": "^11.2.0",

--- a/packages/cli-module-lint/src/commands/package/lint.ts
+++ b/packages/cli-module-lint/src/commands/package/lint.ts
@@ -26,7 +26,7 @@ export default async ({ args, info }: CliCommandContext) => {
     _: directories,
   } = cli(
     {
-      help: { ...info, usage: `${info.usage} [directories...]` },
+      name: info.usage,
       booleanFlagNegation: true,
       parameters: ['[directories...]'],
       flags: {

--- a/packages/cli-module-lint/src/commands/repo/lint.ts
+++ b/packages/cli-module-lint/src/commands/repo/lint.ts
@@ -65,7 +65,7 @@ export default async ({ args, info }: CliCommandContext) => {
     },
   } = cli(
     {
-      help: info,
+      name: info.usage,
       booleanFlagNegation: true,
       flags: {
         fix: {

--- a/packages/cli-module-maintenance/cli-report.md
+++ b/packages/cli-module-maintenance/cli-report.md
@@ -33,7 +33,7 @@ Commands:
 ### `backstage-cli-module-maintenance repo fix`
 
 ```
-Usage: @backstage/cli-module-maintenance repo fix
+Usage: @backstage/cli-module-maintenance repo fix [flags...]
 
 Options:
   --check
@@ -44,7 +44,7 @@ Options:
 ### `backstage-cli-module-maintenance repo list-deprecations`
 
 ```
-Usage: @backstage/cli-module-maintenance repo list-deprecations
+Usage: @backstage/cli-module-maintenance repo list-deprecations [flags...]
 
 Options:
   --json

--- a/packages/cli-module-maintenance/package.json
+++ b/packages/cli-module-maintenance/package.json
@@ -36,7 +36,7 @@
     "@backstage/cli-common": "workspace:^",
     "@backstage/cli-node": "workspace:^",
     "chalk": "^4.0.0",
-    "cleye": "^2.3.0",
+    "cleye": "^2.6.0",
     "eslint": "^8.6.0",
     "fs-extra": "^11.2.0"
   },

--- a/packages/cli-module-maintenance/src/commands/repo/fix.ts
+++ b/packages/cli-module-maintenance/src/commands/repo/fix.ts
@@ -500,7 +500,7 @@ export default async ({
     flags: { publish, check },
   } = cli(
     {
-      help: info,
+      name: info.usage,
       booleanFlagNegation: true,
       flags: {
         publish: {

--- a/packages/cli-module-maintenance/src/commands/repo/list-deprecations.ts
+++ b/packages/cli-module-maintenance/src/commands/repo/list-deprecations.ts
@@ -27,7 +27,7 @@ export default async ({ args, info }: CliCommandContext) => {
     flags: { json },
   } = cli(
     {
-      help: info,
+      name: info.usage,
       booleanFlagNegation: true,
       flags: {
         json: { type: Boolean, description: 'Output as JSON' },

--- a/packages/cli-module-migrate/cli-report.md
+++ b/packages/cli-module-migrate/cli-report.md
@@ -38,7 +38,7 @@ Commands:
 ### `backstage-cli-module-migrate migrate package-exports`
 
 ```
-Usage: @backstage/cli-module-migrate migrate package-exports
+Usage: @backstage/cli-module-migrate migrate package-exports [flags...]
 
 Options:
   -h, --help
@@ -47,7 +47,7 @@ Options:
 ### `backstage-cli-module-migrate migrate package-lint-configs`
 
 ```
-Usage: @backstage/cli-module-migrate migrate package-lint-configs
+Usage: @backstage/cli-module-migrate migrate package-lint-configs [flags...]
 
 Options:
   -h, --help
@@ -56,7 +56,7 @@ Options:
 ### `backstage-cli-module-migrate migrate package-roles`
 
 ```
-Usage: @backstage/cli-module-migrate migrate package-roles
+Usage: @backstage/cli-module-migrate migrate package-roles [flags...]
 
 Options:
   -h, --help
@@ -65,7 +65,7 @@ Options:
 ### `backstage-cli-module-migrate migrate package-scripts`
 
 ```
-Usage: @backstage/cli-module-migrate migrate package-scripts
+Usage: @backstage/cli-module-migrate migrate package-scripts [flags...]
 
 Options:
   -h, --help
@@ -74,7 +74,7 @@ Options:
 ### `backstage-cli-module-migrate migrate react-router-deps`
 
 ```
-Usage: @backstage/cli-module-migrate migrate react-router-deps
+Usage: @backstage/cli-module-migrate migrate react-router-deps [flags...]
 
 Options:
   -h, --help
@@ -83,7 +83,7 @@ Options:
 ### `backstage-cli-module-migrate versions:bump`
 
 ```
-Usage: @backstage/cli-module-migrate versions:bump
+Usage: @backstage/cli-module-migrate versions:bump [flags...]
 
 Options:
   --pattern <string>
@@ -96,7 +96,7 @@ Options:
 ### `backstage-cli-module-migrate versions:migrate`
 
 ```
-Usage: @backstage/cli-module-migrate versions:migrate
+Usage: @backstage/cli-module-migrate versions:migrate [flags...]
 
 Options:
   --pattern <string>

--- a/packages/cli-module-migrate/package.json
+++ b/packages/cli-module-migrate/package.json
@@ -39,7 +39,7 @@
     "@backstage/release-manifests": "workspace:^",
     "@manypkg/get-packages": "^1.1.3",
     "chalk": "^4.0.0",
-    "cleye": "^2.3.0",
+    "cleye": "^2.6.0",
     "fs-extra": "^11.2.0",
     "minimatch": "^10.2.1",
     "ora": "^5.3.0",

--- a/packages/cli-module-migrate/src/commands/packageExports.ts
+++ b/packages/cli-module-migrate/src/commands/packageExports.ts
@@ -18,7 +18,7 @@ import { cli } from 'cleye';
 import type { CliCommandContext } from '@backstage/cli-node';
 
 export default async ({ args, info }: CliCommandContext) => {
-  cli({ help: info, booleanFlagNegation: true }, undefined, args);
+  cli({ name: info.usage, booleanFlagNegation: true }, undefined, args);
   throw new Error(
     'The `migrate package-exports` command has been removed, use `repo fix` instead.',
   );

--- a/packages/cli-module-migrate/src/commands/packageLintConfigs.ts
+++ b/packages/cli-module-migrate/src/commands/packageLintConfigs.ts
@@ -24,7 +24,7 @@ import type { CliCommandContext } from '@backstage/cli-node';
 const PREFIX = `module.exports = require('@backstage/cli/config/eslint-factory')`;
 
 export default async ({ args, info }: CliCommandContext) => {
-  cli({ help: info, booleanFlagNegation: true }, undefined, args);
+  cli({ name: info.usage, booleanFlagNegation: true }, undefined, args);
   const packages = await PackageGraph.listTargetPackages();
 
   const oldConfigs = [

--- a/packages/cli-module-migrate/src/commands/packageRole.ts
+++ b/packages/cli-module-migrate/src/commands/packageRole.ts
@@ -23,7 +23,7 @@ import { targetPaths } from '@backstage/cli-common';
 import type { CliCommandContext } from '@backstage/cli-node';
 
 export default async ({ args, info }: CliCommandContext) => {
-  cli({ help: info, booleanFlagNegation: true }, undefined, args);
+  cli({ name: info.usage, booleanFlagNegation: true }, undefined, args);
   const { packages } = await getPackages(targetPaths.dir);
 
   await Promise.all(

--- a/packages/cli-module-migrate/src/commands/packageScripts.ts
+++ b/packages/cli-module-migrate/src/commands/packageScripts.ts
@@ -25,7 +25,7 @@ const configArgPattern = /--config[=\s][^\s$]+/;
 const noStartRoles: PackageRole[] = ['cli', 'cli-module', 'common-library'];
 
 export default async ({ args, info }: CliCommandContext) => {
-  cli({ help: info, booleanFlagNegation: true }, undefined, args);
+  cli({ name: info.usage, booleanFlagNegation: true }, undefined, args);
   const packages = await PackageGraph.listTargetPackages();
 
   await Promise.all(

--- a/packages/cli-module-migrate/src/commands/reactRouterDeps.ts
+++ b/packages/cli-module-migrate/src/commands/reactRouterDeps.ts
@@ -24,7 +24,7 @@ const REACT_ROUTER_DEPS = ['react-router', 'react-router-dom'];
 const REACT_ROUTER_RANGE = '6.0.0-beta.0 || ^6.3.0';
 
 export default async ({ args, info }: CliCommandContext) => {
-  cli({ help: info, booleanFlagNegation: true }, undefined, args);
+  cli({ name: info.usage, booleanFlagNegation: true }, undefined, args);
   const packages = await PackageGraph.listTargetPackages();
 
   await Promise.all(

--- a/packages/cli-module-migrate/src/commands/versions/bump.ts
+++ b/packages/cli-module-migrate/src/commands/versions/bump.ts
@@ -79,7 +79,7 @@ export default async ({ args, info }: CliCommandContext) => {
     flags: { pattern: patternFlag, release, skipInstall, skipMigrate },
   } = cli(
     {
-      help: info,
+      name: info.usage,
       booleanFlagNegation: true,
       flags: {
         pattern: {

--- a/packages/cli-module-migrate/src/commands/versions/migrate.ts
+++ b/packages/cli-module-migrate/src/commands/versions/migrate.ts
@@ -44,7 +44,7 @@ export default async ({ args, info }: CliCommandContext) => {
     flags: { pattern, skipCodeChanges },
   } = cli(
     {
-      help: info,
+      name: info.usage,
       booleanFlagNegation: true,
       flags: {
         pattern: {

--- a/packages/cli-module-new/cli-report.md
+++ b/packages/cli-module-new/cli-report.md
@@ -19,7 +19,7 @@ Commands:
 ### `backstage-cli-module-new new`
 
 ```
-Usage: @backstage/cli-module-new new
+Usage: @backstage/cli-module-new new [flags...]
 
 Options:
   --base-version <string>

--- a/packages/cli-module-new/package.json
+++ b/packages/cli-module-new/package.json
@@ -38,7 +38,7 @@
     "@backstage/cli-node": "workspace:^",
     "@backstage/errors": "workspace:^",
     "chalk": "^4.0.0",
-    "cleye": "^2.3.0",
+    "cleye": "^2.6.0",
     "fs-extra": "^11.2.0",
     "handlebars": "^4.7.3",
     "inquirer": "^8.2.0",

--- a/packages/cli-module-new/src/commands/new.ts
+++ b/packages/cli-module-new/src/commands/new.ts
@@ -40,7 +40,7 @@ export default async ({ args, info }: CliCommandContext) => {
     },
   } = cli(
     {
-      help: info,
+      name: info.usage,
       booleanFlagNegation: true,
       flags: {
         select: {

--- a/packages/cli-module-new/templates/cli-module/package.json.hbs
+++ b/packages/cli-module-new/templates/cli-module/package.json.hbs
@@ -22,7 +22,7 @@
   "dependencies": {
     "@backstage/cli-common": "{{versionQuery '@backstage/cli-common'}}",
     "@backstage/cli-node": "{{versionQuery '@backstage/cli-node'}}",
-    "cleye": "^2.3.0"
+    "cleye": "^2.6.0"
   },
   "devDependencies": {
     "@backstage/cli": "{{versionQuery '@backstage/cli'}}"

--- a/packages/cli-module-new/templates/cli-module/src/commands/example.ts
+++ b/packages/cli-module-new/templates/cli-module/src/commands/example.ts
@@ -4,7 +4,7 @@ import type { CliCommandContext } from '@backstage/cli-node';
 export default async ({ args, info }: CliCommandContext) => {
   const { flags } = cli(
     {
-      help: info,
+      name: info.usage,
       booleanFlagNegation: true,
       flags: {
         name: {

--- a/packages/cli-module-test-jest/cli-report.md
+++ b/packages/cli-module-test-jest/cli-report.md
@@ -159,7 +159,7 @@ Commands:
 ### `backstage-cli-module-test-jest repo test`
 
 ```
-Usage: @backstage/cli-module-test-jest repo test
+Usage: @backstage/cli-module-test-jest repo test [flags...]
 
 Options:
   --jest-help

--- a/packages/cli-module-test-jest/package.json
+++ b/packages/cli-module-test-jest/package.json
@@ -38,7 +38,7 @@
     "@backstage/cli-node": "workspace:^",
     "@swc/core": "^1.15.6",
     "@swc/jest": "^0.2.39",
-    "cleye": "^2.3.0",
+    "cleye": "^2.6.0",
     "cross-fetch": "^4.0.0",
     "fs-extra": "^11.2.0",
     "glob": "^13.0.0",

--- a/packages/cli-module-test-jest/src/commands/repo/test.ts
+++ b/packages/cli-module-test-jest/src/commands/repo/test.ts
@@ -146,7 +146,7 @@ export default async ({ args, info }: CliCommandContext) => {
   // args so they can be forwarded to Jest.
   const { flags: opts } = cli(
     {
-      help: info,
+      name: info.usage,
       booleanFlagNegation: true,
       flags: {
         since: {

--- a/packages/cli-module-translations/cli-report.md
+++ b/packages/cli-module-translations/cli-report.md
@@ -33,7 +33,7 @@ Commands:
 ### `backstage-cli-module-translations translations export`
 
 ```
-Usage: @backstage/cli-module-translations translations export
+Usage: @backstage/cli-module-translations translations export [flags...]
 
 Options:
   --output <string>
@@ -44,7 +44,7 @@ Options:
 ### `backstage-cli-module-translations translations import`
 
 ```
-Usage: @backstage/cli-module-translations translations import
+Usage: @backstage/cli-module-translations translations import [flags...]
 
 Options:
   --input <string>

--- a/packages/cli-module-translations/package.json
+++ b/packages/cli-module-translations/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@backstage/cli-common": "workspace:^",
     "@backstage/cli-node": "workspace:^",
-    "cleye": "^2.3.0",
+    "cleye": "^2.6.0",
     "fs-extra": "^11.2.0",
     "ts-morph": "^24.0.0"
   },

--- a/packages/cli-module-translations/src/commands/export.ts
+++ b/packages/cli-module-translations/src/commands/export.ts
@@ -40,7 +40,7 @@ export default async ({ args, info }: CliCommandContext) => {
     flags: { output, pattern },
   } = cli(
     {
-      help: info,
+      name: info.usage,
       booleanFlagNegation: true,
       flags: {
         output: {

--- a/packages/cli-module-translations/src/commands/import.ts
+++ b/packages/cli-module-translations/src/commands/import.ts
@@ -46,7 +46,7 @@ export default async ({ args, info }: CliCommandContext) => {
     flags: { input, output },
   } = cli(
     {
-      help: info,
+      name: info.usage,
       booleanFlagNegation: true,
       flags: {
         input: {

--- a/packages/cli/cli-report.md
+++ b/packages/cli/cli-report.md
@@ -50,7 +50,7 @@ Commands:
 ### `backstage-cli actions execute`
 
 ```
-Usage: backstage-cli actions execute
+Usage: backstage-cli actions execute [flags...] <action-id>
 
 Options:
   --instance <string>
@@ -60,7 +60,7 @@ Options:
 ### `backstage-cli actions list`
 
 ```
-Usage: backstage-cli actions list
+Usage: backstage-cli actions list [flags...]
 
 Options:
   --instance <string>
@@ -85,7 +85,7 @@ Commands:
 ### `backstage-cli actions sources add`
 
 ```
-Usage: backstage-cli actions sources add
+Usage: backstage-cli actions sources add [flags...] <plugin-ids...>
 
 Options:
   -h, --help
@@ -94,7 +94,7 @@ Options:
 ### `backstage-cli actions sources list`
 
 ```
-Usage: backstage-cli actions sources list
+Usage: backstage-cli actions sources list [flags...]
 
 Options:
   -h, --help
@@ -103,7 +103,7 @@ Options:
 ### `backstage-cli actions sources remove`
 
 ```
-Usage: backstage-cli actions sources remove
+Usage: backstage-cli actions sources remove [flags...] <plugin-ids...>
 
 Options:
   -h, --help
@@ -130,7 +130,7 @@ Commands:
 ### `backstage-cli auth list`
 
 ```
-Usage: backstage-cli auth list
+Usage: backstage-cli auth list [flags...]
 
 Options:
   -h, --help
@@ -139,7 +139,7 @@ Options:
 ### `backstage-cli auth login`
 
 ```
-Usage: backstage-cli auth login
+Usage: backstage-cli auth login [flags...]
 
 Options:
   --backend-url <string>
@@ -151,7 +151,7 @@ Options:
 ### `backstage-cli auth logout`
 
 ```
-Usage: backstage-cli auth logout
+Usage: backstage-cli auth logout [flags...]
 
 Options:
   --instance <string>
@@ -161,7 +161,7 @@ Options:
 ### `backstage-cli auth print-token`
 
 ```
-Usage: backstage-cli auth print-token
+Usage: backstage-cli auth print-token [flags...]
 
 Options:
   --instance <string>
@@ -171,7 +171,7 @@ Options:
 ### `backstage-cli auth select`
 
 ```
-Usage: backstage-cli auth select
+Usage: backstage-cli auth select [flags...]
 
 Options:
   --instance <string>
@@ -181,7 +181,7 @@ Options:
 ### `backstage-cli auth show`
 
 ```
-Usage: backstage-cli auth show
+Usage: backstage-cli auth show [flags...]
 
 Options:
   --instance <string>
@@ -191,7 +191,7 @@ Options:
 ### `backstage-cli build-workspace`
 
 ```
-Usage: backstage-cli build-workspace <workspace-dir> [packages...]
+Usage: backstage-cli build-workspace [flags...] <workspace-dir> [packages...]
 
 Options:
   --always-pack
@@ -215,7 +215,7 @@ Commands:
 ### `backstage-cli config docs`
 
 ```
-Usage: backstage-cli config docs
+Usage: backstage-cli config docs [flags...]
 
 Options:
   --package <string>
@@ -225,7 +225,7 @@ Options:
 ### `backstage-cli config schema`
 
 ```
-Usage: backstage-cli config schema
+Usage: backstage-cli config schema [flags...]
 
 Options:
   --format <string>
@@ -237,7 +237,7 @@ Options:
 ### `backstage-cli config:check`
 
 ```
-Usage: backstage-cli config:check
+Usage: backstage-cli config:check [flags...]
 
 Options:
   --config <string>
@@ -252,7 +252,7 @@ Options:
 ### `backstage-cli config:docs`
 
 ```
-Usage: backstage-cli config:docs
+Usage: backstage-cli config:docs [flags...]
 
 Options:
   --package <string>
@@ -262,7 +262,7 @@ Options:
 ### `backstage-cli config:print`
 
 ```
-Usage: backstage-cli config:print
+Usage: backstage-cli config:print [flags...]
 
 Options:
   --config <string>
@@ -277,7 +277,7 @@ Options:
 ### `backstage-cli config:schema`
 
 ```
-Usage: backstage-cli config:schema
+Usage: backstage-cli config:schema [flags...]
 
 Options:
   --format <string>
@@ -289,7 +289,7 @@ Options:
 ### `backstage-cli create-github-app`
 
 ```
-Usage: backstage-cli create-github-app <github-org>
+Usage: backstage-cli create-github-app [flags...] <github-org>
 
 Options:
   -h, --help
@@ -298,7 +298,7 @@ Options:
 ### `backstage-cli info`
 
 ```
-Usage: backstage-cli info
+Usage: backstage-cli info [flags...]
 
 Options:
   --format <string>
@@ -326,7 +326,7 @@ Commands:
 ### `backstage-cli migrate package-exports`
 
 ```
-Usage: backstage-cli migrate package-exports
+Usage: backstage-cli migrate package-exports [flags...]
 
 Options:
   -h, --help
@@ -335,7 +335,7 @@ Options:
 ### `backstage-cli migrate package-lint-configs`
 
 ```
-Usage: backstage-cli migrate package-lint-configs
+Usage: backstage-cli migrate package-lint-configs [flags...]
 
 Options:
   -h, --help
@@ -344,7 +344,7 @@ Options:
 ### `backstage-cli migrate package-roles`
 
 ```
-Usage: backstage-cli migrate package-roles
+Usage: backstage-cli migrate package-roles [flags...]
 
 Options:
   -h, --help
@@ -353,7 +353,7 @@ Options:
 ### `backstage-cli migrate package-scripts`
 
 ```
-Usage: backstage-cli migrate package-scripts
+Usage: backstage-cli migrate package-scripts [flags...]
 
 Options:
   -h, --help
@@ -362,7 +362,7 @@ Options:
 ### `backstage-cli migrate react-router-deps`
 
 ```
-Usage: backstage-cli migrate react-router-deps
+Usage: backstage-cli migrate react-router-deps [flags...]
 
 Options:
   -h, --help
@@ -371,7 +371,7 @@ Options:
 ### `backstage-cli new`
 
 ```
-Usage: backstage-cli new
+Usage: backstage-cli new [flags...]
 
 Options:
   --base-version <string>
@@ -407,7 +407,7 @@ Commands:
 ### `backstage-cli package build`
 
 ```
-Usage: backstage-cli package build
+Usage: backstage-cli package build [flags...]
 
 Options:
   --config <string>
@@ -422,7 +422,7 @@ Options:
 ### `backstage-cli package clean`
 
 ```
-Usage: backstage-cli package clean
+Usage: backstage-cli package clean [flags...]
 
 Options:
   -h, --help
@@ -431,7 +431,7 @@ Options:
 ### `backstage-cli package lint`
 
 ```
-Usage: backstage-cli package lint [directories...]
+Usage: backstage-cli package lint [flags...] [directories...]
 
 Options:
   --fix
@@ -444,7 +444,7 @@ Options:
 ### `backstage-cli package postpack`
 
 ```
-Usage: backstage-cli package postpack
+Usage: backstage-cli package postpack [flags...]
 
 Options:
   -h, --help
@@ -453,7 +453,7 @@ Options:
 ### `backstage-cli package prepack`
 
 ```
-Usage: backstage-cli package prepack
+Usage: backstage-cli package prepack [flags...]
 
 Options:
   -h, --help
@@ -462,7 +462,7 @@ Options:
 ### `backstage-cli package start`
 
 ```
-Usage: backstage-cli package start
+Usage: backstage-cli package start [flags...]
 
 Options:
   --check
@@ -611,7 +611,7 @@ Commands:
 ### `backstage-cli repo build`
 
 ```
-Usage: backstage-cli repo build
+Usage: backstage-cli repo build [flags...]
 
 Options:
   --all
@@ -623,7 +623,7 @@ Options:
 ### `backstage-cli repo clean`
 
 ```
-Usage: backstage-cli repo clean
+Usage: backstage-cli repo clean [flags...]
 
 Options:
   -h, --help
@@ -632,7 +632,7 @@ Options:
 ### `backstage-cli repo fix`
 
 ```
-Usage: backstage-cli repo fix
+Usage: backstage-cli repo fix [flags...]
 
 Options:
   --check
@@ -643,7 +643,7 @@ Options:
 ### `backstage-cli repo lint`
 
 ```
-Usage: backstage-cli repo lint
+Usage: backstage-cli repo lint [flags...]
 
 Options:
   --fix
@@ -659,7 +659,7 @@ Options:
 ### `backstage-cli repo list-deprecations`
 
 ```
-Usage: backstage-cli repo list-deprecations
+Usage: backstage-cli repo list-deprecations [flags...]
 
 Options:
   --json
@@ -669,7 +669,7 @@ Options:
 ### `backstage-cli repo start`
 
 ```
-Usage: backstage-cli repo start [packages...]
+Usage: backstage-cli repo start [flags...] [packages...]
 
 Options:
   --config <string>
@@ -684,7 +684,7 @@ Options:
 ### `backstage-cli repo test`
 
 ```
-Usage: backstage-cli repo test
+Usage: backstage-cli repo test [flags...]
 
 Options:
   --jest-help
@@ -711,7 +711,7 @@ Commands:
 ### `backstage-cli translations export`
 
 ```
-Usage: backstage-cli translations export
+Usage: backstage-cli translations export [flags...]
 
 Options:
   --output <string>
@@ -722,7 +722,7 @@ Options:
 ### `backstage-cli translations import`
 
 ```
-Usage: backstage-cli translations import
+Usage: backstage-cli translations import [flags...]
 
 Options:
   --input <string>
@@ -733,7 +733,7 @@ Options:
 ### `backstage-cli versions:bump`
 
 ```
-Usage: backstage-cli versions:bump
+Usage: backstage-cli versions:bump [flags...]
 
 Options:
   --pattern <string>
@@ -746,7 +746,7 @@ Options:
 ### `backstage-cli versions:migrate`
 
 ```
-Usage: backstage-cli versions:migrate
+Usage: backstage-cli versions:migrate [flags...]
 
 Options:
   --pattern <string>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2467,7 +2467,7 @@ __metadata:
     "@backstage/cli-node": "workspace:^"
     "@backstage/errors": "workspace:^"
     chalk: "npm:^4.0.0"
-    cleye: "npm:^2.3.0"
+    cleye: "npm:^2.6.0"
     marked: "npm:^15.0.12"
     marked-terminal: "npm:^7.3.0"
     strip-ansi: "npm:^7.1.0"
@@ -2487,7 +2487,7 @@ __metadata:
     "@backstage/errors": "workspace:^"
     "@types/fs-extra": "npm:^11.0.0"
     "@types/proper-lockfile": "npm:^4"
-    cleye: "npm:^2.3.0"
+    cleye: "npm:^2.6.0"
     fs-extra: "npm:^11.2.0"
     glob: "npm:^13.0.0"
     inquirer: "npm:^8.2.0"
@@ -2534,7 +2534,7 @@ __metadata:
     buffer: "npm:^6.0.3"
     chalk: "npm:^4.0.0"
     chokidar: "npm:^3.3.1"
-    cleye: "npm:^2.3.0"
+    cleye: "npm:^2.6.0"
     cross-spawn: "npm:^7.0.3"
     css-loader: "npm:^6.5.1"
     ctrlc-windows: "npm:^2.1.0"
@@ -2597,7 +2597,7 @@ __metadata:
     "@manypkg/get-packages": "npm:^1.1.3"
     "@types/json-schema": "npm:^7.0.6"
     chalk: "npm:^4.0.0"
-    cleye: "npm:^2.3.0"
+    cleye: "npm:^2.6.0"
     json-schema: "npm:^0.4.0"
     react-dev-utils: "npm:^12.0.0-next.60"
     yaml: "npm:^2.0.0"
@@ -2617,7 +2617,7 @@ __metadata:
     "@types/express": "npm:^4.17.6"
     "@types/fs-extra": "npm:^11.0.0"
     chalk: "npm:^4.0.0"
-    cleye: "npm:^2.3.0"
+    cleye: "npm:^2.6.0"
     express: "npm:^4.22.0"
     fs-extra: "npm:^11.2.0"
     inquirer: "npm:^8.2.0"
@@ -2636,7 +2636,7 @@ __metadata:
     "@backstage/cli-common": "workspace:^"
     "@backstage/cli-node": "workspace:^"
     "@types/fs-extra": "npm:^11.0.0"
-    cleye: "npm:^2.3.0"
+    cleye: "npm:^2.6.0"
     fs-extra: "npm:^11.2.0"
     minimatch: "npm:^10.2.1"
   bin:
@@ -2654,7 +2654,7 @@ __metadata:
     "@types/fs-extra": "npm:^11.0.0"
     "@types/shell-quote": "npm:^1.7.5"
     chalk: "npm:^4.0.0"
-    cleye: "npm:^2.3.0"
+    cleye: "npm:^2.6.0"
     eslint: "npm:^8.6.0"
     eslint-formatter-friendly: "npm:^7.0.0"
     fs-extra: "npm:^11.2.0"
@@ -2674,7 +2674,7 @@ __metadata:
     "@backstage/cli-node": "workspace:^"
     "@types/fs-extra": "npm:^11.0.0"
     chalk: "npm:^4.0.0"
-    cleye: "npm:^2.3.0"
+    cleye: "npm:^2.6.0"
     eslint: "npm:^8.6.0"
     fs-extra: "npm:^11.2.0"
   bin:
@@ -2697,7 +2697,7 @@ __metadata:
     "@types/fs-extra": "npm:^11.0.0"
     "@types/semver": "npm:^7"
     chalk: "npm:^4.0.0"
-    cleye: "npm:^2.3.0"
+    cleye: "npm:^2.6.0"
     fs-extra: "npm:^11.2.0"
     minimatch: "npm:^10.2.1"
     msw: "npm:^1.0.0"
@@ -2725,7 +2725,7 @@ __metadata:
     "@types/lodash": "npm:^4.14.151"
     "@types/recursive-readdir": "npm:^2.2.0"
     chalk: "npm:^4.0.0"
-    cleye: "npm:^2.3.0"
+    cleye: "npm:^2.6.0"
     fs-extra: "npm:^11.2.0"
     handlebars: "npm:^4.7.3"
     inquirer: "npm:^8.2.0"
@@ -2750,7 +2750,7 @@ __metadata:
     "@backstage/cli-node": "workspace:^"
     "@swc/core": "npm:^1.15.6"
     "@swc/jest": "npm:^0.2.39"
-    cleye: "npm:^2.3.0"
+    cleye: "npm:^2.6.0"
     cross-fetch: "npm:^4.0.0"
     fs-extra: "npm:^11.2.0"
     glob: "npm:^13.0.0"
@@ -2782,7 +2782,7 @@ __metadata:
     "@backstage/cli-common": "workspace:^"
     "@backstage/cli-node": "workspace:^"
     "@types/fs-extra": "npm:^11.0.0"
-    cleye: "npm:^2.3.0"
+    cleye: "npm:^2.6.0"
     fs-extra: "npm:^11.2.0"
     ts-morph: "npm:^24.0.0"
   bin:
@@ -24304,7 +24304,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cleye@npm:^2.3.0":
+"cleye@npm:^2.6.0":
   version: 2.6.0
   resolution: "cleye@npm:2.6.0"
   dependencies:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

A while back I added a [fix to cleye](https://github.com/privatenumber/cleye/releases/tag/v2.4.0) that allows the CLI `name` to contain spaces. This lets us lean on cleye's built-in help text generation rather than assembling the usage string by hand.

This bumps cleye to `^2.6.0` across the CLI module packages and switches every command from passing a pre-built `help.usage` to instead passing the fully-qualified command name as cleye's `name`. cleye then renders the `Usage:` line itself, including `[flags...]` and any declared positional `parameters`. That also lets us drop the bits where we manually appended positional args onto the usage string, which were just duplicating the `parameters` cleye already knew about.

A nice side effect is that the usage line is now consistent everywhere, including a few commands that previously didn't show their arguments at all, e.g.:

```
backstage-cli actions execute [flags...] <action-id>
backstage-cli actions sources add [flags...] <plugin-ids...>
backstage-cli build-workspace [flags...] <workspace-dir> [packages...]
```

The `--help` output now also prints the command name as a heading above the `Usage:` section, which is cleye's standard format. CLI reports have been regenerated to match.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))