### PR TITLE
feat(docs-ui): add docs for using fr units for Column width in Table

### DIFF
--- a/docs-ui/src/app/components/table/components.tsx
+++ b/docs-ui/src/app/components/table/components.tsx
@@ -473,6 +473,105 @@ export function CombinedExample() {
 }
 
 // =============================================================================
+// Column Widths With `fr` Example
+// =============================================================================
+
+const columnWidthsWithFr: ColumnConfig<CatalogItem>[] = [
+  {
+    id: 'name',
+    label: 'Name (3fr)',
+    isRowHeader: true,
+    width: '3fr',
+    cell: item => <CellText title={item.name} description={item.description} />,
+  },
+  {
+    id: 'owner',
+    label: 'Owner (2fr)',
+    width: '2fr',
+    cell: item => <CellText title={item.owner.name} />,
+  },
+  {
+    id: 'type',
+    label: 'Type (1fr)',
+    width: '1fr',
+    cell: item => <CellText title={item.type} />,
+  },
+  {
+    id: 'lifecycle',
+    label: 'Lifecycle (1fr)',
+    width: '1fr',
+    cell: item => <CellText title={item.lifecycle} />,
+  },
+];
+
+export function ColumnWidthsWithFrExample() {
+  const { tableProps } = useTable({
+    mode: 'complete',
+    getData: () => catalogData,
+    paginationOptions: { pageSize: 5 },
+  });
+
+  return (
+    <MemoryRouter>
+      <Table columnConfig={columnWidthsWithFr} {...tableProps} />
+    </MemoryRouter>
+  );
+}
+
+// =============================================================================
+// Column Widths With Constraints Example
+// =============================================================================
+
+const columnWidthsWithConstraints: ColumnConfig<CatalogItem>[] = [
+  {
+    id: 'name',
+    label: 'Name (3fr, min 200px)',
+    isRowHeader: true,
+    defaultWidth: '3fr',
+    minWidth: 200,
+    cell: item => <CellText title={item.name} description={item.description} />,
+  },
+  {
+    id: 'owner',
+    label: 'Owner (2fr, 120–300px)',
+    defaultWidth: '2fr',
+    minWidth: 120,
+    maxWidth: 300,
+    cell: item => <CellText title={item.owner.name} />,
+  },
+  {
+    id: 'type',
+    label: 'Type (1fr, 80–150px)',
+    defaultWidth: '1fr',
+    minWidth: 80,
+    maxWidth: 150,
+    cell: item => <CellText title={item.type} />,
+  },
+  {
+    id: 'lifecycle',
+    label: 'Lifecycle (1fr, 80–150px)',
+    defaultWidth: '1fr',
+    minWidth: 80,
+    maxWidth: 150,
+    cell: item => <CellText title={item.lifecycle} />,
+  },
+];
+
+export function ColumnWidthsWithConstraintsExample() {
+  const { tableProps } = useTable({
+    mode: 'complete',
+    getData: () => catalogData,
+    paginationOptions: { pageSize: 5 },
+  });
+
+  return (
+    <MemoryRouter>
+      <Table columnConfig={columnWidthsWithConstraints} {...tableProps} />
+    </MemoryRouter>
+  );
+}
+
+// =============================================================================
 // Custom Row Example
 // =============================================================================
 

--- a/docs-ui/src/app/components/table/page.mdx
+++ b/docs-ui/src/app/components/table/page.mdx
@@ -8,6 +8,8 @@ import {
   SelectionExample,
   RowActionsExample,
   EmptyStateExample,
+  ColumnWidthsWithFrExample,
+  ColumnWidthsWithConstraintsExample,
   CombinedExample,
   CustomRowExample,
   PrimitivesExample,
@@ -40,6 +42,8 @@ import {
   tableEmptyStateSnippet,
   tableOffsetPaginationSnippet,
   tableCursorPaginationSnippet,
+  tableColumnWidthsWithFrSnippet,
+  tableColumnWidthsWithConstraintsSnippet,
   tableCombinedSnippet,
   tableCustomRowSnippet,
   tablePrimitivesSnippet,
@@ -183,6 +187,25 @@ You can also disable specific rows from being clicked using `getIsDisabled`:
 When the table has no data to display, provide an `emptyState` to show a helpful message instead of an empty table body. Consider providing different messages depending on context - an empty search result is different from a table with no data at all.
 
 <Snippet preview={<EmptyStateExample />} code={tableEmptyStateSnippet} />
+
+### Column Widths with `fr`
+
+Control column widths using `fr` units with `width` for proportional, responsive sizing.
+Columns with larger `fr` values take more space — for example, a `3fr` column is three times wider than a `1fr` column.
+
+<Snippet
+  preview={<ColumnWidthsWithFrExample />}
+  code={tableColumnWidthsWithFrSnippet}
+/>
+
+#### With Constraints
+
+Use `defaultWidth` with `fr` units for the initial proportional layout, then add `minWidth` and `maxWidth` in pixels to prevent columns from becoming too narrow or too wide when the table is resized.
+
+<Snippet
+  preview={<ColumnWidthsWithConstraintsExample />}
+  code={tableColumnWidthsWithConstraintsSnippet}
+/>
 
 ## Server-Side Data
 

--- a/docs-ui/src/app/components/table/snippets.ts
+++ b/docs-ui/src/app/components/table/snippets.ts
@@ -320,6 +320,79 @@ function ItemsTable() {
 }`;
 
 // =============================================================================
+// Column Widths with `fr`
+// =============================================================================
+
+export const tableColumnWidthsWithFrSnippet = `const columns: ColumnConfig<Item>[] = [
+  {
+    id: 'name',
+    label: 'Name (3fr)',
+    isRowHeader: true,
+    width: '3fr',
+    cell: item => (
+      <CellText title={item.name} description={item.description} />
+    ),
+  },
+  {
+    id: 'owner',
+    label: 'Owner (2fr)',
+    width: '2fr',
+    cell: item => <CellText title={item.owner.name} />,
+  },
+  {
+    id: 'type',
+    label: 'Type (1fr)',
+    width: '1fr',
+    cell: item => <CellText title={item.type} />,
+  },
+  {
+    id: 'lifecycle',
+    label: 'Lifecycle (1fr)',
+    width: '1fr',
+    cell: item => <CellText title={item.lifecycle} />,
+  },
+];`;
+
+// =============================================================================
+// Column Widths with Constraints
+// =============================================================================
+
+export const tableColumnWidthsWithConstraintsSnippet = `const columns: ColumnConfig<Item>[] = [
+  {
+    id: 'name',
+    label: 'Name (3fr, min 200px)',
+    isRowHeader: true,
+    defaultWidth: '3fr',
+    minWidth: 200,
+    cell: item => <CellText title={item.name} description={item.description} />,
+  },
+  {
+    id: 'owner',
+    label: 'Owner (2fr, min 120px, max 300px)',
+    defaultWidth: '2fr',
+    minWidth: 120,
+    maxWidth: 300,
+    cell: item => <CellText title={item.owner.name} />,
+  },
+  {
+    id: 'type',
+    label: 'Type (1fr, min 80px, max 150px)',
+    defaultWidth: '1fr',
+    minWidth: 80,
+    maxWidth: 150,
+    cell: item => <CellText title={item.type} />,
+  },
+  {
+    id: 'lifecycle',
+    label: 'Lifecycle (1fr, min 80px, max 150px)',
+    defaultWidth: '1fr',
+    minWidth: 80,
+    maxWidth: 150,
+    cell: item => <CellText title={item.lifecycle} />,
+  },
+];`;
+
+// =============================================================================
 // Custom Tables
 // =============================================================================
 

--- a/packages/ui/src/components/Table/stories/Table.visual.stories.tsx
+++ b/packages/ui/src/components/Table/stories/Table.visual.stories.tsx
@@ -21,6 +21,7 @@ import { Table, CellText, CellProfile, useTable, type ColumnConfig } from '..';
 import { data as data1 } from './mocked-data1';
 import { data as data4 } from './mocked-data4';
 import { selectionData, selectionColumns, tableStoriesMeta } from './utils';
+import { Text } from '../../Text';
 
 const meta = {
   title: 'Backstage UI/Table/visual',
@@ -385,5 +386,109 @@ export const CustomPageSizeOptions: Story = {
     });
 
     return <Table columnConfig={columns} {...tableProps} />;
+  },
+};
+
+export const ColumnWidthsWithFr: Story = {
+  render: () => {
+    const fixedColumns: ColumnConfig<Data1Item>[] = [
+      {
+        id: 'name',
+        label: 'Name (3fr)',
+        isRowHeader: true,
+        width: '3fr',
+        cell: item => (
+          <CellText title={item.name} description={item.description} />
+        ),
+      },
+      {
+        id: 'owner',
+        label: 'Owner (2fr)',
+        width: '2fr',
+        cell: item => <CellText title={item.owner.name} />,
+      },
+      {
+        id: 'type',
+        label: 'Type (1fr)',
+        width: '1fr',
+        cell: item => <CellText title={item.type} />,
+      },
+      {
+        id: 'lifecycle',
+        label: 'Lifecycle (1fr)',
+        width: '1fr',
+        cell: item => <CellText title={item.lifecycle} />,
+      },
+    ];
+
+    const constrainedColumns: ColumnConfig<Data1Item>[] = [
+      {
+        id: 'name',
+        label: 'Name (3fr, min 200px)',
+        isRowHeader: true,
+        defaultWidth: '3fr',
+        minWidth: 200,
+        cell: item => (
+          <CellText title={item.name} description={item.description} />
+        ),
+      },
+      {
+        id: 'owner',
+        label: 'Owner (2fr, 120–300px)',
+        defaultWidth: '2fr',
+        minWidth: 120,
+        maxWidth: 300,
+        cell: item => <CellText title={item.owner.name} />,
+      },
+      {
+        id: 'type',
+        label: 'Type (1fr, 80–150px)',
+        defaultWidth: '1fr',
+        minWidth: 80,
+        maxWidth: 150,
+        cell: item => <CellText title={item.type} />,
+      },
+      {
+        id: 'lifecycle',
+        label: 'Lifecycle (1fr, 80–150px)',
+        defaultWidth: '1fr',
+        minWidth: 80,
+        maxWidth: 150,
+        cell: item => <CellText title={item.lifecycle} />,
+      },
+    ];
+
+    const fixed = useTable({
+      mode: 'complete',
+      getData: () => data1,
+      paginationOptions: { pageSize: 5 },
+    });
+
+    const constrained = useTable({
+      mode: 'complete',
+      getData: () => data1,
+      paginationOptions: { pageSize: 5 },
+    });
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 32 }}>
+        <div>
+          <Text variant="body-large" color="secondary">
+            Fixed ratios with width — columns keep their proportions
+          </Text>
+          <Table columnConfig={fixedColumns} {...fixed.tableProps} />
+        </div>
+        <div>
+          <Text variant="body-large" color="secondary">
+            Resizable with defaultWidth — fr ratios with pixel min/max
+            constraints
+          </Text>
+          <Table
+            columnConfig={constrainedColumns}
+            {...constrained.tableProps}
+          />
+        </div>
+      </div>
+    );
   },
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

**Storybook:**
<img width="1380" height="849" alt="Screenshot 2026-06-11 at 00 02 40" src="https://github.com/user-attachments/assets/0ce2723f-d232-416f-b2d2-b03a4924ecef" />

**Docs-UI > Table > Common Patterns**
<img width="765" height="962" alt="Screenshot 2026-06-10 at 23 59 07" src="https://github.com/user-attachments/assets/7e4fee6c-a8bc-411e-a12c-7ae760a97f83" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
