### PR TITLE
fix(catalog-github): log missing GitHub App installation hint

### DIFF
--- a/.changeset/github-multiorg-missing-app-debug.md
+++ b/.changeset/github-multiorg-missing-app-debug.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+Added a debug log hint when the multi-org GitHub entity provider cannot find a GitHub App installation for an organization.

--- a/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.test.ts
@@ -16,6 +16,7 @@
 
 import { GroupEntity, UserEntity } from '@backstage/catalog-model';
 import { ConfigReader } from '@backstage/config';
+import { NotFoundError } from '@backstage/errors';
 import { GithubCredentialsProvider } from '@backstage/integration';
 import { EntityProviderConnection } from '@backstage/plugin-catalog-node';
 import {
@@ -366,6 +367,38 @@ describe('GithubMultiOrgEntityProvider', () => {
         ]),
         type: 'full',
       });
+    });
+
+    it('should log a debug hint when the GitHub App installation is missing for an org', async () => {
+      const error = new NotFoundError(
+        'No app installation found for orgA in app 123',
+      );
+      mockGetCredentials.mockRejectedValueOnce(error);
+
+      entityProvider = new GithubMultiOrgEntityProvider({
+        id: 'my-id',
+        gitHubConfig,
+        githubCredentialsProvider: {
+          getCredentials: mockGetCredentials,
+        },
+        githubUrl: 'https://github.com',
+        logger,
+        orgs: ['orgA'],
+      });
+
+      await entityProvider.connect(entityProviderConnection);
+
+      await expect(entityProvider.read()).rejects.toThrow(error);
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'GitHub App installation was not found for org "orgA"',
+        ),
+      );
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'https://backstage.io/docs/integrations/github/github-apps/#troubleshooting',
+        ),
+      );
     });
 
     it('should read every accessible org', async () => {

--- a/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
@@ -25,7 +25,7 @@ import {
   stringifyEntityRef,
 } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
-import { toError } from '@backstage/errors';
+import { isError } from '@backstage/errors';
 import {
   DefaultGithubCredentialsProvider,
   GithubAppCredentialsMux,
@@ -370,7 +370,7 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
             url: `${this.options.githubUrl}/${org}`,
           });
       } catch (error) {
-        if (toError(error).name === 'NotFoundError') {
+        if (isError(error) && error.name === 'NotFoundError') {
           logger.debug(
             `GitHub App installation was not found for org "${org}". ` +
               `Make sure the app is installed for the organization and that the app manager has the Owner role. ` +

--- a/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
@@ -25,9 +25,11 @@ import {
   stringifyEntityRef,
 } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
+import { toError } from '@backstage/errors';
 import {
   DefaultGithubCredentialsProvider,
   GithubAppCredentialsMux,
+  GithubCredentials,
   GithubCredentialsProvider,
   GithubIntegrationConfig,
   ScmIntegrations,
@@ -361,10 +363,24 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       : await this.getAllOrgs(this.options.gitHubConfig);
 
     for (const org of orgsToProcess) {
-      const { headers, type: tokenType } =
-        await this.options.githubCredentialsProvider.getCredentials({
-          url: `${this.options.githubUrl}/${org}`,
-        });
+      let credentials: GithubCredentials;
+      try {
+        credentials =
+          await this.options.githubCredentialsProvider.getCredentials({
+            url: `${this.options.githubUrl}/${org}`,
+          });
+      } catch (error) {
+        if (toError(error).name === 'NotFoundError') {
+          logger.debug(
+            `GitHub App installation was not found for org "${org}". ` +
+              `Make sure the app is installed for the organization and that the app manager has the Owner role. ` +
+              `See https://backstage.io/docs/integrations/github/github-apps/#troubleshooting`,
+          );
+        }
+        throw error;
+      }
+
+      const { headers, type: tokenType } = credentials;
       const client = graphql.defaults({
         baseUrl: this.options.gitHubConfig.apiBaseUrl,
         headers,


### PR DESCRIPTION
## Summary

- log a debug hint when `GithubMultiOrgEntityProvider` fails to find a GitHub App installation for an org
- keep the existing failure behavior by rethrowing the original error
- add a regression test and patch changeset for `@backstage/plugin-catalog-backend-module-github`

Closes #32972

## Test plan

- `CI=1 yarn test plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.test.ts --runInBand`
- `yarn lint --since origin/master`
- `yarn tsc --pretty false`
- `yarn workspace @backstage/plugin-catalog-backend-module-github build`