### PR TITLE
Add a way for plugins to provide custom predicate context

### DIFF
--- a/.changeset/async-predicate-context-providers.md
+++ b/.changeset/async-predicate-context-providers.md
@@ -1,0 +1,6 @@
+---
+'@backstage/frontend-plugin-api': patch
+'@backstage/frontend-app-api': patch
+---
+
+Added `ExtensionPredicateContextProviderBlueprint` for declaring predicate context providers that populate custom values in the extension predicate context. This enables gating extension display on arbitrary values loaded asynchronously. Each provider's output is namespaced by its extension ID, and provider failures are isolated so the app still boots.

--- a/docs/frontend-system/architecture/20-extensions.md
+++ b/docs/frontend-system/architecture/20-extensions.md
@@ -76,6 +76,8 @@ const guardedCard = CardBlueprint.make({
 
 Conditions are evaluated when the app tree is prepared, not continuously while the app is running. If the underlying feature flags or permissions change, the app needs to be prepared again in order for the extension tree to change, which in practice typically means reloading the app.
 
+Beyond the built-in `featureFlags` and `permissions` keys, you can supply custom predicate context values — including values loaded asynchronously — using the [`ExtensionPredicateContextProviderBlueprint`](../building-plugins/03-common-extension-blueprints.md#extensionpredicatecontextprovider).
+
 If a plugin or module also provides an `if` predicate, it is combined with the extension-level predicate using logical `AND`. See the [plugin `if` option](./15-plugins.md#if-option) and [frontend modules](./25-extension-overrides.md#creating-a-frontend-module) sections for more details.
 
 ### Configuration & configuration schema

--- a/docs/frontend-system/building-plugins/03-common-extension-blueprints.md
+++ b/docs/frontend-system/building-plugins/03-common-extension-blueprints.md
@@ -29,6 +29,51 @@ Sub-page extensions create tabbed content within a parent page. They are attache
 
 Plugin header action extensions provide plugin-scoped actions that appear in the page header. They are automatically scoped to the plugin that provides them and will appear in the header of all pages belonging to that plugin. Actions are lazy-loaded via a `loader` function that returns a React element.
 
+### ExtensionPredicateContextProvider
+
+Extension predicate context provider extensions supply custom values for the [`if` predicate](../architecture/20-extensions.md) system, enabling you to gate extension visibility on arbitrary data — including values loaded asynchronously from backend plugins.
+
+Each provider is namespaced by its extension ID (e.g. `my-plugin/subscriptions`), and predicates reference the namespace directly.
+
+A **sync** provider resolves immediately with no impact on app startup time. This is useful for values derived from configuration or other synchronous sources:
+
+```ts
+ExtensionPredicateContextProviderBlueprint.make({
+  name: 'subscriptions',
+  params: {
+    resolver: ({ apis }) => {
+      const config = apis.get(configApiRef)!;
+      return config.getOptionalStringArray('myPlugin.subscriptions') ?? [];
+    },
+  },
+});
+
+// Gate a page on a config-driven tier
+PageBlueprint.make({
+  params: { path: '/my-page', loader: () => import('./MyPage') },
+  if: { 'my-plugin/subscriptions': { $contains: 'premium' } },
+});
+```
+
+An **async** provider defers app finalization until it resolves, and is suited for values that require network calls:
+
+```ts
+ExtensionPredicateContextProviderBlueprint.make({
+  name: 'entitlements',
+  params: {
+    loader: async ({ apis }) => {
+      const discoveryApi = apis.get(discoveryApiRef)!;
+      const fetchApi = apis.get(fetchApiRef)!;
+      const url = `${await discoveryApi.getBaseUrl('my-plugin')}/entitlements`;
+      const resp = await fetchApi.fetch(url);
+      return resp.json(); // e.g. ['catalog:write', 'templates:read']
+    },
+  },
+});
+```
+
+Async providers only defer finalization when a predicate actually references their namespace — unused providers are skipped. Provider failures are isolated: the app still boots, and predicates referencing a failed provider evaluate as non-matching.
+
 ## Extension blueprints in `@backstage/frontend-plugin-api/alpha`
 
 ### Plugin Wrapper - [Reference](https://backstage.io/api/stable/variables/_backstage_frontend-plugin-api.packages-frontend-plugin-api_src_alpha.PluginWrapperBlueprint.html)

--- a/packages/frontend-app-api/report.api.md
+++ b/packages/frontend-app-api/report.api.md
@@ -155,6 +155,16 @@ export type AppErrorTypes = {
       error: Error;
     };
   };
+  PREDICATE_CONTEXT_PROVIDER_INVALID: {
+    context: {
+      node: AppNode;
+    };
+  };
+  PREDICATE_CONTEXT_PROVIDER_HAS_PREDICATE: {
+    context: {
+      node: AppNode;
+    };
+  };
   ROUTE_DUPLICATE: {
     context: {
       routeId: string;

--- a/packages/frontend-app-api/src/extensions/Root.ts
+++ b/packages/frontend-app-api/src/extensions/Root.ts
@@ -16,6 +16,7 @@
 
 import {
   ApiBlueprint,
+  ExtensionPredicateContextProviderBlueprint,
   coreExtensionData,
   createExtension,
   createExtensionInput,
@@ -30,6 +31,10 @@ export const Root = createExtension({
     apis: createExtensionInput([ApiBlueprint.dataRefs.factory], {
       replaces: [{ id: 'app', input: 'apis' }],
     }),
+    predicateContextProviders: createExtensionInput([
+      ExtensionPredicateContextProviderBlueprint.dataRefs.resolver.optional(),
+      ExtensionPredicateContextProviderBlueprint.dataRefs.loader.optional(),
+    ]),
   },
   output: [coreExtensionData.reactElement],
   factory: ({ inputs }) => inputs.app,

--- a/packages/frontend-app-api/src/wiring/createErrorCollector.ts
+++ b/packages/frontend-app-api/src/wiring/createErrorCollector.ts
@@ -100,6 +100,13 @@ export type AppErrorTypes = {
   FEATURE_FLAG_INVALID: {
     context: { pluginId: string; flagName: string; error: Error };
   };
+  // predicateContextProviders
+  PREDICATE_CONTEXT_PROVIDER_INVALID: {
+    context: { node: AppNode };
+  };
+  PREDICATE_CONTEXT_PROVIDER_HAS_PREDICATE: {
+    context: { node: AppNode };
+  };
   // routing
   ROUTE_DUPLICATE: {
     context: { routeId: string };

--- a/packages/frontend-app-api/src/wiring/createSpecializedApp.test.tsx
+++ b/packages/frontend-app-api/src/wiring/createSpecializedApp.test.tsx
@@ -1786,5 +1786,131 @@ describe('createSpecializedApp', () => {
         'prepareSpecializedApp requires waiting for the bootstrap app to be ready before calling finalize()',
       );
     });
+
+    it('should include async predicate context provider values in predicate evaluation', async () => {
+      const { ExtensionPredicateContextProviderBlueprint } = await import(
+        '@backstage/frontend-plugin-api'
+      );
+
+      const preparedApp = prepareSpecializedApp({
+        config: new ConfigReader({
+          backend: { baseUrl: 'http://localhost:7007' },
+        }),
+        features: [
+          appPlugin.withOverrides({
+            extensions: [
+              appPlugin
+                .getExtension('sign-in-page:app')
+                .override({ disabled: true }),
+            ],
+          }),
+          createFrontendPlugin({
+            pluginId: 'test',
+            extensions: [
+              ExtensionPredicateContextProviderBlueprint.make({
+                name: 'features',
+                params: {
+                  loader: async () => ['show-page'],
+                },
+              }),
+              createExtension({
+                name: 'gated-element',
+                attachTo: { id: 'app/root', input: 'elements' },
+                if: { 'test/features': { $contains: 'show-page' } },
+                output: [coreExtensionData.reactElement],
+                factory: () => [
+                  coreExtensionData.reactElement(
+                    <div>Provider Gated Element</div>,
+                  ),
+                ],
+              }),
+            ],
+          }),
+        ],
+      });
+
+      const finalizedApp = await waitForFinalizedApp(preparedApp);
+      render(
+        finalizedApp.tree.root.instance!.getData(
+          coreExtensionData.reactElement,
+        ),
+      );
+
+      await expect(
+        screen.findByText('Provider Gated Element'),
+      ).resolves.toBeInTheDocument();
+    });
+
+    it('should fail closed when a predicate context provider throws', async () => {
+      const consoleSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const { ExtensionPredicateContextProviderBlueprint } = await import(
+        '@backstage/frontend-plugin-api'
+      );
+
+      const preparedApp = prepareSpecializedApp({
+        config: new ConfigReader({
+          backend: { baseUrl: 'http://localhost:7007' },
+        }),
+        features: [
+          appPlugin.withOverrides({
+            extensions: [
+              appPlugin
+                .getExtension('sign-in-page:app')
+                .override({ disabled: true }),
+            ],
+          }),
+          createFrontendPlugin({
+            pluginId: 'test',
+            extensions: [
+              ExtensionPredicateContextProviderBlueprint.make({
+                name: 'features',
+                params: {
+                  loader: async () => {
+                    throw new Error('backend unreachable');
+                  },
+                },
+              }),
+              createExtension({
+                name: 'gated-element',
+                attachTo: { id: 'app/root', input: 'elements' },
+                if: { 'test/features': { $contains: 'show-page' } },
+                output: [coreExtensionData.reactElement],
+                factory: () => [
+                  coreExtensionData.reactElement(<div>Should Not Appear</div>),
+                ],
+              }),
+              createExtension({
+                name: 'always-element',
+                attachTo: { id: 'app/root', input: 'elements' },
+                output: [coreExtensionData.reactElement],
+                factory: () => [
+                  coreExtensionData.reactElement(<div>Always Visible</div>),
+                ],
+              }),
+            ],
+          }),
+        ],
+      });
+
+      const finalizedApp = await waitForFinalizedApp(preparedApp);
+      render(
+        finalizedApp.tree.root.instance!.getData(
+          coreExtensionData.reactElement,
+        ),
+      );
+
+      await expect(
+        screen.findByText('Always Visible'),
+      ).resolves.toBeInTheDocument();
+      expect(screen.queryByText('Should Not Appear')).not.toBeInTheDocument();
+      expect(consoleSpy).toHaveBeenCalledWith(
+        'Failed to load extension predicate context provider:',
+        expect.any(Error),
+      );
+
+      consoleSpy.mockRestore();
+    });
   });
 });

--- a/packages/frontend-app-api/src/wiring/predicateContextProviders.ts
+++ b/packages/frontend-app-api/src/wiring/predicateContextProviders.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ApiHolder,
+  AppNode,
+  ExtensionPredicateContextProviderBlueprint,
+} from '@backstage/frontend-plugin-api';
+import { FilterPredicate } from '@backstage/filter-predicates';
+import { instantiateAppNodeSubtree } from '../tree/instantiateAppNodeTree';
+import { ErrorCollector } from './createErrorCollector';
+
+export type PredicateContextProviderEntry = {
+  node: AppNode;
+  namespace: string;
+} & (
+  | { type: 'sync'; resolver: (options: { apis: ApiHolder }) => string[] }
+  | {
+      type: 'async';
+      loader: (options: { apis: ApiHolder }) => Promise<string[]>;
+    }
+);
+
+const EMPTY_API_HOLDER: ApiHolder = {
+  get() {
+    return undefined;
+  },
+};
+
+function getNamespaceFromExtensionId(extensionId: string): string {
+  const colonIndex = extensionId.indexOf(':');
+  if (colonIndex === -1) {
+    return extensionId;
+  }
+  return extensionId.slice(colonIndex + 1);
+}
+
+export function collectPredicateContextProviderEntries(options: {
+  providerNodes: Iterable<AppNode>;
+  collector: ErrorCollector;
+}): PredicateContextProviderEntry[] {
+  const entries: PredicateContextProviderEntry[] = [];
+
+  for (const providerNode of options.providerNodes) {
+    if (providerNode.spec.if !== undefined) {
+      options.collector.report({
+        code: 'PREDICATE_CONTEXT_PROVIDER_HAS_PREDICATE',
+        message:
+          `Extension predicate context provider '${providerNode.spec.id}' must not have an 'if' predicate ` +
+          'because it would create a circular dependency. The predicate has been removed.',
+        context: { node: providerNode },
+      });
+      (
+        providerNode.spec as typeof providerNode.spec & {
+          if?: FilterPredicate;
+        }
+      ).if = undefined;
+    }
+
+    const detachedNode = instantiateAppNodeSubtree({
+      rootNode: providerNode,
+      apis: EMPTY_API_HOLDER,
+      collector: options.collector,
+      writeNodeInstances: false,
+      reuseExistingInstances: false,
+    });
+    if (!detachedNode) {
+      continue;
+    }
+
+    const namespace = getNamespaceFromExtensionId(providerNode.spec.id);
+
+    const resolver = detachedNode.instance?.getData(
+      ExtensionPredicateContextProviderBlueprint.dataRefs.resolver,
+    );
+    if (resolver) {
+      entries.push({ node: providerNode, namespace, type: 'sync', resolver });
+      continue;
+    }
+
+    const loader = detachedNode.instance?.getData(
+      ExtensionPredicateContextProviderBlueprint.dataRefs.loader,
+    );
+    if (loader) {
+      entries.push({ node: providerNode, namespace, type: 'async', loader });
+      continue;
+    }
+
+    options.collector.report({
+      code: 'PREDICATE_CONTEXT_PROVIDER_INVALID',
+      message: `Extension predicate context provider '${providerNode.spec.id}' did not output a resolver or loader`,
+      context: { node: providerNode },
+    });
+  }
+
+  return entries;
+}

--- a/packages/frontend-app-api/src/wiring/predicates.test.ts
+++ b/packages/frontend-app-api/src/wiring/predicates.test.ts
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { FilterPredicate } from '@backstage/filter-predicates';
+import {
+  collectPredicateReferences,
+  createPredicateContextLoader,
+  EMPTY_PREDICATE_CONTEXT,
+} from './predicates';
+
+describe('createPredicateContextLoader', () => {
+  it('should return immediate context when there are no providers or permissions', () => {
+    const loader = createPredicateContextLoader({
+      apis: { get: () => undefined },
+      predicateReferences: EMPTY_PREDICATE_CONTEXT,
+    });
+
+    const result = loader.getImmediate();
+    expect(result).toEqual({ featureFlags: [], permissions: [] });
+  });
+
+  it('should return undefined from getImmediate when a referenced async provider exists', () => {
+    const loader = createPredicateContextLoader({
+      apis: { get: () => undefined },
+      predicateReferences: EMPTY_PREDICATE_CONTEXT,
+      referencedNamespaces: new Set(['test-plugin/features']),
+      providerEntries: [
+        {
+          type: 'async',
+          namespace: 'test-plugin/features',
+          loader: async () => ['enabled'],
+        },
+      ],
+    });
+
+    expect(loader.getImmediate()).toBeUndefined();
+  });
+
+  it('should resolve sync providers in getImmediate', () => {
+    const loader = createPredicateContextLoader({
+      apis: { get: () => undefined },
+      predicateReferences: EMPTY_PREDICATE_CONTEXT,
+      referencedNamespaces: new Set(['my-plugin']),
+      providerEntries: [
+        {
+          type: 'sync',
+          namespace: 'my-plugin',
+          resolver: () => ['value-a', 'value-b'],
+        },
+      ],
+    });
+
+    expect(loader.getImmediate()).toEqual({
+      featureFlags: [],
+      permissions: [],
+      'my-plugin': ['value-a', 'value-b'],
+    });
+  });
+
+  it('should allow immediate context when providers exist but none are referenced', () => {
+    const loader = createPredicateContextLoader({
+      apis: { get: () => undefined },
+      predicateReferences: EMPTY_PREDICATE_CONTEXT,
+      referencedNamespaces: new Set(),
+      providerEntries: [
+        {
+          type: 'async',
+          namespace: 'unreferenced-plugin',
+          loader: async () => ['value'],
+        },
+      ],
+    });
+
+    expect(loader.getImmediate()).toEqual({
+      featureFlags: [],
+      permissions: [],
+    });
+  });
+
+  it('should only invoke referenced provider loaders during load', async () => {
+    const referencedLoader = jest.fn(async () => ['alpha', 'beta']);
+    const unreferencedLoader = jest.fn(async () => ['gamma']);
+
+    const loader = createPredicateContextLoader({
+      apis: { get: () => undefined },
+      predicateReferences: EMPTY_PREDICATE_CONTEXT,
+      referencedNamespaces: new Set(['plugin-a/features']),
+      providerEntries: [
+        {
+          type: 'async',
+          namespace: 'plugin-a/features',
+          loader: referencedLoader,
+        },
+        {
+          type: 'async',
+          namespace: 'plugin-b',
+          loader: unreferencedLoader,
+        },
+      ],
+    });
+
+    const result = await loader.load();
+    expect(result).toEqual({
+      featureFlags: [],
+      permissions: [],
+      'plugin-a/features': ['alpha', 'beta'],
+    });
+    expect(referencedLoader).toHaveBeenCalled();
+    expect(unreferencedLoader).not.toHaveBeenCalled();
+  });
+
+  it('should include both sync and async results in load', async () => {
+    const loader = createPredicateContextLoader({
+      apis: { get: () => undefined },
+      predicateReferences: EMPTY_PREDICATE_CONTEXT,
+      referencedNamespaces: new Set(['sync-plugin', 'async-plugin']),
+      providerEntries: [
+        {
+          type: 'sync',
+          namespace: 'sync-plugin',
+          resolver: () => ['sync-value'],
+        },
+        {
+          type: 'async',
+          namespace: 'async-plugin',
+          loader: async () => ['async-value'],
+        },
+      ],
+    });
+
+    const result = await loader.load();
+    expect(result).toEqual({
+      featureFlags: [],
+      permissions: [],
+      'sync-plugin': ['sync-value'],
+      'async-plugin': ['async-value'],
+    });
+  });
+
+  it('should isolate failed async provider loaders and log the error', async () => {
+    const consoleSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    const testError = new Error('network failure');
+    const loader = createPredicateContextLoader({
+      apis: { get: () => undefined },
+      predicateReferences: EMPTY_PREDICATE_CONTEXT,
+      referencedNamespaces: new Set(['good-plugin', 'bad-plugin']),
+      providerEntries: [
+        {
+          type: 'async',
+          namespace: 'good-plugin',
+          loader: async () => ['value'],
+        },
+        {
+          type: 'async',
+          namespace: 'bad-plugin',
+          loader: async () => {
+            throw testError;
+          },
+        },
+      ],
+    });
+
+    const result = await loader.load();
+
+    expect(result).toEqual({
+      featureFlags: [],
+      permissions: [],
+      'good-plugin': ['value'],
+    });
+    expect(result).not.toHaveProperty('bad-plugin');
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Failed to load extension predicate context provider:',
+      testError,
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it('should isolate failed sync provider resolvers and log the error', () => {
+    const consoleSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    const testError = new Error('resolver failure');
+    const loader = createPredicateContextLoader({
+      apis: { get: () => undefined },
+      predicateReferences: EMPTY_PREDICATE_CONTEXT,
+      referencedNamespaces: new Set(['good-plugin', 'bad-plugin']),
+      providerEntries: [
+        {
+          type: 'sync',
+          namespace: 'good-plugin',
+          resolver: () => ['value'],
+        },
+        {
+          type: 'sync',
+          namespace: 'bad-plugin',
+          resolver: () => {
+            throw testError;
+          },
+        },
+      ],
+    });
+
+    const result = loader.getImmediate();
+
+    expect(result).toEqual({
+      featureFlags: [],
+      permissions: [],
+      'good-plugin': ['value'],
+    });
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Failed to resolve extension predicate context provider:',
+      testError,
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it('should behave identically to the original when no providers are given', async () => {
+    const loader = createPredicateContextLoader({
+      apis: { get: () => undefined },
+      predicateReferences: { featureFlags: [], permissions: [] },
+    });
+
+    const immediate = loader.getImmediate();
+    expect(immediate).toEqual({ featureFlags: [], permissions: [] });
+
+    const loaded = await loader.load();
+    expect(loaded).toEqual({ featureFlags: [], permissions: [] });
+  });
+});
+
+describe('collectPredicateReferences', () => {
+  it('should extract custom namespace references from predicates', () => {
+    const nodes: Array<{ spec: { if?: FilterPredicate } }> = [
+      { spec: { if: { featureFlags: { $contains: 'my-flag' } } } },
+      { spec: { if: { 'my-plugin/features': { $contains: 'enabled' } } } },
+      { spec: { if: undefined } },
+    ];
+
+    const { predicateReferences, referencedNamespaces } =
+      collectPredicateReferences(nodes);
+
+    expect(predicateReferences.featureFlags).toEqual(['my-flag']);
+    expect(predicateReferences.permissions).toEqual([]);
+    expect(referencedNamespaces).toEqual(new Set(['my-plugin/features']));
+  });
+
+  it('should extract namespaces from nested logical operators', () => {
+    const nodes: Array<{ spec: { if?: FilterPredicate } }> = [
+      {
+        spec: {
+          if: {
+            $all: [
+              { 'plugin-a': { $contains: 'x' } },
+              { $any: [{ 'plugin-b/ctx': { $contains: 'y' } }] },
+            ],
+          },
+        },
+      },
+    ];
+
+    const { referencedNamespaces } = collectPredicateReferences(nodes);
+    expect(referencedNamespaces).toEqual(new Set(['plugin-a', 'plugin-b/ctx']));
+  });
+
+  it('should not include well-known keys as custom namespaces', () => {
+    const nodes: Array<{ spec: { if?: FilterPredicate } }> = [
+      {
+        spec: {
+          if: {
+            $all: [
+              { featureFlags: { $contains: 'flag' } },
+              { permissions: { $contains: 'perm' } },
+              { 'custom-ns': { $contains: 'val' } },
+            ],
+          },
+        },
+      },
+    ];
+
+    const { referencedNamespaces } = collectPredicateReferences(nodes);
+    expect(referencedNamespaces).toEqual(new Set(['custom-ns']));
+  });
+});

--- a/packages/frontend-app-api/src/wiring/predicates.ts
+++ b/packages/frontend-app-api/src/wiring/predicates.ts
@@ -29,6 +29,7 @@ import { ForwardedError } from '@backstage/errors';
 export type ExtensionPredicateContext = {
   featureFlags: string[];
   permissions: string[];
+  [namespace: string]: string[];
 };
 
 export const EMPTY_PREDICATE_CONTEXT: ExtensionPredicateContext = {
@@ -50,7 +51,34 @@ export const localPermissionApiRef = createApiRef<MinimalPermissionApi>({
 export function createPredicateContextLoader(options: {
   apis: ApiHolder;
   predicateReferences: ExtensionPredicateContext;
+  referencedNamespaces?: Set<string>;
+  providerEntries?: Array<
+    { namespace: string } & (
+      | {
+          type: 'sync';
+          resolver: (resolverOptions: { apis: ApiHolder }) => string[];
+        }
+      | {
+          type: 'async';
+          loader: (loaderOptions: { apis: ApiHolder }) => Promise<string[]>;
+        }
+    )
+  >;
 }) {
+  const referenced = options.providerEntries?.filter(entry =>
+    options.referencedNamespaces?.has(entry.namespace),
+  );
+  const referencedSync =
+    referenced?.filter(
+      (e): e is Extract<(typeof referenced)[number], { type: 'sync' }> =>
+        e.type === 'sync',
+    ) ?? [];
+  const referencedAsync =
+    referenced?.filter(
+      (e): e is Extract<(typeof referenced)[number], { type: 'async' }> =>
+        e.type === 'async',
+    ) ?? [];
+
   function getActiveFeatureFlags() {
     const featureFlagsApi = options.apis.get(featureFlagsApiRef);
     if (!featureFlagsApi) {
@@ -62,7 +90,27 @@ export function createPredicateContextLoader(options: {
     );
   }
 
+  function resolveSyncProviders(): Record<string, string[]> {
+    const results: Record<string, string[]> = {};
+    for (const entry of referencedSync) {
+      try {
+        results[entry.namespace] = entry.resolver({ apis: options.apis });
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error(
+          'Failed to resolve extension predicate context provider:',
+          error,
+        );
+      }
+    }
+    return results;
+  }
+
   function getImmediate(): ExtensionPredicateContext | undefined {
+    if (referencedAsync.length > 0) {
+      return undefined;
+    }
+
     if (options.predicateReferences.permissions.length > 0) {
       const permissionApi = options.apis.get(localPermissionApiRef);
       if (permissionApi) {
@@ -73,6 +121,7 @@ export function createPredicateContextLoader(options: {
     return {
       featureFlags: getActiveFeatureFlags(),
       permissions: [],
+      ...resolveSyncProviders(),
     };
   }
 
@@ -105,9 +154,32 @@ export function createPredicateContextLoader(options: {
       }
     }
 
+    const asyncResults: Record<string, string[]> = {};
+    if (referencedAsync.length > 0) {
+      const results = await Promise.allSettled(
+        referencedAsync.map(async entry => {
+          const values = await entry.loader({ apis: options.apis });
+          return { namespace: entry.namespace, values };
+        }),
+      );
+      for (const result of results) {
+        if (result.status === 'fulfilled') {
+          asyncResults[result.value.namespace] = result.value.values;
+        } else {
+          // eslint-disable-next-line no-console
+          console.error(
+            'Failed to load extension predicate context provider:',
+            result.reason,
+          );
+        }
+      }
+    }
+
     return {
       featureFlags: getActiveFeatureFlags(),
       permissions: allowedPermissions,
+      ...resolveSyncProviders(),
+      ...asyncResults,
     };
   }
 
@@ -119,9 +191,15 @@ export function createPredicateContextLoader(options: {
 
 export function collectPredicateReferences(
   nodes: Iterable<{ spec: { if?: FilterPredicate } }>,
-): ExtensionPredicateContext {
+): {
+  predicateReferences: ExtensionPredicateContext;
+  referencedNamespaces: Set<string>;
+} {
   const featureFlags = new Set<string>();
   const permissions = new Set<string>();
+  const referencedNamespaces = new Set<string>();
+
+  const wellKnownKeys = new Set(['featureFlags', 'permissions']);
 
   for (const node of nodes) {
     if (node.spec.if === undefined) {
@@ -134,11 +212,19 @@ export function collectPredicateReferences(
     for (const name of extractPermissionNames(node.spec.if)) {
       permissions.add(name);
     }
+    for (const key of extractPredicateExpressionKeys(node.spec.if)) {
+      if (!wellKnownKeys.has(key)) {
+        referencedNamespaces.add(key);
+      }
+    }
   }
 
   return {
-    featureFlags: Array.from(featureFlags),
-    permissions: Array.from(permissions),
+    predicateReferences: {
+      featureFlags: Array.from(featureFlags),
+      permissions: Array.from(permissions),
+    },
+    referencedNamespaces,
   };
 }
 
@@ -190,4 +276,25 @@ function extractPredicateKeyNames(
     }
   }
   return [];
+}
+
+function extractPredicateExpressionKeys(predicate: FilterPredicate): string[] {
+  if (typeof predicate !== 'object' || predicate === null) {
+    return [];
+  }
+  const obj = predicate as Record<string, unknown>;
+  if (Array.isArray(obj.$all)) {
+    return (obj.$all as FilterPredicate[]).flatMap(
+      extractPredicateExpressionKeys,
+    );
+  }
+  if (Array.isArray(obj.$any)) {
+    return (obj.$any as FilterPredicate[]).flatMap(
+      extractPredicateExpressionKeys,
+    );
+  }
+  if (obj.$not !== undefined) {
+    return extractPredicateExpressionKeys(obj.$not as FilterPredicate);
+  }
+  return Object.keys(obj).filter(k => !k.startsWith('$'));
 }

--- a/packages/frontend-app-api/src/wiring/prepareSpecializedApp.tsx
+++ b/packages/frontend-app-api/src/wiring/prepareSpecializedApp.tsx
@@ -86,6 +86,7 @@ import {
   createBootstrapApp,
   prepareFinalizedTree,
 } from './treeLifecycle';
+import { collectPredicateContextProviderEntries } from './predicateContextProviders';
 
 function deduplicateFeatures(
   allFeatures: FrontendFeature[],
@@ -328,7 +329,13 @@ export function prepareSpecializedApp(
     tree,
     collector,
   });
-  const predicateReferences = collectPredicateReferences(tree.nodes.values());
+  const { predicateReferences, referencedNamespaces } =
+    collectPredicateReferences(tree.nodes.values());
+  const predicateContextProviders = collectPredicateContextProviderEntries({
+    providerNodes:
+      tree.root.edges.attachments.get('predicateContextProviders') ?? [],
+    collector,
+  });
   const appApiRegistry = new FrontendApiRegistry();
   const internalStaticFactories =
     internalOptions?.__internal?.apiFactoryOverrides ?? [];
@@ -372,6 +379,8 @@ export function prepareSpecializedApp(
   const predicateContextLoader = createPredicateContextLoader({
     apis: phase.apis,
     predicateReferences,
+    referencedNamespaces,
+    providerEntries: predicateContextProviders,
   });
   let signInRuntime: SignInRuntime | undefined;
   let finalized: FinalizedSpecializedApp | undefined;

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -1597,6 +1597,66 @@ export interface ExtensionInput<
   }>;
 }
 
+// @public (undocumented)
+export type ExtensionPredicateContextProviderAsyncParams = {
+  loader: ExtensionPredicateContextProviderLoader;
+  resolver?: never;
+};
+
+// @public
+export const ExtensionPredicateContextProviderBlueprint: ExtensionBlueprint_2<{
+  kind: 'extension-predicate-context-provider';
+  params:
+    | ExtensionPredicateContextProviderSyncParams
+    | ExtensionPredicateContextProviderAsyncParams;
+  output:
+    | ExtensionDataRef_2<
+        ExtensionPredicateContextProviderResolver,
+        'core.extension-predicate-context-provider.resolver',
+        {
+          optional: true;
+        }
+      >
+    | ExtensionDataRef_2<
+        ExtensionPredicateContextProviderLoader,
+        'core.extension-predicate-context-provider.loader',
+        {
+          optional: true;
+        }
+      >;
+  inputs: {};
+  config: {};
+  configInput: {};
+  dataRefs: {
+    resolver: ConfigurableExtensionDataRef_2<
+      ExtensionPredicateContextProviderResolver,
+      'core.extension-predicate-context-provider.resolver',
+      {}
+    >;
+    loader: ConfigurableExtensionDataRef_2<
+      ExtensionPredicateContextProviderLoader,
+      'core.extension-predicate-context-provider.loader',
+      {}
+    >;
+  };
+}>;
+
+// @public (undocumented)
+export type ExtensionPredicateContextProviderLoader = (options: {
+  apis: ApiHolder;
+}) => Promise<string[]>;
+
+// @public (undocumented)
+export type ExtensionPredicateContextProviderResolver = (options: {
+  apis: ApiHolder;
+}) => string[];
+
+// @public (undocumented)
+export type ExtensionPredicateContextProviderSyncParams = {
+  resolver: ExtensionPredicateContextProviderResolver;
+  loader?: never;
+};
+
 // @public
 export interface ExternalRouteRef<
   TParams extends AnyRouteRefParams = AnyRouteRefParams,

--- a/packages/frontend-plugin-api/src/blueprints/ExtensionPredicateContextProviderBlueprint.test.ts
+++ b/packages/frontend-plugin-api/src/blueprints/ExtensionPredicateContextProviderBlueprint.test.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ExtensionPredicateContextProviderBlueprint } from './ExtensionPredicateContextProviderBlueprint';
+
+describe('ExtensionPredicateContextProviderBlueprint', () => {
+  it('should create an async extension with a loader', () => {
+    const extension = ExtensionPredicateContextProviderBlueprint.make({
+      name: 'test-async',
+      params: {
+        loader: async () => ['value-a', 'value-b'],
+      },
+    });
+
+    expect(extension).toMatchInlineSnapshot(`
+      {
+        "$$type": "@backstage/ExtensionDefinition",
+        "T": undefined,
+        "attachTo": {
+          "id": "root",
+          "input": "predicateContextProviders",
+        },
+        "configSchema": undefined,
+        "disabled": false,
+        "factory": [Function],
+        "if": undefined,
+        "inputs": {},
+        "kind": "extension-predicate-context-provider",
+        "name": "test-async",
+        "output": [
+          {
+            "$$type": "@backstage/ExtensionDataRef",
+            "config": {
+              "optional": true,
+            },
+            "id": "core.extension-predicate-context-provider.resolver",
+            "optional": [Function],
+            "toString": [Function],
+          },
+          {
+            "$$type": "@backstage/ExtensionDataRef",
+            "config": {
+              "optional": true,
+            },
+            "id": "core.extension-predicate-context-provider.loader",
+            "optional": [Function],
+            "toString": [Function],
+          },
+        ],
+        "override": [Function],
+        "toString": [Function],
+        "version": "v2",
+      }
+    `);
+  });
+
+  it('should create a sync extension with a resolver', () => {
+    const extension = ExtensionPredicateContextProviderBlueprint.make({
+      name: 'test-sync',
+      params: {
+        resolver: () => ['value-a', 'value-b'],
+      },
+    });
+
+    expect(extension).toMatchInlineSnapshot(`
+      {
+        "$$type": "@backstage/ExtensionDefinition",
+        "T": undefined,
+        "attachTo": {
+          "id": "root",
+          "input": "predicateContextProviders",
+        },
+        "configSchema": undefined,
+        "disabled": false,
+        "factory": [Function],
+        "if": undefined,
+        "inputs": {},
+        "kind": "extension-predicate-context-provider",
+        "name": "test-sync",
+        "output": [
+          {
+            "$$type": "@backstage/ExtensionDataRef",
+            "config": {
+              "optional": true,
+            },
+            "id": "core.extension-predicate-context-provider.resolver",
+            "optional": [Function],
+            "toString": [Function],
+          },
+          {
+            "$$type": "@backstage/ExtensionDataRef",
+            "config": {
+              "optional": true,
+            },
+            "id": "core.extension-predicate-context-provider.loader",
+            "optional": [Function],
+            "toString": [Function],
+          },
+        ],
+        "override": [Function],
+        "toString": [Function],
+        "version": "v2",
+      }
+    `);
+  });
+
+  it('should expose both data refs', () => {
+    expect(
+      ExtensionPredicateContextProviderBlueprint.dataRefs.loader,
+    ).toBeDefined();
+    expect(
+      ExtensionPredicateContextProviderBlueprint.dataRefs.resolver,
+    ).toBeDefined();
+  });
+});

--- a/packages/frontend-plugin-api/src/blueprints/ExtensionPredicateContextProviderBlueprint.ts
+++ b/packages/frontend-plugin-api/src/blueprints/ExtensionPredicateContextProviderBlueprint.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ApiHolder } from '../apis/system';
+import { createExtensionBlueprint, createExtensionDataRef } from '../wiring';
+
+/**
+ * @public
+ */
+export type ExtensionPredicateContextProviderResolver = (options: {
+  apis: ApiHolder;
+}) => string[];
+
+/**
+ * @public
+ */
+export type ExtensionPredicateContextProviderLoader = (options: {
+  apis: ApiHolder;
+}) => Promise<string[]>;
+
+const resolverDataRef =
+  createExtensionDataRef<ExtensionPredicateContextProviderResolver>().with({
+    id: 'core.extension-predicate-context-provider.resolver',
+  });
+
+const loaderDataRef =
+  createExtensionDataRef<ExtensionPredicateContextProviderLoader>().with({
+    id: 'core.extension-predicate-context-provider.loader',
+  });
+
+/**
+ * @public
+ */
+export type ExtensionPredicateContextProviderSyncParams = {
+  resolver: ExtensionPredicateContextProviderResolver;
+  loader?: never;
+};
+
+/**
+ * @public
+ */
+export type ExtensionPredicateContextProviderAsyncParams = {
+  loader: ExtensionPredicateContextProviderLoader;
+  resolver?: never;
+};
+
+/**
+ * Creates extensions that provide predicate context values, either
+ * synchronously via `resolver` or asynchronously via `loader`.
+ *
+ * @public
+ */
+export const ExtensionPredicateContextProviderBlueprint =
+  createExtensionBlueprint({
+    kind: 'extension-predicate-context-provider',
+    attachTo: { id: 'root', input: 'predicateContextProviders' },
+    output: [resolverDataRef.optional(), loaderDataRef.optional()],
+    dataRefs: {
+      resolver: resolverDataRef,
+      loader: loaderDataRef,
+    },
+    *factory(
+      params:
+        | ExtensionPredicateContextProviderSyncParams
+        | ExtensionPredicateContextProviderAsyncParams,
+    ) {
+      if ('resolver' in params && params.resolver) {
+        yield resolverDataRef(params.resolver);
+      } else if ('loader' in params && params.loader) {
+        yield loaderDataRef(params.loader);
+      }
+    },
+  });

--- a/packages/frontend-plugin-api/src/blueprints/index.ts
+++ b/packages/frontend-plugin-api/src/blueprints/index.ts
@@ -20,6 +20,13 @@ export {
 } from './AnalyticsImplementationBlueprint';
 export { ApiBlueprint } from './ApiBlueprint';
 export { AppRootElementBlueprint } from './AppRootElementBlueprint';
+export {
+  ExtensionPredicateContextProviderBlueprint,
+  type ExtensionPredicateContextProviderAsyncParams,
+  type ExtensionPredicateContextProviderLoader,
+  type ExtensionPredicateContextProviderResolver,
+  type ExtensionPredicateContextProviderSyncParams,
+} from './ExtensionPredicateContextProviderBlueprint';
 export { PageBlueprint } from './PageBlueprint';
 export { SubPageBlueprint } from './SubPageBlueprint';
 export { PluginHeaderActionBlueprint } from './PluginHeaderActionBlueprint';


### PR DESCRIPTION
## What / Why

Permissions and feature flags cover a good swath of use-cases for gating extensions, but I think there are many more use-cases that we might want to enable (e.g. based on values from config, values from backend plugins, etc).

Proposal is to introduce a new extension kind that allows plugins to declare custom extension predicate context, with options for synchronous and asynchronous providers.

It's conceivable that we could migrate the existing `permissions` and `featureFlags` context into the `app` plugin using this system, though I avoided doing that here since it'd be a pretty significant breaking change (they'd be under new keys like `app/featureFlags` or `app/permissions`).

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
