### PR TITLE
fix(catalog-backend): avoid AJV $id collision in SchemaValidator

### DIFF
--- a/.changeset/pretty-baths-kick.md
+++ b/.changeset/pretty-baths-kick.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Fixed a bug where catalog entities could fail to process when catalog model sources are enabled and the catalog mixes `backstage.io/v1alpha1` and `backstage.io/v1beta1` for the same kind.

--- a/plugins/catalog-backend/src/processors/SchemaValidator.test.ts
+++ b/plugins/catalog-backend/src/processors/SchemaValidator.test.ts
@@ -93,4 +93,60 @@ describe('SchemaValidator', () => {
       jest.useRealTimers();
     }
   });
+
+  it('handles distinct schema objects that share the same $id', () => {
+    const validator = new SchemaValidator();
+
+    const base = {
+      $id: 'ApiV1alpha1',
+      type: 'object',
+      required: ['apiVersion', 'spec'],
+      properties: {
+        apiVersion: { type: 'string' },
+        spec: {
+          type: 'object',
+          required: ['owner'],
+          properties: { owner: { type: 'string', minLength: 1 } },
+        },
+      },
+    };
+    const v1alpha1Schema = {
+      ...base,
+      properties: {
+        ...base.properties,
+        apiVersion: { const: 'backstage.io/v1alpha1' },
+      },
+    };
+    const v1beta1Schema = {
+      ...base,
+      properties: {
+        ...base.properties,
+        apiVersion: { const: 'backstage.io/v1beta1' },
+      },
+    };
+
+    // Both schemas carry the same `$id` but are distinct objects, as produced
+    // by the catalog model when a kind shares a schema across apiVersions.
+    // Validating the second one must not fail with an AJV `$id` collision.
+    expect(
+      validator.validate(v1alpha1Schema, {
+        apiVersion: 'backstage.io/v1alpha1',
+        spec: { owner: 'group:default/team-a' },
+      }),
+    ).toEqual([]);
+    expect(
+      validator.validate(v1beta1Schema, {
+        apiVersion: 'backstage.io/v1beta1',
+        spec: { owner: 'group:default/team-b' },
+      }),
+    ).toEqual([]);
+
+    // Each validator still enforces its own apiVersion constraint.
+    expect(
+      validator.validate(v1alpha1Schema, {
+        apiVersion: 'backstage.io/v1beta1',
+        spec: { owner: 'group:default/team-a' },
+      }).length,
+    ).toBeGreaterThan(0);
+  });
 });

--- a/plugins/catalog-backend/src/processors/SchemaValidator.ts
+++ b/plugins/catalog-backend/src/processors/SchemaValidator.ts
@@ -66,6 +66,8 @@ export class SchemaValidator {
       allowUnionTypes: true,
       allErrors: true,
       validateSchema: true,
+      // Schemas share $id across apiVersions; validators are cached by object, not $id.
+      addUsedSchema: false,
     });
     ajvErrors(this.#ajv);
   }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix for #34551. Tested locally and deployed to our test env.

`SchemaValidator` uses a shared AJV instance. Compiled model schemas share `$id` across apiVersions but are different objects: AJV seems to reject the second compile.

Proposed fix is to add [`addUsedSchema: false`](https://ajv.js.org/options.html#addusedschema): it should be safe here. `SchemaValidator` already has a cache layer in an `ExpiryMap` by object, not by `$id`. v1alpha1 and v1beta1 schemas must stay distinct validators even when `$id` matches.

I also considered ephemeral AJV per compile (works but ~2.5× slower on cold compile). Landed on this as I haven't found any measurable perf regression with some local benchmarks.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Tests for new functionality and regression tests for bug fixes
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
