### PR TITLE
chore: clean up released patch files

### DIFF
--- a/.patches/pr-34323.txt
+++ b/.patches/pr-34323.txt
@@ -1,1 +1,0 @@
-Split queryEntities list and count queries to fix CTE materialization bottleneck

--- a/.patches/pr-34415.txt
+++ b/.patches/pr-34415.txt
@@ -1,1 +1,0 @@
-Fix 406 response for repository/archive retrieval in gitlabUrlReader

--- a/.patches/pr-34416.txt
+++ b/.patches/pr-34416.txt
@@ -1,1 +1,0 @@
-Restore runtime dependencies incorrectly demoted to devDependencies

--- a/.patches/pr-34425.txt
+++ b/.patches/pr-34425.txt
@@ -1,1 +1,0 @@
-Fix msgraph userGroupMember filter error by filtering disabled users client-side

--- a/.patches/pr-34505.txt
+++ b/.patches/pr-34505.txt
@@ -1,1 +1,0 @@
-Fix empty userSelect causing all users to be dropped in msgraph module


### PR DESCRIPTION
Removes patch files that have already been included in a release.

- pr-34323.txt
- pr-34415.txt
- pr-34416.txt
- pr-34425.txt
- pr-34505.txt