### PR TITLE
feat(catalog-react): expose refresh on useEntityList

### DIFF
--- a/.changeset/entity-list-provider-refresh.md
+++ b/.changeset/entity-list-provider-refresh.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': minor
+---
+
+Added a `refresh` function to the `useEntityList` hook.

--- a/plugins/catalog-react/report.api.md
+++ b/plugins/catalog-react/report.api.md
@@ -472,6 +472,7 @@ export type EntityListContextProps<
   setLimit: (limit: number) => void;
   setOffset?: (offset: number) => void;
   paginationMode: PaginationMode;
+  refresh?: () => void;
 };
 
 // @public (undocumented)

--- a/plugins/catalog-react/src/deprecated.tsx
+++ b/plugins/catalog-react/src/deprecated.tsx
@@ -79,6 +79,7 @@ export function MockEntityListContextProvider<
       setLimit: value?.setLimit ?? (() => {}),
       setOffset: value?.setOffset,
       paginationMode: value?.paginationMode ?? 'none',
+      refresh: value?.refresh ?? (() => {}),
     }),
     [value, defaultValues, filters, updateFilters],
   );

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.test.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.test.tsx
@@ -417,6 +417,25 @@ describe('<EntityListProvider />', () => {
     });
   });
 
+  it('re-fetches when refresh is called', async () => {
+    const { result } = renderHook(() => useEntityList(), {
+      wrapper: createWrapper({ pagination }),
+    });
+
+    await waitFor(() => {
+      expect(result.current.backendEntities.length).toBe(2);
+    });
+    expect(mockCatalogApi.getEntities).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.refresh?.();
+    });
+
+    await waitFor(() => {
+      expect(mockCatalogApi.getEntities).toHaveBeenCalledTimes(2);
+    });
+  });
+
   it('uses the last applied filter even if an earlier request finishes later', async () => {
     const { result } = renderHook(() => useEntityList(), {
       wrapper: createWrapper({ pagination }),
@@ -729,6 +748,44 @@ describe('<EntityListProvider pagination />', () => {
     ).mock.calls.filter((c: any) => c[0]?.limit === 0).length;
 
     expect(countCallsAfter).toBe(countCallsBefore);
+  });
+
+  it('re-fetches list and count when refresh is called', async () => {
+    const { result } = renderHook(() => useEntityList(), {
+      wrapper: createWrapper({ pagination }),
+    });
+
+    await waitFor(() => {
+      expect(result.current.backendEntities.length).toBe(2);
+    });
+
+    await waitFor(() => {
+      expect(mockCatalogApi.queryEntities).toHaveBeenCalledWith(
+        expect.objectContaining({ limit: 0 }),
+      );
+    });
+
+    const listCallsBefore = (
+      mockCatalogApi.queryEntities as jest.Mock
+    ).mock.calls.filter((c: any) => c[0]?.totalItems === 'exclude').length;
+    const countCallsBefore = (
+      mockCatalogApi.queryEntities as jest.Mock
+    ).mock.calls.filter((c: any) => c[0]?.limit === 0).length;
+
+    act(() => {
+      result.current.refresh?.();
+    });
+
+    await waitFor(() => {
+      const listCallsAfter = (
+        mockCatalogApi.queryEntities as jest.Mock
+      ).mock.calls.filter((c: any) => c[0]?.totalItems === 'exclude').length;
+      const countCallsAfter = (
+        mockCatalogApi.queryEntities as jest.Mock
+      ).mock.calls.filter((c: any) => c[0]?.limit === 0).length;
+      expect(listCallsAfter).toBe(listCallsBefore + 1);
+      expect(countCallsAfter).toBe(countCallsBefore + 1);
+    });
   });
 
   it('returns an error on catalogApi failure', async () => {
@@ -1248,6 +1305,7 @@ describe('versioned context', () => {
       setLimit: jest.fn(),
       setOffset: jest.fn(),
       paginationMode: 'none',
+      refresh: jest.fn(),
     };
 
     const { result } = renderHook(() => useEntityList(), {

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
@@ -127,6 +127,11 @@ export type EntityListContextProps<
   setLimit: (limit: number) => void;
   setOffset?: (offset: number) => void;
   paginationMode: PaginationMode;
+
+  /**
+   * Trigger refresh of entities and entity totals.
+   */
+  refresh?: () => void;
 };
 
 // This context has support for multiple concurrent versions of this package.
@@ -234,6 +239,7 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
   });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | undefined>();
+  const [refreshToken, setRefreshToken] = useState(0);
 
   // Tracks the params of the last API call so identical requests are
   // skipped even when requestedFilters changes (e.g. a label change
@@ -345,7 +351,13 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
 
   // Slight debounce on the refresh, since (especially on page load)
   // several filters will be calling updateFilters in rapid succession.
-  useDebounce(refresh, 10, [adjustedFilters, cursor, limit, offset]);
+  useDebounce(refresh, 10, [
+    adjustedFilters,
+    cursor,
+    limit,
+    offset,
+    refreshToken,
+  ]);
 
   // Fetch the total count separately, only when filters change. This is
   // decoupled from the main list fetch so that page navigation doesn't
@@ -372,7 +384,7 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
       }
     }, [catalogApi, paginationMode, adjustedFilters]);
 
-  useDebounce(refreshCount, 10, [adjustedFilters]);
+  useDebounce(refreshCount, 10, [adjustedFilters, refreshToken]);
 
   // Frontend filtering — synchronous, no debounce needed. Updates
   // instantly when requestedFilters or backendEntities change.
@@ -451,6 +463,12 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
     [paginationMode],
   );
 
+  const triggerRefresh = useCallback(() => {
+    // Clear the ref to allow refetching with the same params.
+    lastFetchParamsRef.current = undefined;
+    setRefreshToken(t => t + 1);
+  }, []);
+
   const pageInfo = useMemo(() => {
     if (paginationMode !== 'cursor') {
       return undefined;
@@ -484,6 +502,7 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
       setLimit,
       setOffset,
       paginationMode,
+      refresh: triggerRefresh,
     }),
     [
       requestedFilters,
@@ -501,6 +520,7 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
       offset,
       setLimit,
       setOffset,
+      triggerRefresh,
     ],
   );
 

--- a/plugins/catalog-react/src/testUtils/MockEntityListContextProvider.tsx
+++ b/plugins/catalog-react/src/testUtils/MockEntityListContextProvider.tsx
@@ -79,6 +79,7 @@ export function MockEntityListContextProvider<
       setLimit: value?.setLimit ?? (() => {}),
       setOffset: value?.setOffset,
       paginationMode: value?.paginationMode ?? 'none',
+      refresh: value?.refresh ?? (() => {}),
     }),
     [value, defaultValues, filters, updateFilters],
   );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds a `refresh()` function to the `EntityListContextProps` returned by `useEntityList`. Calling it re-fetches entities and entity totals from the catalog API, even when filters haven't changed since the last fetch. This is useful for refreshing the list after an external mutation (e.g. registering or unregistering an entity).

### How it works

A `refreshToken` counter is added to the provider state. When `refresh()` is called it clears the cached fetch params (bypassing the dedup check) and increments the token, which triggers the debounced entity fetch and count fetch.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))