### PR TITLE
chore: add kubernetes-react package support metadata

### DIFF
--- a/.changeset/kubernetes-react-support-metadata.md
+++ b/.changeset/kubernetes-react-support-metadata.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-react': patch
+---
+
+Added package homepage and bugs metadata.

--- a/plugins/kubernetes-react/package.json
+++ b/plugins/kubernetes-react/package.json
@@ -21,6 +21,10 @@
     "url": "https://github.com/backstage/backstage",
     "directory": "plugins/kubernetes-react"
   },
+  "homepage": "https://github.com/backstage/backstage/tree/master/plugins/kubernetes-react#readme",
+  "bugs": {
+    "url": "https://github.com/backstage/backstage/issues"
+  },
   "license": "Apache-2.0",
   "sideEffects": false,
   "exports": {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added npm support metadata for `@backstage/plugin-kubernetes-react`:

- `homepage` points to the package README location in this repo
- `bugs.url` points to the Backstage issue tracker

This is metadata-only. It does not change runtime code, dependencies, exports, generated files, or build behavior.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages
- [ ] Added or updated relevant documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. (more info)

Verification:

```sh
node -e "const p=require('./plugins/kubernetes-react/package.json'); if(p.name!=='@backstage/plugin-kubernetes-react'||p.homepage!=='https://github.com/backstage/backstage/tree/master/plugins/kubernetes-react#readme'||p.bugs?.url!=='https://github.com/backstage/backstage/issues') process.exit(1); console.log('package metadata OK')"
git diff --check
```
