### PR TITLE
chore: add cli-common bugs metadata

### DIFF
--- a/.changeset/cli-common-bugs-metadata.md
+++ b/.changeset/cli-common-bugs-metadata.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli-common': patch
+---
+
+Added package bugs metadata.

--- a/packages/cli-common/package.json
+++ b/packages/cli-common/package.json
@@ -17,6 +17,9 @@
     "url": "https://github.com/backstage/backstage",
     "directory": "packages/cli-common"
   },
+  "bugs": {
+    "url": "https://github.com/backstage/backstage/issues"
+  },
   "license": "Apache-2.0",
   "exports": {
     ".": "./src/index.ts",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added npm `bugs.url` metadata for `@backstage/cli-common`, pointing to the Backstage issue tracker.

This is metadata-only. It does not change runtime code, dependencies, exports, generated files, or build behavior.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages
- [ ] Added or updated relevant documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. (more info)

Verification:

```sh
node -e "const p=require('./packages/cli-common/package.json'); if(p.name!=='@backstage/cli-common'||p.bugs?.url!=='https://github.com/backstage/backstage/issues') process.exit(1); console.log('package metadata OK')"
git diff --check
```
