### PR TITLE
chore: add types bugs metadata

### DIFF
--- a/.changeset/types-bugs-metadata.md
+++ b/.changeset/types-bugs-metadata.md
@@ -1,0 +1,5 @@
+---
+'@backstage/types': patch
+---
+
+Added package bugs metadata.

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -20,6 +20,9 @@
     "url": "https://github.com/backstage/backstage",
     "directory": "packages/types"
   },
+  "bugs": {
+    "url": "https://github.com/backstage/backstage/issues"
+  },
   "license": "Apache-2.0",
   "sideEffects": false,
   "main": "src/index.ts",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added npm `bugs.url` metadata for `@backstage/types`, pointing to the Backstage issue tracker.

This is metadata-only. It does not change runtime code, dependencies, exports, generated files, or build behavior.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages
- [ ] Added or updated relevant documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. (more info)

Verification:

```sh
node -e "const p=require('./packages/types/package.json'); if(p.name!=='@backstage/types'||p.bugs?.url!=='https://github.com/backstage/backstage/issues') process.exit(1); console.log('package metadata OK')"
git diff --check
```
