### PR TITLE
chore: add backend-plugin-api bugs metadata

### DIFF
--- a/.changeset/backend-plugin-api-bugs-metadata.md
+++ b/.changeset/backend-plugin-api-bugs-metadata.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-plugin-api': patch
+---
+
+Added package bugs metadata.

--- a/packages/backend-plugin-api/package.json
+++ b/packages/backend-plugin-api/package.json
@@ -17,6 +17,9 @@
     "url": "https://github.com/backstage/backstage",
     "directory": "packages/backend-plugin-api"
   },
+  "bugs": {
+    "url": "https://github.com/backstage/backstage/issues"
+  },
   "license": "Apache-2.0",
   "exports": {
     ".": "./src/index.ts",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added npm `bugs.url` metadata for `@backstage/backend-plugin-api`, pointing to the Backstage issue tracker.

This is metadata-only. It does not change runtime code, dependencies, exports, generated files, or build behavior.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages
- [ ] Added or updated relevant documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. (more info)

Verification:

```sh
node -e "const p=require('./packages/backend-plugin-api/package.json'); if(p.name!=='@backstage/backend-plugin-api'||p.bugs?.url!=='https://github.com/backstage/backstage/issues') process.exit(1); console.log('package metadata OK')"
git diff --check
```
