### PR TITLE
chore: add config-loader bugs metadata

### DIFF
--- a/.changeset/config-loader-bugs-metadata.md
+++ b/.changeset/config-loader-bugs-metadata.md
@@ -1,0 +1,5 @@
+---
+'@backstage/config-loader': patch
+---
+
+Added package bugs metadata.

--- a/packages/config-loader/package.json
+++ b/packages/config-loader/package.json
@@ -20,6 +20,9 @@
     "url": "https://github.com/backstage/backstage",
     "directory": "packages/config-loader"
   },
+  "bugs": {
+    "url": "https://github.com/backstage/backstage/issues"
+  },
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added npm `bugs.url` metadata for `@backstage/config-loader`, pointing to the Backstage issue tracker.

This is metadata-only. It does not change runtime code, dependencies, exports, generated files, or build behavior.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages
- [ ] Added or updated relevant documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. (more info)

Verification:

```sh
node -e "const p=require('./packages/config-loader/package.json'); if(p.name!=='@backstage/config-loader'||p.bugs?.url!=='https://github.com/backstage/backstage/issues') process.exit(1); console.log('package metadata OK')"
git diff --check
```
