### PR TITLE
chore: add package support metadata

### DIFF
--- a/.changeset/package-support-metadata.md
+++ b/.changeset/package-support-metadata.md
@@ -1,0 +1,10 @@
+---
+'@backstage/plugin-kubernetes-react': patch
+'@backstage/cli-common': patch
+'@backstage/config': patch
+'@backstage/types': patch
+'@backstage/backend-plugin-api': patch
+'@backstage/config-loader': patch
+---
+
+Added package support metadata.

--- a/packages/backend-plugin-api/package.json
+++ b/packages/backend-plugin-api/package.json
@@ -17,6 +17,9 @@
     "url": "https://github.com/backstage/backstage",
     "directory": "packages/backend-plugin-api"
   },
+  "bugs": {
+    "url": "https://github.com/backstage/backstage/issues"
+  },
   "license": "Apache-2.0",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/cli-common/package.json
+++ b/packages/cli-common/package.json
@@ -17,6 +17,9 @@
     "url": "https://github.com/backstage/backstage",
     "directory": "packages/cli-common"
   },
+  "bugs": {
+    "url": "https://github.com/backstage/backstage/issues"
+  },
   "license": "Apache-2.0",
   "exports": {
     ".": "./src/index.ts",

--- a/packages/config-loader/package.json
+++ b/packages/config-loader/package.json
@@ -20,6 +20,9 @@
     "url": "https://github.com/backstage/backstage",
     "directory": "packages/config-loader"
   },
+  "bugs": {
+    "url": "https://github.com/backstage/backstage/issues"
+  },
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -20,6 +20,9 @@
     "url": "https://github.com/backstage/backstage",
     "directory": "packages/config"
   },
+  "bugs": {
+    "url": "https://github.com/backstage/backstage/issues"
+  },
   "license": "Apache-2.0",
   "sideEffects": false,
   "main": "src/index.ts",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -20,6 +20,9 @@
     "url": "https://github.com/backstage/backstage",
     "directory": "packages/types"
   },
+  "bugs": {
+    "url": "https://github.com/backstage/backstage/issues"
+  },
   "license": "Apache-2.0",
   "sideEffects": false,
   "main": "src/index.ts",

--- a/plugins/kubernetes-react/package.json
+++ b/plugins/kubernetes-react/package.json
@@ -21,6 +21,10 @@
     "url": "https://github.com/backstage/backstage",
     "directory": "plugins/kubernetes-react"
   },
+  "homepage": "https://github.com/backstage/backstage/tree/master/plugins/kubernetes-react#readme",
+  "bugs": {
+    "url": "https://github.com/backstage/backstage/issues"
+  },
   "license": "Apache-2.0",
   "sideEffects": false,
   "exports": {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Added npm package support metadata for six Backstage packages:

- `@backstage/plugin-kubernetes-react`: adds `homepage` and `bugs.url`
- `@backstage/cli-common`: adds `bugs.url`
- `@backstage/config`: adds `bugs.url`
- `@backstage/types`: adds `bugs.url`
- `@backstage/backend-plugin-api`: adds `bugs.url`
- `@backstage/config-loader`: adds `bugs.url`

The `bugs.url` value points to the Backstage issue tracker. This is metadata-only. It does not change runtime code, dependencies, exports, generated files, or build behavior.

This replaces my earlier smaller PRs for these same package metadata updates, so maintainers can review one batch instead of several tiny PRs.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages
- [ ] Added or updated relevant documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. (more info)

Verification:

```sh
node - <<'NODE'
const checks = [
  ['plugins/kubernetes-react/package.json', '@backstage/plugin-kubernetes-react', 'https://github.com/backstage/backstage/tree/master/plugins/kubernetes-react#readme'],
  ['packages/cli-common/package.json', '@backstage/cli-common'],
  ['packages/config/package.json', '@backstage/config'],
  ['packages/types/package.json', '@backstage/types'],
  ['packages/backend-plugin-api/package.json', '@backstage/backend-plugin-api'],
  ['packages/config-loader/package.json', '@backstage/config-loader'],
]
for (const [file, name, homepage] of checks) {
  const p = require(`./${file}`)
  if (p.name !== name || p.bugs?.url !== 'https://github.com/backstage/backstage/issues') process.exit(1)
  if (homepage && p.homepage !== homepage) process.exit(1)
  console.log(`${p.name} metadata OK`)
}
NODE
git diff --check
```
