### PR TITLE
docs: add bugs metadata to @backstage/backend-openapi-utils

### DIFF
--- a/.changeset/bugs-metadata-utils.md
+++ b/.changeset/bugs-metadata-utils.md
@@ -1,0 +1,3 @@
+---
+@backstage/backend-openapi-utils: docs: add missing bugs metadata to package.json
+---

--- a/packages/backend-openapi-utils/package.json
+++ b/packages/backend-openapi-utils/package.json
@@ -12,7 +12,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/backstage/backstage",
-    "directory": "packages/backend-openapi-utils"
+    "directory": "packages/backend-openapi-utils",
+    "bugs": "https://github.com/backstage/backstage/issues"
   },
   "license": "Apache-2.0",
   "exports": {


### PR DESCRIPTION
This PR adds the missing  metadata to the  package.json to improve package discoverability and support for issue reporting.

Fixes Issue #1303 in charles-microbounties.