### PR TITLE
fix: resolve React console warnings in entity page and sidebar

### DIFF
--- a/.changeset/fix-entity-context-menu-keys.md
+++ b/.changeset/fix-entity-context-menu-keys.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Fixed a missing React key warning for context menu items on the entity page.

--- a/packages/app/src/modules/appModuleNav.tsx
+++ b/packages/app/src/modules/appModuleNav.tsx
@@ -15,7 +15,6 @@
  */
 
 import {
-  Link,
   Sidebar,
   sidebarConfig,
   SidebarDivider,
@@ -25,6 +24,7 @@ import {
   SidebarSpace,
   useSidebarOpenState,
 } from '@backstage/core-components';
+import { Link } from 'react-router-dom';
 import SearchIcon from '@material-ui/icons/Search';
 import MenuIcon from '@material-ui/icons/Menu';
 import { createFrontendModule } from '@backstage/frontend-plugin-api';
@@ -46,6 +46,7 @@ const useSidebarLogoStyles = makeStyles({
   link: {
     width: sidebarConfig.drawerWidthClosed,
     marginLeft: 24,
+    textDecoration: 'none',
   },
 });
 
@@ -55,7 +56,7 @@ const SidebarLogo = () => {
 
   return (
     <div className={classes.root}>
-      <Link to="/" underline="none" className={classes.link} aria-label="Home">
+      <Link to="/" className={classes.link} aria-label="Home">
         {isOpen ? (
           <svg
             style={{

--- a/plugins/catalog/src/components/EntityContextMenu/EntityContextMenu.tsx
+++ b/plugins/catalog/src/components/EntityContextMenu/EntityContextMenu.tsx
@@ -26,7 +26,7 @@ import Tooltip from '@material-ui/core/Tooltip';
 import { Theme, makeStyles } from '@material-ui/core/styles';
 import BugReportIcon from '@material-ui/icons/BugReport';
 import MoreVert from '@material-ui/icons/MoreVert';
-import { SyntheticEvent, useEffect, useState } from 'react';
+import { Fragment, SyntheticEvent, useEffect, useState } from 'react';
 import { IconComponent } from '@backstage/core-plugin-api';
 import { useEntityPermission } from '@backstage/plugin-catalog-react/alpha';
 import { catalogEntityDeletePermission } from '@backstage/plugin-catalog-common/alpha';
@@ -191,7 +191,9 @@ export function EntityContextMenu(props: EntityContextMenuProps) {
             defaultMenuItems
           ) : (
             <EntityContextMenuProvider onMenuClose={onClose}>
-              {contextMenuItems}
+              {contextMenuItems.map((item, index) => (
+                <Fragment key={index}>{item}</Fragment>
+              ))}
             </EntityContextMenuProvider>
           )}
         </MenuList>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes two React console warnings:

- **Missing key warning in `EntityContextMenu`**: Context menu items from `EntityContextMenuItemBlueprint` were rendered as an array without keys. Fixed by wrapping each item in a keyed `Fragment`, using the pre-filter index so keys remain stable when different entity types filter different items.

- **`findDOMNode` deprecation in `SidebarLogo`**: The Backstage `Link` wraps MUI v4's `Link` which uses `withStyles`, triggering a `findDOMNode` call. The sidebar logo only needs simple routing, so it now uses react-router's `Link` directly.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))