### PR TITLE
Make hasLabel.apply and hasAnnotation.apply case insensitive

### DIFF
--- a/.changeset/lovely-wombats-invite.md
+++ b/.changeset/lovely-wombats-invite.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+`HAS_LABEL` and `HAS_ANNOTATION` permission rules are now case insensitive.

--- a/plugins/catalog-backend/src/permissions/rules/hasAnnotation.test.ts
+++ b/plugins/catalog-backend/src/permissions/rules/hasAnnotation.test.ts
@@ -175,6 +175,50 @@ describe('hasAnnotation permission rule', () => {
         ),
       ).toEqual(true);
     });
+
+    it('matches annotation value across case-differing duplicate keys', () => {
+      expect(
+        hasAnnotation.apply(
+          {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Component',
+            metadata: {
+              name: 'test-component',
+              annotations: {
+                Foo: 'false',
+                foo: 'true',
+              },
+            },
+          },
+          {
+            annotation: 'Foo',
+            value: 'true',
+          },
+        ),
+      ).toEqual(true);
+    });
+
+    it('returns false when no case-differing duplicate key has the expected value', () => {
+      expect(
+        hasAnnotation.apply(
+          {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Component',
+            metadata: {
+              name: 'test-component',
+              annotations: {
+                Foo: 'false',
+                foo: 'true',
+              },
+            },
+          },
+          {
+            annotation: 'Foo',
+            value: 'other',
+          },
+        ),
+      ).toEqual(false);
+    });
   });
 
   describe('toQuery', () => {

--- a/plugins/catalog-backend/src/permissions/rules/hasAnnotation.test.ts
+++ b/plugins/catalog-backend/src/permissions/rules/hasAnnotation.test.ts
@@ -134,6 +134,47 @@ describe('hasAnnotation permission rule', () => {
         ),
       ).toEqual(true);
     });
+    it('should be case insensitive when matching annotation', () => {
+      expect(
+        hasAnnotation.apply(
+          {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Component',
+            metadata: {
+              name: 'test-component',
+              annotations: {
+                'other-annotation': 'foo',
+                'backstage.io/test-annotation': 'bar',
+              },
+            },
+          },
+          {
+            annotation: 'BACKSTAGE.IO/TEST-ANNOTATION',
+          },
+        ),
+      ).toEqual(true);
+    });
+    it('should be case insensitive when matching annotation values', () => {
+      expect(
+        hasAnnotation.apply(
+          {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Component',
+            metadata: {
+              name: 'test-component',
+              annotations: {
+                'other-annotation': 'foo',
+                'backstage.io/test-annotation': 'bar',
+              },
+            },
+          },
+          {
+            annotation: 'BACKSTAGE.IO/TEST-ANNOTATION',
+            value: 'BAR',
+          },
+        ),
+      ).toEqual(true);
+    });
   });
 
   describe('toQuery', () => {

--- a/plugins/catalog-backend/src/permissions/rules/hasAnnotation.ts
+++ b/plugins/catalog-backend/src/permissions/rules/hasAnnotation.ts
@@ -37,11 +37,26 @@ export const hasAnnotation = createPermissionRule({
       .optional()
       .describe('Value of the annotation to match on'),
   }),
-  apply: (resource, { annotation, value }) =>
-    !!resource.metadata.annotations?.hasOwnProperty(annotation) &&
-    (value === undefined
-      ? true
-      : resource.metadata.annotations?.[annotation] === value),
+  apply: (resource, { annotation, value }) => {
+    const normalizedAnnotation = annotation.toLocaleLowerCase('en-US');
+    const matchingResourceAnnotation = resource.metadata.annotations
+      ? Object.keys(resource.metadata.annotations).find(
+          key => key.toLocaleLowerCase('en-US') === normalizedAnnotation,
+        )
+      : undefined;
+
+    if (!matchingResourceAnnotation) return false;
+    if (value === undefined) return true;
+
+    const matchingResourceAnnotationValue =
+      resource.metadata.annotations?.[matchingResourceAnnotation];
+
+    return (
+      matchingResourceAnnotationValue !== undefined &&
+      matchingResourceAnnotationValue.toLocaleLowerCase('en-US') ===
+        value.toLocaleLowerCase('en-US')
+    );
+  },
   toQuery: ({ annotation, value }) =>
     value === undefined
       ? {

--- a/plugins/catalog-backend/src/permissions/rules/hasAnnotation.ts
+++ b/plugins/catalog-backend/src/permissions/rules/hasAnnotation.ts
@@ -38,24 +38,32 @@ export const hasAnnotation = createPermissionRule({
       .describe('Value of the annotation to match on'),
   }),
   apply: (resource, { annotation, value }) => {
+    if (!resource.metadata.annotations) return false;
+
+    // exact key match
+    const isExactKeyMatch =
+      !!resource.metadata.annotations?.hasOwnProperty(annotation) &&
+      (value === undefined
+        ? true
+        : resource.metadata.annotations?.[annotation] === value);
+
+    if (isExactKeyMatch) return true;
+
+    // case-insensitive matching if exact match is not found
     const normalizedAnnotation = annotation.toLocaleLowerCase('en-US');
-    const matchingResourceAnnotation = resource.metadata.annotations
-      ? Object.keys(resource.metadata.annotations).find(
-          key => key.toLocaleLowerCase('en-US') === normalizedAnnotation,
-        )
-      : undefined;
+    const normalizedValue = value?.toLocaleLowerCase('en-US');
 
-    if (!matchingResourceAnnotation) return false;
-    if (value === undefined) return true;
-
-    const matchingResourceAnnotationValue =
-      resource.metadata.annotations?.[matchingResourceAnnotation];
-
-    return (
-      matchingResourceAnnotationValue !== undefined &&
-      matchingResourceAnnotationValue.toLocaleLowerCase('en-US') ===
-        value.toLocaleLowerCase('en-US')
-    );
+    for (const [key, val] of Object.entries(resource.metadata.annotations)) {
+      if (key.toLocaleLowerCase('en-US') === normalizedAnnotation) {
+        if (
+          normalizedValue === undefined ||
+          val.toLocaleLowerCase('en-US') === normalizedValue
+        ) {
+          return true;
+        }
+      }
+    }
+    return false;
   },
   toQuery: ({ annotation, value }) =>
     value === undefined

--- a/plugins/catalog-backend/src/permissions/rules/hasLabel.test.ts
+++ b/plugins/catalog-backend/src/permissions/rules/hasLabel.test.ts
@@ -117,6 +117,49 @@ describe('hasLabel permission rule', () => {
         ),
       ).toEqual(true);
     });
+
+    it('performs case-insensitive matching of labels', () => {
+      expect(
+        hasLabel.apply(
+          {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Component',
+            metadata: {
+              name: 'test-component',
+              labels: {
+                someLabel: 'foo',
+                'backstage.io/testLabel': 'bar',
+              },
+            },
+          },
+          {
+            label: 'BACKSTAGE.IO/TESTLABEL',
+          },
+        ),
+      ).toEqual(true);
+    });
+
+    it('performs case-insensitive matching of label values', () => {
+      expect(
+        hasLabel.apply(
+          {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Component',
+            metadata: {
+              name: 'test-component',
+              labels: {
+                someLabel: 'foo',
+                'backstage.io/testLabel': 'bar',
+              },
+            },
+          },
+          {
+            label: 'BACKSTAGE.IO/TESTLABEL',
+            value: 'BAR',
+          },
+        ),
+      ).toEqual(true);
+    });
   });
 
   describe('toQuery', () => {

--- a/plugins/catalog-backend/src/permissions/rules/hasLabel.test.ts
+++ b/plugins/catalog-backend/src/permissions/rules/hasLabel.test.ts
@@ -160,6 +160,50 @@ describe('hasLabel permission rule', () => {
         ),
       ).toEqual(true);
     });
+
+    it('matches label value across case-differing duplicate keys', () => {
+      expect(
+        hasLabel.apply(
+          {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Component',
+            metadata: {
+              name: 'test-component',
+              labels: {
+                Foo: 'false',
+                foo: 'true',
+              },
+            },
+          },
+          {
+            label: 'Foo',
+            value: 'true',
+          },
+        ),
+      ).toEqual(true);
+    });
+
+    it('returns false when no case-differing duplicate key has the expected value', () => {
+      expect(
+        hasLabel.apply(
+          {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Component',
+            metadata: {
+              name: 'test-component',
+              labels: {
+                Foo: 'false',
+                foo: 'true',
+              },
+            },
+          },
+          {
+            label: 'Foo',
+            value: 'other',
+          },
+        ),
+      ).toEqual(false);
+    });
   });
 
   describe('toQuery', () => {

--- a/plugins/catalog-backend/src/permissions/rules/hasLabel.ts
+++ b/plugins/catalog-backend/src/permissions/rules/hasLabel.ts
@@ -31,9 +31,26 @@ export const hasLabel = createPermissionRule({
     label: z.string().describe('Name of the label to match on'),
     value: z.string().optional().describe('Value of the label to match on'),
   }),
-  apply: (resource, { label, value }) =>
-    !!resource.metadata.labels?.hasOwnProperty(label) &&
-    (value === undefined ? true : resource.metadata.labels?.[label] === value),
+  apply: (resource, { label, value }) => {
+    const normalizedLabel = label.toLocaleLowerCase('en-US');
+    const matchingResourceLabel = resource.metadata.labels
+      ? Object.keys(resource.metadata.labels).find(
+          key => key.toLocaleLowerCase('en-US') === normalizedLabel,
+        )
+      : undefined;
+
+    if (!matchingResourceLabel) return false;
+    if (value === undefined) return true;
+
+    const matchingResourceLabelValue =
+      resource.metadata.labels?.[matchingResourceLabel];
+
+    return (
+      matchingResourceLabelValue !== undefined &&
+      matchingResourceLabelValue.toLocaleLowerCase('en-US') ===
+        value.toLocaleLowerCase('en-US')
+    );
+  },
   toQuery: ({ label, value }) =>
     value === undefined
       ? {

--- a/plugins/catalog-backend/src/permissions/rules/hasLabel.ts
+++ b/plugins/catalog-backend/src/permissions/rules/hasLabel.ts
@@ -32,24 +32,32 @@ export const hasLabel = createPermissionRule({
     value: z.string().optional().describe('Value of the label to match on'),
   }),
   apply: (resource, { label, value }) => {
+    if (!resource.metadata.labels) return false;
+
+    // exact key match
+    const isExactKeyMatch =
+      !!resource.metadata.labels?.hasOwnProperty(label) &&
+      (value === undefined
+        ? true
+        : resource.metadata.labels?.[label] === value);
+
+    if (isExactKeyMatch) return true;
+
+    // case-insensitive matching if exact match is not found
     const normalizedLabel = label.toLocaleLowerCase('en-US');
-    const matchingResourceLabel = resource.metadata.labels
-      ? Object.keys(resource.metadata.labels).find(
-          key => key.toLocaleLowerCase('en-US') === normalizedLabel,
-        )
-      : undefined;
+    const normalizedValue = value?.toLocaleLowerCase('en-US');
 
-    if (!matchingResourceLabel) return false;
-    if (value === undefined) return true;
-
-    const matchingResourceLabelValue =
-      resource.metadata.labels?.[matchingResourceLabel];
-
-    return (
-      matchingResourceLabelValue !== undefined &&
-      matchingResourceLabelValue.toLocaleLowerCase('en-US') ===
-        value.toLocaleLowerCase('en-US')
-    );
+    for (const [key, val] of Object.entries(resource.metadata.labels)) {
+      if (key.toLocaleLowerCase('en-US') === normalizedLabel) {
+        if (
+          normalizedValue === undefined ||
+          val.toLocaleLowerCase('en-US') === normalizedValue
+        ) {
+          return true;
+        }
+      }
+    }
+    return false;
   },
   toQuery: ({ label, value }) =>
     value === undefined


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR makes hasLabel.apply and hasAnnotation.apply case insensitive so that catalog list/query behavior and search agree with each other when the label/annotation key in the entity YAML does not use the exact same casing as the label/annotation name in the policy.

Fixes: https://github.com/backstage/backstage/issues/34571

Using the same example policy (with label 'isPublic') and entity (with label 'ispublic') as in https://github.com/backstage/backstage/issues/34571, the entity is visible in both catalog and search results now:

<img width="2945" height="1566" alt="Screenshot From 2026-06-12 13-26-51" src="https://github.com/user-attachments/assets/f0a21680-8932-4662-a06e-ca471d506f62" />
<img width="2945" height="1566" alt="Screenshot From 2026-06-12 13-27-24" src="https://github.com/user-attachments/assets/69b2819c-25f4-4816-8e58-713015e13739" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
