### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/config-loader/package.json
+++ b/packages/config-loader/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@backstage/config-loader",
   "version": "1.10.11",
+  "bugs": {
+    "url": "https://github.com/backstage/backstage/issues"
+  },
   "description": "Config loading functionality used by Backstage backend, and CLI",
   "backstage": {
     "role": "node-library"


### PR DESCRIPTION
Adds missing `bugs` metadata to `packages/config-loader/package.json`.