### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@backstage/types",
   "version": "1.2.2",
+  "bugs": {
+    "url": "https://github.com/backstage/backstage/issues"
+  },
   "description": "Common TypeScript types used within Backstage",
   "backstage": {
     "role": "common-library"


### PR DESCRIPTION
Adds missing `bugs` metadata to `packages/types/package.json`.