### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@backstage/config",
   "version": "1.3.8",
+  "bugs": {
+    "url": "https://github.com/backstage/backstage/issues"
+  },
   "description": "Config API used by Backstage core, backend, and CLI",
   "backstage": {
     "role": "common-library"


### PR DESCRIPTION
Adds missing `bugs` metadata to `packages/config/package.json`.