### PR TITLE
fix(ui): make Skeleton bg-context aware

### DIFF
--- a/.changeset/fuzzy-trams-speak.md
+++ b/.changeset/fuzzy-trams-speak.md
@@ -2,4 +2,6 @@
 '@backstage/ui': patch
 ---
 
-Make Skeleton component background aware
+Make Skeleton component background aware, automatically adjusting its color to maintain visible contrast against neutral parent surfaces.
+
+**Affected components:** Skeleton

--- a/.changeset/fuzzy-trams-speak.md
+++ b/.changeset/fuzzy-trams-speak.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Make Skeleton component background aware

--- a/packages/ui/report.api.md
+++ b/packages/ui/report.api.md
@@ -3840,6 +3840,7 @@ export const SkeletonDefinition: {
   readonly classNames: {
     readonly root: 'bui-Skeleton';
   };
+  readonly bg: 'consumer';
   readonly propDefs: {
     readonly width: {
       readonly default: 80;

--- a/packages/ui/src/components/Skeleton/Skeleton.module.css
+++ b/packages/ui/src/components/Skeleton/Skeleton.module.css
@@ -21,6 +21,18 @@
     animation: var(--bui-animate-pulse);
     background-color: var(--bui-bg-neutral-2);
     border-radius: var(--bui-radius-2);
+
+    &[data-on-bg='neutral-1'] {
+      background-color: var(--bui-bg-neutral-2);
+    }
+
+    &[data-on-bg='neutral-2'] {
+      background-color: var(--bui-bg-neutral-3);
+    }
+
+    &[data-on-bg='neutral-3'] {
+      background-color: var(--bui-bg-neutral-4);
+    }
   }
 
   .bui-Skeleton[data-rounded='true'] {

--- a/packages/ui/src/components/Skeleton/Skeleton.stories.tsx
+++ b/packages/ui/src/components/Skeleton/Skeleton.stories.tsx
@@ -15,7 +15,9 @@
  */
 import preview from '../../../../../.storybook/preview';
 import { Skeleton } from './Skeleton';
+import { Box } from '../Box';
 import { Flex } from '../Flex';
+import { Text } from '../Text';
 
 const meta = preview.meta({
   title: 'Backstage UI/Skeleton',
@@ -73,6 +75,37 @@ export const Demo2 = meta.story({
       <Skeleton width={400} height={160} />
       <Skeleton width={400} height={12} />
       <Skeleton width={240} height={12} />
+    </Flex>
+  ),
+});
+
+export const BackgroundAwareness = meta.story({
+  render: () => (
+    <Flex direction="column" gap="4">
+      <Box bg="neutral" p="4">
+        <Text>Neutral 1 container</Text>
+        <Flex gap="2" mt="2" direction="column" pb="4">
+          <Skeleton width={200} height={12} />
+          <Skeleton width={200} height={12} />
+          <Skeleton width={200} height={12} />
+        </Flex>
+        <Box bg="neutral" p="4">
+          <Text>Neutral 2 container</Text>
+          <Flex gap="2" mt="2" direction="column" pb="4">
+            <Skeleton width={200} height={12} />
+            <Skeleton width={200} height={12} />
+            <Skeleton width={200} height={12} />
+          </Flex>
+          <Box bg="neutral" p="4">
+            <Text>Neutral 3 container</Text>
+            <Flex gap="2" mt="2" direction="column">
+              <Skeleton width={200} height={12} />
+              <Skeleton width={200} height={12} />
+              <Skeleton width={200} height={12} />
+            </Flex>
+          </Box>
+        </Box>
+      </Box>
     </Flex>
   ),
 });

--- a/packages/ui/src/components/Skeleton/definition.ts
+++ b/packages/ui/src/components/Skeleton/definition.ts
@@ -27,6 +27,7 @@ export const SkeletonDefinition = defineComponent<SkeletonOwnProps>()({
   classNames: {
     root: 'bui-Skeleton',
   },
+  bg: 'consumer',
   propDefs: {
     width: { default: 80 },
     height: { default: 24 },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Currently `Skeleton` is not background aware, this PR updates to align with other BUI components (Box, Card, Button etc.)


<img width="870" height="898" alt="Screenshot 2026-06-13 at 21 58 10" src="https://github.com/user-attachments/assets/a356e8b4-04d7-49c6-90ff-a7b778d5b392" />



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
