### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "root",
   "version": "1.52.0-next.2",
+  "bugs": {
+    "url": "https://github.com/backstage/backstage/issues"
+  },
   "backstage": {
     "cli": {
       "new": {


### PR DESCRIPTION
Adds missing `bugs` metadata to `package.json`.

Fixes npm tooling unable to resolve package metadata.