### PR TITLE
feat(ui): add `useBreadcrumbs` hook

### DIFF
--- a/.changeset/loose-cooks-sneeze.md
+++ b/.changeset/loose-cooks-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Added `useBreadcrumbs` hook, `BreadcrumbRegistration` component, and `BreadcrumbsRegistryProvider` for managing breadcrumb trails across the component tree.

--- a/docs-ui/src/app/hooks/use-breadcrumbs/page.mdx
+++ b/docs-ui/src/app/hooks/use-breadcrumbs/page.mdx
@@ -1,0 +1,69 @@
+import { PageTitle } from '@/components/PageTitle';
+import { PropsTable } from '@/components/PropsTable';
+import { CodeBlock } from '@/components/CodeBlock';
+import { breadcrumbEntryDefs } from './props-definition';
+import { Banner } from '@/components/Banner';
+import {
+  breadcrumbRegistrationSnippet,
+  useBreadcrumbsConsumerSnippet,
+  nestedExampleSnippet,
+  subPageRoutesSnippet,
+  stateBasedSnippet,
+} from './snippets';
+
+<PageTitle
+  title="useBreadcrumbs"
+  description="A shared-store system for building breadcrumb trails across page components."
+/>
+
+## Usage
+
+<Banner
+  variant="warning"
+  text="This hook is in alpha and should be used with caution."
+/>
+
+## Overview
+
+The breadcrumb system has two parts:
+
+- **`BreadcrumbRegistration`** — a component that registers a breadcrumb entry in a shared store on mount and removes it on unmount. Nesting depth determines order.
+- **`useBreadcrumbs()`** — a hook that returns the current breadcrumb trail as an array of entries, sorted by depth. Call this anywhere you render breadcrumbs (e.g. NFS > `PageLayout` > `PageHeader`).
+
+Entries are visible to any `useBreadcrumbs()` consumer in the tree, not just descendants of the registration. This means a header component that is a sibling of the registered route content can still read the full trail.
+
+In the new frontend system, `BreadcrumbRegistration` is called automatically by the swapped `PageLayout`, so **plugin authors get breadcrumbs for plugin pages and sub-pages for free**. For plugin-internal routes, wrap route content with `BreadcrumbRegistration` manually.
+
+## Registering a breadcrumb
+
+Wrap your page content with `BreadcrumbRegistration`. The entry is registered in the shared store and available to any `useBreadcrumbs()` consumer.
+
+<CodeBlock code={breadcrumbRegistrationSnippet} />
+
+## Consuming breadcrumbs
+
+Call `useBreadcrumbs()` to get the trail and render it with the `Breadcrumbs` component.
+
+<CodeBlock code={useBreadcrumbsConsumerSnippet} />
+
+## Nested pages
+
+Nesting `BreadcrumbRegistration` components builds the trail in depth order — parent entries come first. Each nesting level increments an internal depth counter used for sorting.
+
+<CodeBlock code={nestedExampleSnippet} />
+
+## Plugin sub-page routes
+
+Plugin root pages and sub-page tabs are registered automatically by the framework if on NFS. For routes **inside** a sub-page component, wrap each route's element with `BreadcrumbRegistration`. This is the only manual step plugin maintainers need.
+
+<CodeBlock code={subPageRoutesSnippet} />
+
+## State-driven views (no routes)
+
+`BreadcrumbRegistration` isn't limited to routes — it works with any state-driven view like tabs, selection panels, or list/detail layouts. The breadcrumb updates reactively when the `label` prop changes.
+
+<CodeBlock code={stateBasedSnippet} />
+
+## BreadcrumbEntry
+
+<PropsTable data={breadcrumbEntryDefs} isHook />

--- a/docs-ui/src/app/hooks/use-breadcrumbs/props-definition.ts
+++ b/docs-ui/src/app/hooks/use-breadcrumbs/props-definition.ts
@@ -1,0 +1,14 @@
+import { type PropDef } from '@/utils/propDefs';
+
+export const breadcrumbEntryDefs: Record<string, PropDef> = {
+  label: {
+    type: 'string',
+    required: true,
+    description: 'Display text for the breadcrumb.',
+  },
+  href: {
+    type: 'string',
+    required: true,
+    description: 'URL the breadcrumb links to.',
+  },
+};

--- a/docs-ui/src/app/hooks/use-breadcrumbs/snippets.ts
+++ b/docs-ui/src/app/hooks/use-breadcrumbs/snippets.ts
@@ -1,0 +1,153 @@
+export const breadcrumbRegistrationSnippet = `import { BreadcrumbRegistration } from '@backstage/ui';
+
+function SettingsPage() {
+  return (
+    <BreadcrumbRegistration entry={{ label: 'Settings', href: '/settings' }}>
+      <h1>Settings</h1>
+      {/* "Settings" is now in the breadcrumb trail for any useBreadcrumbs() consumer */}
+    </BreadcrumbRegistration>
+  );
+}`;
+
+export const useBreadcrumbsConsumerSnippet = `import { useBreadcrumbs } from '@backstage/ui';
+
+function MyHeader({ title }: { title: string }) {
+  const breadcrumbs = useBreadcrumbs();
+
+  return (
+    <nav aria-label="Breadcrumb">
+      <ol>
+        {breadcrumbs.map(entry => (
+          <li key={entry.href}>
+            <a href={entry.href}>{entry.label}</a>
+          </li>
+        ))}
+        <li aria-current="page">{title}</li>
+      </ol>
+    </nav>
+  );
+}`;
+
+export const nestedExampleSnippet = `import { BreadcrumbRegistration, useBreadcrumbs } from '@backstage/ui';
+
+// Depth is tracked automatically via nesting.
+// A sibling header can read the full trail — it doesn't need to be
+// a descendant of the registrations.
+function App() {
+  return (
+    <BreadcrumbRegistration entry={{ label: 'Catalog', href: '/catalog' }}>
+      <PageHeader />
+      <BreadcrumbRegistration entry={{ label: 'Entity', href: '/catalog/entity' }}>
+        {/* useBreadcrumbs() anywhere returns:
+            [{ label: 'Catalog', href: '/catalog' },
+             { label: 'Entity', href: '/catalog/entity' }] */}
+        <EntityContent />
+      </BreadcrumbRegistration>
+    </BreadcrumbRegistration>
+  );
+}`;
+
+export const subPageRoutesSnippet = `// --- plugin.tsx ---
+// The plugin root page and sub-page are registered via blueprints.
+// The framework handles their breadcrumbs automatically — no manual
+// BreadcrumbRegistration needed at this level.
+
+import { PageBlueprint, SubPageBlueprint } from '@backstage/frontend-plugin-api';
+
+// Registered automatically as "Create" breadcrumb
+const scaffolderPage = PageBlueprint.make({
+  params: {
+    path: '/create',
+    title: 'Create',
+    // ...
+  },
+});
+
+// Registered automatically as "Tasks" breadcrumb
+const scaffolderTasksSubPage = SubPageBlueprint.make({
+  name: 'tasks',
+  params: {
+    path: 'tasks',
+    title: 'Tasks',
+    loader: () => import('./components/TasksSubPage').then(m => <m.TasksSubPage />),
+  },
+});
+
+// --- TasksSubPage.tsx ---
+// Inside the sub-page component, internal routes need manual
+// BreadcrumbRegistration. The index route doesn't need one since
+// the sub-page breadcrumb ("Tasks") already covers it.
+
+import { Routes, Route, useParams } from 'react-router-dom';
+import { BreadcrumbRegistration } from '@backstage/ui';
+
+// For dynamic route params, extract the param and use it as the label.
+function TaskDetailWithBreadcrumb() {
+  const { taskId } = useParams<{ taskId: string }>();
+  return (
+    <BreadcrumbRegistration
+      entry={{ label: taskId ?? 'Task', href: taskId ?? '' }}
+    >
+      <OngoingTaskBody />
+    </BreadcrumbRegistration>
+  );
+}
+
+// On /create/tasks         → Create > Tasks          (all automatic)
+// On /create/tasks/abc-123 → Create > Tasks > abc-123 (abc-123 is manual)
+function TasksSubPage() {
+  return (
+    <Routes>
+      <Route path=":taskId" element={<TaskDetailWithBreadcrumb />} />
+      {/* ... */}
+    </Routes>
+  );
+}`;
+
+export const stateBasedSnippet = `import { useState } from 'react';
+import { BreadcrumbRegistration } from '@backstage/ui';
+
+// BreadcrumbRegistration also works with state-driven views
+// that don't use routes — tabs, selection panels, etc.
+// The breadcrumb updates reactively when the label changes.
+
+function ActionsPage() {
+  const [selectedActionId, setSelectedActionId] = useState<string>();
+
+  const content = (
+    <>
+      <ActionList onSelect={setSelectedActionId} />
+      {selectedActionId && <ActionDetail id={selectedActionId} />}
+    </>
+  );
+
+  // Only register a breadcrumb when an action is selected.
+  // On /create/actions             → Create > Actions
+  // On /create/actions (selected)  → Create > Actions > debug:log
+  if (selectedActionId) {
+    return (
+      <BreadcrumbRegistration entry={{ label: selectedActionId, href: '#' }}>
+        {content}
+      </BreadcrumbRegistration>
+    );
+  }
+
+  return content;
+}
+
+// For tab-based views, register the active tab label.
+// Switching tabs updates the breadcrumb automatically.
+// On /create/templating-extensions → Create > Templating Extensions > Filters
+function TemplatingExtensionsContent() {
+  const [tab, setTab] = useState('filter');
+  const tabLabels = { filter: 'Filters', function: 'Functions', value: 'Values' };
+
+  return (
+    <BreadcrumbRegistration entry={{ label: tabLabels[tab], href: '#' }}>
+      <Tabs value={tab} onChange={setTab}>
+        {/* ... */}
+      </Tabs>
+      {/* tab content */}
+    </BreadcrumbRegistration>
+  );
+}`;

--- a/docs-ui/src/utils/data.ts
+++ b/docs-ui/src/utils/data.ts
@@ -181,4 +181,9 @@ export const hooks: Page[] = [
     title: 'useBreakpoint',
     slug: 'use-breakpoint',
   },
+  {
+    title: 'useBreadcrumbs',
+    slug: 'use-breadcrumbs',
+    status: 'new',
+  },
 ];

--- a/packages/ui/report.api.md
+++ b/packages/ui/report.api.md
@@ -493,6 +493,25 @@ export type BoxUtilityProps = {
   maxHeight?: Responsive<string>;
 };
 
+// @public
+export interface BreadcrumbEntry {
+  // (undocumented)
+  href: string;
+  // (undocumented)
+  label: string;
+}
+
+// @public
+export function BreadcrumbRegistration(props: {
+  entry: BreadcrumbEntry;
+  children: ReactNode;
+}): JSX_2.Element;
+
+// @public
+export function BreadcrumbsRegistryProvider(props: {
+  children: ReactNode;
+}): JSX_2.Element;
+
 // @public (undocumented)
 export type Breakpoint = 'initial' | 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
@@ -4572,6 +4591,9 @@ export function useBgConsumer(): BgContextValue;
 
 // @public
 export function useBgProvider(bg?: Responsive<ProviderBg>): BgContextValue;
+
+// @public
+export function useBreadcrumbs(): BreadcrumbEntry[];
 
 // @public (undocumented)
 export const useBreakpoint: () => {

--- a/packages/ui/src/hooks/useBreadcrumbs/index.ts
+++ b/packages/ui/src/hooks/useBreadcrumbs/index.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type { BreadcrumbEntry } from './types';
+
+export {
+  useBreadcrumbs,
+  BreadcrumbRegistration,
+  BreadcrumbsRegistryProvider,
+} from './useBreadcrumbs';

--- a/packages/ui/src/hooks/useBreadcrumbs/types.ts
+++ b/packages/ui/src/hooks/useBreadcrumbs/types.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * A single breadcrumb entry registered by a page component.
+ *
+ * @public
+ */
+export interface BreadcrumbEntry {
+  href: string;
+  label: string;
+}

--- a/packages/ui/src/hooks/useBreadcrumbs/useBreadcrumbs.test.tsx
+++ b/packages/ui/src/hooks/useBreadcrumbs/useBreadcrumbs.test.tsx
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen, act } from '@testing-library/react';
+import { useState } from 'react';
+import {
+  BreadcrumbsRegistryProvider,
+  BreadcrumbRegistration,
+  useBreadcrumbs,
+} from './useBreadcrumbs';
+
+function BreadcrumbDisplay() {
+  const entries = useBreadcrumbs();
+  return (
+    <ul data-testid="breadcrumbs">
+      {entries.map((e, i) => (
+        <li key={i}>
+          {e.label}
+          {e.href && ` (${e.href})`}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+describe('useBreadcrumbs', () => {
+  it('should return an empty array when no breadcrumbs are registered', () => {
+    render(
+      <BreadcrumbsRegistryProvider>
+        <BreadcrumbDisplay />
+      </BreadcrumbsRegistryProvider>,
+    );
+
+    expect(screen.getByTestId('breadcrumbs').children).toHaveLength(0);
+  });
+
+  it('should register a breadcrumb entry and display it', () => {
+    render(
+      <BreadcrumbsRegistryProvider>
+        <BreadcrumbRegistration entry={{ label: 'Home', href: '/home' }}>
+          <BreadcrumbDisplay />
+        </BreadcrumbRegistration>
+      </BreadcrumbsRegistryProvider>,
+    );
+
+    expect(screen.getByText('Home (/home)')).toBeInTheDocument();
+  });
+
+  it('should register multiple breadcrumbs in component tree order', () => {
+    render(
+      <BreadcrumbsRegistryProvider>
+        <BreadcrumbRegistration entry={{ label: 'Home', href: '/home' }}>
+          <BreadcrumbRegistration
+            entry={{ label: 'Settings', href: '/home/settings' }}
+          >
+            <BreadcrumbDisplay />
+          </BreadcrumbRegistration>
+        </BreadcrumbRegistration>
+      </BreadcrumbsRegistryProvider>,
+    );
+
+    const items = screen.getByTestId('breadcrumbs').querySelectorAll('li');
+    expect(items).toHaveLength(2);
+    expect(items[0]).toHaveTextContent('Home (/home)');
+    expect(items[1]).toHaveTextContent('Settings (/home/settings)');
+  });
+
+  it('should remove a breadcrumb when the component unmounts', () => {
+    function Toggle() {
+      const [showChild, setShowChild] = useState(true);
+      return (
+        <BreadcrumbRegistration entry={{ label: 'Home', href: '/home' }}>
+          {showChild && (
+            <BreadcrumbRegistration
+              entry={{ label: 'Settings', href: '/settings' }}
+            >
+              <div />
+            </BreadcrumbRegistration>
+          )}
+          <BreadcrumbDisplay />
+          <button onClick={() => setShowChild(false)}>remove</button>
+        </BreadcrumbRegistration>
+      );
+    }
+
+    render(
+      <BreadcrumbsRegistryProvider>
+        <Toggle />
+      </BreadcrumbsRegistryProvider>,
+    );
+
+    expect(
+      screen.getByTestId('breadcrumbs').querySelectorAll('li'),
+    ).toHaveLength(2);
+
+    act(() => {
+      screen.getByText('remove').click();
+    });
+
+    const items = screen.getByTestId('breadcrumbs').querySelectorAll('li');
+    expect(items).toHaveLength(1);
+    expect(items[0]).toHaveTextContent('Home (/home)');
+  });
+
+  it('should register a breadcrumb entry', () => {
+    render(
+      <BreadcrumbsRegistryProvider>
+        <BreadcrumbRegistration
+          entry={{ label: 'Current Page', href: '/current' }}
+        >
+          <BreadcrumbDisplay />
+        </BreadcrumbRegistration>
+      </BreadcrumbsRegistryProvider>,
+    );
+
+    expect(screen.getByText('Current Page (/current)')).toBeInTheDocument();
+  });
+
+  it('should return an empty array outside of a provider', () => {
+    render(<BreadcrumbDisplay />);
+
+    expect(screen.getByTestId('breadcrumbs').children).toHaveLength(0);
+  });
+});

--- a/packages/ui/src/hooks/useBreadcrumbs/useBreadcrumbs.tsx
+++ b/packages/ui/src/hooks/useBreadcrumbs/useBreadcrumbs.tsx
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react';
+import type { BreadcrumbEntry } from './types';
+
+interface InternalEntry extends BreadcrumbEntry {
+  depth: number;
+}
+
+interface BreadcrumbsStore {
+  register(entry: InternalEntry): () => void;
+  subscribe(listener: () => void): () => void;
+  getEntries(): BreadcrumbEntry[];
+}
+
+function createBreadcrumbsStore(): BreadcrumbsStore {
+  const entries: InternalEntry[] = [];
+  const listeners = new Set<() => void>();
+
+  function notify() {
+    listeners.forEach(l => l());
+  }
+
+  return {
+    register(entry: InternalEntry) {
+      entries.push(entry);
+      entries.sort((a, b) => a.depth - b.depth);
+      notify();
+      return () => {
+        const idx = entries.indexOf(entry);
+        if (idx >= 0) {
+          entries.splice(idx, 1);
+          notify();
+        }
+      };
+    },
+    subscribe(listener: () => void) {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    getEntries() {
+      return entries.map(({ label, href }) => ({ label, href }));
+    },
+  };
+}
+
+const StoreContext = createContext<BreadcrumbsStore | undefined>(undefined);
+const DepthContext = createContext(0);
+
+/**
+ * Provides the breadcrumb registry to the component tree. Place this near the
+ * top of the app so that all nested {@link BreadcrumbRegistration} components
+ * can register entries and {@link useBreadcrumbs} consumers can read them.
+ *
+ * @public
+ */
+export function BreadcrumbsRegistryProvider(props: { children: ReactNode }) {
+  const [store] = useState(createBreadcrumbsStore);
+  return (
+    <StoreContext.Provider value={store}>
+      {props.children}
+    </StoreContext.Provider>
+  );
+}
+
+/**
+ * Returns the current breadcrumb trail registered by page components anywhere
+ * in the tree. Call this in components that render breadcrumbs (e.g. PluginHeader).
+ *
+ * @public
+ */
+export function useBreadcrumbs(): BreadcrumbEntry[] {
+  const store = useContext(StoreContext);
+  const [entries, setEntries] = useState<BreadcrumbEntry[]>(
+    () => store?.getEntries() ?? [],
+  );
+
+  useEffect(() => {
+    if (!store) return undefined;
+    setEntries(store.getEntries());
+    return store.subscribe(() => {
+      setEntries(store.getEntries());
+    });
+  }, [store]);
+
+  return entries;
+}
+
+/**
+ * Registers a breadcrumb entry for the current page. The entry is added on
+ * mount and removed on unmount. Wraps its children and increments the depth
+ * counter so nested registrations are ordered correctly.
+ *
+ * @public
+ */
+export function BreadcrumbRegistration(props: {
+  entry: BreadcrumbEntry;
+  children: ReactNode;
+}) {
+  const store = useContext(StoreContext);
+  const depth = useContext(DepthContext);
+  const { label, href } = props.entry;
+
+  useEffect(() => {
+    if (!store) return undefined;
+    return store.register({ label, href, depth });
+  }, [store, depth, label, href]);
+
+  return (
+    <DepthContext.Provider value={depth + 1}>
+      {props.children}
+    </DepthContext.Provider>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -77,6 +77,12 @@ export { useBreakpoint } from './hooks/useBreakpoint';
 export { useBgProvider, useBgConsumer, BgProvider } from './hooks/useBg';
 export type { BgContextValue, BgProviderProps } from './hooks/useBg';
 export { useAsyncList } from './hooks/useAsyncList';
+export {
+  useBreadcrumbs,
+  BreadcrumbRegistration,
+  BreadcrumbsRegistryProvider,
+} from './hooks/useBreadcrumbs';
+export type { BreadcrumbEntry } from './hooks/useBreadcrumbs';
 export type {
   AsyncListSource,
   IdentifiedOption,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- [x] Adds a `useBreadcrumbs` hook -- needs to be public for NFS page layout to access the hook for NFS auto-population of breadcrumbs
- [x] Adds associated docs page

https://github.com/user-attachments/assets/0b3749e6-5ffc-4211-b2d3-13625b1d7f78



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
