### PR TITLE
fix(catalog-github): warn and skip orgs without GitHub App installation

### DIFF
--- a/.changeset/warm-cats-sleep.md
+++ b/.changeset/warm-cats-sleep.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+Fixed an issue where a missing GitHub App installation for one organization would crash the ingestion of all organizations. The provider now logs a warning and continues to the next org.

--- a/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
@@ -360,56 +360,77 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       ? this.options.orgs
       : await this.getAllOrgs(this.options.gitHubConfig);
 
+    let orgsSucceeded = 0;
+    let lastOrgError: unknown;
+
     for (const org of orgsToProcess) {
-      const { headers, type: tokenType } =
-        await this.options.githubCredentialsProvider.getCredentials({
-          url: `${this.options.githubUrl}/${org}`,
+      try {
+        const { headers, type: tokenType } =
+          await this.options.githubCredentialsProvider.getCredentials({
+            url: `${this.options.githubUrl}/${org}`,
+          });
+        const client = graphql.defaults({
+          baseUrl: this.options.gitHubConfig.apiBaseUrl,
+          headers,
         });
-      const client = graphql.defaults({
-        baseUrl: this.options.gitHubConfig.apiBaseUrl,
-        headers,
-      });
 
-      logger.info(`Reading GitHub users and teams for org: ${org}`);
+        logger.info(`Reading GitHub users and teams for org: ${org}`);
 
-      const pageSizes = this.getPageSizes();
+        const pageSizes = this.getPageSizes();
 
-      const { users } = await getOrganizationUsers(
-        client,
-        org,
-        tokenType,
-        this.options.userTransformer,
-        pageSizes,
-        this.options.excludeSuspendedUsers,
-        this.useRestSuspendedCheck ? this.getRestClient(org) : undefined,
-      );
+        const { users } = await getOrganizationUsers(
+          client,
+          org,
+          tokenType,
+          this.options.userTransformer,
+          pageSizes,
+          this.options.excludeSuspendedUsers,
+          this.useRestSuspendedCheck ? this.getRestClient(org) : undefined,
+        );
 
-      const { teams } = await getOrganizationTeams(
-        client,
-        org,
-        this.defaultMultiOrgTeamTransformer.bind(this),
-        pageSizes,
-      );
+        const { teams } = await getOrganizationTeams(
+          client,
+          org,
+          this.defaultMultiOrgTeamTransformer.bind(this),
+          pageSizes,
+        );
 
-      // Grab current users from `allUsersMap` if they already exist in our
-      // pending users so we can append to their group membership relations
-      const pendingUsers = users.map(u => {
-        const userRef = stringifyEntityRef(u);
-        if (!allUsersMap.has(userRef)) {
-          allUsersMap.set(userRef, u);
+        // Grab current users from `allUsersMap` if they already exist in our
+        // pending users so we can append to their group membership relations
+        const pendingUsers = users.map(u => {
+          const userRef = stringifyEntityRef(u);
+          if (!allUsersMap.has(userRef)) {
+            allUsersMap.set(userRef, u);
+          }
+
+          return allUsersMap.get(userRef);
+        });
+
+        if (areGroupEntities(teams)) {
+          buildOrgHierarchy(teams);
+          if (areUserEntities(pendingUsers)) {
+            assignGroupsToUsers(pendingUsers, teams);
+          }
         }
 
-        return allUsersMap.get(userRef);
-      });
-
-      if (areGroupEntities(teams)) {
-        buildOrgHierarchy(teams);
-        if (areUserEntities(pendingUsers)) {
-          assignGroupsToUsers(pendingUsers, teams);
-        }
+        allTeams.push(...teams);
+        orgsSucceeded++;
+      } catch (e: unknown) {
+        lastOrgError = e;
+        const message = e instanceof Error ? e.message : String(e);
+        logger.warn(
+          `Failed to read GitHub users and teams for org: ${org}. ` +
+            `This can happen when the GitHub App is not installed for this organization. ` +
+            `Ensure the GitHub App is installed and has access to the org. ` +
+            `See https://backstage.io/docs/integrations/github/github-apps/#troubleshooting`,
+          { org, error: message },
+        );
+        continue;
       }
+    }
 
-      allTeams.push(...teams);
+    if (orgsSucceeded === 0 && lastOrgError) {
+      throw lastOrgError;
     }
 
     const allUsers = Array.from(allUsersMap.values());


### PR DESCRIPTION
## Summary
Wraps the per-org processing loop in GithubMultiOrgEntityProvider in a try-catch that logs a warning (with troubleshooting link) and continues to the next org, so a missing GitHub App installation for one org does not block ingestion of all other orgs. If every org fails, the last error is re-raised to preserve existing behavior.

**AI assistance disclosure (per CONTRIBUTING.md):** this PR was prepared with significant AI assistance and is marked accordingly. Currently a draft pending maintainer guidance on the expected error-handling behavior (see discussion below).

Fixes #32972