### PR TITLE
docs: fix broken Figma community link

### DIFF
--- a/docs/dls/design.md
+++ b/docs/dls/design.md
@@ -120,7 +120,7 @@ picked up by our team as something to be added to our design system.
 components. If you’d like to help build up our design system, you can also add
 components we’ve designed to the Storybook as well.
 
-**[Figma](https://www.figma.com/@backstage)** - we're stoked to be using Figma
+**[Figma](https://www.figma.com/community/file/850673348101741100/backstage-design-system)** - we're excited to be using Figma
 Community to share our design assets. You can duplicate our UI Kit and design
 your own plugin for Backstage.
 

--- a/docs/dls/figma.md
+++ b/docs/dls/figma.md
@@ -4,5 +4,5 @@ title: Figma
 description: Documentation on using Figma to build your own plugins for Backstage
 ---
 
-We have a [Figma component library](https://www.figma.com/@backstage) that you
+We have a [Figma component library](https://www.figma.com/community/file/850673348101741100/backstage-design-system) that you
 can use to build your own plugins for Backstage.


### PR DESCRIPTION
The Figma link https://www.figma.com/@backstage returns a 404. Replaced with the working community file URL in both docs/dls/figma.md and docs/dls/design.md. Also replaced "stoked" with "excited" for clarity.

**AI assistance disclosure (per CONTRIBUTING.md):** this change was prepared with AI assistance. It is a documentation link/wording fix that I have reviewed and understand.

Fixes #34460