### PR TITLE
fix(ui): prevent combobox client search crash

### DIFF
--- a/.changeset/ui-fix-combobox-client-search.md
+++ b/.changeset/ui-fix-combobox-client-search.md
@@ -1,0 +1,7 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed `Combobox` client search crashing when used with plain options.
+
+**Affected components:** Combobox

--- a/packages/ui/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/ui/src/components/Combobox/Combobox.stories.tsx
@@ -96,6 +96,16 @@ export const Default = meta.story({
   },
 });
 
+export const WithClientSearch = meta.story({
+  args: {
+    label: 'Country',
+    options: countries,
+    placeholder: 'Search countries',
+    search: true,
+    name: 'country',
+  },
+});
+
 export const WithIcon = meta.story({
   args: {
     ...Default.input.args,

--- a/packages/ui/src/components/Combobox/Combobox.test.tsx
+++ b/packages/ui/src/components/Combobox/Combobox.test.tsx
@@ -378,6 +378,30 @@ describe('Combobox', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('supports client search with plain options', () => {
+    renderCombobox(
+      <Combobox
+        aria-label="Status"
+        options={[
+          { id: 'draft', label: 'Draft' },
+          { id: 'published', label: 'Published' },
+        ]}
+        search
+      />,
+    );
+
+    const input = screen.getByRole('combobox');
+    openCombobox();
+    fireEvent.change(input, {
+      target: { value: 'aft' },
+    });
+
+    expect(screen.getByRole('option', { name: 'Draft' })).toBeVisible();
+    expect(
+      screen.queryByRole('option', { name: 'Published' }),
+    ).not.toBeInTheDocument();
+  });
+
   it('applies a nested custom client filter to full domain rows', () => {
     const filter = jest.fn((owner: Owner, query: string) =>
       owner.email.includes(query),

--- a/packages/ui/src/components/Combobox/Combobox.tsx
+++ b/packages/ui/src/components/Combobox/Combobox.tsx
@@ -178,6 +178,11 @@ function ComboboxImpl<T extends CollectionItem = NormalizedOption>(
   const renderedItems = collectionSource.rendersItems
     ? collection.canonicalItems
     : undefined;
+  const rootItems =
+    renderedItems ??
+    (collectionSource.options !== undefined && search !== undefined
+      ? collection.canonicalItems
+      : undefined);
   const searchProps = typeof search === 'object' ? search : undefined;
   const isDirectAsyncServer =
     searchProps?.mode === 'server' &&
@@ -226,7 +231,7 @@ function ComboboxImpl<T extends CollectionItem = NormalizedOption>(
     <AriaComboBox<T>
       className={classes.root}
       defaultFilter={defaultFilter}
-      items={renderedItems}
+      items={rootItems}
       {...dataAttributes}
       ref={ref}
       {...ariaProps}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes a crash when using BUI `Combobox` with plain options and client-side search under `react-aria-components` 1.17.

Searchable plain options are now passed through React Aria’s filterable collection path, avoiding the `state.collection.filter is not a function` error.

Includes a regression test and a Storybook example.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))