### PR TITLE
fix(ui): correct async pagination scroll containers

### DIFF
--- a/.changeset/ui-async-pagination-scroll-containers.md
+++ b/.changeset/ui-async-pagination-scroll-containers.md
@@ -1,0 +1,9 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed async pagination in `Combobox` and `Select` popovers so additional pages load as users scroll instead of loading every page immediately. `Combobox` now uses `.bui-PopoverContent` as its scroll container, while all `Select` variants use the new `.bui-SelectResults` results container.
+
+Searchable `Select` keeps its search field fixed while results scroll. The new public classes `.bui-SelectContent` and `.bui-SelectResults` expose this layout for theme customization.
+
+**Affected components:** Combobox, Select

--- a/packages/ui/report.api.md
+++ b/packages/ui/report.api.md
@@ -3456,7 +3456,9 @@ export const SelectContentDefinition: {
     readonly [key: string]: string;
   };
   readonly classNames: {
-    readonly root: 'bui-SelectSearchWrapper';
+    readonly root: 'bui-SelectContent';
+    readonly searchWrapper: 'bui-SelectSearchWrapper';
+    readonly results: 'bui-SelectResults';
     readonly search: 'bui-SelectSearch';
     readonly searchClear: 'bui-SelectSearchClear';
   };

--- a/packages/ui/src/components/Combobox/Combobox.module.css
+++ b/packages/ui/src/components/Combobox/Combobox.module.css
@@ -173,8 +173,6 @@
   }
 
   .bui-ComboboxList {
-    overflow: auto;
-    min-height: 0;
     padding-block: var(--bui-space-1);
     padding-inline: var(--bui-space-1);
     transition: opacity 0.2s ease-in-out;

--- a/packages/ui/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/ui/src/components/Combobox/Combobox.stories.tsx
@@ -27,7 +27,8 @@ import { Text } from '../Text';
 import { Form } from 'react-aria-components';
 import { RiCheckLine, RiCloudLine } from '@remixicon/react';
 import { useAsyncList } from '@backstage/ui';
-import type { ReactNode } from 'react';
+import { useState } from 'react';
+import { expect, screen, waitFor } from 'storybook/test';
 
 const meta = preview.meta({
   title: 'Backstage UI/Combobox',
@@ -310,30 +311,56 @@ const serverOptions = serverOwners.map(owner => ({
   label: owner.name,
 }));
 
+const paginatedServerOptions = Array.from({ length: 200 }, (_, index) => ({
+  id: `owner-${index + 1}`,
+  label: `Owner ${String(index + 1).padStart(3, '0')}`,
+}));
+
 const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 const serverDelay = 1_500;
 const serverPageSize = 5;
+const paginationServerDelay = 100;
+const paginationServerPageSize = 10;
 
-function ConstrainedComboboxList({ children }: { children: ReactNode }) {
-  return (
-    <>
-      <style>{`.bui-ComboboxList { max-height: 9rem; }`}</style>
-      {children}
-    </>
-  );
+function readCount(element: HTMLElement) {
+  return Number(element.textContent);
+}
+
+async function waitForRequestCountToStabilize(element: HTMLElement) {
+  let previousCount = readCount(element);
+  let stableChecks = 0;
+
+  for (let index = 0; index < 20; index++) {
+    await wait(250);
+    const currentCount = readCount(element);
+
+    if (currentCount === previousCount) {
+      stableChecks += 1;
+      if (stableChecks === 3) {
+        return currentCount;
+      }
+    } else {
+      previousCount = currentCount;
+      stableChecks = 0;
+    }
+  }
+
+  throw new Error('Request count did not stabilize');
 }
 
 function ServerBackedCombobox() {
+  const [requestCount, setRequestCount] = useState(0);
   const list = useAsyncList({
     async load({ cursor, filterText }) {
-      await wait(serverDelay);
+      setRequestCount(count => count + 1);
+      await wait(paginationServerDelay);
 
       const query = filterText.toLocaleLowerCase();
-      const filteredOptions = serverOptions.filter(option =>
+      const filteredOptions = paginatedServerOptions.filter(option =>
         option.label.toLocaleLowerCase().includes(query),
       );
       const startIndex = cursor ? Number(cursor) : 0;
-      const endIndex = startIndex + serverPageSize;
+      const endIndex = startIndex + paginationServerPageSize;
 
       return {
         items: filteredOptions.slice(startIndex, endIndex),
@@ -344,20 +371,90 @@ function ServerBackedCombobox() {
   });
 
   return (
-    <ConstrainedComboboxList>
-      <Combobox
-        label="Owner"
-        placeholder="Search owners"
-        options={list}
-        search={{ mode: 'server' }}
-        style={{ width: 300 }}
-      />
-    </ConstrainedComboboxList>
+    <div
+      style={{
+        minHeight: '100vh',
+        display: 'grid',
+        placeItems: 'center',
+      }}
+    >
+      <div>
+        <div>
+          Requests:{' '}
+          <output aria-label="Combobox request count">{requestCount}</output>
+        </div>
+        <div>
+          Results:{' '}
+          <output aria-label="Combobox result count">
+            {list.items.length}
+          </output>
+        </div>
+        <Combobox
+          label="Owner"
+          placeholder="Search owners"
+          options={list}
+          search={{ mode: 'server' }}
+          style={{ width: 300 }}
+        />
+      </div>
+    </div>
   );
 }
 
 export const ServerBackedOptions = meta.story({
   render: () => <ServerBackedCombobox />,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  play: async ({ canvas, userEvent }) => {
+    const requestCount = canvas.getByLabelText('Combobox request count');
+    const resultCount = canvas.getByLabelText('Combobox result count');
+
+    await waitFor(() =>
+      expect(readCount(resultCount)).toBe(paginationServerPageSize),
+    );
+    await userEvent.click(canvas.getByRole('button'));
+
+    const listbox = await screen.findByRole('listbox');
+    const scrollElement = listbox.closest('.bui-PopoverContent');
+
+    expect(scrollElement).toBeTruthy();
+    expect(window.getComputedStyle(listbox).maxHeight).toBe('none');
+
+    await waitFor(
+      () =>
+        expect(scrollElement!.scrollHeight).toBeGreaterThan(
+          scrollElement!.clientHeight,
+        ),
+      { timeout: 5_000 },
+    );
+
+    const stabilizedRequestCount = await waitForRequestCountToStabilize(
+      requestCount,
+    );
+
+    expect(stabilizedRequestCount).toBeLessThan(
+      paginatedServerOptions.length / paginationServerPageSize,
+    );
+    expect(readCount(resultCount)).toBeLessThan(paginatedServerOptions.length);
+
+    listbox.focus();
+    await userEvent.keyboard('{End}');
+    const bottomScrollTop =
+      scrollElement!.scrollHeight - scrollElement!.clientHeight;
+    scrollElement!.scrollTop = bottomScrollTop;
+    await waitFor(() =>
+      expect(scrollElement!.scrollTop).toBeGreaterThanOrEqual(
+        bottomScrollTop - 1,
+      ),
+    );
+
+    await waitFor(
+      () =>
+        expect(readCount(requestCount)).toBeGreaterThan(stabilizedRequestCount),
+      { timeout: 5_000 },
+    );
+  },
 });
 
 function ServerBackedCustomCombobox() {
@@ -380,26 +477,24 @@ function ServerBackedCustomCombobox() {
   });
 
   return (
-    <ConstrainedComboboxList>
-      <Combobox
-        label="Owner"
-        placeholder="Search names and roles"
-        items={list}
-        search={{ mode: 'server' }}
-        style={{ width: 300 }}
-      >
-        {owner => (
-          <ComboboxItem textValue={owner.textValue}>
-            <Text as="div" weight="bold">
-              {owner.name}
-            </Text>
-            <Text as="div" variant="body-small" color="secondary">
-              {owner.role}
-            </Text>
-          </ComboboxItem>
-        )}
-      </Combobox>
-    </ConstrainedComboboxList>
+    <Combobox
+      label="Owner"
+      placeholder="Search names and roles"
+      items={list}
+      search={{ mode: 'server' }}
+      style={{ width: 300 }}
+    >
+      {owner => (
+        <ComboboxItem textValue={owner.textValue}>
+          <Text as="div" weight="bold">
+            {owner.name}
+          </Text>
+          <Text as="div" variant="body-small" color="secondary">
+            {owner.role}
+          </Text>
+        </ComboboxItem>
+      )}
+    </Combobox>
   );
 }
 

--- a/packages/ui/src/components/Select/Select.module.css
+++ b/packages/ui/src/components/Select/Select.module.css
@@ -40,6 +40,9 @@
 
     :global(.bui-PopoverContent) {
       padding: 0;
+      display: grid;
+      grid-template-rows: minmax(0, 1fr);
+      overflow: hidden;
     }
   }
 
@@ -141,8 +144,6 @@
   }
 
   .bui-SelectList {
-    overflow: auto;
-    min-height: 0;
     padding-block: var(--bui-space-1);
     padding-inline: var(--bui-space-1);
     transition: opacity 0.2s ease-in-out;
@@ -262,6 +263,18 @@
     align-items: center;
     padding-inline: var(--bui-space-3) 0;
     border-bottom: 1px solid var(--bui-border-2);
+  }
+
+  .bui-SelectContent {
+    display: grid;
+    grid-template-rows: auto minmax(0, 1fr);
+    min-height: 0;
+  }
+
+  .bui-SelectResults {
+    grid-row: 2;
+    min-height: 0;
+    overflow: auto;
   }
 
   .bui-SelectSearch {

--- a/packages/ui/src/components/Select/Select.stories.tsx
+++ b/packages/ui/src/components/Select/Select.stories.tsx
@@ -23,7 +23,8 @@ import { Text } from '../Text';
 import { Form } from 'react-aria-components';
 import { RiCheckLine, RiCloudLine } from '@remixicon/react';
 import { useAsyncList } from '@backstage/ui';
-import type { ReactNode } from 'react';
+import { useState } from 'react';
+import { expect, screen, waitFor } from 'storybook/test';
 
 const meta = preview.meta({
   title: 'Backstage UI/Select',
@@ -261,30 +262,57 @@ const serverOptions = serverOwners.map(owner => ({
   label: owner.name,
 }));
 
+const paginatedServerOptions = Array.from({ length: 200 }, (_, index) => ({
+  id: `owner-${index + 1}`,
+  label: `Owner ${String(index + 1).padStart(3, '0')}`,
+}));
+
 const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 const serverDelay = 1_500;
 const serverPageSize = 5;
+const paginationServerDelay = 100;
+const paginationServerPageSize = 10;
 
-function ConstrainedSelectList({ children }: { children: ReactNode }) {
-  return (
-    <>
-      <style>{`.bui-SelectList { max-height: 9rem; }`}</style>
-      {children}
-    </>
-  );
+function readCount(element: HTMLElement) {
+  return Number(element.textContent);
 }
 
-function ServerBackedSelect() {
+async function waitForRequestCountToStabilize(element: HTMLElement) {
+  let previousCount = readCount(element);
+  let stableChecks = 0;
+
+  for (let index = 0; index < 20; index++) {
+    await wait(250);
+    const currentCount = readCount(element);
+
+    if (currentCount === previousCount) {
+      stableChecks += 1;
+      if (stableChecks === 3) {
+        return currentCount;
+      }
+    } else {
+      previousCount = currentCount;
+      stableChecks = 0;
+    }
+  }
+
+  throw new Error('Request count did not stabilize');
+}
+
+function ServerBackedSelect({ searchable }: { searchable: boolean }) {
+  const label = searchable ? 'Searchable Select' : 'Select';
+  const [requestCount, setRequestCount] = useState(0);
   const list = useAsyncList({
     async load({ cursor, filterText }) {
-      await wait(serverDelay);
+      setRequestCount(count => count + 1);
+      await wait(paginationServerDelay);
 
       const query = filterText.toLocaleLowerCase();
-      const filteredOptions = serverOptions.filter(option =>
+      const filteredOptions = paginatedServerOptions.filter(option =>
         option.label.toLocaleLowerCase().includes(query),
       );
       const startIndex = cursor ? Number(cursor) : 0;
-      const endIndex = startIndex + serverPageSize;
+      const endIndex = startIndex + paginationServerPageSize;
 
       return {
         items: filteredOptions.slice(startIndex, endIndex),
@@ -295,20 +323,161 @@ function ServerBackedSelect() {
   });
 
   return (
-    <ConstrainedSelectList>
-      <Select
-        label="Owner"
-        placeholder="Select an owner"
-        options={list}
-        search={{ mode: 'server', placeholder: 'Search owners...' }}
-        style={{ width: 300 }}
-      />
-    </ConstrainedSelectList>
+    <div
+      style={{
+        minHeight: '100vh',
+        display: 'grid',
+        placeItems: 'center',
+      }}
+    >
+      <div>
+        <div>
+          Requests:{' '}
+          <output aria-label={`${label} request count`}>{requestCount}</output>
+        </div>
+        <div>
+          Results:{' '}
+          <output aria-label={`${label} result count`}>
+            {list.items.length}
+          </output>
+        </div>
+        <Select
+          label="Owner"
+          placeholder="Select an owner"
+          options={list}
+          search={
+            searchable
+              ? { mode: 'server', placeholder: 'Search owners...' }
+              : undefined
+          }
+          style={{ width: 300 }}
+        />
+      </div>
+    </div>
   );
 }
 
+export const ServerBackedNonSearchableOptions = meta.story({
+  render: () => <ServerBackedSelect searchable={false} />,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  play: async ({ canvas, userEvent }) => {
+    const requestCount = canvas.getByLabelText('Select request count');
+    const resultCount = canvas.getByLabelText('Select result count');
+
+    await waitFor(() =>
+      expect(readCount(resultCount)).toBe(paginationServerPageSize),
+    );
+    await userEvent.click(canvas.getByRole('button'));
+
+    const listbox = await screen.findByRole('listbox');
+    const scrollElement = listbox.closest('.bui-SelectResults');
+
+    expect(scrollElement).toBeTruthy();
+    expect(window.getComputedStyle(listbox).maxHeight).toBe('none');
+
+    await waitFor(
+      () =>
+        expect(scrollElement!.scrollHeight).toBeGreaterThan(
+          scrollElement!.clientHeight,
+        ),
+      { timeout: 5_000 },
+    );
+
+    const stabilizedRequestCount = await waitForRequestCountToStabilize(
+      requestCount,
+    );
+
+    expect(stabilizedRequestCount).toBeLessThan(
+      paginatedServerOptions.length / paginationServerPageSize,
+    );
+    expect(readCount(resultCount)).toBeLessThan(paginatedServerOptions.length);
+
+    listbox.focus();
+    await userEvent.keyboard('{End}');
+    const bottomScrollTop =
+      scrollElement!.scrollHeight - scrollElement!.clientHeight;
+    scrollElement!.scrollTop = bottomScrollTop;
+    await waitFor(() =>
+      expect(scrollElement!.scrollTop).toBeGreaterThanOrEqual(
+        bottomScrollTop - 1,
+      ),
+    );
+
+    await waitFor(
+      () =>
+        expect(readCount(requestCount)).toBeGreaterThan(stabilizedRequestCount),
+      { timeout: 5_000 },
+    );
+  },
+});
+
 export const ServerBackedOptions = meta.story({
-  render: () => <ServerBackedSelect />,
+  render: () => <ServerBackedSelect searchable />,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  play: async ({ canvas, userEvent }) => {
+    const requestCount = canvas.getByLabelText(
+      'Searchable Select request count',
+    );
+    const resultCount = canvas.getByLabelText('Searchable Select result count');
+
+    await waitFor(() =>
+      expect(readCount(resultCount)).toBe(paginationServerPageSize),
+    );
+    await userEvent.click(canvas.getByRole('button'));
+
+    const listbox = await screen.findByRole('listbox');
+    const searchbox = await screen.findByRole('searchbox');
+    const scrollElement = listbox.closest('.bui-SelectResults');
+
+    expect(scrollElement).toBeTruthy();
+    expect(scrollElement).not.toContainElement(searchbox);
+    expect(window.getComputedStyle(listbox).maxHeight).toBe('none');
+
+    await waitFor(
+      () =>
+        expect(scrollElement!.scrollHeight).toBeGreaterThan(
+          scrollElement!.clientHeight,
+        ),
+      { timeout: 5_000 },
+    );
+
+    const stabilizedRequestCount = await waitForRequestCountToStabilize(
+      requestCount,
+    );
+
+    expect(stabilizedRequestCount).toBeLessThan(
+      paginatedServerOptions.length / paginationServerPageSize,
+    );
+    expect(readCount(resultCount)).toBeLessThan(paginatedServerOptions.length);
+
+    const searchboxTop = searchbox.getBoundingClientRect().top;
+    listbox.focus();
+    await userEvent.keyboard('{End}');
+    const bottomScrollTop =
+      scrollElement!.scrollHeight - scrollElement!.clientHeight;
+    scrollElement!.scrollTop = bottomScrollTop;
+    await waitFor(() =>
+      expect(scrollElement!.scrollTop).toBeGreaterThanOrEqual(
+        bottomScrollTop - 1,
+      ),
+    );
+
+    await waitFor(
+      () =>
+        expect(readCount(requestCount)).toBeGreaterThan(stabilizedRequestCount),
+      { timeout: 5_000 },
+    );
+    await waitFor(() =>
+      expect(
+        Math.abs(searchbox.getBoundingClientRect().top - searchboxTop),
+      ).toBeLessThan(1),
+    );
+    expect(searchbox).toBeVisible();
+  },
 });
 
 function ServerBackedCustomSelect() {
@@ -331,26 +500,24 @@ function ServerBackedCustomSelect() {
   });
 
   return (
-    <ConstrainedSelectList>
-      <Select
-        label="Owner"
-        placeholder="Select an owner"
-        items={list}
-        search={{ mode: 'server', placeholder: 'Search names and roles...' }}
-        style={{ width: 300 }}
-      >
-        {owner => (
-          <SelectItem textValue={owner.name}>
-            <Text as="div" weight="bold">
-              {owner.name}
-            </Text>
-            <Text as="div" variant="body-small" color="secondary">
-              {owner.role}
-            </Text>
-          </SelectItem>
-        )}
-      </Select>
-    </ConstrainedSelectList>
+    <Select
+      label="Owner"
+      placeholder="Select an owner"
+      items={list}
+      search={{ mode: 'server', placeholder: 'Search names and roles...' }}
+      style={{ width: 300 }}
+    >
+      {owner => (
+        <SelectItem textValue={owner.name}>
+          <Text as="div" weight="bold">
+            {owner.name}
+          </Text>
+          <Text as="div" variant="body-small" color="secondary">
+            {owner.role}
+          </Text>
+        </SelectItem>
+      )}
+    </Select>
   );
 }
 

--- a/packages/ui/src/components/Select/Select.test.tsx
+++ b/packages/ui/src/components/Select/Select.test.tsx
@@ -236,10 +236,17 @@ describe('Select', () => {
     openSelect();
 
     const popover = document.querySelector('.bui-SelectPopover');
+    const listbox = screen.getByRole('listbox');
+    const content = listbox.closest<HTMLElement>('.bui-SelectContent');
+    const results = listbox.closest<HTMLElement>('.bui-SelectResults');
+
     expect(popover).toHaveClass('bui-Popover');
     expect(popover?.querySelector('.bui-PopoverContent')).toHaveClass(
       'bui-Box',
     );
+    expect(content).toBeTruthy();
+    expect(content).toContainElement(results);
+    expect(results).toContainElement(listbox);
   });
 
   it('renders dynamic profile items without repeating their ids', () => {
@@ -473,6 +480,24 @@ describe('Select', () => {
 
     expect(screen.queryByRole('option', { name: 'Draft' })).toBeNull();
     expect(screen.getByRole('option', { name: 'Published' })).toBeVisible();
+  });
+
+  it('renders search outside the shared results scroller', () => {
+    render(<Select aria-label="Status" options={options} search />);
+
+    openSelect();
+
+    const searchbox = screen.getByRole('searchbox');
+    const listbox = screen.getByRole('listbox');
+    const content = searchbox.closest<HTMLElement>('.bui-SelectContent');
+    const results = listbox.closest<HTMLElement>('.bui-SelectResults');
+
+    expect(searchbox.closest('.bui-SelectSearchWrapper')).toBeTruthy();
+    expect(content).toBeTruthy();
+    expect(content).toContainElement(results);
+    expect(results).toContainElement(listbox);
+    expect(results).not.toContainElement(searchbox);
+    expect(content?.closest('.bui-SelectPopover')).toBeTruthy();
   });
 
   it('retains refreshed selected metadata outside manual server results', () => {

--- a/packages/ui/src/components/Select/SelectContent.tsx
+++ b/packages/ui/src/components/Select/SelectContent.tsx
@@ -79,20 +79,22 @@ export function SelectContent<T extends CollectionItem = NormalizedOption>(
   } = ownProps;
 
   const listBox = (
-    <SelectListBox
-      options={options}
-      items={items}
-      dependencies={dependencies}
-      loading={loading}
-      isStale={isStale}
-      retainedOptions={retainedOptions}
-    >
-      {children}
-    </SelectListBox>
+    <div className={classes.results}>
+      <SelectListBox
+        options={options}
+        items={items}
+        dependencies={dependencies}
+        loading={loading}
+        isStale={isStale}
+        retainedOptions={retainedOptions}
+      >
+        {children}
+      </SelectListBox>
+    </div>
   );
 
   if (!search) {
-    return listBox;
+    return <div className={classes.root}>{listBox}</div>;
   }
 
   const searchProps = typeof search === 'object' ? search : undefined;
@@ -110,13 +112,19 @@ export function SelectContent<T extends CollectionItem = NormalizedOption>(
       onInputChange={searchProps?.onInputChange}
       filter={filter}
     >
-      <SearchField autoFocus className={classes.root} aria-label={placeholder}>
-        <Input placeholder={placeholder} className={classes.search} />
-        <Button className={classes.searchClear}>
-          <RiCloseCircleLine />
-        </Button>
-      </SearchField>
-      {listBox}
+      <div className={classes.root}>
+        <SearchField
+          autoFocus
+          className={classes.searchWrapper}
+          aria-label={placeholder}
+        >
+          <Input placeholder={placeholder} className={classes.search} />
+          <Button className={classes.searchClear}>
+            <RiCloseCircleLine />
+          </Button>
+        </SearchField>
+        {listBox}
+      </div>
     </Autocomplete>
   );
 }

--- a/packages/ui/src/components/Select/definition.ts
+++ b/packages/ui/src/components/Select/definition.ts
@@ -75,7 +75,9 @@ export const SelectContentDefinition = defineComponent<SelectContentOwnProps>()(
   {
     styles,
     classNames: {
-      root: 'bui-SelectSearchWrapper',
+      root: 'bui-SelectContent',
+      searchWrapper: 'bui-SelectSearchWrapper',
+      results: 'bui-SelectResults',
       search: 'bui-SelectSearch',
       searchClear: 'bui-SelectSearchClear',
     },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes async pagination in BUI Combobox and Select popovers.

Previously, the list elements were unconstrained scroll containers. React Aria consequently used them as the load-more observer root, leaving the pagination sentinel visible and loading every page recursively.

This changes the scrolling layout so that:

- Combobox uses the constrained popover content as its scroll container.
- All Select variants use a dedicated results scroll container.
- Searchable Select keeps its search field fixed while results scroll.
- Server-backed Storybook interactions verify pagination for Combobox, Select, and searchable Select.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached
- [x] All commits have a `Signed-off-by` line in the message.