### PR TITLE
connections: add optional title field

### DIFF
--- a/.changeset/connection-title-field.md
+++ b/.changeset/connection-title-field.md
@@ -2,4 +2,4 @@
 '@backstage/connections': patch
 ---
 
-Added an optional `title` field to connections, allowing a human-readable display name to be configured for each connection entry.
+Added a `title` field to connections, providing a human-readable display name for each connection. When not explicitly configured, the title defaults to the provider name (e.g. "GitHub") or includes the host when multiple connections share a type (e.g. "GitHub (ghe.acme.com)").

--- a/.changeset/connection-title-field.md
+++ b/.changeset/connection-title-field.md
@@ -1,0 +1,5 @@
+---
+'@backstage/connections': patch
+---
+
+Added an optional `title` field to connections, allowing a human-readable display name to be configured for each connection entry.

--- a/packages/connections/report.api.md
+++ b/packages/connections/report.api.md
@@ -30,7 +30,7 @@ export type Connection<
   TAuthMethod extends string = string,
 > = {
   type: LookupConnectionType<T>['type'];
-  title?: string;
+  title: string;
   auth: string extends TAuthMethod
     ? AuthValue<T>[]
     : Extract<

--- a/packages/connections/report.api.md
+++ b/packages/connections/report.api.md
@@ -97,6 +97,7 @@ export type ConnectionType<
   TAuthMethods extends readonly ConnectionAuthMethod[] = readonly ConnectionAuthMethod[],
 > = {
   type: TType;
+  title: string;
   configSchema: TConfigSchema;
   authMethods: TAuthMethods;
   schema: z.ZodType;

--- a/packages/connections/report.api.md
+++ b/packages/connections/report.api.md
@@ -30,6 +30,7 @@ export type Connection<
   TAuthMethod extends string = string,
 > = {
   type: LookupConnectionType<T>['type'];
+  title?: string;
   auth: string extends TAuthMethod
     ? AuthValue<T>[]
     : Extract<

--- a/packages/connections/src/api/Connection.ts
+++ b/packages/connections/src/api/Connection.ts
@@ -38,7 +38,7 @@ export type Connection<
   TAuthMethod extends string = string,
 > = {
   type: LookupConnectionType<T>['type'];
-  title?: string;
+  title: string;
   auth: string extends TAuthMethod
     ? AuthValue<T>[]
     : Extract<AuthValue<T>, { method: TAuthMethod }>;
@@ -54,7 +54,8 @@ export type AnyConnection = {
 // top-level `match` and per-auth `match` rules used for plugin scoping.
 export type RootConnection<
   T extends ConnectionType | ConnectionTypeKey = ConnectionType,
-> = Omit<Connection<T>, 'auth'> & {
+> = Omit<Connection<T>, 'auth' | 'title'> & {
+  title?: string;
   match?: ConnectionMatch;
   auth: (AuthValue<T> & { match?: ConnectionMatch })[];
 };

--- a/packages/connections/src/api/Connection.ts
+++ b/packages/connections/src/api/Connection.ts
@@ -38,6 +38,7 @@ export type Connection<
   TAuthMethod extends string = string,
 > = {
   type: LookupConnectionType<T>['type'];
+  title?: string;
   auth: string extends TAuthMethod
     ? AuthValue<T>[]
     : Extract<AuthValue<T>, { method: TAuthMethod }>;

--- a/packages/connections/src/api/ConnectionType.ts
+++ b/packages/connections/src/api/ConnectionType.ts
@@ -57,6 +57,7 @@ export type ConnectionType<
   TAuthMethods extends readonly ConnectionAuthMethod[] = readonly ConnectionAuthMethod[],
 > = {
   type: TType;
+  title: string;
   configSchema: TConfigSchema;
   authMethods: TAuthMethods;
   schema: z.ZodType;

--- a/packages/connections/src/api/ConnectionType.ts
+++ b/packages/connections/src/api/ConnectionType.ts
@@ -18,7 +18,7 @@ import type { ConnectionTypeKey, LookupConnectionType } from '../definitions';
 
 // Field names the framework owns at the connection level. Connection-type
 // authors must not declare these in their `configSchema`.
-export type ReservedConnectionFields = 'type' | 'auth' | 'match';
+export type ReservedConnectionFields = 'type' | 'auth' | 'match' | 'title';
 
 // Surfaced when a configSchema declares a reserved key — the message becomes
 // part of the type error so authors see why their schema was rejected.

--- a/packages/connections/src/api/DefaultConnectionService.test.ts
+++ b/packages/connections/src/api/DefaultConnectionService.test.ts
@@ -551,7 +551,7 @@ describe('DefaultConnectionsService', () => {
   });
 
   describe('title', () => {
-    it('includes the title when configured', async () => {
+    it('uses the configured title when provided', async () => {
       const service = DefaultConnectionsService.create({
         logger: mockServices.logger.mock(),
         config: mockConnectionsConfig([
@@ -573,7 +573,7 @@ describe('DefaultConnectionsService', () => {
       expect(connection?.title).toBe('GitHub Production');
     });
 
-    it('omits the title when not configured', async () => {
+    it('defaults to the provider display name for a single connection of that type', async () => {
       const service = DefaultConnectionsService.create({
         logger: mockServices.logger.mock(),
         config: mockConnectionsConfig([
@@ -591,7 +591,72 @@ describe('DefaultConnectionsService', () => {
         authMethods: ['token'],
       });
 
-      expect(connection?.title).toBeUndefined();
+      expect(connection?.title).toBe('GitHub');
+    });
+
+    it('includes the host when multiple connections share a type', async () => {
+      const service = DefaultConnectionsService.create({
+        logger: mockServices.logger.mock(),
+        config: mockConnectionsConfig([
+          {
+            type: 'github',
+            host: 'github.com',
+            auth: [{ method: 'token', token: 'public-token' }],
+          },
+          {
+            type: 'github',
+            host: 'ghe.acme.com',
+            auth: [{ method: 'token', token: 'enterprise-token' }],
+          },
+        ]),
+      });
+
+      const pub = await service.forPlugin('catalog').find({
+        type: 'github',
+        url: 'https://github.com/my-org/my-repo',
+        authMethods: ['token'],
+      });
+      const ent = await service.forPlugin('catalog').find({
+        type: 'github',
+        url: 'https://ghe.acme.com/my-org/my-repo',
+        authMethods: ['token'],
+      });
+
+      expect(pub?.title).toBe('GitHub (github.com)');
+      expect(ent?.title).toBe('GitHub (ghe.acme.com)');
+    });
+
+    it('does not override a configured title even when multiple connections share a type', async () => {
+      const service = DefaultConnectionsService.create({
+        logger: mockServices.logger.mock(),
+        config: mockConnectionsConfig([
+          {
+            type: 'github',
+            host: 'github.com',
+            title: 'Public GitHub',
+            auth: [{ method: 'token', token: 'public-token' }],
+          },
+          {
+            type: 'github',
+            host: 'ghe.acme.com',
+            auth: [{ method: 'token', token: 'enterprise-token' }],
+          },
+        ]),
+      });
+
+      const pub = await service.forPlugin('catalog').find({
+        type: 'github',
+        url: 'https://github.com/my-org/my-repo',
+        authMethods: ['token'],
+      });
+      const ent = await service.forPlugin('catalog').find({
+        type: 'github',
+        url: 'https://ghe.acme.com/my-org/my-repo',
+        authMethods: ['token'],
+      });
+
+      expect(pub?.title).toBe('Public GitHub');
+      expect(ent?.title).toBe('GitHub (ghe.acme.com)');
     });
   });
 

--- a/packages/connections/src/api/DefaultConnectionService.test.ts
+++ b/packages/connections/src/api/DefaultConnectionService.test.ts
@@ -550,6 +550,51 @@ describe('DefaultConnectionsService', () => {
     });
   });
 
+  describe('title', () => {
+    it('includes the title when configured', async () => {
+      const service = DefaultConnectionsService.create({
+        logger: mockServices.logger.mock(),
+        config: mockConnectionsConfig([
+          {
+            type: 'github',
+            host: 'github.com',
+            title: 'GitHub Production',
+            auth: [{ method: 'token', token: 'my-token' }],
+          },
+        ]),
+      });
+
+      const connection = await service.forPlugin('catalog').find({
+        type: 'github',
+        url: 'https://github.com/my-org/my-repo',
+        authMethods: ['token'],
+      });
+
+      expect(connection?.title).toBe('GitHub Production');
+    });
+
+    it('omits the title when not configured', async () => {
+      const service = DefaultConnectionsService.create({
+        logger: mockServices.logger.mock(),
+        config: mockConnectionsConfig([
+          {
+            type: 'github',
+            host: 'github.com',
+            auth: [{ method: 'token', token: 'my-token' }],
+          },
+        ]),
+      });
+
+      const connection = await service.forPlugin('catalog').find({
+        type: 'github',
+        url: 'https://github.com/my-org/my-repo',
+        authMethods: ['token'],
+      });
+
+      expect(connection?.title).toBeUndefined();
+    });
+  });
+
   describe('config validation', () => {
     it('throws with the failing field when a connection is missing a required value', () => {
       expect(() =>

--- a/packages/connections/src/api/DefaultConnectionService.ts
+++ b/packages/connections/src/api/DefaultConnectionService.ts
@@ -20,7 +20,6 @@ import {
 } from '@backstage/backend-plugin-api';
 import {
   ConnectionTypeKey,
-  connectionTypeDisplayNames,
   getConnectionType,
   isConnectionTypeKey,
 } from '../definitions';
@@ -255,7 +254,7 @@ export class DefaultConnectionsService {
     for (const c of this.connections) {
       if (!c.title) {
         const type = c.type as ConnectionTypeKey;
-        const displayName = connectionTypeDisplayNames[type];
+        const displayName = getConnectionType(type).title;
         const host = (c as unknown as { host: string }).host;
         (c as { title?: string }).title =
           typeCounts.get(type)! > 1 ? `${displayName} (${host})` : displayName;

--- a/packages/connections/src/api/DefaultConnectionService.ts
+++ b/packages/connections/src/api/DefaultConnectionService.ts
@@ -20,6 +20,7 @@ import {
 } from '@backstage/backend-plugin-api';
 import {
   ConnectionTypeKey,
+  connectionTypeDisplayNames,
   getConnectionType,
   isConnectionTypeKey,
 } from '../definitions';
@@ -190,6 +191,8 @@ export class DefaultConnectionsService {
       seen.add(key);
     }
 
+    this.#assignDefaultTitles();
+
     this.logger.info(
       `Loaded ${this.connections.length} connection${
         this.connections.length === 1 ? '' : 's'
@@ -241,6 +244,23 @@ export class DefaultConnectionsService {
     return getConnectionType(connection.type).schema.parse(
       connection,
     ) as RootConnection;
+  }
+
+  #assignDefaultTitles(): void {
+    const typeCounts = new Map<string, number>();
+    for (const c of this.connections) {
+      const type = c.type as ConnectionTypeKey;
+      typeCounts.set(type, (typeCounts.get(type) ?? 0) + 1);
+    }
+    for (const c of this.connections) {
+      if (!c.title) {
+        const type = c.type as ConnectionTypeKey;
+        const displayName = connectionTypeDisplayNames[type];
+        const host = (c as unknown as { host: string }).host;
+        (c as { title?: string }).title =
+          typeCounts.get(type)! > 1 ? `${displayName} (${host})` : displayName;
+      }
+    }
   }
 
   #getConnectionsForPlugin(pluginId: string): Connection[] {

--- a/packages/connections/src/definitions/types.ts
+++ b/packages/connections/src/definitions/types.ts
@@ -53,18 +53,3 @@ export type LookupConnectionType<T extends ConnectionTypeKey | ConnectionType> =
 export type ConnectionMatch = {
   plugins: string[];
 };
-
-export const connectionTypeDisplayNames: Record<ConnectionTypeKey, string> = {
-  'aws-codecommit': 'AWS CodeCommit',
-  'aws-s3': 'AWS S3',
-  'azure-blob-storage': 'Azure Blob Storage',
-  azure: 'Azure DevOps',
-  'bitbucket-cloud': 'Bitbucket Cloud',
-  'bitbucket-server': 'Bitbucket Server',
-  gerrit: 'Gerrit',
-  gitea: 'Gitea',
-  github: 'GitHub',
-  gitlab: 'GitLab',
-  'google-gcs': 'Google Cloud Storage',
-  harness: 'Harness',
-};

--- a/packages/connections/src/definitions/types.ts
+++ b/packages/connections/src/definitions/types.ts
@@ -53,3 +53,18 @@ export type LookupConnectionType<T extends ConnectionTypeKey | ConnectionType> =
 export type ConnectionMatch = {
   plugins: string[];
 };
+
+export const connectionTypeDisplayNames: Record<ConnectionTypeKey, string> = {
+  'aws-codecommit': 'AWS CodeCommit',
+  'aws-s3': 'AWS S3',
+  'azure-blob-storage': 'Azure Blob Storage',
+  azure: 'Azure DevOps',
+  'bitbucket-cloud': 'Bitbucket Cloud',
+  'bitbucket-server': 'Bitbucket Server',
+  gerrit: 'Gerrit',
+  gitea: 'Gitea',
+  github: 'GitHub',
+  gitlab: 'GitLab',
+  'google-gcs': 'Google Cloud Storage',
+  harness: 'Harness',
+};

--- a/packages/connections/src/schema/awsCodeCommit.ts
+++ b/packages/connections/src/schema/awsCodeCommit.ts
@@ -19,6 +19,7 @@ import { z } from 'zod/v4';
 /** @public */
 export const AwsCodeCommitConnectionType = createConnectionType({
   type: 'aws-codecommit',
+  title: 'AWS CodeCommit',
   configSchema: z.object({
     host: z.string(),
     region: z.string(),

--- a/packages/connections/src/schema/awsS3.ts
+++ b/packages/connections/src/schema/awsS3.ts
@@ -19,6 +19,7 @@ import { z } from 'zod/v4';
 /** @public */
 export const AwsS3ConnectionType = createConnectionType({
   type: 'aws-s3',
+  title: 'AWS S3',
   configSchema: z.object({
     host: z.string(),
     endpoint: z.string().optional(),

--- a/packages/connections/src/schema/azure.ts
+++ b/packages/connections/src/schema/azure.ts
@@ -19,6 +19,7 @@ import { z } from 'zod/v4';
 /** @public */
 export const AzureConnectionType = createConnectionType({
   type: 'azure',
+  title: 'Azure DevOps',
   configSchema: z.object({
     host: z.string(),
   }),

--- a/packages/connections/src/schema/azureBlobStorage.ts
+++ b/packages/connections/src/schema/azureBlobStorage.ts
@@ -19,6 +19,7 @@ import { z } from 'zod/v4';
 /** @public */
 export const AzureBlobStorageConnectionType = createConnectionType({
   type: 'azure-blob-storage',
+  title: 'Azure Blob Storage',
   configSchema: z.object({
     host: z.string(),
     accountName: z.string().optional(),

--- a/packages/connections/src/schema/bitbucketCloud.ts
+++ b/packages/connections/src/schema/bitbucketCloud.ts
@@ -19,6 +19,7 @@ import { z } from 'zod/v4';
 /** @public */
 export const BitbucketCloudConnectionType = createConnectionType({
   type: 'bitbucket-cloud',
+  title: 'Bitbucket Cloud',
   configSchema: z.object({
     host: z.string(),
   }),

--- a/packages/connections/src/schema/bitbucketServer.ts
+++ b/packages/connections/src/schema/bitbucketServer.ts
@@ -19,6 +19,7 @@ import { z } from 'zod/v4';
 /** @public */
 export const BitbucketServerConnectionType = createConnectionType({
   type: 'bitbucket-server',
+  title: 'Bitbucket Server',
   configSchema: z.object({
     host: z.string(),
     apiBaseUrl: z.string().optional(),

--- a/packages/connections/src/schema/gerrit.ts
+++ b/packages/connections/src/schema/gerrit.ts
@@ -19,6 +19,7 @@ import { z } from 'zod/v4';
 /** @public */
 export const GerritConnectionType = createConnectionType({
   type: 'gerrit',
+  title: 'Gerrit',
   configSchema: z.object({
     host: z.string(),
     baseUrl: z.string().optional(),

--- a/packages/connections/src/schema/gitea.ts
+++ b/packages/connections/src/schema/gitea.ts
@@ -19,6 +19,7 @@ import { z } from 'zod/v4';
 /** @public */
 export const GiteaConnectionType = createConnectionType({
   type: 'gitea',
+  title: 'Gitea',
   configSchema: z.object({
     host: z.string(),
     baseUrl: z.string().optional(),

--- a/packages/connections/src/schema/github.ts
+++ b/packages/connections/src/schema/github.ts
@@ -19,6 +19,7 @@ import { z } from 'zod/v4';
 /** @public */
 export const GithubConnectionType = createConnectionType({
   type: 'github',
+  title: 'GitHub',
   configSchema: z.object({
     host: z.string(),
     apiBaseUrl: z.string().optional(),

--- a/packages/connections/src/schema/gitlab.ts
+++ b/packages/connections/src/schema/gitlab.ts
@@ -19,6 +19,7 @@ import { z } from 'zod/v4';
 /** @public */
 export const GitlabConnectionType = createConnectionType({
   type: 'gitlab',
+  title: 'GitLab',
   configSchema: z.object({
     host: z.string(),
     apiBaseUrl: z.string().optional(),

--- a/packages/connections/src/schema/googleGcs.ts
+++ b/packages/connections/src/schema/googleGcs.ts
@@ -19,6 +19,7 @@ import { z } from 'zod/v4';
 /** @public */
 export const GoogleGcsConnectionType = createConnectionType({
   type: 'google-gcs',
+  title: 'Google Cloud Storage',
   configSchema: z.object({
     host: z.string(),
   }),

--- a/packages/connections/src/schema/harness.ts
+++ b/packages/connections/src/schema/harness.ts
@@ -19,6 +19,7 @@ import { z } from 'zod/v4';
 /** @public */
 export const HarnessConnectionType = createConnectionType({
   type: 'harness',
+  title: 'Harness',
   configSchema: z.object({
     host: z.string(),
   }),

--- a/packages/connections/src/system/createConnectionType.test.ts
+++ b/packages/connections/src/system/createConnectionType.test.ts
@@ -25,6 +25,7 @@ describe('createConnectionType', () => {
 
     const SingleAuthType = createConnectionType({
       type: 'single',
+      title: 'Single',
       configSchema: z.object({ host: z.string() }),
       authMethods: [tokenAuth],
     });
@@ -99,6 +100,7 @@ describe('createConnectionType', () => {
   it('builds a multi-auth-method connection type that discriminates on method', () => {
     const MultiAuthType = createConnectionType({
       type: 'multi',
+      title: 'Multi',
       configSchema: z.object({ host: z.string() }),
       authMethods: [
         { method: 'token', configSchema: z.object({ token: z.string() }) },

--- a/packages/connections/src/system/createConnectionType.test.ts
+++ b/packages/connections/src/system/createConnectionType.test.ts
@@ -75,6 +75,25 @@ describe('createConnectionType', () => {
         auth: [{ method: 'token', token: 'abc' }],
       }),
     ).toThrow();
+
+    // Optional title field should be accepted.
+    expect(
+      SingleAuthType.schema.parse({
+        type: 'single',
+        host: 'example.com',
+        title: 'My Production Instance',
+        auth: [{ method: 'token', token: 'abc' }],
+      }),
+    ).toMatchObject({ title: 'My Production Instance' });
+
+    // Omitting title should still work.
+    expect(
+      SingleAuthType.schema.parse({
+        type: 'single',
+        host: 'example.com',
+        auth: [{ method: 'token', token: 'abc' }],
+      }),
+    ).not.toHaveProperty('title');
   });
 
   it('builds a multi-auth-method connection type that discriminates on method', () => {

--- a/packages/connections/src/system/createConnectionType.ts
+++ b/packages/connections/src/system/createConnectionType.ts
@@ -55,7 +55,7 @@ export function createConnectionType<
   const schema = validated
     .extend({
       type: z.literal(type),
-      title: z.string().optional(),
+      title: z.string().min(1).optional(),
       match: matchSchema,
       auth: z.array(
         authOptions.length === 1

--- a/packages/connections/src/system/createConnectionType.ts
+++ b/packages/connections/src/system/createConnectionType.ts
@@ -33,10 +33,12 @@ export function createConnectionType<
 >({
   configSchema,
   type,
+  title,
   authMethods,
   matchAuth,
 }: {
   type: TType;
+  title: string;
   configSchema: WithoutReservedFields<TConfigSchema>;
   authMethods: TAuthMethods;
   matchAuth?: MatchAuth<TAuthMethods>;
@@ -67,6 +69,7 @@ export function createConnectionType<
     .strict();
   return {
     type,
+    title,
     configSchema: validated,
     authMethods,
     schema,

--- a/packages/connections/src/system/createConnectionType.ts
+++ b/packages/connections/src/system/createConnectionType.ts
@@ -53,6 +53,7 @@ export function createConnectionType<
   const schema = validated
     .extend({
       type: z.literal(type),
+      title: z.string().optional(),
       match: matchSchema,
       auth: z.array(
         authOptions.length === 1


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Implements the `title` field proposed in [BEP 14 PR #34547](https://github.com/backstage/backstage/pull/34547). This adds an optional `title?: string` field to every connection entry, allowing adopters to configure a human-readable display name (e.g. "GitHub Production" instead of just the host).

### Changes

- Added `title` to the Zod schema in `createConnectionType` so it's validated on all connection types
- Added `title` to the `Connection` TypeScript type so it's available on resolved connections
- Added `title` to `ReservedConnectionFields` so connection-type authors can't collide with it
- Updated API report

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

🤖 Generated with [Claude Code](https://claude.com/claude-code)