### PR TITLE
feat(core-components): add components prop to MarkdownContent

### DIFF
--- a/.changeset/add-components-prop-to-markdown-content.md
+++ b/.changeset/add-components-prop-to-markdown-content.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Added an optional `components` prop to `MarkdownContent` that allows consumers to override default element renderers while preserving Backstage theme styling.

--- a/packages/core-components/src/components/MarkdownContent/MarkdownContent.stories.tsx
+++ b/packages/core-components/src/components/MarkdownContent/MarkdownContent.stories.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { PropsWithChildren } from 'react';
 import { MarkdownContent } from './MarkdownContent';
 
 export default {
@@ -144,4 +145,36 @@ export const MarkdownContentGithubFlavoredCommonMark = () => (
 
 export const MarkdownContentGithubFlavoredWithHTML = () => (
   <MarkdownContent content={markdownGithubFlavoredWithHTML} dialect="gfm" />
+);
+
+const markdownWithBlockquote =
+  '# Components Override\n\n' +
+  'The `components` prop allows overriding how markdown elements render.\n\n' +
+  '> This blockquote is rendered as a styled callout using a custom component.\n\n' +
+  'Regular text with **bold**, *italic*, and `inline code` remains unaffected.\n';
+
+export const MarkdownContentWithComponentsOverride = () => (
+  <MarkdownContent
+    content={markdownWithBlockquote}
+    components={{
+      blockquote({ children }: PropsWithChildren) {
+        return (
+          <div
+            style={{
+              borderLeft: '4px solid #1976d2',
+              background: '#e3f2fd',
+              padding: '12px 16px',
+              borderRadius: '4px',
+              margin: '16px 0',
+            }}
+          >
+            <span style={{ marginRight: '8px' }} aria-hidden="true">
+              💡
+            </span>
+            {children}
+          </div>
+        );
+      },
+    }}
+  />
 );

--- a/packages/core-components/src/components/MarkdownContent/MarkdownContent.test.tsx
+++ b/packages/core-components/src/components/MarkdownContent/MarkdownContent.test.tsx
@@ -211,4 +211,21 @@ describe('<MarkdownContent />', () => {
     expect(container.querySelector('script')).toBeNull();
     expect(container.querySelector('style')).toBeNull();
   });
+
+  it('render MarkdownContent component with custom components override', async () => {
+    await renderInTestApp(
+      <MarkdownContent
+        content={'```typescript\nconst x = 1;\n```'}
+        components={{
+          code: ({ children }) => (
+            <div data-testid="custom-code">{children}</div>
+          ),
+        }}
+      />,
+    );
+
+    const customElement = await screen.findByTestId('custom-code');
+    expect(customElement).toBeInTheDocument();
+    expect(customElement).toHaveTextContent('const x = 1;');
+  });
 });

--- a/packages/core-components/src/components/MarkdownContent/MarkdownContent.tsx
+++ b/packages/core-components/src/components/MarkdownContent/MarkdownContent.tsx
@@ -17,7 +17,7 @@
 import { makeStyles } from '@material-ui/core/styles';
 import ReactMarkdown, { Options } from 'react-markdown';
 import gfm from 'remark-gfm';
-import { Children, createElement } from 'react';
+import { Children, createElement, useMemo } from 'react';
 import { CodeSnippet } from '../CodeSnippet';
 import { HeadingProps } from 'react-markdown/lib/ast-to-react';
 import rehypeRaw from 'rehype-raw';
@@ -75,6 +75,7 @@ type Props = {
   transformLinkUri?: (href: string) => string;
   transformImageUri?: (href: string) => string;
   className?: string;
+  components?: Options['components'];
 };
 
 const flatten = (text: string, child: any): string => {
@@ -92,7 +93,7 @@ const headingRenderer = ({ level, children }: HeadingProps) => {
   return createElement(`h${level}`, { id: slug }, children);
 };
 
-const components: Options['components'] = {
+const defaultComponents: Options['components'] = {
   code: ({ inline, className, children, ...props }) => {
     const text = String(children).replace(/\n+$/, '');
     const match = /language-(\w+)/.exec(className || '');
@@ -164,15 +165,20 @@ export function MarkdownContent(props: Props) {
     transformLinkUri,
     transformImageUri,
     className,
+    components: componentOverrides,
   } = props;
   const classes = useStyles();
+  const mergedComponents = useMemo(
+    () => ({ ...defaultComponents, ...componentOverrides }),
+    [componentOverrides],
+  );
   return (
     <ReactMarkdown
       remarkPlugins={dialect === 'gfm' ? [gfm] : []}
       rehypePlugins={dialect === 'gfm' ? gfmRehypePlugins : []}
       className={`${classes.markdown} ${className ?? ''}`.trim()}
       children={content}
-      components={components}
+      components={mergedComponents}
       linkTarget={linkTarget}
       transformLinkUri={transformLinkUri}
       transformImageUri={transformImageUri}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Plugins that need custom markdown element rendering (e.g., mermaid diagrams in code blocks) currently have to replace `MarkdownContent` entirely and duplicate its styles. 

This adds an optional `components` prop that merges overrides on top of the defaults, keeping themed output intact.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
