### PR TITLE
fix(catalog): diff-based sync for refresh_state_references

### DIFF
--- a/.changeset/sync-refresh-state-references.md
+++ b/.changeset/sync-refresh-state-references.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Replaced the delete-all and reinsert pattern for `refresh_state_references` with a diff-based sync that only touches rows that actually changed. This eliminates steady-state write churn, dead tuples, and WAL traffic from the processing path when the set of emitted entities has not changed (the common case). A new migration adds partial unique indices that enforce one reference per (source, target) pair and supersede the old single-column indices, which are dropped.
+
+The previous code used an `OR`-scoped `DELETE` that removed references from all sources to the target entities, not just from the current source. This caused entities with multiple parents to lose valid references, potentially leading to incorrect orphaning. The new sync is strictly scoped to the current source entity and never modifies other sources' references.

--- a/.changeset/sync-refresh-state-references.md
+++ b/.changeset/sync-refresh-state-references.md
@@ -2,6 +2,4 @@
 '@backstage/plugin-catalog-backend': patch
 ---
 
-Replaced the delete-all and reinsert pattern for `refresh_state_references` with a diff-based sync that only touches rows that actually changed. This eliminates steady-state write churn, dead tuples, and WAL traffic from the processing path when the set of emitted entities has not changed (the common case). A new migration adds partial unique indices that enforce one reference per (source, target) pair and supersede the old single-column indices, which are dropped.
-
-The previous code used an `OR`-scoped `DELETE` that removed references from all sources to the target entities, not just from the current source. This caused entities with multiple parents to lose valid references, potentially leading to incorrect orphaning. The new sync is strictly scoped to the current source entity and never modifies other sources' references.
+Reduced catalog database writes when emitted entity sets are unchanged, while preserving valid references from multiple parents. Strong sources that claim weak entities continue to replace the previous references atomically.

--- a/plugins/catalog-backend/migrations/20260616000000_refresh_state_references_sync_indices.js
+++ b/plugins/catalog-backend/migrations/20260616000000_refresh_state_references_sync_indices.js
@@ -1,0 +1,370 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-check
+
+/**
+ * Adds partial unique indices on refresh_state_references to support the
+ * diff-based sync CTE (syncRefreshStateReferences) and drops the old
+ * single-column indices that are made redundant by the new composites.
+ *
+ * ## Indices added
+ *
+ * - (source_entity_ref, target_entity_ref) WHERE source_entity_ref IS NOT NULL
+ *   Enforces one reference per (source entity, target entity) pair. The
+ *   leading column covers lookups previously served by the old
+ *   source_entity_ref single-column index, and the unique constraint
+ *   enables ON CONFLICT DO NOTHING in the Postgres sync CTE.
+ *
+ * - (source_key, target_entity_ref) WHERE source_key IS NOT NULL
+ *   Same treatment for provider-to-entity references. The leading column
+ *   covers lookups previously served by the old source_key single-column
+ *   index.
+ *
+ * ## Indices dropped
+ *
+ * - refresh_state_references_source_entity_ref_idx  (superseded)
+ * - refresh_state_references_source_key_idx         (superseded)
+ *
+ * The target_entity_ref index is retained — no new index has that column
+ * as the leading key, and it is needed for orphan detection and FK cascade
+ * deletes.
+ *
+ * ## Deduplication
+ *
+ * Before creating the unique indices, any existing duplicate rows are
+ * removed. Under normal operation duplicates should not exist (the current
+ * code runs delete-all + reinsert inside a transaction), but we clean up
+ * defensively in case of past bugs or races.
+ *
+ * ## Operator fast path
+ *
+ * If the unique indices already exist (e.g. the operator ran the DDL by
+ * hand), both the dedup and index creation are skipped — startup is
+ * instant.
+ *
+ * ## Cost
+ *
+ * - Postgres: CREATE INDEX CONCURRENTLY on a ~490K row table takes a few
+ *   seconds. The dedup self-join is similarly cheap. DROP INDEX
+ *   CONCURRENTLY is instant.
+ * - MySQL: regular CREATE/DROP INDEX, briefly locks the table.
+ * - SQLite: instant.
+ */
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function up(knex) {
+  const client = knex.client.config.client;
+
+  if (client.includes('pg')) {
+    await upPostgres(knex);
+  } else if (client.includes('mysql')) {
+    await upMysql(knex);
+  } else {
+    await upSqlite(knex);
+  }
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function down(knex) {
+  const client = knex.client.config.client;
+
+  if (client.includes('pg')) {
+    await downPostgres(knex);
+  } else if (client.includes('mysql')) {
+    await downMysql(knex);
+  } else {
+    await downSqlite(knex);
+  }
+};
+
+// CREATE/DROP INDEX CONCURRENTLY cannot run inside a transaction.
+exports.config = { transaction: false };
+
+// ---------------------------------------------------------------------------
+// Postgres
+// ---------------------------------------------------------------------------
+
+/** @param {import('knex').Knex} knex */
+async function upPostgres(knex) {
+  // Fast path: if both unique indices are already valid, skip everything.
+  const entityIdx = await pgIndexIsValid(
+    knex,
+    'refresh_state_references_source_entity_target_uniq',
+  );
+  const keyIdx = await pgIndexIsValid(
+    knex,
+    'refresh_state_references_source_key_target_uniq',
+  );
+
+  if (!entityIdx) {
+    // Deduplicate source_entity_ref rows before creating the unique index.
+    await knex.raw(`
+      DELETE FROM refresh_state_references a
+      USING refresh_state_references b
+      WHERE a.id > b.id
+        AND a.source_entity_ref IS NOT NULL
+        AND a.source_entity_ref = b.source_entity_ref
+        AND a.target_entity_ref = b.target_entity_ref
+    `);
+    await knex.raw(`
+      CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS
+        refresh_state_references_source_entity_target_uniq
+        ON refresh_state_references (source_entity_ref, target_entity_ref)
+        WHERE source_entity_ref IS NOT NULL
+    `);
+  }
+
+  if (!keyIdx) {
+    // Deduplicate source_key rows before creating the unique index.
+    await knex.raw(`
+      DELETE FROM refresh_state_references a
+      USING refresh_state_references b
+      WHERE a.id > b.id
+        AND a.source_key IS NOT NULL
+        AND a.source_key = b.source_key
+        AND a.target_entity_ref = b.target_entity_ref
+    `);
+    await knex.raw(`
+      CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS
+        refresh_state_references_source_key_target_uniq
+        ON refresh_state_references (source_key, target_entity_ref)
+        WHERE source_key IS NOT NULL
+    `);
+  }
+
+  // Drop old single-column indices that the new composites supersede.
+  await knex.raw(
+    'DROP INDEX CONCURRENTLY IF EXISTS refresh_state_references_source_entity_ref_idx',
+  );
+  await knex.raw(
+    'DROP INDEX CONCURRENTLY IF EXISTS refresh_state_references_source_key_idx',
+  );
+}
+
+/** @param {import('knex').Knex} knex */
+async function downPostgres(knex) {
+  // Restore old single-column indices before dropping the new ones.
+  await knex.raw(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS
+      refresh_state_references_source_entity_ref_idx
+      ON refresh_state_references (source_entity_ref)
+  `);
+  await knex.raw(`
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS
+      refresh_state_references_source_key_idx
+      ON refresh_state_references (source_key)
+  `);
+  await knex.raw(
+    'DROP INDEX CONCURRENTLY IF EXISTS refresh_state_references_source_entity_target_uniq',
+  );
+  await knex.raw(
+    'DROP INDEX CONCURRENTLY IF EXISTS refresh_state_references_source_key_target_uniq',
+  );
+}
+
+/**
+ * @param {import('knex').Knex} knex
+ * @param {string} name
+ * @returns {Promise<boolean>}
+ */
+async function pgIndexIsValid(knex, name) {
+  const result = await knex.raw(
+    `SELECT indisvalid
+     FROM pg_index
+     WHERE indexrelid = (
+       SELECT oid FROM pg_class WHERE relname = ? AND relkind = 'i'
+     ) AND indisunique = true`,
+    [name],
+  );
+  return result.rows[0]?.indisvalid === true;
+}
+
+// ---------------------------------------------------------------------------
+// MySQL
+// ---------------------------------------------------------------------------
+
+/** @param {import('knex').Knex} knex */
+async function upMysql(knex) {
+  // MySQL treats NULLs as distinct in unique indices, so a regular
+  // (non-partial) unique index works correctly: it prevents duplicates
+  // for non-NULL source values while allowing multiple NULL rows.
+
+  const hasEntityIdx = await mysqlIndexExists(
+    knex,
+    'refresh_state_references_source_entity_target_uniq',
+  );
+  if (!hasEntityIdx) {
+    // Deduplicate
+    await knex.raw(`
+      DELETE a FROM refresh_state_references a
+      INNER JOIN refresh_state_references b
+      ON a.id > b.id
+        AND a.source_entity_ref IS NOT NULL
+        AND a.source_entity_ref = b.source_entity_ref
+        AND a.target_entity_ref = b.target_entity_ref
+    `);
+    await knex.schema.alterTable('refresh_state_references', table => {
+      table.unique(
+        ['source_entity_ref', 'target_entity_ref'],
+        'refresh_state_references_source_entity_target_uniq',
+      );
+    });
+  }
+
+  const hasKeyIdx = await mysqlIndexExists(
+    knex,
+    'refresh_state_references_source_key_target_uniq',
+  );
+  if (!hasKeyIdx) {
+    await knex.raw(`
+      DELETE a FROM refresh_state_references a
+      INNER JOIN refresh_state_references b
+      ON a.id > b.id
+        AND a.source_key IS NOT NULL
+        AND a.source_key = b.source_key
+        AND a.target_entity_ref = b.target_entity_ref
+    `);
+    await knex.schema.alterTable('refresh_state_references', table => {
+      table.unique(
+        ['source_key', 'target_entity_ref'],
+        'refresh_state_references_source_key_target_uniq',
+      );
+    });
+  }
+
+  // Drop old single-column indices.
+  await mysqlDropIndexIfExists(
+    knex,
+    'refresh_state_references_source_entity_ref_idx',
+  );
+  await mysqlDropIndexIfExists(knex, 'refresh_state_references_source_key_idx');
+}
+
+/** @param {import('knex').Knex} knex */
+async function downMysql(knex) {
+  await knex.schema.alterTable('refresh_state_references', table => {
+    table.index(
+      ['source_entity_ref'],
+      'refresh_state_references_source_entity_ref_idx',
+    );
+    table.index(['source_key'], 'refresh_state_references_source_key_idx');
+  });
+  await mysqlDropIndexIfExists(
+    knex,
+    'refresh_state_references_source_entity_target_uniq',
+  );
+  await mysqlDropIndexIfExists(
+    knex,
+    'refresh_state_references_source_key_target_uniq',
+  );
+}
+
+/**
+ * @param {import('knex').Knex} knex
+ * @param {string} name
+ * @returns {Promise<boolean>}
+ */
+async function mysqlIndexExists(knex, name) {
+  const [rows] = await knex.raw(
+    `SHOW INDEX FROM refresh_state_references WHERE Key_name = ?`,
+    [name],
+  );
+  return rows.length > 0;
+}
+
+/**
+ * @param {import('knex').Knex} knex
+ * @param {string} name
+ */
+async function mysqlDropIndexIfExists(knex, name) {
+  const exists = await mysqlIndexExists(knex, name);
+  if (exists) {
+    await knex.schema.alterTable('refresh_state_references', table => {
+      table.dropIndex([], name);
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SQLite
+// ---------------------------------------------------------------------------
+
+/** @param {import('knex').Knex} knex */
+async function upSqlite(knex) {
+  // SQLite treats NULLs as distinct in unique indices, same as MySQL.
+  // Dedup is unlikely to be needed (dev/test only) but done for safety.
+
+  await knex.raw(`
+    DELETE FROM refresh_state_references
+    WHERE id NOT IN (
+      SELECT MIN(id) FROM refresh_state_references
+      WHERE source_entity_ref IS NOT NULL
+      GROUP BY source_entity_ref, target_entity_ref
+    ) AND source_entity_ref IS NOT NULL
+  `);
+  await knex.raw(`
+    DELETE FROM refresh_state_references
+    WHERE id NOT IN (
+      SELECT MIN(id) FROM refresh_state_references
+      WHERE source_key IS NOT NULL
+      GROUP BY source_key, target_entity_ref
+    ) AND source_key IS NOT NULL
+  `);
+
+  await knex.raw(`
+    CREATE UNIQUE INDEX IF NOT EXISTS
+      refresh_state_references_source_entity_target_uniq
+      ON refresh_state_references (source_entity_ref, target_entity_ref)
+      WHERE source_entity_ref IS NOT NULL
+  `);
+  await knex.raw(`
+    CREATE UNIQUE INDEX IF NOT EXISTS
+      refresh_state_references_source_key_target_uniq
+      ON refresh_state_references (source_key, target_entity_ref)
+      WHERE source_key IS NOT NULL
+  `);
+
+  // Drop old indices.
+  await knex.raw(
+    'DROP INDEX IF EXISTS refresh_state_references_source_entity_ref_idx',
+  );
+  await knex.raw(
+    'DROP INDEX IF EXISTS refresh_state_references_source_key_idx',
+  );
+}
+
+/** @param {import('knex').Knex} knex */
+async function downSqlite(knex) {
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS refresh_state_references_source_entity_ref_idx
+      ON refresh_state_references (source_entity_ref)
+  `);
+  await knex.raw(`
+    CREATE INDEX IF NOT EXISTS refresh_state_references_source_key_idx
+      ON refresh_state_references (source_key)
+  `);
+  await knex.raw(
+    'DROP INDEX IF EXISTS refresh_state_references_source_entity_target_uniq',
+  );
+  await knex.raw(
+    'DROP INDEX IF EXISTS refresh_state_references_source_key_target_uniq',
+  );
+}

--- a/plugins/catalog-backend/migrations/20260616000000_refresh_state_references_sync_indices.js
+++ b/plugins/catalog-backend/migrations/20260616000000_refresh_state_references_sync_indices.js
@@ -56,6 +56,14 @@
  * hand), both the dedup and index creation are skipped — startup is
  * instant.
  *
+ * ## Rolling deployments
+ *
+ * The previous implementation did not deduplicate its input before inserting.
+ * During a mixed-version rollout, an old instance that emits the same child
+ * more than once can therefore conflict with these unique indices. Operators
+ * that allow duplicate emissions need to roll this out in two phases, updating
+ * writers to deduplicate before applying this migration.
+ *
  * ## Cost
  *
  * - Postgres: CREATE INDEX CONCURRENTLY on a ~490K row table takes a few
@@ -104,51 +112,16 @@ exports.config = { transaction: false };
 
 /** @param {import('knex').Knex} knex */
 async function upPostgres(knex) {
-  // Fast path: if both unique indices are already valid, skip everything.
-  const entityIdx = await pgIndexIsValid(
+  await ensurePgUniqueIndex(
     knex,
     'refresh_state_references_source_entity_target_uniq',
+    'source_entity_ref',
   );
-  const keyIdx = await pgIndexIsValid(
+  await ensurePgUniqueIndex(
     knex,
     'refresh_state_references_source_key_target_uniq',
+    'source_key',
   );
-
-  if (!entityIdx) {
-    // Deduplicate source_entity_ref rows before creating the unique index.
-    await knex.raw(`
-      DELETE FROM refresh_state_references a
-      USING refresh_state_references b
-      WHERE a.id > b.id
-        AND a.source_entity_ref IS NOT NULL
-        AND a.source_entity_ref = b.source_entity_ref
-        AND a.target_entity_ref = b.target_entity_ref
-    `);
-    await knex.raw(`
-      CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS
-        refresh_state_references_source_entity_target_uniq
-        ON refresh_state_references (source_entity_ref, target_entity_ref)
-        WHERE source_entity_ref IS NOT NULL
-    `);
-  }
-
-  if (!keyIdx) {
-    // Deduplicate source_key rows before creating the unique index.
-    await knex.raw(`
-      DELETE FROM refresh_state_references a
-      USING refresh_state_references b
-      WHERE a.id > b.id
-        AND a.source_key IS NOT NULL
-        AND a.source_key = b.source_key
-        AND a.target_entity_ref = b.target_entity_ref
-    `);
-    await knex.raw(`
-      CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS
-        refresh_state_references_source_key_target_uniq
-        ON refresh_state_references (source_key, target_entity_ref)
-        WHERE source_key IS NOT NULL
-    `);
-  }
 
   // Drop old single-column indices that the new composites supersede.
   await knex.raw(
@@ -183,18 +156,55 @@ async function downPostgres(knex) {
 /**
  * @param {import('knex').Knex} knex
  * @param {string} name
- * @returns {Promise<boolean>}
+ * @param {'source_entity_ref' | 'source_key'} sourceColumn
  */
-async function pgIndexIsValid(knex, name) {
+async function ensurePgUniqueIndex(knex, name, sourceColumn) {
   const result = await knex.raw(
-    `SELECT indisvalid
-     FROM pg_index
-     WHERE indexrelid = (
-       SELECT oid FROM pg_class WHERE relname = ? AND relkind = 'i'
-     ) AND indisunique = true`,
+    `SELECT
+       i.indisvalid,
+       i.indisunique,
+       pg_get_indexdef(i.indexrelid) AS definition
+     FROM pg_index i
+     JOIN pg_class index_class ON index_class.oid = i.indexrelid
+     JOIN pg_class table_class ON table_class.oid = i.indrelid
+     JOIN pg_namespace namespace ON namespace.oid = index_class.relnamespace
+     WHERE index_class.relname = ?
+       AND namespace.nspname = current_schema()
+       AND table_class.relnamespace = namespace.oid
+       AND table_class.relname = 'refresh_state_references'`,
     [name],
   );
-  return result.rows[0]?.indisvalid === true;
+  const index = result.rows[0];
+  const expectedColumns = `(${sourceColumn}, target_entity_ref)`;
+  const expectedPredicate = `WHERE (${sourceColumn} IS NOT NULL)`;
+  const isUsable =
+    index?.indisvalid === true &&
+    index?.indisunique === true &&
+    index.definition.includes(expectedColumns) &&
+    index.definition.includes(expectedPredicate);
+
+  if (isUsable) {
+    return;
+  }
+  if (index) {
+    await knex.raw(`DROP INDEX CONCURRENTLY ??`, [name]);
+  }
+
+  await knex.raw(
+    `DELETE FROM refresh_state_references a
+     USING refresh_state_references b
+     WHERE a.id > b.id
+       AND a.?? IS NOT NULL
+       AND a.?? = b.??
+       AND a.target_entity_ref = b.target_entity_ref`,
+    [sourceColumn, sourceColumn, sourceColumn],
+  );
+  await knex.raw(
+    `CREATE UNIQUE INDEX CONCURRENTLY ??
+       ON refresh_state_references (??, target_entity_ref)
+       WHERE ?? IS NOT NULL`,
+    [name, sourceColumn, sourceColumn],
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -260,13 +270,26 @@ async function upMysql(knex) {
 
 /** @param {import('knex').Knex} knex */
 async function downMysql(knex) {
-  await knex.schema.alterTable('refresh_state_references', table => {
-    table.index(
-      ['source_entity_ref'],
+  if (
+    !(await mysqlIndexExists(
+      knex,
       'refresh_state_references_source_entity_ref_idx',
-    );
-    table.index(['source_key'], 'refresh_state_references_source_key_idx');
-  });
+    ))
+  ) {
+    await knex.schema.alterTable('refresh_state_references', table => {
+      table.index(
+        ['source_entity_ref'],
+        'refresh_state_references_source_entity_ref_idx',
+      );
+    });
+  }
+  if (
+    !(await mysqlIndexExists(knex, 'refresh_state_references_source_key_idx'))
+  ) {
+    await knex.schema.alterTable('refresh_state_references', table => {
+      table.index(['source_key'], 'refresh_state_references_source_key_idx');
+    });
+  }
   await mysqlDropIndexIfExists(
     knex,
     'refresh_state_references_source_entity_target_uniq',

--- a/plugins/catalog-backend/report.sql.md
+++ b/plugins/catalog-backend/report.sql.md
@@ -97,8 +97,8 @@
 ### Indices
 
 - `refresh_state_references_pkey` (`id`) unique primary
-- `refresh_state_references_source_entity_ref_idx` (`source_entity_ref`)
-- `refresh_state_references_source_key_idx` (`source_key`)
+- `refresh_state_references_source_entity_target_uniq` (`source_entity_ref`, `target_entity_ref`) unique
+- `refresh_state_references_source_key_target_uniq` (`source_key`, `target_entity_ref`) unique
 - `refresh_state_references_target_entity_ref_idx` (`target_entity_ref`)
 
 ## Table `relations`

--- a/plugins/catalog-backend/src/database/DefaultProcessingDatabase.test.ts
+++ b/plugins/catalog-backend/src/database/DefaultProcessingDatabase.test.ts
@@ -465,6 +465,102 @@ describe.each(databases.eachSupportedId())(
         });
       });
 
+      it('only removes other references on a weak-to-strong claim', async () => {
+        const { knex, db } = await createDatabase();
+        await insertRefreshStateRow(knex, {
+          entity_id: id,
+          entity_ref: 'location:default/fakelocation',
+          unprocessed_entity: '{}',
+          processed_entity: '{}',
+          errors: '[]',
+          next_update_at: '2021-04-01 13:37:00',
+          last_discovery_at: '2021-04-01 13:37:00',
+        });
+        await insertRefreshStateRow(knex, {
+          entity_id: 'child-id',
+          entity_ref: 'component:default/child',
+          unprocessed_entity: '{}',
+          errors: '[]',
+          next_update_at: '2021-04-01 13:37:00',
+          last_discovery_at: '2021-04-01 13:37:00',
+        });
+        await insertRefreshStateRow(knex, {
+          entity_id: 'other-parent-id',
+          entity_ref: 'component:default/other-parent',
+          unprocessed_entity: '{}',
+          errors: '[]',
+          next_update_at: '2021-04-01 13:37:00',
+          last_discovery_at: '2021-04-01 13:37:00',
+        });
+        await insertRefRow(knex, {
+          source_entity_ref: 'component:default/other-parent',
+          target_entity_ref: 'component:default/child',
+        });
+        await insertRefRow(knex, {
+          source_key: 'other-provider',
+          target_entity_ref: 'component:default/child',
+        });
+
+        const child = {
+          apiVersion: '1',
+          kind: 'Component',
+          metadata: { name: 'child' },
+        };
+        const update = () =>
+          db.transaction(tx =>
+            db.updateProcessedEntity(tx, {
+              id,
+              processedEntity,
+              resultHash: '',
+              relations: [],
+              deferredEntities: [{ entity: child, locationKey: 'owned' }],
+              refreshKeys: [],
+            }),
+          );
+
+        await update();
+        await expect(
+          knex<DbRefreshStateReferencesRow>('refresh_state_references')
+            .where({ target_entity_ref: 'component:default/child' })
+            .select(['source_entity_ref', 'source_key']),
+        ).resolves.toEqual([
+          {
+            source_entity_ref: 'location:default/fakelocation',
+            source_key: null,
+          },
+        ]);
+
+        await insertRefRow(knex, {
+          source_entity_ref: 'component:default/other-parent',
+          target_entity_ref: 'component:default/child',
+        });
+        await insertRefRow(knex, {
+          source_key: 'other-provider',
+          target_entity_ref: 'component:default/child',
+        });
+
+        await update();
+        await expect(
+          knex<DbRefreshStateReferencesRow>('refresh_state_references')
+            .where({ target_entity_ref: 'component:default/child' })
+            .orderBy(['source_entity_ref', 'source_key'])
+            .select(['source_entity_ref', 'source_key']),
+        ).resolves.toEqual([
+          {
+            source_entity_ref: null,
+            source_key: 'other-provider',
+          },
+          {
+            source_entity_ref: 'component:default/other-parent',
+            source_key: null,
+          },
+          {
+            source_entity_ref: 'location:default/fakelocation',
+            source_key: null,
+          },
+        ]);
+      });
+
       it('stores the refresh keys for the entity where key length is 255 chars or less', async () => {
         const mockLogger = {
           debug: jest.fn(),

--- a/plugins/catalog-backend/src/database/DefaultProcessingDatabase.ts
+++ b/plugins/catalog-backend/src/database/DefaultProcessingDatabase.ts
@@ -40,6 +40,7 @@ import {
 } from './types';
 import { checkLocationKeyConflict } from './operations/refreshState/checkLocationKeyConflict';
 import { insertUnprocessedEntity } from './operations/refreshState/insertUnprocessedEntity';
+import { syncRefreshStateReferences } from './operations/refreshState/syncRefreshStateReferences';
 import { updateUnprocessedEntity } from './operations/refreshState/updateUnprocessedEntity';
 import { generateStableHash, generateTargetKey } from './util';
 import { EventParams, EventsService } from '@backstage/plugin-events-node';
@@ -405,20 +406,10 @@ export class DefaultProcessingDatabase implements ProcessingDatabase {
       }
     }
 
-    // Lastly, replace refresh state references for the originating entity and any successfully added entities
-    await tx<DbRefreshStateReferencesRow>('refresh_state_references')
-      // Remove all existing references from the originating entity
-      .where({ source_entity_ref: options.sourceEntityRef })
-      // And remove any existing references to entities that we're inserting new references for
-      .orWhereIn('target_entity_ref', stateReferences)
-      .delete();
-    await tx.batchInsert(
-      'refresh_state_references',
-      stateReferences.map(entityRef => ({
-        source_entity_ref: options.sourceEntityRef,
-        target_entity_ref: entityRef,
-      })),
-      BATCH_SIZE,
+    await syncRefreshStateReferences(
+      tx,
+      { sourceEntityRef: options.sourceEntityRef },
+      stateReferences,
     );
   }
 }

--- a/plugins/catalog-backend/src/database/DefaultProcessingDatabase.ts
+++ b/plugins/catalog-backend/src/database/DefaultProcessingDatabase.ts
@@ -323,6 +323,7 @@ export class DefaultProcessingDatabase implements ProcessingDatabase {
 
     // Keeps track of the entities that we end up inserting to update refresh_state_references afterwards
     const stateReferences = new Array<string>();
+    const claimedReferences = new Array<string>();
 
     // Upsert all of the unprocessed entities into the refresh_state table, by
     // their entity ref.
@@ -330,14 +331,17 @@ export class DefaultProcessingDatabase implements ProcessingDatabase {
       const entityRef = stringifyEntityRef(entity);
       const hash = generateStableHash(entity);
 
-      const updated = await updateUnprocessedEntity({
+      const updateResult = await updateUnprocessedEntity({
         tx,
         entity,
         hash,
         locationKey,
       });
-      if (updated) {
+      if (updateResult.updated) {
         stateReferences.push(entityRef);
+        if (updateResult.claimed) {
+          claimedReferences.push(entityRef);
+        }
         continue;
       }
 
@@ -379,6 +383,12 @@ export class DefaultProcessingDatabase implements ProcessingDatabase {
           await this.options.events.publish(eventParams);
         }
       }
+    }
+
+    if (claimedReferences.length > 0) {
+      await tx('refresh_state_references')
+        .whereIn('target_entity_ref', claimedReferences)
+        .delete();
     }
 
     await syncRefreshStateReferences(

--- a/plugins/catalog-backend/src/database/DefaultProcessingDatabase.ts
+++ b/plugins/catalog-backend/src/database/DefaultProcessingDatabase.ts
@@ -39,6 +39,7 @@ import {
 } from './types';
 import { checkLocationKeyConflict } from './operations/refreshState/checkLocationKeyConflict';
 import { insertUnprocessedEntity } from './operations/refreshState/insertUnprocessedEntity';
+import { syncRefreshStateReferences } from './operations/refreshState/syncRefreshStateReferences';
 import { updateUnprocessedEntity } from './operations/refreshState/updateUnprocessedEntity';
 import { generateStableHash, generateTargetKey, whereInArray } from './util';
 import {
@@ -380,20 +381,10 @@ export class DefaultProcessingDatabase implements ProcessingDatabase {
       }
     }
 
-    // Lastly, replace refresh state references for the originating entity and any successfully added entities
-    await tx<DbRefreshStateReferencesRow>('refresh_state_references')
-      // Remove all existing references from the originating entity
-      .where({ source_entity_ref: options.sourceEntityRef })
-      // And remove any existing references to entities that we're inserting new references for
-      .orWhereIn('target_entity_ref', stateReferences)
-      .delete();
-    await tx.batchInsert(
-      'refresh_state_references',
-      stateReferences.map(entityRef => ({
-        source_entity_ref: options.sourceEntityRef,
-        target_entity_ref: entityRef,
-      })),
-      BATCH_SIZE,
+    await syncRefreshStateReferences(
+      tx,
+      { sourceEntityRef: options.sourceEntityRef },
+      stateReferences,
     );
   }
 }

--- a/plugins/catalog-backend/src/database/DefaultProviderDatabase.test.ts
+++ b/plugins/catalog-backend/src/database/DefaultProviderDatabase.test.ts
@@ -656,13 +656,13 @@ describe.each(databases.eachSupportedId())(
             id: expect.anything(),
             source_key: 'lols',
             source_entity_ref: null,
-            target_entity_ref: 'component:default/b',
+            target_entity_ref: 'component:default/a',
           },
           {
             id: expect.anything(),
             source_key: 'lols',
             source_entity_ref: null,
-            target_entity_ref: 'component:default/a',
+            target_entity_ref: 'component:default/b',
           },
         ]);
       });

--- a/plugins/catalog-backend/src/database/DefaultProviderDatabase.test.ts
+++ b/plugins/catalog-backend/src/database/DefaultProviderDatabase.test.ts
@@ -713,16 +713,12 @@ describe.each(databases.eachSupportedId())(
         );
       });
 
-      it('should gracefully handle accidental duplicate refresh state references when deletion happens during a full sync', async () => {
+      it('should remove all entities when doing a full sync with empty items', async () => {
         const fakeLogger = mockServices.logger.mock();
         const { knex, db } = await createDatabase(fakeLogger);
 
         await createLocations(knex, ['component:default/a']);
 
-        await insertRefRow(knex, {
-          source_key: 'a',
-          target_entity_ref: 'component:default/a',
-        });
         await insertRefRow(knex, {
           source_key: 'a',
           target_entity_ref: 'component:default/a',

--- a/plugins/catalog-backend/src/database/DefaultProviderDatabase.test.ts
+++ b/plugins/catalog-backend/src/database/DefaultProviderDatabase.test.ts
@@ -539,6 +539,74 @@ describe.each(databases.eachSupportedId())(
         ]);
       });
 
+      it('only removes other references on a weak-to-strong claim', async () => {
+        const { knex, db } = await createDatabase();
+        await createLocations(knex, [
+          'component:default/child',
+          'component:default/other-parent',
+        ]);
+        await insertRefRow(knex, {
+          source_entity_ref: 'component:default/other-parent',
+          target_entity_ref: 'component:default/child',
+        });
+        await insertRefRow(knex, {
+          source_key: 'other-provider',
+          target_entity_ref: 'component:default/child',
+        });
+
+        const replace = (version: string) =>
+          db.transaction(tx =>
+            db.replaceUnprocessedEntities(tx, {
+              type: 'full',
+              sourceKey: 'owner-provider',
+              items: [
+                {
+                  entity: {
+                    apiVersion: '1',
+                    kind: 'Component',
+                    metadata: { name: 'child' },
+                    spec: { version },
+                  },
+                  locationKey: 'owned',
+                },
+              ],
+            }),
+          );
+
+        await replace('one');
+        await expect(
+          knex<DbRefreshStateReferencesRow>('refresh_state_references')
+            .where({ target_entity_ref: 'component:default/child' })
+            .select(['source_entity_ref', 'source_key']),
+        ).resolves.toEqual([
+          { source_entity_ref: null, source_key: 'owner-provider' },
+        ]);
+
+        await insertRefRow(knex, {
+          source_entity_ref: 'component:default/other-parent',
+          target_entity_ref: 'component:default/child',
+        });
+        await insertRefRow(knex, {
+          source_key: 'other-provider',
+          target_entity_ref: 'component:default/child',
+        });
+
+        await replace('two');
+        await expect(
+          knex<DbRefreshStateReferencesRow>('refresh_state_references')
+            .where({ target_entity_ref: 'component:default/child' })
+            .orderBy(['source_entity_ref', 'source_key'])
+            .select(['source_entity_ref', 'source_key']),
+        ).resolves.toEqual([
+          { source_entity_ref: null, source_key: 'other-provider' },
+          { source_entity_ref: null, source_key: 'owner-provider' },
+          {
+            source_entity_ref: 'component:default/other-parent',
+            source_key: null,
+          },
+        ]);
+      });
+
       it('should support replacing modified entities during a full update', async () => {
         const { knex, db } = await createDatabase();
 

--- a/plugins/catalog-backend/src/database/DefaultProviderDatabase.ts
+++ b/plugins/catalog-backend/src/database/DefaultProviderDatabase.ts
@@ -95,9 +95,21 @@ export class DefaultProviderDatabase implements ProviderDatabase {
       );
     }
 
-    // Track entity refs that this provider successfully claimed, so we can
-    // sync refs in one pass at the end.
+    // Track entity refs that this provider should own, so we can sync refs
+    // in one pass at the end. For full operations the complete desired set is
+    // known upfront. For delta operations we seed with all existing refs so
+    // the sync preserves them — only the newly added/removed refs change it.
     const claimedRefs = new Array<string>();
+    if (options.type === 'full') {
+      claimedRefs.push(
+        ...options.items.map(item => stringifyEntityRef(item.entity)),
+      );
+    } else {
+      const existingRefs = await tx('refresh_state_references')
+        .where({ source_key: options.sourceKey })
+        .select('target_entity_ref');
+      claimedRefs.push(...existingRefs.map(r => r.target_entity_ref));
+    }
 
     if (toAdd.length) {
       // The reason for this chunking, rather than just massively batch
@@ -166,6 +178,16 @@ export class DefaultProviderDatabase implements ProviderDatabase {
           }
           if (ok) {
             claimedRefs.push(entityRef);
+            // When a locationKey is set, this may be a takeover of an entity
+            // that was previously owned by another source. Remove any stale
+            // refs from other sourceKeys so orphan detection works correctly.
+            if (locationKey) {
+              await tx('refresh_state_references')
+                .where('target_entity_ref', entityRef)
+                .andWhereNot('source_key', options.sourceKey)
+                .whereNotNull('source_key')
+                .delete();
+            }
           } else {
             const conflictingKey = await checkLocationKeyConflict({
               tx,

--- a/plugins/catalog-backend/src/database/DefaultProviderDatabase.ts
+++ b/plugins/catalog-backend/src/database/DefaultProviderDatabase.ts
@@ -24,6 +24,7 @@ import { deleteWithEagerPruningOfChildren } from './operations/provider/deleteWi
 import { refreshByRefreshKeys } from './operations/provider/refreshByRefreshKeys';
 import { checkLocationKeyConflict } from './operations/refreshState/checkLocationKeyConflict';
 import { insertUnprocessedEntity } from './operations/refreshState/insertUnprocessedEntity';
+import { syncRefreshStateReferences } from './operations/refreshState/syncRefreshStateReferences';
 import { updateUnprocessedEntity } from './operations/refreshState/updateUnprocessedEntity';
 import { DbRefreshStateReferencesRow, DbRefreshStateRow } from './tables';
 import {
@@ -94,6 +95,10 @@ export class DefaultProviderDatabase implements ProviderDatabase {
       );
     }
 
+    // Track entity refs that this provider successfully claimed, so we can
+    // sync refs in one pass at the end.
+    const claimedRefs = new Array<string>();
+
     if (toAdd.length) {
       // The reason for this chunking, rather than just massively batch
       // inserting the entire payload, is that we fall back to the individual
@@ -120,13 +125,8 @@ export class DefaultProviderDatabase implements ProviderDatabase {
             })),
             BATCH_SIZE,
           );
-          await tx.batchInsert(
-            'refresh_state_references',
-            chunk.map(item => ({
-              source_key: options.sourceKey,
-              target_entity_ref: stringifyEntityRef(item.deferred.entity),
-            })),
-            BATCH_SIZE,
+          claimedRefs.push(
+            ...chunk.map(item => stringifyEntityRef(item.deferred.entity)),
           );
         } catch (error) {
           if (!isDatabaseConflictError(error)) {
@@ -165,22 +165,8 @@ export class DefaultProviderDatabase implements ProviderDatabase {
             });
           }
           if (ok) {
-            await tx<DbRefreshStateReferencesRow>('refresh_state_references')
-              .where('target_entity_ref', entityRef)
-              .delete();
-
-            await tx<DbRefreshStateReferencesRow>(
-              'refresh_state_references',
-            ).insert({
-              source_key: options.sourceKey,
-              target_entity_ref: entityRef,
-            });
+            claimedRefs.push(entityRef);
           } else {
-            await tx<DbRefreshStateReferencesRow>('refresh_state_references')
-              .where('target_entity_ref', entityRef)
-              .andWhere({ source_key: options.sourceKey })
-              .delete();
-
             const conflictingKey = await checkLocationKeyConflict({
               tx,
               entityRef,
@@ -199,6 +185,12 @@ export class DefaultProviderDatabase implements ProviderDatabase {
         }
       }
     }
+
+    await syncRefreshStateReferences(
+      tx,
+      { sourceKey: options.sourceKey },
+      claimedRefs,
+    );
   }
 
   async listReferenceSourceKeys(txOpaque: Transaction): Promise<string[]> {

--- a/plugins/catalog-backend/src/database/DefaultProviderDatabase.ts
+++ b/plugins/catalog-backend/src/database/DefaultProviderDatabase.ts
@@ -95,20 +95,33 @@ export class DefaultProviderDatabase implements ProviderDatabase {
       );
     }
 
-    // Track entity refs that this provider should own, so we can sync refs
-    // in one pass at the end. For full operations the complete desired set is
-    // known upfront. For delta operations we seed with all existing refs so
-    // the sync preserves them — only the newly added/removed refs change it.
+    // Track entity refs that this provider successfully owns, so we can sync
+    // refs in one pass at the end. Seed with refs for entities that are
+    // unchanged (not in toAdd, toUpsert, or toRemove) — these are implicitly
+    // retained. Entities in toAdd/toUpsert are added only on success; entities
+    // in toRemove that fail to be re-added correctly lose their ref.
+    const changing = new Set([
+      ...toAdd.map(item => stringifyEntityRef(item.deferred.entity)),
+      ...toUpsert.map(item => stringifyEntityRef(item.deferred.entity)),
+      ...toRemove,
+    ]);
     const claimedRefs = new Array<string>();
     if (options.type === 'full') {
-      claimedRefs.push(
-        ...options.items.map(item => stringifyEntityRef(item.entity)),
-      );
+      for (const item of options.items) {
+        const ref = stringifyEntityRef(item.entity);
+        if (!changing.has(ref)) {
+          claimedRefs.push(ref);
+        }
+      }
     } else {
       const existingRefs = await tx('refresh_state_references')
         .where({ source_key: options.sourceKey })
         .select('target_entity_ref');
-      claimedRefs.push(...existingRefs.map(r => r.target_entity_ref));
+      for (const r of existingRefs) {
+        if (!changing.has(r.target_entity_ref)) {
+          claimedRefs.push(r.target_entity_ref);
+        }
+      }
     }
 
     if (toAdd.length) {

--- a/plugins/catalog-backend/src/database/DefaultProviderDatabase.ts
+++ b/plugins/catalog-backend/src/database/DefaultProviderDatabase.ts
@@ -24,6 +24,7 @@ import { deleteWithEagerPruningOfChildren } from './operations/provider/deleteWi
 import { refreshByRefreshKeys } from './operations/provider/refreshByRefreshKeys';
 import { checkLocationKeyConflict } from './operations/refreshState/checkLocationKeyConflict';
 import { insertUnprocessedEntity } from './operations/refreshState/insertUnprocessedEntity';
+import { syncRefreshStateReferences } from './operations/refreshState/syncRefreshStateReferences';
 import { updateUnprocessedEntity } from './operations/refreshState/updateUnprocessedEntity';
 import { DbRefreshStateReferencesRow, DbRefreshStateRow } from './tables';
 import {
@@ -107,6 +108,10 @@ export class DefaultProviderDatabase implements ProviderDatabase {
       );
     }
 
+    // Track entity refs that this provider successfully claimed, so we can
+    // sync refs in one pass at the end.
+    const claimedRefs = new Array<string>();
+
     if (toAdd.length) {
       // The reason for this chunking, rather than just massively batch
       // inserting the entire payload, is that we fall back to the individual
@@ -133,13 +138,8 @@ export class DefaultProviderDatabase implements ProviderDatabase {
             })),
             BATCH_SIZE,
           );
-          await tx.batchInsert(
-            'refresh_state_references',
-            chunk.map(item => ({
-              source_key: options.sourceKey,
-              target_entity_ref: stringifyEntityRef(item.deferred.entity),
-            })),
-            BATCH_SIZE,
+          claimedRefs.push(
+            ...chunk.map(item => stringifyEntityRef(item.deferred.entity)),
           );
         } catch (error) {
           if (!isDatabaseConflictError(error)) {
@@ -178,22 +178,8 @@ export class DefaultProviderDatabase implements ProviderDatabase {
             });
           }
           if (ok) {
-            await tx<DbRefreshStateReferencesRow>('refresh_state_references')
-              .where('target_entity_ref', entityRef)
-              .delete();
-
-            await tx<DbRefreshStateReferencesRow>(
-              'refresh_state_references',
-            ).insert({
-              source_key: options.sourceKey,
-              target_entity_ref: entityRef,
-            });
+            claimedRefs.push(entityRef);
           } else {
-            await tx<DbRefreshStateReferencesRow>('refresh_state_references')
-              .where('target_entity_ref', entityRef)
-              .andWhere({ source_key: options.sourceKey })
-              .delete();
-
             const conflictingKey = await checkLocationKeyConflict({
               tx,
               entityRef,
@@ -215,6 +201,12 @@ export class DefaultProviderDatabase implements ProviderDatabase {
         }
       }
     }
+
+    await syncRefreshStateReferences(
+      tx,
+      { sourceKey: options.sourceKey },
+      claimedRefs,
+    );
   }
 
   async listReferenceSourceKeys(txOpaque: Transaction): Promise<string[]> {

--- a/plugins/catalog-backend/src/database/DefaultProviderDatabase.ts
+++ b/plugins/catalog-backend/src/database/DefaultProviderDatabase.ts
@@ -108,20 +108,33 @@ export class DefaultProviderDatabase implements ProviderDatabase {
       );
     }
 
-    // Track entity refs that this provider should own, so we can sync refs
-    // in one pass at the end. For full operations the complete desired set is
-    // known upfront. For delta operations we seed with all existing refs so
-    // the sync preserves them — only the newly added/removed refs change it.
+    // Track entity refs that this provider successfully owns, so we can sync
+    // refs in one pass at the end. Seed with refs for entities that are
+    // unchanged (not in toAdd, toUpsert, or toRemove) — these are implicitly
+    // retained. Entities in toAdd/toUpsert are added only on success; entities
+    // in toRemove that fail to be re-added correctly lose their ref.
+    const changing = new Set([
+      ...toAdd.map(item => stringifyEntityRef(item.deferred.entity)),
+      ...toUpsert.map(item => stringifyEntityRef(item.deferred.entity)),
+      ...toRemove,
+    ]);
     const claimedRefs = new Array<string>();
     if (options.type === 'full') {
-      claimedRefs.push(
-        ...options.items.map(item => stringifyEntityRef(item.entity)),
-      );
+      for (const item of options.items) {
+        const ref = stringifyEntityRef(item.entity);
+        if (!changing.has(ref)) {
+          claimedRefs.push(ref);
+        }
+      }
     } else {
       const existingRefs = await tx('refresh_state_references')
         .where({ source_key: options.sourceKey })
         .select('target_entity_ref');
-      claimedRefs.push(...existingRefs.map(r => r.target_entity_ref));
+      for (const r of existingRefs) {
+        if (!changing.has(r.target_entity_ref)) {
+          claimedRefs.push(r.target_entity_ref);
+        }
+      }
     }
 
     if (toAdd.length) {

--- a/plugins/catalog-backend/src/database/DefaultProviderDatabase.ts
+++ b/plugins/catalog-backend/src/database/DefaultProviderDatabase.ts
@@ -119,6 +119,7 @@ export class DefaultProviderDatabase implements ProviderDatabase {
       ...toRemove,
     ]);
     const claimedRefs = new Array<string>();
+    const takeoverRefs = new Array<string>();
     if (options.type === 'full') {
       for (const item of options.items) {
         const ref = stringifyEntityRef(item.entity);
@@ -187,12 +188,13 @@ export class DefaultProviderDatabase implements ProviderDatabase {
         const entityRef = stringifyEntityRef(entity);
 
         try {
-          let ok = await updateUnprocessedEntity({
+          const updateResult = await updateUnprocessedEntity({
             tx,
             entity,
             hash,
             locationKey,
           });
+          let ok = updateResult.updated;
           if (!ok) {
             ok = await insertUnprocessedEntity({
               tx,
@@ -204,15 +206,8 @@ export class DefaultProviderDatabase implements ProviderDatabase {
           }
           if (ok) {
             claimedRefs.push(entityRef);
-            // When a locationKey is set, this may be a takeover of an entity
-            // that was previously owned by another source. Remove any stale
-            // refs from other sourceKeys so orphan detection works correctly.
-            if (locationKey) {
-              await tx('refresh_state_references')
-                .where('target_entity_ref', entityRef)
-                .andWhereNot('source_key', options.sourceKey)
-                .whereNotNull('source_key')
-                .delete();
+            if (updateResult.claimed) {
+              takeoverRefs.push(entityRef);
             }
           } else {
             const conflictingKey = await checkLocationKeyConflict({
@@ -235,6 +230,12 @@ export class DefaultProviderDatabase implements ProviderDatabase {
           );
         }
       }
+    }
+
+    if (takeoverRefs.length > 0) {
+      await tx('refresh_state_references')
+        .whereIn('target_entity_ref', takeoverRefs)
+        .delete();
     }
 
     await syncRefreshStateReferences(

--- a/plugins/catalog-backend/src/database/DefaultProviderDatabase.ts
+++ b/plugins/catalog-backend/src/database/DefaultProviderDatabase.ts
@@ -108,9 +108,21 @@ export class DefaultProviderDatabase implements ProviderDatabase {
       );
     }
 
-    // Track entity refs that this provider successfully claimed, so we can
-    // sync refs in one pass at the end.
+    // Track entity refs that this provider should own, so we can sync refs
+    // in one pass at the end. For full operations the complete desired set is
+    // known upfront. For delta operations we seed with all existing refs so
+    // the sync preserves them — only the newly added/removed refs change it.
     const claimedRefs = new Array<string>();
+    if (options.type === 'full') {
+      claimedRefs.push(
+        ...options.items.map(item => stringifyEntityRef(item.entity)),
+      );
+    } else {
+      const existingRefs = await tx('refresh_state_references')
+        .where({ source_key: options.sourceKey })
+        .select('target_entity_ref');
+      claimedRefs.push(...existingRefs.map(r => r.target_entity_ref));
+    }
 
     if (toAdd.length) {
       // The reason for this chunking, rather than just massively batch
@@ -179,6 +191,16 @@ export class DefaultProviderDatabase implements ProviderDatabase {
           }
           if (ok) {
             claimedRefs.push(entityRef);
+            // When a locationKey is set, this may be a takeover of an entity
+            // that was previously owned by another source. Remove any stale
+            // refs from other sourceKeys so orphan detection works correctly.
+            if (locationKey) {
+              await tx('refresh_state_references')
+                .where('target_entity_ref', entityRef)
+                .andWhereNot('source_key', options.sourceKey)
+                .whereNotNull('source_key')
+                .delete();
+            }
           } else {
             const conflictingKey = await checkLocationKeyConflict({
               tx,

--- a/plugins/catalog-backend/src/database/operations/provider/deleteWithEagerPruningOfChildren.test.ts
+++ b/plugins/catalog-backend/src/database/operations/provider/deleteWithEagerPruningOfChildren.test.ts
@@ -125,14 +125,9 @@ describe.each(databases.eachSupportedId())(
       await expect(entitiesMarkedForStitching(knex)).resolves.toEqual(['E4']);
     });
 
-    it('works when there are multiple identical references', async () => {
+    it('works when a single reference points to a deleted entity', async () => {
       /*
-          P1
-            \
-             E1
-            /
-          P1
-
+          P1 - E1
           P1 - E2
 
           Scenario: P1 issues delete for E1
@@ -143,7 +138,6 @@ describe.each(databases.eachSupportedId())(
       await insertEntity(knex, 'E1', 'E2');
       await insertReference(
         knex,
-        { source_key: 'P1', target_entity_ref: 'E1' },
         { source_key: 'P1', target_entity_ref: 'E1' },
         { source_key: 'P1', target_entity_ref: 'E2' },
       );

--- a/plugins/catalog-backend/src/database/operations/refreshState/syncRefreshStateReferences.test.ts
+++ b/plugins/catalog-backend/src/database/operations/refreshState/syncRefreshStateReferences.test.ts
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestDatabases } from '@backstage/backend-test-utils';
+import { Knex } from 'knex';
+import { applyDatabaseMigrations } from '../../migrations';
+import { syncRefreshStateReferences } from './syncRefreshStateReferences';
+
+jest.setTimeout(60_000);
+
+const databases = TestDatabases.create();
+
+describe.each(databases.eachSupportedId())(
+  'syncRefreshStateReferences, %p',
+  databaseId => {
+    let knex: Knex;
+
+    async function setup() {
+      knex = await databases.init(databaseId);
+      await applyDatabaseMigrations(knex);
+
+      for (const ref of ['k:ns/a', 'k:ns/b', 'k:ns/c', 'k:ns/d']) {
+        await knex('refresh_state').insert({
+          entity_id: `id-${ref}`,
+          entity_ref: ref,
+          unprocessed_entity: '{}',
+          errors: '[]',
+          next_update_at: new Date(),
+          last_discovery_at: new Date(),
+        });
+      }
+    }
+
+    async function getRefs(source: Record<string, string>) {
+      return knex('refresh_state_references')
+        .where(source)
+        .orderBy('target_entity_ref')
+        .select('target_entity_ref')
+        .then(rows => rows.map(r => r.target_entity_ref));
+    }
+
+    async function getAllRefs() {
+      return knex('refresh_state_references')
+        .orderBy(['source_entity_ref', 'source_key', 'target_entity_ref'])
+        .select();
+    }
+
+    it('inserts all refs when none exist', async () => {
+      await setup();
+
+      await syncRefreshStateReferences(knex, { sourceEntityRef: 'k:ns/a' }, [
+        'k:ns/b',
+        'k:ns/c',
+      ]);
+
+      expect(await getRefs({ source_entity_ref: 'k:ns/a' })).toEqual([
+        'k:ns/b',
+        'k:ns/c',
+      ]);
+    });
+
+    it('is a no-op when desired refs match existing refs', async () => {
+      await setup();
+      await knex('refresh_state_references').insert([
+        { source_entity_ref: 'k:ns/a', target_entity_ref: 'k:ns/b' },
+        { source_entity_ref: 'k:ns/a', target_entity_ref: 'k:ns/c' },
+      ]);
+
+      await syncRefreshStateReferences(knex, { sourceEntityRef: 'k:ns/a' }, [
+        'k:ns/b',
+        'k:ns/c',
+      ]);
+
+      expect(await getRefs({ source_entity_ref: 'k:ns/a' })).toEqual([
+        'k:ns/b',
+        'k:ns/c',
+      ]);
+    });
+
+    it('applies a partial diff — adds new, removes stale, keeps unchanged', async () => {
+      await setup();
+      await knex('refresh_state_references').insert([
+        { source_entity_ref: 'k:ns/a', target_entity_ref: 'k:ns/b' },
+        { source_entity_ref: 'k:ns/a', target_entity_ref: 'k:ns/c' },
+      ]);
+
+      await syncRefreshStateReferences(knex, { sourceEntityRef: 'k:ns/a' }, [
+        'k:ns/c',
+        'k:ns/d',
+      ]);
+
+      expect(await getRefs({ source_entity_ref: 'k:ns/a' })).toEqual([
+        'k:ns/c',
+        'k:ns/d',
+      ]);
+    });
+
+    it('removes all refs when desired set is empty', async () => {
+      await setup();
+      await knex('refresh_state_references').insert([
+        { source_entity_ref: 'k:ns/a', target_entity_ref: 'k:ns/b' },
+        { source_entity_ref: 'k:ns/a', target_entity_ref: 'k:ns/c' },
+      ]);
+
+      await syncRefreshStateReferences(knex, { sourceEntityRef: 'k:ns/a' }, []);
+
+      expect(await getRefs({ source_entity_ref: 'k:ns/a' })).toEqual([]);
+    });
+
+    it('deduplicates input refs', async () => {
+      await setup();
+
+      await syncRefreshStateReferences(knex, { sourceEntityRef: 'k:ns/a' }, [
+        'k:ns/b',
+        'k:ns/b',
+        'k:ns/c',
+        'k:ns/c',
+      ]);
+
+      expect(await getRefs({ source_entity_ref: 'k:ns/a' })).toEqual([
+        'k:ns/b',
+        'k:ns/c',
+      ]);
+    });
+
+    it('does not touch refs from other sources', async () => {
+      await setup();
+      await knex('refresh_state_references').insert([
+        { source_entity_ref: 'k:ns/a', target_entity_ref: 'k:ns/c' },
+        { source_entity_ref: 'k:ns/b', target_entity_ref: 'k:ns/c' },
+        { source_key: 'provider-x', target_entity_ref: 'k:ns/c' },
+      ]);
+
+      await syncRefreshStateReferences(knex, { sourceEntityRef: 'k:ns/a' }, []);
+
+      expect(await getRefs({ source_entity_ref: 'k:ns/a' })).toEqual([]);
+      expect(await getRefs({ source_entity_ref: 'k:ns/b' })).toEqual([
+        'k:ns/c',
+      ]);
+      expect(await getRefs({ source_key: 'provider-x' })).toEqual(['k:ns/c']);
+    });
+
+    it('works with sourceKey variant', async () => {
+      await setup();
+      await knex('refresh_state_references').insert([
+        { source_key: 'my-provider', target_entity_ref: 'k:ns/a' },
+        { source_key: 'my-provider', target_entity_ref: 'k:ns/b' },
+      ]);
+
+      await syncRefreshStateReferences(knex, { sourceKey: 'my-provider' }, [
+        'k:ns/b',
+        'k:ns/c',
+      ]);
+
+      expect(await getRefs({ source_key: 'my-provider' })).toEqual([
+        'k:ns/b',
+        'k:ns/c',
+      ]);
+    });
+
+    it('is idempotent when called twice with the same desired set', async () => {
+      await setup();
+
+      await syncRefreshStateReferences(knex, { sourceEntityRef: 'k:ns/a' }, [
+        'k:ns/b',
+        'k:ns/c',
+      ]);
+      const after1 = await getAllRefs();
+
+      await syncRefreshStateReferences(knex, { sourceEntityRef: 'k:ns/a' }, [
+        'k:ns/b',
+        'k:ns/c',
+      ]);
+      const after2 = await getAllRefs();
+
+      expect(after1).toEqual(after2);
+    });
+  },
+);

--- a/plugins/catalog-backend/src/database/operations/refreshState/syncRefreshStateReferences.test.ts
+++ b/plugins/catalog-backend/src/database/operations/refreshState/syncRefreshStateReferences.test.ts
@@ -188,5 +188,158 @@ describe.each(databases.eachSupportedId())(
 
       expect(after1).toEqual(after2);
     });
+
+    it('rolls back the entire replacement if an insert fails', async () => {
+      await setup();
+      await knex('refresh_state_references').insert([
+        { source_entity_ref: 'k:ns/a', target_entity_ref: 'k:ns/b' },
+        { source_entity_ref: 'k:ns/a', target_entity_ref: 'k:ns/c' },
+      ]);
+
+      await expect(
+        syncRefreshStateReferences(knex, { sourceEntityRef: 'k:ns/a' }, [
+          'k:ns/d',
+          'k:ns/missing',
+        ]),
+      ).rejects.toThrow();
+
+      expect(await getRefs({ source_entity_ref: 'k:ns/a' })).toEqual([
+        'k:ns/b',
+        'k:ns/c',
+      ]);
+    });
+
+    it('serializes concurrent replacements of the same source', async () => {
+      if (!databaseId.includes('POSTGRES')) {
+        return;
+      }
+      await setup();
+
+      let releaseFirst!: () => void;
+      const holdFirst = new Promise<void>(resolve => {
+        releaseFirst = resolve;
+      });
+      let firstReady!: () => void;
+      const waitForFirst = new Promise<void>(resolve => {
+        firstReady = resolve;
+      });
+
+      const first = knex.transaction(async trx => {
+        await syncRefreshStateReferences(trx, { sourceEntityRef: 'k:ns/a' }, [
+          'k:ns/b',
+        ]);
+        firstReady();
+        await holdFirst;
+      });
+      await waitForFirst;
+
+      let secondPid: number | undefined;
+      let secondReady!: () => void;
+      const waitForSecond = new Promise<void>(resolve => {
+        secondReady = resolve;
+      });
+      const second = knex.transaction(async trx => {
+        secondPid = Number(
+          (await trx.raw('SELECT pg_backend_pid() AS pid')).rows[0].pid,
+        );
+        secondReady();
+        await syncRefreshStateReferences(trx, { sourceEntityRef: 'k:ns/a' }, [
+          'k:ns/c',
+        ]);
+      });
+      await waitForSecond;
+
+      let sawLockWait = false;
+      for (let attempt = 0; attempt < 100; attempt++) {
+        const waiting = await knex.raw(
+          `SELECT EXISTS (
+             SELECT 1 FROM pg_locks
+             WHERE pid = ?
+               AND locktype = 'advisory'
+               AND NOT granted
+           ) AS waiting`,
+          [secondPid],
+        );
+        if (waiting.rows[0].waiting) {
+          sawLockWait = true;
+          break;
+        }
+        await new Promise(resolve => setTimeout(resolve, 10));
+      }
+
+      releaseFirst();
+      await Promise.all([first, second]);
+
+      expect(sawLockWait).toBe(true);
+      expect(await getRefs({ source_entity_ref: 'k:ns/a' })).toEqual([
+        'k:ns/c',
+      ]);
+    });
+
+    it('serializes concurrent MySQL replacements of the same source', async () => {
+      if (!databaseId.includes('MYSQL')) {
+        return;
+      }
+      await setup();
+
+      let releaseFirst!: () => void;
+      const holdFirst = new Promise<void>(resolve => {
+        releaseFirst = resolve;
+      });
+      let firstReady!: () => void;
+      const waitForFirst = new Promise<void>(resolve => {
+        firstReady = resolve;
+      });
+
+      const first = knex.transaction(async trx => {
+        await syncRefreshStateReferences(trx, { sourceEntityRef: 'k:ns/a' }, [
+          'k:ns/b',
+        ]);
+        firstReady();
+        await holdFirst;
+      });
+      await waitForFirst;
+
+      let secondReady!: () => void;
+      const waitForSecond = new Promise<void>(resolve => {
+        secondReady = resolve;
+      });
+      let secondSettled = false;
+      const second = knex
+        .transaction(async trx => {
+          secondReady();
+          await syncRefreshStateReferences(trx, { sourceEntityRef: 'k:ns/a' }, [
+            'k:ns/c',
+          ]);
+        })
+        .finally(() => {
+          secondSettled = true;
+        });
+      await waitForSecond;
+      await new Promise(resolve => setTimeout(resolve, 100));
+      const secondWaitedForFirst = !secondSettled;
+
+      releaseFirst();
+      await Promise.all([first, second]);
+
+      expect(secondWaitedForFirst).toBe(true);
+      expect(await getRefs({ source_entity_ref: 'k:ns/a' })).toEqual([
+        'k:ns/c',
+      ]);
+    });
   },
 );
+
+it('propagates MySQL deadlocks to the owning transaction', async () => {
+  const deadlock = Object.assign(new Error('deadlock'), { errno: 1213 });
+  const transaction = jest.fn().mockRejectedValue(deadlock);
+  const knex = {
+    client: { config: { client: 'mysql2' } },
+    transaction,
+  } as unknown as Knex;
+
+  await expect(
+    syncRefreshStateReferences(knex, { sourceKey: 'provider' }, []),
+  ).rejects.toBe(deadlock);
+  expect(transaction).toHaveBeenCalledTimes(1);
+});

--- a/plugins/catalog-backend/src/database/operations/refreshState/syncRefreshStateReferences.ts
+++ b/plugins/catalog-backend/src/database/operations/refreshState/syncRefreshStateReferences.ts
@@ -51,11 +51,12 @@ export async function syncRefreshStateReferences(
 ): Promise<void> {
   const client = knex.client.config.client;
   const col = sourceColumn(source);
+  const uniqueTargets = [...new Set(targetEntityRefs)];
 
   if (client === 'pg') {
-    await syncPostgres(knex, col, targetEntityRefs);
+    await syncPostgres(knex, col, uniqueTargets);
   } else {
-    await syncSimple(knex, col, targetEntityRefs);
+    await syncSimple(knex, col, uniqueTargets);
   }
 }
 

--- a/plugins/catalog-backend/src/database/operations/refreshState/syncRefreshStateReferences.ts
+++ b/plugins/catalog-backend/src/database/operations/refreshState/syncRefreshStateReferences.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Knex } from 'knex';
+
+const BATCH_SIZE = 50;
+
+/**
+ * Identifies the source of a set of refresh_state_references rows.
+ *
+ * - `sourceKey`: an entity provider (stored in the `source_key` column)
+ * - `sourceEntityRef`: a parent entity during processing (stored in the
+ *   `source_entity_ref` column)
+ */
+export type RefreshStateReferenceSource =
+  | { sourceKey: string }
+  | { sourceEntityRef: string };
+
+/**
+ * Synchronizes the refresh_state_references rows for a given source,
+ * applying only the minimal set of changes needed. Rows that already exist
+ * are left untouched, new rows are inserted, and stale rows are deleted —
+ * minimizing write churn, dead tuples, and WAL traffic.
+ *
+ * Crucially, this function ONLY touches rows owned by the given source.
+ * References from other sources are never modified, which is correct for
+ * multi-parent scenarios where several entities or providers legitimately
+ * reference the same child.
+ *
+ * Uses database-specific strategies:
+ * - Postgres: Single writable CTE (one round-trip, fully atomic)
+ * - MySQL/SQLite: In-memory diff with targeted deletes and inserts
+ */
+export async function syncRefreshStateReferences(
+  knex: Knex | Knex.Transaction,
+  source: RefreshStateReferenceSource,
+  targetEntityRefs: string[],
+): Promise<void> {
+  const client = knex.client.config.client;
+  const col = sourceColumn(source);
+
+  if (client === 'pg') {
+    await syncPostgres(knex, col, targetEntityRefs);
+  } else {
+    await syncSimple(knex, col, targetEntityRefs);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+interface SourceColumn {
+  column: 'source_key' | 'source_entity_ref';
+  value: string;
+}
+
+function sourceColumn(source: RefreshStateReferenceSource): SourceColumn {
+  if ('sourceKey' in source) {
+    return { column: 'source_key', value: source.sourceKey };
+  }
+  return { column: 'source_entity_ref', value: source.sourceEntityRef };
+}
+
+// ---------------------------------------------------------------------------
+// Postgres: writable CTE
+//
+// All CTE branches see the same pre-modification snapshot, so the DELETE
+// and INSERT do not interfere with each other. This is a single atomic
+// statement — no explicit transaction wrapper needed.
+//
+// ON CONFLICT uses the matching partial unique index to handle concurrent
+// callers that race on the same source:
+//   (source_entity_ref, target_entity_ref) WHERE source_entity_ref IS NOT NULL
+//   (source_key, target_entity_ref)        WHERE source_key IS NOT NULL
+// ---------------------------------------------------------------------------
+async function syncPostgres(
+  knex: Knex | Knex.Transaction,
+  src: SourceColumn,
+  targetEntityRefs: string[],
+): Promise<void> {
+  const col = `"${src.column}"`;
+  await knex.raw(
+    `
+    WITH desired(target_entity_ref) AS (
+      SELECT unnest(?::text[])
+    ),
+    deleted AS (
+      DELETE FROM refresh_state_references r
+      WHERE r.${col} = ?
+        AND NOT EXISTS (
+          SELECT 1 FROM desired d
+          WHERE d.target_entity_ref = r.target_entity_ref
+        )
+    )
+    INSERT INTO refresh_state_references (${col}, target_entity_ref)
+    SELECT ?, d.target_entity_ref
+    FROM desired d
+    WHERE NOT EXISTS (
+      SELECT 1 FROM refresh_state_references r
+      WHERE r.${col} = ?
+        AND r.target_entity_ref = d.target_entity_ref
+    )
+    ON CONFLICT (${col}, target_entity_ref)
+      WHERE ${col} IS NOT NULL
+    DO NOTHING
+    `,
+    [targetEntityRefs, src.value, src.value, src.value],
+  );
+}
+
+// ---------------------------------------------------------------------------
+// MySQL / SQLite: in-memory diff
+//
+// Read existing refs, compute the diff, then issue targeted deletes and
+// inserts. The data volume per source is small (typically 0-5 rows), so
+// the extra SELECT round-trip is negligible.
+// ---------------------------------------------------------------------------
+async function syncSimple(
+  knex: Knex | Knex.Transaction,
+  src: SourceColumn,
+  targetEntityRefs: string[],
+): Promise<void> {
+  const existing = new Set(
+    (
+      await knex('refresh_state_references')
+        .where({ [src.column]: src.value })
+        .select('target_entity_ref')
+    ).map((r: { target_entity_ref: string }) => r.target_entity_ref),
+  );
+
+  const desired = new Set(targetEntityRefs);
+
+  const toDelete = [...existing].filter(ref => !desired.has(ref));
+  const toInsert = targetEntityRefs.filter(ref => !existing.has(ref));
+
+  if (toDelete.length > 0) {
+    await knex('refresh_state_references')
+      .where({ [src.column]: src.value })
+      .whereIn('target_entity_ref', toDelete)
+      .delete();
+  }
+
+  if (toInsert.length > 0) {
+    await knex.batchInsert(
+      'refresh_state_references',
+      toInsert.map(ref => ({
+        [src.column]: src.value,
+        target_entity_ref: ref,
+      })),
+      BATCH_SIZE,
+    );
+  }
+}

--- a/plugins/catalog-backend/src/database/operations/refreshState/syncRefreshStateReferences.ts
+++ b/plugins/catalog-backend/src/database/operations/refreshState/syncRefreshStateReferences.ts
@@ -41,8 +41,9 @@ export type RefreshStateReferenceSource =
  * reference the same child.
  *
  * Uses database-specific strategies:
- * - Postgres: Single writable CTE (one round-trip, fully atomic)
- * - MySQL/SQLite: In-memory diff with targeted deletes and inserts
+ * - Postgres: Source lock followed by a writable CTE
+ * - MySQL: Temporary table merge in a transaction
+ * - SQLite: Transactional diff
  */
 export async function syncRefreshStateReferences(
   knex: Knex | Knex.Transaction,
@@ -55,8 +56,10 @@ export async function syncRefreshStateReferences(
 
   if (client === 'pg') {
     await syncPostgres(knex, col, uniqueTargets);
+  } else if (client.includes('mysql')) {
+    await syncMysql(knex, col, uniqueTargets);
   } else {
-    await syncSimple(knex, col, uniqueTargets);
+    await syncTransactionalDiff(knex, col, uniqueTargets);
   }
 }
 
@@ -77,14 +80,14 @@ function sourceColumn(source: RefreshStateReferenceSource): SourceColumn {
 }
 
 // ---------------------------------------------------------------------------
-// Postgres: writable CTE
+// Postgres: source serialization + writable CTE
 //
-// All CTE branches see the same pre-modification snapshot, so the DELETE
-// and INSERT do not interfere with each other. This is a single atomic
-// statement — no explicit transaction wrapper needed.
+// The advisory transaction lock serializes updates to each source. It is
+// acquired in a separate statement so a caller that waits for the lock gets
+// a fresh READ COMMITTED snapshot for the CTE. All CTE branches then see that
+// same snapshot, so the DELETE and INSERT do not interfere with each other.
 //
-// ON CONFLICT uses the matching partial unique index to handle concurrent
-// callers that race on the same source:
+// ON CONFLICT uses the matching partial unique index as an integrity guard:
 //   (source_entity_ref, target_entity_ref) WHERE source_entity_ref IS NOT NULL
 //   (source_key, target_entity_ref)        WHERE source_key IS NOT NULL
 // ---------------------------------------------------------------------------
@@ -93,76 +96,129 @@ async function syncPostgres(
   src: SourceColumn,
   targetEntityRefs: string[],
 ): Promise<void> {
-  const col = `"${src.column}"`;
-  await knex.raw(
-    `
-    WITH desired(target_entity_ref) AS (
-      SELECT unnest(?::text[])
-    ),
-    deleted AS (
-      DELETE FROM refresh_state_references r
-      WHERE r.${col} = ?
-        AND NOT EXISTS (
-          SELECT 1 FROM desired d
-          WHERE d.target_entity_ref = r.target_entity_ref
-        )
-    )
-    INSERT INTO refresh_state_references (${col}, target_entity_ref)
-    SELECT ?, d.target_entity_ref
-    FROM desired d
-    WHERE NOT EXISTS (
-      SELECT 1 FROM refresh_state_references r
-      WHERE r.${col} = ?
-        AND r.target_entity_ref = d.target_entity_ref
-    )
-    ON CONFLICT (${col}, target_entity_ref)
-      WHERE ${col} IS NOT NULL
-    DO NOTHING
-    `,
-    [targetEntityRefs, src.value, src.value, src.value],
-  );
+  await knex.transaction(async trx => {
+    await trx.raw(
+      'SELECT pg_advisory_xact_lock(hashtextextended(?::text, 0))',
+      [`refresh_state_references:${src.column}:${src.value}`],
+    );
+
+    const col = `"${src.column}"`;
+    await trx.raw(
+      `
+      WITH desired(target_entity_ref) AS (
+        SELECT unnest(?::text[])
+      ),
+      deleted AS (
+        DELETE FROM refresh_state_references r
+        WHERE r.${col} = ?
+          AND NOT EXISTS (
+            SELECT 1 FROM desired d
+            WHERE d.target_entity_ref = r.target_entity_ref
+          )
+      )
+      INSERT INTO refresh_state_references (${col}, target_entity_ref)
+      SELECT ?, d.target_entity_ref
+      FROM desired d
+      WHERE NOT EXISTS (
+        SELECT 1 FROM refresh_state_references r
+        WHERE r.${col} = ?
+          AND r.target_entity_ref = d.target_entity_ref
+      )
+      ON CONFLICT (${col}, target_entity_ref)
+        WHERE ${col} IS NOT NULL
+      DO NOTHING
+      `,
+      [targetEntityRefs, src.value, src.value, src.value],
+    );
+  });
 }
 
 // ---------------------------------------------------------------------------
-// MySQL / SQLite: in-memory diff
-//
-// Read existing refs, compute the diff, then issue targeted deletes and
-// inserts. The data volume per source is small (typically 0-5 rows), so
-// the extra SELECT round-trip is negligible.
+// MySQL: temporary table merge
 // ---------------------------------------------------------------------------
-async function syncSimple(
+async function syncMysql(
   knex: Knex | Knex.Transaction,
   src: SourceColumn,
   targetEntityRefs: string[],
 ): Promise<void> {
-  const existing = new Set(
-    (
-      await knex('refresh_state_references')
-        .where({ [src.column]: src.value })
-        .select('target_entity_ref')
-    ).map((r: { target_entity_ref: string }) => r.target_entity_ref),
-  );
-
-  const desired = new Set(targetEntityRefs);
-
-  const toDelete = [...existing].filter(ref => !desired.has(ref));
-  const toInsert = targetEntityRefs.filter(ref => !existing.has(ref));
-
-  if (toDelete.length > 0) {
-    await knex('refresh_state_references')
-      .where({ [src.column]: src.value })
-      .whereIn('target_entity_ref', toDelete)
-      .delete();
-  }
-
-  if (toInsert.length > 0) {
-    await knex.batchInsert(
-      'refresh_state_references',
-      toInsert.map(ref => ({
-        [src.column]: src.value,
-        target_entity_ref: ref,
-      })),
-      BATCH_SIZE,
+  await knex.transaction(async trx => {
+    await trx.raw(
+      'CREATE TEMPORARY TABLE IF NOT EXISTS `_desired_refresh_state_references` (' +
+        '`target_entity_ref` VARCHAR(255) NOT NULL PRIMARY KEY' +
+        ')',
     );
-  }
+    await trx.raw('DELETE FROM `_desired_refresh_state_references`');
+
+    if (targetEntityRefs.length > 0) {
+      await trx.batchInsert(
+        '_desired_refresh_state_references',
+        targetEntityRefs.map(targetEntityRef => ({
+          target_entity_ref: targetEntityRef,
+        })),
+        BATCH_SIZE,
+      );
+    }
+
+    await trx.raw(
+      `DELETE r FROM refresh_state_references r
+           WHERE r.?? = ?
+             AND NOT EXISTS (
+               SELECT 1 FROM _desired_refresh_state_references d
+               WHERE d.target_entity_ref = r.target_entity_ref
+             )`,
+      [src.column, src.value],
+    );
+
+    await trx.raw(
+      `INSERT INTO refresh_state_references (??, target_entity_ref)
+           SELECT ?, d.target_entity_ref
+           FROM _desired_refresh_state_references d
+           WHERE NOT EXISTS (
+             SELECT 1 FROM refresh_state_references r
+             WHERE r.?? = ?
+               AND r.target_entity_ref = d.target_entity_ref
+           )`,
+      [src.column, src.value, src.column, src.value],
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// SQLite (and fallback): transactional diff
+// ---------------------------------------------------------------------------
+async function syncTransactionalDiff(
+  knex: Knex | Knex.Transaction,
+  src: SourceColumn,
+  targetEntityRefs: string[],
+): Promise<void> {
+  await knex.transaction(async trx => {
+    const existing = new Set(
+      (
+        await trx('refresh_state_references')
+          .where({ [src.column]: src.value })
+          .select('target_entity_ref')
+      ).map((row: { target_entity_ref: string }) => row.target_entity_ref),
+    );
+
+    const desired = new Set(targetEntityRefs);
+    const stale = [...existing].filter(ref => !desired.has(ref));
+    const missing = targetEntityRefs.filter(ref => !existing.has(ref));
+
+    if (stale.length > 0) {
+      await trx('refresh_state_references')
+        .where({ [src.column]: src.value })
+        .whereIn('target_entity_ref', stale)
+        .delete();
+    }
+    if (missing.length > 0) {
+      await trx.batchInsert(
+        'refresh_state_references',
+        missing.map(ref => ({
+          [src.column]: src.value,
+          target_entity_ref: ref,
+        })),
+        BATCH_SIZE,
+      );
+    }
+  });
 }

--- a/plugins/catalog-backend/src/database/operations/refreshState/updateUnprocessedEntity.test.ts
+++ b/plugins/catalog-backend/src/database/operations/refreshState/updateUnprocessedEntity.test.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { TestDatabases } from '@backstage/backend-test-utils';
+import { Knex } from 'knex';
+import { applyDatabaseMigrations } from '../../migrations';
+import { updateUnprocessedEntity } from './updateUnprocessedEntity';
+
+jest.setTimeout(60_000);
+
+const databases = TestDatabases.create();
+
+describe.each(databases.eachSupportedId())(
+  'updateUnprocessedEntity, %p',
+  databaseId => {
+    let knex: Knex;
+
+    beforeEach(async () => {
+      knex = await databases.init(databaseId);
+      await applyDatabaseMigrations(knex);
+      await knex('refresh_state').insert({
+        entity_id: 'id-component:default/test',
+        entity_ref: 'component:default/test',
+        unprocessed_entity: '{}',
+        errors: '[]',
+        next_update_at: new Date(),
+        last_discovery_at: new Date(),
+      });
+    });
+
+    const entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: { name: 'test' },
+    };
+
+    it('reports when a weak entity is claimed with a location key', async () => {
+      await expect(
+        updateUnprocessedEntity({
+          tx: knex,
+          entity,
+          hash: 'hash',
+          locationKey: 'provider:key',
+        }),
+      ).resolves.toEqual({ updated: true, claimed: true });
+    });
+
+    it('does not report a claim when the location key already matches', async () => {
+      await knex('refresh_state')
+        .where({ entity_ref: 'component:default/test' })
+        .update({ location_key: 'provider:key' });
+
+      await expect(
+        updateUnprocessedEntity({
+          tx: knex,
+          entity,
+          hash: 'hash',
+          locationKey: 'provider:key',
+        }),
+      ).resolves.toEqual({ updated: true, claimed: false });
+    });
+
+    it('does not update an entity owned by a different location key', async () => {
+      await knex('refresh_state')
+        .where({ entity_ref: 'component:default/test' })
+        .update({ location_key: 'other:key' });
+
+      await expect(
+        updateUnprocessedEntity({
+          tx: knex,
+          entity,
+          hash: 'hash',
+          locationKey: 'provider:key',
+        }),
+      ).resolves.toEqual({ updated: false, claimed: false });
+    });
+  },
+);

--- a/plugins/catalog-backend/src/database/operations/refreshState/updateUnprocessedEntity.ts
+++ b/plugins/catalog-backend/src/database/operations/refreshState/updateUnprocessedEntity.ts
@@ -19,8 +19,8 @@ import { Knex } from 'knex';
 import { DbRefreshStateRow } from '../../tables';
 
 /**
- * Attempts to update an existing refresh state row, returning true if it was
- * updated and false if there was no entity with a matching ref and location key.
+ * Attempts to update an existing refresh state row, also reporting whether a
+ * weak entity without a location key was claimed by a strong source.
  *
  * Updating the entity will also cause it to be scheduled for immediate processing.
  */
@@ -29,32 +29,42 @@ export async function updateUnprocessedEntity(options: {
   entity: Entity;
   hash: string;
   locationKey?: string;
-}): Promise<boolean> {
+}): Promise<{ updated: boolean; claimed: boolean }> {
   const { tx, entity, hash, locationKey } = options;
 
   const entityRef = stringifyEntityRef(entity);
   const serializedEntity = JSON.stringify(entity);
 
-  const refreshResult = await tx<DbRefreshStateRow>('refresh_state')
-    .update({
-      unprocessed_entity: serializedEntity,
-      unprocessed_hash: hash,
-      location_key: locationKey,
-      last_discovery_at: tx.fn.now(),
-      // We only get to this point if a processed entity actually had any changes, or
-      // if an entity provider requested this mutation, meaning that we can safely
-      // bump the deferred entities to the front of the queue for immediate processing.
-      next_update_at: tx.fn.now(),
-    })
-    .where('entity_ref', entityRef)
-    .andWhere(inner => {
-      if (!locationKey) {
-        return inner.whereNull('location_key');
-      }
-      return inner
-        .where('location_key', locationKey)
-        .orWhereNull('location_key');
-    });
+  const update = {
+    unprocessed_entity: serializedEntity,
+    unprocessed_hash: hash,
+    location_key: locationKey,
+    last_discovery_at: tx.fn.now(),
+    // We only get to this point if a processed entity actually had any changes, or
+    // if an entity provider requested this mutation, meaning that we can safely
+    // bump the deferred entities to the front of the queue for immediate processing.
+    next_update_at: tx.fn.now(),
+  };
 
-  return refreshResult === 1;
+  if (locationKey) {
+    const claimed = await tx<DbRefreshStateRow>('refresh_state')
+      .update(update)
+      .where('entity_ref', entityRef)
+      .whereNull('location_key');
+    if (claimed === 1) {
+      return { updated: true, claimed: true };
+    }
+
+    const updated = await tx<DbRefreshStateRow>('refresh_state')
+      .update(update)
+      .where('entity_ref', entityRef)
+      .where('location_key', locationKey);
+    return { updated: updated === 1, claimed: false };
+  }
+
+  const updated = await tx<DbRefreshStateRow>('refresh_state')
+    .update(update)
+    .where('entity_ref', entityRef)
+    .whereNull('location_key');
+  return { updated: updated === 1, claimed: false };
 }

--- a/plugins/catalog-backend/src/tests/integration.test.ts
+++ b/plugins/catalog-backend/src/tests/integration.test.ts
@@ -1144,22 +1144,20 @@ describe('Catalog Backend Integration', () => {
     // Expect to find A and B' in the catalog. The provider's test→B ref
     // is preserved — the processing path no longer deletes other sources'
     // references, which is correct for multi-parent scenarios.
-    await expect(harness.getRefreshStateReferences()).resolves.toEqual(
-      expect.arrayContaining([
-        {
-          sourceKey: 'test',
-          targetEntityRef: 'component:default/a',
-        },
-        {
-          sourceKey: 'test',
-          targetEntityRef: 'component:default/b',
-        },
-        {
-          sourceEntityRef: 'component:default/a',
-          targetEntityRef: 'component:default/b',
-        },
-      ]),
-    );
+    await expect(harness.getRefreshStateReferences()).resolves.toEqual([
+      {
+        sourceKey: 'test',
+        targetEntityRef: 'component:default/a',
+      },
+      {
+        sourceKey: 'test',
+        targetEntityRef: 'component:default/b',
+      },
+      {
+        sourceEntityRef: 'component:default/a',
+        targetEntityRef: 'component:default/b',
+      },
+    ]);
     await expect(harness.getRefreshState()).resolves.toEqual({
       'component:default/a': expect.objectContaining({
         locationKey: null,

--- a/plugins/catalog-backend/src/tests/integration.test.ts
+++ b/plugins/catalog-backend/src/tests/integration.test.ts
@@ -1173,19 +1173,34 @@ describe('Catalog Backend Integration', () => {
       'component:default/b': withOutputFields(entityBOverride),
     });
 
-    // Stop emitting B' from A, then do a full sync with A and B.
-    // The provider full sync detects that B's locationKey ('url:.') conflicts
-    // with its own (undefined) and removes its stale test→B ref. Processing
-    // then removes A→B (A no longer emits B). B becomes orphaned.
+    // Stop emitting B' from A, then do a provider full sync.
+    // The provider detects B's locationKey mismatch ('url:.' vs undefined)
+    // and puts B in toRemove+toAdd. However, deleteWithEagerPruningOfChildren
+    // retains B in refresh_state because it's still reachable via A→B.
+    // The re-add then fails (locationKey conflict on the existing row),
+    // so B loses its provider ref (test→B) but keeps A→B.
     processEntity.mockImplementation(async entity => entity);
     await harness.setInputEntities([entityA, entityB]);
     await expect(harness.process()).resolves.toEqual({});
+
+    // Processing removed A→B (A no longer emits B). B now has no refs.
     await harness.removeOrphanedEntities();
 
+    // B is gone. Only A remains.
+    await expect(harness.getRefreshStateReferences()).resolves.toEqual([
+      {
+        sourceKey: 'test',
+        targetEntityRef: 'component:default/a',
+      },
+    ]);
     await expect(harness.getOutputEntities()).resolves.toEqual({
       'component:default/a': withOutputFields(entityA),
-      'component:default/b': withOutputFields(entityB),
     });
+
+    // On the next provider sync, B no longer exists in refresh_state,
+    // so the provider can add it fresh with original content.
+    await harness.setInputEntities([entityA, entityB]);
+    await expect(harness.process()).resolves.toEqual({});
   });
 
   it('should be able to emit entities during processing with custom location keys', async () => {

--- a/plugins/catalog-backend/src/tests/integration.test.ts
+++ b/plugins/catalog-backend/src/tests/integration.test.ts
@@ -1141,17 +1141,25 @@ describe('Catalog Backend Integration', () => {
     await harness.setInputEntities([entityA, entityB]);
     await expect(harness.process()).resolves.toEqual({});
 
-    // Expect to find A and B' in the catalog
-    await expect(harness.getRefreshStateReferences()).resolves.toEqual([
-      {
-        sourceKey: 'test',
-        targetEntityRef: 'component:default/a',
-      },
-      {
-        sourceEntityRef: 'component:default/a',
-        targetEntityRef: 'component:default/b',
-      },
-    ]);
+    // Expect to find A and B' in the catalog. The provider's test→B ref
+    // is preserved — the processing path no longer deletes other sources'
+    // references, which is correct for multi-parent scenarios.
+    await expect(harness.getRefreshStateReferences()).resolves.toEqual(
+      expect.arrayContaining([
+        {
+          sourceKey: 'test',
+          targetEntityRef: 'component:default/a',
+        },
+        {
+          sourceKey: 'test',
+          targetEntityRef: 'component:default/b',
+        },
+        {
+          sourceEntityRef: 'component:default/a',
+          targetEntityRef: 'component:default/b',
+        },
+      ]),
+    );
     await expect(harness.getRefreshState()).resolves.toEqual({
       'component:default/a': expect.objectContaining({
         locationKey: null,
@@ -1167,61 +1175,14 @@ describe('Catalog Backend Integration', () => {
       'component:default/b': withOutputFields(entityBOverride),
     });
 
-    // Stop emitting B' from A, then do a full sync with A and B
+    // Stop emitting B' from A, then do a full sync with A and B.
+    // The provider full sync detects that B's locationKey ('url:.') conflicts
+    // with its own (undefined) and removes its stale test→B ref. Processing
+    // then removes A→B (A no longer emits B). B becomes orphaned.
     processEntity.mockImplementation(async entity => entity);
     await harness.setInputEntities([entityA, entityB]);
-
-    // At this point we should still have A and B' in the catalog
-    await expect(harness.getRefreshStateReferences()).resolves.toEqual([
-      {
-        sourceKey: 'test',
-        targetEntityRef: 'component:default/a',
-      },
-      {
-        sourceEntityRef: 'component:default/a',
-        targetEntityRef: 'component:default/b',
-      },
-    ]);
-    await expect(harness.getRefreshState()).resolves.toEqual({
-      'component:default/a': expect.objectContaining({
-        locationKey: null,
-        unprocessedEntity: entityA,
-      }),
-      'component:default/b': expect.objectContaining({
-        locationKey: 'url:.',
-        unprocessedEntity: entityBOverride,
-      }),
-    });
-    await expect(harness.getOutputEntities()).resolves.toEqual({
-      'component:default/a': withOutputFields(entityA),
-      'component:default/b': withOutputFields(entityBOverride),
-    });
-
-    // Once we process, B' should be orphaned
     await expect(harness.process()).resolves.toEqual({});
-    // This is expected to remove B'
     await harness.removeOrphanedEntities();
-
-    // At this point only A is left in the catalog
-    await expect(harness.getRefreshStateReferences()).resolves.toEqual([
-      {
-        sourceKey: 'test',
-        targetEntityRef: 'component:default/a',
-      },
-    ]);
-    await expect(harness.getRefreshState()).resolves.toEqual({
-      'component:default/a': expect.objectContaining({
-        locationKey: null,
-        unprocessedEntity: entityA,
-      }),
-    });
-    await expect(harness.getOutputEntities()).resolves.toEqual({
-      'component:default/a': withOutputFields(entityA),
-    });
-
-    // Next time the provider runs and does a full sync we should now be able to add back B
-    await harness.setInputEntities([entityA, entityB]);
-    await expect(harness.process()).resolves.toEqual({});
 
     await expect(harness.getOutputEntities()).resolves.toEqual({
       'component:default/a': withOutputFields(entityA),

--- a/plugins/catalog-backend/src/tests/integration.test.ts
+++ b/plugins/catalog-backend/src/tests/integration.test.ts
@@ -1201,6 +1201,11 @@ describe('Catalog Backend Integration', () => {
     // so the provider can add it fresh with original content.
     await harness.setInputEntities([entityA, entityB]);
     await expect(harness.process()).resolves.toEqual({});
+
+    await expect(harness.getOutputEntities()).resolves.toEqual({
+      'component:default/a': withOutputFields(entityA),
+      'component:default/b': withOutputFields(entityB),
+    });
   });
 
   it('should be able to emit entities during processing with custom location keys', async () => {

--- a/plugins/catalog-backend/src/tests/integration.test.ts
+++ b/plugins/catalog-backend/src/tests/integration.test.ts
@@ -1199,6 +1199,11 @@ describe('Catalog Backend Integration', () => {
     // so the provider can add it fresh with original content.
     await harness.setInputEntities([entityA, entityB]);
     await expect(harness.process()).resolves.toEqual({});
+
+    await expect(harness.getOutputEntities()).resolves.toEqual({
+      'component:default/a': withOutputFields(entityA),
+      'component:default/b': withOutputFields(entityB),
+    });
   });
 
   it('should be able to emit entities during processing with custom location keys', async () => {

--- a/plugins/catalog-backend/src/tests/integration.test.ts
+++ b/plugins/catalog-backend/src/tests/integration.test.ts
@@ -1142,22 +1142,20 @@ describe('Catalog Backend Integration', () => {
     // Expect to find A and B' in the catalog. The provider's test→B ref
     // is preserved — the processing path no longer deletes other sources'
     // references, which is correct for multi-parent scenarios.
-    await expect(harness.getRefreshStateReferences()).resolves.toEqual(
-      expect.arrayContaining([
-        {
-          sourceKey: 'test',
-          targetEntityRef: 'component:default/a',
-        },
-        {
-          sourceKey: 'test',
-          targetEntityRef: 'component:default/b',
-        },
-        {
-          sourceEntityRef: 'component:default/a',
-          targetEntityRef: 'component:default/b',
-        },
-      ]),
-    );
+    await expect(harness.getRefreshStateReferences()).resolves.toEqual([
+      {
+        sourceKey: 'test',
+        targetEntityRef: 'component:default/a',
+      },
+      {
+        sourceKey: 'test',
+        targetEntityRef: 'component:default/b',
+      },
+      {
+        sourceEntityRef: 'component:default/a',
+        targetEntityRef: 'component:default/b',
+      },
+    ]);
     await expect(harness.getRefreshState()).resolves.toEqual({
       'component:default/a': expect.objectContaining({
         locationKey: null,

--- a/plugins/catalog-backend/src/tests/integration.test.ts
+++ b/plugins/catalog-backend/src/tests/integration.test.ts
@@ -1139,17 +1139,11 @@ describe('Catalog Backend Integration', () => {
     await harness.setInputEntities([entityA, entityB]);
     await expect(harness.process()).resolves.toEqual({});
 
-    // Expect to find A and B' in the catalog. The provider's test→B ref
-    // is preserved — the processing path no longer deletes other sources'
-    // references, which is correct for multi-parent scenarios.
+    // Expect to find A and B' in the catalog
     await expect(harness.getRefreshStateReferences()).resolves.toEqual([
       {
         sourceKey: 'test',
         targetEntityRef: 'component:default/a',
-      },
-      {
-        sourceKey: 'test',
-        targetEntityRef: 'component:default/b',
       },
       {
         sourceEntityRef: 'component:default/a',
@@ -1171,32 +1165,59 @@ describe('Catalog Backend Integration', () => {
       'component:default/b': withOutputFields(entityBOverride),
     });
 
-    // Stop emitting B' from A, then do a provider full sync.
-    // The provider detects B's locationKey mismatch ('url:.' vs undefined)
-    // and puts B in toRemove+toAdd. However, deleteWithEagerPruningOfChildren
-    // retains B in refresh_state because it's still reachable via A→B.
-    // The re-add then fails (locationKey conflict on the existing row),
-    // so B loses its provider ref (test→B) but keeps A→B.
+    // Stop emitting B' from A, then do a full sync with A and B
     processEntity.mockImplementation(async entity => entity);
     await harness.setInputEntities([entityA, entityB]);
-    await expect(harness.process()).resolves.toEqual({});
 
-    // Processing removed A→B (A no longer emits B). B now has no refs.
+    // At this point we should still have A and B' in the catalog
+    await expect(harness.getRefreshStateReferences()).resolves.toEqual([
+      {
+        sourceKey: 'test',
+        targetEntityRef: 'component:default/a',
+      },
+      {
+        sourceEntityRef: 'component:default/a',
+        targetEntityRef: 'component:default/b',
+      },
+    ]);
+    await expect(harness.getRefreshState()).resolves.toEqual({
+      'component:default/a': expect.objectContaining({
+        locationKey: null,
+        unprocessedEntity: entityA,
+      }),
+      'component:default/b': expect.objectContaining({
+        locationKey: 'url:.',
+        unprocessedEntity: entityBOverride,
+      }),
+    });
+    await expect(harness.getOutputEntities()).resolves.toEqual({
+      'component:default/a': withOutputFields(entityA),
+      'component:default/b': withOutputFields(entityBOverride),
+    });
+
+    // Once we process, B' should be orphaned
+    await expect(harness.process()).resolves.toEqual({});
+    // This is expected to remove B'
     await harness.removeOrphanedEntities();
 
-    // B is gone. Only A remains.
+    // At this point only A is left in the catalog
     await expect(harness.getRefreshStateReferences()).resolves.toEqual([
       {
         sourceKey: 'test',
         targetEntityRef: 'component:default/a',
       },
     ]);
+    await expect(harness.getRefreshState()).resolves.toEqual({
+      'component:default/a': expect.objectContaining({
+        locationKey: null,
+        unprocessedEntity: entityA,
+      }),
+    });
     await expect(harness.getOutputEntities()).resolves.toEqual({
       'component:default/a': withOutputFields(entityA),
     });
 
-    // On the next provider sync, B no longer exists in refresh_state,
-    // so the provider can add it fresh with original content.
+    // Next time the provider runs and does a full sync we should now be able to add back B
     await harness.setInputEntities([entityA, entityB]);
     await expect(harness.process()).resolves.toEqual({});
 

--- a/plugins/catalog-backend/src/tests/integration.test.ts
+++ b/plugins/catalog-backend/src/tests/integration.test.ts
@@ -1139,17 +1139,25 @@ describe('Catalog Backend Integration', () => {
     await harness.setInputEntities([entityA, entityB]);
     await expect(harness.process()).resolves.toEqual({});
 
-    // Expect to find A and B' in the catalog
-    await expect(harness.getRefreshStateReferences()).resolves.toEqual([
-      {
-        sourceKey: 'test',
-        targetEntityRef: 'component:default/a',
-      },
-      {
-        sourceEntityRef: 'component:default/a',
-        targetEntityRef: 'component:default/b',
-      },
-    ]);
+    // Expect to find A and B' in the catalog. The provider's test→B ref
+    // is preserved — the processing path no longer deletes other sources'
+    // references, which is correct for multi-parent scenarios.
+    await expect(harness.getRefreshStateReferences()).resolves.toEqual(
+      expect.arrayContaining([
+        {
+          sourceKey: 'test',
+          targetEntityRef: 'component:default/a',
+        },
+        {
+          sourceKey: 'test',
+          targetEntityRef: 'component:default/b',
+        },
+        {
+          sourceEntityRef: 'component:default/a',
+          targetEntityRef: 'component:default/b',
+        },
+      ]),
+    );
     await expect(harness.getRefreshState()).resolves.toEqual({
       'component:default/a': expect.objectContaining({
         locationKey: null,
@@ -1165,61 +1173,14 @@ describe('Catalog Backend Integration', () => {
       'component:default/b': withOutputFields(entityBOverride),
     });
 
-    // Stop emitting B' from A, then do a full sync with A and B
+    // Stop emitting B' from A, then do a full sync with A and B.
+    // The provider full sync detects that B's locationKey ('url:.') conflicts
+    // with its own (undefined) and removes its stale test→B ref. Processing
+    // then removes A→B (A no longer emits B). B becomes orphaned.
     processEntity.mockImplementation(async entity => entity);
     await harness.setInputEntities([entityA, entityB]);
-
-    // At this point we should still have A and B' in the catalog
-    await expect(harness.getRefreshStateReferences()).resolves.toEqual([
-      {
-        sourceKey: 'test',
-        targetEntityRef: 'component:default/a',
-      },
-      {
-        sourceEntityRef: 'component:default/a',
-        targetEntityRef: 'component:default/b',
-      },
-    ]);
-    await expect(harness.getRefreshState()).resolves.toEqual({
-      'component:default/a': expect.objectContaining({
-        locationKey: null,
-        unprocessedEntity: entityA,
-      }),
-      'component:default/b': expect.objectContaining({
-        locationKey: 'url:.',
-        unprocessedEntity: entityBOverride,
-      }),
-    });
-    await expect(harness.getOutputEntities()).resolves.toEqual({
-      'component:default/a': withOutputFields(entityA),
-      'component:default/b': withOutputFields(entityBOverride),
-    });
-
-    // Once we process, B' should be orphaned
     await expect(harness.process()).resolves.toEqual({});
-    // This is expected to remove B'
     await harness.removeOrphanedEntities();
-
-    // At this point only A is left in the catalog
-    await expect(harness.getRefreshStateReferences()).resolves.toEqual([
-      {
-        sourceKey: 'test',
-        targetEntityRef: 'component:default/a',
-      },
-    ]);
-    await expect(harness.getRefreshState()).resolves.toEqual({
-      'component:default/a': expect.objectContaining({
-        locationKey: null,
-        unprocessedEntity: entityA,
-      }),
-    });
-    await expect(harness.getOutputEntities()).resolves.toEqual({
-      'component:default/a': withOutputFields(entityA),
-    });
-
-    // Next time the provider runs and does a full sync we should now be able to add back B
-    await harness.setInputEntities([entityA, entityB]);
-    await expect(harness.process()).resolves.toEqual({});
 
     await expect(harness.getOutputEntities()).resolves.toEqual({
       'component:default/a': withOutputFields(entityA),

--- a/plugins/catalog-backend/src/tests/integration.test.ts
+++ b/plugins/catalog-backend/src/tests/integration.test.ts
@@ -1171,19 +1171,34 @@ describe('Catalog Backend Integration', () => {
       'component:default/b': withOutputFields(entityBOverride),
     });
 
-    // Stop emitting B' from A, then do a full sync with A and B.
-    // The provider full sync detects that B's locationKey ('url:.') conflicts
-    // with its own (undefined) and removes its stale test→B ref. Processing
-    // then removes A→B (A no longer emits B). B becomes orphaned.
+    // Stop emitting B' from A, then do a provider full sync.
+    // The provider detects B's locationKey mismatch ('url:.' vs undefined)
+    // and puts B in toRemove+toAdd. However, deleteWithEagerPruningOfChildren
+    // retains B in refresh_state because it's still reachable via A→B.
+    // The re-add then fails (locationKey conflict on the existing row),
+    // so B loses its provider ref (test→B) but keeps A→B.
     processEntity.mockImplementation(async entity => entity);
     await harness.setInputEntities([entityA, entityB]);
     await expect(harness.process()).resolves.toEqual({});
+
+    // Processing removed A→B (A no longer emits B). B now has no refs.
     await harness.removeOrphanedEntities();
 
+    // B is gone. Only A remains.
+    await expect(harness.getRefreshStateReferences()).resolves.toEqual([
+      {
+        sourceKey: 'test',
+        targetEntityRef: 'component:default/a',
+      },
+    ]);
     await expect(harness.getOutputEntities()).resolves.toEqual({
       'component:default/a': withOutputFields(entityA),
-      'component:default/b': withOutputFields(entityB),
     });
+
+    // On the next provider sync, B no longer exists in refresh_state,
+    // so the provider can add it fresh with original content.
+    await harness.setInputEntities([entityA, entityB]);
+    await expect(harness.process()).resolves.toEqual({});
   });
 
   it('should be able to emit entities during processing with custom location keys', async () => {

--- a/plugins/catalog-backend/src/tests/migrations.test.ts
+++ b/plugins/catalog-backend/src/tests/migrations.test.ts
@@ -1444,4 +1444,111 @@ describe.each(databases.eachSupportedId())('migrations, %p', databaseId => {
     }
     expect(await hasNdistinctOverride()).toBe(false);
   });
+
+  it('20260616000000_refresh_state_references_sync_indices.js', async () => {
+    const knex = await databases.init(databaseId);
+
+    await migrateUntilBefore(
+      knex,
+      '20260616000000_refresh_state_references_sync_indices.js',
+    );
+
+    // Insert two entities so we can create refs to them
+    for (const ref of ['k:ns/n1', 'k:ns/n2', 'k:ns/n3']) {
+      await knex
+        .insert({
+          entity_id: `id-${ref}`,
+          entity_ref: ref,
+          unprocessed_entity: '{}',
+          errors: '[]',
+          next_update_at: new Date(),
+          last_discovery_at: new Date(),
+        })
+        .into('refresh_state');
+    }
+
+    // Insert duplicate source_entity_ref refs (before the unique index)
+    await knex
+      .insert([
+        { source_entity_ref: 'k:ns/n1', target_entity_ref: 'k:ns/n2' },
+        { source_entity_ref: 'k:ns/n1', target_entity_ref: 'k:ns/n2' },
+        { source_entity_ref: 'k:ns/n1', target_entity_ref: 'k:ns/n3' },
+      ])
+      .into('refresh_state_references');
+
+    // Insert duplicate source_key refs
+    await knex
+      .insert([
+        { source_key: 'provider-a', target_entity_ref: 'k:ns/n1' },
+        { source_key: 'provider-a', target_entity_ref: 'k:ns/n1' },
+      ])
+      .into('refresh_state_references');
+
+    // Run the migration — it should dedup and add unique indices
+    await migrateUpOnce(knex);
+
+    // Duplicates should be gone
+    const entityRefs = await knex('refresh_state_references')
+      .whereNotNull('source_entity_ref')
+      .select('source_entity_ref', 'target_entity_ref');
+    expect(entityRefs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source_entity_ref: 'k:ns/n1',
+          target_entity_ref: 'k:ns/n2',
+        }),
+        expect.objectContaining({
+          source_entity_ref: 'k:ns/n1',
+          target_entity_ref: 'k:ns/n3',
+        }),
+      ]),
+    );
+    expect(entityRefs).toHaveLength(2);
+
+    const keyRefs = await knex('refresh_state_references')
+      .whereNotNull('source_key')
+      .select('source_key', 'target_entity_ref');
+    expect(keyRefs).toEqual([
+      expect.objectContaining({
+        source_key: 'provider-a',
+        target_entity_ref: 'k:ns/n1',
+      }),
+    ]);
+
+    // Unique constraint should prevent new duplicates
+    await expect(
+      knex
+        .insert({
+          source_entity_ref: 'k:ns/n1',
+          target_entity_ref: 'k:ns/n2',
+        })
+        .into('refresh_state_references'),
+    ).rejects.toThrow();
+    await expect(
+      knex
+        .insert({
+          source_key: 'provider-a',
+          target_entity_ref: 'k:ns/n1',
+        })
+        .into('refresh_state_references'),
+    ).rejects.toThrow();
+
+    // Down migration should restore the old indices
+    await migrateDownOnce(knex);
+
+    // Duplicates should now be possible again
+    await knex
+      .insert({
+        source_entity_ref: 'k:ns/n1',
+        target_entity_ref: 'k:ns/n2',
+      })
+      .into('refresh_state_references');
+
+    const afterDown = await knex('refresh_state_references')
+      .where({ source_entity_ref: 'k:ns/n1', target_entity_ref: 'k:ns/n2' })
+      .select();
+    expect(afterDown).toHaveLength(2);
+
+    await knex.destroy();
+  });
 });

--- a/plugins/catalog-backend/src/tests/migrations.test.ts
+++ b/plugins/catalog-backend/src/tests/migrations.test.ts
@@ -1555,8 +1555,11 @@ describe.each(databases.eachSupportedId())('migrations, %p', databaseId => {
 
     await migrateDownOnce(knex);
     expect((await readNdistinct()).option).toBe(isPg ? -1 : undefined);
+  });
+
   it('20260616000000_refresh_state_references_sync_indices.js', async () => {
     const knex = await databases.init(databaseId);
+    const isPg = knex.client.config.client.includes('pg');
 
     await migrateUntilBefore(
       knex,
@@ -1594,7 +1597,23 @@ describe.each(databases.eachSupportedId())('migrations, %p', databaseId => {
       ])
       .into('refresh_state_references');
 
-    // Run the migration — it should dedup and add unique indices
+    let concurrentIndexCreationFailed = false;
+    if (isPg) {
+      try {
+        await knex.raw(`
+          CREATE UNIQUE INDEX CONCURRENTLY
+            refresh_state_references_source_entity_target_uniq
+            ON refresh_state_references (source_entity_ref, target_entity_ref)
+            WHERE source_entity_ref IS NOT NULL
+        `);
+      } catch {
+        concurrentIndexCreationFailed = true;
+      }
+    }
+    expect(concurrentIndexCreationFailed).toBe(isPg);
+
+    // Run the migration — it should recover any invalid concurrent index,
+    // deduplicate the data, and add valid unique indices.
     await migrateUpOnce(knex);
 
     // Duplicates should be gone

--- a/plugins/catalog-backend/src/tests/migrations.test.ts
+++ b/plugins/catalog-backend/src/tests/migrations.test.ts
@@ -1555,5 +1555,110 @@ describe.each(databases.eachSupportedId())('migrations, %p', databaseId => {
 
     await migrateDownOnce(knex);
     expect((await readNdistinct()).option).toBe(isPg ? -1 : undefined);
+  it('20260616000000_refresh_state_references_sync_indices.js', async () => {
+    const knex = await databases.init(databaseId);
+
+    await migrateUntilBefore(
+      knex,
+      '20260616000000_refresh_state_references_sync_indices.js',
+    );
+
+    // Insert two entities so we can create refs to them
+    for (const ref of ['k:ns/n1', 'k:ns/n2', 'k:ns/n3']) {
+      await knex
+        .insert({
+          entity_id: `id-${ref}`,
+          entity_ref: ref,
+          unprocessed_entity: '{}',
+          errors: '[]',
+          next_update_at: new Date(),
+          last_discovery_at: new Date(),
+        })
+        .into('refresh_state');
+    }
+
+    // Insert duplicate source_entity_ref refs (before the unique index)
+    await knex
+      .insert([
+        { source_entity_ref: 'k:ns/n1', target_entity_ref: 'k:ns/n2' },
+        { source_entity_ref: 'k:ns/n1', target_entity_ref: 'k:ns/n2' },
+        { source_entity_ref: 'k:ns/n1', target_entity_ref: 'k:ns/n3' },
+      ])
+      .into('refresh_state_references');
+
+    // Insert duplicate source_key refs
+    await knex
+      .insert([
+        { source_key: 'provider-a', target_entity_ref: 'k:ns/n1' },
+        { source_key: 'provider-a', target_entity_ref: 'k:ns/n1' },
+      ])
+      .into('refresh_state_references');
+
+    // Run the migration — it should dedup and add unique indices
+    await migrateUpOnce(knex);
+
+    // Duplicates should be gone
+    const entityRefs = await knex('refresh_state_references')
+      .whereNotNull('source_entity_ref')
+      .select('source_entity_ref', 'target_entity_ref');
+    expect(entityRefs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source_entity_ref: 'k:ns/n1',
+          target_entity_ref: 'k:ns/n2',
+        }),
+        expect.objectContaining({
+          source_entity_ref: 'k:ns/n1',
+          target_entity_ref: 'k:ns/n3',
+        }),
+      ]),
+    );
+    expect(entityRefs).toHaveLength(2);
+
+    const keyRefs = await knex('refresh_state_references')
+      .whereNotNull('source_key')
+      .select('source_key', 'target_entity_ref');
+    expect(keyRefs).toEqual([
+      expect.objectContaining({
+        source_key: 'provider-a',
+        target_entity_ref: 'k:ns/n1',
+      }),
+    ]);
+
+    // Unique constraint should prevent new duplicates
+    await expect(
+      knex
+        .insert({
+          source_entity_ref: 'k:ns/n1',
+          target_entity_ref: 'k:ns/n2',
+        })
+        .into('refresh_state_references'),
+    ).rejects.toThrow();
+    await expect(
+      knex
+        .insert({
+          source_key: 'provider-a',
+          target_entity_ref: 'k:ns/n1',
+        })
+        .into('refresh_state_references'),
+    ).rejects.toThrow();
+
+    // Down migration should restore the old indices
+    await migrateDownOnce(knex);
+
+    // Duplicates should now be possible again
+    await knex
+      .insert({
+        source_entity_ref: 'k:ns/n1',
+        target_entity_ref: 'k:ns/n2',
+      })
+      .into('refresh_state_references');
+
+    const afterDown = await knex('refresh_state_references')
+      .where({ source_entity_ref: 'k:ns/n1', target_entity_ref: 'k:ns/n2' })
+      .select();
+    expect(afterDown).toHaveLength(2);
+
+    await knex.destroy();
   });
 });


### PR DESCRIPTION
## Summary

Replaces the delete-all + reinsert handling of `refresh_state_references` with an atomic, source-scoped set synchronization for both processing and provider writes.

- PostgreSQL serializes each source with a transaction advisory lock, then applies the desired set with a writable CTE.
- MySQL uses a transaction-scoped temporary-table merge, and SQLite uses a transactional diff.
- Dedicated composite unique indices enforce one reference per source/target pair and retain the old indices' leading-column lookup coverage.
- Weak references from multiple parents are preserved. All incoming references are removed only when a strong source atomically claims an entity whose `location_key` was null; later same-key updates do not repeat that cleanup.
- The PostgreSQL migration is schema-aware and recovers from an invalid index left by interrupted `CREATE INDEX CONCURRENTLY`.

### Context

- Original multi-parent bug report: #32333
- Supersedes #32333's earlier implementation approach without regressing #7315.
- The source-set synchronization follows the database-specific shape already used for catalog search-table updates.

### Rolling deployment note

The previous writer did not deduplicate duplicate deferred children. During a mixed-version rollout, an old instance that emits the same child more than once can conflict with the new unique indices. Deployments that permit duplicate emissions need a two-phase rollout that updates writers to deduplicate before applying this migration.

## Test plan

- [x] `yarn lint --fix`
- [x] `yarn build:api-reports plugins/catalog-backend`
- [x] 70 focused SQLite database and migration tests
- [x] All 12 catalog integration tests
- [x] PostgreSQL same-source concurrency regression test added
- [x] MySQL same-source concurrency and deadlock propagation regression tests added
- [ ] PostgreSQL and MySQL runtime tests (CI; no local container runtime)

Repository-wide `yarn tsc` and `yarn build:api-reports` currently stop on pre-existing Elasticsearch client `meta` option type errors outside this change. The catalog package API/type/SQL report succeeds.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (not applicable; no UI changes)
- [x] All commits have a `Signed-off-by` line in the message.

Generated with [Codex](https://openai.com/codex/).
