### PR TITLE
feat(nfs): allow users to supply attributes for permissions

### DIFF
--- a/.changeset/permission-attributes-nfs.md
+++ b/.changeset/permission-attributes-nfs.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-app-api': patch
+---
+
+Extension `if` predicates now support inferring permission attributes from the permission name. When a permission name contains a `#` separator (e.g. `catalog.entity.read#read`), the part after `#` is used as the `action` attribute when evaluating the permission. This removes the need to configure attributes separately for basic permissions.

--- a/.changeset/permission-attributes-nfs.md
+++ b/.changeset/permission-attributes-nfs.md
@@ -2,4 +2,4 @@
 '@backstage/frontend-app-api': patch
 ---
 
-Extension `if` predicates now support specifying permission attributes in the permission reference. When a permission name contains a `#` separator (e.g. `catalog.entity.read#read`), the part after `#` is used as the `action` attribute when evaluating the permission. This removes the need to configure attributes separately for basic permissions.
+Extension `if` predicates now support specifying an `action` attribute in the permission reference. When a permission name contains a `#` separator (e.g. `catalog.entity.read#read`), the part after `#` is used as `attributes.action` when evaluating the permission. This removes the need to configure action attributes separately for basic permissions.

--- a/.changeset/permission-attributes-nfs.md
+++ b/.changeset/permission-attributes-nfs.md
@@ -2,4 +2,4 @@
 '@backstage/frontend-app-api': patch
 ---
 
-Extension `if` predicates now support inferring permission attributes from the permission name. When a permission name contains a `#` separator (e.g. `catalog.entity.read#read`), the part after `#` is used as the `action` attribute when evaluating the permission. This removes the need to configure attributes separately for basic permissions.
+Extension `if` predicates now support specifying permission attributes in the permission reference. When a permission name contains a `#` separator (e.g. `catalog.entity.read#read`), the part after `#` is used as the `action` attribute when evaluating the permission. This removes the need to configure attributes separately for basic permissions.

--- a/docs/frontend-system/architecture/20-extensions.md
+++ b/docs/frontend-system/architecture/20-extensions.md
@@ -74,6 +74,23 @@ const guardedCard = CardBlueprint.make({
 });
 ```
 
+#### Permission name format
+
+Permission names in the `if` predicate support an optional `#action` suffix to specify the `action` attribute on the permission check. The format is `permissionName#action`:
+
+```tsx
+const actionGatedPage = PageBlueprint.make({
+  params: {
+    path: '/edit-catalog',
+    loader: () => import('./EditCatalogPage').then(m => <m.EditCatalogPage />),
+  },
+  // Only shown when the user can perform the 'update' action on catalog.entity
+  if: { permissions: { $contains: 'catalog.entity#update' } },
+});
+```
+
+Without the suffix (e.g. `catalog.entity.create`), the permission is checked with an empty `attributes` object, which matches basic permissions that carry no action. With the suffix (e.g. `catalog.entity#update`), the part before `#` is the permission name and the part after is passed as `attributes.action` to the permission API.
+
 Conditions are evaluated when the app tree is prepared, not continuously while the app is running. If the underlying feature flags or permissions change, the app needs to be prepared again in order for the extension tree to change, which in practice typically means reloading the app.
 
 If a plugin or module also provides an `if` predicate, it is combined with the extension-level predicate using logical `AND`. See the [plugin `if` option](./15-plugins.md#if-option) and [frontend modules](./25-extension-overrides.md#creating-a-frontend-module) sections for more details.

--- a/docs/frontend-system/architecture/20-extensions.md
+++ b/docs/frontend-system/architecture/20-extensions.md
@@ -84,12 +84,12 @@ const actionGatedPage = PageBlueprint.make({
     path: '/edit-catalog',
     loader: () => import('./EditCatalogPage').then(m => <m.EditCatalogPage />),
   },
-  // Only shown when the user can perform the 'update' action on catalog.entity
-  if: { permissions: { $contains: 'catalog.entity#update' } },
+  // Only shown when the user can perform the 'update' action on catalog.entity.refresh
+  if: { permissions: { $contains: 'catalog.entity.refresh#update' } },
 });
 ```
 
-Without the suffix (e.g. `catalog.entity.create`), the permission is checked with an empty `attributes` object, which matches basic permissions that carry no action. With the suffix (e.g. `catalog.entity#update`), the part before `#` is the permission name and the part after is passed as `attributes.action` to the permission API.
+Without the suffix (e.g. `catalog.entity.create`), the permission is checked with an empty `attributes` object, which matches basic permissions that carry no action. With the suffix (e.g. `catalog.entity.refresh#update`), the part before `#` is the permission name and the part after is passed as `attributes.action` to the permission API.
 
 Conditions are evaluated when the app tree is prepared, not continuously while the app is running. If the underlying feature flags or permissions change, the app needs to be prepared again in order for the extension tree to change, which in practice typically means reloading the app.
 

--- a/packages/app/src/examples/pagesPlugin.tsx
+++ b/packages/app/src/examples/pagesPlugin.tsx
@@ -103,6 +103,13 @@ const IndexPage = PageBlueprint.make({
                 — a page that is always visible, but individual cards on it are
                 toggled by permissions
               </li>
+              <li>
+                <Link to="/permission-action-example">
+                  Permission Action Example
+                </Link>{' '}
+                — requires <code>catalog.entity.read#read</code> (action-scoped
+                permission)
+              </li>
             </ul>
 
             <h2>Feature Flag Enablement Examples</h2>
@@ -429,6 +436,50 @@ const FeatureFlagCard = PermissionExampleCardBlueprint.make({
   if: { featureFlags: { $contains: 'experimental-card' } },
 });
 
+// Example: Page enabled only when the user has a specific action on a permission.
+//
+// The `#action` suffix narrows the check to a particular action on the named
+// permission. `catalog.entity.read#read` means "the user must be allowed to
+// perform the 'read' action on the catalog.entity.read permission".
+//
+// Without the suffix (just `catalog.entity.read`) the check uses an empty
+// attributes object — compatible with basic permissions that have no action.
+const PermissionActionPage = PageBlueprint.make({
+  name: 'permissionActionExample',
+  params: {
+    path: '/permission-action-example',
+    loader: async () => {
+      const Component = () => {
+        const indexLink = useRouteRef(indexRouteRef);
+        return (
+          <div>
+            <h1>Action-Scoped Permission Page</h1>
+            <p>
+              This page is only present when the user is allowed to perform the{' '}
+              <code>read</code> action on the <code>catalog.entity.read</code>{' '}
+              permission.
+            </p>
+            <p>
+              It uses the <code>#action</code> suffix format:
+            </p>
+            <pre>
+              {'if: { permissions: { $contains: "catalog.entity.read#read" } }'}
+            </pre>
+            <p>
+              The permission name before <code>#</code> is used to look up the
+              permission, and the part after is passed as the{' '}
+              <code>attributes.action</code> field to the permission API.
+            </p>
+            {indexLink && <Link to={indexLink()}>Go back</Link>}
+          </div>
+        );
+      };
+      return <Component />;
+    },
+  },
+  if: { permissions: { $contains: 'catalog.entity.read#read' } },
+});
+
 // Example: Page enabled only when the user is allowed to create catalog entities.
 //
 // The `if` predicate is evaluated once at app startup (after sign-in),
@@ -488,6 +539,7 @@ export const pagesPlugin = createFrontendPlugin({
     PublicCard,
     RestrictedCard,
     PermissionGatedPage,
+    PermissionActionPage,
     FeatureFlagCard,
   ],
 });

--- a/packages/frontend-app-api/src/wiring/predicates.test.ts
+++ b/packages/frontend-app-api/src/wiring/predicates.test.ts
@@ -1,0 +1,388 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  featureFlagsApiRef,
+  type FeatureFlagsApi,
+} from '@backstage/frontend-plugin-api';
+import type {
+  EvaluatePermissionRequest,
+  EvaluatePermissionResponse,
+} from '@backstage/plugin-permission-common';
+import {
+  collectPredicateReferences,
+  createPredicateContextLoader,
+  localPermissionApiRef,
+} from './predicates';
+
+function makeFeatureFlagsApi(activeFlags: string[] = []): FeatureFlagsApi {
+  return {
+    registerFlag: jest.fn(),
+    getRegisteredFlags: () => [],
+    isActive: (name: string) => activeFlags.includes(name),
+    save: jest.fn(),
+  };
+}
+
+type MinimalPermissionApi = {
+  authorize(
+    request: EvaluatePermissionRequest,
+  ): Promise<EvaluatePermissionResponse>;
+};
+
+function makePermissionApi(
+  handler: (
+    req: EvaluatePermissionRequest,
+  ) => Promise<EvaluatePermissionResponse>,
+): MinimalPermissionApi {
+  return { authorize: handler };
+}
+
+function makeAllowPermissionApi(allowedNames: string[]): MinimalPermissionApi {
+  return makePermissionApi(async req => ({
+    result: allowedNames.includes(req.permission.name) ? 'ALLOW' : 'DENY',
+  }));
+}
+
+function makeApiHolder(
+  featureFlagsApi?: FeatureFlagsApi,
+  permissionApi?: MinimalPermissionApi,
+) {
+  return {
+    get(ref: { id: string }) {
+      if (ref.id === featureFlagsApiRef.id) return featureFlagsApi as any;
+      if (ref.id === localPermissionApiRef.id) return permissionApi as any;
+      return undefined;
+    },
+  };
+}
+
+describe('collectPredicateReferences', () => {
+  it('returns empty arrays when no nodes have predicates', () => {
+    const result = collectPredicateReferences([
+      { spec: {} },
+      { spec: { if: undefined } },
+    ]);
+    expect(result).toEqual({ featureFlags: [], permissions: [] });
+  });
+
+  it('collects feature flag names from $contains expressions', () => {
+    const result = collectPredicateReferences([
+      { spec: { if: { featureFlags: { $contains: 'my-flag' } } } },
+    ]);
+    expect(result.featureFlags).toEqual(['my-flag']);
+    expect(result.permissions).toEqual([]);
+  });
+
+  it('collects permission names from $contains expressions', () => {
+    const result = collectPredicateReferences([
+      { spec: { if: { permissions: { $contains: 'catalog.entity.read' } } } },
+    ]);
+    expect(result.permissions).toEqual(['catalog.entity.read']);
+    expect(result.featureFlags).toEqual([]);
+  });
+
+  it('collects permission names with #action suffix', () => {
+    const result = collectPredicateReferences([
+      {
+        spec: {
+          if: { permissions: { $contains: 'catalog.entity.read#read' } },
+        },
+      },
+    ]);
+    expect(result.permissions).toEqual(['catalog.entity.read#read']);
+  });
+
+  it('deduplicates names across multiple nodes', () => {
+    const result = collectPredicateReferences([
+      { spec: { if: { featureFlags: { $contains: 'flag-a' } } } },
+      { spec: { if: { featureFlags: { $contains: 'flag-a' } } } },
+      { spec: { if: { featureFlags: { $contains: 'flag-b' } } } },
+    ]);
+    expect(result.featureFlags).toEqual(['flag-a', 'flag-b']);
+  });
+
+  it('collects names from $all predicate', () => {
+    const result = collectPredicateReferences([
+      {
+        spec: {
+          if: {
+            $all: [
+              { featureFlags: { $contains: 'flag-a' } },
+              { permissions: { $contains: 'my.permission' } },
+            ],
+          },
+        },
+      },
+    ]);
+    expect(result.featureFlags).toEqual(['flag-a']);
+    expect(result.permissions).toEqual(['my.permission']);
+  });
+
+  it('collects names from $any predicate', () => {
+    const result = collectPredicateReferences([
+      {
+        spec: {
+          if: {
+            $any: [
+              { featureFlags: { $contains: 'flag-x' } },
+              { featureFlags: { $contains: 'flag-y' } },
+            ],
+          },
+        },
+      },
+    ]);
+    expect(result.featureFlags).toEqual(['flag-x', 'flag-y']);
+  });
+
+  it('collects names from $not predicate', () => {
+    const result = collectPredicateReferences([
+      {
+        spec: {
+          if: {
+            $not: { permissions: { $contains: 'admin.access' } },
+          },
+        },
+      },
+    ]);
+    expect(result.permissions).toEqual(['admin.access']);
+  });
+
+  it('collects names from deeply nested predicates', () => {
+    const result = collectPredicateReferences([
+      {
+        spec: {
+          if: {
+            $all: [
+              { featureFlags: { $contains: 'outer-flag' } },
+              {
+                $any: [
+                  { $not: { permissions: { $contains: 'deep.permission' } } },
+                  { featureFlags: { $contains: 'inner-flag' } },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    ]);
+    expect(result.featureFlags).toEqual(['outer-flag', 'inner-flag']);
+    expect(result.permissions).toEqual(['deep.permission']);
+  });
+});
+
+describe('createPredicateContextLoader', () => {
+  describe('getImmediate', () => {
+    it('returns context synchronously when there are no permission references', () => {
+      const loader = createPredicateContextLoader({
+        apis: makeApiHolder(makeFeatureFlagsApi(['active-flag'])),
+        predicateReferences: {
+          featureFlags: ['active-flag', 'inactive-flag'],
+          permissions: [],
+        },
+      });
+
+      expect(loader.getImmediate()).toEqual({
+        featureFlags: ['active-flag'],
+        permissions: [],
+      });
+    });
+
+    it('returns context synchronously when permissions are referenced but the permission API is absent', () => {
+      const loader = createPredicateContextLoader({
+        apis: makeApiHolder(makeFeatureFlagsApi()),
+        predicateReferences: {
+          featureFlags: [],
+          permissions: ['some.permission'],
+        },
+      });
+
+      expect(loader.getImmediate()).toEqual({
+        featureFlags: [],
+        permissions: [],
+      });
+    });
+
+    it('returns undefined when the permission API is present and permissions are referenced', () => {
+      const loader = createPredicateContextLoader({
+        apis: makeApiHolder(makeFeatureFlagsApi(), makeAllowPermissionApi([])),
+        predicateReferences: {
+          featureFlags: [],
+          permissions: ['some.permission'],
+        },
+      });
+
+      expect(loader.getImmediate()).toBeUndefined();
+    });
+
+    it('returns context synchronously when no feature flags API is available', () => {
+      const loader = createPredicateContextLoader({
+        apis: makeApiHolder(undefined, undefined),
+        predicateReferences: { featureFlags: ['flag'], permissions: [] },
+      });
+
+      expect(loader.getImmediate()).toEqual({
+        featureFlags: [],
+        permissions: [],
+      });
+    });
+  });
+
+  describe('load', () => {
+    it('returns only active feature flags when there are no permissions', async () => {
+      const loader = createPredicateContextLoader({
+        apis: makeApiHolder(makeFeatureFlagsApi(['enabled'])),
+        predicateReferences: {
+          featureFlags: ['enabled', 'disabled'],
+          permissions: [],
+        },
+      });
+
+      await expect(loader.load()).resolves.toEqual({
+        featureFlags: ['enabled'],
+        permissions: [],
+      });
+    });
+
+    it('returns allowed permissions', async () => {
+      const loader = createPredicateContextLoader({
+        apis: makeApiHolder(
+          makeFeatureFlagsApi(),
+          makeAllowPermissionApi(['catalog.entity.read']),
+        ),
+        predicateReferences: {
+          featureFlags: [],
+          permissions: ['catalog.entity.read', 'catalog.entity.delete'],
+        },
+      });
+
+      const result = await loader.load();
+      expect(result.permissions).toEqual(['catalog.entity.read']);
+    });
+
+    it('passes permission name and action attributes for permission#action names', async () => {
+      const authorizeRequests: EvaluatePermissionRequest[] = [];
+      const permissionApi = makePermissionApi(async req => {
+        authorizeRequests.push(req);
+        return { result: 'ALLOW' };
+      });
+
+      const loader = createPredicateContextLoader({
+        apis: makeApiHolder(makeFeatureFlagsApi(), permissionApi),
+        predicateReferences: {
+          featureFlags: [],
+          permissions: ['catalog.entity.read#read'],
+        },
+      });
+
+      await loader.load();
+
+      expect(authorizeRequests).toHaveLength(1);
+      expect(authorizeRequests[0].permission).toEqual({
+        name: 'catalog.entity.read',
+        type: 'basic',
+        attributes: { action: 'read' },
+      });
+    });
+
+    it('passes empty attributes for plain permission names without action', async () => {
+      const authorizeRequests: EvaluatePermissionRequest[] = [];
+      const permissionApi = makePermissionApi(async req => {
+        authorizeRequests.push(req);
+        return { result: 'ALLOW' };
+      });
+
+      const loader = createPredicateContextLoader({
+        apis: makeApiHolder(makeFeatureFlagsApi(), permissionApi),
+        predicateReferences: {
+          featureFlags: [],
+          permissions: ['catalog.entity.read'],
+        },
+      });
+
+      await loader.load();
+
+      expect(authorizeRequests[0].permission).toEqual({
+        name: 'catalog.entity.read',
+        type: 'basic',
+        attributes: {},
+      });
+    });
+
+    it('returns the permission#action name in the allowed set (not the split name)', async () => {
+      const loader = createPredicateContextLoader({
+        apis: makeApiHolder(
+          makeFeatureFlagsApi(),
+          makeAllowPermissionApi(['catalog.entity.read']),
+        ),
+        predicateReferences: {
+          featureFlags: [],
+          permissions: ['catalog.entity.read#read'],
+        },
+      });
+
+      const result = await loader.load();
+      expect(result.permissions).toEqual(['catalog.entity.read#read']);
+    });
+
+    it('throws a ForwardedError when the permission API rejects', async () => {
+      const permissionApi = makePermissionApi(async () => {
+        throw new Error('connection refused');
+      });
+
+      const loader = createPredicateContextLoader({
+        apis: makeApiHolder(makeFeatureFlagsApi(), permissionApi),
+        predicateReferences: {
+          featureFlags: [],
+          permissions: ['any.permission'],
+        },
+      });
+
+      await expect(loader.load()).rejects.toThrow(
+        'Failed to authorize extension permissions',
+      );
+    });
+
+    it('throws on invalid permission names with more than one # separator', async () => {
+      const loader = createPredicateContextLoader({
+        apis: makeApiHolder(makeFeatureFlagsApi(), makeAllowPermissionApi([])),
+        predicateReferences: {
+          featureFlags: [],
+          permissions: ['catalog.entity.read#read#extra'],
+        },
+      });
+
+      await expect(loader.load()).rejects.toThrow(
+        'Invalid permission name: catalog.entity.read#read#extra',
+      );
+    });
+
+    it('returns empty permissions when no permission API is registered', async () => {
+      const loader = createPredicateContextLoader({
+        apis: makeApiHolder(makeFeatureFlagsApi(['active'])),
+        predicateReferences: {
+          featureFlags: ['active'],
+          permissions: ['some.permission'],
+        },
+      });
+
+      await expect(loader.load()).resolves.toEqual({
+        featureFlags: ['active'],
+        permissions: [],
+      });
+    });
+  });
+});

--- a/packages/frontend-app-api/src/wiring/predicates.ts
+++ b/packages/frontend-app-api/src/wiring/predicates.ts
@@ -43,6 +43,26 @@ type MinimalPermissionApi = {
   ): Promise<EvaluatePermissionResponse>;
 };
 
+function parsePermissionName(permissionName: string) {
+  const parts = permissionName.split('#');
+  if (parts.length > 2) {
+    throw new Error(
+      `Invalid permission name: ${permissionName}. Permission names must be in the format "permissionName" or "permissionName#action".`,
+    );
+  }
+  if (parts.length === 1) {
+    return {
+      name: parts[0],
+    };
+  }
+  return {
+    name: parts[0],
+    attributes: {
+      action: parts[1],
+    },
+  };
+}
+
 export const localPermissionApiRef = createApiRef<MinimalPermissionApi>({
   id: 'plugin.permission.api',
 });
@@ -87,10 +107,20 @@ export function createPredicateContextLoader(options: {
     if (permissionApi) {
       try {
         const permissionNames = options.predicateReferences.permissions;
+        const hydratedPermissions = permissionNames.map(name => {
+          const { name: permissionName, attributes } =
+            parsePermissionName(name);
+          const permission = {
+            name: permissionName,
+            type: 'basic',
+            attributes: attributes || {},
+          } as const;
+          return permission;
+        });
         const responses = await Promise.all(
-          permissionNames.map(name =>
+          hydratedPermissions.map(permission =>
             permissionApi.authorize({
-              permission: { name, type: 'basic', attributes: {} },
+              permission,
             }),
           ),
         );

--- a/packages/frontend-app-api/src/wiring/predicates.ts
+++ b/packages/frontend-app-api/src/wiring/predicates.ts
@@ -45,20 +45,22 @@ type MinimalPermissionApi = {
 
 function parsePermissionName(permissionName: string) {
   const parts = permissionName.split('#');
-  if (parts.length > 2) {
+  const [name, action, ...rest] = parts;
+
+  if (rest.length > 0 || !name || (parts.length === 2 && !action)) {
     throw new Error(
-      `Invalid permission name: ${permissionName}. Permission names must be in the format "permissionName" or "permissionName#action".`,
+      `Invalid permission name: ${permissionName}. Permission names must be in the format "permissionName" or "permissionName#action" (both parts must be non-empty).`,
     );
   }
-  if (parts.length === 1) {
-    return {
-      name: parts[0],
-    };
+
+  if (action === undefined) {
+    return { name };
   }
+
   return {
-    name: parts[0],
+    name,
     attributes: {
-      action: parts[1],
+      action,
     },
   };
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes https://github.com/backstage/backstage/issues/33912 and supersedes https://github.com/backstage/backstage/pull/34079.

Allow users to supply the `attribute.action` parameter for a permission. From a quick survey of usage, that's the only property that is heavily used today. There was some conversation when designing this if the right long term solution is #34079, but due to complexity with how to delegate permissions to the requisite plugins and how basic permissions are handled today, this is a much easier path.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
