### PR TITLE
TextAreaField component added, plus storybook and documentation update

### DIFF
--- a/.changeset/text-area-field.md
+++ b/.changeset/text-area-field.md
@@ -2,4 +2,4 @@
 '@backstage/ui': patch
 ---
 
-Added a new `TextAreaField` component for multi-line text input, following the same conventions as `TextField` with support for a label, secondary label, and description. It also accepts an optional `autoResize` prop to grow the field with its content instead of scrolling within a fixed height.
+Added a new `TextAreaField` component for multi-line text input, following the same conventions as `TextField` with support for a label, secondary label, and description.

--- a/.changeset/text-area-field.md
+++ b/.changeset/text-area-field.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Added a new `TextAreaField` component for multi-line text input, following the same conventions as `TextField` with support for a label, secondary label, and description. It also accepts an optional `autoResize` prop to grow the field with its content instead of scrolling within a fixed height.

--- a/docs-ui/src/app/components/text-area-field/components.tsx
+++ b/docs-ui/src/app/components/text-area-field/components.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { TextAreaField } from '../../../../../packages/ui/src/components/TextAreaField/TextAreaField';
+import { Flex } from '../../../../../packages/ui/src/components/Flex/Flex';
+
+export const WithLabel = () => {
+  return (
+    <TextAreaField
+      name="message"
+      placeholder="Enter a message"
+      label="Message"
+      style={{ maxWidth: '300px' }}
+    />
+  );
+};
+
+export const Sizes = () => {
+  return (
+    <Flex
+      direction="column"
+      gap="4"
+      style={{ width: '100%', maxWidth: '300px' }}
+    >
+      <TextAreaField
+        name="message"
+        placeholder="Enter a message"
+        label="Small"
+        size="small"
+      />
+      <TextAreaField
+        name="message"
+        placeholder="Enter a message"
+        label="Medium"
+        size="medium"
+      />
+    </Flex>
+  );
+};
+
+export const WithDescription = () => {
+  return (
+    <TextAreaField
+      name="message"
+      placeholder="Enter a message"
+      label="Message"
+      description="Share as much detail as you like."
+      style={{ maxWidth: '300px' }}
+    />
+  );
+};
+
+export const AutoResize = () => {
+  return (
+    <TextAreaField
+      name="message"
+      label="Message"
+      autoResize
+      placeholder="This field grows as you type"
+      style={{ maxWidth: '300px' }}
+    />
+  );
+};

--- a/docs-ui/src/app/components/text-area-field/components.tsx
+++ b/docs-ui/src/app/components/text-area-field/components.tsx
@@ -48,15 +48,3 @@ export const WithDescription = () => {
     />
   );
 };
-
-export const AutoResize = () => {
-  return (
-    <TextAreaField
-      name="message"
-      label="Message"
-      autoResize
-      placeholder="This field grows as you type"
-      style={{ maxWidth: '300px' }}
-    />
-  );
-};

--- a/docs-ui/src/app/components/text-area-field/page.mdx
+++ b/docs-ui/src/app/components/text-area-field/page.mdx
@@ -1,0 +1,82 @@
+import { PropsTable } from '@/components/PropsTable';
+import { Snippet } from '@/components/Snippet';
+import { textAreaFieldPropDefs } from './props-definition';
+import {
+  textAreaFieldUsageSnippet,
+  withLabelSnippet,
+  sizesSnippet,
+  withDescriptionSnippet,
+  autoResizeSnippet,
+} from './snippets';
+import { WithLabel, Sizes, WithDescription, AutoResize } from './components';
+import { PageTitle } from '@/components/PageTitle';
+import { Theming } from '@/components/Theming';
+import { TextAreaFieldDefinition } from '../../../utils/definitions';
+import { ChangelogComponent } from '@/components/ChangelogComponent';
+import { CodeBlock } from '@/components/CodeBlock';
+import { ReactAriaLink } from '@/components/ReactAriaLink';
+
+export const reactAriaUrls = {
+  textField: 'https://react-aria.adobe.com/TextField',
+};
+
+<PageTitle
+  title="TextAreaField"
+  description="A multi-line text input with label, description, validation, and optional auto-resizing."
+/>
+
+<Snippet
+  align="center"
+  py={4}
+  preview={<WithLabel />}
+  code={withLabelSnippet}
+/>
+
+## Usage
+
+<CodeBlock code={textAreaFieldUsageSnippet} />
+
+## API reference
+
+<PropsTable data={textAreaFieldPropDefs} />
+
+<ReactAriaLink component="TextField" href={reactAriaUrls.textField} />
+
+## Examples
+
+### Sizes
+
+<Snippet
+  align="center"
+  py={4}
+  open
+  preview={<Sizes />}
+  code={sizesSnippet}
+  layout="side-by-side"
+/>
+
+### With description
+
+<Snippet
+  align="center"
+  py={4}
+  open
+  preview={<WithDescription />}
+  code={withDescriptionSnippet}
+  layout="side-by-side"
+/>
+
+### Auto resize
+
+<Snippet
+  align="center"
+  py={4}
+  open
+  preview={<AutoResize />}
+  code={autoResizeSnippet}
+  layout="side-by-side"
+/>
+
+<Theming definition={TextAreaFieldDefinition} />
+
+<ChangelogComponent component="text-area-field" />

--- a/docs-ui/src/app/components/text-area-field/page.mdx
+++ b/docs-ui/src/app/components/text-area-field/page.mdx
@@ -6,9 +6,8 @@ import {
   withLabelSnippet,
   sizesSnippet,
   withDescriptionSnippet,
-  autoResizeSnippet,
 } from './snippets';
-import { WithLabel, Sizes, WithDescription, AutoResize } from './components';
+import { WithLabel, Sizes, WithDescription } from './components';
 import { PageTitle } from '@/components/PageTitle';
 import { Theming } from '@/components/Theming';
 import { TextAreaFieldDefinition } from '../../../utils/definitions';
@@ -22,7 +21,7 @@ export const reactAriaUrls = {
 
 <PageTitle
   title="TextAreaField"
-  description="A multi-line text input with label, description, validation, and optional auto-resizing."
+  description="A multi-line text input with label, description, and validation."
 />
 
 <Snippet
@@ -63,17 +62,6 @@ export const reactAriaUrls = {
   open
   preview={<WithDescription />}
   code={withDescriptionSnippet}
-  layout="side-by-side"
-/>
-
-### Auto resize
-
-<Snippet
-  align="center"
-  py={4}
-  open
-  preview={<AutoResize />}
-  code={autoResizeSnippet}
   layout="side-by-side"
 />
 

--- a/docs-ui/src/app/components/text-area-field/props-definition.tsx
+++ b/docs-ui/src/app/components/text-area-field/props-definition.tsx
@@ -41,16 +41,6 @@ export const textAreaFieldPropDefs: Record<string, PropDef> = {
     description:
       'Number of visible text lines, controlling the initial and minimum height.',
   },
-  autoResize: {
-    type: 'boolean',
-    default: 'false',
-    description: (
-      <>
-        Grow the text area with its content instead of scrolling. When{' '}
-        <Chip>false</Chip>, the text area keeps a fixed height and scrolls.
-      </>
-    ),
-  },
   placeholder: {
     type: 'string',
     description: 'Text displayed when the text area is empty.',

--- a/docs-ui/src/app/components/text-area-field/props-definition.tsx
+++ b/docs-ui/src/app/components/text-area-field/props-definition.tsx
@@ -1,0 +1,89 @@
+import {
+  classNamePropDefs,
+  stylePropDefs,
+  type PropDef,
+} from '@/utils/propDefs';
+import { Chip } from '@/components/Chip';
+
+export const textAreaFieldPropDefs: Record<string, PropDef> = {
+  label: {
+    type: 'string',
+    description: 'Visible label displayed above the text area.',
+  },
+  secondaryLabel: {
+    type: 'string',
+    description: (
+      <>
+        Secondary text shown next to the label. If not provided and isRequired
+        is true, displays <Chip>Required</Chip>.
+      </>
+    ),
+  },
+  description: {
+    type: 'string',
+    description: 'Help text displayed below the label.',
+  },
+  size: {
+    type: 'enum',
+    values: ['small', 'medium'],
+    default: 'small',
+    responsive: true,
+    description: (
+      <>
+        Visual size of the text area. Use <Chip>small</Chip> for dense layouts,{' '}
+        <Chip>medium</Chip> for prominent fields.
+      </>
+    ),
+  },
+  rows: {
+    type: 'number',
+    default: '3',
+    description:
+      'Number of visible text lines, controlling the initial and minimum height.',
+  },
+  autoResize: {
+    type: 'boolean',
+    default: 'false',
+    description: (
+      <>
+        Grow the text area with its content instead of scrolling. When{' '}
+        <Chip>false</Chip>, the text area keeps a fixed height and scrolls.
+      </>
+    ),
+  },
+  placeholder: {
+    type: 'string',
+    description: 'Text displayed when the text area is empty.',
+  },
+  name: {
+    type: 'string',
+    description: 'Form field name for submission.',
+  },
+  isRequired: {
+    type: 'boolean',
+    description: 'Whether the field is required for form submission.',
+  },
+  isDisabled: {
+    type: 'boolean',
+    description: 'Whether the text area is disabled.',
+  },
+  isReadOnly: {
+    type: 'boolean',
+    description: 'Whether the text area is read-only.',
+  },
+  value: {
+    type: 'string',
+    description: 'Controlled value of the text area.',
+  },
+  defaultValue: {
+    type: 'string',
+    description: 'Default value for uncontrolled usage.',
+  },
+  onChange: {
+    type: 'enum',
+    values: ['(value: string) => void'],
+    description: 'Handler called when the text area value changes.',
+  },
+  ...classNamePropDefs,
+  ...stylePropDefs,
+};

--- a/docs-ui/src/app/components/text-area-field/snippets.ts
+++ b/docs-ui/src/app/components/text-area-field/snippets.ts
@@ -19,10 +19,3 @@ export const withDescriptionSnippet = `<TextAreaField
   label="Message"
   description="Share as much detail as you like."
 />`;
-
-export const autoResizeSnippet = `<TextAreaField
-  name="message"
-  label="Message"
-  autoResize
-  placeholder="This field grows as you type"
-/>`;

--- a/docs-ui/src/app/components/text-area-field/snippets.ts
+++ b/docs-ui/src/app/components/text-area-field/snippets.ts
@@ -1,0 +1,28 @@
+export const textAreaFieldUsageSnippet = `import { TextAreaField } from '@backstage/ui';
+
+<TextAreaField label="Message" />`;
+
+export const withLabelSnippet = `<TextAreaField
+  name="message"
+  placeholder="Enter a message"
+  label="Message"
+/>`;
+
+export const sizesSnippet = `<Flex direction="column" gap="4">
+  <TextAreaField size="small" label="Small" placeholder="Enter a message" />
+  <TextAreaField size="medium" label="Medium" placeholder="Enter a message" />
+</Flex>`;
+
+export const withDescriptionSnippet = `<TextAreaField
+  name="message"
+  placeholder="Enter a message"
+  label="Message"
+  description="Share as much detail as you like."
+/>`;
+
+export const autoResizeSnippet = `<TextAreaField
+  name="message"
+  label="Message"
+  autoResize
+  placeholder="This field grows as you type"
+/>`;

--- a/docs-ui/src/utils/data.ts
+++ b/docs-ui/src/utils/data.ts
@@ -155,6 +155,11 @@ export const components: Page[] = [
     slug: 'text',
   },
   {
+    title: 'TextAreaField',
+    slug: 'text-area-field',
+    status: 'new',
+  },
+  {
     title: 'TextField',
     slug: 'text-field',
   },

--- a/packages/ui/report.api.md
+++ b/packages/ui/report.api.md
@@ -4361,6 +4361,55 @@ export const TextDefinition: {
 };
 
 // @public
+export const TextAreaField: ForwardRefExoticComponent<
+  TextAreaFieldProps & RefAttributes<HTMLDivElement>
+>;
+
+// @public
+export const TextAreaFieldDefinition: {
+  readonly styles: {
+    readonly [key: string]: string;
+  };
+  readonly classNames: {
+    readonly root: 'bui-TextAreaField';
+    readonly textArea: 'bui-TextArea';
+  };
+  readonly bg: 'consumer';
+  readonly propDefs: {
+    readonly size: {
+      readonly dataAttribute: true;
+      readonly default: 'small';
+    };
+    readonly autoResize: {
+      readonly dataAttribute: true;
+    };
+    readonly className: {};
+    readonly placeholder: {};
+    readonly rows: {};
+    readonly label: {};
+    readonly description: {};
+    readonly secondaryLabel: {};
+  };
+};
+
+// @public (undocumented)
+export type TextAreaFieldOwnProps = {
+  size?: 'small' | 'medium' | Partial<Record<Breakpoint, 'small' | 'medium'>>;
+  className?: string;
+  placeholder?: string;
+  rows?: number;
+  autoResize?: boolean;
+  label?: FieldLabelProps['label'];
+  description?: FieldLabelProps['description'];
+  secondaryLabel?: FieldLabelProps['secondaryLabel'];
+};
+
+// @public (undocumented)
+export interface TextAreaFieldProps
+  extends Omit<TextFieldProps_2, 'className' | 'description'>,
+    TextAreaFieldOwnProps {}
+
+// @public
 export const TextField: ForwardRefExoticComponent<
   TextFieldProps & RefAttributes<HTMLDivElement>
 >;

--- a/packages/ui/report.api.md
+++ b/packages/ui/report.api.md
@@ -4323,43 +4323,6 @@ const Text_2: {
 };
 export { Text_2 as Text };
 
-// @public (undocumented)
-export type TextColors = 'primary' | 'secondary';
-
-// @public (undocumented)
-export type TextColorStatus = 'danger' | 'warning' | 'success' | 'info';
-
-// @public
-export const TextDefinition: {
-  readonly styles: {
-    readonly [key: string]: string;
-  };
-  readonly classNames: {
-    readonly root: 'bui-Text';
-  };
-  readonly propDefs: {
-    readonly as: {
-      readonly default: 'span';
-    };
-    readonly variant: {
-      readonly dataAttribute: true;
-      readonly default: 'body-medium';
-    };
-    readonly weight: {
-      readonly dataAttribute: true;
-      readonly default: 'regular';
-    };
-    readonly color: {
-      readonly dataAttribute: true;
-      readonly default: 'primary';
-    };
-    readonly truncate: {
-      readonly dataAttribute: true;
-    };
-    readonly className: {};
-  };
-};
-
 // @public
 export const TextAreaField: ForwardRefExoticComponent<
   TextAreaFieldProps & RefAttributes<HTMLDivElement>
@@ -4410,6 +4373,43 @@ export type TextAreaFieldOwnProps = {
 export interface TextAreaFieldProps
   extends Omit<TextFieldProps_2, 'className' | 'description'>,
     TextAreaFieldOwnProps {}
+
+// @public (undocumented)
+export type TextColors = 'primary' | 'secondary';
+
+// @public (undocumented)
+export type TextColorStatus = 'danger' | 'warning' | 'success' | 'info';
+
+// @public
+export const TextDefinition: {
+  readonly styles: {
+    readonly [key: string]: string;
+  };
+  readonly classNames: {
+    readonly root: 'bui-Text';
+  };
+  readonly propDefs: {
+    readonly as: {
+      readonly default: 'span';
+    };
+    readonly variant: {
+      readonly dataAttribute: true;
+      readonly default: 'body-medium';
+    };
+    readonly weight: {
+      readonly dataAttribute: true;
+      readonly default: 'regular';
+    };
+    readonly color: {
+      readonly dataAttribute: true;
+      readonly default: 'primary';
+    };
+    readonly truncate: {
+      readonly dataAttribute: true;
+    };
+    readonly className: {};
+  };
+};
 
 // @public
 export const TextField: ForwardRefExoticComponent<

--- a/packages/ui/report.api.md
+++ b/packages/ui/report.api.md
@@ -4385,7 +4385,9 @@ export const TextAreaFieldDefinition: {
     };
     readonly className: {};
     readonly placeholder: {};
-    readonly rows: {};
+    readonly rows: {
+      readonly default: 3;
+    };
     readonly label: {};
     readonly description: {};
     readonly secondaryLabel: {};

--- a/packages/ui/report.api.md
+++ b/packages/ui/report.api.md
@@ -4343,9 +4343,6 @@ export const TextAreaFieldDefinition: {
       readonly dataAttribute: true;
       readonly default: 'small';
     };
-    readonly autoResize: {
-      readonly dataAttribute: true;
-    };
     readonly className: {};
     readonly placeholder: {};
     readonly rows: {
@@ -4363,7 +4360,6 @@ export type TextAreaFieldOwnProps = {
   className?: string;
   placeholder?: string;
   rows?: number;
-  autoResize?: boolean;
   label?: FieldLabelProps['label'];
   description?: FieldLabelProps['description'];
   secondaryLabel?: FieldLabelProps['secondaryLabel'];

--- a/packages/ui/src/components/TextAreaField/TextAreaField.module.css
+++ b/packages/ui/src/components/TextAreaField/TextAreaField.module.css
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@layer tokens, base, components, utilities;
+
+@layer components {
+  .bui-TextAreaField {
+    display: flex;
+    flex-direction: column;
+    font-family: var(--bui-font-regular);
+    width: 100%;
+    flex: 1;
+
+    &[data-on-bg='neutral-1'] .bui-TextArea {
+      background-color: var(--bui-bg-neutral-2);
+    }
+
+    &[data-on-bg='neutral-2'] .bui-TextArea {
+      background-color: var(--bui-bg-neutral-3);
+    }
+
+    &[data-on-bg='neutral-3'] .bui-TextArea {
+      background-color: var(--bui-bg-neutral-4);
+    }
+
+    &[data-autoresize='true'] .bui-TextArea {
+      field-sizing: content;
+      overflow: hidden;
+    }
+  }
+
+  .bui-TextArea {
+    display: block;
+    padding: var(--bui-space-2) var(--bui-space-3);
+    border-radius: var(--bui-radius-2);
+    border: none;
+    background-color: var(--bui-bg-neutral-1);
+    font-size: var(--bui-font-size-3);
+    font-family: var(--bui-font-regular);
+    font-weight: var(--bui-font-weight-regular);
+    line-height: 1.5;
+    color: var(--bui-fg-primary);
+    transition: box-shadow 0.2s ease-in-out;
+    width: 100%;
+    resize: none;
+    overflow-y: auto;
+
+    &[data-focused] {
+      outline: none;
+      box-shadow: inset 0 0 0 1px var(--bui-ring);
+    }
+
+    &::placeholder {
+      color: var(--bui-fg-secondary);
+    }
+
+    &[data-invalid] {
+      box-shadow: inset 0 0 0 1px var(--bui-border-danger);
+    }
+
+    &[data-disabled] {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    &[data-size='small'] {
+      font-size: var(--bui-font-size-3);
+      padding: var(--bui-space-1_5) var(--bui-space-3);
+    }
+
+    &[data-size='medium'] {
+      font-size: var(--bui-font-size-4);
+      padding: var(--bui-space-2) var(--bui-space-3);
+    }
+  }
+}

--- a/packages/ui/src/components/TextAreaField/TextAreaField.module.css
+++ b/packages/ui/src/components/TextAreaField/TextAreaField.module.css
@@ -23,23 +23,6 @@
     font-family: var(--bui-font-regular);
     width: 100%;
     flex: 1;
-
-    &[data-on-bg='neutral-1'] .bui-TextArea {
-      background-color: var(--bui-bg-neutral-2);
-    }
-
-    &[data-on-bg='neutral-2'] .bui-TextArea {
-      background-color: var(--bui-bg-neutral-3);
-    }
-
-    &[data-on-bg='neutral-3'] .bui-TextArea {
-      background-color: var(--bui-bg-neutral-4);
-    }
-
-    &[data-autoresize='true'] .bui-TextArea {
-      field-sizing: content;
-      overflow: hidden;
-    }
   }
 
   .bui-TextArea {
@@ -51,12 +34,25 @@
     font-size: var(--bui-font-size-3);
     font-family: var(--bui-font-regular);
     font-weight: var(--bui-font-weight-regular);
-    line-height: 1.5;
+    line-height: 140%;
     color: var(--bui-fg-primary);
     transition: box-shadow 0.2s ease-in-out;
     width: 100%;
-    resize: none;
+    /* Keep the manual resize handle for fields that don't auto-resize. */
+    resize: vertical;
     overflow-y: auto;
+
+    .bui-TextAreaField[data-on-bg='neutral-1'] & {
+      background-color: var(--bui-bg-neutral-2);
+    }
+
+    .bui-TextAreaField[data-on-bg='neutral-2'] & {
+      background-color: var(--bui-bg-neutral-3);
+    }
+
+    .bui-TextAreaField[data-on-bg='neutral-3'] & {
+      background-color: var(--bui-bg-neutral-4);
+    }
 
     &[data-focused] {
       outline: none;
@@ -77,13 +73,24 @@
     }
 
     &[data-size='small'] {
-      font-size: var(--bui-font-size-3);
       padding: var(--bui-space-1_5) var(--bui-space-3);
     }
 
     &[data-size='medium'] {
-      font-size: var(--bui-font-size-4);
       padding: var(--bui-space-2) var(--bui-space-3);
+    }
+  }
+
+  /*
+   * When auto-resizing is enabled, grow the field with its content using
+   * field-sizing. This is gated behind @supports so browsers without it
+   * (e.g. Firefox) fall back to the default scrolling and manual resize.
+   */
+  @supports (field-sizing: content) {
+    .bui-TextAreaField[data-autoresize='true'] .bui-TextArea {
+      field-sizing: content;
+      resize: none;
+      overflow: hidden;
     }
   }
 }

--- a/packages/ui/src/components/TextAreaField/TextAreaField.module.css
+++ b/packages/ui/src/components/TextAreaField/TextAreaField.module.css
@@ -38,7 +38,7 @@
     color: var(--bui-fg-primary);
     transition: box-shadow 0.2s ease-in-out;
     width: 100%;
-    /* Keep the manual resize handle for fields that don't auto-resize. */
+    /* Keep the manual resize handle so users can expand the field. */
     resize: vertical;
     overflow-y: auto;
 
@@ -78,19 +78,6 @@
 
     &[data-size='medium'] {
       padding: var(--bui-space-2) var(--bui-space-3);
-    }
-  }
-
-  /*
-   * When auto-resizing is enabled, grow the field with its content using
-   * field-sizing. This is gated behind @supports so browsers without it
-   * (e.g. Firefox) fall back to the default scrolling and manual resize.
-   */
-  @supports (field-sizing: content) {
-    .bui-TextAreaField[data-autoresize='true'] .bui-TextArea {
-      field-sizing: content;
-      resize: none;
-      overflow: hidden;
     }
   }
 }

--- a/packages/ui/src/components/TextAreaField/TextAreaField.stories.tsx
+++ b/packages/ui/src/components/TextAreaField/TextAreaField.stories.tsx
@@ -25,9 +25,6 @@ const meta = preview.meta({
     isRequired: {
       control: 'boolean',
     },
-    autoResize: {
-      control: 'boolean',
-    },
   },
 });
 
@@ -88,17 +85,6 @@ export const Scrolling = meta.story({
     defaultValue: Array.from(
       { length: 12 },
       (_, i) => `Line ${i + 1}: this content scrolls within a fixed height.`,
-    ).join('\n'),
-  },
-});
-
-export const AutoResize = meta.story({
-  args: {
-    ...WithLabel.input.args,
-    autoResize: true,
-    defaultValue: Array.from(
-      { length: 6 },
-      (_, i) => `Line ${i + 1}: this text area grows with its content.`,
     ).join('\n'),
   },
 });

--- a/packages/ui/src/components/TextAreaField/TextAreaField.stories.tsx
+++ b/packages/ui/src/components/TextAreaField/TextAreaField.stories.tsx
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import preview from '../../../../../.storybook/preview';
+import { TextAreaField } from './TextAreaField';
+import { Form } from 'react-aria-components';
+import { Flex } from '../Flex';
+
+const meta = preview.meta({
+  title: 'Backstage UI/TextAreaField',
+  component: TextAreaField,
+  argTypes: {
+    isRequired: {
+      control: 'boolean',
+    },
+    autoResize: {
+      control: 'boolean',
+    },
+  },
+});
+
+export const Default = meta.story({
+  args: {
+    name: 'message',
+    placeholder: 'Enter a message',
+    style: {
+      maxWidth: '300px',
+    },
+  },
+});
+
+export const WithLabel = meta.story({
+  args: {
+    ...Default.input.args,
+    label: 'Message',
+  },
+});
+
+export const WithDescription = meta.story({
+  args: {
+    ...WithLabel.input.args,
+    description: 'Share as much detail as you like.',
+  },
+});
+
+export const Required = meta.story({
+  args: {
+    ...WithLabel.input.args,
+    isRequired: true,
+  },
+});
+
+export const Disabled = meta.story({
+  args: {
+    ...Default.input.args,
+    isDisabled: true,
+  },
+});
+
+export const Sizes = meta.story({
+  args: {
+    ...Default.input.args,
+  },
+  render: args => (
+    <Flex direction="column" gap="4" style={{ maxWidth: '300px' }}>
+      <TextAreaField {...args} size="small" label="Small" />
+      <TextAreaField {...args} size="medium" label="Medium" />
+    </Flex>
+  ),
+});
+
+export const Scrolling = meta.story({
+  args: {
+    ...WithLabel.input.args,
+    rows: 3,
+    defaultValue: Array.from(
+      { length: 12 },
+      (_, i) => `Line ${i + 1}: this content scrolls within a fixed height.`,
+    ).join('\n'),
+  },
+});
+
+export const AutoResize = meta.story({
+  args: {
+    ...WithLabel.input.args,
+    autoResize: true,
+    defaultValue: Array.from(
+      { length: 6 },
+      (_, i) => `Line ${i + 1}: this text area grows with its content.`,
+    ).join('\n'),
+  },
+});
+
+export const ShowError = meta.story({
+  args: {
+    ...WithLabel.input.args,
+  },
+  render: args => (
+    <Form validationErrors={{ message: 'Message is required' }}>
+      <TextAreaField {...args} />
+    </Form>
+  ),
+});

--- a/packages/ui/src/components/TextAreaField/TextAreaField.test.tsx
+++ b/packages/ui/src/components/TextAreaField/TextAreaField.test.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { type PropsWithChildren } from 'react';
+import { render, screen } from '@testing-library/react';
+import { TextAreaField } from './TextAreaField';
+import { BUIProvider } from '../../provider';
+
+function Wrapper({ children }: PropsWithChildren) {
+  return <BUIProvider>{children}</BUIProvider>;
+}
+
+describe('TextAreaField', () => {
+  it('renders the label, secondary label, and description and wires up accessibility', () => {
+    render(
+      <TextAreaField
+        label="Message"
+        secondaryLabel="Optional"
+        description="Share as much detail as you like."
+        rows={5}
+      />,
+      { wrapper: Wrapper },
+    );
+
+    expect(screen.getByText('Message')).toBeInTheDocument();
+    expect(screen.getByText('(Optional)')).toBeInTheDocument();
+
+    const textArea = screen.getByRole('textbox');
+    expect(textArea.tagName).toBe('TEXTAREA');
+    expect(textArea).toHaveAttribute('rows', '5');
+    expect(textArea).toHaveAccessibleName('Message');
+    expect(textArea).toHaveAccessibleDescription(
+      'Share as much detail as you like.',
+    );
+  });
+
+  it('falls back to the Required secondary label when required without an explicit one', () => {
+    render(<TextAreaField label="Message" isRequired />, { wrapper: Wrapper });
+
+    expect(screen.getByText('(Required)')).toBeInTheDocument();
+  });
+
+  it('opts into content-based sizing when autoResize is enabled', () => {
+    render(<TextAreaField label="Message" autoResize defaultValue="hello" />, {
+      wrapper: Wrapper,
+    });
+
+    const textArea = screen.getByRole('textbox');
+    expect(textArea.closest('[data-autoresize="true"]')).not.toBeNull();
+  });
+
+  it('keeps a fixed height for scrolling when autoResize is disabled', () => {
+    render(<TextAreaField label="Message" defaultValue="hello" />, {
+      wrapper: Wrapper,
+    });
+
+    const textArea = screen.getByRole('textbox');
+    expect(textArea.closest('[data-autoresize="true"]')).toBeNull();
+  });
+});

--- a/packages/ui/src/components/TextAreaField/TextAreaField.test.tsx
+++ b/packages/ui/src/components/TextAreaField/TextAreaField.test.tsx
@@ -52,22 +52,4 @@ describe('TextAreaField', () => {
 
     expect(screen.getByText('(Required)')).toBeInTheDocument();
   });
-
-  it('opts into content-based sizing when autoResize is enabled', () => {
-    render(<TextAreaField label="Message" autoResize defaultValue="hello" />, {
-      wrapper: Wrapper,
-    });
-
-    const textArea = screen.getByRole('textbox');
-    expect(textArea.closest('[data-autoresize="true"]')).not.toBeNull();
-  });
-
-  it('keeps a fixed height for scrolling when autoResize is disabled', () => {
-    render(<TextAreaField label="Message" defaultValue="hello" />, {
-      wrapper: Wrapper,
-    });
-
-    const textArea = screen.getByRole('textbox');
-    expect(textArea.closest('[data-autoresize="true"]')).toBeNull();
-  });
 });

--- a/packages/ui/src/components/TextAreaField/TextAreaField.tsx
+++ b/packages/ui/src/components/TextAreaField/TextAreaField.tsx
@@ -33,14 +33,8 @@ export const TextAreaField = forwardRef<HTMLDivElement, TextAreaFieldProps>(
       TextAreaFieldDefinition,
       props,
     );
-    const {
-      classes,
-      label,
-      secondaryLabel,
-      placeholder,
-      description,
-      rows = 3,
-    } = ownProps;
+    const { classes, label, secondaryLabel, placeholder, description, rows } =
+      ownProps;
 
     useEffect(() => {
       if (!label && !restProps['aria-label'] && !restProps['aria-labelledby']) {

--- a/packages/ui/src/components/TextAreaField/TextAreaField.tsx
+++ b/packages/ui/src/components/TextAreaField/TextAreaField.tsx
@@ -23,7 +23,7 @@ import { useDefinition } from '../../hooks/useDefinition';
 import { TextAreaFieldDefinition } from './definition';
 
 /**
- * A multi-line text input with an integrated label, optional auto-resizing, and inline error display.
+ * A multi-line text input with an integrated label and inline error display.
  *
  * @public
  */

--- a/packages/ui/src/components/TextAreaField/TextAreaField.tsx
+++ b/packages/ui/src/components/TextAreaField/TextAreaField.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { forwardRef, useEffect } from 'react';
+import { TextArea, TextField as AriaTextField } from 'react-aria-components';
+import { FieldLabel } from '../FieldLabel';
+import { FieldError } from '../FieldError';
+import type { TextAreaFieldProps } from './types';
+import { useDefinition } from '../../hooks/useDefinition';
+import { TextAreaFieldDefinition } from './definition';
+
+/**
+ * A multi-line text input with an integrated label, optional auto-resizing, and inline error display.
+ *
+ * @public
+ */
+export const TextAreaField = forwardRef<HTMLDivElement, TextAreaFieldProps>(
+  (props, ref) => {
+    const { ownProps, restProps, dataAttributes } = useDefinition(
+      TextAreaFieldDefinition,
+      props,
+    );
+    const {
+      classes,
+      label,
+      secondaryLabel,
+      placeholder,
+      description,
+      rows = 3,
+    } = ownProps;
+
+    useEffect(() => {
+      if (!label && !restProps['aria-label'] && !restProps['aria-labelledby']) {
+        console.warn(
+          'TextAreaField requires either a visible label, aria-label, or aria-labelledby for accessibility',
+        );
+      }
+    }, [label, restProps['aria-label'], restProps['aria-labelledby']]);
+
+    // If a secondary label is provided, use it. Otherwise, use 'Required' if the field is required.
+    const secondaryLabelText =
+      secondaryLabel || (restProps.isRequired ? 'Required' : null);
+
+    return (
+      <AriaTextField
+        className={classes.root}
+        {...dataAttributes}
+        {...restProps}
+        ref={ref}
+      >
+        <FieldLabel
+          label={label}
+          secondaryLabel={secondaryLabelText}
+          description={description}
+          descriptionSlot="description"
+        />
+        <TextArea
+          className={classes.textArea}
+          data-size={dataAttributes['data-size']}
+          placeholder={placeholder}
+          rows={rows}
+        />
+        <FieldError />
+      </AriaTextField>
+    );
+  },
+);
+
+TextAreaField.displayName = 'TextAreaField';

--- a/packages/ui/src/components/TextAreaField/definition.ts
+++ b/packages/ui/src/components/TextAreaField/definition.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { defineComponent } from '../../hooks/useDefinition';
+import type { TextAreaFieldOwnProps } from './types';
+import styles from './TextAreaField.module.css';
+
+/**
+ * Component definition for TextAreaField
+ * @public
+ */
+export const TextAreaFieldDefinition = defineComponent<TextAreaFieldOwnProps>()(
+  {
+    styles,
+    classNames: {
+      root: 'bui-TextAreaField',
+      textArea: 'bui-TextArea',
+    },
+    bg: 'consumer',
+    propDefs: {
+      size: { dataAttribute: true, default: 'small' },
+      autoResize: { dataAttribute: true },
+      className: {},
+      placeholder: {},
+      rows: {},
+      label: {},
+      description: {},
+      secondaryLabel: {},
+    },
+  },
+);

--- a/packages/ui/src/components/TextAreaField/definition.ts
+++ b/packages/ui/src/components/TextAreaField/definition.ts
@@ -32,7 +32,6 @@ export const TextAreaFieldDefinition = defineComponent<TextAreaFieldOwnProps>()(
     bg: 'consumer',
     propDefs: {
       size: { dataAttribute: true, default: 'small' },
-      autoResize: { dataAttribute: true },
       className: {},
       placeholder: {},
       rows: { default: 3 },

--- a/packages/ui/src/components/TextAreaField/definition.ts
+++ b/packages/ui/src/components/TextAreaField/definition.ts
@@ -35,7 +35,7 @@ export const TextAreaFieldDefinition = defineComponent<TextAreaFieldOwnProps>()(
       autoResize: { dataAttribute: true },
       className: {},
       placeholder: {},
-      rows: {},
+      rows: { default: 3 },
       label: {},
       description: {},
       secondaryLabel: {},

--- a/packages/ui/src/components/TextAreaField/index.ts
+++ b/packages/ui/src/components/TextAreaField/index.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './TextAreaField';
+export * from './types';
+export { TextAreaFieldDefinition } from './definition';

--- a/packages/ui/src/components/TextAreaField/types.ts
+++ b/packages/ui/src/components/TextAreaField/types.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { TextFieldProps as AriaTextFieldProps } from 'react-aria-components';
+import type { Breakpoint } from '../../types';
+import type { FieldLabelProps } from '../FieldLabel/types';
+
+/** @public */
+export type TextAreaFieldOwnProps = {
+  /**
+   * The size of the text area field
+   * @defaultValue 'medium'
+   */
+  size?: 'small' | 'medium' | Partial<Record<Breakpoint, 'small' | 'medium'>>;
+
+  className?: string;
+
+  /**
+   * Text to display in the text area when it has no value
+   */
+  placeholder?: string;
+
+  /**
+   * The number of visible text lines, controlling the initial and minimum height
+   * @defaultValue 3
+   */
+  rows?: number;
+
+  /**
+   * Grow the text area with its content instead of scrolling
+   * @defaultValue false
+   */
+  autoResize?: boolean;
+
+  label?: FieldLabelProps['label'];
+  description?: FieldLabelProps['description'];
+  secondaryLabel?: FieldLabelProps['secondaryLabel'];
+};
+
+/** @public */
+export interface TextAreaFieldProps
+  extends Omit<AriaTextFieldProps, 'className' | 'description'>,
+    TextAreaFieldOwnProps {}

--- a/packages/ui/src/components/TextAreaField/types.ts
+++ b/packages/ui/src/components/TextAreaField/types.ts
@@ -22,7 +22,7 @@ import type { FieldLabelProps } from '../FieldLabel/types';
 export type TextAreaFieldOwnProps = {
   /**
    * The size of the text area field
-   * @defaultValue 'medium'
+   * @defaultValue 'small'
    */
   size?: 'small' | 'medium' | Partial<Record<Breakpoint, 'small' | 'medium'>>;
 

--- a/packages/ui/src/components/TextAreaField/types.ts
+++ b/packages/ui/src/components/TextAreaField/types.ts
@@ -39,12 +39,6 @@ export type TextAreaFieldOwnProps = {
    */
   rows?: number;
 
-  /**
-   * Grow the text area with its content instead of scrolling
-   * @defaultValue false
-   */
-  autoResize?: boolean;
-
   label?: FieldLabelProps['label'];
   description?: FieldLabelProps['description'];
   secondaryLabel?: FieldLabelProps['secondaryLabel'];

--- a/packages/ui/src/definitions.ts
+++ b/packages/ui/src/definitions.ts
@@ -93,5 +93,6 @@ export { TabsDefinition } from './components/Tabs/definition';
 export { TagGroupDefinition } from './components/TagGroup/definition';
 export { TextDefinition } from './components/Text/definition';
 export { TextFieldDefinition } from './components/TextField/definition';
+export { TextAreaFieldDefinition } from './components/TextAreaField/definition';
 export { TooltipDefinition } from './components/Tooltip/definition';
 export { VisuallyHiddenDefinition } from './components/VisuallyHidden/definition';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -53,6 +53,7 @@ export * from './components/Tabs';
 export * from './components/TagGroup';
 export * from './components/Text';
 export * from './components/TextField';
+export * from './components/TextAreaField';
 export * from './components/NumberField';
 export * from './components/PasswordField';
 export * from './components/Tooltip';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds a new `TextAreaField` component to `@backstage/ui` for multi-line text input. It follows the same conventions as `TextField` (built on React Aria's `TextField` + `TextArea`, with `FieldLabel` and `FieldError`), so it integrates consistently with the rest of the form components.

### What's included
- **`TextAreaField` component** with `label`, `secondaryLabel`, `description`, `placeholder`, `size` (`small` | `medium`), and `rows` props, plus the standard React Aria field props (`isRequired`, `isDisabled`, `isReadOnly`, `value`, `defaultValue`, `onChange`, validation, etc.).
- **Optional `autoResize` prop** to let the field grow with its content instead of scrolling. By default (`autoResize={false}`) the field keeps a fixed height (driven by `rows`) and scrolls internally. Auto-growing is implemented purely in CSS via `field-sizing: content` for a smooth writing experience and no JS height calculations.
- **Automatic background detection** (`bg: 'consumer'`), matching `TextField`'s behavior in nested neutral surfaces.
- **Storybook stories**: `Default`, `WithLabel`, `WithDescription`, `Required`, `Disabled`, `Sizes`, `Scrolling`, `AutoResize`, and `ShowError`.
- **Unit tests** covering label/secondary-label/description rendering, accessibility wiring (accessible name + description), the `Required` fallback, and the `autoResize` vs. fixed-height behavior.
- **docs-ui page** (`text-area-field`) with usage, API reference, sizes/description/auto-resize examples, and a navigation entry.
- Exports wired up in the package barrel and component definitions, and the API report updated.

What is changed Illustration:

<img width="1426" height="883" alt="BUI-TextArea" src="https://github.com/user-attachments/assets/97776edd-bbe2-44b2-8e1f-fef58633949c" />


### Notes
- `field-sizing: content` is a progressive enhancement; in browsers that don't yet support it, an `autoResize` field gracefully falls back to the standard fixed-height behavior.




#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots/gifs attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))