### PR TITLE
chore: allow pending changelog links in release notes

### DIFF
--- a/scripts/verify-links.js
+++ b/scripts/verify-links.js
@@ -157,12 +157,12 @@ async function verifyUrl(basePath, absUrl, docPages) {
       if (docPages.has(url.slice(0, -'.md'.length))) {
         return undefined;
       }
-      const changelogVersion = url.match(/\/(v[^/]+-changelog)\.md$/);
+      const changelogBase = url.match(/\/(v[^/]+)-changelog\.md$/);
       const sourceVersion = basePath.match(/docs\/releases\/(v[^-]+)\.md$/);
       if (
-        changelogVersion &&
+        changelogBase &&
         sourceVersion &&
-        changelogVersion[1].startsWith(sourceVersion[1])
+        changelogBase[1] === sourceVersion[1]
       ) {
         return undefined;
       }

--- a/scripts/verify-links.js
+++ b/scripts/verify-links.js
@@ -150,9 +150,20 @@ async function verifyUrl(basePath, absUrl, docPages) {
     ) &&
     basePath.match(/^(?:docs|microsite)\//)
   ) {
-    // Exception for linking to the changelogs, since we encourage those to be browsed in GitHub
+    // Exception for linking to the changelogs, since we encourage those to be browsed in GitHub.
+    // When linked from the matching release notes file, allow the link even if the changelog
+    // doesn't exist yet — it is generated during the release process after the notes are merged.
     if (absUrl.match(/docs\/releases\/.+-changelog\.md$/)) {
       if (docPages.has(url.slice(0, -'.md'.length))) {
+        return undefined;
+      }
+      const changelogVersion = url.match(/\/(v[^/]+-changelog)\.md$/);
+      const sourceVersion = basePath.match(/docs\/releases\/(v[^-]+)\.md$/);
+      if (
+        changelogVersion &&
+        sourceVersion &&
+        changelogVersion[1].startsWith(sourceVersion[1])
+      ) {
         return undefined;
       }
       return { url: absUrl, basePath, problem: 'missing' };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Release notes are always merged before the changelog file is generated during the release process. This causes the `verify-links` script to fail on the changelog link every time.

This change makes the link verifier allow a changelog link from a release notes file when the versions match (e.g. `v1.52.0-changelog.md` linked from `v1.52.0.md`), instead of failing on the not-yet-created file. Mismatched versions or links from other files still fail as before.

#### :heavy_check_mark: Checklist

- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

🤖 Generated with [Claude Code](https://claude.com/claude-code)