### PR TITLE
chore: add eslint plugin bugs metadata

### DIFF
--- a/.changeset/add-eslint-plugin-bugs-metadata.md
+++ b/.changeset/add-eslint-plugin-bugs-metadata.md
@@ -1,0 +1,5 @@
+---
+'@backstage/eslint-plugin': patch
+---
+
+Added package metadata for the issue tracker.

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -11,6 +11,9 @@
     "url": "https://github.com/backstage/backstage",
     "directory": "packages/eslint-plugin"
   },
+  "bugs": {
+    "url": "https://github.com/backstage/backstage/issues"
+  },
   "license": "Apache-2.0",
   "main": "./index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- add bugs.url metadata to the @backstage/eslint-plugin package manifest
- leave runtime code, dependencies, entry points, and package files unchanged

## Validation
- node package metadata assertion
- npm pack --dry-run --ignore-scripts --json --cache /private/tmp/codex-npm-cache-backstage
- git diff --check