### PR TITLE
Align disabled form control styling

### DIFF
--- a/.changeset/fix-disabled-select-styling.md
+++ b/.changeset/fix-disabled-select-styling.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Standardized disabled styling across form components to consistently use disabled design tokens. Text, password, search, number, date, select, and combobox inputs now use disabled foreground and background tokens instead of opacity-based styles. Icons, chevrons, separators, and placeholders now better match their disabled input state, while interactive adornments keep their normal affordance where appropriate.

--- a/packages/ui/report.api.md
+++ b/packages/ui/report.api.md
@@ -1166,6 +1166,7 @@ export const ComboboxDefinition: {
     readonly root: 'bui-Combobox';
     readonly popover: 'bui-ComboboxPopover';
   };
+  readonly bg: 'consumer';
   readonly propDefs: {
     readonly icon: {};
     readonly size: {
@@ -1198,7 +1199,6 @@ export const ComboboxInputDefinition: {
     readonly input: 'bui-ComboboxInputField';
     readonly chevron: 'bui-ComboboxInputChevron';
   };
-  readonly bg: 'consumer';
   readonly propDefs: {
     readonly icon: {};
     readonly placeholder: {};
@@ -1704,6 +1704,7 @@ export const DatePickerDefinition: {
   readonly classNames: {
     readonly root: 'bui-DatePicker';
   };
+  readonly bg: 'consumer';
   readonly propDefs: {
     readonly size: {
       readonly dataAttribute: true;
@@ -1727,7 +1728,6 @@ export const DatePickerGroupDefinition: {
     readonly segment: 'bui-DatePickerSegment';
     readonly button: 'bui-DatePickerButton';
   };
-  readonly bg: 'consumer';
   readonly propDefs: {};
 };
 
@@ -1758,6 +1758,7 @@ export const DateRangePickerDefinition: {
   readonly classNames: {
     readonly root: 'bui-DateRangePicker';
   };
+  readonly bg: 'consumer';
   readonly propDefs: {
     readonly size: {
       readonly dataAttribute: true;
@@ -3250,6 +3251,7 @@ export const SearchAutocompleteDefinition: {
     readonly popoverWidth: {};
     readonly popoverPlacement: {};
     readonly children: {};
+    readonly isDisabled: {};
     readonly isLoading: {};
     readonly defaultOpen: {};
     readonly className: {};
@@ -3285,6 +3287,7 @@ export type SearchAutocompleteOwnProps = {
   popoverPlacement?: PopoverProps_2['placement'];
   children?: ReactNode;
   isLoading?: boolean;
+  isDisabled?: boolean;
   defaultOpen?: boolean;
   className?: string;
   style?: React.CSSProperties;
@@ -3484,6 +3487,7 @@ export const SelectDefinition: {
     readonly root: 'bui-Select';
     readonly popover: 'bui-SelectPopover';
   };
+  readonly bg: 'consumer';
   readonly propDefs: {
     readonly icon: {};
     readonly size: {

--- a/packages/ui/src/components/Combobox/Combobox.module.css
+++ b/packages/ui/src/components/Combobox/Combobox.module.css
@@ -51,18 +51,6 @@
     background-color: var(--bui-bg-neutral-1);
     transition: box-shadow 0.2s ease-in-out;
 
-    &[data-on-bg='neutral-1'] {
-      background-color: var(--bui-bg-neutral-2);
-    }
-
-    &[data-on-bg='neutral-2'] {
-      background-color: var(--bui-bg-neutral-3);
-    }
-
-    &[data-on-bg='neutral-3'] {
-      background-color: var(--bui-bg-neutral-4);
-    }
-
     .bui-Combobox[data-focus-within] & {
       box-shadow: inset 0 0 0 1px var(--bui-ring);
     }
@@ -87,6 +75,32 @@
 
     &[data-disabled] {
       cursor: not-allowed;
+      color: var(--bui-fg-disabled);
+      background-color: var(--bui-bg-neutral-1-disabled);
+    }
+
+    .bui-Combobox[data-on-bg='neutral-1'] & {
+      background-color: var(--bui-bg-neutral-2);
+
+      &[data-disabled] {
+        background-color: var(--bui-bg-neutral-2-disabled);
+      }
+    }
+
+    .bui-Combobox[data-on-bg='neutral-2'] & {
+      background-color: var(--bui-bg-neutral-3);
+
+      &[data-disabled] {
+        background-color: var(--bui-bg-neutral-3-disabled);
+      }
+    }
+
+    .bui-Combobox[data-on-bg='neutral-3'] & {
+      background-color: var(--bui-bg-neutral-4);
+
+      &[data-disabled] {
+        background-color: var(--bui-bg-neutral-4-disabled);
+      }
     }
   }
 
@@ -105,6 +119,10 @@
     .bui-Combobox[data-size='medium'] & svg {
       width: 1.25rem;
       height: 1.25rem;
+    }
+
+    .bui-ComboboxInput[data-disabled] & {
+      color: var(--bui-fg-disabled);
     }
   }
 
@@ -128,9 +146,13 @@
       color: var(--bui-fg-secondary);
     }
 
-    &[disabled] {
+    &[data-disabled] {
       cursor: not-allowed;
       color: var(--bui-fg-disabled);
+
+      &::placeholder {
+        color: var(--bui-fg-disabled);
+      }
     }
   }
 

--- a/packages/ui/src/components/Combobox/Combobox.stories.tsx
+++ b/packages/ui/src/components/Combobox/Combobox.stories.tsx
@@ -639,6 +639,12 @@ export const AutoBg = meta.story({
         Combobox automatically detects its parent bg context and increments the
         neutral level by 1. No prop is needed — it's fully automatic.
       </div>
+      <div>
+        <Text>Default</Text>
+        <Flex mt="2" style={{ maxWidth: '300px' }}>
+          <Combobox options={fontOptions} aria-label="Font family" />
+        </Flex>
+      </div>
       <Box bg="neutral" p="4">
         <Text>Neutral 1 container</Text>
         <Flex mt="2" style={{ maxWidth: '300px' }}>
@@ -659,6 +665,51 @@ export const AutoBg = meta.story({
             <Text>Neutral 3 container</Text>
             <Flex mt="2" style={{ maxWidth: '300px' }}>
               <Combobox options={fontOptions} aria-label="Font family" />
+            </Flex>
+          </Box>
+        </Box>
+      </Box>
+    </Flex>
+  ),
+});
+
+export const AutoBgDisabled = meta.story({
+  render: () => (
+    <Flex direction="column" gap="4">
+      <div>
+        <Text>Default</Text>
+        <Flex mt="2" style={{ maxWidth: '300px' }}>
+          <Combobox options={fontOptions} aria-label="Font family" isDisabled />
+        </Flex>
+      </div>
+      <Box bg="neutral" p="4">
+        <Text>Neutral 1 container</Text>
+        <Flex mt="2" style={{ maxWidth: '300px' }}>
+          <Combobox options={fontOptions} aria-label="Font family" isDisabled />
+        </Flex>
+      </Box>
+      <Box bg="neutral">
+        <Box bg="neutral" p="4">
+          <Text>Neutral 2 container</Text>
+          <Flex mt="2" style={{ maxWidth: '300px' }}>
+            <Combobox
+              options={fontOptions}
+              aria-label="Font family"
+              isDisabled
+            />
+          </Flex>
+        </Box>
+      </Box>
+      <Box bg="neutral">
+        <Box bg="neutral">
+          <Box bg="neutral" p="4">
+            <Text>Neutral 3 container</Text>
+            <Flex mt="2" style={{ maxWidth: '300px' }}>
+              <Combobox
+                options={fontOptions}
+                aria-label="Font family"
+                isDisabled
+              />
             </Flex>
           </Box>
         </Box>

--- a/packages/ui/src/components/Combobox/definition.ts
+++ b/packages/ui/src/components/Combobox/definition.ts
@@ -34,6 +34,7 @@ export const ComboboxDefinition = defineComponent<ComboboxOwnProps>()({
     root: 'bui-Combobox',
     popover: 'bui-ComboboxPopover',
   },
+  bg: 'consumer',
   propDefs: {
     icon: {},
     size: { dataAttribute: true, default: 'small' },
@@ -62,7 +63,6 @@ export const ComboboxInputDefinition = defineComponent<ComboboxInputOwnProps>()(
       input: 'bui-ComboboxInputField',
       chevron: 'bui-ComboboxInputChevron',
     },
-    bg: 'consumer',
     propDefs: {
       icon: {},
       placeholder: {},

--- a/packages/ui/src/components/DatePicker/DatePicker.module.css
+++ b/packages/ui/src/components/DatePicker/DatePicker.module.css
@@ -46,19 +46,6 @@
     transition: box-shadow 0.2s ease-in-out;
     cursor: text;
 
-    /* bg consumer — auto-increment background based on parent context */
-    &[data-on-bg='neutral-1'] {
-      background-color: var(--bui-bg-neutral-2);
-    }
-
-    &[data-on-bg='neutral-2'] {
-      background-color: var(--bui-bg-neutral-3);
-    }
-
-    &[data-on-bg='neutral-3'] {
-      background-color: var(--bui-bg-neutral-4);
-    }
-
     &[data-focus-within] {
       outline: none;
       box-shadow: inset 0 0 0 1px var(--bui-ring);
@@ -69,8 +56,33 @@
     }
 
     &[data-disabled] {
-      opacity: 0.5;
       cursor: not-allowed;
+      color: var(--bui-fg-disabled);
+      background-color: var(--bui-bg-neutral-1-disabled);
+    }
+
+    .bui-DatePicker[data-on-bg='neutral-1'] & {
+      background-color: var(--bui-bg-neutral-2);
+
+      &[data-disabled] {
+        background-color: var(--bui-bg-neutral-2-disabled);
+      }
+    }
+
+    .bui-DatePicker[data-on-bg='neutral-2'] & {
+      background-color: var(--bui-bg-neutral-3);
+
+      &[data-disabled] {
+        background-color: var(--bui-bg-neutral-3-disabled);
+      }
+    }
+
+    .bui-DatePicker[data-on-bg='neutral-3'] & {
+      background-color: var(--bui-bg-neutral-4);
+
+      &[data-disabled] {
+        background-color: var(--bui-bg-neutral-4-disabled);
+      }
     }
 
     /* Sizes */
@@ -182,6 +194,11 @@
 
     &[data-pressed] {
       color: var(--bui-fg-primary);
+    }
+
+    .bui-DatePicker[data-disabled] & {
+      cursor: not-allowed;
+      color: var(--bui-fg-disabled);
     }
   }
 

--- a/packages/ui/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/ui/src/components/DatePicker/DatePicker.stories.tsx
@@ -24,6 +24,9 @@ import {
 } from '@internationalized/date';
 import { useLocale, Form } from 'react-aria-components';
 import { Button } from '../Button';
+import { Box } from '../Box';
+import { Flex } from '../Flex';
+import { Text } from '../Text';
 
 const meta = preview.meta({
   title: 'Backstage UI/DatePicker',
@@ -105,6 +108,43 @@ export const Disabled = meta.story({
     isDisabled: true,
     defaultValue: parseDate('2025-03-01'),
   },
+});
+
+export const AutoBgDisabled = meta.story({
+  render: () => (
+    <Flex direction="column" gap="4">
+      <div>
+        <Text>Default</Text>
+        <Flex mt="2" style={{ maxWidth: '280px' }}>
+          <DatePicker aria-label="Date" isDisabled />
+        </Flex>
+      </div>
+      <Box bg="neutral" p="4">
+        <Text>Neutral 1 container</Text>
+        <Flex mt="2" style={{ maxWidth: '280px' }}>
+          <DatePicker aria-label="Date" isDisabled />
+        </Flex>
+      </Box>
+      <Box bg="neutral">
+        <Box bg="neutral" p="4">
+          <Text>Neutral 2 container</Text>
+          <Flex mt="2" style={{ maxWidth: '280px' }}>
+            <DatePicker aria-label="Date" isDisabled />
+          </Flex>
+        </Box>
+      </Box>
+      <Box bg="neutral">
+        <Box bg="neutral">
+          <Box bg="neutral" p="4">
+            <Text>Neutral 3 container</Text>
+            <Flex mt="2" style={{ maxWidth: '280px' }}>
+              <DatePicker aria-label="Date" isDisabled />
+            </Flex>
+          </Box>
+        </Box>
+      </Box>
+    </Flex>
+  ),
 });
 
 export const Invalid = meta.story({

--- a/packages/ui/src/components/DatePicker/definition.ts
+++ b/packages/ui/src/components/DatePicker/definition.ts
@@ -27,6 +27,7 @@ export const DatePickerDefinition = defineComponent<DatePickerOwnProps>()({
   classNames: {
     root: 'bui-DatePicker',
   },
+  bg: 'consumer',
   propDefs: {
     size: { dataAttribute: true, default: 'small' },
     className: {},
@@ -50,7 +51,6 @@ export const DatePickerGroupDefinition = defineComponent<
     segment: 'bui-DatePickerSegment',
     button: 'bui-DatePickerButton',
   },
-  bg: 'consumer',
   propDefs: {},
 });
 

--- a/packages/ui/src/components/DateRangePicker/DateRangePicker.module.css
+++ b/packages/ui/src/components/DateRangePicker/DateRangePicker.module.css
@@ -46,19 +46,6 @@
     transition: box-shadow 0.2s ease-in-out;
     cursor: text;
 
-    /* bg consumer — auto-increment background based on parent context */
-    &[data-on-bg='neutral-1'] {
-      background-color: var(--bui-bg-neutral-2);
-    }
-
-    &[data-on-bg='neutral-2'] {
-      background-color: var(--bui-bg-neutral-3);
-    }
-
-    &[data-on-bg='neutral-3'] {
-      background-color: var(--bui-bg-neutral-4);
-    }
-
     &[data-focus-within] {
       outline: none;
       box-shadow: inset 0 0 0 1px var(--bui-ring);
@@ -69,8 +56,33 @@
     }
 
     &[data-disabled] {
-      opacity: 0.5;
       cursor: not-allowed;
+      color: var(--bui-fg-disabled);
+      background-color: var(--bui-bg-neutral-1-disabled);
+    }
+
+    .bui-DateRangePicker[data-on-bg='neutral-1'] & {
+      background-color: var(--bui-bg-neutral-2);
+
+      &[data-disabled] {
+        background-color: var(--bui-bg-neutral-2-disabled);
+      }
+    }
+
+    .bui-DateRangePicker[data-on-bg='neutral-2'] & {
+      background-color: var(--bui-bg-neutral-3);
+
+      &[data-disabled] {
+        background-color: var(--bui-bg-neutral-3-disabled);
+      }
+    }
+
+    .bui-DateRangePicker[data-on-bg='neutral-3'] & {
+      background-color: var(--bui-bg-neutral-4);
+
+      &[data-disabled] {
+        background-color: var(--bui-bg-neutral-4-disabled);
+      }
     }
 
     /* Sizes */
@@ -175,6 +187,10 @@
     flex-shrink: 0;
     user-select: none;
     padding: 0 var(--bui-space-1);
+
+    .bui-DateRangePicker[data-disabled] & {
+      color: var(--bui-fg-disabled);
+    }
   }
 
   /* ============================================================
@@ -208,6 +224,11 @@
 
     &[data-pressed] {
       color: var(--bui-fg-primary);
+    }
+
+    .bui-DateRangePicker[data-disabled] & {
+      cursor: not-allowed;
+      color: var(--bui-fg-disabled);
     }
   }
 

--- a/packages/ui/src/components/DateRangePicker/DateRangePicker.stories.tsx
+++ b/packages/ui/src/components/DateRangePicker/DateRangePicker.stories.tsx
@@ -24,6 +24,9 @@ import {
 } from '@internationalized/date';
 import { useLocale, Form } from 'react-aria-components';
 import { Button } from '../Button';
+import { Box } from '../Box';
+import { Flex } from '../Flex';
+import { Text } from '../Text';
 
 const meta = preview.meta({
   title: 'Backstage UI/DateRangePicker',
@@ -111,6 +114,43 @@ export const Disabled = meta.story({
       end: parseDate('2025-03-15'),
     },
   },
+});
+
+export const AutoBgDisabled = meta.story({
+  render: () => (
+    <Flex direction="column" gap="4">
+      <div>
+        <Text>Default</Text>
+        <Flex mt="2" style={{ maxWidth: '360px' }}>
+          <DateRangePicker aria-label="Date range" isDisabled />
+        </Flex>
+      </div>
+      <Box bg="neutral" p="4">
+        <Text>Neutral 1 container</Text>
+        <Flex mt="2" style={{ maxWidth: '360px' }}>
+          <DateRangePicker aria-label="Date range" isDisabled />
+        </Flex>
+      </Box>
+      <Box bg="neutral">
+        <Box bg="neutral" p="4">
+          <Text>Neutral 2 container</Text>
+          <Flex mt="2" style={{ maxWidth: '360px' }}>
+            <DateRangePicker aria-label="Date range" isDisabled />
+          </Flex>
+        </Box>
+      </Box>
+      <Box bg="neutral">
+        <Box bg="neutral">
+          <Box bg="neutral" p="4">
+            <Text>Neutral 3 container</Text>
+            <Flex mt="2" style={{ maxWidth: '360px' }}>
+              <DateRangePicker aria-label="Date range" isDisabled />
+            </Flex>
+          </Box>
+        </Box>
+      </Box>
+    </Flex>
+  ),
 });
 
 export const Invalid = meta.story({

--- a/packages/ui/src/components/DateRangePicker/definition.ts
+++ b/packages/ui/src/components/DateRangePicker/definition.ts
@@ -28,6 +28,7 @@ export const DateRangePickerDefinition =
     classNames: {
       root: 'bui-DateRangePicker',
     },
+    bg: 'consumer',
     propDefs: {
       size: { dataAttribute: true, default: 'small' },
       className: {},
@@ -53,7 +54,6 @@ export const DateRangePickerGroupDefinition = defineComponent<
     separator: 'bui-DateRangePickerSeparator',
     button: 'bui-DateRangePickerButton',
   },
-  bg: 'consumer',
   propDefs: {},
 });
 

--- a/packages/ui/src/components/NumberField/NumberField.module.css
+++ b/packages/ui/src/components/NumberField/NumberField.module.css
@@ -23,18 +23,6 @@
     font-family: var(--bui-font-regular);
     width: 100%;
     flex-shrink: 0;
-
-    &[data-on-bg='neutral-1'] .bui-Input {
-      background-color: var(--bui-bg-neutral-2);
-    }
-
-    &[data-on-bg='neutral-2'] .bui-Input {
-      background-color: var(--bui-bg-neutral-3);
-    }
-
-    &[data-on-bg='neutral-3'] .bui-Input {
-      background-color: var(--bui-bg-neutral-4);
-    }
   }
 
   .bui-InputWrapper {
@@ -58,8 +46,7 @@
       padding-left: var(--bui-space-9);
     }
 
-    &[data-disabled] {
-      opacity: 0.5;
+    .bui-NumberField[data-disabled] & {
       cursor: not-allowed;
     }
   }
@@ -86,6 +73,10 @@
     &[data-size='medium'] svg {
       width: 1.25rem;
       height: 1.25rem;
+    }
+
+    .bui-NumberField[data-disabled] & {
+      color: var(--bui-fg-disabled);
     }
   }
 
@@ -116,6 +107,40 @@
 
     &[data-invalid] {
       box-shadow: inset 0 0 0 1px var(--bui-border-danger);
+    }
+
+    &[data-disabled] {
+      cursor: not-allowed;
+      color: var(--bui-fg-disabled);
+      background-color: var(--bui-bg-neutral-1-disabled);
+
+      &::placeholder {
+        color: var(--bui-fg-disabled);
+      }
+    }
+
+    .bui-NumberField[data-on-bg='neutral-1'] & {
+      background-color: var(--bui-bg-neutral-2);
+
+      &[data-disabled] {
+        background-color: var(--bui-bg-neutral-2-disabled);
+      }
+    }
+
+    .bui-NumberField[data-on-bg='neutral-2'] & {
+      background-color: var(--bui-bg-neutral-3);
+
+      &[data-disabled] {
+        background-color: var(--bui-bg-neutral-3-disabled);
+      }
+    }
+
+    .bui-NumberField[data-on-bg='neutral-3'] & {
+      background-color: var(--bui-bg-neutral-4);
+
+      &[data-disabled] {
+        background-color: var(--bui-bg-neutral-4-disabled);
+      }
     }
   }
 

--- a/packages/ui/src/components/NumberField/NumberField.stories.tsx
+++ b/packages/ui/src/components/NumberField/NumberField.stories.tsx
@@ -177,6 +177,16 @@ export const AutoBg = meta.story({
         NumberField automatically detects its parent bg context and increments
         the neutral level by 1. No prop is needed — it's fully automatic.
       </div>
+      <div>
+        <Text>Default</Text>
+        <Flex mt="2" style={{ maxWidth: '300px' }}>
+          <NumberField
+            aria-label="Number"
+            placeholder="Enter number"
+            size="small"
+          />
+        </Flex>
+      </div>
       <Box bg="neutral" p="4">
         <Text>Neutral 1 container</Text>
         <Flex mt="2" style={{ maxWidth: '300px' }}>
@@ -208,6 +218,63 @@ export const AutoBg = meta.story({
                 aria-label="Number"
                 placeholder="Enter number"
                 size="small"
+              />
+            </Flex>
+          </Box>
+        </Box>
+      </Box>
+    </Flex>
+  ),
+});
+
+export const AutoBgDisabled = meta.story({
+  render: () => (
+    <Flex direction="column" gap="4">
+      <div>
+        <Text>Default</Text>
+        <Flex mt="2" style={{ maxWidth: '300px' }}>
+          <NumberField
+            aria-label="Number"
+            placeholder="Enter number"
+            size="small"
+            isDisabled
+          />
+        </Flex>
+      </div>
+      <Box bg="neutral" p="4">
+        <Text>Neutral 1 container</Text>
+        <Flex mt="2" style={{ maxWidth: '300px' }}>
+          <NumberField
+            aria-label="Number"
+            placeholder="Enter number"
+            size="small"
+            isDisabled
+          />
+        </Flex>
+      </Box>
+      <Box bg="neutral">
+        <Box bg="neutral" p="4">
+          <Text>Neutral 2 container</Text>
+          <Flex mt="2" style={{ maxWidth: '300px' }}>
+            <NumberField
+              aria-label="Number"
+              placeholder="Enter number"
+              size="small"
+              isDisabled
+            />
+          </Flex>
+        </Box>
+      </Box>
+      <Box bg="neutral">
+        <Box bg="neutral">
+          <Box bg="neutral" p="4">
+            <Text>Neutral 3 container</Text>
+            <Flex mt="2" style={{ maxWidth: '300px' }}>
+              <NumberField
+                aria-label="Number"
+                placeholder="Enter number"
+                size="small"
+                isDisabled
               />
             </Flex>
           </Box>

--- a/packages/ui/src/components/PasswordField/PasswordField.module.css
+++ b/packages/ui/src/components/PasswordField/PasswordField.module.css
@@ -23,18 +23,6 @@
     font-family: var(--bui-font-regular);
     width: 100%;
     flex: 1;
-
-    &[data-on-bg='neutral-1'] .bui-PasswordFieldInput {
-      background-color: var(--bui-bg-neutral-2);
-    }
-
-    &[data-on-bg='neutral-2'] .bui-PasswordFieldInput {
-      background-color: var(--bui-bg-neutral-3);
-    }
-
-    &[data-on-bg='neutral-3'] .bui-PasswordFieldInput {
-      background-color: var(--bui-bg-neutral-4);
-    }
   }
 
   .bui-PasswordFieldInputWrapper {
@@ -58,8 +46,7 @@
       padding-left: var(--bui-space-9);
     }
 
-    &:has([data-disabled]) {
-      opacity: 0.5;
+    .bui-PasswordField[data-disabled] & {
       cursor: not-allowed;
     }
   }
@@ -83,6 +70,10 @@
     &[data-size='medium'] svg {
       width: 1.25rem;
       height: 1.25rem;
+    }
+
+    .bui-PasswordField[data-disabled] & {
+      color: var(--bui-fg-disabled);
     }
   }
 
@@ -122,6 +113,36 @@
 
     &[data-disabled] {
       cursor: not-allowed;
+      color: var(--bui-fg-disabled);
+      background-color: var(--bui-bg-neutral-1-disabled);
+
+      &::placeholder {
+        color: var(--bui-fg-disabled);
+      }
+    }
+
+    .bui-PasswordField[data-on-bg='neutral-1'] & {
+      background-color: var(--bui-bg-neutral-2);
+
+      &[data-disabled] {
+        background-color: var(--bui-bg-neutral-2-disabled);
+      }
+    }
+
+    .bui-PasswordField[data-on-bg='neutral-2'] & {
+      background-color: var(--bui-bg-neutral-3);
+
+      &[data-disabled] {
+        background-color: var(--bui-bg-neutral-3-disabled);
+      }
+    }
+
+    .bui-PasswordField[data-on-bg='neutral-3'] & {
+      background-color: var(--bui-bg-neutral-4);
+
+      &[data-disabled] {
+        background-color: var(--bui-bg-neutral-4-disabled);
+      }
     }
   }
 

--- a/packages/ui/src/components/PasswordField/PasswordField.stories.tsx
+++ b/packages/ui/src/components/PasswordField/PasswordField.stories.tsx
@@ -17,6 +17,8 @@ import preview from '../../../../../.storybook/preview';
 import { PasswordField } from './PasswordField';
 import { Form } from 'react-aria-components';
 import { Flex } from '../Flex';
+import { Box } from '../Box';
+import { Text } from '../Text';
 import { FieldLabel } from '../FieldLabel';
 import { RiSparklingLine } from '@remixicon/react';
 
@@ -138,5 +140,98 @@ export const CustomField = meta.story({
         defaultValue="Custom Field"
       />
     </>
+  ),
+});
+
+export const AutoBg = meta.story({
+  render: () => (
+    <Flex direction="column" gap="4">
+      <div>
+        <Text>Default</Text>
+        <Flex mt="2" style={{ maxWidth: '300px' }}>
+          <PasswordField aria-label="Password" placeholder="Enter password" />
+        </Flex>
+      </div>
+      <Box bg="neutral" p="4">
+        <Text>Neutral 1 container</Text>
+        <Flex mt="2" style={{ maxWidth: '300px' }}>
+          <PasswordField aria-label="Password" placeholder="Enter password" />
+        </Flex>
+      </Box>
+      <Box bg="neutral">
+        <Box bg="neutral" p="4">
+          <Text>Neutral 2 container</Text>
+          <Flex mt="2" style={{ maxWidth: '300px' }}>
+            <PasswordField aria-label="Password" placeholder="Enter password" />
+          </Flex>
+        </Box>
+      </Box>
+      <Box bg="neutral">
+        <Box bg="neutral">
+          <Box bg="neutral" p="4">
+            <Text>Neutral 3 container</Text>
+            <Flex mt="2" style={{ maxWidth: '300px' }}>
+              <PasswordField
+                aria-label="Password"
+                placeholder="Enter password"
+              />
+            </Flex>
+          </Box>
+        </Box>
+      </Box>
+    </Flex>
+  ),
+});
+
+export const AutoBgDisabled = meta.story({
+  render: () => (
+    <Flex direction="column" gap="4">
+      <div>
+        <Text>Default</Text>
+        <Flex mt="2" style={{ maxWidth: '300px' }}>
+          <PasswordField
+            aria-label="Password"
+            placeholder="Enter password"
+            isDisabled
+          />
+        </Flex>
+      </div>
+      <Box bg="neutral" p="4">
+        <Text>Neutral 1 container</Text>
+        <Flex mt="2" style={{ maxWidth: '300px' }}>
+          <PasswordField
+            aria-label="Password"
+            placeholder="Enter password"
+            isDisabled
+          />
+        </Flex>
+      </Box>
+      <Box bg="neutral">
+        <Box bg="neutral" p="4">
+          <Text>Neutral 2 container</Text>
+          <Flex mt="2" style={{ maxWidth: '300px' }}>
+            <PasswordField
+              aria-label="Password"
+              placeholder="Enter password"
+              isDisabled
+            />
+          </Flex>
+        </Box>
+      </Box>
+      <Box bg="neutral">
+        <Box bg="neutral">
+          <Box bg="neutral" p="4">
+            <Text>Neutral 3 container</Text>
+            <Flex mt="2" style={{ maxWidth: '300px' }}>
+              <PasswordField
+                aria-label="Password"
+                placeholder="Enter password"
+                isDisabled
+              />
+            </Flex>
+          </Box>
+        </Box>
+      </Box>
+    </Flex>
   ),
 });

--- a/packages/ui/src/components/SearchAutocomplete/SearchAutocomplete.module.css
+++ b/packages/ui/src/components/SearchAutocomplete/SearchAutocomplete.module.css
@@ -39,16 +39,34 @@
       height: 2.5rem;
     }
 
+    &[data-disabled] {
+      cursor: not-allowed;
+      color: var(--bui-fg-disabled);
+      background-color: var(--bui-bg-neutral-1-disabled);
+    }
+
     &[data-on-bg='neutral-1'] {
       background-color: var(--bui-bg-neutral-2);
+
+      &[data-disabled] {
+        background-color: var(--bui-bg-neutral-2-disabled);
+      }
     }
 
     &[data-on-bg='neutral-2'] {
       background-color: var(--bui-bg-neutral-3);
+
+      &[data-disabled] {
+        background-color: var(--bui-bg-neutral-3-disabled);
+      }
     }
 
     &[data-on-bg='neutral-3'] {
       background-color: var(--bui-bg-neutral-4);
+
+      &[data-disabled] {
+        background-color: var(--bui-bg-neutral-4-disabled);
+      }
     }
   }
 
@@ -77,6 +95,10 @@
         width: 1.25rem;
         height: 1.25rem;
       }
+
+      .bui-SearchAutocomplete[data-disabled] & {
+        color: var(--bui-fg-disabled);
+      }
     }
   }
 
@@ -104,6 +126,15 @@
     &::placeholder {
       color: var(--bui-fg-secondary);
     }
+
+    &[data-disabled] {
+      cursor: not-allowed;
+      color: var(--bui-fg-disabled);
+
+      &::placeholder {
+        color: var(--bui-fg-disabled);
+      }
+    }
   }
 
   .bui-SearchAutocompleteClear {
@@ -122,6 +153,11 @@
 
     &:hover {
       color: var(--bui-fg-primary);
+    }
+
+    .bui-SearchAutocomplete[data-disabled] & {
+      cursor: not-allowed;
+      color: var(--bui-fg-disabled);
     }
 
     & svg {

--- a/packages/ui/src/components/SearchAutocomplete/SearchAutocomplete.stories.tsx
+++ b/packages/ui/src/components/SearchAutocomplete/SearchAutocomplete.stories.tsx
@@ -443,3 +443,23 @@ export const OpenWithLoading = meta.story({
     );
   },
 });
+
+export const Disabled = meta.story({
+  args: {
+    ...WithItems.input.args,
+    isDisabled: true,
+  },
+  render: args => (
+    <SearchAutocomplete {...args} onInputChange={() => {}}>
+      {fruits.map(fruit => (
+        <SearchAutocompleteItem
+          key={fruit.id}
+          id={fruit.id}
+          textValue={fruit.name}
+        >
+          {fruit.name}
+        </SearchAutocompleteItem>
+      ))}
+    </SearchAutocomplete>
+  ),
+});

--- a/packages/ui/src/components/SearchAutocomplete/SearchAutocomplete.tsx
+++ b/packages/ui/src/components/SearchAutocomplete/SearchAutocomplete.tsx
@@ -67,6 +67,7 @@ export function SearchAutocomplete(props: SearchAutocompleteProps) {
     popoverWidth,
     popoverPlacement = 'bottom start',
     children,
+    isDisabled,
     isLoading,
     defaultOpen,
     style,
@@ -117,6 +118,7 @@ export function SearchAutocomplete(props: SearchAutocompleteProps) {
           className={classes.searchField}
           aria-label={ariaLabel ?? (ariaLabelledBy ? undefined : placeholder)}
           aria-labelledby={ariaLabelledBy}
+          isDisabled={isDisabled}
           data-size={dataAttributes['data-size']}
           onKeyDown={e => {
             if (e.key === 'Enter' && !overlayState.isOpen && hasValue) {
@@ -129,6 +131,7 @@ export function SearchAutocomplete(props: SearchAutocompleteProps) {
             ref={triggerRef}
             className={classes.root}
             {...dataAttributes}
+            data-disabled={isDisabled || undefined}
             style={style}
           >
             <div aria-hidden="true">

--- a/packages/ui/src/components/SearchAutocomplete/definition.ts
+++ b/packages/ui/src/components/SearchAutocomplete/definition.ts
@@ -50,6 +50,7 @@ export const SearchAutocompleteDefinition =
       popoverWidth: {},
       popoverPlacement: {},
       children: {},
+      isDisabled: {},
       isLoading: {},
       defaultOpen: {},
       className: {},

--- a/packages/ui/src/components/SearchAutocomplete/types.ts
+++ b/packages/ui/src/components/SearchAutocomplete/types.ts
@@ -78,6 +78,11 @@ export type SearchAutocompleteOwnProps = {
   isLoading?: boolean;
 
   /**
+   * Whether the search input is disabled.
+   */
+  isDisabled?: boolean;
+
+  /**
    * Whether the results popover is open by default.
    */
   defaultOpen?: boolean;

--- a/packages/ui/src/components/SearchField/SearchField.module.css
+++ b/packages/ui/src/components/SearchField/SearchField.module.css
@@ -38,18 +38,6 @@
       }
     }
 
-    &[data-on-bg='neutral-1'] .bui-SearchFieldInputWrapper {
-      background-color: var(--bui-bg-neutral-2);
-    }
-
-    &[data-on-bg='neutral-2'] .bui-SearchFieldInputWrapper {
-      background-color: var(--bui-bg-neutral-3);
-    }
-
-    &[data-on-bg='neutral-3'] .bui-SearchFieldInputWrapper {
-      background-color: var(--bui-bg-neutral-4);
-    }
-
     &[data-startcollapsed='true'] {
       transition: flex-basis 0.3s ease-in-out, width 0.3s ease-in-out,
         max-width 0.3s ease-in-out;
@@ -123,9 +111,34 @@
       height: 2.5rem;
     }
 
-    &[data-disabled] {
-      opacity: 0.5;
+    .bui-SearchField[data-disabled] & {
       cursor: not-allowed;
+      color: var(--bui-fg-disabled);
+      background-color: var(--bui-bg-neutral-1-disabled);
+    }
+
+    .bui-SearchField[data-on-bg='neutral-1'] & {
+      background-color: var(--bui-bg-neutral-2);
+
+      .bui-SearchField[data-disabled] & {
+        background-color: var(--bui-bg-neutral-2-disabled);
+      }
+    }
+
+    .bui-SearchField[data-on-bg='neutral-2'] & {
+      background-color: var(--bui-bg-neutral-3);
+
+      .bui-SearchField[data-disabled] & {
+        background-color: var(--bui-bg-neutral-3-disabled);
+      }
+    }
+
+    .bui-SearchField[data-on-bg='neutral-3'] & {
+      background-color: var(--bui-bg-neutral-4);
+
+      .bui-SearchField[data-disabled] & {
+        background-color: var(--bui-bg-neutral-4-disabled);
+      }
     }
   }
 
@@ -150,6 +163,10 @@
         width: 1.25rem;
         height: 1.25rem;
       }
+    }
+
+    .bui-SearchField[data-disabled] & {
+      color: var(--bui-fg-disabled);
     }
   }
 
@@ -181,6 +198,11 @@
 
     &[data-disabled] {
       cursor: not-allowed;
+      color: var(--bui-fg-disabled);
+
+      &::placeholder {
+        color: var(--bui-fg-disabled);
+      }
     }
 
     &:first-child {
@@ -210,6 +232,11 @@
 
     &:hover {
       color: var(--bui-fg-primary);
+    }
+
+    .bui-SearchField[data-disabled] & {
+      cursor: not-allowed;
+      color: var(--bui-fg-disabled);
     }
 
     & svg {

--- a/packages/ui/src/components/SearchField/SearchField.stories.tsx
+++ b/packages/ui/src/components/SearchField/SearchField.stories.tsx
@@ -356,6 +356,12 @@ export const AutoBg = meta.story({
         SearchField automatically detects its parent bg context and increments
         the neutral level by 1. No prop is needed — it's fully automatic.
       </div>
+      <div>
+        <Text>Default</Text>
+        <Flex mt="2" style={{ maxWidth: '300px' }}>
+          <SearchField aria-label="Search" size="small" />
+        </Flex>
+      </div>
       <Box bg="neutral" p="4">
         <Text>Neutral 1 container</Text>
         <Flex mt="2" style={{ maxWidth: '300px' }}>
@@ -376,6 +382,43 @@ export const AutoBg = meta.story({
             <Text>Neutral 3 container</Text>
             <Flex mt="2" style={{ maxWidth: '300px' }}>
               <SearchField aria-label="Search" size="small" />
+            </Flex>
+          </Box>
+        </Box>
+      </Box>
+    </Flex>
+  ),
+});
+
+export const AutoBgDisabled = meta.story({
+  render: () => (
+    <Flex direction="column" gap="4">
+      <div>
+        <Text>Default</Text>
+        <Flex mt="2" style={{ maxWidth: '300px' }}>
+          <SearchField aria-label="Search" size="small" isDisabled />
+        </Flex>
+      </div>
+      <Box bg="neutral" p="4">
+        <Text>Neutral 1 container</Text>
+        <Flex mt="2" style={{ maxWidth: '300px' }}>
+          <SearchField aria-label="Search" size="small" isDisabled />
+        </Flex>
+      </Box>
+      <Box bg="neutral">
+        <Box bg="neutral" p="4">
+          <Text>Neutral 2 container</Text>
+          <Flex mt="2" style={{ maxWidth: '300px' }}>
+            <SearchField aria-label="Search" size="small" isDisabled />
+          </Flex>
+        </Box>
+      </Box>
+      <Box bg="neutral">
+        <Box bg="neutral">
+          <Box bg="neutral" p="4">
+            <Text>Neutral 3 container</Text>
+            <Flex mt="2" style={{ maxWidth: '300px' }}>
+              <SearchField aria-label="Search" size="small" isDisabled />
             </Flex>
           </Box>
         </Box>

--- a/packages/ui/src/components/Select/Select.module.css
+++ b/packages/ui/src/components/Select/Select.module.css
@@ -54,18 +54,6 @@
     background-color: var(--bui-bg-neutral-1);
     transition: box-shadow 0.2s ease-in-out;
 
-    &[data-on-bg='neutral-1'] {
-      background-color: var(--bui-bg-neutral-2);
-    }
-
-    &[data-on-bg='neutral-2'] {
-      background-color: var(--bui-bg-neutral-3);
-    }
-
-    &[data-on-bg='neutral-3'] {
-      background-color: var(--bui-bg-neutral-4);
-    }
-
     .bui-Select[data-focused] & {
       box-shadow: inset 0 0 0 1px var(--bui-ring);
     }
@@ -108,9 +96,38 @@
       box-shadow: inset 0 0 0 1px var(--bui-border-danger);
     }
 
-    &[disabled] {
+    &[data-disabled] {
       cursor: not-allowed;
       color: var(--bui-fg-disabled);
+      background-color: var(--bui-bg-neutral-1-disabled);
+
+      & svg {
+        color: var(--bui-fg-disabled);
+      }
+    }
+
+    .bui-Select[data-on-bg='neutral-1'] & {
+      background-color: var(--bui-bg-neutral-2);
+
+      &[data-disabled] {
+        background-color: var(--bui-bg-neutral-2-disabled);
+      }
+    }
+
+    .bui-Select[data-on-bg='neutral-2'] & {
+      background-color: var(--bui-bg-neutral-3);
+
+      &[data-disabled] {
+        background-color: var(--bui-bg-neutral-3-disabled);
+      }
+    }
+
+    .bui-Select[data-on-bg='neutral-3'] & {
+      background-color: var(--bui-bg-neutral-4);
+
+      &[data-disabled] {
+        background-color: var(--bui-bg-neutral-4-disabled);
+      }
     }
   }
 
@@ -134,11 +151,15 @@
     color: var(--bui-fg-primary);
     text-align: left;
 
+    &[data-placeholder] {
+      color: var(--bui-fg-secondary);
+    }
+
     & .bui-SelectItemIndicator {
       display: none;
     }
 
-    &[disabled] {
+    .bui-SelectTrigger[data-disabled] & {
       color: var(--bui-fg-disabled);
     }
   }

--- a/packages/ui/src/components/Select/Select.stories.tsx
+++ b/packages/ui/src/components/Select/Select.stories.tsx
@@ -885,6 +885,12 @@ export const AutoBg = meta.story({
         Select automatically detects its parent bg context and increments the
         neutral level by 1. No prop is needed — it's fully automatic.
       </div>
+      <div>
+        <Text>Default</Text>
+        <Flex mt="2" style={{ maxWidth: '300px' }}>
+          <Select options={fontOptions} aria-label="Font family" />
+        </Flex>
+      </div>
       <Box bg="neutral" p="4">
         <Text>Neutral 1 container</Text>
         <Flex mt="2" style={{ maxWidth: '300px' }}>
@@ -905,6 +911,47 @@ export const AutoBg = meta.story({
             <Text>Neutral 3 container</Text>
             <Flex mt="2" style={{ maxWidth: '300px' }}>
               <Select options={fontOptions} aria-label="Font family" />
+            </Flex>
+          </Box>
+        </Box>
+      </Box>
+    </Flex>
+  ),
+});
+
+export const AutoBgDisabled = meta.story({
+  render: () => (
+    <Flex direction="column" gap="4">
+      <div>
+        <Text>Default</Text>
+        <Flex mt="2" style={{ maxWidth: '300px' }}>
+          <Select options={fontOptions} aria-label="Font family" isDisabled />
+        </Flex>
+      </div>
+      <Box bg="neutral" p="4">
+        <Text>Neutral 1 container</Text>
+        <Flex mt="2" style={{ maxWidth: '300px' }}>
+          <Select options={fontOptions} aria-label="Font family" isDisabled />
+        </Flex>
+      </Box>
+      <Box bg="neutral">
+        <Box bg="neutral" p="4">
+          <Text>Neutral 2 container</Text>
+          <Flex mt="2" style={{ maxWidth: '300px' }}>
+            <Select options={fontOptions} aria-label="Font family" isDisabled />
+          </Flex>
+        </Box>
+      </Box>
+      <Box bg="neutral">
+        <Box bg="neutral">
+          <Box bg="neutral" p="4">
+            <Text>Neutral 3 container</Text>
+            <Flex mt="2" style={{ maxWidth: '300px' }}>
+              <Select
+                options={fontOptions}
+                aria-label="Font family"
+                isDisabled
+              />
             </Flex>
           </Box>
         </Box>

--- a/packages/ui/src/components/Select/definition.ts
+++ b/packages/ui/src/components/Select/definition.ts
@@ -35,6 +35,7 @@ export const SelectDefinition = defineComponent<SelectOwnProps>()({
     root: 'bui-Select',
     popover: 'bui-SelectPopover',
   },
+  bg: 'consumer',
   propDefs: {
     icon: {},
     size: { dataAttribute: true, default: 'small' },
@@ -63,7 +64,6 @@ export const SelectTriggerDefinition = defineComponent<SelectTriggerOwnProps>()(
       chevron: 'bui-SelectTriggerChevron',
       value: 'bui-SelectValue',
     },
-    bg: 'consumer',
     propDefs: {
       icon: {},
     },

--- a/packages/ui/src/components/TextField/TextField.module.css
+++ b/packages/ui/src/components/TextField/TextField.module.css
@@ -23,18 +23,6 @@
     font-family: var(--bui-font-regular);
     width: 100%;
     flex: 1;
-
-    &[data-on-bg='neutral-1'] .bui-Input {
-      background-color: var(--bui-bg-neutral-2);
-    }
-
-    &[data-on-bg='neutral-2'] .bui-Input {
-      background-color: var(--bui-bg-neutral-3);
-    }
-
-    &[data-on-bg='neutral-3'] .bui-Input {
-      background-color: var(--bui-bg-neutral-4);
-    }
   }
 
   .bui-InputWrapper {
@@ -80,6 +68,10 @@
       width: 1.25rem;
       height: 1.25rem;
     }
+
+    .bui-TextField[data-disabled] & {
+      color: var(--bui-fg-disabled);
+    }
   }
 
   .bui-Input {
@@ -117,8 +109,37 @@
     }
 
     &[data-disabled] {
-      opacity: 0.5;
       cursor: not-allowed;
+      color: var(--bui-fg-disabled);
+      background-color: var(--bui-bg-neutral-1-disabled);
+
+      &::placeholder {
+        color: var(--bui-fg-disabled);
+      }
+    }
+
+    .bui-TextField[data-on-bg='neutral-1'] & {
+      background-color: var(--bui-bg-neutral-2);
+
+      &[data-disabled] {
+        background-color: var(--bui-bg-neutral-2-disabled);
+      }
+    }
+
+    .bui-TextField[data-on-bg='neutral-2'] & {
+      background-color: var(--bui-bg-neutral-3);
+
+      &[data-disabled] {
+        background-color: var(--bui-bg-neutral-3-disabled);
+      }
+    }
+
+    .bui-TextField[data-on-bg='neutral-3'] & {
+      background-color: var(--bui-bg-neutral-4);
+
+      &[data-disabled] {
+        background-color: var(--bui-bg-neutral-4-disabled);
+      }
     }
   }
 }

--- a/packages/ui/src/components/TextField/TextField.stories.tsx
+++ b/packages/ui/src/components/TextField/TextField.stories.tsx
@@ -155,6 +155,12 @@ export const AutoBg = meta.story({
         TextField automatically detects its parent bg context and increments the
         neutral level by 1. No prop is needed — it's fully automatic.
       </div>
+      <div>
+        <Text>Default</Text>
+        <Flex mt="2" style={{ maxWidth: '300px' }}>
+          <TextField aria-label="Text" placeholder="Enter text" size="small" />
+        </Flex>
+      </div>
       <Box bg="neutral" p="4">
         <Text>Neutral 1 container</Text>
         <Flex mt="2" style={{ maxWidth: '300px' }}>
@@ -182,6 +188,63 @@ export const AutoBg = meta.story({
                 aria-label="Text"
                 placeholder="Enter text"
                 size="small"
+              />
+            </Flex>
+          </Box>
+        </Box>
+      </Box>
+    </Flex>
+  ),
+});
+
+export const AutoBgDisabled = meta.story({
+  render: () => (
+    <Flex direction="column" gap="4">
+      <div>
+        <Text>Default</Text>
+        <Flex mt="2" style={{ maxWidth: '300px' }}>
+          <TextField
+            aria-label="Text"
+            placeholder="Enter text"
+            size="small"
+            isDisabled
+          />
+        </Flex>
+      </div>
+      <Box bg="neutral" p="4">
+        <Text>Neutral 1 container</Text>
+        <Flex mt="2" style={{ maxWidth: '300px' }}>
+          <TextField
+            aria-label="Text"
+            placeholder="Enter text"
+            size="small"
+            isDisabled
+          />
+        </Flex>
+      </Box>
+      <Box bg="neutral">
+        <Box bg="neutral" p="4">
+          <Text>Neutral 2 container</Text>
+          <Flex mt="2" style={{ maxWidth: '300px' }}>
+            <TextField
+              aria-label="Text"
+              placeholder="Enter text"
+              size="small"
+              isDisabled
+            />
+          </Flex>
+        </Box>
+      </Box>
+      <Box bg="neutral">
+        <Box bg="neutral">
+          <Box bg="neutral" p="4">
+            <Text>Neutral 3 container</Text>
+            <Flex mt="2" style={{ maxWidth: '300px' }}>
+              <TextField
+                aria-label="Text"
+                placeholder="Enter text"
+                size="small"
+                isDisabled
               />
             </Flex>
           </Box>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Standardizes disabled styling across Backstage UI form controls so disabled inputs use disabled foreground and background tokens rather than opacity-based styling. This covers text, password, search, number, date, select, and combobox controls, and keeps interactive adornments such as the password visibility toggle using their normal affordance where appropriate.

Also updates AutoBg stories to show the default surface before the layered neutral examples, including disabled variants.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Validation:

- Ran targeted Prettier on changed files
- Ran `git diff --check` and `git diff --cached --check`
- Started Storybook locally for visual review
