### PR TITLE
Add `templateFilter` field to `sub-page:scaffolder/templates`

### DIFF
--- a/.changeset/long-dolls-return.md
+++ b/.changeset/long-dolls-return.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder': minor
 ---
 
-The `sub-page:scaffolder/templates` extension now accepts a `filter` field that lets you filter which templates are shown on the template list page.
+The `sub-page:scaffolder/templates` extension now accepts a `templateFilter` field that lets you filter which templates are shown on the template list page.

--- a/.changeset/long-dolls-return.md
+++ b/.changeset/long-dolls-return.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': minor
+---
+
+The `sub-page:scaffolder/templates` extension now accepts a `filter` field that lets you filter which templates are shown on the template list page.

--- a/docs/features/software-templates/configuration.md
+++ b/docs/features/software-templates/configuration.md
@@ -188,6 +188,24 @@ are also supported — see the
 [entity predicate queries reference](https://backstage.io/docs/features/software-catalog/catalog-customization#entity-predicate-queries)
 for the full grammar.
 
+### Filtering templates in `app-config.yaml`
+
+The `sub-page:scaffolder/templates` extension accepts a `templateFilter` config
+field. It is an [entity predicate query](https://backstage.io/docs/features/software-catalog/catalog-customization#entity-predicate-queries)
+applied to every template before it is displayed. For example, exclude templates
+tagged `wip`:
+
+```yaml
+app:
+  extensions:
+    - sub-page:scaffolder/templates:
+        config:
+          templateFilter:
+            $not:
+              metadata.tags:
+                $contains: wip
+```
+
 ### Replacing the default `TemplateCard`
 
 The `TemplateCard` exported from `@backstage/plugin-scaffolder-react/alpha`

--- a/plugins/scaffolder/report-alpha.api.md
+++ b/plugins/scaffolder/report-alpha.api.md
@@ -527,25 +527,25 @@ const _default: OverridableFrontendPlugin<
     'sub-page:scaffolder/templates': OverridableExtensionDefinition<{
       config: {
         enableBackstageUi: boolean;
-        filter: FilterPredicate | undefined;
         groups:
           | {
               title: string;
               filter: FilterPredicate;
             }[]
           | undefined;
+        templateFilter: FilterPredicate | undefined;
         path: string | undefined;
         title: string | undefined;
       };
       configInput: {
         enableBackstageUi?: boolean | undefined;
-        filter?: FilterPredicate | undefined;
         groups?:
           | {
               title: string;
               filter: FilterPredicate;
             }[]
           | undefined;
+        templateFilter?: FilterPredicate | undefined;
         path?: string | undefined;
         title?: string | undefined;
       };

--- a/plugins/scaffolder/report-alpha.api.md
+++ b/plugins/scaffolder/report-alpha.api.md
@@ -527,6 +527,7 @@ const _default: OverridableFrontendPlugin<
     'sub-page:scaffolder/templates': OverridableExtensionDefinition<{
       config: {
         enableBackstageUi: boolean;
+        filter: FilterPredicate | undefined;
         groups:
           | {
               title: string;
@@ -538,6 +539,7 @@ const _default: OverridableFrontendPlugin<
       };
       configInput: {
         enableBackstageUi?: boolean | undefined;
+        filter?: FilterPredicate | undefined;
         groups?:
           | {
               title: string;

--- a/plugins/scaffolder/src/alpha/components/TemplatesSubPage.tsx
+++ b/plugins/scaffolder/src/alpha/components/TemplatesSubPage.tsx
@@ -66,11 +66,11 @@ import {
 } from '@backstage/plugin-techdocs-common';
 
 function TemplateListContent({
-  filter,
   groups: configuredGroups,
+  templateFilter,
 }: {
-  filter?: (entity: TemplateEntityV1beta3) => boolean;
   groups?: TemplateGroupFilter[];
+  templateFilter?: (entity: TemplateEntityV1beta3) => boolean;
 }) {
   const registerComponentLink = useRouteRef(registerComponentRouteRef);
   const viewTechDocsLink = useRouteRef(viewTechDocRouteRef);
@@ -161,7 +161,7 @@ function TemplateListContent({
           <CatalogFilterLayout.Content>
             <TemplateGroups
               groups={groups}
-              templateFilter={filter}
+              templateFilter={templateFilter}
               onTemplateSelected={onTemplateSelected}
               additionalLinksForEntity={additionalLinksForEntity}
             />
@@ -181,8 +181,8 @@ function TemplateListContent({
 export function TemplatesSubPage(props: {
   formFields?: Array<FormField>;
   formProps?: FormProps;
-  filter?: (entity: TemplateEntityV1beta3) => boolean;
   groups?: TemplateGroupFilter[];
+  templateFilter?: (entity: TemplateEntityV1beta3) => boolean;
 }) {
   const customFieldExtensions = useCustomFieldExtensions(undefined);
   const customLayouts = useCustomLayouts(undefined);
@@ -204,7 +204,10 @@ export function TemplatesSubPage(props: {
       <Route
         index
         element={
-          <TemplateListContent filter={props.filter} groups={props.groups} />
+          <TemplateListContent
+            groups={props.groups}
+            templateFilter={props.templateFilter}
+          />
         }
       />
       <Route

--- a/plugins/scaffolder/src/alpha/components/TemplatesSubPage.tsx
+++ b/plugins/scaffolder/src/alpha/components/TemplatesSubPage.tsx
@@ -66,8 +66,10 @@ import {
 } from '@backstage/plugin-techdocs-common';
 
 function TemplateListContent({
+  filter,
   groups: configuredGroups,
 }: {
+  filter?: (entity: TemplateEntityV1beta3) => boolean;
   groups?: TemplateGroupFilter[];
 }) {
   const registerComponentLink = useRouteRef(registerComponentRouteRef);
@@ -159,6 +161,7 @@ function TemplateListContent({
           <CatalogFilterLayout.Content>
             <TemplateGroups
               groups={groups}
+              templateFilter={filter}
               onTemplateSelected={onTemplateSelected}
               additionalLinksForEntity={additionalLinksForEntity}
             />
@@ -178,6 +181,7 @@ function TemplateListContent({
 export function TemplatesSubPage(props: {
   formFields?: Array<FormField>;
   formProps?: FormProps;
+  filter?: (entity: TemplateEntityV1beta3) => boolean;
   groups?: TemplateGroupFilter[];
 }) {
   const customFieldExtensions = useCustomFieldExtensions(undefined);
@@ -197,7 +201,12 @@ export function TemplatesSubPage(props: {
 
   return (
     <Routes>
-      <Route index element={<TemplateListContent groups={props.groups} />} />
+      <Route
+        index
+        element={
+          <TemplateListContent filter={props.filter} groups={props.groups} />
+        }
+      />
       <Route
         path=":namespace/:templateName"
         element={

--- a/plugins/scaffolder/src/alpha/extensions.test.tsx
+++ b/plugins/scaffolder/src/alpha/extensions.test.tsx
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createExtensionTester } from '@backstage/frontend-test-utils';
+import { scaffolderTemplatesSubPage } from './extensions';
+import {
+  mockApis,
+  renderInTestApp,
+  TestApiProvider,
+} from '@backstage/test-utils';
+import { screen, waitForElementToBeRemoved } from '@testing-library/react';
+import { rootRouteRef } from '../routes';
+import { catalogApiMock } from '@backstage/plugin-catalog-react/testUtils';
+import {
+  catalogApiRef,
+  entityRouteRef,
+  starredEntitiesApiRef,
+} from '@backstage/plugin-catalog-react';
+import { DefaultStarredEntitiesApi } from '@backstage/plugin-catalog';
+import { permissionApiRef } from '@backstage/plugin-permission-react';
+
+describe('scaffolder extensions', () => {
+  describe('sub-page:scaffolder/templates', () => {
+    describe('templateFilter', () => {
+      it('should not filter anything when omitted', async () => {
+        const catalogMock = catalogApiMock({
+          entities: [
+            {
+              apiVersion: 'scaffolder.backstage.io/v1beta3',
+              kind: 'Template',
+              metadata: { name: 'template-foo' },
+              spec: { type: 'service', steps: [] },
+            },
+            {
+              apiVersion: 'scaffolder.backstage.io/v1beta3',
+              kind: 'Template',
+              metadata: { name: 'template-bar' },
+              spec: { type: 'service', steps: [] },
+            },
+            {
+              apiVersion: 'scaffolder.backstage.io/v1beta3',
+              kind: 'Template',
+              metadata: { name: 'template-baz' },
+              spec: { type: 'service', steps: [] },
+            },
+          ],
+        });
+        const tester = createExtensionTester(
+          Object.assign(
+            { namespace: 'scaffolder' },
+            scaffolderTemplatesSubPage,
+          ),
+        );
+        await renderInTestApp(
+          <TestApiProvider
+            apis={[
+              [catalogApiRef, catalogMock],
+              [
+                starredEntitiesApiRef,
+                new DefaultStarredEntitiesApi({
+                  storageApi: mockApis.storage(),
+                }),
+              ],
+              [permissionApiRef, mockApis.permission()],
+            ]}
+          >
+            {tester.reactElement()}
+          </TestApiProvider>,
+          {
+            mountedRoutes: {
+              '/templates/': rootRouteRef,
+              '/catalog/:namespace/:kind/:name': entityRouteRef,
+            },
+          },
+        );
+
+        await waitForElementToBeRemoved(() => screen.getByTestId('progress'));
+        expect(await screen.findByText('template-foo')).toBeInTheDocument();
+        expect(await screen.findByText('template-bar')).toBeInTheDocument();
+        expect(await screen.findByText('template-baz')).toBeInTheDocument();
+      });
+
+      it('should filter templates', async () => {
+        const catalogMock = catalogApiMock({
+          entities: [
+            {
+              apiVersion: 'scaffolder.backstage.io/v1beta3',
+              kind: 'Template',
+              metadata: { name: 'template-foo' },
+              spec: { type: 'service', steps: [] },
+            },
+            {
+              apiVersion: 'scaffolder.backstage.io/v1beta3',
+              kind: 'Template',
+              metadata: { name: 'template-wip', tags: ['wip'] },
+              spec: { type: 'service', steps: [] },
+            },
+          ],
+        });
+        const tester = createExtensionTester(
+          Object.assign(
+            { namespace: 'scaffolder' },
+            scaffolderTemplatesSubPage,
+          ),
+          {
+            config: {
+              templateFilter: {
+                $not: {
+                  'metadata.tags': { $contains: 'wip' },
+                },
+              },
+            },
+          },
+        );
+        await renderInTestApp(
+          <TestApiProvider
+            apis={[
+              [catalogApiRef, catalogMock],
+              [
+                starredEntitiesApiRef,
+                new DefaultStarredEntitiesApi({
+                  storageApi: mockApis.storage(),
+                }),
+              ],
+              [permissionApiRef, mockApis.permission()],
+            ]}
+          >
+            {tester.reactElement()}
+          </TestApiProvider>,
+          {
+            mountedRoutes: {
+              '/templates/': rootRouteRef,
+              '/catalog/:namespace/:kind/:name': entityRouteRef,
+            },
+          },
+        );
+
+        await waitForElementToBeRemoved(() => screen.getByTestId('progress'));
+        expect(await screen.findByText('template-foo')).toBeInTheDocument();
+        expect(screen.queryByText('template-wip')).not.toBeInTheDocument();
+      });
+
+      it.each([
+        ['0', 0],
+        ['false', false],
+        ['empty string', ''],
+      ])(
+        'should filter out everything will null-ish value (%s)',
+        async (_name, value) => {
+          const catalogMock = catalogApiMock({
+            entities: [
+              {
+                apiVersion: 'scaffolder.backstage.io/v1beta3',
+                kind: 'Template',
+                metadata: { name: 'template-foo' },
+                spec: { type: 'service', steps: [] },
+              },
+            ],
+          });
+          const tester = createExtensionTester(
+            Object.assign(
+              { namespace: 'scaffolder' },
+              scaffolderTemplatesSubPage,
+            ),
+            {
+              config: {
+                templateFilter: value,
+              },
+            },
+          );
+          await renderInTestApp(
+            <TestApiProvider
+              apis={[
+                [catalogApiRef, catalogMock],
+                [
+                  starredEntitiesApiRef,
+                  new DefaultStarredEntitiesApi({
+                    storageApi: mockApis.storage(),
+                  }),
+                ],
+                [permissionApiRef, mockApis.permission()],
+              ]}
+            >
+              {tester.reactElement()}
+            </TestApiProvider>,
+            {
+              mountedRoutes: {
+                '/templates/': rootRouteRef,
+                '/catalog/:namespace/:kind/:name': entityRouteRef,
+              },
+            },
+          );
+
+          await waitForElementToBeRemoved(() => screen.getByTestId('progress'));
+          expect(screen.queryByText('template-foo')).not.toBeInTheDocument();
+        },
+      );
+    });
+  });
+});

--- a/plugins/scaffolder/src/alpha/extensions.test.tsx
+++ b/plugins/scaffolder/src/alpha/extensions.test.tsx
@@ -158,7 +158,7 @@ describe('scaffolder extensions', () => {
         ['false', false],
         ['empty string', ''],
       ])(
-'should filter out everything with falsy value (%s)',
+        'should filter out everything with falsy value (%s)',
         async (_name, value) => {
           const catalogMock = catalogApiMock({
             entities: [

--- a/plugins/scaffolder/src/alpha/extensions.test.tsx
+++ b/plugins/scaffolder/src/alpha/extensions.test.tsx
@@ -158,7 +158,7 @@ describe('scaffolder extensions', () => {
         ['false', false],
         ['empty string', ''],
       ])(
-        'should filter out everything will null-ish value (%s)',
+'should filter out everything with falsy value (%s)',
         async (_name, value) => {
           const catalogMock = catalogApiMock({
             entities: [

--- a/plugins/scaffolder/src/alpha/extensions.tsx
+++ b/plugins/scaffolder/src/alpha/extensions.tsx
@@ -61,6 +61,7 @@ export const scaffolderTemplatesSubPage = SubPageBlueprint.makeWithOverrides({
   name: 'templates',
   configSchema: {
     enableBackstageUi: z.boolean().optional().default(false),
+    filter: createZodV4FilterPredicateSchema().optional(),
     groups: z
       .array(
         z.object({
@@ -73,6 +74,9 @@ export const scaffolderTemplatesSubPage = SubPageBlueprint.makeWithOverrides({
   factory(originalFactory, { apis, config }) {
     const formFieldsApi = apis.get(formFieldsApiRef);
 
+    const filter = config.filter
+      ? filterPredicateToFilterFunction(config.filter)
+      : undefined;
     const groups: TemplateGroupFilter[] | undefined = config.groups?.map(
       group => ({
         title: group.title,
@@ -89,6 +93,7 @@ export const scaffolderTemplatesSubPage = SubPageBlueprint.makeWithOverrides({
         return import('./components/TemplatesSubPage').then(m => (
           <m.TemplatesSubPage
             formFields={formFields}
+            filter={filter}
             groups={groups}
             formProps={{
               EXPERIMENTAL_theme: config.enableBackstageUi ? 'bui' : 'mui',

--- a/plugins/scaffolder/src/alpha/extensions.tsx
+++ b/plugins/scaffolder/src/alpha/extensions.tsx
@@ -61,7 +61,6 @@ export const scaffolderTemplatesSubPage = SubPageBlueprint.makeWithOverrides({
   name: 'templates',
   configSchema: {
     enableBackstageUi: z.boolean().optional().default(false),
-    filter: createZodV4FilterPredicateSchema().optional(),
     groups: z
       .array(
         z.object({
@@ -70,19 +69,20 @@ export const scaffolderTemplatesSubPage = SubPageBlueprint.makeWithOverrides({
         }),
       )
       .optional(),
+    templateFilter: createZodV4FilterPredicateSchema().optional(),
   },
   factory(originalFactory, { apis, config }) {
     const formFieldsApi = apis.get(formFieldsApiRef);
 
-    const filter = config.filter
-      ? filterPredicateToFilterFunction(config.filter)
-      : undefined;
     const groups: TemplateGroupFilter[] | undefined = config.groups?.map(
       group => ({
         title: group.title,
         filter: filterPredicateToFilterFunction(group.filter),
       }),
     );
+    const templateFilter = config.templateFilter
+      ? filterPredicateToFilterFunction(config.templateFilter)
+      : undefined;
 
     return originalFactory({
       path: 'templates',
@@ -93,8 +93,8 @@ export const scaffolderTemplatesSubPage = SubPageBlueprint.makeWithOverrides({
         return import('./components/TemplatesSubPage').then(m => (
           <m.TemplatesSubPage
             formFields={formFields}
-            filter={filter}
             groups={groups}
+            templateFilter={templateFilter}
             formProps={{
               EXPERIMENTAL_theme: config.enableBackstageUi ? 'bui' : 'mui',
             }}

--- a/plugins/scaffolder/src/alpha/extensions.tsx
+++ b/plugins/scaffolder/src/alpha/extensions.tsx
@@ -80,9 +80,10 @@ export const scaffolderTemplatesSubPage = SubPageBlueprint.makeWithOverrides({
         filter: filterPredicateToFilterFunction(group.filter),
       }),
     );
-    const templateFilter = config.templateFilter
-      ? filterPredicateToFilterFunction(config.templateFilter)
-      : undefined;
+    const templateFilter =
+      config.templateFilter === undefined
+        ? undefined
+        : filterPredicateToFilterFunction(config.templateFilter);
 
     return originalFactory({
       path: 'templates',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This PR adds a `templateFilter` field to `sub-page:scaffolder/templates`. This option was present in the legacy scaffolder plugin. I've simply exposed it for the alpha plugin. It's implemented using `@backstage/filter-predicates` so that it can be configured through `app-config.yaml`.

I need this feature to migrate my backstage instance to use the NFS scaffolder plugin. We use the filtering option from the old plugin to hide templates with the `wip` tag. This lets our users test and run early versions of templates without exposing them globally.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
