### PR TITLE
fix(catalog-react): show correct owned count when user has no ownership entity refs

### DIFF
--- a/.changeset/fix-owned-count-empty-refs.md
+++ b/.changeset/fix-owned-count-empty-refs.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Fixed an issue where the "Owned" count in `UserListPicker` would display the total number of catalog entities instead of 0 when the logged-in user has no ownership entity refs. The empty `relations.ownedBy` filter was being silently dropped by the catalog client, causing the backend to return all entities with no ownership filter applied.

--- a/.changeset/fix-owned-count-empty-refs.md
+++ b/.changeset/fix-owned-count-empty-refs.md
@@ -3,3 +3,5 @@
 ---
 
 Fixed an issue where the "Owned" count in `UserListPicker` would display the total number of catalog entities instead of 0 when the logged-in user has no ownership entity refs. The empty `relations.ownedBy` filter was being silently dropped by the catalog client, causing the backend to return all entities with no ownership filter applied.
+
+This was a regression introduced in #22131, which removed an explicit `ownershipEntityRefs?.length === 0` guard that had been present since #20339.

--- a/plugins/catalog-react/src/components/UserListPicker/useOwnedEntitiesCount.test.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/useOwnedEntitiesCount.test.tsx
@@ -163,13 +163,11 @@ describe('useOwnedEntitiesCount', () => {
   });
 
   it(`should return count 0 without invoking queryEntities if ownershipEntityRefs is empty`, async () => {
-    jest
-      .spyOn(mockIdentityApi, 'getBackstageIdentity')
-      .mockResolvedValueOnce({
-        type: 'user',
-        ownershipEntityRefs: [],
-        userEntityRef: 'user:default/spiderman',
-      });
+    jest.spyOn(mockIdentityApi, 'getBackstageIdentity').mockResolvedValueOnce({
+      type: 'user',
+      ownershipEntityRefs: [],
+      userEntityRef: 'user:default/spiderman',
+    });
 
     mockCatalogApi.queryEntities.mockResolvedValue({
       items: [],
@@ -187,10 +185,9 @@ describe('useOwnedEntitiesCount', () => {
       expect(mockIdentityApi.getBackstageIdentity).toHaveBeenCalled(),
     );
 
-    await expect(
-      waitFor(() => expect(mockCatalogApi.queryEntities).toHaveBeenCalled()),
-    ).rejects.toThrow();
+    await waitFor(() => expect(result.current.loading).toBe(false));
 
+    expect(mockCatalogApi.queryEntities).not.toHaveBeenCalled();
     expect(result.current).toEqual({
       count: 0,
       loading: false,

--- a/plugins/catalog-react/src/components/UserListPicker/useOwnedEntitiesCount.test.tsx
+++ b/plugins/catalog-react/src/components/UserListPicker/useOwnedEntitiesCount.test.tsx
@@ -162,6 +162,43 @@ describe('useOwnedEntitiesCount', () => {
     });
   });
 
+  it(`should return count 0 without invoking queryEntities if ownershipEntityRefs is empty`, async () => {
+    jest
+      .spyOn(mockIdentityApi, 'getBackstageIdentity')
+      .mockResolvedValueOnce({
+        type: 'user',
+        ownershipEntityRefs: [],
+        userEntityRef: 'user:default/spiderman',
+      });
+
+    mockCatalogApi.queryEntities.mockResolvedValue({
+      items: [],
+      totalItems: 10,
+      pageInfo: {},
+    });
+
+    const { result } = renderHook(() => useOwnedEntitiesCount(), {
+      wrapper: createWrapperWithInitialFilters({
+        namespace: new EntityNamespaceFilter(['a-namespace']),
+      }),
+    });
+
+    await waitFor(() =>
+      expect(mockIdentityApi.getBackstageIdentity).toHaveBeenCalled(),
+    );
+
+    await expect(
+      waitFor(() => expect(mockCatalogApi.queryEntities).toHaveBeenCalled()),
+    ).rejects.toThrow();
+
+    expect(result.current).toEqual({
+      count: 0,
+      loading: false,
+      filter: EntityUserFilter.owned([]),
+      ownershipEntityRefs: [],
+    });
+  });
+
   it(`should send claims in common between owners filter and logged in user`, async () => {
     mockCatalogApi.queryEntities.mockResolvedValue({
       items: [],

--- a/plugins/catalog-react/src/components/UserListPicker/useOwnedEntitiesCount.ts
+++ b/plugins/catalog-react/src/components/UserListPicker/useOwnedEntitiesCount.ts
@@ -109,7 +109,7 @@ function getOwnedCountClaims(
   owners: EntityOwnerFilter | undefined,
   ownershipEntityRefs: string[] | undefined,
 ) {
-  if (ownershipEntityRefs === undefined) {
+  if (!ownershipEntityRefs?.length) {
     return undefined;
   }
   const ownersRefs = owners?.values ?? [];


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When a logged-in user has no ownership entity refs (empty `ownershipEntityRefs: []`), the \"Owned\" count badge in `UserListPicker` was incorrectly showing the total number of catalog entities instead of 0.

The root cause: `getOwnedCountClaims` only guarded against `ownershipEntityRefs === undefined` (the loading state), but not against an empty array. When the refs were `[]`, the function returned `[]` as the owned claims, which was then passed to `catalogApi.queryEntities` as `{ 'relations.ownedBy': [] }`. The catalog client silently drops filter keys with empty array values, so the backend received the request with no ownership filter at all and returned every entity.

The fix changes the guard to `!ownershipEntityRefs?.length`, which treats both `undefined` (still loading) and `[]` (no claims) as reasons to skip the API call and return 0 immediately.

This can happen in practice for users whose entity has not yet been ingested into the catalog, or for identity providers that don't populate ownership refs for certain accounts.

# Before
<img width="742" height="491" alt="Screenshot 2026-06-17 at 23 09 24" src="https://github.com/user-attachments/assets/6a0b3f60-3731-4ef5-8777-e8b7e8a8df94" />

# After
<img width="609" height="369" alt="Screenshot 2026-06-17 at 23 06 08" src="https://github.com/user-attachments/assets/f8aafc08-2f45-4d88-8a46-c1fda7ec1cb9" />

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))