### PR TITLE
fix(catalog): verify catalogEntityDeletePermission in unregister-entity MCP action

### DIFF
--- a/.changeset/flat-dryers-heal.md
+++ b/.changeset/flat-dryers-heal.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+The `unregister-entity` action now checks entity deletion permissions before removing locations and their managed entities.

--- a/plugins/catalog-backend/src/actions/createUnregisterCatalogEntitiesAction.test.ts
+++ b/plugins/catalog-backend/src/actions/createUnregisterCatalogEntitiesAction.test.ts
@@ -16,18 +16,40 @@
 import { createUnregisterCatalogEntitiesAction } from './createUnregisterCatalogEntitiesAction';
 import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
 import { actionsRegistryServiceMock } from '@backstage/backend-test-utils/alpha';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
+import { PermissionsService, AuthService } from '@backstage/backend-plugin-api';
 
 describe('createUnregisterCatalogEntitiesAction', () => {
+  const mockPermissions = {
+    authorize: jest.fn().mockResolvedValue([{ result: AuthorizeResult.ALLOW }]),
+  } as unknown as PermissionsService;
+
+  const mockAuth = {
+    getOwnServiceCredentials: jest.fn().mockResolvedValue({
+      token: 'mock-service-token',
+    }),
+  } as unknown as AuthService;
+
   describe('with locationId', () => {
     it('should successfully unregister a catalog location with a valid locationId', async () => {
       const mockActionsRegistry = actionsRegistryServiceMock();
       const mockCatalog = catalogServiceMock();
 
       mockCatalog.removeLocationById = jest.fn().mockResolvedValue(undefined);
+      mockCatalog.getLocationById = jest.fn().mockResolvedValue({
+        id: 'test-location-id-1234',
+        type: 'url',
+        target:
+          'https://github.com/backstage/demo/blob/master/catalog-info.yaml',
+        entityRef: 'location:default/generated-loc',
+      });
+      mockCatalog.getEntities = jest.fn().mockResolvedValue({ items: [] });
 
       createUnregisterCatalogEntitiesAction({
         catalog: mockCatalog,
         actionsRegistry: mockActionsRegistry,
+        permissions: mockPermissions,
+        auth: mockAuth,
       });
 
       const result = await mockActionsRegistry.invoke({
@@ -52,10 +74,20 @@ describe('createUnregisterCatalogEntitiesAction', () => {
       mockCatalog.removeLocationById = jest
         .fn()
         .mockRejectedValue(new Error(errorMessage));
+      mockCatalog.getLocationById = jest.fn().mockResolvedValue({
+        id: 'test-location-id-1234',
+        type: 'url',
+        target:
+          'https://github.com/backstage/demo/blob/master/catalog-info.yaml',
+        entityRef: 'location:default/generated-loc',
+      });
+      mockCatalog.getEntities = jest.fn().mockResolvedValue({ items: [] });
 
       createUnregisterCatalogEntitiesAction({
         catalog: mockCatalog,
         actionsRegistry: mockActionsRegistry,
+        permissions: mockPermissions,
+        auth: mockAuth,
       });
 
       await expect(
@@ -81,11 +113,14 @@ describe('createUnregisterCatalogEntitiesAction', () => {
           { id: 'location-id-2', target: 'https://other-url.com/catalog.yaml' },
         ],
       });
+      mockCatalog.getEntities = jest.fn().mockResolvedValue({ items: [] });
       mockCatalog.removeLocationById = jest.fn().mockResolvedValue(undefined);
 
       createUnregisterCatalogEntitiesAction({
         catalog: mockCatalog,
         actionsRegistry: mockActionsRegistry,
+        permissions: mockPermissions,
+        auth: mockAuth,
       });
 
       const result = await mockActionsRegistry.invoke({
@@ -122,11 +157,14 @@ describe('createUnregisterCatalogEntitiesAction', () => {
           },
         ],
       });
+      mockCatalog.getEntities = jest.fn().mockResolvedValue({ items: [] });
       mockCatalog.removeLocationById = jest.fn().mockResolvedValue(undefined);
 
       createUnregisterCatalogEntitiesAction({
         catalog: mockCatalog,
         actionsRegistry: mockActionsRegistry,
+        permissions: mockPermissions,
+        auth: mockAuth,
       });
 
       const result = await mockActionsRegistry.invoke({
@@ -162,11 +200,14 @@ describe('createUnregisterCatalogEntitiesAction', () => {
           { id: 'location-id-2', target: locationUrl },
         ],
       });
+      mockCatalog.getEntities = jest.fn().mockResolvedValue({ items: [] });
       mockCatalog.removeLocationById = jest.fn().mockResolvedValue(undefined);
 
       createUnregisterCatalogEntitiesAction({
         catalog: mockCatalog,
         actionsRegistry: mockActionsRegistry,
+        permissions: mockPermissions,
+        auth: mockAuth,
       });
 
       const result = await mockActionsRegistry.invoke({
@@ -208,6 +249,8 @@ describe('createUnregisterCatalogEntitiesAction', () => {
       createUnregisterCatalogEntitiesAction({
         catalog: mockCatalog,
         actionsRegistry: mockActionsRegistry,
+        permissions: mockPermissions,
+        auth: mockAuth,
       });
 
       await expect(
@@ -232,6 +275,8 @@ describe('createUnregisterCatalogEntitiesAction', () => {
       createUnregisterCatalogEntitiesAction({
         catalog: mockCatalog,
         actionsRegistry: mockActionsRegistry,
+        permissions: mockPermissions,
+        auth: mockAuth,
       });
 
       await expect(
@@ -248,6 +293,128 @@ describe('createUnregisterCatalogEntitiesAction', () => {
         name: 'Error',
         message: 'Failed to get locations',
       });
+    });
+  });
+
+  describe('with permission checks', () => {
+    it('should successfully unregister a catalog location if delete permission is allowed', async () => {
+      const mockActionsRegistry = actionsRegistryServiceMock();
+      const mockCatalog = catalogServiceMock();
+      const allowedPermissions = {
+        authorize: jest
+          .fn()
+          .mockResolvedValue([
+            { result: AuthorizeResult.ALLOW },
+            { result: AuthorizeResult.ALLOW },
+          ]),
+      } as unknown as PermissionsService;
+
+      const locationUrl =
+        'https://github.com/backstage/demo/blob/master/catalog-info.yaml';
+
+      mockCatalog.getLocationById = jest.fn().mockResolvedValue({
+        id: 'location-id-1',
+        type: 'url',
+        target: locationUrl,
+        entityRef: 'location:default/generated-loc',
+      });
+      mockCatalog.getEntities = jest.fn().mockResolvedValue({
+        items: [
+          {
+            kind: 'Component',
+            metadata: { name: 'test-component', namespace: 'default' },
+          },
+        ],
+      });
+      mockCatalog.removeLocationById = jest.fn().mockResolvedValue(undefined);
+
+      createUnregisterCatalogEntitiesAction({
+        catalog: mockCatalog,
+        actionsRegistry: mockActionsRegistry,
+        permissions: allowedPermissions,
+        auth: mockAuth,
+      });
+
+      const result = await mockActionsRegistry.invoke({
+        id: 'test:unregister-entity',
+        input: { type: { locationId: 'location-id-1' } },
+      });
+
+      expect(result.output).toEqual({});
+      expect(mockCatalog.getEntities).toHaveBeenCalledWith(
+        {
+          filter: {
+            'metadata.annotations.backstage.io/managed-by-origin-location': `url:${locationUrl}`,
+          },
+          fields: ['kind', 'metadata.name', 'metadata.namespace'],
+        },
+        expect.any(Object),
+      );
+      expect(allowedPermissions.authorize).toHaveBeenCalledWith(
+        [
+          {
+            permission: expect.objectContaining({
+              name: 'catalog.entity.delete',
+            }),
+            resourceRef: 'location:default/generated-loc',
+          },
+          {
+            permission: expect.objectContaining({
+              name: 'catalog.entity.delete',
+            }),
+            resourceRef: 'component:default/test-component',
+          },
+        ],
+        expect.any(Object),
+      );
+      expect(mockCatalog.removeLocationById).toHaveBeenCalledWith(
+        'location-id-1',
+        expect.any(Object),
+      );
+    });
+
+    it('should throw NotAllowedError and not unregister if delete permission is denied', async () => {
+      const mockActionsRegistry = actionsRegistryServiceMock();
+      const mockCatalog = catalogServiceMock();
+      const deniedPermissions = {
+        authorize: jest
+          .fn()
+          .mockResolvedValue([{ result: AuthorizeResult.DENY }]),
+      } as unknown as PermissionsService;
+
+      const locationUrl =
+        'https://github.com/backstage/demo/blob/master/catalog-info.yaml';
+
+      mockCatalog.getLocationById = jest.fn().mockResolvedValue({
+        id: 'location-id-1',
+        type: 'url',
+        target: locationUrl,
+        entityRef: 'location:default/generated-loc',
+      });
+      mockCatalog.getEntities = jest.fn().mockResolvedValue({
+        items: [],
+      });
+      mockCatalog.removeLocationById = jest.fn().mockResolvedValue(undefined);
+
+      createUnregisterCatalogEntitiesAction({
+        catalog: mockCatalog,
+        actionsRegistry: mockActionsRegistry,
+        permissions: deniedPermissions,
+        auth: mockAuth,
+      });
+
+      await expect(
+        mockActionsRegistry.invoke({
+          id: 'test:unregister-entity',
+          input: { type: { locationId: 'location-id-1' } },
+        }),
+      ).rejects.toMatchObject({
+        name: 'NotAllowedError',
+        message:
+          'You are not authorized to delete some of the entities managed by this location.',
+      });
+
+      expect(mockCatalog.removeLocationById).not.toHaveBeenCalled();
     });
   });
 });

--- a/plugins/catalog-backend/src/actions/createUnregisterCatalogEntitiesAction.ts
+++ b/plugins/catalog-backend/src/actions/createUnregisterCatalogEntitiesAction.ts
@@ -13,16 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { PermissionsService, AuthService } from '@backstage/backend-plugin-api';
 import { ActionsRegistryService } from '@backstage/backend-plugin-api/alpha';
-import { NotFoundError } from '@backstage/errors';
+import { Location } from '@backstage/catalog-client';
+import {
+  ANNOTATION_ORIGIN_LOCATION,
+  stringifyEntityRef,
+} from '@backstage/catalog-model';
+import { NotAllowedError, NotFoundError } from '@backstage/errors';
+import { catalogEntityDeletePermission } from '@backstage/plugin-catalog-common/alpha';
 import { CatalogService } from '@backstage/plugin-catalog-node';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
 
 export const createUnregisterCatalogEntitiesAction = ({
   catalog,
   actionsRegistry,
+  permissions,
+  auth,
 }: {
   catalog: CatalogService;
   actionsRegistry: ActionsRegistryService;
+  permissions: PermissionsService;
+  auth: AuthService;
 }) => {
   actionsRegistry.register({
     name: 'unregister-entity',
@@ -63,37 +75,86 @@ Once completed, all entities associated with the Location will be deleted from t
       output: z => z.object({}),
     },
     action: async ({ input: { type }, credentials }) => {
+      let locations: Location[] = [];
+      const serviceCredentials = await auth.getOwnServiceCredentials();
+
       if ('locationId' in type) {
-        await catalog.removeLocationById(type.locationId, {
-          credentials,
+        const location = await catalog.getLocationById(type.locationId, {
+          credentials: serviceCredentials,
         });
-      } else {
-        const locations = await catalog
-          .getLocations(
-            {},
-            {
-              credentials,
-            },
-          )
-          .then(response =>
-            response.items.filter(
-              location =>
-                location.target.toLowerCase() ===
-                type.locationUrl.toLowerCase(),
-            ),
+        if (!location) {
+          throw new NotFoundError(
+            `Location with ID ${type.locationId} not found`,
           );
+        }
+        locations = [location];
+      } else {
+        const response = await catalog.getLocations(
+          {},
+          {
+            credentials: serviceCredentials,
+          },
+        );
+        locations = response.items.filter(
+          location =>
+            location.target.toLowerCase() === type.locationUrl.toLowerCase(),
+        );
 
         if (locations.length === 0) {
           throw new NotFoundError(
             `Location with URL ${type.locationUrl} not found`,
           );
         }
+      }
 
-        for (const location of locations) {
-          await catalog.removeLocationById(location.id, {
-            credentials,
-          });
+      const entitiesToCheck: string[] = [];
+      for (const location of locations) {
+        if (location.entityRef) {
+          entitiesToCheck.push(location.entityRef);
         }
+        const originLocationRef = `${location.type}:${location.target}`;
+        const colocated = await catalog.getEntities(
+          {
+            filter: {
+              [`metadata.annotations.${ANNOTATION_ORIGIN_LOCATION}`]:
+                originLocationRef,
+            },
+            fields: ['kind', 'metadata.name', 'metadata.namespace'],
+          },
+          {
+            credentials: serviceCredentials,
+          },
+        );
+        for (const entity of colocated.items) {
+          const ref = stringifyEntityRef(entity);
+          if (!entitiesToCheck.includes(ref)) {
+            entitiesToCheck.push(ref);
+          }
+        }
+      }
+
+      if (entitiesToCheck.length > 0) {
+        const authorizationResults = await permissions.authorize(
+          entitiesToCheck.map(entityRef => ({
+            permission: catalogEntityDeletePermission,
+            resourceRef: entityRef,
+          })),
+          { credentials },
+        );
+
+        for (const { result } of authorizationResults) {
+          if (result === AuthorizeResult.DENY) {
+            throw new NotAllowedError(
+              'You are not authorized to delete some of the entities managed by this location.',
+            );
+          }
+        }
+      }
+
+      for (const location of locations) {
+        await catalog.removeLocationById(location.id, {
+          credentials,
+        });
       }
 
       return { output: {} };

--- a/plugins/catalog-backend/src/actions/index.ts
+++ b/plugins/catalog-backend/src/actions/index.ts
@@ -16,6 +16,7 @@
 
 import { ActionsRegistryService } from '@backstage/backend-plugin-api/alpha';
 import { CatalogService } from '@backstage/plugin-catalog-node';
+import { PermissionsService, AuthService } from '@backstage/backend-plugin-api';
 import { ModelHolder } from '../model/ModelHolder';
 import { createGetCatalogModelDescriptionAction } from './createGetCatalogModelDescriptionAction.ts';
 import { createGetCatalogEntityAction } from './createGetCatalogEntityAction.ts';
@@ -28,6 +29,8 @@ export const createCatalogActions = (options: {
   actionsRegistry: ActionsRegistryService;
   catalog: CatalogService;
   modelHolder: ModelHolder | undefined;
+  permissions: PermissionsService;
+  auth: AuthService;
   useExperimentalCatalogLayersDescriptions?: boolean;
 }) => {
   createGetCatalogModelDescriptionAction(options);

--- a/plugins/catalog-backend/src/service/CatalogPlugin.ts
+++ b/plugins/catalog-backend/src/service/CatalogPlugin.ts
@@ -288,6 +288,8 @@ export const catalogPlugin = createBackendPlugin({
           catalog,
           actionsRegistry,
           modelHolder,
+          permissions,
+          auth,
           useExperimentalCatalogLayersDescriptions:
             config.getOptionalBoolean(
               'catalog.actions.experimentalCatalogLayersDescriptions.enabled',


### PR DESCRIPTION
## Hey, I just made a Pull Request!
- Fixes: #34617 
#### PR Overview
<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This pull request secures the `catalog:unregister-entity` action (frequently used by AI/MCP servers and backend automation) against unauthorized deletion of components and locations. 

##### The Issue:
Previously, the `unregister-entity` action only verified the broad, non-resource-level permission `catalogLocationDeletePermission`. Under the hood, this deletes both the `Location` resource and all entities managed by that location. Since there was no resource-specific authorization check, any user possessing generic permission to delete *any* location could delete *all* catalog locations and any entity populated by those locations.

##### The Solution:
- Updated the action in `createUnregisterCatalogEntitiesAction.ts` to accept the `PermissionsService` dependency.
- Before removing the location, the action now retrieves the location object and any colocated entities spawned/managed by it (via the `backstage.io/managed-by-origin-location` annotation).
- Resolves each of these items' entity refs and runs a bulk `permissions.authorize` call against the resource-level `catalogEntityDeletePermission`.
- Throws a `NotAllowedError` if permission is denied for any associated entity, preventing unauthorized deletion.
- Injected the `PermissionsService` dependency through the catalog backend plugin initialization (`CatalogPlugin.ts` & `actions/index.ts`).

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.