### PR TITLE
cli-module-new: Replace deprecated alertApiRef by toastApiRef in code example

### DIFF
--- a/.changeset/lovely-meals-warn.md
+++ b/.changeset/lovely-meals-warn.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli-module-new': patch
+---
+
+Updated the `plugin-web-library` template to use `toastApiRef` from `@backstage/frontend-plugin-api` instead of the deprecated `alertApiRef` from `@backstage/core-plugin-api`.

--- a/packages/cli-module-new/templates/plugin-web-library/package.json.hbs
+++ b/packages/cli-module-new/templates/plugin-web-library/package.json.hbs
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@backstage/core-plugin-api": "{{versionQuery '@backstage/core-plugin-api'}}",
+    "@backstage/frontend-plugin-api": "{{versionQuery '@backstage/frontend-plugin-api'}}",
     "@material-ui/core": "{{versionQuery '@material-ui/core' '4.12.2'}}"
   },
   "peerDependencies": {

--- a/packages/cli-module-new/templates/plugin-web-library/src/hooks/useExample/useExample.ts
+++ b/packages/cli-module-new/templates/plugin-web-library/src/hooks/useExample/useExample.ts
@@ -1,15 +1,16 @@
 import { useEffect } from 'react';
-import { useApi, alertApiRef } from '@backstage/core-plugin-api';
+import { useApi } from '@backstage/core-plugin-api';
+import { toastApiRef } from '@backstage/frontend-plugin-api';
 
 /**
- * Shows an example alert.
+ * Shows an example toast.
  *
  * @public
  */
 export function useExample() {
-  const alertApi = useApi(alertApiRef);
+  const toastApi = useApi(toastApiRef);
 
   useEffect(() => {
-    alertApi.post({ message: 'Hello World!' });
-  }, [alertApi]);
+    toastApi.post({ title: 'Hello World!' });
+  }, [toastApi]);
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This update the scaffolded hook example with the new `toastApiRef` when using CLI `yarn changeset @backstage/cli-module-new` 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
