### PR TITLE
feat(mcp): sanitize tool names to use underscores

### DIFF
--- a/.changeset/mcp-actions-sanitize-tool-names.md
+++ b/.changeset/mcp-actions-sanitize-tool-names.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-mcp-actions-backend': minor
+---
+
+MCP tool names are now sanitized so that they only contain alphanumeric characters and underscores. Any other characters, such as `.` and `-`, are replaced with underscores. For example, an action previously exposed as `catalog.get-catalog-entity` is now exposed as `catalog_get_catalog_entity`. This applies both with and without the plugin ID prefix configured via `mcpActions.namespacedToolNames`.

--- a/plugins/mcp-actions-backend/README.md
+++ b/plugins/mcp-actions-backend/README.md
@@ -73,14 +73,18 @@ export const myPlugin = createBackendPlugin({
 
 ### Namespaced Tool Names
 
-By default, MCP tool names include the plugin ID prefix to avoid collisions across plugins. For example, an action registered as `greet-user` by `my-custom-plugin` is exposed as `my-custom-plugin.greet-user`.
+By default, MCP tool names include the plugin ID prefix to avoid collisions across plugins. For example, an action registered as `greet-user` by `my-custom-plugin` is exposed as `my_custom_plugin_greet_user`.
 
-You can disable this if you need the short names for backward compatibility:
+You can disable the plugin ID prefix if you need the short names for backward compatibility:
 
 ```yaml
 mcpActions:
   namespacedToolNames: false
 ```
+
+With namespacing disabled, the same action is exposed as `greet_user`.
+
+In both cases, any characters that are not allowed in MCP tool names (such as `.` and `-`) are replaced with underscores so that the resulting name only contains alphanumeric characters and underscores.
 
 ### Multiple MCP Servers
 

--- a/plugins/mcp-actions-backend/src/plugin.test.ts
+++ b/plugins/mcp-actions-backend/src/plugin.test.ts
@@ -122,7 +122,7 @@ describe('Mcp Backend', () => {
           required: ['name'],
           type: 'object',
         },
-        name: 'local.make-greeting',
+        name: 'local_make_greeting',
       },
     ]);
   });
@@ -165,7 +165,7 @@ describe('Mcp Backend', () => {
           required: ['name'],
           type: 'object',
         },
-        name: 'local.make-greeting',
+        name: 'local_make_greeting',
       },
     ]);
   });
@@ -269,7 +269,7 @@ describe('Mcp Backend', () => {
         ListToolsResultSchema,
       );
       expect(catalogResult.tools).toHaveLength(1);
-      expect(catalogResult.tools[0].name).toBe('catalog-actions.get-entity');
+      expect(catalogResult.tools[0].name).toBe('catalog_actions_get_entity');
 
       const scaffolderClient = new Client({ name: 'test', version: '1.0' });
       const scaffolderTransport = new StreamableHTTPClientTransport(
@@ -282,7 +282,7 @@ describe('Mcp Backend', () => {
       );
       expect(scaffolderResult.tools).toHaveLength(1);
       expect(scaffolderResult.tools[0].name).toBe(
-        'scaffolder-actions.create-app',
+        'scaffolder_actions_create_app',
       );
     });
   });

--- a/plugins/mcp-actions-backend/src/services/McpService.test.ts
+++ b/plugins/mcp-actions-backend/src/services/McpService.test.ts
@@ -98,7 +98,7 @@ describe('McpService', () => {
           required: ['input'],
           type: 'object',
         },
-        name: 'test.mock-action',
+        name: 'test_mock_action',
       },
     ]);
 
@@ -236,7 +236,7 @@ describe('McpService', () => {
     );
 
     expect(first.tools).toHaveLength(1);
-    expect(first.tools[0].name).toBe('plugin.valid');
+    expect(first.tools[0].name).toBe('plugin_valid');
     expect(second.tools).toHaveLength(1);
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('plugin:bad-type'),
@@ -290,7 +290,7 @@ describe('McpService', () => {
     const result = await client.request(
       {
         method: 'tools/call',
-        params: { name: 'test.mock-action', arguments: { input: 'test' } },
+        params: { name: 'test_mock_action', arguments: { input: 'test' } },
       },
       CallToolResultSchema,
     );
@@ -317,7 +317,7 @@ describe('McpService', () => {
       expect.any(Number),
       expect.objectContaining({
         'mcp.method.name': 'tools/call',
-        'gen_ai.tool.name': 'test.mock-action',
+        'gen_ai.tool.name': 'test_mock_action',
         'gen_ai.operation.name': 'execute_tool',
       }),
     );
@@ -422,7 +422,7 @@ describe('McpService', () => {
       client.request(
         {
           method: 'tools/call',
-          params: { name: 'test.failing-action', arguments: {} },
+          params: { name: 'test_failing_action', arguments: {} },
         },
         CallToolResultSchema,
       ),
@@ -434,7 +434,7 @@ describe('McpService', () => {
       expect.any(Number),
       expect.objectContaining({
         'mcp.method.name': 'tools/call',
-        'gen_ai.tool.name': 'test.failing-action',
+        'gen_ai.tool.name': 'test_failing_action',
         'gen_ai.operation.name': 'execute_tool',
         'error.type': 'CustomError',
       }),
@@ -482,7 +482,7 @@ describe('McpService', () => {
     const result = await client.request(
       {
         method: 'tools/call',
-        params: { name: 'test.failing-action', arguments: { value: 'test' } },
+        params: { name: 'test_failing_action', arguments: { value: 'test' } },
       },
       CallToolResultSchema,
     );
@@ -539,7 +539,7 @@ describe('McpService', () => {
     const result = await client.request(
       {
         method: 'tools/call',
-        params: { name: 'test.not-found-action', arguments: { id: 'abc' } },
+        params: { name: 'test_not_found_action', arguments: { id: 'abc' } },
       },
       CallToolResultSchema,
     );
@@ -671,8 +671,8 @@ describe('McpService', () => {
 
       expect(result.tools).toHaveLength(2);
       expect(result.tools.map(t => t.name)).toEqual([
-        'catalog.get-entity',
-        'catalog.delete-entity',
+        'catalog_get_entity',
+        'catalog_delete_entity',
       ]);
     });
 
@@ -712,7 +712,7 @@ describe('McpService', () => {
       );
 
       expect(result.tools).toHaveLength(1);
-      expect(result.tools[0].name).toBe('catalog.get-entity');
+      expect(result.tools[0].name).toBe('catalog_get_entity');
     });
 
     it('should apply include filter rules with glob patterns', async () => {
@@ -751,7 +751,7 @@ describe('McpService', () => {
       );
 
       expect(result.tools).toHaveLength(1);
-      expect(result.tools[0].name).toBe('catalog.get-entity');
+      expect(result.tools[0].name).toBe('catalog_get_entity');
     });
 
     it('should reject tool calls for actions outside the filtered set', async () => {
@@ -787,7 +787,7 @@ describe('McpService', () => {
       const result = await client.request(
         {
           method: 'tools/call',
-          params: { name: 'catalog.get-entity', arguments: {} },
+          params: { name: 'catalog_get_entity', arguments: {} },
         },
         CallToolResultSchema,
       );
@@ -797,7 +797,7 @@ describe('McpService', () => {
           {
             type: 'text',
             text: expect.stringContaining(
-              'Action "catalog.get-entity" not found',
+              'Action "catalog_get_entity" not found',
             ),
           },
         ],
@@ -928,7 +928,7 @@ describe('McpService', () => {
         ListToolsResultSchema,
       );
 
-      expect(result.tools[0].name).toBe('test.mock-action');
+      expect(result.tools[0].name).toBe('test_mock_action');
     });
 
     it('should use short action name when namespacing is disabled', async () => {
@@ -968,7 +968,7 @@ describe('McpService', () => {
         ListToolsResultSchema,
       );
 
-      expect(result.tools[0].name).toBe('mock-action');
+      expect(result.tools[0].name).toBe('mock_action');
     });
 
     it('should match tool calls using the namespaced name', async () => {
@@ -1005,7 +1005,7 @@ describe('McpService', () => {
       const result = await client.request(
         {
           method: 'tools/call',
-          params: { name: 'test.mock-action', arguments: {} },
+          params: { name: 'test_mock_action', arguments: {} },
         },
         CallToolResultSchema,
       );
@@ -1056,7 +1056,7 @@ describe('McpService', () => {
       return client.request(
         {
           method: 'tools/call',
-          params: { name: 'test.mock-action', arguments: { input: 'val' } },
+          params: { name: 'test_mock_action', arguments: { input: 'val' } },
         },
         CallToolResultSchema,
       );
@@ -1069,12 +1069,12 @@ describe('McpService', () => {
 
       expect(tracing.startActiveSpan).toHaveBeenCalledTimes(1);
       const [name, options] = tracing.startActiveSpan.mock.calls[0];
-      expect(name).toBe('tools/call test.mock-action');
+      expect(name).toBe('tools/call test_mock_action');
       expect(options?.kind).toBe('server');
       expect(options?.attributes).toEqual(
         expect.objectContaining({
           'mcp.method.name': 'tools/call',
-          'gen_ai.tool.name': 'test.mock-action',
+          'gen_ai.tool.name': 'test_mock_action',
           'gen_ai.operation.name': 'execute_tool',
         }),
       );
@@ -1230,7 +1230,7 @@ describe('McpService', () => {
         {
           method: 'tools/call',
           params: {
-            name: 'test.failing-action',
+            name: 'test_failing_action',
             arguments: { value: 'test' },
           },
         },

--- a/plugins/mcp-actions-backend/src/services/McpService.ts
+++ b/plugins/mcp-actions-backend/src/services/McpService.ts
@@ -340,10 +340,13 @@ export class McpService {
   }
 
   private getToolName(action: ActionsServiceAction): string {
-    if (this.namespacedToolNames) {
-      return `${action.pluginId}.${action.name}`;
-    }
-    return action.name;
+    const rawName = this.namespacedToolNames
+      ? `${action.pluginId}.${action.name}`
+      : action.name;
+    // MCP tool names must only contain alphanumeric characters and
+    // underscores, so replace any other character (e.g. "." and "-") with an
+    // underscore.
+    return rawName.replace(/[^a-zA-Z0-9_]/g, '_');
   }
 
   private matchesRule(action: ActionsServiceAction, rule: FilterRule): boolean {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

As we are starting to adopt backstage & this MCP org wide we are getting denied by our LLM Providers due to the naming having unsuported characters, so we've made this small contribution in hoping we could fix this issue to be on board on what is the standard across the most used providers (Looking at you Anthropic and Google)

### Summary

The `mcp-actions-backend` plugin exposed MCP tool names that contained `.` and
`-` characters. For example, the catalog action was exposed as
`catalog.get-catalog-entity`. These names are produced by joining the plugin ID
and the action name with a `.`, while action names themselves use `-`.

Several MCP clients expect (or sanitize towards) tool names that only contain
alphanumeric characters and underscores, and some derive namespacing/permission
behaviour from the separator characters in the name:

- **Anthropic Claude Code / Agent SDK** names MCP tools as
  `mcp__<server-name>__<tool-name>`, using underscores as separators.
  ([docs](https://code.claude.com/docs/en/agent-sdk/mcp#tool-naming-convention))
- **Gemini CLI** sanitizes any character that is not a letter, number, or
  underscore in tool names, and its policy parser splits fully-qualified names
  on underscores — so unexpected separators can cause wildcard rules and
  security policies to fail silently.
  ([docs](https://geminicli.com/docs/tools/mcp-server/#3-tool-naming-and-namespaces))

### What changed

- Tool names are now sanitized so they only contain alphanumeric characters and
  underscores. Any other character (e.g. `.` and `-`) is replaced with `_`.
  - `catalog.get-catalog-entity` → `catalog_get_catalog_entity`
- This applies both with the plugin ID prefix and when
  `mcpActions.namespacedToolNames` is disabled (e.g. `make-greeting` →
  `make_greeting`).
- Updated the unit tests for `McpService` and the plugin router to assert the
  sanitized names.
- Updated the plugin README to document the sanitization behaviour.

### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message.