### PR TITLE
Normalize MCP tool names to snake_case for Claude/Gemini compatibility

### DIFF
--- a/.changeset/snake-case-mcp-tool-names.md
+++ b/.changeset/snake-case-mcp-tool-names.md
@@ -4,4 +4,4 @@
 
 MCP tool names are now normalized to `snake_case` before they are exposed. The plugin ID separator and any hyphens in plugin IDs or action names are replaced with underscores, so an action such as `greet-user` from `my-custom-plugin` is now listed as `my_custom_plugin_greet_user`. This fixes tool calling for LLM clients (such as Anthropic Claude and Google Gemini) that reject tool names containing `.` or `-`.
 
-Tool calls that reference the previous, un-normalized name (for example `my-custom-plugin.greet-user`) continue to resolve, so existing clients keep working without changes.
+Tool calls that reference the previous, un-normalized name (for example `my-custom-plugin.greet-user`) continue to resolve, so existing clients keep working without changes. If two actions normalize to the same tool name, only the first is listed and a warning is logged so the collision can be resolved by renaming one of the actions.

--- a/.changeset/snake-case-mcp-tool-names.md
+++ b/.changeset/snake-case-mcp-tool-names.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-mcp-actions-backend': minor
+---
+
+MCP tool names are now normalized to `snake_case` before they are exposed. The plugin ID separator and any hyphens in plugin IDs or action names are replaced with underscores, so an action such as `greet-user` from `my-custom-plugin` is now listed as `my_custom_plugin_greet_user`. This fixes tool calling for LLM clients (such as Anthropic Claude and Google Gemini) that reject tool names containing `.` or `-`.
+
+Tool calls that reference the previous, un-normalized name (for example `my-custom-plugin.greet-user`) continue to resolve, so existing clients keep working without changes.

--- a/.changeset/snake-case-mcp-tool-names.md
+++ b/.changeset/snake-case-mcp-tool-names.md
@@ -2,6 +2,6 @@
 '@backstage/plugin-mcp-actions-backend': minor
 ---
 
-MCP tool names are now normalized to `snake_case` before they are exposed. The plugin ID separator and any hyphens in plugin IDs or action names are replaced with underscores, so an action such as `greet-user` from `my-custom-plugin` is now listed as `my_custom_plugin_greet_user`. This fixes tool calling for LLM clients (such as Anthropic Claude and Google Gemini) that reject tool names containing `.` or `-`.
+MCP tool names are now normalized to `snake_case` before they are exposed (lowercased, with any run of characters other than letters, digits, or underscores replaced by a single underscore), so an action such as `greet-user` from `my-custom-plugin` is now listed as `my_custom_plugin_greet_user`. This fixes tool calling for LLM clients (such as Anthropic Claude and Google Gemini) that reject tool names containing `.` or `-`.
 
 Tool calls that reference the previous, un-normalized name (for example `my-custom-plugin.greet-user`) continue to resolve, so existing clients keep working without changes. If two actions normalize to the same tool name, only the first is listed and a warning is logged so the collision can be resolved by renaming one of the actions.

--- a/plugins/mcp-actions-backend/README.md
+++ b/plugins/mcp-actions-backend/README.md
@@ -90,6 +90,8 @@ Tool names are normalized to `snake_case` before they are exposed: the plugin ID
 
 For backward compatibility, `tools/call` requests still resolve actions referenced by their previous, un-normalized name (for example `my-custom-plugin.greet-user`), so existing clients continue to work without changes.
 
+If two actions normalize to the same tool name, only the first is listed under that name and a warning is logged identifying both actions, so the collision can be resolved by renaming one of them.
+
 ### Multiple MCP Servers
 
 By default, the plugin serves a single MCP server at `/api/mcp-actions/v1` that exposes all available actions. You can split actions into multiple focused servers by configuring `mcpActions.servers`, where each key becomes a separate MCP server endpoint.

--- a/plugins/mcp-actions-backend/README.md
+++ b/plugins/mcp-actions-backend/README.md
@@ -73,7 +73,7 @@ export const myPlugin = createBackendPlugin({
 
 ### Namespaced Tool Names
 
-By default, MCP tool names include the plugin ID prefix to avoid collisions across plugins. For example, an action registered as `greet-user` by `my-custom-plugin` is exposed as `my_custom_plugin_greet_user`.
+By default, MCP tool names include the plugin ID prefix to reduce the risk of collisions across plugins. For example, an action registered as `greet-user` by `my-custom-plugin` is exposed as `my_custom_plugin_greet_user`.
 
 You can disable the plugin ID prefix if you need the short names for backward compatibility:
 

--- a/plugins/mcp-actions-backend/README.md
+++ b/plugins/mcp-actions-backend/README.md
@@ -86,7 +86,7 @@ With namespacing disabled, the same action is exposed as `greet_user`.
 
 #### Tool Name Normalization
 
-Tool names are normalized to `snake_case` before they are exposed: the plugin ID separator (`.`) and any hyphens (`-`) in plugin IDs or action names are replaced with underscores (`_`). While the MCP specification treats tool names as opaque strings, some LLM clients (such as Anthropic Claude and Google Gemini) reject names that contain `.` or `-`, whereas `_` is accepted across all tested providers.
+Tool names are normalized to `snake_case` before they are exposed: any run of characters other than letters, digits, or underscores is replaced with a single underscore and the result is lowercased. While the MCP specification treats tool names as opaque strings, some LLM clients (such as Anthropic Claude and Google Gemini) reject names that contain `.` or `-`, whereas `_` is accepted across all tested providers.
 
 For backward compatibility, `tools/call` requests still resolve actions referenced by their previous, un-normalized name (for example `my-custom-plugin.greet-user`), so existing clients continue to work without changes.
 

--- a/plugins/mcp-actions-backend/README.md
+++ b/plugins/mcp-actions-backend/README.md
@@ -73,14 +73,22 @@ export const myPlugin = createBackendPlugin({
 
 ### Namespaced Tool Names
 
-By default, MCP tool names include the plugin ID prefix to avoid collisions across plugins. For example, an action registered as `greet-user` by `my-custom-plugin` is exposed as `my-custom-plugin.greet-user`.
+By default, MCP tool names include the plugin ID prefix to avoid collisions across plugins. For example, an action registered as `greet-user` by `my-custom-plugin` is exposed as `my_custom_plugin_greet_user`.
 
-You can disable this if you need the short names for backward compatibility:
+You can disable the plugin ID prefix if you need the short names for backward compatibility:
 
 ```yaml
 mcpActions:
   namespacedToolNames: false
 ```
+
+With namespacing disabled, the same action is exposed as `greet_user`.
+
+#### Tool Name Normalization
+
+Tool names are normalized to `snake_case` before they are exposed: the plugin ID separator (`.`) and any hyphens (`-`) in plugin IDs or action names are replaced with underscores (`_`). While the MCP specification treats tool names as opaque strings, some LLM clients (such as Anthropic Claude and Google Gemini) reject names that contain `.` or `-`, whereas `_` is accepted across all tested providers.
+
+For backward compatibility, `tools/call` requests still resolve actions referenced by their previous, un-normalized name (for example `my-custom-plugin.greet-user`), so existing clients continue to work without changes.
 
 ### Multiple MCP Servers
 

--- a/plugins/mcp-actions-backend/src/plugin.test.ts
+++ b/plugins/mcp-actions-backend/src/plugin.test.ts
@@ -122,7 +122,7 @@ describe('Mcp Backend', () => {
           required: ['name'],
           type: 'object',
         },
-        name: 'local.make-greeting',
+        name: 'local_make_greeting',
       },
     ]);
   });
@@ -165,7 +165,7 @@ describe('Mcp Backend', () => {
           required: ['name'],
           type: 'object',
         },
-        name: 'local.make-greeting',
+        name: 'local_make_greeting',
       },
     ]);
   });
@@ -269,7 +269,7 @@ describe('Mcp Backend', () => {
         ListToolsResultSchema,
       );
       expect(catalogResult.tools).toHaveLength(1);
-      expect(catalogResult.tools[0].name).toBe('catalog-actions.get-entity');
+      expect(catalogResult.tools[0].name).toBe('catalog_actions_get_entity');
 
       const scaffolderClient = new Client({ name: 'test', version: '1.0' });
       const scaffolderTransport = new StreamableHTTPClientTransport(
@@ -282,7 +282,7 @@ describe('Mcp Backend', () => {
       );
       expect(scaffolderResult.tools).toHaveLength(1);
       expect(scaffolderResult.tools[0].name).toBe(
-        'scaffolder-actions.create-app',
+        'scaffolder_actions_create_app',
       );
     });
   });

--- a/plugins/mcp-actions-backend/src/services/McpService.test.ts
+++ b/plugins/mcp-actions-backend/src/services/McpService.test.ts
@@ -248,6 +248,83 @@ describe('McpService', () => {
     expect(logger.warn).toHaveBeenCalledTimes(2);
   });
 
+  it('should skip actions whose snake_case tool name collides with an earlier action', async () => {
+    // Both of these normalize to the tool name `catalog_get_entity`.
+    const firstAction = {
+      id: 'catalog:get-entity',
+      pluginId: 'catalog',
+      name: 'get-entity',
+      title: 'Get Entity',
+      description: 'Fetch an entity',
+      schema: {
+        input: { type: 'object' as const },
+        output: { type: 'object' as const },
+      },
+      attributes: { destructive: false, readOnly: true, idempotent: true },
+    };
+    const collidingAction = {
+      id: 'catalog-get:entity',
+      pluginId: 'catalog-get',
+      name: 'entity',
+      title: 'Entity',
+      description: 'Also maps to catalog_get_entity',
+      schema: {
+        input: { type: 'object' as const },
+        output: { type: 'object' as const },
+      },
+      attributes: { destructive: false, readOnly: true, idempotent: true },
+    };
+
+    const fakeActions: ActionsService = {
+      list: jest.fn(async () => ({
+        actions: [firstAction, collidingAction],
+      })),
+      invoke: jest.fn(async () => ({ output: {} })),
+    };
+
+    const logger = mockServices.logger.mock();
+    const mcpService = await McpService.create({
+      actions: fakeActions,
+      metrics: metricsServiceMock.mock(),
+      tracingService: tracingServiceMock.mock(),
+      logger,
+    });
+
+    const server = mcpService.getServer({
+      credentials: mockCredentials.user(),
+    });
+
+    const client = new Client({ name: 'test', version: '1.0' });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    await Promise.all([
+      client.connect(clientTransport),
+      server.connect(serverTransport),
+    ]);
+
+    const first = await client.request(
+      { method: 'tools/list' },
+      ListToolsResultSchema,
+    );
+    const second = await client.request(
+      { method: 'tools/list' },
+      ListToolsResultSchema,
+    );
+
+    // Only the first action keeps the shared tool name.
+    expect(first.tools).toHaveLength(1);
+    expect(first.tools[0].name).toBe('catalog_get_entity');
+    expect(second.tools).toHaveLength(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('catalog-get:entity'),
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('catalog:get-entity'),
+    );
+    // The collision should only be logged once across repeated listings.
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+
   it('should call the action when the tool is invoked', async () => {
     const mockActionsRegistry = actionsRegistryServiceMock();
     const mockAction = jest.fn(async () => ({ output: { output: 'test' } }));

--- a/plugins/mcp-actions-backend/src/services/McpService.test.ts
+++ b/plugins/mcp-actions-backend/src/services/McpService.test.ts
@@ -98,7 +98,7 @@ describe('McpService', () => {
           required: ['input'],
           type: 'object',
         },
-        name: 'test.mock-action',
+        name: 'test_mock_action',
       },
     ]);
 
@@ -236,7 +236,7 @@ describe('McpService', () => {
     );
 
     expect(first.tools).toHaveLength(1);
-    expect(first.tools[0].name).toBe('plugin.valid');
+    expect(first.tools[0].name).toBe('plugin_valid');
     expect(second.tools).toHaveLength(1);
     expect(logger.warn).toHaveBeenCalledWith(
       expect.stringContaining('plugin:bad-type'),
@@ -290,7 +290,7 @@ describe('McpService', () => {
     const result = await client.request(
       {
         method: 'tools/call',
-        params: { name: 'test.mock-action', arguments: { input: 'test' } },
+        params: { name: 'test_mock_action', arguments: { input: 'test' } },
       },
       CallToolResultSchema,
     );
@@ -317,7 +317,7 @@ describe('McpService', () => {
       expect.any(Number),
       expect.objectContaining({
         'mcp.method.name': 'tools/call',
-        'gen_ai.tool.name': 'test.mock-action',
+        'gen_ai.tool.name': 'test_mock_action',
         'gen_ai.operation.name': 'execute_tool',
       }),
     );
@@ -422,7 +422,7 @@ describe('McpService', () => {
       client.request(
         {
           method: 'tools/call',
-          params: { name: 'test.failing-action', arguments: {} },
+          params: { name: 'test_failing_action', arguments: {} },
         },
         CallToolResultSchema,
       ),
@@ -434,7 +434,7 @@ describe('McpService', () => {
       expect.any(Number),
       expect.objectContaining({
         'mcp.method.name': 'tools/call',
-        'gen_ai.tool.name': 'test.failing-action',
+        'gen_ai.tool.name': 'test_failing_action',
         'gen_ai.operation.name': 'execute_tool',
         'error.type': 'CustomError',
       }),
@@ -482,7 +482,7 @@ describe('McpService', () => {
     const result = await client.request(
       {
         method: 'tools/call',
-        params: { name: 'test.failing-action', arguments: { value: 'test' } },
+        params: { name: 'test_failing_action', arguments: { value: 'test' } },
       },
       CallToolResultSchema,
     );
@@ -539,7 +539,7 @@ describe('McpService', () => {
     const result = await client.request(
       {
         method: 'tools/call',
-        params: { name: 'test.not-found-action', arguments: { id: 'abc' } },
+        params: { name: 'test_not_found_action', arguments: { id: 'abc' } },
       },
       CallToolResultSchema,
     );
@@ -671,8 +671,8 @@ describe('McpService', () => {
 
       expect(result.tools).toHaveLength(2);
       expect(result.tools.map(t => t.name)).toEqual([
-        'catalog.get-entity',
-        'catalog.delete-entity',
+        'catalog_get_entity',
+        'catalog_delete_entity',
       ]);
     });
 
@@ -712,7 +712,7 @@ describe('McpService', () => {
       );
 
       expect(result.tools).toHaveLength(1);
-      expect(result.tools[0].name).toBe('catalog.get-entity');
+      expect(result.tools[0].name).toBe('catalog_get_entity');
     });
 
     it('should apply include filter rules with glob patterns', async () => {
@@ -751,7 +751,7 @@ describe('McpService', () => {
       );
 
       expect(result.tools).toHaveLength(1);
-      expect(result.tools[0].name).toBe('catalog.get-entity');
+      expect(result.tools[0].name).toBe('catalog_get_entity');
     });
 
     it('should reject tool calls for actions outside the filtered set', async () => {
@@ -892,7 +892,7 @@ describe('McpService', () => {
   });
 
   describe('namespaced tool names', () => {
-    it('should use action ID as tool name by default', async () => {
+    it('should expose the snake_case namespaced name as tool name by default', async () => {
       const mockActionsRegistry = actionsRegistryServiceMock();
       mockActionsRegistry.register({
         name: 'mock-action',
@@ -928,10 +928,10 @@ describe('McpService', () => {
         ListToolsResultSchema,
       );
 
-      expect(result.tools[0].name).toBe('test.mock-action');
+      expect(result.tools[0].name).toBe('test_mock_action');
     });
 
-    it('should use short action name when namespacing is disabled', async () => {
+    it('should use short snake_case action name when namespacing is disabled', async () => {
       const mockActionsRegistry = actionsRegistryServiceMock();
       mockActionsRegistry.register({
         name: 'mock-action',
@@ -968,10 +968,10 @@ describe('McpService', () => {
         ListToolsResultSchema,
       );
 
-      expect(result.tools[0].name).toBe('mock-action');
+      expect(result.tools[0].name).toBe('mock_action');
     });
 
-    it('should match tool calls using the namespaced name', async () => {
+    it('should match tool calls using the snake_case namespaced name', async () => {
       const mockActionsRegistry = actionsRegistryServiceMock();
       mockActionsRegistry.register({
         name: 'mock-action',
@@ -1005,12 +1005,58 @@ describe('McpService', () => {
       const result = await client.request(
         {
           method: 'tools/call',
+          params: { name: 'test_mock_action', arguments: {} },
+        },
+        CallToolResultSchema,
+      );
+
+      expect(result.isError).toBeUndefined();
+    });
+
+    it('should still match tool calls using the legacy dotted/hyphenated name for backward compatibility', async () => {
+      const mockActionsRegistry = actionsRegistryServiceMock();
+      const mockAction = jest.fn(async () => ({ output: {} }));
+      mockActionsRegistry.register({
+        name: 'mock-action',
+        title: 'Test',
+        description: 'Test',
+        schema: {
+          input: z => z.object({}),
+          output: z => z.object({}),
+        },
+        action: mockAction,
+      });
+
+      const mcpService = await McpService.create({
+        actions: mockActionsRegistry,
+        metrics: metricsServiceMock.mock(),
+        tracingService: tracingServiceMock.mock(),
+      });
+
+      const server = mcpService.getServer({
+        credentials: mockCredentials.user(),
+      });
+
+      const client = new Client({ name: 'test', version: '1.0' });
+      const [clientTransport, serverTransport] =
+        InMemoryTransport.createLinkedPair();
+      await Promise.all([
+        client.connect(clientTransport),
+        server.connect(serverTransport),
+      ]);
+
+      const result = await client.request(
+        {
+          method: 'tools/call',
+          // The legacy name format that earlier versions exposed and that
+          // clients may still have cached.
           params: { name: 'test.mock-action', arguments: {} },
         },
         CallToolResultSchema,
       );
 
       expect(result.isError).toBeUndefined();
+      expect(mockAction).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -1056,7 +1102,7 @@ describe('McpService', () => {
       return client.request(
         {
           method: 'tools/call',
-          params: { name: 'test.mock-action', arguments: { input: 'val' } },
+          params: { name: 'test_mock_action', arguments: { input: 'val' } },
         },
         CallToolResultSchema,
       );
@@ -1069,12 +1115,12 @@ describe('McpService', () => {
 
       expect(tracing.startActiveSpan).toHaveBeenCalledTimes(1);
       const [name, options] = tracing.startActiveSpan.mock.calls[0];
-      expect(name).toBe('tools/call test.mock-action');
+      expect(name).toBe('tools/call test_mock_action');
       expect(options?.kind).toBe('server');
       expect(options?.attributes).toEqual(
         expect.objectContaining({
           'mcp.method.name': 'tools/call',
-          'gen_ai.tool.name': 'test.mock-action',
+          'gen_ai.tool.name': 'test_mock_action',
           'gen_ai.operation.name': 'execute_tool',
         }),
       );
@@ -1230,7 +1276,7 @@ describe('McpService', () => {
         {
           method: 'tools/call',
           params: {
-            name: 'test.failing-action',
+            name: 'test_failing_action',
             arguments: { value: 'test' },
           },
         },

--- a/plugins/mcp-actions-backend/src/services/McpService.ts
+++ b/plugins/mcp-actions-backend/src/services/McpService.ts
@@ -58,7 +58,7 @@ function safeStringify(value: unknown): string {
 // across all tested providers, so we replace any run of characters outside the
 // `[A-Za-z0-9_]` set with a single underscore.
 function snakeCaseToolName(name: string): string {
-  return name.replace(/[^a-zA-Z0-9_]+/g, '_');
+  return name.replace(/[^a-zA-Z0-9_]+/g, '_').toLowerCase();
 }
 
 // Baggage is propagated from untrusted callers, so we forward only an

--- a/plugins/mcp-actions-backend/src/services/McpService.ts
+++ b/plugins/mcp-actions-backend/src/services/McpService.ts
@@ -192,8 +192,9 @@ export class McpService {
 
           const owningActionId = toolNameOwners.get(name);
           if (owningActionId !== undefined && owningActionId !== action.id) {
-            if (!this.warnedCollisionToolNames.has(name)) {
-              this.warnedCollisionToolNames.add(name);
+            const collisionKey = `${name}:${action.id}`;
+            if (!this.warnedCollisionToolNames.has(collisionKey)) {
+              this.warnedCollisionToolNames.add(collisionKey);
               this.logger?.warn(
                 `Skipping MCP tool for action "${action.id}": tool name "${name}" already maps to action "${owningActionId}". Tool names must be unique after snake_case normalization; consider renaming one of the actions.`,
               );

--- a/plugins/mcp-actions-backend/src/services/McpService.ts
+++ b/plugins/mcp-actions-backend/src/services/McpService.ts
@@ -100,6 +100,7 @@ export class McpService {
   private readonly captureToolPayloads: boolean;
   private readonly operationDuration: MetricsServiceHistogram<McpServerOperationAttributes>;
   private readonly warnedSkippedActionIds = new Set<string>();
+  private readonly warnedCollisionToolNames = new Set<string>();
 
   constructor(
     actions: ActionsService,
@@ -181,10 +182,28 @@ export class McpService {
           : allActions;
 
         const tools: Tool[] = [];
+        // Tracks which action each emitted tool name belongs to, so that two
+        // actions whose names normalize to the same snake_case tool name (e.g.
+        // `catalog`/`get-entity` and `catalog-get`/`entity`) don't both appear
+        // in the list under a single, ambiguous name.
+        const toolNameOwners = new Map<string, string>();
         for (const action of actions) {
+          const name = this.getToolName(action);
+
+          const owningActionId = toolNameOwners.get(name);
+          if (owningActionId !== undefined && owningActionId !== action.id) {
+            if (!this.warnedCollisionToolNames.has(name)) {
+              this.warnedCollisionToolNames.add(name);
+              this.logger?.warn(
+                `Skipping MCP tool for action "${action.id}": tool name "${name}" already maps to action "${owningActionId}". Tool names must be unique after snake_case normalization; consider renaming one of the actions.`,
+              );
+            }
+            continue;
+          }
+
           const tool = {
             inputSchema: action.schema.input,
-            name: this.getToolName(action),
+            name,
             description: action.description,
             annotations: {
               title: action.title,
@@ -209,6 +228,7 @@ export class McpService {
             continue;
           }
 
+          toolNameOwners.set(name, action.id);
           tools.push(parsed.data);
         }
 

--- a/plugins/mcp-actions-backend/src/services/McpService.ts
+++ b/plugins/mcp-actions-backend/src/services/McpService.ts
@@ -48,6 +48,19 @@ function safeStringify(value: unknown): string {
   }
 }
 
+// Normalizes a tool name to snake_case for broad LLM client compatibility.
+//
+// The MCP spec treats tool names as opaque strings, but LLM client
+// implementations vary in how strictly they parse them. Anthropic Claude and
+// Google Gemini reject names containing characters such as `.` or `-`, which
+// breaks tool calling for the namespaced (`pluginId.action-name`) and
+// hyphenated action names commonly used in Backstage. Underscores are accepted
+// across all tested providers, so we replace any run of characters outside the
+// `[A-Za-z0-9_]` set with a single underscore.
+function snakeCaseToolName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9_]+/g, '_');
+}
+
 // Baggage is propagated from untrusted callers, so we forward only an
 // explicit allowlist of low-cardinality identifier keys from the OTel
 // `gen_ai.*` registry.
@@ -244,7 +257,12 @@ export class McpService {
                 : allActions;
 
               const action = actions.find(
-                a => this.getToolName(a) === params.name,
+                a =>
+                  this.getToolName(a) === params.name ||
+                  // Backward compatibility: resolve tool calls that still use
+                  // the un-normalized name (e.g. `pluginId.action-name`) that
+                  // earlier versions exposed and clients may have cached.
+                  this.getLegacyToolName(a) === params.name,
               );
 
               if (!action) {
@@ -340,6 +358,12 @@ export class McpService {
   }
 
   private getToolName(action: ActionsServiceAction): string {
+    return snakeCaseToolName(this.getLegacyToolName(action));
+  }
+
+  // The previously exposed, un-normalized tool name. Retained so that
+  // `tools/call` can still route requests that use the old name format.
+  private getLegacyToolName(action: ActionsServiceAction): string {
     if (this.namespacedToolNames) {
       return `${action.pluginId}.${action.name}`;
     }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

MCP tool names are currently exposed as `pluginId.action-name` (e.g. `catalog.get-catalog-entity`). The MCP spec treats tool names as opaque strings, but in practice some providers reject `.` and `-`: Anthropic Claude and Google Gemini both refuse to call such tools, while OpenAI tolerates them. This makes Backstage actions unusable as tools for those providers.

This normalizes exposed tool names to `snake_case` (e.g. `catalog_get_catalog_entity`), which every provider I tested accepts. To avoid breaking clients that already cached the previous names, `tools/call` still resolves an action by its old un-normalized name too.

Because normalization isn't injective, two actions can now collapse to the same name (e.g. plugin `catalog`/action `get-entity` vs plugin `catalog-get`/action `entity`). In that case only the first is listed and a warning is logged identifying both, instead of silently shadowing one.

I verified this end-to-end against a local backend (catalog/scaffolder/search actions) via the MCP Inspector and raw `tools/list`/`tools/call`: names come back in snake_case and a call using a legacy dotted name still routes.

> Note: developed with AI assistance (Claude Code); I've reviewed, run, and tested the change myself.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes) — n/a, backend-only
- [x] All your commits have a `Signed-off-by` line in the message.


### Before & After MCP tool normalization

Before:

<details>

```json
{
  "tools": [
    {
      "name": "catalog.get-catalog-model-description",
      "description": "Returns a markdown formatted description of the current catalog model, including all registered entity kinds, annotations, labels, tags, and relations.",
      "inputSchema": {
        "type": "object",
        "properties": {},
        "additionalProperties": false,
        "$schema": "http://json-schema.org/draft-07/schema#"
      },
      "annotations": {
        "title": "Get a Catalog Model Description",
        "readOnlyHint": true,
        "destructiveHint": false,
        "idempotentHint": true,
        "openWorldHint": false
      }
    },
    {
      "name": "catalog.get-catalog-entity",
      "description": "\nThis allows you to get a single entity from the software catalog.\nEach entity in the software catalog has a unique name, kind, and namespace. The default namespace is \"default\".\nEach entity is identified by a unique entity reference, which is a string of the form \"kind:namespace/name\".\n    ",
      "inputSchema": {
        "type": "object",
        "properties": {
          "kind": {
            "type": "string",
            "description": "The kind of the entity to query. If the kind is unknown it can be omitted."
          },
          "namespace": {
            "type": "string",
            "description": "The namespace of the entity to query. If the namespace is unknown it can be omitted."
          },
          "name": {
            "type": "string",
            "description": "The name of the entity to query"
          }
        },
        "required": [
          "name"
        ],
        "additionalProperties": false,
        "$schema": "http://json-schema.org/draft-07/schema#"
      },
      "annotations": {
        "title": "Get Catalog Entity",
        "readOnlyHint": true,
        "destructiveHint": false,
        "idempotentHint": true,
        "openWorldHint": false
      }
    },
    {
      "name": "catalog.validate-entity",
      "description": "\n      This action can be used to validate catalog-info.yaml file contents meant to be used with the software catalog.\n      It checks both that the YAML syntax is correct, and that the entity content is valid according to the catalog's rules.\n      ",
      "inputSchema": {
        "type": "object",
        "properties": {
          "entity": {
            "type": "string",
            "description": "Entity YAML content to validate"
          },
          "location": {
            "type": "string",
            "format": "uri",
            "description": "Location to validate"
          }
        },
        "required": [
          "entity"
        ],
        "additionalProperties": false,
        "$schema": "http://json-schema.org/draft-07/schema#"
      },
      "annotations": {
        "title": "Validate Catalog Entity",
        "readOnlyHint": true,
        "destructiveHint": false,
        "idempotentHint": true,
        "openWorldHint": false
      }
    },
    {
      "name": "catalog.register-entity",
      "description": "Registers one or more entities in the Backstage catalog by creating a Location entity that points to a remote catalog-info.yaml file.\n\nThis action is similar to the \"Register existing component\" flow in the Backstage UI, where you provide a URL to a catalog-info.yaml file describing catalog entities such as Components, Systems, Resources, APIs, Users, and Groups. The action will create a new Location entity that references the provided file; all entities defined within that file will be imported into the catalog.\n\nA unique identifier (locationId) will be returned for the newly created Location. You can use this identifier in the future to unregister or delete the Location and all entities it owns.\n",
      "inputSchema": {
        "type": "object",
        "properties": {
          "locationUrl": {
            "type": "string",
            "description": "URL reference to the catalog-info.yaml file that describes the entity to register. For example: https://github.com/backstage/demo/blob/master/catalog-info.yaml"
          }
        },
        "required": [
          "locationUrl"
        ],
        "additionalProperties": false,
        "$schema": "http://json-schema.org/draft-07/schema#"
      },
      "annotations": {
        "title": "Register entity in the Catalog",
        "readOnlyHint": false,
        "destructiveHint": false,
        "idempotentHint": false,
        "openWorldHint": false
      }
    },
    {
      "name": "catalog.unregister-entity",
      "description": "Unregisters a Location entity and all entities it owns from the Backstage catalog.\n\nThis action is similar to the \"Unregister location\" function in the Backstage UI, where you provide the unique identifier (locationId) of a Location entity. Alternatively, you can provide the URL used to register the location. The action will remove the specified Location from the catalog as well as all entities that were created when the Location was imported.\n\nOnce completed, all entities associated with the Location will be deleted from the catalog.\n",
      "inputSchema": {
        "type": "object",
        "properties": {
          "type": {
            "anyOf": [
              {
                "type": "object",
                "properties": {
                  "locationId": {
                    "type": "string",
                    "description": "Location ID of the Entity to unregister"
                  }
                },
                "required": [
                  "locationId"
                ],
                "additionalProperties": false
              },
              {
                "type": "object",
                "properties": {
                  "locationUrl": {
                    "type": "string",
                    "description": "URL of the catalog-info.yaml file to unregister for example: https://github.com/backstage/demo/blob/master/catalog-info.yaml"
                  }
                },
                "required": [
                  "locationUrl"
                ],
                "additionalProperties": false
              }
            ],
            "description": "Identifies the entity to unregister. Provide either locationId or locationUrl."
          }
        },
        "required": [
          "type"
        ],
        "additionalProperties": false,
        "$schema": "http://json-schema.org/draft-07/schema#"
      },
      "annotations": {
        "title": "Unregister entity from the Catalog",
        "readOnlyHint": false,
        "destructiveHint": true,
        "idempotentHint": true,
        "openWorldHint": false
      }
    },
    {
      "name": "catalog.query-catalog-entities",
      "description": "\nQuery entities from the Backstage Software Catalog using predicate filters.\n\n## Catalog Model\n\nThe catalog contains entities of different kinds. Every entity has \"kind\", \"apiVersion\", \"metadata\", and optionally \"spec\" and \"relations\". Fields use dot notation for querying.\n\nCommon metadata fields on all entities: name, namespace (default: \"default\"), title, description, labels, annotations, tags (string array), links.\n\nEntity references use the format \"kind:namespace/name\", e.g. \"component:default/my-service\" or \"user:default/jane.doe\".\n\n### Entity Kinds\n\n**Component** - A piece of software such as a service, website, or library.\n  spec fields: type (e.g. \"service\", \"website\", \"library\"), lifecycle (e.g. \"production\", \"experimental\", \"deprecated\"), owner (entity ref), system, subcomponentOf, providesApis, consumesApis, dependsOn, dependencyOf.\n\n**API** - An interface that components expose, such as REST APIs or event streams.\n  spec fields: type (e.g. \"openapi\", \"asyncapi\", \"graphql\", \"grpc\"), lifecycle, owner (entity ref), definition (the API spec content), system.\n\n**System** - A collection of components, APIs, and resources that together expose some functionality.\n  spec fields: owner (entity ref), domain, type.\n\n**Domain** - A grouping of systems that share terminology, domain models, and business purpose.\n  spec fields: owner (entity ref), subdomainOf, type.\n\n**Resource** - Infrastructure required to operate a component, such as databases or storage buckets.\n  spec fields: type, owner (entity ref), system, dependsOn, dependencyOf.\n\n**Group** - An organizational entity such as a team or business unit.\n  spec fields: type (e.g. \"team\", \"business-unit\"), children (entity refs), parent (entity ref), members (entity refs), profile (displayName, email, picture).\n\n**User** - A person, such as an employee or contractor.\n  spec fields: memberOf (entity refs), profile (displayName, email, picture).\n\n**Location** - A marker that references other catalog descriptor files to be ingested.\n  spec fields: type, target, targets, presence.\n\n### Relations\n\nEntities have bidirectional relations stored in the \"relations\" array. Common relation types: ownedBy/ownerOf, dependsOn/dependencyOf, providesApi/apiProvidedBy, consumesApi/apiConsumedBy, parentOf/childOf, memberOf/hasMember, partOf/hasPart.\n\nRelations can be queried via \"relations.<type>\" e.g. \"relations.ownedby: user:default/jane-doe\". The value there must always be a valid entity reference.\n\nWhen querying for entity relationships, prefer using relations over spec fields. For example, use \"relations.ownedby\" instead of \"spec.owner\" to find entities owned by a particular group or user.\n\n## Query Syntax\n\nThe query uses predicate expressions with dot-notation field paths.\n\nSimple matching:\n  { query: { kind: \"Component\" } }\n  { query: { kind: \"Component\", \"spec.type\": \"service\" } }\n\nValue operators:\n  { query: { kind: { \"$in\": [\"API\", \"Component\"] } } }\n  { query: { \"metadata.annotations.backstage.io/techdocs-ref\": { \"$exists\": true } } }\n  { query: { \"metadata.tags\": { \"$contains\": \"java\" } } }\n  { query: { \"metadata.name\": { \"$hasPrefix\": \"team-\" } } }\n\nLogical operators:\n  { query: { \"$all\": [{ kind: \"Component\" }, { \"spec.lifecycle\": \"production\" }] } }\n  { query: { \"$any\": [{ \"spec.type\": \"service\" }, { \"spec.type\": \"website\" }] } }\n  { query: { \"$not\": { kind: \"Group\" } } }\n\nQuerying relations - find all entities owned by a specific group:\n  { query: { \"relations.ownedby\": \"group:default/team-alpha\" } }\n\nCombined example - find production services or websites with TechDocs:\n  { query: { \"$all\": [\n    { kind: \"Component\", \"spec.lifecycle\": \"production\" },\n    { \"$any\": [{ \"spec.type\": \"service\" }, { \"spec.type\": \"website\" }] },\n    { \"metadata.annotations.backstage.io/techdocs-ref\": { \"$exists\": true } }\n  ] } }\n\n## Other Options\n\nLimit returned fields: { fields: [\"kind\", \"metadata.name\", \"metadata.namespace\"] }\nSort results: { orderFields: { field: \"metadata.name\", order: \"asc\" } }\nFull text search: { fullTextFilter: { term: \"auth\", fields: [\"metadata.name\", \"metadata.title\"] } }\nPagination: Use limit (e.g. 20) and the returned nextPageCursor for subsequent requests via cursor.\n",
      "inputSchema": {
        "type": "object",
        "properties": {
          "query": {
            "anyOf": [
              {
                "anyOf": [
                  {
                    "type": "object",
                    "additionalProperties": {
                      "anyOf": [
                        {
                          "type": [
                            "string",
                            "number",
                            "boolean"
                          ]
                        },
                        {
                          "type": "object",
                          "properties": {
                            "$exists": {
                              "type": "boolean"
                            }
                          },
                          "required": [
                            "$exists"
                          ],
                          "additionalProperties": false
                        },
                        {
                          "type": "object",
                          "properties": {
                            "$in": {
                              "type": "array",
                              "items": {
                                "$ref": "#/properties/query/anyOf/0/anyOf/0/additionalProperties/anyOf/0"
                              }
                            }
                          },
                          "required": [
                            "$in"
                          ],
                          "additionalProperties": false
                        },
                        {
                          "type": "object",
                          "properties": {
                            "$contains": {
                              "$ref": "#/properties/query"
                            }
                          },
                          "required": [
                            "$contains"
                          ],
                          "additionalProperties": false
                        },
                        {
                          "type": "object",
                          "properties": {
                            "$hasPrefix": {
                              "type": "string"
                            }
                          },
                          "required": [
                            "$hasPrefix"
                          ],
                          "additionalProperties": false
                        }
                      ]
                    },
                    "propertyNames": {
                      "pattern": "^(?!\\$).*$"
                    }
                  },
                  {
                    "type": "object",
                    "additionalProperties": {
                      "not": {}
                    },
                    "propertyNames": {
                      "pattern": "^\\$"
                    }
                  }
                ]
              },
              {
                "$ref": "#/properties/query/anyOf/0/anyOf/0/additionalProperties/anyOf/0"
              },
              {
                "type": "object",
                "properties": {
                  "$all": {
                    "type": "array",
                    "items": {
                      "$ref": "#/properties/query"
                    }
                  }
                },
                "required": [
                  "$all"
                ],
                "additionalProperties": false
              },
              {
                "type": "object",
                "properties": {
                  "$any": {
                    "type": "array",
                    "items": {
                      "$ref": "#/properties/query"
                    }
                  }
                },
                "required": [
                  "$any"
                ],
                "additionalProperties": false
              },
              {
                "type": "object",
                "properties": {
                  "$not": {
                    "$ref": "#/properties/query"
                  }
                },
                "required": [
                  "$not"
                ],
                "additionalProperties": false
              }
            ],
            "description": "Entity predicate query. Supports field matching, $all, $any, $not, $exists, $in, $contains, and $hasPrefix operators."
          },
          "fields": {
            "type": "array",
            "items": {
              "type": "string"
            },
            "description": "Specific fields to include in the response. If not provided, all fields are returned. Each entry is a dot separated path into an entity, e.g. `spec.type`."
          },
          "limit": {
            "type": "integer",
            "exclusiveMinimum": 0,
            "description": "Maximum number of entities to return at a time."
          },
          "offset": {
            "type": "integer",
            "minimum": 0,
            "description": "Number of entities to skip before returning results."
          },
          "orderFields": {
            "anyOf": [
              {
                "type": "object",
                "properties": {
                  "field": {
                    "type": "string",
                    "description": "Field to order by. The format is a dot separated path into an entity, e.g. `spec.type`."
                  },
                  "order": {
                    "type": "string",
                    "enum": [
                      "asc",
                      "desc"
                    ],
                    "description": "Sort order"
                  }
                },
                "required": [
                  "field",
                  "order"
                ],
                "additionalProperties": false
              },
              {
                "type": "array",
                "items": {
                  "type": "object",
                  "properties": {
                    "field": {
                      "type": "string",
                      "description": "Field to order by. The format is a dot separated path into an entity, e.g. `spec.type`."
                    },
                    "order": {
                      "type": "string",
                      "enum": [
                        "asc",
                        "desc"
                      ],
                      "description": "Sort order"
                    }
                  },
                  "required": [
                    "field",
                    "order"
                  ],
                  "additionalProperties": false
                }
              }
            ],
            "description": "Ordering criteria for the results. Can be a single order directive or an array for multi-field sorting."
          },
          "fullTextFilter": {
            "type": "object",
            "properties": {
              "term": {
                "type": "string",
                "description": "Full text search term"
              },
              "fields": {
                "type": "array",
                "items": {
                  "type": "string"
                },
                "description": "Fields to search within. Each entry is a dot separated path into an entity, e.g. `spec.type`."
              }
            },
            "required": [
              "term"
            ],
            "additionalProperties": false,
            "description": "Full text search criteria"
          },
          "cursor": {
            "type": "string",
            "description": "Cursor for pagination. This can be used only after the first request with a response containing a cursor. If a cursor is given it takes precedence over `offset`."
          }
        },
        "additionalProperties": false,
        "$schema": "http://json-schema.org/draft-07/schema#"
      },
      "annotations": {
        "title": "Query Catalog Entities",
        "readOnlyHint": true,
        "destructiveHint": false,
        "idempotentHint": true,
        "openWorldHint": false
      }
    },
    {
      "name": "scaffolder.list-scaffolder-tasks",
      "description": "\nThis allows you to list scaffolder tasks that have been created.\nEach task has a unique id, specification, and status (one of open, processing, completed, failed, cancelled, skipped).\nEach task includes a timestamp for when it was created, and an optional last heartbeat timestamp indicating the most recent activity.\nSet owned to true to return only tasks created by the current user; omit or set to false for all tasks the credentials can see.\nFiltering by one or multiple statuses is supported. Pagination is supported via limit and offset.\n    ",
      "inputSchema": {
        "type": "object",
        "properties": {
          "owned": {
            "type": "boolean",
            "default": false,
            "description": "If true, return only tasks created by the current user. Requires a user identity."
          },
          "limit": {
            "type": "integer",
            "minimum": 1,
            "maximum": 1000,
            "description": "The maximum number of tasks to return for pagination"
          },
          "offset": {
            "type": "integer",
            "minimum": 0,
            "description": "The offset to start from for pagination"
          },
          "status": {
            "anyOf": [
              {
                "type": "string",
                "enum": [
                  "open",
                  "processing",
                  "completed",
                  "failed",
                  "cancelled",
                  "skipped"
                ]
              },
              {
                "type": "array",
                "items": {
                  "$ref": "#/properties/status/anyOf/0"
                },
                "minItems": 1
              }
            ],
            "description": "Filter tasks by status, or an array of statuses"
          }
        },
        "additionalProperties": false,
        "$schema": "http://json-schema.org/draft-07/schema#"
      },
      "annotations": {
        "title": "List Scaffolder Tasks",
        "readOnlyHint": true,
        "destructiveHint": false,
        "idempotentHint": true,
        "openWorldHint": false
      }
    },
    {
      "name": "scaffolder.dry-run-template",
      "description": "Dry-runs a scaffolder template to validate it without making changes. Returns success with execution logs, or errors for validation failures.",
      "inputSchema": {
        "type": "object",
        "properties": {
          "templateYaml": {
            "type": "string",
            "description": "The YAML content of the scaffolder template to validate"
          },
          "values": {
            "type": "object",
            "additionalProperties": {},
            "description": "Input values for template parameters"
          },
          "files": {
            "type": "array",
            "items": {
              "type": "object",
              "properties": {
                "path": {
                  "type": "string",
                  "description": "File path relative to template root"
                },
                "content": {
                  "type": "string",
                  "description": "File content"
                }
              },
              "required": [
                "path",
                "content"
              ],
              "additionalProperties": false
            },
            "description": "Files required for running the template"
          }
        },
        "required": [
          "templateYaml"
        ],
        "additionalProperties": false,
        "$schema": "http://json-schema.org/draft-07/schema#"
      },
      "annotations": {
        "title": "Dry Run Scaffolder Template",
        "readOnlyHint": true,
        "destructiveHint": false,
        "idempotentHint": true,
        "openWorldHint": false
      }
    },
    {
      "name": "scaffolder.list-scaffolder-actions",
      "description": "Lists all installed Scaffolder actions.\nEach action includes:\n- id: The action identifier\n- description: What the action does\n- schema: Input and output JSON schemas\n- examples: Usage examples when available",
      "inputSchema": {
        "type": "object",
        "properties": {},
        "additionalProperties": false,
        "description": "No input is required",
        "$schema": "http://json-schema.org/draft-07/schema#"
      },
      "annotations": {
        "title": "List Scaffolder Actions",
        "readOnlyHint": true,
        "destructiveHint": false,
        "idempotentHint": true,
        "openWorldHint": false
      }
    },
    {
      "name": "scaffolder.execute-template",
      "description": "Executes a Scaffolder template with its template ref and input parameter values.\nThe template is run using the credentials provided to this action, and respects any RBAC permissions associated with those credentials.\nReturns a taskId that can be used to track execution progress.\nUse the catalog.get-catalog-entity action to fetch the Template entity and discover its parameter schema and secrets definition before calling this action.",
      "inputSchema": {
        "type": "object",
        "properties": {
          "templateRef": {
            "type": "string",
            "description": "The template entity reference to execute, e.g. \"template:default/my-template\""
          },
          "values": {
            "type": "object",
            "additionalProperties": {},
            "description": "Input parameter values required by the template. Use catalog.get-catalog-entity to discover the required parameters for the template."
          },
          "secrets": {
            "type": "object",
            "additionalProperties": {
              "type": "string"
            },
            "description": "Optional secrets to pass to the template execution. Use catalog.get-catalog-entity to discover the secrets definition on the Template entity."
          }
        },
        "required": [
          "templateRef",
          "values"
        ],
        "additionalProperties": false,
        "$schema": "http://json-schema.org/draft-07/schema#"
      },
      "annotations": {
        "title": "Execute Scaffolder Template",
        "readOnlyHint": false,
        "destructiveHint": true,
        "idempotentHint": false,
        "openWorldHint": false
      }
    },
    {
      "name": "scaffolder.get-scaffolder-task-logs",
      "description": "\nRetrieve the log events for a scaffolder task.\nEach log event has a type (log, completion, cancelled, or recovered), a body containing a message and optional step ID and status.\nUse the after parameter to fetch only events after a specific event ID for incremental polling.\n    ",
      "inputSchema": {
        "type": "object",
        "properties": {
          "taskId": {
            "type": "string",
            "description": "The ID of the scaffolder task"
          },
          "after": {
            "type": "integer",
            "minimum": 0,
            "description": "Return only log events after this event ID for incremental polling"
          }
        },
        "required": [
          "taskId"
        ],
        "additionalProperties": false,
        "$schema": "http://json-schema.org/draft-07/schema#"
      },
      "annotations": {
        "title": "Get Scaffolder Task Logs",
        "readOnlyHint": true,
        "destructiveHint": false,
        "idempotentHint": true,
        "openWorldHint": false
      }
    }
  ]
}
```

</details>


After:

<details>

```json
{
  "tools": [
    {
      "name": "catalog_get_catalog_model_description",
      "description": "Returns a markdown formatted description of the current catalog model, including all registered entity kinds, annotations, labels, tags, and relations.",
      "inputSchema": {
        "type": "object",
        "properties": {},
        "additionalProperties": false,
        "$schema": "http://json-schema.org/draft-07/schema#"
      },
      "annotations": {
        "title": "Get a Catalog Model Description",
        "readOnlyHint": true,
        "destructiveHint": false,
        "idempotentHint": true,
        "openWorldHint": false
      }
    },
    {
      "name": "catalog_get_catalog_entity",
      "description": "\nThis allows you to get a single entity from the software catalog.\nEach entity in the software catalog has a unique name, kind, and namespace. The default namespace is \"default\".\nEach entity is identified by a unique entity reference, which is a string of the form \"kind:namespace/name\".\n    ",
      "inputSchema": {
        "type": "object",
        "properties": {
          "kind": {
            "type": "string",
            "description": "The kind of the entity to query. If the kind is unknown it can be omitted."
          },
          "namespace": {
            "type": "string",
            "description": "The namespace of the entity to query. If the namespace is unknown it can be omitted."
          },
          "name": {
            "type": "string",
            "description": "The name of the entity to query"
          }
        },
        "required": [
          "name"
        ],
        "additionalProperties": false,
        "$schema": "http://json-schema.org/draft-07/schema#"
      },
      "annotations": {
        "title": "Get Catalog Entity",
        "readOnlyHint": true,
        "destructiveHint": false,
        "idempotentHint": true,
        "openWorldHint": false
      }
    },
    {
      "name": "catalog_validate_entity",
      "description": "\n      This action can be used to validate catalog-info.yaml file contents meant to be used with the software catalog.\n      It checks both that the YAML syntax is correct, and that the entity content is valid according to the catalog's rules.\n      ",
      "inputSchema": {
        "type": "object",
        "properties": {
          "entity": {
            "type": "string",
            "description": "Entity YAML content to validate"
          },
          "location": {
            "type": "string",
            "format": "uri",
            "description": "Location to validate"
          }
        },
        "required": [
          "entity"
        ],
        "additionalProperties": false,
        "$schema": "http://json-schema.org/draft-07/schema#"
      },
      "annotations": {
        "title": "Validate Catalog Entity",
        "readOnlyHint": true,
        "destructiveHint": false,
        "idempotentHint": true,
        "openWorldHint": false
      }
    },
    {
      "name": "catalog_register_entity",
      "description": "Registers one or more entities in the Backstage catalog by creating a Location entity that points to a remote catalog-info.yaml file.\n\nThis action is similar to the \"Register existing component\" flow in the Backstage UI, where you provide a URL to a catalog-info.yaml file describing catalog entities such as Components, Systems, Resources, APIs, Users, and Groups. The action will create a new Location entity that references the provided file; all entities defined within that file will be imported into the catalog.\n\nA unique identifier (locationId) will be returned for the newly created Location. You can use this identifier in the future to unregister or delete the Location and all entities it owns.\n",
      "inputSchema": {
        "type": "object",
        "properties": {
          "locationUrl": {
            "type": "string",
            "description": "URL reference to the catalog-info.yaml file that describes the entity to register. For example: https://github.com/backstage/demo/blob/master/catalog-info.yaml"
          }
        },
        "required": [
          "locationUrl"
        ],
        "additionalProperties": false,
        "$schema": "http://json-schema.org/draft-07/schema#"
      },
      "annotations": {
        "title": "Register entity in the Catalog",
        "readOnlyHint": false,
        "destructiveHint": false,
        "idempotentHint": false,
        "openWorldHint": false
      }
    },
    {
      "name": "catalog_unregister_entity",
      "description": "Unregisters a Location entity and all entities it owns from the Backstage catalog.\n\nThis action is similar to the \"Unregister location\" function in the Backstage UI, where you provide the unique identifier (locationId) of a Location entity. Alternatively, you can provide the URL used to register the location. The action will remove the specified Location from the catalog as well as all entities that were created when the Location was imported.\n\nOnce completed, all entities associated with the Location will be deleted from the catalog.\n",
      "inputSchema": {
        "type": "object",
        "properties": {
          "type": {
            "anyOf": [
              {
                "type": "object",
                "properties": {
                  "locationId": {
                    "type": "string",
                    "description": "Location ID of the Entity to unregister"
                  }
                },
                "required": [
                  "locationId"
                ],
                "additionalProperties": false
              },
              {
                "type": "object",
                "properties": {
                  "locationUrl": {
                    "type": "string",
                    "description": "URL of the catalog-info.yaml file to unregister for example: https://github.com/backstage/demo/blob/master/catalog-info.yaml"
                  }
                },
                "required": [
                  "locationUrl"
                ],
                "additionalProperties": false
              }
            ],
            "description": "Identifies the entity to unregister. Provide either locationId or locationUrl."
          }
        },
        "required": [
          "type"
        ],
        "additionalProperties": false,
        "$schema": "http://json-schema.org/draft-07/schema#"
      },
      "annotations": {
        "title": "Unregister entity from the Catalog",
        "readOnlyHint": false,
        "destructiveHint": true,
        "idempotentHint": true,
        "openWorldHint": false
      }
    },
    {
      "name": "catalog_query_catalog_entities",
      "description": "\nQuery entities from the Backstage Software Catalog using predicate filters.\n\n## Catalog Model\n\nThe catalog contains entities of different kinds. Every entity has \"kind\", \"apiVersion\", \"metadata\", and optionally \"spec\" and \"relations\". Fields use dot notation for querying.\n\nCommon metadata fields on all entities: name, namespace (default: \"default\"), title, description, labels, annotations, tags (string array), links.\n\nEntity references use the format \"kind:namespace/name\", e.g. \"component:default/my-service\" or \"user:default/jane.doe\".\n\n### Entity Kinds\n\n**Component** - A piece of software such as a service, website, or library.\n  spec fields: type (e.g. \"service\", \"website\", \"library\"), lifecycle (e.g. \"production\", \"experimental\", \"deprecated\"), owner (entity ref), system, subcomponentOf, providesApis, consumesApis, dependsOn, dependencyOf.\n\n**API** - An interface that components expose, such as REST APIs or event streams.\n  spec fields: type (e.g. \"openapi\", \"asyncapi\", \"graphql\", \"grpc\"), lifecycle, owner (entity ref), definition (the API spec content), system.\n\n**System** - A collection of components, APIs, and resources that together expose some functionality.\n  spec fields: owner (entity ref), domain, type.\n\n**Domain** - A grouping of systems that share terminology, domain models, and business purpose.\n  spec fields: owner (entity ref), subdomainOf, type.\n\n**Resource** - Infrastructure required to operate a component, such as databases or storage buckets.\n  spec fields: type, owner (entity ref), system, dependsOn, dependencyOf.\n\n**Group** - An organizational entity such as a team or business unit.\n  spec fields: type (e.g. \"team\", \"business-unit\"), children (entity refs), parent (entity ref), members (entity refs), profile (displayName, email, picture).\n\n**User** - A person, such as an employee or contractor.\n  spec fields: memberOf (entity refs), profile (displayName, email, picture).\n\n**Location** - A marker that references other catalog descriptor files to be ingested.\n  spec fields: type, target, targets, presence.\n\n### Relations\n\nEntities have bidirectional relations stored in the \"relations\" array. Common relation types: ownedBy/ownerOf, dependsOn/dependencyOf, providesApi/apiProvidedBy, consumesApi/apiConsumedBy, parentOf/childOf, memberOf/hasMember, partOf/hasPart.\n\nRelations can be queried via \"relations.<type>\" e.g. \"relations.ownedby: user:default/jane-doe\". The value there must always be a valid entity reference.\n\nWhen querying for entity relationships, prefer using relations over spec fields. For example, use \"relations.ownedby\" instead of \"spec.owner\" to find entities owned by a particular group or user.\n\n## Query Syntax\n\nThe query uses predicate expressions with dot-notation field paths.\n\nSimple matching:\n  { query: { kind: \"Component\" } }\n  { query: { kind: \"Component\", \"spec.type\": \"service\" } }\n\nValue operators:\n  { query: { kind: { \"$in\": [\"API\", \"Component\"] } } }\n  { query: { \"metadata.annotations.backstage.io/techdocs-ref\": { \"$exists\": true } } }\n  { query: { \"metadata.tags\": { \"$contains\": \"java\" } } }\n  { query: { \"metadata.name\": { \"$hasPrefix\": \"team-\" } } }\n\nLogical operators:\n  { query: { \"$all\": [{ kind: \"Component\" }, { \"spec.lifecycle\": \"production\" }] } }\n  { query: { \"$any\": [{ \"spec.type\": \"service\" }, { \"spec.type\": \"website\" }] } }\n  { query: { \"$not\": { kind: \"Group\" } } }\n\nQuerying relations - find all entities owned by a specific group:\n  { query: { \"relations.ownedby\": \"group:default/team-alpha\" } }\n\nCombined example - find production services or websites with TechDocs:\n  { query: { \"$all\": [\n    { kind: \"Component\", \"spec.lifecycle\": \"production\" },\n    { \"$any\": [{ \"spec.type\": \"service\" }, { \"spec.type\": \"website\" }] },\n    { \"metadata.annotations.backstage.io/techdocs-ref\": { \"$exists\": true } }\n  ] } }\n\n## Other Options\n\nLimit returned fields: { fields: [\"kind\", \"metadata.name\", \"metadata.namespace\"] }\nSort results: { orderFields: { field: \"metadata.name\", order: \"asc\" } }\nFull text search: { fullTextFilter: { term: \"auth\", fields: [\"metadata.name\", \"metadata.title\"] } }\nPagination: Use limit (e.g. 20) and the returned nextPageCursor for subsequent requests via cursor.\n",
      "inputSchema": {
        "type": "object",
        "properties": {
          "query": {
            "anyOf": [
              {
                "anyOf": [
                  {
                    "type": "object",
                    "additionalProperties": {
                      "anyOf": [
                        {
                          "type": [
                            "string",
                            "number",
                            "boolean"
                          ]
                        },
                        {
                          "type": "object",
                          "properties": {
                            "$exists": {
                              "type": "boolean"
                            }
                          },
                          "required": [
                            "$exists"
                          ],
                          "additionalProperties": false
                        },
                        {
                          "type": "object",
                          "properties": {
                            "$in": {
                              "type": "array",
                              "items": {
                                "$ref": "#/properties/query/anyOf/0/anyOf/0/additionalProperties/anyOf/0"
                              }
                            }
                          },
                          "required": [
                            "$in"
                          ],
                          "additionalProperties": false
                        },
                        {
                          "type": "object",
                          "properties": {
                            "$contains": {
                              "$ref": "#/properties/query"
                            }
                          },
                          "required": [
                            "$contains"
                          ],
                          "additionalProperties": false
                        },
                        {
                          "type": "object",
                          "properties": {
                            "$hasPrefix": {
                              "type": "string"
                            }
                          },
                          "required": [
                            "$hasPrefix"
                          ],
                          "additionalProperties": false
                        }
                      ]
                    },
                    "propertyNames": {
                      "pattern": "^(?!\\$).*$"
                    }
                  },
                  {
                    "type": "object",
                    "additionalProperties": {
                      "not": {}
                    },
                    "propertyNames": {
                      "pattern": "^\\$"
                    }
                  }
                ]
              },
              {
                "$ref": "#/properties/query/anyOf/0/anyOf/0/additionalProperties/anyOf/0"
              },
              {
                "type": "object",
                "properties": {
                  "$all": {
                    "type": "array",
                    "items": {
                      "$ref": "#/properties/query"
                    }
                  }
                },
                "required": [
                  "$all"
                ],
                "additionalProperties": false
              },
              {
                "type": "object",
                "properties": {
                  "$any": {
                    "type": "array",
                    "items": {
                      "$ref": "#/properties/query"
                    }
                  }
                },
                "required": [
                  "$any"
                ],
                "additionalProperties": false
              },
              {
                "type": "object",
                "properties": {
                  "$not": {
                    "$ref": "#/properties/query"
                  }
                },
                "required": [
                  "$not"
                ],
                "additionalProperties": false
              }
            ],
            "description": "Entity predicate query. Supports field matching, $all, $any, $not, $exists, $in, $contains, and $hasPrefix operators."
          },
          "fields": {
            "type": "array",
            "items": {
              "type": "string"
            },
            "description": "Specific fields to include in the response. If not provided, all fields are returned. Each entry is a dot separated path into an entity, e.g. `spec.type`."
          },
          "limit": {
            "type": "integer",
            "exclusiveMinimum": 0,
            "description": "Maximum number of entities to return at a time."
          },
          "offset": {
            "type": "integer",
            "minimum": 0,
            "description": "Number of entities to skip before returning results."
          },
          "orderFields": {
            "anyOf": [
              {
                "type": "object",
                "properties": {
                  "field": {
                    "type": "string",
                    "description": "Field to order by. The format is a dot separated path into an entity, e.g. `spec.type`."
                  },
                  "order": {
                    "type": "string",
                    "enum": [
                      "asc",
                      "desc"
                    ],
                    "description": "Sort order"
                  }
                },
                "required": [
                  "field",
                  "order"
                ],
                "additionalProperties": false
              },
              {
                "type": "array",
                "items": {
                  "type": "object",
                  "properties": {
                    "field": {
                      "type": "string",
                      "description": "Field to order by. The format is a dot separated path into an entity, e.g. `spec.type`."
                    },
                    "order": {
                      "type": "string",
                      "enum": [
                        "asc",
                        "desc"
                      ],
                      "description": "Sort order"
                    }
                  },
                  "required": [
                    "field",
                    "order"
                  ],
                  "additionalProperties": false
                }
              }
            ],
            "description": "Ordering criteria for the results. Can be a single order directive or an array for multi-field sorting."
          },
          "fullTextFilter": {
            "type": "object",
            "properties": {
              "term": {
                "type": "string",
                "description": "Full text search term"
              },
              "fields": {
                "type": "array",
                "items": {
                  "type": "string"
                },
                "description": "Fields to search within. Each entry is a dot separated path into an entity, e.g. `spec.type`."
              }
            },
            "required": [
              "term"
            ],
            "additionalProperties": false,
            "description": "Full text search criteria"
          },
          "cursor": {
            "type": "string",
            "description": "Cursor for pagination. This can be used only after the first request with a response containing a cursor. If a cursor is given it takes precedence over `offset`."
          }
        },
        "additionalProperties": false,
        "$schema": "http://json-schema.org/draft-07/schema#"
      },
      "annotations": {
        "title": "Query Catalog Entities",
        "readOnlyHint": true,
        "destructiveHint": false,
        "idempotentHint": true,
        "openWorldHint": false
      }
    },
    {
      "name": "scaffolder_list_scaffolder_tasks",
      "description": "\nThis allows you to list scaffolder tasks that have been created.\nEach task has a unique id, specification, and status (one of open, processing, completed, failed, cancelled, skipped).\nEach task includes a timestamp for when it was created, and an optional last heartbeat timestamp indicating the most recent activity.\nSet owned to true to return only tasks created by the current user; omit or set to false for all tasks the credentials can see.\nFiltering by one or multiple statuses is supported. Pagination is supported via limit and offset.\n    ",
      "inputSchema": {
        "type": "object",
        "properties": {
          "owned": {
            "type": "boolean",
            "default": false,
            "description": "If true, return only tasks created by the current user. Requires a user identity."
          },
          "limit": {
            "type": "integer",
            "minimum": 1,
            "maximum": 1000,
            "description": "The maximum number of tasks to return for pagination"
          },
          "offset": {
            "type": "integer",
            "minimum": 0,
            "description": "The offset to start from for pagination"
          },
          "status": {
            "anyOf": [
              {
                "type": "string",
                "enum": [
                  "open",
                  "processing",
                  "completed",
                  "failed",
                  "cancelled",
                  "skipped"
                ]
              },
              {
                "type": "array",
                "items": {
                  "$ref": "#/properties/status/anyOf/0"
                },
                "minItems": 1
              }
            ],
            "description": "Filter tasks by status, or an array of statuses"
          }
        },
        "additionalProperties": false,
        "$schema": "http://json-schema.org/draft-07/schema#"
      },
      "annotations": {
        "title": "List Scaffolder Tasks",
        "readOnlyHint": true,
        "destructiveHint": false,
        "idempotentHint": true,
        "openWorldHint": false
      }
    },
    {
      "name": "scaffolder_dry_run_template",
      "description": "Dry-runs a scaffolder template to validate it without making changes. Returns success with execution logs, or errors for validation failures.",
      "inputSchema": {
        "type": "object",
        "properties": {
          "templateYaml": {
            "type": "string",
            "description": "The YAML content of the scaffolder template to validate"
          },
          "values": {
            "type": "object",
            "additionalProperties": {},
            "description": "Input values for template parameters"
          },
          "files": {
            "type": "array",
            "items": {
              "type": "object",
              "properties": {
                "path": {
                  "type": "string",
                  "description": "File path relative to template root"
                },
                "content": {
                  "type": "string",
                  "description": "File content"
                }
              },
              "required": [
                "path",
                "content"
              ],
              "additionalProperties": false
            },
            "description": "Files required for running the template"
          }
        },
        "required": [
          "templateYaml"
        ],
        "additionalProperties": false,
        "$schema": "http://json-schema.org/draft-07/schema#"
      },
      "annotations": {
        "title": "Dry Run Scaffolder Template",
        "readOnlyHint": true,
        "destructiveHint": false,
        "idempotentHint": true,
        "openWorldHint": false
      }
    },
    {
      "name": "scaffolder_list_scaffolder_actions",
      "description": "Lists all installed Scaffolder actions.\nEach action includes:\n- id: The action identifier\n- description: What the action does\n- schema: Input and output JSON schemas\n- examples: Usage examples when available",
      "inputSchema": {
        "type": "object",
        "properties": {},
        "additionalProperties": false,
        "description": "No input is required",
        "$schema": "http://json-schema.org/draft-07/schema#"
      },
      "annotations": {
        "title": "List Scaffolder Actions",
        "readOnlyHint": true,
        "destructiveHint": false,
        "idempotentHint": true,
        "openWorldHint": false
      }
    },
    {
      "name": "scaffolder_execute_template",
      "description": "Executes a Scaffolder template with its template ref and input parameter values.\nThe template is run using the credentials provided to this action, and respects any RBAC permissions associated with those credentials.\nReturns a taskId that can be used to track execution progress.\nUse the catalog.get-catalog-entity action to fetch the Template entity and discover its parameter schema and secrets definition before calling this action.",
      "inputSchema": {
        "type": "object",
        "properties": {
          "templateRef": {
            "type": "string",
            "description": "The template entity reference to execute, e.g. \"template:default/my-template\""
          },
          "values": {
            "type": "object",
            "additionalProperties": {},
            "description": "Input parameter values required by the template. Use catalog.get-catalog-entity to discover the required parameters for the template."
          },
          "secrets": {
            "type": "object",
            "additionalProperties": {
              "type": "string"
            },
            "description": "Optional secrets to pass to the template execution. Use catalog.get-catalog-entity to discover the secrets definition on the Template entity."
          }
        },
        "required": [
          "templateRef",
          "values"
        ],
        "additionalProperties": false,
        "$schema": "http://json-schema.org/draft-07/schema#"
      },
      "annotations": {
        "title": "Execute Scaffolder Template",
        "readOnlyHint": false,
        "destructiveHint": true,
        "idempotentHint": false,
        "openWorldHint": false
      }
    },
    {
      "name": "scaffolder_get_scaffolder_task_logs",
      "description": "\nRetrieve the log events for a scaffolder task.\nEach log event has a type (log, completion, cancelled, or recovered), a body containing a message and optional step ID and status.\nUse the after parameter to fetch only events after a specific event ID for incremental polling.\n    ",
      "inputSchema": {
        "type": "object",
        "properties": {
          "taskId": {
            "type": "string",
            "description": "The ID of the scaffolder task"
          },
          "after": {
            "type": "integer",
            "minimum": 0,
            "description": "Return only log events after this event ID for incremental polling"
          }
        },
        "required": [
          "taskId"
        ],
        "additionalProperties": false,
        "$schema": "http://json-schema.org/draft-07/schema#"
      },
      "annotations": {
        "title": "Get Scaffolder Task Logs",
        "readOnlyHint": true,
        "destructiveHint": false,
        "idempotentHint": true,
        "openWorldHint": false
      }
    },
    {
      "name": "search_query",
      "description": "\nThis allows you to query the search engine for documents.\nYou can search across all document types, or restrict the query to specific types.\nThe supported document types are: \"tools\", \"software-catalog\", \"techdocs\".\nPagination is supported via the `pageLimit` and `pageCursor` parameters and is enabled by default with limit of 10.\nResults are returned in a paginated format, along with `pageCursor` for navigating to the next page of results.\n    ",
      "inputSchema": {
        "type": "object",
        "properties": {
          "term": {
            "type": "string",
            "description": "The search term to query for"
          },
          "types": {
            "type": "array",
            "items": {
              "type": "string",
              "enum": [
                "tools",
                "software-catalog",
                "techdocs"
              ]
            },
            "description": "The types of documents to query for"
          },
          "filters": {
            "type": "object",
            "additionalProperties": {
              "anyOf": [
                {
                  "type": "string"
                },
                {
                  "type": "number"
                },
                {
                  "type": "boolean"
                },
                {
                  "type": "null"
                },
                {
                  "type": "array",
                  "items": {
                    "$ref": "#/properties/filters/additionalProperties"
                  }
                },
                {
                  "$ref": "#/properties/filters"
                }
              ]
            },
            "description": "The filters to apply to the query"
          },
          "pageLimit": {
            "type": "number",
            "description": "The number of results to return per page. Defaults to 10.",
            "default": 10
          },
          "pageCursor": {
            "type": "string",
            "description": "The cursor for the next page of results"
          }
        },
        "required": [
          "term"
        ],
        "additionalProperties": false,
        "$schema": "http://json-schema.org/draft-07/schema#"
      },
      "annotations": {
        "title": "Query Search Engine",
        "readOnlyHint": true,
        "destructiveHint": true,
        "idempotentHint": false,
        "openWorldHint": false
      }
    }
  ]
}
```

</details>

