### PR TITLE
Fix catalog filter facet scoping

### DIFF
--- a/.changeset/hot-doors-guess.md
+++ b/.changeset/hot-doors-guess.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog-react': patch
+'@backstage/plugin-catalog': patch
+---
+
+Scope catalog filter facet values using active catalog filters.

--- a/plugins/catalog-react/src/components/EntityAutocompletePicker/EntityAutocompletePicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityAutocompletePicker/EntityAutocompletePicker.test.tsx
@@ -87,7 +87,7 @@ describe('<EntityAutocompletePicker/>', () => {
     // should have called catalog backend without any filters applied
     expect(catalogApi.getEntityFacets).toHaveBeenCalledWith({
       facets: ['spec.options'],
-      filter: {},
+      filter: undefined,
     });
 
     fireEvent.click(screen.getByTestId('options-picker-expand'));
@@ -331,7 +331,7 @@ describe('<EntityAutocompletePicker/>', () => {
     expect(screen.queryByText('option2')).not.toBeInTheDocument();
   });
 
-  it('filters available values by kind as default', async () => {
+  it('filters available values by all active filters by default', async () => {
     const mockCatalogApi = makeMockCatalogApi();
     render(
       <TestApiProvider apis={[[catalogApiRef, mockCatalogApi]]}>
@@ -340,6 +340,7 @@ describe('<EntityAutocompletePicker/>', () => {
             filters: {
               kind: new EntityKindFilter('component', 'Component'),
               type: new EntityTypeFilter(['service']),
+              options: new EntityOptionFilter(['ignored']),
             },
           }}
         >
@@ -358,6 +359,7 @@ describe('<EntityAutocompletePicker/>', () => {
         facets: ['spec.options'],
         filter: {
           kind: 'component',
+          'spec.type': ['service'],
         },
       }),
     );

--- a/plugins/catalog-react/src/components/EntityAutocompletePicker/EntityAutocompletePicker.tsx
+++ b/plugins/catalog-react/src/components/EntityAutocompletePicker/EntityAutocompletePicker.tsx
@@ -27,7 +27,7 @@ import {
   useEntityList,
 } from '../../hooks/useEntityListProvider';
 import { EntityFilter } from '../../types';
-import { reduceBackendCatalogFilters } from '../../utils/filters';
+import { reduceCatalogFilters } from '../../utils/filters';
 import { CatalogAutocomplete } from '../CatalogAutocomplete';
 import { AutocompleteRenderOptionState } from '@material-ui/lab/Autocomplete';
 import { isEqual } from 'lodash';
@@ -89,7 +89,7 @@ export function EntityAutocompletePicker<
     Filter,
     InputProps,
     initialSelectedOptions = [],
-    filtersForAvailableValues = ['kind'],
+    filtersForAvailableValues,
     hidden,
     getOptionLabel,
     renderOption,
@@ -103,22 +103,37 @@ export function EntityAutocompletePicker<
   } = useEntityList<T>();
 
   const catalogApi = useApi(catalogApiRef);
-  const availableValuesFilters = filtersForAvailableValues.map(
-    f => filters[f] as EntityFilter | undefined,
-  );
+  const filterString = useMemo(() => {
+    const activeFilters = filtersForAvailableValues
+      ? filtersForAvailableValues.map(
+          f => filters[f] as EntityFilter | undefined,
+        )
+      : Object.keys(filters)
+          .filter(k => k !== name)
+          .map(k => filters[k as keyof T] as EntityFilter | undefined);
+
+    const condensed = reduceCatalogFilters(
+      activeFilters.filter(Boolean) as EntityFilter[],
+    ).filter;
+
+    if (Object.keys(condensed).length === 0) {
+      return undefined;
+    }
+
+    return JSON.stringify(condensed);
+  }, [filters, filtersForAvailableValues, name]);
+
   const { value: availableValues } = useAsync(async () => {
     const facet = path;
     const { facets } = await catalogApi.getEntityFacets({
       facets: [facet],
-      filter: reduceBackendCatalogFilters(
-        availableValuesFilters.filter(Boolean) as EntityFilter[],
-      ),
+      filter: filterString ? JSON.parse(filterString) : undefined,
     });
 
     return Object.fromEntries(
       facets[facet].map(({ value, count }) => [value, count]),
     );
-  }, [...availableValuesFilters]);
+  }, [catalogApi, path, filterString]);
 
   const queryParameters = useMemo(
     () => [queryParameter].flat().filter(Boolean) as string[],

--- a/plugins/catalog-react/src/components/EntityKindPicker/kindFilterUtils.ts
+++ b/plugins/catalog-react/src/components/EntityKindPicker/kindFilterUtils.ts
@@ -17,6 +17,10 @@
 import { useApi } from '@backstage/core-plugin-api';
 import useAsync from 'react-use/esm/useAsync';
 import { catalogApiRef } from '../../api';
+import { useEntityList } from '../../hooks/useEntityListProvider';
+import { EntityFilter } from '../../types';
+import { reduceCatalogFilters } from '../../utils/filters';
+import { useMemo } from 'react';
 
 /**
  * Fetch and return all available kinds.
@@ -27,18 +31,35 @@ export function useAllKinds(): {
   allKinds: Map<string, string>;
 } {
   const catalogApi = useApi(catalogApiRef);
+  const { filters } = useEntityList();
+
+  const filterString = useMemo(() => {
+    const activeFilters = Object.keys(filters)
+      .filter(k => k !== 'kind')
+      .map(k => filters[k as keyof typeof filters] as EntityFilter | undefined)
+      .filter(Boolean) as EntityFilter[];
+
+    const condensed = reduceCatalogFilters(activeFilters).filter;
+    if (Object.keys(condensed).length === 0) {
+      return undefined;
+    }
+    return JSON.stringify(condensed);
+  }, [filters]);
 
   const {
     error,
     loading,
     value: allKinds,
   } = useAsync(async () => {
-    const { facets } = await catalogApi.getEntityFacets({ facets: ['kind'] });
+    const { facets } = await catalogApi.getEntityFacets({
+      facets: ['kind'],
+      filter: filterString ? JSON.parse(filterString) : undefined,
+    });
     const kindFacets = (facets.kind ?? []).map(f => f.value);
     return new Map(
       kindFacets.map(kind => [kind.toLocaleLowerCase('en-US'), kind]),
     );
-  }, [catalogApi]);
+  }, [catalogApi, filterString]);
 
   return { loading, error, allKinds: allKinds ?? new Map() };
 }

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.test.tsx
@@ -535,6 +535,7 @@ describe('<EntityOwnerPicker mode="owners-only" />', () => {
     );
     expect(mockCatalogApi.getEntityFacets).toHaveBeenCalledWith({
       facets: ['relations.ownedBy'],
+      filter: undefined,
     });
     expect(updateFilters).toHaveBeenLastCalledWith({
       owners: undefined,

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/useFacetsEntities.test.ts
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/useFacetsEntities.test.ts
@@ -16,7 +16,10 @@
 
 import { renderHook, waitFor } from '@testing-library/react';
 import { useFacetsEntities } from './useFacetsEntities';
-import { catalogApiMock } from '@backstage/plugin-catalog-react/testUtils';
+import {
+  catalogApiMock,
+  MockEntityListContextProvider,
+} from '@backstage/plugin-catalog-react/testUtils';
 
 const mockCatalogApi = catalogApiMock.mock();
 
@@ -38,7 +41,9 @@ describe('useFacetsEntities', () => {
 
   it(`should return empty items when facets are loading`, () => {
     mockCatalogApi.getEntityFacets.mockReturnValue(new Promise(() => {}));
-    const { result } = renderHook(() => useFacetsEntities({ enabled: true }));
+    const { result } = renderHook(() => useFacetsEntities({ enabled: true }), {
+      wrapper: MockEntityListContextProvider,
+    });
     expect(result.current[0]).toEqual({ value: { items: [] }, loading: true });
   });
 
@@ -47,7 +52,9 @@ describe('useFacetsEntities', () => {
       facets: { 'metadata.tags': [{ value: 'tag', count: 1 }] },
     });
     mockCatalogApi.getEntitiesByRefs.mockResolvedValueOnce({ items: [] });
-    const { result } = renderHook(() => useFacetsEntities({ enabled: true }));
+    const { result } = renderHook(() => useFacetsEntities({ enabled: true }), {
+      wrapper: MockEntityListContextProvider,
+    });
     result.current[1]({ text: '' });
     await waitFor(() => {
       expect(result.current[0]).toEqual({
@@ -63,7 +70,9 @@ describe('useFacetsEntities', () => {
       facetsFromEntityRefs(entityRefs),
     );
 
-    const { result } = renderHook(() => useFacetsEntities({ enabled: true }));
+    const { result } = renderHook(() => useFacetsEntities({ enabled: true }), {
+      wrapper: MockEntityListContextProvider,
+    });
 
     result.current[1]({ text: '' });
     await waitFor(() => {
@@ -102,7 +111,9 @@ describe('useFacetsEntities', () => {
       facetsFromEntityRefs(entityRefs),
     );
 
-    const { result } = renderHook(() => useFacetsEntities({ enabled: true }));
+    const { result } = renderHook(() => useFacetsEntities({ enabled: true }), {
+      wrapper: MockEntityListContextProvider,
+    });
 
     result.current[1]({ text: '' });
     await waitFor(() => {
@@ -173,7 +184,9 @@ describe('useFacetsEntities', () => {
       facetsFromEntityRefs(entityRefs),
     );
 
-    const { result } = renderHook(() => useFacetsEntities({ enabled: true }));
+    const { result } = renderHook(() => useFacetsEntities({ enabled: true }), {
+      wrapper: MockEntityListContextProvider,
+    });
 
     result.current[1]({ text: '' }, { limit: 2 });
     await waitFor(() => {
@@ -283,7 +296,9 @@ describe('useFacetsEntities', () => {
       facetsFromEntityRefs(entityRefs),
     );
 
-    const { result } = renderHook(() => useFacetsEntities({ enabled: true }));
+    const { result } = renderHook(() => useFacetsEntities({ enabled: true }), {
+      wrapper: MockEntityListContextProvider,
+    });
 
     result.current[1]({ text: 'der  ' });
 

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/useFacetsEntities.ts
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/useFacetsEntities.ts
@@ -16,8 +16,11 @@
 import { useApi } from '@backstage/core-plugin-api';
 import useAsyncFn from 'react-use/esm/useAsyncFn';
 import { catalogApiRef } from '../../api';
-import { useState } from 'react';
+import { useMemo } from 'react';
 import { Entity, parseEntityRef } from '@backstage/catalog-model';
+import { useEntityList } from '../../hooks/useEntityListProvider';
+import { EntityFilter } from '../../types';
+import { reduceCatalogFilters } from '../../utils/filters';
 
 type FacetsCursor = {
   start: number;
@@ -43,15 +46,32 @@ type FacetsInitialRequest = {
  */
 export function useFacetsEntities({ enabled }: { enabled: boolean }) {
   const catalogApi = useApi(catalogApiRef);
+  const { filters } = useEntityList();
 
-  const [facetsPromise] = useState(async () => {
+  const filterString = useMemo(() => {
+    const activeFilters = Object.keys(filters)
+      .filter(k => k !== 'owners')
+      .map(k => filters[k as keyof typeof filters] as EntityFilter | undefined)
+      .filter(Boolean) as EntityFilter[];
+
+    const condensed = reduceCatalogFilters(activeFilters).filter;
+    if (Object.keys(condensed).length === 0) {
+      return undefined;
+    }
+    return JSON.stringify(condensed);
+  }, [filters]);
+
+  const facetsPromise = useMemo(async () => {
     if (!enabled) {
       return [];
     }
     const facet = 'relations.ownedBy';
 
     return catalogApi
-      .getEntityFacets({ facets: [facet] })
+      .getEntityFacets({
+        facets: [facet],
+        filter: filterString ? JSON.parse(filterString) : undefined,
+      })
       .then(response =>
         response.facets[facet]
           .map(e => e.value)
@@ -74,7 +94,7 @@ export function useFacetsEntities({ enabled }: { enabled: boolean }) {
           ),
       )
       .catch(() => []);
-  });
+  }, [catalogApi, enabled, filterString]);
 
   return useAsyncFn<
     (

--- a/plugins/catalog/src/components/CatalogKindHeader/kindFilterUtils.ts
+++ b/plugins/catalog/src/components/CatalogKindHeader/kindFilterUtils.ts
@@ -15,8 +15,13 @@
  */
 
 import { useApi } from '@backstage/core-plugin-api';
-import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import {
+  catalogApiRef,
+  EntityFilter,
+  useEntityList,
+} from '@backstage/plugin-catalog-react';
 import useAsync from 'react-use/esm/useAsync';
+import { useMemo } from 'react';
 
 /**
  * Fetch and return all available kinds.
@@ -27,18 +32,40 @@ export function useAllKinds(): {
   allKinds: Map<string, string>;
 } {
   const catalogApi = useApi(catalogApiRef);
+  const { filters } = useEntityList();
+
+  const filterString = useMemo(() => {
+    const activeFilters = Object.keys(filters)
+      .filter(k => k !== 'kind')
+      .map(k => filters[k as keyof typeof filters] as EntityFilter | undefined)
+      .filter(Boolean) as EntityFilter[];
+
+    const condensed = activeFilters.reduce<
+      Record<string, string | symbol | (string | symbol)[]>
+    >((acc, filter) => {
+      return { ...acc, ...(filter.getCatalogFilters?.() || {}) };
+    }, {});
+
+    if (Object.keys(condensed).length === 0) {
+      return undefined;
+    }
+    return JSON.stringify(condensed);
+  }, [filters]);
 
   const {
     error,
     loading,
     value: allKinds,
   } = useAsync(async () => {
-    const { facets } = await catalogApi.getEntityFacets({ facets: ['kind'] });
+    const { facets } = await catalogApi.getEntityFacets({
+      facets: ['kind'],
+      filter: filterString ? JSON.parse(filterString) : undefined,
+    });
     const kindFacets = (facets.kind ?? []).map(f => f.value);
     return new Map(
       kindFacets.map(kind => [kind.toLocaleLowerCase('en-US'), kind]),
     );
-  }, [catalogApi]);
+  }, [catalogApi, filterString]);
 
   return { loading, error, allKinds: allKinds ?? new Map() };
 }


### PR DESCRIPTION
## Fix catalog filter facet scoping

Closes #34615

### What this changes

Updates catalog filter pickers to scope their available facet values using all other currently active catalog filters by default.

Previously, `EntityAutocompletePicker` only scoped available values by the `kind` filter when `filtersForAvailableValues` was not explicitly provided. As a result, facet values could be presented that would never produce results once selected.

With this change:

* `EntityAutocompletePicker` scopes available values using all active filters except its own filter.
* `EntityKindPicker` scopes available kinds using all active filters except `kind`.
* `EntityOwnerPicker` scopes available owners using all active filters except `owners`.
* `CatalogKindHeader` uses the same facet scoping behavior.

### Implementation details

* Removed the implicit default of `filtersForAvailableValues = ['kind']`.
* Derived facet filters from all active catalog filters while excluding the current picker's filter.
* Replaced dynamic dependency arrays with a stable serialized filter key to avoid React Hook dependency array size changes when filters are added or removed.
* Preserved previous behavior for empty filter sets by omitting the `filter` parameter when no filters are active.
* Updated affected tests to reflect the new facet-scoping behavior.

### Verification

Verified manually using the example catalog.

#### Before applying filters

<img width="1470" height="835" alt="facet-scoping-before-filter" src="https://github.com/user-attachments/assets/85493fdb-deb0-4b62-a6fa-5625266670ed" />

#### After applying filters (Kind = API, Lifecycle = Experimental)

<img width="1470" height="835" alt="facet-scoping-after-filter" src="https://github.com/user-attachments/assets/4bb6554a-0bc8-4de7-9a02-0ed04586239e" />

The available values shown in other filter pickers are correctly reduced to values that match the active filter set.

### Tests

* Updated `EntityAutocompletePicker` tests.
* Updated `EntityOwnerPicker` tests.
* Updated `useFacetsEntities` tests.
* Verified all affected test suites pass locally.

#### :heavy_check_mark: Checklist

* [x] A changeset describing the change and affected packages.
* [ ] Added or updated documentation (not required).
* [x] Tests for new functionality and regression tests for bug fixes.
* [x] Screenshots attached (for UI changes).
* [x] All commits have a `Signed-off-by` line in the message.
