### PR TITLE
feat(auth0): make authorization prompt configurable

### DIFF
--- a/.changeset/auth0-configurable-prompt.md
+++ b/.changeset/auth0-configurable-prompt.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-auth-backend-module-auth0-provider': patch
+---
+
+Added an optional `prompt` setting for Auth0 authorization requests. Set it to
+`auto` to let Auth0 determine whether the user needs to be prompted. Existing
+configurations continue to use `consent` by default.

--- a/docs/auth/auth0/provider.md
+++ b/docs/auth/auth0/provider.md
@@ -38,6 +38,8 @@ auth:
         connection: ${AUTH_AUTH0_CONNECTION}
         connectionScope: ${AUTH_AUTH0_CONNECTION_SCOPE}
         organization: ${AUTH_AUTH0_ORGANIZATION_ID}
+        ## uncomment to let Auth0 determine whether to prompt the user
+        # prompt: auto
         ## uncomment to set lifespan of user session
         # sessionDuration: { hours: 24 } # supports `ms` library format (e.g. '24h', '2 days'), ISO duration, "human duration" as used in code
   session:
@@ -62,6 +64,9 @@ Auth0 requires a session, so you need to give the session a secret key.
 - `audience`: The intended recipients of the token.
 - `connection`: Social identity provider name. To check the available social connections, please visit [Auth0 Social Connections](https://marketplace.auth0.com/features/social-connections).
 - `connectionScope`: Additional scopes in the interactive token request. It should always be used in combination with the `connection` parameter.
+- `prompt`: Controls the prompt sent to Auth0. Set this to `auto` to omit the
+  parameter and let Auth0 determine whether to prompt the user. Other values
+  are passed through to Auth0. Defaults to `consent`.
 - `sessionDuration`: Lifespan of the user session.
 - `organization`: Specify a specific organization ID to be targeted as part of the login flow.
 

--- a/plugins/auth-backend-module-auth0-provider/config.d.ts
+++ b/plugins/auth-backend-module-auth0-provider/config.d.ts
@@ -32,6 +32,12 @@ export interface Config {
           audience?: string;
           connection?: string;
           connectionScope?: string;
+          /**
+           * Controls the prompt sent to Auth0. Set to `auto` to omit the
+           * parameter and let Auth0 determine whether to prompt the user.
+           * Defaults to `consent`.
+           */
+          prompt?: string;
           organization?: string;
           /**
            * Whether to perform federated logout, clearing both the Auth0

--- a/plugins/auth-backend-module-auth0-provider/report.api.md
+++ b/plugins/auth-backend-module-auth0-provider/report.api.md
@@ -18,6 +18,7 @@ export const auth0Authenticator: OAuthAuthenticator<
     audience: string | undefined;
     connection: string | undefined;
     connectionScope: string | undefined;
+    prompt: string;
     domain: string;
     clientID: string;
     federated: boolean;
@@ -39,6 +40,7 @@ export function createAuth0Authenticator(options?: {
     audience: string | undefined;
     connection: string | undefined;
     connectionScope: string | undefined;
+    prompt: string;
     domain: string;
     clientID: string;
     federated: boolean;

--- a/plugins/auth-backend-module-auth0-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-auth0-provider/src/authenticator.ts
@@ -43,6 +43,7 @@ export function createAuth0Authenticator(options?: { cache?: CacheService }) {
       const audience = config.getOptionalString('audience');
       const connection = config.getOptionalString('connection');
       const connectionScope = config.getOptionalString('connectionScope');
+      const prompt = config.getOptionalString('prompt') ?? 'consent';
       const callbackURL =
         config.getOptionalString('callbackUrl') ?? callbackUrl;
       const organization = config.getOptionalString('organization');
@@ -102,6 +103,7 @@ export function createAuth0Authenticator(options?: { cache?: CacheService }) {
         audience,
         connection,
         connectionScope,
+        prompt,
         domain,
         clientID,
         federated,
@@ -110,11 +112,17 @@ export function createAuth0Authenticator(options?: { cache?: CacheService }) {
 
     async start(
       input,
-      { helper, audience, connection, connectionScope: connection_scope },
+      {
+        helper,
+        audience,
+        connection,
+        connectionScope: connection_scope,
+        prompt,
+      },
     ) {
       return helper.start(input, {
         accessType: 'offline',
-        prompt: 'consent',
+        ...(prompt !== 'auto' ? { prompt } : {}),
         ...(audience ? { audience } : {}),
         ...(connection ? { connection } : {}),
         ...(connection_scope ? { connection_scope } : {}),

--- a/plugins/auth-backend-module-auth0-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-auth0-provider/src/module.test.ts
@@ -88,6 +88,57 @@ describe('authModuleAuth0Provider', () => {
     });
   });
 
+  it('should configure the authorization prompt', async () => {
+    const { server } = await startTestBackend({
+      features: [
+        authPlugin,
+        authModuleAuth0Provider,
+        mockServices.rootConfig.factory({
+          data: {
+            app: {
+              baseUrl: 'http://localhost:3000',
+            },
+            auth: {
+              providers: {
+                auth0: {
+                  development: {
+                    clientId: 'clientId',
+                    clientSecret: 'clientSecret',
+                    domain: 'domain',
+                    prompt: 'login',
+                  },
+                  production: {
+                    clientId: 'clientId',
+                    clientSecret: 'clientSecret',
+                    domain: 'domain',
+                    prompt: 'auto',
+                  },
+                },
+              },
+              session: {
+                secret: 'secret',
+              },
+            },
+          },
+        }),
+      ],
+    });
+
+    const agent = request.agent(server);
+
+    const explicitPromptResponse = await agent.get(
+      '/api/auth/auth0/start?env=development',
+    );
+    const explicitPromptUrl = new URL(explicitPromptResponse.get('location'));
+    expect(explicitPromptUrl.searchParams.get('prompt')).toBe('login');
+
+    const automaticPromptResponse = await agent.get(
+      '/api/auth/auth0/start?env=production',
+    );
+    const automaticPromptUrl = new URL(automaticPromptResponse.get('location'));
+    expect(automaticPromptUrl.searchParams.has('prompt')).toBe(false);
+  });
+
   it('should pass through organization and invitation parameters to the authorization URL', async () => {
     const { server } = await startTestBackend({
       features: [


### PR DESCRIPTION
## Summary

- Add an optional `prompt` setting to the Auth0 provider.
- Preserve the existing `prompt=consent` behavior when the setting is omitted.
- Treat `prompt: auto` as a sentinel that omits the authorization parameter and lets Auth0 or the upstream identity provider decide whether interaction is required.
- Pass other configured prompt values through unchanged.

This follows the convention already used by the OIDC provider. The `auto` behavior has also been validated in a downstream enterprise identity-provider deployment where the hard-coded consent prompt prevented sign-in from completing.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected package
- [x] Added or updated documentation
- [x] Tests for the new behavior and backward-compatible default
- [ ] Screenshots attached (not applicable; no UI changes)
- [x] All commits have a `Signed-off-by` line

## Verification

- `CI=1 yarn test plugins/auth-backend-module-auth0-provider` (10 tests)
- `yarn lint --fix`
- `yarn prettier --write <changed paths>`
- `yarn tsc`
- `yarn build:api-reports`