### PR TITLE
fix: use stable unique keys in entity card grids

### DIFF
--- a/.changeset/calm-keys-smile.md
+++ b/.changeset/calm-keys-smile.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Fixed the ownership card emitting duplicate React key warnings when different entity kinds share the same type.

--- a/.changeset/neat-docs-wave.md
+++ b/.changeset/neat-docs-wave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fixed duplicate React key warnings when documentation entities share a name across different namespaces or kinds.

--- a/plugins/org/src/components/Cards/OwnershipCard/ComponentsGrid.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/ComponentsGrid.tsx
@@ -157,7 +157,7 @@ export const ComponentsGrid = ({
   return (
     <Grid container className={className}>
       {componentsWithCounters?.map(c => (
-        <Grid item xs={6} md={6} lg={4} key={c.type ?? c.kind}>
+        <Grid item xs={6} md={6} lg={4} key={`${c.kind}:${c.type ?? ''}`}>
           <EntityCountTile
             counter={c.counter}
             kind={c.kind}

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.test.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.test.tsx
@@ -191,6 +191,50 @@ describe('OwnershipCard', () => {
     ).toBeInTheDocument();
   });
 
+  it('uses unique keys for matching types of different kinds', async () => {
+    const catalogApi = catalogApiMock({
+      entities: [
+        {
+          apiVersion: 'backstage.io/v1alpha1',
+          kind: 'Component',
+          metadata: { name: 'my-service' },
+          spec: { type: 'service' },
+        },
+        {
+          apiVersion: 'backstage.io/v1alpha1',
+          kind: 'Resource',
+          metadata: { name: 'service-resource' },
+          spec: { type: 'service' },
+        },
+      ],
+    });
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    try {
+      await renderInTestApp(
+        <TestApiProvider apis={[[catalogApiRef, catalogApi]]}>
+          <EntityProvider entity={groupEntity}>
+            <OwnershipCard />
+          </EntityProvider>
+        </TestApiProvider>,
+        {
+          mountedRoutes: {
+            '/create': catalogIndexRouteRef,
+          },
+        },
+      );
+
+      await expect(screen.findAllByText('SERVICE')).resolves.toHaveLength(2);
+      expect(consoleError.mock.calls.flat().join(' ')).not.toContain(
+        'Encountered two children with the same key',
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   it('applies CustomFilterDefinition', async () => {
     const catalogApi = catalogApiMock({ entities: items });
 

--- a/plugins/techdocs/src/home/components/Grids/InfoCardGrid.test.tsx
+++ b/plugins/techdocs/src/home/components/Grids/InfoCardGrid.test.tsx
@@ -85,6 +85,54 @@ describe('Entity Info Card Grid', () => {
     expect(await screen.findByText('TestTitle2')).toBeInTheDocument();
   });
 
+  it('uses unique keys for entities with matching names', async () => {
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    try {
+      await renderInTestApp(
+        <Wrapper>
+          <InfoCardGrid
+            entities={[
+              {
+                apiVersion: 'version',
+                kind: 'TestKind',
+                metadata: {
+                  namespace: 'first',
+                  name: 'testName',
+                  title: 'First Test Title',
+                },
+              },
+              {
+                apiVersion: 'version',
+                kind: 'TestKind',
+                metadata: {
+                  namespace: 'second',
+                  name: 'testName',
+                  title: 'Second Test Title',
+                },
+              },
+            ]}
+          />
+        </Wrapper>,
+        {
+          mountedRoutes: {
+            '/docs/:namespace/:kind/:name/*': rootDocsRouteRef,
+          },
+        },
+      );
+
+      expect(await screen.findByText('First Test Title')).toBeInTheDocument();
+      expect(screen.getByText('Second Test Title')).toBeInTheDocument();
+      expect(consoleError.mock.calls.flat().join(' ')).not.toContain(
+        'Encountered two children with the same key',
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
   it('should render links correctly', async () => {
     await renderInTestApp(
       <Wrapper>

--- a/plugins/techdocs/src/home/components/Grids/InfoCardGrid.tsx
+++ b/plugins/techdocs/src/home/components/Grids/InfoCardGrid.tsx
@@ -101,7 +101,7 @@ export const InfoCardGrid = (props: InfoCardGridProps) => {
     <ItemCardGrid data-testid="info-card-container">
       {entities.map(entity => (
         <InfoCard
-          key={entity.metadata.name}
+          key={stringifyEntityRef(entity)}
           data-testid={entity?.metadata?.title}
           title={
             entityRefToPresentation?.get(stringifyEntityRef(entity))


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes duplicate React key warnings in two entity card grids:

- Ownership cards now identify aggregate tiles using both entity kind and type.
- TechDocs info card grids now identify entities using their full entity reference.

This prevents collisions when different entity kinds share a type, or when entities share a name across namespaces or kinds.

Regression tests cover both collision scenarios.

### Verification

- `CI=1 yarn test plugins/org/src/components/Cards/OwnershipCard`
- `CI=1 yarn test plugins/techdocs/src/home/components/Grids/InfoCardGrid.test.tsx`
- `yarn tsc`
- `yarn build:api-reports`

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
