### PR TITLE
fix(backend-defaults): split AWS S3 URL parser into readable regexes

### DIFF
--- a/.changeset/aws-s3-url-parser-cleanup.md
+++ b/.changeset/aws-s3-url-parser-cleanup.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Improved readability of the AWS S3 URL parser by splitting the single monolithic regex into two separate patterns (standard S3 and VPC PrivateLink) with named capture groups. Also made the VPC endpoint region mandatory in the regex, fixing a potential mis-parse when the region segment was absent.

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.test.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.test.ts
@@ -191,6 +191,19 @@ describe('parseUrl', () => {
       region: 'eu-central-1',
     });
 
+    expect(
+      parseUrl(
+        'https://my-bucket.bucket.vpce-abc123-xyz.s3.cn-north-1.vpce.amazonaws.com.cn/data.json',
+        {
+          host: 'amazonaws.com',
+        },
+      ),
+    ).toEqual({
+      path: 'data.json',
+      bucket: 'my-bucket',
+      region: 'cn-north-1',
+    });
+
     expect(() =>
       parseUrl(
         'https://my.bucket-3.bucket.vpce-12345678901234567-foobar.s3.eu-central-1.vpce.amazonaws.com/a/puppy.jpg',
@@ -199,9 +212,28 @@ describe('parseUrl', () => {
           s3ForcePathStyle: true,
         },
       ),
-    ).toThrow(
-      `Invalid AWS S3 URL https://my.bucket-3.bucket.vpce-12345678901234567-foobar.s3.eu-central-1.vpce.amazonaws.com/a/puppy.jpg - path style access is not supported for VPC endpoint URLs`,
-    );
+    ).toThrow('path style access is not supported for VPC endpoint URLs');
+  });
+
+  it('rejects invalid AWS URLs', () => {
+    expect(() =>
+      parseUrl('https://not-valid-s3.amazonaws.com/bucket/key', {
+        host: 'amazonaws.com',
+      }),
+    ).toThrow('Invalid AWS S3 URL');
+
+    expect(() =>
+      parseUrl('https://s3.amazonaws.com/bucket-only-no-key', {
+        host: 'amazonaws.com',
+      }),
+    ).toThrow('does not contain bucket in the path');
+
+    expect(() =>
+      parseUrl(
+        'https://bucket.vpce-12345678901234567-foobar.s3.eu-central-1.vpce.amazonaws.com/key',
+        { host: 'amazonaws.com' },
+      ),
+    ).toThrow('Invalid AWS S3 URL');
   });
 
   it('supports all non-aws formats', () => {

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.ts
@@ -51,73 +51,36 @@ import { relative } from 'node:path/posix';
 export const DEFAULT_REGION = 'us-east-1';
 
 /**
- * Path style URLs: https://s3.(region).amazonaws.com/(bucket)/(key)
- * The region can also be on the old form: https://s3-(region).amazonaws.com/(bucket)/(key)
- * Virtual hosted style URLs: https://(bucket).s3.(region).amazonaws.com/(key)
- * See https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#path-style-access
+ * Standard AWS S3 URLs:
+ *   Path style:           https://s3.(region).amazonaws.com/(bucket)/(key)
+ *   Path style (old):     https://s3-(region).amazonaws.com/(bucket)/(key)
+ *   Virtual hosted style: https://(bucket).s3.(region).amazonaws.com/(key)
+ *
+ * AWS PrivateLink (VPC endpoint) S3 URLs:
+ *   https://(bucket).bucket.(vpce-id).s3.(region).vpce.amazonaws.com/(key)
+ *
+ * Both forms may have an optional .cn suffix for China regions.
+ *
+ * See https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html
+ * See https://docs.aws.amazon.com/AmazonS3/latest/userguide/privatelink-interface-endpoints.html
  */
+
+const STANDARD_AWS_HOST_RE =
+  /^(?:(?<bucket>[a-z0-9.-]+)\.)?s3(?:[.-](?<region>[a-z0-9-]+))?\.amazonaws\.com(?:\.cn)?$/;
+
+const VPC_ENDPOINT_HOST_RE =
+  /^(?<bucket>[a-z0-9.-]+)\.bucket\.(?<vpceId>vpce-[a-z0-9-]+)\.s3[.-](?<region>[a-z0-9-]+)\.vpce\.amazonaws\.com(?:\.cn)?$/;
+
 export function parseUrl(
   url: string,
   config: AwsS3IntegrationConfig,
 ): { path: string; bucket: string; region: string } {
   const parsedUrl = new URL(url);
-
-  /**
-   * Removes the leading '/' from the pathname to be processed
-   * as a parameter by AWS S3 SDK getObject method.
-   */
   const pathname = parsedUrl.pathname.substring(1);
   const host = parsedUrl.host;
 
-  // Treat Amazon hosted separately because it has special region logic
-  if (
-    config.host === 'amazonaws.com' ||
-    config.host === 'amazonaws.com.cn' ||
-    config.host.endsWith('.amazonaws.com') ||
-    config.host.endsWith('.amazonaws.com.cn')
-  ) {
-    const match = host.match(
-      /^((?:([a-z0-9.-]+)\.)?s3(?:[.-]([a-z0-9-]+))?\.amazonaws\.com(\.cn)?|(?:([a-z0-9.-]+)\.)?bucket\.(vpce-[a-z0-9-]+)\.s3(?:[.-]([a-z0-9-]+))?\.vpce\.amazonaws\.com(\.cn)?)$/,
-    );
-    if (!match) {
-      throw new Error(`Invalid AWS S3 URL ${url}`);
-    }
-
-    const [, , hostBucket, hostRegion, , vpcBucket, , vpcRegion] = match;
-
-    if (vpcBucket && vpcRegion) {
-      if (config.s3ForcePathStyle) {
-        throw new Error(
-          `Invalid AWS S3 URL ${url} - path style access is not supported for VPC endpoint URLs`,
-        );
-      }
-      return {
-        path: pathname,
-        bucket: vpcBucket,
-        region: vpcRegion,
-      };
-    }
-
-    if (config.s3ForcePathStyle || !hostBucket) {
-      const slashIndex = pathname.indexOf('/');
-      if (slashIndex < 0) {
-        throw new Error(
-          `Invalid path-style AWS S3 URL ${url}, does not contain bucket in the path`,
-        );
-      }
-
-      return {
-        path: pathname.substring(slashIndex + 1),
-        bucket: pathname.substring(0, slashIndex),
-        region: hostRegion ?? DEFAULT_REGION,
-      };
-    }
-
-    return {
-      path: pathname,
-      bucket: hostBucket,
-      region: hostRegion ?? DEFAULT_REGION,
-    };
+  if (isAmazonHost(config.host)) {
+    return parseAmazonUrl(url, host, pathname, config);
   }
 
   const usePathStyle =
@@ -142,6 +105,65 @@ export function parseUrl(
     path: pathname,
     bucket: host.substring(0, host.length - config.host.length - 1),
     region: DEFAULT_REGION,
+  };
+}
+
+function isAmazonHost(host: string): boolean {
+  return (
+    host === 'amazonaws.com' ||
+    host === 'amazonaws.com.cn' ||
+    host.endsWith('.amazonaws.com') ||
+    host.endsWith('.amazonaws.com.cn')
+  );
+}
+
+function parseAmazonUrl(
+  url: string,
+  host: string,
+  pathname: string,
+  config: AwsS3IntegrationConfig,
+): { path: string; bucket: string; region: string } {
+  // Try VPC PrivateLink format first (more specific pattern)
+  const vpcMatch = host.match(VPC_ENDPOINT_HOST_RE);
+  if (vpcMatch?.groups) {
+    if (config.s3ForcePathStyle) {
+      throw new Error(
+        `Invalid AWS S3 URL ${url} - path style access is not supported for VPC endpoint URLs`,
+      );
+    }
+    return {
+      path: pathname,
+      bucket: vpcMatch.groups.bucket,
+      region: vpcMatch.groups.region,
+    };
+  }
+
+  // Try standard AWS S3 format
+  const stdMatch = host.match(STANDARD_AWS_HOST_RE);
+  if (!stdMatch?.groups) {
+    throw new Error(`Invalid AWS S3 URL ${url}`);
+  }
+
+  const { bucket: hostBucket, region: hostRegion } = stdMatch.groups;
+
+  if (config.s3ForcePathStyle || !hostBucket) {
+    const slashIndex = pathname.indexOf('/');
+    if (slashIndex < 0) {
+      throw new Error(
+        `Invalid path-style AWS S3 URL ${url}, does not contain bucket in the path`,
+      );
+    }
+    return {
+      path: pathname.substring(slashIndex + 1),
+      bucket: pathname.substring(0, slashIndex),
+      region: hostRegion ?? DEFAULT_REGION,
+    };
+  }
+
+  return {
+    path: pathname,
+    bucket: hostBucket,
+    region: hostRegion ?? DEFAULT_REGION,
   };
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #34467 — addresses the Copilot review feedback about the brittle regex + positional destructuring.

- Splits the single monolithic regex into two separate patterns with named capture groups:
  - `STANDARD_AWS_HOST_RE` for `s3.(region).amazonaws.com` URLs
  - `VPC_ENDPOINT_HOST_RE` for `(bucket).bucket.(vpce-id).s3.(region).vpce.amazonaws.com` URLs
- Extracts the Amazon-specific parsing into a `parseAmazonUrl` helper
- Makes VPC endpoint region mandatory in the regex (was optional, which could silently mis-parse)
- Adds missing VPC `.cn` endpoint test and invalid URL rejection tests

No behavioral changes for valid URLs. The only change is that a hypothetical VPC endpoint URL missing its region segment now fails to match (instead of silently falling through to path-style parsing with the wrong region).

## Test plan

- [x] All 24 existing tests pass
- [x] New tests for VPC `.cn` endpoints and invalid URL rejection

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.