### PR TITLE
feat(techdocs): add support for multiple publishers (#34457)

### DIFF
--- a/.changeset/techdocs-multi-publisher.md
+++ b/.changeset/techdocs-multi-publisher.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-techdocs-backend': minor
+'@backstage/plugin-techdocs-node': minor
+---
+
+Introduced a new `multi` publisher type for TechDocs, which enables writing documentation to multiple publishers concurrently while reading from the primary one.

--- a/docs/features/techdocs/configuration.md
+++ b/docs/features/techdocs/configuration.md
@@ -182,6 +182,7 @@ This determines where generated documentation files are stored.
 - `'googleGcs'` - techdocs-backend will use a Google Cloud Storage Bucket
 - `'awsS3'` - techdocs-backend will use an Amazon Web Service (AWS) S3 bucket
 - `'azureBlobStorage'` - techdocs-backend will use Azure Blob Storage
+- `'multi'` - techdocs-backend will wrap multiple publishers, writing to all of them but reading from the first one in the list.
 
 **Example:**
 
@@ -519,6 +520,36 @@ techdocs:
       credentials:
         accountName: ${TECHDOCS_AZURE_BLOB_STORAGE_ACCOUNT_NAME}
         accountKey: ${TECHDOCS_AZURE_BLOB_STORAGE_ACCOUNT_KEY}
+```
+
+### Multi
+
+`techdocs.publisher.multi`
+
+This is used to configure the multi publisher option, which allows writing to multiple storage targets simultaneously for redundancy or migration, while reading from the primary one.
+
+Required when `techdocs.publisher.type` is set to `'multi'`.
+
+#### Publishers
+
+`techdocs.publisher.multi.publishers`
+
+(Required) An array of publisher types to use. The first publisher in the list is treated as the primary publisher for read operations. All write operations are broadcasted to all publishers in the list concurrently. You still need to configure each publisher type independently under its own configuration key.
+
+**Example:**
+
+```yaml
+techdocs:
+  publisher:
+    type: 'multi'
+    multi:
+      publishers:
+        - 'awsS3'
+        - 'local'
+    awsS3:
+      bucketName: 'techdocs-storage'
+    local:
+      publishDirectory: '/tmp/techdocs'
 ```
 
 ## Legacy Case Sensitive Triplet Paths

--- a/plugins/techdocs-backend/config.d.ts
+++ b/plugins/techdocs-backend/config.d.ts
@@ -92,6 +92,24 @@ export interface Config {
      */
     publisher?:
       | {
+          type: 'multi';
+          /**
+           * Required when 'type' is set to multi
+           */
+          multi?: {
+            /**
+             * List of publishers to use. The first is treated as primary.
+             */
+            publishers: Array<
+              | 'local'
+              | 'googleGcs'
+              | 'awsS3'
+              | 'azureBlobStorage'
+              | 'openStackSwift'
+            >;
+          };
+        }
+      | {
           type: 'local';
 
           /**

--- a/plugins/techdocs-node/report.api.md
+++ b/plugins/techdocs-node/report.api.md
@@ -229,7 +229,8 @@ export type PublisherType =
   | 'googleGcs'
   | 'awsS3'
   | 'azureBlobStorage'
-  | 'openStackSwift';
+  | 'openStackSwift'
+  | 'multi';
 
 // @public
 export type PublishRequest = {

--- a/plugins/techdocs-node/src/stages/publish/multi.test.ts
+++ b/plugins/techdocs-node/src/stages/publish/multi.test.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import express from 'express';
+import { MultiPublisher } from './multi';
+import {
+  PublisherBase,
+  PublishRequest,
+  PublishResponse,
+  ReadinessResponse,
+  TechDocsMetadata,
+} from './types';
+import { Entity } from '@backstage/catalog-model';
+
+describe('MultiPublisher', () => {
+  const createMockPublisher = (): jest.Mocked<PublisherBase> => ({
+    getReadiness: jest.fn(),
+    publish: jest.fn(),
+    fetchTechDocsMetadata: jest.fn(),
+    docsRouter: jest.fn(),
+    hasDocsBeenGenerated: jest.fn(),
+    migrateDocsCase: jest.fn(),
+  });
+
+  it('should throw an error if no publishers are provided', () => {
+    expect(() => new MultiPublisher([])).toThrow(
+      'MultiPublisher requires at least one publisher',
+    );
+  });
+
+  describe('getReadiness', () => {
+    it('returns isAvailable true when all publishers are available', async () => {
+      const pub1 = createMockPublisher();
+      pub1.getReadiness.mockResolvedValue({ isAvailable: true });
+      const pub2 = createMockPublisher();
+      pub2.getReadiness.mockResolvedValue({ isAvailable: true });
+
+      const multi = new MultiPublisher([pub1, pub2]);
+      const result = await multi.getReadiness();
+
+      expect(result.isAvailable).toBe(true);
+      expect(pub1.getReadiness).toHaveBeenCalled();
+      expect(pub2.getReadiness).toHaveBeenCalled();
+    });
+
+    it('returns isAvailable false when any publisher is not available', async () => {
+      const pub1 = createMockPublisher();
+      pub1.getReadiness.mockResolvedValue({ isAvailable: true });
+      const pub2 = createMockPublisher();
+      pub2.getReadiness.mockResolvedValue({ isAvailable: false });
+
+      const multi = new MultiPublisher([pub1, pub2]);
+      const result = await multi.getReadiness();
+
+      expect(result.isAvailable).toBe(false);
+    });
+  });
+
+  describe('publish', () => {
+    it('publishes to all publishers and returns primary response', async () => {
+      const pub1 = createMockPublisher();
+      const pub2 = createMockPublisher();
+
+      pub1.publish.mockResolvedValue({
+        remoteUrl: 'http://pub1',
+      } as PublishResponse);
+      pub2.publish.mockResolvedValue({
+        remoteUrl: 'http://pub2',
+      } as PublishResponse);
+
+      const multi = new MultiPublisher([pub1, pub2]);
+      const request = {} as PublishRequest;
+
+      const result = await multi.publish(request);
+
+      expect(result?.remoteUrl).toBe('http://pub1');
+      expect(pub1.publish).toHaveBeenCalledWith(request);
+      expect(pub2.publish).toHaveBeenCalledWith(request);
+    });
+  });
+
+  describe('fetchTechDocsMetadata', () => {
+    it('fetches metadata from primary publisher', async () => {
+      const pub1 = createMockPublisher();
+      const pub2 = createMockPublisher();
+
+      pub1.fetchTechDocsMetadata.mockResolvedValue({
+        site_name: 'pub1',
+      } as TechDocsMetadata);
+
+      const multi = new MultiPublisher([pub1, pub2]);
+      const result = await multi.fetchTechDocsMetadata({} as any);
+
+      expect(result.site_name).toBe('pub1');
+      expect(pub1.fetchTechDocsMetadata).toHaveBeenCalled();
+      expect(pub2.fetchTechDocsMetadata).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('hasDocsBeenGenerated', () => {
+    it('checks generation on primary publisher', async () => {
+      const pub1 = createMockPublisher();
+      const pub2 = createMockPublisher();
+
+      pub1.hasDocsBeenGenerated.mockResolvedValue(true);
+
+      const multi = new MultiPublisher([pub1, pub2]);
+      const result = await multi.hasDocsBeenGenerated({} as Entity);
+
+      expect(result).toBe(true);
+      expect(pub1.hasDocsBeenGenerated).toHaveBeenCalled();
+      expect(pub2.hasDocsBeenGenerated).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('docsRouter', () => {
+    it('returns router from primary publisher', () => {
+      const pub1 = createMockPublisher();
+      const pub2 = createMockPublisher();
+
+      const mockRouter = express.Router();
+      pub1.docsRouter.mockReturnValue(mockRouter);
+
+      const multi = new MultiPublisher([pub1, pub2]);
+      const result = multi.docsRouter();
+
+      expect(result).toBe(mockRouter);
+      expect(pub1.docsRouter).toHaveBeenCalled();
+      expect(pub2.docsRouter).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/plugins/techdocs-node/src/stages/publish/multi.test.ts
+++ b/plugins/techdocs-node/src/stages/publish/multi.test.ts
@@ -20,7 +20,6 @@ import {
   PublisherBase,
   PublishRequest,
   PublishResponse,
-  ReadinessResponse,
   TechDocsMetadata,
 } from './types';
 import { Entity } from '@backstage/catalog-model';
@@ -61,6 +60,18 @@ describe('MultiPublisher', () => {
       pub1.getReadiness.mockResolvedValue({ isAvailable: true });
       const pub2 = createMockPublisher();
       pub2.getReadiness.mockResolvedValue({ isAvailable: false });
+
+      const multi = new MultiPublisher([pub1, pub2]);
+      const result = await multi.getReadiness();
+
+      expect(result.isAvailable).toBe(false);
+    });
+
+    it('returns isAvailable false when any publisher rejects its readiness check', async () => {
+      const pub1 = createMockPublisher();
+      pub1.getReadiness.mockResolvedValue({ isAvailable: true });
+      const pub2 = createMockPublisher();
+      pub2.getReadiness.mockRejectedValue(new Error('Connection failed'));
 
       const multi = new MultiPublisher([pub1, pub2]);
       const result = await multi.getReadiness();

--- a/plugins/techdocs-node/src/stages/publish/multi.ts
+++ b/plugins/techdocs-node/src/stages/publish/multi.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import express from 'express';
+import { Entity, CompoundEntityRef } from '@backstage/catalog-model';
+import {
+  PublisherBase,
+  PublishRequest,
+  PublishResponse,
+  ReadinessResponse,
+  TechDocsMetadata,
+  MigrateRequest,
+} from './types';
+
+/**
+ * A publisher that wraps multiple publishers, enabling writing to multiple
+ * storage backends and reading from a primary backend.
+ *
+ * @public
+ */
+export class MultiPublisher implements PublisherBase {
+  private readonly publishers: PublisherBase[];
+
+  constructor(publishers: PublisherBase[]) {
+    if (!publishers || publishers.length === 0) {
+      throw new Error('MultiPublisher requires at least one publisher');
+    }
+    this.publishers = publishers;
+  }
+
+  private get primary(): PublisherBase {
+    return this.publishers[0];
+  }
+
+  async getReadiness(): Promise<ReadinessResponse> {
+    const responses = await Promise.all(
+      this.publishers.map(p => p.getReadiness()),
+    );
+    return {
+      isAvailable: responses.every(r => r.isAvailable),
+    };
+  }
+
+  async publish(request: PublishRequest): Promise<PublishResponse> {
+    // Publish to all concurrently and wait for all to succeed
+    const results = await Promise.all(
+      this.publishers.map(p => p.publish(request)),
+    );
+    // Return the response from the primary publisher
+    return results[0];
+  }
+
+  async fetchTechDocsMetadata(
+    entityName: CompoundEntityRef,
+  ): Promise<TechDocsMetadata> {
+    // Only fetch metadata from the primary publisher
+    return this.primary.fetchTechDocsMetadata(entityName);
+  }
+
+  docsRouter(): express.Handler {
+    // Use the primary publisher's docs router
+    return this.primary.docsRouter();
+  }
+
+  async hasDocsBeenGenerated(entityName: Entity): Promise<boolean> {
+    // Only check if docs have been generated on the primary publisher
+    return this.primary.hasDocsBeenGenerated(entityName);
+  }
+
+  async migrateDocsCase(migrateRequest: MigrateRequest): Promise<void> {
+    // Perform migration on all publishers if they support it
+    await Promise.all(
+      this.publishers.map(async p => {
+        if (p.migrateDocsCase) {
+          await p.migrateDocsCase(migrateRequest);
+        }
+      }),
+    );
+  }
+}

--- a/plugins/techdocs-node/src/stages/publish/multi.ts
+++ b/plugins/techdocs-node/src/stages/publish/multi.ts
@@ -46,11 +46,13 @@ export class MultiPublisher implements PublisherBase {
   }
 
   async getReadiness(): Promise<ReadinessResponse> {
-    const responses = await Promise.all(
+    const responses = await Promise.allSettled(
       this.publishers.map(p => p.getReadiness()),
     );
     return {
-      isAvailable: responses.every(r => r.isAvailable),
+      isAvailable: responses.every(
+        r => r.status === 'fulfilled' && r.value.isAvailable,
+      ),
     };
   }
 

--- a/plugins/techdocs-node/src/stages/publish/publish.test.ts
+++ b/plugins/techdocs-node/src/stages/publish/publish.test.ts
@@ -21,6 +21,7 @@ import { GoogleGCSPublish } from './googleStorage';
 import { AwsS3Publish } from './awsS3';
 import { AzureBlobStoragePublish } from './azureBlobStorage';
 import { OpenStackSwiftPublish } from './openStackSwift';
+import { MultiPublisher } from './multi';
 import { mockServices } from '@backstage/backend-test-utils';
 import { PublisherBase } from './types';
 
@@ -196,5 +197,62 @@ describe('Publisher', () => {
     });
 
     expect(publisher).toBe(customPublisher);
+  });
+
+  it('should create multi publisher from config', async () => {
+    const mockConfig = new ConfigReader({
+      techdocs: {
+        publisher: {
+          type: 'multi',
+          multi: {
+            publishers: ['local', 'googleGcs'],
+          },
+          googleGcs: {
+            credentials: '{}',
+            bucketName: 'bucketName',
+          },
+        },
+      },
+    });
+
+    const publisher = await Publisher.fromConfig(mockConfig, {
+      logger,
+      discovery,
+    });
+    expect(publisher).toBeInstanceOf(MultiPublisher);
+  });
+
+  it('throws if multi publisher has no publishers configured', async () => {
+    const mockConfig = new ConfigReader({
+      techdocs: {
+        publisher: {
+          type: 'multi',
+          multi: {
+            publishers: [],
+          },
+        },
+      },
+    });
+
+    await expect(
+      Publisher.fromConfig(mockConfig, { logger, discovery }),
+    ).rejects.toThrow(/Multi publisher requires at least one publisher/);
+  });
+
+  it('throws if nested multi publishers are configured', async () => {
+    const mockConfig = new ConfigReader({
+      techdocs: {
+        publisher: {
+          type: 'multi',
+          multi: {
+            publishers: ['multi', 'local'],
+          },
+        },
+      },
+    });
+
+    await expect(
+      Publisher.fromConfig(mockConfig, { logger, discovery }),
+    ).rejects.toThrow(/Nested multi publishers are not supported/);
   });
 });

--- a/plugins/techdocs-node/src/stages/publish/publish.ts
+++ b/plugins/techdocs-node/src/stages/publish/publish.ts
@@ -20,6 +20,7 @@ import { AzureBlobStoragePublish } from './azureBlobStorage';
 import { GoogleGCSPublish } from './googleStorage';
 import { LocalPublish } from './local';
 import { OpenStackSwiftPublish } from './openStackSwift';
+import { MultiPublisher } from './multi';
 import {
   PublisherFactory,
   PublisherBase,
@@ -59,6 +60,41 @@ export class Publisher implements PublisherBuilder {
     return publisher;
   }
 
+  private static async createPublisher(
+    publisherType: Exclude<PublisherType, 'multi'>,
+    config: Config,
+    options: PublisherFactory,
+  ): Promise<PublisherBase> {
+    const { logger, discovery } = options;
+
+    switch (publisherType) {
+      case 'googleGcs':
+        logger.info('Creating Google Storage Bucket publisher for TechDocs');
+        return GoogleGCSPublish.fromConfig(
+          config,
+          logger,
+          options.publisherSettings?.googleGcs,
+        );
+      case 'awsS3':
+        logger.info('Creating AWS S3 Bucket publisher for TechDocs');
+        return await AwsS3Publish.fromConfig(config, logger);
+      case 'azureBlobStorage':
+        logger.info(
+          'Creating Azure Blob Storage Container publisher for TechDocs',
+        );
+        return AzureBlobStoragePublish.fromConfig(config, logger);
+      case 'openStackSwift':
+        logger.info(
+          'Creating OpenStack Swift Container publisher for TechDocs',
+        );
+        return OpenStackSwiftPublish.fromConfig(config, logger);
+      case 'local':
+      default:
+        logger.info('Creating Local publisher for TechDocs');
+        return LocalPublish.fromConfig(config, logger, discovery);
+    }
+  }
+
   /**
    * Returns a instance of TechDocs publisher
    * @param config - A Backstage configuration
@@ -68,7 +104,7 @@ export class Publisher implements PublisherBuilder {
     config: Config,
     options: PublisherFactory,
   ): Promise<PublisherBase> {
-    const { logger, discovery, customPublisher } = options;
+    const { logger, customPublisher } = options;
 
     const publishers = new Publisher();
 
@@ -81,56 +117,39 @@ export class Publisher implements PublisherBuilder {
       'techdocs.publisher.type',
     ) ?? 'local') as PublisherType;
 
-    switch (publisherType) {
-      case 'googleGcs':
-        logger.info('Creating Google Storage Bucket publisher for TechDocs');
-        publishers.register(
-          publisherType,
-          GoogleGCSPublish.fromConfig(
+    if (publisherType === 'multi') {
+      logger.info('Creating Multi publisher for TechDocs');
+      const publisherTypes =
+        config.getOptionalStringArray('techdocs.publisher.multi.publishers') ??
+        [];
+
+      if (publisherTypes.length === 0) {
+        throw new Error(
+          'Multi publisher requires at least one publisher in techdocs.publisher.multi.publishers configuration',
+        );
+      }
+
+      const innerPublishers = await Promise.all(
+        publisherTypes.map(async pType => {
+          if (pType === 'multi') {
+            throw new Error('Nested multi publishers are not supported');
+          }
+          return await Publisher.createPublisher(
+            pType as Exclude<PublisherType, 'multi'>,
             config,
-            logger,
-            options.publisherSettings?.googleGcs,
-          ),
-        );
-        break;
-      case 'awsS3':
-        logger.info('Creating AWS S3 Bucket publisher for TechDocs');
-        publishers.register(
-          publisherType,
-          await AwsS3Publish.fromConfig(config, logger),
-        );
-        break;
-      case 'azureBlobStorage':
-        logger.info(
-          'Creating Azure Blob Storage Container publisher for TechDocs',
-        );
-        publishers.register(
-          publisherType,
-          AzureBlobStoragePublish.fromConfig(config, logger),
-        );
-        break;
-      case 'openStackSwift':
-        logger.info(
-          'Creating OpenStack Swift Container publisher for TechDocs',
-        );
-        publishers.register(
-          publisherType,
-          OpenStackSwiftPublish.fromConfig(config, logger),
-        );
-        break;
-      case 'local':
-        logger.info('Creating Local publisher for TechDocs');
-        publishers.register(
-          publisherType,
-          LocalPublish.fromConfig(config, logger, discovery),
-        );
-        break;
-      default:
-        logger.info('Creating Local publisher for TechDocs');
-        publishers.register(
-          publisherType,
-          LocalPublish.fromConfig(config, logger, discovery),
-        );
+            options,
+          );
+        }),
+      );
+
+      publishers.register(publisherType, new MultiPublisher(innerPublishers));
+    } else {
+      const publisher = await Publisher.createPublisher(
+        publisherType as Exclude<PublisherType, 'multi'>,
+        config,
+        options,
+      );
+      publishers.register(publisherType, publisher);
     }
 
     return publishers.get(config);

--- a/plugins/techdocs-node/src/stages/publish/types.ts
+++ b/plugins/techdocs-node/src/stages/publish/types.ts
@@ -47,7 +47,8 @@ export type PublisherType =
   | 'googleGcs'
   | 'awsS3'
   | 'azureBlobStorage'
-  | 'openStackSwift';
+  | 'openStackSwift'
+  | 'multi';
 
 /**
  * Request publish definition


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Closes #34457.

### Description

This PR introduces a new `multi` TechDocs publisher type that enables publishing documentation to multiple storage backends simultaneously.

- Write operations are propagated to all configured publishers.
- Read operations are delegated to the first configured publisher.
- Nested `multi` publishers are explicitly disallowed.
- Publisher creation logic was refactored into a shared `createPublisher()` helper to avoid duplicated factory code.

Example configuration:

```yaml
techdocs:
  publisher:
    type: multi
    multi:
      publishers:
        - awsS3
        - local

    awsS3:
      bucketName: techdocs-storage

    local:
      publishDirectory: /tmp/techdocs
```

### Tests

- Added unit tests for `MultiPublisher`.
- Added factory tests for `Publisher.fromConfig`.
- Added regression tests for:
  - Empty publisher lists.
  - Nested multi publishers.

### Documentation

Updated the TechDocs configuration documentation with details and examples for the new `multi` publisher type.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [x] Added or updated documentation.
- [x] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots attached (not applicable).
- [x] All commits have a `Signed-off-by` line in the message.