### PR TITLE
fix(events): fix flaky concurrent subscriber read test

### DIFF
--- a/plugins/events-backend/src/service/EventsPlugin.test.ts
+++ b/plugins/events-backend/src/service/EventsPlugin.test.ts
@@ -251,23 +251,26 @@ describe.each(eventBusDatabases.eachSupportedId())(
         events: [{ topic: 'test', payload: { n: 1 } }],
       });
 
-      // Two clients for subscriber 2, only one gets the event
-      const res1 = helper.readEvents('tester-2');
-      const res2 = helper.readEvents('tester-2');
+      // Two clients for subscriber 2, only one gets the event.
+      // We wrap each promise to track which index resolved first.
+      const res1Promise = helper.readEvents('tester-2').then(r => r);
+      const res2Promise = helper.readEvents('tester-2').then(r => r);
 
-      const res = await Promise.race([res1, res2]);
-      expect(res.status).toBe(200);
-      expect(res.body).toEqual({
+      const winnerIndex = await Promise.race([
+        res1Promise.then(() => 0),
+        res2Promise.then(() => 1),
+      ]);
+      const winner = await (winnerIndex === 0 ? res1Promise : res2Promise);
+      expect(winner.status).toBe(200);
+      expect(winner.body).toEqual({
         events: [{ topic: 'test', payload: { n: 1 } }],
       });
 
-      // Post another event, which triggers the other client to return
+      // Post another event, which triggers the long-polling client to return
       await helper.publish('test', { n: 2 }).expect(201);
 
-      const otherRes = await Promise.all([res1, res2]).then(rs =>
-        rs.find(r => r !== res),
-      );
-      expect(otherRes?.status).toBe(202);
+      const loser = await (winnerIndex === 0 ? res2Promise : res1Promise);
+      expect(loser.status).toBe(202);
 
       // Reading subscriber 2 should now return the second event only
       await helper.readEvents('tester-2').expect(200, {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes a flaky test in `EventsPlugin.test.ts` — "should only send an event for each subscriber once".

The test fires two concurrent `readEvents` requests for the same subscriber and uses `Promise.race` to find which resolves first, then `Promise.all` + `find(r => r !== res)` to find the other. This relies on reference equality between the response objects, but supertest thenables don't guarantee reference identity across separate `.then()` chains, causing the `find` to occasionally pick the wrong response and fail the 202 assertion.

Replaced with an index-based approach that tracks which promise resolved first, avoiding reference comparison entirely.

#### :heavy_check_mark: Checklist

- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

🤖 Generated with [Claude Code](https://claude.com/claude-code)