### PR TITLE
fix(catalog-graph): fix flaky CatalogGraphCard test after lazy-loading change

### DIFF
--- a/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.test.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphCard/CatalogGraphCard.test.tsx
@@ -37,6 +37,8 @@ import Button from '@material-ui/core/Button';
 import { translationApiRef } from '@backstage/core-plugin-api/alpha';
 import { catalogGraphApiRef, DefaultCatalogGraphApi } from '../../api';
 
+jest.setTimeout(30_000);
+
 describe('<CatalogGraphCard/>', () => {
   let entity: Entity;
   let wrapper: JSX.Element;
@@ -86,8 +88,12 @@ describe('<CatalogGraphCard/>', () => {
       },
     });
 
-    expect(await screen.findByText('b:d/c')).toBeInTheDocument();
-    expect(await screen.findAllByTestId('node')).toHaveLength(1);
+    expect(
+      await screen.findByText('b:d/c', {}, { timeout: 5_000 }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findAllByTestId('node', {}, { timeout: 5_000 }),
+    ).toHaveLength(1);
     expect(catalog.getEntitiesByRefs).toHaveBeenCalledTimes(1);
     expect(catalog.getEntitiesByRefs).toHaveBeenCalledWith(
       expect.objectContaining({ entityRefs: ['b:d/c'] }),
@@ -165,7 +171,9 @@ describe('<CatalogGraphCard/>', () => {
       },
     });
 
-    expect(await screen.findByText('b:d/c')).toBeInTheDocument();
+    expect(
+      await screen.findByText('b:d/c', {}, { timeout: 5_000 }),
+    ).toBeInTheDocument();
     const button = screen.getByText('View graph');
     expect(button).toBeInTheDocument();
     expect(button.closest('a')).toHaveAttribute(
@@ -198,7 +206,9 @@ describe('<CatalogGraphCard/>', () => {
       },
     );
 
-    expect(await screen.findByText('b:d/c')).toBeInTheDocument();
+    expect(
+      await screen.findByText('b:d/c', {}, { timeout: 5_000 }),
+    ).toBeInTheDocument();
     const button = screen.getByText('View graph');
     expect(button).toBeInTheDocument();
     expect(button.closest('a')).toHaveAttribute(
@@ -235,8 +245,10 @@ describe('<CatalogGraphCard/>', () => {
       },
     );
 
-    expect(await screen.findByText('b:d/c')).toBeInTheDocument();
-    await userEvent.click(await screen.findByText('b:d/c'));
+    expect(
+      await screen.findByText('b:d/c', {}, { timeout: 5_000 }),
+    ).toBeInTheDocument();
+    await userEvent.click(screen.getByText('b:d/c'));
 
     expect(analyticsApi.captureEvent).toHaveBeenCalledWith(
       expect.objectContaining({


### PR DESCRIPTION
## Summary

The `DependencyGraph` component was recently lazy-loaded via `React.lazy` + `Suspense` (bc8619c), but the `CatalogGraphCard` tests weren't updated to accommodate the async import. Under CI load, the lazy `import()` can take longer than the default 1-second `findByText` timeout, causing the test to fail intermittently with the graph container rendering as an empty `<div />` (the Suspense fallback).

Increases `findByText`/`findAllByTestId` timeouts to 5 seconds for assertions that depend on the lazy-loaded graph content, and sets `jest.setTimeout` to 30 seconds for the test suite.

The other two test files that render `DependencyGraph` (`EntityRelationsGraph.test.tsx` and `CatalogGraphPage.test.tsx`) are both fully skipped due to a pre-existing d3-drag/jsdom incompatibility, so they are not at risk.

## Test plan

- [x] All 6 CatalogGraphCard tests pass locally
- [x] Verified no other un-skipped tests render the lazy-loaded `DependencyGraph` or `CodeSnippet`

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.