### PR TITLE
feat(backend-test-utils): share test containers across Jest workers via reuse

### DIFF
--- a/.changeset/test-container-reuse.md
+++ b/.changeset/test-container-reuse.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-test-utils': patch
+---
+
+Enabled container reuse so that parallel Jest workers share a single database container instead of each starting their own, reducing memory pressure during local test runs.

--- a/packages/backend-test-utils/src/database/mysql.ts
+++ b/packages/backend-test-utils/src/database/mysql.ts
@@ -58,10 +58,7 @@ export async function startMysqlContainer(image: string): Promise<{
   const { GenericContainer } =
     require('testcontainers') as typeof import('testcontainers');
 
-  // withReuse() lets multiple Jest workers share one container instead
-  // of each starting their own. MySQL uses ~640 MB per container so
-  // parallel workers quickly exhaust memory, causing "Connection lost".
-  const container = await new GenericContainer(image)
+  const builder = new GenericContainer(image)
     .withExposedPorts(3306)
     .withEnvironment({ MYSQL_ROOT_PASSWORD: password })
     .withTmpFs({ '/var/lib/mysql': 'rw' })
@@ -69,16 +66,28 @@ export async function startMysqlContainer(image: string): Promise<{
       '--skip-log-bin',
       '--max-connections=200',
       '--mysql-native-password=ON',
-    ])
-    .withReuse()
-    .start();
+    ]);
+
+  // Try to reuse a running container so parallel Jest workers share one
+  // instance instead of each starting their own (~640 MB per container).
+  // Falls back to a dedicated container if reuse is not available.
+  let container;
+  let reused = false;
+  try {
+    container = await builder.withReuse().start();
+    reused = true;
+  } catch {
+    container = await builder.start();
+  }
 
   const host = container.getHost();
   const port = container.getMappedPort(3306);
   const connection = { host, port, user, password };
-  // Don't stop reused containers — other workers may still be using them.
-  // The container will be cleaned up by testcontainers' reaper (ryuk).
-  const stopContainer = async () => {};
+  const stopContainer = reused
+    ? async () => {}
+    : async () => {
+        await container.stop({ timeout: 10_000 });
+      };
 
   await waitForMysqlReady(connection);
 

--- a/packages/backend-test-utils/src/database/mysql.ts
+++ b/packages/backend-test-utils/src/database/mysql.ts
@@ -51,12 +51,17 @@ export async function startMysqlContainer(image: string): Promise<{
   stopContainer: () => Promise<void>;
 }> {
   const user = 'root';
-  const password = uuid();
+  // Deterministic password so that all Jest workers can connect to
+  // the same reused container without needing to discover the password.
+  const password = 'backstage-test';
 
   // Lazy-load to avoid side-effect of importing testcontainers
   const { GenericContainer } =
     require('testcontainers') as typeof import('testcontainers');
 
+  // withReuse() lets multiple Jest workers share one container instead
+  // of each starting their own. MySQL uses ~640 MB per container so
+  // parallel workers quickly exhaust memory, causing "Connection lost".
   const container = await new GenericContainer(image)
     .withExposedPorts(3306)
     .withEnvironment({ MYSQL_ROOT_PASSWORD: password })
@@ -66,14 +71,15 @@ export async function startMysqlContainer(image: string): Promise<{
       '--max-connections=200',
       '--mysql-native-password=ON',
     ])
+    .withReuse()
     .start();
 
   const host = container.getHost();
   const port = container.getMappedPort(3306);
   const connection = { host, port, user, password };
-  const stopContainer = async () => {
-    await container.stop({ timeout: 10_000 });
-  };
+  // Don't stop reused containers — other workers may still be using them.
+  // The container will be cleaned up by testcontainers' reaper (ryuk).
+  const stopContainer = async () => {};
 
   await waitForMysqlReady(connection);
 

--- a/packages/backend-test-utils/src/database/mysql.ts
+++ b/packages/backend-test-utils/src/database/mysql.ts
@@ -68,22 +68,16 @@ export async function startMysqlContainer(image: string): Promise<{
       '--mysql-native-password=ON',
     ]);
 
-  // Try to reuse a running container so parallel Jest workers share one
-  // instance instead of each starting their own (~640 MB per container).
-  // Falls back to a dedicated container if reuse is not available.
-  let container;
-  let reused = false;
-  try {
-    container = await builder.withReuse().start();
-    reused = true;
-  } catch {
-    container = await builder.start();
-  }
+  // Reuse lets parallel Jest workers share one container instead of each
+  // starting their own (~640 MB per container). Enabled by default in
+  // testcontainers unless TESTCONTAINERS_REUSE_ENABLE=false.
+  const reuse = process.env.TESTCONTAINERS_REUSE_ENABLE !== 'false';
+  const container = await (reuse ? builder.withReuse() : builder).start();
 
   const host = container.getHost();
   const port = container.getMappedPort(3306);
   const connection = { host, port, user, password };
-  const stopContainer = reused
+  const stopContainer = reuse
     ? async () => {}
     : async () => {
         await container.stop({ timeout: 10_000 });

--- a/packages/backend-test-utils/src/database/mysql.ts
+++ b/packages/backend-test-utils/src/database/mysql.ts
@@ -16,7 +16,6 @@
 
 import { randomBytes } from 'node:crypto';
 import knexFactory, { Knex } from 'knex';
-import { randomUUID as uuid } from 'node:crypto';
 import yn from 'yn';
 import { waitForReady } from '../util/waitForReady';
 import { Engine, TEST_POOL_CONFIG, TestDatabaseProperties } from './types';

--- a/packages/backend-test-utils/src/database/postgres.ts
+++ b/packages/backend-test-utils/src/database/postgres.ts
@@ -17,7 +17,6 @@
 import { randomBytes } from 'node:crypto';
 import knexFactory, { Knex } from 'knex';
 import { parse as parsePgConnectionString } from 'pg-connection-string';
-import { randomUUID as uuid } from 'node:crypto';
 import { waitForReady } from '../util/waitForReady';
 import { Engine, TEST_POOL_CONFIG, TestDatabaseProperties } from './types';
 

--- a/packages/backend-test-utils/src/database/postgres.ts
+++ b/packages/backend-test-utils/src/database/postgres.ts
@@ -53,21 +53,31 @@ export async function startPostgresContainer(image: string): Promise<{
   const { GenericContainer } =
     require('testcontainers') as typeof import('testcontainers');
 
-  const container = await new GenericContainer(image)
+  const builder = new GenericContainer(image)
     .withExposedPorts(5432)
     .withEnvironment({
-      // Since postgres 18, the default directory changed - so we pin it here
       PGDATA: '/var/lib/postgresql/data',
       POSTGRES_PASSWORD: password,
     })
-    .withTmpFs({ '/var/lib/postgresql/data': 'rw' })
-    .withReuse()
-    .start();
+    .withTmpFs({ '/var/lib/postgresql/data': 'rw' });
+
+  let container;
+  let reused = false;
+  try {
+    container = await builder.withReuse().start();
+    reused = true;
+  } catch {
+    container = await builder.start();
+  }
 
   const host = container.getHost();
   const port = container.getMappedPort(5432);
   const connection = { host, port, user, password };
-  const stopContainer = async () => {};
+  const stopContainer = reused
+    ? async () => {}
+    : async () => {
+        await container.stop({ timeout: 10_000 });
+      };
 
   await waitForPostgresReady(connection);
 

--- a/packages/backend-test-utils/src/database/postgres.ts
+++ b/packages/backend-test-utils/src/database/postgres.ts
@@ -61,19 +61,13 @@ export async function startPostgresContainer(image: string): Promise<{
     })
     .withTmpFs({ '/var/lib/postgresql/data': 'rw' });
 
-  let container;
-  let reused = false;
-  try {
-    container = await builder.withReuse().start();
-    reused = true;
-  } catch {
-    container = await builder.start();
-  }
+  const reuse = process.env.TESTCONTAINERS_REUSE_ENABLE !== 'false';
+  const container = await (reuse ? builder.withReuse() : builder).start();
 
   const host = container.getHost();
   const port = container.getMappedPort(5432);
   const connection = { host, port, user, password };
-  const stopContainer = reused
+  const stopContainer = reuse
     ? async () => {}
     : async () => {
         await container.stop({ timeout: 10_000 });

--- a/packages/backend-test-utils/src/database/postgres.ts
+++ b/packages/backend-test-utils/src/database/postgres.ts
@@ -48,7 +48,7 @@ export async function startPostgresContainer(image: string): Promise<{
   stopContainer: () => Promise<void>;
 }> {
   const user = 'postgres';
-  const password = uuid();
+  const password = 'backstage-test';
 
   // Lazy-load to avoid side-effect of importing testcontainers
   const { GenericContainer } =
@@ -62,14 +62,13 @@ export async function startPostgresContainer(image: string): Promise<{
       POSTGRES_PASSWORD: password,
     })
     .withTmpFs({ '/var/lib/postgresql/data': 'rw' })
+    .withReuse()
     .start();
 
   const host = container.getHost();
   const port = container.getMappedPort(5432);
   const connection = { host, port, user, password };
-  const stopContainer = async () => {
-    await container.stop({ timeout: 10_000 });
-  };
+  const stopContainer = async () => {};
 
   await waitForPostgresReady(connection);
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

**Draft — exploratory, stacked on #34658.**

Enables testcontainers' `withReuse()` so parallel Jest workers share a single database container instead of each starting their own.

### Why

MySQL uses ~640 MB per container vs ~60 MB for Postgres. When Jest runs 10+ test files in parallel, each starting its own MySQL container, the combined memory pressure can cause OOM and "Connection lost" errors. With reuse, all workers share one container.

### How it works

- testcontainers identifies reusable containers by hashing the full config (image, env, ports, command)
- Passwords are deterministic (`backstage-test`) so all workers produce the same hash — random UUIDs would cause each worker to start its own container
- Reuse is enabled by default in testcontainers unless `TESTCONTAINERS_REUSE_ENABLE=false`
- Containers are cleaned up by testcontainers' reaper (ryuk) rather than in `afterAll`

### Open questions

- Is container reuse needed now that the core fixes in #34658 resolve the startup crash and pool exhaustion?
- The `TESTCONTAINERS_REUSE_ENABLE` env var detection mirrors testcontainers internals — is that stable enough?
- Reused containers survive between test runs (by design) — is that surprising for users?

🤖 Generated with [Claude Code](https://claude.com/claude-code)