### PR TITLE
chore: remove redundant manual knex.destroy() in tests

### DIFF
--- a/packages/backend-defaults/src/entrypoints/scheduler/database/migrations.test.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/database/migrations.test.ts
@@ -99,7 +99,5 @@ describe.each(databases.eachSupportedId())('migrations, %p', databaseId => {
         current_run_expires_at: null,
       },
     ]);
-
-    await knex.destroy();
   });
 });

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.test.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.test.ts
@@ -40,10 +40,6 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
     jest.resetAllMocks();
   });
 
-  afterEach(async () => {
-    await knex?.destroy();
-  });
-
   it('goes through the expected states', async () => {
     const fn = jest.fn(
       async () => new Promise<void>(resolve => setTimeout(resolve, 50)),

--- a/packages/backend-defaults/src/migrations.test.ts
+++ b/packages/backend-defaults/src/migrations.test.ts
@@ -75,8 +75,6 @@ describe.each(databases.eachSupportedId())('migrations, %p', databaseId => {
     await expect(knex('backstage_backend_tasks__tasks')).rejects.toEqual(
       expect.anything(),
     );
-
-    await knex.destroy();
   });
 
   it('20240712211735_nullable_next_run.js', async () => {
@@ -111,7 +109,5 @@ describe.each(databases.eachSupportedId())('migrations, %p', databaseId => {
         next_run_start_at: knex.raw('null'),
       }),
     ).rejects.toEqual(expect.anything());
-
-    await knex.destroy();
   });
 });

--- a/plugins/app-backend/src/migrations.test.ts
+++ b/plugins/app-backend/src/migrations.test.ts
@@ -72,8 +72,6 @@ describe.each(databases.eachSupportedId())('migrations, %p', databaseId => {
     await expect(knex('static_assets_cache')).rejects.toEqual(
       expect.anything(),
     );
-
-    await knex.destroy();
   });
 
   it('20240113144027_assets-namespace.js', async () => {
@@ -129,7 +127,5 @@ describe.each(databases.eachSupportedId())('migrations, %p', databaseId => {
         last_modified_at: expect.anything(),
       },
     ]);
-
-    await knex.destroy();
   });
 });

--- a/plugins/auth-backend/src/migrations.test.ts
+++ b/plugins/auth-backend/src/migrations.test.ts
@@ -65,8 +65,6 @@ describe.each(databases.eachSupportedId())('migrations, %p', databaseId => {
     ]);
 
     await migrateDownOnce(knex);
-
-    await knex.destroy();
   });
 
   it('20240510120825_user_info.js', async () => {
@@ -98,8 +96,6 @@ describe.each(databases.eachSupportedId())('migrations, %p', databaseId => {
     ]);
 
     await migrateDownOnce(knex);
-
-    await knex.destroy();
   });
 
   it('20250707164600_user_created_at.js', async () => {
@@ -174,8 +170,6 @@ describe.each(databases.eachSupportedId())('migrations, %p', databaseId => {
       { exp: expect.any(Date) },
       { exp: expect.any(Date) },
     ]);
-
-    await knex.destroy();
   });
 
   it('20250909120000_oidc_client_registration.js', async () => {
@@ -287,8 +281,6 @@ describe.each(databases.eachSupportedId())('migrations, %p', databaseId => {
     for (const table of tables) {
       await expect(knex.schema.hasTable(table)).resolves.toBe(false);
     }
-
-    await knex.destroy();
   });
 
   it('20251118120000_oauth_state_text.js', async () => {
@@ -365,8 +357,6 @@ describe.each(databases.eachSupportedId())('migrations, %p', databaseId => {
     );
 
     await migrateDownOnce(knex);
-
-    await knex.destroy();
   });
 
   it('20251217120000_drop_oidc_clients_fk.js', async () => {
@@ -425,7 +415,5 @@ describe.each(databases.eachSupportedId())('migrations, %p', databaseId => {
     await expect(
       knex('oauth_authorization_sessions').select('id'),
     ).resolves.toEqual([{ id: 'dcr-session' }]);
-
-    await knex.destroy();
   });
 });

--- a/plugins/catalog-backend/src/processing/evictEntitiesFromOrphanedProviders.test.ts
+++ b/plugins/catalog-backend/src/processing/evictEntitiesFromOrphanedProviders.test.ts
@@ -42,10 +42,6 @@ describe.each(databases.eachSupportedId())('%p', databaseId => {
     db = new DefaultProviderDatabase({ database: knex, logger });
   });
 
-  afterEach(async () => {
-    await knex.destroy();
-  });
-
   describe('getOrphanedEntityProviderNames', () => {
     it('correctly locates and logs orphaned providers', async () => {
       const providers = [

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
@@ -47,10 +47,6 @@ describe.each(databases.eachSupportedId())(
   databaseId => {
     let knex: Knex;
 
-    afterEach(async () => {
-      await knex.destroy();
-    });
-
     async function createDatabase() {
       knex = await databases.init(databaseId);
       await applyDatabaseMigrations(knex);

--- a/plugins/catalog-backend/src/service/request/applyEntityFilterToQuery.test.ts
+++ b/plugins/catalog-backend/src/service/request/applyEntityFilterToQuery.test.ts
@@ -73,10 +73,6 @@ describe.each(databases.eachSupportedId())(
       });
     });
 
-    afterAll(async () => {
-      knex.destroy();
-    });
-
     async function addEntity(entity: Entity) {
       const id = uuid();
       const entityRef = stringifyEntityRef(entity);

--- a/plugins/catalog-backend/src/service/request/applyPredicateEntityFilterToQuery.test.ts
+++ b/plugins/catalog-backend/src/service/request/applyPredicateEntityFilterToQuery.test.ts
@@ -82,10 +82,6 @@ describe.each(databases.eachSupportedId())(
       });
     });
 
-    afterAll(async () => {
-      knex.destroy();
-    });
-
     async function addEntity(entity: Entity) {
       const id = uuid();
       const entityRef = stringifyEntityRef(entity);

--- a/plugins/catalog-backend/src/tests/migrations.test.ts
+++ b/plugins/catalog-backend/src/tests/migrations.test.ts
@@ -152,8 +152,6 @@ describe.each(databases.eachSupportedId())('migrations, %p', databaseId => {
         { entity_id: 'i', key: 'k2', value: null },
       ]),
     );
-
-    await knex.destroy();
   });
 
   it('20221201085245_add_last_updated_at_in_final_entities.js', async () => {
@@ -226,8 +224,6 @@ describe.each(databases.eachSupportedId())('migrations, %p', databaseId => {
         },
       ]),
     );
-
-    await knex.destroy();
   });
 
   it('20230525141717_stitch_queue.js', async () => {
@@ -294,8 +290,6 @@ describe.each(databases.eachSupportedId())('migrations, %p', databaseId => {
         last_discovery_at: expect.anything(),
       },
     ]);
-
-    await knex.destroy();
   });
 
   it('20241003170511_alter_target_in_locations.js', async () => {
@@ -378,8 +372,6 @@ describe.each(databases.eachSupportedId())('migrations, %p', databaseId => {
         },
       ]),
     );
-
-    await knex.destroy();
   });
 
   it('20241024104700_add_entity_ref_to_final_entities.js', async () => {
@@ -481,8 +473,6 @@ describe.each(databases.eachSupportedId())('migrations, %p', databaseId => {
         },
       ]),
     );
-
-    await knex.destroy();
   });
 
   it('20241111000000_drop_redundant_indices.js', async () => {
@@ -495,7 +485,6 @@ describe.each(databases.eachSupportedId())('migrations, %p', databaseId => {
     await migrateDownOnce(knex);
 
     expect(true).toBe(true);
-    await knex.destroy();
   });
 
   it('20250401200503_update_refresh_state_columns.js', async () => {
@@ -575,8 +564,6 @@ describe.each(databases.eachSupportedId())('migrations, %p', databaseId => {
         cache: JSON.stringify({ cacheKey: 'cacheValue' }),
       }),
     );
-
-    await knex.destroy();
   });
 
   it('20250514000000_refresh_state_references_big_increments.js', async () => {
@@ -657,8 +644,6 @@ describe.each(databases.eachSupportedId())('migrations, %p', databaseId => {
         target_entity_ref: 'k:ns/a',
       },
     ]);
-
-    await knex.destroy();
   });
 
   it('20260214000000_search_fk_final_entities.js', async () => {
@@ -906,8 +891,6 @@ describe.each(databases.eachSupportedId())('migrations, %p', databaseId => {
         original_value: 'setting',
       },
     ]);
-
-    await knex.destroy();
   });
 
   it('20260215000000_move_stitch_queue.js', async () => {
@@ -1052,8 +1035,6 @@ describe.each(databases.eachSupportedId())('migrations, %p', databaseId => {
       r => r.entity_id === 'id2',
     );
     expect(id2RefreshRow?.next_stitch_at).toBeNull();
-
-    await knex.destroy();
   });
 
   it('20260510000000_search_indices_and_dedup.js', async () => {
@@ -1137,8 +1118,6 @@ describe.each(databases.eachSupportedId())('migrations, %p', databaseId => {
         original_value: 'extra',
       }),
     ).resolves.not.toThrow();
-
-    await knex.destroy();
   });
 
   it('20260510000000_search_indices_and_dedup.js preconditions met (PG fast path)', async () => {
@@ -1147,7 +1126,6 @@ describe.each(databases.eachSupportedId())('migrations, %p', databaseId => {
     // The fast path (skip dedup when unique index pre-exists) is a
     // PostgreSQL-only code path that checks pg_index.
     if (!knex.client.config.client.includes('pg')) {
-      await knex.destroy();
       return;
     }
 
@@ -1205,7 +1183,6 @@ describe.each(databases.eachSupportedId())('migrations, %p', databaseId => {
     );
 
     await migrateDownOnce(knex);
-    await knex.destroy();
   });
 
   it('20260403000000_add_location_entity_ref.js', async () => {
@@ -1279,8 +1256,6 @@ describe.each(databases.eachSupportedId())('migrations, %p', databaseId => {
 
     const columnsReverted = await knex('locations').columnInfo();
     expect(columnsReverted.location_entity_ref).toBeUndefined();
-
-    await knex.destroy();
   });
 
   it('20260516000000_relations_target_index.js', async () => {
@@ -1350,8 +1325,6 @@ describe.each(databases.eachSupportedId())('migrations, %p', databaseId => {
     // Verify rollback drops the index
     await migrateDownOnce(knex);
     expect(await indexExists('relations_target_entity_ref_idx')).toBe(false);
-
-    await knex.destroy();
   });
 
   it('20260519000000_search_extended_statistics.js', async () => {
@@ -1409,8 +1382,6 @@ describe.each(databases.eachSupportedId())('migrations, %p', databaseId => {
 
     await migrateDownOnce(knex);
     expect(await statsExist()).toBe(false);
-
-    await knex.destroy();
   });
 
   it('20260608000000_search_autovacuum_and_ndistinct.js', async () => {
@@ -1472,7 +1443,5 @@ describe.each(databases.eachSupportedId())('migrations, %p', databaseId => {
       expect(await hasAutovacuumOptions(table)).toBe(false);
     }
     expect(await hasNdistinctOverride()).toBe(false);
-
-    await knex.destroy();
   });
 });

--- a/plugins/catalog-backend/src/tests/performance/getEntitiesPerformance.test.ts
+++ b/plugins/catalog-backend/src/tests/performance/getEntitiesPerformance.test.ts
@@ -131,7 +131,6 @@ describePerformanceTest('getEntities', () => {
 
     afterAll(async () => {
       await backend.stop();
-      await knex.destroy();
     });
 
     it('does a large burst read', async () => {
@@ -156,7 +155,6 @@ describePerformanceTest('getEntities', () => {
 
     afterAll(async () => {
       await backend.stop();
-      await knex.destroy();
     });
 
     it('single matching filter, all fields', async () => {

--- a/plugins/catalog-backend/src/tests/performance/providerDeltaMutations.test.ts
+++ b/plugins/catalog-backend/src/tests/performance/providerDeltaMutations.test.ts
@@ -46,10 +46,6 @@ describePerformanceTest('providerDeltaMutations', () => {
       await applyDatabaseMigrations(knex);
     });
 
-    afterAll(async () => {
-      await knex.destroy();
-    });
-
     it.each([200, 50_000])(
       'inserts and then overwrites identical sets using delta mutations, batch size %p',
       async batchSize => {

--- a/plugins/events-backend/src/migrations.test.ts
+++ b/plugins/events-backend/src/migrations.test.ts
@@ -92,7 +92,5 @@ describe.each(databases.eachSupportedId())('migrations, %p', databaseId => {
     // actually is flaky for some reason specifically on sqlite when
     // performing multiple runs in sequence
     await expect(knex('event_bus_events')).rejects.toEqual(expect.anything());
-
-    await knex.destroy();
   });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Stacked on #34663.

Removes manual `knex.destroy()` calls from test files across multiple packages. `TestDatabases.shutdown()` already destroys all knex instances returned by `init()`, registered automatically via `afterAll` — so the manual calls were redundant.

Affected packages:
- `@backstage/plugin-catalog-backend` (7 files, 24 calls removed)
- `@backstage/plugin-auth-backend` (1 file, 6 calls removed)
- `@backstage/plugin-app-backend` (1 file, 2 calls removed)
- `@backstage/plugin-events-backend` (1 file, 1 call removed)
- `@backstage/backend-defaults` (3 files, 4 calls removed)

Net: 81 lines deleted, 0 added.

#### :heavy_check_mark: Checklist

- [x] All your commits have a `Signed-off-by` line in the message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)