### PR TITLE
fix(backend-test-utils): fix MySQL test failures and pin to 8.4 LTS

### DIFF
--- a/.changeset/mysql-84-test-database.md
+++ b/.changeset/mysql-84-test-database.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-test-utils': minor
+---
+
+**BREAKING**: The `MYSQL_8` test database now uses MySQL 8.4 (the current LTS release) instead of the floating `mysql:8` Docker tag which had moved to 8.4.x. The `--default-authentication-plugin` startup flag has been replaced with `--mysql-native-password=ON` which is the 8.4+ equivalent. If you rely on the `TestDatabases` facility with MySQL, your tests will now run against MySQL 8.4 and you may need to update any custom MySQL connection strings or Docker image overrides accordingly. The connection pool size has also been reduced from 50 to 5 per test database, and idle/stale connections are now reaped automatically.

--- a/.changeset/mysql-84-test-database.md
+++ b/.changeset/mysql-84-test-database.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/backend-test-utils': minor
+'@backstage/backend-test-utils': patch
 ---
 
-**BREAKING**: The `MYSQL_8` test database now uses MySQL 8.4 (the current LTS release) instead of the floating `mysql:8` Docker tag which had moved to 8.4.x. The `--default-authentication-plugin` startup flag has been replaced with `--mysql-native-password=ON` which is the 8.4+ equivalent. If you rely on the `TestDatabases` facility with MySQL, your tests will now run against MySQL 8.4 and you may need to update any custom MySQL connection strings or Docker image overrides accordingly. The connection pool size has also been reduced from 50 to 5 per test database, and idle/stale connections are now reaped automatically.
+The MySQL test database image has been pinned from the floating `mysql:8` tag to `mysql:8.4`, fixing container startup failures caused by a removed configuration flag in newer MySQL 8.4.x releases. The connection pool has been reduced and idle connections are now reaped automatically, improving stability under CI load.

--- a/.changeset/mysql-84-test-database.md
+++ b/.changeset/mysql-84-test-database.md
@@ -2,4 +2,4 @@
 '@backstage/backend-test-utils': patch
 ---
 
-The MySQL test database image has been pinned from the floating `mysql:8` tag to `mysql:8.4`, fixing container startup failures caused by a removed configuration flag in newer MySQL 8.4.x releases. The connection pool has been reduced and idle connections are now reaped automatically, improving stability under CI load.
+Fixed MySQL test database failures by pinning the Docker image from the floating `mysql:8` tag to `mysql:8.4` and replacing a startup flag that was removed in MySQL 8.4. Connection pool reduced from 50 to 5 per test database, idle connections are now reaped after 5 seconds, and container connection limits raised to 1000 for both MySQL and Postgres to handle parallel Jest workers on high-core machines.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,7 @@ jobs:
         ports:
           - 5432/tcp
       mysql8:
-        image: mysql:8
+        image: mysql:8.4
         env:
           MYSQL_ROOT_PASSWORD: root
         options: >-

--- a/.github/workflows/deploy_packages.yml
+++ b/.github/workflows/deploy_packages.yml
@@ -39,7 +39,7 @@ jobs:
         ports:
           - 5432/tcp
       mysql8:
-        image: mysql:8
+        image: mysql:8.4
         env:
           MYSQL_ROOT_PASSWORD: root
         options: >-

--- a/packages/backend-test-utils/src/database/TestDatabases.test.ts
+++ b/packages/backend-test-utils/src/database/TestDatabases.test.ts
@@ -16,7 +16,7 @@
 
 import { TestDatabases } from './TestDatabases';
 
-jest.setTimeout(60_000);
+jest.setTimeout(120_000);
 
 const dbs = TestDatabases.create();
 

--- a/packages/backend-test-utils/src/database/mysql.test.ts
+++ b/packages/backend-test-utils/src/database/mysql.test.ts
@@ -24,7 +24,7 @@ const ourDatabaseIds = Object.entries(allDatabases)
   .filter(([, properties]) => properties.driver.includes('mysql'))
   .map(([id]) => id as TestDatabaseId);
 
-jest.setTimeout(60_000);
+jest.setTimeout(120_000);
 
 describe('startMysqlContainer', () => {
   itIfDocker(

--- a/packages/backend-test-utils/src/database/mysql.test.ts
+++ b/packages/backend-test-utils/src/database/mysql.test.ts
@@ -31,7 +31,7 @@ describe('startMysqlContainer', () => {
     'successfully launches the container and can stop it without problems',
     async () => {
       const { connection, stopContainer } = await startMysqlContainer(
-        'mysql:8',
+        'mysql:8.4',
       );
       const db = knexFactory({ client: 'mysql2', connection });
       try {

--- a/packages/backend-test-utils/src/database/mysql.ts
+++ b/packages/backend-test-utils/src/database/mysql.ts
@@ -207,21 +207,20 @@ export class MysqlEngine implements Engine {
       }
     }
 
+    let adminConnection: Knex | undefined;
     try {
-      const adminConnection = this.#connectAdmin();
-      try {
-        for (const databaseName of this.#databaseNames) {
-          try {
-            await adminConnection.raw('DROP DATABASE ??', [databaseName]);
-          } catch {
-            // Best-effort — the database may already be gone
-          }
+      adminConnection = this.#connectAdmin();
+      for (const databaseName of this.#databaseNames) {
+        try {
+          await adminConnection.raw('DROP DATABASE ??', [databaseName]);
+        } catch {
+          // Best-effort — the database may already be gone
         }
-      } finally {
-        await adminConnection.destroy();
       }
     } catch {
       // Best-effort — the container may already be stopped
+    } finally {
+      await adminConnection?.destroy().catch(() => {});
     }
 
     try {

--- a/packages/backend-test-utils/src/database/mysql.ts
+++ b/packages/backend-test-utils/src/database/mysql.ts
@@ -57,6 +57,12 @@ export async function startMysqlContainer(image: string): Promise<{
   const { GenericContainer } =
     require('testcontainers') as typeof import('testcontainers');
 
+  // Note: testcontainers supports .withReuse() to share a single container
+  // across parallel Jest workers, which would reduce memory from ~640 MB per
+  // worker to one shared instance. We intentionally don't enable it because
+  // reused containers bypass ryuk cleanup and linger indefinitely until
+  // manually stopped. See https://github.com/backstage/backstage/pull/34653
+  // for the exploration and tradeoffs.
   const container = await new GenericContainer(image)
     .withExposedPorts(3306)
     .withEnvironment({ MYSQL_ROOT_PASSWORD: password })

--- a/packages/backend-test-utils/src/database/mysql.ts
+++ b/packages/backend-test-utils/src/database/mysql.ts
@@ -62,9 +62,9 @@ export async function startMysqlContainer(image: string): Promise<{
     .withEnvironment({ MYSQL_ROOT_PASSWORD: password })
     .withTmpFs({ '/var/lib/mysql': 'rw' })
     .withCommand([
-      '--default-authentication-plugin=mysql_native_password',
       '--skip-log-bin',
       '--max-connections=200',
+      '--mysql-native-password=ON',
     ])
     .start();
 

--- a/packages/backend-test-utils/src/database/mysql.ts
+++ b/packages/backend-test-utils/src/database/mysql.ts
@@ -19,26 +19,31 @@ import knexFactory, { Knex } from 'knex';
 import { randomUUID as uuid } from 'node:crypto';
 import yn from 'yn';
 import { waitForReady } from '../util/waitForReady';
-import { Engine, LARGER_POOL_CONFIG, TestDatabaseProperties } from './types';
+import { Engine, TEST_POOL_CONFIG, TestDatabaseProperties } from './types';
 
 async function waitForMysqlReady(
   connection: Knex.MySqlConnectionConfig,
 ): Promise<void> {
-  await waitForReady(async () => {
-    const knex = knexFactory({
-      client: 'mysql2',
-      connection: {
-        // make a copy because the driver mutates this
-        ...connection,
+  const knex = knexFactory({
+    client: 'mysql2',
+    connection: {
+      ...connection,
+      connectTimeout: 5_000,
+    },
+    pool: { min: 0, max: 1 },
+  });
+  try {
+    await waitForReady(
+      async () => {
+        const result = await knex.select(knex.raw('version() AS version'));
+        return Array.isArray(result) && Boolean(result[0]?.version);
       },
-    });
-    try {
-      const result = await knex.select(knex.raw('version() AS version'));
-      return Array.isArray(result) && Boolean(result[0]?.version);
-    } finally {
-      await knex.destroy();
-    }
-  }, 'the database');
+      'the database',
+      60_000,
+    );
+  } finally {
+    await knex.destroy();
+  }
 }
 
 export async function startMysqlContainer(image: string): Promise<{
@@ -59,6 +64,7 @@ export async function startMysqlContainer(image: string): Promise<{
     .withCommand([
       '--default-authentication-plugin=mysql_native_password',
       '--skip-log-bin',
+      '--max-connections=200',
     ])
     .start();
 
@@ -180,9 +186,9 @@ export class MysqlEngine implements Engine {
         connection: {
           ...this.#connection,
           database: databaseName,
-          connectTimeout: 30_000,
+          connectTimeout: 10_000,
         },
-        ...LARGER_POOL_CONFIG,
+        ...TEST_POOL_CONFIG,
       });
       this.#knexInstances.push(knexInstance);
 
@@ -194,25 +200,42 @@ export class MysqlEngine implements Engine {
 
   async shutdown(): Promise<void> {
     for (const instance of this.#knexInstances) {
-      await instance.destroy();
-    }
-
-    const adminConnection = this.#connectAdmin();
-    try {
-      for (const databaseName of this.#databaseNames) {
-        await adminConnection.raw('DROP DATABASE ??', [databaseName]);
+      try {
+        await instance.destroy();
+      } catch {
+        // Best-effort — the connection may already be dead
       }
-    } finally {
-      await adminConnection.destroy();
     }
 
-    await this.#stopContainer?.();
+    try {
+      const adminConnection = this.#connectAdmin();
+      try {
+        for (const databaseName of this.#databaseNames) {
+          try {
+            await adminConnection.raw('DROP DATABASE ??', [databaseName]);
+          } catch {
+            // Best-effort — the database may already be gone
+          }
+        }
+      } finally {
+        await adminConnection.destroy();
+      }
+    } catch {
+      // Best-effort — the container may already be stopped
+    }
+
+    try {
+      await this.#stopContainer?.();
+    } catch {
+      // Best-effort
+    }
   }
 
   #connectAdmin(): Knex {
     const connection = {
       ...this.#connection,
       database: null as unknown as string,
+      connectTimeout: 10_000,
     };
     return knexFactory({
       client: this.#properties.driver,
@@ -220,9 +243,10 @@ export class MysqlEngine implements Engine {
       pool: {
         min: 0,
         max: 1,
-        acquireTimeoutMillis: 20_000,
-        createTimeoutMillis: 20_000,
+        acquireTimeoutMillis: 30_000,
+        createTimeoutMillis: 30_000,
         createRetryIntervalMillis: 1_000,
+        destroyTimeoutMillis: 5_000,
       },
     });
   }

--- a/packages/backend-test-utils/src/database/mysql.ts
+++ b/packages/backend-test-utils/src/database/mysql.ts
@@ -63,7 +63,7 @@ export async function startMysqlContainer(image: string): Promise<{
     .withTmpFs({ '/var/lib/mysql': 'rw' })
     .withCommand([
       '--skip-log-bin',
-      '--max-connections=200',
+      '--max-connections=1000',
       '--mysql-native-password=ON',
     ])
     .start();

--- a/packages/backend-test-utils/src/database/postgres.test.ts
+++ b/packages/backend-test-utils/src/database/postgres.test.ts
@@ -24,7 +24,7 @@ const ourDatabaseIds = Object.entries(allDatabases)
   .filter(([, properties]) => properties.driver === 'pg')
   .map(([id]) => id as TestDatabaseId);
 
-jest.setTimeout(60_000);
+jest.setTimeout(120_000);
 
 describe('startPostgresContainer', () => {
   itIfDocker(

--- a/packages/backend-test-utils/src/database/postgres.ts
+++ b/packages/backend-test-utils/src/database/postgres.ts
@@ -156,21 +156,20 @@ export class PostgresEngine implements Engine {
       }
     }
 
+    let adminConnection: Knex | undefined;
     try {
-      const adminConnection = this.#connectAdmin();
-      try {
-        for (const databaseName of this.#databaseNames) {
-          try {
-            await adminConnection.raw('DROP DATABASE ??', [databaseName]);
-          } catch {
-            // Best-effort — the database may already be gone
-          }
+      adminConnection = this.#connectAdmin();
+      for (const databaseName of this.#databaseNames) {
+        try {
+          await adminConnection.raw('DROP DATABASE ??', [databaseName]);
+        } catch {
+          // Best-effort — the database may already be gone
         }
-      } finally {
-        await adminConnection.destroy();
       }
     } catch {
       // Best-effort — the container may already be stopped
+    } finally {
+      await adminConnection?.destroy().catch(() => {});
     }
 
     try {

--- a/packages/backend-test-utils/src/database/postgres.ts
+++ b/packages/backend-test-utils/src/database/postgres.ts
@@ -19,26 +19,24 @@ import knexFactory, { Knex } from 'knex';
 import { parse as parsePgConnectionString } from 'pg-connection-string';
 import { randomUUID as uuid } from 'node:crypto';
 import { waitForReady } from '../util/waitForReady';
-import { Engine, LARGER_POOL_CONFIG, TestDatabaseProperties } from './types';
+import { Engine, TEST_POOL_CONFIG, TestDatabaseProperties } from './types';
 
 async function waitForPostgresReady(
   connection: Knex.PgConnectionConfig,
 ): Promise<void> {
-  await waitForReady(async () => {
-    const knex = knexFactory({
-      client: 'pg',
-      connection: {
-        // make a copy because the driver mutates this
-        ...connection,
-      },
-    });
-    try {
+  const knex = knexFactory({
+    client: 'pg',
+    connection: { ...connection },
+    pool: { min: 0, max: 1 },
+  });
+  try {
+    await waitForReady(async () => {
       const result = await knex.select(knex.raw('version()'));
       return Array.isArray(result) && Boolean(result[0]?.version);
-    } finally {
-      await knex.destroy();
-    }
-  }, 'the database');
+    }, 'the database');
+  } finally {
+    await knex.destroy();
+  }
 }
 
 export async function startPostgresContainer(image: string): Promise<{
@@ -135,7 +133,7 @@ export class PostgresEngine implements Engine {
           ...this.#connection,
           database: databaseName,
         },
-        ...LARGER_POOL_CONFIG,
+        ...TEST_POOL_CONFIG,
       });
       this.#knexInstances.push(knexInstance);
 
@@ -147,19 +145,35 @@ export class PostgresEngine implements Engine {
 
   async shutdown(): Promise<void> {
     for (const instance of this.#knexInstances) {
-      await instance.destroy();
-    }
-
-    const adminConnection = this.#connectAdmin();
-    try {
-      for (const databaseName of this.#databaseNames) {
-        await adminConnection.raw('DROP DATABASE ??', [databaseName]);
+      try {
+        await instance.destroy();
+      } catch {
+        // Best-effort — the connection may already be dead
       }
-    } finally {
-      await adminConnection.destroy();
     }
 
-    await this.#stopContainer?.();
+    try {
+      const adminConnection = this.#connectAdmin();
+      try {
+        for (const databaseName of this.#databaseNames) {
+          try {
+            await adminConnection.raw('DROP DATABASE ??', [databaseName]);
+          } catch {
+            // Best-effort — the database may already be gone
+          }
+        }
+      } finally {
+        await adminConnection.destroy();
+      }
+    } catch {
+      // Best-effort — the container may already be stopped
+    }
+
+    try {
+      await this.#stopContainer?.();
+    } catch {
+      // Best-effort
+    }
   }
 
   #connectAdmin(): Knex {

--- a/packages/backend-test-utils/src/database/postgres.ts
+++ b/packages/backend-test-utils/src/database/postgres.ts
@@ -62,6 +62,7 @@ export async function startPostgresContainer(image: string): Promise<{
       POSTGRES_PASSWORD: password,
     })
     .withTmpFs({ '/var/lib/postgresql/data': 'rw' })
+    .withCommand(['-c', 'max_connections=1000'])
     .start();
 
   const host = container.getHost();

--- a/packages/backend-test-utils/src/database/postgres.ts
+++ b/packages/backend-test-utils/src/database/postgres.ts
@@ -54,6 +54,7 @@ export async function startPostgresContainer(image: string): Promise<{
   const { GenericContainer } =
     require('testcontainers') as typeof import('testcontainers');
 
+  // See note in mysql.ts about why we don't enable .withReuse() here.
   const container = await new GenericContainer(image)
     .withExposedPorts(5432)
     .withEnvironment({

--- a/packages/backend-test-utils/src/database/postgres.ts
+++ b/packages/backend-test-utils/src/database/postgres.ts
@@ -30,10 +30,14 @@ async function waitForPostgresReady(
     pool: { min: 0, max: 1 },
   });
   try {
-    await waitForReady(async () => {
-      const result = await knex.select(knex.raw('version()'));
-      return Array.isArray(result) && Boolean(result[0]?.version);
-    }, 'the database');
+    await waitForReady(
+      async () => {
+        const result = await knex.select(knex.raw('version()'));
+        return Array.isArray(result) && Boolean(result[0]?.version);
+      },
+      'the database',
+      60_000,
+    );
   } finally {
     await knex.destroy();
   }

--- a/packages/backend-test-utils/src/database/types.ts
+++ b/packages/backend-test-utils/src/database/types.ts
@@ -125,11 +125,17 @@ export const allDatabases: Record<TestDatabaseId, TestDatabaseProperties> =
     },
   });
 
-export const LARGER_POOL_CONFIG = {
+export const TEST_POOL_CONFIG = {
   pool: {
     min: 0,
-    max: 50,
+    max: 5,
     acquireTimeoutMillis: 30_000,
     createTimeoutMillis: 30_000,
+    destroyTimeoutMillis: 5_000,
+    idleTimeoutMillis: 30_000,
+    reapIntervalMillis: 1_000,
   },
 };
+
+/** @deprecated Use TEST_POOL_CONFIG instead */
+export const LARGER_POOL_CONFIG = TEST_POOL_CONFIG;

--- a/packages/backend-test-utils/src/database/types.ts
+++ b/packages/backend-test-utils/src/database/types.ts
@@ -115,7 +115,7 @@ export const allDatabases: Record<TestDatabaseId, TestDatabaseProperties> =
     MYSQL_8: {
       name: 'MySQL 8.x',
       driver: 'mysql2',
-      dockerImageName: getDockerImageForName('mysql:8'),
+      dockerImageName: getDockerImageForName('mysql:8.4'),
       connectionStringEnvironmentVariableName:
         'BACKSTAGE_TEST_DATABASE_MYSQL8_CONNECTION_STRING',
     },

--- a/packages/backend-test-utils/src/database/types.ts
+++ b/packages/backend-test-utils/src/database/types.ts
@@ -132,7 +132,7 @@ export const TEST_POOL_CONFIG = {
     acquireTimeoutMillis: 30_000,
     createTimeoutMillis: 30_000,
     destroyTimeoutMillis: 5_000,
-    idleTimeoutMillis: 30_000,
+    idleTimeoutMillis: 5_000,
     reapIntervalMillis: 1_000,
   },
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes MySQL test failures caused by the floating `mysql:8` Docker tag silently upgrading to MySQL 8.4.x, which removed the `--default-authentication-plugin` startup flag. The container was crashing on startup, causing every MySQL-backed test to fail with `container stopped/paused` errors.

### Root cause

The `mysql:8` tag moved from 8.0.x to 8.4.x. MySQL 8.4 removed the `--default-authentication-plugin` option (deprecated since 8.0), so our container exited immediately with `unknown variable`. This looked like Docker flakiness but was actually a deterministic crash.

### Changes

**Pin MySQL image to `mysql:8.4`.** Both the testcontainers config and the CI workflow services now use `mysql:8.4` instead of the floating `mysql:8` tag, preventing future silent upgrades.

**Replace removed startup flag.** `--default-authentication-plugin=mysql_native_password` replaced with `--mysql-native-password=ON` (the 8.4+ equivalent).

**Pool size: 50 → 5.** Tests run sequentially within each case and don't need concurrent connections. The high pool could exhaust MySQL's `max_connections` limit.

**`--max-connections=1000` on both MySQL and Postgres containers.** On high-core machines, many parallel Jest workers each start their own container and accumulate connection pools. The per-connection memory cost is only paid when connections are actually opened.

**Idle timeout: 30s → 5s.** Connections from completed tests are reaped quickly, freeing slots for other workers.

**Readiness polling: reuse a single connection.** The old pattern created and destroyed a fresh knex instance every 100ms during startup polling. Now uses a single `pool: { max: 1 }` knex instance.

**Readiness timeout: 30s → 60s.** More headroom for slow CI environments. Jest timeouts bumped from 60s to 120s accordingly.

**Tarn pool health settings.** Added `destroyTimeoutMillis` and `reapIntervalMillis` so stale connections get reaped.

**Best-effort shutdown.** Each cleanup step is individually wrapped in try/catch so one failure doesn't abort the rest.

All changes apply to both MySQL and Postgres engines for consistency.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [x] All your commits have a `Signed-off-by` line in the message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)