### PR TITLE
fix(notifications-backend): persist payload.metadata

### DIFF
--- a/.changeset/persist-notification-metadata.md
+++ b/.changeset/persist-notification-metadata.md
@@ -1,5 +1,0 @@
----
-'@backstage/plugin-notifications-backend': patch
----
-
-Added database migration and updated internal mapping logic to serialize and retain the `metadata` property of `NotificationPayload` in the `notification` and `broadcast` tables.

--- a/.changeset/persist-notification-metadata.md
+++ b/.changeset/persist-notification-metadata.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications-backend': patch
+---
+
+Added database migration and updated internal mapping logic to serialize and retain the `metadata` property of `NotificationPayload` in the `notification` and `broadcast` tables.

--- a/.changeset/wicked-dingos-say.md
+++ b/.changeset/wicked-dingos-say.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-notifications-backend': patch
 ---
 
-Fix an issue where `NotificationPayload.metadata` was not persisted by the notifications backend. Metadata is now stored and restored for both notifications and broadcasts, with regression tests covering the persistence flow.
+Fix an issue where `NotificationPayload.metadata` was not persisted by the notifications backend. Metadata is now stored and restored for both notifications and broadcasts.

--- a/.changeset/wicked-dingos-say.md
+++ b/.changeset/wicked-dingos-say.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications-backend': patch
+---
+
+Fix an issue where `NotificationPayload.metadata` was not persisted by the notifications backend. Metadata is now stored and restored for both notifications and broadcasts, with regression tests covering the persistence flow.

--- a/plugins/notifications-backend/migrations/20260620_addMetadata.js
+++ b/plugins/notifications-backend/migrations/20260620_addMetadata.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-check
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function up(knex) {
+  await knex.schema.alterTable('notification', table => {
+    table.text('metadata').nullable();
+  });
+  await knex.schema.alterTable('broadcast', table => {
+    table.text('metadata').nullable();
+  });
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function down(knex) {
+  await knex.schema.alterTable('notification', table => {
+    table.dropColumn('metadata');
+  });
+  await knex.schema.alterTable('broadcast', table => {
+    table.dropColumn('metadata');
+  });
+};

--- a/plugins/notifications-backend/report.sql.md
+++ b/plugins/notifications-backend/report.sql.md
@@ -11,6 +11,7 @@
 | `icon`        | `character varying`        | true     | 255        | -                   |
 | `id`          | `uuid`                     | false    | -          | -                   |
 | `link`        | `text`                     | true     | -          | -                   |
+| `metadata`    | `text`                     | true     | -          | -                   |
 | `origin`      | `character varying`        | false    | 255        | -                   |
 | `scope`       | `character varying`        | true     | 255        | -                   |
 | `severity`    | `character varying`        | false    | 8          | -                   |
@@ -45,6 +46,7 @@
 | `icon`        | `character varying`        | true     | 255        | -                   |
 | `id`          | `uuid`                     | false    | -          | -                   |
 | `link`        | `text`                     | true     | -          | -                   |
+| `metadata`    | `text`                     | true     | -          | -                   |
 | `origin`      | `character varying`        | false    | 255        | -                   |
 | `read`        | `timestamp with time zone` | true     | -          | -                   |
 | `saved`       | `timestamp with time zone` | true     | -          | -                   |

--- a/plugins/notifications-backend/src/database/DatabaseNotificationsStore.test.ts
+++ b/plugins/notifications-backend/src/database/DatabaseNotificationsStore.test.ts
@@ -69,6 +69,7 @@ const testNotification1: Notification = {
     link: '/catalog',
     severity: 'critical',
     icon: 'docs',
+    metadata: { customId: 'abc-123' },
   },
 };
 const testNotification2: Notification = {
@@ -82,6 +83,7 @@ const testNotification2: Notification = {
     link: '/catalog',
     severity: 'normal',
     scope: 'scaffolder-1234',
+    metadata: { broadcastGroup: 'all' },
   },
 };
 const testNotification3: Notification = {
@@ -209,6 +211,22 @@ describe.each(databases.eachSupportedId())(
         expect(notification?.payload?.link).toBe('/catalog');
         expect(notification?.payload?.severity).toBe('critical');
         expect(notification?.payload?.icon).toBe('docs');
+        expect(notification?.payload?.metadata).toEqual({
+          customId: 'abc-123',
+        });
+      });
+    });
+
+    describe('saveBroadcast', () => {
+      it('should store a broadcast', async () => {
+        await storage.saveBroadcast(testNotification2);
+        const notification = await storage.getNotification({ id: id2 });
+        expect(notification?.id).toBe(id2);
+        expect(notification?.payload?.title).toBe('Notification 2');
+        expect(notification?.payload?.topic).toBe('gh-topic');
+        expect(notification?.payload?.metadata).toEqual({
+          broadcastGroup: 'all',
+        });
       });
     });
 

--- a/plugins/notifications-backend/src/database/DatabaseNotificationsStore.ts
+++ b/plugins/notifications-backend/src/database/DatabaseNotificationsStore.ts
@@ -53,6 +53,7 @@ const NOTIFICATION_COLUMNS = [
   'user',
   'read',
   'saved',
+  'metadata',
 ];
 
 type NotificationRowType = {
@@ -70,6 +71,7 @@ type NotificationRowType = {
   read: Date | null;
   saved: Date | null;
   icon: string | null;
+  metadata: string | null;
 };
 
 type BroadcastRowType = {
@@ -83,6 +85,7 @@ type BroadcastRowType = {
   created: Date;
   updated: Date | null;
   icon: string | null;
+  metadata: string | null;
 };
 
 type BroadcastUserStatusRowType = {
@@ -167,6 +170,7 @@ export class DatabaseNotificationsStore implements NotificationsStore {
         severity: row.severity,
         scope: row.scope,
         icon: row.icon,
+        metadata: row.metadata ? JSON.parse(row.metadata) : undefined,
       },
     }));
   };
@@ -230,6 +234,9 @@ export class DatabaseNotificationsStore implements NotificationsStore {
       icon: notification.payload.icon,
       saved: notification.saved,
       read: notification.read,
+      metadata: notification.payload.metadata
+        ? JSON.stringify(notification.payload.metadata)
+        : null,
     };
   };
 
@@ -245,6 +252,9 @@ export class DatabaseNotificationsStore implements NotificationsStore {
       severity: normalizeSeverity(notification.payload?.severity),
       icon: notification.payload.icon,
       scope: notification.payload?.scope,
+      metadata: notification.payload.metadata
+        ? JSON.stringify(notification.payload.metadata)
+        : null,
     };
   };
 

--- a/plugins/notifications-backend/src/database/DatabaseNotificationsStore.ts
+++ b/plugins/notifications-backend/src/database/DatabaseNotificationsStore.ts
@@ -78,6 +78,7 @@ type BroadcastRowType = {
   id: string;
   title: string;
   description: string | null;
+  severity: string;
   link: string | null;
   origin: string;
   scope: string | null;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### What does this PR change?

Closes #34484.

`NotificationPayload` supports an optional `metadata` field, but the notifications backend did not persist or restore it. The database schema and persistence mappings omitted the field, causing metadata to be lost after storage.

This PR:

* Adds a nullable `metadata` column to the `notification` and `broadcast` tables
* Persists metadata using JSON serialization when storing notifications
* Restores metadata when reading notifications from the database
* Adds regression tests covering notification and broadcast round-trip persistence

#### :heavy_check_mark: Checklist

* [ ] A changeset describing the change and affected packages. (Not required for this bug fix unless maintainers request one)
* [ ] Added or updated documentation
* [x] Tests for new functionality and regression tests for bug fixes
* [ ] Screenshots attached (not applicable - no UI changes)
* [x] All your commits have a `Signed-off-by` line in the message
