### PR TITLE
fix(techdocs): isolate DOMPurify instance to prevent hook pollution

### DIFF
--- a/.changeset/slick-dragons-fold.md
+++ b/.changeset/slick-dragons-fold.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+fix(techdocs): isolate DOMPurify instance to prevent hook pollution

--- a/.changeset/slick-dragons-fold.md
+++ b/.changeset/slick-dragons-fold.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-techdocs': patch
 ---
 
-fix(techdocs): isolate DOMPurify instance to prevent hook pollution
+Fixed TechDocs pages sometimes rendering blank due to sanitizer hooks registered by other plugins.

--- a/plugins/techdocs/src/reader/transformers/html/transformer.sanitizer.test.tsx
+++ b/plugins/techdocs/src/reader/transformers/html/transformer.sanitizer.test.tsx
@@ -161,19 +161,23 @@ describe('Transformers > Html > Sanitizer Custom Elements', () => {
       }
     });
 
-    const { result } = renderHook(() => useSanitizerTransformer(), { wrapper });
-    const dirtyDom = document.createElement('html');
-    dirtyDom.innerHTML = `<body><a href="https://example.com">Example</a></body>`;
+    try {
+      const { result } = renderHook(() => useSanitizerTransformer(), {
+        wrapper,
+      });
+      const dirtyDom = document.createElement('html');
+      dirtyDom.innerHTML = `<body><a href="https://example.com">Example</a></body>`;
 
-    const cleanDom = await result.current(dirtyDom);
-    const anchor = cleanDom.querySelector<HTMLAnchorElement>('a');
+      const cleanDom = await result.current(dirtyDom);
+      const anchor = cleanDom.querySelector<HTMLAnchorElement>('a');
 
-    // The globally-registered hook must NOT have touched the TechDocs output.
-    expect(anchor).not.toBeNull();
-    expect(anchor!.style.opacity).not.toBe('0');
-
-    // Cleanup: remove the hook we added so other tests are unaffected.
-    DOMPurify.removeHook('afterSanitizeAttributes');
+      // The globally-registered hook must NOT have touched the TechDocs output.
+      expect(anchor).not.toBeNull();
+      expect(anchor!.style.opacity).not.toBe('0');
+    } finally {
+      // Cleanup: remove the hook we added so other tests are unaffected.
+      DOMPurify.removeHook('afterSanitizeAttributes');
+    }
   });
 
   it('removes javascript: hrefs while preserving link text', async () => {

--- a/plugins/techdocs/src/reader/transformers/html/transformer.sanitizer.test.tsx
+++ b/plugins/techdocs/src/reader/transformers/html/transformer.sanitizer.test.tsx
@@ -168,8 +168,8 @@ describe('Transformers > Html > Sanitizer Custom Elements', () => {
       const dirtyDom = document.createElement('html');
       dirtyDom.innerHTML = `<body><a href="https://example.com">Example</a></body>`;
 
-      const cleanDom = await result.current(dirtyDom);
-      const anchor = cleanDom.querySelector<HTMLAnchorElement>('a');
+      const clearDom = await result.current(dirtyDom);
+      const anchor = clearDom.querySelector<HTMLAnchorElement>('a');
 
       // The globally-registered hook must NOT have touched the TechDocs output.
       expect(anchor).not.toBeNull();

--- a/plugins/techdocs/src/reader/transformers/html/transformer.sanitizer.test.tsx
+++ b/plugins/techdocs/src/reader/transformers/html/transformer.sanitizer.test.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import DOMPurify from 'dompurify';
 import { FC, PropsWithChildren } from 'react';
 import { renderHook } from '@testing-library/react';
 
@@ -142,6 +143,37 @@ describe('Transformers > Html > Sanitizer Custom Elements', () => {
 
     expect(elements).toHaveLength(1);
     expect(elements[0].hasAttribute('dominant-baseline')).toBe(true);
+  });
+
+  it('does not inherit hooks registered on the global DOMPurify singleton', async () => {
+    // Regression test for https://github.com/backstage/backstage/issues/34037
+    //
+    // Swagger UI (and similar plugins) register a global `afterSanitizeAttributes` hook on
+    // the DOMPurify singleton that mutates elements — e.g. setting `opacity: 0` — which
+    // previously bled into TechDocs sanitization because we were using the shared singleton.
+    // The fix creates a fresh, isolated DOMPurify instance per sanitizer call so that
+    // hooks from other plugins cannot pollute it.
+
+    // Simulate a Swagger UI-style hook that sets opacity: 0 on every anchor element.
+    DOMPurify.addHook('afterSanitizeAttributes', node => {
+      if (node.tagName === 'A') {
+        (node as HTMLElement).style.opacity = '0';
+      }
+    });
+
+    const { result } = renderHook(() => useSanitizerTransformer(), { wrapper });
+    const dirtyDom = document.createElement('html');
+    dirtyDom.innerHTML = `<body><a href="https://example.com">Example</a></body>`;
+
+    const cleanDom = await result.current(dirtyDom);
+    const anchor = cleanDom.querySelector<HTMLAnchorElement>('a');
+
+    // The globally-registered hook must NOT have touched the TechDocs output.
+    expect(anchor).not.toBeNull();
+    expect(anchor!.style.opacity).not.toBe('0');
+
+    // Cleanup: remove the hook we added so other tests are unaffected.
+    DOMPurify.removeHook('afterSanitizeAttributes');
   });
 
   it('removes javascript: hrefs while preserving link text', async () => {

--- a/plugins/techdocs/src/reader/transformers/html/transformer.ts
+++ b/plugins/techdocs/src/reader/transformers/html/transformer.ts
@@ -48,17 +48,20 @@ export const useSanitizerTransformer = (): Transformer => {
     async (dom: Element) => {
       const hosts = config?.getOptionalStringArray('allowedIframeHosts');
 
-      DOMPurify.addHook('beforeSanitizeElements', removeUnsafeLinks);
+      // eslint-disable-next-line new-cap
+      const purify = DOMPurify();
+
+      purify.addHook('beforeSanitizeElements', removeUnsafeLinks);
       const tags = ['link', 'meta'];
 
       if (hosts) {
         tags.push('iframe');
-        DOMPurify.addHook('beforeSanitizeElements', removeUnsafeIframes(hosts));
+        purify.addHook('beforeSanitizeElements', removeUnsafeIframes(hosts));
       }
 
-      DOMPurify.addHook('uponSanitizeElement', removeUnsafeMetaTags);
+      purify.addHook('uponSanitizeElement', removeUnsafeMetaTags);
 
-      DOMPurify.addHook('uponSanitizeAttribute', removeRestrictedAttributes);
+      purify.addHook('uponSanitizeAttribute', removeRestrictedAttributes);
 
       const tagNameCheck = config?.getOptionalString(
         'allowedCustomElementTagNameRegExp',
@@ -97,7 +100,7 @@ export const useSanitizerTransformer = (): Transformer => {
       );
 
       // using outerHTML as we want to preserve the html tag attributes (lang)
-      return DOMPurify.sanitize(dom.outerHTML, {
+      return purify.sanitize(dom.outerHTML, {
         ADD_TAGS: tags,
         FORBID_TAGS: ['style'],
         ADD_ATTR: ['http-equiv', 'content', 'dominant-baseline'],

--- a/plugins/techdocs/src/reader/transformers/html/transformer.ts
+++ b/plugins/techdocs/src/reader/transformers/html/transformer.ts
@@ -44,24 +44,32 @@ const useSanitizerConfig = () => {
 export const useSanitizerTransformer = (): Transformer => {
   const config = useSanitizerConfig();
 
+  const purify = useMemo(() => {
+    // eslint-disable-next-line new-cap
+    const instance = DOMPurify();
+
+    instance.addHook('beforeSanitizeElements', removeUnsafeLinks);
+
+    const hosts = config?.getOptionalStringArray('allowedIframeHosts');
+    if (hosts) {
+      instance.addHook('beforeSanitizeElements', removeUnsafeIframes(hosts));
+    }
+
+    instance.addHook('uponSanitizeElement', removeUnsafeMetaTags);
+
+    instance.addHook('uponSanitizeAttribute', removeRestrictedAttributes);
+
+    return instance;
+  }, [config]);
+
   return useCallback(
     async (dom: Element) => {
       const hosts = config?.getOptionalStringArray('allowedIframeHosts');
-
-      // eslint-disable-next-line new-cap
-      const purify = DOMPurify();
-
-      purify.addHook('beforeSanitizeElements', removeUnsafeLinks);
       const tags = ['link', 'meta'];
 
       if (hosts) {
         tags.push('iframe');
-        purify.addHook('beforeSanitizeElements', removeUnsafeIframes(hosts));
       }
-
-      purify.addHook('uponSanitizeElement', removeUnsafeMetaTags);
-
-      purify.addHook('uponSanitizeAttribute', removeRestrictedAttributes);
 
       const tagNameCheck = config?.getOptionalString(
         'allowedCustomElementTagNameRegExp',
@@ -115,6 +123,6 @@ export const useSanitizerTransformer = (): Transformer => {
         },
       }) as Element;
     },
-    [config],
+    [config, purify],
   );
 };


### PR DESCRIPTION
Fixes the TechDocs rendering opacity issue (#34037). Creates an isolated DOMPurify instance to prevent globally registered hooks (e.g. from Swagger UI) from leaking into TechDocs stylesheet sanitization.