### PR TITLE
config-loader: resolve and precompile TypeScript config schemas

### DIFF
--- a/.changeset/calm-schemas-pack.md
+++ b/.changeset/calm-schemas-pack.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli-module-build': patch
+---
+
+Package preparation now converts TypeScript configuration schemas to separate JSON files. Backend builds compile schemas together before assembling the distribution workspace, while package publishing compiles each schema independently.

--- a/.changeset/quiet-schemas-resolve.md
+++ b/.changeset/quiet-schemas-resolve.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/config-loader': patch
+'@backstage/config-loader': minor
 ---
 
 Configuration schemas declared in TypeScript now resolve and validate imported types instead of treating them as unconstrained values. Invalid imports now cause schema loading to fail.

--- a/.changeset/quiet-schemas-resolve.md
+++ b/.changeset/quiet-schemas-resolve.md
@@ -1,0 +1,5 @@
+---
+'@backstage/config-loader': patch
+---
+
+Configuration schemas declared in TypeScript now resolve and validate imported types instead of treating them as unconstrained values. Invalid imports now cause schema loading to fail.

--- a/packages/cli-module-build/src/lib/packager/createDistWorkspace.ts
+++ b/packages/cli-module-build/src/lib/packager/createDistWorkspace.ts
@@ -37,7 +37,7 @@ import {
   getOutputsForRole,
   Output,
 } from '../builder';
-import { productionPack } from './productionPack';
+import { compilePackageConfigSchemas, productionPack } from './productionPack';
 import {
   BackstagePackage,
   PackageRoles,
@@ -326,6 +326,7 @@ async function moveToDistWorkspace(
       FAST_PACK_SCRIPTS.includes(pkg.packageJson.scripts?.prepack),
   );
 
+  const configSchemas = await compilePackageConfigSchemas(fastPackPackages);
   const featureDetectionProject =
     fastPackPackages.length > 0 && enableFeatureDetection
       ? await createTypeDistProject()
@@ -341,6 +342,7 @@ async function moveToDistWorkspace(
       await productionPack({
         packageDir: target.dir,
         targetDir: absoluteOutputPath,
+        configSchema: configSchemas.get(target.name),
         featureDetectionProject,
       });
     }),

--- a/packages/cli-module-build/src/lib/packager/productionPack.test.ts
+++ b/packages/cli-module-build/src/lib/packager/productionPack.test.ts
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createMockDirectory } from '@backstage/backend-test-utils';
+import npmPackList from 'npm-packlist';
+import {
+  compilePackageConfigSchemas,
+  productionPack,
+  revertProductionPack,
+} from './productionPack';
+
+describe('productionPack', () => {
+  const mockDir = createMockDirectory();
+  const originalDir = process.cwd();
+
+  afterEach(() => {
+    process.chdir(originalDir);
+    mockDir.clear();
+  });
+
+  const packageJson = {
+    name: 'test-package',
+    version: '1.0.0',
+    files: ['config.d.ts'],
+    configSchema: 'config.d.ts',
+  };
+  const configSchema = {
+    type: 'object',
+    properties: { value: { type: 'string' } },
+  };
+  const compiledConfigSchema = {
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    ...configSchema,
+  };
+
+  it('should replace TypeScript schemas in dist packages', async () => {
+    mockDir.setContent({
+      package: {
+        'package.json': JSON.stringify(packageJson),
+        'config.d.ts': 'export interface Config { value?: string }',
+      },
+    });
+
+    await productionPack({
+      packageDir: mockDir.resolve('package'),
+      targetDir: mockDir.resolve('target'),
+      configSchema,
+    });
+
+    expect(mockDir.content({ path: 'target', shouldReadAsText: true })).toEqual(
+      {
+        'package.json': `${JSON.stringify(
+          {
+            ...packageJson,
+            files: ['config.schema.json'],
+            configSchema: 'config.schema.json',
+          },
+          null,
+          2,
+        )}\n`,
+        'config.schema.json': `${JSON.stringify(configSchema, null, 2)}\n`,
+      },
+    );
+    expect(mockDir.content({ path: 'package' })).toEqual({
+      'package.json': JSON.stringify(packageJson),
+      'config.d.ts': 'export interface Config { value?: string }',
+    });
+  });
+
+  it('should add the generated schema to the package files', async () => {
+    mockDir.setContent({
+      package: {
+        'package.json': JSON.stringify({
+          ...packageJson,
+          files: ['README.md'],
+        }),
+        'README.md': 'test package',
+        'config.d.ts': 'export interface Config { value?: string }',
+      },
+    });
+
+    await productionPack({
+      packageDir: mockDir.resolve('package'),
+      targetDir: mockDir.resolve('target'),
+      configSchema,
+    });
+
+    const packedContent = mockDir.content({
+      path: 'target',
+      shouldReadAsText: true,
+    }) as Record<string, string>;
+    const packedPackage = JSON.parse(packedContent['package.json']);
+    expect(packedPackage.files).toEqual(['README.md', 'config.schema.json']);
+    expect(packedContent['config.schema.json']).toBeDefined();
+  });
+
+  it('should restore TypeScript schemas after packing for publishing', async () => {
+    mockDir.setContent({
+      package: {
+        'package.json': JSON.stringify(packageJson),
+        'config.d.ts': 'export interface Config { value?: string }',
+      },
+    });
+    process.chdir(mockDir.resolve('package'));
+
+    await productionPack({ packageDir: mockDir.resolve('package') });
+
+    expect(await mockDir.content({ shouldReadAsText: true })).toEqual({
+      package: {
+        'config.d.ts': 'export interface Config { value?: string }',
+        'config.schema.json': `${JSON.stringify(
+          compiledConfigSchema,
+          null,
+          2,
+        )}\n`,
+        'package.json': `${JSON.stringify(
+          {
+            ...packageJson,
+            files: ['config.schema.json'],
+            configSchema: 'config.schema.json',
+          },
+          null,
+          2,
+        )}\n`,
+        'package.json-prepack': JSON.stringify(packageJson),
+      },
+    });
+    await expect(
+      npmPackList({ path: mockDir.resolve('package') }),
+    ).resolves.toEqual(['config.schema.json', 'package.json']);
+
+    await revertProductionPack(mockDir.resolve('package'));
+
+    expect(await mockDir.content()).toEqual({
+      package: {
+        'package.json': JSON.stringify(packageJson),
+        'config.d.ts': 'export interface Config { value?: string }',
+      },
+    });
+  });
+
+  it('should compile multiple package schemas together', async () => {
+    mockDir.setContent({
+      a: {
+        'package.json': JSON.stringify({
+          ...packageJson,
+          name: 'a',
+        }),
+        'config.d.ts': 'export interface Config { a?: string }',
+      },
+      b: {
+        'package.json': JSON.stringify({
+          ...packageJson,
+          name: 'b',
+        }),
+        'config.d.ts': 'export interface Config { b?: number }',
+      },
+    });
+    process.chdir(mockDir.path);
+
+    const schemas = await compilePackageConfigSchemas([
+      {
+        name: 'a',
+        dir: mockDir.resolve('a'),
+        packageJson: { ...packageJson, name: 'a' },
+      },
+      {
+        name: 'b',
+        dir: mockDir.resolve('b'),
+        packageJson: { ...packageJson, name: 'b' },
+      },
+    ]);
+
+    expect(schemas.get('a')).toEqual({
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'object',
+      properties: { a: { type: 'string' } },
+    });
+    expect(schemas.get('b')).toEqual({
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'object',
+      properties: { b: { type: 'number' } },
+    });
+  });
+});

--- a/packages/cli-module-build/src/lib/packager/productionPack.ts
+++ b/packages/cli-module-build/src/lib/packager/productionPack.ts
@@ -17,13 +17,15 @@
 import fs from 'fs-extra';
 import npmPackList from 'npm-packlist';
 import { resolve as resolvePath, posix as posixPath } from 'node:path';
-import { BackstagePackageJson } from '@backstage/cli-node';
+import { BackstagePackageJson, PackageGraphNode } from '@backstage/cli-node';
+import { loadConfigSchema } from '@backstage/config-loader';
 import { readEntryPoints } from '../entryPoints';
 import { getEntryPointDefaultFeatureType } from '../typeDistProject';
 import { Project } from 'ts-morph';
 
 const PKG_PATH = 'package.json';
 const PKG_BACKUP_PATH = 'package.json-prepack';
+const GENERATED_CONFIG_SCHEMA_PATH = 'config.schema.json';
 
 const SKIPPED_KEYS = ['access', 'registry', 'tag'];
 const SCRIPT_EXTS = ['.js', '.jsx', '.ts', '.tsx'];
@@ -31,10 +33,64 @@ const SCRIPT_EXTS = ['.js', '.jsx', '.ts', '.tsx'];
 interface ProductionPackOptions {
   packageDir: string;
   targetDir?: string;
+  configSchema?: ConfigSchemaValue;
   /**
    * Enables package feature detection using this TS-morph project.
    */
   featureDetectionProject?: Project;
+}
+
+type ConfigSchemaValue = Record<string, unknown>;
+
+type PackageJsonWithConfigSchema = BackstagePackageJson & {
+  configSchema?: string | ConfigSchemaValue;
+};
+
+function getTypeScriptConfigSchemaPath(pkg: BackstagePackageJson) {
+  const configSchema = (pkg as PackageJsonWithConfigSchema).configSchema;
+  return typeof configSchema === 'string' && configSchema.endsWith('.d.ts')
+    ? configSchema
+    : undefined;
+}
+
+export async function compilePackageConfigSchemas(
+  packages: Pick<PackageGraphNode, 'name' | 'dir' | 'packageJson'>[],
+) {
+  const schemaPackages = packages.flatMap(pkg => {
+    const schemaPath = getTypeScriptConfigSchemaPath(pkg.packageJson);
+    return schemaPath ? [{ ...pkg, schemaPath }] : [];
+  });
+  if (schemaPackages.length === 0) {
+    return new Map<string, ConfigSchemaValue>();
+  }
+
+  const schema = await loadConfigSchema({
+    dependencies: [],
+    packagePaths: schemaPackages.map(pkg =>
+      resolvePath(pkg.dir, 'package.json'),
+    ),
+    excludePackageDependencies: true,
+  });
+  const serialized = schema.serialize() as {
+    schemas: Array<{
+      packageName: string;
+      path: string;
+      value: ConfigSchemaValue;
+    }>;
+  };
+  const expectedPaths = new Map(
+    schemaPackages.map(pkg => [pkg.name, resolvePath(pkg.dir, pkg.schemaPath)]),
+  );
+  const result = new Map<string, ConfigSchemaValue>();
+  for (const entry of serialized.schemas) {
+    if (
+      expectedPaths.get(entry.packageName) ===
+      resolvePath(process.cwd(), entry.path)
+    ) {
+      result.set(entry.packageName, entry.value);
+    }
+  }
+  return result;
 }
 
 export async function productionPack(options: ProductionPackOptions) {
@@ -68,6 +124,32 @@ export async function productionPack(options: ProductionPackOptions) {
     delete pkg.optionalDependencies;
   }
 
+  const sourceConfigSchemaPath = getTypeScriptConfigSchemaPath(pkg);
+  let generatedConfigSchema: ConfigSchemaValue | undefined;
+  if (sourceConfigSchemaPath) {
+    generatedConfigSchema =
+      options.configSchema ??
+      (
+        await compilePackageConfigSchemas([
+          { name: pkg.name, dir: packageDir, packageJson: pkg },
+        ])
+      ).get(pkg.name);
+    if (!generatedConfigSchema) {
+      throw new Error(`Failed to compile configuration schema for ${pkg.name}`);
+    }
+
+    (pkg as PackageJsonWithConfigSchema).configSchema =
+      GENERATED_CONFIG_SCHEMA_PATH;
+    if (pkg.files) {
+      pkg.files = pkg.files.map(path =>
+        path === sourceConfigSchemaPath ? GENERATED_CONFIG_SCHEMA_PATH : path,
+      );
+      if (!pkg.files.includes(GENERATED_CONFIG_SCHEMA_PATH)) {
+        pkg.files.push(GENERATED_CONFIG_SCHEMA_PATH);
+      }
+    }
+  }
+
   if (targetDir) {
     // Lists all dist files, respecting .npmignore, files field in package.json, etc.
     const filePaths = await npmPackList({
@@ -80,6 +162,9 @@ export async function productionPack(options: ProductionPackOptions) {
 
     await fs.ensureDir(targetDir);
     for (const filePath of filePaths.sort()) {
+      if (filePath === sourceConfigSchemaPath) {
+        continue;
+      }
       const target = resolvePath(targetDir, filePath);
       if (filePath === PKG_PATH) {
         await fs.writeJson(target, pkg, { encoding: 'utf8', spaces: 2 });
@@ -87,7 +172,21 @@ export async function productionPack(options: ProductionPackOptions) {
         await fs.copy(resolvePath(packageDir, filePath), target);
       }
     }
+    if (generatedConfigSchema) {
+      await fs.writeJson(
+        resolvePath(targetDir, GENERATED_CONFIG_SCHEMA_PATH),
+        generatedConfigSchema,
+        { encoding: 'utf8', spaces: 2 },
+      );
+    }
   } else {
+    if (generatedConfigSchema) {
+      await fs.writeJson(
+        resolvePath(packageDir, GENERATED_CONFIG_SCHEMA_PATH),
+        generatedConfigSchema,
+        { encoding: 'utf8', spaces: 2 },
+      );
+    }
     await fs.writeJson(pkgPath, pkg, { encoding: 'utf8', spaces: 2 });
   }
 }
@@ -100,6 +199,10 @@ export async function revertProductionPack(packageDir: string) {
 
     // Check if we're shipping types for other release stages, clean up in that case
     const pkg = await fs.readJson(PKG_PATH);
+
+    if (getTypeScriptConfigSchemaPath(pkg)) {
+      await fs.remove(resolvePath(packageDir, GENERATED_CONFIG_SCHEMA_PATH));
+    }
 
     // Remove any extra entrypoint backwards compatibility directories
     const entryPoints = readEntryPoints(pkg);

--- a/packages/config-loader/package.json
+++ b/packages/config-loader/package.json
@@ -49,7 +49,8 @@
     "json-schema-traverse": "^1.0.0",
     "lodash": "^4.17.21",
     "minimist": "^1.2.5",
-    "typescript-json-schema": "^0.67.0",
+    "ts-json-schema-generator": "^2.9.0",
+    "typescript": "^5.9.3",
     "yaml": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/config-loader/report.api.md
+++ b/packages/config-loader/report.api.md
@@ -188,6 +188,7 @@ export type LoadConfigSchemaOptions = (
   | {
       dependencies: string[];
       packagePaths?: string[];
+      excludePackageDependencies?: boolean;
     }
   | {
       serialized: JsonObject;

--- a/packages/config-loader/src/schema/collect.test.ts
+++ b/packages/config-loader/src/schema/collect.test.ts
@@ -15,7 +15,9 @@
  */
 
 import { createMockDirectory } from '@backstage/backend-test-utils';
+import { JsonObject } from '@backstage/types';
 import { collectConfigSchemas, internal } from './collect';
+import { compileConfigSchemas } from './compile';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
 
@@ -277,6 +279,8 @@ describe('collectConfigSchemas', () => {
             export interface Config {
               /** @visibility secret */
               tsKey: string
+              /** @items.visibility frontend */
+              tsArray?: string[]
             }
           `,
         },
@@ -305,6 +309,13 @@ describe('collectConfigSchemas', () => {
               tsKey: {
                 type: 'string',
                 visibility: 'secret',
+              },
+              tsArray: {
+                type: 'array',
+                items: {
+                  type: 'string',
+                  visibility: 'frontend',
+                },
               },
             },
             required: ['tsKey'],
@@ -429,6 +440,191 @@ describe('collectConfigSchemas', () => {
         'a',
         'schema.d.ts',
       )}, missing Config export`,
+    );
+  });
+
+  it('should resolve imported types and namespace recursive definitions', async () => {
+    mockDir.setContent({
+      node_modules: {
+        a: {
+          'package.json': JSON.stringify({
+            name: 'a',
+            version: '1.0.0',
+            dependencies: { shared: '1.0.0' },
+            configSchema: 'schema.d.ts',
+          }),
+          'schema.d.ts': `
+            import { Shared } from 'shared';
+
+            export interface Config {
+              /**
+               * @visibility frontend
+               * @deprecated Use another key instead.
+               */
+              a?: Shared;
+            }
+          `,
+        },
+        c: {
+          'package.json': JSON.stringify({
+            name: 'c',
+            version: '1.0.0',
+            dependencies: { shared: '1.0.0' },
+            configSchema: 'schema.d.ts',
+          }),
+          'schema.d.ts': `
+            import { Shared } from 'shared';
+
+            export interface Config {
+              c?: Shared;
+            }
+          `,
+        },
+        shared: {
+          'package.json': JSON.stringify({
+            name: 'shared',
+            version: '1.0.0',
+            types: 'index.d.ts',
+          }),
+          'index.d.ts': `
+            export type Shared = {
+              value: string;
+              child?: Shared;
+            };
+          `,
+        },
+      },
+    });
+    process.chdir(mockDir.path);
+
+    type GeneratedSchema = {
+      definitions: Record<string, JsonObject>;
+      properties: Record<string, JsonObject>;
+    };
+    const schemas = await collectConfigSchemas(['a', 'c'], []);
+    const aSchema = schemas.find(schema => schema.packageName === 'a')!
+      .value as GeneratedSchema;
+    const cSchema = schemas.find(schema => schema.packageName === 'c')!
+      .value as GeneratedSchema;
+    const [aDefinitionName] = Object.keys(aSchema.definitions);
+    const [cDefinitionName] = Object.keys(cSchema.definitions);
+
+    expect(aDefinitionName).not.toBe(cDefinitionName);
+    expect(aSchema.properties.a).toEqual({
+      deprecated: 'Use another key instead.',
+      type: 'object',
+      properties: {
+        value: { type: 'string' },
+        child: { $ref: `#/definitions/${aDefinitionName}` },
+      },
+      required: ['value'],
+      visibility: 'frontend',
+    });
+    expect(aSchema.definitions[aDefinitionName]).toEqual({
+      type: 'object',
+      properties: {
+        value: { type: 'string' },
+        child: { $ref: `#/definitions/${aDefinitionName}` },
+      },
+      required: ['value'],
+    });
+    expect(cSchema.properties.c).toEqual({
+      type: 'object',
+      properties: {
+        value: { type: 'string' },
+        child: { $ref: `#/definitions/${cDefinitionName}` },
+      },
+      required: ['value'],
+    });
+  });
+
+  it('should keep same-named local types independent', async () => {
+    mockDir.setContent({
+      node_modules: {
+        a: {
+          'package.json': JSON.stringify({
+            name: 'a',
+            version: '1.0.0',
+            configSchema: 'schema.d.ts',
+          }),
+          'schema.d.ts': `
+            type Local = {
+              aValue: string;
+              child?: Local;
+            };
+            export interface Config { local?: Local }
+          `,
+        },
+        b: {
+          'package.json': JSON.stringify({
+            name: 'b',
+            version: '1.0.0',
+            configSchema: 'schema.d.ts',
+          }),
+          'schema.d.ts': `
+            type Local = {
+              bValue: number;
+              child?: Local;
+            };
+            export interface Config { local?: Local }
+          `,
+        },
+      },
+    });
+    process.chdir(mockDir.path);
+
+    type GeneratedSchema = {
+      definitions: Record<string, JsonObject>;
+      properties: Record<string, JsonObject>;
+    };
+    const schemas = await collectConfigSchemas(['a', 'b'], []);
+    const aSchema = schemas.find(schema => schema.packageName === 'a')!
+      .value as GeneratedSchema;
+    const bSchema = schemas.find(schema => schema.packageName === 'b')!
+      .value as GeneratedSchema;
+    const [aDefinitionName] = Object.keys(aSchema.definitions);
+    const [bDefinitionName] = Object.keys(bSchema.definitions);
+
+    expect(() => compileConfigSchemas(schemas)).not.toThrow();
+    expect(aDefinitionName).not.toBe(bDefinitionName);
+    expect(aSchema.properties.local).toEqual({
+      type: 'object',
+      properties: {
+        aValue: { type: 'string' },
+        child: { $ref: `#/definitions/${aDefinitionName}` },
+      },
+      required: ['aValue'],
+    });
+    expect(bSchema.properties.local).toEqual({
+      type: 'object',
+      properties: {
+        bValue: { type: 'number' },
+        child: { $ref: `#/definitions/${bDefinitionName}` },
+      },
+      required: ['bValue'],
+    });
+  });
+
+  it('should reject unresolved imports', async () => {
+    mockDir.setContent({
+      node_modules: {
+        unresolved: {
+          'package.json': JSON.stringify({
+            name: 'unresolved',
+            version: '1.0.0',
+            configSchema: 'schema.d.ts',
+          }),
+          'schema.d.ts': `
+            import { Missing } from './missing';
+            export interface Config { value?: Missing }
+          `,
+        },
+      },
+    });
+    process.chdir(mockDir.path);
+
+    await expect(collectConfigSchemas(['unresolved'], [])).rejects.toThrow(
+      "Cannot find module './missing'",
     );
   });
 });

--- a/packages/config-loader/src/schema/collect.test.ts
+++ b/packages/config-loader/src/schema/collect.test.ts
@@ -254,6 +254,32 @@ describe('collectConfigSchemas', () => {
     );
   });
 
+  it('should optionally skip schemas in package dependencies', async () => {
+    mockDir.setContent({
+      node_modules: {
+        a: {
+          'package.json': JSON.stringify({
+            name: 'a',
+            version: '1',
+            dependencies: { b: '1' },
+          }),
+        },
+        b: {
+          'package.json': JSON.stringify({
+            name: 'b',
+            version: '1',
+            configSchema: mockSchema,
+          }),
+        },
+      },
+    });
+    process.chdir(mockDir.path);
+
+    await expect(
+      collectConfigSchemas(['a'], [], { excludePackageDependencies: true }),
+    ).resolves.toEqual([]);
+  });
+
   it('should schema of different types', async () => {
     mockDir.setContent({
       node_modules: {

--- a/packages/config-loader/src/schema/collect.ts
+++ b/packages/config-loader/src/schema/collect.ts
@@ -379,7 +379,7 @@ async function compileTsSchemas(
       throw new Error(`Invalid schema in ${path}, missing Config export`);
     }
 
-    const namespace = createHash('sha1')
+    const namespace = createHash('sha256')
       .update(packageName)
       .update('\0')
       .update(path.split(sep).join('/'))

--- a/packages/config-loader/src/schema/collect.ts
+++ b/packages/config-loader/src/schema/collect.ts
@@ -15,7 +15,9 @@
  */
 
 import fs from 'fs-extra';
-import { EOL } from 'node:os';
+import type * as TsJsonSchemaGenerator from 'ts-json-schema-generator';
+import type * as TypeScript from 'typescript';
+import { createHash } from 'node:crypto';
 import {
   resolve as resolvePath,
   relative as relativePath,
@@ -23,8 +25,7 @@ import {
   sep,
 } from 'node:path';
 import { ConfigSchemaPackageEntry } from './types';
-import { JsonObject } from '@backstage/types';
-import { toError } from '@backstage/errors';
+import type { JsonObject } from '@backstage/types';
 
 type Item = {
   name?: string;
@@ -180,9 +181,81 @@ export async function collectConfigSchemas(
   return allSchemas;
 }
 
+function namespaceSchemaDefinitions(
+  schema: JsonObject,
+  namespace: string,
+): JsonObject {
+  const definitions = schema.definitions;
+  if (
+    !definitions ||
+    typeof definitions !== 'object' ||
+    Array.isArray(definitions) ||
+    Object.keys(definitions).length === 0
+  ) {
+    delete schema.definitions;
+    return schema;
+  }
+
+  const renamedDefinitions = Object.fromEntries(
+    Object.entries(definitions).map(([name, definition]) => [
+      `${namespace}-${name}`,
+      definition,
+    ]),
+  );
+  const renamedRefs = new Map<string, string>();
+  for (const name of Object.keys(definitions)) {
+    const renamed = `${namespace}-${name}`;
+    renamedRefs.set(`#/definitions/${name}`, `#/definitions/${renamed}`);
+    renamedRefs.set(
+      `#/definitions/${encodeURIComponent(name)}`,
+      `#/definitions/${encodeURIComponent(renamed)}`,
+    );
+  }
+
+  function rewriteRefs(value: unknown): void {
+    if (Array.isArray(value)) {
+      value.forEach(rewriteRefs);
+      return;
+    }
+    if (!value || typeof value !== 'object') {
+      return;
+    }
+
+    const object = value as Record<string, unknown>;
+    if (typeof object.$ref === 'string') {
+      object.$ref = renamedRefs.get(object.$ref) ?? object.$ref;
+    }
+    Object.values(object).forEach(rewriteRefs);
+  }
+
+  schema.definitions = renamedDefinitions;
+  rewriteRefs(schema);
+  return schema;
+}
+
+function parseNestedSchemaAnnotation(annotation: unknown) {
+  if (typeof annotation !== 'string') {
+    return undefined;
+  }
+
+  const match = annotation.match(/^\.([\w-]+)\s+([\s\S]+)$/);
+  if (!match) {
+    return undefined;
+  }
+
+  const [, key, text] = match;
+  let value: unknown = text.trim();
+  try {
+    value = JSON.parse(value as string);
+  } catch {
+    // Plain strings such as visibility values are not JSON encoded.
+  }
+  return { key, value };
+}
+
 // This handles the support of TypeScript .d.ts config schema declarations.
-// We collect all typescript schema definition and compile them all in one go.
-// This is much faster than compiling them separately.
+// We collect all TypeScript schema definitions and compile them in one shared
+// program, which avoids repeatedly resolving and parsing imported types.
 async function compileTsSchemas(
   entries: { path: string; packageName: string }[],
 ) {
@@ -190,74 +263,131 @@ async function compileTsSchemas(
     return [];
   }
 
-  // Lazy loaded, because this brings up all of TypeScript and we don't
-  // want that eagerly loaded in tests
-  const { getProgramFromFiles, buildGenerator } =
-    require('typescript-json-schema') as typeof import('typescript-json-schema');
+  // Lazy loaded, because these bring up all of TypeScript and we don't want
+  // that eagerly loaded when collecting JSON schemas.
+  const ts: typeof TypeScript = require('typescript');
+  const {
+    AnnotatedTypeFormatter,
+    createFormatter,
+    createParser,
+    DEFAULT_CONFIG,
+    SchemaGenerator,
+  }: typeof TsJsonSchemaGenerator = require('ts-json-schema-generator');
 
-  const program = getProgramFromFiles(
-    entries.map(({ path }) => path),
-    {
-      incremental: false,
-      isolatedModules: true,
-      lib: ['ES5'], // Skipping most libs speeds processing up a lot, we just need the primitive types anyway
-      noEmit: true,
-      noResolve: true,
-      skipLibCheck: true, // Skipping lib checks speeds things up
-      skipDefaultLibCheck: true,
-      strict: true,
-      typeRoots: [], // Do not include any additional types
-      types: [],
+  const currentDir = process.cwd();
+  const rootNames = entries.map(({ path }) => resolvePath(currentDir, path));
+  const compilerOptions: TypeScript.CompilerOptions = {
+    incremental: false,
+    jsx: ts.JsxEmit.Preserve,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    noEmit: true,
+    noResolve: false,
+    skipDefaultLibCheck: true,
+    skipLibCheck: false,
+    strict: true,
+    target: ts.ScriptTarget.ES2022,
+    types: [],
+  };
+
+  const program = ts.createProgram(rootNames, compilerOptions);
+  const diagnostics = [
+    ...program.getOptionsDiagnostics(),
+    ...program.getGlobalDiagnostics(),
+    ...rootNames.flatMap(rootName => {
+      const sourceFile = program.getSourceFile(rootName);
+      return sourceFile
+        ? [
+            ...program.getSyntacticDiagnostics(sourceFile),
+            ...program.getSemanticDiagnostics(sourceFile),
+          ]
+        : [];
+    }),
+  ];
+  if (diagnostics.length > 0) {
+    const message = ts.formatDiagnostics(diagnostics, {
+      getCanonicalFileName: fileName => fileName,
+      getCurrentDirectory: () => currentDir,
+      getNewLine: () => '\n',
+    });
+    throw new Error(`Invalid TypeScript configuration schema:\n${message}`);
+  }
+
+  const generatorConfig = {
+    ...DEFAULT_CONFIG,
+    additionalProperties: true,
+    expose: 'none' as const,
+    extraTags: ['visibility', 'deepVisibility', 'deprecated', 'items'],
+    jsDoc: 'extended' as const,
+    skipTypeCheck: true,
+    topRef: false,
+    tsProgram: program,
+  };
+  const parser = createParser(program, generatorConfig);
+  class NestedAnnotationsFormatter extends AnnotatedTypeFormatter {
+    override getDefinition(type: TsJsonSchemaGenerator.AnnotatedType) {
+      const annotations = type.getAnnotations();
+      const itemsAnnotation = annotations.items;
+      const nestedItems = parseNestedSchemaAnnotation(itemsAnnotation);
+      if (!nestedItems) {
+        return super.getDefinition(type);
+      }
+
+      delete annotations.items;
+      try {
+        const definition = super.getDefinition(type);
+        const items = definition.items;
+        if (items && typeof items === 'object' && !Array.isArray(items)) {
+          Object.assign(items, { [nestedItems.key]: nestedItems.value });
+        }
+        return definition;
+      } finally {
+        annotations.items = itemsAnnotation;
+      }
+    }
+  }
+  const formatter = createFormatter(
+    generatorConfig,
+    (chainFormatter, circularReferenceFormatter) => {
+      chainFormatter.addTypeFormatter(
+        new NestedAnnotationsFormatter(circularReferenceFormatter),
+      );
     },
   );
+  const generator = new SchemaGenerator(
+    program,
+    parser,
+    formatter,
+    generatorConfig,
+  );
 
-  const tsSchemas = entries.map(({ path, packageName }) => {
-    let value;
-    try {
-      const generator = buildGenerator(
-        program,
-        // This enables the use of these tags in TSDoc comments
-        {
-          required: true,
-          validationKeywords: ['visibility', 'deepVisibility', 'deprecated'],
-        },
-        [path.split(sep).join('/')], // Unix paths are expected for all OSes here
-      );
-
-      // All schemas should export a `Config` symbol
-      value = generator?.getSchemaForSymbol('Config') as JsonObject | null;
-
-      // This makes sure that no additional symbols are defined in the schema. We don't allow
-      // this because they share a global namespace and will be merged together, leading to
-      // unpredictable behavior.
-      const userSymbols = new Set(generator?.getUserSymbols());
-      userSymbols.delete('Config');
-      if (userSymbols.size !== 0) {
-        const names = Array.from(userSymbols).join("', '");
-        throw new Error(
-          `Invalid configuration schema in ${path}, additional symbol definitions are not allowed, found '${names}'`,
-        );
-      }
-
-      // This makes sure that no unsupported types are used in the schema, for example `Record<,>`.
-      // The generator will extract these as a schema reference, which will in turn be broken for our usage.
-      const reffedDefs = Object.keys(generator?.ReffedDefinitions ?? {});
-      if (reffedDefs.length !== 0) {
-        const lines = reffedDefs.join(`${EOL}  `);
-        throw new Error(
-          `Invalid configuration schema in ${path}, the following definitions are not supported:${EOL}${EOL}  ${lines}`,
-        );
-      }
-    } catch (error) {
-      const err = toError(error);
-      if (err.message !== 'type Config not found') {
-        throw err;
-      }
-    }
-
-    if (!value) {
+  const tsSchemas = entries.map(({ path, packageName }, index) => {
+    const sourceFile = program.getSourceFile(rootNames[index]);
+    if (!sourceFile) {
       throw new Error(`Invalid schema in ${path}, missing Config export`);
     }
+    const configNode = sourceFile.statements.find(
+      statement =>
+        (ts.isInterfaceDeclaration(statement) ||
+          ts.isTypeAliasDeclaration(statement)) &&
+        statement.name.text === 'Config',
+    );
+    if (!configNode) {
+      throw new Error(`Invalid schema in ${path}, missing Config export`);
+    }
+
+    const namespace = createHash('sha1')
+      .update(packageName)
+      .update('\0')
+      .update(path.split(sep).join('/'))
+      .digest('hex');
+    const value = namespaceSchemaDefinitions(
+      structuredClone(
+        generator.createSchemaFromNodes([configNode]),
+      ) as JsonObject,
+      namespace,
+    );
+
     return { path, value, packageName };
   });
 

--- a/packages/config-loader/src/schema/collect.ts
+++ b/packages/config-loader/src/schema/collect.ts
@@ -55,6 +55,7 @@ export const internal = {
 export async function collectConfigSchemas(
   packageNames: string[],
   packagePaths: string[],
+  options?: { excludePackageDependencies?: boolean },
 ): Promise<ConfigSchemaPackageEntry[]> {
   const schemas = new Array<ConfigSchemaPackageEntry>();
   const tsSchemaPaths = new Array<{ packageName: string; path: string }>();
@@ -150,11 +151,13 @@ export async function collectConfigSchemas(
       }
     }
 
-    await Promise.all(
-      depNames.map(depName =>
-        processItem({ name: depName, parentPath: pkgPath }),
-      ),
-    );
+    if (!options?.excludePackageDependencies) {
+      await Promise.all(
+        depNames.map(depName =>
+          processItem({ name: depName, parentPath: pkgPath }),
+        ),
+      );
+    }
   }
 
   await Promise.all([

--- a/packages/config-loader/src/schema/load.ts
+++ b/packages/config-loader/src/schema/load.ts
@@ -37,7 +37,11 @@ export type LoadConfigSchemaOptions =
       | {
           dependencies: string[];
           packagePaths?: string[];
-          /** @internal */
+          /**
+           * Whether to exclude schemas from package dependencies.
+           *
+           * Defaults to `false`.
+           */
           excludePackageDependencies?: boolean;
         }
       | {

--- a/packages/config-loader/src/schema/load.ts
+++ b/packages/config-loader/src/schema/load.ts
@@ -37,6 +37,8 @@ export type LoadConfigSchemaOptions =
       | {
           dependencies: string[];
           packagePaths?: string[];
+          /** @internal */
+          excludePackageDependencies?: boolean;
         }
       | {
           serialized: JsonObject;
@@ -73,6 +75,9 @@ export async function loadConfigSchema(
     schemas = await collectConfigSchemas(
       options.dependencies,
       options.packagePaths ?? [],
+      {
+        excludePackageDependencies: options.excludePackageDependencies,
+      },
     );
   } else {
     const { serialized } = options;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2942,7 +2942,8 @@ __metadata:
     lodash: "npm:^4.17.21"
     minimist: "npm:^1.2.5"
     msw: "npm:^2.0.0"
-    typescript-json-schema: "npm:^0.67.0"
+    ts-json-schema-generator: "npm:^2.9.0"
+    typescript: "npm:^5.9.3"
     yaml: "npm:^2.0.0"
     zen-observable: "npm:^0.10.0"
   languageName: unknown
@@ -8100,15 +8101,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cspotcode/source-map-support@npm:^0.8.0":
-  version: 0.8.1
-  resolution: "@cspotcode/source-map-support@npm:0.8.1"
-  dependencies:
-    "@jridgewell/trace-mapping": "npm:0.3.9"
-  checksum: 10/b6e38a1712fab242c86a241c229cf562195aad985d0564bd352ac404be583029e89e93028ffd2c251d2c407ecac5fb0cbdca94a2d5c10f29ac806ede0508b3ff
-  languageName: node
-  linkType: hard
-
 "@csstools/color-helpers@npm:^5.1.0":
   version: 5.1.0
   resolution: "@csstools/color-helpers@npm:5.1.0"
@@ -10300,7 +10292,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/resolve-uri@npm:^3.0.3, @jridgewell/resolve-uri@npm:^3.1.0":
+"@jridgewell/resolve-uri@npm:^3.1.0":
   version: 3.1.1
   resolution: "@jridgewell/resolve-uri@npm:3.1.1"
   checksum: 10/64d59df8ae1a4e74315eb1b61e012f1c7bc8aac47a3a1e683f6fe7008eab07bc512a742b7aa7c0405685d1421206de58c9c2e6adbfe23832f8bd69408ffc183e
@@ -10317,20 +10309,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.4.15, @jridgewell/sourcemap-codec@npm:^1.5.0, @jridgewell/sourcemap-codec@npm:^1.5.5":
+"@jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.4.15, @jridgewell/sourcemap-codec@npm:^1.5.0, @jridgewell/sourcemap-codec@npm:^1.5.5":
   version: 1.5.5
   resolution: "@jridgewell/sourcemap-codec@npm:1.5.5"
   checksum: 10/5d9d207b462c11e322d71911e55e21a4e2772f71ffe8d6f1221b8eb5ae6774458c1d242f897fb0814e8714ca9a6b498abfa74dfe4f434493342902b1a48b33a5
-  languageName: node
-  linkType: hard
-
-"@jridgewell/trace-mapping@npm:0.3.9":
-  version: 0.3.9
-  resolution: "@jridgewell/trace-mapping@npm:0.3.9"
-  dependencies:
-    "@jridgewell/resolve-uri": "npm:^3.0.3"
-    "@jridgewell/sourcemap-codec": "npm:^1.4.10"
-  checksum: 10/83deafb8e7a5ca98993c2c6eeaa93c270f6f647a4c0dc00deb38c9cf9b2d3b7bf15e8839540155247ef034a052c0ec4466f980bf0c9e2ab63b97d16c0cedd3ff
   languageName: node
   linkType: hard
 
@@ -18290,34 +18272,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tsconfig/node10@npm:^1.0.7":
-  version: 1.0.9
-  resolution: "@tsconfig/node10@npm:1.0.9"
-  checksum: 10/a33ae4dc2a621c0678ac8ac4bceb8e512ae75dac65417a2ad9b022d9b5411e863c4c198b6ba9ef659e14b9fb609bbec680841a2e84c1172df7a5ffcf076539df
-  languageName: node
-  linkType: hard
-
-"@tsconfig/node12@npm:^1.0.7":
-  version: 1.0.11
-  resolution: "@tsconfig/node12@npm:1.0.11"
-  checksum: 10/5ce29a41b13e7897a58b8e2df11269c5395999e588b9a467386f99d1d26f6c77d1af2719e407621412520ea30517d718d5192a32403b8dfcc163bf33e40a338a
-  languageName: node
-  linkType: hard
-
-"@tsconfig/node14@npm:^1.0.0":
-  version: 1.0.3
-  resolution: "@tsconfig/node14@npm:1.0.3"
-  checksum: 10/19275fe80c4c8d0ad0abed6a96dbf00642e88b220b090418609c4376e1cef81bf16237bf170ad1b341452feddb8115d8dd2e5acdfdea1b27422071163dc9ba9d
-  languageName: node
-  linkType: hard
-
-"@tsconfig/node16@npm:^1.0.2":
-  version: 1.0.3
-  resolution: "@tsconfig/node16@npm:1.0.3"
-  checksum: 10/3a8b657dd047495b7ad23437d6afd20297ce90380ff0bdee93fc7d39a900dbd8d9e26e53ff6b465e7967ce2adf0b218782590ce9013285121e6a5928fbd6819f
-  languageName: node
-  linkType: hard
-
 "@tufjs/canonical-json@npm:2.0.0":
   version: 2.0.0
   resolution: "@tufjs/canonical-json@npm:2.0.0"
@@ -19409,7 +19363,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^24.0.0, @types/node@npm:^24.10.2":
+"@types/node@npm:^24.0.0":
   version: 24.12.4
   resolution: "@types/node@npm:24.12.4"
   dependencies:
@@ -21859,16 +21813,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn-walk@npm:^8.1.1, acorn-walk@npm:^8.3.4":
-  version: 8.3.4
-  resolution: "acorn-walk@npm:8.3.4"
-  dependencies:
-    acorn: "npm:^8.11.0"
-  checksum: 10/871386764e1451c637bb8ab9f76f4995d408057e9909be6fb5ad68537ae3375d85e6a6f170b98989f44ab3ff6c74ad120bc2779a3d577606e7a0cd2b4efcaf77
-  languageName: node
-  linkType: hard
-
-"acorn@npm:^8.11.0, acorn@npm:^8.15.0, acorn@npm:^8.16.0, acorn@npm:^8.4.1, acorn@npm:^8.8.2, acorn@npm:^8.9.0":
+"acorn@npm:^8.15.0, acorn@npm:^8.16.0, acorn@npm:^8.8.2, acorn@npm:^8.9.0":
   version: 8.16.0
   resolution: "acorn@npm:8.16.0"
   bin:
@@ -22337,13 +22282,6 @@ __metadata:
     delegates: "npm:^1.0.0"
     readable-stream: "npm:^3.6.0"
   checksum: 10/7266eee19d0be9dd8e58b63cfb1e1ad45945125fac1e75f00237b55960891bf3bb0be291757a8d9dcf1dbfacfb3802d3eb3f9a064084a6a70a61fe0571f9318f
-  languageName: node
-  linkType: hard
-
-"arg@npm:^4.1.0":
-  version: 4.1.3
-  resolution: "arg@npm:4.1.3"
-  checksum: 10/969b491082f20cad166649fa4d2073ea9e974a4e5ac36247ca23d2e5a8b3cb12d60e9ff70a8acfe26d76566c71fd351ee5e6a9a6595157eb36f92b1fd64e1599
   languageName: node
   linkType: hard
 
@@ -24483,17 +24421,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cliui@npm:^9.0.1":
-  version: 9.0.1
-  resolution: "cliui@npm:9.0.1"
-  dependencies:
-    string-width: "npm:^7.2.0"
-    strip-ansi: "npm:^7.1.0"
-    wrap-ansi: "npm:^9.0.0"
-  checksum: 10/df43d8d1c6e3254cbb64b1905310d5f6672c595496a3cbe76946c6d24777136886470686f2772ac9edfe547a74bb70e8017530b3554715aee119efd7752fc0d9
-  languageName: node
-  linkType: hard
-
 "clone-buffer@npm:^1.0.0":
   version: 1.0.0
   resolution: "clone-buffer@npm:1.0.0"
@@ -25435,7 +25362,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"create-require@npm:^1.1.0, create-require@npm:^1.1.1":
+"create-require@npm:^1.1.1":
   version: 1.1.1
   resolution: "create-require@npm:1.1.1"
   checksum: 10/a9a1503d4390d8b59ad86f4607de7870b39cad43d929813599a23714831e81c520bddf61bcdd1f8e30f05fd3a2b71ae8538e946eb2786dc65c2bbc520f692eff
@@ -26628,13 +26555,6 @@ __metadata:
   version: 0.0.3
   resolution: "diff3@npm:0.0.3"
   checksum: 10/9fb9983052e35209be1912c6999ee4aa1887365666ea28d5aba364ffe8514e0a745a4408a3702b5c5943e717571dcc892073b8f3b48fed5814e2c7fc1883f74e
-  languageName: node
-  linkType: hard
-
-"diff@npm:^4.0.1":
-  version: 4.0.4
-  resolution: "diff@npm:4.0.4"
-  checksum: 10/5019b3f5ae124ea9e95137119e1a83a59c252c75ddac873cc967832fd7a834570a58a4d58b941bdbd07832ebf98dcb232b27c561b7f5584357da6dae59bcac62
   languageName: node
   linkType: hard
 
@@ -35273,13 +35193,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"make-error@npm:^1.1.1":
-  version: 1.3.6
-  resolution: "make-error@npm:1.3.6"
-  checksum: 10/b86e5e0e25f7f777b77fabd8e2cbf15737972869d852a22b7e73c17623928fccb826d8e46b9951501d3f20e51ad74ba8c59ed584f610526a48f8ccf88aaec402
-  languageName: node
-  linkType: hard
-
 "make-fetch-happen@npm:^10.0.1":
   version: 10.2.1
   resolution: "make-fetch-happen@npm:10.2.1"
@@ -39068,13 +38981,6 @@ __metadata:
   version: 1.0.1
   resolution: "path-browserify@npm:1.0.1"
   checksum: 10/7e7368a5207e7c6b9051ef045711d0dc3c2b6203e96057e408e6e74d09f383061010d2be95cb8593fe6258a767c3e9fc6b2bfc7ce8d48ae8c3d9f6994cca9ad8
-  languageName: node
-  linkType: hard
-
-"path-equal@npm:^1.2.5":
-  version: 1.2.5
-  resolution: "path-equal@npm:1.2.5"
-  checksum: 10/fa4ef398dea6bd7bf36c5fe62b5f5c2c14fe1f1340cf355eb8a40c86577318dfa0401df86464bb0cc33ed227f115b2afec10d1adaa64260dedbbc23d33f3abbb
   languageName: node
   linkType: hard
 
@@ -44522,7 +44428,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-width@npm:^7.0.0, string-width@npm:^7.2.0":
+"string-width@npm:^7.0.0":
   version: 7.2.0
   resolution: "string-width@npm:7.2.0"
   dependencies:
@@ -45985,6 +45891,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ts-json-schema-generator@npm:^2.9.0":
+  version: 2.9.0
+  resolution: "ts-json-schema-generator@npm:2.9.0"
+  dependencies:
+    "@types/json-schema": "npm:^7.0.15"
+    commander: "npm:^14.0.3"
+    glob: "npm:^13.0.6"
+    json5: "npm:^2.2.3"
+    normalize-path: "npm:^3.0.0"
+    safe-stable-stringify: "npm:^2.5.0"
+    tslib: "npm:^2.8.1"
+    typescript: "npm:^5.9.3"
+  bin:
+    ts-json-schema-generator: bin/ts-json-schema-generator.js
+  checksum: 10/50a18cb6a1171e495af16a4fe8165000d0155ef693cec9345bacb8a5b6cc559dcc730443ebdc025590cd29ffd2019564267a8222c7f6389bdf5558856fbe479b
+  languageName: node
+  linkType: hard
+
 "ts-mixer@npm:^6.0.3, ts-mixer@npm:^6.0.4":
   version: 6.0.4
   resolution: "ts-mixer@npm:6.0.4"
@@ -45999,44 +45923,6 @@ __metadata:
     "@ts-morph/common": "npm:~0.25.0"
     code-block-writer: "npm:^13.0.3"
   checksum: 10/560f64eac91429f852277af7588d116b83f91ace2e6ba89c71893b364a42c1e9a658fb40ad2c8d1b48af14d744ba1d4ee7a7efeae033d14ad7a6b5f50b83ccca
-  languageName: node
-  linkType: hard
-
-"ts-node@npm:^10.9.2":
-  version: 10.9.2
-  resolution: "ts-node@npm:10.9.2"
-  dependencies:
-    "@cspotcode/source-map-support": "npm:^0.8.0"
-    "@tsconfig/node10": "npm:^1.0.7"
-    "@tsconfig/node12": "npm:^1.0.7"
-    "@tsconfig/node14": "npm:^1.0.0"
-    "@tsconfig/node16": "npm:^1.0.2"
-    acorn: "npm:^8.4.1"
-    acorn-walk: "npm:^8.1.1"
-    arg: "npm:^4.1.0"
-    create-require: "npm:^1.1.0"
-    diff: "npm:^4.0.1"
-    make-error: "npm:^1.1.1"
-    v8-compile-cache-lib: "npm:^3.0.1"
-    yn: "npm:3.1.1"
-  peerDependencies:
-    "@swc/core": ">=1.2.50"
-    "@swc/wasm": ">=1.2.50"
-    "@types/node": "*"
-    typescript: ">=2.7"
-  peerDependenciesMeta:
-    "@swc/core":
-      optional: true
-    "@swc/wasm":
-      optional: true
-  bin:
-    ts-node: dist/bin.js
-    ts-node-cwd: dist/bin-cwd.js
-    ts-node-esm: dist/bin-esm.js
-    ts-node-script: dist/bin-script.js
-    ts-node-transpile-only: dist/bin-transpile.js
-    ts-script: dist/bin-script-deprecated.js
-  checksum: 10/a91a15b3c9f76ac462f006fa88b6bfa528130dcfb849dd7ef7f9d640832ab681e235b8a2bc58ecde42f72851cc1d5d4e22c901b0c11aa51001ea1d395074b794
   languageName: node
   linkType: hard
 
@@ -46377,25 +46263,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript-json-schema@npm:^0.67.0":
-  version: 0.67.4
-  resolution: "typescript-json-schema@npm:0.67.4"
-  dependencies:
-    "@types/json-schema": "npm:^7.0.15"
-    "@types/node": "npm:^24.10.2"
-    glob: "npm:^13.0.6"
-    path-equal: "npm:^1.2.5"
-    safe-stable-stringify: "npm:^2.5.0"
-    ts-node: "npm:^10.9.2"
-    typescript: "npm:~5.9.3"
-    vm2: "npm:^3.11.3"
-    yargs: "npm:^18.0.0"
-  bin:
-    typescript-json-schema: bin/typescript-json-schema
-  checksum: 10/221b8e5efc589cf5784d64e5bf6eaf00f3fe19ef40008e7aaa24dd4c7c5a70c780980cb4824590a969e791606af55875e737d16b899aa296391d2eedbb54811f
-  languageName: node
-  linkType: hard
-
 "typescript@npm:5.8.2":
   version: 5.8.2
   resolution: "typescript@npm:5.8.2"
@@ -46406,7 +46273,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.7.3, typescript@npm:^5.8.3, typescript@npm:~5.9.3":
+"typescript@npm:^5.7.3, typescript@npm:^5.8.3, typescript@npm:^5.9.3":
   version: 5.9.3
   resolution: "typescript@npm:5.9.3"
   bin:
@@ -46436,7 +46303,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.7.3#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.8.3#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A~5.9.3#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A^5.7.3#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.8.3#optional!builtin<compat/typescript>, typescript@patch:typescript@npm%3A^5.9.3#optional!builtin<compat/typescript>":
   version: 5.9.3
   resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
   bin:
@@ -47275,13 +47142,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"v8-compile-cache-lib@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "v8-compile-cache-lib@npm:3.0.1"
-  checksum: 10/88d3423a52b6aaf1836be779cab12f7016d47ad8430dffba6edf766695e6d90ad4adaa3d8eeb512cc05924f3e246c4a4ca51e089dccf4402caa536b5e5be8961
-  languageName: node
-  linkType: hard
-
 "v8-to-istanbul@npm:^9.0.1":
   version: 9.0.1
   resolution: "v8-to-istanbul@npm:9.0.1"
@@ -47493,18 +47353,6 @@ __metadata:
   version: 1.1.2
   resolution: "vm-browserify@npm:1.1.2"
   checksum: 10/ad5b17c9f7a9d9f1ed0e24c897782ab7a587c1fd40f370152482e1af154c7cf0b0bacc45c5ae76a44289881e083ae4ae127808fdff864aa9b562192aae8b5c3b
-  languageName: node
-  linkType: hard
-
-"vm2@npm:^3.11.3":
-  version: 3.11.5
-  resolution: "vm2@npm:3.11.5"
-  dependencies:
-    acorn: "npm:^8.15.0"
-    acorn-walk: "npm:^8.3.4"
-  bin:
-    vm2: bin/vm2
-  checksum: 10/aaaea54b3c51e61bcefb38a1c67c2779efb73a83c1dd73e371652f704097ce71822df510e694a523aa8a3fc47b9ef394c1917b7457f30ef6c6fe62f757442dd4
   languageName: node
   linkType: hard
 
@@ -48288,13 +48136,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:^22.0.0":
-  version: 22.0.0
-  resolution: "yargs-parser@npm:22.0.0"
-  checksum: 10/f13c42bad6ebed1a587a72f2db5694f5fa772bcaf409a701691d13cf74eb5adfcf61a2611de08807e319b829d3e5e6e1578b16ebe174cae8e8be3bf7b8e7a19e
-  languageName: node
-  linkType: hard
-
 "yargs@npm:17.7.2, yargs@npm:^17.3.1, yargs@npm:^17.7.1, yargs@npm:^17.7.2":
   version: 17.7.2
   resolution: "yargs@npm:17.7.2"
@@ -48322,20 +48163,6 @@ __metadata:
     y18n: "npm:^5.0.5"
     yargs-parser: "npm:^20.2.2"
   checksum: 10/807fa21211d2117135d557f95fcd3c3d390530cda2eca0c840f1d95f0f40209dcfeb5ec18c785a1f3425896e623e3b2681e8bb7b6600060eda1c3f4804e7957e
-  languageName: node
-  linkType: hard
-
-"yargs@npm:^18.0.0":
-  version: 18.0.0
-  resolution: "yargs@npm:18.0.0"
-  dependencies:
-    cliui: "npm:^9.0.1"
-    escalade: "npm:^3.1.1"
-    get-caller-file: "npm:^2.0.5"
-    string-width: "npm:^7.2.0"
-    y18n: "npm:^5.0.5"
-    yargs-parser: "npm:^22.0.0"
-  checksum: 10/5af36234871390386b31cac99f00e79fcbc2ead858a61b30a8ca381c5fde5df8af0b407c36b000d3f774bcbe4aec5833f2f1c915f6ddc49ce97b78176b651801
   languageName: node
   linkType: hard
 
@@ -48433,13 +48260,6 @@ __metadata:
     js-yaml: "npm:^3.8.3"
     loader-utils: "npm:^1.1.0"
   checksum: 10/7afc624b3c9d3520698d275069b891a826ecb1ecf3c37e8312737067b23427f1e0d5c4b05cb08bea85d675c0a4f883831bcc82fda34f79158c0659a2d09de920
-  languageName: node
-  linkType: hard
-
-"yn@npm:3.1.1":
-  version: 3.1.1
-  resolution: "yn@npm:3.1.1"
-  checksum: 10/2c487b0e149e746ef48cda9f8bad10fc83693cd69d7f9dcd8be4214e985de33a29c9e24f3c0d6bcf2288427040a8947406ab27f7af67ee9456e6b84854f02dd6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This changes TypeScript configuration schema generation to use ts-json-schema-generator and moves published packages toward precompiled JSON schemas.

Imported types are now fully resolved and validated through a shared TypeScript program. Helper types can be declared alongside Config, generated definitions are namespaced so same-named types remain independent across schema files, and existing annotations such as @items.visibility remain supported.

During package preparation, config.d.ts is compiled to a separate config.schema.json file and the packed package manifest is updated accordingly. The generated JSON file is always added to the package files list, while config.d.ts is omitted from the packed output. Postpack restores the source manifest and removes the generated schema.

Backend distribution builds compile schemas for all fast-packed packages together in one shared pass. Regular package publishing and custom pack flows compile each package independently.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a Signed-off-by line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))