### PR TITLE
Remove obsolete location import error handling in StepReviewLocation

### DIFF
--- a/.changeset/tricky-glasses-relate.md
+++ b/.changeset/tricky-glasses-relate.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-import': patch
+---
+
+Remove obsolete location import error handling in StepReviewLocation.

--- a/plugins/catalog-import/src/components/StepReviewLocation/StepReviewLocation.tsx
+++ b/plugins/catalog-import/src/components/StepReviewLocation/StepReviewLocation.tsx
@@ -95,25 +95,8 @@ export const StepReviewLocation = ({
       });
     } catch (e) {
       const caughtError = toError(e);
-      // TODO: this error should be handled differently. We add it as 'optional' and
-      //       it is not uncommon that a PR has not been merged yet.
-      if (
-        prepareResult.type === 'repository' &&
-        caughtError.message.startsWith(
-          'Location was added but has no entities specified yet',
-        )
-      ) {
-        onReview({
-          ...prepareResult,
-          locations: prepareResult.locations.map(l => ({
-            target: l.target,
-            entities: [],
-          })),
-        });
-      } else {
-        setError(caughtError.message);
-        setSubmitted(false);
-      }
+      setError(caughtError.message);
+      setSubmitted(false);
     }
   }, [prepareResult, onReview, catalogApi, analytics]);
 


### PR DESCRIPTION
## Description

This PR removes obsolete error handling in `StepReviewLocation`.

The component contained special-case handling for the error message:

`Location was added but has no entities specified yet`

This logic appears to be a leftover workaround from older catalog backend behavior where location registration could synchronously fail when no entities were discovered.

In the current implementation, `catalogApi.addLocation()` successfully returns with an empty entity list (`entities: []`) and catalog processing is handled asynchronously. As a result, this error handling branch is no longer exercised and has become dead code.

### Changes

* Remove the obsolete string-matching error handling branch
* Remove the associated stale TODO comment
* Keep the existing generic error handling unchanged

### Testing

* Verified the error string is no longer produced by the current implementation
* Ran TypeScript checks
* Ran lint checks for `@backstage/plugin-catalog-import`
* Ran the plugin test suite successfully

Fixes #34846

#### :heavy_check_mark: Checklist

* [x] A changeset describing the change and affected packages (not required for this internal cleanup)
* [ ] Added or updated documentation (not applicable)
* [ ] Tests for new functionality and regression tests for bug fixes (not applicable, behavior unchanged)
* [ ] Screenshots attached (not applicable, no UI changes)
* [x] All commits have a `Signed-off-by` line in the message
