### PR TITLE
fix: remove missing connections module entry

### DIFF
--- a/packages/connections/package.json
+++ b/packages/connections/package.json
@@ -12,7 +12,6 @@
   "publishConfig": {
     "access": "public",
     "main": "dist/index.cjs.js",
-    "module": "dist/index.esm.js",
     "types": "dist/index.d.ts"
   },
   "keywords": [


### PR DESCRIPTION
## Summary
- remove the publish-time `module` field for `@backstage/connections`
- leave the existing CommonJS `main` and TypeScript `types` publish entries unchanged

## Why
`@backstage/connections@0.0.0` publishes `dist/index.cjs.js` and `dist/index.d.ts`, but its package metadata also advertises `module: dist/index.esm.js`. The npm tarball does not include `dist/index.esm.js`, so bundlers that prefer the legacy `module` field can resolve to a missing file.

## Validation
- `npm view @backstage/connections@0.0.0 main module types --json`
- `npm pack @backstage/connections@0.0.0 --dry-run --json` confirms `dist/index.cjs.js` and `dist/index.d.ts` exist, while `dist/index.esm.js` is absent
- package metadata now omits the broken publish-time `module` override
