### PR TITLE
fix: catalog react undefined filter guards

### DIFF
--- a/.changeset/mean-shrimps-dance.md
+++ b/.changeset/mean-shrimps-dance.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Fix crash in toStreamRequest when filters contain undefined entries

--- a/.changeset/mean-shrimps-dance.md
+++ b/.changeset/mean-shrimps-dance.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog': patch
 ---
 
-Fix crash in toStreamRequest when filters contain undefined entries
+Fix crash when exporting the catalog with unset filters

--- a/plugins/catalog/src/components/CatalogExportButton/file-download/toStreamRequest.test.ts
+++ b/plugins/catalog/src/components/CatalogExportButton/file-download/toStreamRequest.test.ts
@@ -28,6 +28,39 @@ describe('toStreamRequest', () => {
 
       expect(result).toBeUndefined();
     });
+
+    it('does not crash when filters contain undefined values', () => {
+      const filters: DefaultEntityFilters = {
+        kind: undefined,
+        type: undefined,
+        text: undefined,
+        order: undefined,
+      };
+      expect(() => toStreamRequest(filters)).not.toThrow();
+      expect(toStreamRequest(filters)).toBeUndefined();
+    });
+
+    it('handles mix of undefined and valid filters', () => {
+      const textFilter = new EntityTextFilter('search term');
+      const filters: DefaultEntityFilters = {
+        kind: undefined,
+        text: textFilter,
+        order: undefined,
+      };
+      const result = toStreamRequest(filters);
+      expect(result).toEqual({
+        fullTextFilter: {
+          term: 'search term',
+          fields: [
+            'metadata.name',
+            'metadata.title',
+            'spec.profile.displayName',
+            'spec.target',
+            'spec.targets',
+          ],
+        },
+      });
+    });
   });
 
   describe('with backend filters', () => {

--- a/plugins/catalog/src/components/CatalogExportButton/file-download/toStreamRequest.ts
+++ b/plugins/catalog/src/components/CatalogExportButton/file-download/toStreamRequest.ts
@@ -71,7 +71,9 @@ function getBackendFilterObject(
 export const toStreamRequest = (
   filters: DefaultEntityFilters,
 ): StreamEntitiesRequest | undefined => {
-  const backendFilters = Object.values(filters)
+  const filterValues = Object.values(filters).filter(Boolean);
+
+  const backendFilters = filterValues
     .flatMap(f => {
       if (isBackendFilter(f)) {
         const backendFilter = f.getCatalogFilters();
@@ -83,11 +85,11 @@ export const toStreamRequest = (
       return { ...acc, ...getBackendFilterObject(f) };
     }, {} as Record<string, string | string[]>);
 
-  const fullTextFilter = Object.values(filters)
+  const fullTextFilter = filterValues
     .find(isEntityTextFilter)
     ?.getFullTextFilters();
 
-  const orderFieldsFilter = Object.values(filters).find(isEntityOrderFilter);
+  const orderFieldsFilter = filterValues.find(isEntityOrderFilter);
   const orderFields = orderFieldsFilter
     ? (orderFieldsFilter.getOrderFilters() as EntityOrderQuery)
     : undefined;


### PR DESCRIPTION
## Adding undefined filter guards
I was adding the export function from #31837. But it gave me `Failed to export catalog: can't access property "getFullTextFilters", f is undefined`.

<img width="391" height="121" alt="image" src="https://github.com/user-attachments/assets/4ba888ec-9748-49c3-9b60-b811ffda4ca5" />

- Filter out undefined entries from `Object.values(filters)` in `toStreamRequest()` before
  passing them to type guard functions
- `DefaultEntityFilters` has all optional properties, so inactive filters are undefined

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
