### PR TITLE
feat(cli): support custom flags for embedded postgres

### DIFF
--- a/.changeset/warm-flags-flow.md
+++ b/.changeset/warm-flags-flow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli-module-build': patch
+---
+
+Added support for passing custom flags to the embedded postgres processes via `backend.database.connection.flags.postgres` and `backend.database.connection.flags.initdb` configuration properties.

--- a/packages/cli-module-build/package.json
+++ b/packages/cli-module-build/package.json
@@ -99,7 +99,8 @@
     "webpack": "~5.105.0",
     "webpack-dev-server": "^5.0.0",
     "yml-loader": "^2.1.0",
-    "yn": "^4.0.0"
+    "yn": "^4.0.0",
+    "zod": "^3.25.76 || ^4.0.0"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "workspace:^",

--- a/packages/cli-module-build/src/lib/runner/startEmbeddedDb.ts
+++ b/packages/cli-module-build/src/lib/runner/startEmbeddedDb.ts
@@ -62,6 +62,10 @@ export interface EmbeddedDbConnectionConfig {
   port?: number;
   user?: string;
   password?: string;
+  flags?: {
+    postgres?: string[];
+    initdb?: string[];
+  };
 }
 
 export interface StartEmbeddedDbOptions {
@@ -127,6 +131,12 @@ async function startEmbeddedDbInternal(
     password,
     port,
     persistent: false,
+    ...(userConfig?.flags?.postgres
+      ? { postgresFlags: userConfig.flags.postgres }
+      : {}),
+    ...(userConfig?.flags?.initdb
+      ? { initdbFlags: userConfig.flags.initdb }
+      : {}),
     onError(messageOrError) {
       console.error(`[embedded-postgres]`, messageOrError);
     },
@@ -213,13 +223,24 @@ async function readDatabaseConfig(
     const password = config.getOptionalString(
       'backend.database.connection.password',
     );
+    const postgresFlags = config.getOptionalStringArray(
+      'backend.database.connection.flags.postgres',
+    );
+    const initdbFlags = config.getOptionalStringArray(
+      'backend.database.connection.flags.initdb',
+    );
+    const flags =
+      postgresFlags !== undefined || initdbFlags !== undefined
+        ? { postgres: postgresFlags, initdb: initdbFlags }
+        : undefined;
 
     const connection =
       host !== undefined ||
       port !== undefined ||
       user !== undefined ||
-      password !== undefined
-        ? { host, port, user, password }
+      password !== undefined ||
+      flags !== undefined
+        ? { host, port, user, password, flags }
         : undefined;
 
     return { client, connection };

--- a/packages/cli-module-build/src/lib/runner/startEmbeddedDb.ts
+++ b/packages/cli-module-build/src/lib/runner/startEmbeddedDb.ts
@@ -20,6 +20,7 @@ import {
   isAbsolute as isAbsolutePath,
   resolve as resolvePath,
 } from 'node:path';
+import { z } from 'zod';
 import { getPortPromise } from 'portfinder';
 import { ForwardedError } from '@backstage/errors';
 import { ConfigSources } from '@backstage/config-loader';
@@ -67,6 +68,19 @@ export interface EmbeddedDbConnectionConfig {
     initdb?: string[];
   };
 }
+
+const connectionSchema: z.ZodType<EmbeddedDbConnectionConfig> = z.object({
+  host: z.string().optional(),
+  port: z.number().optional(),
+  user: z.string().optional(),
+  password: z.string().optional(),
+  flags: z
+    .object({
+      postgres: z.array(z.string()).optional(),
+      initdb: z.array(z.string()).optional(),
+    })
+    .optional(),
+});
 
 export interface StartEmbeddedDbOptions {
   configPaths?: string[];
@@ -210,38 +224,14 @@ async function readDatabaseConfig(
       return undefined;
     }
 
-    // Only read structured connection config if the value is an object;
-    // it can also be a plain string (e.g. ':memory:' for better-sqlite3).
+    // Parse the raw connection value with zod rather than reading sub-keys
+    // through the config reader, because the config reader's fallback chain
+    // throws when a lower-priority config file has connection as a string.
     const rawConnection = config.getOptional('backend.database.connection');
-    if (typeof rawConnection === 'string' || rawConnection === undefined) {
-      return { client };
-    }
-
-    const host = config.getOptionalString('backend.database.connection.host');
-    const port = config.getOptionalNumber('backend.database.connection.port');
-    const user = config.getOptionalString('backend.database.connection.user');
-    const password = config.getOptionalString(
-      'backend.database.connection.password',
-    );
-    const postgresFlags = config.getOptionalStringArray(
-      'backend.database.connection.flags.postgres',
-    );
-    const initdbFlags = config.getOptionalStringArray(
-      'backend.database.connection.flags.initdb',
-    );
-    const flags =
-      postgresFlags !== undefined || initdbFlags !== undefined
-        ? { postgres: postgresFlags, initdb: initdbFlags }
-        : undefined;
-
-    const connection =
-      host !== undefined ||
-      port !== undefined ||
-      user !== undefined ||
-      password !== undefined ||
-      flags !== undefined
-        ? { host, port, user, password, flags }
-        : undefined;
+    const connectionResult = connectionSchema.safeParse(rawConnection);
+    const connection = connectionResult.success
+      ? connectionResult.data
+      : undefined;
 
     return { client, connection };
   } finally {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2573,6 +2573,7 @@ __metadata:
     webpack-dev-server: "npm:^5.0.0"
     yml-loader: "npm:^2.1.0"
     yn: "npm:^4.0.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
   peerDependencies:
     embedded-postgres: ^18.3.0-beta.16
   peerDependenciesMeta:


### PR DESCRIPTION
Allow users to pass custom flags to the embedded postgres and initdb processes via config:

```yaml
backend:
  database:
    client: embedded-postgres
    connection:
      flags:
        postgres:
          - '-c'
          - 'shared_buffers=256MB'
        initdb:
          - '--locale=en-US'
```

The flags are forwarded to the `embedded-postgres` library's `postgresFlags` and `initdbFlags` options. They are only consumed when starting the embedded process and are not propagated to the child backend process.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))