### PR TITLE
fix(scaffolder): keep underscores in templating extension fragment names

### DIFF
--- a/.changeset/fix-parse-fragment-underscore.md
+++ b/.changeset/fix-parse-fragment-underscore.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Fixed URL fragment parsing on the Templating Extensions page so that extension names containing underscores are no longer truncated.

--- a/plugins/scaffolder/src/components/TemplatingExtensionsPage/navigation.test.ts
+++ b/plugins/scaffolder/src/components/TemplatingExtensionsPage/navigation.test.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ExtensionKind, parseFragment, renderFragment } from './navigation';
+
+describe('navigation', () => {
+  describe('renderFragment', () => {
+    it('produces kind_name format', () => {
+      expect(renderFragment({ kind: 'filter', name: 'foo' })).toBe(
+        'filter_foo',
+      );
+    });
+
+    it('handles names with underscores', () => {
+      expect(renderFragment({ kind: 'filter', name: 'my_custom_filter' })).toBe(
+        'filter_my_custom_filter',
+      );
+    });
+  });
+
+  describe('parseFragment', () => {
+    it('parses a simple fragment', () => {
+      expect(parseFragment('filter_foo')).toEqual({
+        kind: 'filter',
+        name: 'foo',
+      });
+    });
+
+    it('parses a function fragment', () => {
+      expect(parseFragment('function_myFunc')).toEqual({
+        kind: 'function',
+        name: 'myFunc',
+      });
+    });
+
+    it('parses a value fragment', () => {
+      expect(parseFragment('value_myVal')).toEqual({
+        kind: 'value',
+        name: 'myVal',
+      });
+    });
+
+    it('THE BUG CASE — round-trip with underscore in name', () => {
+      const ext = { kind: 'filter' as ExtensionKind, name: 'my_custom_filter' };
+      expect(parseFragment(renderFragment(ext))).toEqual(ext);
+    });
+
+    it('multi-underscore name: a_b_c', () => {
+      expect(parseFragment('function_a_b_c')).toEqual({
+        kind: 'function',
+        name: 'a_b_c',
+      });
+    });
+
+    it('name-less fragment with valid kind returns empty name', () => {
+      expect(parseFragment('value')).toEqual({ kind: 'value', name: '' });
+    });
+
+    it('invalid kind throws', () => {
+      expect(() => parseFragment('bogus_x')).toThrow();
+    });
+  });
+
+  describe('round-trip: all kinds with underscore names', () => {
+    const kinds: ExtensionKind[] = ['filter', 'function', 'value'];
+    for (const kind of kinds) {
+      it(`round-trips ${kind} with underscore name`, () => {
+        const ext = { kind, name: `my_${kind}_name` };
+        expect(parseFragment(renderFragment(ext))).toEqual(ext);
+      });
+    }
+  });
+});

--- a/plugins/scaffolder/src/components/TemplatingExtensionsPage/navigation.test.ts
+++ b/plugins/scaffolder/src/components/TemplatingExtensionsPage/navigation.test.ts
@@ -52,12 +52,12 @@ describe('navigation', () => {
       });
     });
 
-    it('THE BUG CASE — round-trip with underscore in name', () => {
+    it('round-trips a name containing underscores', () => {
       const ext = { kind: 'filter' as ExtensionKind, name: 'my_custom_filter' };
       expect(parseFragment(renderFragment(ext))).toEqual(ext);
     });
 
-    it('multi-underscore name: a_b_c', () => {
+    it('parses a name with multiple underscores', () => {
       expect(parseFragment('function_a_b_c')).toEqual({
         kind: 'function',
         name: 'a_b_c',
@@ -69,11 +69,13 @@ describe('navigation', () => {
     });
 
     it('invalid kind throws', () => {
-      expect(() => parseFragment('bogus_x')).toThrow();
+      expect(() => parseFragment('bogus_x')).toThrow(
+        /Invalid templating extension fragment "bogus_x"/,
+      );
     });
   });
 
-  describe('round-trip: all kinds with underscore names', () => {
+  describe('round-trips all kinds with underscore names', () => {
     const kinds: ExtensionKind[] = ['filter', 'function', 'value'];
     for (const kind of kinds) {
       it(`round-trips ${kind} with underscore name`, () => {

--- a/plugins/scaffolder/src/components/TemplatingExtensionsPage/navigation.ts
+++ b/plugins/scaffolder/src/components/TemplatingExtensionsPage/navigation.ts
@@ -52,5 +52,8 @@ export const parseFragment = (fragment: string): Extension => {
       name: rest.join('_'),
     };
   }
-  throw Error(fragment);
+  const kindList = kinds.join(', ');
+  throw new Error(
+    `Invalid templating extension fragment "${fragment}": unknown kind "${kind}", expected one of ${kindList}.`,
+  );
 };

--- a/plugins/scaffolder/src/components/TemplatingExtensionsPage/navigation.ts
+++ b/plugins/scaffolder/src/components/TemplatingExtensionsPage/navigation.ts
@@ -44,12 +44,12 @@ export const listTemplatingExtensions = (
 export const renderFragment = (e: Extension) => `${e.kind}_${e.name}`;
 
 export const parseFragment = (fragment: string): Extension => {
-  const [k, name] = fragment.split('_', 2);
+  const [k, ...rest] = fragment.split('_');
   const kind = k as ExtensionKind;
   if (kinds.includes(kind)) {
     return {
       kind,
-      name,
+      name: rest.join('_'),
     };
   }
   throw Error(fragment);


### PR DESCRIPTION
Did a deep dive at the issue, found that parseFragment used `fragment.split('_', 2)`, where the second argument is an array-length limit rather than a separator count. What happens here is that any extension name containing an underscore was truncated and the renderFragment/parseFragment round-trip was lost.

- Implemented a fix to split on the first underscore and keep the remainder as the name
- Added unit tests to cover this case
- Validated with lint checks
- Validated that existing tests are also passing
