### PR TITLE
fix(api-docs): fix swagger ui deep link scrolling

### DIFF
--- a/.changeset/soft-ears-open.md
+++ b/.changeset/soft-ears-open.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': patch
+---
+
+Fix Swagger UI deep-link scrolling in API docs by removing a legacy spec loading delay that prevented deep links from scrolling to the target operation on initial page load.

--- a/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinition.tsx
+++ b/plugins/api-docs/src/components/OpenApiDefinitionWidget/OpenApiDefinition.tsx
@@ -15,7 +15,6 @@
  */
 
 import { makeStyles } from '@material-ui/core/styles';
-import { useEffect, useState } from 'react';
 import SwaggerUI from 'swagger-ui-react';
 import 'swagger-ui-react/swagger-ui.css';
 
@@ -197,19 +196,10 @@ export const OpenApiDefinition = ({
 }: OpenApiDefinitionProps) => {
   const classes = useStyles();
 
-  // Due to a bug in the swagger-ui-react component, the component needs
-  // to be created without content first.
-  const [def, setDef] = useState('');
-
-  useEffect(() => {
-    const timer = setTimeout(() => setDef(definition), 0);
-    return () => clearTimeout(timer);
-  }, [definition, setDef]);
-
   return (
     <div className={classes.root}>
       <SwaggerUI
-        spec={def}
+        spec={definition}
         url=""
         deepLinking
         oauth2RedirectUrl={`${window.location.protocol}//${window.location.host}/oauth2-redirect.html`}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Description

Fixes Swagger UI deep-link scrolling for OpenAPI definitions.

Previously, `OpenApiDefinition` delayed passing the API specification to `swagger-ui-react` using a legacy `setTimeout` workaround that was introduced for an older library issue.

Because Swagger UI initially mounted with an empty spec, deep-link processing occurred before the target operation existed in the DOM. As a result, direct navigation and page refreshes would expand the target operation but fail to scroll to it.

This change removes the legacy loading delay and passes the OpenAPI definition directly to `SwaggerUI`, allowing deep-link processing to work correctly during the initial render.

Fixes #34022

#### Testing

* Verified deep-link navigation to API operations.
* Verified page refresh behavior with deep-linked URLs.
* Ran plugin linting successfully.
* Ran plugin test suite successfully.
* Confirmed no regressions in Swagger UI rendering.

#### :heavy_check_mark: Checklist

* [x] A changeset describing the change and affected packages.
* [ ] Added or updated documentation
* [ ] Tests for new functionality and regression tests for bug fixes
* [ ] Screenshots attached (for UI changes)
* [x] All your commits have a `Signed-off-by` line in the message.

