### PR TITLE
feat(catalog): add pending flag to entity list context for stale-while-revalidate

### DIFF
--- a/.changeset/entity-list-pending.md
+++ b/.changeset/entity-list-pending.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-catalog-react': minor
+'@backstage/plugin-catalog': patch
+---
+
+Added a `pending` flag to the entity list context that is `true` only when fetching a new data set (initial load, filter or pagination change) and `false` during background refreshes. The catalog table now uses `pending` instead of `loading` for its skeleton and title spinner, so periodic and window-focus refreshes no longer flash a loading state over the existing table.

--- a/plugins/catalog-react/report.api.md
+++ b/plugins/catalog-react/report.api.md
@@ -478,6 +478,7 @@ export type EntityListContextProps<
   setLimit: (limit: number) => void;
   setOffset?: (offset: number) => void;
   paginationMode: PaginationMode;
+  pending: boolean;
   refresh?: () => void;
 };
 

--- a/plugins/catalog-react/src/deprecated.tsx
+++ b/plugins/catalog-react/src/deprecated.tsx
@@ -69,6 +69,7 @@ export function MockEntityListContextProvider<
       updateFilters: value?.updateFilters ?? updateFilters,
       filters,
       loading: value?.loading ?? false,
+      pending: value?.pending ?? value?.loading ?? false,
       queryParameters: value?.queryParameters ?? defaultValues.queryParameters,
       error: value?.error,
       totalItems:

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.test.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.test.tsx
@@ -436,6 +436,115 @@ describe('<EntityListProvider />', () => {
     });
   });
 
+  it('sets pending to false during a refresh-triggered fetch', async () => {
+    const deferred = createDeferred<GetEntitiesResponse>();
+    const { result } = renderHook(() => useEntityList(), {
+      wrapper: createWrapper({ pagination }),
+    });
+
+    await waitFor(() => {
+      expect(result.current.backendEntities.length).toBe(2);
+      expect(result.current.pending).toBe(false);
+    });
+
+    mockCatalogApi.getEntities!.mockReturnValueOnce(deferred);
+
+    act(() => {
+      result.current.refresh?.();
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(true);
+    });
+    expect(result.current.pending).toBe(false);
+
+    await act(async () => {
+      deferred.resolve({ items: entities });
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+      expect(result.current.pending).toBe(false);
+    });
+  });
+
+  it('sets pending to true during a filter-triggered fetch', async () => {
+    const deferred = createDeferred<GetEntitiesResponse>();
+    const { result } = renderHook(() => useEntityList(), {
+      wrapper: createWrapper({ pagination }),
+    });
+
+    await waitFor(() => {
+      expect(result.current.backendEntities.length).toBe(2);
+    });
+
+    mockCatalogApi.getEntities!.mockReturnValueOnce(deferred);
+
+    act(() => {
+      result.current.updateFilters({
+        kind: new EntityKindFilter('api', 'API'),
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(true);
+    });
+    expect(result.current.pending).toBe(true);
+
+    await act(async () => {
+      deferred.resolve({ items: [] });
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+      expect(result.current.pending).toBe(false);
+    });
+  });
+
+  it('resets pending after a failed refresh so the next filter change is pending', async () => {
+    const { result } = renderHook(() => useEntityList(), {
+      wrapper: createWrapper({ pagination }),
+    });
+
+    await waitFor(() => {
+      expect(result.current.backendEntities.length).toBe(2);
+    });
+
+    mockCatalogApi.getEntities!.mockRejectedValueOnce(new Error('boom'));
+
+    act(() => {
+      result.current.refresh?.();
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).toBeDefined();
+    });
+    expect(result.current.pending).toBe(false);
+
+    const deferred = createDeferred<GetEntitiesResponse>();
+    mockCatalogApi.getEntities!.mockReturnValueOnce(deferred);
+
+    act(() => {
+      result.current.updateFilters({
+        kind: new EntityKindFilter('api', 'API'),
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(true);
+    });
+    expect(result.current.pending).toBe(true);
+
+    await act(async () => {
+      deferred.resolve({ items: [] });
+    });
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+      expect(result.current.pending).toBe(false);
+    });
+  });
+
   it('uses the last applied filter even if an earlier request finishes later', async () => {
     const { result } = renderHook(() => useEntityList(), {
       wrapper: createWrapper({ pagination }),
@@ -1300,6 +1409,7 @@ describe('versioned context', () => {
       updateFilters: jest.fn(),
       queryParameters: {},
       loading: true,
+      pending: true,
       totalItemsLoading: false,
       limit: 277,
       setLimit: jest.fn(),

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
@@ -129,6 +129,16 @@ export type EntityListContextProps<
   paginationMode: PaginationMode;
 
   /**
+   * Whether the provider is loading a new data set (as opposed to
+   * revalidating the current one).  `true` on the initial load and
+   * after filter/pagination changes; `false` during background
+   * refreshes triggered by {@link EntityListContextProps.refresh}.
+   * Falls back to {@link EntityListContextProps.loading} when the
+   * provider implementation doesn't distinguish the two.
+   */
+  pending: boolean;
+
+  /**
    * Trigger refresh of entities and entity totals.
    */
   refresh?: () => void;
@@ -240,6 +250,7 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | undefined>();
   const [refreshToken, setRefreshToken] = useState(0);
+  const staleRefreshRef = useRef(false);
 
   // Tracks the params of the last API call so identical requests are
   // skipped even when requestedFilters changes (e.g. a label change
@@ -332,10 +343,12 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
     try {
       const result = await doFetch();
       if (gen === fetchGenRef.current) {
+        staleRefreshRef.current = false;
         setBackendState(result);
       }
     } catch (e) {
       if (gen === fetchGenRef.current) {
+        staleRefreshRef.current = false;
         // Clear the ref so the same params can be retried, and so
         // a response discarded due to a concurrent request (gen mismatch)
         // doesn't permanently block fetching those params again.
@@ -464,6 +477,7 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
   );
 
   const triggerRefresh = useCallback(() => {
+    staleRefreshRef.current = true;
     // Clear the ref to allow refetching with the same params.
     lastFetchParamsRef.current = undefined;
     setRefreshToken(t => t + 1);
@@ -490,6 +504,7 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
       updateFilters,
       queryParameters,
       loading,
+      pending: loading && !staleRefreshRef.current,
       error,
       pageInfo,
       totalItems:

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
@@ -456,6 +456,7 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
         | Partial<EntityFilter>
         | ((prevFilters: EntityFilters) => Partial<EntityFilters>),
     ) => {
+      staleRefreshRef.current = false;
       // changing filters will affect pagination, so we need to reset
       // the cursor and start from the first page.
       // TODO(vinzscam): this is currently causing issues at page reload
@@ -476,6 +477,16 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
     [paginationMode],
   );
 
+  const updateLimit = useCallback((newLimit: number) => {
+    staleRefreshRef.current = false;
+    setLimit(newLimit);
+  }, []);
+
+  const updateOffset = useCallback((newOffset: number) => {
+    staleRefreshRef.current = false;
+    setOffset(newOffset);
+  }, []);
+
   const triggerRefresh = useCallback(() => {
     staleRefreshRef.current = true;
     // Clear the ref to allow refetching with the same params.
@@ -491,8 +502,18 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
     const prevCursor = backendState.pageInfo?.prevCursor;
     const nextCursor = backendState.pageInfo?.nextCursor;
     return {
-      prev: prevCursor ? () => setCursor(prevCursor) : undefined,
-      next: nextCursor ? () => setCursor(nextCursor) : undefined,
+      prev: prevCursor
+        ? () => {
+            staleRefreshRef.current = false;
+            setCursor(prevCursor);
+          }
+        : undefined,
+      next: nextCursor
+        ? () => {
+            staleRefreshRef.current = false;
+            setCursor(nextCursor);
+          }
+        : undefined,
     };
   }, [paginationMode, backendState.pageInfo]);
 
@@ -514,8 +535,8 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
       totalItemsLoading: paginationMode !== 'none' && totalItemsLoading,
       limit,
       offset,
-      setLimit,
-      setOffset,
+      setLimit: updateLimit,
+      setOffset: updateOffset,
       paginationMode,
       refresh: triggerRefresh,
     }),
@@ -533,8 +554,8 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
       paginationMode,
       limit,
       offset,
-      setLimit,
-      setOffset,
+      updateLimit,
+      updateOffset,
       triggerRefresh,
     ],
   );

--- a/plugins/catalog-react/src/testUtils/MockEntityListContextProvider.tsx
+++ b/plugins/catalog-react/src/testUtils/MockEntityListContextProvider.tsx
@@ -69,6 +69,7 @@ export function MockEntityListContextProvider<
       updateFilters: value?.updateFilters ?? updateFilters,
       filters,
       loading: value?.loading ?? false,
+      pending: value?.pending ?? value?.loading ?? false,
       queryParameters: value?.queryParameters ?? defaultValues.queryParameters,
       error: value?.error,
       totalItems:

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -104,7 +104,7 @@ export const CatalogTable = (props: CatalogTableProps) => {
   const entityListContext = useEntityList();
 
   const {
-    loading,
+    pending,
     error,
     entities,
     filters,
@@ -121,7 +121,7 @@ export const CatalogTable = (props: CatalogTableProps) => {
   if (entities.length > 0) {
     hasHadData.current = true;
   }
-  const isLoading = loading && !hasHadData.current;
+  const isLoading = pending && !hasHadData.current;
 
   const tableColumns = useMemo(
     () =>
@@ -211,10 +211,10 @@ export const CatalogTable = (props: CatalogTableProps) => {
   // Show the count as long as we have one. Hide it only when new rows
   // have arrived but the count hasn't caught up yet — at that point
   // the old count would be wrong for the new data.
-  const countIsStale = !loading && totalItemsLoading;
+  const countIsStale = !pending && totalItemsLoading;
   const currentCount =
     typeof totalItems === 'number' && !countIsStale ? ` (${totalItems})` : '';
-  const somethingIsLoading = loading || totalItemsLoading;
+  const somethingIsLoading = pending || totalItemsLoading;
   // TODO(timbonicus): remove the title from the CatalogTable once using EntitySearchBar
   const titlePreamble = capitalize(
     filters.user?.value ?? t('catalogTable.allFilters'),

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -104,6 +104,7 @@ export const CatalogTable = (props: CatalogTableProps) => {
   const entityListContext = useEntityList();
 
   const {
+    loading,
     pending,
     error,
     entities,
@@ -211,7 +212,7 @@ export const CatalogTable = (props: CatalogTableProps) => {
   // Show the count as long as we have one. Hide it only when new rows
   // have arrived but the count hasn't caught up yet — at that point
   // the old count would be wrong for the new data.
-  const countIsStale = !pending && totalItemsLoading;
+  const countIsStale = !loading && totalItemsLoading;
   const currentCount =
     typeof totalItems === 'number' && !countIsStale ? ` (${totalItems})` : '';
   const somethingIsLoading = pending || totalItemsLoading;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds a `pending` flag to `EntityListContextProps` that is `true` only when fetching a **new** data set (initial load, filter/pagination changes) and `false` during background refreshes via `refresh()`. This matches react-query's `isPending` semantics and enables stale-while-revalidate behavior.

`CatalogTable` now uses `pending` instead of `loading` for its skeleton display and title spinner, so periodic and window-focus refreshes no longer flash a loading state over the existing table.

### Changes

- **`@backstage/plugin-catalog-react`**: Added `pending: boolean` to `EntityListContextProps`, tracked via a `staleRefreshRef` that is set when `triggerRefresh` fires and cleared when data arrives (success or failure).
- **`@backstage/plugin-catalog`**: `CatalogTable` uses `pending` for `isLoading`, `countIsStale`, and `somethingIsLoading` instead of `loading`.
- **Tests**: Three new tests verify `pending` is `false` during refresh, `true` during filter changes, and correctly resets after a failed refresh.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))