### PR TITLE
fix(ui): make span that contains breadcrumb separator align with rest of breadcrumbs text

### DIFF
--- a/.changeset/bright-lions-try.md
+++ b/.changeset/bright-lions-try.md
@@ -1,0 +1,7 @@
+---
+'@backstage/ui': patch
+---
+
+Make PluginHeader > Breadcrumbs separator align with rest of text
+
+**Affected components:** PluginHeader

--- a/packages/ui/src/components/PluginHeader/PluginHeader.module.css
+++ b/packages/ui/src/components/PluginHeader/PluginHeader.module.css
@@ -120,6 +120,10 @@
       flex-shrink: 0;
     }
 
+    & span[aria-hidden] {
+      display: flex;
+    }
+
     &[data-current] {
       flex: 1;
       min-width: 0;

--- a/packages/ui/src/components/PluginHeader/PluginHeader.module.css
+++ b/packages/ui/src/components/PluginHeader/PluginHeader.module.css
@@ -120,7 +120,7 @@
       flex-shrink: 0;
     }
 
-    & span[aria-hidden] {
+    & > span[aria-hidden] {
       display: flex;
     }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

BEFORE:
<img width="367" height="148" alt="Screenshot 2026-06-23 at 10 25 15" src="https://github.com/user-attachments/assets/1a248558-f660-4dd3-9594-a3b5ac1b3d9b" />


AFTER:
<img width="432" height="191" alt="Screenshot 2026-06-23 at 10 24 54" src="https://github.com/user-attachments/assets/354b4626-1546-4dfd-8493-f9958ef17c01" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
