### PR TITLE
backend-defaults: provide connections service by default

### DIFF
--- a/.changeset/calm-connections-connect.md
+++ b/.changeset/calm-connections-connect.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Backends created with `createBackend` now provide the Connections service by default, while still allowing applications to supply a custom implementation.

--- a/packages/backend-defaults/package.json
+++ b/packages/backend-defaults/package.json
@@ -140,6 +140,7 @@
     "@backstage/cli-node": "workspace:^",
     "@backstage/config": "workspace:^",
     "@backstage/config-loader": "workspace:^",
+    "@backstage/connections": "workspace:^",
     "@backstage/errors": "workspace:^",
     "@backstage/integration": "workspace:^",
     "@backstage/integration-aws-node": "workspace:^",

--- a/packages/backend-defaults/src/CreateBackend.test.ts
+++ b/packages/backend-defaults/src/CreateBackend.test.ts
@@ -16,9 +16,28 @@
 
 import {
   coreServices,
+  createBackendPlugin,
   createServiceFactory,
 } from '@backstage/backend-plugin-api';
+import { mockServices } from '@backstage/backend-test-utils';
+import {
+  ConnectionsService,
+  connectionsServiceRef,
+  declareConnection,
+  DefaultConnectionsService,
+} from '@backstage/connections';
 import { createBackend } from './CreateBackend';
+
+function createTestBackend() {
+  const backend = createBackend();
+  backend.add(
+    mockServices.rootConfig.factory({
+      data: { backend: { baseUrl: 'http://localhost:7007' } },
+    }),
+  );
+  backend.add(mockServices.rootHttpRouter.mock().factory);
+  return backend;
+}
 
 describe('createBackend', () => {
   it('should not throw when overriding a default service implementation', async () => {
@@ -82,5 +101,94 @@ describe('createBackend', () => {
     await expect(backend.start()).rejects.toThrow(
       'The core.pluginMetadata service cannot be overridden',
     );
+  });
+
+  it('should provide the connections service by default', async () => {
+    const backend = createTestBackend();
+    let connections: ConnectionsService | undefined;
+    backend.add(
+      createBackendPlugin({
+        pluginId: 'test',
+        register(reg) {
+          reg.registerInit({
+            deps: { connections: connectionsServiceRef },
+            async init(deps) {
+              connections = deps.connections;
+            },
+          });
+        },
+      }),
+    );
+
+    await backend.start();
+    expect(connections).toBeDefined();
+    await backend.stop();
+  });
+
+  it('should allow overriding the default connections service', async () => {
+    const backend = createTestBackend();
+    const customConnections: ConnectionsService = {
+      find: jest.fn(),
+    };
+    const customFactory = jest.fn(() => customConnections);
+    let connections: ConnectionsService | undefined;
+    backend.add(
+      createServiceFactory({
+        service: connectionsServiceRef,
+        deps: {},
+        factory: customFactory,
+      }),
+    );
+    backend.add(
+      createBackendPlugin({
+        pluginId: 'test',
+        register(reg) {
+          declareConnection(reg, {
+            type: 'github',
+            description: 'Used to test the custom service override',
+          });
+          reg.registerInit({
+            deps: { connections: connectionsServiceRef },
+            async init(deps) {
+              connections = deps.connections;
+            },
+          });
+        },
+      }),
+    );
+
+    await backend.start();
+    expect(customFactory).toHaveBeenCalledTimes(1);
+    await connections?.find({
+      type: 'github',
+      url: 'https://github.com/backstage/backstage',
+      authMethods: ['token'],
+    });
+    expect(customConnections.find).toHaveBeenCalledWith({
+      type: 'github',
+      url: 'https://github.com/backstage/backstage',
+      authMethods: ['token'],
+    });
+    await backend.stop();
+  });
+
+  it('should not initialize the connections service unless requested', async () => {
+    const createConnections = jest.spyOn(DefaultConnectionsService, 'create');
+    const backend = createTestBackend();
+    backend.add(
+      createBackendPlugin({
+        pluginId: 'test',
+        register(reg) {
+          reg.registerInit({
+            deps: {},
+            async init() {},
+          });
+        },
+      }),
+    );
+
+    await backend.start();
+    expect(createConnections).not.toHaveBeenCalled();
+    await backend.stop();
   });
 });

--- a/packages/backend-defaults/src/CreateBackend.ts
+++ b/packages/backend-defaults/src/CreateBackend.ts
@@ -16,6 +16,7 @@
 
 import { Backend, createSpecializedBackend } from '@backstage/backend-app-api';
 import { ServiceFactory } from '@backstage/backend-plugin-api';
+import { connectionsServiceFactory } from '@backstage/connections';
 import { auditorServiceFactory } from '@backstage/backend-defaults/auditor';
 import { authServiceFactory } from '@backstage/backend-defaults/auth';
 import { cacheServiceFactory } from '@backstage/backend-defaults/cache';
@@ -49,6 +50,7 @@ export const defaultServiceFactories: ServiceFactory[] = [
   auditorServiceFactory,
   authServiceFactory,
   cacheServiceFactory,
+  connectionsServiceFactory,
   rootConfigServiceFactory,
   databaseServiceFactory,
   discoveryServiceFactory,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2154,6 +2154,7 @@ __metadata:
     "@backstage/cli-node": "workspace:^"
     "@backstage/config": "workspace:^"
     "@backstage/config-loader": "workspace:^"
+    "@backstage/connections": "workspace:^"
     "@backstage/errors": "workspace:^"
     "@backstage/integration": "workspace:^"
     "@backstage/integration-aws-node": "workspace:^"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Makes the Connections service available by default in backends created with `createBackend` from `@backstage/backend-defaults`.

This is the first stage of adopting Connections as a standard backend service. The service remains plugin-scoped and lazily initialized, explicitly provided custom factories continue to override the default, and the auth backend does not depend on Connections yet. Existing Backstage applications therefore require no source-code changes.

Validation:

- `CI=1 yarn test packages/backend-defaults/src/CreateBackend.test.ts --detectOpenHandles`
- `yarn tsc`
- `yarn lint --fix`
- `node scripts/verify-local-dependencies.js`
- `yarn build:api-reports`

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (not applicable)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))