### PR TITLE
chore(integration): migrate tests to MSW v2

### DIFF
--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -53,7 +53,7 @@
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@backstage/config-loader": "workspace:^",
-    "msw": "^1.0.0"
+    "msw": "^2.0.0"
   },
   "configSchema": "config.d.ts"
 }

--- a/packages/integration/src/bitbucketCloud/core.test.ts
+++ b/packages/integration/src/bitbucketCloud/core.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { BitbucketCloudIntegrationConfig } from './config';
@@ -72,8 +72,8 @@ describe('bitbucketCloud core', () => {
     it('handles OAuth token fetch errors', async () => {
       // Test error handling
       worker.use(
-        rest.post(BITBUCKET_CLOUD_OAUTH_TOKEN_URL, (_, res, ctx) =>
-          res(ctx.status(401), ctx.json({ error: 'invalid_client' })),
+        http.post(BITBUCKET_CLOUD_OAUTH_TOKEN_URL, () =>
+          HttpResponse.json({ error: 'invalid_client' }, { status: 401 }),
         ),
       );
 
@@ -93,15 +93,12 @@ describe('bitbucketCloud core', () => {
       // Test OAuth + caching
       let callCount = 0;
       worker.use(
-        rest.post(BITBUCKET_CLOUD_OAUTH_TOKEN_URL, (_, res, ctx) => {
+        http.post(BITBUCKET_CLOUD_OAUTH_TOKEN_URL, () => {
           callCount++;
-          return res(
-            ctx.status(200),
-            ctx.json({
-              access_token: 'test-oauth-token',
-              expires_in: 3600,
-            }),
-          );
+          return HttpResponse.json({
+            access_token: 'test-oauth-token',
+            expires_in: 3600,
+          });
         }),
       );
 
@@ -175,14 +172,9 @@ describe('bitbucketCloud core', () => {
         },
       };
       worker.use(
-        rest.get(
+        http.get(
           'https://api.bitbucket.org/2.0/repositories/backstage/mock',
-          (_, res, ctx) =>
-            res(
-              ctx.status(200),
-              ctx.set('Content-Type', 'application/json'),
-              ctx.json(repoInfoResponse),
-            ),
+          () => HttpResponse.json(repoInfoResponse),
         ),
       );
       const config: BitbucketCloudIntegrationConfig = {

--- a/packages/integration/src/bitbucketServer/core.test.ts
+++ b/packages/integration/src/bitbucketServer/core.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { BitbucketServerIntegrationConfig } from './config';
@@ -108,14 +108,9 @@ describe('bitbucketServer core', () => {
         displayId: 'main',
       };
       worker.use(
-        rest.get(
+        http.get(
           'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/default-branch',
-          (_, res, ctx) =>
-            res(
-              ctx.status(200),
-              ctx.set('Content-Type', 'application/json'),
-              ctx.json(defaultBranchResponse),
-            ),
+          () => HttpResponse.json(defaultBranchResponse),
         ),
       );
 
@@ -151,14 +146,9 @@ describe('bitbucketServer core', () => {
         displayId: 'main',
       };
       worker.use(
-        rest.get(
+        http.get(
           'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/default-branch',
-          (_, res, ctx) =>
-            res(
-              ctx.status(200),
-              ctx.set('Content-Type', 'application/json'),
-              ctx.json(defaultBranchResponse),
-            ),
+          () => HttpResponse.json(defaultBranchResponse),
         ),
       );
       const config: BitbucketServerIntegrationConfig = {
@@ -196,14 +186,9 @@ describe('bitbucketServer core', () => {
         displayId: 'main',
       };
       worker.use(
-        rest.get(
+        http.get(
           'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/default-branch',
-          (_, res, ctx) =>
-            res(
-              ctx.status(200),
-              ctx.set('Content-Type', 'application/json'),
-              ctx.json(defaultBranchResponse),
-            ),
+          () => HttpResponse.json(defaultBranchResponse),
         ),
       );
       const config: BitbucketServerIntegrationConfig = {
@@ -222,23 +207,16 @@ describe('bitbucketServer core', () => {
         displayId: 'main',
       };
       worker.use(
-        rest.get(
+        http.get(
           'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/default-branch',
-          (_, res, ctx) =>
-            res(
-              ctx.status(404),
-              ctx.set('Content-Type', 'application/json'),
-              ctx.json(defaultBranchResponse),
-            ),
+          () =>
+            HttpResponse.json(defaultBranchResponse, {
+              status: 404,
+            }),
         ),
-        rest.get(
+        http.get(
           'https://api.bitbucket.mycompany.net/rest/api/1.0/projects/backstage/repos/mock/branches/default',
-          (_, res, ctx) =>
-            res(
-              ctx.status(200),
-              ctx.set('Content-Type', 'application/json'),
-              ctx.json(defaultBranchResponse),
-            ),
+          () => HttpResponse.json(defaultBranchResponse),
         ),
       );
       const config: BitbucketServerIntegrationConfig = {

--- a/packages/integration/src/gerrit/core.test.ts
+++ b/packages/integration/src/gerrit/core.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import fetch from 'cross-fetch';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
@@ -455,12 +455,10 @@ describe('gerrit core', () => {
       const responseBody = ")]}'[]";
       const apiUrl = 'https://gerrit.com/projects/';
       worker.use(
-        rest.get(apiUrl, (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.text(responseBody),
-          ),
+        http.get(apiUrl, () =>
+          HttpResponse.text(responseBody, {
+            headers: { 'Content-Type': 'application/json' },
+          }),
         ),
       );
       const response = await fetch(apiUrl, { method: 'GET' });
@@ -471,12 +469,10 @@ describe('gerrit core', () => {
       const responseBody = '[]';
       const apiUrl = 'https://gerrit.com/projects/';
       worker.use(
-        rest.get(apiUrl, (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.text(responseBody),
-          ),
+        http.get(apiUrl, () =>
+          HttpResponse.text(responseBody, {
+            headers: { 'Content-Type': 'application/json' },
+          }),
         ),
       );
       const response = await fetch(apiUrl, { method: 'GET' });
@@ -488,12 +484,10 @@ describe('gerrit core', () => {
       const responseBody = ")]}']{}[";
       const apiUrl = 'https://gerrit.com/projects/';
       worker.use(
-        rest.get(apiUrl, (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.text(responseBody),
-          ),
+        http.get(apiUrl, () =>
+          HttpResponse.text(responseBody, {
+            headers: { 'Content-Type': 'application/json' },
+          }),
         ),
       );
       const response = await fetch(apiUrl, { method: 'GET' });

--- a/packages/integration/src/gitlab/GitLabIntegration.test.ts
+++ b/packages/integration/src/gitlab/GitLabIntegration.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { setupServer } from 'msw/node';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { ConfigReader } from '@backstage/config';
 import {
   GitLabIntegration,
@@ -94,9 +94,9 @@ describe('GitLabIntegration', () => {
 
       let calledUrl: string | undefined;
       worker.use(
-        rest.get('https://h.com/api/v4', (req, res, ctx) => {
-          calledUrl = req.url.href;
-          return res(ctx.status(200));
+        http.get('https://h.com/api/v4', ({ request }) => {
+          calledUrl = request.url;
+          return new HttpResponse(null, { status: 200 });
         }),
       );
 
@@ -107,12 +107,12 @@ describe('GitLabIntegration', () => {
     it('applies retry logic when maxRetries > 0', async () => {
       let callCount = 0;
       worker.use(
-        rest.get('https://h.com/api/v4', (_req, res, ctx) => {
+        http.get('https://h.com/api/v4', () => {
           callCount += 1;
           if (callCount === 1) {
-            return res(ctx.status(429), ctx.json({}));
+            return new HttpResponse(null, { status: 429 });
           }
-          return res(ctx.status(200), ctx.json({}));
+          return HttpResponse.json({});
         }),
       );
 
@@ -138,9 +138,9 @@ describe('GitLabIntegration', () => {
     it('does not retry when status code is not in retryStatusCodes', async () => {
       let callCount = 0;
       worker.use(
-        rest.get('https://h.com/api/v4', (_req, res, ctx) => {
+        http.get('https://h.com/api/v4', () => {
           callCount += 1;
-          return res(ctx.status(404));
+          return new HttpResponse(null, { status: 404 });
         }),
       );
 
@@ -165,9 +165,9 @@ describe('GitLabIntegration', () => {
     it('stops retrying after maxRetries attempts', async () => {
       let callCount = 0;
       worker.use(
-        rest.get('https://h.com/api/v4', (_req, res, ctx) => {
+        http.get('https://h.com/api/v4', () => {
           callCount += 1;
-          return res(ctx.status(429));
+          return new HttpResponse(null, { status: 429 });
         }),
       );
 
@@ -222,12 +222,12 @@ describe('GitLabIntegration', () => {
 
       let callCount = 0;
       worker.use(
-        rest.get('https://h.com/api/v4', (_req, res, ctx) => {
+        http.get('https://h.com/api/v4', () => {
           callCount += 1;
           if (callCount === 1) {
-            return res(ctx.status(429), ctx.json({}));
+            return new HttpResponse(null, { status: 429 });
           }
-          return res(ctx.status(200), ctx.json({}));
+          return HttpResponse.json({});
         }),
       );
 
@@ -257,16 +257,15 @@ describe('GitLabIntegration', () => {
     it('retries based on configured status codes', async () => {
       let callCount = 0;
       worker.use(
-        rest.get('https://h.com/api/v4', (_req, res, ctx) => {
+        http.get('https://h.com/api/v4', () => {
           callCount += 1;
           if (callCount === 1) {
-            return res(
-              ctx.status(429),
-              ctx.set('Retry-After', '1'),
-              ctx.json({}),
-            );
+            return new HttpResponse(null, {
+              status: 429,
+              headers: { 'Retry-After': '1' },
+            });
           }
-          return res(ctx.status(200), ctx.json({}));
+          return HttpResponse.json({});
         }),
       );
 
@@ -291,12 +290,12 @@ describe('GitLabIntegration', () => {
     it('retries multiple times for persistent failures', async () => {
       let callCount = 0;
       worker.use(
-        rest.get('https://h.com/api/v4', (_req, res, ctx) => {
+        http.get('https://h.com/api/v4', () => {
           callCount += 1;
           if (callCount < 3) {
-            return res(ctx.status(500), ctx.json({}));
+            return new HttpResponse(null, { status: 500 });
           }
-          return res(ctx.status(200), ctx.json({}));
+          return HttpResponse.json({});
         }),
       );
 
@@ -323,12 +322,12 @@ describe('GitLabIntegration', () => {
     it('retries on transient network errors and returns once recovered', async () => {
       let callCount = 0;
       worker.use(
-        rest.get('https://h.com/api/v4', (_req, res, ctx) => {
+        http.get('https://h.com/api/v4', () => {
           callCount += 1;
           if (callCount === 1) {
-            return res.networkError('boom');
+            return HttpResponse.error();
           }
-          return res(ctx.status(200), ctx.json({}));
+          return HttpResponse.json({});
         }),
       );
 
@@ -353,9 +352,9 @@ describe('GitLabIntegration', () => {
     it('surfaces the error after exhausting retries on persistent network errors', async () => {
       let callCount = 0;
       worker.use(
-        rest.get('https://h.com/api/v4', (_req, res) => {
+        http.get('https://h.com/api/v4', () => {
           callCount += 1;
-          return res.networkError('boom');
+          return HttpResponse.error();
         }),
       );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3559,7 +3559,7 @@ __metadata:
     git-url-parse: "npm:^15.0.0"
     lodash: "npm:^4.17.21"
     luxon: "npm:^3.0.0"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     p-throttle: "npm:^4.1.1"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Migrates MSW-based tests in `@backstage/integration` from MSW 1.x to MSW 2.x.

This is part of the ongoing effort to adopt native `fetch` in backend code ([ADR014](https://github.com/backstage/backstage/blob/master/docs/architecture-decisions/adr014-use-fetch.md)). MSW 1.x does not reliably intercept native `fetch`; MSW 2.x uses updated interceptors that do.

Follows #34683 in the broader MSW 2 migration. Changes are limited to test files and devDependencies — no production code or published API surface is affected.

GitLab retry tests use `new HttpResponse(null, { status })` for retryable error responses. Under MSW 2, JSON error bodies can hang under Jest fake timers because the retry path awaits `response.body?.cancel()` when a body is present. Retry policy and timing behavior remain fully covered.