### PR TITLE
chore(plugin-notifications-backend-module-slack): remove unused msw devDependency

### DIFF
--- a/plugins/notifications-backend-module-slack/knip-report.md
+++ b/plugins/notifications-backend-module-slack/knip-report.md
@@ -4,14 +4,13 @@
 
 | Name         | Location          | Severity |
 | :----------- | :---------------- | :------- |
-| @slack/types | package.json:46:6 | error    |
-| @slack/bolt  | package.json:45:6 | error    |
+| @slack/types | package.json:47:6 | error    |
+| @slack/bolt  | package.json:46:6 | error    |
 
-## Unused devDependencies (3)
+## Unused devDependencies (2)
 
 | Name                  | Location          | Severity |
 | :-------------------- | :---------------- | :------- |
-| @backstage/test-utils | package.json:54:6 | error    |
-| @faker-js/faker       | package.json:55:6 | error    |
-| msw                   | package.json:56:6 | error    |
+| @backstage/test-utils | package.json:56:6 | error    |
+| @faker-js/faker       | package.json:57:6 | error    |
 

--- a/plugins/notifications-backend-module-slack/package.json
+++ b/plugins/notifications-backend-module-slack/package.json
@@ -54,8 +54,7 @@
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@backstage/test-utils": "workspace:^",
-    "@faker-js/faker": "^10.0.0",
-    "msw": "^2.0.0"
+    "@faker-js/faker": "^10.0.0"
   },
   "configSchema": "config.d.ts"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5908,7 +5908,6 @@ __metadata:
     "@slack/web-api": "npm:^7.5.0"
     dataloader: "npm:^2.0.0"
     knex: "npm:^3.0.0"
-    msw: "npm:^2.0.0"
     p-throttle: "npm:^4.1.1"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Removes unused `msw` devDependencies from packages that declare it but never import or use it.