### PR TITLE
chore(catalog): migrate tests to MSW v2

### DIFF
--- a/packages/catalog-client/package.json
+++ b/packages/catalog-client/package.json
@@ -59,6 +59,6 @@
   "devDependencies": {
     "@backstage/cli": "workspace:^",
     "@types/lodash": "^4.14.151",
-    "msw": "^1.0.0"
+    "msw": "^2.0.0"
   }
 }

--- a/packages/catalog-client/src/CatalogClient.test.ts
+++ b/packages/catalog-client/src/CatalogClient.test.ts
@@ -340,7 +340,7 @@ describe('CatalogClient', () => {
     });
 
     it('merges filter and query into $all predicate when both are provided', async () => {
-      expect.assertions(3);
+      expect.assertions(4);
       const entity = {
         apiVersion: '1',
         kind: 'Component',
@@ -353,11 +353,9 @@ describe('CatalogClient', () => {
         http.post(`${mockBaseUrl}/entities/by-refs`, async ({ request }) => {
           expect(new URL(request.url).search).toBe('');
           const body = await request.json();
-          expect(body).toMatchObject({
-            entityRefs: ['k:n/a'],
-            query: {
-              $all: [{ kind: 'Component' }, { kind: 'API' }],
-            },
+          expect(body.entityRefs).toEqual(['k:n/a']);
+          expect(body.query).toEqual({
+            $all: [{ kind: 'Component' }, { kind: 'API' }],
           });
           return HttpResponse.json({ items: [entity] });
         }),

--- a/packages/catalog-client/src/CatalogClient.test.ts
+++ b/packages/catalog-client/src/CatalogClient.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { Entity } from '@backstage/catalog-model';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { CatalogClient } from './CatalogClient';
 import {
@@ -71,8 +71,8 @@ describe('CatalogClient', () => {
 
     beforeEach(() => {
       server.use(
-        rest.get(`${mockBaseUrl}/entities`, (_, res, ctx) => {
-          return res(ctx.json(defaultServiceResponse));
+        http.get(`${mockBaseUrl}/entities`, () => {
+          return HttpResponse.json(defaultServiceResponse);
         }),
       );
     });
@@ -86,14 +86,14 @@ describe('CatalogClient', () => {
       expect.assertions(2);
 
       server.use(
-        rest.get(`${mockBaseUrl}/entities`, (req, res, ctx) => {
-          const queryParams = new URLSearchParams(req.url.search);
+        http.get(`${mockBaseUrl}/entities`, ({ request }) => {
+          const queryParams = new URLSearchParams(new URL(request.url).search);
           expect(queryParams.getAll('filter')).toEqual([
             'a=1,b=2,b=3,ö==',
             'a=2',
             'c',
           ]);
-          return res(ctx.json([]));
+          return HttpResponse.json([]);
         }),
       );
 
@@ -123,10 +123,10 @@ describe('CatalogClient', () => {
       expect.assertions(2);
 
       server.use(
-        rest.get(`${mockBaseUrl}/entities`, (req, res, ctx) => {
-          const queryParams = new URLSearchParams(req.url.search);
+        http.get(`${mockBaseUrl}/entities`, ({ request }) => {
+          const queryParams = new URLSearchParams(new URL(request.url).search);
           expect(queryParams.getAll('filter')).toEqual(['a=1,b=2,b=3,ö==,c']);
-          return res(ctx.json([]));
+          return HttpResponse.json([]);
         }),
       );
 
@@ -148,11 +148,11 @@ describe('CatalogClient', () => {
     it('builds search filters property even those with URL unsafe values', async () => {
       const mockedEndpoint = jest
         .fn()
-        .mockImplementation((_req, res, ctx) =>
-          res(ctx.json({ items: [], totalItems: 0 })),
+        .mockImplementation(() =>
+          HttpResponse.json({ items: [], totalItems: 0 }),
         );
 
-      server.use(rest.get(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
+      server.use(http.get(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
 
       const response = await client.queryEntities(
         {
@@ -170,7 +170,7 @@ describe('CatalogClient', () => {
       expect(mockedEndpoint).toHaveBeenCalledTimes(1);
 
       const queryParams = new URLSearchParams(
-        mockedEndpoint.mock.calls[0][0].url.search,
+        new URL(mockedEndpoint.mock.calls[0][0].request.url).search,
       );
       expect(queryParams.getAll('filter')).toEqual([
         '!@#$%=t?i=1&a:2,^&*(){}[]=t%^url*encoded2,^&*(){}[]=url',
@@ -181,10 +181,10 @@ describe('CatalogClient', () => {
       expect.assertions(2);
 
       server.use(
-        rest.get(`${mockBaseUrl}/entities`, (req, res, ctx) => {
-          const queryParams = new URLSearchParams(req.url.search);
+        http.get(`${mockBaseUrl}/entities`, ({ request }) => {
+          const queryParams = new URLSearchParams(new URL(request.url).search);
           expect(queryParams.getAll('fields')).toEqual(['a.b,ö']);
-          return res(ctx.json([]));
+          return HttpResponse.json([]);
         }),
       );
 
@@ -200,8 +200,8 @@ describe('CatalogClient', () => {
 
     it('handles field filtered entities', async () => {
       server.use(
-        rest.get(`${mockBaseUrl}/entities`, (_req, res, ctx) => {
-          return res(ctx.json([{ apiVersion: '1' }, { apiVersion: '2' }]));
+        http.get(`${mockBaseUrl}/entities`, () => {
+          return HttpResponse.json([{ apiVersion: '1' }, { apiVersion: '2' }]);
         }),
       );
 
@@ -222,9 +222,11 @@ describe('CatalogClient', () => {
       expect.assertions(2);
 
       server.use(
-        rest.get(`${mockBaseUrl}/entities`, (req, res, ctx) => {
-          expect(req.url.search).toBe('?limit=2&offset=1&after=%3D');
-          return res(ctx.json([]));
+        http.get(`${mockBaseUrl}/entities`, ({ request }) => {
+          expect(new URL(request.url).search).toBe(
+            '?limit=2&offset=1&after=%3D',
+          );
+          return HttpResponse.json([]);
         }),
       );
 
@@ -244,13 +246,13 @@ describe('CatalogClient', () => {
       ];
 
       server.use(
-        rest.get(`${mockBaseUrl}/entities`, (req, res, ctx) => {
-          const queryParams = new URLSearchParams(req.url.search);
+        http.get(`${mockBaseUrl}/entities`, ({ request }) => {
+          const queryParams = new URLSearchParams(new URL(request.url).search);
           expect(queryParams.getAll('order')).toEqual([
             'asc:kind',
             'desc:metadata.name',
           ]);
-          return res(ctx.json(sortedEntities));
+          return HttpResponse.json(sortedEntities);
         }),
       );
 
@@ -279,13 +281,15 @@ describe('CatalogClient', () => {
         },
       };
       server.use(
-        rest.post(`${mockBaseUrl}/entities/by-refs`, async (req, res, ctx) => {
-          expect(req.url.search).toBe('?filter=kind%3DAPI%2Ckind%3DComponent');
-          await expect(req.json()).resolves.toEqual({
+        http.post(`${mockBaseUrl}/entities/by-refs`, async ({ request }) => {
+          expect(new URL(request.url).search).toBe(
+            '?filter=kind%3DAPI%2Ckind%3DComponent',
+          );
+          await expect(request.json()).resolves.toEqual({
             entityRefs: ['k:n/a', 'k:n/b'],
             fields: ['a', 'b'],
           });
-          return res(ctx.json({ items: [entity, null] }));
+          return HttpResponse.json({ items: [entity, null] });
         }),
       );
 
@@ -314,13 +318,13 @@ describe('CatalogClient', () => {
         },
       };
       server.use(
-        rest.post(`${mockBaseUrl}/entities/by-refs`, async (req, res, ctx) => {
-          expect(req.url.search).toBe('');
-          await expect(req.json()).resolves.toEqual({
+        http.post(`${mockBaseUrl}/entities/by-refs`, async ({ request }) => {
+          expect(new URL(request.url).search).toBe('');
+          await expect(request.json()).resolves.toEqual({
             entityRefs: ['k:n/a'],
             query: { kind: 'Component' },
           });
-          return res(ctx.json({ items: [entity] }));
+          return HttpResponse.json({ items: [entity] });
         }),
       );
 
@@ -346,14 +350,14 @@ describe('CatalogClient', () => {
         },
       };
       server.use(
-        rest.post(`${mockBaseUrl}/entities/by-refs`, async (req, res, ctx) => {
-          expect(req.url.search).toBe('');
-          const body = await req.json();
+        http.post(`${mockBaseUrl}/entities/by-refs`, async ({ request }) => {
+          expect(new URL(request.url).search).toBe('');
+          const body = await request.json();
           expect(body.entityRefs).toEqual(['k:n/a']);
           expect(body.query).toEqual({
             $all: [{ kind: 'Component' }, { kind: 'API' }],
           });
-          return res(ctx.json({ items: [entity] }));
+          return HttpResponse.json({ items: [entity] });
         }),
       );
 
@@ -380,12 +384,12 @@ describe('CatalogClient', () => {
         },
       };
       server.use(
-        rest.post(`${mockBaseUrl}/entities/by-refs`, async (req, res, ctx) => {
-          expect(req.url.search).toBe('?filter=kind%3DAPI');
-          const body = await req.json();
+        http.post(`${mockBaseUrl}/entities/by-refs`, async ({ request }) => {
+          expect(new URL(request.url).search).toBe('?filter=kind%3DAPI');
+          const body = await request.json();
           expect(body).toEqual({ entityRefs: ['k:n/a'] });
           expect(body.query).toBeUndefined();
-          return res(ctx.json({ items: [entity] }));
+          return HttpResponse.json({ items: [entity] });
         }),
       );
 
@@ -430,8 +434,8 @@ describe('CatalogClient', () => {
 
     beforeEach(() => {
       server.use(
-        rest.get(`${mockBaseUrl}/entities/by-query`, (_, res, ctx) => {
-          return res(ctx.json(defaultResponse));
+        http.get(`${mockBaseUrl}/entities/by-query`, () => {
+          return HttpResponse.json(defaultResponse);
         }),
       );
     });
@@ -447,11 +451,11 @@ describe('CatalogClient', () => {
     it('builds multiple entity search filters properly', async () => {
       const mockedEndpoint = jest
         .fn()
-        .mockImplementation((_req, res, ctx) =>
-          res(ctx.json({ items: [], totalItems: 0 })),
+        .mockImplementation(() =>
+          HttpResponse.json({ items: [], totalItems: 0 }),
         );
 
-      server.use(rest.get(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
+      server.use(http.get(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
 
       const response = await client.queryEntities(
         {
@@ -476,7 +480,7 @@ describe('CatalogClient', () => {
       expect(mockedEndpoint).toHaveBeenCalledTimes(1);
 
       const queryParams = new URLSearchParams(
-        mockedEndpoint.mock.calls[0][0].url.search,
+        new URL(mockedEndpoint.mock.calls[0][0].request.url).search,
       );
       expect(queryParams.getAll('filter')).toEqual([
         'a=1,b=2,b=3,ö==',
@@ -488,11 +492,11 @@ describe('CatalogClient', () => {
     it('builds search filters property even those with URL unsafe values', async () => {
       const mockedEndpoint = jest
         .fn()
-        .mockImplementation((_req, res, ctx) =>
-          res(ctx.json({ items: [], totalItems: 0 })),
+        .mockImplementation(() =>
+          HttpResponse.json({ items: [], totalItems: 0 }),
         );
 
-      server.use(rest.get(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
+      server.use(http.get(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
 
       const response = await client.queryEntities(
         {
@@ -509,7 +513,7 @@ describe('CatalogClient', () => {
       expect(response).toEqual({ items: [], totalItems: 0 });
       expect(mockedEndpoint).toHaveBeenCalledTimes(1);
       const queryParams = new URLSearchParams(
-        mockedEndpoint.mock.calls[0][0].url.search,
+        new URL(mockedEndpoint.mock.calls[0][0].request.url).search,
       );
       expect(queryParams.getAll('filter')).toEqual([
         '!@#$%=t?i=1&a:2,^&*(){}[]=t%^url*encoded2,^&*(){}[]=url',
@@ -519,11 +523,11 @@ describe('CatalogClient', () => {
     it('should send query params correctly on initial request', async () => {
       const mockedEndpoint = jest
         .fn()
-        .mockImplementation((_req, res, ctx) =>
-          res(ctx.json({ items: [], totalItems: 0 })),
+        .mockImplementation(() =>
+          HttpResponse.json({ items: [], totalItems: 0 }),
         );
 
-      server.use(rest.get(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
+      server.use(http.get(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
 
       await client.queryEntities({
         fields: ['a', 'b'],
@@ -538,7 +542,7 @@ describe('CatalogClient', () => {
       });
 
       const queryParams = new URLSearchParams(
-        mockedEndpoint.mock.calls[0][0].url.search,
+        new URL(mockedEndpoint.mock.calls[0][0].request.url).search,
       );
       expect(queryParams.getAll('fields')).toEqual(['a,b']);
       expect(queryParams.getAll('limit')).toEqual(['100']);
@@ -552,11 +556,11 @@ describe('CatalogClient', () => {
     it('should ignore initial query params if cursor is passed', async () => {
       const mockedEndpoint = jest
         .fn()
-        .mockImplementation((_req, res, ctx) =>
-          res(ctx.json({ items: [], totalItems: 0 })),
+        .mockImplementation(() =>
+          HttpResponse.json({ items: [], totalItems: 0 }),
         );
 
-      server.use(rest.get(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
+      server.use(http.get(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
 
       await client.queryEntities({
         fields: ['a', 'b'],
@@ -567,59 +571,59 @@ describe('CatalogClient', () => {
         orderFields: [{ field: 'metadata.name', order: 'asc' }],
         cursor: 'cursor',
       });
-      expect(mockedEndpoint.mock.calls[0][0].url.search).toBe(
+      expect(new URL(mockedEndpoint.mock.calls[0][0].request.url).search).toBe(
         '?fields=a,b&limit=100&cursor=cursor',
       );
     });
 
     it('should return paginated functions if next and prev cursors are present', async () => {
-      const mockedEndpoint = jest.fn().mockImplementation((_req, res, ctx) =>
-        res(
-          ctx.json({
-            items: [
-              {
-                apiVersion: 'v1',
-                kind: 'CustomKind',
-                metadata: {
-                  namespace: 'default',
-                  name: 'e1',
-                },
+      const mockedEndpoint = jest.fn().mockImplementation(() =>
+        HttpResponse.json({
+          items: [
+            {
+              apiVersion: 'v1',
+              kind: 'CustomKind',
+              metadata: {
+                namespace: 'default',
+                name: 'e1',
               },
-              {
-                apiVersion: 'v1',
-                kind: 'CustomKind',
-                metadata: {
-                  namespace: 'default',
-                  name: 'e2',
-                },
-              },
-            ],
-            pageInfo: {
-              nextCursor: 'nextcursor',
-              prevCursor: 'prevcursor',
             },
-            totalItems: 100,
-          } as QueryEntitiesResponse),
-        ),
+            {
+              apiVersion: 'v1',
+              kind: 'CustomKind',
+              metadata: {
+                namespace: 'default',
+                name: 'e2',
+              },
+            },
+          ],
+          pageInfo: {
+            nextCursor: 'nextcursor',
+            prevCursor: 'prevcursor',
+          },
+          totalItems: 100,
+        } as QueryEntitiesResponse),
       );
 
-      server.use(rest.get(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
+      server.use(http.get(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
 
       const response = await client.queryEntities({
         limit: 2,
       });
-      expect(mockedEndpoint.mock.calls[0][0].url.search).toBe('?limit=2');
+      expect(new URL(mockedEndpoint.mock.calls[0][0].request.url).search).toBe(
+        '?limit=2',
+      );
 
       expect(response?.pageInfo.nextCursor).toBeDefined();
       expect(response?.pageInfo.prevCursor).toBeDefined();
 
       await client.queryEntities({ cursor: response!.pageInfo.nextCursor! });
-      expect(mockedEndpoint.mock.calls[1][0].url.search).toBe(
+      expect(new URL(mockedEndpoint.mock.calls[1][0].request.url).search).toBe(
         '?cursor=nextcursor',
       );
 
       await client.queryEntities({ cursor: response!.pageInfo.prevCursor! });
-      expect(mockedEndpoint.mock.calls[2][0].url.search).toBe(
+      expect(new URL(mockedEndpoint.mock.calls[2][0].request.url).search).toBe(
         '?cursor=prevcursor',
       );
     });
@@ -627,9 +631,9 @@ describe('CatalogClient', () => {
     it('should handle errors', async () => {
       const mockedEndpoint = jest
         .fn()
-        .mockImplementation((_req, res, ctx) => res(ctx.status(401)));
+        .mockImplementation(() => new HttpResponse(null, { status: 401 }));
 
-      server.use(rest.get(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
+      server.use(http.get(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
 
       await expect(() => client.queryEntities()).rejects.toThrow(
         /Request failed with 401 Unauthorized/,
@@ -670,16 +674,19 @@ describe('CatalogClient', () => {
     };
 
     it('should use POST endpoint when query is provided', async () => {
-      const mockedEndpoint = jest.fn().mockImplementation((req, res, ctx) => {
-        expect(req.method).toBe('POST');
-        expect(req.body).toMatchObject({
-          query: { kind: 'component' },
-          limit: 20,
+      const mockedEndpoint = jest
+        .fn()
+        .mockImplementation(async ({ request }) => {
+          expect(request.method).toBe('POST');
+          const body = await request.json();
+          expect(body).toMatchObject({
+            query: { kind: 'component' },
+            limit: 20,
+          });
+          return HttpResponse.json(defaultResponse);
         });
-        return res(ctx.json(defaultResponse));
-      });
 
-      server.use(rest.post(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
+      server.use(http.post(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
 
       const response = await client.queryEntities({
         query: { kind: 'component' },
@@ -692,16 +699,19 @@ describe('CatalogClient', () => {
     });
 
     it('should support $all operator', async () => {
-      const mockedEndpoint = jest.fn().mockImplementation((req, res, ctx) => {
-        expect(req.body).toMatchObject({
-          query: {
-            $all: [{ kind: 'component' }, { 'spec.type': 'service' }],
-          },
+      const mockedEndpoint = jest
+        .fn()
+        .mockImplementation(async ({ request }) => {
+          const body = await request.json();
+          expect(body).toMatchObject({
+            query: {
+              $all: [{ kind: 'component' }, { 'spec.type': 'service' }],
+            },
+          });
+          return HttpResponse.json(defaultResponse);
         });
-        return res(ctx.json(defaultResponse));
-      });
 
-      server.use(rest.post(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
+      server.use(http.post(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
 
       await client.queryEntities({
         query: {
@@ -713,16 +723,19 @@ describe('CatalogClient', () => {
     });
 
     it('should support $any operator', async () => {
-      const mockedEndpoint = jest.fn().mockImplementation((req, res, ctx) => {
-        expect(req.body).toMatchObject({
-          query: {
-            $any: [{ 'spec.type': 'service' }, { 'spec.type': 'website' }],
-          },
+      const mockedEndpoint = jest
+        .fn()
+        .mockImplementation(async ({ request }) => {
+          const body = await request.json();
+          expect(body).toMatchObject({
+            query: {
+              $any: [{ 'spec.type': 'service' }, { 'spec.type': 'website' }],
+            },
+          });
+          return HttpResponse.json(defaultResponse);
         });
-        return res(ctx.json(defaultResponse));
-      });
 
-      server.use(rest.post(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
+      server.use(http.post(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
 
       await client.queryEntities({
         query: {
@@ -734,16 +747,19 @@ describe('CatalogClient', () => {
     });
 
     it('should support $not operator', async () => {
-      const mockedEndpoint = jest.fn().mockImplementation((req, res, ctx) => {
-        expect(req.body).toMatchObject({
-          query: {
-            $not: { 'spec.lifecycle': 'experimental' },
-          },
+      const mockedEndpoint = jest
+        .fn()
+        .mockImplementation(async ({ request }) => {
+          const body = await request.json();
+          expect(body).toMatchObject({
+            query: {
+              $not: { 'spec.lifecycle': 'experimental' },
+            },
+          });
+          return HttpResponse.json(defaultResponse);
         });
-        return res(ctx.json(defaultResponse));
-      });
 
-      server.use(rest.post(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
+      server.use(http.post(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
 
       await client.queryEntities({
         query: {
@@ -755,16 +771,19 @@ describe('CatalogClient', () => {
     });
 
     it('should support $exists operator', async () => {
-      const mockedEndpoint = jest.fn().mockImplementation((req, res, ctx) => {
-        expect(req.body).toMatchObject({
-          query: {
-            'spec.owner': { $exists: true },
-          },
+      const mockedEndpoint = jest
+        .fn()
+        .mockImplementation(async ({ request }) => {
+          const body = await request.json();
+          expect(body).toMatchObject({
+            query: {
+              'spec.owner': { $exists: true },
+            },
+          });
+          return HttpResponse.json(defaultResponse);
         });
-        return res(ctx.json(defaultResponse));
-      });
 
-      server.use(rest.post(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
+      server.use(http.post(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
 
       await client.queryEntities({
         query: {
@@ -776,16 +795,19 @@ describe('CatalogClient', () => {
     });
 
     it('should support $in operator', async () => {
-      const mockedEndpoint = jest.fn().mockImplementation((req, res, ctx) => {
-        expect(req.body).toMatchObject({
-          query: {
-            'spec.owner': { $in: ['team-a', 'team-b', 'team-c'] },
-          },
+      const mockedEndpoint = jest
+        .fn()
+        .mockImplementation(async ({ request }) => {
+          const body = await request.json();
+          expect(body).toMatchObject({
+            query: {
+              'spec.owner': { $in: ['team-a', 'team-b', 'team-c'] },
+            },
+          });
+          return HttpResponse.json(defaultResponse);
         });
-        return res(ctx.json(defaultResponse));
-      });
 
-      server.use(rest.post(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
+      server.use(http.post(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
 
       await client.queryEntities({
         query: {
@@ -797,26 +819,32 @@ describe('CatalogClient', () => {
     });
 
     it('should support complex nested predicates', async () => {
-      const mockedEndpoint = jest.fn().mockImplementation((req, res, ctx) => {
-        expect(req.body).toMatchObject({
-          query: {
-            $all: [
-              { kind: 'component' },
-              {
-                $any: [{ 'spec.type': 'service' }, { 'spec.type': 'website' }],
-              },
-              {
-                $not: {
-                  'spec.lifecycle': 'experimental',
+      const mockedEndpoint = jest
+        .fn()
+        .mockImplementation(async ({ request }) => {
+          const body = await request.json();
+          expect(body).toMatchObject({
+            query: {
+              $all: [
+                { kind: 'component' },
+                {
+                  $any: [
+                    { 'spec.type': 'service' },
+                    { 'spec.type': 'website' },
+                  ],
                 },
-              },
-            ],
-          },
+                {
+                  $not: {
+                    'spec.lifecycle': 'experimental',
+                  },
+                },
+              ],
+            },
+          });
+          return HttpResponse.json(defaultResponse);
         });
-        return res(ctx.json(defaultResponse));
-      });
 
-      server.use(rest.post(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
+      server.use(http.post(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
 
       await client.queryEntities({
         query: {
@@ -838,14 +866,17 @@ describe('CatalogClient', () => {
     });
 
     it('should send orderFields with correct format', async () => {
-      const mockedEndpoint = jest.fn().mockImplementation((req, res, ctx) => {
-        expect(req.body.orderBy).toEqual([
-          { field: 'metadata.name', order: 'asc' },
-        ]);
-        return res(ctx.json(defaultResponse));
-      });
+      const mockedEndpoint = jest
+        .fn()
+        .mockImplementation(async ({ request }) => {
+          const body = await request.json();
+          expect(body.orderBy).toEqual([
+            { field: 'metadata.name', order: 'asc' },
+          ]);
+          return HttpResponse.json(defaultResponse);
+        });
 
-      server.use(rest.post(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
+      server.use(http.post(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
 
       await client.queryEntities({
         query: { kind: 'component' },
@@ -856,15 +887,18 @@ describe('CatalogClient', () => {
     });
 
     it('should send multiple orderFields with correct format', async () => {
-      const mockedEndpoint = jest.fn().mockImplementation((req, res, ctx) => {
-        expect(req.body.orderBy).toEqual([
-          { field: 'metadata.name', order: 'asc' },
-          { field: 'spec.type', order: 'desc' },
-        ]);
-        return res(ctx.json(defaultResponse));
-      });
+      const mockedEndpoint = jest
+        .fn()
+        .mockImplementation(async ({ request }) => {
+          const body = await request.json();
+          expect(body.orderBy).toEqual([
+            { field: 'metadata.name', order: 'asc' },
+            { field: 'spec.type', order: 'desc' },
+          ]);
+          return HttpResponse.json(defaultResponse);
+        });
 
-      server.use(rest.post(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
+      server.use(http.post(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
 
       await client.queryEntities({
         query: { kind: 'component' },
@@ -878,12 +912,15 @@ describe('CatalogClient', () => {
     });
 
     it('should send limit and offset parameters in the body', async () => {
-      const mockedEndpoint = jest.fn().mockImplementation((req, res, ctx) => {
-        expect(req.body.limit).toBe(50);
-        return res(ctx.json(defaultResponse));
-      });
+      const mockedEndpoint = jest
+        .fn()
+        .mockImplementation(async ({ request }) => {
+          const body = await request.json();
+          expect(body.limit).toBe(50);
+          return HttpResponse.json(defaultResponse);
+        });
 
-      server.use(rest.post(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
+      server.use(http.post(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
 
       await client.queryEntities({
         query: { kind: 'component' },
@@ -917,13 +954,16 @@ describe('CatalogClient', () => {
         pageInfo: {},
       };
 
-      const mockedEndpoint = jest.fn().mockImplementation((req, res, ctx) => {
-        expect(req.method).toBe('POST');
-        expect(req.body).toMatchObject({ cursor: cursorPayload });
-        return res(ctx.json(page2Response));
-      });
+      const mockedEndpoint = jest
+        .fn()
+        .mockImplementation(async ({ request }) => {
+          expect(request.method).toBe('POST');
+          const body = await request.json();
+          expect(body).toMatchObject({ cursor: cursorPayload });
+          return HttpResponse.json(page2Response);
+        });
 
-      server.use(rest.post(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
+      server.use(http.post(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
 
       const response = await client.queryEntities({
         cursor: cursorPayload,
@@ -945,21 +985,19 @@ describe('CatalogClient', () => {
         }),
       ).toString('base64');
 
-      const mockedGetEndpoint = jest.fn().mockImplementation((_req, res, ctx) =>
-        res(
-          ctx.json({
-            items: [],
-            totalItems: 50,
-            pageInfo: {},
-          }),
-        ),
+      const mockedGetEndpoint = jest.fn().mockImplementation(() =>
+        HttpResponse.json({
+          items: [],
+          totalItems: 50,
+          pageInfo: {},
+        }),
       );
 
       const mockedPostEndpoint = jest.fn();
 
       server.use(
-        rest.get(`${mockBaseUrl}/entities/by-query`, mockedGetEndpoint),
-        rest.post(`${mockBaseUrl}/entities/by-query`, mockedPostEndpoint),
+        http.get(`${mockBaseUrl}/entities/by-query`, mockedGetEndpoint),
+        http.post(`${mockBaseUrl}/entities/by-query`, mockedPostEndpoint),
       );
 
       await client.queryEntities({ cursor: cursorPayload });
@@ -971,9 +1009,9 @@ describe('CatalogClient', () => {
     it('should handle errors from POST endpoint', async () => {
       const mockedEndpoint = jest
         .fn()
-        .mockImplementation((_req, res, ctx) => res(ctx.status(400)));
+        .mockImplementation(() => new HttpResponse(null, { status: 400 }));
 
-      server.use(rest.post(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
+      server.use(http.post(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
 
       await expect(() =>
         client.queryEntities({ query: { kind: 'component' } }),
@@ -1010,12 +1048,16 @@ describe('CatalogClient', () => {
 
     beforeEach(() => {
       server.use(
-        rest.get(`${mockBaseUrl}/entities/by-query`, (req, res, ctx) => {
-          const cursor = req.url.searchParams.get('cursor');
+        http.get(`${mockBaseUrl}/entities/by-query`, ({ request }) => {
+          const cursor = new URL(request.url).searchParams.get('cursor');
           if (cursor === 'next') {
-            return res(ctx.json({ items: [], pageInfo: {}, totalItems: 0 }));
+            return HttpResponse.json({
+              items: [],
+              pageInfo: {},
+              totalItems: 0,
+            });
           }
-          return res(ctx.json(defaultResponse));
+          return HttpResponse.json(defaultResponse);
         }),
       );
     });
@@ -1032,9 +1074,9 @@ describe('CatalogClient', () => {
     it('should handle errors', async () => {
       const mockedEndpoint = jest
         .fn()
-        .mockImplementation((_req, res, ctx) => res(ctx.status(401)));
+        .mockImplementation(() => new HttpResponse(null, { status: 401 }));
 
-      server.use(rest.get(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
+      server.use(http.get(`${mockBaseUrl}/entities/by-query`, mockedEndpoint));
 
       const stream = client.streamEntities({}, { token });
       await expect(async () => {
@@ -1058,16 +1100,16 @@ describe('CatalogClient', () => {
 
     beforeEach(() => {
       server.use(
-        rest.get(
+        http.get(
           `${mockBaseUrl}/entities/by-name/customkind/default/exists`,
-          (_, res, ctx) => {
-            return res(ctx.json(existingEntity));
+          () => {
+            return HttpResponse.json(existingEntity);
           },
         ),
-        rest.get(
+        http.get(
           `${mockBaseUrl}/entities/by-name/customkind/default/missing`,
-          (_, res, ctx) => {
-            return res(ctx.status(404));
+          () => {
+            return new HttpResponse(null, { status: 404 });
           },
         ),
       );
@@ -1122,8 +1164,8 @@ describe('CatalogClient', () => {
 
     beforeEach(() => {
       server.use(
-        rest.get(`${mockBaseUrl}/locations`, (_, res, ctx) => {
-          return res(ctx.json(defaultResponse));
+        http.get(`${mockBaseUrl}/locations`, () => {
+          return HttpResponse.json(defaultResponse);
         }),
       );
     });
@@ -1150,8 +1192,8 @@ describe('CatalogClient', () => {
 
     it('should return empty list with empty result', async () => {
       server.use(
-        rest.get(`${mockBaseUrl}/locations`, (_, res, ctx) => {
-          return res(ctx.json([]));
+        http.get(`${mockBaseUrl}/locations`, () => {
+          return HttpResponse.json([]);
         }),
       );
 
@@ -1163,9 +1205,9 @@ describe('CatalogClient', () => {
       expect.assertions(1);
 
       server.use(
-        rest.get(`${mockBaseUrl}/locations`, (req, res, ctx) => {
-          expect(req.headers.get('authorization')).toBe(`Bearer ${token}`);
-          return res(ctx.json(defaultResponse));
+        http.get(`${mockBaseUrl}/locations`, ({ request }) => {
+          expect(request.headers.get('authorization')).toBe(`Bearer ${token}`);
+          return HttpResponse.json(defaultResponse);
         }),
       );
 
@@ -1176,9 +1218,9 @@ describe('CatalogClient', () => {
       expect.assertions(1);
 
       server.use(
-        rest.get(`${mockBaseUrl}/locations`, (req, res, ctx) => {
-          expect(req.headers.get('authorization')).toBeNull();
-          return res(ctx.json(defaultResponse));
+        http.get(`${mockBaseUrl}/locations`, ({ request }) => {
+          expect(request.headers.get('authorization')).toBeNull();
+          return HttpResponse.json(defaultResponse);
         }),
       );
 
@@ -1200,8 +1242,8 @@ describe('CatalogClient', () => {
       };
 
       server.use(
-        rest.post(`${mockBaseUrl}/locations/by-query`, (_, res, ctx) => {
-          return res(ctx.json(defaultResponse));
+        http.post(`${mockBaseUrl}/locations/by-query`, () => {
+          return HttpResponse.json(defaultResponse);
         }),
       );
 
@@ -1213,17 +1255,18 @@ describe('CatalogClient', () => {
       expect.assertions(2);
 
       server.use(
-        rest.post(
-          `${mockBaseUrl}/locations/by-query`,
-          async (req, res, ctx) => {
-            const body = await req.json();
-            expect(body).toEqual({
-              limit: 50,
-              query: { type: 'url' },
-            });
-            return res(ctx.json({ items: [], totalItems: 0, pageInfo: {} }));
-          },
-        ),
+        http.post(`${mockBaseUrl}/locations/by-query`, async ({ request }) => {
+          const body = await request.json();
+          expect(body).toEqual({
+            limit: 50,
+            query: { type: 'url' },
+          });
+          return HttpResponse.json({
+            items: [],
+            totalItems: 0,
+            pageInfo: {},
+          });
+        }),
       );
 
       const response = await client.queryLocations(
@@ -1241,24 +1284,17 @@ describe('CatalogClient', () => {
       expect.assertions(3);
 
       server.use(
-        rest.post(
-          `${mockBaseUrl}/locations/by-query`,
-          async (req, res, ctx) => {
-            const body = await req.json();
-            expect(body).toEqual({ cursor: 'mycursor' });
-            return res(
-              ctx.json({
-                items: [
-                  { id: '3', type: 'url', target: 'https://example.com/3' },
-                ],
-                totalItems: 10,
-                pageInfo: {
-                  nextCursor: 'nextcursor',
-                },
-              }),
-            );
-          },
-        ),
+        http.post(`${mockBaseUrl}/locations/by-query`, async ({ request }) => {
+          const body = await request.json();
+          expect(body).toEqual({ cursor: 'mycursor' });
+          return HttpResponse.json({
+            items: [{ id: '3', type: 'url', target: 'https://example.com/3' }],
+            totalItems: 10,
+            pageInfo: {
+              nextCursor: 'nextcursor',
+            },
+          });
+        }),
       );
 
       const response = await client.queryLocations({ cursor: 'mycursor' });
@@ -1269,8 +1305,9 @@ describe('CatalogClient', () => {
 
     it('should handle errors', async () => {
       server.use(
-        rest.post(`${mockBaseUrl}/locations/by-query`, (_req, res, ctx) =>
-          res(ctx.status(401)),
+        http.post(
+          `${mockBaseUrl}/locations/by-query`,
+          () => new HttpResponse(null, { status: 401 }),
         ),
       );
 
@@ -1283,9 +1320,13 @@ describe('CatalogClient', () => {
       expect.assertions(1);
 
       server.use(
-        rest.post(`${mockBaseUrl}/locations/by-query`, (req, res, ctx) => {
-          expect(req.headers.get('authorization')).toBe(`Bearer ${token}`);
-          return res(ctx.json({ items: [], totalItems: 0, pageInfo: {} }));
+        http.post(`${mockBaseUrl}/locations/by-query`, ({ request }) => {
+          expect(request.headers.get('authorization')).toBe(`Bearer ${token}`);
+          return HttpResponse.json({
+            items: [],
+            totalItems: 0,
+            pageInfo: {},
+          });
         }),
       );
 
@@ -1310,16 +1351,13 @@ describe('CatalogClient', () => {
       };
 
       server.use(
-        rest.post(
-          `${mockBaseUrl}/locations/by-query`,
-          async (req, res, ctx) => {
-            const body = await req.json();
-            if (body.cursor === 'cursor2') {
-              return res(ctx.json(secondPage));
-            }
-            return res(ctx.json(firstPage));
-          },
-        ),
+        http.post(`${mockBaseUrl}/locations/by-query`, async ({ request }) => {
+          const body = await request.json();
+          if (body.cursor === 'cursor2') {
+            return HttpResponse.json(secondPage);
+          }
+          return HttpResponse.json(firstPage);
+        }),
       );
 
       const stream = client.streamLocations({}, { token });
@@ -1333,8 +1371,12 @@ describe('CatalogClient', () => {
 
     it('should handle empty results', async () => {
       server.use(
-        rest.post(`${mockBaseUrl}/locations/by-query`, (_req, res, ctx) => {
-          return res(ctx.json({ items: [], totalItems: 0, pageInfo: {} }));
+        http.post(`${mockBaseUrl}/locations/by-query`, () => {
+          return HttpResponse.json({
+            items: [],
+            totalItems: 0,
+            pageInfo: {},
+          });
         }),
       );
 
@@ -1349,8 +1391,9 @@ describe('CatalogClient', () => {
 
     it('should handle errors', async () => {
       server.use(
-        rest.post(`${mockBaseUrl}/locations/by-query`, (_req, res, ctx) =>
-          res(ctx.status(401)),
+        http.post(
+          `${mockBaseUrl}/locations/by-query`,
+          () => new HttpResponse(null, { status: 401 }),
         ),
       );
 
@@ -1373,8 +1416,8 @@ describe('CatalogClient', () => {
 
     beforeEach(() => {
       server.use(
-        rest.get(`${mockBaseUrl}/locations/42`, (_, res, ctx) => {
-          return res(ctx.json(defaultResponse));
+        http.get(`${mockBaseUrl}/locations/42`, () => {
+          return HttpResponse.json(defaultResponse);
         }),
       );
     });
@@ -1388,9 +1431,9 @@ describe('CatalogClient', () => {
       expect.assertions(1);
 
       server.use(
-        rest.get(`${mockBaseUrl}/locations/42`, (req, res, ctx) => {
-          expect(req.headers.get('authorization')).toBe(`Bearer ${token}`);
-          return res(ctx.json(defaultResponse));
+        http.get(`${mockBaseUrl}/locations/42`, ({ request }) => {
+          expect(request.headers.get('authorization')).toBe(`Bearer ${token}`);
+          return HttpResponse.json(defaultResponse);
         }),
       );
 
@@ -1401,9 +1444,9 @@ describe('CatalogClient', () => {
       expect.assertions(1);
 
       server.use(
-        rest.get(`${mockBaseUrl}/locations/42`, (req, res, ctx) => {
-          expect(req.headers.get('authorization')).toBeNull();
-          return res(ctx.json(defaultResponse));
+        http.get(`${mockBaseUrl}/locations/42`, ({ request }) => {
+          expect(request.headers.get('authorization')).toBeNull();
+          return HttpResponse.json(defaultResponse);
         }),
       );
 
@@ -1422,8 +1465,8 @@ describe('CatalogClient', () => {
 
     beforeEach(() => {
       server.use(
-        rest.get(`${mockBaseUrl}/locations/by-entity/c/ns/n`, (_, res, ctx) => {
-          return res(ctx.json(defaultResponse));
+        http.get(`${mockBaseUrl}/locations/by-entity/c/ns/n`, () => {
+          return HttpResponse.json(defaultResponse);
         }),
       );
     });
@@ -1440,13 +1483,10 @@ describe('CatalogClient', () => {
       expect.assertions(1);
 
       server.use(
-        rest.get(
-          `${mockBaseUrl}/locations/by-entity/c/ns/n`,
-          (req, res, ctx) => {
-            expect(req.headers.get('authorization')).toBe(`Bearer ${token}`);
-            return res(ctx.json(defaultResponse));
-          },
-        ),
+        http.get(`${mockBaseUrl}/locations/by-entity/c/ns/n`, ({ request }) => {
+          expect(request.headers.get('authorization')).toBe(`Bearer ${token}`);
+          return HttpResponse.json(defaultResponse);
+        }),
       );
 
       await client.getLocationByEntity(
@@ -1459,13 +1499,10 @@ describe('CatalogClient', () => {
       expect.assertions(1);
 
       server.use(
-        rest.get(
-          `${mockBaseUrl}/locations/by-entity/c/ns/n`,
-          (req, res, ctx) => {
-            expect(req.headers.get('authorization')).toBeNull();
-            return res(ctx.json(defaultResponse));
-          },
-        ),
+        http.get(`${mockBaseUrl}/locations/by-entity/c/ns/n`, ({ request }) => {
+          expect(request.headers.get('authorization')).toBeNull();
+          return HttpResponse.json(defaultResponse);
+        }),
       );
 
       await client.getLocationByEntity({
@@ -1479,16 +1516,16 @@ describe('CatalogClient', () => {
   describe('validateEntity', () => {
     it('returns valid false when validation fails', async () => {
       server.use(
-        rest.post(`${mockBaseUrl}/validate-entity`, (_req, res, ctx) => {
-          return res(
-            ctx.status(400),
-            ctx.json({
+        http.post(`${mockBaseUrl}/validate-entity`, () => {
+          return HttpResponse.json(
+            {
               errors: [
                 {
                   message: 'Missing name',
                 },
               ],
-            }),
+            },
+            { status: 400 },
           );
         }),
       );
@@ -1516,8 +1553,8 @@ describe('CatalogClient', () => {
 
     it('returns valid true when validation fails', async () => {
       server.use(
-        rest.post(`${mockBaseUrl}/validate-entity`, (_req, res, ctx) => {
-          return res(ctx.status(200), ctx.text(''));
+        http.post(`${mockBaseUrl}/validate-entity`, () => {
+          return new HttpResponse('', { status: 200 });
         }),
       );
 
@@ -1539,8 +1576,8 @@ describe('CatalogClient', () => {
 
     it('throws unexpected error', async () => {
       server.use(
-        rest.post(`${mockBaseUrl}/validate-entity`, (_req, res, ctx) => {
-          return res(ctx.status(500), ctx.json({}));
+        http.post(`${mockBaseUrl}/validate-entity`, () => {
+          return HttpResponse.json({}, { status: 500 });
         }),
       );
 

--- a/packages/catalog-client/src/CatalogClient.test.ts
+++ b/packages/catalog-client/src/CatalogClient.test.ts
@@ -340,7 +340,7 @@ describe('CatalogClient', () => {
     });
 
     it('merges filter and query into $all predicate when both are provided', async () => {
-      expect.assertions(4);
+      expect.assertions(3);
       const entity = {
         apiVersion: '1',
         kind: 'Component',
@@ -353,9 +353,11 @@ describe('CatalogClient', () => {
         http.post(`${mockBaseUrl}/entities/by-refs`, async ({ request }) => {
           expect(new URL(request.url).search).toBe('');
           const body = await request.json();
-          expect(body.entityRefs).toEqual(['k:n/a']);
-          expect(body.query).toEqual({
-            $all: [{ kind: 'Component' }, { kind: 'API' }],
+          expect(body).toMatchObject({
+            entityRefs: ['k:n/a'],
+            query: {
+              $all: [{ kind: 'Component' }, { kind: 'API' }],
+            },
           });
           return HttpResponse.json({ items: [entity] });
         }),
@@ -374,7 +376,7 @@ describe('CatalogClient', () => {
     });
 
     it('sends filter as query parameter when only filter is provided (backward compat)', async () => {
-      expect.assertions(4);
+      expect.assertions(3);
       const entity = {
         apiVersion: '1',
         kind: 'Component',
@@ -388,7 +390,6 @@ describe('CatalogClient', () => {
           expect(new URL(request.url).search).toBe('?filter=kind%3DAPI');
           const body = await request.json();
           expect(body).toEqual({ entityRefs: ['k:n/a'] });
-          expect(body.query).toBeUndefined();
           return HttpResponse.json({ items: [entity] });
         }),
       );
@@ -1352,7 +1353,7 @@ describe('CatalogClient', () => {
 
       server.use(
         http.post(`${mockBaseUrl}/locations/by-query`, async ({ request }) => {
-          const body = await request.json();
+          const body = (await request.json()) as { cursor?: string };
           if (body.cursor === 'cursor2') {
             return HttpResponse.json(secondPage);
           }

--- a/packages/catalog-client/src/CatalogClient.test.ts
+++ b/packages/catalog-client/src/CatalogClient.test.ts
@@ -340,7 +340,7 @@ describe('CatalogClient', () => {
     });
 
     it('merges filter and query into $all predicate when both are provided', async () => {
-      expect.assertions(4);
+      expect.assertions(3);
       const entity = {
         apiVersion: '1',
         kind: 'Component',
@@ -352,10 +352,11 @@ describe('CatalogClient', () => {
       server.use(
         http.post(`${mockBaseUrl}/entities/by-refs`, async ({ request }) => {
           expect(new URL(request.url).search).toBe('');
-          const body = await request.json();
-          expect(body.entityRefs).toEqual(['k:n/a']);
-          expect(body.query).toEqual({
-            $all: [{ kind: 'Component' }, { kind: 'API' }],
+          await expect(request.json()).resolves.toEqual({
+            entityRefs: ['k:n/a'],
+            query: {
+              $all: [{ kind: 'Component' }, { kind: 'API' }],
+            },
           });
           return HttpResponse.json({ items: [entity] });
         }),

--- a/plugins/bitbucket-cloud-common/package.json
+++ b/plugins/bitbucket-cloud-common/package.json
@@ -47,7 +47,7 @@
   "devDependencies": {
     "@backstage/cli": "workspace:^",
     "@openapitools/openapi-generator-cli": "^2.4.26",
-    "msw": "^1.0.0",
+    "msw": "^2.0.0",
     "ts-morph": "^24.0.0"
   }
 }

--- a/plugins/catalog-backend-module-azure/package.json
+++ b/plugins/catalog-backend-module-azure/package.json
@@ -64,7 +64,7 @@
   "devDependencies": {
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
-    "msw": "^1.0.0"
+    "msw": "^2.0.0"
   },
   "configSchema": "config.d.ts"
 }

--- a/plugins/catalog-backend-module-azure/src/lib/azure.test.ts
+++ b/plugins/catalog-backend-module-azure/src/lib/azure.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { codeSearch, CodeSearchResponse } from './azure';
 import {
@@ -57,11 +57,12 @@ describe('azure', () => {
       const response: CodeSearchResponse = { count: 0, results: [] };
 
       server.use(
-        rest.post(
+        http.post(
           `https://almsearch.dev.azure.com/shopify/_apis/search/codesearchresults`,
-          (req, res, ctx) => {
-            expect(req.headers.get('Authorization')).toBe('Basic OkFCQw==');
-            expect(req.body).toEqual({
+          async ({ request }) => {
+            const body = await request.json();
+            expect(request.headers.get('Authorization')).toBe('Basic OkFCQw==');
+            expect(body).toEqual({
               searchText: 'path:/catalog-info.yaml repo:* proj:engineering',
               $orderBy: [
                 {
@@ -72,7 +73,7 @@ describe('azure', () => {
               $skip: 0,
               $top: 1000,
             });
-            return res(ctx.json(response));
+            return HttpResponse.json(response);
           },
         ),
       );
@@ -123,11 +124,12 @@ describe('azure', () => {
     };
 
     server.use(
-      rest.post(
+      http.post(
         `https://almsearch.dev.azure.com/shopify/_apis/search/codesearchresults`,
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Basic OkFCQw==');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          const body = await request.json();
+          expect(request.headers.get('Authorization')).toBe('Basic OkFCQw==');
+          expect(body).toEqual({
             searchText: 'path:/catalog-info.yaml repo:* proj:engineering',
             $orderBy: [
               {
@@ -138,7 +140,7 @@ describe('azure', () => {
             $skip: 0,
             $top: 1000,
           });
-          return res(ctx.json(response));
+          return HttpResponse.json(response);
         },
       ),
     );
@@ -178,11 +180,12 @@ describe('azure', () => {
     };
 
     server.use(
-      rest.post(
+      http.post(
         `https://almsearch.dev.azure.com/shopify/_apis/search/codesearchresults`,
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Basic OkFCQw==');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          const body = await request.json();
+          expect(request.headers.get('Authorization')).toBe('Basic OkFCQw==');
+          expect(body).toEqual({
             searchText:
               'path:/catalog-info.yaml repo:backstage proj:engineering',
             $orderBy: [
@@ -194,7 +197,7 @@ describe('azure', () => {
             $skip: 0,
             $top: 1000,
           });
-          return res(ctx.json(response));
+          return HttpResponse.json(response);
         },
       ),
     );
@@ -235,11 +238,12 @@ describe('azure', () => {
     };
 
     server.use(
-      rest.post(
+      http.post(
         `https://almsearch.dev.azure.com/shopify/_apis/search/codesearchresults`,
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Basic OkFCQw==');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          const body = await request.json();
+          expect(request.headers.get('Authorization')).toBe('Basic OkFCQw==');
+          expect(body).toEqual({
             searchText:
               'path:/catalog-info.yaml repo:backstage proj:engineering',
             $orderBy: [
@@ -254,7 +258,7 @@ describe('azure', () => {
               Branch: ['topic/catalog-info'],
             },
           });
-          return res(ctx.json(response));
+          return HttpResponse.json(response);
         },
       ),
     );
@@ -295,11 +299,12 @@ describe('azure', () => {
     };
 
     server.use(
-      rest.post(
+      http.post(
         `https://azuredevops.mycompany.com/shopify/_apis/search/codesearchresults`,
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Basic OkFCQw==');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          const body = await request.json();
+          expect(request.headers.get('Authorization')).toBe('Basic OkFCQw==');
+          expect(body).toEqual({
             searchText: 'path:/catalog-info.yaml repo:* proj:engineering',
             $orderBy: [
               {
@@ -310,7 +315,7 @@ describe('azure', () => {
             $skip: 0,
             $top: 1000,
           });
-          return res(ctx.json(response));
+          return HttpResponse.json(response);
         },
       ),
     );
@@ -349,28 +354,29 @@ describe('azure', () => {
     };
 
     server.use(
-      rest.post(
+      http.post(
         `https://almsearch.dev.azure.com/shopify/_apis/search/codesearchresults`,
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Basic OkFCQw==');
-          expect(req.body).toMatchObject({
+        async ({ request }) => {
+          const body = (await request.json()) as {
+            $skip: number;
+            $top: number;
+          };
+          expect(request.headers.get('Authorization')).toBe('Basic OkFCQw==');
+          expect(body).toMatchObject({
             searchText:
               'path:/catalog-info.yaml repo:backstage proj:engineering',
             $top: 1000,
           });
 
-          const body = req.body as { $skip: number; $top: number };
           const countItemsToReturn =
             body.$top + body.$skip > totalCount
               ? totalCount - body.$skip
               : body.$top;
 
-          return res(
-            ctx.json({
-              count: totalCount,
-              results: generateItems(countItemsToReturn),
-            }),
-          );
+          return HttpResponse.json({
+            count: totalCount,
+            results: generateItems(countItemsToReturn),
+          });
         },
       ),
     );
@@ -411,11 +417,12 @@ describe('azure', () => {
     };
 
     server.use(
-      rest.post(
+      http.post(
         `https://almsearch.dev.azure.com/shopify/_apis/search/codesearchresults`,
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Basic OkFCQw==');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          const body = await request.json();
+          expect(request.headers.get('Authorization')).toBe('Basic OkFCQw==');
+          expect(body).toEqual({
             searchText: 'path:/catalog-info.yaml repo:* proj:engineering',
             $orderBy: [
               {
@@ -426,7 +433,7 @@ describe('azure', () => {
             $skip: 0,
             $top: 1000,
           });
-          return res(ctx.json(response));
+          return HttpResponse.json(response);
         },
       ),
     );
@@ -464,10 +471,10 @@ describe('azure', () => {
         : `https://${host}`;
 
       server.use(
-        rest.post(
+        http.post(
           `${expectedBaseUrl}/test-org/_apis/search/codesearchresults`,
-          (_req, res, ctx) => {
-            return res(ctx.json(mockResponse));
+          () => {
+            return HttpResponse.json(mockResponse);
           },
         ),
       );

--- a/plugins/catalog-backend-module-bitbucket-cloud/package.json
+++ b/plugins/catalog-backend-module-bitbucket-cloud/package.json
@@ -65,7 +65,7 @@
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@backstage/plugin-events-backend-test-utils": "workspace:^",
-    "msw": "^1.0.0"
+    "msw": "^2.0.0"
   },
   "configSchema": "config.d.ts"
 }

--- a/plugins/catalog-backend-module-bitbucket-cloud/src/providers/BitbucketCloudEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-bitbucket-cloud/src/providers/BitbucketCloudEntityProvider.test.ts
@@ -31,7 +31,7 @@ import {
 } from '@backstage/plugin-catalog-node';
 import { Events } from '@backstage/plugin-bitbucket-cloud-common';
 import { DefaultEventsService } from '@backstage/plugin-events-node';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import {
   ANNOTATION_BITBUCKET_CLOUD_REPO_URL,
@@ -362,9 +362,9 @@ describe('BitbucketCloudEntityProvider', () => {
     );
 
     server.use(
-      rest.get(
+      http.get(
         `https://api.bitbucket.org/2.0/workspaces/test-ws/projects`,
-        (_req, res, ctx) => {
+        () => {
           const response = {
             values: [
               {
@@ -375,12 +375,12 @@ describe('BitbucketCloudEntityProvider', () => {
               },
             ],
           };
-          return res(ctx.json(response));
+          return HttpResponse.json(response);
         },
       ),
-      rest.get(
+      http.get(
         `https://api.bitbucket.org/2.0/workspaces/test-ws/search/code`,
-        (_req, res, ctx) => {
+        () => {
           const response = {
             values: [
               {
@@ -479,7 +479,7 @@ describe('BitbucketCloudEntityProvider', () => {
               },
             ],
           };
-          return res(ctx.json(response));
+          return HttpResponse.json(response);
         },
       ),
     );
@@ -589,12 +589,12 @@ describe('BitbucketCloudEntityProvider', () => {
     })[0];
 
     server.use(
-      rest.get(
+      http.get(
         `https://api.bitbucket.org/2.0/workspaces/test-ws/search/code`,
-        (req, res, ctx) => {
-          const query = req.url.searchParams.get('search_query');
+        ({ request }) => {
+          const query = new URL(request.url).searchParams.get('search_query');
           if (!query || !query.includes('repo:test-repo')) {
-            return res(ctx.json({ values: [] }));
+            return HttpResponse.json({ values: [] });
           }
 
           const response = {
@@ -657,7 +657,7 @@ describe('BitbucketCloudEntityProvider', () => {
               },
             ],
           };
-          return res(ctx.json(response));
+          return HttpResponse.json(response);
         },
       ),
     );
@@ -794,12 +794,12 @@ describe('BitbucketCloudEntityProvider', () => {
     })[0];
 
     server.use(
-      rest.get(
+      http.get(
         `https://api.bitbucket.org/2.0/workspaces/test-ws/search/code`,
-        (req, res, ctx) => {
-          const query = req.url.searchParams.get('search_query');
+        ({ request }) => {
+          const query = new URL(request.url).searchParams.get('search_query');
           if (!query || !query.includes('repo:test-repo-new')) {
-            return res(ctx.json({ values: [] }));
+            return HttpResponse.json({ values: [] });
           }
 
           const response = {
@@ -834,7 +834,7 @@ describe('BitbucketCloudEntityProvider', () => {
               },
             ],
           };
-          return res(ctx.json(response));
+          return HttpResponse.json(response);
         },
       ),
     );

--- a/plugins/catalog-backend-module-bitbucket-server/package.json
+++ b/plugins/catalog-backend-module-bitbucket-server/package.json
@@ -63,7 +63,7 @@
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@backstage/plugin-events-backend-test-utils": "workspace:^",
-    "msw": "^1.0.0"
+    "msw": "^2.0.0"
   },
   "configSchema": "config.d.ts"
 }

--- a/plugins/catalog-backend-module-bitbucket-server/src/lib/BitbucketServerClient.test.ts
+++ b/plugins/catalog-backend-module-bitbucket-server/src/lib/BitbucketServerClient.test.ts
@@ -16,7 +16,7 @@
 
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { BitbucketServerIntegrationConfig } from '@backstage/integration';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import {
   BitbucketServerClient,
@@ -59,11 +59,12 @@ describe('BitbucketServerClient', () => {
 
   it('listProjects', async () => {
     server.use(
-      rest.get(`${config.apiBaseUrl}/projects`, (req, res, ctx) => {
+      http.get(`${config.apiBaseUrl}/projects`, ({ request }) => {
         if (
-          req.headers.get('authorization') !== 'Basic dGVzdC11c2VyOnRlc3QtcHc='
+          request.headers.get('authorization') !==
+          'Basic dGVzdC11c2VyOnRlc3QtcHc='
         ) {
-          return res(ctx.status(400));
+          return new HttpResponse(null, { status: 400 });
         }
         const response: BitbucketServerPagedResponse<BitbucketServerProject> = {
           size: 1,
@@ -77,7 +78,7 @@ describe('BitbucketServerClient', () => {
             },
           ],
         };
-        return res(ctx.json(response));
+        return HttpResponse.json(response);
       }),
     );
 
@@ -96,14 +97,14 @@ describe('BitbucketServerClient', () => {
 
   it('listRepositories', async () => {
     server.use(
-      rest.get(
+      http.get(
         `${config.apiBaseUrl}/projects/test-project/repos`,
-        (req, res, ctx) => {
+        ({ request }) => {
           if (
-            req.headers.get('authorization') !==
+            request.headers.get('authorization') !==
             'Basic dGVzdC11c2VyOnRlc3QtcHc='
           ) {
-            return res(ctx.status(400));
+            return new HttpResponse(null, { status: 400 });
           }
           const response: BitbucketServerPagedResponse<BitbucketServerRepository> =
             {
@@ -131,7 +132,7 @@ describe('BitbucketServerClient', () => {
                 },
               ],
             };
-          return res(ctx.json(response));
+          return HttpResponse.json(response);
         },
       ),
     );
@@ -158,17 +159,17 @@ describe('BitbucketServerClient', () => {
 
   it('getFile', async () => {
     server.use(
-      rest.get(
+      http.get(
         `${config.apiBaseUrl}/projects/test-project/repos/test-repo/raw/catalog-info.yaml`,
-        (req, res, ctx) => {
+        ({ request }) => {
           if (
-            req.headers.get('authorization') !==
+            request.headers.get('authorization') !==
             'Basic dGVzdC11c2VyOnRlc3QtcHc='
           ) {
-            return res(ctx.status(400));
+            return new HttpResponse(null, { status: 400 });
           }
 
-          return res(ctx.text(catalogInfoFile));
+          return new HttpResponse(catalogInfoFile);
         },
       ),
     );
@@ -183,14 +184,14 @@ describe('BitbucketServerClient', () => {
 
   it('getRepository', async () => {
     server.use(
-      rest.get(
+      http.get(
         `${config.apiBaseUrl}/projects/test-project/repos/test-repo`,
-        (req, res, ctx) => {
+        ({ request }) => {
           if (
-            req.headers.get('authorization') !==
+            request.headers.get('authorization') !==
             'Basic dGVzdC11c2VyOnRlc3QtcHc='
           ) {
-            return res(ctx.status(400));
+            return new HttpResponse(null, { status: 400 });
           }
           const response: BitbucketServerRepository = {
             project: {
@@ -209,7 +210,7 @@ describe('BitbucketServerClient', () => {
             defaultBranch: 'master',
           };
 
-          return res(ctx.json(response));
+          return HttpResponse.json(response);
         },
       ),
     );
@@ -227,10 +228,10 @@ describe('BitbucketServerClient', () => {
 
   it('getRepository no repo', async () => {
     server.use(
-      rest.get(
+      http.get(
         `${config.apiBaseUrl}/projects/test-project/repos/wrong-repo`,
-        (_, res, ctx) => {
-          return res(ctx.status(404));
+        () => {
+          return new HttpResponse(null, { status: 404 });
         },
       ),
     );
@@ -250,14 +251,14 @@ describe('BitbucketServerClient', () => {
 
   it('getDefaultBranch success', async () => {
     server.use(
-      rest.get(
+      http.get(
         `${config.apiBaseUrl}/projects/test-project/repos/test-repo/default-branch`,
-        (req, res, ctx) => {
+        ({ request }) => {
           if (
-            req.headers.get('authorization') !==
+            request.headers.get('authorization') !==
             'Basic dGVzdC11c2VyOnRlc3QtcHc='
           ) {
-            return res(ctx.status(400));
+            return new HttpResponse(null, { status: 400 });
           }
           const response: BitbucketServerDefaultBranch = {
             id: 'refs/heads/master',
@@ -268,7 +269,7 @@ describe('BitbucketServerClient', () => {
             isDefault: true,
           };
 
-          return res(ctx.json(response));
+          return HttpResponse.json(response);
         },
       ),
     );
@@ -282,10 +283,10 @@ describe('BitbucketServerClient', () => {
 
   it('getDefaultBranch endpoint', async () => {
     server.use(
-      rest.get(
+      http.get(
         `${config.apiBaseUrl}/projects/test-project/repos/wrong-repo/default-branch`,
-        (_, res, ctx) => {
-          return res(ctx.status(404));
+        () => {
+          return new HttpResponse(null, { status: 404 });
         },
       ),
     );

--- a/plugins/catalog-backend-module-bitbucket-server/src/providers/BitbucketServerEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-bitbucket-server/src/providers/BitbucketServerEntityProvider.test.ts
@@ -31,7 +31,7 @@ import {
   EntityProviderConnection,
   locationSpecToLocationEntity,
 } from '@backstage/plugin-catalog-node';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import {
   BitbucketServerEntityProvider,
@@ -83,14 +83,12 @@ function setupStubs(
 ) {
   // Stub projects
   server.use(
-    rest.get(`${baseUrl}/rest/api/1.0/projects`, (_, res, ctx) => {
-      return res(
-        ctx.json(
-          pagedResponse(
-            projects.map(p => {
-              return { key: p.key };
-            }),
-          ),
+    http.get(`${baseUrl}/rest/api/1.0/projects`, () => {
+      return HttpResponse.json(
+        pagedResponse(
+          projects.map(p => {
+            return { key: p.key };
+          }),
         ),
       );
     }),
@@ -99,27 +97,24 @@ function setupStubs(
   for (const project of projects) {
     // Stub list repositories
     server.use(
-      rest.get(
-        `${baseUrl}/rest/api/1.0/projects/${project.key}/repos`,
-        (_, res, ctx) => {
-          const response = [];
-          for (const repo of project.repos) {
-            response.push({
-              slug: repo.name,
-              links: {
-                self: [
-                  {
-                    href: `${baseUrl}/projects/${project.key}/repos/${repo.name}/browse`,
-                  },
-                ],
-              },
-              archived: repo.archived ?? false,
-              defaultBranch: defaultBranch,
-            });
-          }
-          return res(ctx.json(pagedResponse(response)));
-        },
-      ),
+      http.get(`${baseUrl}/rest/api/1.0/projects/${project.key}/repos`, () => {
+        const response = [];
+        for (const repo of project.repos) {
+          response.push({
+            slug: repo.name,
+            links: {
+              self: [
+                {
+                  href: `${baseUrl}/projects/${project.key}/repos/${repo.name}/browse`,
+                },
+              ],
+            },
+            archived: repo.archived ?? false,
+            defaultBranch: defaultBranch,
+          });
+        }
+        return HttpResponse.json(pagedResponse(response));
+      }),
     );
   }
 }
@@ -130,37 +125,34 @@ const test1RepoUrl = `https://${host}/projects/TEST/repos/test1/browse`;
 
 function setupRepositoryReqHandler(defaultBranch: string) {
   server.use(
-    rest.get(
-      `https://${host}/rest/api/1.0/projects/TEST/repos/test1`,
-      (_, res, ctx) => {
-        const response = {
-          slug: 'test1',
+    http.get(`https://${host}/rest/api/1.0/projects/TEST/repos/test1`, () => {
+      const response = {
+        slug: 'test1',
+        id: 1,
+        name: 'test1',
+        project: {
+          key: 'TEST',
           id: 1,
-          name: 'test1',
-          project: {
-            key: 'TEST',
-            id: 1,
-            name: 'TEST',
-            links: {
-              self: [
-                {
-                  href: `https://${host}/projects/TEST`,
-                },
-              ],
-            },
-          },
+          name: 'TEST',
           links: {
             self: [
               {
-                href: `${test1RepoUrl}`,
+                href: `https://${host}/projects/TEST`,
               },
             ],
           },
-          defaultBranch: defaultBranch,
-        };
-        return res(ctx.json(response));
-      },
-    ),
+        },
+        links: {
+          self: [
+            {
+              href: `${test1RepoUrl}`,
+            },
+          ],
+        },
+        defaultBranch: defaultBranch,
+      };
+      return HttpResponse.json(response);
+    }),
   );
 }
 
@@ -670,16 +662,16 @@ describe('BitbucketServerEntityProvider', () => {
 
   it('do not add locations when validateLocationsExist and catalog-info does not exist', async () => {
     server.use(
-      rest.get(
+      http.get(
         `https://${host}/rest/api/1.0/projects/project-test/repos/repo-test/raw/catalog-info.yaml`,
-        (_, res, ctx) => {
-          return res(ctx.status(404));
+        () => {
+          return new HttpResponse(null, { status: 404 });
         },
       ),
-      rest.get(
+      http.get(
         `https://${host}/rest/api/1.0/projects/other-project/repos/other-repo/raw/catalog-info.yaml`,
-        (_, res, ctx) => {
-          return res(ctx.status(200));
+        () => {
+          return new HttpResponse(null, { status: 200 });
         },
       ),
     );

--- a/plugins/catalog-backend-module-gerrit/package.json
+++ b/plugins/catalog-backend-module-gerrit/package.json
@@ -60,7 +60,7 @@
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@types/fs-extra": "^11.0.0",
-    "msw": "^1.0.0"
+    "msw": "^2.0.0"
   },
   "configSchema": "config.d.ts"
 }

--- a/plugins/catalog-backend-module-gerrit/src/providers/GerritEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gerrit/src/providers/GerritEntityProvider.test.ts
@@ -26,7 +26,7 @@ import {
 import { ConfigReader } from '@backstage/config';
 import { EntityProviderConnection } from '@backstage/plugin-catalog-node';
 import fs from 'fs-extra';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import path from 'node:path';
 import { GerritEntityProvider } from './GerritEntityProvider';
@@ -116,12 +116,13 @@ describe('GerritEntityProvider', () => {
     const expected = getJsonFixture('expectedProviderEntities.json');
 
     server.use(
-      rest.get('https://g.com/gerrit/projects/', (_, res, ctx) =>
-        res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.body(new Uint8Array(repoBuffer)),
-        ),
+      http.get(
+        'https://g.com/gerrit/projects/',
+        () =>
+          new HttpResponse(repoBuffer, {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
       ),
     );
 
@@ -153,12 +154,13 @@ describe('GerritEntityProvider', () => {
     );
 
     server.use(
-      rest.get('https://g.com/gerrit/projects/', (_, res, ctx) =>
-        res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.body(new Uint8Array(repoBuffer)),
-        ),
+      http.get(
+        'https://g.com/gerrit/projects/',
+        () =>
+          new HttpResponse(repoBuffer, {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
       ),
     );
 
@@ -188,19 +190,21 @@ describe('GerritEntityProvider', () => {
     const expected = getJsonFixture('expectedProviderEntities.json');
 
     server.use(
-      rest.get('https://g.com/gerrit/projects/', (_, res, ctx) =>
-        res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.body(new Uint8Array(repoBuffer)),
-        ),
+      http.get(
+        'https://g.com/gerrit/projects/',
+        () =>
+          new HttpResponse(repoBuffer, {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
       ),
-      rest.get('https://g.com/gerrit/projects/:project/HEAD', (_, res, ctx) =>
-        res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.body(`)]}'\n"refs/heads/main"`),
-        ),
+      http.get(
+        'https://g.com/gerrit/projects/:project/HEAD',
+        () =>
+          new HttpResponse(`)]}'\n"refs/heads/main"`, {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
       ),
     );
 
@@ -252,8 +256,9 @@ describe('GerritEntityProvider', () => {
     })[0];
 
     server.use(
-      rest.get('https://g.com/gerrit/projects/', (_, res, ctx) =>
-        res(ctx.status(500, 'Error!.')),
+      http.get(
+        'https://g.com/gerrit/projects/',
+        () => new HttpResponse('Error!.', { status: 500 }),
       ),
     );
 
@@ -396,12 +401,13 @@ describe('GerritEntityProvider', () => {
     const expected = getJsonFixture('expectedProviderEntities.json');
 
     server.use(
-      rest.get('https://g.com/gerrit/projects/', (_, res, ctx) =>
-        res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.body(new Uint8Array(repoBuffer)),
-        ),
+      http.get(
+        'https://g.com/gerrit/projects/',
+        () =>
+          new HttpResponse(repoBuffer, {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }),
       ),
     );
 

--- a/plugins/catalog-backend-module-gitlab/package.json
+++ b/plugins/catalog-backend-module-gitlab/package.json
@@ -68,7 +68,7 @@
     "@backstage/cli": "workspace:^",
     "@backstage/plugin-events-backend-test-utils": "workspace:^",
     "@types/lodash": "^4.14.151",
-    "msw": "^1.0.0"
+    "msw": "^2.0.0"
   },
   "configSchema": "config.d.ts"
 }

--- a/plugins/catalog-backend-module-gitlab/src/GitLabDiscoveryProcessor.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/GitLabDiscoveryProcessor.test.ts
@@ -20,7 +20,7 @@ import {
 } from '@backstage/backend-test-utils';
 import { ConfigReader } from '@backstage/config';
 import { LocationSpec } from '@backstage/plugin-catalog-node';
-import { rest, RestRequest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { GitLabDiscoveryProcessor, parseUrl } from './GitLabDiscoveryProcessor';
 import { GitLabProject } from './lib';
@@ -65,22 +65,23 @@ function setupFakeServer(
     data: GitLabProject[];
     nextPage?: number;
   },
-  assertion?: (r: RestRequest) => any,
+  assertion?: (request: Request) => any,
 ) {
   server.use(
-    rest.get(url, (req, res, ctx) => {
+    http.get(url, ({ request }) => {
       // Send the request to the assertion to give the test an opportunity to inspect the parameters.
       if (assertion !== undefined) {
-        assertion(req);
+        assertion(request);
       }
 
-      if (req.headers.get('authorization') !== 'Bearer test-token') {
-        return res(ctx.status(401), ctx.json({}));
+      if (request.headers.get('authorization') !== 'Bearer test-token') {
+        return HttpResponse.json({}, { status: 401 });
       }
-      const page = req.url.searchParams.get('page');
-      const include_subgroups = req.url.searchParams.get('include_subgroups');
-      const archived = req.url.searchParams.get('archived');
-      const simple = req.url.searchParams.get('simple');
+      const searchParams = new URL(request.url).searchParams;
+      const page = searchParams.get('page');
+      const include_subgroups = searchParams.get('include_subgroups');
+      const archived = searchParams.get('archived');
+      const simple = searchParams.get('simple');
       const response = listProjectsCallback({
         page: parseInt(page!, 10),
         include_subgroups: include_subgroups === 'true',
@@ -89,9 +90,7 @@ function setupFakeServer(
       });
 
       // Filter the fake results based on the `last_activity_after` parameter
-      const last_activity_after = req.url.searchParams.get(
-        'last_activity_after',
-      );
+      const last_activity_after = searchParams.get('last_activity_after');
       const filteredData = response.data
         .filter(
           v =>
@@ -100,35 +99,34 @@ function setupFakeServer(
         )
         .filter(v => archived || !v.archived);
 
-      return res(
-        ctx.set('x-next-page', response.nextPage?.toString() ?? ''),
-        ctx.json(filteredData),
-      );
+      return HttpResponse.json(filteredData, {
+        headers: { 'x-next-page': response.nextPage?.toString() ?? '' },
+      });
     }),
-    rest.head(
+    http.head(
       `${API_URL}/projects/:projectIdentifier/repository/files/:file_path`,
-      (req, res, ctx) => {
-        if (req.headers.get('authorization') !== 'Bearer test-token') {
-          return res(
-            ctx.status(401),
-            ctx.json({ message: '401 Unauthorized' }),
+      ({ request, params }) => {
+        if (request.headers.get('authorization') !== 'Bearer test-token') {
+          return HttpResponse.json(
+            { message: '401 Unauthorized' },
+            { status: 401 },
           );
         }
-        const ref = req.url.searchParams.get('ref');
+        const ref = new URL(request.url).searchParams.get('ref');
 
         if (ref === 'main' || ref === 'master') {
-          return res(ctx.status(200));
+          return new HttpResponse(null, { status: 200 });
         }
 
         if (
           // Gitlab GET project endpoint can use either numeric project.id or string project.path_with_namespace
-          EXISTING_PROJECT_ID.toString() === req.params.projectIdentifier ||
-          EXISTING_PROJECT_PATH === req.params.projectIdentifier
+          EXISTING_PROJECT_ID.toString() === params.projectIdentifier ||
+          EXISTING_PROJECT_PATH === params.projectIdentifier
         ) {
-          return res(ctx.status(200));
+          return new HttpResponse(null, { status: 200 });
         }
 
-        return res(ctx.status(404));
+        return new HttpResponse(null, { status: 404 });
       },
     ),
   );
@@ -446,7 +444,7 @@ describe('GitlabDiscoveryProcessor', () => {
         request => {
           // We assert that the last activity timestamp is not being sent to the GitLab API as we expect the cache to be empty.
           expect(
-            request.url.searchParams.get('last_activity_after'),
+            new URL(request.url).searchParams.get('last_activity_after'),
           ).toBeNull();
         },
       );
@@ -468,9 +466,9 @@ describe('GitlabDiscoveryProcessor', () => {
         },
         request => {
           // We assert that the last activity timestamp is being sent to the GitLab API since we expect it to be in the cache.
-          expect(request.url.searchParams.get('last_activity_after')).toMatch(
-            SERVER_TIME,
-          );
+          expect(
+            new URL(request.url).searchParams.get('last_activity_after'),
+          ).toMatch(SERVER_TIME);
         },
       );
       const result2: any[] = [];
@@ -502,7 +500,7 @@ describe('GitlabDiscoveryProcessor', () => {
         },
         request => {
           // Verify that simple=true is set in the request
-          expect(request.url.searchParams.get('simple')).toBe('true');
+          expect(new URL(request.url).searchParams.get('simple')).toBe('true');
         },
       );
 
@@ -540,7 +538,7 @@ describe('GitlabDiscoveryProcessor', () => {
         },
         request => {
           // Verify that simple parameter is not set
-          expect(request.url.searchParams.get('simple')).toBeNull();
+          expect(new URL(request.url).searchParams.get('simple')).toBeNull();
         },
       );
 
@@ -572,8 +570,10 @@ describe('GitlabDiscoveryProcessor', () => {
         },
         request => {
           // Verify default parameters: archived=false and simple=true
-          expect(request.url.searchParams.get('archived')).toBe('false');
-          expect(request.url.searchParams.get('simple')).toBe('true');
+          expect(new URL(request.url).searchParams.get('archived')).toBe(
+            'false',
+          );
+          expect(new URL(request.url).searchParams.get('simple')).toBe('true');
         },
       );
 

--- a/plugins/catalog-backend-module-gitlab/src/__testUtils__/handlers.ts
+++ b/plugins/catalog-backend-module-gitlab/src/__testUtils__/handlers.ts
@@ -322,7 +322,7 @@ const httpProjectCatalogDynamic = all_projects_response.flatMap(project => {
       ) {
         return new HttpResponse(null, { status: 200 });
       }
-      return new HttpResponse('Not Found', { status: 404 });
+      return new HttpResponse(null, { status: 404, statusText: 'Not Found' });
     },
   );
 });

--- a/plugins/catalog-backend-module-gitlab/src/__testUtils__/handlers.ts
+++ b/plugins/catalog-backend-module-gitlab/src/__testUtils__/handlers.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { graphql, rest } from 'msw';
+import { http, HttpResponse, graphql } from 'msw';
 import {
   all_groups_response,
   all_projects_response,
@@ -42,28 +42,29 @@ const httpHandlers = [
    */
 
   // fetch all projects in an instance handling archived ones
-  rest.get(`${apiBaseUrl}/projects`, (req, res, ctx) => {
-    const archived = req.url.searchParams.get('archived');
+  http.get(`${apiBaseUrl}/projects`, ({ request }) => {
+    const archived = new URL(request.url).searchParams.get('archived');
 
-    return res(
-      ctx.set('x-next-page', ''),
-      ctx.json(
-        all_projects_response.filter(p =>
-          archived === 'false' ? !p.archived : true,
-        ),
+    return HttpResponse.json(
+      all_projects_response.filter(p =>
+        archived === 'false' ? !p.archived : true,
       ),
+      { headers: { 'x-next-page': '' } },
     );
   }),
 
-  rest.get(`${apiBaseUrl}/projects/42`, (_, res, ctx) => {
-    return res(ctx.status(500), ctx.json({ error: 'Internal Server Error' }));
+  http.get(`${apiBaseUrl}/projects/42`, () => {
+    return HttpResponse.json(
+      { error: 'Internal Server Error' },
+      { status: 500 },
+    );
   }),
 
   // testing non existing file
-  rest.get(
+  http.get(
     `${apiBaseUrl}/projects/test-group%2Ftest-repo1/repository/files/catalog-info.yaml`,
-    (_, res, ctx) => {
-      return res(ctx.status(400), ctx.json({ error: 'Not found' }));
+    () => {
+      return HttpResponse.json({ error: 'Not found' }, { status: 400 });
     },
   ),
 
@@ -71,74 +72,82 @@ const httpHandlers = [
    * Group REST endpoint mocks
    */
 
-  rest.get(`${apiBaseUrl}/groups`, (_req, res, ctx) => {
-    return res(ctx.set('x-next-page', ''), ctx.json(all_groups_response));
+  http.get(`${apiBaseUrl}/groups`, () => {
+    return HttpResponse.json(all_groups_response, {
+      headers: { 'x-next-page': '' },
+    });
   }),
 
-  rest.get(`${apiBaseUrl}/groups/group-with-subgroup`, (_, res, ctx) => {
-    return res(
-      ctx.set('x-next-page', ''),
-      ctx.json(group_with_subgroups_response),
+  http.get(`${apiBaseUrl}/groups/group-with-subgroup`, () => {
+    return HttpResponse.json(group_with_subgroups_response, {
+      headers: { 'x-next-page': '' },
+    });
+  }),
+
+  http.get(`${apiBaseUrl}/groups/group1`, () => {
+    return HttpResponse.json(
+      all_groups_response.find(g => g.full_path === 'group1'),
+      { headers: { 'x-next-page': '' } },
     );
   }),
 
-  rest.get(`${apiBaseUrl}/groups/group1`, (_, res, ctx) => {
-    return res(
-      ctx.set('x-next-page', ''),
-      ctx.json(all_groups_response.find(g => g.full_path === 'group1')),
+  http.get(`${apiBaseUrl}/groups/42`, () => {
+    return HttpResponse.json(
+      { error: 'Internal Server Error' },
+      { status: 500 },
     );
   }),
-
-  rest.get(`${apiBaseUrl}/groups/42`, (_, res, ctx) => {
-    return res(ctx.status(500), ctx.json({ error: 'Internal Server Error' }));
-  }),
-  rest.get(`${apiBaseUrl}/groups/group1/members/all`, (_req, res, ctx) => {
-    return res(ctx.json(all_self_hosted_group1_members));
+  http.get(`${apiBaseUrl}/groups/group1/members/all`, () => {
+    return HttpResponse.json(all_self_hosted_group1_members);
   }),
 
-  rest.get(`${apiBaseUrlSaas}/groups/group1/members/all`, (_req, res, ctx) => {
-    return res(ctx.json(all_saas_users_response));
+  http.get(`${apiBaseUrlSaas}/groups/group1/members/all`, () => {
+    return HttpResponse.json(all_saas_users_response);
   }),
 
-  rest.get(
-    `${apiBaseUrlSaas}/groups/group1%2Fsubgroup1/members/all`,
-    (_req, res, ctx) => {
-      return res(ctx.json(subgroup_saas_users_response)); // To-DO change
-    },
-  ),
-
-  rest.get(`${apiBaseUrlSaas}/groups/456/members/all`, (_req, res, ctx) => {
-    return res(ctx.json(all_saas_users_response));
+  http.get(`${apiBaseUrlSaas}/groups/group1%2Fsubgroup1/members/all`, () => {
+    return HttpResponse.json(subgroup_saas_users_response); // To-DO change
   }),
 
-  rest.get(`${apiBaseUrlSaas}/groups/1/members/all`, (_req, res, ctx) => {
-    return res(ctx.json(all_saas_users_response));
+  http.get(`${apiBaseUrlSaas}/groups/456/members/all`, () => {
+    return HttpResponse.json(all_saas_users_response);
+  }),
+
+  http.get(`${apiBaseUrlSaas}/groups/1/members/all`, () => {
+    return HttpResponse.json(all_saas_users_response);
   }),
 
   // Subgroup 1 members id=6
-  rest.get(`${apiBaseUrlSaas}/groups/6/members/all`, (_req, res, ctx) => {
-    return res(ctx.json(all_saas_subgroup_1_members));
+  http.get(`${apiBaseUrlSaas}/groups/6/members/all`, () => {
+    return HttpResponse.json(all_saas_subgroup_1_members);
   }),
 
   // Subgroup 2 members id=7
-  rest.get(`${apiBaseUrlSaas}/groups/7/members/all`, (_req, res, ctx) => {
-    return res(ctx.json(all_saas_subgroup_2_members));
+  http.get(`${apiBaseUrlSaas}/groups/7/members/all`, () => {
+    return HttpResponse.json(all_saas_subgroup_2_members);
   }),
 
   /**
    * Users REST endpoint mocks
    */
 
-  rest.get(`${apiBaseUrl}/users`, (_req, res, ctx) => {
-    return res(ctx.set('x-next-page', ''), ctx.json(all_users_response));
+  http.get(`${apiBaseUrl}/users`, () => {
+    return HttpResponse.json(all_users_response, {
+      headers: { 'x-next-page': '' },
+    });
   }),
 
-  rest.get(`${apiBaseUrl}/users/${userID}`, (_, res, ctx) => {
-    return res(ctx.json(all_users_response.find(user => user.id === userID)));
+  http.get(`${apiBaseUrl}/users/${userID}`, () => {
+    return HttpResponse.json(
+      all_users_response.find(user => user.id === userID),
+    );
   }),
 
-  rest.get(`${apiBaseUrl}/users/42`, (_, res, ctx) => {
-    return res(ctx.status(500), ctx.json({ error: 'Internal Server Error' }));
+  http.get(`${apiBaseUrl}/users/42`, () => {
+    return HttpResponse.json(
+      { error: 'Internal Server Error' },
+      { status: 500 },
+    );
   }),
 
   /**
@@ -146,27 +155,25 @@ const httpHandlers = [
    */
 
   // mock a 4 page response
-  rest.get(`${apiBaseUrl}${paged_endpoint}`, (req, res, ctx) => {
-    const page = req.url.searchParams.get('page');
+  http.get(`${apiBaseUrl}${paged_endpoint}`, ({ request }) => {
+    const page = new URL(request.url).searchParams.get('page');
     const currentPage = page ? Number(page) : 1;
     const fakePageCount = 4;
 
-    return res(
-      // set next page number header if page requested is less than count
-      ctx.set(
-        'x-next-page',
-        currentPage < fakePageCount ? String(currentPage + 1) : '',
-      ),
-      ctx.json([{ someContentOfPage: currentPage }]),
-    );
+    return HttpResponse.json([{ someContentOfPage: currentPage }], {
+      headers: {
+        'x-next-page':
+          currentPage < fakePageCount ? String(currentPage + 1) : '',
+      },
+    });
   }),
 
-  rest.get(`${apiBaseUrl}${unhealthy_endpoint}`, (_, res, ctx) => {
-    return res(ctx.status(400), ctx.json({ error: 'some error' }));
+  http.get(`${apiBaseUrl}${unhealthy_endpoint}`, () => {
+    return HttpResponse.json({ error: 'some error' }, { status: 400 });
   }),
 
-  rest.get(`${apiBaseUrl}${some_endpoint}`, (req, res, ctx) => {
-    return res(ctx.json([{ endpoint: req.url.toString() }]));
+  http.get(`${apiBaseUrl}${some_endpoint}`, ({ request }) => {
+    return HttpResponse.json([{ endpoint: request.url }]);
   }),
 ];
 
@@ -175,37 +182,33 @@ const httpHandlers = [
 // https://docs.gitlab.com/ee/api/groups.html#list-group-details supports encoded path and id
 const httpGroupFindByEncodedPathDynamic = all_groups_response.flatMap(group => [
   // Handler for apiBaseUrl
-  rest.get(
+  http.get(
     `${apiBaseUrl}/groups/${encodeURIComponent(group.full_path)}`,
-    (_, res, ctx) => {
-      return res(
-        ctx.json(
-          all_groups_response.find(g => g.full_path === group.full_path),
-        ),
+    () => {
+      return HttpResponse.json(
+        all_groups_response.find(g => g.full_path === group.full_path),
       );
     },
   ),
   // Handler for apiSaaSBaseUrl
-  rest.get(
+  http.get(
     `${apiBaseUrlSaas}/groups/${encodeURIComponent(group.full_path)}`,
-    (_, res, ctx) => {
-      return res(
-        ctx.json(
-          all_groups_response.find(g => g.full_path === group.full_path),
-        ),
+    () => {
+      return HttpResponse.json(
+        all_groups_response.find(g => g.full_path === group.full_path),
       );
     },
   ),
 ]);
 
 const httpSearchFilesInGroupDynamic = all_groups_response.map(group => {
-  return rest.get(
+  return http.get(
     `${apiBaseUrl}/groups/${encodeURIComponent(group.full_path)}/search`,
-    (req, res, ctx) => {
-      const scope = req.url.searchParams.get('scope');
+    ({ request }) => {
+      const scope = new URL(request.url).searchParams.get('scope');
 
       if (scope !== 'blobs') {
-        return res(ctx.status(400), ctx.text('400 Bad Request'));
+        return new HttpResponse('400 Bad Request', { status: 400 });
       }
 
       const searchResults = projects_with_catalog_info_yaml
@@ -225,22 +228,22 @@ const httpSearchFilesInGroupDynamic = all_groups_response.map(group => {
           };
         });
 
-      return res(ctx.json(searchResults));
+      return HttpResponse.json(searchResults);
     },
   );
 });
 
 const httpGroupFindByIdDynamic = all_groups_response.map(group => {
-  return rest.get(`${apiBaseUrl}/groups/${group.id}`, (_, res, ctx) => {
-    return res(ctx.json(all_groups_response.find(g => g.id === group.id)));
+  return http.get(`${apiBaseUrl}/groups/${group.id}`, () => {
+    return HttpResponse.json(all_groups_response.find(g => g.id === group.id));
   });
 });
 
 const httpGroupListDescendantProjectsById = all_groups_response.map(group => {
-  return rest.get(
+  return http.get(
     `${apiBaseUrl}/groups/${group.id}/projects`,
-    (req, res, ctx) => {
-      const archived = req.url.searchParams.get('archived');
+    ({ request }) => {
+      const archived = new URL(request.url).searchParams.get('archived');
 
       const projectsInGroup = all_projects_response.filter(
         p =>
@@ -248,16 +251,16 @@ const httpGroupListDescendantProjectsById = all_groups_response.map(group => {
           (archived === 'false' ? !p.archived : true),
       );
 
-      return res(ctx.json(projectsInGroup));
+      return HttpResponse.json(projectsInGroup);
     },
   );
 });
 
 const httpGroupListDescendantProjectsByName = all_groups_response.map(group => {
-  return rest.get(
+  return http.get(
     `${apiBaseUrl}/groups/${group.name}/projects`,
-    (req, res, ctx) => {
-      const archived = req.url.searchParams.get('archived');
+    ({ request }) => {
+      const archived = new URL(request.url).searchParams.get('archived');
 
       const projectsInGroup = all_projects_response.filter(
         p =>
@@ -265,17 +268,17 @@ const httpGroupListDescendantProjectsByName = all_groups_response.map(group => {
           (archived === 'false' ? !p.archived : true),
       );
 
-      return res(ctx.json(projectsInGroup));
+      return HttpResponse.json(projectsInGroup);
     },
   );
 });
 
 const httpGroupListDescendantProjectsByFullPath = all_groups_response.map(
   group => {
-    return rest.get(
+    return http.get(
       `${apiBaseUrl}/groups/${encodeURIComponent(group.full_path)}/projects`,
-      (req, res, ctx) => {
-        const archived = req.url.searchParams.get('archived');
+      ({ request }) => {
+        const archived = new URL(request.url).searchParams.get('archived');
 
         const projectsInGroup = all_projects_response.filter(
           p =>
@@ -283,20 +286,24 @@ const httpGroupListDescendantProjectsByFullPath = all_groups_response.map(
             (archived === 'false' ? !p.archived : true),
         );
 
-        return res(ctx.json(projectsInGroup));
+        return HttpResponse.json(projectsInGroup);
       },
     );
   },
 );
 
 const httpGroupFindByNameDynamic = all_groups_response.map(group => {
-  return rest.get(`${apiBaseUrl}/groups/${group.name}`, (_, res, ctx) => {
-    return res(ctx.json(all_groups_response.find(g => g.name === group.name)));
+  return http.get(`${apiBaseUrl}/groups/${group.name}`, () => {
+    return HttpResponse.json(
+      all_groups_response.find(g => g.name === group.name),
+    );
   });
 });
 const httpProjectFindByIdDynamic = all_projects_response.map(project => {
-  return rest.get(`${apiBaseUrl}/projects/${project.id}`, (_, res, ctx) => {
-    return res(ctx.json(all_projects_response.find(p => p.id === project.id)));
+  return http.get(`${apiBaseUrl}/projects/${project.id}`, () => {
+    return HttpResponse.json(
+      all_projects_response.find(p => p.id === project.id),
+    );
   });
 });
 
@@ -304,18 +311,18 @@ const httpProjectFindByIdDynamic = all_projects_response.map(project => {
  * See https://docs.gitlab.com/api/repository_files/#get-file-from-repository
  */
 const httpProjectCatalogDynamic = all_projects_response.flatMap(project => {
-  return rest.head(
+  return http.head(
     `${apiBaseUrl}/projects/${project.id.toString()}/repository/files/catalog-info.yaml`,
-    (req, res, ctx) => {
-      const branch = req.url.searchParams.get('ref');
+    ({ request }) => {
+      const branch = new URL(request.url).searchParams.get('ref');
       if (
         branch === project.default_branch ||
         branch === 'main' ||
         branch === 'develop'
       ) {
-        return res(ctx.status(200));
+        return new HttpResponse(null, { status: 200 });
       }
-      return res(ctx.status(404, 'Not Found'));
+      return new HttpResponse('Not Found', { status: 404 });
     },
   );
 });
@@ -325,221 +332,222 @@ const httpProjectCatalogDynamic = all_projects_response.flatMap(project => {
  */
 
 const graphqlHandlers = [
+  graphql.link(graphQlBaseUrl).query('getGroupMembers', ({ variables }) => {
+    const { group, relations, endCursor } = variables as {
+      group: string;
+      relations: string[];
+      endCursor?: string;
+    };
+    // group is actually full_path
+    if (group === 'group1/subgroup1' && relations.includes('DIRECT')) {
+      return HttpResponse.json({
+        data: {
+          group: {
+            groupMembers: {
+              nodes: [
+                {
+                  user: {
+                    id: 'gid://gitlab/User/1',
+                    username: 'user1',
+                    publicEmail: 'user1@example.com',
+                    name: 'user1',
+                    state: 'active',
+                    webUrl: 'user1.com',
+                    avatarUrl: 'user1',
+                  },
+                },
+              ],
+              pageInfo: {
+                endCursor: 'end',
+                hasNextPage: false,
+              },
+            },
+          },
+        },
+      });
+    }
+    if (group === 'group1' && relations.includes('DIRECT')) {
+      return HttpResponse.json({
+        data: {
+          group: {
+            groupMembers: {
+              nodes: [
+                {
+                  user: {
+                    id: 'gid://gitlab/User/1',
+                    username: 'user1',
+                    publicEmail: 'user1@example.com',
+                    name: 'user1',
+                    state: 'active',
+                    webUrl: 'user1.com',
+                    avatarUrl: 'user1',
+                  },
+                },
+              ],
+              pageInfo: {
+                endCursor: 'end',
+                hasNextPage: false,
+              },
+            },
+          },
+        },
+      });
+    }
+    // group with no associated members
+    if (group === 'group3' && relations.includes('DIRECT')) {
+      return HttpResponse.json({
+        data: {
+          group: {
+            groupMembers: {
+              nodes: [{}],
+              pageInfo: {
+                endCursor: 'end',
+                hasNextPage: false,
+              },
+            },
+          },
+        },
+      });
+    }
+    if (group === 'saas-multi-user-group') {
+      return HttpResponse.json({
+        data: {
+          group: {
+            groupMembers: {
+              nodes: [
+                {
+                  user: {
+                    id: 'gid://gitlab/User/1',
+                    username: 'user1',
+                    publicEmail: 'user1@example.com',
+                    name: 'user1',
+                    state: 'active',
+                    webUrl: 'user1.com',
+                    avatarUrl: 'user1',
+                  },
+                },
+                {
+                  user: {
+                    id: 'gid://gitlab/User/2',
+                    username: 'user2',
+                    publicEmail: 'user2@example.com',
+                    name: 'user2',
+                    state: 'active',
+                    webUrl: 'user2.com',
+                    avatarUrl: 'user2',
+                  },
+                },
+              ],
+              pageInfo: {
+                endCursor: 'end',
+                hasNextPage: false,
+              },
+            },
+          },
+        },
+      });
+    }
+
+    if (group === 'non-existing-group' || group === '') {
+      return HttpResponse.json({
+        data: {
+          group: {
+            groupMembers: {
+              pageInfo: {
+                endCursor: 'end',
+                hasNextPage: false,
+              },
+            },
+          },
+        },
+      });
+    }
+
+    if (group === 'multi-page' && relations.includes('DIRECT')) {
+      return HttpResponse.json({
+        data: {
+          group: {
+            groupMembers: {
+              nodes: endCursor
+                ? [{ user: { id: 'gid://gitlab/User/2' } }]
+                : [{ user: { id: 'gid://gitlab/User/1' } }],
+              pageInfo: {
+                endCursor: endCursor ? 'end' : 'next',
+                hasNextPage: !endCursor,
+              },
+            },
+          },
+        },
+      });
+    }
+
+    if (group === 'multi-page-saas') {
+      return HttpResponse.json({
+        data: {
+          group: {
+            groupMembers: {
+              nodes: endCursor
+                ? [
+                    {
+                      user: {
+                        id: 'gid://gitlab/User/1',
+                        username: 'user1',
+                        publicEmail: 'user1@example.com',
+                        name: 'user1',
+                        state: 'active',
+                        webUrl: 'user1.com',
+                        avatarUrl: 'user1',
+                      },
+                    },
+                  ]
+                : [
+                    {
+                      user: {
+                        id: 'gid://gitlab/User/2',
+                        username: 'user2',
+                        publicEmail: 'user2@example.com',
+                        name: 'user2',
+                        state: 'active',
+                        webUrl: 'user2.com',
+                        avatarUrl: 'user2',
+                      },
+                    },
+                  ],
+              pageInfo: {
+                endCursor: endCursor ? 'end' : 'next',
+                hasNextPage: !endCursor,
+              },
+            },
+          },
+        },
+      });
+    }
+
+    if (group === 'error-group') {
+      return HttpResponse.json({
+        errors: [{ message: 'Unexpected end of document', locations: [] }],
+      });
+    }
+
+    return new HttpResponse(null, { status: 200 });
+  }),
+
   graphql
     .link(graphQlBaseUrl)
-    .query('getGroupMembers', async (req, res, ctx) => {
-      const { group, relations } = req.variables;
-      // group is actually full_path
-      if (group === 'group1/subgroup1' && relations.includes('DIRECT')) {
-        return res(
-          ctx.data({
-            group: {
-              groupMembers: {
-                nodes: [
-                  {
-                    user: {
-                      id: 'gid://gitlab/User/1',
-                      username: 'user1',
-                      publicEmail: 'user1@example.com',
-                      name: 'user1',
-                      state: 'active',
-                      webUrl: 'user1.com',
-                      avatarUrl: 'user1',
-                    },
-                  },
-                ],
-                pageInfo: {
-                  endCursor: 'end',
-                  hasNextPage: false,
-                },
-              },
-            },
-          }),
-        );
-      }
-      if (group === 'group1' && relations.includes('DIRECT')) {
-        return res(
-          ctx.data({
-            group: {
-              groupMembers: {
-                nodes: [
-                  {
-                    user: {
-                      id: 'gid://gitlab/User/1',
-                      username: 'user1',
-                      publicEmail: 'user1@example.com',
-                      name: 'user1',
-                      state: 'active',
-                      webUrl: 'user1.com',
-                      avatarUrl: 'user1',
-                    },
-                  },
-                ],
-                pageInfo: {
-                  endCursor: 'end',
-                  hasNextPage: false,
-                },
-              },
-            },
-          }),
-        );
-      }
-      // group with no associated members
-      if (group === 'group3' && relations.includes('DIRECT')) {
-        return res(
-          ctx.data({
-            group: {
-              groupMembers: {
-                nodes: [{}],
-                pageInfo: {
-                  endCursor: 'end',
-                  hasNextPage: false,
-                },
-              },
-            },
-          }),
-        );
-      }
-      if (group === 'saas-multi-user-group') {
-        return res(
-          ctx.data({
-            group: {
-              groupMembers: {
-                nodes: [
-                  {
-                    user: {
-                      id: 'gid://gitlab/User/1',
-                      username: 'user1',
-                      publicEmail: 'user1@example.com',
-                      name: 'user1',
-                      state: 'active',
-                      webUrl: 'user1.com',
-                      avatarUrl: 'user1',
-                    },
-                  },
-                  {
-                    user: {
-                      id: 'gid://gitlab/User/2',
-                      username: 'user2',
-                      publicEmail: 'user2@example.com',
-                      name: 'user2',
-                      state: 'active',
-                      webUrl: 'user2.com',
-                      avatarUrl: 'user2',
-                    },
-                  },
-                ],
-                pageInfo: {
-                  endCursor: 'end',
-                  hasNextPage: false,
-                },
-              },
-            },
-          }),
-        );
-      }
-
-      if (group === 'non-existing-group' || group === '') {
-        return res(
-          ctx.data({
-            group: {
-              groupMembers: {
-                pageInfo: {
-                  endCursor: 'end',
-                  hasNextPage: false,
-                },
-              },
-            },
-          }),
-        );
-      }
-
-      if (group === 'multi-page' && relations.includes('DIRECT')) {
-        return res(
-          ctx.data({
-            group: {
-              groupMembers: {
-                nodes: req.variables.endCursor
-                  ? [{ user: { id: 'gid://gitlab/User/2' } }]
-                  : [{ user: { id: 'gid://gitlab/User/1' } }],
-                pageInfo: {
-                  endCursor: req.variables.endCursor ? 'end' : 'next',
-                  hasNextPage: !req.variables.endCursor,
-                },
-              },
-            },
-          }),
-        );
-      }
-
-      if (group === 'multi-page-saas') {
-        return res(
-          ctx.data({
-            group: {
-              groupMembers: {
-                nodes: req.variables.endCursor
-                  ? [
-                      {
-                        user: {
-                          id: 'gid://gitlab/User/1',
-                          username: 'user1',
-                          publicEmail: 'user1@example.com',
-                          name: 'user1',
-                          state: 'active',
-                          webUrl: 'user1.com',
-                          avatarUrl: 'user1',
-                        },
-                      },
-                    ]
-                  : [
-                      {
-                        user: {
-                          id: 'gid://gitlab/User/2',
-                          username: 'user2',
-                          publicEmail: 'user2@example.com',
-                          name: 'user2',
-                          state: 'active',
-                          webUrl: 'user2.com',
-                          avatarUrl: 'user2',
-                        },
-                      },
-                    ],
-                pageInfo: {
-                  endCursor: req.variables.endCursor ? 'end' : 'next',
-                  hasNextPage: !req.variables.endCursor,
-                },
-              },
-            },
-          }),
-        );
-      }
+    .query('listDescendantGroups', ({ variables }) => {
+      const { group, endCursor } = variables as {
+        group: string;
+        endCursor?: string;
+      };
 
       if (group === 'error-group') {
-        return res(
-          ctx.errors([
-            { message: 'Unexpected end of document', locations: [] },
-          ]),
-        );
-      }
-
-      return res(ctx.status(200));
-    }),
-
-  graphql
-    .link(graphQlBaseUrl)
-    .query('listDescendantGroups', async (req, res, ctx) => {
-      const { group } = req.variables;
-
-      if (group === 'error-group') {
-        return res(
-          ctx.errors([
-            { message: 'Unexpected end of document', locations: [] },
-          ]),
-        );
+        return HttpResponse.json({
+          errors: [{ message: 'Unexpected end of document', locations: [] }],
+        });
       }
       if (group === 'group1') {
-        return res(
-          ctx.data({
+        return HttpResponse.json({
+          data: {
             group: {
               descendantGroups: {
                 nodes: [
@@ -559,12 +567,12 @@ const graphqlHandlers = [
                 },
               },
             },
-          }),
-        );
+          },
+        });
       }
       if (group === 'group-with-parent') {
-        return res(
-          ctx.data({
+        return HttpResponse.json({
+          data: {
             group: {
               descendantGroups: {
                 nodes: [
@@ -584,15 +592,15 @@ const graphqlHandlers = [
                 },
               },
             },
-          }),
-        );
+          },
+        });
       }
       if (group === 'root') {
-        return res(
-          ctx.data({
+        return HttpResponse.json({
+          data: {
             group: {
               descendantGroups: {
-                nodes: req.variables.endCursor
+                nodes: endCursor
                   ? [
                       {
                         id: 'gid://gitlab/Group/1',
@@ -616,95 +624,94 @@ const graphqlHandlers = [
                       },
                     ],
                 pageInfo: {
-                  endCursor: req.variables.endCursor ? 'end' : 'next',
-                  hasNextPage: !req.variables.endCursor,
+                  endCursor: endCursor ? 'end' : 'next',
+                  hasNextPage: !endCursor,
                 },
               },
             },
-          }),
-        );
+          },
+        });
       }
 
       if (group === 'non-existing-group') {
-        return res(
-          ctx.data({
+        return HttpResponse.json({
+          data: {
             group: {},
-          }),
-        );
+          },
+        });
       }
-      return res(ctx.status(200));
+      return new HttpResponse(null, { status: 200 });
     }),
 
-  graphql
-    .link(saasGraphQlBaseUrl)
-    .query('getGroupMembers', async (req, res, ctx) => {
-      const { group } = req.variables;
+  graphql.link(saasGraphQlBaseUrl).query('getGroupMembers', ({ variables }) => {
+    const { group } = variables as { group: string };
 
-      if (group === 'saas-multi-user-group') {
-        return res(
-          ctx.data({
-            group: {
-              groupMembers: {
-                nodes: [
-                  {
-                    user: {
-                      id: 'gid://gitlab/User/1',
-                      username: 'user1',
-                      publicEmail: 'user1@example.com',
-                      name: 'user1',
-                      state: 'active',
-                      webUrl: 'user1.com',
-                      avatarUrl: 'user1',
-                    },
+    if (group === 'saas-multi-user-group') {
+      return HttpResponse.json({
+        data: {
+          group: {
+            groupMembers: {
+              nodes: [
+                {
+                  user: {
+                    id: 'gid://gitlab/User/1',
+                    username: 'user1',
+                    publicEmail: 'user1@example.com',
+                    name: 'user1',
+                    state: 'active',
+                    webUrl: 'user1.com',
+                    avatarUrl: 'user1',
                   },
-                  {
-                    user: {
-                      id: 'gid://gitlab/User/2',
-                      username: 'user2',
-                      publicEmail: 'user2@example.com',
-                      name: 'user2',
-                      state: 'active',
-                      webUrl: 'user2.com',
-                      avatarUrl: 'user2',
-                    },
-                  },
-                ],
-                pageInfo: {
-                  endCursor: 'end',
-                  hasNextPage: false,
                 },
+                {
+                  user: {
+                    id: 'gid://gitlab/User/2',
+                    username: 'user2',
+                    publicEmail: 'user2@example.com',
+                    name: 'user2',
+                    state: 'active',
+                    webUrl: 'user2.com',
+                    avatarUrl: 'user2',
+                  },
+                },
+              ],
+              pageInfo: {
+                endCursor: 'end',
+                hasNextPage: false,
               },
             },
-          }),
-        );
-      }
+          },
+        },
+      });
+    }
 
-      if (group === '') {
-        return res(ctx.data({}));
-      }
+    if (group === '') {
+      return HttpResponse.json({ data: {} });
+    }
 
-      if (group === 'error-group') {
-        return res(
-          ctx.errors([
-            { message: 'Unexpected end of document', locations: [] },
-          ]),
-        );
-      }
+    if (group === 'error-group') {
+      return HttpResponse.json({
+        errors: [{ message: 'Unexpected end of document', locations: [] }],
+      });
+    }
 
-      return res(ctx.status(200));
-    }),
+    return new HttpResponse(null, { status: 200 });
+  }),
 
   graphql
     .link(saasGraphQlBaseUrl)
-    .query('listDescendantGroups', async (req, res, ctx) => {
-      const { group } = req.variables;
+    .query('listDescendantGroups', ({ variables }) => {
+      const { group, endCursor } = variables as {
+        group: string;
+        endCursor?: string;
+      };
 
       if (group === 'group1') {
-        return res(
-          ctx.data({
+        return HttpResponse.json({
+          data: {
             group: {
               descendantGroups: {
-                nodes: req.variables.endCursor
+                nodes: endCursor
                   ? [
                       {
                         id: 'gid://gitlab/Group/6',
@@ -728,17 +735,17 @@ const graphqlHandlers = [
                       },
                     ],
                 pageInfo: {
-                  endCursor: req.variables.endCursor ? 'end' : 'next',
-                  hasNextPage: !req.variables.endCursor,
+                  endCursor: endCursor ? 'end' : 'next',
+                  hasNextPage: !endCursor,
                 },
               },
             },
-          }),
-        );
+          },
+        });
       }
 
-      return res(
-        ctx.data({
+      return HttpResponse.json({
+        data: {
           group: {
             descendantGroups: {
               nodes: [
@@ -758,8 +765,8 @@ const graphqlHandlers = [
               },
             },
           },
-        }),
-      );
+        },
+      });
     }),
 ];
 

--- a/plugins/catalog-backend-module-msgraph/package.json
+++ b/plugins/catalog-backend-module-msgraph/package.json
@@ -66,7 +66,7 @@
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@types/lodash": "^4.14.151",
-    "msw": "^1.0.0"
+    "msw": "^2.0.0"
   },
   "configSchema": "config.d.ts"
 }

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/client.test.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/client.test.ts
@@ -16,7 +16,7 @@
 
 import { TokenCredential } from '@azure/identity';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { MicrosoftGraphClient } from './client';
 
@@ -42,8 +42,8 @@ describe('MicrosoftGraphClient', () => {
 
   it('should perform raw request', async () => {
     worker.use(
-      rest.get('https://other.example.com/', (_, res, ctx) =>
-        res(ctx.status(200), ctx.json({ value: 'example' })),
+      http.get('https://other.example.com/', () =>
+        HttpResponse.json({ value: 'example' }),
       ),
     );
 
@@ -59,8 +59,8 @@ describe('MicrosoftGraphClient', () => {
 
   it('should perform simple api request', async () => {
     worker.use(
-      rest.get('https://example.com/users', (_, res, ctx) =>
-        res(ctx.status(200), ctx.json({ value: 'example' })),
+      http.get('https://example.com/users', () =>
+        HttpResponse.json({ value: 'example' }),
       ),
     );
 
@@ -72,8 +72,8 @@ describe('MicrosoftGraphClient', () => {
 
   it('should perform api request with filter, select, expand and top', async () => {
     worker.use(
-      rest.get('https://example.com/users', (req, res, ctx) =>
-        res(ctx.status(200), ctx.json({ queryString: req.url.search })),
+      http.get('https://example.com/users', ({ request }) =>
+        HttpResponse.json({ queryString: new URL(request.url).search }),
       ),
     );
 
@@ -93,8 +93,8 @@ describe('MicrosoftGraphClient', () => {
 
   it('should correctly encode filter with special characters like "&"', async () => {
     worker.use(
-      rest.get('https://example.com/users', (req, res, ctx) =>
-        res(ctx.status(200), ctx.json({ queryString: req.url.search })),
+      http.get('https://example.com/users', ({ request }) =>
+        HttpResponse.json({ queryString: new URL(request.url).search }),
       ),
     );
 
@@ -111,13 +111,10 @@ describe('MicrosoftGraphClient', () => {
 
   it('should perform collection request for a single page', async () => {
     worker.use(
-      rest.get('https://example.com/users', (_, res, ctx) =>
-        res(
-          ctx.status(200),
-          ctx.json({
-            value: ['first'],
-          }),
-        ),
+      http.get('https://example.com/users', () =>
+        HttpResponse.json({
+          value: ['first'],
+        }),
       ),
     );
 
@@ -130,19 +127,16 @@ describe('MicrosoftGraphClient', () => {
 
   it('should perform collection request for multiple pages', async () => {
     worker.use(
-      rest.get('https://example.com/users', (_, res, ctx) =>
-        res(
-          ctx.status(200),
-          ctx.json({
-            value: ['first'],
-            '@odata.nextLink': 'https://example.com/users2',
-          }),
-        ),
+      http.get('https://example.com/users', () =>
+        HttpResponse.json({
+          value: ['first'],
+          '@odata.nextLink': 'https://example.com/users2',
+        }),
       ),
     );
     worker.use(
-      rest.get('https://example.com/users2', (_, res, ctx) =>
-        res(ctx.status(200), ctx.json({ value: ['second'] })),
+      http.get('https://example.com/users2', () =>
+        HttpResponse.json({ value: ['second'] }),
       ),
     );
 
@@ -155,28 +149,25 @@ describe('MicrosoftGraphClient', () => {
 
   it('should load user profile photo with max size of 120', async () => {
     worker.use(
-      rest.get('https://example.com/users/user-id/photos', (_, res, ctx) =>
-        res(
-          ctx.status(200),
-          ctx.json({
-            value: [
-              {
-                height: 120,
-                id: 120,
-              },
-              {
-                height: 500,
-                id: 500,
-              },
-            ],
-          }),
-        ),
+      http.get('https://example.com/users/user-id/photos', () =>
+        HttpResponse.json({
+          value: [
+            {
+              height: 120,
+              id: 120,
+            },
+            {
+              height: 500,
+              id: 500,
+            },
+          ],
+        }),
       ),
     );
     worker.use(
-      rest.get(
+      http.get(
         'https://example.com/users/user-id/photos/120/*',
-        (_, res, ctx) => res(ctx.status(200), ctx.text('911')),
+        () => new HttpResponse('911'),
       ),
     );
 
@@ -187,8 +178,9 @@ describe('MicrosoftGraphClient', () => {
 
   it('should not fail if user has no profile photo', async () => {
     worker.use(
-      rest.get('https://example.com/users/user-id/photos', (_, res, ctx) =>
-        res(ctx.status(404)),
+      http.get(
+        'https://example.com/users/user-id/photos',
+        () => new HttpResponse(null, { status: 404 }),
       ),
     );
 
@@ -199,8 +191,9 @@ describe('MicrosoftGraphClient', () => {
 
   it('should load user profile photo', async () => {
     worker.use(
-      rest.get('https://example.com/users/user-id/photo/*', (_, res, ctx) =>
-        res(ctx.status(200), ctx.text('911')),
+      http.get(
+        'https://example.com/users/user-id/photo/*',
+        () => new HttpResponse('911'),
       ),
     );
 
@@ -211,9 +204,9 @@ describe('MicrosoftGraphClient', () => {
 
   it('should load user profile photo for size 120', async () => {
     worker.use(
-      rest.get(
+      http.get(
         'https://example.com/users/user-id/photos/120/*',
-        (_, res, ctx) => res(ctx.status(200), ctx.text('911')),
+        () => new HttpResponse('911'),
       ),
     );
 
@@ -224,13 +217,10 @@ describe('MicrosoftGraphClient', () => {
 
   it('should load users', async () => {
     worker.use(
-      rest.get('https://example.com/users', (_, res, ctx) =>
-        res(
-          ctx.status(200),
-          ctx.json({
-            value: [{ surname: 'Example' }],
-          }),
-        ),
+      http.get('https://example.com/users', () =>
+        HttpResponse.json({
+          value: [{ surname: 'Example' }],
+        }),
       ),
     );
 
@@ -241,24 +231,21 @@ describe('MicrosoftGraphClient', () => {
 
   it('should load group profile photo with max size of 120', async () => {
     worker.use(
-      rest.get('https://example.com/groups/group-id/photos', (_, res, ctx) =>
-        res(
-          ctx.status(200),
-          ctx.json({
-            value: [
-              {
-                height: 120,
-                id: 120,
-              },
-            ],
-          }),
-        ),
+      http.get('https://example.com/groups/group-id/photos', () =>
+        HttpResponse.json({
+          value: [
+            {
+              height: 120,
+              id: 120,
+            },
+          ],
+        }),
       ),
     );
     worker.use(
-      rest.get(
+      http.get(
         'https://example.com/groups/group-id/photos/120/*',
-        (_, res, ctx) => res(ctx.status(200), ctx.text('911')),
+        () => new HttpResponse('911'),
       ),
     );
 
@@ -269,8 +256,9 @@ describe('MicrosoftGraphClient', () => {
 
   it('should load group profile photo', async () => {
     worker.use(
-      rest.get('https://example.com/groups/group-id/photo/*', (_, res, ctx) =>
-        res(ctx.status(200), ctx.text('911')),
+      http.get(
+        'https://example.com/groups/group-id/photo/*',
+        () => new HttpResponse('911'),
       ),
     );
 
@@ -281,13 +269,10 @@ describe('MicrosoftGraphClient', () => {
 
   it('should load groups', async () => {
     worker.use(
-      rest.get('https://example.com/groups', (_, res, ctx) =>
-        res(
-          ctx.status(200),
-          ctx.json({
-            value: [{ displayName: 'Example' }],
-          }),
-        ),
+      http.get('https://example.com/groups', () =>
+        HttpResponse.json({
+          value: [{ displayName: 'Example' }],
+        }),
       ),
     );
 
@@ -298,16 +283,13 @@ describe('MicrosoftGraphClient', () => {
 
   it('should load group members', async () => {
     worker.use(
-      rest.get('https://example.com/groups/group-id/members', (_, res, ctx) =>
-        res(
-          ctx.status(200),
-          ctx.json({
-            value: [
-              { '@odata.type': '#microsoft.graph.user' },
-              { '@odata.type': '#microsoft.graph.group' },
-            ],
-          }),
-        ),
+      http.get('https://example.com/groups/group-id/members', () =>
+        HttpResponse.json({
+          value: [
+            { '@odata.type': '#microsoft.graph.user' },
+            { '@odata.type': '#microsoft.graph.group' },
+          ],
+        }),
       ),
     );
 
@@ -323,15 +305,12 @@ describe('MicrosoftGraphClient', () => {
 
   it('should load user group members', async () => {
     worker.use(
-      rest.get(
+      http.get(
         'https://example.com/groups/group-id/members/microsoft.graph.user',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.json({
-              value: [{ id: '12345' }, { id: '67890' }],
-            }),
-          ),
+        () =>
+          HttpResponse.json({
+            value: [{ id: '12345' }, { id: '67890' }],
+          }),
       ),
     );
 
@@ -344,13 +323,10 @@ describe('MicrosoftGraphClient', () => {
 
   it('should load organization', async () => {
     worker.use(
-      rest.get('https://example.com/organization/tenant-id', (_, res, ctx) =>
-        res(
-          ctx.status(200),
-          ctx.json({
-            displayName: 'Example',
-          }),
-        ),
+      http.get('https://example.com/organization/tenant-id', () =>
+        HttpResponse.json({
+          displayName: 'Example',
+        }),
       ),
     );
 

--- a/plugins/catalog-backend-module-puppetdb/package.json
+++ b/plugins/catalog-backend-module-puppetdb/package.json
@@ -61,7 +61,7 @@
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@types/lodash": "^4.14.151",
-    "msw": "^1.0.0"
+    "msw": "^2.0.0"
   },
   "configSchema": "config.d.ts"
 }

--- a/plugins/catalog-backend-module-puppetdb/src/puppet/read.test.ts
+++ b/plugins/catalog-backend-module-puppetdb/src/puppet/read.test.ts
@@ -21,7 +21,7 @@ import {
 } from '../providers';
 import { DEFAULT_NAMESPACE } from '@backstage/catalog-model';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { ANNOTATION_PUPPET_CERTNAME, ENDPOINT_FACTSETS } from './constants';
 
@@ -41,11 +41,9 @@ describe('readPuppetNodes', () => {
 
     beforeEach(async () => {
       worker.use(
-        rest.get(`${config.baseUrl}/${ENDPOINT_FACTSETS}`, (_req, res, ctx) => {
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json([
+        http.get(`${config.baseUrl}/${ENDPOINT_FACTSETS}`, () => {
+          return HttpResponse.json(
+            [
               {
                 certname: 'node1',
                 timestamp: 'time1',
@@ -112,7 +110,10 @@ describe('readPuppetNodes', () => {
                   ],
                 },
               },
-            ]),
+            ],
+            {
+              headers: { 'Content-Type': 'application/json' },
+            },
           );
         }),
       );
@@ -196,16 +197,11 @@ describe('readPuppetNodes', () => {
     describe('where no results are matched', () => {
       beforeEach(async () => {
         worker.use(
-          rest.get(
-            `${config.baseUrl}/${ENDPOINT_FACTSETS}`,
-            (_req, res, ctx) => {
-              return res(
-                ctx.status(200),
-                ctx.set('Content-Type', 'application/json'),
-                ctx.json([]),
-              );
-            },
-          ),
+          http.get(`${config.baseUrl}/${ENDPOINT_FACTSETS}`, () => {
+            return HttpResponse.json([], {
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }),
         );
       });
 
@@ -218,25 +214,23 @@ describe('readPuppetNodes', () => {
     describe('where results are matched', () => {
       beforeEach(async () => {
         worker.use(
-          rest.get(
-            `${config.baseUrl}/${ENDPOINT_FACTSETS}`,
-            (_req, res, ctx) => {
-              return res(
-                ctx.status(200),
-                ctx.set('Content-Type', 'application/json'),
-                ctx.json([
-                  {
-                    certname: 'node1',
-                    timestamp: 'time1',
-                    hash: 'hash1',
-                    producer_timestamp: 'producer_time1',
-                    producer: 'producer1',
-                    environment: 'environment1',
-                  },
-                ]),
-              );
-            },
-          ),
+          http.get(`${config.baseUrl}/${ENDPOINT_FACTSETS}`, () => {
+            return HttpResponse.json(
+              [
+                {
+                  certname: 'node1',
+                  timestamp: 'time1',
+                  hash: 'hash1',
+                  producer_timestamp: 'producer_time1',
+                  producer: 'producer1',
+                  environment: 'environment1',
+                },
+              ],
+              {
+                headers: { 'Content-Type': 'application/json' },
+              },
+            );
+          }),
         );
       });
 

--- a/plugins/catalog-import/package.json
+++ b/plugins/catalog-import/package.json
@@ -89,7 +89,7 @@
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.0.0",
     "@types/react": "^18.0.0",
-    "msw": "^1.0.0",
+    "msw": "^2.0.0",
     "react": "^18.0.2",
     "react-dom": "^18.0.2",
     "react-router-dom": "^6.30.2"

--- a/plugins/catalog-import/src/api/AzureRepoApiClient.test.ts
+++ b/plugins/catalog-import/src/api/AzureRepoApiClient.test.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import {
   AzurePrOptions,
   AzurePrResult,
@@ -29,44 +29,42 @@ import { setupServer } from 'msw/node';
 import { registerMswTestHooks } from '@backstage/test-utils';
 
 function mockRepoEndpoint() {
-  return rest.get(
+  return http.get(
     'https://dev.azure.com/acme/project/_apis/git/repositories/:path',
-    (req, res, ctx) => {
-      const { path } = req.params;
+    ({ params }) => {
+      const { path } = params;
       if (path === 'success') {
-        return res(
-          ctx.json({
-            id: '01',
-            name: 'success',
-            defaultBranch: 'refs/heads/master',
-          }),
-        );
+        return HttpResponse.json({
+          id: '01',
+          name: 'success',
+          defaultBranch: 'refs/heads/master',
+        });
       }
       if (path === 'not-found') {
-        return res(
-          ctx.status(404),
-          ctx.json({
+        return HttpResponse.json(
+          {
             message: 'repository not found',
-          }),
+          },
+          { status: 404 },
         );
       }
-      return res(ctx.status(200));
+      return new HttpResponse(null, { status: 200 });
     },
   );
 }
 
 function mockRefsEndpoint() {
-  return rest.get(
+  return http.get(
     'https://dev.azure.com/acme/project/_apis/git/repositories/:repo/refs',
-    (req, res, ctx) => {
-      const filter = req.url.searchParams.get('filter');
-      const { repo } = req.params;
+    ({ params, request }) => {
+      const filter = new URL(request.url).searchParams.get('filter');
+      const { repo } = params;
       if (repo !== 'success') {
-        return res(
-          ctx.status(404),
-          ctx.json({
+        return HttpResponse.json(
+          {
             message: 'repository not found',
-          }),
+          },
+          { status: 404 },
         );
       }
       if (filter === 'heads/main') {
@@ -78,74 +76,70 @@ function mockRefsEndpoint() {
             },
           ],
         };
-        return res(ctx.json(result));
+        return HttpResponse.json(result);
       }
-      return res(ctx.json({ value: [] }));
+      return HttpResponse.json({ value: [] });
     },
   );
 }
 
 function mockPushEndpoint() {
-  return rest.post(
+  return http.post(
     'https://dev.azure.com/acme/project/_apis/git/repositories/:repo/pushes',
-    (req, res, ctx) => {
-      const { repo } = req.params;
+    ({ params }) => {
+      const { repo } = params;
       if (repo === 'success') {
-        return res(
-          ctx.json({
-            refUpdates: [
-              {
-                repositoryId: '01',
-                name: 'refs/heads/backstage-integration',
-                oldObjectId: '0000000000000000000000000000000000000000',
-                newObjectId: '0000000000000000000000000000000000000001',
-              },
-            ],
-          } satisfies { refUpdates: AzureRefUpdate[] }),
-        );
+        return HttpResponse.json({
+          refUpdates: [
+            {
+              repositoryId: '01',
+              name: 'refs/heads/backstage-integration',
+              oldObjectId: '0000000000000000000000000000000000000000',
+              newObjectId: '0000000000000000000000000000000000000001',
+            },
+          ],
+        } satisfies { refUpdates: AzureRefUpdate[] });
       }
 
       if (repo === 'error') {
-        return res(
-          ctx.status(500),
-          ctx.json({
+        return HttpResponse.json(
+          {
             message: 'internal error',
-          }),
+          },
+          { status: 500 },
         );
       }
 
-      return res(
-        ctx.status(500),
-        ctx.json({
+      return HttpResponse.json(
+        {
           message: 'Unexpected call',
-        }),
+        },
+        { status: 500 },
       );
     },
   );
 }
 
 function mockPrEndpoint() {
-  return rest.post(
+  return http.post(
     'https://dev.azure.com/acme/project/_apis/git/repositories/:repo/pullrequests',
-    (req, res, ctx) => {
-      const { repo } = req.params;
+    ({ params }) => {
+      const { repo } = params;
       if (repo === 'success') {
-        return res(
-          ctx.json({
-            pullRequestId: 'PR01',
-            repository: {
-              name: 'success',
-              webUrl: 'https://example.com',
-            },
-          } satisfies AzurePrResult),
-        );
+        return HttpResponse.json({
+          pullRequestId: 'PR01',
+          repository: {
+            name: 'success',
+            webUrl: 'https://example.com',
+          },
+        } satisfies AzurePrResult);
       }
 
-      return res(
-        ctx.status(500),
-        ctx.json({
+      return HttpResponse.json(
+        {
           message: 'internal error',
-        }),
+        },
+        { status: 500 },
       );
     },
   );

--- a/plugins/catalog-import/src/api/CatalogImportClient.test.ts
+++ b/plugins/catalog-import/src/api/CatalogImportClient.test.ts
@@ -59,7 +59,7 @@ import { ScmAuthApi } from '@backstage/integration-react';
 import { catalogApiMock } from '@backstage/plugin-catalog-react/testUtils';
 import { MockFetchApi, registerMswTestHooks } from '@backstage/test-utils';
 import { Octokit } from '@octokit/rest';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import {
   AzurePrOptions,
@@ -301,69 +301,67 @@ describe('CatalogImportClient', () => {
         },
       });
       server.use(
-        rest.post(`${mockBaseUrl}/analyze-location`, (req, res, ctx) => {
-          expect(req.body).toEqual({
+        http.post(`${mockBaseUrl}/analyze-location`, async ({ request }) => {
+          expect(await request.json()).toEqual({
             location: {
               target: 'https://github.com/backstage/backstage',
               type: 'url',
             },
           });
 
-          return res(
-            ctx.json({
-              generateEntities: [],
-              existingEntityFiles: [
-                {
-                  isRegistered: false,
-                  location: {
-                    type: 'url',
-                    target:
-                      'https://github.com/backstage/backstage/blob/main/simple/path/catalog-info.yaml',
-                  },
-                  entity: {
-                    apiVersion: '1',
-                    kind: 'k',
-                    metadata: {
-                      name: 'e',
-                      namespace: 'n',
-                    },
+          return HttpResponse.json({
+            generateEntities: [],
+            existingEntityFiles: [
+              {
+                isRegistered: false,
+                location: {
+                  type: 'url',
+                  target:
+                    'https://github.com/backstage/backstage/blob/main/simple/path/catalog-info.yaml',
+                },
+                entity: {
+                  apiVersion: '1',
+                  kind: 'k',
+                  metadata: {
+                    name: 'e',
+                    namespace: 'n',
                   },
                 },
-                {
-                  isRegistered: false,
-                  location: {
-                    type: 'url',
-                    target:
-                      'https://github.com/backstage/backstage/blob/main/co/mple/x/path/catalog-info.yaml',
-                  },
-                  entity: {
-                    apiVersion: '1',
-                    kind: 'k',
-                    metadata: {
-                      name: 'e',
-                      namespace: 'n',
-                    },
+              },
+              {
+                isRegistered: false,
+                location: {
+                  type: 'url',
+                  target:
+                    'https://github.com/backstage/backstage/blob/main/co/mple/x/path/catalog-info.yaml',
+                },
+                entity: {
+                  apiVersion: '1',
+                  kind: 'k',
+                  metadata: {
+                    name: 'e',
+                    namespace: 'n',
                   },
                 },
-                {
-                  isRegistered: false,
-                  location: {
-                    type: 'url',
-                    target:
-                      'https://github.com/backstage/backstage/blob/main/catalog-info.yaml',
-                  },
-                  entity: {
-                    apiVersion: '1',
-                    kind: 'k',
-                    metadata: {
-                      name: 'e',
-                      namespace: 'n',
-                    },
+              },
+              {
+                isRegistered: false,
+                location: {
+                  type: 'url',
+                  target:
+                    'https://github.com/backstage/backstage/blob/main/catalog-info.yaml',
+                },
+                entity: {
+                  apiVersion: '1',
+                  kind: 'k',
+                  metadata: {
+                    name: 'e',
+                    namespace: 'n',
                   },
                 },
-              ],
-            }),
-          );
+              },
+            ],
+          });
         }),
       );
 
@@ -402,28 +400,26 @@ describe('CatalogImportClient', () => {
       });
 
       server.use(
-        rest.post(`${mockBaseUrl}/analyze-location`, (req, res, ctx) => {
-          expect(req.body).toEqual({
+        http.post(`${mockBaseUrl}/analyze-location`, async ({ request }) => {
+          expect(await request.json()).toEqual({
             location: {
               target: 'https://github.com/backstage/backstage',
               type: 'url',
             },
           });
 
-          return res(
-            ctx.json({
-              generateEntities: [
-                {
-                  entity: {
-                    kind: 'k',
-                    metadata: { name: 'e', namespace: 'n' },
-                  },
-                  fields: [],
+          return HttpResponse.json({
+            generateEntities: [
+              {
+                entity: {
+                  kind: 'k',
+                  metadata: { name: 'e', namespace: 'n' },
                 },
-              ],
-              existingEntityFiles: [],
-            }),
-          );
+                fields: [],
+              },
+            ],
+            existingEntityFiles: [],
+          });
         }),
       );
 
@@ -473,8 +469,8 @@ describe('CatalogImportClient', () => {
       );
 
       server.use(
-        rest.post(`${mockBaseUrl}/analyze-location`, (req, res, ctx) => {
-          expect(req.body).toEqual({
+        http.post(`${mockBaseUrl}/analyze-location`, async ({ request }) => {
+          expect(await request.json()).toEqual({
             location: {
               target: 'https://github.com/acme-corp/our-awesome-api',
               type: 'url',
@@ -482,45 +478,43 @@ describe('CatalogImportClient', () => {
             catalogFilename: 'anvil.yaml',
           });
 
-          return res(
-            ctx.json({
-              generateEntities: [],
-              existingEntityFiles: [
-                {
-                  isRegistered: false,
-                  location: {
-                    type: 'url',
-                    target:
-                      'https://github.com/acme-corp/our-awesome-api/blob/main/anvil.yaml',
-                  },
-                  entity: {
-                    apiVersion: '1',
-                    kind: 'Location',
-                    metadata: {
-                      name: 'my-entity',
-                      namespace: 'my-namespace',
-                    },
+          return HttpResponse.json({
+            generateEntities: [],
+            existingEntityFiles: [
+              {
+                isRegistered: false,
+                location: {
+                  type: 'url',
+                  target:
+                    'https://github.com/acme-corp/our-awesome-api/blob/main/anvil.yaml',
+                },
+                entity: {
+                  apiVersion: '1',
+                  kind: 'Location',
+                  metadata: {
+                    name: 'my-entity',
+                    namespace: 'my-namespace',
                   },
                 },
-                {
-                  isRegistered: false,
-                  location: {
-                    type: 'url',
-                    target:
-                      'https://github.com/acme-corp/our-awesome-api/blob/main/anvil.yaml',
-                  },
-                  entity: {
-                    apiVersion: '1',
-                    kind: 'Component',
-                    metadata: {
-                      name: 'my-entity',
-                      namespace: 'my-namespace',
-                    },
+              },
+              {
+                isRegistered: false,
+                location: {
+                  type: 'url',
+                  target:
+                    'https://github.com/acme-corp/our-awesome-api/blob/main/anvil.yaml',
+                },
+                entity: {
+                  apiVersion: '1',
+                  kind: 'Component',
+                  metadata: {
+                    name: 'my-entity',
+                    namespace: 'my-namespace',
                   },
                 },
-              ],
-            }),
-          );
+              },
+            ],
+          });
         }),
       );
 

--- a/plugins/catalog-node/package.json
+++ b/plugins/catalog-node/package.json
@@ -75,7 +75,7 @@
   "devDependencies": {
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
-    "msw": "^1.0.0"
+    "msw": "^2.0.0"
   },
   "peerDependencies": {
     "@backstage/backend-test-utils": "workspace:^"

--- a/plugins/catalog-node/src/catalogService.test.ts
+++ b/plugins/catalog-node/src/catalogService.test.ts
@@ -26,7 +26,7 @@ import {
   registerMswTestHooks,
   startTestBackend,
 } from '@backstage/backend-test-utils';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { catalogServiceRef } from './catalogService';
 
@@ -60,14 +60,14 @@ describe('catalogServiceRef', () => {
     expect.assertions(1);
 
     server.use(
-      rest.get('http://localhost/api/catalog/entities', (req, res, ctx) => {
-        expect(req.headers.get('authorization')).toBe(
+      http.get('http://localhost:0/api/catalog/entities', ({ request }) => {
+        expect(request.headers.get('authorization')).toBe(
           mockCredentials.service.header({
             onBehalfOf: mockCredentials.user(),
             targetPluginId: 'catalog',
           }),
         );
-        return res(ctx.json({}));
+        return HttpResponse.json({});
       }),
     );
     const tester = ServiceFactoryTester.from(
@@ -91,14 +91,14 @@ describe('catalogServiceRef', () => {
     expect.assertions(1);
 
     server.use(
-      rest.get('http://localhost/api/catalog/entities', (req, res, ctx) => {
-        expect(req.headers.get('authorization')).toBe(
+      http.get('http://localhost:0/api/catalog/entities', ({ request }) => {
+        expect(request.headers.get('authorization')).toBe(
           mockCredentials.service.header({
             onBehalfOf: mockCredentials.service(),
             targetPluginId: 'catalog',
           }),
         );
-        return res(ctx.json({}));
+        return HttpResponse.json({});
       }),
     );
     const tester = ServiceFactoryTester.from(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2389,7 +2389,7 @@ __metadata:
     "@types/lodash": "npm:^4.14.151"
     cross-fetch: "npm:^4.0.0"
     lodash: "npm:^4.17.21"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     uri-template: "npm:^2.0.0"
   languageName: unknown
   linkType: soft
@@ -4361,7 +4361,7 @@ __metadata:
     "@backstage/integration": "workspace:^"
     "@openapitools/openapi-generator-cli": "npm:^2.4.26"
     cross-fetch: "npm:^4.0.0"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     ts-morph: "npm:^24.0.0"
   languageName: unknown
   linkType: soft
@@ -4422,7 +4422,7 @@ __metadata:
     "@backstage/plugin-catalog-common": "workspace:^"
     "@backstage/plugin-catalog-node": "workspace:^"
     "@backstage/plugin-events-node": "workspace:^"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4461,7 +4461,7 @@ __metadata:
     "@backstage/plugin-catalog-node": "workspace:^"
     "@backstage/plugin-events-backend-test-utils": "workspace:^"
     "@backstage/plugin-events-node": "workspace:^"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4480,7 +4480,7 @@ __metadata:
     "@backstage/plugin-catalog-node": "workspace:^"
     "@backstage/plugin-events-backend-test-utils": "workspace:^"
     "@backstage/plugin-events-node": "workspace:^"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4513,7 +4513,7 @@ __metadata:
     "@backstage/plugin-catalog-node": "workspace:^"
     "@types/fs-extra": "npm:^11.0.0"
     fs-extra: "npm:^11.2.0"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     p-limit: "npm:^3.1.0"
   languageName: unknown
   linkType: soft
@@ -4617,7 +4617,7 @@ __metadata:
     "@gitbeaker/rest": "npm:^40.0.3"
     "@types/lodash": "npm:^4.14.151"
     lodash: "npm:^4.17.21"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4708,7 +4708,7 @@ __metadata:
     "@microsoft/microsoft-graph-types": "npm:^2.6.0"
     "@types/lodash": "npm:^4.14.151"
     lodash: "npm:^4.17.21"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     p-limit: "npm:^3.0.2"
     qs: "npm:^6.15.2"
   languageName: unknown
@@ -4746,7 +4746,7 @@ __metadata:
     "@backstage/types": "workspace:^"
     "@types/lodash": "npm:^4.14.151"
     lodash: "npm:^4.17.21"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4935,7 +4935,7 @@ __metadata:
     git-url-parse: "npm:^15.0.0"
     js-base64: "npm:^3.6.0"
     lodash: "npm:^4.17.21"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     react: "npm:^18.0.2"
     react-dom: "npm:^18.0.2"
     react-hook-form: "npm:^7.12.2"
@@ -4969,7 +4969,7 @@ __metadata:
     "@backstage/types": "workspace:^"
     "@opentelemetry/api": "npm:^1.9.0"
     lodash: "npm:^4.17.21"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     yaml: "npm:^2.0.0"
   peerDependencies:
     "@backstage/backend-test-utils": "workspace:^"


### PR DESCRIPTION
Migrates MSW-based tests in catalog-area packages from MSW 1.x to MSW 2.x.

This is part of the ongoing effort to adopt native `fetch` in backend code ([ADR014](https://github.com/backstage/backstage/blob/master/docs/architecture-decisions/adr014-use-fetch.md)). MSW 1.x does not reliably intercept native `fetch`; MSW 2.x uses updated interceptors that do.

Follows #34683 and #34685 in the broader MSW 2 migration. Changes are limited to test files and devDependencies; no production code or published API surface is affected.

### Packages migrated

- `@backstage/catalog-client`
- `@backstage/catalog-node`
- `@backstage/plugin-catalog-import`
- `@backstage/plugin-bitbucket-cloud-common`
- `@backstage/plugin-catalog-backend-module-azure`
- `@backstage/plugin-catalog-backend-module-bitbucket-cloud`
- `@backstage/plugin-catalog-backend-module-bitbucket-server`
- `@backstage/plugin-catalog-backend-module-gerrit`
- `@backstage/plugin-catalog-backend-module-gitlab`
- `@backstage/plugin-catalog-backend-module-msgraph`
- `@backstage/plugin-catalog-backend-module-puppetdb`

(Other catalog packages: `@backstage/plugin-catalog-backend` and `@backstage/plugin-catalog-backend-module-github` were already on MSW 2.)

GitLab shared test handlers also migrate GraphQL and HEAD request mocking.