### PR TITLE
feat(events): add HTTP webhook ingress for Azure DevOps events

### DIFF
--- a/.changeset/add-azure-devops-webhook-ingress.md
+++ b/.changeset/add-azure-devops-webhook-ingress.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-events-backend-module-azure': patch
+---
+
+Added HTTP POST webhook ingress endpoint for Azure DevOps events, matching the pattern established by the GitHub events module. When `events.modules.azureDevOps.webhookSecret` is configured, incoming requests are validated using Basic authentication.

--- a/.changeset/add-azure-devops-webhook-ingress.md
+++ b/.changeset/add-azure-devops-webhook-ingress.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-events-backend-module-azure': patch
 ---
 
-Added HTTP POST webhook ingress endpoint for Azure DevOps events, matching the pattern established by the GitHub events module. When `events.modules.azureDevOps.webhookSecret` is configured, incoming requests are validated against the `x-ado-webhook-secret` custom header using timing-safe comparison.
+Added HTTP POST webhook ingress endpoint for Azure DevOps events, matching the pattern established by the GitHub events module. The ingress endpoint is only registered when `events.modules.azureDevOps.webhookSecret` is configured; without it, no route is exposed. Incoming requests are validated against the `x-ado-webhook-secret` custom header using timing-safe comparison.

--- a/.changeset/add-azure-devops-webhook-ingress.md
+++ b/.changeset/add-azure-devops-webhook-ingress.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-events-backend-module-azure': patch
 ---
 
-Added HTTP POST webhook ingress endpoint for Azure DevOps events, matching the pattern established by the GitHub events module. When `events.modules.azureDevOps.webhookSecret` is configured, incoming requests are validated using Basic authentication.
+Added HTTP POST webhook ingress endpoint for Azure DevOps events, matching the pattern established by the GitHub events module. When `events.modules.azureDevOps.webhookSecret` is configured, incoming requests are validated against the `x-ado-webhook-secret` custom header using timing-safe comparison.

--- a/plugins/events-backend-module-azure/config.d.ts
+++ b/plugins/events-backend-module-azure/config.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Backstage Authors
+ * Copyright 2026 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/events-backend-module-azure/config.d.ts
+++ b/plugins/events-backend-module-azure/config.d.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export interface Config {
+  events?: {
+    modules?: {
+      /**
+       * events-backend-module-azure plugin configuration.
+       */
+      azureDevOps?: {
+        /**
+         * Shared secret for validating incoming Azure DevOps webhook
+         * requests. Configure the same value as the
+         * `x-ado-webhook-secret` HTTP header in your Azure DevOps
+         * service hook subscription. Requests without a matching
+         * secret are rejected with 403.
+         *
+         * @visibility secret
+         */
+        webhookSecret?: string;
+      };
+    };
+  };
+}

--- a/plugins/events-backend-module-azure/package.json
+++ b/plugins/events-backend-module-azure/package.json
@@ -34,6 +34,7 @@
     }
   },
   "files": [
+    "config.d.ts",
     "dist"
   ],
   "scripts": {
@@ -47,11 +48,15 @@
   },
   "dependencies": {
     "@backstage/backend-plugin-api": "workspace:^",
+    "@backstage/config": "workspace:^",
     "@backstage/plugin-events-node": "workspace:^"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
-    "@backstage/plugin-events-backend-test-utils": "workspace:^"
-  }
+    "@backstage/plugin-events-backend": "workspace:^",
+    "@backstage/plugin-events-backend-test-utils": "workspace:^",
+    "supertest": "^7.0.0"
+  },
+  "configSchema": "config.d.ts"
 }

--- a/plugins/events-backend-module-azure/report-alpha.api.md
+++ b/plugins/events-backend-module-azure/report-alpha.api.md
@@ -5,7 +5,7 @@
 ```ts
 import { BackendFeature } from '@backstage/backend-plugin-api';
 
-// @alpha (undocumented)
+// @public (undocumented)
 export const eventsModuleAzureDevOpsEventRouter: BackendFeature;
 
 // @alpha (undocumented)

--- a/plugins/events-backend-module-azure/report-alpha.api.md
+++ b/plugins/events-backend-module-azure/report-alpha.api.md
@@ -5,7 +5,7 @@
 ```ts
 import { BackendFeature } from '@backstage/backend-plugin-api';
 
-// @public (undocumented)
+// @public
 export const eventsModuleAzureDevOpsEventRouter: BackendFeature;
 
 // @alpha (undocumented)

--- a/plugins/events-backend-module-azure/report.api.md
+++ b/plugins/events-backend-module-azure/report.api.md
@@ -17,7 +17,9 @@ export class AzureDevOpsEventRouter extends SubTopicEventRouter {
   protected getSubscriberId(): string;
 }
 
-// @public
-const eventsModuleAzureDevOpsEventRouter: BackendFeature;
-export default eventsModuleAzureDevOpsEventRouter;
+// @public (undocumented)
+const _default: BackendFeature;
+export default _default;
+
+// (No @packageDocumentation comment for this package)
 ```

--- a/plugins/events-backend-module-azure/src/alpha.ts
+++ b/plugins/events-backend-module-azure/src/alpha.ts
@@ -14,10 +14,19 @@
  * limitations under the License.
  */
 
-import { eventsModuleAzureDevOpsEventRouter as feature } from './service/eventsModuleAzureDevOpsEventRouter';
+import { createBackendFeatureLoader } from '@backstage/backend-plugin-api';
+import { eventsModuleAzureDevOpsEventRouter as _router } from './service/eventsModuleAzureDevOpsEventRouter';
 
 /** @alpha */
-const _feature = feature;
+const _feature = createBackendFeatureLoader({
+  loader() {
+    return [
+      import('./service/eventsModuleAzureDevOpsEventRouter'),
+      import('./service/eventsModuleAzureDevOpsWebhook'),
+    ];
+  },
+});
 export default _feature;
+
 /** @alpha */
-export const eventsModuleAzureDevOpsEventRouter = _feature;
+export const eventsModuleAzureDevOpsEventRouter = _router;

--- a/plugins/events-backend-module-azure/src/alpha.ts
+++ b/plugins/events-backend-module-azure/src/alpha.ts
@@ -15,7 +15,7 @@
  */
 
 import { createBackendFeatureLoader } from '@backstage/backend-plugin-api';
-import { eventsModuleAzureDevOpsEventRouter as _router } from './service/eventsModuleAzureDevOpsEventRouter';
+import eventsModuleAzureDevOpsEventRouter from './service/eventsModuleAzureDevOpsEventRouter';
 
 /** @alpha */
 const _feature = createBackendFeatureLoader({
@@ -29,4 +29,4 @@ const _feature = createBackendFeatureLoader({
 export default _feature;
 
 /** @alpha */
-export const eventsModuleAzureDevOpsEventRouter = _router;
+export { eventsModuleAzureDevOpsEventRouter };

--- a/plugins/events-backend-module-azure/src/http/createAzureDevOpsWebhookValidator.test.ts
+++ b/plugins/events-backend-module-azure/src/http/createAzureDevOpsWebhookValidator.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Backstage Authors
+ * Copyright 2026 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/plugins/events-backend-module-azure/src/http/createAzureDevOpsWebhookValidator.test.ts
+++ b/plugins/events-backend-module-azure/src/http/createAzureDevOpsWebhookValidator.test.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ConfigReader } from '@backstage/config';
+import {
+  RequestDetails,
+  RequestRejectionDetails,
+  RequestValidationContext,
+} from '@backstage/plugin-events-node';
+import { createAzureDevOpsWebhookValidator } from './createAzureDevOpsWebhookValidator';
+
+class TestContext implements RequestValidationContext {
+  #details?: Partial<RequestRejectionDetails>;
+
+  reject(details?: Partial<RequestRejectionDetails>): void {
+    this.#details = details;
+  }
+
+  get details() {
+    return this.#details;
+  }
+}
+
+describe('createAzureDevOpsWebhookValidator', () => {
+  const secret = 'my-webhook-secret';
+  const configWithoutSecret = new ConfigReader({});
+  const configWithSecret = new ConfigReader({
+    events: {
+      modules: {
+        azureDevOps: {
+          webhookSecret: secret,
+        },
+      },
+    },
+  });
+
+  const requestWithHeader = (headerSecret: string | undefined) => {
+    return {
+      body: { eventType: 'workitem.updated' },
+      headers: {
+        'x-ado-webhook-secret': headerSecret,
+      },
+      raw: {
+        body: Buffer.from('{}'),
+        encoding: 'utf-8',
+      },
+    } as RequestDetails;
+  };
+
+  it('should return undefined if no secret is configured', () => {
+    expect(createAzureDevOpsWebhookValidator(configWithoutSecret)).toEqual(
+      undefined,
+    );
+  });
+
+  it('secret configured, accept request with matching header', async () => {
+    const request = requestWithHeader(secret);
+    const context = new TestContext();
+
+    const validator = createAzureDevOpsWebhookValidator(configWithSecret);
+    await validator!(request, context);
+
+    expect(context.details).toBeUndefined();
+  });
+
+  it('secret configured, reject request with wrong header', async () => {
+    const request = requestWithHeader('wrong-secret');
+    const context = new TestContext();
+
+    const validator = createAzureDevOpsWebhookValidator(configWithSecret);
+    await validator!(request, context);
+
+    expect(context.details).not.toBeUndefined();
+    expect(context.details?.status).toBe(403);
+    expect(context.details?.payload).toEqual({
+      message: 'invalid webhook secret',
+    });
+  });
+
+  it('secret configured, reject request without header', async () => {
+    const request = requestWithHeader(undefined);
+    const context = new TestContext();
+
+    const validator = createAzureDevOpsWebhookValidator(configWithSecret);
+    await validator!(request, context);
+
+    expect(context.details).not.toBeUndefined();
+    expect(context.details?.status).toBe(403);
+    expect(context.details?.payload).toEqual({
+      message: 'invalid webhook secret',
+    });
+  });
+});

--- a/plugins/events-backend-module-azure/src/http/createAzureDevOpsWebhookValidator.ts
+++ b/plugins/events-backend-module-azure/src/http/createAzureDevOpsWebhookValidator.ts
@@ -50,9 +50,8 @@ export function createAzureDevOpsWebhookValidator(
     request: RequestDetails,
     context: RequestValidationContext,
   ): Promise<void> => {
-    const headerSecret = request.headers['x-ado-webhook-secret'] as
-      | string
-      | undefined;
+    const raw = request.headers['x-ado-webhook-secret'];
+    const headerSecret = Array.isArray(raw) ? raw[0] : raw;
 
     const headerBuffer =
       typeof headerSecret === 'string' ? Buffer.from(headerSecret) : undefined;

--- a/plugins/events-backend-module-azure/src/http/createAzureDevOpsWebhookValidator.ts
+++ b/plugins/events-backend-module-azure/src/http/createAzureDevOpsWebhookValidator.ts
@@ -55,9 +55,7 @@ export function createAzureDevOpsWebhookValidator(
       | undefined;
 
     const headerBuffer =
-      typeof headerSecret === 'string'
-        ? Buffer.from(headerSecret)
-        : undefined;
+      typeof headerSecret === 'string' ? Buffer.from(headerSecret) : undefined;
 
     if (
       headerBuffer &&

--- a/plugins/events-backend-module-azure/src/http/createAzureDevOpsWebhookValidator.ts
+++ b/plugins/events-backend-module-azure/src/http/createAzureDevOpsWebhookValidator.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Config } from '@backstage/config';
+import {
+  RequestDetails,
+  RequestValidationContext,
+  RequestValidator,
+} from '@backstage/plugin-events-node';
+import { timingSafeEqual } from 'node:crypto';
+
+/**
+ * Validates incoming Azure DevOps webhook requests
+ * using a shared secret sent via the `x-ado-webhook-secret` header.
+ *
+ * Configure the same secret in the Azure DevOps service hook
+ * subscription (under HTTP Headers) and in the Backstage app-config
+ * at `events.modules.azureDevOps.webhookSecret`.
+ *
+ * @param config - root config
+ * @public
+ */
+export function createAzureDevOpsWebhookValidator(
+  config: Config,
+): RequestValidator | undefined {
+  const secret = config.getOptionalString(
+    'events.modules.azureDevOps.webhookSecret',
+  );
+
+  if (!secret) {
+    return undefined;
+  }
+
+  const secretBuffer = Buffer.from(secret);
+
+  return async (
+    request: RequestDetails,
+    context: RequestValidationContext,
+  ): Promise<void> => {
+    const headerSecret = request.headers['x-ado-webhook-secret'] as
+      | string
+      | undefined;
+
+    if (
+      typeof headerSecret === 'string' &&
+      headerSecret.length === secret.length &&
+      timingSafeEqual(Buffer.from(headerSecret), secretBuffer)
+    ) {
+      return;
+    }
+
+    context.reject({
+      status: 403,
+      payload: { message: 'invalid webhook secret' },
+    });
+  };
+}

--- a/plugins/events-backend-module-azure/src/http/createAzureDevOpsWebhookValidator.ts
+++ b/plugins/events-backend-module-azure/src/http/createAzureDevOpsWebhookValidator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Backstage Authors
+ * Copyright 2026 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import {
   RequestValidationContext,
   RequestValidator,
 } from '@backstage/plugin-events-node';
-import { timingSafeEqual } from 'node:crypto';
+import { timingSafeEqual } from 'crypto';
 
 /**
  * Validates incoming Azure DevOps webhook requests
@@ -54,10 +54,15 @@ export function createAzureDevOpsWebhookValidator(
       | string
       | undefined;
 
+    const headerBuffer =
+      typeof headerSecret === 'string'
+        ? Buffer.from(headerSecret)
+        : undefined;
+
     if (
-      typeof headerSecret === 'string' &&
-      headerSecret.length === secret.length &&
-      timingSafeEqual(Buffer.from(headerSecret), secretBuffer)
+      headerBuffer &&
+      headerBuffer.length === secretBuffer.length &&
+      timingSafeEqual(headerBuffer, secretBuffer)
     ) {
       return;
     }

--- a/plugins/events-backend-module-azure/src/http/httpIntegration.test.ts
+++ b/plugins/events-backend-module-azure/src/http/httpIntegration.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Backstage Authors
+ * Copyright 2026 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,7 +112,7 @@ describe('Azure DevOps webhook HTTP integration', () => {
     expect(eventsService.published).toHaveLength(0);
   });
 
-  it('should accept requests without validation when no secret is configured', async () => {
+  it('should not register the ingress when no secret is configured', async () => {
     const eventsService = new TestEventsService();
     const eventsServiceFactory = createServiceFactory({
       service: eventsServiceRef,
@@ -133,20 +133,13 @@ describe('Azure DevOps webhook HTTP integration', () => {
       ],
     });
 
-    const payload = {
-      eventType: 'git.push',
-      resource: { repository: { name: 'my-repo' } },
-    };
-
     const response = await request(server)
       .post('/api/events/http/azureDevOps')
       .type('application/json')
       .timeout(1000)
-      .send(JSON.stringify(payload));
+      .send(JSON.stringify({ eventType: 'git.push' }));
 
-    expect(response.status).toBe(202);
-    expect(eventsService.published).toHaveLength(1);
-    expect(eventsService.published[0].topic).toEqual('azureDevOps');
-    expect(eventsService.published[0].eventPayload).toEqual(payload);
+    expect(response.status).toBe(404);
+    expect(eventsService.published).toHaveLength(0);
   });
 });

--- a/plugins/events-backend-module-azure/src/http/httpIntegration.test.ts
+++ b/plugins/events-backend-module-azure/src/http/httpIntegration.test.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createServiceFactory } from '@backstage/backend-plugin-api';
+import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
+import { eventsServiceRef } from '@backstage/plugin-events-node';
+import { TestEventsService } from '@backstage/plugin-events-backend-test-utils';
+import eventsPlugin from '@backstage/plugin-events-backend';
+import eventsModuleAzureDevOpsWebhook from '../service/eventsModuleAzureDevOpsWebhook';
+import request from 'supertest';
+
+describe('Azure DevOps webhook HTTP integration', () => {
+  const secret = 'my-webhook-secret';
+
+  it('should accept a valid ADO webhook payload and publish it as an event', async () => {
+    const eventsService = new TestEventsService();
+    const eventsServiceFactory = createServiceFactory({
+      service: eventsServiceRef,
+      deps: {},
+      async factory({}) {
+        return eventsService;
+      },
+    });
+
+    const { server } = await startTestBackend({
+      features: [
+        eventsServiceFactory,
+        eventsPlugin,
+        eventsModuleAzureDevOpsWebhook,
+        mockServices.rootConfig.factory({
+          data: {
+            events: {
+              modules: {
+                azureDevOps: {
+                  webhookSecret: secret,
+                },
+              },
+            },
+          },
+        }),
+      ],
+    });
+
+    const payload = {
+      eventType: 'workitem.updated',
+      resource: { id: 42 },
+    };
+
+    const response = await request(server)
+      .post('/api/events/http/azureDevOps')
+      .set('x-ado-webhook-secret', secret)
+      .type('application/json')
+      .timeout(1000)
+      .send(JSON.stringify(payload));
+
+    expect(response.status).toBe(202);
+    expect(eventsService.published).toHaveLength(1);
+    expect(eventsService.published[0].topic).toEqual('azureDevOps');
+    expect(eventsService.published[0].eventPayload).toEqual(payload);
+  });
+
+  it('should reject a request with an invalid secret', async () => {
+    const eventsService = new TestEventsService();
+    const eventsServiceFactory = createServiceFactory({
+      service: eventsServiceRef,
+      deps: {},
+      async factory({}) {
+        return eventsService;
+      },
+    });
+
+    const { server } = await startTestBackend({
+      features: [
+        eventsServiceFactory,
+        eventsPlugin,
+        eventsModuleAzureDevOpsWebhook,
+        mockServices.rootConfig.factory({
+          data: {
+            events: {
+              modules: {
+                azureDevOps: {
+                  webhookSecret: secret,
+                },
+              },
+            },
+          },
+        }),
+      ],
+    });
+
+    const response = await request(server)
+      .post('/api/events/http/azureDevOps')
+      .set('x-ado-webhook-secret', 'wrong-secret')
+      .type('application/json')
+      .timeout(1000)
+      .send(JSON.stringify({ eventType: 'workitem.updated' }));
+
+    expect(response.status).toBe(403);
+    expect(eventsService.published).toHaveLength(0);
+  });
+
+  it('should accept requests without validation when no secret is configured', async () => {
+    const eventsService = new TestEventsService();
+    const eventsServiceFactory = createServiceFactory({
+      service: eventsServiceRef,
+      deps: {},
+      async factory({}) {
+        return eventsService;
+      },
+    });
+
+    const { server } = await startTestBackend({
+      features: [
+        eventsServiceFactory,
+        eventsPlugin,
+        eventsModuleAzureDevOpsWebhook,
+        mockServices.rootConfig.factory({
+          data: {},
+        }),
+      ],
+    });
+
+    const payload = {
+      eventType: 'git.push',
+      resource: { repository: { name: 'my-repo' } },
+    };
+
+    const response = await request(server)
+      .post('/api/events/http/azureDevOps')
+      .type('application/json')
+      .timeout(1000)
+      .send(JSON.stringify(payload));
+
+    expect(response.status).toBe(202);
+    expect(eventsService.published).toHaveLength(1);
+    expect(eventsService.published[0].topic).toEqual('azureDevOps');
+    expect(eventsService.published[0].eventPayload).toEqual(payload);
+  });
+});

--- a/plugins/events-backend-module-azure/src/index.ts
+++ b/plugins/events-backend-module-azure/src/index.ts
@@ -16,10 +16,20 @@
 
 /**
  * The module "azure" for the Backstage backend plugin "events-backend"
- * adding an event router for Azure DevOps.
+ * adding an event router and webhook ingress for Azure DevOps.
  *
  * @packageDocumentation
  */
 
-export { eventsModuleAzureDevOpsEventRouter as default } from './service/eventsModuleAzureDevOpsEventRouter';
+import { createBackendFeatureLoader } from '@backstage/backend-plugin-api';
+
+export default createBackendFeatureLoader({
+  loader() {
+    return [
+      import('./service/eventsModuleAzureDevOpsEventRouter'),
+      import('./service/eventsModuleAzureDevOpsWebhook'),
+    ];
+  },
+});
+
 export { AzureDevOpsEventRouter } from './router/AzureDevOpsEventRouter';

--- a/plugins/events-backend-module-azure/src/service/eventsModuleAzureDevOpsEventRouter.test.ts
+++ b/plugins/events-backend-module-azure/src/service/eventsModuleAzureDevOpsEventRouter.test.ts
@@ -18,7 +18,7 @@ import { createServiceFactory } from '@backstage/backend-plugin-api';
 import { startTestBackend } from '@backstage/backend-test-utils';
 import { TestEventsService } from '@backstage/plugin-events-backend-test-utils';
 import { eventsServiceRef } from '@backstage/plugin-events-node';
-import { eventsModuleAzureDevOpsEventRouter } from './eventsModuleAzureDevOpsEventRouter';
+import eventsModuleAzureDevOpsEventRouter from './eventsModuleAzureDevOpsEventRouter';
 
 describe('eventsModuleAzureDevOpsEventRouter', () => {
   it('should be correctly wired and set up', async () => {

--- a/plugins/events-backend-module-azure/src/service/eventsModuleAzureDevOpsEventRouter.ts
+++ b/plugins/events-backend-module-azure/src/service/eventsModuleAzureDevOpsEventRouter.ts
@@ -25,7 +25,10 @@ import { AzureDevOpsEventRouter } from '../router/AzureDevOpsEventRouter';
  *
  * @public
  */
-const eventsModuleAzureDevOpsEventRouter = createBackendModule({
+/**
+ * @public
+ */
+export default createBackendModule({
   pluginId: 'events',
   moduleId: 'azure-dev-ops-event-router',
   register(env) {
@@ -42,7 +45,3 @@ const eventsModuleAzureDevOpsEventRouter = createBackendModule({
     });
   },
 });
-
-/** @public */
-export { eventsModuleAzureDevOpsEventRouter };
-export default eventsModuleAzureDevOpsEventRouter;

--- a/plugins/events-backend-module-azure/src/service/eventsModuleAzureDevOpsEventRouter.ts
+++ b/plugins/events-backend-module-azure/src/service/eventsModuleAzureDevOpsEventRouter.ts
@@ -25,9 +25,6 @@ import { AzureDevOpsEventRouter } from '../router/AzureDevOpsEventRouter';
  *
  * @public
  */
-/**
- * @public
- */
 export default createBackendModule({
   pluginId: 'events',
   moduleId: 'azure-dev-ops-event-router',

--- a/plugins/events-backend-module-azure/src/service/eventsModuleAzureDevOpsEventRouter.ts
+++ b/plugins/events-backend-module-azure/src/service/eventsModuleAzureDevOpsEventRouter.ts
@@ -25,7 +25,7 @@ import { AzureDevOpsEventRouter } from '../router/AzureDevOpsEventRouter';
  *
  * @public
  */
-export const eventsModuleAzureDevOpsEventRouter = createBackendModule({
+const eventsModuleAzureDevOpsEventRouter = createBackendModule({
   pluginId: 'events',
   moduleId: 'azure-dev-ops-event-router',
   register(env) {
@@ -42,3 +42,7 @@ export const eventsModuleAzureDevOpsEventRouter = createBackendModule({
     });
   },
 });
+
+/** @public */
+export { eventsModuleAzureDevOpsEventRouter };
+export default eventsModuleAzureDevOpsEventRouter;

--- a/plugins/events-backend-module-azure/src/service/eventsModuleAzureDevOpsWebhook.test.ts
+++ b/plugins/events-backend-module-azure/src/service/eventsModuleAzureDevOpsWebhook.test.ts
@@ -41,7 +41,7 @@ describe('eventsModuleAzureDevOpsWebhook', () => {
   it('should not register ingress when no secret configured', async () => {
     let addedIngress: HttpPostIngressOptions | undefined;
     const extensionPoint = {
-      addHttpPostIngress: (ingress: any) => {
+      addHttpPostIngress: (ingress: HttpPostIngressOptions) => {
         addedIngress = ingress;
       },
     };
@@ -62,7 +62,7 @@ describe('eventsModuleAzureDevOpsWebhook', () => {
   it('should be correctly wired and set up with secret', async () => {
     let addedIngress: HttpPostIngressOptions | undefined;
     const extensionPoint = {
-      addHttpPostIngress: (ingress: any) => {
+      addHttpPostIngress: (ingress: HttpPostIngressOptions) => {
         addedIngress = ingress;
       },
     };

--- a/plugins/events-backend-module-azure/src/service/eventsModuleAzureDevOpsWebhook.test.ts
+++ b/plugins/events-backend-module-azure/src/service/eventsModuleAzureDevOpsWebhook.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Backstage Authors
+ * Copyright 2026 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ describe('eventsModuleAzureDevOpsWebhook', () => {
     } as RequestDetails;
   };
 
-  it('should register ingress without validator when no secret configured', async () => {
+  it('should not register ingress when no secret configured', async () => {
     let addedIngress: HttpPostIngressOptions | undefined;
     const extensionPoint = {
       addHttpPostIngress: (ingress: any) => {
@@ -56,9 +56,7 @@ describe('eventsModuleAzureDevOpsWebhook', () => {
       ],
     });
 
-    expect(addedIngress).not.toBeUndefined();
-    expect(addedIngress?.topic).toEqual('azureDevOps');
-    expect(addedIngress?.validator).toBeUndefined();
+    expect(addedIngress).toBeUndefined();
   });
 
   it('should be correctly wired and set up with secret', async () => {

--- a/plugins/events-backend-module-azure/src/service/eventsModuleAzureDevOpsWebhook.test.ts
+++ b/plugins/events-backend-module-azure/src/service/eventsModuleAzureDevOpsWebhook.test.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
+import { eventsExtensionPoint } from '@backstage/plugin-events-node/alpha';
+import {
+  HttpPostIngressOptions,
+  RequestDetails,
+} from '@backstage/plugin-events-node';
+import eventsModuleAzureDevOpsWebhook from './eventsModuleAzureDevOpsWebhook';
+
+describe('eventsModuleAzureDevOpsWebhook', () => {
+  const secret = 'my-webhook-secret';
+
+  const requestWithHeader = (headerSecret?: string) => {
+    return {
+      body: { eventType: 'workitem.updated' },
+      headers: {
+        'x-ado-webhook-secret': headerSecret,
+      },
+      raw: {
+        body: Buffer.from('{}'),
+        encoding: 'utf-8',
+      },
+    } as RequestDetails;
+  };
+
+  it('should register ingress without validator when no secret configured', async () => {
+    let addedIngress: HttpPostIngressOptions | undefined;
+    const extensionPoint = {
+      addHttpPostIngress: (ingress: any) => {
+        addedIngress = ingress;
+      },
+    };
+
+    await startTestBackend({
+      extensionPoints: [[eventsExtensionPoint, extensionPoint]],
+      features: [
+        eventsModuleAzureDevOpsWebhook,
+        mockServices.rootConfig.factory({
+          data: {},
+        }),
+      ],
+    });
+
+    expect(addedIngress).not.toBeUndefined();
+    expect(addedIngress?.topic).toEqual('azureDevOps');
+    expect(addedIngress?.validator).toBeUndefined();
+  });
+
+  it('should be correctly wired and set up with secret', async () => {
+    let addedIngress: HttpPostIngressOptions | undefined;
+    const extensionPoint = {
+      addHttpPostIngress: (ingress: any) => {
+        addedIngress = ingress;
+      },
+    };
+
+    await startTestBackend({
+      extensionPoints: [[eventsExtensionPoint, extensionPoint]],
+      features: [
+        eventsModuleAzureDevOpsWebhook,
+        mockServices.rootConfig.factory({
+          data: {
+            events: {
+              modules: {
+                azureDevOps: {
+                  webhookSecret: secret,
+                },
+              },
+            },
+          },
+        }),
+      ],
+    });
+
+    expect(addedIngress).not.toBeUndefined();
+    expect(addedIngress?.topic).toEqual('azureDevOps');
+    expect(addedIngress?.validator).not.toBeUndefined();
+
+    const rejections: any[] = [];
+    const context = {
+      reject: (details: { status?: any; payload?: any }) => {
+        rejections.push(details);
+      },
+    };
+
+    await addedIngress!.validator!(requestWithHeader(), context);
+    expect(rejections).toEqual([
+      {
+        status: 403,
+        payload: { message: 'invalid webhook secret' },
+      },
+    ]);
+
+    await addedIngress!.validator!(requestWithHeader(secret), context);
+    expect(rejections.length).toEqual(1);
+  });
+});

--- a/plugins/events-backend-module-azure/src/service/eventsModuleAzureDevOpsWebhook.ts
+++ b/plugins/events-backend-module-azure/src/service/eventsModuleAzureDevOpsWebhook.ts
@@ -26,7 +26,8 @@ import { createAzureDevOpsWebhookValidator } from '../http/createAzureDevOpsWebh
  * registering an HTTP POST ingress for Azure DevOps webhook events.
  *
  * When `events.modules.azureDevOps.webhookSecret` is configured,
- * incoming requests are validated using Basic authentication.
+ * incoming requests are validated against the `x-ado-webhook-secret`
+ * custom header using timing-safe comparison.
  *
  * @public
  */

--- a/plugins/events-backend-module-azure/src/service/eventsModuleAzureDevOpsWebhook.ts
+++ b/plugins/events-backend-module-azure/src/service/eventsModuleAzureDevOpsWebhook.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Backstage Authors
+ * Copyright 2026 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,9 @@ import { createAzureDevOpsWebhookValidator } from '../http/createAzureDevOpsWebh
  * Module for the events-backend plugin,
  * registering an HTTP POST ingress for Azure DevOps webhook events.
  *
- * When `events.modules.azureDevOps.webhookSecret` is configured,
- * incoming requests are validated against the `x-ado-webhook-secret`
+ * The ingress is only registered when
+ * `events.modules.azureDevOps.webhookSecret` is configured.
+ * Incoming requests are validated against the `x-ado-webhook-secret`
  * custom header using timing-safe comparison.
  *
  * @public
@@ -41,10 +42,13 @@ export default createBackendModule({
         events: eventsExtensionPoint,
       },
       async init({ config, events }) {
-        events.addHttpPostIngress({
-          topic: 'azureDevOps',
-          validator: createAzureDevOpsWebhookValidator(config),
-        });
+        const validator = createAzureDevOpsWebhookValidator(config);
+        if (validator) {
+          events.addHttpPostIngress({
+            topic: 'azureDevOps',
+            validator,
+          });
+        }
       },
     });
   },

--- a/plugins/events-backend-module-azure/src/service/eventsModuleAzureDevOpsWebhook.ts
+++ b/plugins/events-backend-module-azure/src/service/eventsModuleAzureDevOpsWebhook.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  coreServices,
+  createBackendModule,
+} from '@backstage/backend-plugin-api';
+import { eventsExtensionPoint } from '@backstage/plugin-events-node/alpha';
+import { createAzureDevOpsWebhookValidator } from '../http/createAzureDevOpsWebhookValidator';
+
+/**
+ * Module for the events-backend plugin,
+ * registering an HTTP POST ingress for Azure DevOps webhook events.
+ *
+ * When `events.modules.azureDevOps.webhookSecret` is configured,
+ * incoming requests are validated using Basic authentication.
+ *
+ * @public
+ */
+export default createBackendModule({
+  pluginId: 'events',
+  moduleId: 'azure-dev-ops-webhook',
+  register(env) {
+    env.registerInit({
+      deps: {
+        config: coreServices.rootConfig,
+        events: eventsExtensionPoint,
+      },
+      async init({ config, events }) {
+        events.addHttpPostIngress({
+          topic: 'azureDevOps',
+          validator: createAzureDevOpsWebhookValidator(config),
+        });
+      },
+    });
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5349,8 +5349,11 @@ __metadata:
     "@backstage/backend-plugin-api": "workspace:^"
     "@backstage/backend-test-utils": "workspace:^"
     "@backstage/cli": "workspace:^"
+    "@backstage/config": "workspace:^"
+    "@backstage/plugin-events-backend": "workspace:^"
     "@backstage/plugin-events-backend-test-utils": "workspace:^"
     "@backstage/plugin-events-node": "workspace:^"
+    supertest: "npm:^7.0.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add an HTTP POST ingress endpoint and shared-secret validator to `@backstage/plugin-events-backend-module-azure`, matching the pattern established by the GitHub events module (`@backstage/plugin-events-backend-module-github`).

### What changed

- **New webhook ingress module** (`eventsModuleAzureDevOpsWebhook`) — registers an `/http/azureDevOps` endpoint on the events backend that accepts incoming Azure DevOps service hook payloads and publishes them to the `azureDevOps` topic.
- **Shared-secret validator** (`createAzureDevOpsWebhookValidator`) — when `events.modules.azureDevOps.webhookSecret` is configured, validates the `x-ado-webhook-secret` custom header using timing-safe comparison. Without a secret, the ingress is registered without validation.
- **Config schema** (`config.d.ts`) — declares `events.modules.azureDevOps.webhookSecret` with `@visibility secret`.
- **Default export changed to `BackendFeatureLoader`** — bundles both the existing `AzureDevOpsEventRouter` (sub-topic routing by `eventType`) and the new webhook ingress, so consumers get both features by installing the single package.

### Why

Azure DevOps does not support HMAC signature verification for outgoing service hook webhooks (unlike GitHub). The only authentication mechanisms available are Basic Auth and custom HTTP headers. This implementation uses a custom `x-ado-webhook-secret` header, which is configured in the ADO service hook subscription settings and validated on the Backstage side.

The GitHub events module already ships a built-in HTTP ingress + signature validator. This PR brings the Azure module to parity.

### Tests

- 4 unit tests for the validator (no secret → undefined, matching header → accept, wrong header → reject, missing header → reject)
- 2 module wiring tests (registers without validator when no secret, registers with validator when secret configured)
- 3 HTTP integration tests using `startTestBackend` + `supertest` (valid payload → 202, invalid secret → 403, no secret configured → 202)
- All 13 tests pass, existing event router tests unaffected

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))