### PR TITLE
feat(integration): support connections for GitHub credentials

### DIFF
--- a/.changeset/tidy-apes-connect.md
+++ b/.changeset/tidy-apes-connect.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': minor
+---
+
+Added support for creating a GitHub credentials provider backed by the connections service.

--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -40,6 +40,7 @@
     "@azure/identity": "^4.0.0",
     "@azure/storage-blob": "^12.5.0",
     "@backstage/config": "workspace:^",
+    "@backstage/connections": "workspace:^",
     "@backstage/errors": "workspace:^",
     "@octokit/auth-app": "^4.0.0",
     "@octokit/rest": "^19.0.3",

--- a/packages/integration/report.api.md
+++ b/packages/integration/report.api.md
@@ -5,6 +5,7 @@
 ```ts
 import { AnonymousCredential } from '@azure/storage-blob';
 import { Config } from '@backstage/config';
+import type { ConnectionsService } from '@backstage/connections';
 import { ConsumedResponse } from '@backstage/errors';
 import { RestEndpointMethodTypes } from '@octokit/rest';
 import { StorageSharedKeyCredential } from '@azure/storage-blob';
@@ -323,6 +324,9 @@ export class DefaultAzureDevOpsCredentialsProvider
 export class DefaultGithubCredentialsProvider
   implements GithubCredentialsProvider
 {
+  static fromConnections(
+    connections: ConnectionsService,
+  ): DefaultGithubCredentialsProvider;
   // (undocumented)
   static fromIntegrations(
     integrations: ScmIntegrationRegistry,

--- a/packages/integration/src/github/DefaultGithubCredentialsProvider.test.ts
+++ b/packages/integration/src/github/DefaultGithubCredentialsProvider.test.ts
@@ -21,6 +21,7 @@ import { SingleInstanceGithubCredentialsProvider } from './SingleInstanceGithubC
 import { DefaultGithubCredentialsProvider } from './DefaultGithubCredentialsProvider';
 import { ConfigReader } from '@backstage/config';
 import { GithubCredentials } from './types';
+import { ConnectionsService } from '@backstage/connections';
 
 const resultBuilder = (host: string): GithubCredentials => {
   return {
@@ -89,6 +90,91 @@ describe('DefaultGithubCredentialsProvider tests', () => {
       expect(
         SingleInstanceGithubCredentialsProvider.create,
       ).toHaveBeenCalledWith(grithubIntegration);
+    });
+
+    it('creates and reuses providers from the connections service', async () => {
+      const find = jest.fn().mockResolvedValue({
+        type: 'github',
+        title: 'GitHub',
+        host: 'github.com',
+        apiBaseUrl: 'https://api.github.com',
+        rawBaseUrl: 'https://raw.githubusercontent.com',
+        auth: {
+          method: 'app',
+          appId: '123',
+          privateKey: 'private-key',
+          clientId: 'client-id',
+          clientSecret: 'client-secret',
+          webhookSecret: 'webhook-secret',
+          publicAccess: true,
+          orgs: ['backstage'],
+        },
+      });
+      const provider = DefaultGithubCredentialsProvider.fromConnections({
+        find: find as ConnectionsService['find'],
+      });
+
+      await provider.getCredentials({
+        url: 'https://github.com/backstage/backstage',
+      });
+      await provider.getCredentials({
+        url: 'https://github.com/backstage/community',
+      });
+
+      expect(find).toHaveBeenCalledWith({
+        type: 'github',
+        url: 'https://github.com/backstage/backstage',
+        authMethods: ['app', 'token', 'none'],
+      });
+      expect(
+        SingleInstanceGithubCredentialsProvider.create,
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        SingleInstanceGithubCredentialsProvider.create,
+      ).toHaveBeenCalledWith({
+        host: 'github.com',
+        apiBaseUrl: 'https://api.github.com',
+        rawBaseUrl: 'https://raw.githubusercontent.com',
+        apps: [
+          {
+            appId: 123,
+            privateKey: 'private-key',
+            clientId: 'client-id',
+            clientSecret: 'client-secret',
+            webhookSecret: 'webhook-secret',
+            publicAccess: true,
+            allowedInstallationOwners: ['backstage'],
+          },
+        ],
+      });
+    });
+
+    it('creates token providers from the connections service', async () => {
+      const find = jest.fn().mockResolvedValue({
+        type: 'github',
+        title: 'GitHub Enterprise',
+        host: 'github.example.com',
+        auth: {
+          method: 'token',
+          token: 'connection-token',
+        },
+      });
+      const provider = DefaultGithubCredentialsProvider.fromConnections({
+        find: find as ConnectionsService['find'],
+      });
+
+      await provider.getCredentials({
+        url: 'https://github.example.com/backstage/backstage',
+      });
+
+      expect(
+        SingleInstanceGithubCredentialsProvider.create,
+      ).toHaveBeenCalledWith({
+        host: 'github.example.com',
+        apiBaseUrl: undefined,
+        rawBaseUrl: undefined,
+        token: 'connection-token',
+      });
     });
   });
 

--- a/packages/integration/src/github/DefaultGithubCredentialsProvider.ts
+++ b/packages/integration/src/github/DefaultGithubCredentialsProvider.ts
@@ -84,8 +84,9 @@ export class DefaultGithubCredentialsProvider
    */
   async getCredentials(opts: { url: string }): Promise<GithubCredentials> {
     if (this.connections) {
-      // Resolve on every request because the connections service may select a
-      // different GitHub App based on the organization in the URL.
+      // Ask the connections service to select auth for this URL. A host may
+      // have different GitHub Apps for different organizations, so this
+      // selection cannot be done once when the provider is created.
       const connection = await this.connections.find({
         type: 'github',
         url: opts.url,

--- a/packages/integration/src/github/DefaultGithubCredentialsProvider.ts
+++ b/packages/integration/src/github/DefaultGithubCredentialsProvider.ts
@@ -17,6 +17,8 @@
 import { GithubCredentials, GithubCredentialsProvider } from './types';
 import { ScmIntegrationRegistry } from '../registry';
 import { SingleInstanceGithubCredentialsProvider } from './SingleInstanceGithubCredentialsProvider';
+import type { ConnectionsService } from '@backstage/connections';
+import { GithubIntegrationConfig } from './config';
 
 /**
  * Handles the creation and caching of credentials for GitHub integrations.
@@ -41,8 +43,19 @@ export class DefaultGithubCredentialsProvider
     return new DefaultGithubCredentialsProvider(credentialsProviders);
   }
 
+  /**
+   * Creates a credentials provider backed by the connections service.
+   *
+   * @param connections - The connections service used to resolve GitHub credentials.
+   * @public
+   */
+  static fromConnections(connections: ConnectionsService) {
+    return new DefaultGithubCredentialsProvider(new Map(), connections);
+  }
+
   private constructor(
     private readonly providers: Map<string, GithubCredentialsProvider>,
+    private readonly connections?: ConnectionsService,
   ) {}
 
   /**
@@ -70,6 +83,48 @@ export class DefaultGithubCredentialsProvider
    * @returns A promise of {@link GithubCredentials}.
    */
   async getCredentials(opts: { url: string }): Promise<GithubCredentials> {
+    if (this.connections) {
+      const connection = await this.connections.find({
+        type: 'github',
+        url: opts.url,
+        authMethods: ['app', 'token', 'none'],
+      });
+      const { auth } = connection;
+      const providerKey = `${connection.host}:${auth.method}:${
+        auth.method === 'app' ? auth.appId : ''
+      }`;
+
+      let provider = this.providers.get(providerKey);
+      if (!provider) {
+        const config: GithubIntegrationConfig = {
+          host: connection.host,
+          apiBaseUrl: connection.apiBaseUrl,
+          rawBaseUrl: connection.rawBaseUrl,
+        };
+
+        if (auth.method === 'app') {
+          config.apps = [
+            {
+              appId: Number(auth.appId),
+              privateKey: auth.privateKey,
+              clientId: auth.clientId,
+              clientSecret: auth.clientSecret,
+              webhookSecret: auth.webhookSecret,
+              publicAccess: auth.publicAccess,
+              allowedInstallationOwners: auth.orgs,
+            },
+          ];
+        } else if (auth.method === 'token') {
+          config.token = auth.token;
+        }
+
+        provider = SingleInstanceGithubCredentialsProvider.create(config);
+        this.providers.set(providerKey, provider);
+      }
+
+      return provider.getCredentials(opts);
+    }
+
     const parsed = new URL(opts.url);
     const provider = this.providers.get(parsed.host);
 

--- a/packages/integration/src/github/DefaultGithubCredentialsProvider.ts
+++ b/packages/integration/src/github/DefaultGithubCredentialsProvider.ts
@@ -84,18 +84,25 @@ export class DefaultGithubCredentialsProvider
    */
   async getCredentials(opts: { url: string }): Promise<GithubCredentials> {
     if (this.connections) {
+      // Resolve on every request because the connections service may select a
+      // different GitHub App based on the organization in the URL.
       const connection = await this.connections.find({
         type: 'github',
         url: opts.url,
         authMethods: ['app', 'token', 'none'],
       });
       const { auth } = connection;
+
+      // Keep one provider per host and selected auth method. In particular,
+      // reusing an App provider preserves its installation-token cache.
       const providerKey = `${connection.host}:${auth.method}:${
         auth.method === 'app' ? auth.appId : ''
       }`;
 
       let provider = this.providers.get(providerKey);
       if (!provider) {
+        // Adapt the connection schema to the existing provider configuration
+        // so credential creation and token caching stay in one implementation.
         const config: GithubIntegrationConfig = {
           host: connection.host,
           apiBaseUrl: connection.apiBaseUrl,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3552,6 +3552,7 @@ __metadata:
     "@backstage/cli": "workspace:^"
     "@backstage/config": "workspace:^"
     "@backstage/config-loader": "workspace:^"
+    "@backstage/connections": "workspace:^"
     "@backstage/errors": "workspace:^"
     "@octokit/auth-app": "npm:^4.0.0"
     "@octokit/rest": "npm:^19.0.3"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds a `DefaultGithubCredentialsProvider.fromConnections` factory so consumers can resolve GitHub App, token, and anonymous credentials through `@backstage/connections`.

The connections-backed provider preserves the existing GitHub App token cache by reusing single-instance providers for each resolved host and auth method. This is intended to dogfood the connections service and surface integration issues before broader adoption.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Validation:

- `CI=1 yarn test packages/integration/src/github/DefaultGithubCredentialsProvider.test.ts`
- `yarn tsc`
- `yarn lint --fix`
- `yarn build:api-reports`
