### PR TITLE
Use twelve-character frontend asset hashes

### DIFF
--- a/.changeset/twelve-character-asset-hashes.md
+++ b/.changeset/twelve-character-asset-hashes.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli-module-build': patch
+---
+
+Increase generated frontend static asset filename hashes to 12 characters to reduce the chance of collisions across long-lived cached builds.

--- a/packages/cli-module-build/src/lib/bundler/config.ts
+++ b/packages/cli-module-build/src/lib/bundler/config.ts
@@ -37,6 +37,7 @@ import yn from 'yn';
 import { hasReactDomClient } from './hasReactDomClient';
 import { createWorkspaceLinkingPlugins } from './linkWorkspaces';
 import { ConfigInjectingHtmlWebpackPlugin } from './ConfigInjectingHtmlWebpackPlugin';
+import { STATIC_ASSET_HASH_LENGTH } from './staticAssetHash';
 
 export function resolveBaseUrl(
   config: Config,
@@ -372,10 +373,12 @@ export async function createConfig(
       uniqueName: options.moduleFederationRemote?.name,
       path: paths.targetDist,
       publicPath: options.moduleFederationRemote ? 'auto' : `${publicPath}/`,
-      filename: isDev ? '[name].js' : 'static/[name].[contenthash:8].js',
+      filename: isDev
+        ? '[name].js'
+        : `static/[name].[contenthash:${STATIC_ASSET_HASH_LENGTH}].js`,
       chunkFilename: isDev
         ? '[name].chunk.js'
-        : 'static/[name].[contenthash:8].chunk.js',
+        : `static/[name].[contenthash:${STATIC_ASSET_HASH_LENGTH}].chunk.js`,
       ...(isDev
         ? {
             devtoolModuleFilenameTemplate: (info: any) =>

--- a/packages/cli-module-build/src/lib/bundler/optimization.ts
+++ b/packages/cli-module-build/src/lib/bundler/optimization.ts
@@ -20,6 +20,7 @@ import {
   LightningCssMinimizerRspackPlugin,
   RspackOptionsNormalized,
 } from '@rspack/core';
+import { STATIC_ASSET_HASH_LENGTH } from './staticAssetHash';
 
 export const optimization = (
   options: BundlingOptions,
@@ -72,7 +73,7 @@ export const optimization = (
           },
           filename: isDev
             ? 'module-[name].js'
-            : 'static/module-[name].[contenthash:8].js',
+            : `static/module-[name].[contenthash:${STATIC_ASSET_HASH_LENGTH}].js`,
           priority: 10,
           minSize: 100000,
           minChunks: 1,

--- a/packages/cli-module-build/src/lib/bundler/staticAssetHash.ts
+++ b/packages/cli-module-build/src/lib/bundler/staticAssetHash.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Static assets may remain cached across many builds, so use enough hash
+// characters to keep filename collisions unlikely across deployments.
+export const STATIC_ASSET_HASH_LENGTH = 12;

--- a/packages/cli-module-build/src/lib/bundler/transforms.ts
+++ b/packages/cli-module-build/src/lib/bundler/transforms.ts
@@ -20,6 +20,7 @@ import {
   CssExtractRspackPlugin,
   WebpackPluginInstance,
 } from '@rspack/core';
+import { STATIC_ASSET_HASH_LENGTH } from './staticAssetHash';
 
 type Transforms = {
   loaders: RuleSetRule[];
@@ -138,14 +139,14 @@ export const transforms = (options: TransformOptions): Transforms => {
       ],
       type: 'asset/resource',
       generator: {
-        filename: 'static/[name].[hash:8][ext]',
+        filename: `static/[name].[hash:${STATIC_ASSET_HASH_LENGTH}][ext]`,
       },
     },
     {
       test: /\.(eot|woff|woff2|ttf)$/i,
       type: 'asset/resource',
       generator: {
-        filename: 'static/[name].[hash][ext][query]',
+        filename: `static/[name].[hash:${STATIC_ASSET_HASH_LENGTH}][ext][query]`,
       },
     },
     {
@@ -156,7 +157,7 @@ export const transforms = (options: TransformOptions): Transforms => {
       include: /\.(md)$/,
       type: 'asset/resource',
       generator: {
-        filename: 'static/[name].[hash][ext][query]',
+        filename: `static/[name].[hash:${STATIC_ASSET_HASH_LENGTH}][ext][query]`,
       },
     },
     {
@@ -185,8 +186,8 @@ export const transforms = (options: TransformOptions): Transforms => {
   if (!isDev) {
     plugins.push(
       new CssExtractPlugin({
-        filename: 'static/[name].[contenthash:8].css',
-        chunkFilename: 'static/[name].[id].[contenthash:8].css',
+        filename: `static/[name].[contenthash:${STATIC_ASSET_HASH_LENGTH}].css`,
+        chunkFilename: `static/[name].[id].[contenthash:${STATIC_ASSET_HASH_LENGTH}].css`,
         insert: insertBeforeJssStyles, // Only applies to async chunks
       }),
     );


### PR DESCRIPTION
Update the frontend bundler configurations so all hashed static asset filenames use 12-character hashes. This covers Rspack and legacy Webpack production output for JavaScript entries, lazy chunks, split vendor chunks, extracted CSS, and resource assets, as well as resource assets emitted by development builds.

The longer hashes reduce collision risk when the app backend retains and serves aggressively cached static assets from multiple builds for extended periods. Filename structure and content-based cache invalidation semantics are otherwise unchanged.

Verification includes full type checking and linting, API report generation, and a representative example-app production build whose emitted JavaScript, CSS, SVG, and source-map filenames all matched the 12-character hash patterns.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

<!-- mana-workspace:KSZyuAVRNZx -->