### PR TITLE
refactor(catalog): forward entity layout routes

### DIFF
--- a/plugins/catalog/src/alpha/components/EntityLayout/EntityLayout.tsx
+++ b/plugins/catalog/src/alpha/components/EntityLayout/EntityLayout.tsx
@@ -36,7 +36,12 @@ import { catalogTranslationRef } from '../../translation';
 import { EntityHeader } from '../EntityHeader';
 import { EntityTabs } from '../EntityTabs';
 import { EntityContentGroupDefinitions } from '@backstage/plugin-catalog-react/alpha';
-import { EntityLayoutRoute, useEntityLayoutRoutes } from './entityLayoutRoutes';
+import {
+  EntityLayoutRoute,
+  EntityLayoutRouteData,
+  filterEntityLayoutRoutes,
+  useEntityLayoutRouteChildren,
+} from './entityLayoutRoutes';
 
 export type { EntityLayoutRouteProps } from './entityLayoutRoutes';
 
@@ -82,22 +87,26 @@ export interface EntityLayoutProps {
  *
  * @public
  */
-export const EntityLayout = (props: EntityLayoutProps) => {
+export function InternalEntityLayout(
+  props: Omit<EntityLayoutProps, 'children'> & {
+    routes: EntityLayoutRouteData[];
+  },
+) {
   const {
     UNSTABLE_extraContextMenuItems,
     contextMenuItems,
-    children,
     header,
     NotFoundComponent,
     parentEntityRelations,
     groupDefinitions,
     defaultContentOrder,
     showNavItemIcons,
+    routes,
   } = props;
   const { kind } = useRouteRefParams(entityRouteRef);
   const { entity, loading, error } = useAsyncEntity();
 
-  const routes = useEntityLayoutRoutes(children, entity);
+  const visibleRoutes = filterEntityLayoutRoutes(routes, entity);
 
   const { t } = useTranslationRef(catalogTranslationRef);
 
@@ -115,7 +124,7 @@ export const EntityLayout = (props: EntityLayoutProps) => {
 
       {entity && (
         <EntityTabs
-          routes={routes}
+          routes={visibleRoutes}
           groupDefinitions={groupDefinitions}
           defaultContentOrder={defaultContentOrder}
           showIcons={showNavItemIcons}
@@ -148,6 +157,12 @@ export const EntityLayout = (props: EntityLayoutProps) => {
       )}
     </Page>
   );
+}
+
+export const EntityLayout = (props: EntityLayoutProps) => {
+  const { children, ...layoutProps } = props;
+  const routes = useEntityLayoutRouteChildren(children);
+  return <InternalEntityLayout {...layoutProps} routes={routes} />;
 };
 
 EntityLayout.Route = EntityLayoutRoute;

--- a/plugins/catalog/src/alpha/components/EntityLayout/EntityLayout.tsx
+++ b/plugins/catalog/src/alpha/components/EntityLayout/EntityLayout.tsx
@@ -38,20 +38,14 @@ import { EntityTabs } from '../EntityTabs';
 import { EntityContentGroupDefinitions } from '@backstage/plugin-catalog-react/alpha';
 import {
   EntityLayoutRoute,
-  EntityLayoutRouteData,
   filterEntityLayoutRoutes,
-  useEntityLayoutRouteChildren,
 } from './entityLayoutRoutes';
 
-export type { EntityLayoutRouteProps } from './entityLayoutRoutes';
-
-/** @public */
-export interface EntityLayoutProps {
+interface EntityLayoutProps {
   UNSTABLE_extraContextMenuItems?: ComponentProps<
     typeof EntityHeader
   >['UNSTABLE_extraContextMenuItems'];
   contextMenuItems?: ComponentProps<typeof EntityHeader>['contextMenuItems'];
-  children?: ReactNode;
   header?: JSX.Element;
   NotFoundComponent?: ReactNode;
   /**
@@ -68,30 +62,10 @@ export interface EntityLayoutProps {
   groupDefinitions: EntityContentGroupDefinitions;
   defaultContentOrder?: 'title' | 'natural';
   showNavItemIcons?: boolean;
+  routes: EntityLayoutRoute[];
 }
 
-/**
- * EntityLayout is a compound component, which allows you to define a layout for
- * entities using a sub-navigation mechanism.
- *
- * Consists of two parts: EntityLayout and EntityLayout.Route
- *
- * @example
- * ```jsx
- * <EntityLayout>
- *   <EntityLayout.Route path="/example" title="Example tab">
- *     <div>This is rendered under /example/anything-here route</div>
- *   </EntityLayout.Route>
- * </EntityLayout>
- * ```
- *
- * @public
- */
-export function InternalEntityLayout(
-  props: Omit<EntityLayoutProps, 'children'> & {
-    routes: EntityLayoutRouteData[];
-  },
-) {
+export function EntityLayout(props: EntityLayoutProps) {
   const {
     UNSTABLE_extraContextMenuItems,
     contextMenuItems,
@@ -158,11 +132,3 @@ export function InternalEntityLayout(
     </Page>
   );
 }
-
-export const EntityLayout = (props: EntityLayoutProps) => {
-  const { children, ...layoutProps } = props;
-  const routes = useEntityLayoutRouteChildren(children);
-  return <InternalEntityLayout {...layoutProps} routes={routes} />;
-};
-
-EntityLayout.Route = EntityLayoutRoute;

--- a/plugins/catalog/src/alpha/components/EntityLayout/EntityLayoutBui.test.tsx
+++ b/plugins/catalog/src/alpha/components/EntityLayout/EntityLayoutBui.test.tsx
@@ -30,7 +30,6 @@ import {
 } from '@backstage/plugin-catalog-react/alpha';
 import { catalogApiMock } from '@backstage/plugin-catalog-react/testUtils';
 import { EntityLayoutBui } from './EntityLayoutBui';
-import { EntityLayoutRoute } from './entityLayoutRoutes';
 
 const componentEntity: Entity = {
   apiVersion: 'backstage.io/v1alpha1',
@@ -59,16 +58,25 @@ async function renderLayout(options: {
       error={options.error}
     >
       <EntityLayoutBui
+        routes={[
+          {
+            path: '/overview',
+            title: 'Overview',
+            children: <div>Overview content</div>,
+          },
+          {
+            path: '/hidden',
+            title: 'Hidden',
+            children: <div>Hidden content</div>,
+            if: () => false,
+          },
+        ]}
         groupDefinitions={defaultEntityContentGroupDefinitions}
         defaultContentOrder="title"
         contextMenuItems={[]}
         NotFoundComponent={options.NotFoundComponent}
         HeaderComponent={options.HeaderComponent}
-      >
-        <EntityLayoutRoute path="/overview" title="Overview">
-          <div>Overview content</div>
-        </EntityLayoutRoute>
-      </EntityLayoutBui>
+      />
     </AsyncEntityProvider>,
     {
       apis: [

--- a/plugins/catalog/src/alpha/components/EntityLayout/EntityLayoutBui.tsx
+++ b/plugins/catalog/src/alpha/components/EntityLayout/EntityLayoutBui.tsx
@@ -40,7 +40,7 @@ import { catalogTranslationRef } from '../../translation';
 import { EntityHeaderBui } from '../EntityHeader/EntityHeaderBui';
 import { useEntityTabs } from '../EntityTabs/useEntityTabs';
 import {
-  EntityLayoutRouteData,
+  EntityLayoutRoute,
   filterEntityLayoutRoutes,
 } from './entityLayoutRoutes';
 
@@ -146,7 +146,7 @@ function EntityLayoutContent(props: {
 }
 
 export function EntityLayoutBui(props: {
-  routes: EntityLayoutRouteData[];
+  routes: EntityLayoutRoute[];
   NotFoundComponent?: ReactNode;
   groupDefinitions: EntityContentGroupDefinitions;
   defaultContentOrder: 'title' | 'natural';

--- a/plugins/catalog/src/alpha/components/EntityLayout/EntityLayoutBui.tsx
+++ b/plugins/catalog/src/alpha/components/EntityLayout/EntityLayoutBui.tsx
@@ -39,7 +39,10 @@ import {
 import { catalogTranslationRef } from '../../translation';
 import { EntityHeaderBui } from '../EntityHeader/EntityHeaderBui';
 import { useEntityTabs } from '../EntityTabs/useEntityTabs';
-import { useEntityLayoutRoutes } from './entityLayoutRoutes';
+import {
+  EntityLayoutRouteData,
+  filterEntityLayoutRoutes,
+} from './entityLayoutRoutes';
 
 function EntityDocumentTitle(props: { activeContentTitle?: string }) {
   const configApi = useApi(configApiRef);
@@ -143,7 +146,7 @@ function EntityLayoutContent(props: {
 }
 
 export function EntityLayoutBui(props: {
-  children?: ReactNode;
+  routes: EntityLayoutRouteData[];
   NotFoundComponent?: ReactNode;
   groupDefinitions: EntityContentGroupDefinitions;
   defaultContentOrder: 'title' | 'natural';
@@ -151,7 +154,7 @@ export function EntityLayoutBui(props: {
   HeaderComponent?: ComponentType<EntityHeaderLayoutProps>;
 }) {
   const {
-    children,
+    routes,
     NotFoundComponent,
     groupDefinitions,
     defaultContentOrder,
@@ -159,8 +162,12 @@ export function EntityLayoutBui(props: {
     HeaderComponent,
   } = props;
   const { entity } = useAsyncEntity();
-  const routes = useEntityLayoutRoutes(children, entity);
-  const tabs = useEntityTabs({ routes, groupDefinitions, defaultContentOrder });
+  const visibleRoutes = filterEntityLayoutRoutes(routes, entity);
+  const tabs = useEntityTabs({
+    routes: visibleRoutes,
+    groupDefinitions,
+    defaultContentOrder,
+  });
 
   return (
     <main>

--- a/plugins/catalog/src/alpha/components/EntityLayout/entityLayoutRoutes.tsx
+++ b/plugins/catalog/src/alpha/components/EntityLayout/entityLayoutRoutes.tsx
@@ -30,6 +30,8 @@ export type EntityLayoutRouteProps = {
   if?: (entity: Entity) => boolean;
 };
 
+export type EntityLayoutRouteData = EntityLayoutRouteProps;
+
 const dataKey = 'plugin.catalog.entityLayoutRoute';
 
 export const EntityLayoutRoute: (props: EntityLayoutRouteProps) => null = () =>
@@ -38,10 +40,7 @@ attachComponentData(EntityLayoutRoute, dataKey, true);
 // Ensures mount points discovered within a route use the route's own path.
 attachComponentData(EntityLayoutRoute, 'core.gatherMountPoints', true);
 
-export function useEntityLayoutRoutes(
-  children: ReactNode,
-  entity: Entity | undefined,
-) {
+export function useEntityLayoutRouteChildren(children: ReactNode) {
   return useElementFilter(
     children,
     elements =>
@@ -52,18 +51,17 @@ export function useEntityLayoutRoutes(
             'Child of EntityLayout must be an EntityLayout.Route',
         })
         .getElements<EntityLayoutRouteProps>()
-        .flatMap(({ props }) => {
-          if (!entity || (props.if && !props.if(entity))) return [];
-          return [
-            {
-              path: props.path,
-              title: props.title,
-              group: props.group,
-              icon: props.icon,
-              children: props.children,
-            },
-          ];
-        }),
-    [entity],
+        .map(({ props }) => props),
+    [],
   );
+}
+
+export function filterEntityLayoutRoutes(
+  routes: EntityLayoutRouteData[],
+  entity: Entity | undefined,
+) {
+  if (!entity) {
+    return [];
+  }
+  return routes.filter(route => !route.if || route.if(entity));
 }

--- a/plugins/catalog/src/alpha/components/EntityLayout/entityLayoutRoutes.tsx
+++ b/plugins/catalog/src/alpha/components/EntityLayout/entityLayoutRoutes.tsx
@@ -15,13 +15,9 @@
  */
 
 import { Entity } from '@backstage/catalog-model';
-import {
-  attachComponentData,
-  useElementFilter,
-} from '@backstage/core-plugin-api';
-import { ReactElement, ReactNode } from 'react';
+import { ReactElement } from 'react';
 
-export type EntityLayoutRouteProps = {
+export type EntityLayoutRoute = {
   path: string;
   title: string;
   group?: string;
@@ -30,34 +26,8 @@ export type EntityLayoutRouteProps = {
   if?: (entity: Entity) => boolean;
 };
 
-export type EntityLayoutRouteData = EntityLayoutRouteProps;
-
-const dataKey = 'plugin.catalog.entityLayoutRoute';
-
-export const EntityLayoutRoute: (props: EntityLayoutRouteProps) => null = () =>
-  null;
-attachComponentData(EntityLayoutRoute, dataKey, true);
-// Ensures mount points discovered within a route use the route's own path.
-attachComponentData(EntityLayoutRoute, 'core.gatherMountPoints', true);
-
-export function useEntityLayoutRouteChildren(children: ReactNode) {
-  return useElementFilter(
-    children,
-    elements =>
-      elements
-        .selectByComponentData({
-          key: dataKey,
-          withStrictError:
-            'Child of EntityLayout must be an EntityLayout.Route',
-        })
-        .getElements<EntityLayoutRouteProps>()
-        .map(({ props }) => props),
-    [],
-  );
-}
-
 export function filterEntityLayoutRoutes(
-  routes: EntityLayoutRouteData[],
+  routes: EntityLayoutRoute[],
   entity: Entity | undefined,
 ) {
   if (!entity) {

--- a/plugins/catalog/src/alpha/pages.tsx
+++ b/plugins/catalog/src/alpha/pages.tsx
@@ -209,10 +209,11 @@ export const catalogEntityPage = PageBlueprint.makeWithOverrides({
       // `core-compat-api` package.
       routeRef: convertLegacyRouteRef(entityRouteRef), // READ THE ABOVE
       loader: async () => {
-        const [{ EntityLayout }, { EntityLayoutBui }] = await Promise.all([
-          import('./components/EntityLayout'),
-          import('./components/EntityLayout/EntityLayoutBui'),
-        ]);
+        const [{ InternalEntityLayout }, { EntityLayoutBui }] =
+          await Promise.all([
+            import('./components/EntityLayout/EntityLayout'),
+            import('./components/EntityLayout/EntityLayoutBui'),
+          ]);
 
         const menuItems = inputs.contextMenuItems.map(item => ({
           data: item.get(EntityContextMenuItemBlueprint.dataRefs.data),
@@ -259,21 +260,17 @@ export const catalogEntityPage = PageBlueprint.makeWithOverrides({
             {} as EntityContentGroupDefinitions,
           ) ?? defaultEntityContentGroupDefinitions;
 
-        const routes = inputs.contents.map(output => (
-          <EntityLayout.Route
-            group={output.get(EntityContentBlueprint.dataRefs.group)}
-            key={output.get(coreExtensionData.routePath)}
-            path={output.get(coreExtensionData.routePath)}
-            title={output.get(EntityContentBlueprint.dataRefs.title)}
-            icon={output.get(EntityContentBlueprint.dataRefs.icon)}
-            if={buildFilterFn(
-              output.get(EntityContentBlueprint.dataRefs.filterFunction),
-              output.get(EntityContentBlueprint.dataRefs.filterExpression),
-            )}
-          >
-            {output.get(coreExtensionData.reactElement)}
-          </EntityLayout.Route>
-        ));
+        const routes = inputs.contents.map(output => ({
+          group: output.get(EntityContentBlueprint.dataRefs.group),
+          path: output.get(coreExtensionData.routePath),
+          title: output.get(EntityContentBlueprint.dataRefs.title),
+          icon: output.get(EntityContentBlueprint.dataRefs.icon),
+          if: buildFilterFn(
+            output.get(EntityContentBlueprint.dataRefs.filterFunction),
+            output.get(EntityContentBlueprint.dataRefs.filterExpression),
+          ),
+          children: output.get(coreExtensionData.reactElement),
+        }));
 
         const Component = () => {
           const routeParams = useRouteRefParams(entityRouteRef);
@@ -301,23 +298,21 @@ export const catalogEntityPage = PageBlueprint.makeWithOverrides({
           const layout =
             HeaderComponent || !legacyHeader ? (
               <EntityLayoutBui
+                routes={routes}
                 HeaderComponent={HeaderComponent}
                 contextMenuItems={filteredMenuItems}
                 groupDefinitions={groupDefinitions}
                 defaultContentOrder={config.defaultContentOrder}
-              >
-                {routes}
-              </EntityLayoutBui>
+              />
             ) : (
-              <EntityLayout
+              <InternalEntityLayout
+                routes={routes}
                 header={legacyHeader}
                 contextMenuItems={filteredMenuItems}
                 groupDefinitions={groupDefinitions}
                 defaultContentOrder={config.defaultContentOrder}
                 showNavItemIcons={config.showNavItemIcons}
-              >
-                {routes}
-              </EntityLayout>
+              />
             );
 
           return (

--- a/plugins/catalog/src/alpha/pages.tsx
+++ b/plugins/catalog/src/alpha/pages.tsx
@@ -209,11 +209,10 @@ export const catalogEntityPage = PageBlueprint.makeWithOverrides({
       // `core-compat-api` package.
       routeRef: convertLegacyRouteRef(entityRouteRef), // READ THE ABOVE
       loader: async () => {
-        const [{ InternalEntityLayout }, { EntityLayoutBui }] =
-          await Promise.all([
-            import('./components/EntityLayout/EntityLayout'),
-            import('./components/EntityLayout/EntityLayoutBui'),
-          ]);
+        const [{ EntityLayout }, { EntityLayoutBui }] = await Promise.all([
+          import('./components/EntityLayout'),
+          import('./components/EntityLayout/EntityLayoutBui'),
+        ]);
 
         const menuItems = inputs.contextMenuItems.map(item => ({
           data: item.get(EntityContextMenuItemBlueprint.dataRefs.data),
@@ -305,7 +304,7 @@ export const catalogEntityPage = PageBlueprint.makeWithOverrides({
                 defaultContentOrder={config.defaultContentOrder}
               />
             ) : (
-              <InternalEntityLayout
+              <EntityLayout
                 routes={routes}
                 header={legacyHeader}
                 contextMenuItems={filteredMenuItems}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Follow-up cleanup from #34530 and [this review comment](https://github.com/backstage/backstage/pull/34530#discussion_r3460875938).

The new frontend Catalog entity page previously converted entity content route data into React elements, which the entity layouts then converted back into route data.

This updates the internal layouts to receive route data directly as props. The public `EntityLayout.Route` compound component API remains unchanged.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
