### PR TITLE
Bug fix: core page overflow nested bui box in portal plugins

### DIFF
--- a/.changeset/core-page-nested-overflow.md
+++ b/.changeset/core-page-nested-overflow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+The `Page` component no longer creates its own scroll container when it is rendered inside a full-height container from `@backstage/ui`, preventing nested scrollbars in apps that use the new layout primitives.

--- a/packages/core-components/src/layout/Page/Page.tsx
+++ b/packages/core-components/src/layout/Page/Page.tsx
@@ -30,6 +30,12 @@ const useStyles = makeStyles(
       gridTemplateColumns: 'auto 1fr auto',
       overflowY: 'auto',
       height: '100vh',
+      // When nested inside a @backstage/ui Box/FullPage (<main class="bui-Box">),
+      // let the outer container own the scroll to avoid nested scrollbars.
+      'main.bui-Box &': {
+        overflowY: 'hidden',
+        height: '100%',
+      },
       [theme.breakpoints.down('xs')]: {
         height: '100%',
       },


### PR DESCRIPTION
Hey, I just made a Pull Request!
When the legacy Page component (@backstage/core-components) is rendered inside one of the new @backstage/ui full-height layout primitives, both the outer <main class="bui-Box"> and the inner Page <main> set up their own scroll container at 100vh. This produces a nested/double scrollbar and can clip content in portal plugins that embed legacy pages inside the new layout.

This change makes the legacy Page defer scrolling to the outer container only when it is nested inside a <main class="bui-Box">. It does this with a CSS-only JSS ancestor selector, so there's no new prop, no runtime detection, and no behavior change for standalone (non-nested) usage:

'main.bui-Box &': {
  overflowY: 'hidden',
  height: '100%',
},
The selector compiles to main.bui-Box .BackstagePage-root-* (specificity (0,2,0)), which overrides the base overflowY: 'auto' / height: '100vh' rule ((0,1,0)) regardless of style injection order. When there's no bui-Box ancestor, Page keeps its existing overflowY: 'auto' + height: '100vh' behavior, and the existing @media print and mobile breakpoint rules are untouched.


<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
