### PR TITLE
fix(backend-defaults): handle NULL next_run_start_at in scheduler task upsert

### DIFF
--- a/.changeset/fix-scheduler-null-next-run.md
+++ b/.changeset/fix-scheduler-null-next-run.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Fixed a bug in the scheduler where tasks transitioning from manual trigger to a cadence-based schedule would become permanently unscheduled. The SQL CASE expression in `persistTask()` did not handle NULL `next_run_start_at` values, causing the comparison `value < NULL` to evaluate to NULL in SQL three-valued logic and always take the ELSE branch, preserving the existing NULL forever.

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.test.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.test.ts
@@ -580,4 +580,89 @@ describe('TaskWorker', () => {
       await knex.destroy();
     },
   );
+
+  it.each(databases.eachSupportedId())(
+    'next_run_start_at is populated when transitioning from manual trigger to cadence-based schedule, %p',
+    async databaseId => {
+      const knex = await databases.init(databaseId);
+      await migrateBackendTasks(knex);
+
+      const fn = jest.fn(
+        async () => new Promise<void>(resolve => setTimeout(resolve, 50)),
+      );
+
+      // First, register the task with manual trigger so next_run_start_at is NULL
+      const manualSettings: TaskSettingsV2 = {
+        version: 2,
+        cadence: 'manual',
+        timeoutAfterDuration: 'PT1M',
+      };
+
+      const worker = new TaskWorker('task99', fn, knex, logger);
+      await worker.persistTask(manualSettings);
+
+      const rowBeforeTransition = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
+      expect(rowBeforeTransition.next_run_start_at).toBeNull();
+
+      // Now re-register the same task with a duration-based cadence
+      const cadenceSettings: TaskSettingsV2 = {
+        version: 2,
+        cadence: 'PT4H',
+        timeoutAfterDuration: 'PT1M',
+      };
+
+      await worker.persistTask(cadenceSettings);
+
+      const rowAfterTransition = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
+      expect(rowAfterTransition.next_run_start_at).not.toBeNull();
+
+      // Verify the next_run_start_at is approximately 4 hours from now
+      const nextStartAt = DateTime.fromJSDate(
+        new Date(rowAfterTransition.next_run_start_at!),
+      );
+      const now = DateTime.now();
+      expect(nextStartAt.diff(now).as('hours')).toBeCloseTo(4, 0);
+
+      await knex.destroy();
+    },
+  );
+
+  it.each(databases.eachSupportedId())(
+    'next_run_start_at is populated when transitioning from manual trigger to cron schedule, %p',
+    async databaseId => {
+      const knex = await databases.init(databaseId);
+      await migrateBackendTasks(knex);
+
+      const fn = jest.fn(
+        async () => new Promise<void>(resolve => setTimeout(resolve, 50)),
+      );
+
+      // First, register the task with manual trigger so next_run_start_at is NULL
+      const manualSettings: TaskSettingsV2 = {
+        version: 2,
+        cadence: 'manual',
+        timeoutAfterDuration: 'PT1M',
+      };
+
+      const worker = new TaskWorker('task99', fn, knex, logger);
+      await worker.persistTask(manualSettings);
+
+      const rowBeforeTransition = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
+      expect(rowBeforeTransition.next_run_start_at).toBeNull();
+
+      // Now re-register the same task with a cron schedule
+      const cronSettings: TaskSettingsV2 = {
+        version: 2,
+        cadence: '*/15 * * * *',
+        timeoutAfterDuration: 'PT1M',
+      };
+
+      await worker.persistTask(cronSettings);
+
+      const rowAfterTransition = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
+      expect(rowAfterTransition.next_run_start_at).not.toBeNull();
+
+      await knex.destroy();
+    },
+  );
 });

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.ts
@@ -297,8 +297,9 @@ export class TaskWorker {
           ? {
               settings_json: settingsJson,
               next_run_start_at: this.knex.raw(
-                `CASE WHEN ?? < ?? THEN ?? ELSE ?? END`,
+                `CASE WHEN ?? IS NULL OR ?? < ?? THEN ?? ELSE ?? END`,
                 [
+                  'next_run_start_at',
                   nextStartAt,
                   'next_run_start_at',
                   nextStartAt,
@@ -309,8 +310,9 @@ export class TaskWorker {
           : {
               settings_json: this.knex.ref('excluded.settings_json'),
               next_run_start_at: this.knex.raw(
-                `CASE WHEN ?? < ?? THEN ?? ELSE ?? END`,
+                `CASE WHEN ?? IS NULL OR ?? < ?? THEN ?? ELSE ?? END`,
                 [
+                  `${DB_TASKS_TABLE}.next_run_start_at`,
                   nextStartAt,
                   `${DB_TASKS_TABLE}.next_run_start_at`,
                   nextStartAt,


### PR DESCRIPTION
## Summary

Fixes a bug where tasks transitioning from `trigger: 'manual'` to a cadence-based schedule (duration or cron) become permanently unscheduled.

The `persistTask()` upsert uses a CASE expression to conditionally update `next_run_start_at`. When the existing value is NULL (as it is for manual-trigger tasks), the comparison `computed < NULL` evaluates to NULL in SQL three-valued logic. The CASE takes the ELSE branch, preserving the NULL forever. The scheduler polls for `next_run_start_at <= now()` and never finds these tasks.

The fix adds an `IS NULL` guard to both the MySQL and PostgreSQL/SQLite code paths so that a NULL existing value always adopts the newly computed start time.

## Test plan

- [x] Added integration tests for manual → duration and manual → cron transitions
- [x] Verified `next_run_start_at` is NULL after manual registration, then populated after re-registration with a cadence
- [x] All 12 existing + new tests pass