### PR TITLE
fix(backend-defaults): handle NULL next_run_start_at in scheduler task upsert

### DIFF
--- a/.changeset/fix-scheduler-null-next-run.md
+++ b/.changeset/fix-scheduler-null-next-run.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Fixed a bug in the scheduler where tasks transitioning from manual trigger to a cadence-based schedule would become permanently unscheduled. The SQL CASE expression in `persistTask()` did not handle NULL `next_run_start_at` values, causing the comparison `value < NULL` to evaluate to NULL in SQL three-valued logic and always take the ELSE branch, preserving the existing NULL forever.

--- a/.changeset/fix-scheduler-null-next-run.md
+++ b/.changeset/fix-scheduler-null-next-run.md
@@ -2,4 +2,4 @@
 '@backstage/backend-defaults': patch
 ---
 
-Fixed a bug in the scheduler where tasks transitioning from manual trigger to a cadence-based schedule would become permanently unscheduled. The SQL CASE expression in `persistTask()` did not handle NULL `next_run_start_at` values, causing the comparison `value < NULL` to evaluate to NULL in SQL three-valued logic and always take the ELSE branch, preserving the existing NULL forever.
+Fixed a bug where scheduled tasks that were initially registered with a manual trigger and later re-registered with a duration or cron cadence would never be scheduled to run.

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.test.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.test.ts
@@ -586,56 +586,6 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
     );
   });
 
-  it('next_run_start_at is updated when re-registering with a shorter cadence', async () => {
-    const fn = jest.fn(
-      async () => new Promise<void>(resolve => setTimeout(resolve, 50)),
-    );
-
-    const initialSettings: TaskSettingsV2 = {
-      version: 2,
-      cadence: 'PT120M',
-      initialDelayDuration: 'PT2M',
-      timeoutAfterDuration: 'PT1M',
-    };
-
-    const worker = new TaskWorker('task99', fn, knex, logger);
-    await worker.persistTask(initialSettings);
-    await worker.tryClaimTask('ticket', initialSettings);
-    await worker.tryReleaseTask('ticket', initialSettings);
-
-    const rowAfterClaimAndRelease = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
-
-    const settings: TaskSettingsV2 = {
-      ...initialSettings,
-      cadence: 'PT60M',
-    };
-    await worker.persistTask(settings);
-    const row1 = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
-
-    const rowAfterClaimAndReleaseNextStartAt = DateTime.fromJSDate(
-      new Date(rowAfterClaimAndRelease.next_run_start_at!),
-    );
-    const row1NextStartAt = DateTime.fromJSDate(
-      new Date(row1.next_run_start_at!),
-    );
-    const now = DateTime.now();
-    expect(
-      rowAfterClaimAndReleaseNextStartAt.diff(row1NextStartAt).as('minutes'),
-    ).toBeCloseTo(62, 1);
-    expect(row1NextStartAt.diff(now).as('minutes')).toBeCloseTo(60, 1);
-    expect(
-      rowAfterClaimAndReleaseNextStartAt.diff(now).as('minutes'),
-    ).toBeCloseTo(122, 1);
-
-    const settings2 = {
-      ...settings,
-    };
-    await worker.persistTask(settings2);
-    const row2 = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
-
-    expect(row2.next_run_start_at).toStrictEqual(row1.next_run_start_at);
-  });
-
   it('next_run_start_at is populated when transitioning from manual trigger to cadence-based schedule', async () => {
     const fn = jest.fn(
       async () => new Promise<void>(resolve => setTimeout(resolve, 50)),

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.test.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.test.ts
@@ -586,178 +586,117 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
     );
   });
 
-  it.each(databases.eachSupportedId())(
-    'next_run_start_at is updated when re-registering with a shorter cadence, %p',
-    async databaseId => {
-      const knex = await databases.init(databaseId);
-      await migrateBackendTasks(knex);
+  it('next_run_start_at is updated when re-registering with a shorter cadence', async () => {
+    const fn = jest.fn(
+      async () => new Promise<void>(resolve => setTimeout(resolve, 50)),
+    );
 
-      const fn = jest.fn(
-        async () => new Promise<void>(resolve => setTimeout(resolve, 50)),
-      );
+    const initialSettings: TaskSettingsV2 = {
+      version: 2,
+      cadence: 'PT120M',
+      initialDelayDuration: 'PT2M',
+      timeoutAfterDuration: 'PT1M',
+    };
 
-      const initialSettings: TaskSettingsV2 = {
-        version: 2,
-        cadence: 'PT120M',
-        initialDelayDuration: 'PT2M',
-        timeoutAfterDuration: 'PT1M',
-      };
+    const worker = new TaskWorker('task99', fn, knex, logger);
+    await worker.persistTask(initialSettings);
+    await worker.tryClaimTask('ticket', initialSettings);
+    await worker.tryReleaseTask('ticket', initialSettings);
 
-      const worker = new TaskWorker('task99', fn, knex, logger);
-      await worker.persistTask(initialSettings);
-      // replicate task running, sets next_run_start_at based on cadence
-      await worker.tryClaimTask('ticket', initialSettings);
-      await worker.tryReleaseTask('ticket', initialSettings);
+    const rowAfterClaimAndRelease = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
 
-      // grab initial row for comparisons later
-      const rowAfterClaimAndRelease = (
-        await knex<DbTasksRow>(DB_TASKS_TABLE)
-      )[0];
+    const settings: TaskSettingsV2 = {
+      ...initialSettings,
+      cadence: 'PT60M',
+    };
+    await worker.persistTask(settings);
+    const row1 = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
 
-      const settings: TaskSettingsV2 = {
-        ...initialSettings,
-        cadence: 'PT60M',
-      };
-      await worker.persistTask(settings);
-      const row1 = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
+    const rowAfterClaimAndReleaseNextStartAt = DateTime.fromJSDate(
+      new Date(rowAfterClaimAndRelease.next_run_start_at!),
+    );
+    const row1NextStartAt = DateTime.fromJSDate(
+      new Date(row1.next_run_start_at!),
+    );
+    const now = DateTime.now();
+    expect(
+      rowAfterClaimAndReleaseNextStartAt.diff(row1NextStartAt).as('minutes'),
+    ).toBeCloseTo(62, 1);
+    expect(row1NextStartAt.diff(now).as('minutes')).toBeCloseTo(60, 1);
+    expect(
+      rowAfterClaimAndReleaseNextStartAt.diff(now).as('minutes'),
+    ).toBeCloseTo(122, 1);
 
-      const rowAfterClaimAndReleaseNextStartAt = DateTime.fromJSDate(
-        new Date(rowAfterClaimAndRelease.next_run_start_at!),
-      );
-      const row1NextStartAt = DateTime.fromJSDate(
-        new Date(row1.next_run_start_at!),
-      );
-      const now = DateTime.now();
-      expect(
-        rowAfterClaimAndReleaseNextStartAt.diff(row1NextStartAt).as('minutes'),
-      ).toBeCloseTo(62, 1); // ensure that next start at is sooner than initial by one hour, plus the 2 minute delay (set my tryReleaseTask)
-      expect(row1NextStartAt.diff(now).as('minutes')).toBeCloseTo(60, 1); // ensure that next start at is later than now by one hour (2 minute delay doesn't take effect here)
-      expect(
-        rowAfterClaimAndReleaseNextStartAt.diff(now).as('minutes'),
-      ).toBeCloseTo(122, 1); // includes 2 minute start delay (which is persisted from tryReleaseTask)
+    const settings2 = {
+      ...settings,
+    };
+    await worker.persistTask(settings2);
+    const row2 = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
 
-      const settings2 = {
-        ...settings,
-      };
-      await worker.persistTask(settings2);
-      const row2 = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
+    expect(row2.next_run_start_at).toStrictEqual(row1.next_run_start_at);
+  });
 
-      expect(row2.next_run_start_at).toStrictEqual(row1.next_run_start_at);
+  it('next_run_start_at is populated when transitioning from manual trigger to cadence-based schedule', async () => {
+    const fn = jest.fn(
+      async () => new Promise<void>(resolve => setTimeout(resolve, 50)),
+    );
 
-      await knex.destroy();
-    },
-  );
+    const manualSettings: TaskSettingsV2 = {
+      version: 2,
+      cadence: 'manual',
+      timeoutAfterDuration: 'PT1M',
+    };
 
-  it.each(databases.eachSupportedId())(
-    'next_run_start_at is not set for manually-triggered tasks, %p',
-    async databaseId => {
-      const knex = await databases.init(databaseId);
-      await migrateBackendTasks(knex);
+    const worker = new TaskWorker('task99', fn, knex, logger);
+    await worker.persistTask(manualSettings);
 
-      const fn = jest.fn(
-        async () => new Promise<void>(resolve => setTimeout(resolve, 50)),
-      );
+    const rowBeforeTransition = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
+    expect(rowBeforeTransition.next_run_start_at).toBeNull();
 
-      const initialSettings: TaskSettingsV2 = {
-        version: 2,
-        cadence: 'manual',
-        timeoutAfterDuration: 'PT1M',
-      };
+    const cadenceSettings: TaskSettingsV2 = {
+      version: 2,
+      cadence: 'PT4H',
+      timeoutAfterDuration: 'PT1M',
+    };
 
-      const worker = new TaskWorker('task99', fn, knex, logger);
-      await worker.persistTask(initialSettings);
-      await worker.tryClaimTask('ticket', initialSettings);
-      await worker.tryReleaseTask('ticket', initialSettings);
+    await worker.persistTask(cadenceSettings);
 
-      const row = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
-      expect(row.next_run_start_at).toBeNull();
+    const rowAfterTransition = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
+    expect(rowAfterTransition.next_run_start_at).not.toBeNull();
 
-      await knex.destroy();
-    },
-  );
+    const nextStartAt = DateTime.fromJSDate(
+      new Date(rowAfterTransition.next_run_start_at!),
+    );
+    const now = DateTime.now();
+    expect(nextStartAt.diff(now).as('hours')).toBeCloseTo(4, 0);
+  });
 
-  it.each(databases.eachSupportedId())(
-    'next_run_start_at is populated when transitioning from manual trigger to cadence-based schedule, %p',
-    async databaseId => {
-      const knex = await databases.init(databaseId);
-      await migrateBackendTasks(knex);
+  it('next_run_start_at is populated when transitioning from manual trigger to cron schedule', async () => {
+    const fn = jest.fn(
+      async () => new Promise<void>(resolve => setTimeout(resolve, 50)),
+    );
 
-      const fn = jest.fn(
-        async () => new Promise<void>(resolve => setTimeout(resolve, 50)),
-      );
+    const manualSettings: TaskSettingsV2 = {
+      version: 2,
+      cadence: 'manual',
+      timeoutAfterDuration: 'PT1M',
+    };
 
-      // First, register the task with manual trigger so next_run_start_at is NULL
-      const manualSettings: TaskSettingsV2 = {
-        version: 2,
-        cadence: 'manual',
-        timeoutAfterDuration: 'PT1M',
-      };
+    const worker = new TaskWorker('task99', fn, knex, logger);
+    await worker.persistTask(manualSettings);
 
-      const worker = new TaskWorker('task99', fn, knex, logger);
-      await worker.persistTask(manualSettings);
+    const rowBeforeTransition = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
+    expect(rowBeforeTransition.next_run_start_at).toBeNull();
 
-      const rowBeforeTransition = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
-      expect(rowBeforeTransition.next_run_start_at).toBeNull();
+    const cronSettings: TaskSettingsV2 = {
+      version: 2,
+      cadence: '*/15 * * * *',
+      timeoutAfterDuration: 'PT1M',
+    };
 
-      // Now re-register the same task with a duration-based cadence
-      const cadenceSettings: TaskSettingsV2 = {
-        version: 2,
-        cadence: 'PT4H',
-        timeoutAfterDuration: 'PT1M',
-      };
+    await worker.persistTask(cronSettings);
 
-      await worker.persistTask(cadenceSettings);
-
-      const rowAfterTransition = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
-      expect(rowAfterTransition.next_run_start_at).not.toBeNull();
-
-      // Verify the next_run_start_at is approximately 4 hours from now
-      const nextStartAt = DateTime.fromJSDate(
-        new Date(rowAfterTransition.next_run_start_at!),
-      );
-      const now = DateTime.now();
-      expect(nextStartAt.diff(now).as('hours')).toBeCloseTo(4, 0);
-
-      await knex.destroy();
-    },
-  );
-
-  it.each(databases.eachSupportedId())(
-    'next_run_start_at is populated when transitioning from manual trigger to cron schedule, %p',
-    async databaseId => {
-      const knex = await databases.init(databaseId);
-      await migrateBackendTasks(knex);
-
-      const fn = jest.fn(
-        async () => new Promise<void>(resolve => setTimeout(resolve, 50)),
-      );
-
-      // First, register the task with manual trigger so next_run_start_at is NULL
-      const manualSettings: TaskSettingsV2 = {
-        version: 2,
-        cadence: 'manual',
-        timeoutAfterDuration: 'PT1M',
-      };
-
-      const worker = new TaskWorker('task99', fn, knex, logger);
-      await worker.persistTask(manualSettings);
-
-      const rowBeforeTransition = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
-      expect(rowBeforeTransition.next_run_start_at).toBeNull();
-
-      // Now re-register the same task with a cron schedule
-      const cronSettings: TaskSettingsV2 = {
-        version: 2,
-        cadence: '*/15 * * * *',
-        timeoutAfterDuration: 'PT1M',
-      };
-
-      await worker.persistTask(cronSettings);
-
-      const rowAfterTransition = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
-      expect(rowAfterTransition.next_run_start_at).not.toBeNull();
-
-      await knex.destroy();
-    },
-  );
+    const rowAfterTransition = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
+    expect(rowAfterTransition.next_run_start_at).not.toBeNull();
+  });
 });

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.test.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.test.ts
@@ -585,4 +585,179 @@ describe.each(databases.eachSupportedId())('TaskWorker, %s', databaseId => {
       ConflictError,
     );
   });
+
+  it.each(databases.eachSupportedId())(
+    'next_run_start_at is updated when re-registering with a shorter cadence, %p',
+    async databaseId => {
+      const knex = await databases.init(databaseId);
+      await migrateBackendTasks(knex);
+
+      const fn = jest.fn(
+        async () => new Promise<void>(resolve => setTimeout(resolve, 50)),
+      );
+
+      const initialSettings: TaskSettingsV2 = {
+        version: 2,
+        cadence: 'PT120M',
+        initialDelayDuration: 'PT2M',
+        timeoutAfterDuration: 'PT1M',
+      };
+
+      const worker = new TaskWorker('task99', fn, knex, logger);
+      await worker.persistTask(initialSettings);
+      // replicate task running, sets next_run_start_at based on cadence
+      await worker.tryClaimTask('ticket', initialSettings);
+      await worker.tryReleaseTask('ticket', initialSettings);
+
+      // grab initial row for comparisons later
+      const rowAfterClaimAndRelease = (
+        await knex<DbTasksRow>(DB_TASKS_TABLE)
+      )[0];
+
+      const settings: TaskSettingsV2 = {
+        ...initialSettings,
+        cadence: 'PT60M',
+      };
+      await worker.persistTask(settings);
+      const row1 = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
+
+      const rowAfterClaimAndReleaseNextStartAt = DateTime.fromJSDate(
+        new Date(rowAfterClaimAndRelease.next_run_start_at!),
+      );
+      const row1NextStartAt = DateTime.fromJSDate(
+        new Date(row1.next_run_start_at!),
+      );
+      const now = DateTime.now();
+      expect(
+        rowAfterClaimAndReleaseNextStartAt.diff(row1NextStartAt).as('minutes'),
+      ).toBeCloseTo(62, 1); // ensure that next start at is sooner than initial by one hour, plus the 2 minute delay (set my tryReleaseTask)
+      expect(row1NextStartAt.diff(now).as('minutes')).toBeCloseTo(60, 1); // ensure that next start at is later than now by one hour (2 minute delay doesn't take effect here)
+      expect(
+        rowAfterClaimAndReleaseNextStartAt.diff(now).as('minutes'),
+      ).toBeCloseTo(122, 1); // includes 2 minute start delay (which is persisted from tryReleaseTask)
+
+      const settings2 = {
+        ...settings,
+      };
+      await worker.persistTask(settings2);
+      const row2 = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
+
+      expect(row2.next_run_start_at).toStrictEqual(row1.next_run_start_at);
+
+      await knex.destroy();
+    },
+  );
+
+  it.each(databases.eachSupportedId())(
+    'next_run_start_at is not set for manually-triggered tasks, %p',
+    async databaseId => {
+      const knex = await databases.init(databaseId);
+      await migrateBackendTasks(knex);
+
+      const fn = jest.fn(
+        async () => new Promise<void>(resolve => setTimeout(resolve, 50)),
+      );
+
+      const initialSettings: TaskSettingsV2 = {
+        version: 2,
+        cadence: 'manual',
+        timeoutAfterDuration: 'PT1M',
+      };
+
+      const worker = new TaskWorker('task99', fn, knex, logger);
+      await worker.persistTask(initialSettings);
+      await worker.tryClaimTask('ticket', initialSettings);
+      await worker.tryReleaseTask('ticket', initialSettings);
+
+      const row = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
+      expect(row.next_run_start_at).toBeNull();
+
+      await knex.destroy();
+    },
+  );
+
+  it.each(databases.eachSupportedId())(
+    'next_run_start_at is populated when transitioning from manual trigger to cadence-based schedule, %p',
+    async databaseId => {
+      const knex = await databases.init(databaseId);
+      await migrateBackendTasks(knex);
+
+      const fn = jest.fn(
+        async () => new Promise<void>(resolve => setTimeout(resolve, 50)),
+      );
+
+      // First, register the task with manual trigger so next_run_start_at is NULL
+      const manualSettings: TaskSettingsV2 = {
+        version: 2,
+        cadence: 'manual',
+        timeoutAfterDuration: 'PT1M',
+      };
+
+      const worker = new TaskWorker('task99', fn, knex, logger);
+      await worker.persistTask(manualSettings);
+
+      const rowBeforeTransition = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
+      expect(rowBeforeTransition.next_run_start_at).toBeNull();
+
+      // Now re-register the same task with a duration-based cadence
+      const cadenceSettings: TaskSettingsV2 = {
+        version: 2,
+        cadence: 'PT4H',
+        timeoutAfterDuration: 'PT1M',
+      };
+
+      await worker.persistTask(cadenceSettings);
+
+      const rowAfterTransition = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
+      expect(rowAfterTransition.next_run_start_at).not.toBeNull();
+
+      // Verify the next_run_start_at is approximately 4 hours from now
+      const nextStartAt = DateTime.fromJSDate(
+        new Date(rowAfterTransition.next_run_start_at!),
+      );
+      const now = DateTime.now();
+      expect(nextStartAt.diff(now).as('hours')).toBeCloseTo(4, 0);
+
+      await knex.destroy();
+    },
+  );
+
+  it.each(databases.eachSupportedId())(
+    'next_run_start_at is populated when transitioning from manual trigger to cron schedule, %p',
+    async databaseId => {
+      const knex = await databases.init(databaseId);
+      await migrateBackendTasks(knex);
+
+      const fn = jest.fn(
+        async () => new Promise<void>(resolve => setTimeout(resolve, 50)),
+      );
+
+      // First, register the task with manual trigger so next_run_start_at is NULL
+      const manualSettings: TaskSettingsV2 = {
+        version: 2,
+        cadence: 'manual',
+        timeoutAfterDuration: 'PT1M',
+      };
+
+      const worker = new TaskWorker('task99', fn, knex, logger);
+      await worker.persistTask(manualSettings);
+
+      const rowBeforeTransition = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
+      expect(rowBeforeTransition.next_run_start_at).toBeNull();
+
+      // Now re-register the same task with a cron schedule
+      const cronSettings: TaskSettingsV2 = {
+        version: 2,
+        cadence: '*/15 * * * *',
+        timeoutAfterDuration: 'PT1M',
+      };
+
+      await worker.persistTask(cronSettings);
+
+      const rowAfterTransition = (await knex<DbTasksRow>(DB_TASKS_TABLE))[0];
+      expect(rowAfterTransition.next_run_start_at).not.toBeNull();
+
+      await knex.destroy();
+    },
+  );
 });

--- a/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.ts
+++ b/packages/backend-defaults/src/entrypoints/scheduler/lib/TaskWorker.ts
@@ -355,8 +355,9 @@ export class TaskWorker {
           ? {
               settings_json: settingsJson,
               next_run_start_at: this.knex.raw(
-                `CASE WHEN ?? < ?? THEN ?? ELSE ?? END`,
+                `CASE WHEN ?? IS NULL OR ?? < ?? THEN ?? ELSE ?? END`,
                 [
+                  'next_run_start_at',
                   nextStartAt,
                   'next_run_start_at',
                   nextStartAt,
@@ -367,8 +368,9 @@ export class TaskWorker {
           : {
               settings_json: this.knex.ref('excluded.settings_json'),
               next_run_start_at: this.knex.raw(
-                `CASE WHEN ?? < ?? THEN ?? ELSE ?? END`,
+                `CASE WHEN ?? IS NULL OR ?? < ?? THEN ?? ELSE ?? END`,
                 [
+                  `${DB_TASKS_TABLE}.next_run_start_at`,
                   nextStartAt,
                   `${DB_TASKS_TABLE}.next_run_start_at`,
                   nextStartAt,


### PR DESCRIPTION
## Summary

Fixes a bug where tasks transitioning from `trigger: 'manual'` to a cadence-based schedule (duration or cron) become permanently unscheduled.

The `persistTask()` upsert uses a CASE expression to conditionally update `next_run_start_at`. When the existing value is NULL (as it is for manual-trigger tasks), the comparison `computed < NULL` evaluates to NULL in SQL three-valued logic. The CASE takes the ELSE branch, preserving the NULL forever. The scheduler polls for `next_run_start_at <= now()` and never finds these tasks.

The fix adds an `IS NULL` guard to both the MySQL and PostgreSQL/SQLite code paths so that a NULL existing value always adopts the newly computed start time.

## Test plan

- [x] Added integration tests for manual → duration and manual → cron transitions
- [x] Verified `next_run_start_at` is NULL after manual registration, then populated after re-registration with a cadence
- [x] All 12 existing + new tests pass