### PR TITLE
refactor(catalog-backend): migrate from EntityFilter to FilterPredicate

### DIFF
--- a/.changeset/catalog-filter-predicate-migration.md
+++ b/.changeset/catalog-filter-predicate-migration.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Migrated internal query filter handling from `EntityFilter` to `FilterPredicate`, simplifying the filter parsing and query application pipeline.

--- a/plugins/catalog-backend/src/catalog/types.ts
+++ b/plugins/catalog-backend/src/catalog/types.ts
@@ -16,6 +16,7 @@
 
 import { BackstageCredentials } from '@backstage/backend-plugin-api';
 import { Entity } from '@backstage/catalog-model';
+import { EntityFilter } from '@backstage/plugin-catalog-node';
 import { FilterPredicate } from '@backstage/filter-predicates';
 
 /**
@@ -283,18 +284,11 @@ export type Cursor = {
    */
   orderFieldValues: Array<string | null>;
   /**
-   * A filter to be applied to the full list of entities.
-   *
-   * @remarks
-   * For backward compatibility, this may also be an EntityFilter from the
-   * legacy filter system. Both shapes are accepted by the cursor parser and
-   * passed through to the query builder which handles both.
+   * A legacy EntityFilter to be applied to the full list of entities.
    */
-  filter?: FilterPredicate;
+  filter?: EntityFilter;
   /**
-   * @deprecated Merged into `filter` for new cursors. Old cursors that
-   * carried a separate `query` field are still accepted for backward
-   * compatibility.
+   * A predicate-based filter to be applied to the full list of entities.
    */
   query?: FilterPredicate;
   /**

--- a/plugins/catalog-backend/src/catalog/types.ts
+++ b/plugins/catalog-backend/src/catalog/types.ts
@@ -16,7 +16,6 @@
 
 import { BackstageCredentials } from '@backstage/backend-plugin-api';
 import { Entity } from '@backstage/catalog-model';
-import { EntityFilter } from '@backstage/plugin-catalog-node';
 import { FilterPredicate } from '@backstage/filter-predicates';
 
 /**
@@ -46,7 +45,7 @@ export type PageInfo =
     };
 
 export type EntitiesRequest = {
-  filter?: EntityFilter;
+  filter?: FilterPredicate;
   fields?: (entity: Entity) => Entity;
   order?: EntityOrder[];
   pagination?: EntityPagination;
@@ -81,15 +80,11 @@ export interface EntitiesBatchRequest {
    */
   entityRefs: string[];
   /**
-   * Any additional filters to apply in the selection of the entities. Entities
-   * that do not match the filter result in a null entry in the response, as if
-   * they did not exist.
+   * Filters to apply in the selection of the entities. Entities that do not
+   * match the filter result in a null entry in the response, as if they did
+   * not exist.
    */
-  filter?: EntityFilter;
-  /**
-   * Predicate-based query for filtering entities.
-   */
-  query?: FilterPredicate;
+  filter?: FilterPredicate;
   /**
    * Strips out only the parts of the entity bodies to include in the response.
    */
@@ -123,11 +118,7 @@ export interface EntityFacetsRequest {
   /**
    * A filter to apply on the full list of entities before computing the facets.
    */
-  filter?: EntityFilter;
-  /**
-   * Predicate-based query for filtering entities.
-   */
-  query?: FilterPredicate;
+  filter?: FilterPredicate;
   /**
    * The facets to compute.
    *
@@ -220,11 +211,7 @@ export interface QueryEntitiesInitialRequest {
   fields?: (entity: Entity) => Entity;
   limit?: number;
   offset?: number;
-  filter?: EntityFilter;
-  /**
-   * Predicate-based query for filtering entities.
-   */
-  query?: FilterPredicate;
+  filter?: FilterPredicate;
   orderFields?: EntityOrder[];
   fullTextFilter?: {
     term: string;
@@ -298,11 +285,7 @@ export type Cursor = {
   /**
    * A filter to be applied to the full list of entities.
    */
-  filter?: EntityFilter;
-  /**
-   * A predicate-based query to be applied to the full list of entities.
-   */
-  query?: FilterPredicate;
+  filter?: FilterPredicate;
   /**
    * true if the cursor is a previous cursor.
    */

--- a/plugins/catalog-backend/src/catalog/types.ts
+++ b/plugins/catalog-backend/src/catalog/types.ts
@@ -284,8 +284,19 @@ export type Cursor = {
   orderFieldValues: Array<string | null>;
   /**
    * A filter to be applied to the full list of entities.
+   *
+   * @remarks
+   * For backward compatibility, this may also be an EntityFilter from the
+   * legacy filter system. Both shapes are accepted by the cursor parser and
+   * passed through to the query builder which handles both.
    */
   filter?: FilterPredicate;
+  /**
+   * @deprecated Merged into `filter` for new cursors. Old cursors that
+   * carried a separate `query` field are still accepted for backward
+   * compatibility.
+   */
+  query?: FilterPredicate;
   /**
    * true if the cursor is a previous cursor.
    */

--- a/plugins/catalog-backend/src/catalog/types.ts
+++ b/plugins/catalog-backend/src/catalog/types.ts
@@ -284,11 +284,15 @@ export type Cursor = {
    */
   orderFieldValues: Array<string | null>;
   /**
-   * A legacy EntityFilter to be applied to the full list of entities.
+   * A legacy EntityFilter carried over from older cursor formats. Converted to
+   * a FilterPredicate at query time. Not used by new code paths and may be
+   * removed in a future release.
    */
   filter?: EntityFilter;
   /**
-   * A predicate-based filter to be applied to the full list of entities.
+   * The primary filter applied to the full list of entities. Named "query"
+   * rather than "filter" to avoid colliding with the legacy EntityFilter field
+   * above.
    */
   query?: FilterPredicate;
   /**

--- a/plugins/catalog-backend/src/catalog/types.ts
+++ b/plugins/catalog-backend/src/catalog/types.ts
@@ -16,8 +16,8 @@
 
 import { BackstageCredentials } from '@backstage/backend-plugin-api';
 import { Entity } from '@backstage/catalog-model';
-import { EntityFilter } from '@backstage/plugin-catalog-node';
-import { FilterPredicate } from '@backstage/filter-predicates';
+import type { EntityFilter } from '@backstage/plugin-catalog-node';
+import type { FilterPredicate } from '@backstage/filter-predicates';
 
 /**
  * A pagination rule for entities.

--- a/plugins/catalog-backend/src/service/AuthorizedEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/AuthorizedEntitiesCatalog.test.ts
@@ -22,6 +22,7 @@ import { CatalogPermissionRule } from '../permissions';
 import { AuthorizedEntitiesCatalog } from './AuthorizedEntitiesCatalog';
 import { Cursor, QueryEntitiesResponse } from '../catalog/types';
 import { Entity } from '@backstage/catalog-model';
+import { EntityFilter } from '@backstage/plugin-catalog-node';
 import { FilterPredicate } from '@backstage/filter-predicates';
 import { mockCredentials } from '@backstage/backend-test-utils';
 
@@ -210,7 +211,8 @@ describe('AuthorizedEntitiesCatalog', () => {
         },
       ]);
 
-      const requestFilter: FilterPredicate = { name: 'name' };
+      const userFilter: FilterPredicate = { name: 'name' };
+      const permFilter: EntityFilter = { key: 'kind', values: ['b'] };
 
       const entities = [
         {
@@ -231,47 +233,52 @@ describe('AuthorizedEntitiesCatalog', () => {
           nextCursor: {
             isPrevious: false,
             orderFieldValues: ['xxx', null],
-            filter: { $all: [{ kind: 'b' }, requestFilter] },
+            filter: permFilter,
+            query: userFilter,
           },
           prevCursor: {
             isPrevious: true,
             orderFieldValues: ['a', null],
-            filter: { $all: [{ kind: 'b' }, requestFilter] },
+            filter: permFilter,
+            query: userFilter,
           },
         },
         totalItems: 4,
       } as QueryEntitiesResponse);
       const catalog = createCatalog(isEntityKind);
 
+      // Initial request: user filter goes into request.filter (FilterPredicate)
       let response = await catalog.queryEntities({
         credentials: mockCredentials.none(),
-        filter: { name: 'name' },
+        filter: userFilter,
       });
 
       expect(fakeCatalog.queryEntities).toHaveBeenCalledWith({
         credentials: mockCredentials.none(),
-        filter: { $all: [{ kind: 'b' }, requestFilter] },
+        filter: { $all: [{ kind: 'b' }, userFilter] },
       });
 
+      // Response cursors should have the user's original filters restored
       expect(response).toEqual({
         items: { type: 'object', entities: entities },
         totalItems: 4,
         pageInfo: {
           nextCursor: {
             isPrevious: false,
-            filter: requestFilter,
             orderFieldValues: ['xxx', null],
+            query: userFilter,
           },
           prevCursor: {
             isPrevious: true,
-            filter: requestFilter,
             orderFieldValues: ['a', null],
+            query: userFilter,
           },
         },
       });
 
+      // Cursor request: user filter is in cursor.query
       const cursor: Cursor = {
-        filter: requestFilter,
+        query: userFilter,
         orderFields: [{ field: 'name', order: 'asc' }],
         isPrevious: false,
         orderFieldValues: ['a', null],
@@ -285,7 +292,7 @@ describe('AuthorizedEntitiesCatalog', () => {
         credentials: mockCredentials.none(),
         cursor: {
           ...cursor,
-          filter: { $all: [{ kind: 'b' }, requestFilter] },
+          filter: permFilter,
         },
       });
 
@@ -295,13 +302,13 @@ describe('AuthorizedEntitiesCatalog', () => {
         pageInfo: {
           nextCursor: {
             isPrevious: false,
-            filter: requestFilter,
             orderFieldValues: ['xxx', null],
+            query: userFilter,
           },
           prevCursor: {
             isPrevious: true,
-            filter: requestFilter,
             orderFieldValues: ['a', null],
+            query: userFilter,
           },
         },
       });
@@ -334,7 +341,8 @@ describe('AuthorizedEntitiesCatalog', () => {
           nextCursor: {
             isPrevious: false,
             orderFieldValues: ['xxx', null],
-            filter: { $all: [{ kind: 'b' }, userFilter] },
+            filter: { key: 'kind', values: ['b'] },
+            query: userFilter,
             orderFields: [{ field: 'name', order: 'asc' }],
           },
         },
@@ -356,7 +364,7 @@ describe('AuthorizedEntitiesCatalog', () => {
       expect(response.pageInfo.nextCursor).toEqual({
         isPrevious: false,
         orderFieldValues: ['xxx', null],
-        filter: userFilter,
+        query: userFilter,
         orderFields: [{ field: 'name', order: 'asc' }],
       });
     });
@@ -382,19 +390,23 @@ describe('AuthorizedEntitiesCatalog', () => {
         } as unknown as Entity,
       ];
 
+      const permFilter: EntityFilter = { key: 'kind', values: ['b'] };
+
       fakeCatalog.queryEntities.mockResolvedValue({
         items: { type: 'object', entities },
         pageInfo: {
           nextCursor: {
             isPrevious: false,
             orderFieldValues: ['yyy', null],
-            filter: { $all: [{ kind: 'b' }, userFilter] },
+            filter: permFilter,
+            query: userFilter,
             orderFields: [{ field: 'name', order: 'asc' }],
           },
           prevCursor: {
             isPrevious: true,
             orderFieldValues: ['aaa', null],
-            filter: { $all: [{ kind: 'b' }, userFilter] },
+            filter: permFilter,
+            query: userFilter,
             orderFields: [{ field: 'name', order: 'asc' }],
           },
         },
@@ -404,7 +416,7 @@ describe('AuthorizedEntitiesCatalog', () => {
       const catalog = createCatalog(isEntityKind);
 
       const cursor: Cursor = {
-        filter: userFilter,
+        query: userFilter,
         orderFields: [{ field: 'name', order: 'asc' }],
         isPrevious: false,
         orderFieldValues: ['xxx', null],
@@ -419,21 +431,21 @@ describe('AuthorizedEntitiesCatalog', () => {
         credentials: mockCredentials.none(),
         cursor: {
           ...cursor,
-          filter: { $all: [{ kind: 'b' }, userFilter] },
+          filter: permFilter,
         },
       });
 
       expect(response.pageInfo.nextCursor).toEqual({
         isPrevious: false,
         orderFieldValues: ['yyy', null],
-        filter: userFilter,
+        query: userFilter,
         orderFields: [{ field: 'name', order: 'asc' }],
       });
 
       expect(response.pageInfo.prevCursor).toEqual({
         isPrevious: true,
         orderFieldValues: ['aaa', null],
-        filter: userFilter,
+        query: userFilter,
         orderFields: [{ field: 'name', order: 'asc' }],
       });
     });

--- a/plugins/catalog-backend/src/service/AuthorizedEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/AuthorizedEntitiesCatalog.test.ts
@@ -22,7 +22,6 @@ import { CatalogPermissionRule } from '../permissions';
 import { AuthorizedEntitiesCatalog } from './AuthorizedEntitiesCatalog';
 import { Cursor, QueryEntitiesResponse } from '../catalog/types';
 import { Entity } from '@backstage/catalog-model';
-import { EntityFilter } from '@backstage/plugin-catalog-node';
 import { FilterPredicate } from '@backstage/filter-predicates';
 import { mockCredentials } from '@backstage/backend-test-utils';
 
@@ -83,7 +82,7 @@ describe('AuthorizedEntitiesCatalog', () => {
 
       expect(fakeCatalog.entities).toHaveBeenCalledWith({
         credentials: mockCredentials.none(),
-        filter: { key: 'kind', values: ['b'] },
+        filter: { kind: 'b' },
       });
     });
 
@@ -140,7 +139,7 @@ describe('AuthorizedEntitiesCatalog', () => {
       expect(fakeCatalog.entitiesBatch).toHaveBeenCalledWith({
         entityRefs: ['component:default/component-a'],
         credentials: mockCredentials.none(),
-        filter: { key: 'kind', values: ['b'] },
+        filter: { kind: 'b' },
       });
     });
 
@@ -172,7 +171,7 @@ describe('AuthorizedEntitiesCatalog', () => {
       await expect(
         catalog.queryEntities({
           credentials: mockCredentials.none(),
-          filter: { key: 'kind', values: ['b'] },
+          filter: { kind: 'b' },
         }),
       ).resolves.toEqual({
         items: { type: 'object', entities: [] },
@@ -191,12 +190,12 @@ describe('AuthorizedEntitiesCatalog', () => {
 
       await catalog.queryEntities({
         credentials: mockCredentials.none(),
-        filter: { key: 'kind', values: ['b'] },
+        filter: { kind: 'b' },
       });
 
       expect(fakeCatalog.queryEntities).toHaveBeenCalledWith({
         credentials: mockCredentials.none(),
-        filter: { key: 'kind', values: ['b'] },
+        filter: { kind: 'b' },
       });
     });
 
@@ -211,7 +210,7 @@ describe('AuthorizedEntitiesCatalog', () => {
         },
       ]);
 
-      const requestFilter: EntityFilter = { key: 'name', values: ['name'] };
+      const requestFilter: FilterPredicate = { name: 'name' };
 
       const entities = [
         {
@@ -232,12 +231,12 @@ describe('AuthorizedEntitiesCatalog', () => {
           nextCursor: {
             isPrevious: false,
             orderFieldValues: ['xxx', null],
-            filter: { allOf: [{ key: 'kind', values: ['b'] }, requestFilter] },
+            filter: { $all: [{ kind: 'b' }, requestFilter] },
           },
           prevCursor: {
             isPrevious: true,
             orderFieldValues: ['a', null],
-            filter: { allOf: [{ key: 'kind', values: ['b'] }, requestFilter] },
+            filter: { $all: [{ kind: 'b' }, requestFilter] },
           },
         },
         totalItems: 4,
@@ -246,12 +245,12 @@ describe('AuthorizedEntitiesCatalog', () => {
 
       let response = await catalog.queryEntities({
         credentials: mockCredentials.none(),
-        filter: { key: 'name', values: ['name'] },
+        filter: { name: 'name' },
       });
 
       expect(fakeCatalog.queryEntities).toHaveBeenCalledWith({
         credentials: mockCredentials.none(),
-        filter: { allOf: [{ key: 'kind', values: ['b'] }, requestFilter] },
+        filter: { $all: [{ kind: 'b' }, requestFilter] },
       });
 
       expect(response).toEqual({
@@ -286,7 +285,7 @@ describe('AuthorizedEntitiesCatalog', () => {
         credentials: mockCredentials.none(),
         cursor: {
           ...cursor,
-          filter: { allOf: [{ key: 'kind', values: ['b'] }, requestFilter] },
+          filter: { $all: [{ kind: 'b' }, requestFilter] },
         },
       });
 
@@ -308,7 +307,7 @@ describe('AuthorizedEntitiesCatalog', () => {
       });
     });
 
-    it('passes through query alongside permission filter on CONDITIONAL with initial request', async () => {
+    it('combines user filter with permission filter on CONDITIONAL with initial request', async () => {
       fakePermissionApi.authorizeConditional.mockResolvedValue([
         {
           result: AuthorizeResult.CONDITIONAL,
@@ -319,7 +318,7 @@ describe('AuthorizedEntitiesCatalog', () => {
         },
       ]);
 
-      const userQuery: FilterPredicate = { 'metadata.name': 'my-entity' };
+      const userFilter: FilterPredicate = { 'metadata.name': 'my-entity' };
 
       const entities = [
         {
@@ -335,8 +334,7 @@ describe('AuthorizedEntitiesCatalog', () => {
           nextCursor: {
             isPrevious: false,
             orderFieldValues: ['xxx', null],
-            query: userQuery,
-            filter: { key: 'kind', values: ['b'] },
+            filter: { $all: [{ kind: 'b' }, userFilter] },
             orderFields: [{ field: 'name', order: 'asc' }],
           },
         },
@@ -347,25 +345,23 @@ describe('AuthorizedEntitiesCatalog', () => {
 
       const response = await catalog.queryEntities({
         credentials: mockCredentials.none(),
-        query: userQuery,
+        filter: userFilter,
       });
 
       expect(fakeCatalog.queryEntities).toHaveBeenCalledWith({
         credentials: mockCredentials.none(),
-        query: userQuery,
-        filter: { key: 'kind', values: ['b'] },
+        filter: { $all: [{ kind: 'b' }, userFilter] },
       });
 
       expect(response.pageInfo.nextCursor).toEqual({
         isPrevious: false,
         orderFieldValues: ['xxx', null],
-        query: userQuery,
-        filter: undefined,
+        filter: userFilter,
         orderFields: [{ field: 'name', order: 'asc' }],
       });
     });
 
-    it('passes through cursor query alongside permission filter on CONDITIONAL with cursor request', async () => {
+    it('combines cursor filter with permission filter on CONDITIONAL with cursor request', async () => {
       fakePermissionApi.authorizeConditional.mockResolvedValue([
         {
           result: AuthorizeResult.CONDITIONAL,
@@ -376,7 +372,7 @@ describe('AuthorizedEntitiesCatalog', () => {
         },
       ]);
 
-      const userQuery: FilterPredicate = { 'metadata.name': 'my-entity' };
+      const userFilter: FilterPredicate = { 'metadata.name': 'my-entity' };
 
       const entities = [
         {
@@ -392,15 +388,13 @@ describe('AuthorizedEntitiesCatalog', () => {
           nextCursor: {
             isPrevious: false,
             orderFieldValues: ['yyy', null],
-            query: userQuery,
-            filter: { key: 'kind', values: ['b'] },
+            filter: { $all: [{ kind: 'b' }, userFilter] },
             orderFields: [{ field: 'name', order: 'asc' }],
           },
           prevCursor: {
             isPrevious: true,
             orderFieldValues: ['aaa', null],
-            query: userQuery,
-            filter: { key: 'kind', values: ['b'] },
+            filter: { $all: [{ kind: 'b' }, userFilter] },
             orderFields: [{ field: 'name', order: 'asc' }],
           },
         },
@@ -410,7 +404,7 @@ describe('AuthorizedEntitiesCatalog', () => {
       const catalog = createCatalog(isEntityKind);
 
       const cursor: Cursor = {
-        query: userQuery,
+        filter: userFilter,
         orderFields: [{ field: 'name', order: 'asc' }],
         isPrevious: false,
         orderFieldValues: ['xxx', null],
@@ -425,23 +419,21 @@ describe('AuthorizedEntitiesCatalog', () => {
         credentials: mockCredentials.none(),
         cursor: {
           ...cursor,
-          filter: { key: 'kind', values: ['b'] },
+          filter: { $all: [{ kind: 'b' }, userFilter] },
         },
       });
 
       expect(response.pageInfo.nextCursor).toEqual({
         isPrevious: false,
         orderFieldValues: ['yyy', null],
-        query: userQuery,
-        filter: undefined,
+        filter: userFilter,
         orderFields: [{ field: 'name', order: 'asc' }],
       });
 
       expect(response.pageInfo.prevCursor).toEqual({
         isPrevious: true,
         orderFieldValues: ['aaa', null],
-        query: userQuery,
-        filter: undefined,
+        filter: userFilter,
         orderFields: [{ field: 'name', order: 'asc' }],
       });
     });
@@ -657,7 +649,7 @@ describe('AuthorizedEntitiesCatalog', () => {
       expect(fakeCatalog.facets).toHaveBeenCalledWith({
         facets: ['a'],
         credentials: mockCredentials.none(),
-        filter: { key: 'kind', values: ['b'] },
+        filter: { kind: 'b' },
       });
     });
 

--- a/plugins/catalog-backend/src/service/AuthorizedEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/AuthorizedEntitiesCatalog.ts
@@ -36,7 +36,7 @@ import {
   QueryEntitiesResponse,
 } from '../catalog/types';
 import { FilterPredicate } from '@backstage/filter-predicates';
-import { basicEntityFilter } from './request';
+import { basicEntityFilter, entityFilterToFilterPredicate } from './request';
 import { isQueryEntitiesCursorRequest } from './util';
 import { EntityFilter } from '@backstage/plugin-catalog-node';
 import {
@@ -59,6 +59,16 @@ export class AuthorizedEntitiesCatalog implements EntitiesCatalog {
     this.transformConditions = transformConditions;
   }
 
+  private permissionPredicate(
+    conditions: Parameters<ConditionTransformer<EntityFilter>>[0],
+    requestFilter?: FilterPredicate,
+  ): FilterPredicate {
+    const permFilter = entityFilterToFilterPredicate(
+      this.transformConditions(conditions),
+    );
+    return requestFilter ? { $all: [permFilter, requestFilter] } : permFilter;
+  }
+
   async entities(request: EntitiesRequest): Promise<EntitiesResponse> {
     const authorizeDecision = (
       await this.permissionApi.authorizeConditional(
@@ -75,14 +85,12 @@ export class AuthorizedEntitiesCatalog implements EntitiesCatalog {
     }
 
     if (authorizeDecision.result === AuthorizeResult.CONDITIONAL) {
-      const permissionFilter: EntityFilter = this.transformConditions(
-        authorizeDecision.conditions,
-      );
       return this.entitiesCatalog.entities({
         ...request,
-        filter: request?.filter
-          ? { allOf: [permissionFilter, request.filter] }
-          : permissionFilter,
+        filter: this.permissionPredicate(
+          authorizeDecision.conditions,
+          request.filter,
+        ),
       });
     }
 
@@ -109,14 +117,12 @@ export class AuthorizedEntitiesCatalog implements EntitiesCatalog {
     }
 
     if (authorizeDecision.result === AuthorizeResult.CONDITIONAL) {
-      const permissionFilter: EntityFilter = this.transformConditions(
-        authorizeDecision.conditions,
-      );
       return this.entitiesCatalog.entitiesBatch({
         ...request,
-        filter: request?.filter
-          ? { allOf: [permissionFilter, request.filter] }
-          : permissionFilter,
+        filter: this.permissionPredicate(
+          authorizeDecision.conditions,
+          request.filter,
+        ),
       });
     }
 
@@ -142,36 +148,29 @@ export class AuthorizedEntitiesCatalog implements EntitiesCatalog {
     }
 
     if (authorizeDecision.result === AuthorizeResult.CONDITIONAL) {
-      const permissionFilter: EntityFilter = this.transformConditions(
-        authorizeDecision.conditions,
-      );
-
       let permissionedRequest: QueryEntitiesRequest;
-      let requestFilter: EntityFilter | undefined;
-      let requestQuery: FilterPredicate | undefined;
+      let requestFilter: FilterPredicate | undefined;
 
       if (isQueryEntitiesCursorRequest(request)) {
         requestFilter = request.cursor.filter;
-        requestQuery = request.cursor.query;
-
         permissionedRequest = {
           ...request,
           cursor: {
             ...request.cursor,
-            filter: request.cursor.filter
-              ? { allOf: [permissionFilter, request.cursor.filter] }
-              : permissionFilter,
+            filter: this.permissionPredicate(
+              authorizeDecision.conditions,
+              request.cursor.filter,
+            ),
           },
         };
       } else {
         requestFilter = request.filter;
-        requestQuery = request.query;
-
         permissionedRequest = {
           ...request,
-          filter: request.filter
-            ? { allOf: [permissionFilter, request.filter] }
-            : permissionFilter,
+          filter: this.permissionPredicate(
+            authorizeDecision.conditions,
+            request.filter,
+          ),
         };
       }
 
@@ -182,13 +181,11 @@ export class AuthorizedEntitiesCatalog implements EntitiesCatalog {
       const prevCursor: Cursor | undefined = response.pageInfo.prevCursor && {
         ...response.pageInfo.prevCursor,
         filter: requestFilter,
-        query: requestQuery,
       };
 
       const nextCursor: Cursor | undefined = response.pageInfo.nextCursor && {
         ...response.pageInfo.nextCursor,
         filter: requestFilter,
-        query: requestQuery,
       };
 
       return {
@@ -218,14 +215,12 @@ export class AuthorizedEntitiesCatalog implements EntitiesCatalog {
       throw new NotAllowedError();
     }
     if (authorizeResponse.result === AuthorizeResult.CONDITIONAL) {
-      const permissionFilter: EntityFilter = this.transformConditions(
-        authorizeResponse.conditions,
-      );
       const { entities } = await this.entitiesCatalog.entities({
         credentials: options.credentials,
-        filter: {
-          allOf: [permissionFilter, basicEntityFilter({ 'metadata.uid': uid })],
-        },
+        filter: this.permissionPredicate(
+          authorizeResponse.conditions,
+          basicEntityFilter({ 'metadata.uid': uid }),
+        ),
       });
       if (entities.entities.length === 0) {
         throw new NotAllowedError();
@@ -305,14 +300,12 @@ export class AuthorizedEntitiesCatalog implements EntitiesCatalog {
     }
 
     if (authorizeDecision.result === AuthorizeResult.CONDITIONAL) {
-      const permissionFilter: EntityFilter = this.transformConditions(
-        authorizeDecision.conditions,
-      );
       return this.entitiesCatalog.facets({
         ...request,
-        filter: request?.filter
-          ? { allOf: [permissionFilter, request.filter] }
-          : permissionFilter,
+        filter: this.permissionPredicate(
+          authorizeDecision.conditions,
+          request.filter,
+        ),
       });
     }
 

--- a/plugins/catalog-backend/src/service/AuthorizedEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/AuthorizedEntitiesCatalog.ts
@@ -148,23 +148,28 @@ export class AuthorizedEntitiesCatalog implements EntitiesCatalog {
     }
 
     if (authorizeDecision.result === AuthorizeResult.CONDITIONAL) {
+      const permissionFilter: EntityFilter = this.transformConditions(
+        authorizeDecision.conditions,
+      );
+
       let permissionedRequest: QueryEntitiesRequest;
-      let requestFilter: FilterPredicate | undefined;
+      let requestFilter: EntityFilter | undefined;
+      let requestQuery: FilterPredicate | undefined;
 
       if (isQueryEntitiesCursorRequest(request)) {
         requestFilter = request.cursor.filter;
+        requestQuery = request.cursor.query;
         permissionedRequest = {
           ...request,
           cursor: {
             ...request.cursor,
-            filter: this.permissionPredicate(
-              authorizeDecision.conditions,
-              request.cursor.filter,
-            ),
+            filter: request.cursor.filter
+              ? { allOf: [permissionFilter, request.cursor.filter] }
+              : permissionFilter,
           },
         };
       } else {
-        requestFilter = request.filter;
+        requestQuery = request.filter;
         permissionedRequest = {
           ...request,
           filter: this.permissionPredicate(
@@ -181,11 +186,13 @@ export class AuthorizedEntitiesCatalog implements EntitiesCatalog {
       const prevCursor: Cursor | undefined = response.pageInfo.prevCursor && {
         ...response.pageInfo.prevCursor,
         filter: requestFilter,
+        query: requestQuery,
       };
 
       const nextCursor: Cursor | undefined = response.pageInfo.nextCursor && {
         ...response.pageInfo.nextCursor,
         filter: requestFilter,
+        query: requestQuery,
       };
 
       return {

--- a/plugins/catalog-backend/src/service/AuthorizedEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/AuthorizedEntitiesCatalog.ts
@@ -157,6 +157,10 @@ export class AuthorizedEntitiesCatalog implements EntitiesCatalog {
       let requestQuery: FilterPredicate | undefined;
 
       if (isQueryEntitiesCursorRequest(request)) {
+        // Cursor path: combine permission filter with the cursor's legacy
+        // EntityFilter field directly, since the downstream code converts it
+        // via entityFilterToFilterPredicate. Cannot use permissionPredicate()
+        // here because cursor.filter is EntityFilter, not FilterPredicate.
         requestFilter = request.cursor.filter;
         requestQuery = request.cursor.query;
         permissionedRequest = {

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
@@ -285,11 +285,8 @@ describe.each(databases.eachSupportedId())(
           logger: mockServices.logger.mock(),
         });
 
-        const testFilter = {
-          key: 'spec.test',
-        };
         const res = await catalog.entities({
-          filter: testFilter,
+          filter: { 'spec.test': { $exists: true } },
           credentials: mockCredentials.none(),
         });
         const entities = entitiesResponseToObjects(res.entities);
@@ -322,8 +319,8 @@ describe.each(databases.eachSupportedId())(
         });
 
         const testFilter = {
-          not: {
-            key: 'spec.test',
+          $not: {
+            'spec.test': { $exists: true },
           },
         };
         const res = await catalog.entities({
@@ -371,29 +368,16 @@ describe.each(databases.eachSupportedId())(
           logger: mockServices.logger.mock(),
         });
 
-        const testFilter1 = {
-          key: 'metadata.org',
-          values: ['b'],
-        };
-        const testFilter2 = {
-          key: 'metadata.desc',
-        };
-        const testFilter3 = {
-          key: 'metadata.color',
-          values: ['blue'],
-        };
-        const testFilter4 = {
-          not: {
-            key: 'metadata.color',
-            values: ['red'],
-          },
-        };
         const res = await catalog.entities({
           filter: {
-            allOf: [
-              testFilter1,
+            $all: [
+              { 'metadata.org': 'b' },
               {
-                anyOf: [testFilter2, testFilter3, testFilter4],
+                $any: [
+                  { 'metadata.desc': { $exists: true } },
+                  { 'metadata.color': 'blue' },
+                  { $not: { 'metadata.color': 'red' } },
+                ],
               },
             ],
           },
@@ -427,17 +411,13 @@ describe.each(databases.eachSupportedId())(
           logger: mockServices.logger.mock(),
         });
 
-        const testFilter1 = {
-          key: 'metadata.org',
-          values: ['b'],
-        };
-        const testFilter2 = {
-          key: 'metadata.desc',
-        };
         const res = await catalog.entities({
           filter: {
-            not: {
-              allOf: [testFilter1, testFilter2],
+            $not: {
+              $all: [
+                { 'metadata.org': 'b' },
+                { 'metadata.desc': { $exists: true } },
+              ],
             },
           },
 
@@ -471,12 +451,8 @@ describe.each(databases.eachSupportedId())(
           logger: mockServices.logger.mock(),
         });
 
-        const testFilter = {
-          key: 'kind',
-          values: [],
-        };
         const res = await catalog.entities({
-          filter: testFilter,
+          filter: { kind: { $in: [] } },
           credentials: mockCredentials.none(),
         });
         const entities = entitiesResponseToObjects(res.entities);
@@ -585,13 +561,13 @@ describe.each(databases.eachSupportedId())(
 
         await expect(
           f({
-            filter: { key: 'spec.b', values: ['lonely'] },
+            filter: { 'spec.b': 'lonely' },
           }),
         ).resolves.toEqual(['n2']);
 
         await expect(
           f({
-            filter: { not: { key: 'spec.b', values: ['lonely'] } },
+            filter: { $not: { 'spec.b': 'lonely' } },
           }),
         ).resolves.toEqual(['n1', 'n3']);
       });
@@ -664,7 +640,7 @@ describe.each(databases.eachSupportedId())(
 
         await expect(
           f({
-            filter: { not: { key: 'spec.b', values: ['lonely'] } },
+            filter: { $not: { 'spec.b': 'lonely' } },
             order: [
               { field: 'spec.a', order: 'asc' },
               { field: 'metadata.name', order: 'desc' },
@@ -978,7 +954,7 @@ describe.each(databases.eachSupportedId())(
 
         const res = await catalog.entitiesBatch({
           entityRefs: ['k:default/two', 'k:default/one'],
-          filter: { key: 'spec.owner', values: ['me'] },
+          filter: { 'spec.owner': 'me' },
           credentials: mockCredentials.none(),
         });
         const items = entitiesResponseToObjects(res.items);
@@ -1849,10 +1825,7 @@ describe.each(databases.eachSupportedId())(
         // initial request
         const request1: QueryEntitiesInitialRequest = {
           limit,
-          filter: {
-            key: 'kind',
-            values: ['included'],
-          },
+          filter: { kind: 'included' },
           orderFields: [{ field: 'metadata.name', order: 'asc' }],
           credentials: mockCredentials.none(),
         };
@@ -2161,8 +2134,7 @@ describe.each(databases.eachSupportedId())(
 
         // Use filter to restrict to kind=component, and query to restrict to name=A
         const response = await catalog.queryEntities({
-          filter: { key: 'kind', values: ['component'] },
-          query: { 'metadata.name': 'a' },
+          filter: { $all: [{ kind: 'component' }, { 'metadata.name': 'a' }] },
           orderFields: [{ field: 'metadata.name', order: 'asc' }],
           credentials: mockCredentials.none(),
         });
@@ -2221,7 +2193,7 @@ describe.each(databases.eachSupportedId())(
           logger: mockServices.logger.mock(),
         });
 
-        const filter = { key: 'spec.should_include_this' };
+        const filter = { 'spec.should_include_this': { $exists: true } };
 
         // Page through all entities with limit=2, sorting by spec.b ASC.
         // We expect to see n1(alpha), n2(beta), n3(gamma) — and NOT n4 or n5.
@@ -2429,7 +2401,7 @@ describe.each(databases.eachSupportedId())(
         await expect(
           catalog.facets({
             facets: ['kind'],
-            filter: { key: 'metadata.name', values: ['two'] },
+            filter: { 'metadata.name': 'two' },
             credentials: mockCredentials.none(),
           }),
         ).resolves.toEqual({
@@ -2444,7 +2416,7 @@ describe.each(databases.eachSupportedId())(
         await expect(
           catalog.facets({
             facets: ['kind'],
-            filter: { not: { key: 'metadata.name', values: ['two'] } },
+            filter: { $not: { 'metadata.name': 'two' } },
             credentials: mockCredentials.none(),
           }),
         ).resolves.toEqual({
@@ -2689,7 +2661,7 @@ describe.each(databases.eachSupportedId())(
         await expect(
           catalog.facets({
             facets: ['metadata.name'],
-            filter: { key: 'kind', values: ['component'] },
+            filter: { kind: 'component' },
             credentials: mockCredentials.none(),
           }),
         ).resolves.toEqual({
@@ -2723,7 +2695,7 @@ describe.each(databases.eachSupportedId())(
 
         const result = await catalog.facets({
           facets: ['spec.type'],
-          query: { kind: 'component' },
+          filter: { kind: 'component' },
           credentials: mockCredentials.none(),
         });
         expect(result.facets['spec.type']).toHaveLength(2);
@@ -2761,7 +2733,7 @@ describe.each(databases.eachSupportedId())(
 
         const result = await catalog.facets({
           facets: ['kind'],
-          query: { kind: { $in: ['component', 'api'] } },
+          filter: { kind: { $in: ['component', 'api'] } },
           credentials: mockCredentials.none(),
         });
         expect(result.facets.kind).toHaveLength(2);
@@ -2801,10 +2773,7 @@ describe.each(databases.eachSupportedId())(
           catalog.facets({
             facets: ['metadata.name'],
             filter: {
-              allOf: [
-                { key: 'kind', values: ['component'] },
-                { key: 'spec.type', values: ['service'] },
-              ],
+              $all: [{ kind: 'component' }, { 'spec.type': 'service' }],
             },
             credentials: mockCredentials.none(),
           }),
@@ -2841,10 +2810,7 @@ describe.each(databases.eachSupportedId())(
           catalog.facets({
             facets: ['metadata.name'],
             filter: {
-              anyOf: [
-                { key: 'kind', values: ['component'] },
-                { key: 'kind', values: ['api'] },
-              ],
+              $any: [{ kind: 'component' }, { kind: 'api' }],
             },
             credentials: mockCredentials.none(),
           }),
@@ -2883,8 +2849,9 @@ describe.each(databases.eachSupportedId())(
         await expect(
           catalog.facets({
             facets: ['spec.type'],
-            filter: { key: 'kind', values: ['component'] },
-            query: { 'metadata.name': 'one' },
+            filter: {
+              $all: [{ kind: 'component' }, { 'metadata.name': 'one' }],
+            },
             credentials: mockCredentials.none(),
           }),
         ).resolves.toEqual({

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
@@ -998,7 +998,7 @@ describe.each(databases.eachSupportedId())(
         });
 
         const filter = {
-          key: 'spec.should_include_this',
+          'spec.should_include_this': { $exists: true },
         };
 
         const limit = 2;
@@ -1171,7 +1171,7 @@ describe.each(databases.eachSupportedId())(
         });
 
         const filter = {
-          key: 'spec.should_include_this',
+          'spec.should_include_this': { $exists: true },
         };
 
         const limit = 2;
@@ -1345,7 +1345,7 @@ describe.each(databases.eachSupportedId())(
         });
 
         const filter = {
-          key: 'spec.should_include_this',
+          'spec.should_include_this': { $exists: true },
         };
 
         const request: QueryEntitiesInitialRequest = {
@@ -1451,7 +1451,7 @@ describe.each(databases.eachSupportedId())(
         });
 
         const filter = {
-          key: 'spec.should_include_this',
+          'spec.should_include_this': { $exists: true },
         };
 
         const request: QueryEntitiesInitialRequest = {
@@ -1546,7 +1546,7 @@ describe.each(databases.eachSupportedId())(
         });
 
         const filter = {
-          key: 'spec.should_include_this',
+          'spec.should_include_this': { $exists: true },
         };
 
         const request: QueryEntitiesInitialRequest = {

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -429,6 +429,15 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
           knex: this.database,
         });
       }
+      // @deprecated — old cursors may carry a separate query field
+      if (cursor.query) {
+        applyEntityFilterToQuery({
+          filter: cursor.query,
+          targetQuery: q,
+          onEntityIdField: 'final_entities.entity_id',
+          knex: this.database,
+        });
+      }
 
       if (normalizedFullTextFilterTerm) {
         if (

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -864,14 +864,12 @@ function parseCursorFromRequest(
   if (isQueryEntitiesInitialRequest(request)) {
     const {
       filter,
-      query,
       orderFields: sortFields = [],
       fullTextFilter,
       totalItems: totalItemsMode = 'include',
     } = request;
     return {
       filter,
-      query,
       orderFields: sortFields,
       fullTextFilter,
       totalItemsMode,

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -51,6 +51,7 @@ import {
 } from './util';
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { applyEntityFilterToQuery } from './request/applyEntityFilterToQuery';
+import { entityFilterToFilterPredicate } from './request/entityFilterToFilterPredicate';
 import { processRawEntitiesResult } from './response';
 
 const DEFAULT_LIMIT = 200;
@@ -423,13 +424,12 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
     ) => {
       if (cursor.filter) {
         applyEntityFilterToQuery({
-          filter: cursor.filter,
+          filter: entityFilterToFilterPredicate(cursor.filter),
           targetQuery: q,
           onEntityIdField: 'final_entities.entity_id',
           knex: this.database,
         });
       }
-      // @deprecated — old cursors may carry a separate query field
       if (cursor.query) {
         applyEntityFilterToQuery({
           filter: cursor.query,
@@ -878,7 +878,7 @@ function parseCursorFromRequest(
       totalItems: totalItemsMode = 'include',
     } = request;
     return {
-      filter,
+      query: filter,
       orderFields: sortFields,
       fullTextFilter,
       totalItemsMode,

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -363,10 +363,9 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
         query = query.whereIn('final_entities.entity_ref', chunk);
       }
 
-      if (request?.filter || request?.query) {
+      if (request?.filter) {
         query = applyEntityFilterToQuery({
           filter: request.filter,
-          query: request.query,
           targetQuery: query,
           onEntityIdField: 'final_entities.entity_id',
           knex: this.database,
@@ -422,10 +421,9 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
       q: Knex.QueryBuilder,
       options?: { searchInScope?: boolean },
     ) => {
-      if (cursor.filter || cursor.query) {
+      if (cursor.filter) {
         applyEntityFilterToQuery({
           filter: cursor.filter,
-          query: cursor.query,
           targetQuery: q,
           onEntityIdField: 'final_entities.entity_id',
           knex: this.database,
@@ -813,7 +811,7 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
       .groupBy(['search.key', 'search.original_value'])
       .orderBy(['search.key', 'search.original_value']);
 
-    if (request.filter || request.query) {
+    if (request.filter) {
       // Build a subquery that finds matching entity IDs via
       // final_entities, so that the EXISTS-based filters correlate
       // against one-row-per-entity rather than the much larger search
@@ -825,7 +823,6 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
 
       applyEntityFilterToQuery({
         filter: request.filter,
-        query: request.query,
         targetQuery: entityIdSubquery,
         onEntityIdField: 'final_entities.entity_id',
         knex: this.database,

--- a/plugins/catalog-backend/src/service/createRouter.test.ts
+++ b/plugins/catalog-backend/src/service/createRouter.test.ts
@@ -198,14 +198,11 @@ describe('createRouter readonly disabled', () => {
       expect(entitiesCatalog.queryEntities).toHaveBeenCalledTimes(1);
       expect(entitiesCatalog.queryEntities).toHaveBeenCalledWith({
         filter: {
-          anyOf: [
+          $any: [
             {
-              allOf: [
-                { key: 'a', values: ['1', '2'] },
-                { key: 'b', values: ['3'] },
-              ],
+              $all: [{ a: { $in: ['1', '2'] } }, { b: '3' }],
             },
-            { key: 'c', values: ['4'] },
+            { c: '4' },
           ],
         },
         limit: 10000,
@@ -242,14 +239,11 @@ describe('createRouter readonly disabled', () => {
       expect(entitiesCatalog.entities).toHaveBeenCalledTimes(1);
       expect(entitiesCatalog.entities).toHaveBeenCalledWith({
         filter: {
-          anyOf: [
+          $any: [
             {
-              allOf: [
-                { key: 'a', values: ['1', '2'] },
-                { key: 'b', values: ['3'] },
-              ],
+              $all: [{ a: { $in: ['1', '2'] } }, { b: '3' }],
             },
-            { key: 'c', values: ['4'] },
+            { c: '4' },
           ],
         },
         credentials: mockCredentials.user(),
@@ -294,14 +288,11 @@ describe('createRouter readonly disabled', () => {
       expect(entitiesCatalog.queryEntities).toHaveBeenCalledTimes(1);
       expect(entitiesCatalog.queryEntities).toHaveBeenCalledWith({
         filter: {
-          anyOf: [
+          $any: [
             {
-              allOf: [
-                { key: 'a', values: ['1', '2'] },
-                { key: 'b', values: ['3'] },
-              ],
+              $all: [{ a: { $in: ['1', '2'] } }, { b: '3' }],
             },
-            { key: 'c', values: ['4'] },
+            { c: '4' },
           ],
         },
         orderFields: [
@@ -334,14 +325,11 @@ describe('createRouter readonly disabled', () => {
       expect(entitiesCatalog.queryEntities).toHaveBeenCalledTimes(1);
       expect(entitiesCatalog.queryEntities).toHaveBeenCalledWith({
         filter: {
-          anyOf: [
+          $any: [
             {
-              allOf: [
-                { key: 'a', values: ['1', '2'] },
-                { key: 'b', values: ['3'] },
-              ],
+              $all: [{ a: { $in: ['1', '2'] } }, { b: '3' }],
             },
-            { key: 'c', values: ['4'] },
+            { c: '4' },
           ],
         },
         orderFields: [
@@ -494,7 +482,7 @@ describe('createRouter readonly disabled', () => {
       });
       expect(entitiesCatalog.queryEntities).toHaveBeenCalledWith(
         expect.objectContaining({
-          query: { kind: 'b' },
+          filter: { kind: 'b' },
           limit: 10,
           credentials: mockCredentials.user(),
         }),
@@ -518,7 +506,7 @@ describe('createRouter readonly disabled', () => {
       expect(response.status).toEqual(200);
       expect(entitiesCatalog.queryEntities).toHaveBeenCalledWith(
         expect.objectContaining({
-          query: { kind: 'b' },
+          filter: { kind: 'b' },
           limit: 2,
           offset: 3,
           credentials: mockCredentials.user(),
@@ -710,7 +698,7 @@ describe('createRouter readonly disabled', () => {
         entityRefs: [entityRef],
         fields: expect.any(Function),
         credentials: mockCredentials.user(),
-        filter: { key: 'kind', values: ['Component'] },
+        filter: { kind: 'Component' },
       });
       expect(response.status).toEqual(200);
       expect(response.body).toEqual({ items: [entity] });
@@ -744,14 +732,13 @@ describe('createRouter readonly disabled', () => {
         entityRefs: [entityRef],
         fields: undefined,
         credentials: mockCredentials.user(),
-        filter: undefined,
-        query: { kind: 'Component' },
+        filter: { kind: 'Component' },
       });
       expect(response.status).toEqual(200);
       expect(response.body).toEqual({ items: [entity] });
     });
 
-    it('forwards both filter query param and body query predicate independently', async () => {
+    it('forwards both filter query param and body query predicate merged', async () => {
       const entity: Entity = {
         apiVersion: 'a',
         kind: 'component',
@@ -776,8 +763,9 @@ describe('createRouter readonly disabled', () => {
         entityRefs: [entityRef],
         fields: undefined,
         credentials: mockCredentials.user(),
-        filter: { key: 'kind', values: ['Component'] },
-        query: { 'metadata.namespace': 'default' },
+        filter: {
+          $all: [{ kind: 'Component' }, { 'metadata.namespace': 'default' }],
+        },
       });
       expect(response.status).toEqual(200);
     });
@@ -1405,7 +1393,7 @@ describe('createRouter readonly disabled', () => {
       expect(entitiesCatalog.facets).toHaveBeenCalledWith(
         expect.objectContaining({
           facets: ['spec.type'],
-          filter: { key: 'kind', values: ['Component'] },
+          filter: { kind: 'Component' },
         }),
       );
     });
@@ -1431,7 +1419,7 @@ describe('createRouter readonly disabled', () => {
       expect(entitiesCatalog.facets).toHaveBeenCalledWith(
         expect.objectContaining({
           facets: ['spec.type'],
-          query: { kind: 'Component' },
+          filter: { kind: 'Component' },
         }),
       );
     });

--- a/plugins/catalog-backend/src/service/createRouter.ts
+++ b/plugins/catalog-backend/src/service/createRouter.ts
@@ -511,10 +511,14 @@ export async function createRouter(
 
       try {
         const request = entitiesBatchRequest(req);
+        const parsedFilter = parseEntityFilterParams(req.query);
+        const combinedFilter =
+          parsedFilter && request.filter
+            ? { $all: [parsedFilter, request.filter] }
+            : parsedFilter ?? request.filter;
         const { items } = await entitiesCatalog.entitiesBatch({
           entityRefs: request.entityRefs,
-          filter: parseEntityFilterParams(req.query),
-          query: request.query,
+          filter: combinedFilter,
           fields: parseEntityTransformParams(req.query, request.fields),
           credentials: await httpAuth.credentials(req),
         });
@@ -570,10 +574,10 @@ export async function createRouter(
       });
 
       try {
-        const { facets, query } = parseEntityFacetsQuery(req.body ?? {});
+        const { facets, filter } = parseEntityFacetsQuery(req.body ?? {});
 
         const response = await entitiesCatalog.facets({
-          query,
+          filter,
           facets,
           credentials: await httpAuth.credentials(req),
         });

--- a/plugins/catalog-backend/src/service/request/applyEntityFilterToQuery.test.ts
+++ b/plugins/catalog-backend/src/service/request/applyEntityFilterToQuery.test.ts
@@ -23,7 +23,7 @@ import {
 } from '../../database/tables';
 import { Knex } from 'knex';
 import { applyDatabaseMigrations } from '../../database/migrations';
-import { EntityFilter } from '@backstage/plugin-catalog-node';
+import { FilterPredicate } from '@backstage/filter-predicates';
 import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
 import { randomUUID as uuid } from 'node:crypto';
 import { buildEntitySearch } from '../../database/operations/stitcher/buildEntitySearch';
@@ -102,7 +102,7 @@ describe.each(databases.eachSupportedId())(
     // #endregion
 
     describe('exists strategy', () => {
-      async function query(filter: EntityFilter): Promise<string[]> {
+      async function query(filter: FilterPredicate): Promise<string[]> {
         const q =
           knex<DbFinalEntitiesRow>('final_entities').whereNotNull(
             'final_entity',
@@ -121,64 +121,55 @@ describe.each(databases.eachSupportedId())(
       }
 
       it('filters correctly', async () => {
-        await expect(query({ key: 'spec.foo' })).resolves.toEqual([
-          '1',
-          '2',
-          '3',
-        ]);
+        await expect(query({ 'spec.foo': { $exists: true } })).resolves.toEqual(
+          ['1', '2', '3'],
+        );
+
+        await expect(query({ 'spec.foo': 'a' })).resolves.toEqual(['1', '2']);
+
+        await expect(query({ 'spec.foo': 'b' })).resolves.toEqual(['3']);
 
         await expect(
-          query({ key: 'spec.foo', values: ['a'] }),
-        ).resolves.toEqual(['1', '2']);
-
-        await expect(
-          query({ key: 'spec.foo', values: ['b'] }),
-        ).resolves.toEqual(['3']);
-
-        await expect(
-          query({ key: 'spec.foo', values: ['a', 'b'] }),
+          query({ 'spec.foo': { $in: ['a', 'b'] } }),
         ).resolves.toEqual(['1', '2', '3']);
 
         await expect(
           query({
-            anyOf: [
-              { key: 'spec.foo', values: ['a'] },
-              { key: 'spec.foo', values: ['b'] },
-            ],
+            $any: [{ 'spec.foo': 'a' }, { 'spec.foo': 'b' }],
           }),
         ).resolves.toEqual(['1', '2', '3']);
 
-        await expect(
-          query({ not: { key: 'spec.foo', values: ['a'] } }),
-        ).resolves.toEqual(['3', '4']);
+        await expect(query({ $not: { 'spec.foo': 'a' } })).resolves.toEqual([
+          '3',
+          '4',
+        ]);
 
         await expect(
           query({
-            not: {
-              anyOf: [
-                { key: 'spec.foo', values: ['a'] },
-                { key: 'spec.foo', values: ['b'] },
-              ],
+            $not: {
+              $any: [{ 'spec.foo': 'a' }, { 'spec.foo': 'b' }],
             },
           }),
         ).resolves.toEqual(['4']);
 
         await expect(
           query({
-            allOf: [
-              { key: 'spec.foo' },
-              { not: { key: 'spec.foo', values: ['a'] } },
+            $all: [
+              { 'spec.foo': { $exists: true } },
+              { $not: { 'spec.foo': 'a' } },
             ],
           }),
         ).resolves.toEqual(['3']);
 
-        await expect(query({ key: 'spec.unique' })).resolves.toEqual(['1']);
+        await expect(
+          query({ 'spec.unique': { $exists: true } }),
+        ).resolves.toEqual(['1']);
 
         await expect(
           query({
-            allOf: [
-              { key: 'spec.foo', values: ['a'] },
-              { not: { key: 'spec.unique' } },
+            $all: [
+              { 'spec.foo': 'a' },
+              { $not: { 'spec.unique': { $exists: true } } },
             ],
           }),
         ).resolves.toEqual(['2']);

--- a/plugins/catalog-backend/src/service/request/applyEntityFilterToQuery.ts
+++ b/plugins/catalog-backend/src/service/request/applyEntityFilterToQuery.ts
@@ -14,145 +14,26 @@
  * limitations under the License.
  */
 
-import {
-  EntitiesSearchFilter,
-  EntityFilter,
-} from '@backstage/plugin-catalog-node';
 import { FilterPredicate } from '@backstage/filter-predicates';
 import { Knex } from 'knex';
 import { applyPredicateEntityFilterToQuery } from './applyPredicateEntityFilterToQuery';
-import { searchExists, SEARCH_FLT_ALIAS } from './searchSubquery';
 
-function isEntitiesSearchFilter(
-  filter: EntitiesSearchFilter | EntityFilter,
-): filter is EntitiesSearchFilter {
-  return filter.hasOwnProperty('key');
-}
-
-function isOrEntityFilter(
-  filter: EntityFilter,
-): filter is { anyOf: EntityFilter[] } {
-  return filter.hasOwnProperty('anyOf');
-}
-
-function isNegationEntityFilter(
-  filter: EntityFilter,
-): filter is { not: EntityFilter } {
-  return filter.hasOwnProperty('not');
-}
-
-/**
- * Applies filtering through correlated EXISTS subqueries. Example:
- *
- * ```
- * SELECT * FROM final_entities
- * WHERE
- *   EXISTS (
- *     SELECT 1 FROM search AS search_flt
- *     WHERE search_flt.entity_id = final_entities.entity_id
- *       AND key = 'kind' AND value = 'component'
- *   )
- *   AND EXISTS (
- *     SELECT 1 FROM search AS search_flt
- *     WHERE search_flt.entity_id = final_entities.entity_id
- *       AND key = 'spec.lifecycle' AND value = 'production'
- *   )
- *   AND final_entities.final_entity IS NOT NULL
- * ```
- *
- * The EXISTS strategy enables efficient semi-join plans, particularly on
- * PostgreSQL with large datasets, since the database can stop scanning as
- * soon as the first matching row is found.
- */
-function applyExistsStrategy(
-  filter: EntityFilter,
-  targetQuery: Knex.QueryBuilder,
-  onEntityIdField: string,
-  knex: Knex,
-  negate: boolean,
-): Knex.QueryBuilder {
-  if (isNegationEntityFilter(filter)) {
-    return applyExistsStrategy(
-      filter.not,
-      targetQuery,
-      onEntityIdField,
-      knex,
-      !negate,
-    );
-  }
-
-  if (isEntitiesSearchFilter(filter)) {
-    const key = filter.key.toLowerCase();
-    const values = filter.values?.map(v => v.toLowerCase());
-    const subquery = searchExists(knex, onEntityIdField)
-      .where(`${SEARCH_FLT_ALIAS}.key`, key)
-      .andWhere(function keyFilter() {
-        if (values?.length === 1) {
-          this.where(`${SEARCH_FLT_ALIAS}.value`, values.at(0));
-        } else if (values) {
-          this.whereIn(`${SEARCH_FLT_ALIAS}.value`, values);
-        }
-      });
-    return negate
-      ? targetQuery.whereNotExists(subquery)
-      : targetQuery.whereExists(subquery);
-  }
-
-  return targetQuery[negate ? 'andWhereNot' : 'andWhere'](
-    function filterFunction() {
-      if (isOrEntityFilter(filter)) {
-        for (const subFilter of filter.anyOf ?? []) {
-          this.orWhere(subQuery =>
-            applyExistsStrategy(
-              subFilter,
-              subQuery,
-              onEntityIdField,
-              knex,
-              false,
-            ),
-          );
-        }
-      } else {
-        for (const subFilter of filter.allOf ?? []) {
-          this.andWhere(subQuery =>
-            applyExistsStrategy(
-              subFilter,
-              subQuery,
-              onEntityIdField,
-              knex,
-              false,
-            ),
-          );
-        }
-      }
-    },
-  );
-}
-
-// The actual exported function
 export function applyEntityFilterToQuery(options: {
-  filter?: EntityFilter;
-  query?: FilterPredicate;
+  filter?: FilterPredicate;
   targetQuery: Knex.QueryBuilder;
   onEntityIdField: string;
   knex: Knex;
 }): Knex.QueryBuilder {
-  const { filter, query, targetQuery, onEntityIdField, knex } = options;
+  const { filter, targetQuery, onEntityIdField, knex } = options;
 
-  let result = targetQuery;
-
-  if (filter) {
-    result = applyExistsStrategy(filter, result, onEntityIdField, knex, false);
+  if (!filter) {
+    return targetQuery;
   }
 
-  if (query) {
-    result = applyPredicateEntityFilterToQuery({
-      filter: query,
-      targetQuery: result,
-      onEntityIdField,
-      knex,
-    });
-  }
-
-  return result;
+  return applyPredicateEntityFilterToQuery({
+    filter,
+    targetQuery,
+    onEntityIdField,
+    knex,
+  });
 }

--- a/plugins/catalog-backend/src/service/request/applyPredicateEntityFilterToQuery.test.ts
+++ b/plugins/catalog-backend/src/service/request/applyPredicateEntityFilterToQuery.test.ts
@@ -111,7 +111,7 @@ describe.each(databases.eachSupportedId())(
       const q =
         knex<DbFinalEntitiesRow>('final_entities').whereNotNull('final_entity');
       applyEntityFilterToQuery({
-        query: predicate,
+        filter: predicate,
         targetQuery: q,
         onEntityIdField: 'final_entities.entity_id',
         knex,
@@ -407,8 +407,7 @@ describe.each(databases.eachSupportedId())(
             'final_entity',
           );
         applyEntityFilterToQuery({
-          filter: { key: 'kind', values: ['component'] },
-          query: { 'spec.type': 'service' },
+          filter: { $all: [{ kind: 'component' }, { 'spec.type': 'service' }] },
           targetQuery: q,
           onEntityIdField: 'final_entities.entity_id',
           knex,

--- a/plugins/catalog-backend/src/service/request/basicEntityFilter.ts
+++ b/plugins/catalog-backend/src/service/request/basicEntityFilter.ts
@@ -14,29 +14,21 @@
  * limitations under the License.
  */
 
-import {
-  EntitiesSearchFilter,
-  EntityFilter,
-} from '@backstage/plugin-catalog-node';
+import { FilterPredicate } from '@backstage/filter-predicates';
 
 /**
- * Forms a full EntityFilter based on a single key-value(s) object.
+ * Forms a FilterPredicate based on a single key-value(s) object.
  */
 export function basicEntityFilter(
   items: Record<string, string | string[]>,
-): EntityFilter {
-  const filtersByKey: Record<string, EntitiesSearchFilter> = {};
-
-  for (const [key, value] of Object.entries(items)) {
-    const values = [value].flat();
-
-    const f =
-      key in filtersByKey
-        ? filtersByKey[key]
-        : (filtersByKey[key] = { key, values: [] });
-
-    f.values!.push(...values);
-  }
-
-  return { anyOf: [{ allOf: Object.values(filtersByKey) }] };
+): FilterPredicate {
+  const predicates: FilterPredicate[] = Object.entries(items).map(
+    ([key, value]) => {
+      const values = [value].flat();
+      return values.length === 1
+        ? { [key]: values[0] }
+        : { [key]: { $in: values } };
+    },
+  );
+  return predicates.length === 1 ? predicates[0] : { $all: predicates };
 }

--- a/plugins/catalog-backend/src/service/request/basicEntityFilter.ts
+++ b/plugins/catalog-backend/src/service/request/basicEntityFilter.ts
@@ -22,13 +22,11 @@ import { FilterPredicate } from '@backstage/filter-predicates';
 export function basicEntityFilter(
   items: Record<string, string | string[]>,
 ): FilterPredicate {
-  const predicates: FilterPredicate[] = Object.entries(items).map(
-    ([key, value]) => {
-      const values = [value].flat();
-      return values.length === 1
-        ? { [key]: values[0] }
-        : { [key]: { $in: values } };
-    },
-  );
+  const predicates = Object.entries(items).map(([key, value]) => {
+    const values = [value].flat();
+    return (
+      values.length === 1 ? { [key]: values[0] } : { [key]: { $in: values } }
+    ) as FilterPredicate;
+  });
   return predicates.length === 1 ? predicates[0] : { $all: predicates };
 }

--- a/plugins/catalog-backend/src/service/request/entitiesBatchRequest.ts
+++ b/plugins/catalog-backend/src/service/request/entitiesBatchRequest.ts
@@ -34,7 +34,7 @@ const schema = z.object({
 export interface ParsedEntitiesBatchRequest {
   entityRefs: string[];
   fields?: string[];
-  query?: FilterPredicate;
+  filter?: FilterPredicate;
 }
 
 export function entitiesBatchRequest(req: Request): ParsedEntitiesBatchRequest {
@@ -46,5 +46,6 @@ export function entitiesBatchRequest(req: Request): ParsedEntitiesBatchRequest {
       )}`,
     );
   }
-  return result.data;
+  const { query, ...rest } = result.data;
+  return { ...rest, filter: query };
 }

--- a/plugins/catalog-backend/src/service/request/entityFilterToFilterPredicate.test.ts
+++ b/plugins/catalog-backend/src/service/request/entityFilterToFilterPredicate.test.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { entityFilterToFilterPredicate } from './entityFilterToFilterPredicate';
+
+describe('entityFilterToFilterPredicate', () => {
+  it('converts a key-existence filter', () => {
+    expect(entityFilterToFilterPredicate({ key: 'metadata.name' })).toEqual({
+      'metadata.name': { $exists: true },
+    });
+  });
+
+  it('converts a single-value filter', () => {
+    expect(
+      entityFilterToFilterPredicate({ key: 'kind', values: ['component'] }),
+    ).toEqual({ kind: 'component' });
+  });
+
+  it('converts a multi-value filter', () => {
+    expect(
+      entityFilterToFilterPredicate({
+        key: 'kind',
+        values: ['component', 'api'],
+      }),
+    ).toEqual({ kind: { $in: ['component', 'api'] } });
+  });
+
+  it('converts allOf', () => {
+    expect(
+      entityFilterToFilterPredicate({
+        allOf: [
+          { key: 'kind', values: ['component'] },
+          { key: 'metadata.namespace', values: ['default'] },
+        ],
+      }),
+    ).toEqual({
+      $all: [{ kind: 'component' }, { 'metadata.namespace': 'default' }],
+    });
+  });
+
+  it('converts anyOf', () => {
+    expect(
+      entityFilterToFilterPredicate({
+        anyOf: [
+          { key: 'kind', values: ['component'] },
+          { key: 'kind', values: ['api'] },
+        ],
+      }),
+    ).toEqual({
+      $any: [{ kind: 'component' }, { kind: 'api' }],
+    });
+  });
+
+  it('converts not', () => {
+    expect(
+      entityFilterToFilterPredicate({
+        not: { key: 'kind', values: ['component'] },
+      }),
+    ).toEqual({ $not: { kind: 'component' } });
+  });
+
+  it('converts nested combinations', () => {
+    expect(
+      entityFilterToFilterPredicate({
+        allOf: [
+          { key: 'kind', values: ['component'] },
+          { not: { key: 'metadata.namespace', values: ['default'] } },
+        ],
+      }),
+    ).toEqual({
+      $all: [
+        { kind: 'component' },
+        { $not: { 'metadata.namespace': 'default' } },
+      ],
+    });
+  });
+});

--- a/plugins/catalog-backend/src/service/request/entityFilterToFilterPredicate.ts
+++ b/plugins/catalog-backend/src/service/request/entityFilterToFilterPredicate.ts
@@ -32,12 +32,12 @@ export function entityFilterToFilterPredicate(
   if (isEntitiesSearchFilter(filter)) {
     const { key, values } = filter;
     if (!values) {
-      return { [key]: { $exists: true } };
+      return { [key]: { $exists: true } } as FilterPredicate;
     }
     if (values.length === 1) {
-      return { [key]: values[0] };
+      return { [key]: values[0] } as FilterPredicate;
     }
-    return { [key]: { $in: values } };
+    return { [key]: { $in: values } } as FilterPredicate;
   }
 
   if ('not' in filter) {

--- a/plugins/catalog-backend/src/service/request/entityFilterToFilterPredicate.ts
+++ b/plugins/catalog-backend/src/service/request/entityFilterToFilterPredicate.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  EntitiesSearchFilter,
+  EntityFilter,
+} from '@backstage/plugin-catalog-node';
+import { FilterPredicate } from '@backstage/filter-predicates';
+
+function isEntitiesSearchFilter(
+  filter: EntityFilter,
+): filter is EntitiesSearchFilter {
+  return filter.hasOwnProperty('key');
+}
+
+export function entityFilterToFilterPredicate(
+  filter: EntityFilter,
+): FilterPredicate {
+  if (isEntitiesSearchFilter(filter)) {
+    const { key, values } = filter;
+    if (!values) {
+      return { [key]: { $exists: true } };
+    }
+    if (values.length === 1) {
+      return { [key]: values[0] };
+    }
+    return { [key]: { $in: values } };
+  }
+
+  if ('not' in filter) {
+    return { $not: entityFilterToFilterPredicate(filter.not) };
+  }
+
+  if ('anyOf' in filter) {
+    return { $any: filter.anyOf.map(entityFilterToFilterPredicate) };
+  }
+
+  return { $all: filter.allOf.map(entityFilterToFilterPredicate) };
+}

--- a/plugins/catalog-backend/src/service/request/entityFilterToFilterPredicate.ts
+++ b/plugins/catalog-backend/src/service/request/entityFilterToFilterPredicate.ts
@@ -23,7 +23,7 @@ import { FilterPredicate } from '@backstage/filter-predicates';
 function isEntitiesSearchFilter(
   filter: EntityFilter,
 ): filter is EntitiesSearchFilter {
-  return filter.hasOwnProperty('key');
+  return Object.prototype.hasOwnProperty.call(filter, 'key');
 }
 
 export function entityFilterToFilterPredicate(

--- a/plugins/catalog-backend/src/service/request/index.ts
+++ b/plugins/catalog-backend/src/service/request/index.ts
@@ -16,6 +16,7 @@
 
 export { entitiesBatchRequest } from './entitiesBatchRequest';
 export { basicEntityFilter } from './basicEntityFilter';
+export { entityFilterToFilterPredicate } from './entityFilterToFilterPredicate';
 export { parseEntityFilterParams } from './parseEntityFilterParams';
 export { parseEntityTransformParams } from './parseEntityTransformParams';
 export { parseQueryEntitiesParams } from './parseQueryEntitiesParams';

--- a/plugins/catalog-backend/src/service/request/parseEntityFacetsQuery.test.ts
+++ b/plugins/catalog-backend/src/service/request/parseEntityFacetsQuery.test.ts
@@ -20,7 +20,7 @@ describe('parseEntityFacetsQuery', () => {
   it('parses facets with no query', () => {
     expect(parseEntityFacetsQuery({ facets: ['kind'] })).toEqual({
       facets: ['kind'],
-      query: undefined,
+      filter: undefined,
     });
   });
 
@@ -32,7 +32,7 @@ describe('parseEntityFacetsQuery', () => {
       }),
     ).toEqual({
       facets: ['spec.type'],
-      query: { kind: 'Component' },
+      filter: { kind: 'Component' },
     });
   });
 
@@ -42,7 +42,7 @@ describe('parseEntityFacetsQuery', () => {
     };
     expect(parseEntityFacetsQuery({ facets: ['spec.type'], query })).toEqual({
       facets: ['spec.type'],
-      query,
+      filter: query,
     });
   });
 

--- a/plugins/catalog-backend/src/service/request/parseEntityFacetsQuery.ts
+++ b/plugins/catalog-backend/src/service/request/parseEntityFacetsQuery.ts
@@ -27,7 +27,7 @@ const filterPredicateSchema = createZodV3FilterPredicateSchema(z);
 
 export interface ParsedEntityFacetsQuery {
   facets: string[];
-  query?: FilterPredicate;
+  filter?: FilterPredicate;
 }
 
 export function parseEntityFacetsQuery(
@@ -52,5 +52,5 @@ export function parseEntityFacetsQuery(
     query = result.data;
   }
 
-  return { facets, query };
+  return { facets, filter: query };
 }

--- a/plugins/catalog-backend/src/service/request/parseEntityFilterParams.test.ts
+++ b/plugins/catalog-backend/src/service/request/parseEntityFilterParams.test.ts
@@ -27,7 +27,7 @@ describe('parseEntityFilterParams', () => {
 
   it('supports single-string format', () => {
     const result = parseEntityFilterParams({ filter: 'a=1' })!;
-    expect(result).toEqual({ key: 'a', values: ['1'] });
+    expect(result).toEqual({ a: '1' });
   });
 
   it('supports array-of-strings format', () => {
@@ -35,10 +35,7 @@ describe('parseEntityFilterParams', () => {
       filter: ['a=1', 'b=2'],
     });
     expect(result).toEqual({
-      anyOf: [
-        { key: 'a', values: ['1'] },
-        { key: 'b', values: ['2'] },
-      ],
+      $any: [{ a: '1' }, { b: '2' }],
     });
   });
 
@@ -47,13 +44,10 @@ describe('parseEntityFilterParams', () => {
       filter: ['a=1', 'b=2,b=3,c=4'],
     });
     expect(result).toEqual({
-      anyOf: [
-        { key: 'a', values: ['1'] },
+      $any: [
+        { a: '1' },
         {
-          allOf: [
-            { key: 'b', values: ['2', '3'] },
-            { key: 'c', values: ['4'] },
-          ],
+          $all: [{ b: { $in: ['2', '3'] } }, { c: '4' }],
         },
       ],
     });

--- a/plugins/catalog-backend/src/service/request/parseEntityFilterParams.ts
+++ b/plugins/catalog-backend/src/service/request/parseEntityFilterParams.ts
@@ -15,11 +15,19 @@
  */
 
 import { InputError } from '@backstage/errors';
+import { FilterPredicate } from '@backstage/filter-predicates';
 import { parseStringsParam } from './common';
-import {
-  EntitiesSearchFilter,
-  EntityFilter,
-} from '@backstage/plugin-catalog-node';
+import { EntitiesSearchFilter } from '@backstage/plugin-catalog-node';
+
+function searchFilterToPredicate(f: EntitiesSearchFilter): FilterPredicate {
+  if (!f.values) {
+    return { [f.key]: { $exists: true } };
+  }
+  if (f.values.length === 1) {
+    return { [f.key]: f.values[0] };
+  }
+  return { [f.key]: { $in: f.values } };
+}
 
 /**
  * Parses the filtering part of a query, like
@@ -27,15 +35,12 @@ import {
  */
 export function parseEntityFilterParams(
   params: Record<string, unknown>,
-): EntityFilter | undefined {
-  // Each filter string is on the form a=b,c=d
+): FilterPredicate | undefined {
   const filterStrings = parseStringsParam(params.filter, 'filter');
   if (!filterStrings) {
     return undefined;
   }
 
-  // Outer array: "any of the inner ones"
-  // Inner arrays: "all of these must match"
   const filters = filterStrings
     .map(parseEntityFilterString)
     .filter((r): r is EntitiesSearchFilter[] => Boolean(r));
@@ -43,10 +48,11 @@ export function parseEntityFilterParams(
     return undefined;
   }
 
-  const outer = filters.map(inner =>
-    inner.length === 1 ? inner[0] : { allOf: inner },
-  );
-  return outer.length === 1 ? outer[0] : { anyOf: outer };
+  const outer: FilterPredicate[] = filters.map(inner => {
+    const predicates = inner.map(searchFilterToPredicate);
+    return predicates.length === 1 ? predicates[0] : { $all: predicates };
+  });
+  return outer.length === 1 ? outer[0] : { $any: outer };
 }
 
 /**

--- a/plugins/catalog-backend/src/service/request/parseEntityFilterParams.ts
+++ b/plugins/catalog-backend/src/service/request/parseEntityFilterParams.ts
@@ -21,12 +21,12 @@ import { EntitiesSearchFilter } from '@backstage/plugin-catalog-node';
 
 function searchFilterToPredicate(f: EntitiesSearchFilter): FilterPredicate {
   if (!f.values) {
-    return { [f.key]: { $exists: true } };
+    return { [f.key]: { $exists: true } } as FilterPredicate;
   }
   if (f.values.length === 1) {
-    return { [f.key]: f.values[0] };
+    return { [f.key]: f.values[0] } as FilterPredicate;
   }
-  return { [f.key]: { $in: f.values } };
+  return { [f.key]: { $in: f.values } } as FilterPredicate;
 }
 
 /**

--- a/plugins/catalog-backend/src/service/request/parseEntityQuery.test.ts
+++ b/plugins/catalog-backend/src/service/request/parseEntityQuery.test.ts
@@ -23,7 +23,7 @@ describe('parseEntityQuery', () => {
     it('returns empty result for empty request', () => {
       const result = parseEntityQuery({});
       expect(result).toEqual({
-        query: undefined,
+        filter: undefined,
         orderFields: undefined,
         fullTextFilter: undefined,
         fields: undefined,
@@ -36,7 +36,7 @@ describe('parseEntityQuery', () => {
       const query = { kind: 'component' };
       const result = parseEntityQuery({ query });
       expect(result).toEqual(
-        expect.objectContaining({ query: { kind: 'component' } }),
+        expect.objectContaining({ filter: { kind: 'component' } }),
       );
     });
 

--- a/plugins/catalog-backend/src/service/request/parseEntityQuery.test.ts
+++ b/plugins/catalog-backend/src/service/request/parseEntityQuery.test.ts
@@ -49,19 +49,19 @@ describe('parseEntityQuery', () => {
         ],
       };
       const result = parseEntityQuery({ query });
-      expect(result).toEqual(expect.objectContaining({ query }));
+      expect(result).toEqual(expect.objectContaining({ filter: query }));
     });
 
     it('parses query with $exists operator', () => {
       const query = { 'metadata.labels.team': { $exists: true } };
       const result = parseEntityQuery({ query });
-      expect(result).toEqual(expect.objectContaining({ query }));
+      expect(result).toEqual(expect.objectContaining({ filter: query }));
     });
 
     it('parses query with $in operator', () => {
       const query = { kind: { $in: ['component', 'api'] } };
       const result = parseEntityQuery({ query });
-      expect(result).toEqual(expect.objectContaining({ query }));
+      expect(result).toEqual(expect.objectContaining({ filter: query }));
     });
 
     it('passes through limit', () => {

--- a/plugins/catalog-backend/src/service/request/parseEntityQuery.ts
+++ b/plugins/catalog-backend/src/service/request/parseEntityQuery.ts
@@ -80,7 +80,7 @@ export type ParsedEntityQuery =
       limit?: number;
     }
   | {
-      query?: FilterPredicate;
+      filter?: FilterPredicate;
       orderFields?: EntityOrder[];
       fullTextFilter?: { term: string; fields?: string[] };
       fields?: string[];
@@ -121,7 +121,7 @@ export function parseEntityQuery(
   const totalItemsMode = parseTotalItems(request.totalItems);
 
   return {
-    query,
+    filter: query,
     orderFields,
     fullTextFilter: request.fullTextFilter
       ? {

--- a/plugins/catalog-backend/src/service/util.ts
+++ b/plugins/catalog-backend/src/service/util.ts
@@ -25,7 +25,7 @@ import {
   QueryEntitiesInitialRequest,
   QueryEntitiesRequest,
 } from '../catalog/types';
-import { CatalogProcessor, EntityFilter } from '@backstage/plugin-catalog-node';
+import { CatalogProcessor } from '@backstage/plugin-catalog-node';
 import {
   Entity,
   parseEntityRef,
@@ -99,17 +99,6 @@ export function isQueryEntitiesCursorRequest(
   return !!(input as QueryEntitiesCursorRequest).cursor;
 }
 
-const entityFilterParser: z.ZodSchema<EntityFilter> = z.lazy(() =>
-  z
-    .object({
-      key: z.string(),
-      values: z.array(z.string()).optional(),
-    })
-    .or(z.object({ not: entityFilterParser }))
-    .or(z.object({ anyOf: z.array(entityFilterParser) }))
-    .or(z.object({ allOf: z.array(entityFilterParser) })),
-);
-
 const filterPredicateSchema = createZodV3FilterPredicateSchema(z);
 
 export const cursorParser: z.ZodSchema<Cursor> = z.object({
@@ -123,9 +112,8 @@ export const cursorParser: z.ZodSchema<Cursor> = z.object({
     })
     .optional(),
   orderFieldValues: z.array(z.string().or(z.null())),
-  filter: entityFilterParser.optional(),
+  filter: filterPredicateSchema.optional(),
   isPrevious: z.boolean(),
-  query: filterPredicateSchema.optional(),
   firstSortFieldValues: z.array(z.string().or(z.null())).optional(),
   totalItems: z.number().optional(),
 });

--- a/plugins/catalog-backend/src/service/util.ts
+++ b/plugins/catalog-backend/src/service/util.ts
@@ -15,7 +15,10 @@
  */
 
 import { InputError, NotAllowedError } from '@backstage/errors';
-import { createZodV3FilterPredicateSchema } from '@backstage/filter-predicates';
+import {
+  createZodV3FilterPredicateSchema,
+  FilterPredicate,
+} from '@backstage/filter-predicates';
 import { Request } from 'express';
 import lodash from 'lodash';
 import { z } from 'zod/v3';
@@ -100,6 +103,8 @@ export function isQueryEntitiesCursorRequest(
   return !!(input as QueryEntitiesCursorRequest).cursor;
 }
 
+const filterPredicateSchema = createZodV3FilterPredicateSchema(z);
+
 // @deprecated — accepts the legacy EntityFilter shape in cursor.filter
 // for backward compatibility with cursors already held by clients.
 const legacyEntityFilterSchema: z.ZodSchema<EntityFilter> = z.lazy(() =>
@@ -112,8 +117,6 @@ const legacyEntityFilterSchema: z.ZodSchema<EntityFilter> = z.lazy(() =>
     .or(z.object({ anyOf: z.array(legacyEntityFilterSchema) }))
     .or(z.object({ allOf: z.array(legacyEntityFilterSchema) })),
 );
-
-const filterPredicateSchema = createZodV3FilterPredicateSchema(z);
 
 const cursorParser = z.object({
   orderFields: z.array(
@@ -148,32 +151,19 @@ export function decodeCursor(encodedCursor: string): Cursor {
       throw new InputError(`Malformed cursor: ${result.error}`);
     }
 
-    const { filter: rawFilter, query, ...rest } = result.data;
+    const { filter, ...rest } = result.data;
 
-    // Convert legacy EntityFilter format to FilterPredicate
+    // If the filter was an old-style EntityFilter that only matched
+    // legacyEntityFilterSchema, convert it to a FilterPredicate.
     const convertedFilter =
-      rawFilter && isLegacyEntityFilter(rawFilter)
-        ? entityFilterToFilterPredicate(rawFilter)
-        : rawFilter;
+      filter && !filterPredicateSchema.safeParse(filter).success
+        ? entityFilterToFilterPredicate(filter as EntityFilter)
+        : (filter as FilterPredicate | undefined);
 
-    // Merge deprecated query field into filter
-    const mergedFilter =
-      convertedFilter && query
-        ? { $all: [convertedFilter, query] }
-        : convertedFilter ?? query;
-
-    return { ...rest, filter: mergedFilter };
+    return { ...rest, filter: convertedFilter };
   } catch (e) {
     throw new InputError(`Malformed cursor: ${e}`);
   }
-}
-
-function isLegacyEntityFilter(value: unknown): value is EntityFilter {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    ('key' in value || 'allOf' in value || 'anyOf' in value || 'not' in value)
-  );
 }
 
 // TODO(freben): This is added as a compatibility guarantee, until we can be

--- a/plugins/catalog-backend/src/service/util.ts
+++ b/plugins/catalog-backend/src/service/util.ts
@@ -25,7 +25,8 @@ import {
   QueryEntitiesInitialRequest,
   QueryEntitiesRequest,
 } from '../catalog/types';
-import { CatalogProcessor } from '@backstage/plugin-catalog-node';
+import { CatalogProcessor, EntityFilter } from '@backstage/plugin-catalog-node';
+import { entityFilterToFilterPredicate } from './request';
 import {
   Entity,
   parseEntityRef,
@@ -101,7 +102,20 @@ export function isQueryEntitiesCursorRequest(
 
 const filterPredicateSchema = createZodV3FilterPredicateSchema(z);
 
-export const cursorParser: z.ZodSchema<Cursor> = z.object({
+// @deprecated — accepts the legacy EntityFilter shape in cursor.filter
+// for backward compatibility with cursors already held by clients.
+const entityFilterParser: z.ZodSchema<EntityFilter> = z.lazy(() =>
+  z
+    .object({
+      key: z.string(),
+      values: z.array(z.string()).optional(),
+    })
+    .or(z.object({ not: entityFilterParser }))
+    .or(z.object({ anyOf: z.array(entityFilterParser) }))
+    .or(z.object({ allOf: z.array(entityFilterParser) })),
+);
+
+const rawCursorParser = z.object({
   orderFields: z.array(
     z.object({ field: z.string(), order: z.enum(['asc', 'desc']) }),
   ),
@@ -112,8 +126,10 @@ export const cursorParser: z.ZodSchema<Cursor> = z.object({
     })
     .optional(),
   orderFieldValues: z.array(z.string().or(z.null())),
-  filter: filterPredicateSchema.optional(),
+  filter: filterPredicateSchema.or(entityFilterParser).optional(),
   isPrevious: z.boolean(),
+  // @deprecated — old cursors may carry a separate query field
+  query: filterPredicateSchema.optional(),
   firstSortFieldValues: z.array(z.string().or(z.null())).optional(),
   totalItems: z.number().optional(),
 });
@@ -123,15 +139,38 @@ export function encodeCursor(cursor: Cursor) {
   return Buffer.from(json, 'utf8').toString('base64');
 }
 
-export function decodeCursor(encodedCursor: string) {
+function isLegacyEntityFilter(value: unknown): value is EntityFilter {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    ('key' in value || 'allOf' in value || 'anyOf' in value || 'not' in value)
+  );
+}
+
+export function decodeCursor(encodedCursor: string): Cursor {
   try {
     const data = Buffer.from(encodedCursor, 'base64').toString('utf8');
-    const result = cursorParser.safeParse(JSON.parse(data));
+    const result = rawCursorParser.safeParse(JSON.parse(data));
 
     if (!result.success) {
       throw new InputError(`Malformed cursor: ${result.error}`);
     }
-    return result.data;
+
+    const { filter: rawFilter, query, ...rest } = result.data;
+
+    // Convert legacy EntityFilter format to FilterPredicate
+    const convertedFilter =
+      rawFilter && isLegacyEntityFilter(rawFilter)
+        ? entityFilterToFilterPredicate(rawFilter)
+        : rawFilter;
+
+    // Merge deprecated query field into filter
+    const mergedFilter =
+      convertedFilter && query
+        ? { $all: [convertedFilter, query] }
+        : convertedFilter ?? query;
+
+    return { ...rest, filter: mergedFilter };
   } catch (e) {
     throw new InputError(`Malformed cursor: ${e}`);
   }

--- a/plugins/catalog-backend/src/service/util.ts
+++ b/plugins/catalog-backend/src/service/util.ts
@@ -100,22 +100,22 @@ export function isQueryEntitiesCursorRequest(
   return !!(input as QueryEntitiesCursorRequest).cursor;
 }
 
-const filterPredicateSchema = createZodV3FilterPredicateSchema(z);
-
 // @deprecated — accepts the legacy EntityFilter shape in cursor.filter
 // for backward compatibility with cursors already held by clients.
-const entityFilterParser: z.ZodSchema<EntityFilter> = z.lazy(() =>
+const legacyEntityFilterSchema: z.ZodSchema<EntityFilter> = z.lazy(() =>
   z
     .object({
       key: z.string(),
       values: z.array(z.string()).optional(),
     })
-    .or(z.object({ not: entityFilterParser }))
-    .or(z.object({ anyOf: z.array(entityFilterParser) }))
-    .or(z.object({ allOf: z.array(entityFilterParser) })),
+    .or(z.object({ not: legacyEntityFilterSchema }))
+    .or(z.object({ anyOf: z.array(legacyEntityFilterSchema) }))
+    .or(z.object({ allOf: z.array(legacyEntityFilterSchema) })),
 );
 
-const rawCursorParser = z.object({
+const filterPredicateSchema = createZodV3FilterPredicateSchema(z);
+
+const cursorParser = z.object({
   orderFields: z.array(
     z.object({ field: z.string(), order: z.enum(['asc', 'desc']) }),
   ),
@@ -126,7 +126,7 @@ const rawCursorParser = z.object({
     })
     .optional(),
   orderFieldValues: z.array(z.string().or(z.null())),
-  filter: filterPredicateSchema.or(entityFilterParser).optional(),
+  filter: filterPredicateSchema.or(legacyEntityFilterSchema).optional(),
   isPrevious: z.boolean(),
   // @deprecated — old cursors may carry a separate query field
   query: filterPredicateSchema.optional(),
@@ -139,18 +139,10 @@ export function encodeCursor(cursor: Cursor) {
   return Buffer.from(json, 'utf8').toString('base64');
 }
 
-function isLegacyEntityFilter(value: unknown): value is EntityFilter {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    ('key' in value || 'allOf' in value || 'anyOf' in value || 'not' in value)
-  );
-}
-
 export function decodeCursor(encodedCursor: string): Cursor {
   try {
     const data = Buffer.from(encodedCursor, 'base64').toString('utf8');
-    const result = rawCursorParser.safeParse(JSON.parse(data));
+    const result = cursorParser.safeParse(JSON.parse(data));
 
     if (!result.success) {
       throw new InputError(`Malformed cursor: ${result.error}`);
@@ -174,6 +166,14 @@ export function decodeCursor(encodedCursor: string): Cursor {
   } catch (e) {
     throw new InputError(`Malformed cursor: ${e}`);
   }
+}
+
+function isLegacyEntityFilter(value: unknown): value is EntityFilter {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    ('key' in value || 'allOf' in value || 'anyOf' in value || 'not' in value)
+  );
 }
 
 // TODO(freben): This is added as a compatibility guarantee, until we can be

--- a/plugins/catalog-backend/src/service/util.ts
+++ b/plugins/catalog-backend/src/service/util.ts
@@ -15,10 +15,7 @@
  */
 
 import { InputError, NotAllowedError } from '@backstage/errors';
-import {
-  createZodV3FilterPredicateSchema,
-  FilterPredicate,
-} from '@backstage/filter-predicates';
+import { createZodV3FilterPredicateSchema } from '@backstage/filter-predicates';
 import { Request } from 'express';
 import lodash from 'lodash';
 import { z } from 'zod/v3';
@@ -29,7 +26,6 @@ import {
   QueryEntitiesRequest,
 } from '../catalog/types';
 import { CatalogProcessor, EntityFilter } from '@backstage/plugin-catalog-node';
-import { entityFilterToFilterPredicate } from './request';
 import {
   Entity,
   parseEntityRef,
@@ -103,22 +99,20 @@ export function isQueryEntitiesCursorRequest(
   return !!(input as QueryEntitiesCursorRequest).cursor;
 }
 
-const filterPredicateSchema = createZodV3FilterPredicateSchema(z);
-
-// @deprecated — accepts the legacy EntityFilter shape in cursor.filter
-// for backward compatibility with cursors already held by clients.
-const legacyEntityFilterSchema: z.ZodSchema<EntityFilter> = z.lazy(() =>
+const entityFilterParser: z.ZodSchema<EntityFilter> = z.lazy(() =>
   z
     .object({
       key: z.string(),
       values: z.array(z.string()).optional(),
     })
-    .or(z.object({ not: legacyEntityFilterSchema }))
-    .or(z.object({ anyOf: z.array(legacyEntityFilterSchema) }))
-    .or(z.object({ allOf: z.array(legacyEntityFilterSchema) })),
+    .or(z.object({ not: entityFilterParser }))
+    .or(z.object({ anyOf: z.array(entityFilterParser) }))
+    .or(z.object({ allOf: z.array(entityFilterParser) })),
 );
 
-const cursorParser = z.object({
+const filterPredicateSchema = createZodV3FilterPredicateSchema(z);
+
+export const cursorParser: z.ZodSchema<Cursor> = z.object({
   orderFields: z.array(
     z.object({ field: z.string(), order: z.enum(['asc', 'desc']) }),
   ),
@@ -129,9 +123,8 @@ const cursorParser = z.object({
     })
     .optional(),
   orderFieldValues: z.array(z.string().or(z.null())),
-  filter: filterPredicateSchema.or(legacyEntityFilterSchema).optional(),
+  filter: entityFilterParser.optional(),
   isPrevious: z.boolean(),
-  // @deprecated — old cursors may carry a separate query field
   query: filterPredicateSchema.optional(),
   firstSortFieldValues: z.array(z.string().or(z.null())).optional(),
   totalItems: z.number().optional(),
@@ -142,7 +135,7 @@ export function encodeCursor(cursor: Cursor) {
   return Buffer.from(json, 'utf8').toString('base64');
 }
 
-export function decodeCursor(encodedCursor: string): Cursor {
+export function decodeCursor(encodedCursor: string) {
   try {
     const data = Buffer.from(encodedCursor, 'base64').toString('utf8');
     const result = cursorParser.safeParse(JSON.parse(data));
@@ -150,17 +143,7 @@ export function decodeCursor(encodedCursor: string): Cursor {
     if (!result.success) {
       throw new InputError(`Malformed cursor: ${result.error}`);
     }
-
-    const { filter, ...rest } = result.data;
-
-    // If the filter was an old-style EntityFilter that only matched
-    // legacyEntityFilterSchema, convert it to a FilterPredicate.
-    const convertedFilter =
-      filter && !filterPredicateSchema.safeParse(filter).success
-        ? entityFilterToFilterPredicate(filter as EntityFilter)
-        : (filter as FilterPredicate | undefined);
-
-    return { ...rest, filter: convertedFilter };
+    return result.data;
   } catch (e) {
     throw new InputError(`Malformed cursor: ${e}`);
   }


### PR DESCRIPTION
## Summary

Replaces all internal usage of `EntityFilter` types with `FilterPredicate` in the catalog backend. `EntityFilter` is now only used at the HTTP request parsing edge (parsing `?filter=` query params) and as the output type of the permission condition transformer (which lives in `plugin-permission-node` and is out of scope).

### Changes

- `parseEntityFilterParams` now returns `FilterPredicate` directly
- `basicEntityFilter` returns `FilterPredicate`
- All service types (`EntitiesRequest`, `Cursor`, `EntitiesBatchRequest`, etc.) use `FilterPredicate` exclusively
- Merged the dual `filter`/`query` fields into a single `filter: FilterPredicate` field
- `AuthorizedEntitiesCatalog` converts permission conditions to `FilterPredicate` at the boundary via new `entityFilterToFilterPredicate` converter
- Removed the `EntityFilter` SQL builder (`applyExistsStrategy`), consolidated to the `FilterPredicate` code path
- Cursor serialization simplified to validate only `FilterPredicate`

### WIP

- [ ] Test files need updating to use `FilterPredicate` syntax

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages.
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message.