### PR TITLE
Expose and update doc landing page

### DIFF
--- a/docs/landing-page/doc-landing-page.md
+++ b/docs/landing-page/doc-landing-page.md
@@ -70,6 +70,7 @@ description: Documentation landing page.
     </td>
     <td valign='top'><i>Additional Backstage Features</i><br><br>
       <ul>
+        <li><a href='https://backstage.io/docs/ai/generated-index/'>AI</a></li>
         <li><a href='https://backstage.io/docs/features/search/'>Search</a></li>
         <li><a href='https://backstage.io/docs/features/software-catalog/'>Software Catalog</a></li>
         <li><a href='https://backstage.io/docs/features/software-templates/'>Software Templates (aka Scaffolder)</a></li>

--- a/microsite/docusaurus.config.ts
+++ b/microsite/docusaurus.config.ts
@@ -506,7 +506,7 @@ const config: Config = {
       },
       items: [
         {
-          to: '/landing-page/doc-landing-page',
+          to: '/docs/landing-page/doc-landing-page',
           label: 'Docs',
           position: 'left',
         },

--- a/microsite/docusaurus.config.ts
+++ b/microsite/docusaurus.config.ts
@@ -506,7 +506,7 @@ const config: Config = {
       },
       items: [
         {
-          to: '/docs/landing-page/doc-landing-page',
+          to: '/landing-page/doc-landing-page',
           label: 'Docs',
           position: 'left',
         },

--- a/microsite/docusaurus.config.ts
+++ b/microsite/docusaurus.config.ts
@@ -312,7 +312,7 @@ const config: Config = {
         redirects: [
           {
             from: '/docs',
-            to: '/docs/overview/what-is-backstage',
+            to: '/docs/landing-page/doc-landing-page',
           },
           {
             from: '/docs/features/software-catalog/software-catalog-overview',

--- a/microsite/docusaurus.config.ts
+++ b/microsite/docusaurus.config.ts
@@ -506,7 +506,7 @@ const config: Config = {
       },
       items: [
         {
-          to: 'docs/overview/what-is-backstage',
+          to: '/docs/landing-page/doc-landing-page',
           label: 'Docs',
           position: 'left',
         },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Modified docusaurus.config.ts to have the doc landing page displayed when you select the top **Doc** navigation button. Also made some updates to the page, including adding a link to the new AI pages.

This work pertains to the following features/issues:

- Feature: Reorganize Table of Contents https://github.com/backstage/backstage/issues/21946
still need to add Integrator Guide to TOC, as per Feature: Write an integrator guide https://github.com/backstage/backstage/issues/21945. This work will be done in a separate PR.
- Feature: Write an Admin Guide https://github.com/backstage/backstage/issues/21923  still need to add instructions for starting and stopping a production server.
- Feature: Write a Developer Guide https://github.com/backstage/backstage/issues/21944 - this is the **Using Backstage** pages under **Try Backstage**.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
