### PR TITLE
Add `initialFilter` config to `page:techdocs`

### DIFF
--- a/.changeset/itchy-sloths-bathe.md
+++ b/.changeset/itchy-sloths-bathe.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': minor
+---
+
+Add `initialFilter` config for `page:techdocs`. Valid options are `all`, `owned` and `starred`. Defaults to `owned`.

--- a/plugins/techdocs/report-alpha.api.md
+++ b/plugins/techdocs/report-alpha.api.md
@@ -261,13 +261,13 @@ const _default: OverridableFrontendPlugin<
       };
     }>;
     'page:techdocs': OverridableExtensionDefinition<{
-      kind: 'page';
-      name: undefined;
       config: {
+        initialFilter: 'all' | 'owned' | 'starred' | undefined;
         path: string | undefined;
         title: string | undefined;
       };
       configInput: {
+        initialFilter?: 'all' | 'owned' | 'starred' | undefined;
         path?: string | undefined;
         title?: string | undefined;
       };
@@ -327,6 +327,8 @@ const _default: OverridableFrontendPlugin<
           }
         >;
       };
+      kind: 'page';
+      name: undefined;
       params: {
         path: string;
         title?: string;

--- a/plugins/techdocs/report-alpha.api.md
+++ b/plugins/techdocs/report-alpha.api.md
@@ -262,7 +262,7 @@ const _default: OverridableFrontendPlugin<
     }>;
     'page:techdocs': OverridableExtensionDefinition<{
       config: {
-        initialFilter: 'all' | 'owned' | 'starred' | undefined;
+        initialFilter: 'all' | 'owned' | 'starred';
         path: string | undefined;
         title: string | undefined;
       };

--- a/plugins/techdocs/src/alpha/index.tsx
+++ b/plugins/techdocs/src/alpha/index.tsx
@@ -148,7 +148,7 @@ const techDocsSearchFilterResultTypeExtension =
  */
 const techDocsPage = PageBlueprint.makeWithOverrides({
   configSchema: {
-    initialFilter: z.enum(['all', 'owned', 'starred']).optional(),
+    initialFilter: z.enum(['all', 'owned', 'starred']).default('owned'),
   },
   factory(originalFactory, { config }) {
     return originalFactory({

--- a/plugins/techdocs/src/alpha/index.tsx
+++ b/plugins/techdocs/src/alpha/index.tsx
@@ -146,16 +146,21 @@ const techDocsSearchFilterResultTypeExtension =
  *
  * @alpha
  */
-const techDocsPage = PageBlueprint.make({
-  params: {
-    path: '/docs',
-    routeRef: rootRouteRef,
-    title: 'Docs',
-    icon: <RiArticleLine />,
-    loader: () =>
-      import('./components/TechDocsIndexPageContent').then(m => (
-        <m.TechDocsIndexPageContent />
-      )),
+const techDocsPage = PageBlueprint.makeWithOverrides({
+  configSchema: {
+    initialFilter: z.enum(['all', 'owned', 'starred']).optional(),
+  },
+  factory(originalFactory, { config }) {
+    return originalFactory({
+      path: '/docs',
+      routeRef: rootRouteRef,
+      title: 'Docs',
+      icon: <RiArticleLine />,
+      loader: () =>
+        import('./components/TechDocsIndexPageContent').then(m => (
+          <m.TechDocsIndexPageContent initialFilter={config.initialFilter} />
+        )),
+    });
   },
 });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

I've added a new `initialFilter` option on `page:techdocs`. This option was available in the old frontend system but not the new one. This change ports it over.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
