### PR TITLE
kubernetes-react: fix broken configuration schema

### DIFF
--- a/.changeset/curvy-peaches-wait.md
+++ b/.changeset/curvy-peaches-wait.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-react': patch
+---
+
+Fixed broken type import in configuration schema.

--- a/.patches/pr-34715.txt
+++ b/.patches/pr-34715.txt
@@ -1,0 +1,1 @@
+Fix broken configuration schema in `@backstage/plugin-kubernetes-react`.

--- a/plugins/kubernetes-react/config.d.ts
+++ b/plugins/kubernetes-react/config.d.ts
@@ -1,4 +1,4 @@
-import { PodExecTerminal } from './src/components/PodExecTerminal/PodExecTerminal';
+import { PodExecTerminal } from '.';
 /*
  * Copyright 2023 The Backstage Authors
  *


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Now that configuration schema is properly resolved, this invalid `src/` import of course breaks the schema collection.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
