### PR TITLE
fix(kubernetes-react): remove unused import from config.d.ts

### DIFF
--- a/.changeset/kubernetes-react-config-schema-import.md
+++ b/.changeset/kubernetes-react-config-schema-import.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-react': patch
+---
+
+Removed an unused `import` of `PodExecTerminal` from `config.d.ts`. The import referenced a file under `src/`, which is not part of the published package (only `dist` and `config.d.ts` are shipped), causing `error TS2307: Cannot find module './src/components/PodExecTerminal/PodExecTerminal'` during config schema extraction in consuming apps.

--- a/.changeset/kubernetes-react-config-schema-import.md
+++ b/.changeset/kubernetes-react-config-schema-import.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-kubernetes-react': patch
 ---
 
-Removed an unused `import` of `PodExecTerminal` from `config.d.ts`. The import referenced a file under `src/`, which is not part of the published package (only `dist` and `config.d.ts` are shipped), causing `error TS2307: Cannot find module './src/components/PodExecTerminal/PodExecTerminal'` during config schema extraction in consuming apps.
+Fixed the published configuration schema so that it no longer references a file that is excluded from the package. This previously caused configuration schema extraction to fail in apps that depend on this plugin.

--- a/.patches/pr-34721.txt
+++ b/.patches/pr-34721.txt
@@ -1,0 +1,1 @@
+Fix broken configuration schema in `@backstage/plugin-kubernetes-react`.

--- a/plugins/kubernetes-react/config.d.ts
+++ b/plugins/kubernetes-react/config.d.ts
@@ -1,4 +1,3 @@
-import { PodExecTerminal } from './src/components/PodExecTerminal/PodExecTerminal';
 /*
  * Copyright 2023 The Backstage Authors
  *


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`plugins/kubernetes-react/config.d.ts` started with a stray, unused import:

```ts
import { PodExecTerminal } from './src/components/PodExecTerminal/PodExecTerminal';
```

`PodExecTerminal` is never referenced in the file (the `Config` interface does not use it), and it sits above the license header — it looks like an accidental editor auto-import.

The package only publishes `dist` and `config.d.ts` (see the `files` field in `package.json`), so the `./src/...` path does not exist in the published package. This breaks config schema extraction in consuming apps:

```
Skipping config schema extraction for "@internal/app": Invalid TypeScript configuration schema:
node_modules/@backstage/plugin-kubernetes-react/config.d.ts(1,33): error TS2307: Cannot find module './src/components/PodExecTerminal/PodExecTerminal' or its corresponding type declarations.
```

This PR simply removes the unused import.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.

Made with [Cursor](https://cursor.com)