### PR TITLE
fix(cli): catch unused imports in config.d.ts via eslint

### DIFF
--- a/.changeset/lint-unused-imports-config-schema.md
+++ b/.changeset/lint-unused-imports-config-schema.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli': patch
+---
+
+The shared ESLint configuration now reports unused imports in `config.d.ts` configuration schema files. These declaration files are not covered by the TypeScript compiler's unused-variable checks, which previously allowed a stray import to slip through. Such an import can resolve during local development but break configuration schema loading for consumers of the published package, so it is now caught at lint time.

--- a/packages/cli/config/eslint-factory.js
+++ b/packages/cli/config/eslint-factory.js
@@ -191,7 +191,7 @@ function createConfig(dir, extraConfig = {}) {
         // this file resolves fine within the monorepo but breaks config schema
         // extraction in consuming apps, since only the declaration itself is
         // published. We therefore catch unused imports here explicitly.
-        files: ['config.d.ts'],
+        files: ['**/config.d.ts'],
         rules: {
           'no-unused-vars': 'off',
           'unused-imports/no-unused-imports': 'error',

--- a/packages/cli/config/eslint-factory.js
+++ b/packages/cli/config/eslint-factory.js
@@ -183,6 +183,20 @@ function createConfig(dir, extraConfig = {}) {
           ],
         },
       },
+      {
+        // The unused variable checks above are disabled for TypeScript files
+        // and instead delegated to the TypeScript compiler. The compiler does
+        // not however report unused declarations in declaration files, leaving
+        // the published config schema declaration unchecked. A stray import in
+        // this file resolves fine within the monorepo but breaks config schema
+        // extraction in consuming apps, since only the declaration itself is
+        // published. We therefore catch unused imports here explicitly.
+        files: ['config.d.ts'],
+        rules: {
+          'no-unused-vars': 'off',
+          'unused-imports/no-unused-imports': 'error',
+        },
+      },
       ...(overrides ?? []),
     ],
   };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Background / why this slipped through

While fixing #34721 (a stray, unused import in `@backstage/plugin-kubernetes-react`'s `config.d.ts` that broke config schema extraction in consuming apps), the obvious question came up: why didn't linting catch an unused import?

It turns out `config.d.ts` schema files have **no unused-import enforcement** at all:

- `@typescript-eslint/no-unused-vars` is intentionally disabled for all `*.ts(x)` files in the shared ESLint config, delegating unused-variable detection to the TypeScript compiler (`noUnusedLocals`).
- The TypeScript compiler does **not** report unused declarations in declaration (`.d.ts`) files, and `skipLibCheck: true` skips them further.
- `unused-imports/no-unused-imports` is only enabled for generated files.

So an unused import in a `config.d.ts` falls through every net. It's especially dangerous there because the file is published while `src/` is not, so a stray `./src/...` import resolves fine in the monorepo but breaks `config.d.ts` resolution for adopters.

### Change

Enable `unused-imports/no-unused-imports` specifically for `config.d.ts` files in the shared ESLint config (`@backstage/cli`).

I verified this catches exactly the original bug and nothing else: linting every `config.d.ts` in the repo with this rule produces a single error — the `@backstage/plugin-kubernetes-react` one fixed in #34721 — and all other schema files pass unchanged.

> [!NOTE]
> This is a **draft** and depends on #34721. Because the bug it detects still exists on `master`, repo lint will fail here until #34721 is merged and this branch is rebased. That red CI is the rule doing its job.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.

Made with [Cursor](https://cursor.com)