### PR TITLE
fix(e2e-test): add retry and delay to prevent flaky backend startup test

### DIFF
--- a/packages/e2e-test/src/commands/runCommand.ts
+++ b/packages/e2e-test/src/commands/runCommand.ts
@@ -81,9 +81,9 @@ export async function runCommand(opts: OptionValues) {
       '--config',
       productionConfig,
     );
+    // Brief pause to let the OS reclaim the port from the previous backend
+    await new Promise(resolve => setTimeout(resolve, 3000));
   }
-  // Brief pause to let the OS reclaim the port from the previous backend
-  await new Promise(resolve => setTimeout(resolve, 3000));
   print('Testing the Database backend startup');
   await testBackendStart(appDir);
 
@@ -521,8 +521,12 @@ async function testBackendStart(appDir: string, ...args: string[]) {
     await new Promise(resolve => setTimeout(resolve, 2000));
 
     print('Try to fetch entities from the backend');
-    let lastError: Error | undefined;
-    for (let attempt = 0; attempt < 3; attempt++) {
+    const maxAttempts = 3;
+    const errors: Error[] = [];
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      if (attempt > 1) {
+        await new Promise(resolve => setTimeout(resolve, 2000));
+      }
       try {
         const res = await fetch('http://localhost:7007/api/catalog/entities');
         if (!res.ok) {
@@ -531,16 +535,25 @@ async function testBackendStart(appDir: string, ...args: string[]) {
           );
         }
         const content = await res.text();
-        JSON.parse(content);
-        lastError = undefined;
+        try {
+          JSON.parse(content);
+        } catch (parseError) {
+          throw new Error(
+            `Failed to parse entities JSON response: ${parseError}\n${content}`,
+          );
+        }
+        errors.length = 0;
         break;
       } catch (error) {
-        lastError = error as Error;
-        await new Promise(resolve => setTimeout(resolve, 2000));
+        errors.push(error as Error);
       }
     }
-    if (lastError) {
-      throw lastError;
+    if (errors.length > 0) {
+      throw new Error(
+        `Failed to fetch entities after ${maxAttempts} attempts:\n${errors
+          .map((e, i) => `  attempt ${i + 1}: ${e.message}`)
+          .join('\n')}`,
+      );
     }
     print('Entities fetched successfully');
     successful = true;

--- a/packages/e2e-test/src/commands/runCommand.ts
+++ b/packages/e2e-test/src/commands/runCommand.ts
@@ -28,6 +28,7 @@ import mysql from 'mysql2/promise';
 import pgtools from 'pgtools';
 
 import { OptionValues } from 'commander';
+import { isError, stringifyError } from '@backstage/errors';
 import { findOwnPaths, runOutput, run } from '@backstage/cli-common';
 
 /* eslint-disable-next-line no-restricted-syntax */
@@ -545,7 +546,7 @@ async function testBackendStart(appDir: string, ...args: string[]) {
         errors.length = 0;
         break;
       } catch (error) {
-        errors.push(error as Error);
+        errors.push(isError(error) ? error : new Error(stringifyError(error)));
       }
     }
     if (errors.length > 0) {

--- a/packages/e2e-test/src/commands/runCommand.ts
+++ b/packages/e2e-test/src/commands/runCommand.ts
@@ -16,7 +16,6 @@
 
 import os from 'node:os';
 import fs from 'fs-extra';
-import fetch from 'cross-fetch';
 import handlebars from 'handlebars';
 import killTree from 'tree-kill';
 import { resolve as resolvePath, join as joinPath } from 'node:path';

--- a/packages/e2e-test/src/commands/runCommand.ts
+++ b/packages/e2e-test/src/commands/runCommand.ts
@@ -547,7 +547,9 @@ async function testBackendStart(appDir: string, ...args: string[]) {
           JSON.parse(content);
         } catch (parseError) {
           throw new Error(
-            `Failed to parse entities JSON response: ${parseError}\n${content}`,
+            `Failed to parse entities JSON response: ${stringifyError(
+              parseError,
+            )}\n${content}`,
           );
         }
         errors.length = 0;
@@ -559,7 +561,7 @@ async function testBackendStart(appDir: string, ...args: string[]) {
     if (errors.length > 0) {
       throw new Error(
         `Failed to fetch entities after ${maxAttempts} attempts:\n${errors
-          .map((e, i) => `  attempt ${i + 1}: ${e.message}`)
+          .map(e => `  - ${e.message}`)
           .join('\n')}`,
       );
     }

--- a/packages/e2e-test/src/commands/runCommand.ts
+++ b/packages/e2e-test/src/commands/runCommand.ts
@@ -526,6 +526,14 @@ async function testBackendStart(appDir: string, ...args: string[]) {
     const errors: Error[] = [];
     for (let attempt = 1; attempt <= maxAttempts; attempt++) {
       if (attempt > 1) {
+        if (child.exitCode !== null) {
+          errors.push(
+            new Error(
+              `Backend process exited with code ${child.exitCode} before fetch could succeed`,
+            ),
+          );
+          break;
+        }
         await new Promise(resolve => setTimeout(resolve, 2000));
       }
       try {
@@ -560,6 +568,10 @@ async function testBackendStart(appDir: string, ...args: string[]) {
     successful = true;
   } catch (error) {
     print('');
+    print(`Backend stdout:\n${stdout}`);
+    if (stderr) {
+      print(`Backend stderr:\n${stderr}`);
+    }
     throw new Error(`Backend failed to startup: ${error}`);
   } finally {
     print('Stopping the child process');

--- a/packages/e2e-test/src/commands/runCommand.ts
+++ b/packages/e2e-test/src/commands/runCommand.ts
@@ -82,6 +82,8 @@ export async function runCommand(opts: OptionValues) {
       productionConfig,
     );
   }
+  // Brief pause to let the OS reclaim the port from the previous backend
+  await new Promise(resolve => setTimeout(resolve, 3000));
   print('Testing the Database backend startup');
   await testBackendStart(appDir);
 
@@ -516,23 +518,29 @@ async function testBackendStart(appDir: string, ...args: string[]) {
       // Skipping the whole block
       throw new Error(stderr);
     }
-    await new Promise(resolve => setTimeout(resolve, 1000));
+    await new Promise(resolve => setTimeout(resolve, 2000));
 
     print('Try to fetch entities from the backend');
-    // Try fetch entities, should be ok
-    const res = await fetch('http://localhost:7007/api/catalog/entities');
-    if (!res.ok) {
-      throw new Error(
-        `Failed to fetch entities: ${res.status} ${res.statusText}`,
-      );
+    let lastError: Error | undefined;
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        const res = await fetch('http://localhost:7007/api/catalog/entities');
+        if (!res.ok) {
+          throw new Error(
+            `Failed to fetch entities: ${res.status} ${res.statusText}`,
+          );
+        }
+        const content = await res.text();
+        JSON.parse(content);
+        lastError = undefined;
+        break;
+      } catch (error) {
+        lastError = error as Error;
+        await new Promise(resolve => setTimeout(resolve, 2000));
+      }
     }
-    const content = await res.text();
-    try {
-      JSON.parse(content);
-    } catch (error) {
-      throw new Error(
-        `Failed to parse entities JSON response: ${error}\n${content}`,
-      );
+    if (lastError) {
+      throw lastError;
     }
     print('Entities fetched successfully');
     successful = true;


### PR DESCRIPTION
## Summary

Fixes intermittent E2E test failures where the backend startup test fails with `FetchError: Premature close` when fetching entities.

### Root cause

The `cross-fetch` library (wrapping `node-fetch`) has body stream handling issues on Node 22. The backend responds with HTTP 200, but `node-fetch` fails to read the response body, reporting "Premature close". This affects both the external test client AND the backend's own internal search collators (which also use `node-fetch`), confirming the issue is in the fetch library, not the server.

### Fix

- **Replace `cross-fetch` with native `fetch`** — Node 22 has a built-in `fetch` (undici-based) that handles response bodies correctly. Removed the `cross-fetch` import.
- **Add retry with dead-process detection** — Retry the entities fetch up to 3 times, but check if the backend process has already exited before retrying (no point retrying against a dead port).
- **Log stdout/stderr on failure** — When the backend test fails, print the full backend output for diagnosis.
- **Add delay between sequential backend starts** — When both database and SQLite backend tests run, add a 3-second delay between them for port release.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages.
- [x] All your commits have a `Signed-off-by` line in the message.