### PR TITLE
fix: always rebuild patch-release branch from scratch

### DIFF
--- a/scripts/patch-release-for-pr.js
+++ b/scripts/patch-release-for-pr.js
@@ -230,19 +230,13 @@ async function main(args) {
     process.env.PATCH_RELEASE_BRANCH ||
     `patch-release-pr-${prNumbers.join('-')}`;
 
-  // Check if branch already exists (for CI workflows using fixed branch name)
+  // Always start fresh from the release base to keep the PR diff clean
   try {
-    await run(
-      'git',
-      'show-ref',
-      '--verify',
-      '--quiet',
-      `refs/heads/${branchName}`,
-    );
-    await run('git', 'checkout', branchName);
+    await run('git', 'branch', '-D', branchName);
   } catch {
-    await run('git', 'checkout', '-b', branchName);
+    // Branch didn't exist locally, that's fine
   }
+  await run('git', 'checkout', '-b', branchName);
 
   const appliedPrNumbers = [];
 
@@ -344,15 +338,27 @@ async function main(args) {
     )}`,
   );
 
+  // Copy patch files from master so they appear in the PR diff
+  for (const prNumber of appliedPrNumbers) {
+    const patchFileName = `pr-${prNumber}.txt`;
+    const patchFilePath = path.join(rootDir, '.patches', patchFileName);
+    try {
+      const content = await run(
+        'git',
+        'show',
+        `origin/master:.patches/${patchFileName}`,
+      );
+      await fs.writeFile(patchFilePath, content);
+    } catch {
+      // Patch file may not exist on master (e.g. added in a separate PR)
+    }
+  }
+
   console.log('Running "yarn install" ...');
   await run('yarn', 'install');
 
   console.log('Running "yarn release" ...');
   await run('yarn', 'release');
-
-  // Note: Patch files are not deleted here because this script runs in the patch
-  // release branch, not master. The cleanup_patch-files.yml workflow handles
-  // deletion from master after the patch release PR is merged.
 
   await run('git', 'add', '.');
   await run(

--- a/scripts/patch-release-for-pr.js
+++ b/scripts/patch-release-for-pr.js
@@ -339,18 +339,19 @@ async function main(args) {
   );
 
   // Copy patch files from master so they appear in the PR diff
+  const patchesDir = path.join(rootDir, '.patches');
+  await fs.ensureDir(patchesDir);
   for (const prNumber of appliedPrNumbers) {
     const patchFileName = `pr-${prNumber}.txt`;
-    const patchFilePath = path.join(rootDir, '.patches', patchFileName);
     try {
       const content = await run(
         'git',
         'show',
         `origin/master:.patches/${patchFileName}`,
       );
-      await fs.writeFile(patchFilePath, content);
+      await fs.writeFile(path.join(patchesDir, patchFileName), content);
     } catch {
-      // Patch file may not exist on master (e.g. added in a separate PR)
+      console.log(`Patch file ${patchFileName} not found on master, skipping`);
     }
   }
 
@@ -370,12 +371,8 @@ async function main(args) {
     'Generate Release',
   );
 
-  // Use force push if using a specific branch name (for CI workflows)
-  if (process.env.PATCH_RELEASE_BRANCH) {
-    await run('git', 'push', 'origin', '-u', '--force-with-lease', branchName);
-  } else {
-    await run('git', 'push', 'origin', '-u', branchName);
-  }
+  // Always force push since we rebuild the branch from scratch each time
+  await run('git', 'push', 'origin', '-u', '--force-with-lease', branchName);
 
   // Generate PR body using only applied patches
   let body;

--- a/scripts/patch-release-for-pr.js
+++ b/scripts/patch-release-for-pr.js
@@ -344,10 +344,10 @@ async function main(args) {
   for (const prNumber of appliedPrNumbers) {
     const patchFileName = `pr-${prNumber}.txt`;
     try {
-      const content = await run(
+      const { stdout: content } = await execFile(
         'git',
-        'show',
-        `origin/master:.patches/${patchFileName}`,
+        ['show', `origin/master:.patches/${patchFileName}`],
+        { cwd: rootDir },
       );
       await fs.writeFile(path.join(patchesDir, patchFileName), content);
     } catch {


### PR DESCRIPTION
## Summary

Fixes a confusing inconsistency in the patch release PR diff where some patch files and their code changes don't appear because they were applied in a previous workflow run.

### Problem

The patch release workflow reused the existing `patch-release` branch, incrementally layering new cherry-picks on top. When a new patch was added to `.patches/`, the workflow would check out the existing branch (which already had previous patches applied) and only cherry-pick the new one. This meant:

- The PR commits showed all patches (e.g., "Patch from PR #34699", "#34702", "#34721")
- But the PR diff only showed the *latest* additions (#34699 and #34721), not #34702
- The `.patches/pr-34702.txt` file didn't appear in the diff even though its code changes were present

This made the PR confusing to review — you couldn't tell which patches were included just by looking at the diff.

### Fix

Always create a fresh branch from the release base (`patch/v1.52.0`) and re-apply all patches from scratch. Also explicitly copy patch files from `master` so they appear in the diff alongside their code changes. This produces a clean, complete PR diff every time the workflow runs.

#### :heavy_check_mark: Checklist

- [x] All your commits have a `Signed-off-by` line in the message.