### PR TITLE
chore: clean up released patch files

### DIFF
--- a/.patches/pr-34699.txt
+++ b/.patches/pr-34699.txt
@@ -1,1 +1,0 @@
-Internal refactor of the specialized app sign-in runtime to initialize it once instead of reassigning it.

--- a/.patches/pr-34721.txt
+++ b/.patches/pr-34721.txt
@@ -1,1 +1,0 @@
-Fix broken configuration schema in `@backstage/plugin-kubernetes-react`.


### PR DESCRIPTION
Removes patch files that have already been included in a release.

- pr-34699.txt
- pr-34721.txt