### PR TITLE
fix(auth-backend): fix DCR loopback redirect URI port matching

### DIFF
--- a/.changeset/dcr-loopback-redirect-ports.md
+++ b/.changeset/dcr-loopback-redirect-ports.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Fixed dynamic client registration authorization for desktop OAuth clients using loopback redirect URIs, allowing the callback port to differ from the registered redirect URI.

--- a/plugins/auth-backend/src/service/OidcService.test.ts
+++ b/plugins/auth-backend/src/service/OidcService.test.ts
@@ -448,6 +448,80 @@ describe('OidcService', () => {
         });
       });
 
+      it('should accept loopback redirect URI with a different port and matching query', async () => {
+        const { service } = await createOidcService({ databaseId });
+
+        const client = await service.registerClient({
+          clientName: 'Test Client',
+          redirectUris: ['http://localhost:3000/callback?client=desktop'],
+        });
+
+        const authSession = await service.createAuthorizationSession({
+          clientId: client.clientId,
+          redirectUri: 'http://localhost:60056/callback?client=desktop',
+          responseType: 'code',
+          scope: 'openid',
+        });
+
+        expect(authSession).toEqual({
+          id: expect.any(String),
+          clientName: 'Test Client',
+          scope: 'openid',
+          redirectUri: 'http://localhost:60056/callback?client=desktop',
+        });
+      });
+
+      it('should reject loopback redirect URI with a different query', async () => {
+        const { service } = await createOidcService({ databaseId });
+
+        const client = await service.registerClient({
+          clientName: 'Test Client',
+          redirectUris: ['http://localhost:3000/callback?client=desktop'],
+        });
+
+        await expect(
+          service.createAuthorizationSession({
+            clientId: client.clientId,
+            redirectUri: 'http://localhost:60056/callback?client=other',
+            responseType: 'code',
+          }),
+        ).rejects.toThrow('Invalid redirect_uri');
+      });
+
+      it('should reject requested redirect URI containing a fragment', async () => {
+        const { service } = await createOidcService({ databaseId });
+
+        const client = await service.registerClient({
+          clientName: 'Test Client',
+          redirectUris: ['http://localhost:3000/callback'],
+        });
+
+        await expect(
+          service.createAuthorizationSession({
+            clientId: client.clientId,
+            redirectUri: 'http://localhost:60056/callback#fragment',
+            responseType: 'code',
+          }),
+        ).rejects.toThrow('Invalid redirect_uri');
+      });
+
+      it('should reject registered redirect URI containing a fragment', async () => {
+        const { service } = await createOidcService({ databaseId });
+
+        const client = await service.registerClient({
+          clientName: 'Test Client',
+          redirectUris: ['http://localhost:3000/callback#fragment'],
+        });
+
+        await expect(
+          service.createAuthorizationSession({
+            clientId: client.clientId,
+            redirectUri: 'http://localhost:60056/callback',
+            responseType: 'code',
+          }),
+        ).rejects.toThrow('Invalid redirect_uri');
+      });
+
       it('should throw error for invalid client', async () => {
         const { service } = await createOidcService({ databaseId });
 

--- a/plugins/auth-backend/src/service/OidcService.test.ts
+++ b/plugins/auth-backend/src/service/OidcService.test.ts
@@ -425,6 +425,29 @@ describe('OidcService', () => {
         });
       });
 
+      it('should accept loopback redirect URI with a different port per RFC 8252', async () => {
+        const { service } = await createOidcService({ databaseId });
+
+        const client = await service.registerClient({
+          clientName: 'Test Client',
+          redirectUris: ['http://localhost:3000/callback'],
+        });
+
+        const authSession = await service.createAuthorizationSession({
+          clientId: client.clientId,
+          redirectUri: 'http://localhost:60056/callback',
+          responseType: 'code',
+          scope: 'openid',
+        });
+
+        expect(authSession).toEqual({
+          id: expect.any(String),
+          clientName: 'Test Client',
+          scope: 'openid',
+          redirectUri: 'http://localhost:60056/callback',
+        });
+      });
+
       it('should throw error for invalid client', async () => {
         const { service } = await createOidcService({ databaseId });
 

--- a/plugins/auth-backend/src/service/OidcService.ts
+++ b/plugins/auth-backend/src/service/OidcService.ts
@@ -57,14 +57,18 @@ const LOOPBACK_REDIRECT_PATTERNS = [
 
 /**
  * RFC 8252 Section 7.3: For loopback redirect URIs, the authorization server
- * MUST allow any port to be specified at the time of the request. This matches
- * redirect URIs by scheme, hostname, and path only, ignoring the port.
+ * MUST allow any port to be specified at the time of the request. This ignores
+ * only the port, while keeping the rest of the redirect URI matching strict.
  */
 function matchesRedirectUri(
   requestUri: string,
   registeredUris: string[],
 ): boolean {
   const requested = new URL(requestUri);
+
+  if (requested.hash) {
+    return false;
+  }
 
   if (!LOOPBACK_HOSTS.includes(requested.hostname)) {
     return registeredUris.includes(requestUri);
@@ -78,10 +82,12 @@ function matchesRedirectUri(
       return false;
     }
     return (
+      !reg.hash &&
       LOOPBACK_HOSTS.includes(reg.hostname) &&
       reg.protocol === requested.protocol &&
       reg.hostname === requested.hostname &&
-      reg.pathname === requested.pathname
+      reg.pathname === requested.pathname &&
+      reg.search === requested.search
     );
   });
 }

--- a/plugins/auth-backend/src/service/OidcService.ts
+++ b/plugins/auth-backend/src/service/OidcService.ts
@@ -395,7 +395,10 @@ export class OidcService {
       throw new InputError('Invalid client_id');
     }
 
-    if (opts.redirectUri && !client.redirectUris.includes(opts.redirectUri)) {
+    if (
+      opts.redirectUri &&
+      !matchesRedirectUri(opts.redirectUri, client.redirectUris)
+    ) {
       throw new InputError(`Invalid redirect_uri '${opts.redirectUri}'`);
     }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes DCR authorization for desktop OAuth clients (VS Code) that use loopback redirect URIs with dynamic callback ports.

Previously, DCR clients validated `redirect_uri` with strict string comparison, so authorization failed if a client registered one loopback port (e.g., http://127.0.0.1:33418/) but the authorization request uses a different port (e.g., http://127.0.0.1:63847/). RFC 8252 requires loopback redirects to allow any port at authorization time. 

This updates DCR redirect matching to use the existing loopback-aware matcher and adds a regression test for the differing-port case.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
