### PR TITLE
feat: added `workflowAccess` support to `publish:github`

### DIFF
--- a/.changeset/sharp-beers-wave.md
+++ b/.changeset/sharp-beers-wave.md
@@ -12,7 +12,7 @@ to the workflows during creation.
     id: create-repo
     input:
       repoUrl: github.com?owner=owner&repo=repo
-      visibility: private
+      repoVisibility: private
 +     workflowAccess: organization
 ```
 

--- a/.changeset/sharp-beers-wave.md
+++ b/.changeset/sharp-beers-wave.md
@@ -1,0 +1,19 @@
+---
+'@backstage/plugin-scaffolder-backend-module-github': patch
+---
+
+Added options to set [workflow access level][access-level] for repositories to `publish:github`
+
+This is useful when creating repositories for GitHub Actions to manage access
+to the workflows during creation.
+
+```diff
+ - action: publish:github
+    id: create-repo
+    input:
+      repoUrl: github.com?owner=owner&repo=repo
+      visibility: private
++     workflowAccess: organization
+```
+
+[access-level]: https://docs.github.com/en/rest/actions/permissions?apiVersion=2022-11-28#set-the-level-of-access-for-workflows-outside-of-the-repository

--- a/plugins/scaffolder-backend-module-github/report.api.md
+++ b/plugins/scaffolder-backend-module-github/report.api.md
@@ -394,9 +394,15 @@ export function createPublishGithubAction(options: {
 }): TemplateAction<
   {
     repoUrl: string;
-    description?: string | undefined;
-    homepage?: string | undefined;
     access?: string | undefined;
+    allowAutoMerge?: boolean | undefined;
+    allowMergeCommit?: boolean | undefined;
+    allowRebaseMerge?: boolean | undefined;
+    allowSquashMerge?: boolean | undefined;
+    allowUpdateBranch?: boolean | undefined;
+    autoInit?: boolean | undefined;
+    blockCreations?: boolean | undefined;
+    branch?: string | undefined;
     bypassPullRequestAllowances?:
       | {
           users?: string[] | undefined;
@@ -404,40 +410,6 @@ export function createPublishGithubAction(options: {
           teams?: string[] | undefined;
         }
       | undefined;
-    requiredApprovingReviewCount?: number | undefined;
-    restrictions?:
-      | {
-          users: string[];
-          teams: string[];
-          apps?: string[] | undefined;
-        }
-      | undefined;
-    requireCodeOwnerReviews?: boolean | undefined;
-    dismissStaleReviews?: boolean | undefined;
-    requiredStatusCheckContexts?: string[] | undefined;
-    requireBranchesToBeUpToDate?: boolean | undefined;
-    requiredConversationResolution?: boolean | undefined;
-    requireLastPushApproval?: boolean | undefined;
-    repoVisibility?: 'internal' | 'private' | 'public' | undefined;
-    defaultBranch?: string | undefined;
-    protectDefaultBranch?: boolean | undefined;
-    protectEnforceAdmins?: boolean | undefined;
-    deleteBranchOnMerge?: boolean | undefined;
-    gitCommitMessage?: string | undefined;
-    gitAuthorName?: string | undefined;
-    gitAuthorEmail?: string | undefined;
-    allowMergeCommit?: boolean | undefined;
-    allowSquashMerge?: boolean | undefined;
-    squashMergeCommitTitle?: 'PR_TITLE' | 'COMMIT_OR_PR_TITLE' | undefined;
-    squashMergeCommitMessage?:
-      | 'PR_BODY'
-      | 'COMMIT_MESSAGES'
-      | 'BLANK'
-      | undefined;
-    allowRebaseMerge?: boolean | undefined;
-    allowAutoMerge?: boolean | undefined;
-    allowUpdateBranch?: boolean | undefined;
-    sourcePath?: string | undefined;
     collaborators?:
       | (
           | {
@@ -450,23 +422,55 @@ export function createPublishGithubAction(options: {
             }
         )[]
       | undefined;
+    customProperties?: Record<string, string | string[]> | undefined;
+    defaultBranch?: string | undefined;
+    deleteBranchOnMerge?: boolean | undefined;
+    description?: string | undefined;
+    dismissStaleReviews?: boolean | undefined;
+    gitAuthorEmail?: string | undefined;
+    gitAuthorName?: string | undefined;
+    gitCommitMessage?: string | undefined;
+    hasIssues?: boolean | undefined;
     hasProjects?: boolean | undefined;
     hasWiki?: boolean | undefined;
-    hasIssues?: boolean | undefined;
-    token?: string | undefined;
-    topics?: string[] | undefined;
-    repoVariables?: Record<string, string> | undefined;
-    secrets?: Record<string, string> | undefined;
+    homepage?: string | undefined;
     oidcCustomization?:
       | {
           useDefault: boolean;
           includeClaimKeys?: string[] | undefined;
         }
       | undefined;
+    protectDefaultBranch?: boolean | undefined;
+    protectEnforceAdmins?: boolean | undefined;
+    repoVariables?: Record<string, string> | undefined;
+    repoVisibility?: 'internal' | 'private' | 'public' | undefined;
+    requireBranchesToBeUpToDate?: boolean | undefined;
+    requireCodeOwnerReviews?: boolean | undefined;
+    requiredApprovingReviewCount?: number | undefined;
     requiredCommitSigning?: boolean | undefined;
+    requiredConversationResolution?: boolean | undefined;
     requiredLinearHistory?: boolean | undefined;
-    customProperties?: Record<string, string | string[]> | undefined;
+    requiredStatusCheckContexts?: string[] | undefined;
+    requireLastPushApproval?: boolean | undefined;
+    restrictions?:
+      | {
+          users: string[];
+          teams: string[];
+          apps?: string[] | undefined;
+        }
+      | undefined;
+    secrets?: Record<string, string> | undefined;
+    sourcePath?: string | undefined;
+    squashMergeCommitMessage?:
+      | 'PR_BODY'
+      | 'COMMIT_MESSAGES'
+      | 'BLANK'
+      | undefined;
+    squashMergeCommitTitle?: 'PR_TITLE' | 'COMMIT_OR_PR_TITLE' | undefined;
     subscribe?: boolean | undefined;
+    token?: string | undefined;
+    topics?: string[] | undefined;
+    workflowAccess?: 'none' | 'organization' | 'user' | undefined;
   },
   {
     remoteUrl: string;

--- a/plugins/scaffolder-backend-module-github/report.api.md
+++ b/plugins/scaffolder-backend-module-github/report.api.md
@@ -394,15 +394,23 @@ export function createPublishGithubAction(options: {
 }): TemplateAction<
   {
     repoUrl: string;
+    description?: string | undefined;
+    sourcePath?: string | undefined;
+    token?: string | undefined;
+    subscribe?: boolean | undefined;
+    homepage?: string | undefined;
     access?: string | undefined;
-    allowAutoMerge?: boolean | undefined;
-    allowMergeCommit?: boolean | undefined;
-    allowRebaseMerge?: boolean | undefined;
-    allowSquashMerge?: boolean | undefined;
-    allowUpdateBranch?: boolean | undefined;
-    autoInit?: boolean | undefined;
-    blockCreations?: boolean | undefined;
-    branch?: string | undefined;
+    restrictions?:
+      | {
+          users: string[];
+          teams: string[];
+          apps?: string[] | undefined;
+        }
+      | undefined;
+    topics?: string[] | undefined;
+    secrets?: Record<string, string> | undefined;
+    defaultBranch?: string | undefined;
+    requireCodeOwnerReviews?: boolean | undefined;
     bypassPullRequestAllowances?:
       | {
           users?: string[] | undefined;
@@ -410,6 +418,20 @@ export function createPublishGithubAction(options: {
           teams?: string[] | undefined;
         }
       | undefined;
+    requiredApprovingReviewCount?: number | undefined;
+    requiredStatusCheckContexts?: string[] | undefined;
+    requireBranchesToBeUpToDate?: boolean | undefined;
+    requiredConversationResolution?: boolean | undefined;
+    requireLastPushApproval?: boolean | undefined;
+    dismissStaleReviews?: boolean | undefined;
+    requiredCommitSigning?: boolean | undefined;
+    requiredLinearHistory?: boolean | undefined;
+    allowAutoMerge?: boolean | undefined;
+    allowMergeCommit?: boolean | undefined;
+    allowRebaseMerge?: boolean | undefined;
+    allowSquashMerge?: boolean | undefined;
+    allowUpdateBranch?: boolean | undefined;
+    autoInit?: boolean | undefined;
     collaborators?:
       | (
           | {
@@ -423,17 +445,13 @@ export function createPublishGithubAction(options: {
         )[]
       | undefined;
     customProperties?: Record<string, string | string[]> | undefined;
-    defaultBranch?: string | undefined;
     deleteBranchOnMerge?: boolean | undefined;
-    description?: string | undefined;
-    dismissStaleReviews?: boolean | undefined;
     gitAuthorEmail?: string | undefined;
     gitAuthorName?: string | undefined;
     gitCommitMessage?: string | undefined;
     hasIssues?: boolean | undefined;
     hasProjects?: boolean | undefined;
     hasWiki?: boolean | undefined;
-    homepage?: string | undefined;
     oidcCustomization?:
       | {
           useDefault: boolean;
@@ -444,32 +462,12 @@ export function createPublishGithubAction(options: {
     protectEnforceAdmins?: boolean | undefined;
     repoVariables?: Record<string, string> | undefined;
     repoVisibility?: 'internal' | 'private' | 'public' | undefined;
-    requireBranchesToBeUpToDate?: boolean | undefined;
-    requireCodeOwnerReviews?: boolean | undefined;
-    requiredApprovingReviewCount?: number | undefined;
-    requiredCommitSigning?: boolean | undefined;
-    requiredConversationResolution?: boolean | undefined;
-    requiredLinearHistory?: boolean | undefined;
-    requiredStatusCheckContexts?: string[] | undefined;
-    requireLastPushApproval?: boolean | undefined;
-    restrictions?:
-      | {
-          users: string[];
-          teams: string[];
-          apps?: string[] | undefined;
-        }
-      | undefined;
-    secrets?: Record<string, string> | undefined;
-    sourcePath?: string | undefined;
     squashMergeCommitMessage?:
       | 'PR_BODY'
       | 'COMMIT_MESSAGES'
       | 'BLANK'
       | undefined;
     squashMergeCommitTitle?: 'PR_TITLE' | 'COMMIT_OR_PR_TITLE' | undefined;
-    subscribe?: boolean | undefined;
-    token?: string | undefined;
-    topics?: string[] | undefined;
     workflowAccess?: 'none' | 'organization' | 'user' | undefined;
   },
   {

--- a/plugins/scaffolder-backend-module-github/report.api.md
+++ b/plugins/scaffolder-backend-module-github/report.api.md
@@ -431,7 +431,6 @@ export function createPublishGithubAction(options: {
     allowRebaseMerge?: boolean | undefined;
     allowSquashMerge?: boolean | undefined;
     allowUpdateBranch?: boolean | undefined;
-    autoInit?: boolean | undefined;
     collaborators?:
       | (
           | {

--- a/plugins/scaffolder-backend-module-github/src/actions/github.examples.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/github.examples.ts
@@ -67,4 +67,21 @@ export const examples: TemplateExample[] = [
       ],
     }),
   },
+  {
+    description:
+      'Initializes a GitHub repository with workflow access set to organization',
+    example: yaml.stringify({
+      steps: [
+        {
+          id: 'publish',
+          action: 'publish:github',
+          name: 'Publish to GitHub',
+          input: {
+            repoUrl: 'github.com?repo=repo&owner=owner',
+            workflowAccess: 'organization',
+          },
+        },
+      ],
+    }),
+  },
 ];

--- a/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
@@ -121,6 +121,27 @@ describe('publish:github', () => {
     },
   });
 
+  const runHandlerForType = async (
+    type: 'organization' | 'user',
+    input: any = null,
+  ) => {
+    mockOctokit.rest.users.getByUsername.mockResolvedValue({
+      data: { type: `${type.at(0)?.toUpperCase()}${type.slice(1)}` },
+    });
+
+    const methodName =
+      type === 'organization' ? 'createInOrg' : 'createForAuthenticatedUser';
+    mockOctokit.rest.repos[methodName].mockResolvedValue({ data: {} });
+
+    return action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        ...input,
+      },
+    });
+  };
+
   beforeEach(() => {
     octokitMock.mockImplementation(() => mockOctokit);
     initRepoAndPushMocked.mockResolvedValue({
@@ -1889,30 +1910,53 @@ describe('publish:github', () => {
     });
   });
 
-  it('should configure workflowAccess', async () => {
-    mockOctokit.rest.users.getByUsername.mockResolvedValue({
-      data: { type: 'Organization' },
-    });
-    mockOctokit.rest.repos.createInOrg.mockResolvedValue({ data: {} });
+  it('should configure autoInit for orgs', async () => {
+    await runHandlerForType('organization', { autoInit: true });
 
+    expect(mockOctokit.rest.repos.createInOrg).toHaveBeenCalledWith(
+      expect.objectContaining({ auto_init: true }),
+    );
+  });
+
+  it('should configure autoInit for users', async () => {
+    await runHandlerForType('user', { autoInit: false });
+
+    expect(
+      mockOctokit.rest.repos.createForAuthenticatedUser,
+    ).toHaveBeenCalledWith(expect.objectContaining({ auto_init: false }));
+  });
+
+  it('should configure workflowAccess for orgs', async () => {
     mockOctokit.rest.actions.setWorkflowAccessToRepository.mockResolvedValueOnce(
       {
         data: {},
       },
     );
 
-    await action.handler({
-      ...mockContext,
-      input: {
-        ...mockContext.input,
-        workflowAccess: 'organization',
-      },
-    });
+    await runHandlerForType('organization', { workflowAccess: 'organization' });
 
     expect(
       mockOctokit.rest.actions.setWorkflowAccessToRepository,
     ).toHaveBeenCalledWith({
       access_level: 'organization',
+      owner: 'owner',
+      repo: 'repo',
+    });
+  });
+
+  it('should configure workflowAccess for users', async () => {
+    mockOctokit.rest.actions.setWorkflowAccessToRepository.mockResolvedValueOnce(
+      {
+        data: {},
+      },
+    );
+
+    await runHandlerForType('user', { workflowAccess: 'user' });
+
+    expect(
+      mockOctokit.rest.actions.setWorkflowAccessToRepository,
+    ).toHaveBeenCalledWith({
+      access_level: 'user',
       owner: 'owner',
       repo: 'repo',
     });

--- a/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
@@ -123,7 +123,7 @@ describe('publish:github', () => {
 
   const runHandlerForType = async (
     type: 'organization' | 'user',
-    input: any = null,
+    input: any = {},
   ) => {
     mockOctokit.rest.users.getByUsername.mockResolvedValue({
       data: { type: `${type.at(0)?.toUpperCase()}${type.slice(1)}` },
@@ -1910,57 +1910,26 @@ describe('publish:github', () => {
     });
   });
 
-  it('should configure autoInit for orgs', async () => {
-    await runHandlerForType('organization', { autoInit: true });
+  it.each(['organization', 'user'] as const)(
+    'should configure workflowAccess for %ss',
+    async type => {
+      mockOctokit.rest.actions.setWorkflowAccessToRepository.mockResolvedValueOnce(
+        {
+          data: {},
+        },
+      );
 
-    expect(mockOctokit.rest.repos.createInOrg).toHaveBeenCalledWith(
-      expect.objectContaining({ auto_init: true }),
-    );
-  });
+      await runHandlerForType(type, { workflowAccess: type });
 
-  it('should configure autoInit for users', async () => {
-    await runHandlerForType('user', { autoInit: false });
-
-    expect(
-      mockOctokit.rest.repos.createForAuthenticatedUser,
-    ).toHaveBeenCalledWith(expect.objectContaining({ auto_init: false }));
-  });
-
-  it('should configure workflowAccess for orgs', async () => {
-    mockOctokit.rest.actions.setWorkflowAccessToRepository.mockResolvedValueOnce(
-      {
-        data: {},
-      },
-    );
-
-    await runHandlerForType('organization', { workflowAccess: 'organization' });
-
-    expect(
-      mockOctokit.rest.actions.setWorkflowAccessToRepository,
-    ).toHaveBeenCalledWith({
-      access_level: 'organization',
-      owner: 'owner',
-      repo: 'repo',
-    });
-  });
-
-  it('should configure workflowAccess for users', async () => {
-    mockOctokit.rest.actions.setWorkflowAccessToRepository.mockResolvedValueOnce(
-      {
-        data: {},
-      },
-    );
-
-    await runHandlerForType('user', { workflowAccess: 'user' });
-
-    expect(
-      mockOctokit.rest.actions.setWorkflowAccessToRepository,
-    ).toHaveBeenCalledWith({
-      access_level: 'user',
-      owner: 'owner',
-      repo: 'repo',
-    });
-  });
+      expect(
+        mockOctokit.rest.actions.setWorkflowAccessToRepository,
+      ).toHaveBeenCalledWith({
+        access_level: type,
+        owner: 'owner',
+        repo: 'repo',
+      });
+    },
+  );
 
   describe('GraphQL API fallback', () => {
     let readdirSpy: jest.SpyInstance;

--- a/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
@@ -80,6 +80,7 @@ const mockOctokit = {
       createRepoVariable: jest.fn(),
       createOrUpdateRepoSecret: jest.fn(),
       getRepoPublicKey: jest.fn(),
+      setWorkflowAccessToRepository: jest.fn(),
     },
     activity: {
       setRepoSubscription: jest.fn(),
@@ -1885,6 +1886,35 @@ describe('publish:github', () => {
       repo: 'repo',
       subscribed: true,
       ignored: false,
+    });
+  });
+
+  it('should configure workflowAccess', async () => {
+    mockOctokit.rest.users.getByUsername.mockResolvedValue({
+      data: { type: 'Organization' },
+    });
+    mockOctokit.rest.repos.createInOrg.mockResolvedValue({ data: {} });
+
+    mockOctokit.rest.actions.setWorkflowAccessToRepository.mockResolvedValueOnce(
+      {
+        data: {},
+      },
+    );
+
+    await action.handler({
+      ...mockContext,
+      input: {
+        ...mockContext.input,
+        workflowAccess: 'organization',
+      },
+    });
+
+    expect(
+      mockOctokit.rest.actions.setWorkflowAccessToRepository,
+    ).toHaveBeenCalledWith({
+      access_level: 'organization',
+      owner: 'owner',
+      repo: 'repo',
     });
   });
 

--- a/plugins/scaffolder-backend-module-github/src/actions/github.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/github.ts
@@ -67,7 +67,11 @@ export function createPublishGithubAction(options: {
     examples,
     schema: {
       input: {
-        ...withoutProperties(inputProps, ['blockCreations', 'branch']),
+        ...withoutProperties(inputProps, [
+          'autoInit',
+          'blockCreations',
+          'branch',
+        ]),
       },
       output: {
         remoteUrl: outputProps.remoteUrl,

--- a/plugins/scaffolder-backend-module-github/src/actions/github.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/github.ts
@@ -64,6 +64,7 @@ export function createPublishGithubAction(options: {
     },
     async handler(ctx) {
       const {
+        autoInit,
         repoUrl,
         description,
         homepage,
@@ -157,7 +158,7 @@ export function createPublishGithubAction(options: {
             customProperties,
             subscribe,
             ctx.logger,
-            undefined, // autoInit
+            autoInit,
             workflowAccess,
           );
 

--- a/plugins/scaffolder-backend-module-github/src/actions/github.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/github.ts
@@ -47,6 +47,19 @@ export function createPublishGithubAction(options: {
 }) {
   const { integrations, config, githubCredentialsProvider } = options;
 
+  function dynamicOmit<T extends object, K extends keyof T>(
+    object: T,
+    keys: K[],
+  ): Omit<T, K> {
+    const result = { ...object };
+
+    keys.forEach(key => {
+      delete result[key];
+    });
+
+    return result;
+  }
+
   return createTemplateAction({
     id: 'publish:github',
     description:
@@ -54,7 +67,7 @@ export function createPublishGithubAction(options: {
     examples,
     schema: {
       input: {
-        ...inputProps,
+        ...dynamicOmit(inputProps, ['blockCreations', 'branch']),
       },
       output: {
         remoteUrl: outputProps.remoteUrl,

--- a/plugins/scaffolder-backend-module-github/src/actions/github.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/github.ts
@@ -54,49 +54,7 @@ export function createPublishGithubAction(options: {
     examples,
     schema: {
       input: {
-        repoUrl: inputProps.repoUrl,
-        description: inputProps.description,
-        homepage: inputProps.homepage,
-        access: inputProps.access,
-        bypassPullRequestAllowances: inputProps.bypassPullRequestAllowances,
-        requiredApprovingReviewCount: inputProps.requiredApprovingReviewCount,
-        restrictions: inputProps.restrictions,
-        requireCodeOwnerReviews: inputProps.requireCodeOwnerReviews,
-        dismissStaleReviews: inputProps.dismissStaleReviews,
-        requiredStatusCheckContexts: inputProps.requiredStatusCheckContexts,
-        requireBranchesToBeUpToDate: inputProps.requireBranchesToBeUpToDate,
-        requiredConversationResolution:
-          inputProps.requiredConversationResolution,
-        requireLastPushApproval: inputProps.requireLastPushApproval,
-        repoVisibility: inputProps.repoVisibility,
-        defaultBranch: inputProps.defaultBranch,
-        protectDefaultBranch: inputProps.protectDefaultBranch,
-        protectEnforceAdmins: inputProps.protectEnforceAdmins,
-        deleteBranchOnMerge: inputProps.deleteBranchOnMerge,
-        gitCommitMessage: inputProps.gitCommitMessage,
-        gitAuthorName: inputProps.gitAuthorName,
-        gitAuthorEmail: inputProps.gitAuthorEmail,
-        allowMergeCommit: inputProps.allowMergeCommit,
-        allowSquashMerge: inputProps.allowSquashMerge,
-        squashMergeCommitTitle: inputProps.squashMergeCommitTitle,
-        squashMergeCommitMessage: inputProps.squashMergeCommitMessage,
-        allowRebaseMerge: inputProps.allowRebaseMerge,
-        allowAutoMerge: inputProps.allowAutoMerge,
-        allowUpdateBranch: inputProps.allowUpdateBranch,
-        sourcePath: inputProps.sourcePath,
-        collaborators: inputProps.collaborators,
-        hasProjects: inputProps.hasProjects,
-        hasWiki: inputProps.hasWiki,
-        hasIssues: inputProps.hasIssues,
-        token: inputProps.token,
-        topics: inputProps.topics,
-        repoVariables: inputProps.repoVariables,
-        secrets: inputProps.secrets,
-        oidcCustomization: inputProps.oidcCustomization,
-        requiredCommitSigning: inputProps.requiredCommitSigning,
-        requiredLinearHistory: inputProps.requiredLinearHistory,
-        customProperties: inputProps.customProperties,
-        subscribe: inputProps.subscribe,
+        ...inputProps,
       },
       output: {
         remoteUrl: outputProps.remoteUrl,
@@ -147,6 +105,7 @@ export function createPublishGithubAction(options: {
         subscribe = false,
         requiredCommitSigning = false,
         requiredLinearHistory = false,
+        workflowAccess,
       } = ctx.input;
 
       const { host, owner, repo } = parseRepoUrl(repoUrl, integrations);
@@ -198,6 +157,8 @@ export function createPublishGithubAction(options: {
             customProperties,
             subscribe,
             ctx.logger,
+            undefined, // autoInit
+            workflowAccess,
           );
 
           return {

--- a/plugins/scaffolder-backend-module-github/src/actions/github.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/github.ts
@@ -47,7 +47,7 @@ export function createPublishGithubAction(options: {
 }) {
   const { integrations, config, githubCredentialsProvider } = options;
 
-  function dynamicOmit<T extends object, K extends keyof T>(
+  function withoutProperties<T extends object, K extends keyof T>(
     object: T,
     keys: K[],
   ): Omit<T, K> {
@@ -67,7 +67,7 @@ export function createPublishGithubAction(options: {
     examples,
     schema: {
       input: {
-        ...dynamicOmit(inputProps, ['blockCreations', 'branch']),
+        ...withoutProperties(inputProps, ['blockCreations', 'branch']),
       },
       output: {
         remoteUrl: outputProps.remoteUrl,
@@ -77,7 +77,6 @@ export function createPublishGithubAction(options: {
     },
     async handler(ctx) {
       const {
-        autoInit,
         repoUrl,
         description,
         homepage,
@@ -171,7 +170,6 @@ export function createPublishGithubAction(options: {
             customProperties,
             subscribe,
             ctx.logger,
-            autoInit,
             workflowAccess,
           );
 

--- a/plugins/scaffolder-backend-module-github/src/actions/github.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/github.ts
@@ -29,23 +29,10 @@ import {
   createGithubRepoWithCollaboratorsAndTopics,
   initRepoPushAndProtect,
 } from './helpers';
-import { getOctokitOptions } from '../util';
+import { getOctokitOptions, withoutProperties } from '../util';
 import * as inputProps from './inputProperties';
 import * as outputProps from './outputProperties';
 import { examples } from './github.examples';
-
-function withoutProperties<T extends object, K extends keyof T>(
-  object: T,
-  keys: K[],
-): Omit<T, K> {
-  const result: Partial<T> = { ...object };
-
-  keys.forEach(key => {
-    delete result[key];
-  });
-
-  return result as Omit<T, K>;
-}
 
 /**
  * Creates a new action that initializes a git repository of the content in the workspace
@@ -66,13 +53,11 @@ export function createPublishGithubAction(options: {
       'Initializes a git repository of contents in workspace and publishes it to GitHub.',
     examples,
     schema: {
-      input: {
-        ...withoutProperties(inputProps, [
-          'autoInit',
-          'blockCreations',
-          'branch',
-        ]),
-      },
+      input: withoutProperties(inputProps, [
+        'autoInit',
+        'blockCreations',
+        'branch',
+      ]),
       output: {
         remoteUrl: outputProps.remoteUrl,
         repoContentsUrl: outputProps.repoContentsUrl,

--- a/plugins/scaffolder-backend-module-github/src/actions/github.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/github.ts
@@ -34,6 +34,19 @@ import * as inputProps from './inputProperties';
 import * as outputProps from './outputProperties';
 import { examples } from './github.examples';
 
+function withoutProperties<T extends object, K extends keyof T>(
+  object: T,
+  keys: K[],
+): Omit<T, K> {
+  const result: Partial<T> = { ...object };
+
+  keys.forEach(key => {
+    delete result[key];
+  });
+
+  return result as Omit<T, K>;
+}
+
 /**
  * Creates a new action that initializes a git repository of the content in the workspace
  * and publishes it to GitHub.
@@ -46,19 +59,6 @@ export function createPublishGithubAction(options: {
   githubCredentialsProvider?: GithubCredentialsProvider;
 }) {
   const { integrations, config, githubCredentialsProvider } = options;
-
-  function withoutProperties<T extends object, K extends keyof T>(
-    object: T,
-    keys: K[],
-  ): Omit<T, K> {
-    const result = { ...object };
-
-    keys.forEach(key => {
-      delete result[key];
-    });
-
-    return result;
-  }
 
   return createTemplateAction({
     id: 'publish:github',

--- a/plugins/scaffolder-backend-module-github/src/actions/githubRepoCreate.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubRepoCreate.ts
@@ -133,8 +133,8 @@ export function createGithubRepoCreateAction(options: {
             customProperties,
             subscribe,
             ctx.logger,
-            autoInit,
             workflowAccess,
+            autoInit,
           );
           return newRepo.clone_url;
         },

--- a/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
@@ -80,8 +80,8 @@ export async function createGithubRepoWithCollaboratorsAndTopics(
   customProperties: { [key: string]: string | string[] } | undefined,
   subscribe: boolean | undefined,
   logger: LoggerService,
-  autoInit?: boolean | undefined,
   workflowAccess?: 'none' | 'organization' | 'user',
+  autoInit?: boolean | undefined,
 ) {
   const user = await client.rest.users.getByUsername({
     username: owner,

--- a/plugins/scaffolder-backend-module-github/src/util.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/util.test.ts
@@ -17,7 +17,7 @@
 import { Octokit } from 'octokit';
 import { retry } from '@octokit/plugin-retry';
 import { mockServices } from '@backstage/backend-test-utils';
-import { isRetryEnabled, getOctokitClient } from './util';
+import { isRetryEnabled, getOctokitClient, withoutProperties } from './util';
 
 jest.mock('octokit', () => ({
   Octokit: Object.assign(jest.fn(), {
@@ -156,6 +156,30 @@ describe('getOctokitClient', () => {
         retryAfter: 1000,
       },
       log: logger,
+    });
+  });
+});
+
+describe('withoutProperties', () => {
+  const starterObject = {
+    catpants: true,
+    foo: 'bar',
+    milliseconds: 60_000,
+  } as const;
+
+  it('should remove known properties', () => {
+    expect(withoutProperties(starterObject, ['foo', 'milliseconds'])).toEqual({
+      catpants: true,
+    });
+  });
+
+  it('should not error with unknown properties even though tyepscript complains', () => {
+    expect(
+      // @ts-expect-error
+      withoutProperties(starterObject, ['baz', 'catpants', 'not-here']),
+    ).toEqual({
+      foo: 'bar',
+      milliseconds: 60_000,
     });
   });
 });

--- a/plugins/scaffolder-backend-module-github/src/util.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/util.test.ts
@@ -173,7 +173,7 @@ describe('withoutProperties', () => {
     });
   });
 
-  it('should not error with unknown properties even though tyepscript complains', () => {
+  it('should not error with unknown properties even though TypeScript complains', () => {
     expect(
       // @ts-expect-error
       withoutProperties(starterObject, ['baz', 'catpants', 'not-here']),

--- a/plugins/scaffolder-backend-module-github/src/util.ts
+++ b/plugins/scaffolder-backend-module-github/src/util.ts
@@ -217,3 +217,16 @@ export async function getOctokitOptions(options: {
     previews: ['nebula-preview'],
   };
 }
+
+export function withoutProperties<T extends object, K extends keyof T>(
+  object: T,
+  keys: K[],
+): Omit<T, K> {
+  const result: Partial<T> = { ...object };
+
+  keys.forEach(key => {
+    delete result[key];
+  });
+
+  return result as Omit<T, K>;
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Updated `publish:github` to support [setting workflow access level](https://docs.github.com/en/rest/actions/permissions?apiVersion=2022-11-28#set-the-level-of-access-for-workflows-outside-of-the-repository). This is primarily used when creating repositories for GitHub Actions.

This is a continuation of the work from #32237. I've only recently been able to update and noticed that this was missed initially.

> [!NOTE]
>
> There may be a [similar bug with `autoInit`](https://github.com/backstage/backstage/pull/34732/changes#diff-c2ff5c516a78f6660e155b9ada42f07f4b4503a9dca2368238def0c396cd449dR161) which I noticed was also not passed to `createGithubRepoWithCollaboratorsAndTopics` I didn't investigate, but I thought it was worth sharing.

EDIT: 

> [!IMPORTANT]
>
> I changed the order of the params passed to `createGithubRepoWithCollaboratorsAndTopics`  so I could side step all of the implementation issues surrounding `autoInit` since they are unrelated to this change.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
