### PR TITLE
fix(home): persist widget state on add, remove and clear all

### DIFF
--- a/.changeset/huge-actors-eat.md
+++ b/.changeset/huge-actors-eat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home': patch
+---
+
+fix(home): persist widget state on add, remove and clear all

--- a/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.tsx
+++ b/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.tsx
@@ -275,11 +275,14 @@ export const CustomHomepageGrid = (props: CustomHomepageGridProps) => {
         resizable: widget.resizable,
       },
     ]);
+    setEditMode(true);
     setAddWidgetDialogOpen(false);
   };
 
   const handleRemove = (widgetId: string) => {
-    setWidgets(widgets.filter(w => w.id !== widgetId));
+    const remaining = widgets.filter(w => w.id !== widgetId);
+    setWidgets(remaining);
+    storeWidgets(remaining);
   };
 
   const handleSettingsSave = (
@@ -296,7 +299,9 @@ export const CustomHomepageGrid = (props: CustomHomepageGridProps) => {
   };
 
   const clearLayout = () => {
-    setWidgets(widgets.filter(w => w.deletable === false));
+    const remaining = widgets.filter(w => w.deletable === false);
+    setWidgets(remaining);
+    storeWidgets(remaining);
   };
 
   const changeEditMode = (mode: boolean) => {

--- a/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.tsx
+++ b/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.tsx
@@ -280,9 +280,11 @@ export const CustomHomepageGrid = (props: CustomHomepageGridProps) => {
   };
 
   const handleRemove = (widgetId: string) => {
-    const remaining = widgets.filter(w => w.id !== widgetId);
-    setWidgets(remaining);
-    storeWidgets(remaining);
+    setWidgets(prevWidgets => {
+      const remaining = prevWidgets.filter(w => w.id !== widgetId);
+      storeWidgets(remaining);
+      return remaining;
+    });
   };
 
   const handleSettingsSave = (


### PR DESCRIPTION
Fixes #34704

## Problem
- Adding first widget showed "Edit" instead of "Save" button
- Deleting the last widget did not persist the empty state
- "Clear All" button did not persist changes after page refresh

## Root Cause
handleAdd, handleRemove, and clearLayout were only calling 
setWidgets (local state) but never storeWidgets (storage persistence).

## Solution
- handleAdd: added setEditMode(true) so "Save" button appears immediately
- handleRemove: added storeWidgets(remaining) to persist deletions
- clearLayout: added storeWidgets(remaining) to persist clear all

## Testing
1. Add a widget → "Save" button appears immediately ✅
2. Save → refresh → widget persists ✅
3. Edit → Clear All → refresh → empty ✅
4. Edit → delete last widget → refresh → empty ✅