### PR TITLE
Homepage widgets now persist state when adding, removing, and clearing

### DIFF
--- a/.changeset/three-yaks-write.md
+++ b/.changeset/three-yaks-write.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-home': patch
+---
+
+Persist Custom Homepage widget layout changes (add/remove/clear all) across page reloads

--- a/plugins/home/src/components/CustomHomepage/CustomHomepageButtons.tsx
+++ b/plugins/home/src/components/CustomHomepage/CustomHomepageButtons.tsx
@@ -110,18 +110,16 @@ export const CustomHomepageButtons = (props: CustomHomepageButtonsProps) => {
           >
             {t('customHomepageButtons.addWidget')}
           </Button>
-          {numWidgets > 0 && (
-            <Button
-              className={styles.contentHeaderBtn}
-              variant="contained"
-              color="primary"
-              onClick={() => changeEditMode(false)}
-              size="small"
-              startIcon={<SaveIcon />}
-            >
-              {t('customHomepageButtons.save')}
-            </Button>
-          )}
+          <Button
+            className={styles.contentHeaderBtn}
+            variant="contained"
+            color="primary"
+            onClick={() => changeEditMode(false)}
+            size="small"
+            startIcon={<SaveIcon />}
+          >
+            {t('customHomepageButtons.save')}
+          </Button>
         </>
       )}
     </>

--- a/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.test.tsx
+++ b/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.test.tsx
@@ -266,4 +266,111 @@ describe('CustomHomepageGrid', () => {
       ),
     ).toBeInTheDocument();
   });
+
+  it('should show save button immediately when adding first widget to empty layout', async () => {
+    const mockStorage = mockApis.storage();
+
+    await renderInTestApp(
+      <TestApiProvider apis={[[storageApiRef, mockStorage]]}>
+        <CustomHomepageGrid config={[]}>
+          <ComponentA />
+        </CustomHomepageGrid>
+      </TestApiProvider>,
+    );
+
+    const addWidgetButton = screen.getByRole('button', { name: 'Add widget' });
+    await userEvent.click(addWidgetButton);
+
+    const addButton = screen.getByText('A');
+    await userEvent.click(addButton);
+
+    const saveButton = await screen.findByRole('button', { name: 'Save' });
+    expect(saveButton).toBeVisible();
+
+    await userEvent.click(saveButton);
+
+    expect(
+      mockStorage.forBucket('home.customHomepage').snapshot('home'),
+    ).toEqual({
+      key: 'home',
+      presence: 'present',
+      value: expect.any(String),
+    });
+  });
+
+  it('should keep save button visible when removing last widget and persist empty layout', async () => {
+    const mockStorage = mockApis.storage();
+
+    await renderInTestApp(
+      <TestApiProvider apis={[[storageApiRef, mockStorage]]}>
+        <CustomHomepageGrid config={defaultConfig.slice(0, 1)}>
+          <ComponentA />
+        </CustomHomepageGrid>
+      </TestApiProvider>,
+    );
+
+    expect(screen.getByText('A')).toBeInTheDocument();
+
+    const editButton = screen.getByRole('button', { name: 'Edit' });
+    await userEvent.click(editButton);
+
+    const deleteButton = screen.getByRole('button', { name: 'Delete widget' });
+    await userEvent.click(deleteButton);
+
+    const saveButton = await screen.findByRole('button', { name: 'Save' });
+    expect(saveButton).toBeVisible();
+
+    await userEvent.click(saveButton);
+
+    expect(screen.queryByText('A')).not.toBeInTheDocument();
+
+    expect(
+      mockStorage.forBucket('home.customHomepage').snapshot('home'),
+    ).toEqual({
+      key: 'home',
+      presence: 'present',
+      value: expect.stringMatching(/"default":\[\]/),
+    });
+  });
+
+  it('should keep save button visible when clearing all widgets and persist empty layout', async () => {
+    const mockStorage = mockApis.storage();
+
+    await renderInTestApp(
+      <TestApiProvider apis={[[storageApiRef, mockStorage]]}>
+        <CustomHomepageGrid config={defaultConfig}>
+          <ComponentA />
+          <ComponentB />
+          <ComponentC />
+        </CustomHomepageGrid>
+      </TestApiProvider>,
+    );
+
+    expect(screen.getByText('A')).toBeInTheDocument();
+    expect(screen.getByText('B')).toBeInTheDocument();
+    expect(screen.getByText('C')).toBeInTheDocument();
+
+    const editButton = screen.getByRole('button', { name: 'Edit' });
+    await userEvent.click(editButton);
+
+    const clearAllButton = screen.getByRole('button', { name: 'Clear all' });
+    await userEvent.click(clearAllButton);
+
+    const saveButton = await screen.findByRole('button', { name: 'Save' });
+    expect(saveButton).toBeVisible();
+
+    await userEvent.click(saveButton);
+
+    expect(screen.queryByText('A')).not.toBeInTheDocument();
+    expect(screen.queryByText('B')).not.toBeInTheDocument();
+    expect(screen.queryByText('C')).not.toBeInTheDocument();
+
+    expect(
+      mockStorage.forBucket('home.customHomepage').snapshot('home'),
+    ).toEqual({
+      key: 'home',
+      presence: 'present',
+      value: expect.stringMatching(/"default":\[\]/),
+    });
+  });
 });

--- a/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.tsx
+++ b/plugins/home/src/components/CustomHomepage/CustomHomepageGrid.tsx
@@ -271,15 +271,18 @@ export const CustomHomepageGrid = (props: CustomHomepageGridProps) => {
         layout: {
           i: widgetId,
           x: 0,
-          y: Math.max(...widgets.map(w => w.layout.y + w.layout.h)) + 1,
+          y:
+            widgets.length > 0
+              ? Math.max(...widgets.map(w => w.layout.y + w.layout.h)) + 1
+              : 0,
           w: Math.min(widget.maxWidth ?? Number.MAX_VALUE, widget.width ?? 12),
           h: Math.min(widget.maxHeight ?? Number.MAX_VALUE, widget.height ?? 4),
           minW: widget.minWidth,
           maxW: widget.maxWidth,
           minH: widget.minHeight,
           maxH: widget.maxHeight,
-          isResizable: editMode,
-          isDraggable: editMode,
+          isResizable: widget.resizable !== false,
+          isDraggable: widget.movable !== false,
         },
         settings: {},
         movable: widget.movable,
@@ -287,11 +290,12 @@ export const CustomHomepageGrid = (props: CustomHomepageGridProps) => {
         resizable: widget.resizable,
       },
     ]);
+    setEditMode(true);
     setAddWidgetDialogOpen(false);
   };
 
   const handleRemove = (widgetId: string) => {
-    setWidgets(widgets.filter(w => w.id !== widgetId));
+    setWidgets(prevWidgets => prevWidgets.filter(w => w.id !== widgetId));
   };
 
   const handleSettingsSave = (
@@ -308,7 +312,7 @@ export const CustomHomepageGrid = (props: CustomHomepageGridProps) => {
   };
 
   const clearLayout = () => {
-    setWidgets(widgets.filter(w => w.deletable === false));
+    setWidgets(prevWidgets => prevWidgets.filter(w => w.deletable === false));
   };
 
   const changeEditMode = (mode: boolean) => {


### PR DESCRIPTION
## Summary

Fixes the homepage widget persistence issues where:
- Adding the first widget showed "Edit" instead of "Save" button
- Deleting the last widget or clicking "Clear All" did not persist the empty state
- Cancel button could not revert deletions properly

## Changes

- `CustomHomepageGrid.tsx`: Set `editMode=true` immediately after adding a widget so the Save button appears. Used functional state updates in `handleRemove` and `clearLayout` to avoid stale closure bugs.
- `CustomHomepageButtons.tsx`: Always show Save button in edit mode so empty widget list can be persisted.

## Testing

1. Add a widget → Save button appears immediately 
2. Save → refresh → widget persists 
3. Edit → Clear All → Save button still visible 
4. Edit → Clear All → Save → refresh → empty 
5. Edit → Clear All → Cancel → refresh → widget still there 

## Links

Fixes #34704