### PR TITLE
fix(plugin-api-docs): migrate deprecated config.schema to configSchema

### DIFF
--- a/.changeset/short-beers-flash.md
+++ b/.changeset/short-beers-flash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-api-docs': patch
+---
+
+Migrate plugin-api-docs to the configSchema API to remove the deprecated config.schema usage.

--- a/plugins/api-docs/package.json
+++ b/plugins/api-docs/package.json
@@ -72,7 +72,7 @@
     "graphql": "^16.0.0",
     "graphql-ws": "^5.4.1",
     "swagger-ui-react": "^5.27.1",
-    "zod": "^4.4.3"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",

--- a/plugins/api-docs/package.json
+++ b/plugins/api-docs/package.json
@@ -71,7 +71,8 @@
     "graphiql": "^3.9.0",
     "graphql": "^16.0.0",
     "graphql-ws": "^5.4.1",
-    "swagger-ui-react": "^5.27.1"
+    "swagger-ui-react": "^5.27.1",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",

--- a/plugins/api-docs/src/alpha.tsx
+++ b/plugins/api-docs/src/alpha.tsx
@@ -21,6 +21,7 @@ import {
   PageBlueprint,
   createFrontendPlugin,
 } from '@backstage/frontend-plugin-api';
+import { z } from 'zod/v4';
 
 import {
   ApiEntity,
@@ -56,12 +57,9 @@ const apiDocsConfigApi = ApiBlueprint.make({
 });
 
 const apiDocsExplorerPage = PageBlueprint.makeWithOverrides({
-  config: {
-    schema: {
-      // Omitting columns and actions for now as their types are too complex to map to zod
-      initiallySelectedFilter: z =>
-        z.enum(['owned', 'starred', 'all']).optional(),
-    },
+  configSchema: {
+    // Omitting columns and actions for now as their types are too complex to map to zod
+    initiallySelectedFilter: z.enum(['owned', 'starred', 'all']).optional(),
   },
   factory(originalFactory, { config }) {
     return originalFactory({

--- a/yarn.lock
+++ b/yarn.lock
@@ -3656,6 +3656,7 @@ __metadata:
     react-dom: "npm:^18.0.2"
     react-router-dom: "npm:^6.30.2"
     swagger-ui-react: "npm:^5.27.1"
+    zod: "npm:^4.4.3"
   peerDependencies:
     "@types/react": ^17.0.0 || ^18.0.0
     react: ^17.0.0 || ^18.0.0
@@ -48384,10 +48385,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.25 || ^4.0, zod@npm:^3.25.76 || ^4.0.0, zod@npm:^4.0.0, zod@npm:^4.1.11":
-  version: 4.3.6
-  resolution: "zod@npm:4.3.6"
-  checksum: 10/25fc0f62e01b557b4644bf0b393bbaf47542ab30877c37837ea8caf314a8713d220c7d7fe51f68ffa72f0e1018ddfa34d96f1973d23033f5a2a5a9b6b9d9da01
+"zod@npm:^3.25 || ^4.0, zod@npm:^3.25.76 || ^4.0.0, zod@npm:^4.0.0, zod@npm:^4.1.11, zod@npm:^4.4.3":
+  version: 4.4.3
+  resolution: "zod@npm:4.4.3"
+  checksum: 10/804b9a42aa8f35f2b3c5a8dff906291cb749115f83ee2afe3576d70b5b5c53c965365c7f4967690647a9c54af9838ff232a85ff9577a0a36c44b68bc6cdefe36
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3656,7 +3656,7 @@ __metadata:
     react-dom: "npm:^18.0.2"
     react-router-dom: "npm:^6.30.2"
     swagger-ui-react: "npm:^5.27.1"
-    zod: "npm:^4.4.3"
+    zod: "npm:^4.0.0"
   peerDependencies:
     "@types/react": ^17.0.0 || ^18.0.0
     react: ^17.0.0 || ^18.0.0
@@ -48385,10 +48385,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.25 || ^4.0, zod@npm:^3.25.76 || ^4.0.0, zod@npm:^4.0.0, zod@npm:^4.1.11, zod@npm:^4.4.3":
-  version: 4.4.3
-  resolution: "zod@npm:4.4.3"
-  checksum: 10/804b9a42aa8f35f2b3c5a8dff906291cb749115f83ee2afe3576d70b5b5c53c965365c7f4967690647a9c54af9838ff232a85ff9577a0a36c44b68bc6cdefe36
+"zod@npm:^3.25 || ^4.0, zod@npm:^3.25.76 || ^4.0.0, zod@npm:^4.0.0, zod@npm:^4.1.11":
+  version: 4.3.6
+  resolution: "zod@npm:4.3.6"
+  checksum: 10/25fc0f62e01b557b4644bf0b393bbaf47542ab30877c37837ea8caf314a8713d220c7d7fe51f68ffa72f0e1018ddfa34d96f1973d23033f5a2a5a9b6b9d9da01
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

This PR migrates `@backstage/plugin-api-docs` from the deprecated `config.schema` API to the new `configSchema` API using Zod v4.

### Changes made

* Replaced the deprecated `config.schema` definition with `configSchema`.
* Updated the configuration schema to use `zod/v4`.
* Added the required `zod` dependency to `plugins/api-docs` following existing repository conventions.
* Added a patch changeset for `@backstage/plugin-api-docs`.
* Preserved the existing runtime behavior while removing the deprecation warning emitted during plugin initialization.

Closes #34731.

#### :heavy_check_mark: Checklist

* [x] A changeset describing the change and affected packages.
* [ ] Added or updated documentation.
* [ ] Tests for new functionality and regression tests for bug fixes.
* [ ] Screenshots attached (for UI changes).
* [x] All my commits have a `Signed-off-by` line in the message.