### PR TITLE
docs: fix incorrect 'its' to 'it's'

### DIFF
--- a/docs/features/software-templates/input-examples.md
+++ b/docs/features/software-templates/input-examples.md
@@ -218,7 +218,7 @@ parameters:
 
 ## Markdown text blocks
 
-Its possible to render markdown text blocks in the form. This is useful to add some help text or instructions for the user.
+It's possible to render markdown text blocks in the form. This is useful to add some help text or instructions for the user.
 
 ```yaml
 parameters:
@@ -237,7 +237,7 @@ parameters:
 
 ## Use parameters as condition in steps
 
-Its possible to conditionally run steps based on the value of a parameter. In the example below, we trigger the steps depending on the value of the `environment` parameter.
+It's possible to conditionally run steps based on the value of a parameter. In the example below, we trigger the steps depending on the value of the `environment` parameter.
 
 ```yaml
 - name: Only development environments
@@ -374,7 +374,7 @@ Testing of this functionality is not yet supported using _create/edit_. In addit
 
 :::
 
-Its possible to use placeholders to reference remote files. This is useful when you have some standard parameters or actions that you want to reuse across multiple templates.
+It's possible to use placeholders to reference remote files. This is useful when you have some standard parameters or actions that you want to reuse across multiple templates.
 
 ### template.yaml
 

--- a/docs/golden-path/adoption/007-plugin-ownership.md
+++ b/docs/golden-path/adoption/007-plugin-ownership.md
@@ -17,7 +17,7 @@ Inner sourcing is a genuinely rewarding initiative, but it works best when some
 groundwork is already in place. Jumping into it too early can create unnecessary
 friction for both the contributing teams and the team that owns Backstage.
 
-Before inviting contributions, its a good idea to have the following in place:
+Before inviting contributions, it's a good idea to have the following in place:
 
 - **A consistent starting point for new plugins.** Running `yarn new` out of the
   box will scaffold a working Backstage plugin, which is a great starting point.


### PR DESCRIPTION
Corrects the possessive `its` to the contraction `it's` (it is) where the grammar requires it:

- `docs/golden-path/adoption/007-plugin-ownership.md`: `its a good idea` -> `it's a good idea`
- `docs/features/software-templates/input-examples.md`: `Its possible to` -> `It's possible to` (3 occurrences)

Genuine grammar fixes, no wording or meaning changes.