### PR TITLE
fix(sidebar) replacing hardcoded color with theme-palette

### DIFF
--- a/.changeset/sidebar-selected-item-background.md
+++ b/.changeset/sidebar-selected-item-background.md
@@ -3,4 +3,4 @@
 '@backstage/core-components': patch
 ---
 
-Added `selectedBackground` and `selectedColor` options to the `navigation.submenu` palette, allowing adopters to customize the background and text color of selected sidebar submenu items. Previously these colors were hardcoded and could not be changed through theme configuration.
+Added `selectedBackground` and `selectedColor` options to the navigation palette, allowing adopters to customize the background and text color of selected sidebar nested menu items. Previously these colors were hardcoded and could not be changed through theme configuration.

--- a/.changeset/sidebar-selected-item-background.md
+++ b/.changeset/sidebar-selected-item-background.md
@@ -3,4 +3,4 @@
 '@backstage/core-components': patch
 ---
 
-Added `selectedBackground` and `selectedColor` options to the navigation nested menu palette, allowing adopters to customize the background and text color of selected sidebar nested menu items. Previously these colors were hardcoded and could not be changed through theme configuration.
+Added `selectedBackground` and `selectedColor` options to the `navigation.submenu` palette, allowing adopters to customize the background and text color of selected sidebar submenu items. Previously these colors were hardcoded and could not be changed through theme configuration.

--- a/.changeset/sidebar-selected-item-background.md
+++ b/.changeset/sidebar-selected-item-background.md
@@ -1,0 +1,6 @@
+---
+'@backstage/theme': patch
+'@backstage/core-components': patch
+---
+
+Added `selectedBackground` and `selectedColor` options to the navigation nested menu palette, allowing adopters to customize the background and text color of selected sidebar nested menu items. Previously these colors were hardcoded and could not be changed through theme configuration.

--- a/.changeset/sidebar-submenu-selected-background.md
+++ b/.changeset/sidebar-submenu-selected-background.md
@@ -1,6 +1,0 @@
----
-'@backstage/theme': patch
-'@backstage/core-components': patch
----
-
-Added a `selectedItemBackground` option to the navigation submenu palette, allowing adopters to customize the background color of selected sidebar submenu items. Previously this color was hardcoded and could not be changed through theme configuration.

--- a/.changeset/sidebar-submenu-selected-background.md
+++ b/.changeset/sidebar-submenu-selected-background.md
@@ -1,0 +1,6 @@
+---
+'@backstage/theme': patch
+'@backstage/core-components': patch
+---
+
+Added a `selectedItemBackground` option to the navigation palette, allowing adopters to customize the background color of selected sidebar menu items. Previously this color was hardcoded and could not be changed through theme configuration.

--- a/.changeset/sidebar-submenu-selected-background.md
+++ b/.changeset/sidebar-submenu-selected-background.md
@@ -3,4 +3,4 @@
 '@backstage/core-components': patch
 ---
 
-Added a `selectedItemBackground` option to the navigation palette, allowing adopters to customize the background color of selected sidebar menu items. Previously this color was hardcoded and could not be changed through theme configuration.
+Added a `selectedItemBackground` option to the navigation submenu palette, allowing adopters to customize the background color of selected sidebar submenu items. Previously this color was hardcoded and could not be changed through theme configuration.

--- a/packages/core-components/src/layout/Sidebar/Bar.test.tsx
+++ b/packages/core-components/src/layout/Sidebar/Bar.test.tsx
@@ -15,6 +15,11 @@
  */
 
 import { renderInTestApp } from '@backstage/test-utils';
+import {
+  createUnifiedTheme,
+  palettes,
+  UnifiedThemeProvider,
+} from '@backstage/theme';
 import AcUnitIcon from '@material-ui/icons/AcUnit';
 import CreateComponentIcon from '@material-ui/icons/AddCircleOutline';
 import BuildRoundedIcon from '@material-ui/icons/BuildRounded';
@@ -132,6 +137,111 @@ describe('Sidebar', () => {
         'href',
         'https://backstage.io/',
       );
+    });
+  });
+});
+
+describe('Submenu selected item theming', () => {
+  it('applies custom palette overrides for selected submenu item background and text color', async () => {
+    const customTheme = createUnifiedTheme({
+      palette: {
+        ...palettes.light,
+        navigation: {
+          ...palettes.light.navigation,
+          submenu: {
+            ...palettes.light.navigation.submenu,
+            selectedBackground: '#123456',
+            selectedColor: '#abcdef',
+          },
+        },
+      },
+    });
+
+    await renderInTestApp(
+      <UnifiedThemeProvider theme={customTheme}>
+        <SidebarPinStateProvider
+          value={{
+            isPinned: false,
+            isMobile: false,
+            toggleSidebarPinState: () => {},
+          }}
+        >
+          <Sidebar disableExpandOnHover>
+            <SidebarItem icon={MenuBookIcon} onClick={() => {}} text="Catalog">
+              <SidebarSubmenu title="Catalog">
+                <SidebarSubmenuItem
+                  title="Tools"
+                  to="/"
+                  icon={BuildRoundedIcon}
+                />
+              </SidebarSubmenu>
+            </SidebarItem>
+          </Sidebar>
+        </SidebarPinStateProvider>
+      </UnifiedThemeProvider>,
+      { routeEntries: ['/'] },
+    );
+
+    await userEvent.hover(screen.getByTestId('item-with-submenu'));
+    const toolsItem = await screen.findByText('Tools');
+    const selectedElement = toolsItem.closest(
+      '[class*="selected"]',
+    ) as HTMLElement;
+
+    expect(selectedElement).toBeInTheDocument();
+    expect(selectedElement).toHaveStyle({
+      background: '#123456',
+      color: '#abcdef',
+    });
+  });
+
+  it('falls back to default colors when no palette overrides are provided', async () => {
+    const defaultTheme = createUnifiedTheme({
+      palette: {
+        ...palettes.light,
+        navigation: {
+          ...palettes.light.navigation,
+          submenu: {
+            background: '#404040',
+          },
+        },
+      },
+    });
+
+    await renderInTestApp(
+      <UnifiedThemeProvider theme={defaultTheme}>
+        <SidebarPinStateProvider
+          value={{
+            isPinned: false,
+            isMobile: false,
+            toggleSidebarPinState: () => {},
+          }}
+        >
+          <Sidebar disableExpandOnHover>
+            <SidebarItem icon={MenuBookIcon} onClick={() => {}} text="Catalog">
+              <SidebarSubmenu title="Catalog">
+                <SidebarSubmenuItem
+                  title="Tools"
+                  to="/"
+                  icon={BuildRoundedIcon}
+                />
+              </SidebarSubmenu>
+            </SidebarItem>
+          </Sidebar>
+        </SidebarPinStateProvider>
+      </UnifiedThemeProvider>,
+      { routeEntries: ['/'] },
+    );
+
+    await userEvent.hover(screen.getByTestId('item-with-submenu'));
+    const toolsItem = await screen.findByText('Tools');
+    const selectedElement = toolsItem.closest(
+      '[class*="selected"]',
+    ) as HTMLElement;
+
+    expect(selectedElement).toBeInTheDocument();
+    expect(selectedElement).toHaveStyle({
+      background: '#6f6f6f',
     });
   });
 });

--- a/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
@@ -65,8 +65,10 @@ const useStyles = makeStyles(
     },
     selected: {
       background:
-        theme.palette.navigation.submenu?.selectedItemBackground ?? '#6f6f6f',
-      color: theme.palette.common.white,
+        theme.palette.navigation.submenu?.selectedBackground ?? '#6f6f6f',
+      color:
+        theme.palette.navigation.submenu?.selectedColor ??
+        theme.palette.common.white,
     },
     label: {
       margin: theme.spacing(1.75),

--- a/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
+++ b/packages/core-components/src/layout/Sidebar/SidebarSubmenuItem.tsx
@@ -64,7 +64,8 @@ const useStyles = makeStyles(
       width: '100%',
     },
     selected: {
-      background: '#6f6f6f',
+      background:
+        theme.palette.navigation.submenu?.selectedItemBackground ?? '#6f6f6f',
       color: theme.palette.common.white,
     },
     label: {

--- a/packages/theme/report.api.md
+++ b/packages/theme/report.api.md
@@ -55,6 +55,7 @@ export type BackstagePaletteAdditions = {
     };
     submenu?: {
       background: string;
+      selectedItemBackground?: string;
     };
   };
   tabbar: {
@@ -305,6 +306,7 @@ export const palettes: {
       };
       submenu: {
         background: string;
+        selectedItemBackground: string;
       };
     };
     pinSidebarButton: {
@@ -379,6 +381,7 @@ export const palettes: {
       };
       submenu: {
         background: string;
+        selectedItemBackground: string;
       };
     };
     pinSidebarButton: {

--- a/packages/theme/report.api.md
+++ b/packages/theme/report.api.md
@@ -55,7 +55,8 @@ export type BackstagePaletteAdditions = {
     };
     submenu?: {
       background: string;
-      selectedItemBackground?: string;
+      selectedBackground?: string;
+      selectedColor?: string;
     };
   };
   tabbar: {
@@ -306,7 +307,8 @@ export const palettes: {
       };
       submenu: {
         background: string;
-        selectedItemBackground: string;
+        selectedBackground: string;
+        selectedColor: string;
       };
     };
     pinSidebarButton: {
@@ -381,7 +383,8 @@ export const palettes: {
       };
       submenu: {
         background: string;
-        selectedItemBackground: string;
+        selectedBackground: string;
+        selectedColor: string;
       };
     };
     pinSidebarButton: {

--- a/packages/theme/src/base/palettes.ts
+++ b/packages/theme/src/base/palettes.ts
@@ -80,6 +80,7 @@ export const palettes = {
       },
       submenu: {
         background: '#404040',
+        selectedItemBackground: '#6f6f6f',
       },
     },
     pinSidebarButton: {
@@ -154,6 +155,7 @@ export const palettes = {
       },
       submenu: {
         background: '#404040',
+        selectedItemBackground: '#6f6f6f',
       },
     },
     pinSidebarButton: {

--- a/packages/theme/src/base/palettes.ts
+++ b/packages/theme/src/base/palettes.ts
@@ -80,7 +80,8 @@ export const palettes = {
       },
       submenu: {
         background: '#404040',
-        selectedItemBackground: '#6f6f6f',
+        selectedBackground: '#6f6f6f',
+        selectedColor: '#FFFFFF',
       },
     },
     pinSidebarButton: {
@@ -155,7 +156,8 @@ export const palettes = {
       },
       submenu: {
         background: '#404040',
-        selectedItemBackground: '#6f6f6f',
+        selectedBackground: '#6f6f6f',
+        selectedColor: '#FFFFFF',
       },
     },
     pinSidebarButton: {

--- a/packages/theme/src/base/types.ts
+++ b/packages/theme/src/base/types.ts
@@ -52,7 +52,8 @@ export type BackstagePaletteAdditions = {
     };
     submenu?: {
       background: string;
-      selectedItemBackground?: string;
+      selectedBackground?: string;
+      selectedColor?: string;
     };
   };
   tabbar: {

--- a/packages/theme/src/base/types.ts
+++ b/packages/theme/src/base/types.ts
@@ -52,6 +52,7 @@ export type BackstagePaletteAdditions = {
     };
     submenu?: {
       background: string;
+      selectedItemBackground?: string;
     };
   };
   tabbar: {


### PR DESCRIPTION
## Description

Hey, I just made a Pull Request!

Fixes: #34740

### Summary

Replaces hardcoded colors used for the `SidebarSubmenuItem` selected state with configurable theme palette tokens under `navigation.submenu`, allowing adopters to customize the appearance through their theme configuration.

### New Palette Tokens

| Token | Description | Default |
| ------ | ----------- | ------- |
| `navigation.submenu.selectedBackground` | Background color of the selected submenu item | `#6f6f6f` |
| `navigation.submenu.selectedColor` | Text color of the selected submenu item | `#FFFFFF` |

### Changes

| File / Area | Change |
| ------------ | ------ |
| `BackstagePaletteAdditions` | Added optional `selectedBackground` and `selectedColor` properties under `navigation.submenu` |
| Built-in themes | Added default values for both light and dark palettes |
| `SidebarSubmenuItem` | Replaced hardcoded selected-state colors with palette tokens, falling back to the previous hardcoded values when tokens are not provided |

### Why?

This change makes the selected submenu styling fully themeable while maintaining backward compatibility through fallback values.

---

### ✅ Checklist

- [x] A changeset describing the change and affected packages. (more info)
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a Signed-off-by line in the message. (more info)