### PR TITLE
fix(create-app): pin @types/node in seed lockfile to fix e2e tsc:full

### DIFF
--- a/.changeset/sqjl-cszr-taic.md
+++ b/.changeset/sqjl-cszr-taic.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Pinned `@types/node` to `22.20.0` in the seed lockfile to prevent yarn from resolving the `*` wildcard (from `@jest/environment-jsdom-abstract`) to `@types/node@26.0.0`, which breaks `tsc:full` due to incompatible `EventEmitter` types in `tarn`.

--- a/packages/create-app/seed-yarn.lock
+++ b/packages/create-app/seed-yarn.lock
@@ -80,3 +80,12 @@ fast-xml-builder@*:
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.5.5.tgz#b7089ca4410374c75150baf277353ef76db69f96"
   integrity sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==
+
+// @types/node@26.0.0 uses a new packaging format (node-bin-setup) whose
+// EventEmitter types break tarn's Pool.d.ts with skipLibCheck disabled.
+// Pin to the latest 22.x (the current "latest" dist-tag) until tarn ships
+// compatible types.
+"@types/node@*":
+  version "22.20.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.20.0.tgz#431f5007396bc1a1a47b9c7df60f3e5e0b5b7304"
+  integrity sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`@jest/environment-jsdom-abstract` depends on `@types/node: *`, which yarn 4 resolves to the highest semver version — `@types/node@26.0.0` since its release on June 19. That version's `EventEmitter` types break `tarn`'s `Pool.d.ts` when `skipLibCheck` is disabled, which is exactly what the template's `tsc:full` script does. This has been causing all E2E Linux CI runs to fail since ~June 27.

This pins `@types/node@*` to `22.20.0` (the current `latest` dist-tag) in the seed lockfile, preventing the wildcard from jumping to the incompatible 26.x major version.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))