### PR TITLE
Fix Table not filling container width in Firefox with ResizableTableContainer

### DIFF
--- a/.changeset/fix-table-resizable-overflow.md
+++ b/.changeset/fix-table-resizable-overflow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed Table not filling container width in Firefox when using `TableRoot` directly inside `ResizableTableContainer`. Changed `overflow: hidden` to `overflow: auto` on the resizable container so it handles scrolling for direct `TableRoot` usages, complementing the scroll container wrapper added in #34539 for the high-level `Table` component.

--- a/.changeset/fix-table-resizable-overflow.md
+++ b/.changeset/fix-table-resizable-overflow.md
@@ -2,4 +2,4 @@
 '@backstage/ui': patch
 ---
 
-Fixed Table not filling container width in Firefox when using `TableRoot` directly inside `ResizableTableContainer`. Changed `overflow: hidden` to `overflow: auto` on the resizable container so it handles scrolling for direct `TableRoot` usages, complementing the scroll container wrapper added in #34539 for the high-level `Table` component.
+Fixed Table not filling container width in Firefox when using `TableRoot` directly inside `ResizableTableContainer`. Changed `overflow: hidden` to `overflow: auto` on the resizable container so it handles scrolling for direct `TableRoot` usages.

--- a/packages/ui/src/components/Table/Table.module.css
+++ b/packages/ui/src/components/Table/Table.module.css
@@ -27,7 +27,7 @@
     flex-direction: column;
     flex: 1;
     min-height: 0;
-    overflow: hidden;
+    overflow: auto;
   }
 
   .bui-TableScrollContainer {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Follow-up to #34539. That PR fixed the Firefox `<table>` shrink-wrap bug for the high-level `Table` component by moving `overflow` to a scroll container `<div>`. However, when `TableRoot` is used directly inside `ResizableTableContainer` (without the high-level `Table` wrapper), there is no scroll container div.

The resizable container's `overflow: hidden` clips content, but Firefox still creates an anonymous wrapper box around the `<table>`, causing it to shrink-wrap to content width instead of filling the container.

This PR changes `overflow: hidden` to `overflow: auto` on `.bui-TableResizableContainer`, which moves the overflow handling to a block-level `<div>` — avoiding Firefox's anonymous wrapper behavior.

### Changes

- `packages/ui/src/components/Table/Table.module.css`: `overflow: hidden` → `overflow: auto` on `.bui-TableResizableContainer`

### Tested

- Firefox 152.0 (aarch64) — table fills container width correctly
- Chrome — no regression

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.