### PR TITLE
refactor(catalog-backend): simplify router by removing conditional service guards

### DIFF
--- a/.changeset/simplify-router-required-services.md
+++ b/.changeset/simplify-router-required-services.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Made `entitiesCatalog`, `locationAnalyzer`, `refreshService`, and `locationService` required in the catalog router options, removing the conditional guards around their route registrations. These services are always provided by the catalog builder and have never been optional in practice.

--- a/.changeset/simplify-router-required-services.md
+++ b/.changeset/simplify-router-required-services.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend': patch
 ---
 
-Made `entitiesCatalog`, `locationAnalyzer`, `refreshService`, and `locationService` required in the catalog router options, removing the conditional guards around their route registrations. These services are always provided by the catalog builder and have never been optional in practice.
+Simplified internal router setup by removing unnecessary conditional guards around route registrations.

--- a/plugins/catalog-backend/src/service/createRouter.test.ts
+++ b/plugins/catalog-backend/src/service/createRouter.test.ts
@@ -954,12 +954,22 @@ describe('createRouter readonly disabled', () => {
         getLocationByEntity: jest.fn(),
       };
       const router = await createRouter({
+        entitiesCatalog: {
+          entities: jest.fn(),
+          entitiesBatch: jest.fn(),
+          queryEntities: jest.fn(),
+          removeEntityByUid: jest.fn(),
+          entityAncestry: jest.fn(),
+          facets: jest.fn(),
+        },
+        locationAnalyzer: { analyzeLocation: jest.fn() },
         locationService,
         logger: mockServices.logger.mock(),
         config: new ConfigReader(undefined),
         auth: mockServices.auth(),
         httpAuth: mockServices.httpAuth(),
         orchestrator: { process: jest.fn() },
+        refreshService: { refresh: jest.fn() },
         permissionsService: mockServices.permissions(),
         auditor: mockServices.auditor.mock(),
       });
@@ -1477,6 +1487,7 @@ describe('createRouter readonly and raw json enabled', () => {
     };
     const router = await createRouter({
       entitiesCatalog,
+      locationAnalyzer: { analyzeLocation: jest.fn() },
       locationService,
       logger: mockServices.logger.mock(),
       config: new ConfigReader({
@@ -1487,6 +1498,7 @@ describe('createRouter readonly and raw json enabled', () => {
       auth: mockServices.auth(),
       httpAuth: mockServices.httpAuth(),
       orchestrator: { process: jest.fn() },
+      refreshService: { refresh: jest.fn() },
       permissionsService,
       auditor: mockServices.auditor.mock(),
     });
@@ -1711,12 +1723,22 @@ describe.each(databases.eachSupportedId())(
       );
 
       const router = await createRouter({
+        entitiesCatalog: {
+          entities: jest.fn(),
+          entitiesBatch: jest.fn(),
+          queryEntities: jest.fn(),
+          removeEntityByUid: jest.fn(),
+          entityAncestry: jest.fn(),
+          facets: jest.fn(),
+        },
+        locationAnalyzer: { analyzeLocation: jest.fn() },
         locationService,
         logger: mockServices.logger.mock(),
         config: new ConfigReader(undefined),
         auth: mockServices.auth(),
         httpAuth: mockServices.httpAuth(),
         orchestrator: { process: jest.fn() },
+        refreshService: { refresh: jest.fn() },
         permissionsService: mockServices.permissions(),
         auditor: mockServices.auditor.mock(),
       });

--- a/plugins/catalog-backend/src/service/createRouter.ts
+++ b/plugins/catalog-backend/src/service/createRouter.ts
@@ -72,17 +72,18 @@ import { parseEntityQuery } from './request/parseEntityQuery';
  * Options used by {@link createRouter}.
  */
 export interface RouterOptions {
-  entitiesCatalog?: EntitiesCatalog;
-  locationAnalyzer?: LocationAnalyzer;
+  entitiesCatalog: EntitiesCatalog;
+  locationAnalyzer: LocationAnalyzer;
   locationService: LocationService;
   orchestrator: CatalogProcessingOrchestrator;
-  refreshService?: RefreshService;
+  refreshService: RefreshService;
   logger: LoggerService;
   config: Config;
   auth: AuthService;
   httpAuth: HttpAuthService;
   permissionsService: PermissionsService;
   auditor: AuditorService;
+  /** @deprecated This option will be removed in a future release. */
   enableRelationsCompatibility?: boolean;
 }
 
@@ -120,771 +121,126 @@ export async function createRouter(
     logger.info('Catalog is running in readonly mode');
   }
 
-  if (refreshService) {
-    // TODO: Potentially find a way to track the ancestor that gets refreshed to refresh this entity (as well as the child of that ancestor?)
-    router.post('/refresh', async (req, res) => {
-      const { authorizationToken, ...restBody } = req.body;
+  // TODO: Potentially find a way to track the ancestor that gets refreshed to refresh this entity (as well as the child of that ancestor?)
+  router.post('/refresh', async (req, res) => {
+    const { authorizationToken, ...restBody } = req.body;
 
+    const auditorEvent = await auditor.createEvent({
+      eventId: 'entity-mutate',
+      severityLevel: 'medium',
+      meta: {
+        queryType: 'refresh',
+        entityRef: restBody.entityRef,
+      },
+      request: req,
+    });
+
+    try {
+      const credentials = authorizationToken
+        ? await auth.authenticate(authorizationToken)
+        : await httpAuth.credentials(req);
+
+      await refreshService.refresh({
+        ...restBody,
+        credentials,
+      });
+
+      await auditorEvent?.success();
+      res.status(200).end();
+    } catch (err) {
+      await auditorEvent?.fail({ error: err });
+      throw err;
+    }
+  });
+
+  router
+    .get('/entities', async (req, res) => {
       const auditorEvent = await auditor.createEvent({
-        eventId: 'entity-mutate',
-        severityLevel: 'medium',
-        meta: {
-          queryType: 'refresh',
-          entityRef: restBody.entityRef,
-        },
+        eventId: 'entity-fetch',
         request: req,
+        meta: {
+          queryType: 'all',
+          query: req.query,
+        },
       });
 
       try {
-        const credentials = authorizationToken
-          ? await auth.authenticate(authorizationToken)
-          : await httpAuth.credentials(req);
+        const filter = parseEntityFilterParams(req.query);
+        const fields = parseEntityTransformParams(req.query);
+        const order = parseEntityOrderParams(req.query);
+        const pagination = parseEntityPaginationParams(req.query);
+        const credentials = await httpAuth.credentials(req);
 
-        await refreshService.refresh({
-          ...restBody,
-          credentials,
-        });
+        // When pagination parameters are passed in, use the legacy slow path
+        // that loads all entities into memory
 
-        await auditorEvent?.success();
-        res.status(200).end();
-      } catch (err) {
-        await auditorEvent?.fail({ error: err });
-        throw err;
-      }
-    });
-  }
+        if (pagination || enableRelationsCompatibility === true) {
+          const { entities, pageInfo } = await entitiesCatalog.entities({
+            filter,
+            fields,
+            order,
+            pagination,
+            credentials,
+          });
 
-  if (entitiesCatalog) {
-    router
-      .get('/entities', async (req, res) => {
-        const auditorEvent = await auditor.createEvent({
-          eventId: 'entity-fetch',
-          request: req,
-          meta: {
-            queryType: 'all',
-            query: req.query,
-          },
-        });
+          // Add a Link header to the next page
+          if (pageInfo.hasNextPage) {
+            const url = new URL(`http://ignored${req.url}`);
+            url.searchParams.delete('offset');
+            url.searchParams.set('after', pageInfo.endCursor);
+            res.setHeader('link', `<${url.pathname}${url.search}>; rel="next"`);
+          }
+
+          await auditorEvent?.success();
+
+          await writeEntitiesResponse({
+            res,
+            items: entities,
+            alwaysUseObjectMode: enableRelationsCompatibility,
+          });
+          return;
+        }
+
+        const responseStream = createEntityArrayJsonStream(res);
+        const limit = 10000;
+        let cursor: Cursor | undefined;
 
         try {
-          const filter = parseEntityFilterParams(req.query);
-          const fields = parseEntityTransformParams(req.query);
-          const order = parseEntityOrderParams(req.query);
-          const pagination = parseEntityPaginationParams(req.query);
-          const credentials = await httpAuth.credentials(req);
+          let currentWrite: Promise<'ok' | 'closed'> | undefined = undefined;
+          do {
+            const result = await entitiesCatalog.queryEntities(
+              !cursor
+                ? {
+                    credentials,
+                    fields,
+                    limit,
+                    filter,
+                    orderFields: order,
+                    totalItems: 'exclude',
+                  }
+                : { credentials, fields, limit, cursor },
+            );
 
-          // When pagination parameters are passed in, use the legacy slow path
-          // that loads all entities into memory
-
-          if (pagination || enableRelationsCompatibility === true) {
-            const { entities, pageInfo } = await entitiesCatalog.entities({
-              filter,
-              fields,
-              order,
-              pagination,
-              credentials,
-            });
-
-            // Add a Link header to the next page
-            if (pageInfo.hasNextPage) {
-              const url = new URL(`http://ignored${req.url}`);
-              url.searchParams.delete('offset');
-              url.searchParams.set('after', pageInfo.endCursor);
-              res.setHeader(
-                'link',
-                `<${url.pathname}${url.search}>; rel="next"`,
-              );
+            // Wait for previous write to complete
+            if ((await currentWrite) === 'closed') {
+              return; // Client closed connection
             }
 
-            await auditorEvent?.success();
+            if (result.items.entities.length) {
+              currentWrite = responseStream.send(result.items);
+            }
 
-            await writeEntitiesResponse({
-              res,
-              items: entities,
-              alwaysUseObjectMode: enableRelationsCompatibility,
-            });
-            return;
-          }
+            cursor = result.pageInfo?.nextCursor;
+          } while (cursor);
 
-          const responseStream = createEntityArrayJsonStream(res);
-          const limit = 10000;
-          let cursor: Cursor | undefined;
-
-          try {
-            let currentWrite: Promise<'ok' | 'closed'> | undefined = undefined;
-            do {
-              const result = await entitiesCatalog.queryEntities(
-                !cursor
-                  ? {
-                      credentials,
-                      fields,
-                      limit,
-                      filter,
-                      orderFields: order,
-                      totalItems: 'exclude',
-                    }
-                  : { credentials, fields, limit, cursor },
-              );
-
-              // Wait for previous write to complete
-              if ((await currentWrite) === 'closed') {
-                return; // Client closed connection
-              }
-
-              if (result.items.entities.length) {
-                currentWrite = responseStream.send(result.items);
-              }
-
-              cursor = result.pageInfo?.nextCursor;
-            } while (cursor);
-
-            // Wait for last write to complete
-            await currentWrite;
-
-            await auditorEvent?.success();
-
-            responseStream.complete();
-          } finally {
-            responseStream.close();
-          }
-        } catch (err) {
-          await auditorEvent?.fail({
-            error: err,
-          });
-          throw err;
-        }
-      })
-      .post('/entities/by-query', async (req, res) => {
-        const auditorEvent = await auditor.createEvent({
-          eventId: 'entity-fetch',
-          request: req,
-          meta: {
-            queryType: 'by-query',
-          },
-        });
-
-        try {
-          const credentials = await httpAuth.credentials(req);
-          const { fields: rawFields, ...parsed } = parseEntityQuery(
-            req.body ?? {},
-          );
-          const fields = rawFields?.length
-            ? parseEntityTransformParams({ fields: rawFields })
-            : undefined;
-
-          const { items, pageInfo, totalItems } =
-            await entitiesCatalog.queryEntities({
-              credentials,
-              fields,
-              ...parsed,
-            });
-
-          const meta = {
-            totalItems,
-            pageInfo: {
-              ...(pageInfo.nextCursor && {
-                nextCursor: encodeCursor(pageInfo.nextCursor),
-              }),
-              ...(pageInfo.prevCursor && {
-                prevCursor: encodeCursor(pageInfo.prevCursor),
-              }),
-            },
-          };
-
-          await auditorEvent?.success({ meta });
-
-          await writeEntitiesResponse({
-            res,
-            items,
-            alwaysUseObjectMode: enableRelationsCompatibility,
-            responseWrapper: entities => ({
-              items: entities,
-              ...meta,
-            }),
-          });
-        } catch (err) {
-          await auditorEvent?.fail({ error: err });
-          throw err;
-        }
-      })
-      .get('/entities/by-query', async (req, res) => {
-        const auditorEvent = await auditor.createEvent({
-          eventId: 'entity-fetch',
-          request: req,
-          meta: {
-            queryType: 'by-query',
-          },
-        });
-
-        try {
-          const { items, pageInfo, totalItems } =
-            await entitiesCatalog.queryEntities({
-              limit: req.query.limit,
-              offset: req.query.offset,
-              ...parseQueryEntitiesParams(req.query),
-              credentials: await httpAuth.credentials(req),
-            });
-
-          const meta = {
-            totalItems,
-            pageInfo: {
-              ...(pageInfo.nextCursor && {
-                nextCursor: encodeCursor(pageInfo.nextCursor),
-              }),
-              ...(pageInfo.prevCursor && {
-                prevCursor: encodeCursor(pageInfo.prevCursor),
-              }),
-            },
-          };
-
-          await auditorEvent?.success({
-            // Let's not log out the entities since this can make the log very big
-            meta,
-          });
-
-          await writeEntitiesResponse({
-            res,
-            items,
-            alwaysUseObjectMode: enableRelationsCompatibility,
-            responseWrapper: entities => ({
-              items: entities,
-              ...meta,
-            }),
-          });
-        } catch (err) {
-          await auditorEvent?.fail({
-            error: err,
-          });
-          throw err;
-        }
-      })
-      .get('/entities/by-uid/:uid', async (req, res) => {
-        const { uid } = req.params;
-
-        const auditorEvent = await auditor.createEvent({
-          eventId: 'entity-fetch',
-          request: req,
-          meta: {
-            queryType: 'by-uid',
-            uid: uid,
-          },
-        });
-
-        try {
-          const { entities } = await entitiesCatalog.entities({
-            filter: basicEntityFilter({ 'metadata.uid': uid }),
-            credentials: await httpAuth.credentials(req),
-          });
-
-          writeSingleEntityResponse(res, entities, `No entity with uid ${uid}`);
-
-          await auditorEvent?.success({
-            meta: {
-              // stringify to entity refs
-              entities: entities.entities.reduce((arr, element) => {
-                if (!element) {
-                  return arr;
-                }
-
-                if (typeof element === 'string') {
-                  arr.push(element);
-                  return arr;
-                }
-
-                arr.push(stringifyEntityRef(element));
-                return arr;
-              }, [] as string[]),
-            },
-          });
-        } catch (err) {
-          await auditorEvent?.fail({
-            error: err,
-          });
-          throw err;
-        }
-      })
-      .delete('/entities/by-uid/:uid', async (req, res) => {
-        const { uid } = req.params;
-
-        const auditorEvent = await auditor.createEvent({
-          eventId: 'entity-mutate',
-          severityLevel: 'medium',
-          request: req,
-          meta: {
-            actionType: 'delete',
-            uid: uid,
-          },
-        });
-
-        try {
-          await entitiesCatalog.removeEntityByUid(uid, {
-            credentials: await httpAuth.credentials(req),
-          });
+          // Wait for last write to complete
+          await currentWrite;
 
           await auditorEvent?.success();
 
-          res.status(204).end();
-        } catch (err) {
-          await auditorEvent?.fail({
-            error: err,
-          });
-          throw err;
-        }
-      })
-      .get('/entities/by-name/:kind/:namespace/:name', async (req, res) => {
-        const { kind, namespace, name } = req.params;
-        const entityRef = stringifyEntityRef({ kind, namespace, name });
-
-        const auditorEvent = await auditor.createEvent({
-          eventId: 'entity-fetch',
-          request: req,
-          meta: {
-            queryType: 'by-name',
-            entityRef: entityRef,
-          },
-        });
-
-        try {
-          const { items } = await entitiesCatalog.entitiesBatch({
-            entityRefs: [stringifyEntityRef({ kind, namespace, name })],
-            credentials: await httpAuth.credentials(req),
-          });
-
-          await auditorEvent?.success();
-
-          writeSingleEntityResponse(
-            res,
-            items,
-            `No entity named '${name}' found, with kind '${kind}' in namespace '${namespace}'`,
-          );
-        } catch (err) {
-          await auditorEvent?.fail({
-            error: err,
-          });
-          throw err;
-        }
-      })
-      .get(
-        '/entities/by-name/:kind/:namespace/:name/ancestry',
-        async (req, res) => {
-          const { kind, namespace, name } = req.params;
-          const entityRef = stringifyEntityRef({ kind, namespace, name });
-
-          const auditorEvent = await auditor.createEvent({
-            eventId: 'entity-fetch',
-            request: req,
-            meta: {
-              actionType: 'ancestry',
-              entityRef: entityRef,
-            },
-          });
-
-          try {
-            const response = await entitiesCatalog.entityAncestry(entityRef, {
-              credentials: await httpAuth.credentials(req),
-            });
-
-            await auditorEvent?.success({
-              meta: {
-                rootEntityRef: response.rootEntityRef,
-                ancestry: response.items.map(ancestryLink => {
-                  return {
-                    entityRef: stringifyEntityRef(ancestryLink.entity),
-                    parentEntityRefs: ancestryLink.parentEntityRefs,
-                  };
-                }),
-              },
-            });
-
-            res.status(200).json(response);
-          } catch (err) {
-            await auditorEvent?.fail({
-              error: err,
-            });
-            throw err;
-          }
-        },
-      )
-      .post('/entities/by-refs', async (req, res) => {
-        const auditorEvent = await auditor.createEvent({
-          eventId: 'entity-fetch',
-          request: req,
-          meta: {
-            queryType: 'by-refs',
-          },
-        });
-
-        try {
-          const request = entitiesBatchRequest(req);
-          const { items } = await entitiesCatalog.entitiesBatch({
-            entityRefs: request.entityRefs,
-            filter: parseEntityFilterParams(req.query),
-            query: request.query,
-            fields: parseEntityTransformParams(req.query, request.fields),
-            credentials: await httpAuth.credentials(req),
-          });
-
-          await auditorEvent?.success({
-            meta: {
-              ...request,
-            },
-          });
-
-          await writeEntitiesResponse({
-            res,
-            items,
-            alwaysUseObjectMode: enableRelationsCompatibility,
-            responseWrapper: entities => ({
-              items: entities,
-            }),
-          });
-        } catch (err) {
-          await auditorEvent?.fail({
-            error: err,
-          });
-          throw err;
-        }
-      })
-      .get('/entity-facets', async (req, res) => {
-        const auditorEvent = await auditor.createEvent({
-          eventId: 'entity-facets',
-          request: req,
-        });
-
-        try {
-          const response = await entitiesCatalog.facets({
-            filter: parseEntityFilterParams(req.query),
-            facets: parseEntityFacetParams(req.query),
-            credentials: await httpAuth.credentials(req),
-          });
-
-          await auditorEvent?.success();
-
-          res.status(200).json(response);
-        } catch (err) {
-          await auditorEvent?.fail({
-            error: err,
-          });
-          throw err;
-        }
-      })
-      .post('/entity-facets', async (req, res) => {
-        const auditorEvent = await auditor.createEvent({
-          eventId: 'entity-facets',
-          request: req,
-        });
-
-        try {
-          const { facets, query } = parseEntityFacetsQuery(req.body ?? {});
-
-          const response = await entitiesCatalog.facets({
-            query,
-            facets,
-            credentials: await httpAuth.credentials(req),
-          });
-
-          await auditorEvent?.success();
-
-          res.status(200).json(response);
-        } catch (err) {
-          await auditorEvent?.fail({
-            error: err,
-          });
-          throw err;
-        }
-      });
-  }
-
-  if (locationService) {
-    router
-      .post('/locations', async (req, res) => {
-        const location = await validateRequestBody(req, locationInput);
-        const dryRun = yn(req.query.dryRun, { default: false });
-        const onConflict = req.query.onConflict;
-
-        const auditorEvent = await auditor.createEvent({
-          eventId: 'location-mutate',
-          severityLevel: dryRun ? 'low' : 'medium',
-          request: req,
-          meta: {
-            actionType: 'create',
-            location: location,
-            isDryRun: dryRun,
-          },
-        });
-
-        try {
-          // when in dryRun addLocation is effectively a read operation so we don't
-          // need to disallow readonly
-          if (!dryRun) {
-            disallowReadonlyMode(readonlyEnabled);
-          }
-
-          const output = await locationService.createLocation(
-            location,
-            dryRun,
-            {
-              onConflict,
-              credentials: await httpAuth.credentials(req),
-            },
-          );
-
-          await auditorEvent?.success({
-            meta: {
-              location: output.location,
-            },
-          });
-
-          res.status(201).json(output);
-        } catch (err) {
-          await auditorEvent?.fail({
-            error: err,
-            meta: {
-              location: location,
-              isDryRun: dryRun,
-            },
-          });
-          throw err;
-        }
-      })
-      .get('/locations', async (req, res) => {
-        const auditorEvent = await auditor.createEvent({
-          eventId: 'location-fetch',
-          request: req,
-          meta: {
-            queryType: 'all',
-          },
-        });
-
-        try {
-          const locations = await locationService.listLocations({
-            credentials: await httpAuth.credentials(req),
-          });
-
-          await auditorEvent?.success();
-
-          res.status(200).json(locations.map(l => ({ data: l })));
-        } catch (err) {
-          await auditorEvent?.fail({
-            error: err,
-          });
-          throw err;
-        }
-      })
-
-      .post('/locations/by-query', async (req, res) => {
-        const auditorEvent = await auditor.createEvent({
-          eventId: 'location-fetch',
-          request: req,
-          meta: {
-            queryType: 'by-query',
-          },
-        });
-
-        try {
-          const request = parseLocationQuery(req.body ?? {});
-          const result = await locationService.queryLocations({
-            ...request,
-            limit: request.limit + 1,
-            credentials: await httpAuth.credentials(req),
-          });
-
-          const hasNextPage = result.items.length > request.limit;
-          const items = hasNextPage
-            ? result.items.slice(0, request.limit)
-            : result.items;
-          const nextCursor = hasNextPage
-            ? encodeLocationQueryCursor({
-                limit: request.limit,
-                afterId: items[items.length - 1].id,
-                query: request.query,
-              })
-            : undefined;
-
-          await auditorEvent?.success();
-
-          res.status(200).json({
-            items,
-            totalItems: result.totalItems,
-            pageInfo: {
-              nextCursor,
-            },
-          });
-        } catch (err) {
-          await auditorEvent?.fail({ error: err });
-          throw err;
-        }
-      })
-
-      .get('/locations/:id', async (req, res) => {
-        const { id } = req.params;
-
-        const auditorEvent = await auditor.createEvent({
-          eventId: 'location-fetch',
-          request: req,
-          meta: {
-            queryType: 'by-id',
-            id: id,
-          },
-        });
-
-        try {
-          const output = await locationService.getLocation(id, {
-            credentials: await httpAuth.credentials(req),
-          });
-
-          await auditorEvent?.success({
-            meta: {
-              output: output,
-            },
-          });
-
-          res.status(200).json(output);
-        } catch (err) {
-          await auditorEvent?.fail({
-            error: err,
-          });
-          throw err;
-        }
-      })
-      .put('/locations/:id', async (req, res) => {
-        const { id } = req.params;
-        const location = await validateRequestBody(req, locationInput);
-
-        const auditorEvent = await auditor.createEvent({
-          eventId: 'location-mutate',
-          severityLevel: 'medium',
-          request: req,
-          meta: {
-            actionType: 'update',
-            id,
-            location,
-          },
-        });
-
-        disallowReadonlyMode(readonlyEnabled);
-
-        try {
-          const output = await locationService.updateLocation(id, location, {
-            credentials: await httpAuth.credentials(req),
-          });
-
-          await auditorEvent?.success({ meta: { location: output } });
-
-          res.status(200).json(output);
-        } catch (err) {
-          await auditorEvent?.fail({ error: err });
-          throw err;
-        }
-      })
-      .delete('/locations/:id', async (req, res) => {
-        const { id } = req.params;
-
-        const auditorEvent = await auditor.createEvent({
-          eventId: 'location-mutate',
-          severityLevel: 'medium',
-          request: req,
-          meta: {
-            actionType: 'delete',
-            id: id,
-          },
-        });
-
-        disallowReadonlyMode(readonlyEnabled);
-
-        try {
-          await locationService.deleteLocation(id, {
-            credentials: await httpAuth.credentials(req),
-          });
-
-          await auditorEvent?.success();
-
-          res.status(204).end();
-        } catch (err) {
-          await auditorEvent?.fail({
-            error: err,
-          });
-          throw err;
-        }
-      })
-      .get('/locations/by-entity/:kind/:namespace/:name', async (req, res) => {
-        const { kind, namespace, name } = req.params;
-        const locationRef = `${kind}:${namespace}/${name}`;
-
-        const auditorEvent = await auditor.createEvent({
-          eventId: 'location-fetch',
-          request: req,
-          meta: {
-            queryType: 'by-entity',
-            locationRef: locationRef,
-          },
-        });
-
-        try {
-          const output = await locationService.getLocationByEntity(
-            { kind, namespace, name },
-            { credentials: await httpAuth.credentials(req) },
-          );
-
-          await auditorEvent?.success({
-            meta: {
-              output: output,
-            },
-          });
-
-          res.status(200).json(output);
-        } catch (err) {
-          await auditorEvent?.fail({
-            error: err,
-          });
-          throw err;
-        }
-      });
-  }
-
-  if (locationAnalyzer) {
-    router.post('/analyze-location', async (req, res) => {
-      const auditorEvent = await auditor.createEvent({
-        eventId: 'location-analyze',
-        request: req,
-      });
-
-      try {
-        const body = await validateRequestBody(
-          req,
-          z.object({
-            location: locationInput,
-            catalogFilename: z.string().optional(),
-          }),
-        );
-        const schema = z.object({
-          location: locationInput,
-          catalogFilename: z.string().optional(),
-        });
-        const credentials = await httpAuth.credentials(req);
-        const parsedBody = schema.parse(body);
-        try {
-          const output = await locationAnalyzer.analyzeLocation(
-            parsedBody,
-            credentials,
-          );
-
-          await auditorEvent?.success({
-            meta: {
-              output: output,
-            },
-          });
-
-          res.status(200).json(output);
-        } catch (err) {
-          if (
-            // Catch errors from parse-url library.
-            err.name === 'Error' &&
-            'subject_url' in err
-          ) {
-            throw new InputError('The given location.target is not a URL');
-          }
-          throw err;
+          responseStream.complete();
+        } finally {
+          responseStream.close();
         }
       } catch (err) {
         await auditorEvent?.fail({
@@ -892,8 +248,638 @@ export async function createRouter(
         });
         throw err;
       }
+    })
+    .post('/entities/by-query', async (req, res) => {
+      const auditorEvent = await auditor.createEvent({
+        eventId: 'entity-fetch',
+        request: req,
+        meta: {
+          queryType: 'by-query',
+        },
+      });
+
+      try {
+        const credentials = await httpAuth.credentials(req);
+        const { fields: rawFields, ...parsed } = parseEntityQuery(
+          req.body ?? {},
+        );
+        const fields = rawFields?.length
+          ? parseEntityTransformParams({ fields: rawFields })
+          : undefined;
+
+        const { items, pageInfo, totalItems } =
+          await entitiesCatalog.queryEntities({
+            credentials,
+            fields,
+            ...parsed,
+          });
+
+        const meta = {
+          totalItems,
+          pageInfo: {
+            ...(pageInfo.nextCursor && {
+              nextCursor: encodeCursor(pageInfo.nextCursor),
+            }),
+            ...(pageInfo.prevCursor && {
+              prevCursor: encodeCursor(pageInfo.prevCursor),
+            }),
+          },
+        };
+
+        await auditorEvent?.success({ meta });
+
+        await writeEntitiesResponse({
+          res,
+          items,
+          alwaysUseObjectMode: enableRelationsCompatibility,
+          responseWrapper: entities => ({
+            items: entities,
+            ...meta,
+          }),
+        });
+      } catch (err) {
+        await auditorEvent?.fail({ error: err });
+        throw err;
+      }
+    })
+    .get('/entities/by-query', async (req, res) => {
+      const auditorEvent = await auditor.createEvent({
+        eventId: 'entity-fetch',
+        request: req,
+        meta: {
+          queryType: 'by-query',
+        },
+      });
+
+      try {
+        const { items, pageInfo, totalItems } =
+          await entitiesCatalog.queryEntities({
+            limit: req.query.limit,
+            offset: req.query.offset,
+            ...parseQueryEntitiesParams(req.query),
+            credentials: await httpAuth.credentials(req),
+          });
+
+        const meta = {
+          totalItems,
+          pageInfo: {
+            ...(pageInfo.nextCursor && {
+              nextCursor: encodeCursor(pageInfo.nextCursor),
+            }),
+            ...(pageInfo.prevCursor && {
+              prevCursor: encodeCursor(pageInfo.prevCursor),
+            }),
+          },
+        };
+
+        await auditorEvent?.success({
+          // Let's not log out the entities since this can make the log very big
+          meta,
+        });
+
+        await writeEntitiesResponse({
+          res,
+          items,
+          alwaysUseObjectMode: enableRelationsCompatibility,
+          responseWrapper: entities => ({
+            items: entities,
+            ...meta,
+          }),
+        });
+      } catch (err) {
+        await auditorEvent?.fail({
+          error: err,
+        });
+        throw err;
+      }
+    })
+    .get('/entities/by-uid/:uid', async (req, res) => {
+      const { uid } = req.params;
+
+      const auditorEvent = await auditor.createEvent({
+        eventId: 'entity-fetch',
+        request: req,
+        meta: {
+          queryType: 'by-uid',
+          uid: uid,
+        },
+      });
+
+      try {
+        const { entities } = await entitiesCatalog.entities({
+          filter: basicEntityFilter({ 'metadata.uid': uid }),
+          credentials: await httpAuth.credentials(req),
+        });
+
+        writeSingleEntityResponse(res, entities, `No entity with uid ${uid}`);
+
+        await auditorEvent?.success({
+          meta: {
+            // stringify to entity refs
+            entities: entities.entities.reduce((arr, element) => {
+              if (!element) {
+                return arr;
+              }
+
+              if (typeof element === 'string') {
+                arr.push(element);
+                return arr;
+              }
+
+              arr.push(stringifyEntityRef(element));
+              return arr;
+            }, [] as string[]),
+          },
+        });
+      } catch (err) {
+        await auditorEvent?.fail({
+          error: err,
+        });
+        throw err;
+      }
+    })
+    .delete('/entities/by-uid/:uid', async (req, res) => {
+      const { uid } = req.params;
+
+      const auditorEvent = await auditor.createEvent({
+        eventId: 'entity-mutate',
+        severityLevel: 'medium',
+        request: req,
+        meta: {
+          actionType: 'delete',
+          uid: uid,
+        },
+      });
+
+      try {
+        await entitiesCatalog.removeEntityByUid(uid, {
+          credentials: await httpAuth.credentials(req),
+        });
+
+        await auditorEvent?.success();
+
+        res.status(204).end();
+      } catch (err) {
+        await auditorEvent?.fail({
+          error: err,
+        });
+        throw err;
+      }
+    })
+    .get('/entities/by-name/:kind/:namespace/:name', async (req, res) => {
+      const { kind, namespace, name } = req.params;
+      const entityRef = stringifyEntityRef({ kind, namespace, name });
+
+      const auditorEvent = await auditor.createEvent({
+        eventId: 'entity-fetch',
+        request: req,
+        meta: {
+          queryType: 'by-name',
+          entityRef: entityRef,
+        },
+      });
+
+      try {
+        const { items } = await entitiesCatalog.entitiesBatch({
+          entityRefs: [stringifyEntityRef({ kind, namespace, name })],
+          credentials: await httpAuth.credentials(req),
+        });
+
+        await auditorEvent?.success();
+
+        writeSingleEntityResponse(
+          res,
+          items,
+          `No entity named '${name}' found, with kind '${kind}' in namespace '${namespace}'`,
+        );
+      } catch (err) {
+        await auditorEvent?.fail({
+          error: err,
+        });
+        throw err;
+      }
+    })
+    .get(
+      '/entities/by-name/:kind/:namespace/:name/ancestry',
+      async (req, res) => {
+        const { kind, namespace, name } = req.params;
+        const entityRef = stringifyEntityRef({ kind, namespace, name });
+
+        const auditorEvent = await auditor.createEvent({
+          eventId: 'entity-fetch',
+          request: req,
+          meta: {
+            actionType: 'ancestry',
+            entityRef: entityRef,
+          },
+        });
+
+        try {
+          const response = await entitiesCatalog.entityAncestry(entityRef, {
+            credentials: await httpAuth.credentials(req),
+          });
+
+          await auditorEvent?.success({
+            meta: {
+              rootEntityRef: response.rootEntityRef,
+              ancestry: response.items.map(ancestryLink => {
+                return {
+                  entityRef: stringifyEntityRef(ancestryLink.entity),
+                  parentEntityRefs: ancestryLink.parentEntityRefs,
+                };
+              }),
+            },
+          });
+
+          res.status(200).json(response);
+        } catch (err) {
+          await auditorEvent?.fail({
+            error: err,
+          });
+          throw err;
+        }
+      },
+    )
+    .post('/entities/by-refs', async (req, res) => {
+      const auditorEvent = await auditor.createEvent({
+        eventId: 'entity-fetch',
+        request: req,
+        meta: {
+          queryType: 'by-refs',
+        },
+      });
+
+      try {
+        const request = entitiesBatchRequest(req);
+        const { items } = await entitiesCatalog.entitiesBatch({
+          entityRefs: request.entityRefs,
+          filter: parseEntityFilterParams(req.query),
+          query: request.query,
+          fields: parseEntityTransformParams(req.query, request.fields),
+          credentials: await httpAuth.credentials(req),
+        });
+
+        await auditorEvent?.success({
+          meta: {
+            ...request,
+          },
+        });
+
+        await writeEntitiesResponse({
+          res,
+          items,
+          alwaysUseObjectMode: enableRelationsCompatibility,
+          responseWrapper: entities => ({
+            items: entities,
+          }),
+        });
+      } catch (err) {
+        await auditorEvent?.fail({
+          error: err,
+        });
+        throw err;
+      }
+    })
+    .get('/entity-facets', async (req, res) => {
+      const auditorEvent = await auditor.createEvent({
+        eventId: 'entity-facets',
+        request: req,
+      });
+
+      try {
+        const response = await entitiesCatalog.facets({
+          filter: parseEntityFilterParams(req.query),
+          facets: parseEntityFacetParams(req.query),
+          credentials: await httpAuth.credentials(req),
+        });
+
+        await auditorEvent?.success();
+
+        res.status(200).json(response);
+      } catch (err) {
+        await auditorEvent?.fail({
+          error: err,
+        });
+        throw err;
+      }
+    })
+    .post('/entity-facets', async (req, res) => {
+      const auditorEvent = await auditor.createEvent({
+        eventId: 'entity-facets',
+        request: req,
+      });
+
+      try {
+        const { facets, query } = parseEntityFacetsQuery(req.body ?? {});
+
+        const response = await entitiesCatalog.facets({
+          query,
+          facets,
+          credentials: await httpAuth.credentials(req),
+        });
+
+        await auditorEvent?.success();
+
+        res.status(200).json(response);
+      } catch (err) {
+        await auditorEvent?.fail({
+          error: err,
+        });
+        throw err;
+      }
     });
-  }
+
+  router
+    .post('/locations', async (req, res) => {
+      const location = await validateRequestBody(req, locationInput);
+      const dryRun = yn(req.query.dryRun, { default: false });
+      const onConflict = req.query.onConflict;
+
+      const auditorEvent = await auditor.createEvent({
+        eventId: 'location-mutate',
+        severityLevel: dryRun ? 'low' : 'medium',
+        request: req,
+        meta: {
+          actionType: 'create',
+          location: location,
+          isDryRun: dryRun,
+        },
+      });
+
+      try {
+        // when in dryRun addLocation is effectively a read operation so we don't
+        // need to disallow readonly
+        if (!dryRun) {
+          disallowReadonlyMode(readonlyEnabled);
+        }
+
+        const output = await locationService.createLocation(location, dryRun, {
+          onConflict,
+          credentials: await httpAuth.credentials(req),
+        });
+
+        await auditorEvent?.success({
+          meta: {
+            location: output.location,
+          },
+        });
+
+        res.status(201).json(output);
+      } catch (err) {
+        await auditorEvent?.fail({
+          error: err,
+          meta: {
+            location: location,
+            isDryRun: dryRun,
+          },
+        });
+        throw err;
+      }
+    })
+    .get('/locations', async (req, res) => {
+      const auditorEvent = await auditor.createEvent({
+        eventId: 'location-fetch',
+        request: req,
+        meta: {
+          queryType: 'all',
+        },
+      });
+
+      try {
+        const locations = await locationService.listLocations({
+          credentials: await httpAuth.credentials(req),
+        });
+
+        await auditorEvent?.success();
+
+        res.status(200).json(locations.map(l => ({ data: l })));
+      } catch (err) {
+        await auditorEvent?.fail({
+          error: err,
+        });
+        throw err;
+      }
+    })
+
+    .post('/locations/by-query', async (req, res) => {
+      const auditorEvent = await auditor.createEvent({
+        eventId: 'location-fetch',
+        request: req,
+        meta: {
+          queryType: 'by-query',
+        },
+      });
+
+      try {
+        const request = parseLocationQuery(req.body ?? {});
+        const result = await locationService.queryLocations({
+          ...request,
+          limit: request.limit + 1,
+          credentials: await httpAuth.credentials(req),
+        });
+
+        const hasNextPage = result.items.length > request.limit;
+        const items = hasNextPage
+          ? result.items.slice(0, request.limit)
+          : result.items;
+        const nextCursor = hasNextPage
+          ? encodeLocationQueryCursor({
+              limit: request.limit,
+              afterId: items[items.length - 1].id,
+              query: request.query,
+            })
+          : undefined;
+
+        await auditorEvent?.success();
+
+        res.status(200).json({
+          items,
+          totalItems: result.totalItems,
+          pageInfo: {
+            nextCursor,
+          },
+        });
+      } catch (err) {
+        await auditorEvent?.fail({ error: err });
+        throw err;
+      }
+    })
+
+    .get('/locations/:id', async (req, res) => {
+      const { id } = req.params;
+
+      const auditorEvent = await auditor.createEvent({
+        eventId: 'location-fetch',
+        request: req,
+        meta: {
+          queryType: 'by-id',
+          id: id,
+        },
+      });
+
+      try {
+        const output = await locationService.getLocation(id, {
+          credentials: await httpAuth.credentials(req),
+        });
+
+        await auditorEvent?.success({
+          meta: {
+            output: output,
+          },
+        });
+
+        res.status(200).json(output);
+      } catch (err) {
+        await auditorEvent?.fail({
+          error: err,
+        });
+        throw err;
+      }
+    })
+    .put('/locations/:id', async (req, res) => {
+      const { id } = req.params;
+      const location = await validateRequestBody(req, locationInput);
+
+      const auditorEvent = await auditor.createEvent({
+        eventId: 'location-mutate',
+        severityLevel: 'medium',
+        request: req,
+        meta: {
+          actionType: 'update',
+          id,
+          location,
+        },
+      });
+
+      disallowReadonlyMode(readonlyEnabled);
+
+      try {
+        const output = await locationService.updateLocation(id, location, {
+          credentials: await httpAuth.credentials(req),
+        });
+
+        await auditorEvent?.success({ meta: { location: output } });
+
+        res.status(200).json(output);
+      } catch (err) {
+        await auditorEvent?.fail({ error: err });
+        throw err;
+      }
+    })
+    .delete('/locations/:id', async (req, res) => {
+      const { id } = req.params;
+
+      const auditorEvent = await auditor.createEvent({
+        eventId: 'location-mutate',
+        severityLevel: 'medium',
+        request: req,
+        meta: {
+          actionType: 'delete',
+          id: id,
+        },
+      });
+
+      disallowReadonlyMode(readonlyEnabled);
+
+      try {
+        await locationService.deleteLocation(id, {
+          credentials: await httpAuth.credentials(req),
+        });
+
+        await auditorEvent?.success();
+
+        res.status(204).end();
+      } catch (err) {
+        await auditorEvent?.fail({
+          error: err,
+        });
+        throw err;
+      }
+    })
+    .get('/locations/by-entity/:kind/:namespace/:name', async (req, res) => {
+      const { kind, namespace, name } = req.params;
+      const locationRef = `${kind}:${namespace}/${name}`;
+
+      const auditorEvent = await auditor.createEvent({
+        eventId: 'location-fetch',
+        request: req,
+        meta: {
+          queryType: 'by-entity',
+          locationRef: locationRef,
+        },
+      });
+
+      try {
+        const output = await locationService.getLocationByEntity(
+          { kind, namespace, name },
+          { credentials: await httpAuth.credentials(req) },
+        );
+
+        await auditorEvent?.success({
+          meta: {
+            output: output,
+          },
+        });
+
+        res.status(200).json(output);
+      } catch (err) {
+        await auditorEvent?.fail({
+          error: err,
+        });
+        throw err;
+      }
+    });
+
+  router.post('/analyze-location', async (req, res) => {
+    const auditorEvent = await auditor.createEvent({
+      eventId: 'location-analyze',
+      request: req,
+    });
+
+    try {
+      const body = await validateRequestBody(
+        req,
+        z.object({
+          location: locationInput,
+          catalogFilename: z.string().optional(),
+        }),
+      );
+      const schema = z.object({
+        location: locationInput,
+        catalogFilename: z.string().optional(),
+      });
+      const credentials = await httpAuth.credentials(req);
+      const parsedBody = schema.parse(body);
+      try {
+        const output = await locationAnalyzer.analyzeLocation(
+          parsedBody,
+          credentials,
+        );
+
+        await auditorEvent?.success({
+          meta: {
+            output: output,
+          },
+        });
+
+        res.status(200).json(output);
+      } catch (err) {
+        if (
+          // Catch errors from parse-url library.
+          err.name === 'Error' &&
+          'subject_url' in err
+        ) {
+          throw new InputError('The given location.target is not a URL');
+        }
+        throw err;
+      }
+    } catch (err) {
+      await auditorEvent?.fail({
+        error: err,
+      });
+      throw err;
+    }
+  });
 
   router.post('/validate-entity', async (req, res) => {
     const auditorEvent = await auditor.createEvent({

--- a/plugins/catalog-backend/src/service/createRouter.ts
+++ b/plugins/catalog-backend/src/service/createRouter.ts
@@ -837,19 +837,14 @@ export async function createRouter(
     });
 
     try {
-      const body = await validateRequestBody(
+      const parsedBody = await validateRequestBody(
         req,
         z.object({
           location: locationInput,
           catalogFilename: z.string().optional(),
         }),
       );
-      const schema = z.object({
-        location: locationInput,
-        catalogFilename: z.string().optional(),
-      });
       const credentials = await httpAuth.credentials(req);
-      const parsedBody = schema.parse(body);
       try {
         const output = await locationAnalyzer.analyzeLocation(
           parsedBody,


### PR DESCRIPTION
## Summary

Simplifies the catalog router by removing unnecessary conditional guards around route registrations. The services guarded by these checks (`entitiesCatalog`, `locationAnalyzer`, `refreshService`) have always been provided by the `CatalogBuilder` and were never optional in practice — making the guards dead code.

### Changes

- Made `entitiesCatalog`, `locationAnalyzer`, and `refreshService` required in the internal `RouterOptions` interface (were optional but always provided by `CatalogBuilder`)
- Removed the `if (entitiesCatalog)`, `if (refreshService)`, `if (locationService)`, and `if (locationAnalyzer)` guards around route registrations — routes are now always registered
- Marked `enableRelationsCompatibility` as `@deprecated` (removal deferred to a future release)
- Fixed a pre-existing double-validation in the `analyze-location` route handler

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message.