### PR TITLE
fix(home): restore routeRef in analytics and register visited widgets

### DIFF
--- a/.changeset/true-ideas-rhyme.md
+++ b/.changeset/true-ideas-rhyme.md
@@ -1,0 +1,6 @@
+---
+'@backstage/frontend-app-api': patch
+'@backstage/plugin-home': patch
+---
+
+Restored the `routeRef` in the navigation analytics event context and registered the `HomePageRecentlyVisited` and `HomePageTopVisited` widgets in the new frontend system.

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -59,6 +59,9 @@ app:
     - entity-card:org/ownership:
         config:
           ownedKinds: ['Component', 'API', 'System']
+    # Enable visit tracking for HomePageRecentlyVisited and HomePageTopVisited widgets
+    - api:home/visits: true
+    - app-root-element:home/visit-listener: true
 
     # - apis.plugin.graphiql.browse.gitlab: true
     # - graphiql-endpoint:graphiql/gitlab: true

--- a/packages/frontend-app-api/src/routing/RouteTracker.test.tsx
+++ b/packages/frontend-app-api/src/routing/RouteTracker.test.tsx
@@ -27,6 +27,7 @@ import {
   AppNode,
   useAnalytics,
 } from '@backstage/frontend-plugin-api';
+import { OpaqueRouteRef } from '@internal/frontend';
 import { MATCH_ALL_ROUTE } from './extractRouteInfoFromAppNode';
 
 describe('RouteTracker', () => {
@@ -34,11 +35,15 @@ describe('RouteTracker', () => {
   const routeRef1 = createRouteRef();
   const routeRef2 = createRouteRef();
 
+  OpaqueRouteRef.toInternal(routeRef0).setId('route0');
+  OpaqueRouteRef.toInternal(routeRef1).setId('route1');
+  OpaqueRouteRef.toInternal(routeRef2).setId('route2');
+
   const routeObjects: BackstageRouteObject[] = [
     {
       path: '',
       element: <div>home page</div>,
-      routeRefs: new Set([routeRef0]),
+      routeRefs: new Set([createRouteRef(), routeRef0]),
       caseSensitive: false,
       children: [MATCH_ALL_ROUTE],
       appNode: {
@@ -102,6 +107,7 @@ describe('RouteTracker', () => {
       context: {
         extensionId: 'plugin1.page.index',
         pluginId: 'plugin1',
+        routeRef: 'route1',
       },
       subject: '/path/foo/bar',
       value: undefined,
@@ -133,6 +139,7 @@ describe('RouteTracker', () => {
       context: {
         extensionId: 'plugin2.page.index',
         pluginId: 'plugin2',
+        routeRef: 'route2',
       },
       subject: '/path2/hello',
       value: undefined,
@@ -157,6 +164,7 @@ describe('RouteTracker', () => {
       context: {
         extensionId: 'plugin1.page.index',
         pluginId: 'plugin1',
+        routeRef: 'route1',
       },
       subject: '/path/foo/bar?q=1#header-1',
       value: undefined,
@@ -178,6 +186,7 @@ describe('RouteTracker', () => {
       context: {
         extensionId: 'home.page.index',
         pluginId: 'home',
+        routeRef: 'route0',
       },
       subject: '/',
       value: undefined,
@@ -243,6 +252,7 @@ describe('RouteTracker', () => {
       context: {
         extensionId: 'plugin2.page.index',
         pluginId: 'plugin2',
+        routeRef: 'route2',
       },
       subject: '/path2/param-value/sub-route',
       value: undefined,

--- a/packages/frontend-app-api/src/routing/RouteTracker.tsx
+++ b/packages/frontend-app-api/src/routing/RouteTracker.tsx
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import { useEffect } from 'react';
 import { matchRoutes, useLocation } from 'react-router-dom';
 import {
@@ -21,6 +20,7 @@ import {
   AnalyticsContext,
   AnalyticsEventAttributes,
 } from '@backstage/frontend-plugin-api';
+import { OpaqueRouteRef } from '@internal/frontend';
 import { BackstageRouteObject } from './types';
 
 /**
@@ -34,7 +34,6 @@ const getExtensionContext = (
   try {
     // Find matching routes for the given path name.
     const matches = matchRoutes(routes, { pathname });
-
     // Of the matching routes, get the last (e.g. most specific) instance of
     // the BackstageRouteObject that contains a routeRef. Filtering by routeRef
     // ensures subRouteRefs are aligned to their parent routes' context.
@@ -42,18 +41,15 @@ const getExtensionContext = (
       ?.filter(match => match?.route.routeRefs?.size > 0)
       .pop();
     const routeObject = routeMatch?.route;
-
     // If there is no route object, then allow inheritance of default context.
     if (!routeObject) {
       return undefined;
     }
-
     // If the matched route is the root route (no path), and the pathname is
     // not the path of the homepage, then inherit from the default context.
     if (routeObject.path === '' && pathname !== '/') {
       return undefined;
     }
-
     const params = Object.entries(
       routeMatch?.params || {},
     ).reduce<AnalyticsEventAttributes>((acc, [key, value]) => {
@@ -62,14 +58,26 @@ const getExtensionContext = (
       }
       return acc;
     }, {});
-
     const plugin = routeObject.appNode?.spec.plugin;
     const extension = routeObject.appNode?.spec.extension;
+
+    // If there is a single route ref, use it.
+    let routeRef: string | undefined;
+    for (const ref of routeObject.routeRefs) {
+      if (ref && OpaqueRouteRef.isType(ref)) {
+        const description = OpaqueRouteRef.toInternal(ref).getDescription();
+        if (!description.startsWith('created at ')) {
+          routeRef = description;
+          break;
+        }
+      }
+    }
 
     return {
       params,
       pluginId: plugin?.id || 'root',
       extensionId: extension?.id || 'App',
+      ...(routeRef ? { routeRef } : {}),
     };
   } catch {
     return undefined;
@@ -96,7 +104,6 @@ const TrackNavigation = ({
       attributes,
     });
   }, [analytics, pathname, search, hash, attributes]);
-
   return null;
 };
 
@@ -110,12 +117,10 @@ export const RouteTracker = ({
   routeObjects: BackstageRouteObject[];
 }) => {
   const { pathname, search, hash } = useLocation();
-
   const { params, ...attributes } = getExtensionContext(
     pathname,
     routeObjects,
   ) || { params: {} };
-
   return (
     <AnalyticsContext attributes={attributes}>
       <TrackNavigation

--- a/plugins/home/report-alpha.api.md
+++ b/plugins/home/report-alpha.api.md
@@ -62,6 +62,15 @@ const _default: OverridableFrontendPlugin<
       inputs: {};
       params: HomePageWidgetBlueprintParams;
     }>;
+    'home-page-widget:home/recently-visited': OverridableExtensionDefinition<{
+      kind: 'home-page-widget';
+      name: 'recently-visited';
+      config: {};
+      configInput: {};
+      output: ExtensionDataRef<HomePageWidgetData, 'home.widget.data', {}>;
+      inputs: {};
+      params: HomePageWidgetBlueprintParams;
+    }>;
     'home-page-widget:home/starred-entities': OverridableExtensionDefinition<{
       kind: 'home-page-widget';
       name: 'starred-entities';
@@ -74,6 +83,15 @@ const _default: OverridableFrontendPlugin<
     'home-page-widget:home/toolkit': OverridableExtensionDefinition<{
       kind: 'home-page-widget';
       name: 'toolkit';
+      config: {};
+      configInput: {};
+      output: ExtensionDataRef<HomePageWidgetData, 'home.widget.data', {}>;
+      inputs: {};
+      params: HomePageWidgetBlueprintParams;
+    }>;
+    'home-page-widget:home/top-visited': OverridableExtensionDefinition<{
+      kind: 'home-page-widget';
+      name: 'top-visited';
       config: {};
       configInput: {};
       output: ExtensionDataRef<HomePageWidgetData, 'home.widget.data', {}>;

--- a/plugins/home/src/alpha.tsx
+++ b/plugins/home/src/alpha.tsx
@@ -191,6 +191,34 @@ const homePageRandomJokeWidget = HomePageWidgetBlueprint.make({
   },
 });
 
+const homePageRecentlyVisitedWidget = HomePageWidgetBlueprint.make({
+  name: 'recently-visited',
+  params: {
+    name: 'HomePageRecentlyVisited',
+    title: 'Recently Visited',
+    components: () =>
+      import('./homePageComponents/VisitedByType/RecentlyVisited').then(m => ({
+        Content: m.Content,
+        Actions: m.Actions,
+        ContextProvider: m.ContextProvider,
+      })),
+  },
+});
+
+const homePageTopVisitedWidget = HomePageWidgetBlueprint.make({
+  name: 'top-visited',
+  params: {
+    name: 'HomePageTopVisited',
+    title: 'Top Visited',
+    components: () =>
+      import('./homePageComponents/VisitedByType/TopVisited').then(m => ({
+        Content: m.Content,
+        Actions: m.Actions,
+        ContextProvider: m.ContextProvider,
+      })),
+  },
+});
+
 /**
  * Home plugin for the new frontend system.
  *
@@ -211,6 +239,8 @@ export default createFrontendPlugin({
     homePageToolkitWidget,
     homePageStarredEntitiesWidget,
     homePageRandomJokeWidget,
+    homePageRecentlyVisitedWidget,
+    homePageTopVisitedWidget,
   ],
   routes: {
     root: rootRouteRef,


### PR DESCRIPTION
This PR resolves an issue where the HomePageRecentlyVisited and HomePageTopVisited widgets failed to update in the new Backstage frontend system. The fix addresses two underlying problems: missing routing context in analytics events, and missing extension registrations.

Restored routing context: Updated RouteTracker in @backstage/frontend-app-api to extract the routeRef from the matched route and include it in the navigation analytics event context. This restores parity with the legacy system and ensures VisitListener receives the required data to record visits.

Updated tests: Modified RouteTracker.test.tsx to assert the presence of routeRef in the analytics context.

Registered widget extensions: Ported HomePageRecentlyVisited and HomePageTopVisited to the new frontend system by registering them as HomePageWidgetBlueprint extensions in the home plugin (plugins/home/src/alpha.tsx). Crucially, included the ContextProvider required by these widgets.

Enabled visit tracking: Updated the example app-config.yaml to enable the api:home/visits and app-root-element:home/visit-listener extensions, which are disabled by default.

<img width="1470" height="838" alt="Screenshot 2026-07-02 at 12 08 43 PM" src="https://github.com/user-attachments/assets/ac6fd635-41ab-4956-96b9-f05d29243238" />



closes #34757 