### PR TITLE
fix(signals-backend): correct HTTP error responses in WebSocket upgrade handler

### DIFF
--- a/.changeset/fix-signals-websocket-error-responses.md
+++ b/.changeset/fix-signals-websocket-error-responses.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-signals-backend': patch
 ---
 
-Fixed WebSocket upgrade error responses to use correct HTTP headers, preventing load balancers from reporting 502 errors when authentication fails. Error responses no longer include `Upgrade` and `Connection: Upgrade` headers (which are only valid for 101 responses), and use `socket.end()` instead of `socket.destroy()` to ensure the response is fully flushed before closing the connection.
+Fixed WebSocket upgrade error responses to prevent load balancers from returning 502 when authentication fails. Error responses now use valid HTTP headers, ensuring the actual error status (401 or 500) is delivered to the client instead of being masked.

--- a/.changeset/fix-signals-websocket-error-responses.md
+++ b/.changeset/fix-signals-websocket-error-responses.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-signals-backend': patch
+---
+
+Fixed WebSocket upgrade error responses to use correct HTTP headers, preventing load balancers from reporting 502 errors when authentication fails. Error responses no longer include `Upgrade` and `Connection: Upgrade` headers (which are only valid for 101 responses), and use `socket.end()` instead of `socket.destroy()` to ensure the response is fully flushed before closing the connection.

--- a/plugins/signals-backend/src/service/router.test.ts
+++ b/plugins/signals-backend/src/service/router.test.ts
@@ -95,20 +95,18 @@ describe('handleUpgrade', () => {
     );
     trigger.on('error', () => {});
     await new Promise<void>((resolve, reject) => {
-      const timeout = setTimeout(
-        () => reject(new Error('Timed out waiting for upgrade listener')),
-        5000,
-      );
-      const check = () => {
+      const start = Date.now();
+      const poll = setInterval(() => {
         if (server.listenerCount('upgrade') > 0) {
-          clearTimeout(timeout);
+          clearInterval(poll);
           trigger.destroy();
           resolve();
-        } else {
-          setTimeout(check, 10);
+        } else if (Date.now() - start > 5000) {
+          clearInterval(poll);
+          trigger.destroy();
+          reject(new Error('Timed out waiting for upgrade listener'));
         }
-      };
-      check();
+      }, 10);
     });
 
     return { server, port };
@@ -179,7 +177,7 @@ describe('handleUpgrade', () => {
       expect(result.headers.upgrade).toBeUndefined();
     } finally {
       server.closeAllConnections();
-      server.close();
+      await new Promise<void>(resolve => server.close(() => resolve()));
     }
   });
 
@@ -202,7 +200,7 @@ describe('handleUpgrade', () => {
       expect(result.headers.upgrade).toBeUndefined();
     } finally {
       server.closeAllConnections();
-      server.close();
+      await new Promise<void>(resolve => server.close(() => resolve()));
     }
   });
 });

--- a/plugins/signals-backend/src/service/router.test.ts
+++ b/plugins/signals-backend/src/service/router.test.ts
@@ -16,6 +16,7 @@
 
 import express from 'express';
 import http from 'node:http';
+import { PassThrough } from 'node:stream';
 import request from 'supertest';
 import { createRouter } from './router';
 import { mockErrorHandler, mockServices } from '@backstage/backend-test-utils';
@@ -59,9 +60,9 @@ describe('createRouter', () => {
 });
 
 describe('handleUpgrade', () => {
-  async function startServerWithAuth(
+  async function setupServer(
     authOverride?: Partial<AuthService>,
-  ): Promise<{ server: http.Server; port: number }> {
+  ): Promise<http.Server> {
     const auth = Object.assign(
       mockServices.auth(),
       authOverride,
@@ -81,124 +82,83 @@ describe('handleUpgrade', () => {
 
     const app = express().use(router);
     const server = http.createServer(app);
-
     await new Promise<void>(resolve => server.listen(0, resolve));
     const port = (server.address() as { port: number }).port;
 
-    // Trigger upgrade middleware registration via a normal HTTP request
-    // with the Upgrade header so the middleware subscribes to 'upgrade'.
-    // The middleware does not call next() after registering, so the
-    // request will hang — we just need it to reach the server.
-    const trigger = http.get(
-      { port, path: '/', headers: { Upgrade: 'websocket' } },
-      res => res.resume(),
+    // Register the upgrade handler by sending one request with the
+    // Upgrade header through express. Uses the 'newListener' event
+    // for deterministic, polling-free detection.
+    await new Promise<void>(resolve => {
+      server.on('newListener', event => {
+        if (event === 'upgrade') resolve();
+      });
+      const trigger = http.get(
+        { port, path: '/', headers: { Upgrade: 'websocket' } },
+        res => res.resume(),
+      );
+      trigger.on('error', () => {});
+    });
+
+    return server;
+  }
+
+  function emitUpgrade(server: http.Server, token: string): Promise<string> {
+    const socket = new PassThrough();
+    server.emit(
+      'upgrade',
+      { url: '/api/signals', headers: { 'sec-websocket-protocol': token } },
+      socket,
+      Buffer.alloc(0),
     );
-    trigger.on('error', () => {});
-    await new Promise<void>((resolve, reject) => {
-      const start = Date.now();
-      const poll = setInterval(() => {
-        if (server.listenerCount('upgrade') > 0) {
-          clearInterval(poll);
-          trigger.destroy();
-          resolve();
-        } else if (Date.now() - start > 5000) {
-          clearInterval(poll);
-          trigger.destroy();
-          reject(new Error('Timed out waiting for upgrade listener'));
-        }
-      }, 10);
-    });
-
-    return { server, port };
-  }
-
-  function sendUpgradeRequest(
-    port: number,
-    token = 'invalid-token',
-  ): Promise<{
-    statusCode: number;
-    statusMessage: string;
-    headers: http.IncomingHttpHeaders;
-  }> {
-    return new Promise((resolve, reject) => {
-      const req = http.request({
-        port,
-        path: '/api/signals',
-        headers: {
-          Connection: 'Upgrade',
-          Upgrade: 'websocket',
-          'Sec-WebSocket-Version': '13',
-          'Sec-WebSocket-Key': 'dGhlIHNhbXBsZSBub25jZQ==',
-          'Sec-WebSocket-Protocol': token,
-        },
-      });
-
-      req.on('upgrade', (_res, socket) => {
-        socket.end();
-        reject(new Error('Should not have received upgrade'));
-      });
-
-      req.on('response', res => {
-        res.resume();
-        res.on('end', () => {
-          resolve({
-            statusCode: res.statusCode!,
-            statusMessage: res.statusMessage!,
-            headers: res.headers,
-          });
-        });
-      });
-
-      req.on('error', reject);
-      req.end();
+    return new Promise(resolve => {
+      const chunks: Buffer[] = [];
+      socket.on('data', chunk => chunks.push(chunk));
+      socket.on('end', () => resolve(Buffer.concat(chunks).toString()));
     });
   }
 
-  let handleUpgradeSpy: jest.SpyInstance | undefined;
-
-  afterEach(() => {
-    handleUpgradeSpy?.mockRestore();
-  });
-
-  it('returns 401 without upgrade headers when auth fails', async () => {
-    const { server, port } = await startServerWithAuth({
+  it('writes 401 response without upgrade headers when auth fails', async () => {
+    const server = await setupServer({
       authenticate: async () => {
         throw new Error('Invalid token');
       },
     });
 
     try {
-      const result = await sendUpgradeRequest(port);
+      const response = await emitUpgrade(server, 'invalid-token');
 
-      expect(result.statusCode).toBe(401);
-      expect(result.statusMessage).toBe('Unauthorized');
-      expect(result.headers.connection).toBe('close');
-      expect(result.headers['content-length']).toBe('0');
-      expect(result.headers.upgrade).toBeUndefined();
+      expect(response).toBe(
+        'HTTP/1.1 401 Unauthorized\r\n' +
+          'Content-Length: 0\r\n' +
+          'Connection: close\r\n' +
+          '\r\n',
+      );
     } finally {
       server.closeAllConnections();
       await new Promise<void>(resolve => server.close(() => resolve()));
     }
   });
 
-  it('returns 500 without upgrade headers when handleUpgrade throws', async () => {
-    handleUpgradeSpy = jest
+  it('writes 500 response without upgrade headers when handleUpgrade throws', async () => {
+    const spy = jest
       .spyOn(WebSocketServer.prototype, 'handleUpgrade')
       .mockImplementation(() => {
         throw new Error('WebSocket upgrade failed');
       });
 
-    const { server, port } = await startServerWithAuth();
+    const server = await setupServer();
 
     try {
-      const result = await sendUpgradeRequest(port, 'mock-user-token');
+      const response = await emitUpgrade(server, 'mock-user-token');
 
-      expect(result.statusCode).toBe(500);
-      expect(result.statusMessage).toBe('Internal Server Error');
-      expect(result.headers.connection).toBe('close');
-      expect(result.headers['content-length']).toBe('0');
-      expect(result.headers.upgrade).toBeUndefined();
+      expect(response).toBe(
+        'HTTP/1.1 500 Internal Server Error\r\n' +
+          'Content-Length: 0\r\n' +
+          'Connection: close\r\n' +
+          '\r\n',
+      );
     } finally {
+      spy.mockRestore();
       server.closeAllConnections();
       await new Promise<void>(resolve => server.close(() => resolve()));
     }

--- a/plugins/signals-backend/src/service/router.test.ts
+++ b/plugins/signals-backend/src/service/router.test.ts
@@ -117,7 +117,12 @@ describe('handleUpgrade', () => {
     );
     return new Promise(resolve => {
       const chunks: Buffer[] = [];
-      const done = () => resolve(Buffer.concat(chunks).toString());
+      let resolved = false;
+      const done = () => {
+        if (resolved) return;
+        resolved = true;
+        resolve(Buffer.concat(chunks).toString());
+      };
       socket.on('data', chunk => chunks.push(chunk));
       socket.on('end', done);
       socket.on('close', done);

--- a/plugins/signals-backend/src/service/router.test.ts
+++ b/plugins/signals-backend/src/service/router.test.ts
@@ -117,8 +117,10 @@ describe('handleUpgrade', () => {
     );
     return new Promise(resolve => {
       const chunks: Buffer[] = [];
+      const done = () => resolve(Buffer.concat(chunks).toString());
       socket.on('data', chunk => chunks.push(chunk));
-      socket.on('end', () => resolve(Buffer.concat(chunks).toString()));
+      socket.on('end', done);
+      socket.on('close', done);
     });
   }
 

--- a/plugins/signals-backend/src/service/router.test.ts
+++ b/plugins/signals-backend/src/service/router.test.ts
@@ -15,9 +15,12 @@
  */
 
 import express from 'express';
+import http from 'node:http';
 import request from 'supertest';
 import { createRouter } from './router';
 import { mockErrorHandler, mockServices } from '@backstage/backend-test-utils';
+import { AuthService } from '@backstage/backend-plugin-api';
+import { WebSocketServer } from 'ws';
 
 const eventsServiceMock = mockServices.events.mock();
 const discovery = mockServices.discovery.mock({
@@ -52,5 +55,139 @@ describe('createRouter', () => {
       expect(response.status).toEqual(200);
       expect(response.body).toEqual({ status: 'ok' });
     });
+  });
+});
+
+describe('handleUpgrade', () => {
+  async function startServerWithAuth(
+    authOverride?: Partial<AuthService>,
+  ): Promise<{ server: http.Server; port: number }> {
+    const auth = Object.assign(
+      mockServices.auth(),
+      authOverride,
+    ) as AuthService;
+
+    const router = await createRouter({
+      logger: mockServices.logger.mock(),
+      events: mockServices.events.mock(),
+      discovery: mockServices.discovery.mock({
+        getBaseUrl: async () => '/api/signals',
+      }),
+      userInfo: mockServices.userInfo.mock(),
+      config: mockServices.rootConfig(),
+      lifecycle: mockServices.lifecycle.mock(),
+      auth,
+    });
+
+    const app = express().use(router);
+    const server = http.createServer(app);
+
+    await new Promise<void>(resolve => server.listen(0, resolve));
+    const port = (server.address() as { port: number }).port;
+
+    // Trigger upgrade middleware registration via a normal HTTP request
+    // with the Upgrade header so the middleware subscribes to 'upgrade'.
+    // The middleware does not call next() after registering, so the
+    // request will hang — we just need it to reach the server.
+    const trigger = http.get(
+      { port, path: '/', headers: { Upgrade: 'websocket' } },
+      res => res.resume(),
+    );
+    trigger.on('error', () => {});
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    return { server, port };
+  }
+
+  function sendUpgradeRequest(
+    port: number,
+    token = 'invalid-token',
+  ): Promise<{
+    statusCode: number;
+    statusMessage: string;
+    headers: http.IncomingHttpHeaders;
+  }> {
+    return new Promise((resolve, reject) => {
+      const req = http.request({
+        port,
+        path: '/api/signals',
+        headers: {
+          Connection: 'Upgrade',
+          Upgrade: 'websocket',
+          'Sec-WebSocket-Version': '13',
+          'Sec-WebSocket-Key': 'dGhlIHNhbXBsZSBub25jZQ==',
+          'Sec-WebSocket-Protocol': token,
+        },
+      });
+
+      req.on('upgrade', (_res, socket) => {
+        socket.end();
+        reject(new Error('Should not have received upgrade'));
+      });
+
+      req.on('response', res => {
+        res.resume();
+        res.on('end', () => {
+          resolve({
+            statusCode: res.statusCode!,
+            statusMessage: res.statusMessage!,
+            headers: res.headers,
+          });
+        });
+      });
+
+      req.on('error', reject);
+      req.end();
+    });
+  }
+
+  let handleUpgradeSpy: jest.SpyInstance;
+
+  afterEach(() => {
+    handleUpgradeSpy?.mockRestore();
+  });
+
+  it('returns 401 without upgrade headers when auth fails', async () => {
+    const { server, port } = await startServerWithAuth({
+      authenticate: async () => {
+        throw new Error('Invalid token');
+      },
+    });
+
+    try {
+      const result = await sendUpgradeRequest(port);
+
+      expect(result.statusCode).toBe(401);
+      expect(result.statusMessage).toBe('Unauthorized');
+      expect(result.headers.connection).toBe('close');
+      expect(result.headers['content-length']).toBe('0');
+      expect(result.headers.upgrade).toBeUndefined();
+    } finally {
+      server.closeAllConnections();
+      server.close();
+    }
+  });
+
+  it('returns 500 without upgrade headers when handleUpgrade throws', async () => {
+    handleUpgradeSpy = jest
+      .spyOn(WebSocketServer.prototype, 'handleUpgrade')
+      .mockImplementation(() => {
+        throw new Error('WebSocket upgrade failed');
+      });
+
+    const { server, port } = await startServerWithAuth();
+
+    try {
+      const result = await sendUpgradeRequest(port, 'mock-user-token');
+
+      expect(result.statusCode).toBe(500);
+      expect(result.statusMessage).toBe('Internal Server Error');
+      expect(result.headers.connection).toBe('close');
+      expect(result.headers['content-length']).toBe('0');
+      expect(result.headers.upgrade).toBeUndefined();
+    } finally {
+      server.closeAllConnections();
+      server.close();
+    }
   });
 });

--- a/plugins/signals-backend/src/service/router.test.ts
+++ b/plugins/signals-backend/src/service/router.test.ts
@@ -86,18 +86,23 @@ describe('handleUpgrade', () => {
     const port = (server.address() as { port: number }).port;
 
     // Register the upgrade handler by sending one request with the
-    // Upgrade header through express. Uses the 'newListener' event
-    // for deterministic, polling-free detection.
-    await new Promise<void>(resolve => {
-      server.on('newListener', event => {
-        if (event === 'upgrade') resolve();
-      });
+    // Upgrade header through express. Guard against the listener
+    // already being registered, and clean up the trigger request.
+    if (server.listenerCount('upgrade') === 0) {
       const trigger = http.get(
         { port, path: '/', headers: { Upgrade: 'websocket' } },
         res => res.resume(),
       );
       trigger.on('error', () => {});
-    });
+      await new Promise<void>(resolve => {
+        server.on('newListener', event => {
+          if (event === 'upgrade') {
+            trigger.destroy();
+            resolve();
+          }
+        });
+      });
+    }
 
     return server;
   }

--- a/plugins/signals-backend/src/service/router.test.ts
+++ b/plugins/signals-backend/src/service/router.test.ts
@@ -94,7 +94,22 @@ describe('handleUpgrade', () => {
       res => res.resume(),
     );
     trigger.on('error', () => {});
-    await new Promise(resolve => setTimeout(resolve, 100));
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error('Timed out waiting for upgrade listener')),
+        5000,
+      );
+      const check = () => {
+        if (server.listenerCount('upgrade') > 0) {
+          clearTimeout(timeout);
+          trigger.destroy();
+          resolve();
+        } else {
+          setTimeout(check, 10);
+        }
+      };
+      check();
+    });
 
     return { server, port };
   }
@@ -141,7 +156,7 @@ describe('handleUpgrade', () => {
     });
   }
 
-  let handleUpgradeSpy: jest.SpyInstance;
+  let handleUpgradeSpy: jest.SpyInstance | undefined;
 
   afterEach(() => {
     handleUpgradeSpy?.mockRestore();

--- a/plugins/signals-backend/src/service/router.ts
+++ b/plugins/signals-backend/src/service/router.ts
@@ -87,13 +87,12 @@ export async function createRouter(
       }
     } catch (e) {
       logger.error(`Failed to authenticate WebSocket connection: ${e}`);
-      socket.write(
-        'HTTP/1.1 401 Web Socket Protocol Handshake\r\n' +
-          'Upgrade: WebSocket\r\n' +
-          'Connection: Upgrade\r\n' +
+      socket.end(
+        'HTTP/1.1 401 Unauthorized\r\n' +
+          'Content-Length: 0\r\n' +
+          'Connection: close\r\n' +
           '\r\n',
       );
-      socket.destroy();
       return;
     }
 
@@ -108,13 +107,12 @@ export async function createRouter(
       );
     } catch (e) {
       logger.error(`Failed to handle WebSocket upgrade: ${e}`);
-      socket.write(
-        'HTTP/1.1 500 Web Socket Protocol Handshake\r\n' +
-          'Upgrade: WebSocket\r\n' +
-          'Connection: Upgrade\r\n' +
+      socket.end(
+        'HTTP/1.1 500 Internal Server Error\r\n' +
+          'Content-Length: 0\r\n' +
+          'Connection: close\r\n' +
           '\r\n',
       );
-      socket.destroy();
     }
   };
 

--- a/plugins/signals-backend/src/service/router.ts
+++ b/plugins/signals-backend/src/service/router.ts
@@ -92,6 +92,7 @@ export async function createRouter(
           'Content-Length: 0\r\n' +
           'Connection: close\r\n' +
           '\r\n',
+        () => socket.destroy(),
       );
       return;
     }
@@ -112,6 +113,7 @@ export async function createRouter(
           'Content-Length: 0\r\n' +
           'Connection: close\r\n' +
           '\r\n',
+        () => socket.destroy(),
       );
     }
   };


### PR DESCRIPTION
When authentication fails during a WebSocket upgrade in the signals plugin, the error response includes `Upgrade: WebSocket` and `Connection: Upgrade` headers. These headers are only valid on `101 Switching Protocols` responses — sending them on `401` or `500` responses confuses load balancers, which see a partial/malformed upgrade handshake, close the backend connection, and surface `502` to the client instead of the real error.

Additionally, `socket.destroy()` tears down the socket immediately, which can race the response write — the client (or LB) may never see the status line at all.

This PR replaces the incorrect headers with `Content-Length: 0` and `Connection: close`, and switches from `socket.write()` + `socket.destroy()` to `socket.end()` so the response is fully flushed before the socket closes.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))