### PR TITLE
fix(catalog): call useProps unconditionally in About card icon links

### DIFF
--- a/.changeset/fix-icon-link-hooks-violation.md
+++ b/.changeset/fix-icon-link-hooks-violation.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Fixed a React rules of hooks violation in the About card's icon link rendering. The `useProps()` hook for each `EntityIconLinkBlueprint` is now always called regardless of the filter result, preventing crashes when navigating between entities with different filter outcomes.

--- a/plugins/catalog/src/alpha/entityCards.tsx
+++ b/plugins/catalog/src/alpha/entityCards.tsx
@@ -38,17 +38,18 @@ export const catalogAboutEntityCard = EntityCardBlueprint.makeWithOverrides({
   factory(originalFactory, { inputs }) {
     function Subheader() {
       const { entity } = useEntity();
-      // The "useProps" functions may be calling other hooks, so we need to
-      // call them in a component function to avoid breaking the rules of hooks.
+      // Always call useProps() for every icon link to maintain a consistent
+      // hook call order across renders (rules of hooks). The filter is only
+      // used to decide whether to include the result in the rendered output.
       const links = inputs.iconLinks.reduce((rest, iconLink) => {
+        const props = iconLink.get(
+          EntityIconLinkBlueprint.dataRefs.useProps,
+        )();
         const filter = buildFilterFn(
           iconLink.get(EntityIconLinkBlueprint.dataRefs.filterFunction),
           iconLink.get(EntityIconLinkBlueprint.dataRefs.filterExpression),
         );
         if (filter(entity)) {
-          const props = iconLink.get(
-            EntityIconLinkBlueprint.dataRefs.useProps,
-          )();
           return [...rest, props];
         }
         return rest;

--- a/plugins/catalog/src/alpha/entityCards.tsx
+++ b/plugins/catalog/src/alpha/entityCards.tsx
@@ -42,9 +42,7 @@ export const catalogAboutEntityCard = EntityCardBlueprint.makeWithOverrides({
       // hook call order across renders (rules of hooks). The filter is only
       // used to decide whether to include the result in the rendered output.
       const links = inputs.iconLinks.reduce((rest, iconLink) => {
-        const props = iconLink.get(
-          EntityIconLinkBlueprint.dataRefs.useProps,
-        )();
+        const props = iconLink.get(EntityIconLinkBlueprint.dataRefs.useProps)();
         const filter = buildFilterFn(
           iconLink.get(EntityIconLinkBlueprint.dataRefs.filterFunction),
           iconLink.get(EntityIconLinkBlueprint.dataRefs.filterExpression),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #34763

The `Subheader` component in `catalogAboutEntityCard` calls `useProps()` for each registered `EntityIconLinkBlueprint` inside a `reduce`. Since [91f5ed82d661](https://github.com/backstage/backstage/commit/91f5ed82d661cb32c1cc8e0d95d13a7277786052), `useProps()` is called conditionally — only when `filter(entity)` returns `true`. Because `useProps` is a hook (it may call `useEntity()`, `useRouteRef()`, `useAsync()`, etc.), this violates React's rules of hooks: the number of hook calls must be identical between renders.

When a user navigates between entities on the same page type (e.g., from a Component to its parent System), filters may evaluate differently for the new entity, changing the number of `useProps()` invocations and causing:

```
TypeError: can't access property "length", prevDeps is undefined
```

### Fix

Move `useProps()` before the filter check so it is always called for every icon link on every render. The filter result is still used to decide whether to include the link props in the rendered output, the only change is the call order.

  ```diff
   const links = inputs.iconLinks.reduce((rest, iconLink) => {
  +  const props = iconLink.get(
  +    EntityIconLinkBlueprint.dataRefs.useProps,
  +  )();
     const filter = buildFilterFn(
       iconLink.get(EntityIconLinkBlueprint.dataRefs.filterFunction),
       iconLink.get(EntityIconLinkBlueprint.dataRefs.filterExpression),
     );
     if (filter(entity)) {
  -    const props = iconLink.get(
  -      EntityIconLinkBlueprint.dataRefs.useProps,
  -    )();
       return [...rest, props];
     }
     return rest;
   }, new Array<IconLinkVerticalProps>());
```

This restores the behavior from before 91f5ed82d661, where useProps() was always called unconditionally which the original code comment explicitly acknowledged was necessary to avoid breaking the rules of hooks.

## Reproduction

1. Register an EntityIconLinkBlueprint with a filter that evaluates differently for different entities (e.g., checking for a specific annotation) and a useProps that calls any React hook
2. Navigate to an entity where the filter passes
3. Click a link to navigate to another entity (same page type) where the filter does not pass
4. Observe the crash
