### PR TITLE
Add default connections service factory

### DIFF
--- a/.changeset/calm-connections-serve.md
+++ b/.changeset/calm-connections-serve.md
@@ -1,0 +1,5 @@
+---
+'@backstage/connections': patch
+---
+
+Added a default implementation for the connections service so backend modules can depend on it without requiring apps to explicitly install the connections service factory.

--- a/packages/connections/src/service.ts
+++ b/packages/connections/src/service.ts
@@ -22,9 +22,9 @@ import {
 } from '@backstage/backend-plugin-api';
 import { ConnectionsService, DefaultConnectionsService } from './api';
 
-function createConnectionsServiceFactory(
-  service: ServiceRef<ConnectionsService, 'plugin', 'singleton'>,
-) {
+function createConnectionsServiceFactory<
+  TInstances extends 'singleton' | 'multiton',
+>(service: ServiceRef<ConnectionsService, 'plugin', TInstances>) {
   return createServiceFactory({
     service,
     deps: {

--- a/packages/connections/src/service.ts
+++ b/packages/connections/src/service.ts
@@ -18,30 +18,40 @@ import {
   coreServices,
   createServiceFactory,
   createServiceRef,
+  type ServiceRef,
 } from '@backstage/backend-plugin-api';
 import { ConnectionsService, DefaultConnectionsService } from './api';
+
+function createConnectionsServiceFactory(
+  service: ServiceRef<ConnectionsService, 'plugin', 'singleton'>,
+) {
+  return createServiceFactory({
+    service,
+    deps: {
+      pluginMetadata: coreServices.pluginMetadata,
+      rootLogger: coreServices.rootLogger,
+      logger: coreServices.logger,
+      config: coreServices.rootConfig,
+    },
+    async createRootContext({ rootLogger, config }) {
+      return DefaultConnectionsService.create({ logger: rootLogger, config });
+    },
+
+    async factory({ logger, pluginMetadata }, connectionsService) {
+      const pluginId = pluginMetadata.getId();
+      return connectionsService.forPlugin(pluginId, { logger });
+    },
+  });
+}
 
 /** @public */
 export const connectionsServiceRef = createServiceRef<ConnectionsService>({
   id: 'core.connections',
   scope: 'plugin',
+  defaultFactory: async service => createConnectionsServiceFactory(service),
 });
 
 /** @public */
-export const connectionsServiceFactory = createServiceFactory({
-  service: connectionsServiceRef,
-  deps: {
-    pluginMetadata: coreServices.pluginMetadata,
-    rootLogger: coreServices.rootLogger,
-    logger: coreServices.logger,
-    config: coreServices.rootConfig,
-  },
-  async createRootContext({ rootLogger, config }) {
-    return DefaultConnectionsService.create({ logger: rootLogger, config });
-  },
-
-  async factory({ logger, pluginMetadata }, connectionsService) {
-    const pluginId = pluginMetadata.getId();
-    return connectionsService.forPlugin(pluginId, { logger });
-  },
-});
+export const connectionsServiceFactory = createConnectionsServiceFactory(
+  connectionsServiceRef,
+);

--- a/plugins/connections-example-backend-module-gitlab/src/module.test.ts
+++ b/plugins/connections-example-backend-module-gitlab/src/module.test.ts
@@ -21,7 +21,6 @@ import { startTestBackend } from '@backstage/backend-test-utils';
 import { mockServices } from '@backstage/backend-test-utils';
 import {
   connectionsServiceRef,
-  connectionsServiceFactory,
   declareConnection,
 } from '@backstage/connections';
 
@@ -71,7 +70,6 @@ describe('connections-example-backend-module-gitlab', () => {
     await startTestBackend({
       features: [
         testConfig,
-        connectionsServiceFactory,
         createBackendPlugin({
           pluginId: 'test',
           register(env) {
@@ -111,7 +109,6 @@ describe('connections-example-backend-module-gitlab', () => {
     await startTestBackend({
       features: [
         testConfig,
-        connectionsServiceFactory,
         createBackendPlugin({
           pluginId: 'test',
           register(reg) {
@@ -184,7 +181,7 @@ describe('connections-example-backend-module-gitlab', () => {
     });
 
     await startTestBackend({
-      features: [testConfig, connectionsServiceFactory, testPlugin, testModule],
+      features: [testConfig, testPlugin, testModule],
     });
   });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds a default factory to the connections service ref, allowing backend modules to depend on `connectionsServiceRef` without requiring apps to explicitly install `connectionsServiceFactory`.

The explicit `connectionsServiceFactory` export remains available and now shares the same factory creation path as the default factory. The GitLab connections module test now exercises the default factory path by omitting the explicit service factory.

Tested with:

```sh
CI=1 yarn test plugins/connections-example-backend-module-gitlab/src/module.test.ts
```

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))