### PR TITLE
fix(cli-module-actions): handle failing plugin sources in actions list

### DIFF
--- a/.changeset/shaggy-baths-grin.md
+++ b/.changeset/shaggy-baths-grin.md
@@ -2,4 +2,4 @@
 '@backstage/cli-module-actions': minor
 ---
 
-The `actions list` command now returns partial results when some plugin sources fail, instead of failing entirely. Failed sources are reported as warnings. Added `--output json` flag for structured output including an `errors` array.
+The `actions list` command now returns partial results when some plugin sources fail, instead of failing entirely. Failed sources are reported as warnings.

--- a/.changeset/shaggy-baths-grin.md
+++ b/.changeset/shaggy-baths-grin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli-module-actions': minor
+---
+
+The `actions list` command now returns partial results when some plugin sources fail, instead of failing entirely. Failed sources are reported as warnings. Added `--output json` flag for structured output including an `errors` array.

--- a/packages/cli-module-actions/src/commands/list.test.ts
+++ b/packages/cli-module-actions/src/commands/list.test.ts
@@ -30,10 +30,8 @@ jest.mock('../lib/ActionsClient', () => ({
 }));
 
 import listCommand from './list';
-import { cli } from 'cleye';
 import { resolveAuth } from '../lib/resolveAuth';
 
-const mockCli = cli as jest.MockedFunction<typeof cli>;
 const mockResolveAuth = resolveAuth as jest.MockedFunction<typeof resolveAuth>;
 
 const baseContext: CliCommandContext = {
@@ -126,76 +124,6 @@ describe('list command', () => {
     const stderr = stderrSpy.mock.calls.map(c => c[0]).join('');
     expect(stderr).toContain('catalog');
     expect(stderr).toContain('notifications');
-    expect(process.exitCode).toBe(1);
-  });
-
-  it('outputs JSON with actions and errors arrays when --output=json', async () => {
-    mockResolveAuth.mockResolvedValue(authResponse());
-    (mockCli as jest.Mock).mockReturnValue({
-      flags: { output: 'json' },
-    });
-    const result: ListResult = {
-      grouped: [
-        {
-          pluginId: 'catalog',
-          actions: [
-            {
-              id: 'catalog:refresh',
-              name: 'refresh',
-              schema: { input: {}, output: {} },
-            },
-          ],
-        },
-      ],
-      failed: [
-        {
-          pluginId: 'notifications',
-          message: 'Request failed with 404 Not Found',
-        },
-      ],
-    };
-    mockList.mockResolvedValue(result);
-
-    await listCommand(baseContext);
-
-    const stdout = stdoutSpy.mock.calls.map(c => c[0]).join('');
-    const parsed = JSON.parse(stdout);
-    expect(parsed.actions).toEqual([
-      {
-        id: 'catalog:refresh',
-        name: 'refresh',
-        pluginId: 'catalog',
-        schema: { input: {}, output: {} },
-      },
-    ]);
-    expect(parsed.errors).toEqual([
-      {
-        pluginId: 'notifications',
-        message: 'Request failed with 404 Not Found',
-      },
-    ]);
-    expect(process.exitCode).toBeUndefined();
-  });
-
-  it('sets exit code 1 in JSON mode when all sources fail', async () => {
-    mockResolveAuth.mockResolvedValue(authResponse());
-    (mockCli as jest.Mock).mockReturnValue({
-      flags: { output: 'json' },
-    });
-    const result: ListResult = {
-      grouped: [],
-      failed: [
-        { pluginId: 'catalog', message: 'Request failed with 404 Not Found' },
-      ],
-    };
-    mockList.mockResolvedValue(result);
-
-    await listCommand(baseContext);
-
-    const stdout = stdoutSpy.mock.calls.map(c => c[0]).join('');
-    const parsed = JSON.parse(stdout);
-    expect(parsed.actions).toEqual([]);
-    expect(parsed.errors).toHaveLength(1);
     expect(process.exitCode).toBe(1);
   });
 

--- a/packages/cli-module-actions/src/commands/list.test.ts
+++ b/packages/cli-module-actions/src/commands/list.test.ts
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2025 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { CliCommandContext } from '@backstage/cli-node';
+import type { ListResult } from '../lib/ActionsClient';
+
+const mockList = jest.fn();
+
+jest.mock('cleye', () => ({
+  cli: jest.fn().mockReturnValue({ flags: {} }),
+}));
+jest.mock('../lib/resolveAuth', () => ({ resolveAuth: jest.fn() }));
+jest.mock('../lib/ActionsClient', () => ({
+  ActionsClient: jest.fn().mockImplementation(() => ({
+    list: mockList,
+  })),
+}));
+
+import listCommand from './list';
+import { cli } from 'cleye';
+import { resolveAuth } from '../lib/resolveAuth';
+
+const mockCli = cli as jest.MockedFunction<typeof cli>;
+const mockResolveAuth = resolveAuth as jest.MockedFunction<typeof resolveAuth>;
+
+const baseContext: CliCommandContext = {
+  args: [],
+  info: { name: 'list', description: 'List actions' },
+} as unknown as CliCommandContext;
+
+function authResponse() {
+  return {
+    accessToken: 'test-token',
+    baseUrl: 'https://backstage.example.com',
+    instanceName: 'default',
+    pluginSources: ['catalog', 'notifications'],
+  };
+}
+
+describe('list command', () => {
+  let stderrSpy: jest.SpiedFunction<typeof process.stderr.write>;
+  let stdoutSpy: jest.SpiedFunction<typeof process.stdout.write>;
+  let originalExitCode: typeof process.exitCode;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+    stderrSpy = jest
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+    stdoutSpy = jest
+      .spyOn(process.stdout, 'write')
+      .mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stderrSpy.mockRestore();
+    stdoutSpy.mockRestore();
+    process.exitCode = originalExitCode;
+  });
+
+  it('lists actions from all successful sources and warns about failed ones', async () => {
+    mockResolveAuth.mockResolvedValue(authResponse());
+    const result: ListResult = {
+      grouped: [
+        {
+          pluginId: 'catalog',
+          actions: [
+            {
+              id: 'catalog:refresh',
+              name: 'refresh',
+              title: 'Refresh entity',
+              schema: { input: {}, output: {} },
+            },
+          ],
+        },
+      ],
+      failed: [
+        {
+          pluginId: 'notifications',
+          message: 'Request failed with 404 Not Found',
+        },
+      ],
+    };
+    mockList.mockResolvedValue(result);
+
+    await listCommand(baseContext);
+
+    const stdout = stdoutSpy.mock.calls.map(c => c[0]).join('');
+    expect(stdout).toContain('catalog:refresh');
+
+    const stderr = stderrSpy.mock.calls.map(c => c[0]).join('');
+    expect(stderr).toContain('notifications');
+    expect(stderr).toContain('404');
+
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('sets exit code 1 and lists all failures when every source fails', async () => {
+    mockResolveAuth.mockResolvedValue(authResponse());
+    const result: ListResult = {
+      grouped: [],
+      failed: [
+        { pluginId: 'catalog', message: 'Request failed with 404 Not Found' },
+        { pluginId: 'notifications', message: 'Network error' },
+      ],
+    };
+    mockList.mockResolvedValue(result);
+
+    await listCommand(baseContext);
+
+    const stderr = stderrSpy.mock.calls.map(c => c[0]).join('');
+    expect(stderr).toContain('catalog');
+    expect(stderr).toContain('notifications');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('outputs JSON with actions and errors arrays when --output=json', async () => {
+    mockResolveAuth.mockResolvedValue(authResponse());
+    (mockCli as jest.Mock).mockReturnValue({
+      flags: { output: 'json' },
+    });
+    const result: ListResult = {
+      grouped: [
+        {
+          pluginId: 'catalog',
+          actions: [
+            {
+              id: 'catalog:refresh',
+              name: 'refresh',
+              schema: { input: {}, output: {} },
+            },
+          ],
+        },
+      ],
+      failed: [
+        {
+          pluginId: 'notifications',
+          message: 'Request failed with 404 Not Found',
+        },
+      ],
+    };
+    mockList.mockResolvedValue(result);
+
+    await listCommand(baseContext);
+
+    const stdout = stdoutSpy.mock.calls.map(c => c[0]).join('');
+    const parsed = JSON.parse(stdout);
+    expect(parsed.actions).toEqual([
+      {
+        id: 'catalog:refresh',
+        name: 'refresh',
+        pluginId: 'catalog',
+        schema: { input: {}, output: {} },
+      },
+    ]);
+    expect(parsed.errors).toEqual([
+      {
+        pluginId: 'notifications',
+        message: 'Request failed with 404 Not Found',
+      },
+    ]);
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('sets exit code 1 in JSON mode when all sources fail', async () => {
+    mockResolveAuth.mockResolvedValue(authResponse());
+    (mockCli as jest.Mock).mockReturnValue({
+      flags: { output: 'json' },
+    });
+    const result: ListResult = {
+      grouped: [],
+      failed: [
+        { pluginId: 'catalog', message: 'Request failed with 404 Not Found' },
+      ],
+    };
+    mockList.mockResolvedValue(result);
+
+    await listCommand(baseContext);
+
+    const stdout = stdoutSpy.mock.calls.map(c => c[0]).join('');
+    const parsed = JSON.parse(stdout);
+    expect(parsed.actions).toEqual([]);
+    expect(parsed.errors).toHaveLength(1);
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('preserves existing behavior when all sources succeed', async () => {
+    mockResolveAuth.mockResolvedValue(authResponse());
+    const result: ListResult = {
+      grouped: [
+        {
+          pluginId: 'catalog',
+          actions: [
+            {
+              id: 'catalog:refresh',
+              name: 'refresh',
+              title: 'Refresh',
+              schema: { input: {}, output: {} },
+            },
+          ],
+        },
+        {
+          pluginId: 'notifications',
+          actions: [
+            {
+              id: 'notifications:send',
+              name: 'send',
+              title: 'Send notification',
+              schema: { input: {}, output: {} },
+            },
+          ],
+        },
+      ],
+      failed: [],
+    };
+    mockList.mockResolvedValue(result);
+
+    await listCommand(baseContext);
+
+    const stdout = stdoutSpy.mock.calls.map(c => c[0]).join('');
+    expect(stdout).toContain('catalog:refresh');
+    expect(stdout).toContain('notifications:send');
+
+    const stderr = stderrSpy.mock.calls.map(c => c[0]).join('');
+    expect(stderr).toBe('');
+
+    expect(process.exitCode).toBeUndefined();
+  });
+});

--- a/packages/cli-module-actions/src/commands/list.ts
+++ b/packages/cli-module-actions/src/commands/list.ts
@@ -15,6 +15,7 @@
  */
 
 import { cli } from 'cleye';
+import chalk from 'chalk';
 import type { CliCommandContext } from '@backstage/cli-node';
 import { ActionsClient } from '../lib/ActionsClient';
 import { resolveAuth } from '../lib/resolveAuth';
@@ -22,7 +23,7 @@ import { formatActionList } from '../lib/format';
 
 export default async ({ args, info }: CliCommandContext) => {
   const {
-    flags: { instance: instanceFlag },
+    flags: { instance: instanceFlag, output: outputFlag },
   } = cli(
     {
       name: info.usage,
@@ -30,6 +31,10 @@ export default async ({ args, info }: CliCommandContext) => {
         instance: {
           type: String,
           description: 'Name of the instance to use',
+        },
+        output: {
+          type: String,
+          description: 'Output format: "human" (default) or "json"',
         },
       },
     },
@@ -49,13 +54,49 @@ export default async ({ args, info }: CliCommandContext) => {
   }
 
   const client = new ActionsClient(baseUrl, accessToken);
-  const grouped = await client.list(pluginSources);
+  const { grouped, failed } = await client.list(pluginSources);
+
+  if (outputFlag === 'json') {
+    const actions = grouped.flatMap(g =>
+      g.actions.map(a => ({ ...a, pluginId: g.pluginId })),
+    );
+    const errors = failed.map(f => ({
+      pluginId: f.pluginId,
+      message: f.message,
+    }));
+    process.stdout.write(`${JSON.stringify({ actions, errors })}\n`);
+    if (grouped.length === 0) {
+      process.exitCode = 1;
+    }
+    return;
+  }
 
   const hasActions = grouped.some(g => g.actions.length > 0);
-  if (!hasActions) {
+
+  if (grouped.length === 0 && failed.length > 0) {
+    for (const { pluginId, message } of failed) {
+      process.stderr.write(
+        chalk.yellow(`Warning: source '${pluginId}' failed — ${message}\n`),
+      );
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!hasActions && failed.length === 0) {
     process.stderr.write('No actions found.\n');
     return;
   }
 
-  process.stdout.write(`${formatActionList(grouped)}\n`);
+  if (hasActions) {
+    process.stdout.write(`${formatActionList(grouped)}\n`);
+  }
+
+  for (const { pluginId, message } of failed) {
+    process.stderr.write(
+      chalk.yellow(
+        `Warning: source '${pluginId}' returned an error — skipped (${message})\n`,
+      ),
+    );
+  }
 };

--- a/packages/cli-module-actions/src/commands/list.ts
+++ b/packages/cli-module-actions/src/commands/list.ts
@@ -23,7 +23,7 @@ import { formatActionList } from '../lib/format';
 
 export default async ({ args, info }: CliCommandContext) => {
   const {
-    flags: { instance: instanceFlag, output: outputFlag },
+    flags: { instance: instanceFlag },
   } = cli(
     {
       name: info.usage,
@@ -31,10 +31,6 @@ export default async ({ args, info }: CliCommandContext) => {
         instance: {
           type: String,
           description: 'Name of the instance to use',
-        },
-        output: {
-          type: String,
-          description: 'Output format: "human" (default) or "json"',
         },
       },
     },
@@ -55,21 +51,6 @@ export default async ({ args, info }: CliCommandContext) => {
 
   const client = new ActionsClient(baseUrl, accessToken);
   const { grouped, failed } = await client.list(pluginSources);
-
-  if (outputFlag === 'json') {
-    const actions = grouped.flatMap(g =>
-      g.actions.map(a => ({ ...a, pluginId: g.pluginId })),
-    );
-    const errors = failed.map(f => ({
-      pluginId: f.pluginId,
-      message: f.message,
-    }));
-    process.stdout.write(`${JSON.stringify({ actions, errors })}\n`);
-    if (grouped.length === 0) {
-      process.exitCode = 1;
-    }
-    return;
-  }
 
   const hasActions = grouped.some(g => g.actions.length > 0);
 

--- a/packages/cli-module-actions/src/lib/ActionsClient.test.ts
+++ b/packages/cli-module-actions/src/lib/ActionsClient.test.ts
@@ -34,9 +34,9 @@ describe('ActionsClient', () => {
   });
 
   describe('list', () => {
-    it('returns empty array when no plugin sources provided', async () => {
+    it('returns empty results when no plugin sources provided', async () => {
       const result = await client.list([]);
-      expect(result).toEqual([]);
+      expect(result).toEqual({ grouped: [], failed: [] });
       expect(mockHttpJson).not.toHaveBeenCalled();
     });
 
@@ -75,16 +75,50 @@ describe('ActionsClient', () => {
           headers: { Authorization: 'Bearer test-token' },
         }),
       );
-      expect(result).toEqual([
-        { pluginId: 'catalog', actions: catalogActions },
-        { pluginId: 'scaffolder', actions: scaffolderActions },
-      ]);
+      expect(result).toEqual({
+        grouped: [
+          { pluginId: 'catalog', actions: catalogActions },
+          { pluginId: 'scaffolder', actions: scaffolderActions },
+        ],
+        failed: [],
+      });
     });
 
-    it('propagates errors from httpJson', async () => {
+    it('returns partial results and failed sources when some sources fail', async () => {
+      const catalogActions = [
+        {
+          id: 'catalog:refresh',
+          name: 'refresh',
+          schema: { input: {}, output: {} },
+        },
+      ];
+
+      mockHttpJson
+        .mockResolvedValueOnce({ actions: catalogActions })
+        .mockRejectedValueOnce(new Error('Request failed with 404 Not Found'));
+
+      const result = await client.list(['catalog', 'scaffolder']);
+
+      expect(result).toEqual({
+        grouped: [{ pluginId: 'catalog', actions: catalogActions }],
+        failed: [
+          {
+            pluginId: 'scaffolder',
+            message: 'Request failed with 404 Not Found',
+          },
+        ],
+      });
+    });
+
+    it('reports all sources as failed when all fail', async () => {
       mockHttpJson.mockRejectedValue(new Error('Network error'));
 
-      await expect(client.list(['catalog'])).rejects.toThrow('Network error');
+      const result = await client.list(['catalog']);
+
+      expect(result).toEqual({
+        grouped: [],
+        failed: [{ pluginId: 'catalog', message: 'Network error' }],
+      });
     });
   });
 

--- a/packages/cli-module-actions/src/lib/ActionsClient.ts
+++ b/packages/cli-module-actions/src/lib/ActionsClient.ts
@@ -54,14 +54,21 @@ function pluginActionsUrl(baseUrl: string, pluginId: string): string {
 
 export type GroupedActions = { pluginId: string; actions: ActionDef[] }[];
 
+export type FailedSource = { pluginId: string; message: string };
+
+export type ListResult = {
+  grouped: GroupedActions;
+  failed: FailedSource[];
+};
+
 export class ActionsClient {
   constructor(
     private readonly baseUrl: string,
     private readonly accessToken: string,
   ) {}
 
-  async list(pluginSources: string[]): Promise<GroupedActions> {
-    return Promise.all(
+  async list(pluginSources: string[]): Promise<ListResult> {
+    const results = await Promise.allSettled(
       pluginSources.map(async pluginId => {
         const url = pluginActionsUrl(this.baseUrl, pluginId);
         const response = await httpJson<ListActionsResponse>(url, {
@@ -71,11 +78,28 @@ export class ActionsClient {
         return { pluginId, actions: response.actions };
       }),
     );
+
+    const grouped: GroupedActions = [];
+    const failed: FailedSource[] = [];
+
+    for (let i = 0; i < results.length; i++) {
+      const result = results[i];
+      if (result.status === 'fulfilled') {
+        grouped.push(result.value);
+      } else {
+        failed.push({
+          pluginId: pluginSources[i],
+          message: result.reason?.message ?? String(result.reason),
+        });
+      }
+    }
+
+    return { grouped, failed };
   }
 
   async listForPlugin(actionId: string): Promise<ActionDef[]> {
     const pluginId = extractPluginId(actionId);
-    const grouped = await this.list([pluginId]);
+    const { grouped } = await this.list([pluginId]);
     return grouped.flatMap(g => g.actions);
   }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!
 The actions list command fails entirely when any configured plugin source returns a non-200 response (e.g. 404). This makes it unusable when even one source is temporarily unavailable or misconfigured — you get zero results instead of the actions that are available.

  This change makes actions list resilient to individual source failures:

  - Sources that respond successfully are listed as before
  - Sources that fail get a yellow warning printed to stderr after the action list
  - Exit code is 0 when at least one source succeeds; 1 only when all sources fail


see attached recording for this change:


https://github.com/user-attachments/assets/6805b74b-f73a-41a1-97c6-3e035b7e87e5



  :heavy_check_mark: Checklist

  - [x] A changeset describing the change and affected packages. (more info
  (https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
  - [ ] Added or updated documentation
  - [x] Tests for new functionality and regression tests for bug fixes
  - [x] Screenshots attached (for UI changes)
  - [x] All your commits have a Signed-off-by line in the message. (more info
  (https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))