### PR TITLE
microsite: add Roadmap plugin to directory

### DIFF
--- a/microsite/data/plugins/roadmap.yaml
+++ b/microsite/data/plugins/roadmap.yaml
@@ -1,0 +1,10 @@
+---
+title: Roadmap
+author: Tyler Rothenberg
+authorUrl: https://github.com/rothenbergt
+category: Productivity
+description: A public roadmap board for your platform. Users can suggest features, vote on ideas, and comment, while admins manage statuses.
+documentation: https://github.com/rothenbergt/backstage-roadmap-plugin
+npmPackageName: '@rothenbergt/backstage-plugin-roadmap'
+addedDate: '2026-07-04'
+status: active


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds the [Roadmap plugin](https://github.com/rothenbergt/backstage-roadmap-plugin) to the plugin directory.

Embracing the Developer Experience model of asking our customers what they need and how we can improve their lives, this plugin gives them a public roadmap right inside Backstage. Users can suggest features, vote on ideas, and comment, giving the DevEx/platform team a clear signal on what to build next, while admins manage statuses as work moves from suggestion to shipped. Data lives in a plugin database by default, with optional GitLab issues as the datasource.

- npm: [`@rothenbergt/backstage-plugin-roadmap`](https://www.npmjs.com/package/@rothenbergt/backstage-plugin-roadmap) (frontend; README covers installing the backend package too)
- Verified with `node ./scripts/verify-plugin-directory.js` and it passes
- No custom icon, using the default

## :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages (not needed, microsite data only)
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes (n/a)
- [x] Screenshots attached (for UI changes) (n/a)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))