### PR TITLE
fix(catalog-github): log debug hint when GitHub App installation is m…

### DIFF
--- a/.changeset/github-multiorg-missing-app-debug.md
+++ b/.changeset/github-multiorg-missing-app-debug.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+Added a debug log hint when the multi-org GitHub entity provider cannot find a GitHub App installation for an organization.

--- a/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.test.ts
@@ -16,6 +16,7 @@
 
 import { GroupEntity, UserEntity } from '@backstage/catalog-model';
 import { ConfigReader } from '@backstage/config';
+import { NotFoundError } from '@backstage/errors';
 import { GithubCredentialsProvider } from '@backstage/integration';
 import { EntityProviderConnection } from '@backstage/plugin-catalog-node';
 import {
@@ -366,6 +367,38 @@ describe('GithubMultiOrgEntityProvider', () => {
         ]),
         type: 'full',
       });
+    });
+
+    it('should log a debug hint when the GitHub App installation is missing for an org', async () => {
+      const error = new NotFoundError(
+        'No app installation found for orgA in app 123',
+      );
+      mockGetCredentials.mockRejectedValueOnce(error);
+
+      entityProvider = new GithubMultiOrgEntityProvider({
+        id: 'my-id',
+        gitHubConfig,
+        githubCredentialsProvider: {
+          getCredentials: mockGetCredentials,
+        },
+        githubUrl: 'https://github.com',
+        logger,
+        orgs: ['orgA'],
+      });
+
+      await entityProvider.connect(entityProviderConnection);
+
+      await expect(entityProvider.read()).rejects.toThrow(error);
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'GitHub App installation was not found for org "orgA"',
+        ),
+      );
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'https://backstage.io/docs/integrations/github/github-apps/#troubleshooting',
+        ),
+      );
     });
 
     it('should read every accessible org', async () => {

--- a/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
@@ -25,9 +25,11 @@ import {
   stringifyEntityRef,
 } from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
+import { isError } from '@backstage/errors';
 import {
   DefaultGithubCredentialsProvider,
   GithubAppCredentialsMux,
+  GithubCredentials,
   GithubCredentialsProvider,
   GithubIntegrationConfig,
   ScmIntegrations,
@@ -361,10 +363,24 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       : await this.getAllOrgs(this.options.gitHubConfig);
 
     for (const org of orgsToProcess) {
-      const { headers, type: tokenType } =
-        await this.options.githubCredentialsProvider.getCredentials({
-          url: `${this.options.githubUrl}/${org}`,
-        });
+      let credentials: GithubCredentials;
+      try {
+        credentials =
+          await this.options.githubCredentialsProvider.getCredentials({
+            url: `${this.options.githubUrl}/${org}`,
+          });
+      } catch (error) {
+        if (isError(error) && error.name === 'NotFoundError') {
+          logger.debug(
+            `GitHub App installation was not found for org "${org}". ` +
+              `Make sure the app is installed for the organization and that the app manager has the Owner role. ` +
+              `See https://backstage.io/docs/integrations/github/github-apps/#troubleshooting`,
+          );
+        }
+        throw error;
+      }
+
+      const { headers, type: tokenType } = credentials;
       const client = graphql.defaults({
         baseUrl: this.options.gitHubConfig.apiBaseUrl,
         headers,


### PR DESCRIPTION
# PR Description

### Context

When `GithubMultiOrgEntityProvider` processes configured orgs, it calls `getCredentials()` for each org. If the GitHub App is not installed for a particular org, `SingleInstanceGithubCredentialsProvider` throws a `NotFoundError` ("No app installation found for {org} in {appId}"). This error propagates up without any actionable context, often manifesting as a confusing rate-limit error downstream — leaving users with no clue that the root cause is a missing GitHub App installation.

This is especially painful for users who have the GitHub Apps role but not the Owner role on their GitHub org, and may not realize the app needs to be explicitly installed.

Fixes #32972



#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes) — *N/A, no UI changes*
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
