### PR TITLE
feat(auth): add token revocation support for CIMD clients

### DIFF
--- a/.changeset/cimd-token-revocation.md
+++ b/.changeset/cimd-token-revocation.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Added token revocation support for clients using client ID metadata documents (CIMD). The `/v1/revoke` endpoint is now available whenever dynamic client registration or client ID metadata documents are enabled, and is advertised through `revocation_endpoint` in the OpenID provider configuration.

--- a/plugins/auth-backend/src/service/OidcRouter.test.ts
+++ b/plugins/auth-backend/src/service/OidcRouter.test.ts
@@ -142,6 +142,7 @@ describe('OidcRouter', () => {
   async function createRouterWithOfflineAccess(
     databaseId: TestDatabaseId,
     refreshTokenConfig?: Record<string, unknown>,
+    extraAuthConfig?: Record<string, unknown>,
   ) {
     const knex = await databases.init(databaseId);
 
@@ -189,6 +190,7 @@ describe('OidcRouter', () => {
             enabled: true,
             ...refreshTokenConfig,
           },
+          ...extraAuthConfig,
         },
       },
     });
@@ -938,84 +940,84 @@ describe('OidcRouter', () => {
       });
     });
 
+    async function doAuthFlowWithOfflineAccess(
+      databaseId_: TestDatabaseId,
+      refreshTokenConfig?: Record<string, unknown>,
+    ) {
+      const result = await createRouterWithOfflineAccess(
+        databaseId_,
+        refreshTokenConfig,
+      );
+      const {
+        mocks: { auth, service, tokenIssuer, httpAuth },
+        router,
+      } = result;
+
+      tokenIssuer.issueToken.mockResolvedValue({
+        token: 'mock-access-token',
+      });
+
+      httpAuth.credentials.mockResolvedValueOnce(
+        mockCredentials.user(MOCK_USER_ENTITY_REF),
+      );
+      auth.isPrincipal.mockReturnValueOnce(true);
+
+      const client = await service.registerClient({
+        clientName: 'Test Client',
+        redirectUris: ['https://example.com/callback'],
+        responseTypes: ['code'],
+        grantTypes: ['authorization_code', 'refresh_token'],
+        scope: 'openid offline_access',
+      });
+
+      const authSession = await service.createAuthorizationSession({
+        clientId: client.clientId,
+        redirectUri: 'https://example.com/callback',
+        responseType: 'code',
+        scope: 'openid offline_access',
+      });
+
+      const { server } = await startTestBackend({
+        features: [
+          createBackendPlugin({
+            pluginId: 'auth',
+            register(reg) {
+              reg.registerInit({
+                deps: { httpRouter: coreServices.httpRouter },
+                async init({ httpRouter }) {
+                  httpRouter.use(router.getRouter());
+                  httpRouter.addAuthPolicy({
+                    path: '/',
+                    allow: 'unauthenticated',
+                  });
+                },
+              });
+            },
+          }),
+        ],
+      });
+
+      const approvalResponse = await request(server)
+        .post(`/api/auth/v1/sessions/${authSession.id}/approve`)
+        .set('Authorization', `Bearer ${MOCK_USER_TOKEN}`)
+        .expect(200);
+
+      const redirectUrl = new URL(approvalResponse.body.redirectUrl);
+      const authorizationCode = redirectUrl.searchParams.get('code')!;
+
+      const tokenResponse = await request(server)
+        .post('/api/auth/v1/token')
+        .send({
+          grant_type: 'authorization_code',
+          code: authorizationCode,
+          redirect_uri: 'https://example.com/callback',
+        })
+        .expect(200);
+
+      return { server, tokenResponse, client, ...result };
+    }
+
     describe('refresh tokens', () => {
-      async function doAuthFlowWithOfflineAccess(
-        databaseId_: TestDatabaseId,
-        refreshTokenConfig?: Record<string, unknown>,
-      ) {
-        const result = await createRouterWithOfflineAccess(
-          databaseId_,
-          refreshTokenConfig,
-        );
-        const {
-          mocks: { auth, service, tokenIssuer, httpAuth },
-          router,
-        } = result;
-
-        tokenIssuer.issueToken.mockResolvedValue({
-          token: 'mock-access-token',
-        });
-
-        httpAuth.credentials.mockResolvedValueOnce(
-          mockCredentials.user(MOCK_USER_ENTITY_REF),
-        );
-        auth.isPrincipal.mockReturnValueOnce(true);
-
-        const client = await service.registerClient({
-          clientName: 'Test Client',
-          redirectUris: ['https://example.com/callback'],
-          responseTypes: ['code'],
-          grantTypes: ['authorization_code', 'refresh_token'],
-          scope: 'openid offline_access',
-        });
-
-        const authSession = await service.createAuthorizationSession({
-          clientId: client.clientId,
-          redirectUri: 'https://example.com/callback',
-          responseType: 'code',
-          scope: 'openid offline_access',
-        });
-
-        const { server } = await startTestBackend({
-          features: [
-            createBackendPlugin({
-              pluginId: 'auth',
-              register(reg) {
-                reg.registerInit({
-                  deps: { httpRouter: coreServices.httpRouter },
-                  async init({ httpRouter }) {
-                    httpRouter.use(router.getRouter());
-                    httpRouter.addAuthPolicy({
-                      path: '/',
-                      allow: 'unauthenticated',
-                    });
-                  },
-                });
-              },
-            }),
-          ],
-        });
-
-        const approvalResponse = await request(server)
-          .post(`/api/auth/v1/sessions/${authSession.id}/approve`)
-          .set('Authorization', `Bearer ${MOCK_USER_TOKEN}`)
-          .expect(200);
-
-        const redirectUrl = new URL(approvalResponse.body.redirectUrl);
-        const authorizationCode = redirectUrl.searchParams.get('code')!;
-
-        const tokenResponse = await request(server)
-          .post('/api/auth/v1/token')
-          .send({
-            grant_type: 'authorization_code',
-            code: authorizationCode,
-            redirect_uri: 'https://example.com/callback',
-          })
-          .expect(200);
-
-        return { server, tokenResponse, client, ...result };
-      }
-
       it('should return a refresh token when offline_access scope is requested', async () => {
         const { tokenResponse } = await doAuthFlowWithOfflineAccess(databaseId);
 
@@ -1273,6 +1275,242 @@ describe('OidcRouter', () => {
           );
           expect(mocks.catalog.getEntityByRef).not.toHaveBeenCalled();
         });
+      });
+    });
+
+    describe('token revocation', () => {
+      async function doCimdAuthFlowWithOfflineAccess(
+        databaseId_: TestDatabaseId,
+      ) {
+        const cimdClientId = 'https://example.com/oauth-client';
+        mockFetchCimdMetadata.mockResolvedValue({
+          clientId: cimdClientId,
+          clientName: 'Test CIMD Client',
+          redirectUris: ['http://localhost:8080/callback'],
+          responseTypes: ['code'],
+          grantTypes: ['authorization_code', 'refresh_token'],
+          scope: 'openid offline_access',
+        });
+
+        // Only CIMD enabled, NOT DCR
+        const result = await createRouterWithOfflineAccess(
+          databaseId_,
+          undefined,
+          {
+            experimentalDynamicClientRegistration: { enabled: false },
+            experimentalClientIdMetadataDocuments: {
+              enabled: true,
+              allowedClientIdPatterns: ['https://example.com/*'],
+              allowedRedirectUriPatterns: ['*'],
+            },
+          },
+        );
+        const {
+          mocks: { auth, service, tokenIssuer, httpAuth },
+          router,
+        } = result;
+
+        tokenIssuer.issueToken.mockResolvedValue({
+          token: 'mock-access-token',
+        });
+
+        httpAuth.credentials.mockResolvedValueOnce(
+          mockCredentials.user(MOCK_USER_ENTITY_REF),
+        );
+        auth.isPrincipal.mockReturnValueOnce(true);
+
+        const codeVerifier = 'test-code-verifier-for-pkce';
+        const codeChallenge = crypto
+          .createHash('sha256')
+          .update(codeVerifier)
+          .digest('base64url');
+
+        const authSession = await service.createAuthorizationSession({
+          clientId: cimdClientId,
+          redirectUri: 'http://localhost:8080/callback',
+          responseType: 'code',
+          scope: 'openid offline_access',
+          codeChallenge,
+          codeChallengeMethod: 'S256',
+        });
+
+        const { server } = await startTestBackend({
+          features: [
+            createBackendPlugin({
+              pluginId: 'auth',
+              register(reg) {
+                reg.registerInit({
+                  deps: { httpRouter: coreServices.httpRouter },
+                  async init({ httpRouter }) {
+                    httpRouter.use(router.getRouter());
+                    httpRouter.addAuthPolicy({
+                      path: '/',
+                      allow: 'unauthenticated',
+                    });
+                  },
+                });
+              },
+            }),
+          ],
+        });
+
+        const approvalResponse = await request(server)
+          .post(`/api/auth/v1/sessions/${authSession.id}/approve`)
+          .set('Authorization', `Bearer ${MOCK_USER_TOKEN}`)
+          .expect(200);
+
+        const redirectUrl = new URL(approvalResponse.body.redirectUrl);
+        const authorizationCode = redirectUrl.searchParams.get('code')!;
+
+        const tokenResponse = await request(server)
+          .post('/api/auth/v1/token')
+          .send({
+            grant_type: 'authorization_code',
+            code: authorizationCode,
+            redirect_uri: 'http://localhost:8080/callback',
+            code_verifier: codeVerifier,
+          })
+          .expect(200);
+
+        return { server, tokenResponse, cimdClientId, ...result };
+      }
+
+      it('should revoke a refresh token for a DCR client with valid client credentials', async () => {
+        const { server, tokenResponse, client } =
+          await doAuthFlowWithOfflineAccess(databaseId);
+
+        await request(server)
+          .post('/api/auth/v1/revoke')
+          .send({
+            token: tokenResponse.body.refresh_token,
+            client_id: client.clientId,
+            client_secret: client.clientSecret,
+          })
+          .expect(200);
+
+        // The revoked refresh token can no longer be used
+        await request(server)
+          .post('/api/auth/v1/token')
+          .send({
+            grant_type: 'refresh_token',
+            refresh_token: tokenResponse.body.refresh_token,
+          })
+          .expect(400);
+      });
+
+      it('should return 200 for an invalid token', async () => {
+        const { server, client } = await doAuthFlowWithOfflineAccess(
+          databaseId,
+        );
+
+        // RFC 7009 responds with 200 even when the token is unknown
+        await request(server)
+          .post('/api/auth/v1/revoke')
+          .send({
+            token: 'not-a-valid-token',
+            client_id: client.clientId,
+            client_secret: client.clientSecret,
+          })
+          .expect(200);
+      });
+
+      it('should reject revocation with missing or invalid DCR client credentials', async () => {
+        const { server, tokenResponse, client, mocks } =
+          await doAuthFlowWithOfflineAccess(databaseId);
+
+        // No client identification at all
+        await request(server)
+          .post('/api/auth/v1/revoke')
+          .send({ token: tokenResponse.body.refresh_token })
+          .expect(401);
+
+        // DCR clients are confidential and must provide their secret
+        await request(server)
+          .post('/api/auth/v1/revoke')
+          .send({
+            token: tokenResponse.body.refresh_token,
+            client_id: client.clientId,
+          })
+          .expect(401);
+
+        await request(server)
+          .post('/api/auth/v1/revoke')
+          .send({
+            token: tokenResponse.body.refresh_token,
+            client_id: client.clientId,
+            client_secret: 'wrong-secret',
+          })
+          .expect(401);
+
+        // The refresh token was not revoked by the failed attempts
+        mocks.tokenIssuer.issueToken.mockResolvedValue({
+          token: 'mock-refreshed-token',
+        });
+        await request(server)
+          .post('/api/auth/v1/token')
+          .send({
+            grant_type: 'refresh_token',
+            refresh_token: tokenResponse.body.refresh_token,
+          })
+          .expect(200);
+      });
+
+      it('should revoke a refresh token for a CIMD client without a client secret', async () => {
+        const { server, tokenResponse, cimdClientId } =
+          await doCimdAuthFlowWithOfflineAccess(databaseId);
+
+        expect(tokenResponse.body.refresh_token).toEqual(expect.any(String));
+
+        await request(server)
+          .post('/api/auth/v1/revoke')
+          .send({
+            token: tokenResponse.body.refresh_token,
+            client_id: cimdClientId,
+          })
+          .expect(200);
+
+        // The revoked refresh token can no longer be used
+        await request(server)
+          .post('/api/auth/v1/token')
+          .send({
+            grant_type: 'refresh_token',
+            refresh_token: tokenResponse.body.refresh_token,
+          })
+          .expect(400);
+      });
+
+      it('should reject revocation for client IDs outside the allowed CIMD patterns', async () => {
+        const { server, tokenResponse, mocks } =
+          await doCimdAuthFlowWithOfflineAccess(databaseId);
+
+        await request(server)
+          .post('/api/auth/v1/revoke')
+          .send({
+            token: tokenResponse.body.refresh_token,
+            client_id: 'https://evil.example.net/oauth-client',
+          })
+          .expect(401);
+
+        // Non-CIMD client IDs cannot authenticate without a secret either
+        await request(server)
+          .post('/api/auth/v1/revoke')
+          .send({
+            token: tokenResponse.body.refresh_token,
+            client_id: 'some-random-client',
+          })
+          .expect(401);
+
+        // The refresh token was not revoked by the failed attempts
+        mocks.tokenIssuer.issueToken.mockResolvedValue({
+          token: 'mock-refreshed-token',
+        });
+        await request(server)
+          .post('/api/auth/v1/token')
+          .send({
+            grant_type: 'refresh_token',
+            refresh_token: tokenResponse.body.refresh_token,
+          })
+          .expect(200);
       });
     });
 

--- a/plugins/auth-backend/src/service/OidcRouter.ts
+++ b/plugins/auth-backend/src/service/OidcRouter.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import Router from 'express-promise-router';
-import { OidcService } from './OidcService';
+import { OidcClientCredentials, OidcService } from './OidcService';
 import { AuthenticationError, isError } from '@backstage/errors';
 import {
   AuthService,
@@ -84,15 +84,12 @@ function validateRequest<T>(schema: z.ZodSchema<T>, data: unknown): T {
   return parseResult.data;
 }
 
-async function authenticateClient(opts: {
+function parseClientCredentials(opts: {
   req: { headers: { authorization?: string } };
-  oidc: OidcService;
   bodyClientId?: string;
   bodyClientSecret?: string;
-}): Promise<{ clientId: string; clientSecret: string }> {
-  const { req, oidc, bodyClientId, bodyClientSecret } = opts;
-  let clientId: string | undefined;
-  let clientSecret: string | undefined;
+}): Partial<OidcClientCredentials> {
+  const { req, bodyClientId, bodyClientSecret } = opts;
 
   const basicAuth = req.headers.authorization?.match(/^Basic[ ]+([^\s]+)$/i);
   if (basicAuth) {
@@ -100,20 +97,32 @@ async function authenticateClient(opts: {
       const decoded = Buffer.from(basicAuth[1], 'base64').toString('utf8');
       const idx = decoded.indexOf(':');
       if (idx >= 0) {
-        clientId = decoded.slice(0, idx);
-        clientSecret = decoded.slice(idx + 1);
+        const clientId = decoded.slice(0, idx);
+        const clientSecret = decoded.slice(idx + 1);
+        if (clientId && clientSecret) {
+          return { clientId, clientSecret };
+        }
       }
     } catch {
       /* ignore */
     }
   }
 
-  if (!clientId || !clientSecret) {
-    if (bodyClientId && bodyClientSecret) {
-      clientId = bodyClientId;
-      clientSecret = bodyClientSecret;
-    }
-  }
+  return { clientId: bodyClientId, clientSecret: bodyClientSecret };
+}
+
+async function authenticateClient(opts: {
+  req: { headers: { authorization?: string } };
+  oidc: OidcService;
+  bodyClientId?: string;
+  bodyClientSecret?: string;
+}): Promise<Required<OidcClientCredentials>> {
+  const { req, oidc, bodyClientId, bodyClientSecret } = opts;
+  const { clientId, clientSecret } = parseClientCredentials({
+    req,
+    bodyClientId,
+    bodyClientSecret,
+  });
 
   if (!clientId || !clientSecret) {
     throw new OidcError(
@@ -124,11 +133,11 @@ async function authenticateClient(opts: {
   }
 
   try {
-    const ok = await oidc.verifyClientCredentials({
+    const isValidClient = await oidc.verifyClientCredentials({
       clientId,
       clientSecret,
     });
-    if (!ok) {
+    if (!isValidClient) {
       throw new OidcError('invalid_client', 'Invalid client credentials', 401);
     }
   } catch (e) {
@@ -511,6 +520,56 @@ export class OidcRouter {
           throw OidcError.fromError(error);
         }
       });
+
+      // Token Revocation endpoint (RFC 7009-like)
+      // Allows clients to revoke refresh tokens. DCR clients are confidential
+      // and must authenticate with their client secret, while CIMD clients
+      // are public clients that only identify themselves with their client ID
+      router.post('/v1/revoke', async (req, res) => {
+        try {
+          const {
+            token,
+            client_id: bodyClientId,
+            client_secret: bodyClientSecret,
+          } = validateRequest(revokeRequestBodySchema, req.body ?? {});
+
+          const { clientId, clientSecret } = parseClientCredentials({
+            req,
+            bodyClientId,
+            bodyClientSecret,
+          });
+
+          if (!clientId) {
+            throw new OidcError(
+              'invalid_client',
+              'Client authentication required',
+              401,
+            );
+          }
+
+          const isValidClient = await this.oidc.verifyRevocationClient({
+            clientId,
+            clientSecret,
+          });
+          if (!isValidClient) {
+            throw new OidcError(
+              'invalid_client',
+              'Invalid client credentials',
+              401,
+            );
+          }
+
+          try {
+            await this.oidc.revokeRefreshToken(token);
+          } catch (e) {
+            this.logger.error('Failed to revoke token', e);
+          }
+
+          return res.status(200).send('');
+        } catch (e) {
+          throw OidcError.fromError(e);
+        }
+      });
     }
 
     // Dynamic Client Registration endpoint - only available when DCR is enabled
@@ -540,36 +599,6 @@ export class OidcRouter {
             redirect_uris: client.redirectUris,
             client_secret: client.clientSecret,
           });
-        } catch (e) {
-          throw OidcError.fromError(e);
-        }
-      });
-
-      // Token Revocation endpoint (RFC 7009-like)
-      // Allows clients to revoke refresh tokens
-      router.post('/v1/revoke', async (req, res) => {
-        try {
-          const {
-            token,
-            client_id: bodyClientId,
-            client_secret: bodyClientSecret,
-          } = validateRequest(revokeRequestBodySchema, req.body ?? {});
-
-          await authenticateClient({
-            req,
-            oidc: this.oidc,
-            bodyClientId,
-            bodyClientSecret,
-          });
-
-          try {
-            await this.oidc.revokeRefreshToken(token);
-          } catch (e) {
-            // RFC 7009 says always respond 200 even for invalid tokens
-            this.logger.debug('Failed to revoke token', e);
-          }
-
-          return res.status(200).send('');
         } catch (e) {
           throw OidcError.fromError(e);
         }

--- a/plugins/auth-backend/src/service/OidcService.test.ts
+++ b/plugins/auth-backend/src/service/OidcService.test.ts
@@ -1001,6 +1001,10 @@ describe('OidcService', () => {
           const config = service.getConfiguration();
 
           expect(config.client_id_metadata_document_supported).toBe(true);
+          expect(config.revocation_endpoint).toBe(
+            'http://mock-base-url/v1/revoke',
+          );
+          expect(config).not.toHaveProperty('registration_endpoint');
         });
 
         it('should not include client_id_metadata_document_supported when CIMD is disabled', async () => {
@@ -1018,6 +1022,72 @@ describe('OidcService', () => {
           expect(config).not.toHaveProperty(
             'client_id_metadata_document_supported',
           );
+          expect(config).not.toHaveProperty('revocation_endpoint');
+        });
+      });
+
+      describe('verifyRevocationClient', () => {
+        it('should verify CIMD clients by client ID and DCR clients by secret', async () => {
+          const { service } = await createOidcService({
+            databaseId,
+            config: {
+              auth: {
+                experimentalClientIdMetadataDocuments: {
+                  enabled: true,
+                  allowedClientIdPatterns: ['https://example.com/*'],
+                  allowedRedirectUriPatterns: ['*'],
+                },
+              },
+            },
+          });
+
+          // CIMD clients are public clients and do not need a secret
+          await expect(
+            service.verifyRevocationClient({ clientId: cimdClientId }),
+          ).resolves.toBe(true);
+
+          // CIMD clients outside the allowed patterns are rejected
+          await expect(
+            service.verifyRevocationClient({
+              clientId: 'https://evil.example.net/oauth-metadata.json',
+            }),
+          ).resolves.toBe(false);
+
+          // DCR clients must present a valid client secret
+          const client = await service.registerClient({
+            clientName: 'Test Client',
+            redirectUris: ['http://localhost:8080/callback'],
+          });
+          await expect(
+            service.verifyRevocationClient({ clientId: client.clientId }),
+          ).resolves.toBe(false);
+          await expect(
+            service.verifyRevocationClient({
+              clientId: client.clientId,
+              clientSecret: 'wrong-secret',
+            }),
+          ).resolves.toBe(false);
+          await expect(
+            service.verifyRevocationClient({
+              clientId: client.clientId,
+              clientSecret: client.clientSecret,
+            }),
+          ).resolves.toBe(true);
+        });
+
+        it('should reject CIMD client IDs when CIMD is disabled', async () => {
+          const { service } = await createOidcService({
+            databaseId,
+            config: {
+              auth: {
+                experimentalClientIdMetadataDocuments: { enabled: false },
+              },
+            },
+          });
+
+          await expect(
+            service.verifyRevocationClient({ clientId: cimdClientId }),
+          ).resolves.toBe(false);
         });
       });
 

--- a/plugins/auth-backend/src/service/OidcService.ts
+++ b/plugins/auth-backend/src/service/OidcService.ts
@@ -86,6 +86,16 @@ function matchesRedirectUri(
   });
 }
 
+/**
+ * Credentials presented by an OAuth client. Confidential clients authenticate
+ * with both a client ID and a client secret, while public clients identify
+ * themselves with a client ID alone.
+ */
+export type OidcClientCredentials = {
+  clientId: string;
+  clientSecret?: string;
+};
+
 export class OidcService {
   private readonly auth: AuthService;
   private readonly tokenIssuer: TokenIssuer;
@@ -181,6 +191,8 @@ export class OidcService {
       code_challenge_methods_supported: ['S256', 'plain'],
       ...(dcrEnabled && {
         registration_endpoint: `${this.baseUrl}/v1/register`,
+      }),
+      ...((dcrEnabled || cimdEnabled) && {
         revocation_endpoint: `${this.baseUrl}/v1/revoke`,
       }),
       ...(cimdEnabled && { client_id_metadata_document_supported: true }),
@@ -625,10 +637,9 @@ export class OidcService {
   /**
    * Verifies client credentials against the registered OIDC clients
    */
-  public async verifyClientCredentials(options: {
-    clientId: string;
-    clientSecret: string;
-  }): Promise<boolean> {
+  public async verifyClientCredentials(
+    options: Required<OidcClientCredentials>,
+  ): Promise<boolean> {
     const { clientId, clientSecret } = options;
     const client = await this.oidc.getClient({ clientId });
     if (!client?.clientSecret) {
@@ -640,6 +651,42 @@ export class OidcService {
       return false;
     }
     return crypto.timingSafeEqual(expected, provided);
+  }
+
+  /**
+   * Verifies a client for token revocation. DCR clients are confidential
+   * clients and must present a valid client secret, while CIMD clients are
+   * public clients that are identified by their client ID alone. The CIMD
+   * metadata document is deliberately not fetched here, so that tokens can
+   * still be revoked when the document is unreachable or has been removed.
+   */
+  public async verifyRevocationClient(
+    options: OidcClientCredentials,
+  ): Promise<boolean> {
+    const { clientId, clientSecret } = options;
+
+    let cimdUrl: URL | undefined;
+    try {
+      cimdUrl = validateCimdUrl(clientId);
+    } catch {
+      // Not a valid CIMD URL, fall through to DCR
+    }
+
+    if (cimdUrl) {
+      const cimd = this.getCimdConfig();
+      return (
+        cimd.enabled &&
+        cimd.allowedClientIdPatterns.some(pattern =>
+          matcher.isMatch(clientId, pattern),
+        )
+      );
+    }
+
+    if (!clientSecret) {
+      return false;
+    }
+
+    return this.verifyClientCredentials({ clientId, clientSecret });
   }
 
   /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

## What

Adds token revocation support for CIMD clients. The `/v1/revoke` endpoint is now registered whenever dynamic client registration or client ID metadata documents are enabled (previously it required DCR), and the OpenID provider configuration advertises `revocation_endpoint` in both cases.

DCR clients keep authenticating with their client secret. CIMD clients are public clients, so they are verified by checking that the client ID is a valid CIMD URL that matches the configured allowed client ID patterns. The metadata document is deliberately not fetched during revocation, so tokens can still be revoked when the document is unreachable or has been removed.

## Why

CIMD clients can request `offline_access` and end up holding refresh tokens, but they have no way to revoke them: the revoke endpoint only exists when DCR is enabled and always requires a client secret, which public CIMD clients don't have.

## How to test

Run the example backend with `yarn start`, then log in with the CLI, which goes through the CIMD client (`http://localhost:7007/api/auth/.well-known/oauth-client/cli.json`) and requests `openid offline_access`:

```sh
yarn backstage-cli auth login
# Select http://localhost:7007 (app-config.yaml)
# Login successful
```

Grab the stored refresh token. The CLI keeps it in the OS keychain, so on macOS:

```sh
security find-generic-password -s "backstage-cli:auth-instance:localhost:7007" -a "refreshToken" -w
```

On platforms without keychain support the CLI falls back to storing it under `~/.local/share/backstage-cli/auth-secrets/`.

Confirm the token works. Each refresh rotates it, so use the `refresh_token` from the response in the next steps:

```sh
curl -s -X POST http://localhost:7007/api/auth/v1/token -H 'Content-Type: application/json' \
  -d '{"grant_type":"refresh_token","refresh_token":"<REFRESH_TOKEN>"}'
# 200 with a new access_token and a rotated refresh_token
```

Revoke it as the CIMD client, identifying with just the client ID and no secret:

```sh
curl -si -X POST http://localhost:7007/api/auth/v1/revoke -H 'Content-Type: application/json' \
  -d '{"token":"<REFRESH_TOKEN>","client_id":"http://localhost:7007/api/auth/.well-known/oauth-client/cli.json"}'
# HTTP/1.1 200 OK with an empty body
```

Try the refresh grant again with the same token:

```json
{
  "error": "invalid_grant",
  "error_description": "Invalid refresh token"
}
```

Note that revoking also works with an already-rotated token string, since revocation deletes the whole offline session rather than just the presented token.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
