### PR TITLE
Remove `aws-sdk-client-mock` and migrate AWS-related tests to native Jest mocks

### DIFF
--- a/packages/backend-defaults/package.json
+++ b/packages/backend-defaults/package.json
@@ -214,7 +214,6 @@
     "@types/node-forge": "^1.3.0",
     "@types/pg-format": "^1.0.5",
     "@types/yauzl": "^2.10.0",
-    "aws-sdk-client-mock": "^4.0.0",
     "better-sqlite3": "^12.0.0",
     "get-port": "^5.1.1",
     "http-errors": "^2.0.0",

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsCodeCommitUrlReader.test.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsCodeCommitUrlReader.test.ts
@@ -21,7 +21,6 @@ import { AwsCodeCommitUrlReader, parseUrl } from './AwsCodeCommitUrlReader';
 import { UrlReaderPredicateTuple } from './types';
 import path from 'node:path';
 import { NotModifiedError } from '@backstage/errors';
-import { mockClient } from 'aws-sdk-client-mock';
 import {
   CodeCommitClient,
   GetFileCommand,
@@ -34,6 +33,8 @@ import {
   readAwsCodeCommitIntegrationConfig,
 } from '@backstage/integration';
 import { mockServices } from '@backstage/backend-test-utils';
+
+const codeCommitSendMock = jest.fn();
 
 const AMAZON_AWS_CODECOMMIT_HOST = 'console.aws.amazon.com';
 
@@ -197,8 +198,6 @@ describe('parseUrl', () => {
 });
 
 describe('AwsCodeCommitUrlReader', () => {
-  const codeCommitClient = mockClient(CodeCommitClient);
-
   const createReader = (config: JsonObject): UrlReaderPredicateTuple[] => {
     return AwsCodeCommitUrlReader.factory({
       config: new ConfigReader(config),
@@ -377,15 +376,21 @@ describe('AwsCodeCommitUrlReader', () => {
     });
 
     beforeEach(() => {
-      codeCommitClient.reset();
-
-      codeCommitClient.on(GetFileCommand).resolves({
-        fileContent: fs.readFileSync(
-          path.resolve(
-            __dirname,
-            '__fixtures__/awsCodeCommit/awsCodeCommit-mock-object.yaml',
-          ),
-        ),
+      jest
+        .spyOn(CodeCommitClient.prototype, 'send')
+        .mockImplementation(codeCommitSendMock);
+      codeCommitSendMock.mockImplementation(async command => {
+        if (command instanceof GetFileCommand) {
+          return {
+            fileContent: fs.readFileSync(
+              path.resolve(
+                __dirname,
+                '__fixtures__/awsCodeCommit/awsCodeCommit-mock-object.yaml',
+              ),
+            ),
+          };
+        }
+        throw new Error(`No mock for ${command.constructor.name}`);
       });
     });
 
@@ -422,16 +427,22 @@ describe('AwsCodeCommitUrlReader', () => {
     });
 
     beforeEach(() => {
-      codeCommitClient.reset();
-
-      codeCommitClient.on(GetFileCommand).resolves({
-        fileContent: fs.readFileSync(
-          path.resolve(
-            __dirname,
-            '__fixtures__/awsCodeCommit/awsCodeCommit-mock-object.yaml',
-          ),
-        ),
-        commitId: `123abc`,
+      jest
+        .spyOn(CodeCommitClient.prototype, 'send')
+        .mockImplementation(codeCommitSendMock);
+      codeCommitSendMock.mockImplementation(async command => {
+        if (command instanceof GetFileCommand) {
+          return {
+            fileContent: fs.readFileSync(
+              path.resolve(
+                __dirname,
+                '__fixtures__/awsCodeCommit/awsCodeCommit-mock-object.yaml',
+              ),
+            ),
+            commitId: `123abc`,
+          };
+        }
+        throw new Error(`No mock for ${command.constructor.name}`);
       });
     });
 
@@ -478,20 +489,26 @@ describe('AwsCodeCommitUrlReader', () => {
     });
 
     beforeEach(() => {
-      codeCommitClient.reset();
-
-      codeCommitClient.on(GetFileCommand).resolves({
-        fileContent: fs.readFileSync(
-          path.resolve(
-            __dirname,
-            '__fixtures__/awsCodeCommit/awsCodeCommit-mock-object.yaml',
-          ),
-        ),
-        commitId: `123abc`,
-        blobId: '999',
-        filePath: 'catalog.yaml',
-        fileMode: 'EXECUTABLE',
-        fileSize: 123,
+      jest
+        .spyOn(CodeCommitClient.prototype, 'send')
+        .mockImplementation(codeCommitSendMock);
+      codeCommitSendMock.mockImplementation(async command => {
+        if (command instanceof GetFileCommand) {
+          return {
+            fileContent: fs.readFileSync(
+              path.resolve(
+                __dirname,
+                '__fixtures__/awsCodeCommit/awsCodeCommit-mock-object.yaml',
+              ),
+            ),
+            commitId: `123abc`,
+            blobId: '999',
+            filePath: 'catalog.yaml',
+            fileMode: 'EXECUTABLE',
+            fileSize: 123,
+          };
+        }
+        throw new Error(`No mock for ${command.constructor.name}`);
       });
     });
 
@@ -511,71 +528,76 @@ describe('AwsCodeCommitUrlReader', () => {
     let awsCodeCommitUrlReader: AwsCodeCommitUrlReader;
 
     beforeEach(() => {
-      codeCommitClient.reset();
-
-      codeCommitClient
-        .on(GetFolderCommand, {
-          folderPath: `/`,
-          repositoryName: `my-test-techdocs`,
-          commitSpecifier: undefined,
-        })
-        .resolves({
-          files: [
-            {
-              absolutePath: `awsCodeCommit-mock-object.yaml`,
-              relativePath: `awsCodeCommit-mock-object.yaml`,
-            },
-          ],
-          subFolders: [
-            {
-              absolutePath: `subFolder`,
-              relativePath: `subFolder`,
-            },
-          ],
-        });
-      codeCommitClient
-        .on(GetFolderCommand, {
-          folderPath: `subFolder`,
-          repositoryName: `my-test-techdocs`,
-          commitSpecifier: undefined,
-        })
-        .resolves({
-          files: [
-            {
-              absolutePath: `subFolder/awsCodeCommit-mock-object2.yaml`,
-              relativePath: `subFolder/awsCodeCommit-mock-object2.yaml`,
-            },
-          ],
-        });
-
-      codeCommitClient
-        .on(GetFileCommand, {
-          filePath: `awsCodeCommit-mock-object.yaml`,
-          commitSpecifier: undefined,
-          repositoryName: `my-test-techdocs`,
-        })
-        .resolves({
-          fileContent: fs.readFileSync(
-            path.resolve(
-              __dirname,
-              '__fixtures__/awsCodeCommit/awsCodeCommit-mock-object.yaml',
-            ),
-          ),
-        });
-      codeCommitClient
-        .on(GetFileCommand, {
-          filePath: `subFolder/awsCodeCommit-mock-object2.yaml`,
-          commitSpecifier: undefined,
-          repositoryName: `my-test-techdocs`,
-        })
-        .resolves({
-          fileContent: fs.readFileSync(
-            path.resolve(
-              __dirname,
-              '__fixtures__/awsCodeCommit/subFolder/awsCodeCommit-mock-object2.yaml',
-            ),
-          ),
-        });
+      jest
+        .spyOn(CodeCommitClient.prototype, 'send')
+        .mockImplementation(codeCommitSendMock);
+      codeCommitSendMock.mockImplementation(async command => {
+        if (command instanceof GetFolderCommand) {
+          const input = command.input;
+          if (
+            input.repositoryName === 'my-test-techdocs' &&
+            input.folderPath === '/'
+          ) {
+            return {
+              files: [
+                {
+                  absolutePath: `awsCodeCommit-mock-object.yaml`,
+                  relativePath: `awsCodeCommit-mock-object.yaml`,
+                },
+              ],
+              subFolders: [
+                {
+                  absolutePath: `subFolder`,
+                  relativePath: `subFolder`,
+                },
+              ],
+            };
+          }
+          if (
+            input.repositoryName === 'my-test-techdocs' &&
+            input.folderPath === 'subFolder'
+          ) {
+            return {
+              files: [
+                {
+                  absolutePath: `subFolder/awsCodeCommit-mock-object2.yaml`,
+                  relativePath: `subFolder/awsCodeCommit-mock-object2.yaml`,
+                },
+              ],
+            };
+          }
+        }
+        if (command instanceof GetFileCommand) {
+          const input = command.input;
+          if (
+            input.repositoryName === 'my-test-techdocs' &&
+            input.filePath === 'awsCodeCommit-mock-object.yaml'
+          ) {
+            return {
+              fileContent: fs.readFileSync(
+                path.resolve(
+                  __dirname,
+                  '__fixtures__/awsCodeCommit/awsCodeCommit-mock-object.yaml',
+                ),
+              ),
+            };
+          }
+          if (
+            input.repositoryName === 'my-test-techdocs' &&
+            input.filePath === 'subFolder/awsCodeCommit-mock-object2.yaml'
+          ) {
+            return {
+              fileContent: fs.readFileSync(
+                path.resolve(
+                  __dirname,
+                  '__fixtures__/awsCodeCommit/subFolder/awsCodeCommit-mock-object2.yaml',
+                ),
+              ),
+            };
+          }
+        }
+        throw new Error(`No mock for ${command.constructor.name}`);
+      });
 
       const config = new ConfigReader({
         accessKeyId: 'fake-access-key',
@@ -624,16 +646,22 @@ describe('AwsCodeCommitUrlReader', () => {
     });
 
     beforeEach(() => {
-      codeCommitClient.reset();
-
-      codeCommitClient.on(GetFileCommand).resolves({
-        fileContent: fs.readFileSync(
-          path.resolve(
-            __dirname,
-            '__fixtures__/awsCodeCommit/awsCodeCommit-mock-object.yaml',
-          ),
-        ),
-        commitId: `123abc`,
+      jest
+        .spyOn(CodeCommitClient.prototype, 'send')
+        .mockImplementation(codeCommitSendMock);
+      codeCommitSendMock.mockImplementation(async command => {
+        if (command instanceof GetFileCommand) {
+          return {
+            fileContent: fs.readFileSync(
+              path.resolve(
+                __dirname,
+                '__fixtures__/awsCodeCommit/awsCodeCommit-mock-object.yaml',
+              ),
+            ),
+            commitId: `123abc`,
+          };
+        }
+        throw new Error(`No mock for ${command.constructor.name}`);
       });
     });
 

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsCodeCommitUrlReader.test.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsCodeCommitUrlReader.test.ts
@@ -198,6 +198,11 @@ describe('parseUrl', () => {
 });
 
 describe('AwsCodeCommitUrlReader', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    codeCommitSendMock.mockReset();
+  });
+
   const createReader = (config: JsonObject): UrlReaderPredicateTuple[] => {
     return AwsCodeCommitUrlReader.factory({
       config: new ConfigReader(config),

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.test.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.test.ts
@@ -26,7 +26,6 @@ import { DefaultAwsCredentialsManager } from '@backstage/integration-aws-node';
 import { UrlReaderPredicateTuple } from './types';
 import path from 'node:path';
 import { NotModifiedError } from '@backstage/errors';
-import { mockClient } from 'aws-sdk-client-mock';
 import {
   S3Client,
   ListObjectsV2Command,
@@ -37,6 +36,8 @@ import {
 import { sdkStreamMixin } from '@aws-sdk/util-stream-node';
 import fs from 'node:fs';
 import { mockServices } from '@backstage/backend-test-utils';
+
+const s3SendMock = jest.fn();
 
 const treeResponseFactory = DefaultReadTreeResponseFactory.create({
   config: new ConfigReader({}),
@@ -269,8 +270,6 @@ describe('parseUrl', () => {
 });
 
 describe('AwsS3UrlReader', () => {
-  const s3Client = mockClient(S3Client);
-
   const createReader = (config: JsonObject): UrlReaderPredicateTuple[] => {
     return AwsS3UrlReader.factory({
       config: new ConfigReader(config),
@@ -378,18 +377,22 @@ describe('AwsS3UrlReader', () => {
     });
 
     beforeEach(() => {
-      s3Client.reset();
-
-      s3Client.on(GetObjectCommand).resolves({
-        Body: sdkStreamMixin(
-          fs.createReadStream(
-            path.resolve(
-              __dirname,
-              '__fixtures__/awsS3/awsS3-mock-object.yaml',
+      jest.spyOn(S3Client.prototype, 'send').mockImplementation(s3SendMock);
+      s3SendMock.mockImplementation(async command => {
+        if (command instanceof GetObjectCommand) {
+          return {
+            Body: sdkStreamMixin(
+              fs.createReadStream(
+                path.resolve(
+                  __dirname,
+                  '__fixtures__/awsS3/awsS3-mock-object.yaml',
+                ),
+              ),
             ),
-          ),
-        ),
-        ETag: '123abc',
+            ETag: '123abc',
+          };
+        }
+        throw new Error(`No mock for ${command.constructor.name}`);
       });
     });
 
@@ -426,19 +429,23 @@ describe('AwsS3UrlReader', () => {
     });
 
     beforeEach(() => {
-      s3Client.reset();
-
-      s3Client.on(GetObjectCommand).resolves({
-        Body: sdkStreamMixin(
-          fs.createReadStream(
-            path.resolve(
-              __dirname,
-              '__fixtures__/awsS3/awsS3-mock-object.yaml',
+      jest.spyOn(S3Client.prototype, 'send').mockImplementation(s3SendMock);
+      s3SendMock.mockImplementation(async command => {
+        if (command instanceof GetObjectCommand) {
+          return {
+            Body: sdkStreamMixin(
+              fs.createReadStream(
+                path.resolve(
+                  __dirname,
+                  '__fixtures__/awsS3/awsS3-mock-object.yaml',
+                ),
+              ),
             ),
-          ),
-        ),
-        ETag: '123abc',
-        LastModified: new Date('2020-01-01T00:00:00Z'),
+            ETag: '123abc',
+            LastModified: new Date('2020-01-01T00:00:00Z'),
+          };
+        }
+        throw new Error(`No mock for ${command.constructor.name}`);
       });
     });
 
@@ -489,16 +496,22 @@ describe('AwsS3UrlReader', () => {
     });
 
     beforeEach(() => {
-      s3Client.on(GetObjectCommand).resolves({
-        Body: sdkStreamMixin(
-          fs.createReadStream(
-            path.resolve(
-              __dirname,
-              '__fixtures__/awsS3/awsS3-mock-object.yaml',
+      jest.spyOn(S3Client.prototype, 'send').mockImplementation(s3SendMock);
+      s3SendMock.mockImplementation(async command => {
+        if (command instanceof GetObjectCommand) {
+          return {
+            Body: sdkStreamMixin(
+              fs.createReadStream(
+                path.resolve(
+                  __dirname,
+                  '__fixtures__/awsS3/awsS3-mock-object.yaml',
+                ),
+              ),
             ),
-          ),
-        ),
-        ETag: '123abc',
+            ETag: '123abc',
+          };
+        }
+        throw new Error(`No mock for ${command.constructor.name}`);
       });
     });
 
@@ -526,13 +539,18 @@ describe('AwsS3UrlReader', () => {
     });
 
     beforeEach(() => {
-      s3Client.reset();
       const t = new S3ServiceException({
         name: '304',
         $fault: 'client',
         $metadata: { httpStatusCode: 304 },
       });
-      s3Client.on(GetObjectCommand).rejects(t);
+      jest.spyOn(S3Client.prototype, 'send').mockImplementation(s3SendMock);
+      s3SendMock.mockImplementation(async command => {
+        if (command instanceof GetObjectCommand) {
+          throw t;
+        }
+        throw new Error(`No mock for ${command.constructor.name}`);
+      });
     });
 
     it('returns contents of an object in a bucket', async () => {
@@ -561,13 +579,18 @@ describe('AwsS3UrlReader', () => {
     });
 
     beforeEach(() => {
-      s3Client.reset();
       const t = new S3ServiceException({
         name: '304',
         $fault: 'client',
         $metadata: { httpStatusCode: 304 },
       });
-      s3Client.on(GetObjectCommand).rejects(t);
+      jest.spyOn(S3Client.prototype, 'send').mockImplementation(s3SendMock);
+      s3SendMock.mockImplementation(async command => {
+        if (command instanceof GetObjectCommand) {
+          throw t;
+        }
+        throw new Error(`No mock for ${command.constructor.name}`);
+      });
     });
 
     it('returns contents of an object in a bucket', async () => {
@@ -586,7 +609,7 @@ describe('AwsS3UrlReader', () => {
     let awsS3UrlReader: AwsS3UrlReader;
 
     beforeEach(() => {
-      s3Client.reset();
+      jest.spyOn(S3Client.prototype, 'send').mockImplementation(s3SendMock);
 
       const object: Object = {
         Key: 'awsS3-mock-object.yaml',
@@ -597,17 +620,23 @@ describe('AwsS3UrlReader', () => {
         Contents: objectList,
       };
 
-      s3Client.on(ListObjectsV2Command).resolves(output);
-
-      s3Client.on(GetObjectCommand).resolves({
-        Body: sdkStreamMixin(
-          fs.createReadStream(
-            path.resolve(
-              __dirname,
-              '__fixtures__/awsS3/awsS3-mock-object.yaml',
+      s3SendMock.mockImplementation(async command => {
+        if (command instanceof ListObjectsV2Command) {
+          return output;
+        }
+        if (command instanceof GetObjectCommand) {
+          return {
+            Body: sdkStreamMixin(
+              fs.createReadStream(
+                path.resolve(
+                  __dirname,
+                  '__fixtures__/awsS3/awsS3-mock-object.yaml',
+                ),
+              ),
             ),
-          ),
-        ),
+          };
+        }
+        throw new Error(`No mock for ${command.constructor.name}`);
       });
 
       const config = new ConfigReader({
@@ -650,19 +679,23 @@ describe('AwsS3UrlReader', () => {
     });
 
     beforeEach(() => {
-      s3Client.reset();
-
-      s3Client.on(GetObjectCommand).resolves({
-        Body: sdkStreamMixin(
-          fs.createReadStream(
-            path.resolve(
-              __dirname,
-              '__fixtures__/awsS3/awsS3-mock-object.yaml',
+      jest.spyOn(S3Client.prototype, 'send').mockImplementation(s3SendMock);
+      s3SendMock.mockImplementation(async command => {
+        if (command instanceof GetObjectCommand) {
+          return {
+            Body: sdkStreamMixin(
+              fs.createReadStream(
+                path.resolve(
+                  __dirname,
+                  '__fixtures__/awsS3/awsS3-mock-object.yaml',
+                ),
+              ),
             ),
-          ),
-        ),
-        ETag: '123abc',
-        LastModified: new Date('2020-01-01T00:00:00Z'),
+            ETag: '123abc',
+            LastModified: new Date('2020-01-01T00:00:00Z'),
+          };
+        }
+        throw new Error(`No mock for ${command.constructor.name}`);
       });
     });
 

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.test.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.test.ts
@@ -270,6 +270,11 @@ describe('parseUrl', () => {
 });
 
 describe('AwsS3UrlReader', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    s3SendMock.mockReset();
+  });
+
   const createReader = (config: JsonObject): UrlReaderPredicateTuple[] => {
     return AwsS3UrlReader.factory({
       config: new ConfigReader(config),

--- a/packages/integration-aws-node/package.json
+++ b/packages/integration-aws-node/package.json
@@ -47,9 +47,7 @@
   "devDependencies": {
     "@backstage/cli": "workspace:^",
     "@backstage/config-loader": "workspace:^",
-    "@backstage/test-utils": "workspace:^",
-    "aws-sdk-client-mock": "^4.0.0",
-    "aws-sdk-client-mock-jest": "^4.0.0"
+    "@backstage/test-utils": "workspace:^"
   },
   "configSchema": "config.d.ts"
 }

--- a/packages/integration-aws-node/src/DefaultAwsCredentialsManager.test.ts
+++ b/packages/integration-aws-node/src/DefaultAwsCredentialsManager.test.ts
@@ -46,6 +46,7 @@ jest.mock('@aws-sdk/credential-providers', () => {
 describe('DefaultAwsCredentialsManager', () => {
   beforeEach(() => {
     process.env = { ...env };
+    jest.restoreAllMocks();
     jest.resetAllMocks();
 
     stsSendShouldReject = false;
@@ -169,6 +170,7 @@ describe('DefaultAwsCredentialsManager', () => {
 
   afterEach(() => {
     process.env = env;
+    jest.restoreAllMocks();
     if (tmpDir) {
       rmSync(tmpDir, { recursive: true, force: true });
     }
@@ -554,6 +556,7 @@ describe('DefaultAwsCredentialsManager', () => {
         DefaultAwsCredentialsManager.fromConfig(configWithRegion);
       await provider.getCredentialProvider({ accountId: '123456789012' });
 
+      expect(stsSendMock).toHaveBeenCalledTimes(1);
       const stsClient = stsSendMock.mock.contexts[0] as STSClient;
       expect(await stsClient.config.region()).toEqual(region);
     });

--- a/packages/integration-aws-node/src/DefaultAwsCredentialsManager.test.ts
+++ b/packages/integration-aws-node/src/DefaultAwsCredentialsManager.test.ts
@@ -554,7 +554,7 @@ describe('DefaultAwsCredentialsManager', () => {
         DefaultAwsCredentialsManager.fromConfig(configWithRegion);
       await provider.getCredentialProvider({ accountId: '123456789012' });
 
-      const stsClient = stsSendMock.mock.instances[0] as STSClient;
+      const stsClient = stsSendMock.mock.contexts[0] as STSClient;
       expect(await stsClient.config.region()).toEqual(region);
     });
 

--- a/packages/integration-aws-node/src/DefaultAwsCredentialsManager.test.ts
+++ b/packages/integration-aws-node/src/DefaultAwsCredentialsManager.test.ts
@@ -15,8 +15,6 @@
  */
 
 import { DefaultAwsCredentialsManager } from './DefaultAwsCredentialsManager';
-import { mockClient, AwsClientStub } from 'aws-sdk-client-mock';
-import 'aws-sdk-client-mock-jest';
 import { STSClient, GetCallerIdentityCommand } from '@aws-sdk/client-sts';
 import { Config, ConfigReader } from '@backstage/config';
 import {
@@ -29,7 +27,9 @@ import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 
 const env = process.env;
-let stsMock: AwsClientStub<STSClient>;
+const stsSendMock = jest.fn();
+let stsSendShouldReject = false;
+let stsSendRejectMessage: string | undefined;
 let config: Config;
 let tmpDir: string;
 
@@ -48,7 +48,20 @@ describe('DefaultAwsCredentialsManager', () => {
     process.env = { ...env };
     jest.resetAllMocks();
 
-    stsMock = mockClient(STSClient);
+    stsSendShouldReject = false;
+    stsSendRejectMessage = undefined;
+    jest.spyOn(STSClient.prototype, 'send').mockImplementation(stsSendMock);
+    stsSendMock.mockImplementation(async command => {
+      if (command instanceof GetCallerIdentityCommand) {
+        if (stsSendShouldReject) {
+          throw new Error(stsSendRejectMessage ?? 'No credentials found');
+        }
+        return {
+          Account: '123456789012',
+        };
+      }
+      throw new Error(`No mock for ${command.constructor.name}`);
+    });
 
     config = new ConfigReader({
       aws: {
@@ -90,23 +103,6 @@ describe('DefaultAwsCredentialsManager', () => {
         },
       },
     });
-
-    stsMock.on(GetCallerIdentityCommand).resolvesOnce({
-      Account: '123456789012',
-    });
-
-    stsMock
-      .on(GetCallerIdentityCommand)
-      .callsFake(async (_input, getClient) => {
-        const client = getClient();
-        const region = await client.config.region();
-        if (!region) {
-          throw new Error('Region is missing');
-        }
-        return {
-          Account: '123456789012',
-        };
-      });
 
     // Mock fromTemporaryCredentials to return credential providers
     // based on the RoleArn, instead of mocking internal nested STS clients.
@@ -325,7 +321,10 @@ describe('DefaultAwsCredentialsManager', () => {
       });
 
       expect(awsCredentialProvider1).toBe(awsCredentialProvider2);
-      expect(stsMock).toHaveReceivedCommandTimes(GetCallerIdentityCommand, 1);
+      expect(stsSendMock).toHaveBeenCalledTimes(1);
+      expect(stsSendMock.mock.calls[0][0]).toBeInstanceOf(
+        GetCallerIdentityCommand,
+      );
     });
 
     it('retrieves the ini provider chain for the given account ID', async () => {
@@ -489,7 +488,8 @@ describe('DefaultAwsCredentialsManager', () => {
     });
 
     it('rejects main account that has invalid credentials', async () => {
-      stsMock.on(GetCallerIdentityCommand).rejects('No credentials found');
+      stsSendShouldReject = true;
+      stsSendRejectMessage = 'No credentials found';
       const minConfig = new ConfigReader({});
       const provider = DefaultAwsCredentialsManager.fromConfig(minConfig);
       await expect(
@@ -554,7 +554,8 @@ describe('DefaultAwsCredentialsManager', () => {
         DefaultAwsCredentialsManager.fromConfig(configWithRegion);
       await provider.getCredentialProvider({ accountId: '123456789012' });
 
-      expect(await stsMock.call(0).thisValue.config.region()).toEqual(region);
+      const stsClient = stsSendMock.mock.instances[0] as STSClient;
+      expect(await stsClient.config.region()).toEqual(region);
     });
 
     it('uses fromTokenFile when webIdentityTokenFile is set per-account with a roleName', async () => {

--- a/plugins/catalog-backend-module-aws/package.json
+++ b/plugins/catalog-backend-module-aws/package.json
@@ -72,8 +72,6 @@
     "@aws-sdk/util-stream-node": "^3.350.0",
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
-    "aws-sdk-client-mock": "^4.0.0",
-    "aws-sdk-client-mock-jest": "^4.0.0",
     "yaml": "^2.0.0"
   },
   "configSchema": "config.d.ts"

--- a/plugins/catalog-backend-module-aws/src/processors/AwsEKSClusterProcessor.test.ts
+++ b/plugins/catalog-backend-module-aws/src/processors/AwsEKSClusterProcessor.test.ts
@@ -31,6 +31,12 @@ describe('AwsEKSClusterProcessor', () => {
     const location = { type: 'aws-eks', target: '957140518395/us-west-2' };
     const emit = jest.fn();
 
+    afterEach(() => {
+      jest.restoreAllMocks();
+      eksSendMock.mockReset();
+      emit.mockReset();
+    });
+
     it('generates cluster correctly', async () => {
       jest.spyOn(EKSClient.prototype, 'send').mockImplementation(eksSendMock);
       const clusters: ListClustersResponse = {

--- a/plugins/catalog-backend-module-aws/src/processors/AwsEKSClusterProcessor.test.ts
+++ b/plugins/catalog-backend-module-aws/src/processors/AwsEKSClusterProcessor.test.ts
@@ -15,7 +15,6 @@
  */
 
 import { AwsEKSClusterProcessor } from './AwsEKSClusterProcessor';
-import { mockClient } from 'aws-sdk-client-mock';
 import {
   ListClustersResponse,
   DescribeClusterResponse,
@@ -24,6 +23,8 @@ import {
   EKSClient,
 } from '@aws-sdk/client-eks';
 
+const eksSendMock = jest.fn();
+
 describe('AwsEKSClusterProcessor', () => {
   describe('readLocation', () => {
     const processor = new (AwsEKSClusterProcessor as any)({});
@@ -31,6 +32,7 @@ describe('AwsEKSClusterProcessor', () => {
     const emit = jest.fn();
 
     it('generates cluster correctly', async () => {
+      jest.spyOn(EKSClient.prototype, 'send').mockImplementation(eksSendMock);
       const clusters: ListClustersResponse = {
         clusters: ['backstage-test'],
         nextToken: undefined,
@@ -46,10 +48,15 @@ describe('AwsEKSClusterProcessor', () => {
           },
         },
       };
-      const mock = mockClient(EKSClient);
-
-      mock.on(ListClustersCommand).resolves(clusters);
-      mock.on(DescribeClusterCommand).resolves(cluster);
+      eksSendMock.mockImplementation(async command => {
+        if (command instanceof ListClustersCommand) {
+          return clusters;
+        }
+        if (command instanceof DescribeClusterCommand) {
+          return cluster;
+        }
+        throw new Error(`Unexpected command: ${command.constructor.name}`);
+      });
 
       await processor.readLocation(location, false, emit);
 

--- a/plugins/catalog-backend-module-aws/src/processors/AwsOrganizationCloudAccountProcessor.test.ts
+++ b/plugins/catalog-backend-module-aws/src/processors/AwsOrganizationCloudAccountProcessor.test.ts
@@ -56,9 +56,9 @@ describe('AwsOrganizationCloudAccountProcessor', () => {
         throw new Error(`Unexpected command: ${command.constructor.name}`);
       });
       await processor.readLocation(location, false, emit);
-      expect(organizationsSendMock).toHaveBeenCalledWith(
-        expect.any(ListAccountsCommand),
-        undefined,
+      expect(organizationsSendMock).toHaveBeenCalledTimes(1);
+      expect(organizationsSendMock.mock.calls[0][0]).toBeInstanceOf(
+        ListAccountsCommand,
       );
       expect(emit).toHaveBeenCalledWith({
         type: 'entity',
@@ -116,9 +116,9 @@ describe('AwsOrganizationCloudAccountProcessor', () => {
         throw new Error(`Unexpected command: ${command.constructor.name}`);
       });
       await processor.readLocation(locationTest, false, emit);
-      expect(organizationsSendMock).toHaveBeenCalledWith(
-        expect.any(ListAccountsCommand),
-        undefined,
+      expect(organizationsSendMock).toHaveBeenCalledTimes(1);
+      expect(organizationsSendMock.mock.calls[0][0]).toBeInstanceOf(
+        ListAccountsCommand,
       );
       expect(emit).toHaveBeenCalledTimes(1);
       expect(emit).toHaveBeenCalledWith({

--- a/plugins/catalog-backend-module-aws/src/processors/AwsOrganizationCloudAccountProcessor.test.ts
+++ b/plugins/catalog-backend-module-aws/src/processors/AwsOrganizationCloudAccountProcessor.test.ts
@@ -15,7 +15,10 @@
  */
 
 import { AwsOrganizationCloudAccountProcessor } from './AwsOrganizationCloudAccountProcessor';
-import { OrganizationsClient } from '@aws-sdk/client-organizations';
+import {
+  ListAccountsCommand,
+  OrganizationsClient,
+} from '@aws-sdk/client-organizations';
 
 const organizationsSendMock = jest.fn();
 
@@ -27,25 +30,36 @@ describe('AwsOrganizationCloudAccountProcessor', () => {
     const location = { type: 'aws-cloud-accounts', target: '' };
     const emit = jest.fn();
     afterEach(() => {
-      jest.clearAllMocks();
+      jest.restoreAllMocks();
+      organizationsSendMock.mockReset();
+      emit.mockReset();
     });
 
     it('generates component entities for accounts', async () => {
       jest
         .spyOn(OrganizationsClient.prototype, 'send')
         .mockImplementation(organizationsSendMock);
-      organizationsSendMock.mockResolvedValue({
-        Accounts: [
-          {
-            Arn: 'arn:aws:organizations::192594491037:account/o-1vl18kc5a3/957140518395',
-            Name: 'Test Account',
-            Email: 'aws-test-account@backstage.io',
-            Status: 'ACTIVE',
-          },
-        ],
-        NextToken: undefined,
+      organizationsSendMock.mockImplementation(async command => {
+        if (command instanceof ListAccountsCommand) {
+          return {
+            Accounts: [
+              {
+                Arn: 'arn:aws:organizations::192594491037:account/o-1vl18kc5a3/957140518395',
+                Name: 'Test Account',
+                Email: 'aws-test-account@backstage.io',
+                Status: 'ACTIVE',
+              },
+            ],
+            NextToken: undefined,
+          };
+        }
+        throw new Error(`Unexpected command: ${command.constructor.name}`);
       });
       await processor.readLocation(location, false, emit);
+      expect(organizationsSendMock).toHaveBeenCalledWith(
+        expect.any(ListAccountsCommand),
+        undefined,
+      );
       expect(emit).toHaveBeenCalledWith({
         type: 'entity',
         location,
@@ -83,20 +97,29 @@ describe('AwsOrganizationCloudAccountProcessor', () => {
         type: 'aws-cloud-accounts',
         target: 'o-1vl18kc5a3',
       };
-      organizationsSendMock.mockResolvedValue({
-        Accounts: [
-          {
-            Arn: 'arn:aws:organizations::192594491037:account/o-1vl18kc5a3/957140518395',
-            Name: 'Test Account',
-          },
-          {
-            Arn: 'arn:aws:organizations::192594491037:account/o-zzzzzzzzz/957140518395',
-            Name: 'Test Account 2',
-          },
-        ],
-        NextToken: undefined,
+      organizationsSendMock.mockImplementation(async command => {
+        if (command instanceof ListAccountsCommand) {
+          return {
+            Accounts: [
+              {
+                Arn: 'arn:aws:organizations::192594491037:account/o-1vl18kc5a3/957140518395',
+                Name: 'Test Account',
+              },
+              {
+                Arn: 'arn:aws:organizations::192594491037:account/o-zzzzzzzzz/957140518395',
+                Name: 'Test Account 2',
+              },
+            ],
+            NextToken: undefined,
+          };
+        }
+        throw new Error(`Unexpected command: ${command.constructor.name}`);
       });
       await processor.readLocation(locationTest, false, emit);
+      expect(organizationsSendMock).toHaveBeenCalledWith(
+        expect.any(ListAccountsCommand),
+        undefined,
+      );
       expect(emit).toHaveBeenCalledTimes(1);
       expect(emit).toHaveBeenCalledWith({
         type: 'entity',

--- a/plugins/catalog-backend-module-aws/src/processors/AwsOrganizationCloudAccountProcessor.test.ts
+++ b/plugins/catalog-backend-module-aws/src/processors/AwsOrganizationCloudAccountProcessor.test.ts
@@ -15,10 +15,7 @@
  */
 
 import { AwsOrganizationCloudAccountProcessor } from './AwsOrganizationCloudAccountProcessor';
-import {
-  ListAccountsCommand,
-  OrganizationsClient,
-} from '@aws-sdk/client-organizations';
+import { OrganizationsClient } from '@aws-sdk/client-organizations';
 
 const organizationsSendMock = jest.fn();
 

--- a/plugins/catalog-backend-module-aws/src/processors/AwsOrganizationCloudAccountProcessor.test.ts
+++ b/plugins/catalog-backend-module-aws/src/processors/AwsOrganizationCloudAccountProcessor.test.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import { mockClient } from 'aws-sdk-client-mock';
-import 'aws-sdk-client-mock-jest';
 import { AwsOrganizationCloudAccountProcessor } from './AwsOrganizationCloudAccountProcessor';
 import {
   ListAccountsCommand,
   OrganizationsClient,
 } from '@aws-sdk/client-organizations';
+
+const organizationsSendMock = jest.fn();
 
 describe('AwsOrganizationCloudAccountProcessor', () => {
   describe('readLocation', () => {
@@ -29,14 +29,15 @@ describe('AwsOrganizationCloudAccountProcessor', () => {
     });
     const location = { type: 'aws-cloud-accounts', target: '' };
     const emit = jest.fn();
-    const mock = mockClient(OrganizationsClient);
-
     afterEach(() => {
-      jest.resetAllMocks();
+      jest.clearAllMocks();
     });
 
     it('generates component entities for accounts', async () => {
-      mock.on(ListAccountsCommand).resolves({
+      jest
+        .spyOn(OrganizationsClient.prototype, 'send')
+        .mockImplementation(organizationsSendMock);
+      organizationsSendMock.mockResolvedValue({
         Accounts: [
           {
             Arn: 'arn:aws:organizations::192594491037:account/o-1vl18kc5a3/957140518395',
@@ -78,11 +79,14 @@ describe('AwsOrganizationCloudAccountProcessor', () => {
     });
 
     it('filters out accounts not in specified location target', async () => {
+      jest
+        .spyOn(OrganizationsClient.prototype, 'send')
+        .mockImplementation(organizationsSendMock);
       const locationTest = {
         type: 'aws-cloud-accounts',
         target: 'o-1vl18kc5a3',
       };
-      mock.on(ListAccountsCommand).resolves({
+      organizationsSendMock.mockResolvedValue({
         Accounts: [
           {
             Arn: 'arn:aws:organizations::192594491037:account/o-1vl18kc5a3/957140518395',

--- a/plugins/catalog-backend-module-aws/src/processors/AwsS3DiscoveryProcessor.test.ts
+++ b/plugins/catalog-backend-module-aws/src/processors/AwsS3DiscoveryProcessor.test.ts
@@ -28,14 +28,14 @@ import {
   ListObjectsV2Output,
   GetObjectCommand,
 } from '@aws-sdk/client-s3';
-import { mockClient } from 'aws-sdk-client-mock';
 import { sdkStreamMixin } from '@aws-sdk/util-stream-node';
 import fs from 'node:fs';
 import path from 'node:path';
 import YAML from 'yaml';
 import { mockServices } from '@backstage/backend-test-utils';
 
-const s3Client = mockClient(S3Client);
+const s3SendMock = jest.fn();
+
 const object: Object = {
   Key: 'awsS3-mock-object.txt',
 };
@@ -60,14 +60,21 @@ describe('readLocation', () => {
   };
 
   beforeEach(() => {
-    s3Client.reset();
-    s3Client.on(ListObjectsV2Command).resolves(output);
-    s3Client.on(GetObjectCommand).resolves({
-      Body: sdkStreamMixin(
-        fs.createReadStream(
-          path.resolve(__dirname, '__fixtures__/awsS3-mock-object.txt'),
-        ),
-      ),
+    jest.spyOn(S3Client.prototype, 'send').mockImplementation(s3SendMock);
+    s3SendMock.mockImplementation(async command => {
+      if (command instanceof ListObjectsV2Command) {
+        return output;
+      }
+      if (command instanceof GetObjectCommand) {
+        return {
+          Body: sdkStreamMixin(
+            fs.createReadStream(
+              path.resolve(__dirname, '__fixtures__/awsS3-mock-object.txt'),
+            ),
+          ),
+        };
+      }
+      throw new Error(`No mock for ${command.constructor.name}`);
     });
   });
 

--- a/plugins/catalog-backend-module-aws/src/processors/AwsS3DiscoveryProcessor.test.ts
+++ b/plugins/catalog-backend-module-aws/src/processors/AwsS3DiscoveryProcessor.test.ts
@@ -59,6 +59,11 @@ describe('readLocation', () => {
     target: 'https://testbucket.s3.us-east-2.amazonaws.com',
   };
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+    s3SendMock.mockReset();
+  });
+
   beforeEach(() => {
     jest.spyOn(S3Client.prototype, 'send').mockImplementation(s3SendMock);
     s3SendMock.mockImplementation(async command => {

--- a/plugins/catalog-backend-module-aws/src/providers/AwsS3EntityProvider.test.ts
+++ b/plugins/catalog-backend-module-aws/src/providers/AwsS3EntityProvider.test.ts
@@ -22,10 +22,10 @@ import {
 import { ConfigReader } from '@backstage/config';
 import { EntityProviderConnection } from '@backstage/plugin-catalog-node';
 import { AwsS3EntityProvider } from './AwsS3EntityProvider';
-import { mockClient } from 'aws-sdk-client-mock';
-import 'aws-sdk-client-mock-jest';
 import { ListObjectsV2Command, S3Client } from '@aws-sdk/client-s3';
 import { mockServices } from '@backstage/backend-test-utils';
+
+const s3SendMock = jest.fn();
 
 class PersistingTaskRunner implements SchedulerServiceTaskRunner {
   private tasks: SchedulerServiceTaskInvocationDefinition[] = [];
@@ -53,10 +53,15 @@ describe('AwsS3EntityProvider', () => {
   };
 
   const keys = ['key1.yaml', 'key2.yaml', 'key3.yaml', 'key 4.yaml'];
-  const mock = mockClient(S3Client);
 
   beforeEach(() => {
-    mock.on(ListObjectsV2Command).callsFake(async req => {
+    jest.spyOn(S3Client.prototype, 'send').mockImplementation(s3SendMock);
+    s3SendMock.mockImplementation(async command => {
+      if (!(command instanceof ListObjectsV2Command)) {
+        throw new Error(`No mock for ${command.constructor.name}`);
+      }
+
+      const req = command.input;
       const prefix = req.Prefix ?? '';
 
       if (!req.ContinuationToken) {

--- a/plugins/catalog-backend-module-aws/src/providers/AwsS3EntityProvider.test.ts
+++ b/plugins/catalog-backend-module-aws/src/providers/AwsS3EntityProvider.test.ts
@@ -84,7 +84,8 @@ describe('AwsS3EntityProvider', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    jest.restoreAllMocks();
+    s3SendMock.mockReset();
     process.env.AWS_REGION = undefined;
   });
 

--- a/plugins/events-backend-module-aws-sqs/package.json
+++ b/plugins/events-backend-module-aws-sqs/package.json
@@ -58,8 +58,7 @@
     "@aws-sdk/types": "^3.347.0",
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
-    "@backstage/plugin-events-backend-test-utils": "workspace:^",
-    "aws-sdk-client-mock": "^4.0.0"
+    "@backstage/plugin-events-backend-test-utils": "workspace:^"
   },
   "configSchema": "config.d.ts"
 }

--- a/plugins/events-backend-module-aws-sqs/src/publisher/AwsSqsConsumingEventPublisher.test.ts
+++ b/plugins/events-backend-module-aws-sqs/src/publisher/AwsSqsConsumingEventPublisher.test.ts
@@ -28,6 +28,11 @@ import { mockServices } from '@backstage/backend-test-utils';
 const sqsSendMock = jest.fn();
 
 describe('AwsSqsConsumingEventPublisher', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    sqsSendMock.mockReset();
+  });
+
   it('creates one publisher instance per configured topic', async () => {
     const config = new ConfigReader({
       events: {
@@ -144,7 +149,7 @@ describe('AwsSqsConsumingEventPublisher', () => {
       },
     } as unknown as SchedulerService;
 
-    // on the first attempt, we will return 1 message and 0 messages afterwards
+    // on the first attempt, we will return 0 messages; on the second attempt, 2 messages; afterwards 0 messages
     let receiveCalls = 0;
     jest.spyOn(SQSClient.prototype, 'send').mockImplementation(sqsSendMock);
     sqsSendMock.mockImplementation(async command => {
@@ -204,6 +209,44 @@ describe('AwsSqsConsumingEventPublisher', () => {
     await taskFn!();
     await taskFn!();
     await taskFn!();
+
+    const receiveMessageCommands = sqsSendMock.mock.calls
+      .map(call => call[0])
+      .filter(
+        (command): command is ReceiveMessageCommand =>
+          command instanceof ReceiveMessageCommand,
+      );
+    expect(receiveMessageCommands).toHaveLength(3);
+    for (const command of receiveMessageCommands) {
+      expect(command.input).toEqual(
+        expect.objectContaining({
+          MaxNumberOfMessages: 10,
+          QueueUrl: 'https://fake1.queue.url',
+          WaitTimeSeconds: 20,
+        }),
+      );
+    }
+
+    const deleteMessageCommands = sqsSendMock.mock.calls
+      .map(call => call[0])
+      .filter(
+        (command): command is DeleteMessageBatchCommand =>
+          command instanceof DeleteMessageBatchCommand,
+      );
+    expect(deleteMessageCommands).toHaveLength(1);
+    expect(deleteMessageCommands[0].input).toEqual({
+      QueueUrl: 'https://fake1.queue.url',
+      Entries: [
+        {
+          Id: 'message-0',
+          ReceiptHandle: 'fake-handle1',
+        },
+        {
+          Id: 'message-1',
+          ReceiptHandle: 'fake-handle2',
+        },
+      ],
+    });
 
     expect(events.published).toHaveLength(2);
     expect(events.published[0].topic).toEqual('fake1');

--- a/plugins/events-backend-module-aws-sqs/src/publisher/AwsSqsConsumingEventPublisher.test.ts
+++ b/plugins/events-backend-module-aws-sqs/src/publisher/AwsSqsConsumingEventPublisher.test.ts
@@ -22,9 +22,10 @@ import {
 import { SchedulerService } from '@backstage/backend-plugin-api';
 import { ConfigReader } from '@backstage/config';
 import { TestEventsService } from '@backstage/plugin-events-backend-test-utils';
-import { mockClient } from 'aws-sdk-client-mock';
 import { AwsSqsConsumingEventPublisher } from './AwsSqsConsumingEventPublisher';
 import { mockServices } from '@backstage/backend-test-utils';
+
+const sqsSendMock = jest.fn();
 
 describe('AwsSqsConsumingEventPublisher', () => {
   it('creates one publisher instance per configured topic', async () => {
@@ -144,58 +145,51 @@ describe('AwsSqsConsumingEventPublisher', () => {
     } as unknown as SchedulerService;
 
     // on the first attempt, we will return 1 message and 0 messages afterwards
-    const sqsMock = mockClient(SQSClient);
-    sqsMock
-      .on(ReceiveMessageCommand, {
-        MaxNumberOfMessages: 10,
-        QueueUrl: 'https://fake1.queue.url',
-        WaitTimeSeconds: 20,
-      })
-      .resolvesOnce({
-        Messages: [],
-      })
-      .resolvesOnce({
-        Messages: [
-          {
-            Body: '{"event":"payload1"}',
-            ReceiptHandle: 'fake-handle1',
-            MessageAttributes: {
-              'X-Custom-Attr': {
-                DataType: 'String',
-                StringValue: 'value',
+    let receiveCalls = 0;
+    jest.spyOn(SQSClient.prototype, 'send').mockImplementation(sqsSendMock);
+    sqsSendMock.mockImplementation(async command => {
+      if (command instanceof ReceiveMessageCommand) {
+        receiveCalls += 1;
+        if (receiveCalls === 1) {
+          return { Messages: [] };
+        }
+        if (receiveCalls === 2) {
+          return {
+            Messages: [
+              {
+                Body: '{"event":"payload1"}',
+                ReceiptHandle: 'fake-handle1',
+                MessageAttributes: {
+                  'X-Custom-Attr': {
+                    DataType: 'String',
+                    StringValue: 'value',
+                  },
+                },
               },
+              {
+                Body: '{"event":"payload2"}',
+                ReceiptHandle: 'fake-handle2',
+              },
+            ],
+          };
+        }
+        return { Messages: [] };
+      }
+      if (command instanceof DeleteMessageBatchCommand) {
+        return {
+          Failed: [
+            {
+              Id: 'message-1',
+              Message: 'test failure',
+              SenderFault: true,
+              Code: '400',
             },
-          },
-          {
-            Body: '{"event":"payload2"}',
-            ReceiptHandle: 'fake-handle2',
-          },
-        ],
-      })
-      .on(DeleteMessageBatchCommand, {
-        Entries: [
-          {
-            Id: 'message-0',
-            ReceiptHandle: 'fake-handle1',
-          },
-          {
-            Id: 'message-1',
-            ReceiptHandle: 'fake-handle2',
-          },
-        ],
-        QueueUrl: 'https://fake1.queue.url',
-      })
-      .resolvesOnce({
-        Failed: [
-          {
-            Id: 'message-1',
-            Message: 'test failure',
-            SenderFault: true,
-            Code: '400',
-          },
-        ],
-        Successful: [{ Id: 'message-0' }],
-      });
+          ],
+          Successful: [{ Id: 'message-0' }],
+        };
+      }
+      throw new Error(`No mock for ${command.constructor.name}`);
+    });
 
     const publishers = AwsSqsConsumingEventPublisher.fromConfig({
       config,

--- a/plugins/techdocs-node/package.json
+++ b/plugins/techdocs-node/package.json
@@ -85,7 +85,6 @@
     "@types/mime-types": "^2.1.0",
     "@types/recursive-readdir": "^2.2.0",
     "@types/supertest": "^2.0.8",
-    "aws-sdk-client-mock": "^4.0.0",
     "supertest": "^7.0.0"
   }
 }

--- a/plugins/techdocs-node/src/stages/publish/awsS3.test.ts
+++ b/plugins/techdocs-node/src/stages/publish/awsS3.test.ts
@@ -32,7 +32,6 @@ import {
   AwsCredentialProviderOptions,
   DefaultAwsCredentialsManager,
 } from '@backstage/integration-aws-node';
-import { mockClient, AwsClientStub } from 'aws-sdk-client-mock';
 import express from 'express';
 import request from 'supertest';
 import path from 'node:path';
@@ -47,10 +46,97 @@ import {
 jest.setTimeout(30_000);
 
 const env = process.env;
-let s3Mock: AwsClientStub<S3Client>;
-
 // Create a new MockDirectory for each test to avoid Windows file locking issues
 let mockDir: ReturnType<typeof createMockDirectory>;
+
+const s3SendMock = jest.fn();
+
+async function defaultS3SendImplementation(command: unknown) {
+  if (command instanceof HeadObjectCommand) {
+    if (!fs.pathExistsSync(mockDir.resolve(command.input.Key!))) {
+      throw new Error('File does not exist');
+    }
+    return {};
+  }
+
+  if (command instanceof GetObjectCommand) {
+    if (fs.pathExistsSync(mockDir.resolve(command.input.Key!))) {
+      return {
+        Body: Readable.from(
+          fs.readFileSync(mockDir.resolve(command.input.Key!)),
+        ),
+      };
+    }
+
+    throw new Error(`The file ${command.input.Key} does not exist!`);
+  }
+
+  if (command instanceof HeadBucketCommand) {
+    if (command.input.Bucket === 'errorBucket') {
+      throw new Error('Bucket does not exist');
+    }
+    return {};
+  }
+
+  if (command instanceof ListObjectsV2Command) {
+    if (
+      command.input.Bucket === 'delete_stale_files_success' ||
+      command.input.Bucket === 'delete_stale_files_error'
+    ) {
+      return {
+        Contents: [{ Key: 'stale_file.png' }],
+      };
+    }
+    return {};
+  }
+
+  if (command instanceof DeleteObjectCommand) {
+    if (command.input.Bucket === 'delete_stale_files_error') {
+      throw new Error('Message');
+    }
+    return {};
+  }
+
+  if (command instanceof UploadPartCommand) {
+    throw new Error('UploadPartCommand is not mocked');
+  }
+
+  if (command instanceof PutObjectCommand) {
+    // Body can be undefined in tests; ensure it's a valid MockDirectoryContent value
+    mockDir.addContent({
+      [command.input.Key!]: (command.input.Body ?? '') as any,
+    });
+    return {};
+  }
+
+  throw new Error(
+    `No mock for ${
+      (command as { constructor: { name: string } }).constructor.name
+    }`,
+  );
+}
+
+function mockDefaultS3Send() {
+  s3SendMock.mockImplementation(defaultS3SendImplementation);
+}
+
+function mockListObjectsRetry(
+  error: S3ServiceException,
+  resolveValue: { Contents: [] } = { Contents: [] },
+) {
+  let listObjectsCallCount = 0;
+  s3SendMock.mockImplementation(async command => {
+    if (command instanceof ListObjectsV2Command) {
+      listObjectsCallCount++;
+      if (listObjectsCallCount === 1) {
+        throw error;
+      }
+      return resolveValue;
+    }
+
+    return defaultS3SendImplementation(command);
+  });
+}
 
 function getMockCredentialProvider(): Promise<AwsCredentialProvider> {
   return Promise.resolve({
@@ -199,55 +285,8 @@ describe('AwsS3Publish', () => {
       [directory]: files,
     });
 
-    s3Mock = mockClient(S3Client);
-
-    s3Mock.on(HeadObjectCommand).callsFake(input => {
-      if (!fs.pathExistsSync(mockDir.resolve(input.Key))) {
-        throw new Error('File does not exist');
-      }
-      return {};
-    });
-
-    s3Mock.on(GetObjectCommand).callsFake(input => {
-      if (fs.pathExistsSync(mockDir.resolve(input.Key))) {
-        return {
-          Body: Readable.from(fs.readFileSync(mockDir.resolve(input.Key))),
-        };
-      }
-
-      throw new Error(`The file ${input.Key} does not exist!`);
-    });
-
-    s3Mock.on(HeadBucketCommand).callsFake(input => {
-      if (input.Bucket === 'errorBucket') {
-        throw new Error('Bucket does not exist');
-      }
-      return {};
-    });
-
-    s3Mock.on(ListObjectsV2Command).callsFake(input => {
-      if (
-        input.Bucket === 'delete_stale_files_success' ||
-        input.Bucket === 'delete_stale_files_error'
-      ) {
-        return {
-          Contents: [{ Key: 'stale_file.png' }],
-        };
-      }
-      return {};
-    });
-
-    s3Mock.on(DeleteObjectCommand).callsFake(input => {
-      if (input.Bucket === 'delete_stale_files_error') {
-        throw new Error('Message');
-      }
-      return {};
-    });
-
-    s3Mock.on(UploadPartCommand).rejects();
-    s3Mock.on(PutObjectCommand).callsFake(input => {
-      mockDir.addContent({ [input.Key]: input.Body });
-    });
+    jest.spyOn(S3Client.prototype, 'send').mockImplementation(s3SendMock);
+    mockDefaultS3Send();
   });
 
   afterEach(() => {
@@ -514,16 +553,13 @@ describe('AwsS3Publish', () => {
         return error.name === 'NetworkingError';
       });
 
-      s3Mock
-        .on(ListObjectsV2Command)
-        .rejectsOnce(
-          new S3ServiceException({
-            name: 'NetworkingError',
-            $fault: 'client',
-            $metadata: {},
-          }),
-        )
-        .resolvesOnce({ Contents: [] });
+      mockListObjectsRetry(
+        new S3ServiceException({
+          name: 'NetworkingError',
+          $fault: 'client',
+          $metadata: {},
+        }),
+      );
 
       await (publisher as AwsS3Publish).retryOperation(
         async () => {
@@ -540,16 +576,13 @@ describe('AwsS3Publish', () => {
 
     it('should use default retry strategy when no custom strategy provided', async () => {
       const publisher = await createPublisherFromConfig();
-      s3Mock
-        .on(ListObjectsV2Command)
-        .rejectsOnce(
-          new S3ServiceException({
-            name: 'RequestTimeout',
-            $fault: 'client',
-            $metadata: {},
-          }),
-        )
-        .resolvesOnce({ Contents: [] });
+      mockListObjectsRetry(
+        new S3ServiceException({
+          name: 'RequestTimeout',
+          $fault: 'client',
+          $metadata: {},
+        }),
+      );
 
       await (publisher as AwsS3Publish).retryOperation(
         async () => {
@@ -563,16 +596,13 @@ describe('AwsS3Publish', () => {
 
     it('should retry on server errors (5xx)', async () => {
       const publisher = await createPublisherFromConfig();
-      s3Mock
-        .on(ListObjectsV2Command)
-        .rejectsOnce(
-          new S3ServiceException({
-            name: 'InternalError',
-            $fault: 'server',
-            $metadata: { httpStatusCode: 500 },
-          }),
-        )
-        .resolvesOnce({ Contents: [] });
+      mockListObjectsRetry(
+        new S3ServiceException({
+          name: 'InternalError',
+          $fault: 'server',
+          $metadata: { httpStatusCode: 500 },
+        }),
+      );
 
       await (publisher as AwsS3Publish).retryOperation(
         async () => {
@@ -586,16 +616,13 @@ describe('AwsS3Publish', () => {
 
     it('should retry on specific 4xx errors that are transient', async () => {
       const publisher = await createPublisherFromConfig();
-      s3Mock
-        .on(ListObjectsV2Command)
-        .rejectsOnce(
-          new S3ServiceException({
-            name: 'RequestTimeout',
-            $fault: 'client',
-            $metadata: { httpStatusCode: 408 },
-          }),
-        )
-        .resolvesOnce({ Contents: [] });
+      mockListObjectsRetry(
+        new S3ServiceException({
+          name: 'RequestTimeout',
+          $fault: 'client',
+          $metadata: { httpStatusCode: 408 },
+        }),
+      );
 
       await (publisher as AwsS3Publish).retryOperation(
         async () => {
@@ -610,16 +637,13 @@ describe('AwsS3Publish', () => {
     it('should use exact error code matching for transient errors', async () => {
       const publisher = await createPublisherFromConfig();
       // Test that ConnectionError (exact match) is retried, but ConnectionErrorSomething (substring) is not
-      s3Mock
-        .on(ListObjectsV2Command)
-        .rejectsOnce(
-          new S3ServiceException({
-            name: 'ConnectionError',
-            $fault: 'client',
-            $metadata: {},
-          }),
-        )
-        .resolvesOnce({ Contents: [] });
+      mockListObjectsRetry(
+        new S3ServiceException({
+          name: 'ConnectionError',
+          $fault: 'client',
+          $metadata: {},
+        }),
+      );
 
       await (publisher as AwsS3Publish).retryOperation(
         async () => {
@@ -635,16 +659,13 @@ describe('AwsS3Publish', () => {
       const publisher = await createPublisherFromConfig();
       const startTime = Date.now();
 
-      s3Mock
-        .on(ListObjectsV2Command)
-        .rejectsOnce(
-          new S3ServiceException({
-            name: 'SlowDown',
-            $fault: 'server',
-            $metadata: {},
-          }),
-        )
-        .resolvesOnce({ Contents: [] });
+      mockListObjectsRetry(
+        new S3ServiceException({
+          name: 'SlowDown',
+          $fault: 'server',
+          $metadata: {},
+        }),
+      );
 
       await (publisher as AwsS3Publish).retryOperation(
         async () => {
@@ -919,10 +940,13 @@ describe('AwsS3Publish', () => {
     });
 
     it('should return an error if the techdocs_metadata.json file cannot be read from stream', async () => {
-      s3Mock.on(GetObjectCommand).callsFake(() => {
-        return {
-          Body: new ErrorReadable('No stream!'),
-        };
+      s3SendMock.mockImplementation(async command => {
+        if (command instanceof GetObjectCommand) {
+          return {
+            Body: new ErrorReadable('No stream!'),
+          };
+        }
+        return defaultS3SendImplementation(command);
       });
 
       const publisher = await createPublisherFromConfig();
@@ -1058,10 +1082,13 @@ describe('AwsS3Publish', () => {
     });
 
     it('should return 404 if file cannot be read from stream', async () => {
-      s3Mock.on(GetObjectCommand).callsFake(() => {
-        return {
-          Body: new ErrorReadable('No stream!'),
-        };
+      s3SendMock.mockImplementation(async command => {
+        if (command instanceof GetObjectCommand) {
+          return {
+            Body: new ErrorReadable('No stream!'),
+          };
+        }
+        return defaultS3SendImplementation(command);
       });
 
       const response = await request(app).get(

--- a/plugins/techdocs-node/src/stages/publish/awsS3.test.ts
+++ b/plugins/techdocs-node/src/stages/publish/awsS3.test.ts
@@ -222,6 +222,8 @@ const createPublisherFromConfig = async ({
 };
 
 describe('AwsS3Publish', () => {
+  let s3SendSpy: jest.SpyInstance;
+
   const entity = {
     apiVersion: '1',
     kind: 'Component',
@@ -285,11 +287,15 @@ describe('AwsS3Publish', () => {
       [directory]: files,
     });
 
-    jest.spyOn(S3Client.prototype, 'send').mockImplementation(s3SendMock);
+    s3SendSpy = jest
+      .spyOn(S3Client.prototype, 'send')
+      .mockImplementation(s3SendMock);
     mockDefaultS3Send();
   });
 
   afterEach(() => {
+    s3SendSpy?.mockRestore();
+    s3SendMock.mockReset();
     process.env = env;
   });
 

--- a/plugins/techdocs-node/src/stages/publish/awsS3.test.ts
+++ b/plugins/techdocs-node/src/stages/publish/awsS3.test.ts
@@ -592,6 +592,8 @@ describe('AwsS3Publish', () => {
         'TestOperation',
         3,
       );
+
+      expect(s3SendMock).toHaveBeenCalledTimes(2);
     });
 
     it('should retry on server errors (5xx)', async () => {
@@ -612,6 +614,8 @@ describe('AwsS3Publish', () => {
         'TestOperation',
         3,
       );
+
+      expect(s3SendMock).toHaveBeenCalledTimes(2);
     });
 
     it('should retry on specific 4xx errors that are transient', async () => {
@@ -632,6 +636,8 @@ describe('AwsS3Publish', () => {
         'TestOperation',
         3,
       );
+
+      expect(s3SendMock).toHaveBeenCalledTimes(2);
     });
 
     it('should use exact error code matching for transient errors', async () => {
@@ -653,6 +659,8 @@ describe('AwsS3Publish', () => {
         'TestOperation',
         3,
       );
+
+      expect(s3SendMock).toHaveBeenCalledTimes(2);
     });
 
     it('should apply exponential backoff with correct calculation', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2170,7 +2170,6 @@ __metadata:
     "@types/pg-format": "npm:^1.0.5"
     "@types/yauzl": "npm:^2.10.0"
     archiver: "npm:^7.0.0"
-    aws-sdk-client-mock: "npm:^4.0.0"
     base64-stream: "npm:^1.0.0"
     better-sqlite3: "npm:^12.0.0"
     compression: "npm:^1.7.4"
@@ -3494,8 +3493,6 @@ __metadata:
     "@backstage/config-loader": "workspace:^"
     "@backstage/errors": "workspace:^"
     "@backstage/test-utils": "workspace:^"
-    aws-sdk-client-mock: "npm:^4.0.0"
-    aws-sdk-client-mock-jest: "npm:^4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4400,8 +4397,6 @@ __metadata:
     "@backstage/plugin-catalog-common": "workspace:^"
     "@backstage/plugin-catalog-node": "workspace:^"
     "@backstage/plugin-kubernetes-common": "workspace:^"
-    aws-sdk-client-mock: "npm:^4.0.0"
-    aws-sdk-client-mock-jest: "npm:^4.0.0"
     p-limit: "npm:^3.0.2"
     yaml: "npm:^2.0.0"
   languageName: unknown
@@ -5334,7 +5329,6 @@ __metadata:
     "@backstage/plugin-events-backend-test-utils": "workspace:^"
     "@backstage/plugin-events-node": "workspace:^"
     "@backstage/types": "workspace:^"
-    aws-sdk-client-mock: "npm:^4.0.0"
     luxon: "npm:^3.0.0"
   languageName: unknown
   linkType: soft
@@ -7272,7 +7266,6 @@ __metadata:
     "@types/mime-types": "npm:^2.1.0"
     "@types/recursive-readdir": "npm:^2.2.0"
     "@types/supertest": "npm:^2.0.8"
-    aws-sdk-client-mock: "npm:^4.0.0"
     dockerode: "npm:^4.0.0"
     express: "npm:^4.22.0"
     fs-extra: "npm:^11.2.0"
@@ -16333,16 +16326,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sinonjs/commons@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@sinonjs/commons@npm:2.0.0"
-  dependencies:
-    type-detect: "npm:4.0.8"
-  checksum: 10/bd6b44957077cd99067dcf401e80ed5ea03ba930cba2066edbbfe302d5fc973a108db25c0ae4930ee53852716929e4c94fa3b8a1510a51ac6869443a139d1e3d
-  languageName: node
-  linkType: hard
-
-"@sinonjs/commons@npm:^3.0.0, @sinonjs/commons@npm:^3.0.1":
+"@sinonjs/commons@npm:^3.0.1":
   version: 3.0.1
   resolution: "@sinonjs/commons@npm:3.0.1"
   dependencies:
@@ -16351,39 +16335,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sinonjs/fake-timers@npm:11.2.2":
-  version: 11.2.2
-  resolution: "@sinonjs/fake-timers@npm:11.2.2"
-  dependencies:
-    "@sinonjs/commons": "npm:^3.0.0"
-  checksum: 10/da7dfa677b2362bc5a321fc1563184755b5c62fbb1a72457fb9e901cd187ba9dc834f9e8a0fb5a4e1d1e6e6ad4c5b54e90900faa44dd6c82d3c49c92ec23ecd4
-  languageName: node
-  linkType: hard
-
-"@sinonjs/fake-timers@npm:^13.0.0, @sinonjs/fake-timers@npm:^13.0.1":
+"@sinonjs/fake-timers@npm:^13.0.0":
   version: 13.0.5
   resolution: "@sinonjs/fake-timers@npm:13.0.5"
   dependencies:
     "@sinonjs/commons": "npm:^3.0.1"
   checksum: 10/11ee417968fc4dce1896ab332ac13f353866075a9d2a88ed1f6258f17cc4f7d93e66031b51fcddb8c203aa4d53fd980b0ae18aba06269f4682164878a992ec3f
-  languageName: node
-  linkType: hard
-
-"@sinonjs/samsam@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "@sinonjs/samsam@npm:8.0.0"
-  dependencies:
-    "@sinonjs/commons": "npm:^2.0.0"
-    lodash.get: "npm:^4.4.2"
-    type-detect: "npm:^4.0.8"
-  checksum: 10/0c9928a7d16a2428ba561e410d9d637c08014d549cac4979c63a6580c56b69378dba80ea01b17e8e163f2ca5dd331376dae92eae8364857ef827ae59dbcfe0ce
-  languageName: node
-  linkType: hard
-
-"@sinonjs/text-encoding@npm:^0.7.3":
-  version: 0.7.3
-  resolution: "@sinonjs/text-encoding@npm:0.7.3"
-  checksum: 10/f0cc89bae36e7ce159187dece7800b78831288f1913e9ae8cf8a878da5388232d2049740f6f4a43ec4b43b8ad1beb55f919f45eb9a577adb4a2a6eacb27b25fc
   languageName: node
   linkType: hard
 
@@ -20058,22 +20015,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/sinon@npm:^17.0.3":
-  version: 17.0.3
-  resolution: "@types/sinon@npm:17.0.3"
-  dependencies:
-    "@types/sinonjs__fake-timers": "npm:*"
-  checksum: 10/3f82b4a477c0c57fa4f4f4fb7585cb72c2a65a7e41e5271b54edca296c8dc242c2d8e709de7a8f16af8693c87cb3ad9d96981069ae683f7197a1134892035833
-  languageName: node
-  linkType: hard
-
-"@types/sinonjs__fake-timers@npm:*":
-  version: 8.1.2
-  resolution: "@types/sinonjs__fake-timers@npm:8.1.2"
-  checksum: 10/5f0ddaa4c79924f6fa82ae5f4f2894f4c1d40740690866665d06a74c7e0f220989c99a7f49561c1d9ad6b15a3a8a7cf7be9dc306a7e42fc1c9cf2c89ad80bef3
-  languageName: node
-  linkType: hard
-
 "@types/sockjs@npm:^0.3.36":
   version: 0.3.36
   resolution: "@types/sockjs@npm:0.3.36"
@@ -20753,7 +20694,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/expect@npm:3.2.4, @vitest/expect@npm:>1.6.0":
+"@vitest/expect@npm:3.2.4":
   version: 3.2.4
   resolution: "@vitest/expect@npm:3.2.4"
   dependencies:
@@ -22772,34 +22713,6 @@ __metadata:
   version: 5.7.7
   resolution: "avsc@npm:5.7.7"
   checksum: 10/d217af16981fb94c29554e61d0aad87b1bcea8b5fe6f714c8cba26af1402ae0ae6783635844029211842a84cd57d678a6d7f18ce560d3de01226f2c97a1c6b1d
-  languageName: node
-  linkType: hard
-
-"aws-sdk-client-mock-jest@npm:^4.0.0":
-  version: 4.1.0
-  resolution: "aws-sdk-client-mock-jest@npm:4.1.0"
-  dependencies:
-    "@vitest/expect": "npm:>1.6.0"
-    expect: "npm:>28.1.3"
-    tslib: "npm:^2.1.0"
-  peerDependencies:
-    aws-sdk-client-mock: 4.1.0
-    vitest: ">1.6.0"
-  peerDependenciesMeta:
-    vitest:
-      optional: true
-  checksum: 10/d17acb560aabe6dd23a737ba08f300d4afb2325f188106b647f92397b63c3d17d3f43e141173d327eb10b365e4d8274f78897411f686a0dcd6628dfbb268b1a3
-  languageName: node
-  linkType: hard
-
-"aws-sdk-client-mock@npm:^4.0.0":
-  version: 4.1.0
-  resolution: "aws-sdk-client-mock@npm:4.1.0"
-  dependencies:
-    "@types/sinon": "npm:^17.0.3"
-    sinon: "npm:^18.0.1"
-    tslib: "npm:^2.1.0"
-  checksum: 10/fb855e3817784f81ffa7cf48fae12330284708ff3d266515229103c30d7943cd26680c9911387e6f878841829ebea2164fb8b0bea37dce8957563d50a8eba96b
   languageName: node
   linkType: hard
 
@@ -26328,7 +26241,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"diff@npm:^5.0.0, diff@npm:^5.1.0, diff@npm:^5.2.0":
+"diff@npm:^5.0.0, diff@npm:^5.1.0":
   version: 5.2.0
   resolution: "diff@npm:5.2.0"
   checksum: 10/01b7b440f83a997350a988e9d2f558366c0f90f15be19f4aa7f1bb3109a4e153dfc3b9fbf78e14ea725717017407eeaa2271e3896374a0181e8f52445740846d
@@ -28139,7 +28052,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expect@npm:30.2.0, expect@npm:>28.1.3, expect@npm:^30.0.0":
+"expect@npm:30.2.0, expect@npm:^30.0.0":
   version: 30.2.0
   resolution: "expect@npm:30.2.0"
   dependencies:
@@ -33581,13 +33494,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"just-extend@npm:^6.2.0":
-  version: 6.2.0
-  resolution: "just-extend@npm:6.2.0"
-  checksum: 10/1f487b074b9e5773befdd44dc5d1b446f01f24f7d4f1f255d51c0ef7f686e8eb5f95d983b792b9ca5c8b10cd7e60a924d64103725759eddbd7f18bcb22743f92
-  languageName: node
-  linkType: hard
-
 "jwa@npm:^1.4.2":
   version: 1.4.2
   resolution: "jwa@npm:1.4.2"
@@ -34462,7 +34368,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:^11.0.0, lru-cache@npm:^11.1.0, lru-cache@npm:^11.2.1, lru-cache@npm:^11.2.2, lru-cache@npm:^11.2.4":
+"lru-cache@npm:^11.0.0, lru-cache@npm:^11.2.2, lru-cache@npm:^11.2.4":
+  version: 11.2.6
+  resolution: "lru-cache@npm:11.2.6"
+  checksum: 10/91222bbd59f793a0a0ad57789388f06b34ac9bb1613433c1d1810457d09db5cd3ec8943227ce2e1f5d6a0a15d6f1a9f129cb2c49ae9b6b10e82d4965fddecbef
+  languageName: node
+  linkType: hard
+
+"lru-cache@npm:^11.1.0, lru-cache@npm:^11.2.1":
   version: 11.5.1
   resolution: "lru-cache@npm:11.5.1"
   checksum: 10/02c4f73967d91fb101f4accf8ebac9e0541e08e16d987bdb9e9737f13e5f2c4bc33c593b98ec30e4486bf899bc97edb36fbd133684b36087336559e41edafdea
@@ -36368,19 +36281,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nise@npm:^6.0.0":
-  version: 6.1.1
-  resolution: "nise@npm:6.1.1"
-  dependencies:
-    "@sinonjs/commons": "npm:^3.0.1"
-    "@sinonjs/fake-timers": "npm:^13.0.1"
-    "@sinonjs/text-encoding": "npm:^0.7.3"
-    just-extend: "npm:^6.2.0"
-    path-to-regexp: "npm:^8.1.0"
-  checksum: 10/2d3175587cf0a351e2c91eb643fdc59d266de39f394a3ac0bace38571749d1e7f25341d763899245139b8f0d2ee048b2d3387d75ecf94c4897e947d5fc881eea
-  languageName: node
-  linkType: hard
-
 "no-case@npm:^3.0.4":
   version: 3.0.4
   resolution: "no-case@npm:3.0.4"
@@ -36519,27 +36419,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-gyp@npm:^12.0.0, node-gyp@npm:^12.1.0":
-  version: 12.4.0
-  resolution: "node-gyp@npm:12.4.0"
-  dependencies:
-    env-paths: "npm:^2.2.0"
-    exponential-backoff: "npm:^3.1.1"
-    graceful-fs: "npm:^4.2.6"
-    nopt: "npm:^9.0.0"
-    proc-log: "npm:^6.0.0"
-    semver: "npm:^7.3.5"
-    tar: "npm:^7.5.4"
-    tinyglobby: "npm:^0.2.12"
-    undici: "npm:^6.25.0"
-    which: "npm:^6.0.0"
-  bin:
-    node-gyp: bin/node-gyp.js
-  checksum: 10/b1f52282398b08ed485f7d93859d45a7bd54f9a3ba8f1e2626ebc2e7e150834c20d90d7f204e07f67c0a88e85c7400d90e01618d7e6d7dd8056bc493821ef181
-  languageName: node
-  linkType: hard
-
-"node-gyp@npm:latest":
+"node-gyp@npm:^12.0.0, node-gyp@npm:latest":
   version: 12.3.0
   resolution: "node-gyp@npm:12.3.0"
   dependencies:
@@ -36556,6 +36436,26 @@ __metadata:
   bin:
     node-gyp: bin/node-gyp.js
   checksum: 10/cd97bf17f0f3e6288c42cc23a6db8528a98e7530abdb72ab558272906d603362e4558069f99f8a5250bc78f65ff305b1438caca4f1b31c81904a8798c242603e
+  languageName: node
+  linkType: hard
+
+"node-gyp@npm:^12.1.0":
+  version: 12.4.0
+  resolution: "node-gyp@npm:12.4.0"
+  dependencies:
+    env-paths: "npm:^2.2.0"
+    exponential-backoff: "npm:^3.1.1"
+    graceful-fs: "npm:^4.2.6"
+    nopt: "npm:^9.0.0"
+    proc-log: "npm:^6.0.0"
+    semver: "npm:^7.3.5"
+    tar: "npm:^7.5.4"
+    tinyglobby: "npm:^0.2.12"
+    undici: "npm:^6.25.0"
+    which: "npm:^6.0.0"
+  bin:
+    node-gyp: bin/node-gyp.js
+  checksum: 10/b1f52282398b08ed485f7d93859d45a7bd54f9a3ba8f1e2626ebc2e7e150834c20d90d7f204e07f67c0a88e85c7400d90e01618d7e6d7dd8056bc493821ef181
   languageName: node
   linkType: hard
 
@@ -42769,20 +42669,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sinon@npm:^18.0.1":
-  version: 18.0.1
-  resolution: "sinon@npm:18.0.1"
-  dependencies:
-    "@sinonjs/commons": "npm:^3.0.1"
-    "@sinonjs/fake-timers": "npm:11.2.2"
-    "@sinonjs/samsam": "npm:^8.0.0"
-    diff: "npm:^5.2.0"
-    nise: "npm:^6.0.0"
-    supports-color: "npm:^7"
-  checksum: 10/65be65a7c5dbef7e9e315820bcd17fe0387fb07cb5dd41d3d6a89177e9a2ca463144676d8407348dc075758daa7cf37b9376d35bd1bc7e06717e87d03aa26111
-  languageName: node
-  linkType: hard
-
 "sisteransi@npm:^1.0.5":
   version: 1.0.5
   resolution: "sisteransi@npm:1.0.5"
@@ -43462,7 +43348,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"streamx@npm:^2.12.5, streamx@npm:^2.15.0, streamx@npm:^2.21.0":
+"streamx@npm:^2.12.5":
   version: 2.28.0
   resolution: "streamx@npm:2.28.0"
   dependencies:
@@ -43470,6 +43356,17 @@ __metadata:
     fast-fifo: "npm:^1.3.2"
     text-decoder: "npm:^1.1.0"
   checksum: 10/ed9a289f09dca9a7bb03790f8b60f9e6bab1032e3fc426e939e7c8207b0511777d96905589a7c9c6d9c9b32e2f94dc884c2e5477ac38524e37f9ea0dfaf8227d
+  languageName: node
+  linkType: hard
+
+"streamx@npm:^2.15.0, streamx@npm:^2.21.0":
+  version: 2.23.0
+  resolution: "streamx@npm:2.23.0"
+  dependencies:
+    events-universal: "npm:^1.0.0"
+    fast-fifo: "npm:^1.3.2"
+    text-decoder: "npm:^1.1.0"
+  checksum: 10/4969d7032b16497172afa2f8ac889d137764963ae564daf1611a03225dd62d9316d51de8098b5866d21722babde71353067184e7a3e9795d6dc17c902904a780
   languageName: node
   linkType: hard
 
@@ -43567,13 +43464,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-width@npm:^8.1.0, string-width@npm:^8.2.0":
+"string-width@npm:^8.1.0":
   version: 8.2.1
   resolution: "string-width@npm:8.2.1"
   dependencies:
     get-east-asian-width: "npm:^1.5.0"
     strip-ansi: "npm:^7.1.2"
   checksum: 10/cfadcc454b357d1a2ef88afb85068c7605900c9920362a16df9b4c320cf411983cee51b9832b70772d138674c2851d506f39c7e669c961a1cdd1258207580805
+  languageName: node
+  linkType: hard
+
+"string-width@npm:^8.2.0":
+  version: 8.2.0
+  resolution: "string-width@npm:8.2.0"
+  dependencies:
+    get-east-asian-width: "npm:^1.5.0"
+    strip-ansi: "npm:^7.1.2"
+  checksum: 10/c4f62877ec08fca155e84a260eb4f58f473cfe5169bd1c1e21ffb563d8e0b7f6d705cc3d250f2ed6bb4f30ee9732ad026f54afaac77aa487e3d1dc1b1969e51b
   languageName: node
   linkType: hard
 
@@ -44004,7 +43911,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^7, supports-color@npm:^7.0.0, supports-color@npm:^7.1.0":
+"supports-color@npm:^7.0.0, supports-color@npm:^7.1.0":
   version: 7.2.0
   resolution: "supports-color@npm:7.2.0"
   dependencies:
@@ -45156,7 +45063,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-detect@npm:4.0.8, type-detect@npm:^4.0.8":
+"type-detect@npm:4.0.8":
   version: 4.0.8
   resolution: "type-detect@npm:4.0.8"
   checksum: 10/5179e3b8ebc51fce1b13efb75fdea4595484433f9683bbc2dca6d99789dba4e602ab7922d2656f2ce8383987467f7770131d4a7f06a26287db0615d2f4c4ce7d

--- a/yarn.lock
+++ b/yarn.lock
@@ -34368,14 +34368,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:^11.0.0, lru-cache@npm:^11.2.2, lru-cache@npm:^11.2.4":
-  version: 11.2.6
-  resolution: "lru-cache@npm:11.2.6"
-  checksum: 10/91222bbd59f793a0a0ad57789388f06b34ac9bb1613433c1d1810457d09db5cd3ec8943227ce2e1f5d6a0a15d6f1a9f129cb2c49ae9b6b10e82d4965fddecbef
-  languageName: node
-  linkType: hard
-
-"lru-cache@npm:^11.1.0, lru-cache@npm:^11.2.1":
+"lru-cache@npm:^11.0.0, lru-cache@npm:^11.1.0, lru-cache@npm:^11.2.1, lru-cache@npm:^11.2.2, lru-cache@npm:^11.2.4":
   version: 11.5.1
   resolution: "lru-cache@npm:11.5.1"
   checksum: 10/02c4f73967d91fb101f4accf8ebac9e0541e08e16d987bdb9e9737f13e5f2c4bc33c593b98ec30e4486bf899bc97edb36fbd133684b36087336559e41edafdea
@@ -36419,27 +36412,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-gyp@npm:^12.0.0, node-gyp@npm:latest":
-  version: 12.3.0
-  resolution: "node-gyp@npm:12.3.0"
-  dependencies:
-    env-paths: "npm:^2.2.0"
-    exponential-backoff: "npm:^3.1.1"
-    graceful-fs: "npm:^4.2.6"
-    nopt: "npm:^9.0.0"
-    proc-log: "npm:^6.0.0"
-    semver: "npm:^7.3.5"
-    tar: "npm:^7.5.4"
-    tinyglobby: "npm:^0.2.12"
-    undici: "npm:^6.25.0"
-    which: "npm:^6.0.0"
-  bin:
-    node-gyp: bin/node-gyp.js
-  checksum: 10/cd97bf17f0f3e6288c42cc23a6db8528a98e7530abdb72ab558272906d603362e4558069f99f8a5250bc78f65ff305b1438caca4f1b31c81904a8798c242603e
-  languageName: node
-  linkType: hard
-
-"node-gyp@npm:^12.1.0":
+"node-gyp@npm:^12.0.0, node-gyp@npm:^12.1.0":
   version: 12.4.0
   resolution: "node-gyp@npm:12.4.0"
   dependencies:
@@ -36456,6 +36429,26 @@ __metadata:
   bin:
     node-gyp: bin/node-gyp.js
   checksum: 10/b1f52282398b08ed485f7d93859d45a7bd54f9a3ba8f1e2626ebc2e7e150834c20d90d7f204e07f67c0a88e85c7400d90e01618d7e6d7dd8056bc493821ef181
+  languageName: node
+  linkType: hard
+
+"node-gyp@npm:latest":
+  version: 12.3.0
+  resolution: "node-gyp@npm:12.3.0"
+  dependencies:
+    env-paths: "npm:^2.2.0"
+    exponential-backoff: "npm:^3.1.1"
+    graceful-fs: "npm:^4.2.6"
+    nopt: "npm:^9.0.0"
+    proc-log: "npm:^6.0.0"
+    semver: "npm:^7.3.5"
+    tar: "npm:^7.5.4"
+    tinyglobby: "npm:^0.2.12"
+    undici: "npm:^6.25.0"
+    which: "npm:^6.0.0"
+  bin:
+    node-gyp: bin/node-gyp.js
+  checksum: 10/cd97bf17f0f3e6288c42cc23a6db8528a98e7530abdb72ab558272906d603362e4558069f99f8a5250bc78f65ff305b1438caca4f1b31c81904a8798c242603e
   languageName: node
   linkType: hard
 
@@ -43348,7 +43341,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"streamx@npm:^2.12.5":
+"streamx@npm:^2.12.5, streamx@npm:^2.15.0, streamx@npm:^2.21.0":
   version: 2.28.0
   resolution: "streamx@npm:2.28.0"
   dependencies:
@@ -43356,17 +43349,6 @@ __metadata:
     fast-fifo: "npm:^1.3.2"
     text-decoder: "npm:^1.1.0"
   checksum: 10/ed9a289f09dca9a7bb03790f8b60f9e6bab1032e3fc426e939e7c8207b0511777d96905589a7c9c6d9c9b32e2f94dc884c2e5477ac38524e37f9ea0dfaf8227d
-  languageName: node
-  linkType: hard
-
-"streamx@npm:^2.15.0, streamx@npm:^2.21.0":
-  version: 2.23.0
-  resolution: "streamx@npm:2.23.0"
-  dependencies:
-    events-universal: "npm:^1.0.0"
-    fast-fifo: "npm:^1.3.2"
-    text-decoder: "npm:^1.1.0"
-  checksum: 10/4969d7032b16497172afa2f8ac889d137764963ae564daf1611a03225dd62d9316d51de8098b5866d21722babde71353067184e7a3e9795d6dc17c902904a780
   languageName: node
   linkType: hard
 
@@ -43464,23 +43446,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-width@npm:^8.1.0":
+"string-width@npm:^8.1.0, string-width@npm:^8.2.0":
   version: 8.2.1
   resolution: "string-width@npm:8.2.1"
   dependencies:
     get-east-asian-width: "npm:^1.5.0"
     strip-ansi: "npm:^7.1.2"
   checksum: 10/cfadcc454b357d1a2ef88afb85068c7605900c9920362a16df9b4c320cf411983cee51b9832b70772d138674c2851d506f39c7e669c961a1cdd1258207580805
-  languageName: node
-  linkType: hard
-
-"string-width@npm:^8.2.0":
-  version: 8.2.0
-  resolution: "string-width@npm:8.2.0"
-  dependencies:
-    get-east-asian-width: "npm:^1.5.0"
-    strip-ansi: "npm:^7.1.2"
-  checksum: 10/c4f62877ec08fca155e84a260eb4f58f473cfe5169bd1c1e21ffb563d8e0b7f6d705cc3d250f2ed6bb4f30ee9732ad026f54afaac77aa487e3d1dc1b1969e51b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR removes the seemingly unmaintained `aws-sdk-client-mock`, unblocking the upgrade to Jest 30.3.

Jest was pinned to 30.2 instead of 30.3 in https://github.com/backstage/backstage/pull/34182 because Jest 30.3+ depends on `@sinonjs/fake-timers@^15`, which conflicts with `@types/sinon@^17` pulled in by `aws-sdk-client-mock`.

Those type incompatibilities have since been fixed in `@types/sinon@21.0.1` (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/74827), but `aws-sdk-client-mock` still depends on the older version and appears to be unmaintained (last commit ~2 years ago, with no response to issues or PRs).

Alternatives considered were adding a dependency resolution for `@types/sinon@21.0.1` or replacing `aws-sdk-client-mock` with another library, but I couldn't find a well-supported alternative. Removing it seemed like the cleanest long-term solution.

Relates to https://github.com/backstage/backstage/issues/34627

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))