### PR TITLE
Fix orderfield numeric sort

### DIFF
--- a/.changeset/fast-ducks-behave.md
+++ b/.changeset/fast-ducks-behave.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend': patch
 ---
 
-Fix numeric sorting for 'orderFields' in catalog backend queries
+Fix numeric sorting for `orderFields` in catalog backend queries

--- a/.changeset/fast-ducks-behave.md
+++ b/.changeset/fast-ducks-behave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Fix numeric sorting for orderFields in catalog backend queries

--- a/.changeset/fast-ducks-behave.md
+++ b/.changeset/fast-ducks-behave.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend': patch
 ---
 
-Fix numeric sorting for orderFields in catalog backend queries
+Fix numeric sorting for 'orderFields' in catalog backend queries

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
@@ -2173,6 +2173,61 @@ describe.each(databases.eachSupportedId())(
         ]);
       });
 
+      it('sorts numeric fields numerically', async () => {
+        // Regression test for numeric orderField sorting.
+        // The search table stores values as strings, which causes lexicographic sorting.
+        // For example, "88" would sort before "1200" in descending order because
+        // string comparison compares characters instead of numeric values.
+        // This test verifies that numeric fields are sorted by their actual numeric
+        // value when using orderFields.
+
+        await createDatabase();
+
+        await addEntityToSearch({
+          apiVersion: 'a',
+          kind: 'k',
+          metadata: {
+            name: 'service-alpha',
+            stats: {
+              downloadsTotal: 1200,
+            },
+          },
+          spec: {},
+        });
+
+        await addEntityToSearch({
+          apiVersion: 'a',
+          kind: 'k',
+          metadata: {
+            name: 'service-beta',
+            stats: {
+              downloadsTotal: 88,
+            },
+          },
+          spec: {},
+        });
+
+        const catalog = new DefaultEntitiesCatalog({
+          database: knex,
+          logger: mockServices.logger.mock(),
+        });
+
+        const response = await catalog.queryEntities({
+          orderFields: [
+            {
+              field: 'metadata.stats.downloadstotal',
+              order: 'desc',
+            },
+          ],
+          limit: 10,
+          credentials: mockCredentials.none(),
+        });
+
+        expect(
+          entitiesResponseToObjects(response.items).map(e => e!.metadata.name),
+        ).toEqual(['service-alpha', 'service-beta']);
+      });
+
       it('should exclude entities with NULL sort-field values from all pages', async () => {
         await createDatabase();
 

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -556,10 +556,18 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
     if (isFetchingBackwards) {
       order = invertOrder(order);
     }
-    dbQuery.orderBy([
-      ...(sortField ? [{ column: 'filtered.value', order }] : []),
-      { column: 'filtered.entity_id', order },
-    ]);
+    if (sortField) {
+      dbQuery.orderByRaw(
+        `CASE
+          WHEN filtered.value GLOB '-[0-9]*'
+            OR filtered.value GLOB '[0-9]*'
+          THEN CAST(filtered.value AS INTEGER)
+          ELSE filtered.value
+        END ${order}`,
+      );
+    }
+
+    dbQuery.orderBy('filtered.entity_id', order);
 
     // Apply a manually set initial offset
     if (

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -557,14 +557,24 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
       order = invertOrder(order);
     }
     if (sortField) {
-      dbQuery.orderByRaw(
-        `CASE
-          WHEN filtered.value GLOB '-[0-9]*'
-            OR filtered.value GLOB '[0-9]*'
-          THEN CAST(filtered.value AS INTEGER)
-          ELSE filtered.value
-        END ${order}`,
-      );
+      if (this.database.client.config.client === 'pg') {
+        dbQuery.orderByRaw(
+          `CASE
+            WHEN filtered.value ~ '^-?[0-9]+$'
+            THEN CAST(filtered.value AS INTEGER)
+            ELSE filtered.value
+          END ${order}`,
+        );
+      } else {
+        dbQuery.orderByRaw(
+          `CASE
+            WHEN filtered.value GLOB '-[0-9]*'
+              OR filtered.value GLOB '[0-9]*'
+            THEN CAST(filtered.value AS INTEGER)
+            ELSE filtered.value
+          END ${order}`,
+        );
+      }
     }
 
     dbQuery.orderBy('filtered.entity_id', order);

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -562,6 +562,13 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
           `CASE
             WHEN filtered.value ~ '^-?[0-9]+$'
             THEN CAST(filtered.value AS INTEGER)
+            ELSE NULL
+          END ${order}`,
+        );
+        dbQuery.orderByRaw(
+          `CASE
+            WHEN filtered.value ~ '^-?[0-9]+$'
+            THEN NULL
             ELSE filtered.value
           END ${order}`,
         );
@@ -571,6 +578,14 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
             WHEN filtered.value GLOB '-[0-9]*'
               OR filtered.value GLOB '[0-9]*'
             THEN CAST(filtered.value AS INTEGER)
+            ELSE NULL
+          END ${order}`,
+        );
+        dbQuery.orderByRaw(
+          `CASE
+            WHEN filtered.value GLOB '-[0-9]*'
+              OR filtered.value GLOB '[0-9]*'
+            THEN NULL
             ELSE filtered.value
           END ${order}`,
         );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix numeric sorting for catalog entity ordering.

The catalog search table stores entity values as strings, which caused numeric fields to be sorted lexicographically instead of numerically.

For example:
- Expected descending order: `1200`, `88`, `9`
- Previous behavior could incorrectly order values based on string comparison.

This change updates the query ordering logic to cast numeric values before sorting while preserving existing sorting behavior for non-numeric values.

The solution uses query-time casting for numeric values instead of introducing a database schema change or migration. This keeps the existing search table structure unchanged while allowing numeric fields to sort correctly.

Added a regression test covering numeric order field sorting.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
