### PR TITLE
Bug Fix: Preserve EntityTypePicker initialFilter when kind changes

### DIFF
--- a/.changeset/fix-entity-type-picker-initial-filter.md
+++ b/.changeset/fix-entity-type-picker-initial-filter.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Fixed a regression where `EntityTypePicker`'s `initialFilter` prop was being cleared when used alongside `EntityKindPicker` inside `EntityListProvider`. The type filter is now correctly preserved after the available types load for the selected kind.

--- a/plugins/catalog-react/src/components/EntityTypePicker/EntityTypePicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityTypePicker/EntityTypePicker.test.tsx
@@ -153,6 +153,30 @@ describe('<EntityTypePicker/>', () => {
     });
   });
 
+  it('applies initialFilter when kind filter is set without a matching query parameter', async () => {
+    const updateFilters = jest.fn();
+    await renderInTestApp(
+      <ApiProvider apis={apis}>
+        <MockEntityListContextProvider
+          value={{
+            filters: { kind: new EntityKindFilter('component', 'Component') },
+            updateFilters,
+          }}
+        >
+          <EntityTypePicker initialFilter="service" />
+        </MockEntityListContextProvider>
+      </ApiProvider>,
+    );
+
+    await waitFor(() => screen.getByText('Type'));
+
+    // initialFilter should be applied; no subsequent call should clear it
+    expect(updateFilters).toHaveBeenCalledWith({
+      type: new EntityTypeFilter(['service']),
+    });
+    expect(updateFilters).not.toHaveBeenLastCalledWith({ type: undefined });
+  });
+
   it('responds to external queryParameters changes', async () => {
     const updateFilters = jest.fn();
     const rendered = await renderInTestApp(

--- a/plugins/catalog-react/src/hooks/useEntityTypeFilter.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityTypeFilter.tsx
@@ -80,7 +80,7 @@ export function useEntityTypeFilter(): {
         .then(response => response.facets['spec.type'] || []);
       return items;
     }
-    return [];
+    return undefined;
   }, [kind, catalogApi]);
 
   const facetsRef = useRef(facets);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When kind changed from `undefined` to a real value, React 18's automatic batching caused the stale facets response (`[]` the result of the prior `kind=undefined` fetch) to appear in the same render as the new kind, so the facets validation effect treated empty stale data as a valid response for the new kind and wiped `selectedTypes`.

Returning undefined instead of `[]` when kind is absent lets the existing `!facets` guard short-circuit correctly on stale data, so the `initialFilter` survives until the real facets for the new kind arrive.

Used Claude a bit to debug this as I am not super familiar with React 18 or its automatic batching! But tested locally and it does seem to work and tests are green!

Fixes #34674 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
