### PR TITLE
chore(auth): migrate tests to MSW v2

### DIFF
--- a/plugins/auth-backend-module-microsoft-provider/package.json
+++ b/plugins/auth-backend-module-microsoft-provider/package.json
@@ -49,7 +49,7 @@
     "@backstage/plugin-auth-backend": "workspace:^",
     "@backstage/types": "workspace:^",
     "@types/passport-microsoft": "^1.0.0",
-    "msw": "^1.0.0",
+    "msw": "^2.0.0",
     "supertest": "^7.0.0"
   },
   "configSchema": "config.d.ts"

--- a/plugins/auth-backend-module-microsoft-provider/src/authenticator.test.ts
+++ b/plugins/auth-backend-module-microsoft-provider/src/authenticator.test.ts
@@ -25,7 +25,7 @@ import {
   PassportOAuthAuthenticatorHelper,
 } from '@backstage/plugin-auth-node';
 import express from 'express';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { FakeMicrosoftAPI } from './__testUtils__/fake';
 import { microsoftAuthenticator } from './authenticator';
@@ -54,55 +54,52 @@ describe('microsoftAuthenticator', () => {
     jest.clearAllMocks();
 
     server.use(
-      rest.post(
+      http.post(
         'https://login.microsoftonline.com/tenantId/oauth2/v2.0/token',
-        async (req, res, ctx) => {
-          return res(
-            ctx.json({
-              ...microsoftApi.token(new URLSearchParams(await req.text())),
-              token_type: 'Bearer',
-              expires_in: 123,
-              ext_expires_in: 123,
-            }),
-          );
+        async ({ request }) => {
+          return HttpResponse.json({
+            ...microsoftApi.token(new URLSearchParams(await request.text())),
+            token_type: 'Bearer',
+            expires_in: 123,
+            ext_expires_in: 123,
+          });
         },
       ),
-      rest.get('https://graph.microsoft.com/v1.0/me/', (req, res, ctx) => {
+      http.get('https://graph.microsoft.com/v1.0/me/', ({ request }) => {
         if (
           !microsoftApi.tokenHasScope(
-            req.headers.get('authorization')!.replace(/^Bearer /, ''),
+            request.headers.get('authorization')!.replace(/^Bearer /, ''),
             'User.Read',
           )
         ) {
-          return res(ctx.status(403));
+          return new HttpResponse(null, { status: 403 });
         }
-        return res(
-          ctx.json({
-            id: 'conrad',
-            displayName: 'Conrad',
-            surname: 'Ribas',
-            givenName: 'Francisco',
-            mail: 'conrad@example.com',
-          }),
-        );
+        return HttpResponse.json({
+          id: 'conrad',
+          displayName: 'Conrad',
+          surname: 'Ribas',
+          givenName: 'Francisco',
+          mail: 'conrad@example.com',
+        });
       }),
-      rest.get(
+      http.get(
         'https://graph.microsoft.com/v1.0/me/photos/*',
-        async (req, res, ctx) => {
+        async ({ request }) => {
           if (
             !microsoftApi.tokenHasScope(
-              req.headers.get('authorization')!.replace(/^Bearer /, ''),
+              request.headers.get('authorization')!.replace(/^Bearer /, ''),
               'User.Read',
             )
           ) {
-            return res(ctx.status(403));
+            return new HttpResponse(null, { status: 403 });
           }
-          const imageBuffer = new Uint8Array([104, 111, 119, 100, 121]).buffer;
-          return res(
-            ctx.set('Content-Length', imageBuffer.byteLength.toString()),
-            ctx.set('Content-Type', 'image/jpeg'),
-            ctx.body(imageBuffer),
-          );
+          const imageBuffer = new Uint8Array([104, 111, 119, 100, 121]);
+          return new HttpResponse(imageBuffer, {
+            headers: {
+              'Content-Length': imageBuffer.byteLength.toString(),
+              'Content-Type': 'image/jpeg',
+            },
+          });
         },
       ),
     );
@@ -212,8 +209,8 @@ describe('microsoftAuthenticator', () => {
 
     it('omits photo data when fetching it fails', async () => {
       server.use(
-        rest.get('https://graph.microsoft.com/v1.0/me/photos/*', (_, res) =>
-          res.networkError('remote hung up'),
+        http.get('https://graph.microsoft.com/v1.0/me/photos/*', () =>
+          HttpResponse.error(),
         ),
       );
 

--- a/plugins/auth-backend-module-oidc-provider/package.json
+++ b/plugins/auth-backend-module-oidc-provider/package.json
@@ -52,7 +52,7 @@
     "express-promise-router": "^4.1.1",
     "express-session": "^1.17.3",
     "jose": "^5.0.0",
-    "msw": "^1.3.1",
+    "msw": "^2.0.0",
     "supertest": "^7.0.0"
   },
   "configSchema": "config.d.ts"

--- a/plugins/auth-backend-module-oidc-provider/src/authenticator.test.ts
+++ b/plugins/auth-backend-module-oidc-provider/src/authenticator.test.ts
@@ -79,6 +79,7 @@ describe('oidcAuthenticator', () => {
         nonce =
           new URL(request.url).searchParams.get('nonce') ??
           'nonceGeneratedByAuthServer';
+        return HttpResponse.text('');
       }),
       http.post('https://oidc.test/oauth2/token', async ({ request }) => {
         const formBody = new URLSearchParams(await request.text());

--- a/plugins/auth-backend-module-oidc-provider/src/authenticator.test.ts
+++ b/plugins/auth-backend-module-oidc-provider/src/authenticator.test.ts
@@ -26,7 +26,7 @@ import { setupServer } from 'msw/node';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { ConfigReader } from '@backstage/config';
 import { JWK, SignJWT, exportJWK, generateKeyPair } from 'jose';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import express from 'express';
 import { custom } from 'openid-client';
 
@@ -69,33 +69,24 @@ describe('oidcAuthenticator', () => {
 
   beforeEach(() => {
     mswServer.use(
-      rest.get(
-        'https://oidc.test/.well-known/openid-configuration',
-        (_req, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(issuerMetadata),
-          ),
+      http.get('https://oidc.test/.well-known/openid-configuration', () =>
+        HttpResponse.json(issuerMetadata),
       ),
-      rest.get('https://oidc.test/jwks.json', async (_req, res, ctx) =>
-        res(ctx.status(200), ctx.json({ keys: [{ ...publicKey }] })),
+      http.get('https://oidc.test/jwks.json', async () =>
+        HttpResponse.json({ keys: [{ ...publicKey }] }),
       ),
-      rest.get(
-        'https://oidc.test/oauth2/authorize',
-        async (req, _res, _ctx) => {
-          nonce =
-            new URL(req.url).searchParams.get('nonce') ??
-            'nonceGeneratedByAuthServer';
-        },
-      ),
-      rest.post('https://oidc.test/oauth2/token', async (req, res, ctx) => {
-        const formBody = new URLSearchParams(await req.text());
+      http.get('https://oidc.test/oauth2/authorize', async ({ request }) => {
+        nonce =
+          new URL(request.url).searchParams.get('nonce') ??
+          'nonceGeneratedByAuthServer';
+      }),
+      http.post('https://oidc.test/oauth2/token', async ({ request }) => {
+        const formBody = new URLSearchParams(await request.text());
         if (
           formBody.get('grant_type') === 'refresh_token' &&
           revokedTokenMap[formBody.get('refresh_token') as string]
         ) {
-          return res(ctx.json({}));
+          return HttpResponse.json({});
         }
 
         const keyPair = await generateKeyPair('RS256');
@@ -114,39 +105,32 @@ describe('oidcAuthenticator', () => {
           .setProtectedHeader({ alg: privateKey.alg, kid: privateKey.kid })
           .sign(keyPair.privateKey);
 
-        return res(
-          req.headers.get('Authorization')
-            ? ctx.json({
-                access_token: 'accessToken',
-                id_token: idToken,
-                refresh_token: 'refreshToken',
-                scope: 'testScope',
-                expires_in: 3600,
-              })
-            : ctx.status(401),
-        );
+        return request.headers.get('Authorization')
+          ? HttpResponse.json({
+              access_token: 'accessToken',
+              id_token: idToken,
+              refresh_token: 'refreshToken',
+              scope: 'testScope',
+              expires_in: 3600,
+            })
+          : new HttpResponse(null, { status: 401 });
       }),
-      rest.get(
-        'https://oidc.test/idp/userinfo.openid',
-        async (_req, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.json({
-              sub: 'test',
-              name: 'Alice Adams',
-              given_name: 'Alice',
-              family_name: 'Adams',
-              email: 'alice@test.com',
-              picture: 'http://testPictureUrl/photo.jpg',
-            }),
-          ),
+      http.get('https://oidc.test/idp/userinfo.openid', async () =>
+        HttpResponse.json({
+          sub: 'test',
+          name: 'Alice Adams',
+          given_name: 'Alice',
+          family_name: 'Adams',
+          email: 'alice@test.com',
+          picture: 'http://testPictureUrl/photo.jpg',
+        }),
       ),
-      rest.post(
+      http.post(
         'https://oidc.test/oauth2/revoke_token',
-        async (req, res, ctx) => {
-          const formBody = new URLSearchParams(await req.text());
+        async ({ request }) => {
+          const formBody = new URLSearchParams(await request.text());
           revokedTokenMap[formBody.get('token') as string] = true;
-          return res(ctx.status(200));
+          return new HttpResponse(null, { status: 200 });
         },
       ),
     );
@@ -623,17 +607,11 @@ describe('oidcAuthenticator', () => {
 
       // override .well-known endpoint response, set revocation_endpoint to undefined
       mswServer.use(
-        rest.get(
-          'https://oidc.test/.well-known/openid-configuration',
-          (_req, res, ctx) =>
-            res(
-              ctx.status(200),
-              ctx.set('Content-Type', 'application/json'),
-              ctx.json({
-                ...issuerMetadata,
-                revocation_endpoint: undefined,
-              }),
-            ),
+        http.get('https://oidc.test/.well-known/openid-configuration', () =>
+          HttpResponse.json({
+            ...issuerMetadata,
+            revocation_endpoint: undefined,
+          }),
         ),
       );
 

--- a/plugins/auth-backend-module-oidc-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-oidc-provider/src/module.test.ts
@@ -17,7 +17,7 @@
 import request from 'supertest';
 import { decodeOAuthState } from '@backstage/plugin-auth-node';
 import { setupServer } from 'msw/node';
-import { rest } from 'msw';
+import { http, HttpResponse, passthrough } from 'msw';
 import {
   mockServices,
   registerMswTestHooks,
@@ -61,59 +61,45 @@ describe('authModuleOidcProvider', () => {
     jest.clearAllMocks();
 
     mswServer.use(
-      rest.get(
-        'https://oidc.test/.well-known/openid-configuration',
-        (_req, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(issuerMetadata),
-          ),
+      http.get('https://oidc.test/.well-known/openid-configuration', () =>
+        HttpResponse.json(issuerMetadata),
       ),
-      rest.get(
+      http.get(
         'https://oidc.test/oauth2/authorize',
-        async (req, _res, _ctx) => {
-          nonce =
-            new URL(req.url).searchParams.get('nonce') ??
-            'nonceGeneratedByAuthServer';
+        async ({ request: httpRequest }) => {
+          const url = new URL(httpRequest.url);
+          nonce = url.searchParams.get('nonce') ?? 'nonceGeneratedByAuthServer';
+          const callbackUrl = new URL(url.searchParams.get('redirect_uri')!);
+          callbackUrl.searchParams.set('code', 'authorization_code');
+          callbackUrl.searchParams.set('state', url.searchParams.get('state')!);
+          callbackUrl.searchParams.set('scope', 'test-scope');
+          return HttpResponse.redirect(callbackUrl.toString(), 302);
         },
       ),
-      rest.get('https://oidc.test/oauth2/authorize', async (req, res, ctx) => {
-        const callbackUrl = new URL(req.url.searchParams.get('redirect_uri')!);
-        callbackUrl.searchParams.set('code', 'authorization_code');
-        callbackUrl.searchParams.set(
-          'state',
-          req.url.searchParams.get('state')!,
-        );
-        callbackUrl.searchParams.set('scope', 'test-scope');
-        return res(
-          ctx.status(302),
-          ctx.set('Location', callbackUrl.toString()),
-        );
-      }),
-      rest.get('https://oidc.test/jwks.json', async (_req, res, ctx) =>
-        res(ctx.status(200), ctx.json({ keys: [{ ...publicKey }] })),
+      http.get('https://oidc.test/jwks.json', async () =>
+        HttpResponse.json({ keys: [{ ...publicKey }] }),
       ),
-      rest.post('https://oidc.test/oauth2/token', async (req, res, ctx) => {
-        const keyPair = await generateKeyPair('RS256');
-        const privateKey = await exportJWK(keyPair.privateKey);
-        publicKey = await exportJWK(keyPair.publicKey);
-        publicKey.alg = privateKey.alg = 'RS256';
+      http.post(
+        'https://oidc.test/oauth2/token',
+        async ({ request: httpRequest }) => {
+          const keyPair = await generateKeyPair('RS256');
+          const privateKey = await exportJWK(keyPair.privateKey);
+          publicKey = await exportJWK(keyPair.publicKey);
+          publicKey.alg = privateKey.alg = 'RS256';
 
-        idToken = await new SignJWT({
-          sub: 'test',
-          iss: 'https://oidc.test',
-          iat: Date.now(),
-          aud: 'clientId',
-          exp: Date.now() + 10000,
-          nonce,
-        })
-          .setProtectedHeader({ alg: privateKey.alg, kid: privateKey.kid })
-          .sign(keyPair.privateKey);
+          idToken = await new SignJWT({
+            sub: 'test',
+            iss: 'https://oidc.test',
+            iat: Date.now(),
+            aud: 'clientId',
+            exp: Date.now() + 10000,
+            nonce,
+          })
+            .setProtectedHeader({ alg: privateKey.alg, kid: privateKey.kid })
+            .sign(keyPair.privateKey);
 
-        return res(
-          req.headers.get('Authorization')
-            ? ctx.json({
+          return httpRequest.headers.get('Authorization')
+            ? HttpResponse.json({
                 access_token: 'accessToken',
                 id_token: idToken,
                 refresh_token: 'refreshToken',
@@ -121,23 +107,18 @@ describe('authModuleOidcProvider', () => {
                 token_type: '',
                 expires_in: 3600,
               })
-            : ctx.status(401),
-        );
-      }),
-      rest.get(
-        'https://oidc.test/idp/userinfo.openid',
-        async (_req, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.json({
-              sub: 'test',
-              name: 'Alice Adams',
-              given_name: 'Alice',
-              family_name: 'Adams',
-              email: 'alice@test.com',
-              picture: 'http://testPictureUrl/photo.jpg',
-            }),
-          ),
+            : new HttpResponse(null, { status: 401 });
+        },
+      ),
+      http.get('https://oidc.test/idp/userinfo.openid', async () =>
+        HttpResponse.json({
+          sub: 'test',
+          name: 'Alice Adams',
+          given_name: 'Alice',
+          family_name: 'Adams',
+          email: 'alice@test.com',
+          picture: 'http://testPictureUrl/photo.jpg',
+        }),
       ),
     );
 
@@ -169,7 +150,10 @@ describe('authModuleOidcProvider', () => {
     backstageServer = backend.server;
     const port = backend.server.port();
     appUrl = `http://localhost:${port}`;
-    mswServer.use(rest.all(`http://*:${port}/*`, req => req.passthrough()));
+    mswServer.use(
+      http.all(`http://127.0.0.1:${port}/*`, passthrough),
+      http.all(`http://localhost:${port}/*`, passthrough),
+    );
   });
 
   afterEach(() => {

--- a/plugins/auth-backend-module-oidc-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-oidc-provider/src/module.test.ts
@@ -150,10 +150,7 @@ describe('authModuleOidcProvider', () => {
     backstageServer = backend.server;
     const port = backend.server.port();
     appUrl = `http://localhost:${port}`;
-    mswServer.use(
-      http.all(`http://127.0.0.1:${port}/*`, passthrough),
-      http.all(`http://localhost:${port}/*`, passthrough),
-    );
+    mswServer.use(http.all(`http://*:${port}/*`, passthrough));
   });
 
   afterEach(() => {

--- a/plugins/auth-backend-module-pinniped-provider/package.json
+++ b/plugins/auth-backend-module-pinniped-provider/package.json
@@ -49,7 +49,7 @@
     "express": "^4.22.0",
     "express-session": "^1.17.3",
     "jose": "^5.0.0",
-    "msw": "^1.3.0",
+    "msw": "^2.0.0",
     "passport": "^0.7.0",
     "supertest": "^7.0.0"
   }

--- a/plugins/auth-backend-module-pinniped-provider/src/authenticator.test.ts
+++ b/plugins/auth-backend-module-pinniped-provider/src/authenticator.test.ts
@@ -26,7 +26,7 @@ import { setupServer } from 'msw/node';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { ConfigReader } from '@backstage/config';
 import { JWK, SignJWT, exportJWK, generateKeyPair } from 'jose';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import express from 'express';
 import { DateTime } from 'luxon';
 
@@ -89,20 +89,15 @@ describe('pinnipedAuthenticator', () => {
     jest.restoreAllMocks();
 
     mswServer.use(
-      rest.get(
+      http.get(
         'https://federationDomain.test/.well-known/openid-configuration',
-        (_req, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(issuerMetadata),
-          ),
+        () => HttpResponse.json(issuerMetadata),
       ),
-      rest.get('https://pinniped.test/jwks.json', async (_req, res, ctx) =>
-        res(ctx.status(200), ctx.json({ keys: [{ ...publicKey }] })),
+      http.get('https://pinniped.test/jwks.json', async () =>
+        HttpResponse.json({ keys: [{ ...publicKey }] }),
       ),
-      rest.post('https://pinniped.test/oauth2/token', async (req, res, ctx) => {
-        const formBody = new URLSearchParams(await req.text());
+      http.post('https://pinniped.test/oauth2/token', async ({ request }) => {
+        const formBody = new URLSearchParams(await request.text());
         const isGrantTypeTokenExchange =
           formBody.get('grant_type') ===
           'urn:ietf:params:oauth:grant-type:token-exchange';
@@ -114,19 +109,17 @@ describe('pinnipedAuthenticator', () => {
           formBody.get('requested_token_type') ===
             'urn:ietf:params:oauth:token-type:jwt';
 
-        return res(
-          req.headers.get('Authorization') &&
-            (!isGrantTypeTokenExchange || hasValidTokenExchangeParams)
-            ? ctx.json({
-                access_token: isGrantTypeTokenExchange
-                  ? clusterScopedIdToken
-                  : 'accessToken',
-                refresh_token: 'refreshToken',
-                ...(!isGrantTypeTokenExchange && { id_token: idToken }),
-                scope: 'testScope',
-              })
-            : ctx.status(401),
-        );
+        return request.headers.get('Authorization') &&
+          (!isGrantTypeTokenExchange || hasValidTokenExchangeParams)
+          ? HttpResponse.json({
+              access_token: isGrantTypeTokenExchange
+                ? clusterScopedIdToken
+                : 'accessToken',
+              refresh_token: 'refreshToken',
+              ...(!isGrantTypeTokenExchange && { id_token: idToken }),
+              scope: 'testScope',
+            })
+          : new HttpResponse(null, { status: 401 });
       }),
     );
 
@@ -288,9 +281,9 @@ describe('pinnipedAuthenticator', () => {
 
     it('refreshes oidc metadata after a failed fetch', async () => {
       mswServer.use(
-        rest.get(
+        http.get(
           'https://federationDomain.test/.well-known/openid-configuration',
-          (_req, res, _ctx) => res.networkError('Timeout'),
+          () => HttpResponse.error(),
         ),
       );
 
@@ -305,14 +298,9 @@ describe('pinnipedAuthenticator', () => {
         });
 
       mswServer.use(
-        rest.get(
+        http.get(
           'https://federationDomain.test/.well-known/openid-configuration',
-          (_req, res, ctx) =>
-            res(
-              ctx.status(200),
-              ctx.set('Content-Type', 'application/json'),
-              ctx.json(issuerMetadata),
-            ),
+          () => HttpResponse.json(issuerMetadata),
         ),
       );
 
@@ -326,18 +314,14 @@ describe('pinnipedAuthenticator', () => {
 
     it('caches oidc metadata after a success', async () => {
       // we start with 1 because the supervisor was called once already when we initialize.
-      let supervisorCalls: number = 1;
+      let supervisorCalls: number = 0;
 
       mswServer.use(
-        rest.get(
+        http.get(
           'https://federationDomain.test/.well-known/openid-configuration',
-          (_req, res, ctx) => {
+          () => {
             supervisorCalls += 1;
-            return res(
-              ctx.status(200),
-              ctx.set('Content-Type', 'application/json'),
-              ctx.json(issuerMetadata),
-            );
+            return HttpResponse.json(issuerMetadata);
           },
         ),
       );
@@ -350,20 +334,16 @@ describe('pinnipedAuthenticator', () => {
 
     it('refreshes oidc metadata when current one in cache expires', async () => {
       // we start with 1 because the supervisor was called once already when we initialize.
-      let supervisorCalls: number = 1;
+      let supervisorCalls: number = 0;
       const fixedTime = DateTime.local();
       jest.spyOn(DateTime, 'local').mockImplementation(() => fixedTime);
 
       mswServer.use(
-        rest.get(
+        http.get(
           'https://federationDomain.test/.well-known/openid-configuration',
-          (_req, res, ctx) => {
+          () => {
             supervisorCalls += 1;
-            return res(
-              ctx.status(200),
-              ctx.set('Content-Type', 'application/json'),
-              ctx.json(issuerMetadata),
-            );
+            return HttpResponse.json(issuerMetadata);
           },
         ),
       );
@@ -455,44 +435,37 @@ describe('pinnipedAuthenticator', () => {
 
     it('fails on network error during token exchange', async () => {
       mswServer.use(
-        rest.post(
-          'https://pinniped.test/oauth2/token',
-          async (req, res, ctx) => {
-            const formBody = new URLSearchParams(await req.text());
-            const isGrantTypeTokenExchange =
-              formBody.get('grant_type') ===
-              'urn:ietf:params:oauth:grant-type:token-exchange';
-            const hasValidTokenExchangeParams =
-              formBody.get('subject_token') === 'accessToken' &&
-              formBody.get('audience') === 'test_cluster' &&
-              formBody.get('subject_token_type') ===
-                'urn:ietf:params:oauth:token-type:access_token' &&
-              formBody.get('requested_token_type') ===
-                'urn:ietf:params:oauth:token-type:jwt';
+        http.post('https://pinniped.test/oauth2/token', async ({ request }) => {
+          const formBody = new URLSearchParams(await request.text());
+          const isGrantTypeTokenExchange =
+            formBody.get('grant_type') ===
+            'urn:ietf:params:oauth:grant-type:token-exchange';
+          const hasValidTokenExchangeParams =
+            formBody.get('subject_token') === 'accessToken' &&
+            formBody.get('audience') === 'test_cluster' &&
+            formBody.get('subject_token_type') ===
+              'urn:ietf:params:oauth:token-type:access_token' &&
+            formBody.get('requested_token_type') ===
+              'urn:ietf:params:oauth:token-type:jwt';
 
-            mswServer.use(
-              rest.post(
-                'https://pinniped.test/oauth2/token',
-                async (_req, response, _ctx) =>
-                  response.networkError('Connection timed out'),
-              ),
-            );
+          mswServer.use(
+            http.post('https://pinniped.test/oauth2/token', () =>
+              HttpResponse.error(),
+            ),
+          );
 
-            return res(
-              req.headers.get('Authorization') &&
-                (!isGrantTypeTokenExchange || hasValidTokenExchangeParams)
-                ? ctx.json({
-                    access_token: isGrantTypeTokenExchange
-                      ? clusterScopedIdToken
-                      : 'accessToken',
-                    refresh_token: 'refreshToken',
-                    ...(!isGrantTypeTokenExchange && { id_token: idToken }),
-                    scope: 'testScope',
-                  })
-                : ctx.status(401),
-            );
-          },
-        ),
+          return request.headers.get('Authorization') &&
+            (!isGrantTypeTokenExchange || hasValidTokenExchangeParams)
+            ? HttpResponse.json({
+                access_token: isGrantTypeTokenExchange
+                  ? clusterScopedIdToken
+                  : 'accessToken',
+                refresh_token: 'refreshToken',
+                ...(!isGrantTypeTokenExchange && { id_token: idToken }),
+                scope: 'testScope',
+              })
+            : new HttpResponse(null, { status: 401 });
+        }),
       );
 
       oauthState.audience = 'test_cluster';
@@ -513,7 +486,7 @@ describe('pinnipedAuthenticator', () => {
       await expect(
         pinnipedAuthenticator.authenticate(handlerRequest, authCtx),
       ).rejects.toThrow(
-        `Failed to get cluster specific ID token for "test_cluster": Error: RFC8693 token exchange failed with error: NetworkError: Connection timed out`,
+        /Failed to get cluster specific ID token for "test_cluster".*Network error/,
       );
     });
 
@@ -561,9 +534,9 @@ describe('pinnipedAuthenticator', () => {
 
     it('refreshes oidc metadata after a failed fetch', async () => {
       mswServer.use(
-        rest.get(
+        http.get(
           'https://federationDomain.test/.well-known/openid-configuration',
-          (_req, res, _ctx) => res.networkError('Timeout'),
+          () => HttpResponse.error(),
         ),
       );
 
@@ -578,14 +551,9 @@ describe('pinnipedAuthenticator', () => {
         });
 
       mswServer.use(
-        rest.get(
+        http.get(
           'https://federationDomain.test/.well-known/openid-configuration',
-          (_req, res, ctx) =>
-            res(
-              ctx.status(200),
-              ctx.set('Content-Type', 'application/json'),
-              ctx.json(issuerMetadata),
-            ),
+          () => HttpResponse.json(issuerMetadata),
         ),
       );
 
@@ -597,18 +565,14 @@ describe('pinnipedAuthenticator', () => {
     });
 
     it('caches oidc metadata after a success', async () => {
-      let supervisorCalls: number = 1;
+      let supervisorCalls: number = 0;
 
       mswServer.use(
-        rest.get(
+        http.get(
           'https://federationDomain.test/.well-known/openid-configuration',
-          (_req, res, ctx) => {
+          () => {
             supervisorCalls += 1;
-            return res(
-              ctx.status(200),
-              ctx.set('Content-Type', 'application/json'),
-              ctx.json(issuerMetadata),
-            );
+            return HttpResponse.json(issuerMetadata);
           },
         ),
       );
@@ -641,27 +605,14 @@ describe('pinnipedAuthenticator', () => {
       jest.spyOn(DateTime, 'local').mockImplementation(() => fixedTime);
 
       mswServer.use(
-        rest.get(
+        http.get(
           'https://federationDomain.test/.well-known/openid-configuration',
-          (_req, res, ctx) => {
+          () => {
             supervisorCalls += 1;
-            return res(
-              ctx.status(200),
-              ctx.set('Content-Type', 'application/json'),
-              ctx.json(issuerMetadata),
-            );
+            return HttpResponse.json(issuerMetadata);
           },
         ),
       );
-
-      authCtx = pinnipedAuthenticator.initialize({
-        callbackUrl: 'https://backstage.test/callback',
-        config: new ConfigReader({
-          federationDomain: 'https://federationDomain.test',
-          clientId: 'clientId',
-          clientSecret: 'clientSecret',
-        }),
-      });
 
       await pinnipedAuthenticator.authenticate(handlerRequest, authCtx);
 
@@ -730,9 +681,9 @@ describe('pinnipedAuthenticator', () => {
 
     it('refreshes oidc metadata after a failed fetch', async () => {
       mswServer.use(
-        rest.get(
+        http.get(
           'https://federationDomain.test/.well-known/openid-configuration',
-          (_req, res, _ctx) => res.networkError('Timeout'),
+          () => HttpResponse.error(),
         ),
       );
 
@@ -747,14 +698,9 @@ describe('pinnipedAuthenticator', () => {
         });
 
       mswServer.use(
-        rest.get(
+        http.get(
           'https://federationDomain.test/.well-known/openid-configuration',
-          (_req, res, ctx) =>
-            res(
-              ctx.status(200),
-              ctx.set('Content-Type', 'application/json'),
-              ctx.json(issuerMetadata),
-            ),
+          () => HttpResponse.json(issuerMetadata),
         ),
       );
 
@@ -766,18 +712,14 @@ describe('pinnipedAuthenticator', () => {
     });
 
     it('caches oidc metadata after a success', async () => {
-      let supervisorCalls: number = 1;
+      let supervisorCalls: number = 0;
 
       mswServer.use(
-        rest.get(
+        http.get(
           'https://federationDomain.test/.well-known/openid-configuration',
-          (_req, res, ctx) => {
+          () => {
             supervisorCalls += 1;
-            return res(
-              ctx.status(200),
-              ctx.set('Content-Type', 'application/json'),
-              ctx.json(issuerMetadata),
-            );
+            return HttpResponse.json(issuerMetadata);
           },
         ),
       );
@@ -789,20 +731,16 @@ describe('pinnipedAuthenticator', () => {
     });
 
     it('refreshes oidc metadata when current one in cache expires', async () => {
-      let supervisorCalls: number = 1;
+      let supervisorCalls: number = 0;
       const fixedTime = DateTime.local();
       jest.spyOn(DateTime, 'local').mockImplementation(() => fixedTime);
 
       mswServer.use(
-        rest.get(
+        http.get(
           'https://federationDomain.test/.well-known/openid-configuration',
-          (_req, res, ctx) => {
+          () => {
             supervisorCalls += 1;
-            return res(
-              ctx.status(200),
-              ctx.set('Content-Type', 'application/json'),
-              ctx.json(issuerMetadata),
-            );
+            return HttpResponse.json(issuerMetadata);
           },
         ),
       );

--- a/plugins/auth-backend-module-pinniped-provider/src/authenticator.test.ts
+++ b/plugins/auth-backend-module-pinniped-provider/src/authenticator.test.ts
@@ -313,7 +313,7 @@ describe('pinnipedAuthenticator', () => {
     });
 
     it('caches oidc metadata after a success', async () => {
-      // we start with 1 because the supervisor was called once already when we initialize.
+      // Count metadata fetches after this handler is installed; the first start() should fetch once, the second should use cache.
       let supervisorCalls: number = 0;
 
       mswServer.use(
@@ -333,7 +333,7 @@ describe('pinnipedAuthenticator', () => {
     });
 
     it('refreshes oidc metadata when current one in cache expires', async () => {
-      // we start with 1 because the supervisor was called once already when we initialize.
+      // Count metadata fetches after this handler is installed; expect a refetch once the cache TTL expires.
       let supervisorCalls: number = 0;
       const fixedTime = DateTime.local();
       jest.spyOn(DateTime, 'local').mockImplementation(() => fixedTime);

--- a/plugins/auth-backend-module-pinniped-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-pinniped-provider/src/module.test.ts
@@ -158,10 +158,7 @@ describe('authModulePinnipedProvider', () => {
     server = backend.server;
     port = backend.server.port();
 
-    mswServer.use(
-      http.all(`http://127.0.0.1:${port}/*`, passthrough),
-      http.all(`http://localhost:${port}/*`, passthrough),
-    );
+    mswServer.use(http.all(`http://*:${port}/*`, passthrough));
   });
 
   it('should start', async () => {

--- a/plugins/auth-backend-module-pinniped-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-pinniped-provider/src/module.test.ts
@@ -20,7 +20,7 @@ import {
 } from '@backstage/backend-test-utils';
 import { Server } from 'node:http';
 import { JWK, SignJWT, exportJWK, generateKeyPair } from 'jose';
-import { rest } from 'msw';
+import { http, HttpResponse, passthrough } from 'msw';
 import { setupServer } from 'msw/node';
 import request from 'supertest';
 import { authModulePinnipedProvider } from './module';
@@ -83,53 +83,42 @@ describe('authModulePinnipedProvider', () => {
     jest.clearAllMocks();
 
     mswServer.use(
-      rest.get(
+      http.get(
         'https://federationDomain.test/.well-known/openid-configuration',
-        (_req, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(issuerMetadata),
-          ),
+        () => HttpResponse.json(issuerMetadata),
       ),
-      rest.get(
+      http.get(
         'https://pinniped.test/oauth2/authorize',
-        async (req, res, ctx) => {
-          const callbackUrl = new URL(
-            req.url.searchParams.get('redirect_uri')!,
-          );
+        async ({ request: httpRequest }) => {
+          const url = new URL(httpRequest.url);
+          const callbackUrl = new URL(url.searchParams.get('redirect_uri')!);
           callbackUrl.searchParams.set('code', 'authorization_code');
-          callbackUrl.searchParams.set(
-            'state',
-            req.url.searchParams.get('state')!,
-          );
+          callbackUrl.searchParams.set('state', url.searchParams.get('state')!);
           callbackUrl.searchParams.set('scope', 'test-scope');
-          return res(
-            ctx.status(302),
-            ctx.set('Location', callbackUrl.toString()),
-          );
+          return HttpResponse.redirect(callbackUrl.toString(), 302);
         },
       ),
-      rest.get('https://pinniped.test/jwks.json', async (_req, res, ctx) =>
-        res(ctx.status(200), ctx.json({ keys: [{ ...publicKey }] })),
+      http.get('https://pinniped.test/jwks.json', async () =>
+        HttpResponse.json({ keys: [{ ...publicKey }] }),
       ),
-      rest.post('https://pinniped.test/oauth2/token', async (req, res, ctx) => {
-        const formBody = new URLSearchParams(await req.text());
-        const isGrantTypeTokenExchange =
-          formBody.get('grant_type') ===
-          'urn:ietf:params:oauth:grant-type:token-exchange';
-        const hasValidTokenExchangeParams =
-          formBody.get('subject_token') === 'accessToken' &&
-          formBody.get('audience') === 'test_cluster' &&
-          formBody.get('subject_token_type') ===
-            'urn:ietf:params:oauth:token-type:access_token' &&
-          formBody.get('requested_token_type') ===
-            'urn:ietf:params:oauth:token-type:jwt';
+      http.post(
+        'https://pinniped.test/oauth2/token',
+        async ({ request: httpRequest }) => {
+          const formBody = new URLSearchParams(await httpRequest.text());
+          const isGrantTypeTokenExchange =
+            formBody.get('grant_type') ===
+            'urn:ietf:params:oauth:grant-type:token-exchange';
+          const hasValidTokenExchangeParams =
+            formBody.get('subject_token') === 'accessToken' &&
+            formBody.get('audience') === 'test_cluster' &&
+            formBody.get('subject_token_type') ===
+              'urn:ietf:params:oauth:token-type:access_token' &&
+            formBody.get('requested_token_type') ===
+              'urn:ietf:params:oauth:token-type:jwt';
 
-        return res(
-          req.headers.get('Authorization') &&
+          return httpRequest.headers.get('Authorization') &&
             (!isGrantTypeTokenExchange || hasValidTokenExchangeParams)
-            ? ctx.json({
+            ? HttpResponse.json({
                 access_token: isGrantTypeTokenExchange
                   ? clusterScopedIdToken
                   : 'accessToken',
@@ -137,9 +126,9 @@ describe('authModulePinnipedProvider', () => {
                 ...(!isGrantTypeTokenExchange && { id_token: idToken }),
                 scope: 'testScope',
               })
-            : ctx.status(401),
-        );
-      }),
+            : new HttpResponse(null, { status: 401 });
+        },
+      ),
     );
 
     const backend = await startTestBackend({
@@ -169,7 +158,10 @@ describe('authModulePinnipedProvider', () => {
     server = backend.server;
     port = backend.server.port();
 
-    mswServer.use(rest.all(`http://*:${port}/*`, req => req.passthrough()));
+    mswServer.use(
+      http.all(`http://127.0.0.1:${port}/*`, passthrough),
+      http.all(`http://localhost:${port}/*`, passthrough),
+    );
   });
 
   it('should start', async () => {

--- a/plugins/auth-backend/package.json
+++ b/plugins/auth-backend/package.json
@@ -78,7 +78,7 @@
     "@types/express": "^4.17.6",
     "@types/express-session": "^1.17.2",
     "@types/passport": "^1.0.3",
-    "msw": "^1.0.0",
+    "msw": "^2.0.0",
     "supertest": "^7.0.0"
   },
   "configSchema": "config.d.ts"

--- a/plugins/auth-backend/src/service/CimdClient.test.ts
+++ b/plugins/auth-backend/src/service/CimdClient.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { validateCimdUrl, fetchCimdMetadata } from './CimdClient';
@@ -137,11 +137,8 @@ describe('CimdClient', () => {
 
     it('should fetch and return valid metadata', async () => {
       server.use(
-        rest.get(
-          'https://example.com/oauth-metadata.json',
-          (_req, res, ctx) => {
-            return res(ctx.json(validMetadata));
-          },
+        http.get('https://example.com/oauth-metadata.json', () =>
+          HttpResponse.json(validMetadata),
         ),
       );
 
@@ -166,11 +163,8 @@ describe('CimdClient', () => {
       };
 
       server.use(
-        rest.get(
-          'https://example.com/oauth-metadata.json',
-          (_req, res, ctx) => {
-            return res(ctx.json(metadataWithoutName));
-          },
+        http.get('https://example.com/oauth-metadata.json', () =>
+          HttpResponse.json(metadataWithoutName),
         ),
       );
 
@@ -246,24 +240,16 @@ describe('CimdClient', () => {
         const redirectTarget = jest.fn();
 
         server.use(
-          rest.get(
-            'https://example.com/oauth-metadata.json',
-            (_req, res, ctx) => {
-              return res(
-                ctx.status(302),
-                ctx.set('Location', 'http://127.0.0.1:8080/internal'),
-              );
-            },
+          http.get('https://example.com/oauth-metadata.json', () =>
+            HttpResponse.redirect('http://127.0.0.1:8080/internal', 302),
           ),
-          rest.get('http://127.0.0.1:8080/internal', (_req, res, ctx) => {
+          http.get('http://127.0.0.1:8080/internal', () => {
             redirectTarget();
-            return res(
-              ctx.json({
-                client_id: 'https://example.com/oauth-metadata.json',
-                client_name: 'Sneaky Client',
-                redirect_uris: ['http://localhost:8080/callback'],
-              }),
-            );
+            return HttpResponse.json({
+              client_id: 'https://example.com/oauth-metadata.json',
+              client_name: 'Sneaky Client',
+              redirect_uris: ['http://localhost:8080/callback'],
+            });
           }),
         );
 
@@ -280,9 +266,9 @@ describe('CimdClient', () => {
     describe('HTTP error handling', () => {
       it('should throw for network errors', async () => {
         server.use(
-          rest.get('https://example.com/oauth-metadata.json', (_req, res) => {
-            return res.networkError('Connection refused');
-          }),
+          http.get('https://example.com/oauth-metadata.json', () =>
+            HttpResponse.error(),
+          ),
         );
 
         await expect(
@@ -294,11 +280,9 @@ describe('CimdClient', () => {
 
       it('should throw for non-OK response', async () => {
         server.use(
-          rest.get(
+          http.get(
             'https://example.com/oauth-metadata.json',
-            (_req, res, ctx) => {
-              return res(ctx.status(404));
-            },
+            () => new HttpResponse(null, { status: 404 }),
           ),
         );
 
@@ -313,11 +297,8 @@ describe('CimdClient', () => {
     describe('metadata validation', () => {
       it('should throw for invalid JSON', async () => {
         server.use(
-          rest.get(
-            'https://example.com/oauth-metadata.json',
-            (_req, res, ctx) => {
-              return res(ctx.body('not json'));
-            },
+          http.get('https://example.com/oauth-metadata.json', () =>
+            HttpResponse.text('not json'),
           ),
         );
 
@@ -359,11 +340,8 @@ describe('CimdClient', () => {
         };
 
         server.use(
-          rest.get(
-            'https://example.com/oauth-metadata.json',
-            (_req, res, ctx) => {
-              return res(ctx.json(mismatchedMetadata));
-            },
+          http.get('https://example.com/oauth-metadata.json', () =>
+            HttpResponse.json(mismatchedMetadata),
           ),
         );
 
@@ -381,11 +359,8 @@ describe('CimdClient', () => {
         };
 
         server.use(
-          rest.get(
-            'https://example.com/oauth-metadata.json',
-            (_req, res, ctx) => {
-              return res(ctx.json(noRedirectUris));
-            },
+          http.get('https://example.com/oauth-metadata.json', () =>
+            HttpResponse.json(noRedirectUris),
           ),
         );
 
@@ -404,11 +379,8 @@ describe('CimdClient', () => {
         };
 
         server.use(
-          rest.get(
-            'https://example.com/oauth-metadata.json',
-            (_req, res, ctx) => {
-              return res(ctx.json(emptyRedirectUris));
-            },
+          http.get('https://example.com/oauth-metadata.json', () =>
+            HttpResponse.json(emptyRedirectUris),
           ),
         );
 
@@ -430,11 +402,8 @@ describe('CimdClient', () => {
         };
 
         server.use(
-          rest.get(
-            'https://example.com/oauth-metadata.json',
-            (_req, res, ctx) => {
-              return res(ctx.json(withSecret));
-            },
+          http.get('https://example.com/oauth-metadata.json', () =>
+            HttpResponse.json(withSecret),
           ),
         );
 
@@ -454,11 +423,8 @@ describe('CimdClient', () => {
         };
 
         server.use(
-          rest.get(
-            'https://example.com/oauth-metadata.json',
-            (_req, res, ctx) => {
-              return res(ctx.json(withSecretExpiry));
-            },
+          http.get('https://example.com/oauth-metadata.json', () =>
+            HttpResponse.json(withSecretExpiry),
           ),
         );
 
@@ -478,11 +444,8 @@ describe('CimdClient', () => {
         };
 
         server.use(
-          rest.get(
-            'https://example.com/oauth-metadata.json',
-            (_req, res, ctx) => {
-              return res(ctx.json(withForbiddenAuth));
-            },
+          http.get('https://example.com/oauth-metadata.json', () =>
+            HttpResponse.json(withForbiddenAuth),
           ),
         );
 
@@ -502,11 +465,8 @@ describe('CimdClient', () => {
         };
 
         server.use(
-          rest.get(
-            'https://example.com/oauth-metadata.json',
-            (_req, res, ctx) => {
-              return res(ctx.json(withNoneAuth));
-            },
+          http.get('https://example.com/oauth-metadata.json', () =>
+            HttpResponse.json(withNoneAuth),
           ),
         );
 
@@ -526,11 +486,8 @@ describe('CimdClient', () => {
         };
 
         server.use(
-          rest.get(
-            'https://example.com/oauth-metadata.json',
-            (_req, res, ctx) => {
-              return res(ctx.json(withPrivateKeyAuth));
-            },
+          http.get('https://example.com/oauth-metadata.json', () =>
+            HttpResponse.json(withPrivateKeyAuth),
           ),
         );
 

--- a/plugins/auth-node/package.json
+++ b/plugins/auth-node/package.json
@@ -60,7 +60,7 @@
     "@backstage/cli": "workspace:^",
     "cookie-parser": "^1.4.6",
     "express-promise-router": "^4.1.1",
-    "msw": "^1.0.0",
+    "msw": "^2.0.0",
     "supertest": "^7.0.0"
   }
 }

--- a/plugins/auth-node/src/identity/DefaultIdentityClient.test.ts
+++ b/plugins/auth-node/src/identity/DefaultIdentityClient.test.ts
@@ -21,7 +21,8 @@ import {
   SignJWT,
 } from 'jose';
 import { cloneDeep } from 'lodash';
-import { rest } from 'msw';
+import { registerMswTestHooks } from '@backstage/backend-test-utils';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { randomUUID as uuid } from 'node:crypto';
 
@@ -102,9 +103,7 @@ describe('DefaultIdentityClient', () => {
   let factory: FakeTokenFactory;
   const keyDurationSeconds = 5;
 
-  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
-  afterAll(() => server.close());
-  afterEach(() => server.resetHandlers());
+  registerMswTestHooks(server);
 
   beforeEach(() => {
     client = DefaultIdentityClient.create({ discovery, issuer: mockBaseUrl });
@@ -117,13 +116,10 @@ describe('DefaultIdentityClient', () => {
   describe('identity client configuration', () => {
     beforeEach(() => {
       server.use(
-        rest.get(
-          `${mockBaseUrl}/.well-known/jwks.json`,
-          async (_, res, ctx) => {
-            const keys = await factory.listPublicKeys();
-            return res(ctx.json(keys));
-          },
-        ),
+        http.get(`${mockBaseUrl}/.well-known/jwks.json`, async () => {
+          const keys = await factory.listPublicKeys();
+          return HttpResponse.json(keys);
+        }),
       );
     });
 
@@ -178,13 +174,10 @@ describe('DefaultIdentityClient', () => {
   describe('authenticate', () => {
     beforeEach(() => {
       server.use(
-        rest.get(
-          `${mockBaseUrl}/.well-known/jwks.json`,
-          async (_, res, ctx) => {
-            const keys = await factory.listPublicKeys();
-            return res(ctx.json(keys));
-          },
-        ),
+        http.get(`${mockBaseUrl}/.well-known/jwks.json`, async () => {
+          const keys = await factory.listPublicKeys();
+          return HttpResponse.json(keys);
+        }),
       );
     });
 
@@ -322,12 +315,9 @@ describe('DefaultIdentityClient', () => {
       // Only return the key from a single token
       const singleKey = cloneDeep(await factory.listPublicKeys());
       server.use(
-        rest.get(
-          `${mockBaseUrl}/.well-known/jwks.json`,
-          async (_, res, ctx) => {
-            return res(ctx.json(singleKey));
-          },
-        ),
+        http.get(`${mockBaseUrl}/.well-known/jwks.json`, async () => {
+          return HttpResponse.json(singleKey);
+        }),
       );
       // Update the discovery endpoint to point to a new URL
       discovery.getBaseUrl = async () => {
@@ -338,10 +328,10 @@ describe('DefaultIdentityClient', () => {
       };
       let calledUpdatedEndpoint = false;
       server.use(
-        rest.get(`${updatedURL}/.well-known/jwks.json`, async (_, res, ctx) => {
+        http.get(`${updatedURL}/.well-known/jwks.json`, async () => {
           const keys = await factory.listPublicKeys();
           calledUpdatedEndpoint = true;
-          return res(ctx.json(keys));
+          return HttpResponse.json(keys);
         }),
       );
       // Advance time
@@ -372,13 +362,10 @@ describe('DefaultIdentityClient', () => {
   describe('getIdentity', () => {
     beforeEach(() => {
       server.use(
-        rest.get(
-          `${mockBaseUrl}/.well-known/jwks.json`,
-          async (_, res, ctx) => {
-            const keys = await factory.listPublicKeys();
-            return res(ctx.json(keys));
-          },
-        ),
+        http.get(`${mockBaseUrl}/.well-known/jwks.json`, async () => {
+          const keys = await factory.listPublicKeys();
+          return HttpResponse.json(keys);
+        }),
       );
     });
 

--- a/plugins/auth-node/src/identity/IdentityClient.test.ts
+++ b/plugins/auth-node/src/identity/IdentityClient.test.ts
@@ -22,7 +22,7 @@ import {
   SignJWT,
 } from 'jose';
 import { cloneDeep } from 'lodash';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { randomUUID as uuid } from 'node:crypto';
 
@@ -115,13 +115,10 @@ describe('IdentityClient', () => {
   describe('identity client configuration', () => {
     beforeEach(() => {
       server.use(
-        rest.get(
-          `${mockBaseUrl}/.well-known/jwks.json`,
-          async (_, res, ctx) => {
-            const keys = await factory.listPublicKeys();
-            return res(ctx.json(keys));
-          },
-        ),
+        http.get(`${mockBaseUrl}/.well-known/jwks.json`, async () => {
+          const keys = await factory.listPublicKeys();
+          return HttpResponse.json(keys);
+        }),
       );
     });
 
@@ -176,13 +173,10 @@ describe('IdentityClient', () => {
   describe('authenticate', () => {
     beforeEach(() => {
       server.use(
-        rest.get(
-          `${mockBaseUrl}/.well-known/jwks.json`,
-          async (_, res, ctx) => {
-            const keys = await factory.listPublicKeys();
-            return res(ctx.json(keys));
-          },
-        ),
+        http.get(`${mockBaseUrl}/.well-known/jwks.json`, async () => {
+          const keys = await factory.listPublicKeys();
+          return HttpResponse.json(keys);
+        }),
       );
     });
 
@@ -320,12 +314,9 @@ describe('IdentityClient', () => {
       // Only return the key from a single token
       const singleKey = cloneDeep(await factory.listPublicKeys());
       server.use(
-        rest.get(
-          `${mockBaseUrl}/.well-known/jwks.json`,
-          async (_, res, ctx) => {
-            return res(ctx.json(singleKey));
-          },
-        ),
+        http.get(`${mockBaseUrl}/.well-known/jwks.json`, async () => {
+          return HttpResponse.json(singleKey);
+        }),
       );
       // Update the discovery endpoint to point to a new URL
       discovery.getBaseUrl = async () => {
@@ -336,10 +327,10 @@ describe('IdentityClient', () => {
       };
       let calledUpdatedEndpoint = false;
       server.use(
-        rest.get(`${updatedURL}/.well-known/jwks.json`, async (_, res, ctx) => {
+        http.get(`${updatedURL}/.well-known/jwks.json`, async () => {
           const keys = await factory.listPublicKeys();
           calledUpdatedEndpoint = true;
-          return res(ctx.json(keys));
+          return HttpResponse.json(keys);
         }),
       );
       // Advance time

--- a/yarn.lock
+++ b/yarn.lock
@@ -4053,7 +4053,7 @@ __metadata:
     "@types/passport-microsoft": "npm:^1.0.0"
     express: "npm:^4.22.0"
     jose: "npm:^5.0.0"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     passport-microsoft: "npm:^1.0.0"
     supertest: "npm:^7.0.0"
     zod: "npm:^3.25.76 || ^4.0.0"
@@ -4109,7 +4109,7 @@ __metadata:
     express-promise-router: "npm:^4.1.1"
     express-session: "npm:^1.17.3"
     jose: "npm:^5.0.0"
-    msw: "npm:^1.3.1"
+    msw: "npm:^2.0.0"
     openid-client: "npm:^5.5.0"
     passport: "npm:^0.7.0"
     supertest: "npm:^7.0.0"
@@ -4193,7 +4193,7 @@ __metadata:
     express-session: "npm:^1.17.3"
     jose: "npm:^5.0.0"
     luxon: "npm:^3.4.3"
-    msw: "npm:^1.3.0"
+    msw: "npm:^2.0.0"
     openid-client: "npm:^5.4.3"
     passport: "npm:^0.7.0"
     supertest: "npm:^7.0.0"
@@ -4255,7 +4255,7 @@ __metadata:
     luxon: "npm:^3.0.0"
     matcher: "npm:^4.0.0"
     minimatch: "npm:^10.2.1"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     passport: "npm:^0.7.0"
     supertest: "npm:^7.0.0"
     zod: "npm:^3.25.76 || ^4.0.0"
@@ -4283,7 +4283,7 @@ __metadata:
     express-promise-router: "npm:^4.1.1"
     jose: "npm:^5.0.0"
     lodash: "npm:^4.17.21"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     passport: "npm:^0.7.0"
     supertest: "npm:^7.0.0"
     zod: "npm:^3.25.76 || ^4.0.0"
@@ -36020,7 +36020,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"msw@npm:^1.0.0, msw@npm:^1.2.1, msw@npm:^1.3.0, msw@npm:^1.3.1":
+"msw@npm:^1.0.0, msw@npm:^1.2.1, msw@npm:^1.3.1":
   version: 1.3.5
   resolution: "msw@npm:1.3.5"
   dependencies:


### PR DESCRIPTION
Migrates MSW-based tests in auth-area packages from MSW 1.x to MSW 2.x.

This is part of the ongoing effort to adopt native `fetch` in backend code ([ADR014](https://github.com/backstage/backstage/blob/master/docs/architecture-decisions/adr014-use-fetch.md)). MSW 1.x does not reliably intercept native `fetch`; MSW 2.x uses updated interceptors that do.

Follows #34685 in the broader MSW 2 migration. Changes are limited to test files and devDependencies; no production code or published API surface is affected.

### Packages migrated

- `@backstage/plugin-auth-backend`
- `@backstage/plugin-auth-node`
- `@backstage/plugin-auth-backend-module-microsoft-provider`
- `@backstage/plugin-auth-backend-module-oidc-provider`
- `@backstage/plugin-auth-backend-module-pinniped-provider`

(Other auth provider modules: AWS ALB, Cloudflare Access, OpenShift, VMware Cloud were already on MSW 2.)