### PR TITLE
fix(catalog): prevent error when catalog filter is undefined

### DIFF
--- a/.changeset/pretty-weeks-try.md
+++ b/.changeset/pretty-weeks-try.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Fixed a crash in the catalog export when an entity list filter is `undefined`, which could occur if optional filters were not set.

--- a/plugins/catalog/src/components/CatalogExportButton/file-download/toStreamRequest.test.ts
+++ b/plugins/catalog/src/components/CatalogExportButton/file-download/toStreamRequest.test.ts
@@ -291,6 +291,29 @@ describe('toStreamRequest', () => {
     });
   });
 
+  describe('with undefined filter values', () => {
+    it('does not throw when a filter entry is undefined', () => {
+      const mockBackendFilter = {
+        getCatalogFilters: () => ({
+          kind: ['Component'],
+        }),
+      };
+
+      const filters: DefaultEntityFilters = {
+        kind: mockBackendFilter as any,
+        text: undefined,
+      };
+
+      const result = toStreamRequest(filters);
+
+      expect(result).toEqual({
+        filter: {
+          kind: ['Component'],
+        },
+      });
+    });
+  });
+
   describe('with combined filters', () => {
     it('combines backend, text, and order filters', () => {
       const mockBackendFilter = {

--- a/plugins/catalog/src/components/CatalogExportButton/file-download/toStreamRequest.ts
+++ b/plugins/catalog/src/components/CatalogExportButton/file-download/toStreamRequest.ts
@@ -28,11 +28,11 @@ function isBackendFilter(f: any): f is { getCatalogFilters: () => any } {
 }
 
 function isEntityTextFilter(f: any): f is EntityTextFilter {
-  return !!(f as EntityTextFilter)?.getFullTextFilters;
+  return typeof f?.getFullTextFilters === 'function';
 }
 
 function isEntityOrderFilter(f: any): f is EntityOrderFilter {
-  return !!(f as EntityOrderFilter)?.getOrderFilters;
+  return typeof f?.getOrderFilters === 'function';
 }
 
 function getBackendFilterObject(

--- a/plugins/catalog/src/components/CatalogExportButton/file-download/toStreamRequest.ts
+++ b/plugins/catalog/src/components/CatalogExportButton/file-download/toStreamRequest.ts
@@ -28,11 +28,11 @@ function isBackendFilter(f: any): f is { getCatalogFilters: () => any } {
 }
 
 function isEntityTextFilter(f: any): f is EntityTextFilter {
-  return !!(f as EntityTextFilter).getFullTextFilters;
+  return !!(f as EntityTextFilter)?.getFullTextFilters;
 }
 
 function isEntityOrderFilter(f: any): f is EntityOrderFilter {
-  return !!(f as EntityOrderFilter).getOrderFilters;
+  return !!(f as EntityOrderFilter)?.getOrderFilters;
 }
 
 function getBackendFilterObject(


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Fixes catalog export (CSV/JSON/custom exporters) crashing whenever any EntityListFilters value is undefined, which is a normal/expected state (e.g. cleared search box).

resolves: https://github.com/backstage/backstage/issues/34789

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
