### PR TITLE
Use pull_request_target in automate_yarn-lock-changes.yml

### DIFF
--- a/.github/workflows/automate_yarn-lock-changes.yml
+++ b/.github/workflows/automate_yarn-lock-changes.yml
@@ -1,8 +1,8 @@
 name: Yarn Lock Changes
-on: 
+on:
   pull_request_target:
     paths:
-       - 'yarn.lock'
+      - 'yarn.lock'
 
 jobs:
   yarn-lock-changes:

--- a/.github/workflows/automate_yarn-lock-changes.yml
+++ b/.github/workflows/automate_yarn-lock-changes.yml
@@ -1,5 +1,8 @@
 name: Yarn Lock Changes
-on: [pull_request]
+on: 
+  pull_request_target:
+    paths:
+       - 'yarn.lock'
 
 jobs:
   yarn-lock-changes:
@@ -15,6 +18,10 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Fetch the commit that's merged into the base rather than the target ref.
+          ref: 'refs/pull/${{ github.event.pull_request.number }}/merge'
+          persist-credentials: false
 
       - name: Yarn Lock Changes
         uses: Simek/yarn-lock-changes@59f47ee499424d2c2437c5aebf863b5c6d50a5bc # v0.14.1


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`pull-request` doesn't pass repo secrets to PRs opened from forks due to which the `Simek/yarn-lock-changes` action fails with `Error: Resource not accessible by integration - https://docs.github.com/rest/issues/comments#create-an-issue-comment`

as in https://github.com/backstage/backstage/actions/runs/28904576110/job/85748743886?pr=34780

Switching to `pull_request_target` should allow secrets to pass and not cause this error. 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
