### PR TITLE
Remove deprecated frontend API identity aliases

### DIFF
--- a/.changeset/remove-frontend-api-identity-aliases.md
+++ b/.changeset/remove-frontend-api-identity-aliases.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': minor
+---
+
+Removed deprecated frontend plugin identity aliases. Use `pluginId`, `CreateFrontendPluginOptions`, and `PageLayoutTab`, and create API references with `createApiRef<T>().with(...)`.

--- a/packages/core-compat-api/src/collectLegacyRoutes.test.tsx
+++ b/packages/core-compat-api/src/collectLegacyRoutes.test.tsx
@@ -81,7 +81,7 @@ describe('collectLegacyRoutes', () => {
 
     expect(
       collected.map(p => ({
-        id: p.$$type === '@backstage/FrontendPlugin' ? p.id : p.pluginId,
+        id: p.pluginId,
         extensions: OpaqueFrontendPlugin.toInternal(p).extensions.map(e => ({
           id: e.id,
           attachTo: e.attachTo,
@@ -180,7 +180,7 @@ describe('collectLegacyRoutes', () => {
 
     expect(
       collected.map(p => ({
-        id: p.$$type === '@backstage/FrontendPlugin' ? p.id : p.pluginId,
+        id: p.pluginId,
         extensions: OpaqueFrontendPlugin.toInternal(p).extensions.map(e => ({
           id: e.id,
           attachTo: e.attachTo,

--- a/packages/core-compat-api/src/compatWrapper/BackwardsCompatProvider.tsx
+++ b/packages/core-compat-api/src/compatWrapper/BackwardsCompatProvider.tsx
@@ -66,7 +66,7 @@ export function toLegacyPlugin(
 
   legacy = {
     getId(): string {
-      return plugin.pluginId ?? plugin.id;
+      return plugin.pluginId;
     },
     get routes() {
       return {};

--- a/packages/core-compat-api/src/convertLegacyApp.test.tsx
+++ b/packages/core-compat-api/src/convertLegacyApp.test.tsx
@@ -103,6 +103,7 @@ describe('convertLegacyApp', () => {
             id: 'api:example-1/plugin.example.service',
             attachTo: { id: 'root', input: 'apis' },
             disabled: false,
+            defaultConfig: undefined,
           },
         ],
       },
@@ -124,17 +125,19 @@ describe('convertLegacyApp', () => {
         ],
       },
       {
-        id: undefined,
+        id: 'app',
         extensions: [
           {
             id: 'app/layout',
             attachTo: { id: 'app/root', input: 'children' },
             disabled: false,
+            defaultConfig: undefined,
           },
           {
             id: 'app/nav',
             attachTo: { id: 'app/layout', input: 'nav' },
             disabled: true,
+            defaultConfig: undefined,
           },
         ],
       },

--- a/packages/core-compat-api/src/convertLegacyApp.test.tsx
+++ b/packages/core-compat-api/src/convertLegacyApp.test.tsx
@@ -81,7 +81,7 @@ describe('convertLegacyApp', () => {
 
     expect(
       collected.map((p: any /* TODO */) => ({
-        id: p.id,
+        id: p.pluginId,
         extensions: p.extensions.map((e: any) => ({
           id: e.id,
           attachTo: e.attachTo,
@@ -152,7 +152,7 @@ describe('convertLegacyApp', () => {
 
     expect(
       collected.map((p: any /* TODO */) => ({
-        id: p.id,
+        id: p.pluginId,
         extensions: p.extensions.map((e: any) => ({
           id: e.id,
           attachTo: e.attachTo,

--- a/packages/core-compat-api/src/convertLegacyPlugin.test.tsx
+++ b/packages/core-compat-api/src/convertLegacyPlugin.test.tsx
@@ -41,7 +41,6 @@ describe('convertLegacyPlugin', () => {
         "featureFlags": [],
         "getExtension": [Function],
         "icon": undefined,
-        "id": "test",
         "if": undefined,
         "info": [Function],
         "infoOptions": undefined,
@@ -82,7 +81,7 @@ describe('convertLegacyPlugin', () => {
 
     const internalConverted = OpaqueFrontendPlugin.toInternal(converted);
 
-    expect(internalConverted.id).toBe('test');
+    expect(internalConverted.pluginId).toBe('test');
     expect(internalConverted.routes).toEqual({
       test: routeRef,
     });

--- a/packages/core-compat-api/src/withApis.test.tsx
+++ b/packages/core-compat-api/src/withApis.test.tsx
@@ -24,7 +24,7 @@ import { withApis } from './withApis';
 
 describe('withApis', () => {
   type MyApi = () => string;
-  const myApiRef = createApiRef<MyApi>({ id: 'my-api' });
+  const myApiRef = createApiRef<MyApi>().with({ id: 'my-api' });
 
   const MyComponent = withApis({ getMessage: myApiRef })(({ getMessage }) => {
     return <p>message: {getMessage()}</p>;
@@ -42,7 +42,7 @@ describe('withApis', () => {
   });
 
   it('should ignore properties from the prototype', () => {
-    const otherRef = createApiRef<number>({ id: 'other' });
+    const otherRef = createApiRef<number>().with({ id: 'other' });
     const proto = { other: otherRef };
     const props = { getMessage: { enumerable: true, value: myApiRef } };
     const obj = Object.create(proto, props) as {

--- a/packages/core-plugin-api/src/apis/system/ApiRef.ts
+++ b/packages/core-plugin-api/src/apis/system/ApiRef.ts
@@ -20,17 +20,13 @@ import {
   type ApiRefConfig,
 } from '@backstage/frontend-plugin-api';
 
-const createFrontendApiRefCompat = createFrontendApiRef as <T>(
-  config: ApiRefConfig,
-) => ApiRef<T>;
-
 /**
  * Creates a reference to an API.
  *
  * @public
  */
 export function createApiRef<T>(config: ApiRefConfig): ApiRef<T> {
-  return createFrontendApiRefCompat<T>(config);
+  return createFrontendApiRef<T>().with(config);
 }
 
 export type { ApiRefConfig };

--- a/packages/core-plugin-api/src/app/useApp.test.tsx
+++ b/packages/core-plugin-api/src/app/useApp.test.tsx
@@ -60,7 +60,7 @@ describe('useApp', () => {
     };
 
     const mockPlugin = {
-      id: 'test-plugin',
+      pluginId: 'test-plugin',
     };
 
     const mockAppNode: AppNode = {

--- a/packages/core-plugin-api/src/app/useApp.tsx
+++ b/packages/core-plugin-api/src/app/useApp.tsx
@@ -53,7 +53,7 @@ function toLegacyPlugin(plugin: FrontendPlugin): BackstagePlugin {
 
   legacy = {
     getId(): string {
-      return plugin.pluginId ?? plugin.id;
+      return plugin.pluginId;
     },
     get routes() {
       return {};

--- a/packages/frontend-app-api/src/routing/RouteTracker.test.tsx
+++ b/packages/frontend-app-api/src/routing/RouteTracker.test.tsx
@@ -44,7 +44,7 @@ describe('RouteTracker', () => {
       appNode: {
         spec: {
           extension: { id: 'home.page.index' },
-          plugin: { id: 'home' },
+          plugin: { pluginId: 'home' },
         },
       } as AppNode,
     },
@@ -57,7 +57,7 @@ describe('RouteTracker', () => {
       appNode: {
         spec: {
           extension: { id: 'plugin1.page.index' },
-          plugin: { id: 'plugin1' },
+          plugin: { pluginId: 'plugin1' },
         },
       } as AppNode,
     },
@@ -70,7 +70,7 @@ describe('RouteTracker', () => {
       appNode: {
         spec: {
           extension: { id: 'plugin2.page.index' },
-          plugin: { id: 'plugin2' },
+          plugin: { pluginId: 'plugin2' },
         },
       } as AppNode,
     },

--- a/packages/frontend-app-api/src/routing/RouteTracker.tsx
+++ b/packages/frontend-app-api/src/routing/RouteTracker.tsx
@@ -68,7 +68,7 @@ const getExtensionContext = (
 
     return {
       params,
-      pluginId: plugin?.id || 'root',
+      pluginId: plugin?.pluginId || 'root',
       extensionId: extension?.id || 'App',
     };
   } catch {

--- a/packages/frontend-app-api/src/routing/collectRouteIds.ts
+++ b/packages/frontend-app-api/src/routing/collectRouteIds.ts
@@ -48,7 +48,7 @@ export function collectRouteIds(
     }
 
     for (const [name, ref] of Object.entries(feature.routes)) {
-      const refId = `${feature.id}.${name}`;
+      const refId = `${feature.pluginId}.${name}`;
       if (routesById.has(refId)) {
         collector.report({
           code: 'ROUTE_DUPLICATE',
@@ -68,7 +68,7 @@ export function collectRouteIds(
       }
     }
     for (const [name, ref] of Object.entries(feature.externalRoutes)) {
-      const refId = `${feature.id}.${name}`;
+      const refId = `${feature.pluginId}.${name}`;
       if (externalRoutesById.has(refId)) {
         collector.report({
           code: 'ROUTE_DUPLICATE',

--- a/packages/frontend-app-api/src/routing/extractRouteInfoFromAppNode.ts
+++ b/packages/frontend-app-api/src/routing/extractRouteInfoFromAppNode.ts
@@ -71,7 +71,10 @@ export function extractRouteInfoFromAppNode(
       ?.replace(/^\//, '');
 
     const foundRouteRef = current.instance?.getData(coreExtensionData.routeRef);
-    const routeRef = routeAliasResolver(foundRouteRef, current.spec.plugin?.id);
+    const routeRef = routeAliasResolver(
+      foundRouteRef,
+      current.spec.plugin?.pluginId,
+    );
     if (foundRouteRef && routeRef !== foundRouteRef) {
       routeAliases.set(foundRouteRef, routeRef);
     }

--- a/packages/frontend-app-api/src/wiring/FrontendApiRegistry.test.ts
+++ b/packages/frontend-app-api/src/wiring/FrontendApiRegistry.test.ts
@@ -25,7 +25,7 @@ import {
 
 describe('FrontendApiResolver', () => {
   it('should cache falsy API values', () => {
-    const falseApiRef = createApiRef<boolean>({ id: 'test.false' });
+    const falseApiRef = createApiRef<boolean>().with({ id: 'test.false' });
     const falseFactoryFn = jest.fn(() => false);
     const registry = new FrontendApiRegistry();
 
@@ -43,8 +43,10 @@ describe('FrontendApiResolver', () => {
   });
 
   it('should resolve falsy dependencies', () => {
-    const falseApiRef = createApiRef<boolean>({ id: 'test.false' });
-    const dependentApiRef = createApiRef<string>({ id: 'test.dependent' });
+    const falseApiRef = createApiRef<boolean>().with({ id: 'test.false' });
+    const dependentApiRef = createApiRef<string>().with({
+      id: 'test.dependent',
+    });
     const falseFactoryFn = jest.fn(() => false);
     const dependentFactoryFn = jest.fn((deps: { falseDependency: boolean }) =>
       deps.falseDependency === false ? 'resolved' : 'unexpected',

--- a/packages/frontend-app-api/src/wiring/apiFactories.test.ts
+++ b/packages/frontend-app-api/src/wiring/apiFactories.test.ts
@@ -224,7 +224,7 @@ describe('registerFeatureFlagDeclarationsInHolder', () => {
 
 describe('wrapFeatureFlagApiFactory', () => {
   it('should not wrap factories for non-feature-flag APIs', () => {
-    const otherApiRef = createApiRef<{}>({ id: 'test.other' });
+    const otherApiRef = createApiRef<{}>().with({ id: 'test.other' });
     const factory = {
       api: otherApiRef,
       deps: {},

--- a/packages/frontend-app-api/src/wiring/apiFactories.ts
+++ b/packages/frontend-app-api/src/wiring/apiFactories.ts
@@ -188,7 +188,7 @@ function registerFeatureFlagDeclarations(
     let source: string | undefined;
 
     if (OpaqueFrontendPlugin.isType(feature)) {
-      pluginId = feature.id;
+      pluginId = feature.pluginId;
       flags = OpaqueFrontendPlugin.toInternal(feature).featureFlags;
       source = 'Plugin';
     } else if (isInternalFrontendModule(feature)) {

--- a/packages/frontend-app-api/src/wiring/createSpecializedApp.test.tsx
+++ b/packages/frontend-app-api/src/wiring/createSpecializedApp.test.tsx
@@ -295,7 +295,9 @@ describe('createSpecializedApp', () => {
   });
 
   it('should select the API factory from the owning plugin on conflict', () => {
-    const testApiRef = createApiRef<{ value: string }>({ id: 'test.api' });
+    const testApiRef = createApiRef<{ value: string }>().with({
+      id: 'test.api',
+    });
     const appRootPlugin = createFrontendPlugin({
       pluginId: 'app',
       extensions: [
@@ -372,7 +374,9 @@ describe('createSpecializedApp', () => {
   });
 
   it('should allow API overrides within the same plugin', () => {
-    const testApiRef = createApiRef<{ value: string }>({ id: 'test.api' });
+    const testApiRef = createApiRef<{ value: string }>().with({
+      id: 'test.api',
+    });
     const appRootPlugin = createFrontendPlugin({
       pluginId: 'app',
       extensions: [
@@ -426,7 +430,9 @@ describe('createSpecializedApp', () => {
   });
 
   it('should reuse provided apis', async () => {
-    const testApiRef = createApiRef<{ value: string }>({ id: 'test.api' });
+    const testApiRef = createApiRef<{ value: string }>().with({
+      id: 'test.api',
+    });
     const app = createSpecializedApp({
       features: [
         createFrontendPlugin({
@@ -1025,7 +1031,9 @@ describe('createSpecializedApp', () => {
         name: 'visible-api',
         params: defineParams =>
           defineParams({
-            api: createApiRef<{ value: string }>({ id: 'test.visible-api' }),
+            api: createApiRef<{ value: string }>().with({
+              id: 'test.visible-api',
+            }),
             deps: {},
             factory: () => ({ value: 'visible' }),
           }),
@@ -1034,7 +1042,9 @@ describe('createSpecializedApp', () => {
         name: 'deferred-api',
         params: defineParams =>
           defineParams({
-            api: createApiRef<{ value: string }>({ id: 'test.deferred-api' }),
+            api: createApiRef<{ value: string }>().with({
+              id: 'test.deferred-api',
+            }),
             deps: {},
             factory: () => ({ value: 'deferred' }),
           }),
@@ -1084,7 +1094,7 @@ describe('createSpecializedApp', () => {
     });
 
     it('should ignore deferred overrides of materialized bootstrap APIs', () => {
-      const apiRef = createApiRef<{ value: string }>({
+      const apiRef = createApiRef<{ value: string }>().with({
         id: 'test.bootstrap-frozen-api',
       });
       let bootstrapApiValue: string | undefined;
@@ -1190,7 +1200,7 @@ describe('createSpecializedApp', () => {
     });
 
     it('should allow deferred overrides of bootstrap APIs that were not materialized', () => {
-      const apiRef = createApiRef<{ value: string }>({
+      const apiRef = createApiRef<{ value: string }>().with({
         id: 'test.bootstrap-overridable-api',
       });
       let finalApiValue: string | undefined;
@@ -1635,7 +1645,7 @@ describe('createSpecializedApp', () => {
         getCredentials: async () => ({ token: 'token' }),
         signOut: async () => {},
       };
-      const delayedApiRef = createApiRef<{ value: string }>({
+      const delayedApiRef = createApiRef<{ value: string }>().with({
         id: 'test.delayed-api',
       });
       const featureFlagsApi = {

--- a/packages/frontend-app-api/src/wiring/predicates.ts
+++ b/packages/frontend-app-api/src/wiring/predicates.ts
@@ -65,7 +65,7 @@ function parsePermissionName(permissionName: string) {
   };
 }
 
-export const localPermissionApiRef = createApiRef<MinimalPermissionApi>({
+export const localPermissionApiRef = createApiRef<MinimalPermissionApi>().with({
   id: 'plugin.permission.api',
 });
 

--- a/packages/frontend-app-api/src/wiring/prepareSpecializedApp.tsx
+++ b/packages/frontend-app-api/src/wiring/prepareSpecializedApp.tsx
@@ -101,10 +101,10 @@ function deduplicateFeatures(
       if (!OpaqueFrontendPlugin.isType(feature)) {
         return true;
       }
-      if (seenIds.has(feature.id)) {
+      if (seenIds.has(feature.pluginId!)) {
         return false;
       }
-      seenIds.add(feature.id);
+      seenIds.add(feature.pluginId!);
       return true;
     })
     .reverse();

--- a/packages/frontend-defaults/src/createApp.test.tsx
+++ b/packages/frontend-defaults/src/createApp.test.tsx
@@ -119,7 +119,7 @@ describe('createApp', () => {
   });
 
   it('should provide app APIs to sign-in pages before finalization', async () => {
-    const signInApiRef = createApiRef<{ value: string }>({
+    const signInApiRef = createApiRef<{ value: string }>().with({
       id: 'test.sign-in-api',
     });
 

--- a/packages/frontend-defaults/src/resolution.test.ts
+++ b/packages/frontend-defaults/src/resolution.test.ts
@@ -53,7 +53,7 @@ describe('resolveAsyncFeatures', () => {
     expect(features).toMatchObject([
       {
         $$type: '@backstage/FrontendPlugin',
-        id: 'test-feature',
+        pluginId: 'test-feature',
         version: 'v1',
         extensions: [
           {
@@ -97,7 +97,7 @@ describe('resolveAsyncFeatures', () => {
     expect(features).toMatchObject([
       {
         $$type: '@backstage/FrontendPlugin',
-        id: 'test',
+        pluginId: 'test',
         version: 'v1',
         extensions: [
           {

--- a/packages/frontend-dynamic-feature-loader/src/loader.test.tsx
+++ b/packages/frontend-dynamic-feature-loader/src/loader.test.tsx
@@ -291,7 +291,7 @@ describe('dynamicFrontendFeaturesLoader', () => {
     expect(features).toMatchObject([
       {
         $$type: '@backstage/FrontendPlugin',
-        id: 'test-plugin',
+        pluginId: 'test-plugin',
         version: 'v1',
       },
     ]);
@@ -405,12 +405,12 @@ describe('dynamicFrontendFeaturesLoader', () => {
     expect(features).toMatchObject([
       {
         $$type: '@backstage/FrontendPlugin',
-        id: 'plugin-1',
+        pluginId: 'plugin-1',
         version: 'v1',
       },
       {
         $$type: '@backstage/FrontendPlugin',
-        id: 'plugin-2',
+        pluginId: 'plugin-2',
         version: 'v1',
       },
     ]);
@@ -510,12 +510,12 @@ describe('dynamicFrontendFeaturesLoader', () => {
     expect(features).toMatchObject([
       {
         $$type: '@backstage/FrontendPlugin',
-        id: 'test-plugin',
+        pluginId: 'test-plugin',
         version: 'v1',
       },
       {
         $$type: '@backstage/FrontendPlugin',
-        id: 'test-plugin-alpha',
+        pluginId: 'test-plugin-alpha',
         version: 'v1',
       },
     ]);
@@ -591,7 +591,7 @@ describe('dynamicFrontendFeaturesLoader', () => {
     expect(features).toMatchObject([
       {
         $$type: '@backstage/FrontendPlugin',
-        id: 'test-plugin',
+        pluginId: 'test-plugin',
         version: 'v1',
       },
     ]);
@@ -776,7 +776,7 @@ describe('dynamicFrontendFeaturesLoader', () => {
     expect(features).toMatchObject([
       {
         $$type: '@backstage/FrontendPlugin',
-        id: 'plugin-2',
+        pluginId: 'plugin-2',
         version: 'v1',
       },
     ]);
@@ -892,7 +892,7 @@ describe('dynamicFrontendFeaturesLoader', () => {
     expect(features).toMatchObject([
       {
         $$type: '@backstage/FrontendPlugin',
-        id: 'plugin-2',
+        pluginId: 'plugin-2',
         version: 'v1',
       },
     ]);
@@ -996,7 +996,7 @@ describe('dynamicFrontendFeaturesLoader', () => {
     expect(features).toMatchObject([
       {
         $$type: '@backstage/FrontendPlugin',
-        id: 'plugin-2',
+        pluginId: 'plugin-2',
         version: 'v1',
       },
     ]);
@@ -1094,7 +1094,7 @@ describe('dynamicFrontendFeaturesLoader', () => {
     expect(features).toMatchObject([
       {
         $$type: '@backstage/FrontendPlugin',
-        id: 'plugin-2',
+        pluginId: 'plugin-2',
         version: 'v1',
       },
     ]);

--- a/packages/frontend-plugin-api/report-alpha.api.md
+++ b/packages/frontend-plugin-api/report-alpha.api.md
@@ -526,8 +526,6 @@ export interface FrontendPlugin<
   // (undocumented)
   readonly externalRoutes: TExternalRoutes;
   readonly icon?: IconElement;
-  // @deprecated
-  readonly id: string;
   info(): Promise<FrontendPluginInfo>;
   readonly pluginId: string;
   // (undocumented)

--- a/packages/frontend-plugin-api/report.api.md
+++ b/packages/frontend-plugin-api/report.api.md
@@ -457,11 +457,6 @@ export function createApiFactory<Api, Impl extends Api>(
   instance: Impl,
 ): ApiFactory<Api, Impl, {}>;
 
-// @public @deprecated
-export function createApiRef<T>(config: ApiRefConfig): ApiRef<T> & {
-  readonly $$type: '@backstage/ApiRef';
-};
-
 // @public
 export function createApiRef<T>(): {
   with<const TId extends string>(
@@ -1725,8 +1720,6 @@ export interface FrontendPlugin<
   // (undocumented)
   readonly externalRoutes: TExternalRoutes;
   readonly icon?: IconElement;
-  // @deprecated
-  readonly id: string;
   info(): Promise<FrontendPluginInfo>;
   readonly pluginId: string;
   // (undocumented)
@@ -2283,9 +2276,6 @@ export interface PageLayoutTab {
   label: string;
 }
 
-// @public @deprecated (undocumented)
-export type PageTab = PageLayoutTab;
-
 // @public
 export type PendingOAuthRequest = {
   provider: AuthProviderInfo;
@@ -2318,18 +2308,6 @@ export const pluginHeaderActionsApiRef: ApiRef_2<
 > & {
   readonly $$type: '@backstage/ApiRef';
 };
-
-// @public @deprecated (undocumented)
-export type PluginOptions<
-  TId extends string,
-  TRoutes extends {
-    [name in string]: RouteRef | SubRouteRef;
-  },
-  TExternalRoutes extends {
-    [name in string]: ExternalRouteRef;
-  },
-  TExtensions extends readonly ExtensionDefinition[],
-> = CreateFrontendPluginOptions<TId, TRoutes, TExternalRoutes, TExtensions>;
 
 // @public
 export type PluginWrapperApi = {

--- a/packages/frontend-plugin-api/src/apis/definitions/ToastApi.ts
+++ b/packages/frontend-plugin-api/src/apis/definitions/ToastApi.ts
@@ -104,6 +104,6 @@ export type ToastApi = {
  *
  * @public
  */
-export const toastApiRef: ApiRef<ToastApi> = createApiRef({
+export const toastApiRef: ApiRef<ToastApi> = createApiRef<ToastApi>().with({
   id: 'core.toast',
 });

--- a/packages/frontend-plugin-api/src/apis/system/ApiRef.test.ts
+++ b/packages/frontend-plugin-api/src/apis/system/ApiRef.test.ts
@@ -18,31 +18,6 @@ import { createApiRef } from './ApiRef';
 import type { ApiRef as ApiRefType } from './types';
 
 describe('ApiRef', () => {
-  it('should be created with config', () => {
-    const ref = createApiRef({ id: 'abc' });
-    expect(ref.$$type).toBe('@backstage/ApiRef');
-    expect(ref.id).toBe('abc');
-    expect(String(ref)).toBe('apiRef{abc}');
-    expect(ref.T).toBeNull();
-  });
-
-  it('should not accept pluginId with deprecated config form', () => {
-    expect(createApiRef<string>({ id: 'abc' }).id).toBe('abc');
-
-    // @ts-expect-error pluginId is only supported through .with(...)
-    createApiRef<string>({ id: 'abc', pluginId: 'test' });
-  });
-
-  it('should keep the deprecated config form id wide', () => {
-    const ref = createApiRef<string>({ id: 'abc' });
-    const wideRef: ApiRefType<string> = ref;
-    expect(wideRef.id).toBe('abc');
-
-    // @ts-expect-error deprecated config form should not infer literal ids
-    const literalRef: ApiRefType<string, 'abc'> = ref;
-    expect(literalRef.id).toBe('abc');
-  });
-
   it('should be created with builder pattern', () => {
     const ref = createApiRef<string>().with({ id: 'abc', pluginId: 'test' });
     expect(ref.$$type).toBe('@backstage/ApiRef');
@@ -67,7 +42,7 @@ describe('ApiRef', () => {
 
   it('should reject invalid ids', () => {
     for (const id of ['a', 'abc', 'ab-c', 'a.b.c', 'a-b.c', 'abc.a-b-c.abc3']) {
-      expect(createApiRef({ id }).id).toBe(id);
+      expect(createApiRef().with({ id }).id).toBe(id);
     }
 
     for (const id of [
@@ -83,7 +58,7 @@ describe('ApiRef', () => {
       '',
       '_',
     ]) {
-      expect(() => createApiRef({ id }).id).toThrow(
+      expect(() => createApiRef().with({ id }).id).toThrow(
         `API id must only contain period separated lowercase alphanum tokens with dashes, got '${id}'`,
       );
     }

--- a/packages/frontend-plugin-api/src/apis/system/ApiRef.ts
+++ b/packages/frontend-plugin-api/src/apis/system/ApiRef.ts
@@ -77,31 +77,6 @@ function makeApiRef<T, TId extends string>(
  * });
  * ```
  *
- * The legacy way to create an API reference is:
- *
- * ```ts
- * const myApiRef = createApiRef<MyApi>({ id: 'plugin.my.api' });
- * ```
- *
- * @public
- */
-/**
- * Creates a reference to an API.
- *
- * @deprecated Use `createApiRef<T>().with(...)` instead.
- * @public
- */
-export function createApiRef<T>(
-  config: ApiRefConfig,
-): ApiRef<T> & { readonly $$type: '@backstage/ApiRef' };
-/**
- * Creates a reference to an API.
- *
- * @remarks
- *
- * Returns a builder with a `.with()` method for providing the API reference
- * configuration.
- *
  * @public
  */
 export function createApiRef<T>(): {
@@ -110,20 +85,7 @@ export function createApiRef<T>(): {
   ): ApiRef<T, TId> & {
     readonly $$type: '@backstage/ApiRef';
   };
-};
-export function createApiRef<T>(config?: ApiRefConfig):
-  | (ApiRef<T> & { readonly $$type: '@backstage/ApiRef' })
-  | {
-      with<const TId extends string>(
-        config: ApiRefConfig & { id: TId; pluginId?: string },
-      ): ApiRef<T, TId> & {
-        readonly $$type: '@backstage/ApiRef';
-      };
-    } {
-  if (config) {
-    validateId(config.id);
-    return makeApiRef<T, string>(config);
-  }
+} {
   return {
     with<const TId extends string>(
       withConfig: ApiRefConfig & { id: TId; pluginId?: string },

--- a/packages/frontend-plugin-api/src/components/PageLayout.tsx
+++ b/packages/frontend-plugin-api/src/components/PageLayout.tsx
@@ -30,12 +30,6 @@ export interface PageLayoutTab {
 }
 
 /**
- * @deprecated Use {@link PageLayoutTab} instead
- * @public
- */
-export type PageTab = PageLayoutTab;
-
-/**
  * Props for the PageLayout component
  * @public
  */

--- a/packages/frontend-plugin-api/src/components/index.ts
+++ b/packages/frontend-plugin-api/src/components/index.ts
@@ -29,5 +29,4 @@ export {
   PageLayout,
   type PageLayoutProps,
   type PageLayoutTab,
-  type PageTab,
 } from './PageLayout';

--- a/packages/frontend-plugin-api/src/wiring/createFrontendPlugin.ts
+++ b/packages/frontend-plugin-api/src/wiring/createFrontendPlugin.ts
@@ -150,12 +150,6 @@ export interface FrontendPlugin<
    */
   readonly pluginId: string;
   /**
-   * Deprecated alias for `pluginId`.
-   *
-   * @deprecated Use `pluginId` instead.
-   */
-  readonly id: string;
-  /**
    * The display title of the plugin, used in page headers and navigation.
    * Falls back to the plugin ID if not provided.
    */
@@ -201,17 +195,6 @@ export interface CreateFrontendPluginOptions<
   if?: FilterPredicate;
   info?: FrontendPluginInfoOptions;
 }
-
-/**
- * @deprecated Use {@link CreateFrontendPluginOptions} instead.
- * @public
- */
-export type PluginOptions<
-  TId extends string,
-  TRoutes extends { [name in string]: RouteRef | SubRouteRef },
-  TExternalRoutes extends { [name in string]: ExternalRouteRef },
-  TExtensions extends readonly ExtensionDefinition[],
-> = CreateFrontendPluginOptions<TId, TRoutes, TExternalRoutes, TExtensions>;
 
 /**
  * Creates a new plugin that can be installed in a Backstage app.
@@ -279,7 +262,6 @@ export function createFrontendPlugin<
 
   return OpaqueFrontendPlugin.createInstance('v1', {
     pluginId,
-    id: pluginId,
     title: options.title,
     icon: options.icon,
     routes: options.routes ?? ({} as TRoutes),

--- a/packages/frontend-plugin-api/src/wiring/index.ts
+++ b/packages/frontend-plugin-api/src/wiring/index.ts
@@ -38,7 +38,6 @@ export {
   type CreateFrontendPluginOptions,
   type FrontendPlugin,
   type OverridableFrontendPlugin,
-  type PluginOptions,
   type FrontendPluginInfo,
   type FrontendPluginInfoOptions,
 } from './createFrontendPlugin';

--- a/packages/frontend-test-utils/src/apis/TestApiProvider.test.tsx
+++ b/packages/frontend-test-utils/src/apis/TestApiProvider.test.tsx
@@ -19,10 +19,10 @@ import { TestApiProvider } from './TestApiProvider';
 import { mockApis } from './mockApis';
 import { render, screen } from '@testing-library/react';
 
-const xApiRef = createApiRef<{ a: string; b: number }>({
+const xApiRef = createApiRef<{ a: string; b: number }>().with({
   id: 'x',
 });
-const yApiRef = createApiRef<string>({
+const yApiRef = createApiRef<string>().with({
   id: 'y',
 });
 

--- a/packages/frontend-test-utils/src/apis/createApiMock.test.ts
+++ b/packages/frontend-test-utils/src/apis/createApiMock.test.ts
@@ -24,7 +24,7 @@ describe('createApiMock', () => {
     count: number;
   };
 
-  const testApiRef = createApiRef<TestApi>({ id: 'test.create-mock' });
+  const testApiRef = createApiRef<TestApi>().with({ id: 'test.create-mock' });
 
   it('returns a factory function that produces jest mocks', () => {
     const mock = createApiMock(testApiRef, () => ({

--- a/plugins/app/src/apis/toastApiForwarderRef.ts
+++ b/plugins/app/src/apis/toastApiForwarderRef.ts
@@ -56,6 +56,6 @@ export type ToastApiForwarderApi = ToastApi & {
  *
  * @internal
  */
-export const toastApiForwarderRef = createApiRef<ToastApiForwarderApi>({
+export const toastApiForwarderRef = createApiRef<ToastApiForwarderApi>().with({
   id: 'app.toast.internal-forwarder',
 });

--- a/plugins/app/src/extensions/LegacyComponentsApi.ts
+++ b/plugins/app/src/extensions/LegacyComponentsApi.ts
@@ -38,7 +38,7 @@ export const LegacyComponentsApi = ApiBlueprint.make({
     defineParams({
       api: createApiRef<{
         getComponent(ref: { id: string }): ComponentType<any>;
-      }>({ id: 'core.components' }),
+      }>().with({ id: 'core.components' }),
       deps: {},
       factory: () => ({
         getComponent(ref) {

--- a/plugins/app/src/extensions/PluginWrapperApi.ts
+++ b/plugins/app/src/extensions/PluginWrapperApi.ts
@@ -39,7 +39,7 @@ export const PluginWrapperApi = ApiBlueprint.makeWithOverrides({
           return DefaultPluginWrapperApi.fromWrappers(
             inputs.wrappers.map(wrapperInput => ({
               loader: wrapperInput.get(PluginWrapperBlueprint.dataRefs.wrapper),
-              pluginId: wrapperInput.node.spec.plugin.id ?? 'app',
+              pluginId: wrapperInput.node.spec.plugin.pluginId ?? 'app',
             })),
           );
         },

--- a/plugins/app/src/extensions/components.tsx
+++ b/plugins/app/src/extensions/components.tsx
@@ -61,7 +61,7 @@ export const ErrorDisplay = SwappableComponentBlueprint.make({
       component: SwappableErrorDisplay,
       loader: () => props => {
         const { plugin, error, resetError } = props;
-        const title = `Error in ${plugin?.id}`;
+        const title = `Error in ${plugin?.pluginId}`;
         return (
           <ErrorPanel title={title} error={error} defaultExpanded>
             <Button variant="outlined" onClick={resetError}>

--- a/plugins/home/src/alpha.test.ts
+++ b/plugins/home/src/alpha.test.ts
@@ -88,7 +88,7 @@ describe('Home Plugin Alpha', () => {
 
   describe('Plugin Structure', () => {
     it('should have correct plugin metadata', () => {
-      expect(homePlugin.id).toBe('home');
+      expect(homePlugin.pluginId).toBe('home');
       expect(homePlugin.routes.root).toBeDefined();
     });
 

--- a/plugins/scaffolder-react/src/api/ref.ts
+++ b/plugins/scaffolder-react/src/api/ref.ts
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-import { createApiRef } from '@backstage/frontend-plugin-api';
-import { ScaffolderApi } from './types';
+import { createApiRef, type ApiRef } from '@backstage/frontend-plugin-api';
+import { type ScaffolderApi } from '@backstage/plugin-scaffolder-common';
 
 /** @public */
-export const scaffolderApiRef = createApiRef<ScaffolderApi>({
+export const scaffolderApiRef: ApiRef<ScaffolderApi> & {
+  readonly $$type: '@backstage/ApiRef';
+} = createApiRef<ScaffolderApi>().with({
   id: 'plugin.scaffolder.service',
 });

--- a/plugins/scaffolder-react/src/next/api/index.ts
+++ b/plugins/scaffolder-react/src/next/api/index.ts
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-import { createApiRef } from '@backstage/frontend-plugin-api';
+import { createApiRef, type ApiRef } from '@backstage/frontend-plugin-api';
 import { ScaffolderFormFieldsApi } from './types';
 
 export { type FormField, type ScaffolderFormFieldsApi } from './types';
 
 /** @alpha */
-export const formFieldsApiRef = createApiRef<ScaffolderFormFieldsApi>({
+export const formFieldsApiRef: ApiRef<ScaffolderFormFieldsApi> & {
+  readonly $$type: '@backstage/ApiRef';
+} = createApiRef<ScaffolderFormFieldsApi>().with({
   id: 'plugin.scaffolder.form-fields-loader',
 });

--- a/plugins/scaffolder/src/alpha/api/ref.ts
+++ b/plugins/scaffolder/src/alpha/api/ref.ts
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-import { createApiRef } from '@backstage/frontend-plugin-api';
+import { createApiRef, type ApiRef } from '@backstage/frontend-plugin-api';
 import { ScaffolderFormDecoratorsApi } from './types';
 
 /** @public */
-export const formDecoratorsApiRef = createApiRef<ScaffolderFormDecoratorsApi>({
+export const formDecoratorsApiRef: ApiRef<ScaffolderFormDecoratorsApi> & {
+  readonly $$type: '@backstage/ApiRef';
+} = createApiRef<ScaffolderFormDecoratorsApi>().with({
   id: 'plugin.scaffolder.form-decorators',
 });

--- a/plugins/techdocs/src/alpha/addonsApi.ts
+++ b/plugins/techdocs/src/alpha/addonsApi.ts
@@ -26,7 +26,7 @@ interface TechDocsAddonsApi {
   getAddons(): TechDocsAddonOptions[];
 }
 
-export const techdocsAddonsApiRef = createApiRef<TechDocsAddonsApi>({
+export const techdocsAddonsApiRef = createApiRef<TechDocsAddonsApi>().with({
   id: 'plugin.techdocs.addons',
 });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Removes the deprecated `createApiRef(config)` overload, `FrontendPlugin.id`, `PluginOptions`, and `PageTab`, and migrates repository consumers to the current builder and identity APIs.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))