### PR TITLE
Remove deprecated compatibility and app aliases

### DIFF
--- a/.changeset/remove-app-react-aliases.md
+++ b/.changeset/remove-app-react-aliases.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-app-react': minor
+---
+
+Removed deprecated blueprint and navigation parameters. Use `component` in the app root wrapper and router blueprints, and consume `navItems` in custom navigation components.

--- a/.changeset/remove-core-compat-aliases.md
+++ b/.changeset/remove-core-compat-aliases.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-compat-api': minor
+---
+
+Removed the deprecated `convertLegacyApp` alias and its options type; use `convertLegacyAppRoot` instead. The deprecated `defaultPath` page override was also removed in favor of `path`.

--- a/.changeset/update-app-nav-content.md
+++ b/.changeset/update-app-nav-content.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-app': minor
+---
+
+Custom navigation components now receive `navItems` without the deprecated flat `items` collection.

--- a/packages/core-compat-api/report.api.md
+++ b/packages/core-compat-api/report.api.md
@@ -33,12 +33,6 @@ import { TypesToApiRefs } from '@backstage/frontend-plugin-api';
 // @public
 export function compatWrapper(element: ReactNode): JSX_3.Element;
 
-// @public @deprecated (undocumented)
-export const convertLegacyApp: typeof convertLegacyAppRoot;
-
-// @public @deprecated (undocumented)
-export type ConvertLegacyAppOptions = ConvertLegacyAppRootOptions;
-
 // @public (undocumented)
 export function convertLegacyAppOptions(options?: {
   apis?: Iterable<AnyApiFactory>;
@@ -68,7 +62,6 @@ export function convertLegacyPageExtension(
   overrides?: {
     name?: string;
     path?: string;
-    defaultPath?: [Error: `Use the 'path' override instead`];
   },
 ): ExtensionDefinition;
 

--- a/packages/core-compat-api/src/convertLegacyApp.test.tsx
+++ b/packages/core-compat-api/src/convertLegacyApp.test.tsx
@@ -60,7 +60,7 @@ const ExamplePage2 = examplePlugin2.provide(
   }),
 );
 
-describe('convertLegacyApp', () => {
+describe('convertLegacyAppRoot', () => {
   it('should find and extract root and routes', () => {
     const collected = convertLegacyAppRoot(
       <>

--- a/packages/core-compat-api/src/convertLegacyApp.ts
+++ b/packages/core-compat-api/src/convertLegacyApp.ts
@@ -171,17 +171,3 @@ export function convertLegacyAppRoot(
     }),
   ];
 }
-
-/**
- * @public
- * @deprecated
- * Use `convertLegacyAppRoot` instead.
- */
-export const convertLegacyApp = convertLegacyAppRoot;
-
-/**
- * @public
- * @deprecated
- * Use `ConvertLegacyAppRootOptions` instead.
- */
-export type ConvertLegacyAppOptions = ConvertLegacyAppRootOptions;

--- a/packages/core-compat-api/src/convertLegacyPageExtension.tsx
+++ b/packages/core-compat-api/src/convertLegacyPageExtension.tsx
@@ -33,10 +33,6 @@ export function convertLegacyPageExtension(
   overrides?: {
     name?: string;
     path?: string;
-    /**
-     * @deprecated Use the `path` param instead.
-     */
-    defaultPath?: [Error: `Use the 'path' override instead`];
   },
 ): ExtensionDefinition {
   const element = <LegacyExtension />;

--- a/packages/core-compat-api/src/index.ts
+++ b/packages/core-compat-api/src/index.ts
@@ -18,8 +18,6 @@ export * from './compatWrapper';
 export * from './apis';
 
 export {
-  convertLegacyApp,
-  type ConvertLegacyAppOptions,
   convertLegacyAppRoot,
   type ConvertLegacyAppRootOptions,
 } from './convertLegacyApp';

--- a/plugins/app-react/report.api.md
+++ b/plugins/app-react/report.api.md
@@ -295,14 +295,14 @@ export const TranslationBlueprint: ExtensionBlueprint<{
     resource: TranslationResource | TranslationMessages;
   };
   output: ExtensionDataRef<
+    | TranslationResource<string>
     | TranslationMessages<
         string,
         {
           [x: string]: string;
         },
         boolean
-      >
-    | TranslationResource<string>,
+      >,
     'core.translation.translation',
     {}
   >;
@@ -311,14 +311,14 @@ export const TranslationBlueprint: ExtensionBlueprint<{
   configInput: {};
   dataRefs: {
     translation: ConfigurableExtensionDataRef<
+      | TranslationResource<string>
       | TranslationMessages<
           string,
           {
             [x: string]: string;
           },
           boolean
-        >
-      | TranslationResource<string>,
+        >,
       'core.translation.translation',
       {}
     >;

--- a/plugins/app-react/report.api.md
+++ b/plugins/app-react/report.api.md
@@ -58,7 +58,6 @@ export type AnalyticsImplementationFactory<
 export const AppRootWrapperBlueprint: ExtensionBlueprint<{
   kind: 'app-root-wrapper';
   params: {
-    Component?: [error: 'Use the `component` parameter instead'];
     component: (props: { children: ReactNode }) => JSX.Element | null;
   };
   output: ExtensionDataRef<
@@ -135,14 +134,6 @@ export type NavContentComponent = (
 
 // @public
 export interface NavContentComponentProps {
-  // @deprecated
-  items: Array<{
-    icon: IconComponent;
-    title: string;
-    routeRef: RouteRef<undefined>;
-    to: string;
-    text: string;
-  }>;
   navItems: NavContentNavItems;
 }
 
@@ -175,7 +166,6 @@ export interface NavContentNavItemsWithComponent {
 export const RouterBlueprint: ExtensionBlueprint<{
   kind: 'app-router-component';
   params: {
-    Component?: [error: 'Use the `component` parameter instead'];
     component: (props: { children: ReactNode }) => JSX.Element | null;
   };
   output: ExtensionDataRef<
@@ -305,14 +295,14 @@ export const TranslationBlueprint: ExtensionBlueprint<{
     resource: TranslationResource | TranslationMessages;
   };
   output: ExtensionDataRef<
-    | TranslationResource<string>
     | TranslationMessages<
         string,
         {
           [x: string]: string;
         },
         boolean
-      >,
+      >
+    | TranslationResource<string>,
     'core.translation.translation',
     {}
   >;
@@ -321,14 +311,14 @@ export const TranslationBlueprint: ExtensionBlueprint<{
   configInput: {};
   dataRefs: {
     translation: ConfigurableExtensionDataRef<
-      | TranslationResource<string>
       | TranslationMessages<
           string,
           {
             [x: string]: string;
           },
           boolean
-        >,
+        >
+      | TranslationResource<string>,
       'core.translation.translation',
       {}
     >;

--- a/plugins/app-react/src/blueprints/AppRootWrapperBlueprint.tsx
+++ b/plugins/app-react/src/blueprints/AppRootWrapperBlueprint.tsx
@@ -39,8 +39,6 @@ export const AppRootWrapperBlueprint = createExtensionBlueprint({
     component: componentDataRef,
   },
   *factory(params: {
-    /** @deprecated use the `component` parameter instead */
-    Component?: [error: 'Use the `component` parameter instead'];
     component: (props: { children: ReactNode }) => JSX.Element | null;
   }) {
     yield componentDataRef(params.component);

--- a/plugins/app-react/src/blueprints/NavContentBlueprint.test.tsx
+++ b/plugins/app-react/src/blueprints/NavContentBlueprint.test.tsx
@@ -136,50 +136,6 @@ describe('NavContentBlueprint', () => {
     `);
   });
 
-  it('should return a valid component with legacy items', () => {
-    const extension = NavContentBlueprint.make({
-      name: 'test',
-      params: {
-        component: ({ items }) => (
-          <div>
-            Items:
-            {items.map((item, index) => (
-              <a key={index} href={item.to}>
-                {item.title}
-              </a>
-            ))}
-          </div>
-        ),
-      },
-    });
-
-    const tester = createExtensionTester(extension);
-
-    expect(
-      tester.get(NavContentBlueprint.dataRefs.component)({
-        navItems: mockNavItems([]),
-        items: [
-          {
-            to: '/',
-            text: 'Home',
-            title: 'Home',
-            icon: () => null,
-            routeRef,
-          },
-        ],
-      }),
-    ).toEqual(
-      <div>
-        Items:
-        {[
-          <a key={0} href="/">
-            Home
-          </a>,
-        ]}
-      </div>,
-    );
-  });
-
   it('should return a valid component with navItems', () => {
     const items: NavContentNavItem[] = [
       {
@@ -225,7 +181,6 @@ describe('NavContentBlueprint', () => {
     expect(
       tester.get(NavContentBlueprint.dataRefs.component)({
         navItems: mockNavItems(items),
-        items: [],
       }),
     ).toEqual(
       <div>
@@ -289,7 +244,7 @@ describe('NavContentBlueprint', () => {
     const tester = createExtensionTester(extension);
     const Component = tester.get(NavContentBlueprint.dataRefs.component);
 
-    render(<Component navItems={mockNavItems(items)} items={[]} />);
+    render(<Component navItems={mockNavItems(items)} />);
 
     const homeLink = screen.getByText('Home');
     expect(homeLink).toBeInTheDocument();
@@ -352,7 +307,7 @@ describe('NavContentBlueprint', () => {
     const tester = createExtensionTester(extension);
     const Component = tester.get(NavContentBlueprint.dataRefs.component);
 
-    render(<Component navItems={mockNavItems(items)} items={[]} />);
+    render(<Component navItems={mockNavItems(items)} />);
 
     expect(screen.getByText('Catalog').closest('nav')).toBeTruthy();
     expect(screen.queryByText('DevTools')?.closest('nav')).toBeFalsy();

--- a/plugins/app-react/src/blueprints/NavContentBlueprint.ts
+++ b/plugins/app-react/src/blueprints/NavContentBlueprint.ts
@@ -15,12 +15,7 @@
  */
 
 import { ComponentType } from 'react';
-import {
-  AppNode,
-  IconComponent,
-  IconElement,
-  RouteRef,
-} from '@backstage/frontend-plugin-api';
+import { AppNode, IconElement, RouteRef } from '@backstage/frontend-plugin-api';
 import {
   createExtensionBlueprint,
   createExtensionDataRef,
@@ -97,20 +92,6 @@ export interface NavContentComponentProps {
    * for placing specific items in specific positions.
    */
   navItems: NavContentNavItems;
-
-  /**
-   * Flat list of nav items for simple rendering. Use `navItems` for more
-   * control over item placement.
-   *
-   * @deprecated Use `navItems` instead.
-   */
-  items: Array<{
-    icon: IconComponent;
-    title: string;
-    routeRef: RouteRef<undefined>;
-    to: string;
-    text: string;
-  }>;
 }
 
 /**

--- a/plugins/app-react/src/blueprints/RouterBlueprint.tsx
+++ b/plugins/app-react/src/blueprints/RouterBlueprint.tsx
@@ -37,8 +37,6 @@ export const RouterBlueprint = createExtensionBlueprint({
     component: componentDataRef,
   },
   *factory(params: {
-    /** @deprecated use the `component` parameter instead */
-    Component?: [error: 'Use the `component` parameter instead'];
     component: (props: { children: ReactNode }) => JSX.Element | null;
   }) {
     yield componentDataRef(params.component);

--- a/plugins/app/report.api.md
+++ b/plugins/app/report.api.md
@@ -771,14 +771,14 @@ const appPlugin: OverridableFrontendPlugin<
       inputs: {
         translations: ExtensionInput<
           ConfigurableExtensionDataRef<
+            | TranslationResource<string>
             | TranslationMessages<
                 string,
                 {
                   [x: string]: string;
                 },
                 boolean
-              >
-            | TranslationResource<string>,
+              >,
             'core.translation.translation',
             {}
           >,
@@ -818,7 +818,7 @@ const appPlugin: OverridableFrontendPlugin<
       config: {
         transientTimeoutMs: number;
         anchorOrigin: {
-          vertical: 'bottom' | 'top';
+          vertical: 'top' | 'bottom';
           horizontal: 'center' | 'left' | 'right';
         };
       };
@@ -826,7 +826,7 @@ const appPlugin: OverridableFrontendPlugin<
         transientTimeoutMs?: number | undefined;
         anchorOrigin?:
           | {
-              vertical?: 'bottom' | 'top' | undefined;
+              vertical?: 'top' | 'bottom' | undefined;
               horizontal?: 'center' | 'left' | 'right' | undefined;
             }
           | undefined;

--- a/plugins/app/report.api.md
+++ b/plugins/app/report.api.md
@@ -771,14 +771,14 @@ const appPlugin: OverridableFrontendPlugin<
       inputs: {
         translations: ExtensionInput<
           ConfigurableExtensionDataRef<
-            | TranslationResource<string>
             | TranslationMessages<
                 string,
                 {
                   [x: string]: string;
                 },
                 boolean
-              >,
+              >
+            | TranslationResource<string>,
             'core.translation.translation',
             {}
           >,
@@ -818,7 +818,7 @@ const appPlugin: OverridableFrontendPlugin<
       config: {
         transientTimeoutMs: number;
         anchorOrigin: {
-          vertical: 'top' | 'bottom';
+          vertical: 'bottom' | 'top';
           horizontal: 'center' | 'left' | 'right';
         };
       };
@@ -826,7 +826,7 @@ const appPlugin: OverridableFrontendPlugin<
         transientTimeoutMs?: number | undefined;
         anchorOrigin?:
           | {
-              vertical?: 'top' | 'bottom' | undefined;
+              vertical?: 'bottom' | 'top' | undefined;
               horizontal?: 'center' | 'left' | 'right' | undefined;
             }
           | undefined;

--- a/plugins/app/src/extensions/AppNav.test.tsx
+++ b/plugins/app/src/extensions/AppNav.test.tsx
@@ -19,8 +19,10 @@ import { renderTestApp } from '@backstage/frontend-test-utils';
 import {
   PageBlueprint,
   createExtension,
+  createFrontendModule,
   createRouteRef,
 } from '@backstage/frontend-plugin-api';
+import { NavContentBlueprint } from '@backstage/plugin-app-react';
 import { legacyNavItemTargetDataRef } from './legacyNavItem';
 
 const DEFAULT_CONFIG = {
@@ -88,5 +90,34 @@ describe('AppNav', () => {
         within(screen.getByRole('navigation')).getByText('Legacy Nav Title'),
       ).toBeInTheDocument();
     });
+  });
+
+  it('should pass only navItems to custom navigation content', async () => {
+    const customNav = NavContentBlueprint.make({
+      params: {
+        component: props => (
+          <div>
+            {'items' in props
+              ? 'legacy items provided'
+              : `${props.navItems.rest().length} nav item provided`}
+          </div>
+        ),
+      },
+    });
+
+    renderTestApp({
+      extensions: [mockPage],
+      features: [
+        createFrontendModule({
+          pluginId: 'app',
+          extensions: [customNav],
+        }),
+      ],
+      config: DEFAULT_CONFIG,
+    });
+
+    await expect(
+      screen.findByText('1 nav item provided'),
+    ).resolves.toBeInTheDocument();
   });
 });

--- a/plugins/app/src/extensions/AppNav.tsx
+++ b/plugins/app/src/extensions/AppNav.tsx
@@ -153,23 +153,6 @@ function NavContentRenderer(props: {
   const appTreeApi = useApi(appTreeApiRef);
   const routeResolutionApi = useApi(routeResolutionApiRef);
 
-  // Deprecated items: just resolve nav item routeRefs to paths, no page discovery.
-  const legacyItems = useMemo(() => {
-    return props.legacyNavItems.flatMap(item => {
-      const link = routeResolutionApi.resolve(item.routeRef);
-      if (!link) return [];
-      return [
-        {
-          to: link(),
-          text: item.title,
-          icon: item.icon,
-          title: item.title,
-          routeRef: item.routeRef,
-        },
-      ];
-    });
-  }, [props.legacyNavItems, routeResolutionApi]);
-
   // New navItems: discover pages from the extension tree, merged with nav items.
   const navItems = useMemo(() => {
     const { tree } = appTreeApi.getTree();
@@ -241,7 +224,7 @@ function NavContentRenderer(props: {
     return new NavItemBag(items);
   }, [appTreeApi, routeResolutionApi, props.legacyNavItems]);
 
-  return <props.Content navItems={navItems} items={legacyItems} />;
+  return <props.Content navItems={navItems} />;
 }
 
 export const AppNav = createExtension({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Removes the legacy app conversion aliases, `defaultPath`, deprecated blueprint `Component` parameters, and the flat navigation `items` collection.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))