### PR TITLE
core-app-api: support internal-only discovery endpoints

### DIFF
--- a/.changeset/tidy-otters-skip.md
+++ b/.changeset/tidy-otters-skip.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-app-api': patch
+---
+
+Fixed the default fetch API to support discovery endpoints that only define an internal target.

--- a/packages/core-app-api/src/apis/implementations/FetchApi/IdentityAuthInjectorFetchMiddleware.test.ts
+++ b/packages/core-app-api/src/apis/implementations/FetchApi/IdentityAuthInjectorFetchMiddleware.test.ts
@@ -144,6 +144,10 @@ describe('IdentityAuthInjectorFetchMiddleware', () => {
               },
               plugins: ['q4'],
             },
+            {
+              target: { internal: 'https://internal.example.com' },
+              plugins: ['internal'],
+            },
           ],
         },
       });

--- a/packages/core-app-api/src/apis/implementations/FetchApi/IdentityAuthInjectorFetchMiddleware.ts
+++ b/packages/core-app-api/src/apis/implementations/FetchApi/IdentityAuthInjectorFetchMiddleware.ts
@@ -55,8 +55,11 @@ export class IdentityAuthInjectorFetchMiddleware implements FetchMiddleware {
     return endpointConfigs.flatMap(c => {
       const target =
         typeof c.get('target') === 'object'
-          ? c.getString('target.external')
+          ? c.getOptionalString('target.external')
           : c.getString('target');
+      if (!target) {
+        return [];
+      }
       const plugins = c.getStringArray('plugins');
       return plugins.map(pluginId =>
         target.replace(/\{\{\s*pluginId\s*\}\}/g, pluginId),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes an issue where the default fetch API required object-form discovery endpoints to define an external target, even when an endpoint was intended only for backend-to-backend discovery.

Internal-only endpoints are now ignored when deriving browser URL prefixes for identity token injection, matching the behavior of frontend discovery.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))