### PR TITLE
Control documentation search type through TechDocs

### DIFF
--- a/.changeset/mighty-teeth-live.md
+++ b/.changeset/mighty-teeth-live.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+The TechDocs plugin now adds the Documentation result type to the Search page when it is installed.

--- a/.changeset/sharp-sides-follow.md
+++ b/.changeset/sharp-sides-follow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search': patch
+---
+
+The Search page no longer shows the Documentation result type unless it is provided by an installed plugin.

--- a/plugins/search/src/alpha.tsx
+++ b/plugins/search/src/alpha.tsx
@@ -23,7 +23,6 @@ import { z } from 'zod/v4';
 import {
   CatalogIcon,
   Content,
-  DocsIcon,
   useSidebarPinState,
 } from '@backstage/core-components';
 import {
@@ -159,11 +158,6 @@ export const searchPage = PageBlueprint.makeWithOverrides({
                           value: 'software-catalog',
                           name: 'Software Catalog',
                           icon: <CatalogIcon />,
-                        },
-                        {
-                          value: 'techdocs',
-                          name: 'Documentation',
-                          icon: <DocsIcon />,
                         },
                       ].concat(resultTypes)}
                     />

--- a/plugins/techdocs/report-alpha.api.md
+++ b/plugins/techdocs/report-alpha.api.md
@@ -22,6 +22,7 @@ import { OverridableFrontendPlugin } from '@backstage/frontend-plugin-api';
 import { ReactElement } from 'react';
 import { RouteRef } from '@backstage/core-plugin-api';
 import { RouteRef as RouteRef_2 } from '@backstage/frontend-plugin-api';
+import { SearchFilterResultTypeBlueprintParams } from '@backstage/plugin-search-react/alpha';
 import { SearchResultItemExtensionComponent } from '@backstage/plugin-search-react/alpha';
 import { SearchResultItemExtensionPredicate } from '@backstage/plugin-search-react/alpha';
 import { SearchResultListItemBlueprintParams } from '@backstage/plugin-search-react/alpha';
@@ -437,6 +438,23 @@ const _default: OverridableFrontendPlugin<
       params: {
         loader: () => Promise<JSX.Element>;
       };
+    }>;
+    'search-filter-result-type:techdocs': OverridableExtensionDefinition<{
+      kind: 'search-filter-result-type';
+      name: undefined;
+      config: {};
+      configInput: {};
+      output: ExtensionDataRef<
+        {
+          value: string;
+          name: string;
+          icon: JSX_2.Element;
+        },
+        'search.filters.result-types.type',
+        {}
+      >;
+      inputs: {};
+      params: SearchFilterResultTypeBlueprintParams;
     }>;
     'search-result-list-item:techdocs': OverridableExtensionDefinition<{
       config: {

--- a/plugins/techdocs/src/alpha/index.tsx
+++ b/plugins/techdocs/src/alpha/index.tsx
@@ -35,7 +35,10 @@ import {
   EntityContentBlueprint,
   EntityIconLinkBlueprint,
 } from '@backstage/plugin-catalog-react/alpha';
-import { SearchResultListItemBlueprint } from '@backstage/plugin-search-react/alpha';
+import {
+  SearchFilterResultTypeBlueprint,
+  SearchResultListItemBlueprint,
+} from '@backstage/plugin-search-react/alpha';
 import {
   AddonBlueprint,
   attachTechDocsAddonComponentData,
@@ -126,6 +129,15 @@ export const techDocsSearchResultListItemExtension =
           );
         },
       });
+    },
+  });
+
+const techDocsSearchFilterResultTypeExtension =
+  SearchFilterResultTypeBlueprint.make({
+    params: {
+      value: 'techdocs',
+      name: 'Documentation',
+      icon: <DocsIcon />,
     },
   });
 
@@ -291,6 +303,7 @@ export default createFrontendPlugin({
     techdocsEntityIconLink,
     techDocsEntityContent,
     techDocsEntityContentEmptyState,
+    techDocsSearchFilterResultTypeExtension,
     techDocsSearchResultListItemExtension,
   ],
   routes: {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This updates the new frontend system’s Search page so that the Documentation result type is no longer included by default. Instead, the TechDocs plugin contributes the result type when installed, ensuring that documentation search is only shown in apps that use TechDocs.

### Before
<img width="2168" height="1309" alt="Before" src="https://github.com/user-attachments/assets/f8e727c3-3320-45e3-962a-8b88b58d8c55" />

### After
<img width="2168" height="1309" alt="After" src="https://github.com/user-attachments/assets/afe622cf-ef2b-475f-b61c-89a737f49c82" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
