### PR TITLE
feat(auth): promote CIMD and deprecate DCR

### DIFF
--- a/.changeset/bright-dogs-listen.md
+++ b/.changeset/bright-dogs-listen.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-mcp-actions-backend': patch
+---
+
+Updated OAuth discovery to use the stable `auth.clientIdMetadataDocuments` configuration while retaining compatibility with the deprecated experimental key.

--- a/.changeset/calm-cats-share.md
+++ b/.changeset/calm-cats-share.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Promoted Client ID Metadata Documents (CIMD) to the stable `auth.clientIdMetadataDocuments` configuration. The previous `auth.experimentalClientIdMetadataDocuments` key remains supported as a deprecated alias. Dynamic Client Registration now logs a deprecation warning when enabled and users should migrate to CIMD.

--- a/.changeset/quick-apples-smile.md
+++ b/.changeset/quick-apples-smile.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Updated generated app configurations to use the stable Client ID Metadata Documents setting and stop advertising deprecated Dynamic Client Registration.

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -351,9 +351,7 @@ scaffolder:
       environment: ${NODE_ENV}
 
 auth:
-  experimentalDynamicClientRegistration:
-    enabled: true
-  experimentalClientIdMetadataDocuments:
+  clientIdMetadataDocuments:
     enabled: true
 
   ### Add auth.keyStore.provider to more granularly control how to store JWK data when running

--- a/docs/ai/mcp-actions.md
+++ b/docs/ai/mcp-actions.md
@@ -157,14 +157,11 @@ Authorization: Bearer <token>
 For more details about external access tokens and service-to-service authentication, see the
 [Service-to-Service Auth documentation](../auth/service-to-service-auth.md).
 
-### Experimental Authentication methods
+### OAuth authentication
 
-The MCP Actions Backend supports two experimental authentication methods based on the MCP specification:
+The MCP Actions Backend supports [Client ID Metadata Documents (CIMD)](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#client-id-metadata-documents) based on the MCP specification.
 
-- [Client ID Metadata Documents (CIMD)](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#client-id-metadata-documents)
-- [Dynamic Client Registration (DCR)](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization#dynamic-client-registration)
-
-They have the following requirements:
+CIMD has the following requirements:
 
 - You must be using the [New Frontend System](../frontend-system/architecture/00-index.md).
 - The `@backstage/plugin-auth-backend` plugin must be configured.
@@ -193,19 +190,15 @@ Follow these steps to install and configure the new `@backstage/plugin-auth` fro
 
 #### Client ID Metadata Documents
 
-:::warning
-This feature is highly experimental; proceed with caution. Client support is also currently limited but quickly being implemented.
-:::
-
 The [November 2025 MCP specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization) outlined a new authorization method to replace Dynamic Client Registration called [Client ID Metadata Documents (CIMD)](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#client-id-metadata-documents).
 
 Using Client ID Metadata Documents means you do not need to manually configure a token in your MCP client settings. Instead, a client can request a token on your behalf. When adding the MCP server to an MCP client like Cursor or Claude, a popup requiring your approval will open in your Backstage instance (powered by the `auth` plugin).
 
-This can be enabled in the `auth-backend` plugin by using the `auth.experimentalClientIdMetadataDocuments.enabled` flag in config:
+This can be enabled in the `auth-backend` plugin by using the `auth.clientIdMetadataDocuments.enabled` flag in config:
 
 ```yaml title="app-config.yaml"
 auth:
-  experimentalClientIdMetadataDocuments:
+  clientIdMetadataDocuments:
     enabled: true
     # Optional: override which client_id URLs are allowed.
     # Defaults to Claude, VS Code, and the built-in Backstage CLI.
@@ -226,8 +219,8 @@ auth:
 
 #### Dynamic Client Registration
 
-:::warning
-This feature is highly experimental; proceed with caution. This method will likely be deprecated and replaced by [Client ID Metadata Documents](#client-id-metadata-documents) in the future. Only use in cases where clients do not yet support Client ID Metadata Documents.
+:::caution
+Dynamic Client Registration is deprecated. Migrate to [Client ID Metadata Documents](#client-id-metadata-documents). Only use DCR for clients that do not yet support CIMD.
 :::
 
 Using Dynamic Client Registration means you do not need to manually configure a token in your MCP client settings. Instead, a client can request a token on your behalf. When adding the MCP server to an MCP client like Cursor or Claude, a popup requiring your approval will open in your Backstage instance (powered by the `auth` plugin).

--- a/packages/create-app/templates/default-app/app-config.yaml.hbs
+++ b/packages/create-app/templates/default-app/app-config.yaml.hbs
@@ -84,7 +84,7 @@ auth:
     guest: {}
   # see https://backstage.io/docs/ai/mcp-actions#client-id-metadata-documents
   # to learn more about client id metadata documents
-  experimentalClientIdMetadataDocuments:
+  clientIdMetadataDocuments:
     enabled: false
     # Optional: restrict which `client_id` URLs are allowed (defaults to ['*'])
     # allowedClientIdPatterns:

--- a/packages/create-app/templates/legacy-app/app-config.yaml.hbs
+++ b/packages/create-app/templates/legacy-app/app-config.yaml.hbs
@@ -73,16 +73,9 @@ auth:
   providers:
     # See https://backstage.io/docs/auth/guest/provider
     guest: {}
-  # see https://backstage.io/docs/ai/mcp-actions#dynamic-client-registration
-  # to learn more about dynamic client registration
-  experimentalDynamicClientRegistration:
-    enabled: false
-    # Optional: limit valid callback URLs for added security
-    # allowedRedirectUriPatterns:
-    #   - cursor://*
   # see https://backstage.io/docs/ai/mcp-actions#client-id-metadata-documents
   # to learn more about client id metadata documents
-  experimentalClientIdMetadataDocuments:
+  clientIdMetadataDocuments:
     enabled: true
     # Optional: restrict which `client_id` URLs are allowed (defaults to ['*'])
     # allowedClientIdPatterns:

--- a/plugins/auth-backend/config.d.ts
+++ b/plugins/auth-backend/config.d.ts
@@ -153,6 +153,7 @@ export interface Config {
 
     /**
      * Configuration for dynamic client registration
+     * @deprecated Use `auth.clientIdMetadataDocuments` instead.
      */
     experimentalDynamicClientRegistration?: {
       /**
@@ -173,6 +174,37 @@ export interface Config {
      * Configuration for Client ID Metadata Documents (CIMD)
      *
      * @see https://datatracker.ietf.org/doc/draft-ietf-oauth-client-id-metadata-document/
+     */
+    clientIdMetadataDocuments?: {
+      /**
+       * Whether to enable Client ID Metadata Documents support
+       * Defaults to false
+       */
+      enabled?: boolean;
+
+      /**
+       * A list of allowed URI patterns for client_id URLs.
+       * Uses glob-style pattern matching where `*` matches any characters.
+       * Defaults to `['https://claude.ai/*', 'https://vscode.dev/*', '{baseUrl}/.well-known/oauth-client/cli.json']`
+       * where `{baseUrl}` is the auth backend's base URL.
+       *
+       * @example ['https://example.com/*', 'https://*.trusted-domain.com/*']
+       */
+      allowedClientIdPatterns?: string[];
+
+      /**
+       * A list of allowed URI patterns for redirect URIs.
+       * Uses glob-style pattern matching where `*` matches any characters.
+       * Defaults to loopback addresses (localhost, 127.0.0.1, [::1]).
+       *
+       * @example ['http://localhost:*', 'http://127.0.0.1:*\/callback']
+       */
+      allowedRedirectUriPatterns?: string[];
+    };
+
+    /**
+     * Configuration for Client ID Metadata Documents (CIMD)
+     * @deprecated This is no longer experimental; use `auth.clientIdMetadataDocuments` instead.
      */
     experimentalClientIdMetadataDocuments?: {
       /**

--- a/plugins/auth-backend/src/service/OidcRouter.test.ts
+++ b/plugins/auth-backend/src/service/OidcRouter.test.ts
@@ -28,6 +28,7 @@ import {
 } from '@backstage/backend-test-utils';
 import request from 'supertest';
 import crypto from 'node:crypto';
+import type { JsonObject } from '@backstage/types';
 import { OidcRouter } from './OidcRouter';
 import { UserInfoDatabase } from '../database/UserInfoDatabase';
 import { OidcDatabase } from '../database/OidcDatabase';
@@ -64,7 +65,15 @@ describe('OidcRouter', () => {
     mockFetchCimdMetadata.mockReset();
   });
 
-  async function createRouter(databaseId: TestDatabaseId) {
+  async function createRouter(
+    databaseId: TestDatabaseId,
+    authConfig: JsonObject = {
+      experimentalDynamicClientRegistration: {
+        enabled: true,
+        allowedRedirectUriPatterns: ['*'],
+      },
+    },
+  ) {
     const knex = await databases.init(databaseId);
 
     await knex.migrate.latest({
@@ -93,14 +102,10 @@ describe('OidcRouter', () => {
 
     const mockAuth = mockServices.auth.mock();
     const mockHttpAuth = mockServices.httpAuth.mock();
+    const mockLogger = mockServices.logger.mock();
     const mockConfig = mockServices.rootConfig({
       data: {
-        auth: {
-          experimentalDynamicClientRegistration: {
-            enabled: true,
-            allowedRedirectUriPatterns: ['*'],
-          },
-        },
+        auth: authConfig,
       },
     });
 
@@ -111,7 +116,7 @@ describe('OidcRouter', () => {
       userInfo: userInfoDatabase,
       oidc: oidcDatabase,
       config: mockConfig,
-      logger: mockServices.logger.mock(),
+      logger: mockLogger,
     });
 
     const oidcRouter = OidcRouter.create({
@@ -119,7 +124,7 @@ describe('OidcRouter', () => {
       tokenIssuer: mockTokenIssuer,
       baseUrl: 'http://localhost:7000',
       appUrl: 'http://localhost:3000',
-      logger: mockServices.logger.mock(),
+      logger: mockLogger,
       userInfo: userInfoDatabase,
       oidc: oidcDatabase,
       httpAuth: mockHttpAuth,
@@ -135,6 +140,7 @@ describe('OidcRouter', () => {
         userInfo: userInfoDatabase,
         service: oidcService,
         tokenIssuer: mockTokenIssuer,
+        logger: mockLogger,
       },
     };
   }
@@ -245,6 +251,34 @@ describe('OidcRouter', () => {
   }
 
   describe.each(databases.eachSupportedId())('%p', databaseId => {
+    describe('deprecation warnings', () => {
+      it('should warn when DCR is enabled', async () => {
+        const {
+          router,
+          mocks: { logger },
+        } = await createRouter(databaseId);
+
+        router.getRouter();
+
+        expect(logger.warn).toHaveBeenCalledWith(
+          "DEPRECATION WARNING: The 'auth.experimentalDynamicClientRegistration' configuration is deprecated. Migrate to Client ID Metadata Documents (CIMD) using 'auth.clientIdMetadataDocuments'.",
+        );
+      });
+
+      it('should not warn when only CIMD is enabled', async () => {
+        const {
+          router,
+          mocks: { logger },
+        } = await createRouter(databaseId, {
+          experimentalClientIdMetadataDocuments: { enabled: true },
+        });
+
+        router.getRouter();
+
+        expect(logger.warn).not.toHaveBeenCalled();
+      });
+    });
+
     describe('/v1/userinfo', () => {
       it('should return user info for full tokens', async () => {
         const {
@@ -1298,7 +1332,7 @@ describe('OidcRouter', () => {
           undefined,
           {
             experimentalDynamicClientRegistration: { enabled: false },
-            experimentalClientIdMetadataDocuments: {
+            clientIdMetadataDocuments: {
               enabled: true,
               allowedClientIdPatterns: ['https://example.com/*'],
               allowedRedirectUriPatterns: ['*'],
@@ -1587,7 +1621,7 @@ describe('OidcRouter', () => {
           config: mockServices.rootConfig({
             data: {
               auth: {
-                experimentalClientIdMetadataDocuments: {
+                clientIdMetadataDocuments: {
                   enabled: true,
                   allowedClientIdPatterns: ['*'],
                   allowedRedirectUriPatterns: ['*'],
@@ -1681,7 +1715,7 @@ describe('OidcRouter', () => {
         const mockConfig = mockServices.rootConfig({
           data: {
             auth: {
-              experimentalClientIdMetadataDocuments: {
+              clientIdMetadataDocuments: {
                 enabled: true,
                 allowedClientIdPatterns: ['*'],
                 allowedRedirectUriPatterns: ['*'],

--- a/plugins/auth-backend/src/service/OidcRouter.ts
+++ b/plugins/auth-backend/src/service/OidcRouter.ts
@@ -202,6 +202,8 @@ export class OidcRouter {
 
     router.use(json());
 
+    const cimdEnabled = this.oidc.isCimdEnabled();
+
     // OpenID Provider Configuration endpoint
     // https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig
     // Returns the OpenID Provider Configuration document containing metadata about the provider
@@ -220,10 +222,6 @@ export class OidcRouter {
     // CIMD metadata endpoint for the Backstage CLI
     // Automatically available when CIMD is enabled
     router.get('/.well-known/oauth-client/cli.json', (_req, res) => {
-      const cimdEnabled = this.config.getOptionalBoolean(
-        'auth.experimentalClientIdMetadataDocuments.enabled',
-      );
-
       if (!cimdEnabled) {
         res.status(404).json({
           error: 'not_found',
@@ -263,12 +261,16 @@ export class OidcRouter {
       res.json(userInfo);
     });
 
-    const dcrEnabled = this.config.getOptionalBoolean(
-      'auth.experimentalDynamicClientRegistration.enabled',
-    );
-    const cimdEnabled = this.config.getOptionalBoolean(
-      'auth.experimentalClientIdMetadataDocuments.enabled',
-    );
+    const dcrEnabled =
+      this.config.getOptionalBoolean(
+        'auth.experimentalDynamicClientRegistration.enabled',
+      ) ?? false;
+
+    if (dcrEnabled) {
+      this.logger.warn(
+        "DEPRECATION WARNING: The 'auth.experimentalDynamicClientRegistration' configuration is deprecated. Migrate to Client ID Metadata Documents (CIMD) using 'auth.clientIdMetadataDocuments'.",
+      );
+    }
 
     if (dcrEnabled || cimdEnabled) {
       // Authorization endpoint

--- a/plugins/auth-backend/src/service/OidcService.test.ts
+++ b/plugins/auth-backend/src/service/OidcService.test.ts
@@ -989,7 +989,7 @@ describe('OidcService', () => {
             databaseId,
             config: {
               auth: {
-                experimentalClientIdMetadataDocuments: {
+                clientIdMetadataDocuments: {
                   enabled: true,
                   allowedClientIdPatterns: ['*'],
                   allowedRedirectUriPatterns: ['*'],
@@ -1007,12 +1007,29 @@ describe('OidcService', () => {
           expect(config).not.toHaveProperty('registration_endpoint');
         });
 
+        it('should support the deprecated experimental CIMD configuration', async () => {
+          const { service } = await createOidcService({
+            databaseId,
+            config: {
+              auth: {
+                experimentalClientIdMetadataDocuments: {
+                  enabled: true,
+                },
+              },
+            },
+          });
+
+          const config = service.getConfiguration();
+
+          expect(config.client_id_metadata_document_supported).toBe(true);
+        });
+
         it('should not include client_id_metadata_document_supported when CIMD is disabled', async () => {
           const { service } = await createOidcService({
             databaseId,
             config: {
               auth: {
-                experimentalClientIdMetadataDocuments: { enabled: false },
+                clientIdMetadataDocuments: { enabled: false },
               },
             },
           });
@@ -1032,7 +1049,7 @@ describe('OidcService', () => {
             databaseId,
             config: {
               auth: {
-                experimentalClientIdMetadataDocuments: {
+                clientIdMetadataDocuments: {
                   enabled: true,
                   allowedClientIdPatterns: ['https://example.com/*'],
                   allowedRedirectUriPatterns: ['*'],
@@ -1080,7 +1097,7 @@ describe('OidcService', () => {
             databaseId,
             config: {
               auth: {
-                experimentalClientIdMetadataDocuments: { enabled: false },
+                clientIdMetadataDocuments: { enabled: false },
               },
             },
           });
@@ -1097,7 +1114,7 @@ describe('OidcService', () => {
             databaseId,
             config: {
               auth: {
-                experimentalClientIdMetadataDocuments: {
+                clientIdMetadataDocuments: {
                   enabled: true,
                   allowedClientIdPatterns: ['*'],
                 },
@@ -1126,7 +1143,7 @@ describe('OidcService', () => {
             databaseId,
             config: {
               auth: {
-                experimentalClientIdMetadataDocuments: {
+                clientIdMetadataDocuments: {
                   enabled: true,
                   allowedClientIdPatterns: ['*'],
                 },
@@ -1149,7 +1166,7 @@ describe('OidcService', () => {
             databaseId,
             config: {
               auth: {
-                experimentalClientIdMetadataDocuments: {
+                clientIdMetadataDocuments: {
                   enabled: true,
                   allowedClientIdPatterns: ['*'],
                   allowedRedirectUriPatterns: ['*'],
@@ -1183,7 +1200,7 @@ describe('OidcService', () => {
             databaseId,
             config: {
               auth: {
-                experimentalClientIdMetadataDocuments: { enabled: false },
+                clientIdMetadataDocuments: { enabled: false },
               },
             },
           });
@@ -1202,7 +1219,7 @@ describe('OidcService', () => {
             databaseId,
             config: {
               auth: {
-                experimentalClientIdMetadataDocuments: {
+                clientIdMetadataDocuments: {
                   enabled: true,
                   allowedClientIdPatterns: ['https://trusted.com/*'],
                 },
@@ -1224,7 +1241,7 @@ describe('OidcService', () => {
             databaseId,
             config: {
               auth: {
-                experimentalClientIdMetadataDocuments: {
+                clientIdMetadataDocuments: {
                   enabled: true,
                   allowedClientIdPatterns: ['https://example.com/*'],
                 },
@@ -1252,7 +1269,7 @@ describe('OidcService', () => {
             databaseId,
             config: {
               auth: {
-                experimentalClientIdMetadataDocuments: {
+                clientIdMetadataDocuments: {
                   enabled: true,
                   allowedClientIdPatterns: ['*'],
                   allowedRedirectUriPatterns: ['*'],
@@ -1275,7 +1292,7 @@ describe('OidcService', () => {
             databaseId,
             config: {
               auth: {
-                experimentalClientIdMetadataDocuments: {
+                clientIdMetadataDocuments: {
                   enabled: true,
                   allowedClientIdPatterns: ['*'],
                   allowedRedirectUriPatterns: ['https://*.example.com/*'],
@@ -1303,7 +1320,7 @@ describe('OidcService', () => {
             databaseId,
             config: {
               auth: {
-                experimentalClientIdMetadataDocuments: {
+                clientIdMetadataDocuments: {
                   enabled: true,
                   allowedClientIdPatterns: ['*'],
                   allowedRedirectUriPatterns: ['*'],
@@ -1338,7 +1355,7 @@ describe('OidcService', () => {
             databaseId,
             config: {
               auth: {
-                experimentalClientIdMetadataDocuments: {
+                clientIdMetadataDocuments: {
                   enabled: true,
                   allowedClientIdPatterns: ['*'],
                   allowedRedirectUriPatterns: ['*'],
@@ -1367,7 +1384,7 @@ describe('OidcService', () => {
             databaseId,
             config: {
               auth: {
-                experimentalClientIdMetadataDocuments: {
+                clientIdMetadataDocuments: {
                   enabled: true,
                   allowedClientIdPatterns: ['*'],
                   allowedRedirectUriPatterns: [
@@ -1405,7 +1422,7 @@ describe('OidcService', () => {
             databaseId,
             config: {
               auth: {
-                experimentalClientIdMetadataDocuments: {
+                clientIdMetadataDocuments: {
                   enabled: true,
                   allowedClientIdPatterns: ['*'],
                   allowedRedirectUriPatterns: [
@@ -1443,7 +1460,7 @@ describe('OidcService', () => {
             databaseId,
             config: {
               auth: {
-                experimentalClientIdMetadataDocuments: {
+                clientIdMetadataDocuments: {
                   enabled: true,
                   allowedClientIdPatterns: ['*'],
                   allowedRedirectUriPatterns: ['http://localhost:*'],
@@ -1467,7 +1484,7 @@ describe('OidcService', () => {
             databaseId,
             config: {
               auth: {
-                experimentalClientIdMetadataDocuments: {
+                clientIdMetadataDocuments: {
                   enabled: true,
                   allowedClientIdPatterns: ['*'],
                   allowedRedirectUriPatterns: ['http://localhost:*'],
@@ -1491,7 +1508,7 @@ describe('OidcService', () => {
             databaseId,
             config: {
               auth: {
-                experimentalClientIdMetadataDocuments: {
+                clientIdMetadataDocuments: {
                   enabled: true,
                   allowedClientIdPatterns: ['*'],
                   allowedRedirectUriPatterns: ['*'],
@@ -1516,7 +1533,7 @@ describe('OidcService', () => {
             databaseId,
             config: {
               auth: {
-                experimentalClientIdMetadataDocuments: {
+                clientIdMetadataDocuments: {
                   enabled: true,
                   allowedClientIdPatterns: ['*'],
                   allowedRedirectUriPatterns: ['*'],
@@ -1557,7 +1574,7 @@ describe('OidcService', () => {
             databaseId,
             config: {
               auth: {
-                experimentalClientIdMetadataDocuments: {
+                clientIdMetadataDocuments: {
                   enabled: true,
                   allowedClientIdPatterns: ['*'],
                   allowedRedirectUriPatterns: ['*'],
@@ -1609,7 +1626,7 @@ describe('OidcService', () => {
             databaseId,
             config: {
               auth: {
-                experimentalClientIdMetadataDocuments: {
+                clientIdMetadataDocuments: {
                   enabled: true,
                   allowedClientIdPatterns: ['*'],
                   allowedRedirectUriPatterns: ['*'],
@@ -1662,7 +1679,7 @@ describe('OidcService', () => {
             databaseId,
             config: {
               auth: {
-                experimentalClientIdMetadataDocuments: {
+                clientIdMetadataDocuments: {
                   enabled: true,
                   allowedClientIdPatterns: ['*'],
                   allowedRedirectUriPatterns: ['*'],
@@ -1697,7 +1714,7 @@ describe('OidcService', () => {
             databaseId,
             config: {
               auth: {
-                experimentalClientIdMetadataDocuments: {
+                clientIdMetadataDocuments: {
                   enabled: true,
                   allowedClientIdPatterns: ['*'],
                   allowedRedirectUriPatterns: ['*'],

--- a/plugins/auth-backend/src/service/OidcService.ts
+++ b/plugins/auth-backend/src/service/OidcService.ts
@@ -152,7 +152,7 @@ export class OidcService {
     const dcrEnabled = this.config.getOptionalBoolean(
       'auth.experimentalDynamicClientRegistration.enabled',
     );
-    const { enabled: cimdEnabled } = this.getCimdConfig();
+    const cimdEnabled = this.isCimdEnabled();
 
     return {
       issuer: this.baseUrl,
@@ -197,6 +197,10 @@ export class OidcService {
       }),
       ...(cimdEnabled && { client_id_metadata_document_supported: true }),
     };
+  }
+
+  public isCimdEnabled(): boolean {
+    return this.getCimdConfig().enabled;
   }
 
   public async listPublicKeys() {
@@ -321,21 +325,22 @@ export class OidcService {
   }
 
   private getCimdConfig() {
+    const configPath = this.config.has('auth.clientIdMetadataDocuments')
+      ? 'auth.clientIdMetadataDocuments'
+      : 'auth.experimentalClientIdMetadataDocuments';
     const enabled =
-      this.config.getOptionalBoolean(
-        'auth.experimentalClientIdMetadataDocuments.enabled',
-      ) ?? false;
+      this.config.getOptionalBoolean(`${configPath}.enabled`) ?? false;
 
     const cliClientId = `${this.baseUrl}/.well-known/oauth-client/cli.json`;
 
     return {
       enabled,
       allowedClientIdPatterns: this.config.getOptionalStringArray(
-        'auth.experimentalClientIdMetadataDocuments.allowedClientIdPatterns',
+        `${configPath}.allowedClientIdPatterns`,
       ) ?? ['https://claude.ai/*', 'https://vscode.dev/*', cliClientId],
       allowedRedirectUriPatterns:
         this.config.getOptionalStringArray(
-          'auth.experimentalClientIdMetadataDocuments.allowedRedirectUriPatterns',
+          `${configPath}.allowedRedirectUriPatterns`,
         ) ?? LOOPBACK_REDIRECT_PATTERNS,
     };
   }

--- a/plugins/mcp-actions-backend/README.md
+++ b/plugins/mcp-actions-backend/README.md
@@ -203,12 +203,9 @@ node -p 'require("crypto").randomBytes(24).toString("base64")'
 
 Set the `MCP_TOKEN` environment variable with this token, and configure your MCP client to use it in the [Authorization header](#configuring-mcp-clients)
 
-#### Experimental: Dynamic Client Registration
+#### Client ID Metadata Documents
 
-> [!CAUTION]
-> This is highly experimental, proceed with caution.
-
-You can configure the `auth-backend` and install the `auth` frontend plugin in order to enable [Dynamic Client Registration](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization#dynamic-client-registration) with MCP Clients.
+You can configure the `auth-backend` and install the `auth` frontend plugin to enable [Client ID Metadata Documents](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#client-id-metadata-documents) with MCP clients.
 
 This means that there is no token required in your MCP settings, and a token will be given to a client that requests a token on your behalf. When adding the MCP server to an MCP client like Cursor or Claude, a popup that requires your approval will be opened in your Backstage instance, which is powered by the `auth` plugin.
 
@@ -216,14 +213,12 @@ You will need to add the `@backstage/plugin-auth` package to your `app` `package
 
 ```yaml
 auth:
-  experimentalDynamicClientRegistration:
-    # enable the feature
+  clientIdMetadataDocuments:
     enabled: true
-
-    # this is optional and will default to *, but you can limit the callback URLs which are valid for added security
-    allowedRedirectUriPatterns:
-      - cursor://*
 ```
+
+> [!CAUTION]
+> Dynamic Client Registration is deprecated. Existing DCR configurations continue to work, but should be migrated to Client ID Metadata Documents.
 
 > [!NOTE]
 > The `@backstage/plugin-auth` package is currently only available in the new frontend system.

--- a/plugins/mcp-actions-backend/src/plugin.test.ts
+++ b/plugins/mcp-actions-backend/src/plugin.test.ts
@@ -386,7 +386,7 @@ describe('Mcp Backend', () => {
                 },
               },
               auth: {
-                experimentalClientIdMetadataDocuments: {
+                clientIdMetadataDocuments: {
                   enabled: true,
                 },
               },
@@ -402,6 +402,27 @@ describe('Mcp Backend', () => {
       expect(response.body.resource).toMatch(/\/api\/mcp-actions\/v1$/);
       expect(response.body.authorization_servers).toHaveLength(1);
       expect(response.body.authorization_servers[0]).toMatch(/\/api\/auth$/);
+    });
+
+    it('should support the deprecated experimental CIMD configuration', async () => {
+      const { server } = await startTestBackend({
+        features: [
+          mcpPlugin,
+          mockPluginWithActions,
+          mockServices.rootConfig.factory({
+            data: {
+              backend: { actions: { pluginSources: ['local'] } },
+              auth: {
+                experimentalClientIdMetadataDocuments: { enabled: true },
+              },
+            },
+          }),
+        ],
+      });
+
+      await request(server)
+        .get('/.well-known/oauth-protected-resource/api/mcp-actions/v1')
+        .expect(200);
     });
   });
 });

--- a/plugins/mcp-actions-backend/src/plugin.ts
+++ b/plugins/mcp-actions-backend/src/plugin.ts
@@ -117,13 +117,13 @@ export const mcpPlugin = createBackendPlugin({
 
         httpRouter.use(router);
 
+        const cimdConfigPath = config.has('auth.clientIdMetadataDocuments')
+          ? 'auth.clientIdMetadataDocuments'
+          : 'auth.experimentalClientIdMetadataDocuments';
         const oauthEnabled =
           config.getOptionalBoolean(
             'auth.experimentalDynamicClientRegistration.enabled',
-          ) ||
-          config.getOptionalBoolean(
-            'auth.experimentalClientIdMetadataDocuments.enabled',
-          );
+          ) || config.getOptionalBoolean(`${cimdConfigPath}.enabled`);
 
         if (oauthEnabled) {
           // OAuth Authorization Server Metadata (RFC 8414)


### PR DESCRIPTION
## Hey, I just made a Pull Request!

## What

Promotes Client ID Metadata Documents (CIMD) from experimental to stable configuration across the auth backend and MCP Actions backend.

The stable key is now `auth.clientIdMetadataDocuments`. The previous experimental key remains supported as a deprecated alias. Dynamic Client Registration continues to work, but now emits a user-facing deprecation warning and is no longer advertised in generated app configuration.

The docs, create-app templates, configuration types, tests, and changesets now use the same migration path.

## Why

CIMD replaces DCR in the current MCP authorization specification. This gives Backstage adopters a stable configuration path while preserving compatibility for existing deployments and giving DCR users a clear migration warning.

To test:

```sh
CI=1 BACKSTAGE_TEST_DISABLE_DOCKER=1 yarn test plugins/auth-backend/src/service/OidcService.test.ts --no-watch
CI=1 BACKSTAGE_TEST_DISABLE_DOCKER=1 yarn test plugins/auth-backend/src/service/OidcRouter.test.ts --no-watch
CI=1 yarn test plugins/mcp-actions-backend/src/plugin.test.ts --no-watch
yarn tsc
yarn build:api-reports
```

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
