### PR TITLE
fix(techdocs): isolate DOMPurify instance to prevent hook pollution

### DIFF
--- a/.changeset/techdocs-dompurify-hook-isolation.md
+++ b/.changeset/techdocs-dompurify-hook-isolation.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fixed TechDocs pages sometimes rendering blank due to sanitizer hooks registered by other plugins.

--- a/plugins/techdocs/src/reader/transformers/html/transformer.sanitizer.test.tsx
+++ b/plugins/techdocs/src/reader/transformers/html/transformer.sanitizer.test.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import DOMPurify from 'dompurify';
 import { FC, PropsWithChildren } from 'react';
 import { renderHook } from '@testing-library/react';
 
@@ -173,5 +174,55 @@ describe('Transformers > Html > Sanitizer Custom Elements', () => {
     expect(clearDom.textContent).toContain('JS 3 (whitespace)');
     expect(clearDom.textContent).toContain('JS 4 (mixed case)');
     expect(clearDom.textContent).toContain('JS 5 (entity-encoded colon)');
+  });
+
+  it('does not inherit hooks registered on the global DOMPurify singleton', async () => {
+    // Regression test for https://github.com/backstage/backstage/issues/34037
+    //
+    // Swagger UI (and similar plugins) register a global `afterSanitizeAttributes` hook on
+    // the DOMPurify singleton that mutates elements — e.g. setting `opacity: 0` — which
+    // previously bled into TechDocs sanitization because we were using the shared singleton.
+    // The fix creates a fresh, isolated DOMPurify instance per `useSanitizerTransformer` hook instance so that
+    // hooks from other plugins cannot pollute it.
+
+    // Simulate a global hook that mutates both the root HTML element and links/anchors.
+    const hook = (node: Element) => {
+      if (node.tagName === 'HTML') {
+        (node as HTMLElement).style.opacity = '0';
+      }
+      if (node.tagName === 'LINK' || node.tagName === 'A') {
+        node.setAttribute('rel', 'noopener noreferrer');
+      }
+    };
+    DOMPurify.addHook('afterSanitizeAttributes', hook);
+
+    try {
+      const { result } = renderHook(() => useSanitizerTransformer(), {
+        wrapper,
+      });
+      const dirtyDom = document.createElement('html');
+      dirtyDom.innerHTML = `
+        <head>
+          <link rel="stylesheet" href="main.484c7ddc.min.css">
+        </head>
+        <body>
+          <a href="https://example.com">Example</a>
+        </body>
+      `;
+
+      const cleanDom = await result.current(dirtyDom);
+      const link = cleanDom.querySelector<HTMLLinkElement>('link');
+      const anchor = cleanDom.querySelector<HTMLAnchorElement>('a');
+
+      // The globally-registered hook must NOT have touched the TechDocs output.
+      expect((cleanDom as HTMLElement).style.opacity).not.toBe('0');
+      expect(link).not.toBeNull();
+      expect(link!.getAttribute('rel')).toBe('stylesheet');
+      expect(anchor).not.toBeNull();
+      expect(anchor!.getAttribute('rel')).not.toBe('noopener noreferrer');
+    } finally {
+      // Cleanup: remove the hook we added so other tests are unaffected.
+      DOMPurify.removeHook('afterSanitizeAttributes');
+    }
   });
 });

--- a/plugins/techdocs/src/reader/transformers/html/transformer.ts
+++ b/plugins/techdocs/src/reader/transformers/html/transformer.ts
@@ -44,21 +44,32 @@ const useSanitizerConfig = () => {
 export const useSanitizerTransformer = (): Transformer => {
   const config = useSanitizerConfig();
 
+  const purify = useMemo(() => {
+    // eslint-disable-next-line new-cap
+    const instance = DOMPurify();
+
+    instance.addHook('beforeSanitizeElements', removeUnsafeLinks);
+
+    const hosts = config?.getOptionalStringArray('allowedIframeHosts');
+    if (hosts) {
+      instance.addHook('beforeSanitizeElements', removeUnsafeIframes(hosts));
+    }
+
+    instance.addHook('uponSanitizeElement', removeUnsafeMetaTags);
+
+    instance.addHook('uponSanitizeAttribute', removeRestrictedAttributes);
+
+    return instance;
+  }, [config]);
+
   return useCallback(
     async (dom: Element) => {
       const hosts = config?.getOptionalStringArray('allowedIframeHosts');
-
-      DOMPurify.addHook('beforeSanitizeElements', removeUnsafeLinks);
       const tags = ['link', 'meta'];
 
       if (hosts) {
         tags.push('iframe');
-        DOMPurify.addHook('beforeSanitizeElements', removeUnsafeIframes(hosts));
       }
-
-      DOMPurify.addHook('uponSanitizeElement', removeUnsafeMetaTags);
-
-      DOMPurify.addHook('uponSanitizeAttribute', removeRestrictedAttributes);
 
       const tagNameCheck = config?.getOptionalString(
         'allowedCustomElementTagNameRegExp',
@@ -97,7 +108,7 @@ export const useSanitizerTransformer = (): Transformer => {
       );
 
       // using outerHTML as we want to preserve the html tag attributes (lang)
-      return DOMPurify.sanitize(dom.outerHTML, {
+      return purify.sanitize(dom.outerHTML, {
         ADD_TAGS: tags,
         FORBID_TAGS: ['style'],
         ADD_ATTR: ['http-equiv', 'content', 'dominant-baseline'],
@@ -112,6 +123,6 @@ export const useSanitizerTransformer = (): Transformer => {
         },
       }) as Element;
     },
-    [config],
+    [config, purify],
   );
 };


### PR DESCRIPTION
Fixes the TechDocs rendering opacity issue (#34037). Creates an isolated DOMPurify instance to prevent globally registered hooks (e.g. from Swagger UI) from leaking into TechDocs stylesheet sanitization.

## Changes

- Switch TechDocs HTML sanitization to use a fresh, isolated DOMPurify instance rather than the shared singleton.
- Add a regression test ensuring TechDocs sanitization does not inherit globally registered DOMPurify hooks.
- Wrap the global hook test body in try/finally to ensure proper cleanup.

Fixes backstage/backstage#34037