### PR TITLE
fix(docs): convert absolute backstage.io links to relative links in docs/auth

### DIFF
--- a/docs/auth/aws-alb/provider.md
+++ b/docs/auth/aws-alb/provider.md
@@ -73,4 +73,4 @@ backend.add(import('@backstage/plugin-auth-backend-module-aws-alb-provider'));
 
 See [Sign-In with Proxy Providers](../index.md#sign-in-with-proxy-providers) for pointers on how to set up the sign-in page and also make it work smoothly for local development. You'll use `awsalb` as the provider name.
 
-If you [provide a custom sign in resolver](https://backstage.io/docs/auth/identity-resolver#building-custom-resolvers), you can skip the `signIn` block entirely.
+If you [provide a custom sign in resolver](../identity-resolver.md#building-custom-resolvers), you can skip the `signIn` block entirely.

--- a/docs/auth/cloudflare/provider.md
+++ b/docs/auth/cloudflare/provider.md
@@ -91,4 +91,4 @@ backend.add(
 
 See [Sign-In with Proxy Providers](../index.md#sign-in-with-proxy-providers) for pointers on how to set up the sign-in page and also make it work smoothly for local development. You'll use `cfaccess` as the provider name.
 
-If you [provide a custom sign-in resolver](https://backstage.io/docs/auth/identity-resolver#building-custom-resolvers), you can skip the `signIn` block entirely.
+If you [provide a custom sign-in resolver](../identity-resolver.md#building-custom-resolvers), you can skip the `signIn` block entirely.

--- a/docs/auth/google/gcp-iap-auth.md
+++ b/docs/auth/google/gcp-iap-auth.md
@@ -76,4 +76,4 @@ backend.add(import('@backstage/plugin-auth-backend-module-gcp-iap-provider'));
 
 See [Sign-In with Proxy Providers](../index.md#sign-in-with-proxy-providers) for pointers on how to set up the sign-in page, and to also make it work smoothly for local development. You'll use `gcpIap` as the provider name.
 
-If you [provide a custom sign in resolver](https://backstage.io/docs/auth/identity-resolver#building-custom-resolvers), you can skip the `signIn` block entirely.
+If you [provide a custom sign in resolver](../identity-resolver.md#building-custom-resolvers), you can skip the `signIn` block entirely.

--- a/docs/auth/identity-resolver.md
+++ b/docs/auth/identity-resolver.md
@@ -17,7 +17,7 @@ listed below.
 ## Quick Start
 
 Backstage projects created with `npx @backstage/create-app` come configured with
-a [guest auth provider](https://backstage.io/docs/auth/guest/provider). This
+a [guest auth provider](./guest/provider.md). This
 provider makes all users share a single "guest" identity. This is useful for
 testing purposes and quickly getting started locally, but is not safe for use in
 production and that particular provider will refuse to work there.

--- a/docs/auth/index--old.md
+++ b/docs/auth/index--old.md
@@ -16,7 +16,7 @@ access to external resources.
 
 :::note Note
 
-Identity management and the Sign-In page in Backstage will block external access by default, without setting `backend.auth.dangerouslyDisableDefaultAuthPolicy` in configuration. Even so, the frontend bundle is not protected from external access, protecting it requires the use of the [experimental public entry point](https://backstage.io/docs/tutorials/enable-public-entry/). You can learn more about this in the [Threat Model](../overview/threat-model.md#operator-responsibilities).
+Identity management and the Sign-In page in Backstage will block external access by default, without setting `backend.auth.dangerouslyDisableDefaultAuthPolicy` in configuration. Even so, the frontend bundle is not protected from external access, protecting it requires the use of the [experimental public entry point](../tutorials/enable-public-entry.md). You can learn more about this in the [Threat Model](../overview/threat-model.md#operator-responsibilities).
 
 :::
 

--- a/docs/auth/index.md
+++ b/docs/auth/index.md
@@ -12,7 +12,7 @@ The authentication system in Backstage serves two distinct purposes: sign-in and
 
 :::note Note
 
-Identity management and the Sign-In page in Backstage will only block external access when using the new backend system, without setting `backend.auth.dangerouslyDisableDefaultAuthPolicy` in configuration. Even so, the frontend bundle is not protected from external access, protecting it requires the use of the [experimental public entry point](https://backstage.io/docs/tutorials/enable-public-entry/). You can learn more about this in the [Threat Model](../overview/threat-model.md#operator-responsibilities).
+Identity management and the Sign-In page in Backstage will only block external access when using the new backend system, without setting `backend.auth.dangerouslyDisableDefaultAuthPolicy` in configuration. Even so, the frontend bundle is not protected from external access, protecting it requires the use of the [experimental public entry point](../tutorials/enable-public-entry.md). You can learn more about this in the [Threat Model](../overview/threat-model.md#operator-responsibilities).
 
 :::
 

--- a/docs/auth/microsoft/azure-easyauth.md
+++ b/docs/auth/microsoft/azure-easyauth.md
@@ -109,4 +109,4 @@ backend.add(
 
 See [Sign-In with Proxy Providers](../index.md#sign-in-with-proxy-providers) for pointers on how to set up the sign-in page, and to also make it work smoothly for local development. You'll use `azureEasyAuth` as the provider name.
 
-If you [provide a custom sign in resolver](https://backstage.io/docs/auth/identity-resolver#building-custom-resolvers), you can skip the `signIn` block entirely.
+If you [provide a custom sign in resolver](../identity-resolver.md#building-custom-resolvers), you can skip the `signIn` block entirely.

--- a/docs/auth/oauth2-proxy/provider.md
+++ b/docs/auth/oauth2-proxy/provider.md
@@ -75,4 +75,4 @@ backend.add(
 
 See [Sign-In with Proxy Providers](../index.md#sign-in-with-proxy-providers) for pointers on how to set up the sign-in page, and to also make it work smoothly for local development. You'll use `oauth2Proxy` as the provider name.
 
-If you [provide a custom sign in resolver](https://backstage.io/docs/auth/identity-resolver#building-custom-resolvers), you can skip the `signIn` block entirely.
+If you [provide a custom sign in resolver](../identity-resolver.md#building-custom-resolvers), you can skip the `signIn` block entirely.

--- a/docs/auth/oidc--old.md
+++ b/docs/auth/oidc--old.md
@@ -288,6 +288,6 @@ in the Auth Provider Factory, the resolver, and the different variables each pro
 needs in the YAML config or env variables.
 :::
 
-[1]: https://backstage.io/docs/auth/identity-resolver
-[3]: https://backstage.io/docs/auth/#sign-in-configuration
-[4]: https://backstage.io/docs/api/utility-apis
+[1]: ./identity-resolver.md
+[3]: ./index.md#sign-in-configuration
+[4]: ../api/utility-apis.md


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Converts absolute `https://backstage.io/docs/...` links to relative markdown paths in `docs/auth/`, per the [doc style guide](https://backstage.io/docs/contribute/doc-style-guide#links).

Part of #34768 — scoping this first PR to one folder (`docs/auth/`) to keep it reviewable. Happy to follow up with more folders if this approach looks good.

**Note:** links inside YAML config comments (e.g. `# See https://backstage.io/docs/...#resolvers`) were intentionally left as absolute URLs, since those are example config text meant to be copied into a user's own `app-config.yaml`, not doc navigation links.

#### ✔️ Checklist

- [ ] A changeset describing the change and affected packages. (N/A — docs-only change)
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.