### PR TITLE
Fixed an issue where two "Notifications" links were displayed in the Sidebar

### DIFF
--- a/.changeset/violet-women-call.md
+++ b/.changeset/violet-women-call.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Fixed an issue where two "Notifications" links were displayed in the sidebar.

--- a/packages/create-app/templates/default-app/packages/app/src/modules/nav/Sidebar.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/modules/nav/Sidebar.tsx
@@ -12,6 +12,7 @@ import MenuIcon from '@material-ui/icons/Menu';
 import SearchIcon from '@material-ui/icons/Search';
 import { SidebarSearchModal } from '@backstage/plugin-search';
 import { UserSettingsSignInAvatar } from '@backstage/plugin-user-settings';
+import { NotificationsSidebarItem } from '@backstage/plugin-notifications';
 
 export const SidebarContent = NavContentBlueprint.make({
   params: {
@@ -22,6 +23,7 @@ export const SidebarContent = NavContentBlueprint.make({
 
       // Skipped items
       nav.take('page:search'); // Using search modal instead
+      nav.take('page:notifications'); // Using NotificationsSidebarItem manually instead
 
       return (
         <Sidebar>
@@ -40,7 +42,7 @@ export const SidebarContent = NavContentBlueprint.make({
           </SidebarGroup>
           <SidebarSpace />
           <SidebarDivider />
-          {nav.take('page:notifications')}
+          <NotificationsSidebarItem />
           <SidebarDivider />
           <SidebarGroup
             label="Settings"

--- a/packages/create-app/templates/default-app/packages/app/src/modules/nav/Sidebar.tsx
+++ b/packages/create-app/templates/default-app/packages/app/src/modules/nav/Sidebar.tsx
@@ -12,7 +12,6 @@ import MenuIcon from '@material-ui/icons/Menu';
 import SearchIcon from '@material-ui/icons/Search';
 import { SidebarSearchModal } from '@backstage/plugin-search';
 import { UserSettingsSignInAvatar } from '@backstage/plugin-user-settings';
-import { NotificationsSidebarItem } from '@backstage/plugin-notifications';
 
 export const SidebarContent = NavContentBlueprint.make({
   params: {
@@ -41,7 +40,7 @@ export const SidebarContent = NavContentBlueprint.make({
           </SidebarGroup>
           <SidebarSpace />
           <SidebarDivider />
-          <NotificationsSidebarItem />
+          {nav.take('page:notifications')}
           <SidebarDivider />
           <SidebarGroup
             label="Settings"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

We can see two "Notifications" link in the Sidebar when we generate code using 'create-app' command.
I think only the second "Notifications" link is needed.

<img width="303" height="975" alt="Screenshot 2026-07-09 at 9 13 24" src="https://github.com/user-attachments/assets/1fdf0f0d-479a-476e-8c71-d587b174dba3" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

fixes #34814
