### PR TITLE
fix(auth-node): return 400 instead of 500 on malformed OAuth origin

### DIFF
--- a/.changeset/fix-oauth-start-500-error.md
+++ b/.changeset/fix-oauth-start-500-error.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-node': patch
+---
+
+Fix OAuth start handler crashing with a 500 error on malformed origins, now returns a 400 error.

--- a/plugins/auth-node/src/oauth/createOAuthRouteHandlers.test.ts
+++ b/plugins/auth-node/src/oauth/createOAuthRouteHandlers.test.ts
@@ -271,6 +271,60 @@ describe('createOAuthRouteHandlers', () => {
         { ctx: 'authenticator' },
       );
     });
+
+    it('should reject malformed origin', async () => {
+      const app = wrapInApp(createOAuthRouteHandlers(baseConfig));
+      const res = await request(app)
+        .get('/my-provider/start')
+        .query({ env: 'development', origin: 'not-a-valid-url' });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        error: {
+          name: 'InputError',
+          message: expect.stringContaining(
+            'App origin is invalid, failed to parse',
+          ),
+        },
+      });
+    });
+
+    it('should reject empty origin', async () => {
+      const app = wrapInApp(createOAuthRouteHandlers(baseConfig));
+      const res = await request(app)
+        .get('/my-provider/start')
+        .query({ env: 'development', origin: '' });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        error: {
+          name: 'InputError',
+          message: expect.stringContaining(
+            'App origin is invalid, failed to parse',
+          ),
+        },
+      });
+    });
+
+    it('should reject disallowed origin', async () => {
+      const app = wrapInApp(
+        createOAuthRouteHandlers({
+          ...baseConfig,
+          isOriginAllowed: () => false,
+        }),
+      );
+      const res = await request(app)
+        .get('/my-provider/start')
+        .query({ env: 'development', origin: 'https://disallowed.com' });
+
+      expect(res.status).toBe(403);
+      expect(res.body).toMatchObject({
+        error: {
+          name: 'NotAllowedError',
+          message: "Origin 'https://disallowed.com' is not allowed",
+        },
+      });
+    });
   });
 
   describe('frameHandler', () => {

--- a/plugins/auth-node/src/oauth/createOAuthRouteHandlers.ts
+++ b/plugins/auth-node/src/oauth/createOAuthRouteHandlers.ts
@@ -135,6 +135,23 @@ export function createOAuthRouteHandlers<TProfile>(
     ): Promise<void> {
       const env = req.query.env?.toString();
       const origin = req.query.origin?.toString();
+      if (origin !== undefined) {
+        let parsedOrigin: URL;
+        try {
+          parsedOrigin = new URL(origin);
+        } catch (error) {
+          throw new InputError(
+            `App origin is invalid, failed to parse: ${error.message}`,
+          );
+        }
+
+        if (
+          typeof isOriginAllowed === 'function' &&
+          !isOriginAllowed(parsedOrigin.origin)
+        ) {
+          throw new NotAllowedError(`Origin '${origin}' is not allowed`);
+        }
+      }
       const redirectUrl = req.query.redirectUrl?.toString();
       const flow = req.query.flow?.toString();
 

--- a/plugins/auth-node/src/oauth/createOAuthRouteHandlers.ts
+++ b/plugins/auth-node/src/oauth/createOAuthRouteHandlers.ts
@@ -134,21 +134,15 @@ export function createOAuthRouteHandlers<TProfile>(
       res: express.Response,
     ): Promise<void> {
       const env = req.query.env?.toString();
-      const origin = req.query.origin?.toString();
+      let origin = req.query.origin?.toString();
       if (origin !== undefined) {
-        let parsedOrigin: URL;
         try {
-          parsedOrigin = new URL(origin);
-        } catch (error) {
-          throw new InputError(
-            `App origin is invalid, failed to parse: ${error.message}`,
-          );
+          origin = new URL(origin).origin;
+        } catch {
+          throw new InputError('App origin is invalid, failed to parse');
         }
 
-        if (
-          typeof isOriginAllowed === 'function' &&
-          !isOriginAllowed(parsedOrigin.origin)
-        ) {
+        if (!isOriginAllowed(origin)) {
           throw new NotAllowedError(`Origin '${origin}' is not allowed`);
         }
       }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR adds safety validation to the OAuth `start` route handler inside `@backstage/plugin-auth-node`. 

### What was changed:
- Added a `try/catch` safety guard around `new URL(origin)` parsing inside the `start` handler to catch malformed URLs gracefully.
- Configured it to correctly bubble up an `InputError` (resulting in a clean HTTP 400 Bad Request client error) instead of throwing an unhandled `ERR_INVALID_URL` that crashes into an HTTP 500 error.
- Added explicit test cases inside `createOAuthRouteHandlers.test.ts` to verify that both malformed origins and disallowed origins are rejected with clean, expected responses.
- Added a changeset file to automate package release notes.

Fixes #34767

#### Checklist
- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a 'Signed-off-by' line in the message.