### PR TITLE
feat(auth-backend-module-auth0-provider): forward screen_hint and login_hint to Auth0

### DIFF
--- a/.changeset/auth0-screen-hint-login-hint.md
+++ b/.changeset/auth0-screen-hint-login-hint.md
@@ -1,0 +1,9 @@
+---
+'@backstage/plugin-auth-backend-module-auth0-provider': patch
+---
+
+Added `screen_hint` and `login_hint` parameter forwarding to the Auth0 strategy.
+When these parameters are present in the OAuth start request query string, they
+are forwarded to Auth0's `/authorize` endpoint. This allows callers to guide
+users to the signup or login screen (`screen_hint=signup`) and pre-fill the
+email field (`login_hint=user@example.com`) during invitation flows.

--- a/.changeset/auth0-screen-hint-login-hint.md
+++ b/.changeset/auth0-screen-hint-login-hint.md
@@ -2,7 +2,7 @@
 '@backstage/plugin-auth-backend-module-auth0-provider': patch
 ---
 
-Added `screen_hint` and `login_hint` parameter forwarding to the Auth0 strategy.
+Added `screen_hint` and `login_hint` parameter forwarding for the Auth0 authentication provider.
 When these parameters are present in the OAuth start request query string, they
 are forwarded to Auth0's `/authorize` endpoint. This allows callers to guide
 users to the signup or login screen (`screen_hint=signup`) and pre-fill the

--- a/plugins/auth-backend-module-auth0-provider/src/authenticator.test.ts
+++ b/plugins/auth-backend-module-auth0-provider/src/authenticator.test.ts
@@ -243,6 +243,111 @@ describe('createAuth0Authenticator', () => {
     expect(result.fullProfile).toEqual(updatedProfile);
   });
 
+  describe('start', () => {
+    it('should pass prompt from config to helper.start', async () => {
+      const configWithPrompt = mockServices.rootConfig({
+        data: {
+          clientId: 'test-client-id',
+          clientSecret: 'test-client-secret',
+          domain: 'test.auth0.com',
+          prompt: 'login',
+        },
+      });
+
+      const mockStart = jest.fn();
+      mockFrom.mockReturnValue({
+        start: mockStart,
+        authenticate: jest.fn(),
+        fetchProfile: jest.fn(),
+      } as any);
+
+      const authenticator = createAuth0Authenticator({ cache });
+      const ctx = authenticator.initialize({
+        callbackUrl: 'http://localhost/callback',
+        config: configWithPrompt,
+      });
+
+      await authenticator.start(
+        {
+          req: {} as express.Request,
+          scope: 'openid',
+          state: 'test-state',
+        },
+        ctx,
+      );
+
+      expect(mockStart).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ prompt: 'login' }),
+      );
+    });
+
+    it('should default prompt to consent', async () => {
+      const mockStart = jest.fn();
+      mockFrom.mockReturnValue({
+        start: mockStart,
+        authenticate: jest.fn(),
+        fetchProfile: jest.fn(),
+      } as any);
+
+      const authenticator = createAuth0Authenticator({ cache });
+      const ctx = authenticator.initialize({
+        callbackUrl: 'http://localhost/callback',
+        config: mockConfig,
+      });
+
+      await authenticator.start(
+        {
+          req: {} as express.Request,
+          scope: 'openid',
+          state: 'test-state',
+        },
+        ctx,
+      );
+
+      expect(mockStart).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ prompt: 'consent' }),
+      );
+    });
+
+    it('should omit prompt when set to auto', async () => {
+      const configWithAuto = mockServices.rootConfig({
+        data: {
+          clientId: 'test-client-id',
+          clientSecret: 'test-client-secret',
+          domain: 'test.auth0.com',
+          prompt: 'auto',
+        },
+      });
+
+      const mockStart = jest.fn();
+      mockFrom.mockReturnValue({
+        start: mockStart,
+        authenticate: jest.fn(),
+        fetchProfile: jest.fn(),
+      } as any);
+
+      const authenticator = createAuth0Authenticator({ cache });
+      const ctx = authenticator.initialize({
+        callbackUrl: 'http://localhost/callback',
+        config: configWithAuto,
+      });
+
+      await authenticator.start(
+        {
+          req: {} as express.Request,
+          scope: 'openid',
+          state: 'test-state',
+        },
+        ctx,
+      );
+
+      const startOptions = mockStart.mock.calls[0][1];
+      expect(startOptions).not.toHaveProperty('prompt');
+    });
+  });
+
   it('should skip cache when id_token has no sub claim', async () => {
     const header = Buffer.from(JSON.stringify({ alg: 'none' })).toString(
       'base64url',

--- a/plugins/auth-backend-module-auth0-provider/src/strategy.test.ts
+++ b/plugins/auth-backend-module-auth0-provider/src/strategy.test.ts
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Auth0Strategy } from './strategy';
+import { InputError } from '@backstage/errors';
+import express from 'express';
+
+jest.mock('passport-auth0', () => {
+  class MockAuth0Strategy {
+    authenticate() {}
+    authorizationParams() {
+      return {};
+    }
+  }
+  return { __esModule: true, default: MockAuth0Strategy };
+});
+
+describe('Auth0Strategy', () => {
+  const defaultOptions = {
+    clientID: 'test-client-id',
+    clientSecret: 'test-client-secret',
+    callbackURL: 'http://localhost/callback',
+    domain: 'test.auth0.com',
+    passReqToCallback: true as const,
+    store: {
+      store(_req: express.Request, cb: Function) {
+        cb(null, null);
+      },
+      verify(_req: express.Request, _state: string, cb: Function) {
+        cb(null, true);
+      },
+    },
+  };
+
+  const noopVerify = () => {};
+
+  function createRequest(query: Record<string, string> = {}): express.Request {
+    return { query } as unknown as express.Request;
+  }
+
+  describe('authenticate', () => {
+    it('forwards organization and invitation from req.query', () => {
+      const strategy = new Auth0Strategy(defaultOptions, noopVerify);
+      const superAuth = jest.spyOn(
+        Object.getPrototypeOf(Object.getPrototypeOf(strategy)),
+        'authenticate',
+      );
+
+      const req = createRequest({
+        organization: 'org_abc',
+        invitation: 'uinv_123',
+      });
+
+      strategy.authenticate(req, { scope: 'openid' });
+
+      expect(superAuth).toHaveBeenCalledWith(req, {
+        scope: 'openid',
+        organization: 'org_abc',
+        invitation: 'uinv_123',
+      });
+    });
+
+    it('forwards screen_hint and login_hint from req.query', () => {
+      const strategy = new Auth0Strategy(defaultOptions, noopVerify);
+      const superAuth = jest.spyOn(
+        Object.getPrototypeOf(Object.getPrototypeOf(strategy)),
+        'authenticate',
+      );
+
+      const req = createRequest({
+        screen_hint: 'signup',
+        login_hint: 'user@example.com',
+      });
+
+      strategy.authenticate(req, { scope: 'openid' });
+
+      expect(superAuth).toHaveBeenCalledWith(req, {
+        scope: 'openid',
+        screen_hint: 'signup',
+        login_hint: 'user@example.com',
+      });
+    });
+
+    it('does not include absent query params', () => {
+      const strategy = new Auth0Strategy(defaultOptions, noopVerify);
+      const superAuth = jest.spyOn(
+        Object.getPrototypeOf(Object.getPrototypeOf(strategy)),
+        'authenticate',
+      );
+
+      const req = createRequest({});
+
+      strategy.authenticate(req, { scope: 'openid' });
+
+      expect(superAuth).toHaveBeenCalledWith(req, { scope: 'openid' });
+    });
+
+    it('throws InputError on organization mismatch', () => {
+      const strategy = new Auth0Strategy(
+        { ...defaultOptions, organization: 'org_configured' },
+        noopVerify,
+      );
+
+      const req = createRequest({ organization: 'org_different' });
+
+      expect(() => strategy.authenticate(req, {})).toThrow(InputError);
+    });
+
+    it('allows matching organization', () => {
+      const strategy = new Auth0Strategy(
+        { ...defaultOptions, organization: 'org_abc' },
+        noopVerify,
+      );
+      const superAuth = jest.spyOn(
+        Object.getPrototypeOf(Object.getPrototypeOf(strategy)),
+        'authenticate',
+      );
+
+      const req = createRequest({ organization: 'org_abc' });
+
+      strategy.authenticate(req, {});
+
+      expect(superAuth).toHaveBeenCalledWith(req, { organization: 'org_abc' });
+    });
+  });
+
+  describe('authorizationParams', () => {
+    it('includes organization from config when not in options', () => {
+      const strategy = new Auth0Strategy(
+        { ...defaultOptions, organization: 'org_configured' },
+        noopVerify,
+      );
+
+      const params = strategy.authorizationParams({});
+
+      expect(params.organization).toBe('org_configured');
+    });
+
+    it('prefers organization from options over config', () => {
+      const strategy = new Auth0Strategy(
+        { ...defaultOptions, organization: 'org_configured' },
+        noopVerify,
+      );
+
+      const params = strategy.authorizationParams({
+        organization: 'org_override',
+      });
+
+      expect(params.organization).toBe('org_override');
+    });
+
+    it('forwards invitation', () => {
+      const strategy = new Auth0Strategy(defaultOptions, noopVerify);
+
+      const params = strategy.authorizationParams({
+        invitation: 'uinv_123',
+      });
+
+      expect(params.invitation).toBe('uinv_123');
+    });
+
+    it('forwards screen_hint', () => {
+      const strategy = new Auth0Strategy(defaultOptions, noopVerify);
+
+      const params = strategy.authorizationParams({
+        screen_hint: 'signup',
+      });
+
+      expect(params.screen_hint).toBe('signup');
+    });
+
+    it('forwards login_hint', () => {
+      const strategy = new Auth0Strategy(defaultOptions, noopVerify);
+
+      const params = strategy.authorizationParams({
+        login_hint: 'user@example.com',
+      });
+
+      expect(params.login_hint).toBe('user@example.com');
+    });
+
+    it('does not include absent params', () => {
+      const strategy = new Auth0Strategy(defaultOptions, noopVerify);
+
+      const params = strategy.authorizationParams({});
+
+      expect(params).toEqual({});
+    });
+
+    it('forwards all params together', () => {
+      const strategy = new Auth0Strategy(
+        { ...defaultOptions, organization: 'org_abc' },
+        noopVerify,
+      );
+
+      const params = strategy.authorizationParams({
+        invitation: 'uinv_123',
+        screen_hint: 'signup',
+        login_hint: 'user@example.com',
+      });
+
+      expect(params).toEqual({
+        organization: 'org_abc',
+        invitation: 'uinv_123',
+        screen_hint: 'signup',
+        login_hint: 'user@example.com',
+      });
+    });
+  });
+});

--- a/plugins/auth-backend-module-auth0-provider/src/strategy.test.ts
+++ b/plugins/auth-backend-module-auth0-provider/src/strategy.test.ts
@@ -36,10 +36,10 @@ describe('Auth0Strategy', () => {
     domain: 'test.auth0.com',
     passReqToCallback: true as const,
     store: {
-      store(_req: express.Request, cb: Function) {
+      store(_req: express.Request, cb: any) {
         cb(null, null);
       },
-      verify(_req: express.Request, _state: string, cb: Function) {
+      verify(_req: express.Request, _state: string, cb: any) {
         cb(null, true);
       },
     },

--- a/plugins/auth-backend-module-auth0-provider/src/strategy.ts
+++ b/plugins/auth-backend-module-auth0-provider/src/strategy.ts
@@ -50,7 +50,7 @@ export class Auth0Strategy extends Auth0InternalStrategy {
   }
 
   authenticate(req: express.Request, options: Record<string, any>): void {
-    const { organization, invitation } = req.query;
+    const { organization, invitation, screen_hint, login_hint } = req.query;
 
     // Throw an error if the organization in the request does not match the organization configured in the strategy
     if (
@@ -67,6 +67,8 @@ export class Auth0Strategy extends Auth0InternalStrategy {
       ...options,
       ...(organization ? { organization } : {}),
       ...(invitation ? { invitation } : {}),
+      ...(screen_hint ? { screen_hint } : {}),
+      ...(login_hint ? { login_hint } : {}),
     });
   }
 
@@ -79,6 +81,14 @@ export class Auth0Strategy extends Auth0InternalStrategy {
 
     if (options.invitation) {
       params.invitation = options.invitation;
+    }
+
+    if (options.screen_hint) {
+      params.screen_hint = options.screen_hint;
+    }
+
+    if (options.login_hint) {
+      params.login_hint = options.login_hint;
     }
 
     return params;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds `screen_hint` and `login_hint` parameter forwarding to the Auth0 strategy, complementing the existing `organization` and `invitation` parameter support.

When these parameters are present in the OAuth start request query string, they are forwarded to Auth0's `/authorize` endpoint. This enables callers to:

- **`screen_hint=signup`** - Guide users directly to the signup screen (useful during invitation flows where new users are expected)
- **`login_hint=user@example.com`** - Pre-fill the email field on the Auth0 Universal Login page

These are standard Auth0 `/authorize` parameters documented at https://auth0.com/docs/authenticate/login/auth0-universal-login/universal-login-vs-classic-login/universal-experience#signup

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))