### PR TITLE
core-app-api: support wildcard frontend discovery targets

### DIFF
--- a/.changeset/fuzzy-pandas-discover.md
+++ b/.changeset/fuzzy-pandas-discover.md
@@ -1,0 +1,6 @@
+---
+'@backstage/core-app-api': patch
+'@backstage/plugin-app': patch
+---
+
+Added support for wildcard plugin entries in frontend discovery endpoints, matching the backend discovery behavior.

--- a/.changeset/tidy-otters-skip.md
+++ b/.changeset/tidy-otters-skip.md
@@ -1,5 +1,6 @@
 ---
 '@backstage/core-app-api': patch
+'@backstage/plugin-app': patch
 ---
 
 Fixed the default fetch API to support discovery endpoints that only define an internal target.

--- a/packages/core-app-api/config.d.ts
+++ b/packages/core-app-api/config.d.ts
@@ -167,6 +167,7 @@ export interface Config {
           };
       /**
        * Array of plugins which use the target baseUrl.
+       * Use `'*'` to configure a fallback target for all plugins without an explicit target.
        *
        * @visibility frontend
        */

--- a/packages/core-app-api/src/apis/implementations/DiscoveryApi/FrontendHostDiscovery.test.ts
+++ b/packages/core-app-api/src/apis/implementations/DiscoveryApi/FrontendHostDiscovery.test.ts
@@ -140,6 +140,35 @@ describe('FrontendHostDiscovery', () => {
     );
   });
 
+  it('uses a wildcard target for plugins without a specific target', async () => {
+    const discovery = FrontendHostDiscovery.fromConfig(
+      new ConfigReader({
+        backend: {
+          baseUrl: 'http://localhost:40',
+        },
+        discovery: {
+          endpoints: [
+            {
+              target: 'http://catalog-backend:8080/api/catalog',
+              plugins: ['catalog'],
+            },
+            {
+              target: 'http://common-backend:8080/api/{{pluginId}}',
+              plugins: ['*'],
+            },
+          ],
+        },
+      }),
+    );
+
+    await expect(discovery.getBaseUrl('catalog')).resolves.toBe(
+      'http://catalog-backend:8080/api/catalog',
+    );
+    await expect(discovery.getBaseUrl('scaffolder')).resolves.toBe(
+      'http://common-backend:8080/api/scaffolder',
+    );
+  });
+
   it('replaces {{pluginId}} or {{ pluginId }} in the target', async () => {
     const discovery = FrontendHostDiscovery.fromConfig(
       new ConfigReader({

--- a/packages/core-app-api/src/apis/implementations/DiscoveryApi/FrontendHostDiscovery.ts
+++ b/packages/core-app-api/src/apis/implementations/DiscoveryApi/FrontendHostDiscovery.ts
@@ -40,10 +40,14 @@ export class FrontendHostDiscovery implements DiscoveryApi {
    *        internal: https://internal.example.com/search
    *        external: https://example.com/search
    *      plugins: [search]
+   *    - target: https://example.com/api/{{pluginId}}
+   *      plugins: ['*']
    * ```
    *
-   * If a plugin is not declared in the config, the discovery will fall back to using the baseUrl with
-   * the provided `pathPattern` appended. The default path pattern is `"/api/{{ pluginId }}"`.
+   * If a plugin is not declared in the config, discovery will first use the
+   * wildcard target, if one is configured, and otherwise fall back to using
+   * the baseUrl with the provided `pathPattern` appended. The default path
+   * pattern is `"/api/{{ pluginId }}"`.
    */
   static fromConfig(config: Config, options?: { pathPattern?: string }) {
     const path = options?.pathPattern ?? '/api/{{ pluginId }}';
@@ -83,7 +87,7 @@ export class FrontendHostDiscovery implements DiscoveryApi {
   }
 
   async getBaseUrl(pluginId: string): Promise<string> {
-    const endpoint = this.endpoints.get(pluginId);
+    const endpoint = this.endpoints.get(pluginId) ?? this.endpoints.get('*');
     if (endpoint) {
       return endpoint.getBaseUrl(pluginId);
     }

--- a/packages/core-app-api/src/apis/implementations/FetchApi/IdentityAuthInjectorFetchMiddleware.test.ts
+++ b/packages/core-app-api/src/apis/implementations/FetchApi/IdentityAuthInjectorFetchMiddleware.test.ts
@@ -57,6 +57,50 @@ describe('IdentityAuthInjectorFetchMiddleware', () => {
     expect(middleware.allowUrl('http://b.com:8080')).toEqual(true);
   });
 
+  it('creates using wildcard discovery endpoints', async () => {
+    const middleware = IdentityAuthInjectorFetchMiddleware.create({
+      identityApi: undefined as any,
+      config: new ConfigReader({
+        backend: { baseUrl: 'https://example.com' },
+        discovery: {
+          endpoints: [
+            {
+              target: 'https://gateway.example.com/api/{{pluginId}}',
+              plugins: ['*'],
+            },
+            {
+              target:
+                'https://{{pluginId}}.plugins.example.com/api/{{pluginId}}',
+              plugins: ['*'],
+            },
+          ],
+        },
+      }),
+    });
+
+    expect(
+      middleware.allowUrl('https://gateway.example.com/api/catalog'),
+    ).toEqual(true);
+    expect(
+      middleware.allowUrl(
+        'https://gateway.example.com/api/catalog/entities/by-query',
+      ),
+    ).toEqual(true);
+    expect(
+      middleware.allowUrl(
+        'https://catalog.plugins.example.com/api/catalog/entities',
+      ),
+    ).toEqual(true);
+    expect(
+      middleware.allowUrl(
+        'https://catalog.plugins.example.com/api/search/query',
+      ),
+    ).toEqual(false);
+    expect(middleware.allowUrl('https://evil.example.com/api/catalog')).toEqual(
+      false,
+    );
+  });
+
   it('injects the header only when a token is available', async () => {
     const identityApi = mockApis.identity.mock();
 
@@ -147,6 +191,10 @@ describe('IdentityAuthInjectorFetchMiddleware', () => {
             {
               target: { internal: 'https://internal.example.com' },
               plugins: ['internal'],
+            },
+            {
+              target: 'https://wildcard.example.com/{{pluginId}}',
+              plugins: ['*'],
             },
           ],
         },

--- a/packages/core-app-api/src/apis/implementations/FetchApi/IdentityAuthInjectorFetchMiddleware.test.ts
+++ b/packages/core-app-api/src/apis/implementations/FetchApi/IdentityAuthInjectorFetchMiddleware.test.ts
@@ -82,6 +82,9 @@ describe('IdentityAuthInjectorFetchMiddleware', () => {
       middleware.allowUrl('https://gateway.example.com/api/catalog'),
     ).toEqual(true);
     expect(
+      middleware.allowUrl('https://gateway.example.com/api/catalog?x=1'),
+    ).toEqual(true);
+    expect(
       middleware.allowUrl(
         'https://gateway.example.com/api/catalog/entities/by-query',
       ),

--- a/packages/core-app-api/src/apis/implementations/FetchApi/IdentityAuthInjectorFetchMiddleware.ts
+++ b/packages/core-app-api/src/apis/implementations/FetchApi/IdentityAuthInjectorFetchMiddleware.ts
@@ -18,6 +18,8 @@ import { Config } from '@backstage/config';
 import { IdentityApi } from '@backstage/core-plugin-api';
 import { FetchMiddleware } from './types';
 
+const PLUGIN_ID_TEMPLATE = /\{\{\s*pluginId\s*\}\}/g;
+
 /**
  * A fetch middleware, which injects a Backstage token header when the user is
  * signed in.
@@ -53,17 +55,17 @@ export class IdentityAuthInjectorFetchMiddleware implements FetchMiddleware {
     const endpointConfigs =
       config.getOptionalConfigArray('discovery.endpoints') || [];
     return endpointConfigs.flatMap(c => {
-      const target =
-        typeof c.get('target') === 'object'
-          ? c.getOptionalString('target.external')
-          : c.getString('target');
+      const target = getExternalTarget(c);
       if (!target) {
         return [];
       }
       const plugins = c.getStringArray('plugins');
-      return plugins.map(pluginId =>
-        target.replace(/\{\{\s*pluginId\s*\}\}/g, pluginId),
-      );
+      return plugins.flatMap(pluginId => {
+        if (pluginId === '*') {
+          return [];
+        }
+        return target.replace(PLUGIN_ID_TEMPLATE, pluginId);
+      });
     });
   }
 
@@ -119,14 +121,54 @@ function buildMatcher(options: {
   } else if (options.urlPrefixAllowlist) {
     return buildPrefixMatcher(options.urlPrefixAllowlist);
   } else if (options.config) {
-    return buildPrefixMatcher([
+    const prefixMatcher = buildPrefixMatcher([
       options.config.getString('backend.baseUrl'),
       ...IdentityAuthInjectorFetchMiddleware.getDiscoveryUrlPrefixes(
         options.config,
       ),
     ]);
+    const wildcardMatcher = buildWildcardDiscoveryMatcher(options.config);
+    return url => prefixMatcher(url) || wildcardMatcher(url);
   }
   return () => false;
+}
+
+function getExternalTarget(config: Config): string | undefined {
+  return typeof config.get('target') === 'object'
+    ? config.getOptionalString('target.external')
+    : config.getString('target');
+}
+
+function buildWildcardDiscoveryMatcher(
+  config: Config,
+): (url: string) => boolean {
+  const matchers =
+    config.getOptionalConfigArray('discovery.endpoints')?.flatMap(endpoint => {
+      if (!endpoint.getStringArray('plugins').includes('*')) {
+        return [];
+      }
+      const target = getExternalTarget(endpoint);
+      return target ? [buildUrlPatternMatcher(target)] : [];
+    }) ?? [];
+
+  return url => matchers.some(matcher => matcher(url));
+}
+
+function buildUrlPatternMatcher(pattern: string): (url: string) => boolean {
+  const parts = pattern.replace(/\/$/, '').split(PLUGIN_ID_TEMPLATE);
+  let source = escapeRegExp(parts[0]);
+
+  for (let i = 1; i < parts.length; i++) {
+    source += i === 1 ? '([^/?#]+)' : '\\1';
+    source += escapeRegExp(parts[i]);
+  }
+
+  const regex = new RegExp(`^${source}(?:/|$)`);
+  return url => regex.test(url);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function buildPrefixMatcher(prefixes: string[]): (url: string) => boolean {

--- a/packages/core-app-api/src/apis/implementations/FetchApi/IdentityAuthInjectorFetchMiddleware.ts
+++ b/packages/core-app-api/src/apis/implementations/FetchApi/IdentityAuthInjectorFetchMiddleware.ts
@@ -163,7 +163,7 @@ function buildUrlPatternMatcher(pattern: string): (url: string) => boolean {
     source += escapeRegExp(parts[i]);
   }
 
-  const regex = new RegExp(`^${source}(?:/|$)`);
+  const regex = new RegExp(`^${source}(?:/|$|[?#])`);
   return url => regex.test(url);
 }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This fixes a difference between backend and frontend discovery configuration. Backend discovery already treats `plugins: ['*']` as a fallback target, while frontend discovery treated `'*'` as a literal plugin ID.

Frontend discovery now uses the same precedence as backend discovery:

1. An explicitly configured plugin target
2. A wildcard target
3. The default `backend.baseUrl` target

The default fetch middleware also recognizes wildcard discovery URL patterns when deciding whether to attach identity tokens, without allowing unrelated URLs.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
