### PR TITLE
fix(notifications): allow origin overrides when channel is disabled

### DIFF
--- a/.changeset/fix-origin-override-channel-disabled.md
+++ b/.changeset/fix-origin-override-channel-disabled.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications-backend': patch
+---
+
+Fixed config-level origin overrides being ignored when the channel is disabled. Previously, setting `enabled: false` on a channel would prevent origin-level `enabled: true` overrides from taking effect. Now, admins can disable a channel by default while still enabling specific origins.

--- a/plugins/notifications-backend/src/service/router.test.ts
+++ b/plugins/notifications-backend/src/service/router.test.ts
@@ -735,6 +735,130 @@ describe.each(databases.eachSupportedId())('createRouter (%s)', databaseId => {
         .select();
       expect(notifications).toHaveLength(1); // Notification created for enabled topic
     });
+
+    it('should send notification when origin is enabled in config even if channel is disabled', async () => {
+      const configWithOriginOverride = mockServices.rootConfig({
+        data: {
+          app: { baseUrl: 'http://localhost' },
+          notifications: {
+            defaultSettings: {
+              channels: [
+                {
+                  id: 'Web',
+                  enabled: false,
+                  origins: [
+                    {
+                      id: 'external:test-service',
+                      enabled: true,
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      });
+
+      const routerWithOriginOverride = await createRouter({
+        logger: mockServices.logger.mock(),
+        store,
+        signals: signalService,
+        userInfo,
+        config: configWithOriginOverride,
+        httpAuth,
+        auth,
+        catalog,
+      });
+      const appWithOriginOverride = express()
+        .use(routerWithOriginOverride)
+        .use(mockErrorHandler());
+
+      const sendNotification = (opts: NotificationSendOptions) =>
+        request(appWithOriginOverride)
+          .post('/notifications')
+          .send(opts)
+          .set('Content-Type', 'application/json')
+          .set('Accept', 'application/json');
+
+      const response = await sendNotification({
+        recipients: {
+          type: 'entity',
+          entityRef: ['user:default/mock'],
+        },
+        payload: {
+          title: 'soundcheck notification',
+          topic: 'test-topic',
+        },
+      });
+
+      expect(response.status).toEqual(200);
+      expect(response.body).toHaveLength(1);
+      expect(response.body[0]).toMatchObject({
+        origin: 'external:test-service',
+        payload: {
+          title: 'soundcheck notification',
+        },
+      });
+    });
+
+    it('should not send notification for non-matching origin when channel is disabled with origin overrides', async () => {
+      const configWithOriginOverride = mockServices.rootConfig({
+        data: {
+          app: { baseUrl: 'http://localhost' },
+          notifications: {
+            defaultSettings: {
+              channels: [
+                {
+                  id: 'Web',
+                  enabled: false,
+                  origins: [
+                    {
+                      id: 'external:other-service',
+                      enabled: true,
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      });
+
+      const routerWithOriginOverride = await createRouter({
+        logger: mockServices.logger.mock(),
+        store,
+        signals: signalService,
+        userInfo,
+        config: configWithOriginOverride,
+        httpAuth,
+        auth,
+        catalog,
+      });
+      const appWithOriginOverride = express()
+        .use(routerWithOriginOverride)
+        .use(mockErrorHandler());
+
+      const sendNotification = (opts: NotificationSendOptions) =>
+        request(appWithOriginOverride)
+          .post('/notifications')
+          .send(opts)
+          .set('Content-Type', 'application/json')
+          .set('Accept', 'application/json');
+
+      const response = await sendNotification({
+        recipients: {
+          type: 'entity',
+          entityRef: ['user:default/mock'],
+        },
+        payload: {
+          title: 'test notification',
+          topic: 'test-topic',
+        },
+      });
+
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual([]);
+    });
   });
 
   describe('POST /notifications with custom receiver resolver', () => {

--- a/plugins/notifications-backend/src/service/router.ts
+++ b/plugins/notifications-backend/src/service/router.ts
@@ -291,15 +291,14 @@ export async function createRouter(
       };
     }
 
-    // Add config default origins if not in user settings
-    // Only add origins if the channel is enabled (not explicitly disabled)
+    // Add config default origins if not in user settings.
+    // Origins are always merged so that an admin can set a channel to disabled
+    // by default while still enabling specific origins (e.g. enabled: false
+    // globally with plugin:soundcheck enabled: true).
     const defaultChannelSettings = defaultNotificationSettings?.channels?.find(
       c => c.id.toLowerCase() === opts.channel.toLowerCase(),
     );
-    if (
-      defaultChannelSettings?.origins &&
-      settings.channels[0].enabled !== false
-    ) {
+    if (defaultChannelSettings?.origins) {
       for (const defaultOrigin of defaultChannelSettings.origins) {
         if (
           !settings.channels[0].origins.some(


### PR DESCRIPTION
## Summary
- Fixes config-level origin `enabled` overrides being silently ignored when the channel has `enabled: false`
- Removes the `enabled !== false` guard on origin merging in `isNotificationsEnabled` so admins can configure a channel as opt-in (disabled by default) while explicitly enabling specific origins
- `isNotificationsEnabledFor` already handles precedence correctly: explicit origin > channel default

## Context
When configuring notifications like:
```yaml
notifications:
  defaultSettings:
    channels:
      - id: 'SlackNotificationProcessor'
        enabled: false
        origins:
          - id: 'plugin:soundcheck'
            enabled: true
```
The intent is "Slack off globally, but on for soundcheck." However, the `isNotificationsEnabled` function skipped merging default origins when `settings.channels[0].enabled` was `false` (line 301), so `isNotificationsEnabledFor` never saw the origin entries and fell back to the channel's disabled state — effectively disabling Slack for everything.

## Test plan
- [x] Added test: notification sends when origin is enabled in config even if channel is disabled
- [x] Added test: notification is blocked for non-matching origins when channel is disabled with origin overrides
- [x] Existing test still passes: channel disabled with no origin overrides still blocks all notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)