### PR TITLE
catalog-backend-module-msgraph: reject userGroupMemberPath combined with userFilter

### DIFF
--- a/.changeset/olive-melons-repeat.md
+++ b/.changeset/olive-melons-repeat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-msgraph': patch
+---
+
+Configuring `userGroupMember.path` together with `user.filter` is now rejected with a configuration error, as the two options are mutually exclusive. This matches the existing validation for `userGroupMember.filter` and `userGroupMember.search`.

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/config.test.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/config.test.ts
@@ -235,6 +235,25 @@ describe('readProviderConfigs', () => {
     );
   });
 
+  it('should reject userFilter combined with userGroupMemberPath', () => {
+    const config = {
+      catalog: {
+        providers: {
+          microsoftGraphOrg: {
+            customProviderId: {
+              tenantId: 'tenantId',
+              user: { filter: "userType eq 'member'" },
+              userGroupMember: { path: 'some-path' },
+            },
+          },
+        },
+      },
+    };
+    expect(() => readProviderConfigs(new ConfigReader(config))).toThrow(
+      'userGroupMemberPath cannot be specified',
+    );
+  });
+
   it('should fail if clientId is set without clientSecret', () => {
     const config = {
       catalog: {

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/config.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/config.ts
@@ -355,6 +355,11 @@ export function readProviderConfig(
       `userGroupMemberSearch cannot be specified when userFilter is defined.`,
     );
   }
+  if (userFilter && userGroupMemberPath) {
+    throw new Error(
+      `userGroupMemberPath cannot be specified when userFilter is defined.`,
+    );
+  }
 
   if (clientId && !clientSecret) {
     throw new Error(`clientSecret must be provided when clientId is defined.`);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The msgraph org data provider already rejects configurations that set `user.filter` together with `userGroupMember.filter` or `userGroupMember.search`, since users are either ingested via a filter or via group memberships — not both. However, setting `userGroupMember.path` alongside `user.filter` slipped through this validation. This change extends the same validation to `userGroupMember.path`, so such configurations now fail with a clear error at startup instead of silently ignoring one of the options.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

🤖 Generated with [Claude Code](https://claude.com/claude-code)