### PR TITLE
Include custom catalog kinds in search filter

### DIFF
--- a/.changeset/weak-paws-win.md
+++ b/.changeset/weak-paws-win.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search': patch
+---
+
+Include custom catalog entity kinds in the search page kind filter.

--- a/plugins/search/package.json
+++ b/plugins/search/package.json
@@ -78,6 +78,7 @@
     "@backstage/cli": "workspace:^",
     "@backstage/core-app-api": "workspace:^",
     "@backstage/dev-utils": "workspace:^",
+    "@backstage/frontend-test-utils": "workspace:^",
     "@backstage/test-utils": "workspace:^",
     "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^6.0.0",

--- a/plugins/search/src/alpha.test.tsx
+++ b/plugins/search/src/alpha.test.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  createExtensionTester,
+  renderInTestApp,
+} from '@backstage/frontend-test-utils';
+import { catalogApiMock } from '@backstage/plugin-catalog-react/testUtils';
+import { searchApiRef } from '@backstage/plugin-search-react';
+import { searchPage } from './alpha';
+
+describe('searchPage', () => {
+  it('includes custom catalog kinds in the kind filter', async () => {
+    const catalogApi = catalogApiMock.mock({
+      getEntityFacets: jest.fn().mockResolvedValue({
+        facets: {
+          kind: [
+            { value: 'CustomKind', count: 1 },
+            { value: 'Component', count: 2 },
+          ],
+        },
+      }),
+    });
+    const searchApi = {
+      query: jest.fn().mockResolvedValue({ results: [], numberOfResults: 0 }),
+    };
+
+    const tester = createExtensionTester(searchPage);
+    await renderInTestApp(tester.reactElement(), {
+      apis: [catalogApi, [searchApiRef, searchApi]],
+      config: {
+        backend: { baseUrl: 'http://localhost:7007' },
+        search: { query: { pageLimit: 10 } },
+      },
+    });
+
+    const kindFilter = within(await screen.findByLabelText('Kind')).getByRole(
+      'button',
+    );
+    await waitFor(() =>
+      expect(kindFilter).not.toHaveAttribute('aria-disabled'),
+    );
+    await userEvent.click(kindFilter);
+
+    expect(
+      await screen.findByRole('option', { name: 'CustomKind' }),
+    ).toBeInTheDocument();
+    expect(catalogApi.getEntityFacets).toHaveBeenCalledWith({
+      facets: ['kind'],
+    });
+  });
+});

--- a/plugins/search/src/alpha.tsx
+++ b/plugins/search/src/alpha.tsx
@@ -195,17 +195,14 @@ export const searchPage = PageBlueprint.makeWithOverrides({
                         className={classes.filter}
                         label="Kind"
                         name="kind"
-                        values={[
-                          'API',
-                          'Component',
-                          'Domain',
-                          'Group',
-                          'Location',
-                          'Resource',
-                          'System',
-                          'Template',
-                          'User',
-                        ]}
+                        values={async () => {
+                          const { facets } = await catalogApi.getEntityFacets({
+                            facets: ['kind'],
+                          });
+                          return (facets.kind ?? [])
+                            .map(facet => facet.value)
+                            .sort((a, b) => a.localeCompare(b));
+                        }}
                       />
                       <SearchFilter.Checkbox
                         className={classes.filter}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7006,6 +7006,7 @@ __metadata:
     "@backstage/dev-utils": "workspace:^"
     "@backstage/errors": "workspace:^"
     "@backstage/frontend-plugin-api": "workspace:^"
+    "@backstage/frontend-test-utils": "workspace:^"
     "@backstage/plugin-catalog-react": "workspace:^"
     "@backstage/plugin-search-common": "workspace:^"
     "@backstage/plugin-search-react": "workspace:^"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updates the search page’s Kind filter to load available entity kinds from the catalog rather than relying on a hardcoded list. This ensures custom entity kinds are included while preserving catalog-provided casing and alphabetical ordering. A page-level test verifies that custom kinds returned by the catalog appear in the filter.

<img width="2168" height="1309" alt="Kind filter" src="https://github.com/user-attachments/assets/f0dca0b0-a1fb-4775-97d0-1b55f40c401a" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
