### PR TITLE
chore(deps): clean up dependencies in backend-openapi-utils

### DIFF
--- a/.changeset/brown-eagles-know.md
+++ b/.changeset/brown-eagles-know.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-openapi-utils': patch
+---
+
+Cleaned up dependencies in backend-openapi-utils by removing unused dependencies and moving `mockttp` as a dev dependency

--- a/packages/backend-openapi-utils/package.json
+++ b/packages/backend-openapi-utils/package.json
@@ -46,7 +46,6 @@
   },
   "dependencies": {
     "@apidevtools/swagger-parser": "^10.1.0",
-    "@backstage/backend-plugin-api": "workspace:^",
     "@backstage/errors": "workspace:^",
     "@backstage/types": "workspace:^",
     "@types/express": "^4.17.6",
@@ -58,13 +57,13 @@
     "get-port": "^5.1.1",
     "json-schema-to-ts": "^3.0.0",
     "lodash": "^4.17.21",
-    "mockttp": "^3.13.0",
     "openapi-merge": "^1.3.2",
     "openapi3-ts": "^3.1.2"
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",
     "@backstage/test-utils": "workspace:^",
+    "mockttp": "^3.13.0",
     "msw": "^2.0.0",
     "supertest": "^7.0.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2285,7 +2285,6 @@ __metadata:
   resolution: "@backstage/backend-openapi-utils@workspace:packages/backend-openapi-utils"
   dependencies:
     "@apidevtools/swagger-parser": "npm:^10.1.0"
-    "@backstage/backend-plugin-api": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/errors": "workspace:^"
     "@backstage/test-utils": "workspace:^"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- Moves `mockttp` to `devDependencies` so its transitive dependency tree is no longer installed in by adopters, reducing noise in CVEs reports
- Removes unused `@backstage/backend-plugin-api` dep as reported in [knip-report.md](https://github.com/backstage/backstage/blob/master/packages/backend-openapi-utils/knip-report.md)

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
