### PR TITLE
fix(ui): update Spotify theme Button styling

### DIFF
--- a/.storybook/themes/spotify.css
+++ b/.storybook/themes/spotify.css
@@ -130,6 +130,7 @@
 
   .bui-ButtonIcon {
     padding: 0;
+    border-radius: var(--bui-radius-full);
   }
 
   .bui-MenuPopup {

--- a/.storybook/themes/spotify.css
+++ b/.storybook/themes/spotify.css
@@ -133,6 +133,11 @@
     border-radius: var(--bui-radius-full);
   }
 
+  .bui-ButtonLink {
+    border-radius: var(--bui-radius-full);
+    padding-inline: var(--bui-space-4);
+  }
+
   .bui-MenuPopup {
     box-sizing: border-box;
     max-width: 21.25rem;

--- a/.storybook/themes/spotify.css
+++ b/.storybook/themes/spotify.css
@@ -124,8 +124,8 @@
     CircularSp-Cyrl, CircularSp-Grek, CircularSp-Deva;
 
   .bui-Button {
-    border-radius: var(--bui-radius-3);
-    padding-inline: var(--bui-space-3);
+    border-radius: var(--bui-radius-full);
+    padding-inline: var(--bui-space-4);
   }
 
   .bui-ButtonIcon {

--- a/packages/ui/src/components/Button/Button.stories.tsx
+++ b/packages/ui/src/components/Button/Button.stories.tsx
@@ -64,27 +64,42 @@ export const Variants = meta.story({
       },
     },
   },
-  render: () => (
+  render: args => (
     <Flex direction="column" gap="4">
       <Flex align="center">
-        <Button iconStart={<RiCloudLine />} variant="primary">
+        <Button iconStart={<RiCloudLine />} variant="primary" {...args}>
           Button
         </Button>
-        <Button iconStart={<RiCloudLine />} variant="secondary">
+        <Button iconStart={<RiCloudLine />} variant="secondary" {...args}>
           Button
         </Button>
-        <Button iconStart={<RiCloudLine />} variant="tertiary">
+        <Button iconStart={<RiCloudLine />} variant="tertiary" {...args}>
           Button
         </Button>
       </Flex>
       <Flex align="center">
-        <Button iconStart={<RiCloudLine />} variant="primary" destructive>
+        <Button
+          iconStart={<RiCloudLine />}
+          variant="primary"
+          destructive
+          {...args}
+        >
           Button
         </Button>
-        <Button iconStart={<RiCloudLine />} variant="secondary" destructive>
+        <Button
+          iconStart={<RiCloudLine />}
+          variant="secondary"
+          destructive
+          {...args}
+        >
           Button
         </Button>
-        <Button iconStart={<RiCloudLine />} variant="tertiary" destructive>
+        <Button
+          iconStart={<RiCloudLine />}
+          variant="tertiary"
+          destructive
+          {...args}
+        >
           Button
         </Button>
       </Flex>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Updates the Button styling in the Spotify Storybook theme:

- Use a fully rounded border radius (`--bui-radius-full`) instead of `--bui-radius-3`
- Use wider inline padding (`--bui-space-4`) instead of `--bui-space-3`

Also updates the Button `Variants` story to spread `args` onto each button so the variants can be tweaked via Storybook controls.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

> Note: no changeset was added since these changes only touch the Storybook theme and a `.stories.tsx` file, neither of which affects the published package output.