### PR TITLE
docs: fix dead Jest documentation links

### DIFF
--- a/docs/plugins/testing.md
+++ b/docs/plugins/testing.md
@@ -16,7 +16,7 @@ You may want to consider migrating to Jest 30, to do this, you can follow this g
 
 :::
 
-Backstage uses [Jest](https://facebook.github.io/jest/) for all our unit testing
+Backstage uses [Jest](https://jestjs.io/) for all our unit testing
 needs.
 
 Jest is a Facebook-built unit testing framework specifically built for React. It
@@ -274,7 +274,7 @@ Testing an API involves verifying four things:
 
 #### Mocking API Calls
 
-[Mocking in Jest](https://facebook.github.io/jest/docs/en/mock-functions.html)
+[Mocking in Jest](https://jestjs.io/docs/mock-functions)
 involves wrapping existing functions (like an API call function) with an
 alternative.
 


### PR DESCRIPTION
The testing docs link to Jest at `https://facebook.github.io/jest/`, which no longer exists (Jest moved off `facebook.github.io`). Both the intro link and the "Mocking in Jest" link return HTTP 404:

- `https://facebook.github.io/jest/` -> `https://jestjs.io/`
- `https://facebook.github.io/jest/docs/en/mock-functions.html` -> `https://jestjs.io/docs/mock-functions`

This points them at the current Jest site (both new URLs return HTTP 200). Docs-only change.