### PR TITLE
Export CatalogExportButton from plugin-catalog

### DIFF
--- a/.changeset/smart-bikes-admire.md
+++ b/.changeset/smart-bikes-admire.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Export CatalogExportButton from the plugin, which was previously missing from the package exports.

--- a/plugins/catalog/report.api.md
+++ b/plugins/catalog/report.api.md
@@ -81,6 +81,12 @@ export type Breakpoint = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 export const CatalogEntityPage: () => JSX.Element;
 
 // @public
+export const CatalogExportButton: (input: {
+  settings?: CatalogExportSettings;
+  iconOnly?: boolean;
+}) => JSX_2.Element;
+
+// @public
 export type CatalogExporter = (options: {
   apis: ApiHolder;
   columns: CatalogExportSettingsColumn[];

--- a/plugins/catalog/src/components/CatalogExportButton/index.ts
+++ b/plugins/catalog/src/components/CatalogExportButton/index.ts
@@ -17,5 +17,6 @@ export type {
   CatalogExportSettings,
   CatalogExporterConfig,
 } from './CatalogExportButton';
+export { CatalogExportButton } from './CatalogExportButton';
 export type { CatalogExportSettingsColumn } from './file-download/serializeEntities';
 export type { CatalogExporter } from './file-download/useStreamingExport';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #34820

Exports `CatalogExportButton` from `plugins/catalog/src/components/CatalogExportButton/index.ts`. The component was already fully implemented but only its related types (`CatalogExportSettings`, `CatalogExporterConfig`) were being exported — not the component itself — so it couldn't be imported and used outside the plugin.

Verified with a full `tsc --noEmit` type-check across the repo (no errors) and confirmed the export chain end-to-end.

#### :heavy_check_mark: Checklist
<!--- Please include the following in your Pull Request when applicable: -->
- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))