### PR TITLE
docs(docker): warn that host build steps must use same Node version as Docker image

### DIFF
--- a/.changeset/fix-docker-node-version-alignment-docs.md
+++ b/.changeset/fix-docker-node-version-alignment-docs.md
@@ -2,4 +2,4 @@
 '@backstage/create-app': patch
 ---
 
-Added a comment to the example backend Dockerfiles clarifying that the host build steps (`yarn install`, `yarn build:backend`) must use the same Node version as the Docker base image (Node 24). Using a mismatched version — especially combined with a shared BuildKit Yarn cache — can cause native modules to fail silently at runtime.
+Clarified that the host build steps must use the same Node version as the Docker base image in the Dockerfile.

--- a/.changeset/fix-docker-node-version-alignment-docs.md
+++ b/.changeset/fix-docker-node-version-alignment-docs.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Added a comment to the example backend Dockerfiles clarifying that the host build steps (`yarn install`, `yarn build:backend`) must use the same Node version as the Docker base image (Node 24). Using a mismatched version — especially combined with a shared BuildKit Yarn cache — can cause native modules to fail silently at runtime.

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -37,6 +37,15 @@ The required steps in the host build are to install dependencies with
 `yarn install`, generate type definitions using `yarn tsc`, and build the backend
 package with `yarn build:backend`.
 
+:::note
+Run these commands with the **same Node version as the Docker base image** (currently Node 24).
+Using a different version — for example Node 22 — causes native modules such as `better-sqlite3`
+and `cpu-features` to be compiled against a different ABI. At runtime inside the container they
+will fail to load, which can manifest as silent hangs or cryptic errors. This risk is especially
+pronounced when a BuildKit `--mount=type=cache` is used for the Yarn cache, because stale
+pre-compiled binaries from a previous Node version may be served from cache without recompilation.
+:::
+
 In a CI workflow it might look something like this, from the root:
 
 ```bash

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -38,12 +38,7 @@ The required steps in the host build are to install dependencies with
 package with `yarn build:backend`.
 
 :::note
-Run these commands with the **same Node version as the Docker base image** (currently Node 24).
-Using a different version — for example Node 22 — causes native modules such as `better-sqlite3`
-and `cpu-features` to be compiled against a different ABI. At runtime inside the container they
-will fail to load, which can manifest as silent hangs or cryptic errors. This risk is especially
-pronounced when a BuildKit `--mount=type=cache` is used for the Yarn cache, because stale
-pre-compiled binaries from a previous Node version may be served from cache without recompilation.
+Run these commands with the same Node version as the Docker base image (currently Node 24). Using a different version will cause native modules to fail at runtime.
 :::
 
 In a CI workflow it might look something like this, from the root:

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -38,7 +38,7 @@ The required steps in the host build are to install dependencies with
 package with `yarn build:backend`.
 
 :::note
-Run these commands with the same Node version as the Docker base image (currently Node 24). Using a different version will cause native modules to fail at runtime.
+Run these commands with the same Node version as the Docker base image. Using a different version will cause native modules to fail at runtime.
 :::
 
 In a CI workflow it might look something like this, from the root:

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -7,11 +7,8 @@
 # yarn tsc
 # yarn build:backend
 #
-# These commands must be run with Node 24, matching this image's runtime.
-# Using a different Node version can cause native modules (e.g. better-sqlite3,
-# cpu-features) to be compiled against a different ABI, resulting in silent
-# failures or hangs at runtime — especially if Yarn's build cache is shared
-# across Node versions via a BuildKit --mount=type=cache.
+# Host build steps (yarn install, yarn build:backend) must use the same
+# Node version as the FROM image below. Mismatched versions break native modules.
 #
 # Once the commands have been run, you can build the image using `yarn build-image`
 

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -7,6 +7,12 @@
 # yarn tsc
 # yarn build:backend
 #
+# These commands must be run with Node 24, matching this image's runtime.
+# Using a different Node version can cause native modules (e.g. better-sqlite3,
+# cpu-features) to be compiled against a different ABI, resulting in silent
+# failures or hangs at runtime — especially if Yarn's build cache is shared
+# across Node versions via a BuildKit --mount=type=cache.
+#
 # Once the commands have been run, you can build the image using `yarn build-image`
 
 FROM node:24-trixie-slim

--- a/packages/create-app/templates/default-app/packages/backend/Dockerfile
+++ b/packages/create-app/templates/default-app/packages/backend/Dockerfile
@@ -7,11 +7,8 @@
 # yarn tsc
 # yarn build:backend
 #
-# These commands must be run with Node 24, matching this image's runtime.
-# Using a different Node version can cause native modules (e.g. better-sqlite3,
-# cpu-features) to be compiled against a different ABI, resulting in silent
-# failures or hangs at runtime — especially if Yarn's build cache is shared
-# across Node versions via a BuildKit --mount=type=cache.
+# Host build steps (yarn install, yarn build:backend) must use the same
+# Node version as the FROM image below. Mismatched versions break native modules.
 #
 # Once the commands have been run, you can build the image using `yarn build-image`
 #

--- a/packages/create-app/templates/default-app/packages/backend/Dockerfile
+++ b/packages/create-app/templates/default-app/packages/backend/Dockerfile
@@ -7,6 +7,12 @@
 # yarn tsc
 # yarn build:backend
 #
+# These commands must be run with Node 24, matching this image's runtime.
+# Using a different Node version can cause native modules (e.g. better-sqlite3,
+# cpu-features) to be compiled against a different ABI, resulting in silent
+# failures or hangs at runtime — especially if Yarn's build cache is shared
+# across Node versions via a BuildKit --mount=type=cache.
+#
 # Once the commands have been run, you can build the image using `yarn build-image`
 #
 # Alternatively, there is also a multi-stage Dockerfile documented here:

--- a/packages/create-app/templates/legacy-app/packages/backend/Dockerfile
+++ b/packages/create-app/templates/legacy-app/packages/backend/Dockerfile
@@ -7,11 +7,8 @@
 # yarn tsc
 # yarn build:backend
 #
-# These commands must be run with Node 24, matching this image's runtime.
-# Using a different Node version can cause native modules (e.g. better-sqlite3,
-# cpu-features) to be compiled against a different ABI, resulting in silent
-# failures or hangs at runtime — especially if Yarn's build cache is shared
-# across Node versions via a BuildKit --mount=type=cache.
+# Host build steps (yarn install, yarn build:backend) must use the same
+# Node version as the FROM image below. Mismatched versions break native modules.
 #
 # Once the commands have been run, you can build the image using `yarn build-image`
 #

--- a/packages/create-app/templates/legacy-app/packages/backend/Dockerfile
+++ b/packages/create-app/templates/legacy-app/packages/backend/Dockerfile
@@ -7,6 +7,12 @@
 # yarn tsc
 # yarn build:backend
 #
+# These commands must be run with Node 24, matching this image's runtime.
+# Using a different Node version can cause native modules (e.g. better-sqlite3,
+# cpu-features) to be compiled against a different ABI, resulting in silent
+# failures or hangs at runtime — especially if Yarn's build cache is shared
+# across Node versions via a BuildKit --mount=type=cache.
+#
 # Once the commands have been run, you can build the image using `yarn build-image`
 #
 # Alternatively, there is also a multi-stage Dockerfile documented here:


### PR DESCRIPTION
## Summary

Closes #34507 (documentation aspect)

The TechDocs hang reported in #34507 was traced to a Node version mismatch between the host build environment and the Docker image. When `yarn install` / `yarn build:backend` run under Node 22 and the Docker image uses `node:24-trixie-slim`, native modules such as `better-sqlite3`, `cpu-features`, and `ssh2` are compiled against a different ABI. They then fail to load at runtime — especially when a BuildKit `--mount=type=cache` reuses stale Node 22 compiled binaries inside the Node 24 container.

This PR makes the risk explicit in:
- `packages/backend/Dockerfile` — the example app Dockerfile
- `packages/create-app/templates/default-app/packages/backend/Dockerfile`
- `packages/create-app/templates/legacy-app/packages/backend/Dockerfile`
- `docs/deployment/docker.md` — the deployment guide

No code or base image changes. The Dockerfiles remain at `node:24-trixie-slim`.

## Test plan

- [ ] Read the updated comments in each Dockerfile and the note in `docs/deployment/docker.md` to confirm they clearly describe the risk and the expected Node version.