### PR TITLE
fix(catalog-backend-module-github): set Group namespace from GitHub org on custom teamTransformer

### DIFF
--- a/.changeset/fix-github-org-group-namespace-custom-transformer.md
+++ b/.changeset/fix-github-org-group-namespace-custom-transformer.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+Fix Group namespace from GitHub org on custom `teamTransformer`.

--- a/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.test.ts
@@ -958,6 +958,224 @@ describe('GithubMultiOrgEntityProvider', () => {
       });
     });
 
+    it('should assign organization namespace for custom teamTransformer', async () => {
+      mockClient
+        .mockResolvedValueOnce({
+          organization: {
+            membersWithRole: {
+              pageInfo: { hasNextPage: false },
+              nodes: [
+                {
+                  login: 'a',
+                  id: 'f',
+                  name: 'b',
+                  bio: 'c',
+                  email: 'd',
+                  avatarUrl: 'e',
+                },
+              ],
+            },
+          },
+        })
+        .mockResolvedValueOnce({
+          organization: {
+            teams: {
+              pageInfo: { hasNextPage: false },
+              nodes: [
+                {
+                  slug: 'team',
+                  combinedSlug: 'orgC/team',
+                  name: 'Team',
+                  description: 'The one and only team',
+                  avatarUrl: 'http://example.com/team.jpeg',
+                  parentTeam: undefined,
+                  members: {
+                    pageInfo: { hasNextPage: false },
+                    nodes: [{ login: 'a', id: 'f' }],
+                  },
+                },
+              ],
+            },
+          },
+        });
+
+      (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
+
+      const customTeamTransformer = jest
+        .fn()
+        .mockImplementation(async (team, _ctx) => {
+          return {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Group',
+            metadata: {
+              name: `${team.slug}-custom`,
+              description: team.description,
+              annotations: {
+                'github.com/team-slug': team.combinedSlug,
+              },
+            },
+            spec: {
+              type: 'team',
+              children: [],
+            },
+          };
+        });
+
+      entityProvider = new GithubMultiOrgEntityProvider({
+        id: 'my-id',
+        gitHubConfig,
+        githubCredentialsProvider: {
+          getCredentials: mockGetCredentials,
+        },
+        githubUrl: 'https://github.com',
+        logger,
+        orgs: ['orgC'],
+        teamTransformer: customTeamTransformer,
+      });
+
+      await entityProvider.connect(entityProviderConnection);
+      await entityProvider.read();
+
+      expect(customTeamTransformer).toHaveBeenCalled();
+      expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith({
+        entities: expect.arrayContaining([
+          {
+            entity: {
+              apiVersion: 'backstage.io/v1alpha1',
+              kind: 'Group',
+              metadata: {
+                annotations: {
+                  'backstage.io/managed-by-location':
+                    'url:https://github.com/orgs/orgC/teams/team',
+                  'backstage.io/managed-by-origin-location':
+                    'url:https://github.com/orgs/orgC/teams/team',
+                  'github.com/team-slug': 'orgC/team',
+                },
+                name: 'team-custom',
+                description: 'The one and only team',
+                namespace: 'orgc',
+              },
+              spec: {
+                children: [],
+                type: 'team',
+              },
+            },
+            locationKey: 'github-multi-org-provider:my-id',
+          },
+        ]),
+        type: 'full',
+      });
+    });
+
+    it('should respect alwaysUseDefaultNamespace option for custom teamTransformer', async () => {
+      mockClient
+        .mockResolvedValueOnce({
+          organization: {
+            membersWithRole: {
+              pageInfo: { hasNextPage: false },
+              nodes: [
+                {
+                  login: 'a',
+                  id: 'f',
+                  name: 'b',
+                  bio: 'c',
+                  email: 'd',
+                  avatarUrl: 'e',
+                },
+              ],
+            },
+          },
+        })
+        .mockResolvedValueOnce({
+          organization: {
+            teams: {
+              pageInfo: { hasNextPage: false },
+              nodes: [
+                {
+                  slug: 'team',
+                  combinedSlug: 'orgC/team',
+                  name: 'Team',
+                  description: 'The one and only team',
+                  avatarUrl: 'http://example.com/team.jpeg',
+                  parentTeam: undefined,
+                  members: {
+                    pageInfo: { hasNextPage: false },
+                    nodes: [{ login: 'a', id: 'f' }],
+                  },
+                },
+              ],
+            },
+          },
+        });
+
+      (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
+
+      const customTeamTransformer = jest
+        .fn()
+        .mockImplementation(async (team, _ctx) => {
+          return {
+            apiVersion: 'backstage.io/v1alpha1',
+            kind: 'Group',
+            metadata: {
+              name: `${team.slug}-custom`,
+              description: team.description,
+              annotations: {
+                'github.com/team-slug': team.combinedSlug,
+              },
+            },
+            spec: {
+              type: 'team',
+              children: [],
+            },
+          };
+        });
+
+      entityProvider = new GithubMultiOrgEntityProvider({
+        id: 'my-id',
+        gitHubConfig,
+        githubCredentialsProvider: {
+          getCredentials: mockGetCredentials,
+        },
+        githubUrl: 'https://github.com',
+        logger,
+        orgs: ['orgC'],
+        alwaysUseDefaultNamespace: true,
+        teamTransformer: customTeamTransformer,
+      });
+
+      await entityProvider.connect(entityProviderConnection);
+      await entityProvider.read();
+
+      expect(customTeamTransformer).toHaveBeenCalled();
+      expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith({
+        entities: expect.arrayContaining([
+          {
+            entity: {
+              apiVersion: 'backstage.io/v1alpha1',
+              kind: 'Group',
+              metadata: {
+                annotations: {
+                  'backstage.io/managed-by-location':
+                    'url:https://github.com/orgs/orgC/teams/team',
+                  'backstage.io/managed-by-origin-location':
+                    'url:https://github.com/orgs/orgC/teams/team',
+                  'github.com/team-slug': 'orgC/team',
+                },
+                name: 'team-custom',
+                description: 'The one and only team',
+              },
+              spec: {
+                children: [],
+                type: 'team',
+              },
+            },
+            locationKey: 'github-multi-org-provider:my-id',
+          },
+        ]),
+        type: 'full',
+      });
+    });
+
     it('should not call applyMutation if an error is thrown', async () => {
       entityProvider = new GithubMultiOrgEntityProvider({
         id: 'my-id',

--- a/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
@@ -1012,21 +1012,24 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
     team: GithubTeam,
     ctx: TransformerContext,
   ): Promise<Entity | undefined> {
-    if (this.options.teamTransformer) {
-      return await this.options.teamTransformer(team, ctx);
-    }
+    const result = this.options.teamTransformer
+      ? await this.options.teamTransformer(team, ctx)
+      : await defaultOrganizationTeamTransformer(team, ctx);
 
-    const result = await defaultOrganizationTeamTransformer(team, ctx);
-
-    if (result && result.spec) {
-      if (!this.options.alwaysUseDefaultNamespace) {
+    if (result) {
+      if (
+        !this.options.alwaysUseDefaultNamespace &&
+        !result.metadata.namespace
+      ) {
         result.metadata.namespace = ctx.org.toLocaleLowerCase('en-US');
       }
 
-      // Group `spec.members` inherits the namespace of it's group so need to explicitly specify refs here
-      result.spec.members = team.members.map(
-        user => `${DEFAULT_NAMESPACE}/${user.login}`,
-      );
+      if (result.spec && !this.options.teamTransformer) {
+        // Group `spec.members` inherits the namespace of it's group so need to explicitly specify refs here
+        result.spec.members = team.members.map(
+          user => `${DEFAULT_NAMESPACE}/${user.login}`,
+        );
+      }
     }
 
     return result;

--- a/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
@@ -1024,7 +1024,15 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
         result.metadata.namespace = ctx.org.toLocaleLowerCase('en-US');
       }
 
-      if (result.spec && !this.options.teamTransformer) {
+      if (isGroupEntity(result) && result.spec.members) {
+        result.spec.members = result.spec.members.map(m => {
+          const { namespace, name } = parseEntityRef(m, {
+            defaultKind: 'user',
+            defaultNamespace: DEFAULT_NAMESPACE,
+          });
+          return `${namespace}/${name}`;
+        });
+      } else if (result.spec && !this.options.teamTransformer) {
         // Group `spec.members` inherits the namespace of it's group so need to explicitly specify refs here
         result.spec.members = team.members.map(
           user => `${DEFAULT_NAMESPACE}/${user.login}`,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Description
This PR fixes an issue where the `GitHubOrgEntityProvider` fails to set the Group entity namespace to the corresponding GitHub organization name when a custom `teamTransformer` is provided.

The implementation ensures that `defaultMultiOrgTeamTransformer` consistently applies the organization name namespace across both default and user-defined transformers, while safely checking to prevent overwriting an existing custom namespace.

Fixes #34818

#### ✔ Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.