### PR TITLE
fix(core-components): don't leak literal 0 from Filters on empty array

### DIFF
--- a/.changeset/filters-empty-array-leaked-render.md
+++ b/.changeset/filters-empty-array-leaked-render.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Fixed the table filters sidebar rendering a stray `0` when no filters are configured.

--- a/packages/core-components/src/components/Table/Filters.test.tsx
+++ b/packages/core-components/src/components/Table/Filters.test.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderInTestApp } from '@backstage/test-utils';
+import { screen } from '@testing-library/react';
+import { Filters } from './Filters';
+
+describe('Filters', () => {
+  it('renders nothing for the filters when the array is empty', async () => {
+    await renderInTestApp(<Filters filters={[]} onChangeFilters={() => {}} />);
+
+    // `props.filters?.length` is `0` for an empty array, and `0` is a valid
+    // React node, so a naive `length && ...` guard leaks the literal `0` into
+    // the DOM. Nothing filter-related should be rendered here.
+    expect(screen.queryByText('0')).not.toBeInTheDocument();
+  });
+
+  it('renders a select for each provided filter', async () => {
+    await renderInTestApp(
+      <Filters
+        filters={[
+          { type: 'select', element: { label: 'Owner', items: [] } },
+          { type: 'select', element: { label: 'Kind', items: [] } },
+        ]}
+        onChangeFilters={() => {}}
+      />,
+    );
+
+    expect(screen.getByText('Owner')).toBeInTheDocument();
+    expect(screen.getByText('Kind')).toBeInTheDocument();
+  });
+});

--- a/packages/core-components/src/components/Table/Filters.tsx
+++ b/packages/core-components/src/components/Table/Filters.tsx
@@ -120,7 +120,7 @@ export const Filters = (props: Props) => {
         </Button>
       </Box>
       <Box className={classes.filters}>
-        {props.filters?.length &&
+        {!!props.filters?.length &&
           props.filters.map(filter => (
             <Select
               triggerReset={reset}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The table filters sidebar (`Filters` in `@backstage/core-components`) guarded its rendering with:

```tsx
{props.filters?.length && props.filters.map(...)}
```

When `filters` is an empty array, `props.filters?.length` is `0`. Because `0` is a valid React node, React renders the literal character `0` into the DOM instead of rendering nothing. This coerces the guard to a boolean (`!!`) so nothing is rendered when there are no filters.

Fixes #34840.

### ✔️ Checklist

- [x] A changeset describing the change and affecting packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))