### PR TITLE
fix(auth-node): return 400 for malformed origin on OAuth start

### DIFF
--- a/.changeset/oauth-start-malformed-origin.md
+++ b/.changeset/oauth-start-malformed-origin.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-node': patch
+---
+
+The OAuth `start` endpoint now responds with a `400` for a malformed `origin` query parameter instead of failing with a `500`.

--- a/plugins/auth-node/src/oauth/createOAuthRouteHandlers.test.ts
+++ b/plugins/auth-node/src/oauth/createOAuthRouteHandlers.test.ts
@@ -189,6 +189,21 @@ describe('createOAuthRouteHandlers', () => {
       });
     });
 
+    it('should reject a malformed origin with a 400', async () => {
+      const app = wrapInApp(createOAuthRouteHandlers(baseConfig));
+      const res = await request(app)
+        .get('/my-provider/start')
+        .query({ env: 'development', origin: '@@IWy0O' });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        error: {
+          name: 'InputError',
+          message: 'Invalid origin provided in request query parameters',
+        },
+      });
+    });
+
     it('should start', async () => {
       const agent = request.agent(
         wrapInApp(createOAuthRouteHandlers(baseConfig)),

--- a/plugins/auth-node/src/oauth/createOAuthRouteHandlers.ts
+++ b/plugins/auth-node/src/oauth/createOAuthRouteHandlers.ts
@@ -142,6 +142,20 @@ export function createOAuthRouteHandlers<TProfile>(
         throw new InputError('No env provided in request query parameters');
       }
 
+      // Validate `origin` up front. It is otherwise passed unchecked into
+      // `new URL()` deeper inside the cookie manager, where a malformed value
+      // (e.g. `?origin=@@IWy0O`) throws `ERR_INVALID_URL` and surfaces as a
+      // 500. The sibling `frameHandler` guards the same value.
+      if (origin !== undefined) {
+        try {
+          void new URL(origin);
+        } catch {
+          throw new InputError(
+            'Invalid origin provided in request query parameters',
+          );
+        }
+      }
+
       const nonce = crypto.randomBytes(16).toString('base64');
       // set a nonce cookie before redirecting to oauth provider
       cookieManager.setNonce(res, nonce, origin);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The OAuth `start` route handler in `@backstage/plugin-auth-node` reads the `origin` query parameter and passes it straight through to the cookie manager:

```ts
const origin = req.query.origin?.toString(); // raw, unvalidated
cookieManager.setNonce(res, nonce, origin);
```

`setNonce` → `getConfig(origin)` → the default cookie configurer calls `new URL(appOrigin)`. A request with a malformed `origin` (e.g. `?origin=@@IWy0O`) throws `ERR_INVALID_URL`, which surfaces as an HTTP **500** instead of a client error.

The sibling `frameHandler` already guards this exact case. This validates `origin` up front in `start` and throws an `InputError` (400) when it can't be parsed, matching the env-check just above it.

Fixes #34767.

### ✔️ Checklist

- [x] A changeset describing the change and affecting packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))