### PR TITLE
chore(msw): Migrated notifications plugin to msw 2

### DIFF
--- a/.changeset/early-ways-carry.md
+++ b/.changeset/early-ways-carry.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-notifications-node': patch
+'@backstage/plugin-notifications': patch
+---
+
+Migrated tests to msw version 2.

--- a/plugins/notifications-node/package.json
+++ b/plugins/notifications-node/package.json
@@ -44,6 +44,6 @@
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@backstage/test-utils": "workspace:^",
-    "msw": "^1.0.0"
+    "msw": "^2.0.0"
   }
 }

--- a/plugins/notifications-node/src/service/DefaultNotificationService.test.ts
+++ b/plugins/notifications-node/src/service/DefaultNotificationService.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { registerMswTestHooks } from '@backstage/test-utils';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { NotificationPayload } from '@backstage/plugin-notifications-common';
 import {
@@ -55,16 +55,16 @@ describe('DefaultNotificationService', () => {
       };
 
       server.use(
-        rest.post('http://example.com', async (req, res, ctx) => {
-          const json = await req.json();
+        http.post('http://example.com', async ({ request }) => {
+          const json = await request.json();
           expect(json).toEqual(body);
-          expect(req.headers.get('Authorization')).toBe(
+          expect(request.headers.get('Authorization')).toBe(
             mockCredentials.service.header({
               onBehalfOf: await auth.getOwnServiceCredentials(),
               targetPluginId: 'notifications',
             }),
           );
-          return res(ctx.status(200));
+          return new HttpResponse(null, { status: 200 });
         }),
       );
       await expect(service.send(body)).resolves.toBeUndefined();
@@ -77,16 +77,16 @@ describe('DefaultNotificationService', () => {
       };
 
       server.use(
-        rest.post('http://example.com', async (req, res, ctx) => {
-          const json = await req.json();
+        http.post('http://example.com', async ({ request }) => {
+          const json = await request.json();
           expect(json).toEqual(body);
-          expect(req.headers.get('Authorization')).toBe(
+          expect(request.headers.get('Authorization')).toBe(
             mockCredentials.service.header({
               onBehalfOf: await auth.getOwnServiceCredentials(),
               targetPluginId: 'notifications',
             }),
           );
-          return res(ctx.status(400));
+          return new HttpResponse(null, { status: 400 });
         }),
       );
       await expect(service.send(body)).rejects.toThrow(

--- a/plugins/notifications/package.json
+++ b/plugins/notifications/package.json
@@ -74,7 +74,7 @@
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^16.0.0",
     "@types/react": "^18.0.0",
-    "msw": "^1.0.0",
+    "msw": "^2.0.0",
     "react": "^18.0.2",
     "react-dom": "^18.0.2",
     "react-router-dom": "^6.30.2"

--- a/plugins/notifications/src/api/NotificationsClient.test.ts
+++ b/plugins/notifications/src/api/NotificationsClient.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { MockFetchApi, registerMswTestHooks } from '@backstage/test-utils';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { NotificationsClient } from './NotificationsClient';
 import { Notification } from '@backstage/plugin-notifications-common';
@@ -51,8 +51,8 @@ describe('NotificationsClient', () => {
 
     it('should fetch notifications from correct endpoint', async () => {
       server.use(
-        rest.get(`${mockBaseUrl}/notifications`, (_, res, ctx) =>
-          res(ctx.json(expectedResp)),
+        http.get(`${mockBaseUrl}/notifications`, () =>
+          HttpResponse.json(expectedResp),
         ),
       );
       const response = await client.getNotifications();
@@ -61,11 +61,12 @@ describe('NotificationsClient', () => {
 
     it('should fetch notifications with options', async () => {
       server.use(
-        rest.get(`${mockBaseUrl}/notifications`, (req, res, ctx) => {
-          expect(req.url.search).toBe(
-            '?limit=10&offset=0&search=find+me&read=true&createdAfter=1970-01-01T00%3A00%3A00.005Z',
+        http.get(`${mockBaseUrl}/notifications`, ({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.toString()).toBe(
+            'limit=10&offset=0&search=find+me&read=true&createdAfter=1970-01-01T00%3A00%3A00.005Z',
           );
-          return res(ctx.json(expectedResp));
+          return HttpResponse.json(expectedResp);
         }),
       );
       const response = await client.getNotifications({
@@ -80,9 +81,12 @@ describe('NotificationsClient', () => {
 
     it('should fetch notifications of the topic', async () => {
       server.use(
-        rest.get(`${mockBaseUrl}/notifications`, (req, res, ctx) => {
-          expect(req.url.search).toBe(`?limit=10&offset=0&topic=${testTopic}`);
-          return res(ctx.json(expectedResp));
+        http.get(`${mockBaseUrl}/notifications`, ({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.toString()).toBe(
+            `limit=10&offset=0&topic=${testTopic}`,
+          );
+          return HttpResponse.json(expectedResp);
         }),
       );
 
@@ -96,9 +100,10 @@ describe('NotificationsClient', () => {
 
     it('should omit unselected fetch options', async () => {
       server.use(
-        rest.get(`${mockBaseUrl}/notifications`, (req, res, ctx) => {
-          expect(req.url.search).toBe('?limit=10');
-          return res(ctx.json(expectedResp));
+        http.get(`${mockBaseUrl}/notifications`, ({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.toString()).toBe('limit=10');
+          return HttpResponse.json(expectedResp);
         }),
       );
       const response = await client.getNotifications({
@@ -110,9 +115,10 @@ describe('NotificationsClient', () => {
 
     it('should fetch single notification', async () => {
       server.use(
-        rest.get(`${mockBaseUrl}/notifications/:id`, (req, res, ctx) => {
-          expect(req.params.id).toBe('acdaa8ca-262b-43c1-b74b-de06e5f3b3c7');
-          return res(ctx.json(testNotification));
+        http.get(`${mockBaseUrl}/notifications/:id`, ({ params }) => {
+          const { id } = params;
+          expect(id).toBe('acdaa8ca-262b-43c1-b74b-de06e5f3b3c7');
+          return HttpResponse.json(testNotification);
         }),
       );
 
@@ -124,8 +130,8 @@ describe('NotificationsClient', () => {
 
     it('should fetch status from correct endpoint', async () => {
       server.use(
-        rest.get(`${mockBaseUrl}/status`, (_, res, ctx) =>
-          res(ctx.json({ read: 1, unread: 1 })),
+        http.get(`${mockBaseUrl}/status`, () =>
+          HttpResponse.json({ read: 1, unread: 1 }),
         ),
       );
       const response = await client.getStatus();
@@ -134,13 +140,13 @@ describe('NotificationsClient', () => {
 
     it('should update notifications', async () => {
       server.use(
-        rest.post(
+        http.post(
           `${mockBaseUrl}/notifications/update`,
-          async (req, res, ctx) => {
-            expect(await req.json()).toEqual({
+          async ({ request }) => {
+            expect(await request.json()).toEqual({
               ids: ['acdaa8ca-262b-43c1-b74b-de06e5f3b3c7'],
             });
-            return res(ctx.json(expectedResp));
+            return HttpResponse.json(expectedResp);
           },
         ),
       );
@@ -156,8 +162,8 @@ describe('NotificationsClient', () => {
 
     it('should fetch topics from correct endpoint', async () => {
       server.use(
-        rest.get(`${mockBaseUrl}/topics`, (_, res, ctx) =>
-          res(ctx.json(expectedResp)),
+        http.get(`${mockBaseUrl}/topics`, () =>
+          HttpResponse.json(expectedResp),
         ),
       );
       const response = await client.getTopics();
@@ -166,11 +172,12 @@ describe('NotificationsClient', () => {
 
     it('should fetch topics with options', async () => {
       server.use(
-        rest.get(`${mockBaseUrl}/topics`, (req, res, ctx) => {
-          expect(req.url.search).toBe(
-            '?search=find+me&read=true&createdAfter=1970-01-01T00%3A00%3A00.005Z',
+        http.get(`${mockBaseUrl}/topics`, ({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.toString()).toBe(
+            'search=find+me&read=true&createdAfter=1970-01-01T00%3A00%3A00.005Z',
           );
-          return res(ctx.json(expectedResp));
+          return HttpResponse.json(expectedResp);
         }),
       );
 

--- a/plugins/notifications/src/api/NotificationsClient.test.ts
+++ b/plugins/notifications/src/api/NotificationsClient.test.ts
@@ -63,9 +63,13 @@ describe('NotificationsClient', () => {
       server.use(
         http.get(`${mockBaseUrl}/notifications`, ({ request }) => {
           const url = new URL(request.url);
-          expect(url.searchParams.toString()).toBe(
-            'limit=10&offset=0&search=find+me&read=true&createdAfter=1970-01-01T00%3A00%3A00.005Z',
-          );
+          expect(Object.fromEntries(url.searchParams)).toEqual({
+            limit: '10',
+            offset: '0',
+            search: 'find me',
+            read: 'true',
+            createdAfter: '1970-01-01T00:00:00.005Z',
+          });
           return HttpResponse.json(expectedResp);
         }),
       );
@@ -83,9 +87,11 @@ describe('NotificationsClient', () => {
       server.use(
         http.get(`${mockBaseUrl}/notifications`, ({ request }) => {
           const url = new URL(request.url);
-          expect(url.searchParams.toString()).toBe(
-            `limit=10&offset=0&topic=${testTopic}`,
-          );
+          expect(Object.fromEntries(url.searchParams)).toEqual({
+            limit: '10',
+            offset: '0',
+            topic: testTopic,
+          });
           return HttpResponse.json(expectedResp);
         }),
       );
@@ -174,9 +180,11 @@ describe('NotificationsClient', () => {
       server.use(
         http.get(`${mockBaseUrl}/topics`, ({ request }) => {
           const url = new URL(request.url);
-          expect(url.searchParams.toString()).toBe(
-            'search=find+me&read=true&createdAfter=1970-01-01T00%3A00%3A00.005Z',
-          );
+          expect(Object.fromEntries(url.searchParams)).toEqual({
+            search: 'find me',
+            read: 'true',
+            createdAfter: '1970-01-01T00:00:00.005Z',
+          });
           return HttpResponse.json(expectedResp);
         }),
       );

--- a/yarn.lock
+++ b/yarn.lock
@@ -5962,7 +5962,7 @@ __metadata:
     "@backstage/cli": "workspace:^"
     "@backstage/plugin-notifications-common": "workspace:^"
     "@backstage/test-utils": "workspace:^"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
   languageName: unknown
   linkType: soft
 
@@ -5987,7 +5987,7 @@ __metadata:
     "@testing-library/react": "npm:^16.0.0"
     "@types/react": "npm:^18.0.0"
     lodash: "npm:^4.17.21"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     notistack: "npm:^3.0.1"
     react: "npm:^18.0.2"
     react-aria-components: "npm:~1.17.0"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Migrated the notifications and notification-node plugins to msw 2.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
