### PR TITLE
feat(backend-defaults): support claim matching in jwks external access

### DIFF
--- a/.changeset/olive-brooms-invent.md
+++ b/.changeset/olive-brooms-invent.md
@@ -2,4 +2,4 @@
 '@backstage/backend-defaults': patch
 ---
 
-The `jwks` external access method now supports an optional `claims` config option, letting you restrict which callers are accepted based on the claims in their JWT. Each entry maps a claim name to a single allowed value or a list of allowed values, and a token is accepted only if every listed claim is present and matches one of its allowed values. When a claim's value is an array or a space-delimited string (such as an OAuth `scope`), it is enough that one of those values matches. These checks apply in addition to the existing `issuer`, `algorithm`, and `audience` checks.
+The `jwks` external access method now supports an optional `claims` config option, letting you restrict which callers are accepted based on the claims in their JWT.

--- a/.changeset/olive-brooms-invent.md
+++ b/.changeset/olive-brooms-invent.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+The `jwks` external access method now supports an optional `claims` config option, letting you restrict which callers are accepted based on the claims in their JWT. Each entry maps a claim name to a single allowed value or a list of allowed values, and a token is accepted only if every listed claim is present and matches one of its allowed values. When a claim's value is an array or a space-delimited string (such as an OAuth `scope`), it is enough that one of those values matches. These checks apply in addition to the existing `issuer`, `algorithm`, and `audience` checks.

--- a/docs/auth/service-to-service-auth.md
+++ b/docs/auth/service-to-service-auth.md
@@ -212,8 +212,10 @@ claim that matches one of the audiences specified, or have no audience specified
 `claims` optionally restricts which callers are accepted based on the claims in their JWT. Each
 entry maps a claim name to a single allowed value or a list of allowed values. A token is accepted
 only if every listed claim is present and matches one of its allowed values. When a claim's value is
-itself an array, or a space-delimited string such as an OAuth `scope`, it is enough that one of
-those values matches. This applies in addition to the `issuer`, `algorithm`, and `audience` checks
+itself an array, it is enough that one of its entries matches. The `scope` claim is treated
+specially: since it's conventionally a space-delimited string of individual scopes (as used by
+OAuth), it is enough that one of its space-separated entries matches.. This applies
+in addition to the `issuer`, `algorithm`, and `audience` checks
 above, so all of them must pass. For example, the configuration above only accepts tokens whose
 `department` claim is `platform` and whose `scope` claim contains `catalog:read` or `catalog:write`.
 

--- a/docs/auth/service-to-service-auth.md
+++ b/docs/auth/service-to-service-auth.md
@@ -189,6 +189,9 @@ backend:
           algorithm: RS256
           audience: example, other-example
           subjectPrefix: custom-prefix
+          claims:
+            department: platform
+            scope: [catalog:read, catalog:write]
       - type: jwks
         options:
           url: https://another-example.com/.well-known/jwks.json
@@ -205,6 +208,14 @@ must have been signed using one of the listed algorithms.
 
 `audience` specifies the intended audience(s) of the JWT. The passed JWTs must have an "aud"
 claim that matches one of the audiences specified, or have no audience specified.
+
+`claims` optionally restricts which callers are accepted based on the claims in their JWT. Each
+entry maps a claim name to a single allowed value or a list of allowed values. A token is accepted
+only if every listed claim is present and matches one of its allowed values. When a claim's value is
+itself an array, or a space-delimited string such as an OAuth `scope`, it is enough that one of
+those values matches. This applies in addition to the `issuer`, `algorithm`, and `audience` checks
+above, so all of them must pass. For example, the configuration above only accepts tokens whose
+`department` claim is `platform` and whose `scope` claim contains `catalog:read` or `catalog:write`.
 
 For additional details regarding the JWKS configuration, please consult your authentication
 provider's documentation.

--- a/packages/backend-defaults/config.d.ts
+++ b/packages/backend-defaults/config.d.ts
@@ -539,6 +539,20 @@ export interface Config {
                * Useful for debugging and tracking purposes.
                */
               subjectPrefix?: string;
+              /**
+               * Restricts which callers are accepted based on the claims in their JWT.
+               * Each entry maps a claim name to a single allowed value or a list of allowed values.
+               * A token is accepted only if every listed claim is present and matches one of its allowed values;
+               * for claims whose value is an array or a space-delimited string, it is enough that one of those values matches.
+               * Numbers and booleans are compared by their string representation.
+               */
+              claims?: {
+                [claim: string]:
+                  | string
+                  | number
+                  | boolean
+                  | Array<string | number | boolean>;
+              };
             };
             /**
              * Restricts what types of access that are permitted for this access

--- a/packages/backend-defaults/src/entrypoints/auth/external/jwks.test.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/external/jwks.test.ts
@@ -182,7 +182,7 @@ describe('JWKSHandler', () => {
           tier: ['gold', 'silver'],
           // matched against one entry of a claim that is an array
           groups: 'admins',
-          // matched against one token of a space-delimited claim
+          // matched against one token of the space-delimited `scope` claim
           scope: 'catalog:read',
         },
       }),
@@ -249,6 +249,32 @@ describe('JWKSHandler', () => {
     await expect(
       jwksTokenHandler.verifyToken(partialMatch, context),
     ).resolves.toBeUndefined();
+  });
+
+  it('only splits the `scope` claim on spaces, not other claims', async () => {
+    const context = jwksTokenHandler.initialize({
+      options: new ConfigReader({
+        url: `${mockBaseUrl}/.well-known/jwks.json`,
+        algorithm: 'RS256',
+        issuer: mockBaseUrl,
+        audience: 'backstage',
+        claims: { name: 'jane', scope: 'catalog:read' },
+      }),
+    });
+
+    // A `name` of "jane doe" must not match an allowed value of "jane" just
+    // because "jane" is one of its space-separated words.
+    const token = await factory.issueToken({
+      claims: {
+        sub: mockSubject,
+        name: 'jane doe',
+        scope: 'catalog:read catalog:write',
+      },
+    });
+
+    const result = await jwksTokenHandler.verifyToken(token, context);
+
+    expect(result).toBeUndefined();
   });
 
   it('rejects a token when a required claim does not match', async () => {

--- a/packages/backend-defaults/src/entrypoints/auth/external/jwks.test.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/external/jwks.test.ts
@@ -44,6 +44,7 @@ class FakeTokenFactory {
     claims: {
       sub: string;
       ent?: string[];
+      [claim: string]: unknown;
     };
   }): Promise<string> {
     const pair = await generateKeyPair('RS256');
@@ -53,14 +54,13 @@ class FakeTokenFactory {
     this.keys.push(publicKey as AnyJWK);
 
     const iss = this.options.issuer;
-    const sub = params.claims.sub;
-    const ent = params.claims.ent;
+    const { sub, ...extraClaims } = params.claims;
     const aud = 'backstage';
     const iat = Math.floor(Date.now() / 1000);
     const exp = iat + this.options.keyDurationSeconds;
 
-    return new SignJWT({ iss, sub, aud, iat, exp, ent, kid })
-      .setProtectedHeader({ alg: 'RS256', ent: ent, kid: kid })
+    return new SignJWT({ ...extraClaims, iss, sub, aud, iat, exp, kid })
+      .setProtectedHeader({ alg: 'RS256', kid })
       .setIssuer(iss)
       .setAudience(aud)
       .setSubject(sub)
@@ -166,5 +166,206 @@ describe('JWKSHandler', () => {
     expect(result).toEqual({
       subject: `external:${validEntry.options.subjectPrefix}:${mockSubject}`,
     });
+  });
+
+  it('accepts a token whose claims match the required values', async () => {
+    const context = jwksTokenHandler.initialize({
+      options: new ConfigReader({
+        url: `${mockBaseUrl}/.well-known/jwks.json`,
+        algorithm: 'RS256',
+        issuer: mockBaseUrl,
+        audience: 'backstage',
+        claims: {
+          // single exact value
+          department: 'platform',
+          // one-of a configured list
+          tier: ['gold', 'silver'],
+          // matched against one entry of a claim that is an array
+          groups: 'admins',
+          // matched against one token of a space-delimited claim
+          scope: 'catalog:read',
+        },
+      }),
+    });
+
+    const token = await factory.issueToken({
+      claims: {
+        sub: mockSubject,
+        department: 'platform',
+        tier: 'silver',
+        groups: ['viewers', 'admins'],
+        scope: 'catalog:read catalog:write',
+      },
+    });
+
+    const result = await jwksTokenHandler.verifyToken(token, context);
+
+    expect(result).toEqual({ subject: `external:${mockSubject}` });
+  });
+
+  it('matches numeric and boolean claim values by their string form', async () => {
+    const context = jwksTokenHandler.initialize({
+      options: new ConfigReader({
+        url: `${mockBaseUrl}/.well-known/jwks.json`,
+        algorithm: 'RS256',
+        issuer: mockBaseUrl,
+        audience: 'backstage',
+        claims: { ver: 2, verified: true },
+      }),
+    });
+
+    const token = await factory.issueToken({
+      claims: { sub: mockSubject, ver: 2, verified: true },
+    });
+
+    const result = await jwksTokenHandler.verifyToken(token, context);
+
+    expect(result).toEqual({ subject: `external:${mockSubject}` });
+  });
+
+  it('treats a single string allowed value as one exact value, not comma/space-split', async () => {
+    const context = jwksTokenHandler.initialize({
+      options: new ConfigReader({
+        url: `${mockBaseUrl}/.well-known/jwks.json`,
+        algorithm: 'RS256',
+        issuer: mockBaseUrl,
+        audience: 'backstage',
+        claims: { department: 'platform, other-department' },
+      }),
+    });
+
+    // Unlike `issuer`/`audience`/`algorithm`, a single `claims` string value is
+    // not split on comma/space - use an array for multiple allowed values.
+    const exactMatch = await factory.issueToken({
+      claims: { sub: mockSubject, department: 'platform, other-department' },
+    });
+    await expect(
+      jwksTokenHandler.verifyToken(exactMatch, context),
+    ).resolves.toEqual({ subject: `external:${mockSubject}` });
+
+    const partialMatch = await factory.issueToken({
+      claims: { sub: mockSubject, department: 'platform' },
+    });
+    await expect(
+      jwksTokenHandler.verifyToken(partialMatch, context),
+    ).resolves.toBeUndefined();
+  });
+
+  it('rejects a token when a required claim does not match', async () => {
+    const context = jwksTokenHandler.initialize({
+      options: new ConfigReader({
+        url: `${mockBaseUrl}/.well-known/jwks.json`,
+        algorithm: 'RS256',
+        issuer: mockBaseUrl,
+        audience: 'backstage',
+        claims: {
+          department: 'platform',
+          tier: ['gold', 'silver'],
+        },
+      }),
+    });
+
+    // `tier` is not one of the allowed values, even though `department` matches
+    const token = await factory.issueToken({
+      claims: { sub: mockSubject, department: 'platform', tier: 'bronze' },
+    });
+
+    const result = await jwksTokenHandler.verifyToken(token, context);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('rejects an invalid claims config value', () => {
+    expect(() => {
+      jwksTokenHandler.initialize({
+        options: new ConfigReader({
+          url: `${mockBaseUrl}/.well-known/jwks.json`,
+          claims: { department: {} },
+        }),
+      });
+    }).toThrow(
+      "Invalid value for 'claims.department' in JWKS external access config, expected a non-empty string, number, boolean, or array of those",
+    );
+  });
+
+  it('rejects a token that is missing a required claim entirely', async () => {
+    const context = jwksTokenHandler.initialize({
+      options: new ConfigReader({
+        url: `${mockBaseUrl}/.well-known/jwks.json`,
+        algorithm: 'RS256',
+        issuer: mockBaseUrl,
+        audience: 'backstage',
+        claims: { department: 'platform' },
+      }),
+    });
+
+    const token = await factory.issueToken({
+      claims: { sub: mockSubject },
+    });
+
+    const result = await jwksTokenHandler.verifyToken(token, context);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('supports claim names containing dots and slashes', async () => {
+    // Regression test: claim names are commonly namespaced with dots and
+    // slashes, which are not valid `Config` key path segments. Reading them via
+    // `Config.get(claimName)` would throw `Invalid config key`, so both config
+    // parsing and matching must treat claim names as opaque strings.
+    const context = jwksTokenHandler.initialize({
+      options: new ConfigReader({
+        url: `${mockBaseUrl}/.well-known/jwks.json`,
+        algorithm: 'RS256',
+        issuer: mockBaseUrl,
+        audience: 'backstage',
+        claims: {
+          'example.com/access_policy': 'allow',
+          'https://example.com/roles': ['operator', 'auditor'],
+        },
+      }),
+    });
+
+    const token = await factory.issueToken({
+      claims: {
+        sub: mockSubject,
+        'example.com/access_policy': 'allow',
+        'https://example.com/roles': ['auditor'],
+      },
+    });
+
+    const result = await jwksTokenHandler.verifyToken(token, context);
+
+    expect(result).toEqual({ subject: `external:${mockSubject}` });
+  });
+
+  it('applies claim checks alongside issuer and audience verification', async () => {
+    const context = jwksTokenHandler.initialize({
+      options: new ConfigReader({
+        url: `${mockBaseUrl}/.well-known/jwks.json`,
+        algorithm: 'RS256',
+        issuer: mockBaseUrl,
+        audience: 'backstage',
+        subjectPrefix: 'custom-prefix',
+        claims: { sub: mockSubject },
+      }),
+    });
+
+    const matching = await factory.issueToken({
+      claims: { sub: mockSubject },
+    });
+    await expect(
+      jwksTokenHandler.verifyToken(matching, context),
+    ).resolves.toEqual({
+      subject: `external:custom-prefix:${mockSubject}`,
+    });
+
+    // Same valid issuer/audience, but a `sub` that is not in the allowed set.
+    const wrongSubject = await factory.issueToken({
+      claims: { sub: 'someone_else' },
+    });
+    await expect(
+      jwksTokenHandler.verifyToken(wrongSubject, context),
+    ).resolves.toBeUndefined();
   });
 });

--- a/packages/backend-defaults/src/entrypoints/auth/external/jwks.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/external/jwks.ts
@@ -40,25 +40,26 @@ type JWKSTokenContext = {
 const readClaimAllowedValues = (value: unknown): string[] | undefined => {
   const rawValues = Array.isArray(value) ? value : [value];
 
-  const values = [
-    ...new Set(
-      rawValues
-        .map(rawValue => {
-          if (typeof rawValue === 'string') {
-            return rawValue;
-          }
+  const values: string[] = [];
+  for (const rawValue of rawValues) {
+    if (typeof rawValue === 'string') {
+      if (rawValue.length === 0) {
+        return undefined;
+      }
+      values.push(rawValue);
+      continue;
+    }
 
-          if (typeof rawValue === 'number' || typeof rawValue === 'boolean') {
-            return String(rawValue);
-          }
+    if (typeof rawValue === 'number' || typeof rawValue === 'boolean') {
+      values.push(String(rawValue));
+      continue;
+    }
 
-          return undefined;
-        })
-        .filter((rawValue): rawValue is string => Boolean(rawValue)),
-    ),
-  ];
+    return undefined;
+  }
 
-  return values.length ? values : undefined;
+  const deduped = [...new Set(values)];
+  return deduped.length ? deduped : undefined;
 };
 
 // Normalizes a verified JWT claim value into the set of values it satisfies:

--- a/packages/backend-defaults/src/entrypoints/auth/external/jwks.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/external/jwks.ts
@@ -63,13 +63,15 @@ const readClaimAllowedValues = (value: unknown): string[] | undefined => {
 };
 
 // Normalizes a verified JWT claim value into the set of values it satisfies:
-// the value itself, plus - for a space-delimited string (e.g. OAuth `scope`)
-// or an array - each of its entries, all by their string form.
-const claimValues = (claimValue: unknown): Set<string> => {
+// the value itself, plus each entry of an array claim.
+//
+// Note: `scope` is the only claim the OAuth2/JWT RFCs (RFC 6749 §3.3,
+// RFC 8693 §4.2, RFC 9068 §2.2.3) define as space-delimited.
+const claimValues = (claim: string, claimValue: unknown): Set<string> => {
   let values: unknown[];
   if (Array.isArray(claimValue)) {
     values = claimValue;
-  } else if (typeof claimValue === 'string') {
+  } else if (claim === 'scope' && typeof claimValue === 'string') {
     values = [claimValue, ...claimValue.split(' ')];
   } else {
     values = [claimValue];
@@ -150,7 +152,7 @@ export const jwksTokenHandler = createExternalTokenHandler<JWKSTokenContext>({
       const { sub } = payload;
       if (sub) {
         const allClaimsMatch = context.claims.every(({ claim, anyOf }) => {
-          const actual = claimValues(payload[claim]);
+          const actual = claimValues(claim, payload[claim]);
           return anyOf.some(required => actual.has(required));
         });
         if (!allClaimsMatch) {

--- a/packages/backend-defaults/src/entrypoints/auth/external/jwks.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/external/jwks.ts
@@ -30,6 +30,60 @@ type JWKSTokenContext = {
   url: URL;
   jwks: JWTVerifyGetKey;
   allAccessRestrictions?: AccessRestrictionsMap;
+  claims: Array<{ claim: string; anyOf: string[] }>;
+};
+
+// Normalizes a configured `claims` value into a deduped list of allowed
+// string values. Each string/number/boolean is one exact allowed value; use
+// an array for multiple. Works off an already-extracted raw value rather
+// than a `Config` key lookup (see the call site in `initialize`).
+const readClaimAllowedValues = (value: unknown): string[] | undefined => {
+  const rawValues = Array.isArray(value) ? value : [value];
+
+  const values = [
+    ...new Set(
+      rawValues
+        .map(rawValue => {
+          if (typeof rawValue === 'string') {
+            return rawValue;
+          }
+
+          if (typeof rawValue === 'number' || typeof rawValue === 'boolean') {
+            return String(rawValue);
+          }
+
+          return undefined;
+        })
+        .filter((rawValue): rawValue is string => Boolean(rawValue)),
+    ),
+  ];
+
+  return values.length ? values : undefined;
+};
+
+// Normalizes a verified JWT claim value into the set of values it satisfies:
+// the value itself, plus - for a space-delimited string (e.g. OAuth `scope`)
+// or an array - each of its entries, all by their string form.
+const claimValues = (claimValue: unknown): Set<string> => {
+  let values: unknown[];
+  if (Array.isArray(claimValue)) {
+    values = claimValue;
+  } else if (typeof claimValue === 'string') {
+    values = [claimValue, ...claimValue.split(' ')];
+  } else {
+    values = [claimValue];
+  }
+
+  return new Set(
+    values
+      .filter(
+        value =>
+          typeof value === 'string' ||
+          typeof value === 'number' ||
+          typeof value === 'boolean',
+      )
+      .map(String),
+  );
 };
 
 export const jwksTokenHandler = createExternalTokenHandler<JWKSTokenContext>({
@@ -48,6 +102,30 @@ export const jwksTokenHandler = createExternalTokenHandler<JWKSTokenContext>({
     const url = new URL(options.getString('url'));
     const jwks = createRemoteJWKSet(url);
     const allAccessRestrictions = readAccessRestrictionsFromConfig(options);
+
+    // Claim names are arbitrary strings and commonly namespaced with dots or
+    // slashes (e.g. `example.com/team` or an Auth0-style
+    // `https://example.com/claim`). They therefore can't be looked up via
+    // `Config.get(key)`, which always splits `key` on `.` as a path and rejects
+    // `/`. Reading the whole `claims` block once as a raw value (a no-argument
+    // `.get()` skips path splitting) and iterating it with plain property
+    // access avoids that.
+    const claimsConfig = options.getOptionalConfig('claims');
+    const claims = claimsConfig
+      ? Object.entries(claimsConfig.get<Record<string, unknown>>()).map(
+          ([claim, value]) => {
+            const anyOf = readClaimAllowedValues(value);
+            if (!anyOf) {
+              throw new Error(
+                `Invalid value for 'claims.${claim}' in JWKS external access config, expected a non-empty string, number, boolean, or array of those`,
+              );
+            }
+
+            return { claim, anyOf };
+          },
+        )
+      : [];
+
     return {
       algorithms,
       audiences,
@@ -56,20 +134,28 @@ export const jwksTokenHandler = createExternalTokenHandler<JWKSTokenContext>({
       subjectPrefix,
       url,
       allAccessRestrictions,
+      claims,
     };
   },
 
   async verifyToken(token: string, context: JWKSTokenContext) {
     try {
-      const {
-        payload: { sub },
-      } = await jwtVerify(token, context.jwks, {
+      const { payload } = await jwtVerify(token, context.jwks, {
         algorithms: context.algorithms,
         issuer: context.issuers,
         audience: context.audiences,
       });
 
+      const { sub } = payload;
       if (sub) {
+        const allClaimsMatch = context.claims.every(({ claim, anyOf }) => {
+          const actual = claimValues(payload[claim]);
+          return anyOf.some(required => actual.has(required));
+        });
+        if (!allClaimsMatch) {
+          return undefined;
+        }
+
         const prefix = context.subjectPrefix
           ? `external:${context.subjectPrefix}:`
           : 'external:';
@@ -80,6 +166,7 @@ export const jwksTokenHandler = createExternalTokenHandler<JWKSTokenContext>({
     } catch {
       return undefined;
     }
+
     return undefined;
   },
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds an optional `claims` option to the built-in `jwks` external access handler, letting operators restrict callers based on JWT claim values (exact match, or one-of-array; AND across claims).

Implements #25409. Also addresses #30806 (restricting by `sub`/`oid`), which this generalizes to any claim.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))