### PR TITLE
fix(catalog-graph): correct mobile layout overlapping issues

### DIFF
--- a/.changeset/fix-catalog-graph-mobile-layout.md
+++ b/.changeset/fix-catalog-graph-mobile-layout.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-graph': patch
+---
+
+Fixed an issue where the catalog graph legend and filters would overlap on mobile screens by correcting the flex layout to properly stack and scroll.

--- a/plugins/catalog-graph/src/components/CatalogGraphPage/CatalogGraphPage.tsx
+++ b/plugins/catalog-graph/src/components/CatalogGraphPage/CatalogGraphPage.tsx
@@ -27,7 +27,7 @@ import {
   entityPresentationSnapshot,
   entityRouteRef,
 } from '@backstage/plugin-catalog-react';
-import Grid from '@material-ui/core/Grid';
+
 import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
@@ -67,14 +67,23 @@ const useStyles = makeStyles(
       minHeight: 0,
     },
     container: {
-      height: '100%',
-      maxHeight: '100%',
+      display: 'flex',
+      flexDirection: 'column',
       minHeight: 0,
+      [theme.breakpoints.up('lg')]: {
+        flexDirection: 'row',
+        height: '100%',
+        maxHeight: '100%',
+      },
     },
     fullHeight: {
-      maxHeight: '100%',
       display: 'flex',
-      minHeight: 0,
+      flex: 1,
+      minHeight: '50vh',
+      [theme.breakpoints.up('lg')]: {
+        maxHeight: '100%',
+        minHeight: 0,
+      },
     },
     graphWrapper: {
       position: 'relative',
@@ -99,8 +108,13 @@ const useStyles = makeStyles(
       display: 'grid',
       gridGap: theme.spacing(1),
       gridAutoRows: 'auto',
+      flexShrink: 0,
+      marginBottom: theme.spacing(2),
       [theme.breakpoints.up('lg')]: {
         display: 'block',
+        width: '16.666667%',
+        marginBottom: 0,
+        paddingRight: theme.spacing(2),
       },
       [theme.breakpoints.only('md')]: {
         gridTemplateColumns: 'repeat(3, 1fr)',
@@ -205,9 +219,9 @@ export const CatalogGraphPage = (
             {t('catalogGraphPage.supportButtonDescription')}
           </SupportButton>
         </ContentHeader>
-        <Grid container alignItems="stretch" className={classes.container}>
+        <div className={classes.container}>
           {showFilters && (
-            <Grid item xs={12} lg={2} className={classes.filters}>
+            <div className={classes.filters}>
               <MaxDepthFilter value={maxDepth} onChange={setMaxDepth} />
               <SelectedKindsFilter
                 value={selectedKinds}
@@ -229,9 +243,9 @@ export const CatalogGraphPage = (
                 onChange={setMergeRelations}
                 label={t('catalogGraphPage.mergeRelationsSwitchLabel')}
               />
-            </Grid>
+            </div>
           )}
-          <Grid item xs className={classes.fullHeight}>
+          <div className={classes.fullHeight}>
             <Paper className={classes.graphWrapper}>
               <Typography
                 variant="caption"
@@ -268,8 +282,8 @@ export const CatalogGraphPage = (
                 curve={curve}
               />
             </Paper>
-          </Grid>
-        </Grid>
+          </div>
+        </div>
       </Content>
     </Page>
   );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #34847

This PR fixes a responsive layout issue in `@backstage/plugin-catalog-graph` where the legend text overlaps with the filters panel on mobile screens. 

## Screenshot

<img width="330" height="717" alt="Screenshot 2026-07-14 at 6 21 10 AM" src="https://github.com/user-attachments/assets/d54be3be-eb5e-4372-b483-bf38d657922c" />


**Changes made:**
- Removed the strict `maxHeight: '100%'` constraint on the graph container for mobile screens to allow scrolling.
- Replaced the Material-UI `<Grid>` components with standard `<div>` wrappers inside `CatalogGraphPage` to prevent default `flex-direction: row` injections from overriding mobile column layouts.
- Added a `minHeight: '50vh'` to the graph canvas wrapper on small screens so it renders cleanly below the filters instead of squishing to `0` height.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))