### PR TITLE
chore: clean up released patch files

### DIFF
--- a/.patches/pr-34702.txt
+++ b/.patches/pr-34702.txt
@@ -1,1 +1,0 @@
-Fix scheduler tasks stuck with NULL next_run_start_at when switching from manual trigger to cadence


### PR DESCRIPTION
Removes patch files that have already been included in a release.

- pr-34702.txt