### PR TITLE
docs(ui): add scrolling and error examples to TextAreaField page

### DIFF
--- a/docs-ui/src/app/components/text-area-field/components.tsx
+++ b/docs-ui/src/app/components/text-area-field/components.tsx
@@ -2,6 +2,7 @@
 
 import { TextAreaField } from '../../../../../packages/ui/src/components/TextAreaField/TextAreaField';
 import { Flex } from '../../../../../packages/ui/src/components/Flex/Flex';
+import { Form } from 'react-aria-components';
 
 export const WithLabel = () => {
   return (
@@ -46,5 +47,33 @@ export const WithDescription = () => {
       description="Share as much detail as you like."
       style={{ maxWidth: '300px' }}
     />
+  );
+};
+
+export const Scrolling = () => {
+  return (
+    <TextAreaField
+      name="message"
+      label="Message"
+      rows={3}
+      defaultValue={Array.from(
+        { length: 12 },
+        (_, i) => `Line ${i + 1}: this content scrolls within a fixed height.`,
+      ).join('\n')}
+      style={{ maxWidth: '300px' }}
+    />
+  );
+};
+
+export const ShowError = () => {
+  return (
+    <Form validationErrors={{ message: 'Message is required' }}>
+      <TextAreaField
+        name="message"
+        placeholder="Enter a message"
+        label="Message"
+        style={{ maxWidth: '300px' }}
+      />
+    </Form>
   );
 };

--- a/docs-ui/src/app/components/text-area-field/page.mdx
+++ b/docs-ui/src/app/components/text-area-field/page.mdx
@@ -6,8 +6,16 @@ import {
   withLabelSnippet,
   sizesSnippet,
   withDescriptionSnippet,
+  scrollingSnippet,
+  showErrorSnippet,
 } from './snippets';
-import { WithLabel, Sizes, WithDescription } from './components';
+import {
+  WithLabel,
+  Sizes,
+  WithDescription,
+  Scrolling,
+  ShowError,
+} from './components';
 import { PageTitle } from '@/components/PageTitle';
 import { Theming } from '@/components/Theming';
 import { TextAreaFieldDefinition } from '../../../utils/definitions';
@@ -62,6 +70,28 @@ export const reactAriaUrls = {
   open
   preview={<WithDescription />}
   code={withDescriptionSnippet}
+  layout="side-by-side"
+/>
+
+### Scrolling
+
+<Snippet
+  align="center"
+  py={4}
+  open
+  preview={<Scrolling />}
+  code={scrollingSnippet}
+  layout="side-by-side"
+/>
+
+### Show error
+
+<Snippet
+  align="center"
+  py={4}
+  open
+  preview={<ShowError />}
+  code={showErrorSnippet}
   layout="side-by-side"
 />
 

--- a/docs-ui/src/app/components/text-area-field/snippets.ts
+++ b/docs-ui/src/app/components/text-area-field/snippets.ts
@@ -19,3 +19,21 @@ export const withDescriptionSnippet = `<TextAreaField
   label="Message"
   description="Share as much detail as you like."
 />`;
+
+export const scrollingSnippet = `<TextAreaField
+  name="message"
+  label="Message"
+  rows={3}
+  defaultValue={Array.from(
+    { length: 12 },
+    (_, i) => \`Line \${i + 1}: this content scrolls within a fixed height.\`,
+  ).join('\\n')}
+/>`;
+
+export const showErrorSnippet = `<Form validationErrors={{ message: 'Message is required' }}>
+  <TextAreaField
+    name="message"
+    placeholder="Enter a message"
+    label="Message"
+  />
+</Form>`;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

 Updating the documentation for the Textfield. The scrolling and error functionality were already implemented, but the documentation was missing. I've now added it.

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
