### PR TITLE
feat(kubernetes): add clusterLocatorContinueOnError config option

### DIFF
--- a/.changeset/resilient-cluster-supplier.md
+++ b/.changeset/resilient-cluster-supplier.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-kubernetes-backend': patch
 ---
 
-Added a `kubernetes.clusterLocatorContinueOnError` configuration option. When set to `true`, a failing cluster locator no longer causes the entire cluster list to be empty — errors are logged and clusters from the remaining successful locators are still returned. The default is `false`, preserving the existing behavior.
+Added a `kubernetes.clusterLocatorContinueOnError` configuration option. When set to `true`, a failing cluster locator no longer causes the entire cluster list request to fail — errors are logged and clusters from the remaining successful locators are still returned. The default is `false`, preserving the existing behavior.

--- a/.changeset/resilient-cluster-supplier.md
+++ b/.changeset/resilient-cluster-supplier.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Added a `kubernetes.clusterLocatorContinueOnError` configuration option. When set to `true`, a failing cluster locator no longer causes the entire cluster list to be empty — errors are logged and clusters from the remaining successful locators are still returned. The default is `false`, preserving the existing behavior.

--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -128,6 +128,25 @@ Valid values are:
 
 - `catalogRelation` - This configuration assumes that the current component runs only on all clusters it is dependant on.
 
+### `clusterLocatorContinueOnError` (optional)
+
+Controls whether the Kubernetes backend continues returning clusters when one
+or more cluster locators fail. When set to `true`, errors from individual
+locators are logged and clusters from the remaining successful locators are
+still returned. When set to `false` (the default), a single locator failure
+causes the entire cluster list request to fail.
+
+This is useful when you have multiple cluster locators configured and want to
+avoid a problem with one source (for example, a permission error in a single GKE
+project) from blocking all other clusters.
+
+```yaml
+kubernetes:
+  clusterLocatorContinueOnError: true
+```
+
+The default value is `false`.
+
 ### `clusterLocatorMethods`
 
 This is an array used to determine where to retrieve cluster configuration from.

--- a/plugins/kubernetes-backend/config.d.ts
+++ b/plugins/kubernetes-backend/config.d.ts
@@ -35,6 +35,14 @@ export interface Config {
     serviceLocatorMethod: {
       type: 'multiTenant' | 'singleTenant' | 'catalogRelation';
     };
+    /**
+     * Whether to continue returning clusters from successful locators when
+     * one or more locators fail. When set to `true`, errors are logged and
+     * only the clusters from successful locators are returned. Defaults to
+     * `false`, which preserves the existing behaviour of failing the entire
+     * request when any locator errors.
+     */
+    clusterLocatorContinueOnError?: boolean;
     clusterLocatorMethods: Array<
       | {
           /** @visibility frontend */

--- a/plugins/kubernetes-backend/src/cluster-locator/index.test.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/index.test.ts
@@ -176,4 +176,111 @@ describe('getCombinedClusterSupplier', () => {
 
     expect(warn).toHaveBeenCalledWith(`Duplicate cluster name 'cluster'`);
   });
+
+  it('rejects when a supplier fails and continueOnError is not set', async () => {
+    const config = mockServices.rootConfig({
+      data: {
+        kubernetes: {
+          clusterLocatorMethods: [
+            {
+              type: 'config',
+              clusters: [
+                {
+                  name: 'cluster1',
+                  url: 'http://localhost:8080',
+                  authProvider: 'serviceAccount',
+                },
+              ],
+            },
+            { type: 'catalog' },
+          ],
+        },
+      },
+    });
+    const mockStrategy: jest.Mocked<AuthenticationStrategy> = {
+      getCredential: jest.fn(),
+      validateCluster: jest.fn().mockReturnValue([]),
+      presentAuthMetadata: jest.fn(),
+    };
+
+    const catalogMock = catalogServiceMock({
+      entities: [],
+    });
+    catalogMock.getEntities = jest
+      .fn()
+      .mockRejectedValue(new Error('catalog down'));
+
+    const auth = mockServices.auth();
+    const credentials = mockCredentials.user();
+
+    const clusterSupplier = getCombinedClusterSupplier(
+      config,
+      catalogMock,
+      mockStrategy,
+      mockServices.logger.mock(),
+      undefined,
+      auth,
+    );
+
+    await expect(clusterSupplier.getClusters({ credentials })).rejects.toThrow(
+      'catalog down',
+    );
+  });
+
+  it('returns clusters from successful suppliers when continueOnError is true', async () => {
+    const config = mockServices.rootConfig({
+      data: {
+        kubernetes: {
+          clusterLocatorContinueOnError: true,
+          clusterLocatorMethods: [
+            {
+              type: 'config',
+              clusters: [
+                {
+                  name: 'cluster1',
+                  url: 'http://localhost:8080',
+                  authProvider: 'serviceAccount',
+                },
+              ],
+            },
+            { type: 'catalog' },
+          ],
+        },
+      },
+    });
+    const mockStrategy: jest.Mocked<AuthenticationStrategy> = {
+      getCredential: jest.fn(),
+      validateCluster: jest.fn().mockReturnValue([]),
+      presentAuthMetadata: jest.fn(),
+    };
+
+    const catalogMock = catalogServiceMock({
+      entities: [],
+    });
+    catalogMock.getEntities = jest
+      .fn()
+      .mockRejectedValue(new Error('catalog down'));
+
+    const logger = mockServices.logger.mock();
+    const errorSpy = jest.spyOn(logger, 'error');
+    const auth = mockServices.auth();
+    const credentials = mockCredentials.user();
+
+    const clusterSupplier = getCombinedClusterSupplier(
+      config,
+      catalogMock,
+      mockStrategy,
+      logger,
+      undefined,
+      auth,
+    );
+    const result = await clusterSupplier.getClusters({ credentials });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('cluster1');
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Failed to retrieve clusters from supplier',
+      expect.any(Error),
+    );
+  });
 });

--- a/plugins/kubernetes-backend/src/cluster-locator/index.test.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/index.test.ts
@@ -279,7 +279,7 @@ describe('getCombinedClusterSupplier', () => {
     expect(result).toHaveLength(1);
     expect(result[0].name).toBe('cluster1');
     expect(errorSpy).toHaveBeenCalledWith(
-      'Failed to retrieve clusters from supplier',
+      expect.stringContaining('Failed to retrieve clusters from supplier'),
       expect.any(Error),
     );
   });

--- a/plugins/kubernetes-backend/src/cluster-locator/index.test.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/index.test.ts
@@ -279,7 +279,9 @@ describe('getCombinedClusterSupplier', () => {
     expect(result).toHaveLength(1);
     expect(result[0].name).toBe('cluster1');
     expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Failed to retrieve clusters from supplier'),
+      expect.stringContaining(
+        'Failed to retrieve clusters from cluster locator method',
+      ),
       expect.any(Error),
     );
   });

--- a/plugins/kubernetes-backend/src/cluster-locator/index.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/index.ts
@@ -65,13 +65,18 @@ class CombinedClustersSupplier implements KubernetesClustersSupplier {
       this.clusterSuppliers.map(supplier => supplier.getClusters(options)),
     );
     const clusters: ClusterDetails[] = [];
-    for (const result of results) {
+    for (let i = 0; i < results.length; i++) {
+      const result = results[i];
       if (result.status === 'fulfilled') {
         clusters.push(...result.value);
       } else {
+        const reason =
+          result.reason instanceof Error
+            ? result.reason
+            : new Error(String(result.reason));
         this.logger.error(
-          'Failed to retrieve clusters from supplier',
-          result.reason,
+          `Failed to retrieve clusters from supplier at index ${i}`,
+          reason,
         );
       }
     }

--- a/plugins/kubernetes-backend/src/cluster-locator/index.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/index.ts
@@ -35,24 +35,47 @@ import { CatalogService } from '@backstage/plugin-catalog-node';
 class CombinedClustersSupplier implements KubernetesClustersSupplier {
   readonly clusterSuppliers: KubernetesClustersSupplier[];
   readonly logger: LoggerService;
+  readonly continueOnError: boolean;
 
   constructor(
     clusterSuppliers: KubernetesClustersSupplier[],
     logger: LoggerService,
+    continueOnError: boolean = false,
   ) {
     this.clusterSuppliers = clusterSuppliers;
     this.logger = logger;
+    this.continueOnError = continueOnError;
   }
 
   async getClusters(options: {
     credentials: BackstageCredentials;
   }): Promise<ClusterDetails[]> {
-    const clusters = await Promise.all(
-      this.clusterSuppliers.map(supplier => supplier.getClusters(options)),
-    ).then(res => {
-      return res.flat();
-    });
+    const clusters = this.continueOnError
+      ? await this.getClustersSettled(options)
+      : await Promise.all(
+          this.clusterSuppliers.map(supplier => supplier.getClusters(options)),
+        ).then(res => res.flat());
     return this.warnDuplicates(clusters);
+  }
+
+  private async getClustersSettled(options: {
+    credentials: BackstageCredentials;
+  }): Promise<ClusterDetails[]> {
+    const results = await Promise.allSettled(
+      this.clusterSuppliers.map(supplier => supplier.getClusters(options)),
+    );
+    const clusters: ClusterDetails[] = [];
+    for (const result of results) {
+      if (result.status === 'fulfilled') {
+        clusters.push(...result.value);
+      } else {
+        this.logger.error(
+          'Failed to retrieve clusters from supplier',
+          result.reason,
+        );
+      }
+    }
+    return clusters;
   }
 
   private warnDuplicates(clusters: ClusterDetails[]): ClusterDetails[] {
@@ -107,5 +130,13 @@ export const getCombinedClusterSupplier = (
       }
     });
 
-  return new CombinedClustersSupplier(clusterSuppliers, logger);
+  const continueOnError =
+    rootConfig.getOptionalBoolean('kubernetes.clusterLocatorContinueOnError') ??
+    false;
+
+  return new CombinedClustersSupplier(
+    clusterSuppliers,
+    logger,
+    continueOnError,
+  );
 };

--- a/plugins/kubernetes-backend/src/cluster-locator/index.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/index.ts
@@ -15,6 +15,7 @@
  */
 
 import { Config } from '@backstage/config';
+import { toError } from '@backstage/errors';
 import { Duration } from 'luxon';
 import { ConfigClusterLocator } from './ConfigClusterLocator';
 import { GkeClusterLocator } from './GkeClusterLocator';
@@ -70,13 +71,9 @@ class CombinedClustersSupplier implements KubernetesClustersSupplier {
       if (result.status === 'fulfilled') {
         clusters.push(...result.value);
       } else {
-        const reason =
-          result.reason instanceof Error
-            ? result.reason
-            : new Error(String(result.reason));
         this.logger.error(
-          `Failed to retrieve clusters from supplier at index ${i}`,
-          reason,
+          `Failed to retrieve clusters from cluster locator method #${i + 1}`,
+          toError(result.reason),
         );
       }
     }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `CombinedClustersSupplier` uses `Promise.all` to fetch clusters from all configured locators. If any single locator fails (e.g. a GKE project with a permission error), the entire cluster list is empty — no clusters are returned for any locator.

This adds a new `kubernetes.clusterLocatorContinueOnError` config option. When set to `true`, `Promise.allSettled` is used instead so that errors are logged per-supplier and clusters from the remaining successful locators are still returned. The default is `false`, preserving the existing fail-fast behaviour.

**Example config:**
```yaml
kubernetes:
  clusterLocatorContinueOnError: true
  clusterLocatorMethods:
    - type: gke
      projectId: project-a
    - type: gke
      projectId: project-b
```

If `project-b` fails, clusters from `project-a` are still returned and the error is logged.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))