### PR TITLE
config-loader: add TypeScript schema error recovery

### DIFF
--- a/.changeset/config-schema-strict-flag.md
+++ b/.changeset/config-schema-strict-flag.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/cli-module-config': minor
+'@backstage/cli-module-config': patch
 ---
 
 The `--strict` flag for `config:check` now treats TypeScript configuration schema errors as fatal. The same flag is now also available for `config:schema`.

--- a/.changeset/config-schema-strict-flag.md
+++ b/.changeset/config-schema-strict-flag.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli-module-config': minor
+---
+
+The `--strict` flag for `config:check` now treats TypeScript configuration schema errors as fatal. The same flag is now also available for `config:schema`.

--- a/.changeset/log-schema-warnings.md
+++ b/.changeset/log-schema-warnings.md
@@ -1,0 +1,6 @@
+---
+'@backstage/backend-defaults': patch
+'@backstage/backend-dynamic-feature-service': patch
+---
+
+TypeScript configuration schema warnings discovered while setting up secret redaction are now reported through the Backstage logger.

--- a/.changeset/quiet-schema-warnings.md
+++ b/.changeset/quiet-schema-warnings.md
@@ -2,4 +2,4 @@
 '@backstage/config-loader': patch
 ---
 
-Added an `onSchemaError` callback that allows callers to report TypeScript configuration schema errors and continue loading. Without a handler, schema errors are thrown.
+Added an `onSchemaError` callback that allows callers to report TypeScript configuration schema errors and continue loading. The callback receives a `ConfigSchemaError` containing the source package, relative file path, and underlying cause. Without a handler, schema errors are thrown.

--- a/.changeset/quiet-schema-warnings.md
+++ b/.changeset/quiet-schema-warnings.md
@@ -2,4 +2,4 @@
 '@backstage/config-loader': patch
 ---
 
-Added an `onSchemaError` callback that allows callers to report TypeScript configuration schema errors and continue loading. The callback receives a `ConfigSchemaError` containing the source package, relative file path, and underlying cause. Without a handler, schema errors are thrown.
+Added an `onSchemaError` callback that allows callers to report TypeScript configuration schema errors and continue loading. The callback receives a `ConfigSchemaError` containing the source package and underlying cause. Without a handler, schema errors are thrown.

--- a/.changeset/quiet-schema-warnings.md
+++ b/.changeset/quiet-schema-warnings.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/config-loader': minor
+'@backstage/config-loader': patch
 ---
 
 Added an `onSchemaError` callback that allows callers to report TypeScript configuration schema errors and continue loading. Without a handler, schema errors are thrown.

--- a/.changeset/quiet-schema-warnings.md
+++ b/.changeset/quiet-schema-warnings.md
@@ -1,0 +1,5 @@
+---
+'@backstage/config-loader': minor
+---
+
+TypeScript configuration schema errors are now reported as warnings while a best-effort schema is generated. Set `schemaErrorMode` to `'error'` to retain strict loading, and use `onSchemaError` to route warnings to a custom handler.

--- a/.changeset/quiet-schema-warnings.md
+++ b/.changeset/quiet-schema-warnings.md
@@ -2,4 +2,4 @@
 '@backstage/config-loader': minor
 ---
 
-TypeScript configuration schema errors are now reported as warnings while a best-effort schema is generated. Set `schemaErrorMode` to `'error'` to retain strict loading, and use `onSchemaError` to route warnings to a custom handler.
+Added an `onSchemaError` callback that allows callers to report TypeScript configuration schema errors and continue loading. Without a handler, schema errors are thrown.

--- a/.changeset/strict-schema-artifacts.md
+++ b/.changeset/strict-schema-artifacts.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli-module-build': patch
+---
+
+Frontend builds and packaged or bundled plugins continue to validate TypeScript configuration schemas strictly, preventing invalid schemas from being included in production artifacts.

--- a/.changeset/strict-schema-artifacts.md
+++ b/.changeset/strict-schema-artifacts.md
@@ -2,4 +2,4 @@
 '@backstage/cli-module-build': patch
 ---
 
-Frontend builds and packaged or bundled plugins continue to validate TypeScript configuration schemas strictly, preventing invalid schemas from being included in production artifacts.
+Package preparation for publishing validates TypeScript configuration schemas strictly, preventing invalid schemas from being published. Other build and bundle paths report schema errors as warnings.

--- a/.patches/pr-34862.txt
+++ b/.patches/pr-34862.txt
@@ -1,1 +1,1 @@
-Warn on TypeScript configuration schema errors by default while keeping production artifact generation strict
+Allow callers to warn and continue on TypeScript configuration schema errors while keeping strict loading by default

--- a/.patches/pr-34862.txt
+++ b/.patches/pr-34862.txt
@@ -1,0 +1,1 @@
+Warn on TypeScript configuration schema errors by default while keeping production artifact generation strict

--- a/.patches/pr-34862.txt
+++ b/.patches/pr-34862.txt
@@ -1,1 +1,1 @@
-Allow callers to warn and continue on TypeScript configuration schema errors while keeping strict loading by default
+Errors in TypeScript configuration schema definitions no longer prevent apps from building or starting and are logged as warnings instead

--- a/packages/backend-defaults/src/entrypoints/rootConfig/createConfigSecretEnumerator.ts
+++ b/packages/backend-defaults/src/entrypoints/rootConfig/createConfigSecretEnumerator.ts
@@ -31,6 +31,7 @@ export async function createConfigSecretEnumerator(options: {
     options.schema ??
     (await loadConfigSchema({
       dependencies: packages.map(p => p.packageJson.name),
+      onSchemaError: error => logger.warn(error.message),
     }));
 
   return (config: Config) => {

--- a/packages/backend-dynamic-feature-service/src/schemas/rootLogger.ts
+++ b/packages/backend-dynamic-feature-service/src/schemas/rootLogger.ts
@@ -63,6 +63,7 @@ const dynamicPluginsRootLoggerServiceFactoryWithOptions = (
         dependencies: (
           await getPackages(process.cwd())
         ).packages.map(p => p.packageJson.name),
+        onSchemaError: error => logger.warn(error.message),
       });
 
       const secretEnumerator = await createConfigSecretEnumerator({

--- a/packages/cli-module-build/src/commands/package/bundle/command.test.ts
+++ b/packages/cli-module-build/src/commands/package/bundle/command.test.ts
@@ -939,6 +939,12 @@ describe('bundle command', () => {
 
         await bundleCommand(defaultOpts);
 
+        expect(mockLoadConfigSchema).toHaveBeenCalledWith({
+          dependencies: [],
+          packagePaths: ['package.json'],
+          onSchemaError: expect.any(Function),
+        });
+
         const pkg = await fs.readJson(joinPath(ctx.targetDir, 'package.json'));
         expect(pkg.configSchema).toBe('dist/.config-schema.json');
         const schemaFile = await fs.readJson(

--- a/packages/cli-module-build/src/commands/package/bundle/command.ts
+++ b/packages/cli-module-build/src/commands/package/bundle/command.ts
@@ -434,7 +434,6 @@ export async function bundleCommand(opts: BundleOptions): Promise<void> {
     const configSchema = await loadConfigSchema({
       dependencies: [],
       packagePaths: ['package.json'],
-      schemaErrorMode: 'error',
     });
     const serialized = configSchema.serialize() as {
       schemas: typeof schemas;

--- a/packages/cli-module-build/src/commands/package/bundle/command.ts
+++ b/packages/cli-module-build/src/commands/package/bundle/command.ts
@@ -434,6 +434,7 @@ export async function bundleCommand(opts: BundleOptions): Promise<void> {
     const configSchema = await loadConfigSchema({
       dependencies: [],
       packagePaths: ['package.json'],
+      schemaErrorMode: 'error',
     });
     const serialized = configSchema.serialize() as {
       schemas: typeof schemas;

--- a/packages/cli-module-build/src/commands/package/bundle/command.ts
+++ b/packages/cli-module-build/src/commands/package/bundle/command.ts
@@ -434,6 +434,7 @@ export async function bundleCommand(opts: BundleOptions): Promise<void> {
     const configSchema = await loadConfigSchema({
       dependencies: [],
       packagePaths: ['package.json'],
+      onSchemaError: error => console.warn(error.message),
     });
     const serialized = configSchema.serialize() as {
       schemas: typeof schemas;

--- a/packages/cli-module-build/src/lib/buildFrontend.ts
+++ b/packages/cli-module-build/src/lib/buildFrontend.ts
@@ -46,6 +46,7 @@ export async function buildFrontend(options: BuildAppOptions) {
     ...(await loadCliConfig({
       args: configPaths,
       fromPackage: packageJson.name,
+      schemaErrorMode: 'error',
     })),
     webpack,
   });

--- a/packages/cli-module-build/src/lib/buildFrontend.ts
+++ b/packages/cli-module-build/src/lib/buildFrontend.ts
@@ -46,7 +46,6 @@ export async function buildFrontend(options: BuildAppOptions) {
     ...(await loadCliConfig({
       args: configPaths,
       fromPackage: packageJson.name,
-      schemaErrorMode: 'error',
     })),
     webpack,
   });

--- a/packages/cli-module-build/src/lib/bundler/server.ts
+++ b/packages/cli-module-build/src/lib/bundler/server.ts
@@ -82,7 +82,6 @@ DEPRECATION WARNING: React Router Beta is deprecated and support for it will be 
     targetDir: options.targetDir,
     fromPackage: name,
     withFilteredKeys: true,
-    onSchemaError: error => console.warn(error.message),
     watch(appConfigs) {
       latestFrontendAppConfigs = appConfigs;
 

--- a/packages/cli-module-build/src/lib/bundler/server.ts
+++ b/packages/cli-module-build/src/lib/bundler/server.ts
@@ -82,6 +82,7 @@ DEPRECATION WARNING: React Router Beta is deprecated and support for it will be 
     targetDir: options.targetDir,
     fromPackage: name,
     withFilteredKeys: true,
+    onSchemaError: error => console.warn(error.message),
     watch(appConfigs) {
       latestFrontendAppConfigs = appConfigs;
 

--- a/packages/cli-module-build/src/lib/config.ts
+++ b/packages/cli-module-build/src/lib/config.ts
@@ -28,6 +28,7 @@ type Options = {
   fromPackage?: string;
   withFilteredKeys?: boolean;
   watch?: (newFrontendAppConfigs: AppConfig[]) => void;
+  schemaErrorMode?: 'warn' | 'error';
 };
 
 export async function loadCliConfig(options: Options) {
@@ -58,6 +59,7 @@ export async function loadCliConfig(options: Options) {
   const schema = await loadConfigSchema({
     dependencies: localPackageNames,
     packagePaths: [targetPaths.resolveRoot('package.json')],
+    schemaErrorMode: options.schemaErrorMode,
   });
 
   const source = ConfigSources.default({

--- a/packages/cli-module-build/src/lib/config.ts
+++ b/packages/cli-module-build/src/lib/config.ts
@@ -28,7 +28,6 @@ type Options = {
   fromPackage?: string;
   withFilteredKeys?: boolean;
   watch?: (newFrontendAppConfigs: AppConfig[]) => void;
-  onSchemaError?: (error: Error) => void;
 };
 
 export async function loadCliConfig(options: Options) {
@@ -59,7 +58,7 @@ export async function loadCliConfig(options: Options) {
   const schema = await loadConfigSchema({
     dependencies: localPackageNames,
     packagePaths: [targetPaths.resolveRoot('package.json')],
-    onSchemaError: options.onSchemaError,
+    onSchemaError: error => console.warn(error.message),
   });
 
   const source = ConfigSources.default({

--- a/packages/cli-module-build/src/lib/config.ts
+++ b/packages/cli-module-build/src/lib/config.ts
@@ -28,7 +28,7 @@ type Options = {
   fromPackage?: string;
   withFilteredKeys?: boolean;
   watch?: (newFrontendAppConfigs: AppConfig[]) => void;
-  schemaErrorMode?: 'warn' | 'error';
+  onSchemaError?: (error: Error) => void;
 };
 
 export async function loadCliConfig(options: Options) {
@@ -59,7 +59,7 @@ export async function loadCliConfig(options: Options) {
   const schema = await loadConfigSchema({
     dependencies: localPackageNames,
     packagePaths: [targetPaths.resolveRoot('package.json')],
-    schemaErrorMode: options.schemaErrorMode,
+    onSchemaError: options.onSchemaError,
   });
 
   const source = ConfigSources.default({

--- a/packages/cli-module-build/src/lib/packager/createDistWorkspace.ts
+++ b/packages/cli-module-build/src/lib/packager/createDistWorkspace.ts
@@ -326,7 +326,9 @@ async function moveToDistWorkspace(
       FAST_PACK_SCRIPTS.includes(pkg.packageJson.scripts?.prepack),
   );
 
-  const configSchemas = await compilePackageConfigSchemas(fastPackPackages);
+  const configSchemas = await compilePackageConfigSchemas(fastPackPackages, {
+    onSchemaError: error => logger.warn(error.message),
+  });
   const featureDetectionProject =
     fastPackPackages.length > 0 && enableFeatureDetection
       ? await createTypeDistProject()

--- a/packages/cli-module-build/src/lib/packager/productionPack.test.ts
+++ b/packages/cli-module-build/src/lib/packager/productionPack.test.ts
@@ -195,4 +195,27 @@ describe('productionPack', () => {
       properties: { b: { type: 'number' } },
     });
   });
+
+  it('should reject invalid TypeScript schemas during package preparation', async () => {
+    mockDir.setContent({
+      package: {
+        'package.json': JSON.stringify(packageJson),
+        'config.d.ts': `
+          import { Missing } from './missing';
+          export interface Config { value?: Missing }
+        `,
+      },
+    });
+    process.chdir(mockDir.path);
+
+    await expect(
+      compilePackageConfigSchemas([
+        {
+          name: packageJson.name,
+          dir: mockDir.resolve('package'),
+          packageJson,
+        },
+      ]),
+    ).rejects.toThrow("Cannot find module './missing'");
+  });
 });

--- a/packages/cli-module-build/src/lib/packager/productionPack.test.ts
+++ b/packages/cli-module-build/src/lib/packager/productionPack.test.ts
@@ -218,4 +218,39 @@ describe('productionPack', () => {
       ]),
     ).rejects.toThrow("Cannot find module './missing'");
   });
+
+  it('should handle invalid TypeScript schemas when preparing a bundle', async () => {
+    mockDir.setContent({
+      package: {
+        'package.json': JSON.stringify(packageJson),
+        'config.d.ts': `
+          export interface Config { value?: Missing }
+        `,
+      },
+    });
+    process.chdir(mockDir.path);
+
+    const onSchemaError = jest.fn();
+    const schemas = await compilePackageConfigSchemas(
+      [
+        {
+          name: packageJson.name,
+          dir: mockDir.resolve('package'),
+          packageJson,
+        },
+      ],
+      { onSchemaError },
+    );
+
+    expect(onSchemaError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("Cannot find name 'Missing'"),
+      }),
+    );
+    expect(schemas.get(packageJson.name)).toEqual({
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      type: 'object',
+      properties: { value: {} },
+    });
+  });
 });

--- a/packages/cli-module-build/src/lib/packager/productionPack.ts
+++ b/packages/cli-module-build/src/lib/packager/productionPack.ts
@@ -97,6 +97,7 @@ export async function compilePackageConfigSchemas(
       result.set(entry.packageName, entry.value);
     }
   }
+  // Use an unconstrained fallback so productionPack doesn't retry omitted schemas in strict mode.
   if (options.onSchemaError) {
     for (const { name } of schemaPackages) {
       if (!result.has(name)) {

--- a/packages/cli-module-build/src/lib/packager/productionPack.ts
+++ b/packages/cli-module-build/src/lib/packager/productionPack.ts
@@ -42,6 +42,10 @@ interface ProductionPackOptions {
 
 type ConfigSchemaValue = Record<string, unknown>;
 
+type CompilePackageConfigSchemasOptions = {
+  onSchemaError?: (error: Error) => void;
+};
+
 type PackageJsonWithConfigSchema = BackstagePackageJson & {
   configSchema?: string | ConfigSchemaValue;
 };
@@ -55,6 +59,7 @@ function getTypeScriptConfigSchemaPath(pkg: BackstagePackageJson) {
 
 export async function compilePackageConfigSchemas(
   packages: Pick<PackageGraphNode, 'name' | 'dir' | 'packageJson'>[],
+  options: CompilePackageConfigSchemasOptions = {},
 ) {
   const schemaPackages = packages.flatMap(pkg => {
     const schemaPath = getTypeScriptConfigSchemaPath(pkg.packageJson);
@@ -70,6 +75,7 @@ export async function compilePackageConfigSchemas(
       resolvePath(pkg.dir, 'package.json'),
     ),
     excludePackageDependencies: true,
+    onSchemaError: options.onSchemaError,
   });
   const serialized = schema.serialize() as {
     schemas: Array<{
@@ -88,6 +94,13 @@ export async function compilePackageConfigSchemas(
       resolvePath(process.cwd(), entry.path)
     ) {
       result.set(entry.packageName, entry.value);
+    }
+  }
+  if (options.onSchemaError) {
+    for (const { name } of schemaPackages) {
+      if (!result.has(name)) {
+        result.set(name, {});
+      }
     }
   }
   return result;

--- a/packages/cli-module-build/src/lib/packager/productionPack.ts
+++ b/packages/cli-module-build/src/lib/packager/productionPack.ts
@@ -19,6 +19,7 @@ import npmPackList from 'npm-packlist';
 import { resolve as resolvePath, posix as posixPath } from 'node:path';
 import { BackstagePackageJson, PackageGraphNode } from '@backstage/cli-node';
 import { loadConfigSchema } from '@backstage/config-loader';
+import type { ConfigSchemaError } from '@backstage/config-loader';
 import { readEntryPoints } from '../entryPoints';
 import { getEntryPointDefaultFeatureType } from '../typeDistProject';
 import { Project } from 'ts-morph';
@@ -43,7 +44,7 @@ interface ProductionPackOptions {
 type ConfigSchemaValue = Record<string, unknown>;
 
 type CompilePackageConfigSchemasOptions = {
-  onSchemaError?: (error: Error) => void;
+  onSchemaError?: (error: ConfigSchemaError) => void;
 };
 
 type PackageJsonWithConfigSchema = BackstagePackageJson & {

--- a/packages/cli-module-build/src/lib/packager/productionPack.ts
+++ b/packages/cli-module-build/src/lib/packager/productionPack.ts
@@ -70,6 +70,7 @@ export async function compilePackageConfigSchemas(
       resolvePath(pkg.dir, 'package.json'),
     ),
     excludePackageDependencies: true,
+    schemaErrorMode: 'error',
   });
   const serialized = schema.serialize() as {
     schemas: Array<{

--- a/packages/cli-module-build/src/lib/packager/productionPack.ts
+++ b/packages/cli-module-build/src/lib/packager/productionPack.ts
@@ -70,7 +70,6 @@ export async function compilePackageConfigSchemas(
       resolvePath(pkg.dir, 'package.json'),
     ),
     excludePackageDependencies: true,
-    schemaErrorMode: 'error',
   });
   const serialized = schema.serialize() as {
     schemas: Array<{

--- a/packages/cli-module-config/cli-report.md
+++ b/packages/cli-module-config/cli-report.md
@@ -54,6 +54,7 @@ Options:
   --format <string>
   --merge
   --package <string>
+  --strict
   -h, --help
 ```
 
@@ -106,5 +107,6 @@ Options:
   --format <string>
   --merge
   --package <string>
+  --strict
   -h, --help
 ```

--- a/packages/cli-module-config/src/commands/schema.ts
+++ b/packages/cli-module-config/src/commands/schema.ts
@@ -24,7 +24,7 @@ import type { CliCommandContext } from '@backstage/cli-node';
 
 export default async ({ args, info }: CliCommandContext) => {
   const {
-    flags: { merge, format, package: pkg },
+    flags: { merge, format, package: pkg, strict },
   } = cli(
     {
       name: info.usage,
@@ -36,6 +36,10 @@ export default async ({ args, info }: CliCommandContext) => {
           type: Boolean,
           description: 'Merge all schemas into a single schema',
         },
+        strict: {
+          type: Boolean,
+          description: 'Treat TypeScript configuration schema errors as fatal',
+        },
       },
     },
     undefined,
@@ -46,6 +50,7 @@ export default async ({ args, info }: CliCommandContext) => {
     args: [],
     fromPackage: pkg,
     mockEnv: true,
+    strict,
   });
 
   let configSchema: JsonObject | JSONSchema;

--- a/packages/cli-module-config/src/lib/config.ts
+++ b/packages/cli-module-config/src/lib/config.ts
@@ -64,6 +64,7 @@ export async function loadCliConfig(options: Options) {
     // Include the package.json in the project root if it exists
     packagePaths: [targetPaths.resolveRoot('package.json')],
     noUndeclaredProperties: options.strict,
+    schemaErrorMode: options.strict ? 'error' : 'warn',
   });
 
   const source = ConfigSources.default({

--- a/packages/cli-module-config/src/lib/config.ts
+++ b/packages/cli-module-config/src/lib/config.ts
@@ -64,7 +64,9 @@ export async function loadCliConfig(options: Options) {
     // Include the package.json in the project root if it exists
     packagePaths: [targetPaths.resolveRoot('package.json')],
     noUndeclaredProperties: options.strict,
-    schemaErrorMode: options.strict ? 'error' : 'warn',
+    onSchemaError: options.strict
+      ? undefined
+      : error => console.warn(error.message),
   });
 
   const source = ConfigSources.default({

--- a/packages/cli/cli-report.md
+++ b/packages/cli/cli-report.md
@@ -235,6 +235,7 @@ Options:
   --format <string>
   --merge
   --package <string>
+  --strict
   -h, --help
 ```
 
@@ -287,6 +288,7 @@ Options:
   --format <string>
   --merge
   --package <string>
+  --strict
   -h, --help
 ```
 

--- a/packages/config-loader/report.api.md
+++ b/packages/config-loader/report.api.md
@@ -46,6 +46,14 @@ export type ConfigSchema = {
 };
 
 // @public
+export class ConfigSchemaError extends Error {
+  constructor(options: { source: string; path: string; cause: Error });
+  readonly cause: Error;
+  readonly path: string;
+  readonly source: string;
+}
+
+// @public
 export type ConfigSchemaProcessingOptions = {
   visibility?: ConfigVisibility[];
   ignoreSchemaErrors?: boolean;
@@ -189,7 +197,7 @@ export type LoadConfigSchemaOptions = (
       dependencies: string[];
       packagePaths?: string[];
       excludePackageDependencies?: boolean;
-      onSchemaError?: (error: Error) => void;
+      onSchemaError?: (error: ConfigSchemaError) => void;
     }
   | {
       serialized: JsonObject;

--- a/packages/config-loader/report.api.md
+++ b/packages/config-loader/report.api.md
@@ -189,7 +189,6 @@ export type LoadConfigSchemaOptions = (
       dependencies: string[];
       packagePaths?: string[];
       excludePackageDependencies?: boolean;
-      schemaErrorMode?: 'warn' | 'error';
       onSchemaError?: (error: Error) => void;
     }
   | {

--- a/packages/config-loader/report.api.md
+++ b/packages/config-loader/report.api.md
@@ -5,6 +5,7 @@
 ```ts
 import { AppConfig } from '@backstage/config';
 import { Config } from '@backstage/config';
+import { CustomErrorBase } from '@backstage/errors';
 import { HumanDuration } from '@backstage/types';
 import { JsonObject } from '@backstage/types';
 import type { JSONSchema7 } from 'json-schema';
@@ -46,9 +47,11 @@ export type ConfigSchema = {
 };
 
 // @public
-export class ConfigSchemaError extends Error {
+export class ConfigSchemaError extends CustomErrorBase {
   constructor(options: { source: string; path: string; cause: Error });
   readonly cause: Error;
+  // (undocumented)
+  name: 'ConfigSchemaError';
   readonly path: string;
   readonly source: string;
 }

--- a/packages/config-loader/report.api.md
+++ b/packages/config-loader/report.api.md
@@ -5,7 +5,6 @@
 ```ts
 import { AppConfig } from '@backstage/config';
 import { Config } from '@backstage/config';
-import { CustomErrorBase } from '@backstage/errors';
 import { HumanDuration } from '@backstage/types';
 import { JsonObject } from '@backstage/types';
 import type { JSONSchema7 } from 'json-schema';
@@ -47,7 +46,7 @@ export type ConfigSchema = {
 };
 
 // @public
-export class ConfigSchemaError extends CustomErrorBase {
+export class ConfigSchemaError extends Error {
   constructor(options: { source: string; cause: Error });
   readonly cause: Error;
   // (undocumented)

--- a/packages/config-loader/report.api.md
+++ b/packages/config-loader/report.api.md
@@ -48,11 +48,10 @@ export type ConfigSchema = {
 
 // @public
 export class ConfigSchemaError extends CustomErrorBase {
-  constructor(options: { source: string; path: string; cause: Error });
+  constructor(options: { source: string; cause: Error });
   readonly cause: Error;
   // (undocumented)
   name: 'ConfigSchemaError';
-  readonly path: string;
   readonly source: string;
 }
 

--- a/packages/config-loader/report.api.md
+++ b/packages/config-loader/report.api.md
@@ -189,6 +189,8 @@ export type LoadConfigSchemaOptions = (
       dependencies: string[];
       packagePaths?: string[];
       excludePackageDependencies?: boolean;
+      schemaErrorMode?: 'warn' | 'error';
+      onSchemaError?: (error: Error) => void;
     }
   | {
       serialized: JsonObject;

--- a/packages/config-loader/src/index.ts
+++ b/packages/config-loader/src/index.ts
@@ -20,7 +20,11 @@
  * @packageDocumentation
  */
 
-export { loadConfigSchema, mergeConfigSchemas } from './schema';
+export {
+  ConfigSchemaError,
+  loadConfigSchema,
+  mergeConfigSchemas,
+} from './schema';
 export type {
   ConfigSchema,
   ConfigSchemaProcessingOptions,

--- a/packages/config-loader/src/schema/ConfigSchemaError.ts
+++ b/packages/config-loader/src/schema/ConfigSchemaError.ts
@@ -30,8 +30,9 @@ export class ConfigSchemaError extends Error {
 
   constructor(options: { source: string; cause: Error }) {
     const { source, cause } = options;
+    const causeMessage = cause.message.replace(/\s*\r?\n\s*/g, ' ').trim();
     super(
-      `The TypeScript configuration schema for package '${source}' contains errors:\n${cause.message}`,
+      `The TypeScript configuration schema for package '${source}' contains an error: ${causeMessage}`,
       { cause },
     );
 

--- a/packages/config-loader/src/schema/ConfigSchemaError.ts
+++ b/packages/config-loader/src/schema/ConfigSchemaError.ts
@@ -27,20 +27,16 @@ export class ConfigSchemaError extends CustomErrorBase {
   /** The package that provided the configuration schema. */
   readonly source: string;
 
-  /** The schema file path, relative to the current working directory. */
-  readonly path: string;
-
   /** The underlying error that caused schema loading to fail. */
   declare readonly cause: Error;
 
-  constructor(options: { source: string; path: string; cause: Error }) {
-    const { source, path, cause } = options;
+  constructor(options: { source: string; cause: Error }) {
+    const { source, cause } = options;
     super(
-      `TypeScript configuration schema for package '${source}' at ${path} contains errors`,
+      `TypeScript configuration schema for package '${source}' contains errors`,
       cause,
     );
 
     this.source = source;
-    this.path = path;
   }
 }

--- a/packages/config-loader/src/schema/ConfigSchemaError.ts
+++ b/packages/config-loader/src/schema/ConfigSchemaError.ts
@@ -31,7 +31,7 @@ export class ConfigSchemaError extends CustomErrorBase {
   readonly path: string;
 
   /** The underlying error that caused schema loading to fail. */
-  override readonly cause: Error;
+  declare readonly cause: Error;
 
   constructor(options: { source: string; path: string; cause: Error }) {
     const { source, path, cause } = options;
@@ -42,6 +42,5 @@ export class ConfigSchemaError extends CustomErrorBase {
 
     this.source = source;
     this.path = path;
-    this.cause = cause;
   }
 }

--- a/packages/config-loader/src/schema/ConfigSchemaError.ts
+++ b/packages/config-loader/src/schema/ConfigSchemaError.ts
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
+import { CustomErrorBase } from '@backstage/errors';
+
 /**
  * An error encountered while loading a TypeScript configuration schema.
  *
  * @public
  */
-export class ConfigSchemaError extends Error {
+export class ConfigSchemaError extends CustomErrorBase {
+  name = 'ConfigSchemaError' as const;
+
   /** The package that provided the configuration schema. */
   readonly source: string;
 
@@ -32,11 +36,10 @@ export class ConfigSchemaError extends Error {
   constructor(options: { source: string; path: string; cause: Error }) {
     const { source, path, cause } = options;
     super(
-      `TypeScript configuration schema for package '${source}' at ${path} contains errors:\n${cause.message}`,
-      { cause },
+      `TypeScript configuration schema for package '${source}' at ${path} contains errors`,
+      cause,
     );
 
-    this.name = 'ConfigSchemaError';
     this.source = source;
     this.path = path;
     this.cause = cause;

--- a/packages/config-loader/src/schema/ConfigSchemaError.ts
+++ b/packages/config-loader/src/schema/ConfigSchemaError.ts
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
-import { CustomErrorBase } from '@backstage/errors';
-
 /**
  * An error encountered while loading a TypeScript configuration schema.
  *
  * @public
  */
-export class ConfigSchemaError extends CustomErrorBase {
+export class ConfigSchemaError extends Error {
   name = 'ConfigSchemaError' as const;
 
   /** The package that provided the configuration schema. */
@@ -33,10 +31,11 @@ export class ConfigSchemaError extends CustomErrorBase {
   constructor(options: { source: string; cause: Error }) {
     const { source, cause } = options;
     super(
-      `TypeScript configuration schema for package '${source}' contains errors`,
-      cause,
+      `The TypeScript configuration schema for package '${source}' contains errors:\n${cause.message}`,
+      { cause },
     );
 
     this.source = source;
+    Error.captureStackTrace?.(this, this.constructor);
   }
 }

--- a/packages/config-loader/src/schema/ConfigSchemaError.ts
+++ b/packages/config-loader/src/schema/ConfigSchemaError.ts
@@ -37,6 +37,7 @@ export class ConfigSchemaError extends Error {
     );
 
     this.source = source;
+    this.cause = cause;
     Error.captureStackTrace?.(this, this.constructor);
   }
 }

--- a/packages/config-loader/src/schema/ConfigSchemaError.ts
+++ b/packages/config-loader/src/schema/ConfigSchemaError.ts
@@ -32,7 +32,7 @@ export class ConfigSchemaError extends Error {
     const { source, cause } = options;
     const causeMessage = cause.message.replace(/\s*\r?\n\s*/g, ' ').trim();
     super(
-      `The TypeScript configuration schema for package '${source}' contains an error — ${causeMessage}`,
+      `The TypeScript configuration schema for package '${source}' contains an error - ${causeMessage}`,
       { cause },
     );
 

--- a/packages/config-loader/src/schema/ConfigSchemaError.ts
+++ b/packages/config-loader/src/schema/ConfigSchemaError.ts
@@ -32,7 +32,7 @@ export class ConfigSchemaError extends Error {
     const { source, cause } = options;
     const causeMessage = cause.message.replace(/\s*\r?\n\s*/g, ' ').trim();
     super(
-      `The TypeScript configuration schema for package '${source}' contains an error: ${causeMessage}`,
+      `The TypeScript configuration schema for package '${source}' contains an error — ${causeMessage}`,
       { cause },
     );
 

--- a/packages/config-loader/src/schema/ConfigSchemaError.ts
+++ b/packages/config-loader/src/schema/ConfigSchemaError.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * An error encountered while loading a TypeScript configuration schema.
+ *
+ * @public
+ */
+export class ConfigSchemaError extends Error {
+  /** The package that provided the configuration schema. */
+  readonly source: string;
+
+  /** The schema file path, relative to the current working directory. */
+  readonly path: string;
+
+  /** The underlying error that caused schema loading to fail. */
+  override readonly cause: Error;
+
+  constructor(options: { source: string; path: string; cause: Error }) {
+    const { source, path, cause } = options;
+    super(
+      `TypeScript configuration schema for package '${source}' at ${path} contains errors:\n${cause.message}`,
+      { cause },
+    );
+
+    this.name = 'ConfigSchemaError';
+    this.source = source;
+    this.path = path;
+    this.cause = cause;
+  }
+}

--- a/packages/config-loader/src/schema/collect.test.ts
+++ b/packages/config-loader/src/schema/collect.test.ts
@@ -632,7 +632,7 @@ describe('collectConfigSchemas', () => {
     });
   });
 
-  it('should warn about unresolved imports by default and support strict checking', async () => {
+  it('should use best-effort schemas for unresolved types and support strict checking', async () => {
     mockDir.setContent({
       node_modules: {
         unresolved: {
@@ -643,7 +643,10 @@ describe('collectConfigSchemas', () => {
           }),
           'schema.d.ts': `
             import { Missing } from './missing';
-            export interface Config { value?: Missing }
+            export interface Config {
+              value?: Missing;
+              duration?: HumanDuration;
+            }
           `,
         },
       },
@@ -660,10 +663,21 @@ describe('collectConfigSchemas', () => {
         message: expect.stringContaining("Cannot find module './missing'"),
       }),
     );
+    expect(onSchemaError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("Cannot find name 'HumanDuration'"),
+      }),
+    );
     expect(schemas).toEqual([
       expect.objectContaining({
         packageName: 'unresolved',
         path: path.join('node_modules', 'unresolved', 'schema.d.ts'),
+        value: expect.objectContaining({
+          properties: {
+            value: {},
+            duration: {},
+          },
+        }),
       }),
     ]);
     expect(() => compileConfigSchemas(schemas)).not.toThrow();

--- a/packages/config-loader/src/schema/collect.test.ts
+++ b/packages/config-loader/src/schema/collect.test.ts
@@ -632,7 +632,7 @@ describe('collectConfigSchemas', () => {
     });
   });
 
-  it('should use best-effort schemas for unresolved types and support strict checking', async () => {
+  it('should handle unresolved types when an error handler is provided', async () => {
     mockDir.setContent({
       node_modules: {
         unresolved: {
@@ -682,16 +682,8 @@ describe('collectConfigSchemas', () => {
     ]);
     expect(() => compileConfigSchemas(schemas)).not.toThrow();
 
-    const consoleWarn = jest.spyOn(console, 'warn').mockImplementation();
-    await collectConfigSchemas(['unresolved'], []);
-    expect(consoleWarn).toHaveBeenCalledWith(
-      expect.stringContaining("Cannot find module './missing'"),
+    await expect(collectConfigSchemas(['unresolved'], [])).rejects.toThrow(
+      "Cannot find module './missing'",
     );
-
-    await expect(
-      collectConfigSchemas(['unresolved'], [], {
-        schemaErrorMode: 'error',
-      }),
-    ).rejects.toThrow("Cannot find module './missing'");
   });
 });

--- a/packages/config-loader/src/schema/collect.test.ts
+++ b/packages/config-loader/src/schema/collect.test.ts
@@ -673,7 +673,7 @@ describe('collectConfigSchemas', () => {
       });
       expect(schemaError).not.toHaveProperty('path');
       expect(schemaError.message).toBe(
-        `The TypeScript configuration schema for package 'unresolved' contains an error — ${schemaError.cause.message}`,
+        `The TypeScript configuration schema for package 'unresolved' contains an error - ${schemaError.cause.message}`,
       );
       expect(schemaError.message).not.toContain('\n');
     }
@@ -733,7 +733,7 @@ describe('collectConfigSchemas', () => {
       source: 'a',
       cause,
       message:
-        "The TypeScript configuration schema for package 'a' contains an error — Failed to generate schema",
+        "The TypeScript configuration schema for package 'a' contains an error - Failed to generate schema",
     });
   });
 });

--- a/packages/config-loader/src/schema/collect.test.ts
+++ b/packages/config-loader/src/schema/collect.test.ts
@@ -673,7 +673,7 @@ describe('collectConfigSchemas', () => {
       });
       expect(schemaError).not.toHaveProperty('path');
       expect(schemaError.message).toBe(
-        `The TypeScript configuration schema for package 'unresolved' contains an error: ${schemaError.cause.message}`,
+        `The TypeScript configuration schema for package 'unresolved' contains an error — ${schemaError.cause.message}`,
       );
       expect(schemaError.message).not.toContain('\n');
     }
@@ -733,7 +733,7 @@ describe('collectConfigSchemas', () => {
       source: 'a',
       cause,
       message:
-        "The TypeScript configuration schema for package 'a' contains an error: Failed to generate schema",
+        "The TypeScript configuration schema for package 'a' contains an error — Failed to generate schema",
     });
   });
 });

--- a/packages/config-loader/src/schema/collect.test.ts
+++ b/packages/config-loader/src/schema/collect.test.ts
@@ -466,7 +466,6 @@ describe('collectConfigSchemas', () => {
     await expect(collectConfigSchemas(['a'], [])).rejects.toMatchObject({
       name: 'ConfigSchemaError',
       source: 'a',
-      path: path.join('node_modules', 'a', 'schema.d.ts'),
       message: expect.stringContaining(
         'The schema does not export a Config type',
       ),
@@ -670,19 +669,14 @@ describe('collectConfigSchemas', () => {
     expect(schemaError).toMatchObject({
       name: 'ConfigSchemaError',
       source: 'unresolved',
-      path: path.join('node_modules', 'unresolved', 'schema.d.ts'),
       message: expect.stringContaining(
-        "TypeScript configuration schema for package 'unresolved' at " +
-          `${path.join(
-            'node_modules',
-            'unresolved',
-            'schema.d.ts',
-          )} contains errors`,
+        "TypeScript configuration schema for package 'unresolved' contains errors",
       ),
       cause: expect.objectContaining({
         message: expect.stringContaining("Cannot find module './missing'"),
       }),
     });
+    expect(schemaError).not.toHaveProperty('path');
     expect(schemaError.cause.message).toContain(
       "Cannot find name 'HumanDuration'",
     );
@@ -705,7 +699,7 @@ describe('collectConfigSchemas', () => {
     );
   });
 
-  it('should report schema generation errors with their source location', async () => {
+  it('should report schema generation errors with their source and cause', async () => {
     mockDir.setContent({
       node_modules: {
         a: {
@@ -720,18 +714,7 @@ describe('collectConfigSchemas', () => {
     });
     process.chdir(mockDir.path);
 
-    const cause = Object.assign(new Error('Failed to generate schema'), {
-      diagnostic: {
-        file: {
-          fileName: path.join(
-            process.cwd(),
-            'node_modules',
-            'a',
-            'imported.d.ts',
-          ),
-        },
-      },
-    });
+    const cause = new Error('Failed to generate schema');
     jest
       .spyOn(SchemaGenerator.prototype, 'createSchemaFromNodes')
       .mockImplementation(() => {
@@ -746,7 +729,6 @@ describe('collectConfigSchemas', () => {
       expect.objectContaining({
         name: 'ConfigSchemaError',
         source: 'a',
-        path: path.join('node_modules', 'a', 'imported.d.ts'),
         cause,
       }),
     );

--- a/packages/config-loader/src/schema/collect.test.ts
+++ b/packages/config-loader/src/schema/collect.test.ts
@@ -18,8 +18,10 @@ import { createMockDirectory } from '@backstage/backend-test-utils';
 import { JsonObject } from '@backstage/types';
 import { collectConfigSchemas, internal } from './collect';
 import { compileConfigSchemas } from './compile';
+import { ConfigSchemaError } from './ConfigSchemaError';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
+import { SchemaGenerator } from 'ts-json-schema-generator';
 
 const mockSchema = {
   type: 'object',
@@ -461,13 +463,17 @@ describe('collectConfigSchemas', () => {
     });
     process.chdir(mockDir.path);
 
-    await expect(collectConfigSchemas(['a'], [])).rejects.toThrow(
-      `Invalid schema in ${path.join(
-        'node_modules',
-        'a',
-        'schema.d.ts',
-      )}, missing Config export`,
-    );
+    await expect(collectConfigSchemas(['a'], [])).rejects.toMatchObject({
+      name: 'ConfigSchemaError',
+      source: 'a',
+      path: path.join('node_modules', 'a', 'schema.d.ts'),
+      message: expect.stringContaining(
+        'The schema does not export a Config type',
+      ),
+      cause: expect.objectContaining({
+        message: 'The schema does not export a Config type',
+      }),
+    });
   });
 
   it('should resolve imported types and namespace recursive definitions', async () => {
@@ -658,15 +664,27 @@ describe('collectConfigSchemas', () => {
       onSchemaError,
     });
 
-    expect(onSchemaError).toHaveBeenCalledWith(
-      expect.objectContaining({
+    expect(onSchemaError).toHaveBeenCalledTimes(1);
+    const schemaError = onSchemaError.mock.calls[0][0];
+    expect(schemaError).toBeInstanceOf(ConfigSchemaError);
+    expect(schemaError).toMatchObject({
+      name: 'ConfigSchemaError',
+      source: 'unresolved',
+      path: path.join('node_modules', 'unresolved', 'schema.d.ts'),
+      message: expect.stringContaining(
+        "TypeScript configuration schema for package 'unresolved' at " +
+          `${path.join(
+            'node_modules',
+            'unresolved',
+            'schema.d.ts',
+          )} contains errors`,
+      ),
+      cause: expect.objectContaining({
         message: expect.stringContaining("Cannot find module './missing'"),
       }),
-    );
-    expect(onSchemaError).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: expect.stringContaining("Cannot find name 'HumanDuration'"),
-      }),
+    });
+    expect(schemaError.cause.message).toContain(
+      "Cannot find name 'HumanDuration'",
     );
     expect(schemas).toEqual([
       expect.objectContaining({
@@ -684,6 +702,53 @@ describe('collectConfigSchemas', () => {
 
     await expect(collectConfigSchemas(['unresolved'], [])).rejects.toThrow(
       "Cannot find module './missing'",
+    );
+  });
+
+  it('should report schema generation errors with their source location', async () => {
+    mockDir.setContent({
+      node_modules: {
+        a: {
+          'package.json': JSON.stringify({
+            name: 'a',
+            version: '1.0.0',
+            configSchema: 'schema.d.ts',
+          }),
+          'schema.d.ts': `export interface Config { value?: string }`,
+        },
+      },
+    });
+    process.chdir(mockDir.path);
+
+    const cause = Object.assign(new Error('Failed to generate schema'), {
+      diagnostic: {
+        file: {
+          fileName: path.join(
+            process.cwd(),
+            'node_modules',
+            'a',
+            'imported.d.ts',
+          ),
+        },
+      },
+    });
+    jest
+      .spyOn(SchemaGenerator.prototype, 'createSchemaFromNodes')
+      .mockImplementation(() => {
+        throw cause;
+      });
+    const onSchemaError = jest.fn();
+
+    await expect(
+      collectConfigSchemas(['a'], [], { onSchemaError }),
+    ).resolves.toEqual([]);
+    expect(onSchemaError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'ConfigSchemaError',
+        source: 'a',
+        path: path.join('node_modules', 'a', 'imported.d.ts'),
+        cause,
+      }),
     );
   });
 });

--- a/packages/config-loader/src/schema/collect.test.ts
+++ b/packages/config-loader/src/schema/collect.test.ts
@@ -677,6 +677,9 @@ describe('collectConfigSchemas', () => {
       }),
     });
     expect(schemaError).not.toHaveProperty('path');
+    expect(schemaError.message).toBe(
+      `The TypeScript configuration schema for package 'unresolved' contains errors:\n${schemaError.cause.message}`,
+    );
     expect(schemaError.cause.message).toContain(
       "Cannot find name 'HumanDuration'",
     );

--- a/packages/config-loader/src/schema/collect.test.ts
+++ b/packages/config-loader/src/schema/collect.test.ts
@@ -663,26 +663,25 @@ describe('collectConfigSchemas', () => {
       onSchemaError,
     });
 
-    expect(onSchemaError).toHaveBeenCalledTimes(1);
-    const schemaError = onSchemaError.mock.calls[0][0];
-    expect(schemaError).toBeInstanceOf(ConfigSchemaError);
-    expect(schemaError).toMatchObject({
-      name: 'ConfigSchemaError',
-      source: 'unresolved',
-      message: expect.stringContaining(
-        "TypeScript configuration schema for package 'unresolved' contains errors",
-      ),
-      cause: expect.objectContaining({
-        message: expect.stringContaining("Cannot find module './missing'"),
-      }),
-    });
-    expect(schemaError).not.toHaveProperty('path');
-    expect(schemaError.message).toBe(
-      `The TypeScript configuration schema for package 'unresolved' contains errors:\n${schemaError.cause.message}`,
-    );
-    expect(schemaError.cause.message).toContain(
-      "Cannot find name 'HumanDuration'",
-    );
+    expect(onSchemaError).toHaveBeenCalledTimes(2);
+    const schemaErrors = onSchemaError.mock.calls.map(([error]) => error);
+    for (const schemaError of schemaErrors) {
+      expect(schemaError).toBeInstanceOf(ConfigSchemaError);
+      expect(schemaError).toMatchObject({
+        name: 'ConfigSchemaError',
+        source: 'unresolved',
+      });
+      expect(schemaError).not.toHaveProperty('path');
+      expect(schemaError.message).toBe(
+        `The TypeScript configuration schema for package 'unresolved' contains an error: ${schemaError.cause.message}`,
+      );
+      expect(schemaError.message).not.toContain('\n');
+    }
+    const causeMessages = schemaErrors.map(error => error.cause.message);
+    expect(causeMessages).toEqual([
+      expect.stringContaining("Cannot find module './missing'"),
+      expect.stringContaining("Cannot find name 'HumanDuration'"),
+    ]);
     expect(schemas).toEqual([
       expect.objectContaining({
         packageName: 'unresolved',
@@ -717,7 +716,7 @@ describe('collectConfigSchemas', () => {
     });
     process.chdir(mockDir.path);
 
-    const cause = new Error('Failed to generate schema');
+    const cause = new Error('Failed to\ngenerate schema');
     jest
       .spyOn(SchemaGenerator.prototype, 'createSchemaFromNodes')
       .mockImplementation(() => {
@@ -728,12 +727,13 @@ describe('collectConfigSchemas', () => {
     await expect(
       collectConfigSchemas(['a'], [], { onSchemaError }),
     ).resolves.toEqual([]);
-    expect(onSchemaError).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: 'ConfigSchemaError',
-        source: 'a',
-        cause,
-      }),
-    );
+    const schemaError = onSchemaError.mock.calls[0][0];
+    expect(schemaError).toMatchObject({
+      name: 'ConfigSchemaError',
+      source: 'a',
+      cause,
+      message:
+        "The TypeScript configuration schema for package 'a' contains an error: Failed to generate schema",
+    });
   });
 });

--- a/packages/config-loader/src/schema/collect.test.ts
+++ b/packages/config-loader/src/schema/collect.test.ts
@@ -65,6 +65,7 @@ describe('collectConfigSchemas', () => {
   });
 
   afterEach(() => {
+    jest.restoreAllMocks();
     mockDir.clear();
   });
 
@@ -631,7 +632,7 @@ describe('collectConfigSchemas', () => {
     });
   });
 
-  it('should reject unresolved imports', async () => {
+  it('should warn about unresolved imports by default and support strict checking', async () => {
     mockDir.setContent({
       node_modules: {
         unresolved: {
@@ -649,8 +650,34 @@ describe('collectConfigSchemas', () => {
     });
     process.chdir(mockDir.path);
 
-    await expect(collectConfigSchemas(['unresolved'], [])).rejects.toThrow(
-      "Cannot find module './missing'",
+    const onSchemaError = jest.fn();
+    const schemas = await collectConfigSchemas(['unresolved'], [], {
+      onSchemaError,
+    });
+
+    expect(onSchemaError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("Cannot find module './missing'"),
+      }),
     );
+    expect(schemas).toEqual([
+      expect.objectContaining({
+        packageName: 'unresolved',
+        path: path.join('node_modules', 'unresolved', 'schema.d.ts'),
+      }),
+    ]);
+    expect(() => compileConfigSchemas(schemas)).not.toThrow();
+
+    const consoleWarn = jest.spyOn(console, 'warn').mockImplementation();
+    await collectConfigSchemas(['unresolved'], []);
+    expect(consoleWarn).toHaveBeenCalledWith(
+      expect.stringContaining("Cannot find module './missing'"),
+    );
+
+    await expect(
+      collectConfigSchemas(['unresolved'], [], {
+        schemaErrorMode: 'error',
+      }),
+    ).rejects.toThrow("Cannot find module './missing'");
   });
 });

--- a/packages/config-loader/src/schema/collect.ts
+++ b/packages/config-loader/src/schema/collect.ts
@@ -332,19 +332,21 @@ async function compileTsSchemas(
       return;
     }
 
-    const cause = new Error(
-      ts
-        .formatDiagnostics(diagnostics, {
-          getCanonicalFileName: fileName => fileName,
-          getCurrentDirectory: () => currentDir,
-          getNewLine: () => '\n',
-        })
-        .trimEnd(),
-    );
-    handleSchemaError(
-      options,
-      new ConfigSchemaError({ source: packageName, cause }),
-    );
+    for (const diagnostic of diagnostics) {
+      const cause = new Error(
+        ts
+          .formatDiagnostics([diagnostic], {
+            getCanonicalFileName: fileName => fileName,
+            getCurrentDirectory: () => currentDir,
+            getNewLine: () => '\n',
+          })
+          .trimEnd(),
+      );
+      handleSchemaError(
+        options,
+        new ConfigSchemaError({ source: packageName, cause }),
+      );
+    }
   });
 
   const generatorConfig = {

--- a/packages/config-loader/src/schema/collect.ts
+++ b/packages/config-loader/src/schema/collect.ts
@@ -27,6 +27,7 @@ import {
 } from 'node:path';
 import { ConfigSchemaPackageEntry } from './types';
 import type { JsonObject } from '@backstage/types';
+import { ConfigSchemaError } from './ConfigSchemaError';
 
 type Item = {
   name?: string;
@@ -36,7 +37,7 @@ type Item = {
 
 type CollectConfigSchemasOptions = {
   excludePackageDependencies?: boolean;
-  onSchemaError?: (error: Error) => void;
+  onSchemaError?: (error: ConfigSchemaError) => void;
 };
 
 const req =
@@ -264,7 +265,7 @@ function parseNestedSchemaAnnotation(annotation: unknown) {
 
 function handleSchemaError(
   options: CollectConfigSchemasOptions | undefined,
-  error: Error,
+  error: ConfigSchemaError,
 ) {
   if (!options?.onSchemaError) {
     throw error;
@@ -312,30 +313,57 @@ async function compileTsSchemas(
   };
 
   const program = ts.createProgram(rootNames, compilerOptions);
-  const diagnostics = [
+  const sharedDiagnostics = [
     ...program.getOptionsDiagnostics(),
     ...program.getGlobalDiagnostics(),
-    ...rootNames.flatMap(rootName => {
-      const sourceFile = program.getSourceFile(rootName);
-      return sourceFile
+  ];
+  entries.forEach(({ path, packageName }, index) => {
+    const sourceFile = program.getSourceFile(rootNames[index]);
+    const diagnostics = [
+      ...(index === 0 ? sharedDiagnostics : []),
+      ...(sourceFile
         ? [
             ...program.getSyntacticDiagnostics(sourceFile),
             ...program.getSemanticDiagnostics(sourceFile),
           ]
-        : [];
-    }),
-  ];
-  if (diagnostics.length > 0) {
-    const message = ts.formatDiagnostics(diagnostics, {
-      getCanonicalFileName: fileName => fileName,
-      getCurrentDirectory: () => currentDir,
-      getNewLine: () => '\n',
-    });
-    handleSchemaError(
-      options,
-      new Error(`TypeScript configuration schema contains errors:\n${message}`),
-    );
-  }
+        : []),
+    ];
+    if (diagnostics.length === 0) {
+      return;
+    }
+
+    const diagnosticsByPath = new Map<string, TypeScript.Diagnostic[]>();
+    for (const diagnostic of diagnostics) {
+      const diagnosticPath = diagnostic.file
+        ? relativePath(currentDir, diagnostic.file.fileName)
+        : path;
+      const pathDiagnostics = diagnosticsByPath.get(diagnosticPath);
+      if (pathDiagnostics) {
+        pathDiagnostics.push(diagnostic);
+      } else {
+        diagnosticsByPath.set(diagnosticPath, [diagnostic]);
+      }
+    }
+    for (const [diagnosticPath, pathDiagnostics] of diagnosticsByPath) {
+      const cause = new Error(
+        ts
+          .formatDiagnostics(pathDiagnostics, {
+            getCanonicalFileName: fileName => fileName,
+            getCurrentDirectory: () => currentDir,
+            getNewLine: () => '\n',
+          })
+          .trimEnd(),
+      );
+      handleSchemaError(
+        options,
+        new ConfigSchemaError({
+          source: packageName,
+          path: diagnosticPath,
+          cause,
+        }),
+      );
+    }
+  });
 
   const generatorConfig = {
     ...DEFAULT_CONFIG,
@@ -407,7 +435,11 @@ async function compileTsSchemas(
   const tsSchemas = entries.flatMap(({ path, packageName }, index) => {
     const sourceFile = program.getSourceFile(rootNames[index]);
     if (!sourceFile) {
-      throw new Error(`Invalid schema in ${path}, missing Config export`);
+      throw new ConfigSchemaError({
+        source: packageName,
+        path,
+        cause: new Error('The schema source file could not be loaded'),
+      });
     }
     const configNode = sourceFile.statements.find(
       statement =>
@@ -416,7 +448,11 @@ async function compileTsSchemas(
         statement.name.text === 'Config',
     );
     if (!configNode) {
-      throw new Error(`Invalid schema in ${path}, missing Config export`);
+      throw new ConfigSchemaError({
+        source: packageName,
+        path,
+        cause: new Error('The schema does not export a Config type'),
+      });
     }
 
     const namespace = createHash('sha256')
@@ -435,12 +471,26 @@ async function compileTsSchemas(
       return [{ path, value, packageName }];
     } catch (error) {
       const cause = toError(error);
+      let errorPath = path;
+      if (
+        'diagnostic' in cause &&
+        cause.diagnostic &&
+        typeof cause.diagnostic === 'object' &&
+        'file' in cause.diagnostic &&
+        cause.diagnostic.file &&
+        typeof cause.diagnostic.file === 'object' &&
+        'fileName' in cause.diagnostic.file &&
+        typeof cause.diagnostic.file.fileName === 'string'
+      ) {
+        errorPath = relativePath(currentDir, cause.diagnostic.file.fileName);
+      }
       handleSchemaError(
         options,
-        new Error(
-          `Unable to generate TypeScript configuration schema at ${path}: ${cause.message}`,
-          { cause },
-        ),
+        new ConfigSchemaError({
+          source: packageName,
+          path: errorPath,
+          cause,
+        }),
       );
       return [];
     }

--- a/packages/config-loader/src/schema/collect.ts
+++ b/packages/config-loader/src/schema/collect.ts
@@ -36,7 +36,6 @@ type Item = {
 
 type CollectConfigSchemasOptions = {
   excludePackageDependencies?: boolean;
-  schemaErrorMode?: 'warn' | 'error';
   onSchemaError?: (error: Error) => void;
 };
 
@@ -263,16 +262,14 @@ function parseNestedSchemaAnnotation(annotation: unknown) {
   return { key, value };
 }
 
-function reportSchemaWarning(
+function handleSchemaError(
   options: CollectConfigSchemasOptions | undefined,
-  message: string,
+  error: Error,
 ) {
-  const warning = new Error(message);
-  if (options?.onSchemaError) {
-    options.onSchemaError(warning);
-  } else {
-    console.warn(warning.message);
+  if (!options?.onSchemaError) {
+    throw error;
   }
+  options.onSchemaError(error);
 }
 
 // This handles the support of TypeScript .d.ts config schema declarations.
@@ -334,13 +331,9 @@ async function compileTsSchemas(
       getCurrentDirectory: () => currentDir,
       getNewLine: () => '\n',
     });
-    if (options?.schemaErrorMode === 'error') {
-      throw new Error(`Invalid TypeScript configuration schema:\n${message}`);
-    }
-
-    reportSchemaWarning(
+    handleSchemaError(
       options,
-      `TypeScript configuration schema contains errors:\n${message}`,
+      new Error(`TypeScript configuration schema contains errors:\n${message}`),
     );
   }
 
@@ -356,7 +349,7 @@ async function compileTsSchemas(
   };
   const typeChecker = program.getTypeChecker();
   const parser = createParser(program, generatorConfig, mutableParser => {
-    if (options?.schemaErrorMode === 'error') {
+    if (!options?.onSchemaError) {
       return;
     }
 
@@ -441,14 +434,13 @@ async function compileTsSchemas(
 
       return [{ path, value, packageName }];
     } catch (error) {
-      if (options?.schemaErrorMode === 'error') {
-        throw error;
-      }
-
-      const detail = toError(error).message;
-      reportSchemaWarning(
+      const cause = toError(error);
+      handleSchemaError(
         options,
-        `Skipping TypeScript configuration schema at ${path} because it could not be generated: ${detail}`,
+        new Error(
+          `Unable to generate TypeScript configuration schema at ${path}: ${cause.message}`,
+          { cause },
+        ),
       );
       return [];
     }

--- a/packages/config-loader/src/schema/collect.ts
+++ b/packages/config-loader/src/schema/collect.ts
@@ -15,6 +15,7 @@
  */
 
 import fs from 'fs-extra';
+import { toError } from '@backstage/errors';
 import type * as TsJsonSchemaGenerator from 'ts-json-schema-generator';
 import type * as TypeScript from 'typescript';
 import { createHash } from 'node:crypto';
@@ -262,6 +263,18 @@ function parseNestedSchemaAnnotation(annotation: unknown) {
   return { key, value };
 }
 
+function reportSchemaWarning(
+  options: CollectConfigSchemasOptions | undefined,
+  message: string,
+) {
+  const warning = new Error(message);
+  if (options?.onSchemaError) {
+    options.onSchemaError(warning);
+  } else {
+    console.warn(warning.message);
+  }
+}
+
 // This handles the support of TypeScript .d.ts config schema declarations.
 // We collect all TypeScript schema definitions and compile them in one shared
 // program, which avoids repeatedly resolving and parsing imported types.
@@ -278,6 +291,7 @@ async function compileTsSchemas(
   const ts: typeof TypeScript = require('typescript');
   const {
     AnnotatedTypeFormatter,
+    AnyType,
     createFormatter,
     createParser,
     DEFAULT_CONFIG,
@@ -324,14 +338,10 @@ async function compileTsSchemas(
       throw new Error(`Invalid TypeScript configuration schema:\n${message}`);
     }
 
-    const warning = new Error(
+    reportSchemaWarning(
+      options,
       `TypeScript configuration schema contains errors; using a best-effort schema:\n${message}`,
     );
-    if (options?.onSchemaError) {
-      options.onSchemaError(warning);
-    } else {
-      console.warn(warning.message);
-    }
   }
 
   const generatorConfig = {
@@ -344,7 +354,26 @@ async function compileTsSchemas(
     topRef: false,
     tsProgram: program,
   };
-  const parser = createParser(program, generatorConfig);
+  const typeChecker = program.getTypeChecker();
+  const parser = createParser(program, generatorConfig, mutableParser => {
+    if (options?.schemaErrorMode === 'error') {
+      return;
+    }
+
+    // Preserve the rest of a schema by treating unresolved references as unconstrained values.
+    mutableParser.addNodeParser({
+      supportsNode(node) {
+        if (!ts.isTypeReferenceNode(node)) {
+          return false;
+        }
+        const symbol = typeChecker.getSymbolAtLocation(node.typeName);
+        return !symbol?.declarations?.length;
+      },
+      createType() {
+        return new AnyType();
+      },
+    });
+  });
   class NestedAnnotationsFormatter extends AnnotatedTypeFormatter {
     override getDefinition(type: TsJsonSchemaGenerator.AnnotatedType) {
       const annotations = type.getAnnotations();
@@ -382,7 +411,7 @@ async function compileTsSchemas(
     generatorConfig,
   );
 
-  const tsSchemas = entries.map(({ path, packageName }, index) => {
+  const tsSchemas = entries.flatMap(({ path, packageName }, index) => {
     const sourceFile = program.getSourceFile(rootNames[index]);
     if (!sourceFile) {
       throw new Error(`Invalid schema in ${path}, missing Config export`);
@@ -402,14 +431,27 @@ async function compileTsSchemas(
       .update('\0')
       .update(path.split(sep).join('/'))
       .digest('hex');
-    const value = namespaceSchemaDefinitions(
-      structuredClone(
-        generator.createSchemaFromNodes([configNode]),
-      ) as JsonObject,
-      namespace,
-    );
+    try {
+      const value = namespaceSchemaDefinitions(
+        structuredClone(
+          generator.createSchemaFromNodes([configNode]),
+        ) as JsonObject,
+        namespace,
+      );
 
-    return { path, value, packageName };
+      return [{ path, value, packageName }];
+    } catch (error) {
+      if (options?.schemaErrorMode === 'error') {
+        throw error;
+      }
+
+      const detail = toError(error).message;
+      reportSchemaWarning(
+        options,
+        `Skipping TypeScript configuration schema at ${path} because it could not be generated: ${detail}`,
+      );
+      return [];
+    }
   });
 
   return tsSchemas;

--- a/packages/config-loader/src/schema/collect.ts
+++ b/packages/config-loader/src/schema/collect.ts
@@ -317,7 +317,7 @@ async function compileTsSchemas(
     ...program.getOptionsDiagnostics(),
     ...program.getGlobalDiagnostics(),
   ];
-  entries.forEach(({ path, packageName }, index) => {
+  entries.forEach(({ packageName }, index) => {
     const sourceFile = program.getSourceFile(rootNames[index]);
     const diagnostics = [
       ...(index === 0 ? sharedDiagnostics : []),
@@ -332,37 +332,19 @@ async function compileTsSchemas(
       return;
     }
 
-    const diagnosticsByPath = new Map<string, TypeScript.Diagnostic[]>();
-    for (const diagnostic of diagnostics) {
-      const diagnosticPath = diagnostic.file
-        ? relativePath(currentDir, diagnostic.file.fileName)
-        : path;
-      const pathDiagnostics = diagnosticsByPath.get(diagnosticPath);
-      if (pathDiagnostics) {
-        pathDiagnostics.push(diagnostic);
-      } else {
-        diagnosticsByPath.set(diagnosticPath, [diagnostic]);
-      }
-    }
-    for (const [diagnosticPath, pathDiagnostics] of diagnosticsByPath) {
-      const cause = new Error(
-        ts
-          .formatDiagnostics(pathDiagnostics, {
-            getCanonicalFileName: fileName => fileName,
-            getCurrentDirectory: () => currentDir,
-            getNewLine: () => '\n',
-          })
-          .trimEnd(),
-      );
-      handleSchemaError(
-        options,
-        new ConfigSchemaError({
-          source: packageName,
-          path: diagnosticPath,
-          cause,
-        }),
-      );
-    }
+    const cause = new Error(
+      ts
+        .formatDiagnostics(diagnostics, {
+          getCanonicalFileName: fileName => fileName,
+          getCurrentDirectory: () => currentDir,
+          getNewLine: () => '\n',
+        })
+        .trimEnd(),
+    );
+    handleSchemaError(
+      options,
+      new ConfigSchemaError({ source: packageName, cause }),
+    );
   });
 
   const generatorConfig = {
@@ -437,7 +419,6 @@ async function compileTsSchemas(
     if (!sourceFile) {
       throw new ConfigSchemaError({
         source: packageName,
-        path,
         cause: new Error('The schema source file could not be loaded'),
       });
     }
@@ -450,7 +431,6 @@ async function compileTsSchemas(
     if (!configNode) {
       throw new ConfigSchemaError({
         source: packageName,
-        path,
         cause: new Error('The schema does not export a Config type'),
       });
     }
@@ -471,26 +451,9 @@ async function compileTsSchemas(
       return [{ path, value, packageName }];
     } catch (error) {
       const cause = toError(error);
-      let errorPath = path;
-      if (
-        'diagnostic' in cause &&
-        cause.diagnostic &&
-        typeof cause.diagnostic === 'object' &&
-        'file' in cause.diagnostic &&
-        cause.diagnostic.file &&
-        typeof cause.diagnostic.file === 'object' &&
-        'fileName' in cause.diagnostic.file &&
-        typeof cause.diagnostic.file.fileName === 'string'
-      ) {
-        errorPath = relativePath(currentDir, cause.diagnostic.file.fileName);
-      }
       handleSchemaError(
         options,
-        new ConfigSchemaError({
-          source: packageName,
-          path: errorPath,
-          cause,
-        }),
+        new ConfigSchemaError({ source: packageName, cause }),
       );
       return [];
     }

--- a/packages/config-loader/src/schema/collect.ts
+++ b/packages/config-loader/src/schema/collect.ts
@@ -340,7 +340,7 @@ async function compileTsSchemas(
 
     reportSchemaWarning(
       options,
-      `TypeScript configuration schema contains errors; using a best-effort schema:\n${message}`,
+      `TypeScript configuration schema contains errors:\n${message}`,
     );
   }
 

--- a/packages/config-loader/src/schema/collect.ts
+++ b/packages/config-loader/src/schema/collect.ts
@@ -33,6 +33,12 @@ type Item = {
   packagePath?: string;
 };
 
+type CollectConfigSchemasOptions = {
+  excludePackageDependencies?: boolean;
+  schemaErrorMode?: 'warn' | 'error';
+  onSchemaError?: (error: Error) => void;
+};
+
 const req =
   typeof __non_webpack_require__ === 'undefined'
     ? require
@@ -55,7 +61,7 @@ export const internal = {
 export async function collectConfigSchemas(
   packageNames: string[],
   packagePaths: string[],
-  options?: { excludePackageDependencies?: boolean },
+  options?: CollectConfigSchemasOptions,
 ): Promise<ConfigSchemaPackageEntry[]> {
   const schemas = new Array<ConfigSchemaPackageEntry>();
   const tsSchemaPaths = new Array<{ packageName: string; path: string }>();
@@ -165,7 +171,7 @@ export async function collectConfigSchemas(
     ...packagePaths.map(path => processItem({ name: path, packagePath: path })),
   ]);
 
-  const tsSchemas = await compileTsSchemas(tsSchemaPaths);
+  const tsSchemas = await compileTsSchemas(tsSchemaPaths, options);
   const allSchemas = schemas.concat(tsSchemas);
 
   const hasBackendDefaults = allSchemas.some(
@@ -261,6 +267,7 @@ function parseNestedSchemaAnnotation(annotation: unknown) {
 // program, which avoids repeatedly resolving and parsing imported types.
 async function compileTsSchemas(
   entries: { path: string; packageName: string }[],
+  options?: CollectConfigSchemasOptions,
 ) {
   if (entries.length === 0) {
     return [];
@@ -313,7 +320,18 @@ async function compileTsSchemas(
       getCurrentDirectory: () => currentDir,
       getNewLine: () => '\n',
     });
-    throw new Error(`Invalid TypeScript configuration schema:\n${message}`);
+    if (options?.schemaErrorMode === 'error') {
+      throw new Error(`Invalid TypeScript configuration schema:\n${message}`);
+    }
+
+    const warning = new Error(
+      `TypeScript configuration schema contains errors; using a best-effort schema:\n${message}`,
+    );
+    if (options?.onSchemaError) {
+      options.onSchemaError(warning);
+    } else {
+      console.warn(warning.message);
+    }
   }
 
   const generatorConfig = {

--- a/packages/config-loader/src/schema/index.ts
+++ b/packages/config-loader/src/schema/index.ts
@@ -16,6 +16,7 @@
 
 export { mergeConfigSchemas } from './compile';
 export { loadConfigSchema } from './load';
+export { ConfigSchemaError } from './ConfigSchemaError';
 export type { LoadConfigSchemaOptions } from './load';
 export type {
   ConfigSchema,

--- a/packages/config-loader/src/schema/load.test.ts
+++ b/packages/config-loader/src/schema/load.test.ts
@@ -126,6 +126,48 @@ describe('loadConfigSchema', () => {
     );
   });
 
+  it('should use onSchemaError to opt into recovery', async () => {
+    mockDir.setContent({
+      'package.json': JSON.stringify({
+        name: 'a',
+        configSchema: 'config.d.ts',
+      }),
+      'config.d.ts': `
+        export interface Config {
+          value?: Missing;
+        }
+      `,
+    });
+    process.chdir(mockDir.path);
+
+    const onSchemaError = jest.fn();
+    const schema = await loadConfigSchema({
+      dependencies: [],
+      packagePaths: ['package.json'],
+      onSchemaError,
+    });
+
+    expect(onSchemaError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.stringContaining("Cannot find name 'Missing'"),
+      }),
+    );
+    expect(schema.serialize().schemas).toEqual([
+      expect.objectContaining({
+        value: expect.objectContaining({
+          properties: { value: {} },
+        }),
+      }),
+    ]);
+
+    await expect(
+      loadConfigSchema({
+        dependencies: [],
+        packagePaths: ['package.json'],
+      }),
+    ).rejects.toThrow("Cannot find name 'Missing'");
+  });
+
   describe('should consider schema', () => {
     it('when filtering simple config', async () => {
       mockDir.setContent({

--- a/packages/config-loader/src/schema/load.test.ts
+++ b/packages/config-loader/src/schema/load.test.ts
@@ -16,6 +16,7 @@
 
 import { createMockDirectory } from '@backstage/backend-test-utils';
 import { loadConfigSchema } from './load';
+import { ConfigSchemaError } from './ConfigSchemaError';
 
 // cwd must be restored
 const origDir = process.cwd();
@@ -149,9 +150,14 @@ describe('loadConfigSchema', () => {
 
     expect(onSchemaError).toHaveBeenCalledWith(
       expect.objectContaining({
-        message: expect.stringContaining("Cannot find name 'Missing'"),
+        source: 'a',
+        path: 'config.d.ts',
+        cause: expect.objectContaining({
+          message: expect.stringContaining("Cannot find name 'Missing'"),
+        }),
       }),
     );
+    expect(onSchemaError.mock.calls[0][0]).toBeInstanceOf(ConfigSchemaError);
     expect(schema.serialize().schemas).toEqual([
       expect.objectContaining({
         value: expect.objectContaining({

--- a/packages/config-loader/src/schema/load.test.ts
+++ b/packages/config-loader/src/schema/load.test.ts
@@ -151,7 +151,6 @@ describe('loadConfigSchema', () => {
     expect(onSchemaError).toHaveBeenCalledWith(
       expect.objectContaining({
         source: 'a',
-        path: 'config.d.ts',
         cause: expect.objectContaining({
           message: expect.stringContaining("Cannot find name 'Missing'"),
         }),

--- a/packages/config-loader/src/schema/load.ts
+++ b/packages/config-loader/src/schema/load.ts
@@ -44,19 +44,12 @@ export type LoadConfigSchemaOptions =
            */
           excludePackageDependencies?: boolean;
           /**
-           * How to handle errors encountered when compiling TypeScript
-           * configuration schemas.
+           * Receives TypeScript configuration schema errors and allows schema
+           * loading to continue. Unresolved types are treated as unconstrained
+           * values, while schemas that cannot be generated are omitted.
            *
-           * Defaults to `'warn'`, which reports the error and continues with a
-           * best-effort schema. Set to `'error'` to make schema compilation
-           * errors fatal.
-           */
-          schemaErrorMode?: 'warn' | 'error';
-          /**
-           * Receives TypeScript configuration schema errors when
-           * `schemaErrorMode` is `'warn'`.
-           *
-           * Defaults to logging the error to the console.
+           * Without this callback, TypeScript configuration schema errors are
+           * thrown.
            */
           onSchemaError?: (error: Error) => void;
         }
@@ -97,7 +90,6 @@ export async function loadConfigSchema(
       options.packagePaths ?? [],
       {
         excludePackageDependencies: options.excludePackageDependencies,
-        schemaErrorMode: options.schemaErrorMode,
         onSchemaError: options.onSchemaError,
       },
     );

--- a/packages/config-loader/src/schema/load.ts
+++ b/packages/config-loader/src/schema/load.ts
@@ -26,6 +26,7 @@ import {
   CONFIG_VISIBILITIES,
 } from './types';
 import { normalizeAjvPath } from './utils';
+import type { ConfigSchemaError } from './ConfigSchemaError';
 
 /**
  * Options that control the loading of configuration schema files in the backend.
@@ -44,14 +45,14 @@ export type LoadConfigSchemaOptions =
            */
           excludePackageDependencies?: boolean;
           /**
-           * Receives TypeScript configuration schema errors and allows schema
+           * Receives `ConfigSchemaError` instances and allows TypeScript schema
            * loading to continue. Unresolved types are treated as unconstrained
            * values, while schemas that cannot be generated are omitted.
            *
            * Without this callback, TypeScript configuration schema errors are
            * thrown.
            */
-          onSchemaError?: (error: Error) => void;
+          onSchemaError?: (error: ConfigSchemaError) => void;
         }
       | {
           serialized: JsonObject;

--- a/packages/config-loader/src/schema/load.ts
+++ b/packages/config-loader/src/schema/load.ts
@@ -43,6 +43,22 @@ export type LoadConfigSchemaOptions =
            * Defaults to `false`.
            */
           excludePackageDependencies?: boolean;
+          /**
+           * How to handle errors encountered when compiling TypeScript
+           * configuration schemas.
+           *
+           * Defaults to `'warn'`, which reports the error and continues with a
+           * best-effort schema. Set to `'error'` to make schema compilation
+           * errors fatal.
+           */
+          schemaErrorMode?: 'warn' | 'error';
+          /**
+           * Receives TypeScript configuration schema errors when
+           * `schemaErrorMode` is `'warn'`.
+           *
+           * Defaults to logging the error to the console.
+           */
+          onSchemaError?: (error: Error) => void;
         }
       | {
           serialized: JsonObject;
@@ -81,6 +97,8 @@ export async function loadConfigSchema(
       options.packagePaths ?? [],
       {
         excludePackageDependencies: options.excludePackageDependencies,
+        schemaErrorMode: options.schemaErrorMode,
+        onSchemaError: options.onSchemaError,
       },
     );
   } else {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds an `onSchemaError` callback to configuration schema loading. TypeScript schema errors are thrown when no handler is provided. When a handler is present, it receives the error and loading continues; unresolved type references become unconstrained schema values, while declarations that still cannot be generated are omitted.

Schema failures are reported as `ConfigSchemaError` instances with a consistent message, the source package, and the underlying cause. Diagnostic causes retain file locations when available.

Backend schema discovery, non-strict config commands, frontend builds, and plugin bundle paths provide handlers that surface these errors as warnings. Package preparation for publishing omits the handler and remains strict, preventing plugins with invalid TypeScript configuration schemas from being published.

The existing `config:check --strict` now covers schema compilation as well, and `config:schema --strict` offers the same opt-in. Hard schema failures such as a missing `Config` declaration remain fatal, but use the same structured error type.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

<!-- mana-workspace:9Q2R3obqRU8 -->