### PR TITLE
chore: pin safe @asyncapi versions to mitigate supply chain attack

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,10 @@
     "rejectFrontendNetworkRequests": true
   },
   "resolutions": {
+    "@asyncapi/generator": "3.3.0",
+    "@asyncapi/generator-helpers": "1.1.0",
+    "@asyncapi/generator-components": "0.7.0",
+    "@asyncapi/specs": "6.11.1",
     "@remixicon/react": ">=4.6.0 <4.9.0",
     "@changesets/assemble-release-plan@^6.0.0": "patch:@changesets/assemble-release-plan@npm%3A6.0.0#./.yarn/patches/@changesets-assemble-release-plan-npm-6.0.0-f7b3005037.patch",
     "@material-ui/pickers@^3.2.10": "patch:@material-ui/pickers@npm%3A3.3.11#./.yarn/patches/@material-ui-pickers-npm-3.3.11-1c8f68ea20.patch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -389,12 +389,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@asyncapi/specs@npm:^6.8.0":
-  version: 6.8.0
-  resolution: "@asyncapi/specs@npm:6.8.0"
+"@asyncapi/specs@npm:6.11.1":
+  version: 6.11.1
+  resolution: "@asyncapi/specs@npm:6.11.1"
   dependencies:
     "@types/json-schema": "npm:^7.0.11"
-  checksum: 10/4789e27ff134c0e426327873258da4c8b3ca4156136e698d21af5ca708adce9174ee8ceddaa36a85ed7a1ff6d7cc4bf7eaf88f0e66205f3440879d0297e76671
+  checksum: 10/51a9f8e61b85c519baee392641c83f021419f64c68e508732d6461c6b6a60d9891d84e53489a916ef0903a80dd736b0a0631bb97567488b7cc4383437806b84d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Overview of changes
This PR mitigates a [recently disclosed supply chain attack](https://safedep.io/asyncapi-generator-supply-chain-attack-miasma-rat/) targeting `@asyncapi` packages. The attack introduced a credential-stealing backdoor in specific versions (`@asyncapi/generator` 3.3.1, `@asyncapi/generator-helpers` 1.1.1, `@asyncapi/generator-components` 0.7.1, and `@asyncapi/specs` 6.11.2).

Although our `yarn.lock` never fetched the malicious versions (we were safely on `6.8.0` for `@asyncapi/specs`), this PR proactively uses Yarn `resolutions` to pin the dependency tree to the safe versions recommended by the security advisory.

### Changes:
- Added `@asyncapi` safe versions to the `resolutions` block in the root `package.json`.
- Updated `yarn.lock` to ensure all transitive `@asyncapi` dependencies enforce these safe limits globally.

### Security Impact
- **No exposure**: The compromised packages were never present in our lockfile.
- **Prevention**: This patch ensures no local developer or CI pipeline can accidentally resolve to the compromised versions in the future.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. *(N/A: Root config files do not require changesets)*
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.