### PR TITLE
Document /validate-entity request body in OpenAPI spec

### DIFF
--- a/.changeset/catalog-validate-entity-openapi-shape.md
+++ b/.changeset/catalog-validate-entity-openapi-shape.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+The `POST /validate-entity` endpoint's request body is now documented in the OpenAPI spec using a generic input shape, rather than being excluded from OpenAPI request validation entirely. This is an internal cleanup with no change to the endpoint's runtime behavior or error responses.

--- a/packages/catalog-client/src/schema/openapi/generated/models/ValidateEntityRequest.model.ts
+++ b/packages/catalog-client/src/schema/openapi/generated/models/ValidateEntityRequest.model.ts
@@ -22,6 +22,6 @@
  * @public
  */
 export interface ValidateEntityRequest {
-  location: string;
-  entity: { [key: string]: any };
+  location?: any | null;
+  entity?: any | null;
 }

--- a/plugins/catalog-backend/src/schema/openapi.yaml
+++ b/plugins/catalog-backend/src/schema/openapi.yaml
@@ -1567,11 +1567,5 @@ paths:
             schema:
               type: object
               properties:
-                location:
-                  type: string
-                entity:
-                  type: object
-                  additionalProperties: {}
-              required:
-                - location
-                - entity
+                location: {}
+                entity: {}

--- a/plugins/catalog-backend/src/schema/openapi/generated/models/ValidateEntityRequest.model.ts
+++ b/plugins/catalog-backend/src/schema/openapi/generated/models/ValidateEntityRequest.model.ts
@@ -22,6 +22,6 @@
  * @public
  */
 export interface ValidateEntityRequest {
-  location: string;
-  entity: { [key: string]: any };
+  location?: any | null;
+  entity?: any | null;
 }

--- a/plugins/catalog-backend/src/schema/openapi/generated/router.ts
+++ b/plugins/catalog-backend/src/schema/openapi/generated/router.ts
@@ -1919,15 +1919,9 @@ export const spec = {
               schema: {
                 type: 'object',
                 properties: {
-                  location: {
-                    type: 'string',
-                  },
-                  entity: {
-                    type: 'object',
-                    additionalProperties: {},
-                  },
+                  location: {},
+                  entity: {},
                 },
-                required: ['location', 'entity'],
               },
             },
           },

--- a/plugins/catalog-backend/src/service/createRouter.ts
+++ b/plugins/catalog-backend/src/service/createRouter.ts
@@ -92,13 +92,7 @@ export interface RouterOptions {
 export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {
-  const router = await createOpenApiRouter({
-    validatorOptions: {
-      // We want the spec to be up to date with the expected value, but the return type needs
-      //  to be controlled by the router implementation not the request validator.
-      ignorePaths: /^\/validate-entity\/?$/,
-    },
-  });
+  const router = await createOpenApiRouter();
   const {
     entitiesCatalog,
     locationAnalyzer,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `POST /validate-entity` endpoint's request body was previously excluded entirely from OpenAPI request validation (via `ignorePaths`) because its `location`/`entity` shape couldn't be expressed precisely under the existing schema. This change documents the request body using a generic input shape instead, so the endpoint is now covered by OpenAPI validation and the generated client/router types reflect the actual spec. There is no change to the endpoint's runtime behavior or error responses.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))