### PR TITLE
fix(docs): make YouTube embed responsive on mobile

### DIFF
--- a/docs/overview/what-is-backstage.md
+++ b/docs/overview/what-is-backstage.md
@@ -14,7 +14,16 @@ high-quality code quickly — without compromising autonomy.
 Backstage unifies all your infrastructure tooling, services, and documentation
 to create a streamlined development environment from end to end.
 
-<iframe width="672" height="378" src="https://www.youtube.com/embed/85TQEpNCaU0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<div style="position: relative; width: 100%; max-width: 672px; padding-bottom: 56.25%; height: 0; margin: 0 auto;">
+  <iframe
+    src="https://www.youtube.com/embed/85TQEpNCaU0"
+    title="What is Backstage?"
+    frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowfullscreen
+    style="position: absolute; inset: 0; width: 100%; height: 100%;"
+  ></iframe>
+</div>
 
 Out of the box, Backstage includes:
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

 

Fixes a mobile UI issue on the What is Backstage docs page where the embedded YouTube video overflowed the viewport.

 

### Changes

- Replaced fixed iframe dimensions with a responsive embed container

- Preserved 16:9 aspect ratio while fitting within mobile width

- Prevented horizontal overflow on small screens

 

Fixes #34821

 

### Screenshot (after change)

<img width="161" height="314" alt="issue-34821" src="https://github.com/user-attachments/assets/614b8730-dbae-4e7b-bf81-542232d03697" />

 

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))

- [x] Added or updated documentation

- [ ] Tests for new functionality and regression tests for bug fixes

- [x] Screenshots attached (for UI changes)

- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))