### PR TITLE
feat(catalog-model): add agentskills.io fields to AiResource skill spec

### DIFF
--- a/.changeset/airesource-skill-agentskills-fields.md
+++ b/.changeset/airesource-skill-agentskills-fields.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': patch
+---
+
+Added optional `allowedTools`, `license`, and `compatibility` fields to the `AiResource` skill spec, aligning with the [agentskills.io](https://agentskills.io/specification) open specification.

--- a/packages/catalog-model/examples/ai-resources/frontend-design-skill.yaml
+++ b/packages/catalog-model/examples/ai-resources/frontend-design-skill.yaml
@@ -16,3 +16,9 @@ spec:
   agents:
     - claude-code
     - copilot
+  allowedTools:
+    - Read
+    - Write
+    - Bash
+  license: Apache-2.0
+  compatibility: Node.js 20+, macOS/Linux

--- a/packages/catalog-model/report-alpha.api.md
+++ b/packages/catalog-model/report-alpha.api.md
@@ -585,6 +585,9 @@ export interface SkillAiResourceEntityV1alpha1
     categories?: string[];
     agents?: string[];
     dependsOn?: string[];
+    allowedTools?: string[];
+    license?: string;
+    compatibility?: string;
   };
 }
 

--- a/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.test.ts
+++ b/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.test.ts
@@ -157,6 +157,16 @@ describe('AiResourceV1alpha1 skill validator', () => {
     await expect(skillValidator.check(entity)).resolves.toBe(true);
   });
 
+  it('accepts skill with allowedTools, license, and compatibility', async () => {
+    entity.spec = {
+      ...entity.spec,
+      allowedTools: ['Read', 'Write', 'Bash'],
+      license: 'Apache-2.0',
+      compatibility: 'Node.js 20+, macOS/Linux',
+    };
+    await expect(skillValidator.check(entity)).resolves.toBe(true);
+  });
+
   it('rejects non-skill type', async () => {
     (entity as any).spec.type = 'rule';
     await expect(skillValidator.check(entity)).rejects.toThrow(/type/);
@@ -199,6 +209,51 @@ describe('AiResourceV1alpha1 skill validator', () => {
   it('rejects dependsOn with empty strings', async () => {
     (entity as any).spec.dependsOn = [''];
     await expect(skillValidator.check(entity)).rejects.toThrow(/dependsOn/);
+  });
+
+  it('accepts missing allowedTools', async () => {
+    delete (entity as any).spec.allowedTools;
+    await expect(skillValidator.check(entity)).resolves.toBe(true);
+  });
+
+  it('rejects allowedTools with empty strings', async () => {
+    (entity as any).spec.allowedTools = [''];
+    await expect(skillValidator.check(entity)).rejects.toThrow(/allowedTools/);
+  });
+
+  it('rejects allowedTools with wrong type', async () => {
+    (entity as any).spec.allowedTools = 'not-an-array';
+    await expect(skillValidator.check(entity)).rejects.toThrow(/allowedTools/);
+  });
+
+  it('accepts missing license', async () => {
+    delete (entity as any).spec.license;
+    await expect(skillValidator.check(entity)).resolves.toBe(true);
+  });
+
+  it('rejects empty license', async () => {
+    (entity as any).spec.license = '';
+    await expect(skillValidator.check(entity)).rejects.toThrow(/license/);
+  });
+
+  it('rejects wrong license type', async () => {
+    (entity as any).spec.license = 42;
+    await expect(skillValidator.check(entity)).rejects.toThrow(/license/);
+  });
+
+  it('accepts missing compatibility', async () => {
+    delete (entity as any).spec.compatibility;
+    await expect(skillValidator.check(entity)).resolves.toBe(true);
+  });
+
+  it('rejects empty compatibility', async () => {
+    (entity as any).spec.compatibility = '';
+    await expect(skillValidator.check(entity)).rejects.toThrow(/compatibility/);
+  });
+
+  it('rejects wrong compatibility type', async () => {
+    (entity as any).spec.compatibility = 42;
+    await expect(skillValidator.check(entity)).rejects.toThrow(/compatibility/);
   });
 });
 

--- a/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.ts
@@ -63,6 +63,9 @@ export interface SkillAiResourceEntityV1alpha1
     categories?: string[];
     agents?: string[];
     dependsOn?: string[];
+    allowedTools?: string[];
+    license?: string;
+    compatibility?: string;
   };
 }
 

--- a/packages/catalog-model/src/schema/kinds/AiResource.v1alpha1.skill.schema.json
+++ b/packages/catalog-model/src/schema/kinds/AiResource.v1alpha1.skill.schema.json
@@ -17,7 +17,10 @@
         "system": "ai-tooling",
         "disciplines": ["web"],
         "categories": ["framework"],
-        "agents": ["claude-code"]
+        "agents": ["claude-code"],
+        "allowedTools": ["Read", "Write", "Bash"],
+        "license": "Apache-2.0",
+        "compatibility": "Node.js 20+, macOS/Linux"
       }
     }
   ],
@@ -92,6 +95,26 @@
                 "type": "string",
                 "minLength": 1
               }
+            },
+            "allowedTools": {
+              "type": "array",
+              "description": "Tools or capabilities the skill is designed to use, as defined by the agentskills.io specification.",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "license": {
+              "type": "string",
+              "description": "An SPDX license identifier or free-text license for the skill content, as defined by the agentskills.io specification.",
+              "examples": ["MIT", "Apache-2.0", "UNLICENSED"],
+              "minLength": 1
+            },
+            "compatibility": {
+              "type": "string",
+              "description": "Intended product, system packages, network access, or other environmental requirements, as defined by the agentskills.io specification.",
+              "examples": ["Node.js 20+, macOS/Linux", "Python 3.11+, Docker"],
+              "minLength": 1
             }
           }
         }


### PR DESCRIPTION
## Proposal: upstream agentskills.io fields to the AiResource skill spec

This PR proposes adding three optional fields to the `AiResource` skill spec (`spec.type: 'skill'`), aligning it with the [agentskills.io](https://agentskills.io/specification) open specification. These fields are already widely used across the AI coding tool ecosystem (Claude Code, Cursor, Copilot, Codex, Gemini CLI, and others) and are standard [SKILL.md frontmatter](https://agentskills.io/specification) keys.

### Current skill spec

```ts
spec: {
  type: 'skill';
  lifecycle: string;
  owner: string;
  system?: string;
  disciplines?: string[];
  categories?: string[];
  agents?: string[];
  dependsOn?: string[];
}
```

### Proposed skill spec

```ts
spec: {
  type: 'skill';
  lifecycle: string;
  owner: string;
  system?: string;
  disciplines?: string[];
  categories?: string[];
  agents?: string[];
  dependsOn?: string[];
  allowedTools?: string[];   // NEW
  license?: string;          // NEW
  compatibility?: string;    // NEW
}
```

### Field-by-field reasoning

#### `allowedTools?: string[]`

Lists the tools or capabilities the skill is designed to use (e.g. `["Read", "Write", "Bash"]`). This is a standard agentskills.io frontmatter field (`allowed-tools`). Agent harnesses use it to restrict or scope tool access when a skill is active — for example, a documentation-only skill might declare `["Read"]` to signal it doesn't need write access.

Without this in the spec, adopters must store it in an annotation and parse it themselves, losing the benefit of schema validation and the typed TypeScript interface.

#### `license?: string`

An SPDX license identifier or free-text license string (e.g. `"Apache-2.0"`, `"MIT"`). Standard agentskills.io field. Skills are authored content that may be shared across organizations, so license metadata is important for catalog consumers to surface and filter on — especially in enterprise contexts where legal compliance gates adoption.

#### `compatibility?: string`

Describes the intended product, system packages, network access, or other environmental requirements (e.g. `"Node.js 20+, macOS/Linux"`). Standard agentskills.io field. This tells consumers whether a skill is applicable to their environment before they install or activate it. It subsumes the narrower "environment" concept some implementations use today.

### Why now?

- The `AiResource` kind is `@alpha` (`v1alpha1`) with no downstream consumers yet beyond Spotify Portal, so the bar for schema evolution is low.
- All three fields come from an established open spec rather than a single-vendor proposal.
- Spotify Portal is actively migrating its proprietary `AiContext` kind onto `AiResource`. Without these fields in the spec, Portal must store them as annotations and lose schema validation. Adding them upstream means Portal validates against the stock schema with no fork.
- The original [AiResource RFC](https://github.com/backstage/backstage/issues/33575) scoped the initial kind to the minimum viable fields. These three are the most immediate fields needed by a real adopter.

### What this PR does NOT propose (future follow-ups)

#### Rule `activation` field (`spec.type: 'rule'`)

The original RFC included an `activation` field for rules that was dropped from the merged schema. Portal needs activation metadata to install rules into agent harnesses (Claude Code `paths`/`globs`, Cursor `alwaysApply`, etc.). The proposed shape is a discriminated union, but the exact design is still being finalized internally. We plan to propose this as a separate PR once the shape settles — storing it as a Portal annotation in the interim.

#### Other Portal-internal mappings

Several `AiContext` fields are being migrated into standard Backstage metadata rather than new spec fields:
- `labels` → `metadata.tags`
- `usecases` → folded into `metadata.description`
- `source.docs` / `source.examples` → `metadata.links`
- `ruleType` → `metadata.labels`
- `environment` → subsumed by `compatibility`

These don't require upstream schema changes.

### Changes in this PR

| File | Change |
|---|---|
| `AiResource.v1alpha1.skill.schema.json` | Add `allowedTools`, `license`, `compatibility` as optional properties |
| `AiResourceEntityV1alpha1.ts` | Add fields to `SkillAiResourceEntityV1alpha1` interface |
| `AiResourceEntityV1alpha1.test.ts` | Add validation tests (acceptance + rejection) for each new field |
| `report-alpha.api.md` | Updated API report |
| `frontend-design-skill.yaml` | Updated example entity |
| Changeset | Patch for `@backstage/catalog-model` |