### PR TITLE
docs: truncate MkDocs build in CI

### DIFF
--- a/.github/workflows/verify_microsite-noop.yml
+++ b/.github/workflows/verify_microsite-noop.yml
@@ -9,6 +9,7 @@ on:
       - 'microsite/**'
       - 'beps/**'
       - 'mkdocs.yml'
+      - 'mkdocs-ci.yml'
       - 'docs/**'
 
 permissions:

--- a/.github/workflows/verify_microsite.yml
+++ b/.github/workflows/verify_microsite.yml
@@ -7,6 +7,7 @@ on:
       - 'microsite/**'
       - 'beps/**'
       - 'mkdocs.yml'
+      - 'mkdocs-ci.yml'
       - 'docs/**'
 
 permissions:
@@ -284,7 +285,7 @@ jobs:
           clean: false
 
       - name: Build MkDocs for TechDocs
-        run: mkdocs build --strict
+        run: mkdocs build --strict --config-file mkdocs-ci.yml
 
       - name: download next OpenAPI API docs
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/mkdocs-ci.yml
+++ b/mkdocs-ci.yml
@@ -1,0 +1,27 @@
+INHERIT: mkdocs.yml
+
+# The complete documentation is built and validated by Docusaurus. Keep this
+# TechDocs build focused on the overview while preserving its relative paths.
+exclude_docs: |
+  /*
+  !/overview/
+  !/assets/
+
+validation:
+  links:
+    # Overview pages link to documents intentionally excluded from this build.
+    not_found: info
+
+nav:
+  - Overview:
+      - What is Backstage?: 'overview/what-is-backstage.md'
+      - Technical overview: 'overview/technical-overview.md'
+      - Architecture overview: 'overview/architecture-overview.md'
+      - Project Roadmap: 'overview/roadmap.md'
+      - Vision: 'overview/vision.md'
+      - The Spotify Story: 'overview/background.md'
+      - Strategies for adopting: 'overview/adopting.md'
+      - Release & Versioning Policy: 'overview/versioning-policy.md'
+      - Backstage Threat Model: 'overview/threat-model.md'
+      - Support and community: 'overview/support.md'
+      - Logo assets: 'overview/logos.md'


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds a CI-specific MkDocs configuration that builds only the Overview documentation and shared assets. It inherits the main configuration and keeps `docs` as the documentation root, preserving existing relative paths while excluding the rest of the documentation from rendering. Links to pages intentionally omitted from this reduced build are reported at informational level so `--strict` remains enabled for all other warnings.

The microsite workflow now uses this configuration and both workflow path filters include it. In a local comparison, the strict MkDocs build decreased from approximately 47 seconds to 1.4 seconds.

Closes #29662

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. (Not applicable; no packages changed.)
- [ ] Added or updated documentation (Not applicable; this changes CI validation.)
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (Not applicable; no UI changes.)
- [x] All your commits have a `Signed-off-by` line in the message.