### PR TITLE
Change ComboboxInput border-radius variable

### DIFF
--- a/.changeset/every-bears-look.md
+++ b/.changeset/every-bears-look.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+unify border radius of combobox to align with other form components

--- a/.changeset/every-bears-look.md
+++ b/.changeset/every-bears-look.md
@@ -2,4 +2,4 @@
 '@backstage/ui': patch
 ---
 
-unify border radius of combobox to align with other form components
+Align Combobox input border radius with other form components.

--- a/packages/ui/src/components/Combobox/Combobox.module.css
+++ b/packages/ui/src/components/Combobox/Combobox.module.css
@@ -45,7 +45,7 @@
 
   .bui-ComboboxInput {
     box-sizing: border-box;
-    border-radius: var(--bui-radius-3);
+    border-radius: var(--bui-radius-2);
     border: none;
     outline: none;
     background-color: var(--bui-bg-neutral-1);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The border radius of other form elements is set to `--bui-radius-2`. To make it consistent, the Combobox should also have a border radius of `--bui-radius-2` instead of `--bui-radius-3`

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
