### PR TITLE
Add activation field to AiResource rule spec

### DIFF
--- a/.changeset/airesource-rule-activation-field.md
+++ b/.changeset/airesource-rule-activation-field.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/catalog-model': patch
+'@backstage/catalog-model': minor
 ---
 
 Added optional `activation` field to the `@alpha` AiResource rule spec. The field is a harness-discriminated array that describes how a rule is activated in different agent harnesses (e.g. Claude Code, Cursor, Codex), each with its native configuration.

--- a/.changeset/airesource-rule-activation-field.md
+++ b/.changeset/airesource-rule-activation-field.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': patch
+---
+
+Added optional `activation` field to the `@alpha` AiResource rule spec. The field is a harness-discriminated array that describes how a rule is activated in different agent harnesses (e.g. Claude Code, Cursor, Codex), each with its native configuration.

--- a/.changeset/airesource-rule-activation-field.md
+++ b/.changeset/airesource-rule-activation-field.md
@@ -2,4 +2,4 @@
 '@backstage/catalog-model': minor
 ---
 
-Added optional `activation` field to the `@alpha` AiResource rule spec. The field is a harness-discriminated array that describes how a rule is activated in different agent harnesses (e.g. Claude Code, Cursor, Codex), each with its native configuration.
+Added optional `activation` field to the `@alpha` AiResource rule spec. The field is a harness-discriminated array that describes how a rule is activated in the supported agent harnesses (Claude Code, Cursor, Codex), each with its native configuration. Entries are validated against the set of supported harnesses.

--- a/packages/catalog-model/examples/ai-resources/use-internal-apis-rule.yaml
+++ b/packages/catalog-model/examples/ai-resources/use-internal-apis-rule.yaml
@@ -22,3 +22,4 @@ spec:
       alwaysApply: false
       globs:
         - 'src/**'
+    - harness: codex

--- a/packages/catalog-model/examples/ai-resources/use-internal-apis-rule.yaml
+++ b/packages/catalog-model/examples/ai-resources/use-internal-apis-rule.yaml
@@ -13,3 +13,12 @@ spec:
     - backend
   category: architecture
   rationale: Ensures consistent error handling, authentication, and observability across all service calls
+  activation:
+    - harness: claude
+      paths:
+        - 'src/**'
+      description: Apply when editing source files
+    - harness: cursor
+      alwaysApply: false
+      globs:
+        - 'src/**'

--- a/packages/catalog-model/report-alpha.api.md
+++ b/packages/catalog-model/report-alpha.api.md
@@ -9,15 +9,10 @@ import { JsonValue } from '@backstage/types';
 import { SerializedError } from '@backstage/errors';
 
 // @alpha
-export type ActivationConstraint<T extends string> = T extends 'claude'
-  ? ClaudeActivationV1
-  : T extends 'cursor'
-  ? CursorActivationV1
-  : {
-      harness: T;
-    } & {
-      [key: string]: JsonValue;
-    };
+export type AiResourceActivationEntry =
+  | ClaudeActivationV1
+  | CursorActivationV1
+  | CodexActivationV1;
 
 // @alpha
 export const aiResourceEntityModel: CatalogModelLayer;
@@ -450,6 +445,11 @@ export type ClaudeActivationV1 = {
 };
 
 // @alpha
+export type CodexActivationV1 = {
+  harness: 'codex';
+};
+
+// @alpha
 export function compileCatalogModel(
   inputs: Iterable<CatalogModelLayer>,
 ): CatalogModel;
@@ -592,7 +592,7 @@ export interface RuleAiResourceEntityV1alpha1
     disciplines?: string[];
     category: string;
     rationale: string;
-    activation?: Array<ActivationConstraint<string>>;
+    activation?: AiResourceActivationEntry[];
   };
 }
 

--- a/packages/catalog-model/report-alpha.api.md
+++ b/packages/catalog-model/report-alpha.api.md
@@ -9,6 +9,17 @@ import { JsonValue } from '@backstage/types';
 import { SerializedError } from '@backstage/errors';
 
 // @alpha
+export type ActivationConstraint<T extends string> = T extends 'claude'
+  ? ClaudeCodeActivationV1
+  : T extends 'cursor'
+  ? CursorActivationV1
+  : {
+      harness: T;
+    } & {
+      [key: string]: JsonValue;
+    };
+
+// @alpha
 export const aiResourceEntityModel: CatalogModelLayer;
 
 // @alpha
@@ -432,6 +443,13 @@ export interface CatalogModelUpdateTagDefinition {
 }
 
 // @alpha
+export type ClaudeCodeActivationV1 = {
+  harness: 'claude';
+  paths?: string[];
+  description?: string;
+};
+
+// @alpha
 export function compileCatalogModel(
   inputs: Iterable<CatalogModelLayer>,
 ): CatalogModel;
@@ -447,6 +465,14 @@ export function createCatalogModelLayerBuilder(options: {
   layerId: string;
 }): CatalogModelLayerBuilder & {
   build(): CatalogModelLayer;
+};
+
+// @alpha
+export type CursorActivationV1 = {
+  harness: 'cursor';
+  alwaysApply?: boolean;
+  globs?: string[];
+  description?: string;
 };
 
 // @alpha
@@ -566,10 +592,7 @@ export interface RuleAiResourceEntityV1alpha1
     disciplines?: string[];
     category: string;
     rationale: string;
-    activation?: Array<{
-      harness: string;
-      [key: string]: JsonValue;
-    }>;
+    activation?: Array<ActivationConstraint<string>>;
   };
 }
 

--- a/packages/catalog-model/report-alpha.api.md
+++ b/packages/catalog-model/report-alpha.api.md
@@ -10,7 +10,7 @@ import { SerializedError } from '@backstage/errors';
 
 // @alpha
 export type ActivationConstraint<T extends string> = T extends 'claude'
-  ? ClaudeCodeActivationV1
+  ? ClaudeActivationV1
   : T extends 'cursor'
   ? CursorActivationV1
   : {
@@ -443,7 +443,7 @@ export interface CatalogModelUpdateTagDefinition {
 }
 
 // @alpha
-export type ClaudeCodeActivationV1 = {
+export type ClaudeActivationV1 = {
   harness: 'claude';
   paths?: string[];
   description?: string;

--- a/packages/catalog-model/report-alpha.api.md
+++ b/packages/catalog-model/report-alpha.api.md
@@ -566,6 +566,10 @@ export interface RuleAiResourceEntityV1alpha1
     disciplines?: string[];
     category: string;
     rationale: string;
+    activation?: Array<{
+      harness: string;
+      [key: string]: JsonValue;
+    }>;
   };
 }
 

--- a/packages/catalog-model/src/alpha.ts
+++ b/packages/catalog-model/src/alpha.ts
@@ -30,9 +30,10 @@ export type {
 export type {
   AiResourceEntityV1alpha1,
   AiResourceEntityV1alpha1Default,
-  ActivationConstraint,
+  AiResourceActivationEntry,
   ClaudeActivationV1,
   CursorActivationV1,
+  CodexActivationV1,
   SkillAiResourceEntityV1alpha1,
   RuleAiResourceEntityV1alpha1,
 } from './kinds/AiResourceEntityV1alpha1';

--- a/packages/catalog-model/src/alpha.ts
+++ b/packages/catalog-model/src/alpha.ts
@@ -31,7 +31,7 @@ export type {
   AiResourceEntityV1alpha1,
   AiResourceEntityV1alpha1Default,
   ActivationConstraint,
-  ClaudeCodeActivationV1,
+  ClaudeActivationV1,
   CursorActivationV1,
   SkillAiResourceEntityV1alpha1,
   RuleAiResourceEntityV1alpha1,

--- a/packages/catalog-model/src/alpha.ts
+++ b/packages/catalog-model/src/alpha.ts
@@ -30,6 +30,9 @@ export type {
 export type {
   AiResourceEntityV1alpha1,
   AiResourceEntityV1alpha1Default,
+  ActivationConstraint,
+  ClaudeCodeActivationV1,
+  CursorActivationV1,
   SkillAiResourceEntityV1alpha1,
   RuleAiResourceEntityV1alpha1,
 } from './kinds/AiResourceEntityV1alpha1';

--- a/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.test.ts
+++ b/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.test.ts
@@ -302,6 +302,11 @@ describe('AiResourceV1alpha1 rule validator', () => {
     await expect(ruleValidator.check(entity)).rejects.toThrow(/harness/);
   });
 
+  it('rejects empty activation array', async () => {
+    (entity as any).spec.activation = [];
+    await expect(ruleValidator.check(entity)).rejects.toThrow(/activation/);
+  });
+
   it('rejects activation with wrong type', async () => {
     (entity as any).spec.activation = 'not-an-array';
     await expect(ruleValidator.check(entity)).rejects.toThrow(/activation/);

--- a/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.test.ts
+++ b/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.test.ts
@@ -273,6 +273,39 @@ describe('AiResourceV1alpha1 rule validator', () => {
     (entity as any).spec.disciplines = [''];
     await expect(ruleValidator.check(entity)).rejects.toThrow(/disciplines/);
   });
+
+  it('accepts valid activation', async () => {
+    (entity as any).spec.activation = [
+      {
+        harness: 'claude',
+        paths: ['src/**'],
+        description: 'Apply when editing source',
+      },
+      { harness: 'cursor', alwaysApply: false, globs: ['src/**'] },
+      { harness: 'codex' },
+    ];
+    await expect(ruleValidator.check(entity)).resolves.toBe(true);
+  });
+
+  it('accepts missing activation', async () => {
+    delete (entity as any).spec.activation;
+    await expect(ruleValidator.check(entity)).resolves.toBe(true);
+  });
+
+  it('rejects activation items without harness', async () => {
+    (entity as any).spec.activation = [{ paths: ['src/**'] }];
+    await expect(ruleValidator.check(entity)).rejects.toThrow(/harness/);
+  });
+
+  it('rejects activation with empty harness', async () => {
+    (entity as any).spec.activation = [{ harness: '' }];
+    await expect(ruleValidator.check(entity)).rejects.toThrow(/harness/);
+  });
+
+  it('rejects activation with wrong type', async () => {
+    (entity as any).spec.activation = 'not-an-array';
+    await expect(ruleValidator.check(entity)).rejects.toThrow(/activation/);
+  });
 });
 
 describe('isAiResourceEntity', () => {

--- a/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.test.ts
+++ b/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.test.ts
@@ -311,6 +311,53 @@ describe('AiResourceV1alpha1 rule validator', () => {
     (entity as any).spec.activation = 'not-an-array';
     await expect(ruleValidator.check(entity)).rejects.toThrow(/activation/);
   });
+
+  it('accepts known-harness entries with only the harness field', async () => {
+    (entity as any).spec.activation = [
+      { harness: 'claude' },
+      { harness: 'cursor' },
+    ];
+    await expect(ruleValidator.check(entity)).resolves.toBe(true);
+  });
+
+  it('rejects entries with fields not defined for the harness', async () => {
+    (entity as any).spec.activation = [
+      { harness: 'claude', globs: ['src/**'] },
+    ];
+    await expect(ruleValidator.check(entity)).rejects.toThrow(/activation/);
+  });
+
+  it('rejects claude activation with wrong paths type', async () => {
+    (entity as any).spec.activation = [{ harness: 'claude', paths: 42 }];
+    await expect(ruleValidator.check(entity)).rejects.toThrow(/paths/);
+  });
+
+  it('rejects claude activation with empty path globs', async () => {
+    (entity as any).spec.activation = [{ harness: 'claude', paths: [''] }];
+    await expect(ruleValidator.check(entity)).rejects.toThrow(/paths/);
+  });
+
+  it('rejects cursor activation with wrong alwaysApply type', async () => {
+    (entity as any).spec.activation = [
+      { harness: 'cursor', alwaysApply: 'yes' },
+    ];
+    await expect(ruleValidator.check(entity)).rejects.toThrow(/alwaysApply/);
+  });
+
+  it('rejects cursor activation with wrong globs type', async () => {
+    (entity as any).spec.activation = [{ harness: 'cursor', globs: 'src/**' }];
+    await expect(ruleValidator.check(entity)).rejects.toThrow(/globs/);
+  });
+
+  it('rejects unsupported harnesses', async () => {
+    (entity as any).spec.activation = [{ harness: 'windsurf' }];
+    await expect(ruleValidator.check(entity)).rejects.toThrow(/activation/);
+  });
+
+  it('rejects codex activation with extra fields', async () => {
+    (entity as any).spec.activation = [{ harness: 'codex', paths: ['src/**'] }];
+    await expect(ruleValidator.check(entity)).rejects.toThrow(/activation/);
+  });
 });
 
 describe('isAiResourceEntity', () => {

--- a/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.ts
@@ -18,7 +18,7 @@ import { createCatalogModelLayer } from '../model/createCatalogModelLayer';
 import type { Entity } from '../entity/Entity';
 import { entityKindSchemaValidator } from '../validation';
 import type { KindValidator } from './types';
-import type { JsonObject, JsonValue } from '@backstage/types';
+import type { JsonObject } from '@backstage/types';
 import defaultJsonSchema from '../schema/kinds/AiResource.v1alpha1.schema.json';
 import skillJsonSchema from '../schema/kinds/AiResource.v1alpha1.skill.schema.json';
 import ruleJsonSchema from '../schema/kinds/AiResource.v1alpha1.rule.schema.json';
@@ -90,32 +90,34 @@ export type CursorActivationV1 = {
 };
 
 /**
- * Resolves the activation entry type for a given harness. Known harnesses
- * resolve to their strict native shape; unknown harnesses fall back to an
- * open shape that only requires the `harness` discriminator.
- *
- * @remarks
- *
- * The strict branches only apply when the harness is known at compile time,
- * e.g. in code that constructs activation entries:
- *
- * ```ts
- * const entry: ActivationConstraint<'claude'> = {
- *   harness: 'claude',
- *   paths: ['src/**'],
- * };
- * ```
- *
- * When reading entities from the catalog the harness is only known at
- * runtime, so `ActivationConstraint<string>` resolves to the open fallback.
+ * Activation entry for the Codex harness.
  *
  * @alpha
  */
-export type ActivationConstraint<T extends string> = T extends 'claude'
-  ? ClaudeActivationV1
-  : T extends 'cursor'
-  ? CursorActivationV1
-  : { harness: T } & { [key: string]: JsonValue };
+export type CodexActivationV1 = {
+  harness: 'codex';
+};
+
+/**
+ * A single activation entry for an AiResource rule, describing how the rule
+ * is activated in a specific agent harness.
+ *
+ * @remarks
+ *
+ * The union is discriminated by the `harness` field and is closed: each
+ * supported harness has its own typed variant, and entries for other
+ * harnesses are rejected at validation. Support for a new harness is added
+ * as a new variant of this union.
+ *
+ * All fields other than `harness` are optional. A bare entry such as
+ * `{ harness: 'claude' }` means the rule is always active in that harness.
+ *
+ * @alpha
+ */
+export type AiResourceActivationEntry =
+  | ClaudeActivationV1
+  | CursorActivationV1
+  | CodexActivationV1;
 
 /**
  * AiResource entity with spec.type 'rule'. Represents a governance rule
@@ -133,7 +135,7 @@ export interface RuleAiResourceEntityV1alpha1
     disciplines?: string[];
     category: string;
     rationale: string;
-    activation?: Array<ActivationConstraint<string>>;
+    activation?: AiResourceActivationEntry[];
   };
 }
 

--- a/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.ts
@@ -18,7 +18,7 @@ import { createCatalogModelLayer } from '../model/createCatalogModelLayer';
 import type { Entity } from '../entity/Entity';
 import { entityKindSchemaValidator } from '../validation';
 import type { KindValidator } from './types';
-import type { JsonObject } from '@backstage/types';
+import type { JsonObject, JsonValue } from '@backstage/types';
 import defaultJsonSchema from '../schema/kinds/AiResource.v1alpha1.schema.json';
 import skillJsonSchema from '../schema/kinds/AiResource.v1alpha1.skill.schema.json';
 import ruleJsonSchema from '../schema/kinds/AiResource.v1alpha1.rule.schema.json';
@@ -82,6 +82,7 @@ export interface RuleAiResourceEntityV1alpha1
     disciplines?: string[];
     category: string;
     rationale: string;
+    activation?: Array<{ harness: string; [key: string]: JsonValue }>;
   };
 }
 

--- a/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.ts
@@ -71,7 +71,7 @@ export interface SkillAiResourceEntityV1alpha1
  *
  * @alpha
  */
-export type ClaudeCodeActivationV1 = {
+export type ClaudeActivationV1 = {
   harness: 'claude';
   paths?: string[];
   description?: string;
@@ -112,7 +112,7 @@ export type CursorActivationV1 = {
  * @alpha
  */
 export type ActivationConstraint<T extends string> = T extends 'claude'
-  ? ClaudeCodeActivationV1
+  ? ClaudeActivationV1
   : T extends 'cursor'
   ? CursorActivationV1
   : { harness: T } & { [key: string]: JsonValue };

--- a/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.ts
@@ -67,6 +67,57 @@ export interface SkillAiResourceEntityV1alpha1
 }
 
 /**
+ * Activation entry for the Claude Code harness.
+ *
+ * @alpha
+ */
+export type ClaudeCodeActivationV1 = {
+  harness: 'claude';
+  paths?: string[];
+  description?: string;
+};
+
+/**
+ * Activation entry for the Cursor harness.
+ *
+ * @alpha
+ */
+export type CursorActivationV1 = {
+  harness: 'cursor';
+  alwaysApply?: boolean;
+  globs?: string[];
+  description?: string;
+};
+
+/**
+ * Resolves the activation entry type for a given harness. Known harnesses
+ * resolve to their strict native shape; unknown harnesses fall back to an
+ * open shape that only requires the `harness` discriminator.
+ *
+ * @remarks
+ *
+ * The strict branches only apply when the harness is known at compile time,
+ * e.g. in code that constructs activation entries:
+ *
+ * ```ts
+ * const entry: ActivationConstraint<'claude'> = {
+ *   harness: 'claude',
+ *   paths: ['src/**'],
+ * };
+ * ```
+ *
+ * When reading entities from the catalog the harness is only known at
+ * runtime, so `ActivationConstraint<string>` resolves to the open fallback.
+ *
+ * @alpha
+ */
+export type ActivationConstraint<T extends string> = T extends 'claude'
+  ? ClaudeCodeActivationV1
+  : T extends 'cursor'
+  ? CursorActivationV1
+  : { harness: T } & { [key: string]: JsonValue };
+
+/**
  * AiResource entity with spec.type 'rule'. Represents a governance rule
  * or constraint for AI coding tools.
  *
@@ -82,7 +133,7 @@ export interface RuleAiResourceEntityV1alpha1
     disciplines?: string[];
     category: string;
     rationale: string;
-    activation?: Array<{ harness: string; [key: string]: JsonValue }>;
+    activation?: Array<ActivationConstraint<string>>;
   };
 }
 

--- a/packages/catalog-model/src/schema/kinds/AiResource.v1alpha1.rule.schema.json
+++ b/packages/catalog-model/src/schema/kinds/AiResource.v1alpha1.rule.schema.json
@@ -81,19 +81,74 @@
             },
             "activation": {
               "type": "array",
-              "description": "Describes how the rule is activated in agent harnesses. Each entry targets a specific harness and carries its native activation fields.",
+              "description": "Describes how the rule is activated in agent harnesses. Each entry targets a supported harness and carries its native activation fields.",
               "minItems": 1,
               "items": {
-                "type": "object",
-                "required": ["harness"],
-                "properties": {
-                  "harness": {
-                    "type": "string",
-                    "description": "The agent harness type (e.g. claude, cursor, codex).",
-                    "minLength": 1
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "required": ["harness"],
+                    "additionalProperties": false,
+                    "properties": {
+                      "harness": {
+                        "const": "claude",
+                        "description": "Activation for the Claude Code harness."
+                      },
+                      "paths": {
+                        "type": "array",
+                        "description": "File globs that activate the rule in Claude Code.",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "description": {
+                        "type": "string",
+                        "description": "Describes when Claude Code should apply the rule.",
+                        "minLength": 1
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "required": ["harness"],
+                    "additionalProperties": false,
+                    "properties": {
+                      "harness": {
+                        "const": "cursor",
+                        "description": "Activation for the Cursor harness."
+                      },
+                      "alwaysApply": {
+                        "type": "boolean",
+                        "description": "Whether Cursor should always apply the rule."
+                      },
+                      "globs": {
+                        "type": "array",
+                        "description": "File globs that activate the rule in Cursor.",
+                        "items": {
+                          "type": "string",
+                          "minLength": 1
+                        }
+                      },
+                      "description": {
+                        "type": "string",
+                        "description": "Describes when Cursor should apply the rule.",
+                        "minLength": 1
+                      }
+                    }
+                  },
+                  {
+                    "type": "object",
+                    "required": ["harness"],
+                    "additionalProperties": false,
+                    "properties": {
+                      "harness": {
+                        "const": "codex",
+                        "description": "Activation for the Codex harness."
+                      }
+                    }
                   }
-                },
-                "additionalProperties": true
+                ]
               }
             }
           }

--- a/packages/catalog-model/src/schema/kinds/AiResource.v1alpha1.rule.schema.json
+++ b/packages/catalog-model/src/schema/kinds/AiResource.v1alpha1.rule.schema.json
@@ -82,6 +82,7 @@
             "activation": {
               "type": "array",
               "description": "Describes how the rule is activated in agent harnesses. Each entry targets a specific harness and carries its native activation fields.",
+              "minItems": 1,
               "items": {
                 "type": "object",
                 "required": ["harness"],

--- a/packages/catalog-model/src/schema/kinds/AiResource.v1alpha1.rule.schema.json
+++ b/packages/catalog-model/src/schema/kinds/AiResource.v1alpha1.rule.schema.json
@@ -78,6 +78,22 @@
               "type": "string",
               "description": "Explanation of why this rule exists.",
               "minLength": 1
+            },
+            "activation": {
+              "type": "array",
+              "description": "Describes how the rule is activated in agent harnesses. Each entry targets a specific harness and carries its native activation fields.",
+              "items": {
+                "type": "object",
+                "required": ["harness"],
+                "properties": {
+                  "harness": {
+                    "type": "string",
+                    "description": "The agent harness type (e.g. claude, cursor, codex).",
+                    "minLength": 1
+                  }
+                },
+                "additionalProperties": true
+              }
             }
           }
         }


### PR DESCRIPTION
Add an optional `activation` field to the `@alpha` AiResource rule spec (`RuleAiResourceEntityV1alpha1`). This field was part of the [original AiResource RFC (#33575)](https://github.com/backstage/backstage/issues/33575) but was dropped from the merged v1alpha1 schema.

The field uses a **harness-discriminated array** where each entry targets a specific agent harness (e.g. `claude`, `cursor`, `codex`) and carries that tool's native activation fields:

```yaml
activation:
  - harness: claude
    paths: ['src/**']
    description: Apply when editing source files
  - harness: cursor
    alwaysApply: false
    globs: ['src/**']
  - harness: codex
```

This avoids the lossy translation problems of a generic strategy-based shape — each harness gets its exact native fields, and new tools are added as new entries without touching existing ones.

Resolves #34876 (rule activation portion — skill fields in a separate PR)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

🤖 Generated with [Claude Code](https://claude.com/claude-code)