### PR TITLE
Add agentskills.io fields to AiResource skill spec

### DIFF
--- a/.changeset/airesource-skill-agentskills-fields.md
+++ b/.changeset/airesource-skill-agentskills-fields.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': patch
+---
+
+Added optional `allowedTools`, `license`, and `compatibility` fields to the `@alpha` AiResource skill spec, aligned with the agentskills.io specification.

--- a/.changeset/airesource-skill-agentskills-fields.md
+++ b/.changeset/airesource-skill-agentskills-fields.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/catalog-model': patch
+'@backstage/catalog-model': minor
 ---
 
 Added optional `allowedTools`, `license`, and `compatibility` fields to the `@alpha` AiResource skill spec, aligned with the agentskills.io specification.

--- a/packages/catalog-model/examples/ai-resources/frontend-design-skill.yaml
+++ b/packages/catalog-model/examples/ai-resources/frontend-design-skill.yaml
@@ -16,9 +16,6 @@ spec:
   agents:
     - claude-code
     - copilot
-  allowedTools:
-    - Read
-    - Edit
-    - WebSearch
+  allowedTools: Read Edit WebSearch
   license: Apache-2.0
   compatibility: Node.js 20+, macOS/Linux

--- a/packages/catalog-model/examples/ai-resources/frontend-design-skill.yaml
+++ b/packages/catalog-model/examples/ai-resources/frontend-design-skill.yaml
@@ -16,6 +16,6 @@ spec:
   agents:
     - claude-code
     - copilot
-  allowedTools: Read Edit WebSearch
+  allowedTools: Bash(git:*) Bash(jq:*) Read Edit
   license: Apache-2.0
   compatibility: Node.js 20+, macOS/Linux

--- a/packages/catalog-model/examples/ai-resources/frontend-design-skill.yaml
+++ b/packages/catalog-model/examples/ai-resources/frontend-design-skill.yaml
@@ -16,3 +16,9 @@ spec:
   agents:
     - claude-code
     - copilot
+  allowedTools:
+    - Read
+    - Edit
+    - WebSearch
+  license: Apache-2.0
+  compatibility: Node.js 20+, macOS/Linux

--- a/packages/catalog-model/report-alpha.api.md
+++ b/packages/catalog-model/report-alpha.api.md
@@ -585,7 +585,7 @@ export interface SkillAiResourceEntityV1alpha1
     categories?: string[];
     agents?: string[];
     dependsOn?: string[];
-    allowedTools?: string[];
+    allowedTools?: string;
     license?: string;
     compatibility?: string;
   };

--- a/packages/catalog-model/report-alpha.api.md
+++ b/packages/catalog-model/report-alpha.api.md
@@ -585,6 +585,9 @@ export interface SkillAiResourceEntityV1alpha1
     categories?: string[];
     agents?: string[];
     dependsOn?: string[];
+    allowedTools?: string[];
+    license?: string;
+    compatibility?: string;
   };
 }
 

--- a/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.test.ts
+++ b/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.test.ts
@@ -200,6 +200,66 @@ describe('AiResourceV1alpha1 skill validator', () => {
     (entity as any).spec.dependsOn = [''];
     await expect(skillValidator.check(entity)).rejects.toThrow(/dependsOn/);
   });
+
+  it('accepts valid allowedTools', async () => {
+    entity.spec = {
+      type: 'skill',
+      lifecycle: 'production',
+      owner: 'team-a',
+      allowedTools: ['Read', 'Write', 'Bash'],
+    };
+    await expect(skillValidator.check(entity)).resolves.toBe(true);
+  });
+
+  it('rejects allowedTools with empty strings', async () => {
+    (entity as any).spec.allowedTools = [''];
+    await expect(skillValidator.check(entity)).rejects.toThrow(/allowedTools/);
+  });
+
+  it('rejects allowedTools with wrong type', async () => {
+    (entity as any).spec.allowedTools = 'not-an-array';
+    await expect(skillValidator.check(entity)).rejects.toThrow(/allowedTools/);
+  });
+
+  it('accepts valid license', async () => {
+    entity.spec = {
+      type: 'skill',
+      lifecycle: 'production',
+      owner: 'team-a',
+      license: 'Apache-2.0',
+    };
+    await expect(skillValidator.check(entity)).resolves.toBe(true);
+  });
+
+  it('rejects empty license', async () => {
+    (entity as any).spec.license = '';
+    await expect(skillValidator.check(entity)).rejects.toThrow(/license/);
+  });
+
+  it('rejects wrong license type', async () => {
+    (entity as any).spec.license = 42;
+    await expect(skillValidator.check(entity)).rejects.toThrow(/license/);
+  });
+
+  it('accepts valid compatibility', async () => {
+    entity.spec = {
+      type: 'skill',
+      lifecycle: 'production',
+      owner: 'team-a',
+      compatibility: 'Node.js 20+, macOS/Linux',
+    };
+    await expect(skillValidator.check(entity)).resolves.toBe(true);
+  });
+
+  it('rejects empty compatibility', async () => {
+    (entity as any).spec.compatibility = '';
+    await expect(skillValidator.check(entity)).rejects.toThrow(/compatibility/);
+  });
+
+  it('rejects wrong compatibility type', async () => {
+    (entity as any).spec.compatibility = 42;
+    await expect(skillValidator.check(entity)).rejects.toThrow(/compatibility/);
+  });
 });
 
 describe('AiResourceV1alpha1 rule validator', () => {

--- a/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.test.ts
+++ b/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.test.ts
@@ -221,6 +221,11 @@ describe('AiResourceV1alpha1 skill validator', () => {
     await expect(skillValidator.check(entity)).rejects.toThrow(/allowedTools/);
   });
 
+  it('rejects allowedTools with wrong item type', async () => {
+    (entity as any).spec.allowedTools = [42];
+    await expect(skillValidator.check(entity)).rejects.toThrow(/allowedTools/);
+  });
+
   it('accepts valid license', async () => {
     entity.spec = {
       type: 'skill',

--- a/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.test.ts
+++ b/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.test.ts
@@ -206,23 +206,18 @@ describe('AiResourceV1alpha1 skill validator', () => {
       type: 'skill',
       lifecycle: 'production',
       owner: 'team-a',
-      allowedTools: ['Read', 'Write', 'Bash'],
+      allowedTools: 'Bash(git:*) Bash(jq:*) Read',
     };
     await expect(skillValidator.check(entity)).resolves.toBe(true);
   });
 
-  it('rejects allowedTools with empty strings', async () => {
-    (entity as any).spec.allowedTools = [''];
+  it('rejects empty allowedTools', async () => {
+    (entity as any).spec.allowedTools = '';
     await expect(skillValidator.check(entity)).rejects.toThrow(/allowedTools/);
   });
 
   it('rejects allowedTools with wrong type', async () => {
-    (entity as any).spec.allowedTools = 'not-an-array';
-    await expect(skillValidator.check(entity)).rejects.toThrow(/allowedTools/);
-  });
-
-  it('rejects allowedTools with wrong item type', async () => {
-    (entity as any).spec.allowedTools = [42];
+    (entity as any).spec.allowedTools = ['Read', 'Write'];
     await expect(skillValidator.check(entity)).rejects.toThrow(/allowedTools/);
   });
 

--- a/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.test.ts
+++ b/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.test.ts
@@ -256,6 +256,11 @@ describe('AiResourceV1alpha1 skill validator', () => {
     await expect(skillValidator.check(entity)).rejects.toThrow(/compatibility/);
   });
 
+  it('rejects compatibility longer than 500 characters', async () => {
+    (entity as any).spec.compatibility = 'a'.repeat(501);
+    await expect(skillValidator.check(entity)).rejects.toThrow(/compatibility/);
+  });
+
   it('rejects wrong compatibility type', async () => {
     (entity as any).spec.compatibility = 42;
     await expect(skillValidator.check(entity)).rejects.toThrow(/compatibility/);

--- a/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.ts
@@ -63,6 +63,9 @@ export interface SkillAiResourceEntityV1alpha1
     categories?: string[];
     agents?: string[];
     dependsOn?: string[];
+    allowedTools?: string[];
+    license?: string;
+    compatibility?: string;
   };
 }
 

--- a/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.ts
@@ -63,7 +63,7 @@ export interface SkillAiResourceEntityV1alpha1
     categories?: string[];
     agents?: string[];
     dependsOn?: string[];
-    allowedTools?: string[];
+    allowedTools?: string;
     license?: string;
     compatibility?: string;
   };

--- a/packages/catalog-model/src/schema/kinds/AiResource.v1alpha1.skill.schema.json
+++ b/packages/catalog-model/src/schema/kinds/AiResource.v1alpha1.skill.schema.json
@@ -92,6 +92,26 @@
                 "type": "string",
                 "minLength": 1
               }
+            },
+            "allowedTools": {
+              "type": "array",
+              "description": "Tools or capabilities the skill is designed to use, as defined by the agentskills.io specification.",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "license": {
+              "type": "string",
+              "description": "An SPDX license identifier or free-text license for the skill content, as defined by the agentskills.io specification.",
+              "examples": ["MIT", "Apache-2.0", "UNLICENSED"],
+              "minLength": 1
+            },
+            "compatibility": {
+              "type": "string",
+              "description": "Intended product, system packages, network access, or other environmental requirements, as defined by the agentskills.io specification.",
+              "examples": ["Node.js 20+, macOS/Linux", "Python 3.11+, Docker"],
+              "minLength": 1
             }
           }
         }

--- a/packages/catalog-model/src/schema/kinds/AiResource.v1alpha1.skill.schema.json
+++ b/packages/catalog-model/src/schema/kinds/AiResource.v1alpha1.skill.schema.json
@@ -94,12 +94,13 @@
               }
             },
             "allowedTools": {
-              "type": "array",
-              "description": "Tools or capabilities the skill is designed to use, as defined by the agentskills.io specification.",
-              "items": {
-                "type": "string",
-                "minLength": 1
-              }
+              "type": "string",
+              "description": "Space-separated string of tools the skill is pre-approved to use, as defined by the agentskills.io specification.",
+              "examples": [
+                "Bash(git:*) Bash(jq:*) Read",
+                "Read Edit WebSearch"
+              ],
+              "minLength": 1
             },
             "license": {
               "type": "string",

--- a/packages/catalog-model/src/schema/kinds/AiResource.v1alpha1.skill.schema.json
+++ b/packages/catalog-model/src/schema/kinds/AiResource.v1alpha1.skill.schema.json
@@ -112,7 +112,8 @@
               "type": "string",
               "description": "Intended product, system packages, network access, or other environmental requirements, as defined by the agentskills.io specification.",
               "examples": ["Node.js 20+, macOS/Linux", "Python 3.11+, Docker"],
-              "minLength": 1
+              "minLength": 1,
+              "maxLength": 500
             }
           }
         }


### PR DESCRIPTION
Add three optional fields from the [agentskills.io](https://agentskills.io/specification) specification to the `@alpha` AiResource skill spec (`SkillAiResourceEntityV1alpha1`):

- **`allowedTools?: string`** — Tools or capabilities the skill is designed to use (e.g. `"Read Write Bash"`). Agent harnesses use this to restrict or scope tool access when a skill is active.
- **`license?: string`** — An SPDX license identifier or free-text license string (e.g. `"Apache-2.0"`). Skills are authored content that may be shared across organizations, so license metadata is important for catalog consumers.
- **`compatibility?: string`** — Environmental requirements (e.g. `"Node.js 20+, macOS/Linux"`). Tells consumers whether a skill is applicable to their environment before they install or activate it.

All three fields are optional and backwards-compatible.

Resolves #34876 (skill fields portion — rule activation in a separate PR)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

🤖 Generated with [Claude Code](https://claude.com/claude-code)