### PR TITLE
Add plugin spec type to AiResource kind

### DIFF
--- a/.changeset/airesource-plugin-spec-type.md
+++ b/.changeset/airesource-plugin-spec-type.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': minor
+---
+
+Added `plugin` spec type to the `@alpha` AiResource kind, representing a packaged collection of skills distributed as a unit. Plugins reference their contained skills via `spec.skills` entity references, generating `hasPart` catalog relations.

--- a/packages/catalog-model/examples/ai-resources/code-review-plugin.yaml
+++ b/packages/catalog-model/examples/ai-resources/code-review-plugin.yaml
@@ -1,0 +1,14 @@
+apiVersion: backstage.io/v1alpha1
+kind: AiResource
+metadata:
+  name: code-review-plugin
+  description: Plugin for automated code review that bundles review skills for multiple languages
+spec:
+  type: plugin
+  lifecycle: production
+  owner: team-a
+  system: artist-engagement-portal
+  skills:
+    - airesource:default/typescript-best-practices
+    - airesource:default/security-review
+  version: '1.0.0'

--- a/packages/catalog-model/examples/all-ai-resources.yaml
+++ b/packages/catalog-model/examples/all-ai-resources.yaml
@@ -7,3 +7,4 @@ spec:
   targets:
     - ./ai-resources/frontend-design-skill.yaml
     - ./ai-resources/use-internal-apis-rule.yaml
+    - ./ai-resources/code-review-plugin.yaml

--- a/packages/catalog-model/report-alpha.api.md
+++ b/packages/catalog-model/report-alpha.api.md
@@ -15,7 +15,8 @@ export const aiResourceEntityModel: CatalogModelLayer;
 export type AiResourceEntityV1alpha1 =
   | AiResourceEntityV1alpha1Default
   | SkillAiResourceEntityV1alpha1
-  | RuleAiResourceEntityV1alpha1;
+  | RuleAiResourceEntityV1alpha1
+  | PluginAiResourceEntityV1alpha1;
 
 // @alpha
 export interface AiResourceEntityV1alpha1Default extends Entity {
@@ -516,6 +517,11 @@ export function isMcpServerApiEntity(
 ): entity is McpServerApiEntity;
 
 // @alpha
+export const isPluginAiResourceEntity: (
+  entity: Entity,
+) => entity is PluginAiResourceEntityV1alpha1;
+
+// @alpha
 export const isRuleAiResourceEntity: (
   entity: Entity,
 ) => entity is RuleAiResourceEntityV1alpha1;
@@ -553,6 +559,23 @@ export type McpServerRemote = {
   type: string;
   url: string;
 };
+
+// @alpha
+export interface PluginAiResourceEntityV1alpha1
+  extends AiResourceEntityV1alpha1Default {
+  // (undocumented)
+  spec: {
+    type: 'plugin';
+    lifecycle: string;
+    owner: string;
+    system?: string;
+    skills: string[];
+    version?: string;
+  };
+}
+
+// @alpha
+export const pluginAiResourceEntityV1alpha1Validator: KindValidator;
 
 // @alpha
 export interface RuleAiResourceEntityV1alpha1

--- a/packages/catalog-model/src/alpha.ts
+++ b/packages/catalog-model/src/alpha.ts
@@ -32,14 +32,17 @@ export type {
   AiResourceEntityV1alpha1Default,
   SkillAiResourceEntityV1alpha1,
   RuleAiResourceEntityV1alpha1,
+  PluginAiResourceEntityV1alpha1,
 } from './kinds/AiResourceEntityV1alpha1';
 export {
   aiResourceEntityV1alpha1Validator,
   skillAiResourceEntityV1alpha1Validator,
   ruleAiResourceEntityV1alpha1Validator,
+  pluginAiResourceEntityV1alpha1Validator,
   isAiResourceEntity,
   isSkillAiResourceEntity,
   isRuleAiResourceEntity,
+  isPluginAiResourceEntity,
   aiResourceEntityModel,
 } from './kinds/AiResourceEntityV1alpha1';
 export type {

--- a/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.test.ts
+++ b/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.test.ts
@@ -21,13 +21,16 @@ import {
   type AiResourceEntityV1alpha1Default,
   type SkillAiResourceEntityV1alpha1,
   type RuleAiResourceEntityV1alpha1,
+  type PluginAiResourceEntityV1alpha1,
   aiResourceEntityModel,
   aiResourceEntityV1alpha1Validator as defaultValidator,
   skillAiResourceEntityV1alpha1Validator as skillValidator,
   ruleAiResourceEntityV1alpha1Validator as ruleValidator,
+  pluginAiResourceEntityV1alpha1Validator as pluginValidator,
   isAiResourceEntity,
   isSkillAiResourceEntity,
   isRuleAiResourceEntity,
+  isPluginAiResourceEntity,
 } from './AiResourceEntityV1alpha1';
 
 describe('AiResourceV1alpha1 default validator', () => {
@@ -398,6 +401,7 @@ describe('aiResourceEntityModel', () => {
     ]);
     expect(relations?.find(r => r.forward.type === 'partOf')?.toKind).toEqual([
       'System',
+      'AiResource',
     ]);
     expect(
       relations?.find(r => r.forward.type === 'dependsOn')?.toKind,
@@ -413,5 +417,129 @@ describe('aiResourceEntityModel', () => {
         .getRelations({ kind: 'AiResource' })
         ?.find(r => r.forward.type === 'dependencyOf')?.toKind,
     ).toEqual(['AiResource']);
+  });
+});
+
+describe('AiResourceV1alpha1 plugin validator', () => {
+  let entity: PluginAiResourceEntityV1alpha1;
+
+  beforeEach(() => {
+    entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'AiResource',
+      metadata: {
+        name: 'code-review-plugin',
+      },
+      spec: {
+        type: 'plugin',
+        lifecycle: 'production',
+        owner: 'ai-platform-team',
+        system: 'ai-tooling',
+        skills: ['airesource:default/typescript-best-practices'],
+        version: '1.0.0',
+      },
+    };
+  });
+
+  it('accepts valid plugin data with all fields', async () => {
+    await expect(pluginValidator.check(entity)).resolves.toBe(true);
+  });
+
+  it('accepts plugin with only required fields', async () => {
+    entity.spec = {
+      type: 'plugin',
+      lifecycle: 'production',
+      owner: 'team-a',
+      skills: ['airesource:default/some-skill'],
+    };
+    await expect(pluginValidator.check(entity)).resolves.toBe(true);
+  });
+
+  it('rejects non-plugin type', async () => {
+    (entity as any).spec.type = 'skill';
+    await expect(pluginValidator.check(entity)).rejects.toThrow(/type/);
+  });
+
+  it('rejects missing lifecycle', async () => {
+    delete (entity as any).spec.lifecycle;
+    await expect(pluginValidator.check(entity)).rejects.toThrow(/lifecycle/);
+  });
+
+  it('rejects missing owner', async () => {
+    delete (entity as any).spec.owner;
+    await expect(pluginValidator.check(entity)).rejects.toThrow(/owner/);
+  });
+
+  it('rejects missing skills', async () => {
+    delete (entity as any).spec.skills;
+    await expect(pluginValidator.check(entity)).rejects.toThrow(/skills/);
+  });
+
+  it('accepts empty skills array', async () => {
+    entity.spec.skills = [];
+    await expect(pluginValidator.check(entity)).resolves.toBe(true);
+  });
+
+  it('rejects skills with empty strings', async () => {
+    (entity as any).spec.skills = [''];
+    await expect(pluginValidator.check(entity)).rejects.toThrow(/skills/);
+  });
+
+  it('rejects skills with wrong type', async () => {
+    (entity as any).spec.skills = 'not-an-array';
+    await expect(pluginValidator.check(entity)).rejects.toThrow(/skills/);
+  });
+
+  it('rejects skills with wrong item type', async () => {
+    (entity as any).spec.skills = [42];
+    await expect(pluginValidator.check(entity)).rejects.toThrow(/skills/);
+  });
+
+  it('accepts missing optional fields', async () => {
+    delete (entity as any).spec.system;
+    delete (entity as any).spec.version;
+    await expect(pluginValidator.check(entity)).resolves.toBe(true);
+  });
+
+  it('rejects empty version', async () => {
+    (entity as any).spec.version = '';
+    await expect(pluginValidator.check(entity)).rejects.toThrow(/version/);
+  });
+
+  it('rejects wrong version type', async () => {
+    (entity as any).spec.version = 42;
+    await expect(pluginValidator.check(entity)).rejects.toThrow(/version/);
+  });
+});
+
+describe('isPluginAiResourceEntity', () => {
+  it('returns true for a plugin AiResource', () => {
+    const entity: Entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'AiResource',
+      metadata: { name: 'test' },
+      spec: { type: 'plugin' },
+    };
+    expect(isPluginAiResourceEntity(entity)).toBe(true);
+  });
+
+  it('returns false for a non-plugin AiResource', () => {
+    const entity: Entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'AiResource',
+      metadata: { name: 'test' },
+      spec: { type: 'skill' },
+    };
+    expect(isPluginAiResourceEntity(entity)).toBe(false);
+  });
+
+  it('returns false for a different kind', () => {
+    const entity: Entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: { name: 'test' },
+      spec: { type: 'plugin' },
+    };
+    expect(isPluginAiResourceEntity(entity)).toBe(false);
   });
 });

--- a/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.ts
@@ -22,6 +22,7 @@ import type { JsonObject } from '@backstage/types';
 import defaultJsonSchema from '../schema/kinds/AiResource.v1alpha1.schema.json';
 import skillJsonSchema from '../schema/kinds/AiResource.v1alpha1.skill.schema.json';
 import ruleJsonSchema from '../schema/kinds/AiResource.v1alpha1.rule.schema.json';
+import pluginJsonSchema from '../schema/kinds/AiResource.v1alpha1.plugin.schema.json';
 
 /**
  * Default AiResource entity for types that don't have a structured spec.
@@ -86,6 +87,24 @@ export interface RuleAiResourceEntityV1alpha1
 }
 
 /**
+ * AiResource entity with spec.type 'plugin'. Represents a packaged collection
+ * of skills distributed as a unit.
+ *
+ * @alpha
+ */
+export interface PluginAiResourceEntityV1alpha1
+  extends AiResourceEntityV1alpha1Default {
+  spec: {
+    type: 'plugin';
+    lifecycle: string;
+    owner: string;
+    system?: string;
+    skills: string[];
+    version?: string;
+  };
+}
+
+/**
  * Backstage catalog AiResource kind Entity. Represents contextual information
  * consumed by AI coding tools, such as skills and rules.
  *
@@ -94,7 +113,8 @@ export interface RuleAiResourceEntityV1alpha1
 export type AiResourceEntityV1alpha1 =
   | AiResourceEntityV1alpha1Default
   | SkillAiResourceEntityV1alpha1
-  | RuleAiResourceEntityV1alpha1;
+  | RuleAiResourceEntityV1alpha1
+  | PluginAiResourceEntityV1alpha1;
 
 const defaultValidator = entityKindSchemaValidator(defaultJsonSchema);
 
@@ -152,6 +172,16 @@ export const isRuleAiResourceEntity = (
 ): entity is RuleAiResourceEntityV1alpha1 =>
   isAiResourceEntity(entity) && entity.spec?.type === 'rule';
 
+/**
+ * Type guard for {@link PluginAiResourceEntityV1alpha1}.
+ *
+ * @alpha
+ */
+export const isPluginAiResourceEntity = (
+  entity: Entity,
+): entity is PluginAiResourceEntityV1alpha1 =>
+  isAiResourceEntity(entity) && entity.spec?.type === 'plugin';
+
 const ruleValidator = entityKindSchemaValidator(ruleJsonSchema);
 
 /**
@@ -162,6 +192,19 @@ const ruleValidator = entityKindSchemaValidator(ruleJsonSchema);
 export const ruleAiResourceEntityV1alpha1Validator: KindValidator = {
   async check(data: Entity) {
     return ruleValidator(data) === data;
+  },
+};
+
+const pluginValidator = entityKindSchemaValidator(pluginJsonSchema);
+
+/**
+ * Entity data validator for {@link PluginAiResourceEntityV1alpha1}.
+ *
+ * @alpha
+ */
+export const pluginAiResourceEntityV1alpha1Validator: KindValidator = {
+  async check(data: Entity) {
+    return pluginValidator(data) === data;
   },
 };
 
@@ -232,6 +275,23 @@ export const aiResourceEntityModel = createCatalogModelLayer({
             jsonSchema: ruleJsonSchema as JsonObject,
           },
         },
+        {
+          name: 'v1alpha1',
+          specType: 'plugin',
+          relationFields: [
+            ...baseRelationFields,
+            {
+              selector: { path: 'spec.skills' },
+              relation: 'hasPart',
+              defaultKind: 'AiResource',
+              defaultNamespace: 'inherit' as const,
+              allowedKinds: ['AiResource'],
+            },
+          ],
+          schema: {
+            jsonSchema: pluginJsonSchema as JsonObject,
+          },
+        },
       ],
     });
     model.updateRelationPair({
@@ -251,6 +311,12 @@ export const aiResourceEntityModel = createCatalogModelLayer({
       toKind: 'AiResource',
       forward: { type: 'dependsOn' },
       reverse: { type: 'dependencyOf' },
+    });
+    model.updateRelationPair({
+      fromKind: 'AiResource',
+      toKind: 'AiResource',
+      forward: { type: 'hasPart' },
+      reverse: { type: 'partOf' },
     });
   },
 });

--- a/packages/catalog-model/src/schema/kinds/AiResource.v1alpha1.plugin.schema.json
+++ b/packages/catalog-model/src/schema/kinds/AiResource.v1alpha1.plugin.schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "AiResourceV1alpha1Plugin",
+  "description": "An AI resource of type 'plugin', representing a packaged collection of skills distributed as a unit.",
+  "examples": [
+    {
+      "apiVersion": "backstage.io/v1alpha1",
+      "kind": "AiResource",
+      "metadata": {
+        "name": "code-review-plugin",
+        "description": "A plugin for automated code review"
+      },
+      "spec": {
+        "type": "plugin",
+        "lifecycle": "production",
+        "owner": "ai-platform-team",
+        "system": "ai-tooling",
+        "skills": ["airesource:default/typescript-best-practices"],
+        "version": "1.0.0"
+      }
+    }
+  ],
+  "allOf": [
+    {
+      "$ref": "Entity"
+    },
+    {
+      "type": "object",
+      "required": ["spec"],
+      "properties": {
+        "apiVersion": {
+          "enum": ["backstage.io/v1alpha1"]
+        },
+        "kind": {
+          "enum": ["AiResource"]
+        },
+        "spec": {
+          "type": "object",
+          "required": ["type", "lifecycle", "owner", "skills"],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["plugin"],
+              "description": "The type of AI resource."
+            },
+            "lifecycle": {
+              "type": "string",
+              "description": "The lifecycle state of the AI resource.",
+              "examples": ["experimental", "production", "deprecated"],
+              "minLength": 1
+            },
+            "owner": {
+              "type": "string",
+              "description": "An entity reference to the owner of the AI resource.",
+              "examples": ["ai-platform-team", "user:john.johnson"],
+              "minLength": 1
+            },
+            "system": {
+              "type": "string",
+              "description": "An entity reference to the system that the AI resource belongs to.",
+              "minLength": 1
+            },
+            "skills": {
+              "type": "array",
+              "description": "Entity references to skills this plugin contains.",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "version": {
+              "type": "string",
+              "description": "The version of the plugin.",
+              "examples": ["1.0.0", "2.1.0-beta.1"],
+              "minLength": 1
+            }
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add a new `plugin` spec type to the `@alpha` AiResource catalog kind, representing a packaged collection of skills distributed as a unit.

The plugin/marketplace packaging pattern is widely adopted across agent harnesses — Claude Code (`.claude-plugin/`), Codex, and Cursor all support plugin packaging. This adds first-class catalog support for representing these packages.

**What's included:**
- JSON schema (`AiResource.v1alpha1.plugin.schema.json`) with `skills` (required entity ref array) and `version` (optional)
- TypeScript interface `PluginAiResourceEntityV1alpha1`, validator, and `isPluginAiResourceEntity` type guard
- Model registration with `hasPart` relation on `spec.skills` → AiResource (same parent→child pattern as System → Component)
- Example YAML and tests

**Schema:**
```yaml
apiVersion: backstage.io/v1alpha1
kind: AiResource
metadata:
  name: code-review-plugin
spec:
  type: plugin
  lifecycle: production
  owner: team-developer-tools
  skills:
    - airesource:default/typescript-best-practices
    - airesource:default/security-review
  version: '1.0.0'
```

Related: #34876

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))