### PR TITLE
Add marketplace spec type to AiResource kind

### DIFF
--- a/.changeset/airesource-marketplace-spec-type.md
+++ b/.changeset/airesource-marketplace-spec-type.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': minor
+---
+
+Added `marketplace` spec type to the `@alpha` AiResource kind, representing a curated registry of plugins for discovery and distribution. Marketplaces reference their contained plugins via `spec.plugins` entity references, generating `hasPart` catalog relations.

--- a/packages/catalog-model/examples/ai-resources/company-ai-marketplace.yaml
+++ b/packages/catalog-model/examples/ai-resources/company-ai-marketplace.yaml
@@ -1,0 +1,14 @@
+apiVersion: backstage.io/v1alpha1
+kind: AiResource
+metadata:
+  name: company-ai-tools
+  description: Company marketplace for AI coding tools used across engineering teams
+spec:
+  type: marketplace
+  lifecycle: production
+  owner: team-a
+  system: artist-engagement-portal
+  plugins:
+    - airesource:default/code-review-plugin
+    - airesource:default/testing-plugin
+  version: '1.0.0'

--- a/packages/catalog-model/examples/all-ai-resources.yaml
+++ b/packages/catalog-model/examples/all-ai-resources.yaml
@@ -8,3 +8,4 @@ spec:
     - ./ai-resources/frontend-design-skill.yaml
     - ./ai-resources/use-internal-apis-rule.yaml
     - ./ai-resources/code-review-plugin.yaml
+    - ./ai-resources/company-ai-marketplace.yaml

--- a/packages/catalog-model/report-alpha.api.md
+++ b/packages/catalog-model/report-alpha.api.md
@@ -16,7 +16,8 @@ export type AiResourceEntityV1alpha1 =
   | AiResourceEntityV1alpha1Default
   | SkillAiResourceEntityV1alpha1
   | RuleAiResourceEntityV1alpha1
-  | PluginAiResourceEntityV1alpha1;
+  | PluginAiResourceEntityV1alpha1
+  | MarketplaceAiResourceEntityV1alpha1;
 
 // @alpha
 export interface AiResourceEntityV1alpha1Default extends Entity {
@@ -512,6 +513,11 @@ export const isAiResourceEntity: (
 ) => entity is AiResourceEntityV1alpha1;
 
 // @alpha
+export const isMarketplaceAiResourceEntity: (
+  entity: Entity,
+) => entity is MarketplaceAiResourceEntityV1alpha1;
+
+// @alpha
 export function isMcpServerApiEntity(
   entity: ApiEntityV1alpha1 | McpServerApiEntity,
 ): entity is McpServerApiEntity;
@@ -535,6 +541,23 @@ export const isSkillAiResourceEntity: (
 export type KindValidator = {
   check(entity: Entity): Promise<boolean>;
 };
+
+// @alpha
+export interface MarketplaceAiResourceEntityV1alpha1
+  extends AiResourceEntityV1alpha1Default {
+  // (undocumented)
+  spec: {
+    type: 'marketplace';
+    lifecycle: string;
+    owner: string;
+    system?: string;
+    plugins: string[];
+    version?: string;
+  };
+}
+
+// @alpha
+export const marketplaceAiResourceEntityV1alpha1Validator: KindValidator;
 
 // @alpha
 export interface McpServerApiEntity extends Omit<ApiEntityV1alpha1, 'spec'> {

--- a/packages/catalog-model/src/alpha.ts
+++ b/packages/catalog-model/src/alpha.ts
@@ -33,16 +33,19 @@ export type {
   SkillAiResourceEntityV1alpha1,
   RuleAiResourceEntityV1alpha1,
   PluginAiResourceEntityV1alpha1,
+  MarketplaceAiResourceEntityV1alpha1,
 } from './kinds/AiResourceEntityV1alpha1';
 export {
   aiResourceEntityV1alpha1Validator,
   skillAiResourceEntityV1alpha1Validator,
   ruleAiResourceEntityV1alpha1Validator,
   pluginAiResourceEntityV1alpha1Validator,
+  marketplaceAiResourceEntityV1alpha1Validator,
   isAiResourceEntity,
   isSkillAiResourceEntity,
   isRuleAiResourceEntity,
   isPluginAiResourceEntity,
+  isMarketplaceAiResourceEntity,
   aiResourceEntityModel,
 } from './kinds/AiResourceEntityV1alpha1';
 export type {

--- a/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.test.ts
+++ b/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.test.ts
@@ -22,15 +22,18 @@ import {
   type SkillAiResourceEntityV1alpha1,
   type RuleAiResourceEntityV1alpha1,
   type PluginAiResourceEntityV1alpha1,
+  type MarketplaceAiResourceEntityV1alpha1,
   aiResourceEntityModel,
   aiResourceEntityV1alpha1Validator as defaultValidator,
   skillAiResourceEntityV1alpha1Validator as skillValidator,
   ruleAiResourceEntityV1alpha1Validator as ruleValidator,
   pluginAiResourceEntityV1alpha1Validator as pluginValidator,
+  marketplaceAiResourceEntityV1alpha1Validator as marketplaceValidator,
   isAiResourceEntity,
   isSkillAiResourceEntity,
   isRuleAiResourceEntity,
   isPluginAiResourceEntity,
+  isMarketplaceAiResourceEntity,
 } from './AiResourceEntityV1alpha1';
 
 describe('AiResourceV1alpha1 default validator', () => {
@@ -577,6 +580,100 @@ describe('AiResourceV1alpha1 plugin validator', () => {
   });
 });
 
+describe('AiResourceV1alpha1 marketplace validator', () => {
+  let entity: MarketplaceAiResourceEntityV1alpha1;
+
+  beforeEach(() => {
+    entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'AiResource',
+      metadata: {
+        name: 'company-ai-tools',
+      },
+      spec: {
+        type: 'marketplace',
+        lifecycle: 'production',
+        owner: 'ai-platform-team',
+        system: 'ai-tooling',
+        plugins: ['airesource:default/code-review-plugin'],
+        version: '1.0.0',
+      },
+    };
+  });
+
+  it('accepts valid marketplace data with all fields', async () => {
+    await expect(marketplaceValidator.check(entity)).resolves.toBe(true);
+  });
+
+  it('accepts marketplace with only required fields', async () => {
+    entity.spec = {
+      type: 'marketplace',
+      lifecycle: 'production',
+      owner: 'team-a',
+      plugins: ['airesource:default/some-plugin'],
+    };
+    await expect(marketplaceValidator.check(entity)).resolves.toBe(true);
+  });
+
+  it('rejects non-marketplace type', async () => {
+    (entity as any).spec.type = 'skill';
+    await expect(marketplaceValidator.check(entity)).rejects.toThrow(/type/);
+  });
+
+  it('rejects missing lifecycle', async () => {
+    delete (entity as any).spec.lifecycle;
+    await expect(marketplaceValidator.check(entity)).rejects.toThrow(
+      /lifecycle/,
+    );
+  });
+
+  it('rejects missing owner', async () => {
+    delete (entity as any).spec.owner;
+    await expect(marketplaceValidator.check(entity)).rejects.toThrow(/owner/);
+  });
+
+  it('rejects missing plugins', async () => {
+    delete (entity as any).spec.plugins;
+    await expect(marketplaceValidator.check(entity)).rejects.toThrow(/plugins/);
+  });
+
+  it('accepts empty plugins array', async () => {
+    entity.spec.plugins = [];
+    await expect(marketplaceValidator.check(entity)).resolves.toBe(true);
+  });
+
+  it('rejects plugins with empty strings', async () => {
+    (entity as any).spec.plugins = [''];
+    await expect(marketplaceValidator.check(entity)).rejects.toThrow(/plugins/);
+  });
+
+  it('rejects plugins with wrong type', async () => {
+    (entity as any).spec.plugins = 'not-an-array';
+    await expect(marketplaceValidator.check(entity)).rejects.toThrow(/plugins/);
+  });
+
+  it('rejects plugins with wrong item type', async () => {
+    (entity as any).spec.plugins = [42];
+    await expect(marketplaceValidator.check(entity)).rejects.toThrow(/plugins/);
+  });
+
+  it('accepts missing optional fields', async () => {
+    delete (entity as any).spec.system;
+    delete (entity as any).spec.version;
+    await expect(marketplaceValidator.check(entity)).resolves.toBe(true);
+  });
+
+  it('rejects empty version', async () => {
+    (entity as any).spec.version = '';
+    await expect(marketplaceValidator.check(entity)).rejects.toThrow(/version/);
+  });
+
+  it('rejects wrong version type', async () => {
+    (entity as any).spec.version = 42;
+    await expect(marketplaceValidator.check(entity)).rejects.toThrow(/version/);
+  });
+});
+
 describe('isPluginAiResourceEntity', () => {
   it('returns true for a plugin AiResource', () => {
     const entity: Entity = {
@@ -606,5 +703,37 @@ describe('isPluginAiResourceEntity', () => {
       spec: { type: 'plugin' },
     };
     expect(isPluginAiResourceEntity(entity)).toBe(false);
+  });
+});
+
+describe('isMarketplaceAiResourceEntity', () => {
+  it('returns true for a marketplace AiResource', () => {
+    const entity: Entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'AiResource',
+      metadata: { name: 'test' },
+      spec: { type: 'marketplace' },
+    };
+    expect(isMarketplaceAiResourceEntity(entity)).toBe(true);
+  });
+
+  it('returns false for a non-marketplace AiResource', () => {
+    const entity: Entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'AiResource',
+      metadata: { name: 'test' },
+      spec: { type: 'skill' },
+    };
+    expect(isMarketplaceAiResourceEntity(entity)).toBe(false);
+  });
+
+  it('returns false for a different kind', () => {
+    const entity: Entity = {
+      apiVersion: 'backstage.io/v1alpha1',
+      kind: 'Component',
+      metadata: { name: 'test' },
+      spec: { type: 'marketplace' },
+    };
+    expect(isMarketplaceAiResourceEntity(entity)).toBe(false);
   });
 });

--- a/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.ts
@@ -23,6 +23,7 @@ import defaultJsonSchema from '../schema/kinds/AiResource.v1alpha1.schema.json';
 import skillJsonSchema from '../schema/kinds/AiResource.v1alpha1.skill.schema.json';
 import ruleJsonSchema from '../schema/kinds/AiResource.v1alpha1.rule.schema.json';
 import pluginJsonSchema from '../schema/kinds/AiResource.v1alpha1.plugin.schema.json';
+import marketplaceJsonSchema from '../schema/kinds/AiResource.v1alpha1.marketplace.schema.json';
 
 /**
  * Default AiResource entity for types that don't have a structured spec.
@@ -108,6 +109,24 @@ export interface PluginAiResourceEntityV1alpha1
 }
 
 /**
+ * AiResource entity with spec.type 'marketplace'. Represents a curated
+ * registry of plugins for discovery and distribution.
+ *
+ * @alpha
+ */
+export interface MarketplaceAiResourceEntityV1alpha1
+  extends AiResourceEntityV1alpha1Default {
+  spec: {
+    type: 'marketplace';
+    lifecycle: string;
+    owner: string;
+    system?: string;
+    plugins: string[];
+    version?: string;
+  };
+}
+
+/**
  * Backstage catalog AiResource kind Entity. Represents contextual information
  * consumed by AI coding tools, such as skills and rules.
  *
@@ -117,7 +136,8 @@ export type AiResourceEntityV1alpha1 =
   | AiResourceEntityV1alpha1Default
   | SkillAiResourceEntityV1alpha1
   | RuleAiResourceEntityV1alpha1
-  | PluginAiResourceEntityV1alpha1;
+  | PluginAiResourceEntityV1alpha1
+  | MarketplaceAiResourceEntityV1alpha1;
 
 const defaultValidator = entityKindSchemaValidator(defaultJsonSchema);
 
@@ -185,6 +205,16 @@ export const isPluginAiResourceEntity = (
 ): entity is PluginAiResourceEntityV1alpha1 =>
   isAiResourceEntity(entity) && entity.spec?.type === 'plugin';
 
+/**
+ * Type guard for {@link MarketplaceAiResourceEntityV1alpha1}.
+ *
+ * @alpha
+ */
+export const isMarketplaceAiResourceEntity = (
+  entity: Entity,
+): entity is MarketplaceAiResourceEntityV1alpha1 =>
+  isAiResourceEntity(entity) && entity.spec?.type === 'marketplace';
+
 const ruleValidator = entityKindSchemaValidator(ruleJsonSchema);
 
 /**
@@ -208,6 +238,19 @@ const pluginValidator = entityKindSchemaValidator(pluginJsonSchema);
 export const pluginAiResourceEntityV1alpha1Validator: KindValidator = {
   async check(data: Entity) {
     return pluginValidator(data) === data;
+  },
+};
+
+const marketplaceValidator = entityKindSchemaValidator(marketplaceJsonSchema);
+
+/**
+ * Entity data validator for {@link MarketplaceAiResourceEntityV1alpha1}.
+ *
+ * @alpha
+ */
+export const marketplaceAiResourceEntityV1alpha1Validator: KindValidator = {
+  async check(data: Entity) {
+    return marketplaceValidator(data) === data;
   },
 };
 
@@ -293,6 +336,23 @@ export const aiResourceEntityModel = createCatalogModelLayer({
           ],
           schema: {
             jsonSchema: pluginJsonSchema as JsonObject,
+          },
+        },
+        {
+          name: 'v1alpha1',
+          specType: 'marketplace',
+          relationFields: [
+            ...baseRelationFields,
+            {
+              selector: { path: 'spec.plugins' },
+              relation: 'hasPart',
+              defaultKind: 'AiResource',
+              defaultNamespace: 'inherit' as const,
+              allowedKinds: ['AiResource'],
+            },
+          ],
+          schema: {
+            jsonSchema: marketplaceJsonSchema as JsonObject,
           },
         },
       ],

--- a/packages/catalog-model/src/schema/kinds/AiResource.v1alpha1.marketplace.schema.json
+++ b/packages/catalog-model/src/schema/kinds/AiResource.v1alpha1.marketplace.schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "AiResourceV1alpha1Marketplace",
+  "description": "An AI resource of type 'marketplace', representing a curated registry of plugins for discovery and distribution.",
+  "examples": [
+    {
+      "apiVersion": "backstage.io/v1alpha1",
+      "kind": "AiResource",
+      "metadata": {
+        "name": "company-ai-tools",
+        "description": "Company marketplace for AI coding tools"
+      },
+      "spec": {
+        "type": "marketplace",
+        "lifecycle": "production",
+        "owner": "ai-platform-team",
+        "system": "ai-tooling",
+        "plugins": ["airesource:default/code-review-plugin"],
+        "version": "1.0.0"
+      }
+    }
+  ],
+  "allOf": [
+    {
+      "$ref": "Entity"
+    },
+    {
+      "type": "object",
+      "required": ["spec"],
+      "properties": {
+        "apiVersion": {
+          "enum": ["backstage.io/v1alpha1"]
+        },
+        "kind": {
+          "enum": ["AiResource"]
+        },
+        "spec": {
+          "type": "object",
+          "required": ["type", "lifecycle", "owner", "plugins"],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["marketplace"],
+              "description": "The type of AI resource."
+            },
+            "lifecycle": {
+              "type": "string",
+              "description": "The lifecycle state of the AI resource.",
+              "examples": ["experimental", "production", "deprecated"],
+              "minLength": 1
+            },
+            "owner": {
+              "type": "string",
+              "description": "An entity reference to the owner of the AI resource.",
+              "examples": ["ai-platform-team", "user:john.johnson"],
+              "minLength": 1
+            },
+            "system": {
+              "type": "string",
+              "description": "An entity reference to the system that the AI resource belongs to.",
+              "minLength": 1
+            },
+            "plugins": {
+              "type": "array",
+              "description": "Entity references to plugins available in this marketplace.",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "version": {
+              "type": "string",
+              "description": "The version of the marketplace.",
+              "examples": ["1.0.0", "2.1.0-beta.1"],
+              "minLength": 1
+            }
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add a new `marketplace` spec type to the `@alpha` AiResource catalog kind, representing a curated registry of plugins for discovery and distribution.

The plugin/marketplace packaging pattern is widely adopted across agent harnesses — Claude Code (`.claude-plugin/`), Codex, and Cursor all support marketplace-style distribution. This adds first-class catalog support for representing these registries.

**What's included:**
- JSON schema (`AiResource.v1alpha1.marketplace.schema.json`) with `plugins` (required entity ref array) and `version` (optional)
- TypeScript interface `MarketplaceAiResourceEntityV1alpha1`, validator, and `isMarketplaceAiResourceEntity` type guard
- Model registration with `hasPart` relation on `spec.plugins` → AiResource (same parent→child pattern as System → Component)
- Example YAML and tests

**Schema:**
```yaml
apiVersion: backstage.io/v1alpha1
kind: AiResource
metadata:
  name: company-ai-tools
spec:
  type: marketplace
  lifecycle: production
  owner: team-ai-platform
  plugins:
    - airesource:default/code-review-plugin
    - airesource:default/testing-plugin
  version: '1.0.0'
```

Together with #34891 (plugin spec type), this completes the marketplace → plugins → skills hierarchy in the AiResource catalog kind.

Related: #34876, #34891

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))