### PR TITLE
feat(scaffolder): add ui:options for custom labels and disabling repo…

### DIFF
--- a/.changeset/repo-url-picker-custom-labels.md
+++ b/.changeset/repo-url-picker-custom-labels.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': minor
+---
+
+Added new `ui:options` to `RepoUrlPicker` for per-template customization: `ownerLabel`, `ownerDescription`, `repoLabel`, `repoDescription` to override field labels, and `disableRepoAutocomplete` to render a plain text input instead of the autocomplete dropdown.

--- a/docs/features/software-templates/ui-options-examples.md
+++ b/docs/features/software-templates/ui-options-examples.md
@@ -472,6 +472,81 @@ repoUrl:
 
 The supported `additionalScopes` values are `gerrit`, `github`, `gitlab`, `bitbucket`, and `azure`.
 
+### `ownerLabel`
+
+Custom label for the owner/namespace field. Overrides the default label for the given SCM provider picker.
+
+- Show `GitLab Namespace` instead of the default `Owner` label
+
+```yaml
+repoUrl:
+  title: Repository Location
+  type: string
+  ui:field: RepoUrlPicker
+  ui:options:
+    ownerLabel: GitLab Namespace
+```
+
+### `ownerDescription`
+
+Custom description for the owner/namespace field. Overrides the default helper text.
+
+- Show custom guidance for the owner field
+
+```yaml
+repoUrl:
+  title: Repository Location
+  type: string
+  ui:field: RepoUrlPicker
+  ui:options:
+    ownerDescription: Your username or group path where the repository will be created
+```
+
+### `repoLabel`
+
+Custom label for the repository name field. Overrides the default `Repository` label.
+
+- Show `New Repository Name` instead of the default label
+
+```yaml
+repoUrl:
+  title: Repository Location
+  type: string
+  ui:field: RepoUrlPicker
+  ui:options:
+    repoLabel: New Repository Name
+```
+
+### `repoDescription`
+
+Custom description for the repository name field. Overrides the default helper text.
+
+- Show custom guidance for the repository name field
+
+```yaml
+repoUrl:
+  title: Repository Location
+  type: string
+  ui:field: RepoUrlPicker
+  ui:options:
+    repoDescription: Type a new repository name
+```
+
+### `disableRepoAutocomplete`
+
+If true, renders a plain text input instead of an autocomplete dropdown for the repository name.
+
+- Disable the repository autocomplete dropdown
+
+```yaml
+repoUrl:
+  title: Repository Location
+  type: string
+  ui:field: RepoUrlPicker
+  ui:options:
+    disableRepoAutocomplete: true
+```
+
 ## RepoBranchPicker
 
 The input props that can be specified under `ui:options` for the `RepoBranchPicker` field extension.

--- a/plugins/scaffolder/report.api.md
+++ b/plugins/scaffolder/report.api.md
@@ -438,10 +438,10 @@ export const RepoUrlPickerFieldExtension: FieldExtensionComponent_2<
     allowedOwners?: string[] | undefined;
     allowedProjects?: string[] | undefined;
     ownerDescription?: string | undefined;
+    disableRepoAutocomplete?: boolean | undefined;
     allowedRepos?: string[] | undefined;
     repoLabel?: string | undefined;
     repoDescription?: string | undefined;
-    disableRepoAutocomplete?: boolean | undefined;
     allowedHosts?: string[] | undefined;
     requestUserCredentials?:
       | {
@@ -470,10 +470,10 @@ export const RepoUrlPickerFieldSchema: FieldSchema_2<
     allowedOwners?: string[] | undefined;
     allowedProjects?: string[] | undefined;
     ownerDescription?: string | undefined;
+    disableRepoAutocomplete?: boolean | undefined;
     allowedRepos?: string[] | undefined;
     repoLabel?: string | undefined;
     repoDescription?: string | undefined;
-    disableRepoAutocomplete?: boolean | undefined;
     allowedHosts?: string[] | undefined;
     requestUserCredentials?:
       | {

--- a/plugins/scaffolder/report.api.md
+++ b/plugins/scaffolder/report.api.md
@@ -435,9 +435,9 @@ export const RepoUrlPickerFieldExtension: FieldExtensionComponent_2<
   {
     ownerLabel?: string | undefined;
     allowedOrganizations?: string[] | undefined;
+    ownerDescription?: string | undefined;
     allowedOwners?: string[] | undefined;
     allowedProjects?: string[] | undefined;
-    ownerDescription?: string | undefined;
     disableRepoAutocomplete?: boolean | undefined;
     allowedRepos?: string[] | undefined;
     repoLabel?: string | undefined;
@@ -467,9 +467,9 @@ export const RepoUrlPickerFieldSchema: FieldSchema_2<
   {
     ownerLabel?: string | undefined;
     allowedOrganizations?: string[] | undefined;
+    ownerDescription?: string | undefined;
     allowedOwners?: string[] | undefined;
     allowedProjects?: string[] | undefined;
-    ownerDescription?: string | undefined;
     disableRepoAutocomplete?: boolean | undefined;
     allowedRepos?: string[] | undefined;
     repoLabel?: string | undefined;

--- a/plugins/scaffolder/report.api.md
+++ b/plugins/scaffolder/report.api.md
@@ -433,10 +433,15 @@ export const repoPickerValidation: (
 export const RepoUrlPickerFieldExtension: FieldExtensionComponent_2<
   string,
   {
+    ownerLabel?: string | undefined;
     allowedOrganizations?: string[] | undefined;
     allowedOwners?: string[] | undefined;
     allowedProjects?: string[] | undefined;
+    ownerDescription?: string | undefined;
     allowedRepos?: string[] | undefined;
+    repoLabel?: string | undefined;
+    repoDescription?: string | undefined;
+    disableRepoAutocomplete?: boolean | undefined;
     allowedHosts?: string[] | undefined;
     requestUserCredentials?:
       | {
@@ -460,10 +465,15 @@ export const RepoUrlPickerFieldExtension: FieldExtensionComponent_2<
 export const RepoUrlPickerFieldSchema: FieldSchema_2<
   string,
   {
+    ownerLabel?: string | undefined;
     allowedOrganizations?: string[] | undefined;
     allowedOwners?: string[] | undefined;
     allowedProjects?: string[] | undefined;
+    ownerDescription?: string | undefined;
     allowedRepos?: string[] | undefined;
+    repoLabel?: string | undefined;
+    repoDescription?: string | undefined;
+    disableRepoAutocomplete?: boolean | undefined;
     allowedHosts?: string[] | undefined;
     requestUserCredentials?:
       | {

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/AzureRepoPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/AzureRepoPicker.tsx
@@ -30,6 +30,8 @@ export const AzureRepoPicker = (
   props: BaseRepoUrlPickerProps<{
     allowedOrganizations?: string[];
     allowedProject?: string[];
+    ownerLabel?: string;
+    ownerDescription?: string;
   }>,
 ) => {
   const theme = useScaffolderTheme();
@@ -40,6 +42,8 @@ export const AzureRepoPicker = (
     state,
     onChange,
     isDisabled,
+    ownerLabel,
+    ownerDescription,
   } = props;
   const { t } = useTranslationRef(scaffolderTranslationRef);
 
@@ -56,8 +60,11 @@ export const AzureRepoPicker = (
         return (
           <BuiSelect
             className={overrides.select}
-            label={t('fields.azureRepoPicker.organization.title')}
-            description={t('fields.azureRepoPicker.organization.description')}
+            label={ownerLabel ?? t('fields.azureRepoPicker.organization.title')}
+            description={
+              ownerDescription ??
+              t('fields.azureRepoPicker.organization.description')
+            }
             isDisabled={isDisabled || allowedOrganizations.length === 1}
             isInvalid={rawErrors?.length > 0 && !organization}
             selectedKey={organization ?? null}
@@ -72,8 +79,11 @@ export const AzureRepoPicker = (
 
       return (
         <BuiTextField
-          label={t('fields.azureRepoPicker.organization.title')}
-          description={t('fields.azureRepoPicker.organization.description')}
+          label={ownerLabel ?? t('fields.azureRepoPicker.organization.title')}
+          description={
+            ownerDescription ??
+            t('fields.azureRepoPicker.organization.description')
+          }
           onChange={value => onChange({ organization: value })}
           isDisabled={isDisabled}
           value={organization ?? ''}
@@ -147,7 +157,9 @@ export const AzureRepoPicker = (
           <>
             <MuiSelect
               native
-              label={t('fields.azureRepoPicker.organization.title')}
+              label={
+                ownerLabel ?? t('fields.azureRepoPicker.organization.title')
+              }
               onChange={s =>
                 onChange({ organization: String(Array.isArray(s) ? s[0] : s) })
               }
@@ -156,15 +168,19 @@ export const AzureRepoPicker = (
               items={organizationItems}
             />
             <FormHelperText>
-              {t('fields.azureRepoPicker.organization.description')}
+              {ownerDescription ??
+                t('fields.azureRepoPicker.organization.description')}
             </FormHelperText>
           </>
         ) : (
           <MuiTextField
             id="orgInput"
-            label={t('fields.azureRepoPicker.organization.title')}
+            label={ownerLabel ?? t('fields.azureRepoPicker.organization.title')}
             onChange={e => onChange({ organization: e.target.value })}
-            helperText={t('fields.azureRepoPicker.organization.description')}
+            helperText={
+              ownerDescription ??
+              t('fields.azureRepoPicker.organization.description')
+            }
             disabled={isDisabled}
             value={organization}
           />

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/BitbucketRepoPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/BitbucketRepoPicker.tsx
@@ -45,6 +45,8 @@ export const BitbucketRepoPicker = (
     allowedOwners?: string[];
     allowedProjects?: string[];
     accessToken?: string;
+    ownerLabel?: string;
+    ownerDescription?: string;
   }>,
 ) => {
   const theme = useScaffolderTheme();
@@ -56,6 +58,8 @@ export const BitbucketRepoPicker = (
     state,
     accessToken,
     isDisabled,
+    ownerLabel,
+    ownerDescription,
   } = props;
   const { t } = useTranslationRef(scaffolderTranslationRef);
 
@@ -171,8 +175,13 @@ export const BitbucketRepoPicker = (
         return (
           <BuiSelect
             className={overrides.select}
-            label={t('fields.bitbucketRepoPicker.workspaces.title')}
-            description={t('fields.bitbucketRepoPicker.workspaces.description')}
+            label={
+              ownerLabel ?? t('fields.bitbucketRepoPicker.workspaces.title')
+            }
+            description={
+              ownerDescription ??
+              t('fields.bitbucketRepoPicker.workspaces.description')
+            }
             isDisabled={isDisabled || allowedOwners.length === 1}
             isInvalid={rawErrors?.length > 0 && !workspace}
             selectedKey={workspace ?? null}
@@ -192,8 +201,13 @@ export const BitbucketRepoPicker = (
 
       return (
         <BuiAutocomplete
-          label={t('fields.bitbucketRepoPicker.workspaces.inputTitle')}
-          description={t('fields.bitbucketRepoPicker.workspaces.description')}
+          label={
+            ownerLabel ?? t('fields.bitbucketRepoPicker.workspaces.inputTitle')
+          }
+          description={
+            ownerDescription ??
+            t('fields.bitbucketRepoPicker.workspaces.description')
+          }
           inputValue={workspace ?? ''}
           onInputChange={value => onChange({ workspace: value })}
           onSelectionChange={(key: Key | null) => {
@@ -280,7 +294,9 @@ export const BitbucketRepoPicker = (
           {allowedOwners?.length ? (
             <MuiSelect
               native
-              label={t('fields.bitbucketRepoPicker.workspaces.title')}
+              label={
+                ownerLabel ?? t('fields.bitbucketRepoPicker.workspaces.title')
+              }
               onChange={s =>
                 onChange({ workspace: String(Array.isArray(s) ? s[0] : s) })
               }
@@ -298,7 +314,10 @@ export const BitbucketRepoPicker = (
               renderInput={params => (
                 <MuiTextField
                   {...params}
-                  label={t('fields.bitbucketRepoPicker.workspaces.inputTitle')}
+                  label={
+                    ownerLabel ??
+                    t('fields.bitbucketRepoPicker.workspaces.inputTitle')
+                  }
                   disabled={isDisabled}
                   required
                 />
@@ -309,7 +328,8 @@ export const BitbucketRepoPicker = (
             />
           )}
           <FormHelperText>
-            {t('fields.bitbucketRepoPicker.workspaces.description')}
+            {ownerDescription ??
+              t('fields.bitbucketRepoPicker.workspaces.description')}
           </FormHelperText>
         </FormControl>
       )}

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/GerritRepoPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/GerritRepoPicker.tsx
@@ -21,9 +21,21 @@ import { scaffolderTranslationRef } from '../../../translation';
 import { useScaffolderTheme } from '@backstage/plugin-scaffolder-react/alpha';
 import { TextField as BuiTextField } from '@backstage/ui';
 
-export const GerritRepoPicker = (props: BaseRepoUrlPickerProps) => {
+export const GerritRepoPicker = (
+  props: BaseRepoUrlPickerProps<{
+    ownerLabel?: string;
+    ownerDescription?: string;
+  }>,
+) => {
   const theme = useScaffolderTheme();
-  const { onChange, rawErrors, state, isDisabled } = props;
+  const {
+    onChange,
+    rawErrors,
+    state,
+    isDisabled,
+    ownerLabel,
+    ownerDescription,
+  } = props;
   const { t } = useTranslationRef(scaffolderTranslationRef);
   const { workspace, owner } = state;
 
@@ -31,8 +43,10 @@ export const GerritRepoPicker = (props: BaseRepoUrlPickerProps) => {
     return (
       <>
         <BuiTextField
-          label={t('fields.gerritRepoPicker.owner.title')}
-          description={t('fields.gerritRepoPicker.owner.description')}
+          label={ownerLabel ?? t('fields.gerritRepoPicker.owner.title')}
+          description={
+            ownerDescription ?? t('fields.gerritRepoPicker.owner.description')
+          }
           onChange={value => onChange({ owner: value })}
           isDisabled={isDisabled}
           value={owner ?? ''}
@@ -56,9 +70,11 @@ export const GerritRepoPicker = (props: BaseRepoUrlPickerProps) => {
       <FormControl margin="normal" error={rawErrors?.length > 0 && !workspace}>
         <MuiTextField
           id="ownerInput"
-          label={t('fields.gerritRepoPicker.owner.title')}
+          label={ownerLabel ?? t('fields.gerritRepoPicker.owner.title')}
           onChange={e => onChange({ owner: e.target.value })}
-          helperText={t('fields.gerritRepoPicker.owner.description')}
+          helperText={
+            ownerDescription ?? t('fields.gerritRepoPicker.owner.description')
+          }
           disabled={isDisabled}
           value={owner}
         />

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/GiteaRepoPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/GiteaRepoPicker.tsx
@@ -29,10 +29,20 @@ export const GiteaRepoPicker = (
   props: BaseRepoUrlPickerProps<{
     allowedOwners?: string[];
     allowedRepos?: string[];
+    ownerLabel?: string;
+    ownerDescription?: string;
   }>,
 ) => {
   const theme = useScaffolderTheme();
-  const { allowedOwners = [], state, onChange, rawErrors, isDisabled } = props;
+  const {
+    allowedOwners = [],
+    state,
+    onChange,
+    rawErrors,
+    isDisabled,
+    ownerLabel,
+    ownerDescription,
+  } = props;
   const { t } = useTranslationRef(scaffolderTranslationRef);
 
   const { owner } = state;
@@ -44,8 +54,10 @@ export const GiteaRepoPicker = (
       return (
         <BuiSelect
           className={overrides.select}
-          label={t('fields.giteaRepoPicker.owner.title')}
-          description={t('fields.giteaRepoPicker.owner.description')}
+          label={ownerLabel ?? t('fields.giteaRepoPicker.owner.title')}
+          description={
+            ownerDescription ?? t('fields.giteaRepoPicker.owner.description')
+          }
           isDisabled={isDisabled || allowedOwners.length === 1}
           isInvalid={rawErrors?.length > 0 && !owner}
           selectedKey={owner ?? null}
@@ -60,8 +72,10 @@ export const GiteaRepoPicker = (
 
     return (
       <BuiTextField
-        label={t('fields.giteaRepoPicker.owner.inputTitle')}
-        description={t('fields.giteaRepoPicker.owner.description')}
+        label={ownerLabel ?? t('fields.giteaRepoPicker.owner.inputTitle')}
+        description={
+          ownerDescription ?? t('fields.giteaRepoPicker.owner.description')
+        }
         onChange={value => onChange({ owner: value })}
         isDisabled={isDisabled}
         value={owner ?? ''}
@@ -86,7 +100,7 @@ export const GiteaRepoPicker = (
           <>
             <MuiSelect
               native
-              label={t('fields.giteaRepoPicker.owner.title')}
+              label={ownerLabel ?? t('fields.giteaRepoPicker.owner.title')}
               onChange={selected =>
                 onChange({
                   owner: String(
@@ -99,16 +113,20 @@ export const GiteaRepoPicker = (
               items={ownerItems}
             />
             <FormHelperText>
-              {t('fields.giteaRepoPicker.owner.description')}
+              {ownerDescription ??
+                t('fields.giteaRepoPicker.owner.description')}
             </FormHelperText>
           </>
         ) : (
           <>
             <MuiTextField
               id="ownerInput"
-              label={t('fields.giteaRepoPicker.owner.inputTitle')}
+              label={ownerLabel ?? t('fields.giteaRepoPicker.owner.inputTitle')}
               onChange={e => onChange({ owner: e.target.value })}
-              helperText={t('fields.giteaRepoPicker.owner.description')}
+              helperText={
+                ownerDescription ??
+                t('fields.giteaRepoPicker.owner.description')
+              }
               disabled={isDisabled}
               value={owner}
             />

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/GithubRepoPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/GithubRepoPicker.test.tsx
@@ -169,6 +169,53 @@ describe('GithubRepoPicker', () => {
         { timeout: 1500 },
       );
     });
+
+    it('still populates owners when disableRepoAutocomplete is true', async () => {
+      const onChange = jest.fn();
+
+      const { getAllByRole, getByText } = await renderInTestApp(
+        <TestApiProvider apis={[[scaffolderApiRef, scaffolderApiMock]]}>
+          <GithubRepoPicker
+            onChange={onChange}
+            rawErrors={[]}
+            state={{ host: 'github.com', repoName: 'repo' }}
+            accessToken="foo"
+            disableRepoAutocomplete
+          />
+        </TestApiProvider>,
+      );
+
+      // Owner autocomplete is still populated from the fetch even though
+      // repo autocomplete is disabled
+      const ownerInput = getAllByRole('textbox')[0];
+      await userEvent.click(ownerInput);
+      await waitFor(() => expect(getByText('spotify')).toBeInTheDocument());
+    });
+
+    it('does not surface repository suggestions when disableRepoAutocomplete is true', async () => {
+      const onChange = jest.fn();
+
+      await renderInTestApp(
+        <TestApiProvider apis={[[scaffolderApiRef, scaffolderApiMock]]}>
+          <GithubRepoPicker
+            onChange={onChange}
+            rawErrors={[]}
+            state={{ host: 'github.com', owner: 'spotify' }}
+            accessToken="foo"
+            disableRepoAutocomplete
+          />
+        </TestApiProvider>,
+      );
+
+      // Repo suggestions are cleared rather than populated with fetched repos
+      await waitFor(
+        () => expect(onChange).toHaveBeenCalledWith({ availableRepos: [] }),
+        { timeout: 1500 },
+      );
+      expect(onChange).not.toHaveBeenCalledWith({
+        availableRepos: [{ name: 'backstage' }],
+      });
+    });
   });
 
   describe('GithubRepoPicker - isDisabled', () => {

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/GithubRepoPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/GithubRepoPicker.tsx
@@ -37,6 +37,8 @@ export const GithubRepoPicker = (
   props: BaseRepoUrlPickerProps<{
     allowedOwners?: string[];
     accessToken?: string;
+    ownerLabel?: string;
+    ownerDescription?: string;
   }>,
 ) => {
   const theme = useScaffolderTheme();
@@ -47,6 +49,8 @@ export const GithubRepoPicker = (
     onChange,
     accessToken,
     isDisabled,
+    ownerLabel,
+    ownerDescription,
   } = props;
   const { t } = useTranslationRef(scaffolderTranslationRef);
 
@@ -112,8 +116,10 @@ export const GithubRepoPicker = (
       return (
         <BuiSelect
           className={overrides.select}
-          label={t('fields.githubRepoPicker.owner.title')}
-          description={t('fields.githubRepoPicker.owner.description')}
+          label={ownerLabel ?? t('fields.githubRepoPicker.owner.title')}
+          description={
+            ownerDescription ?? t('fields.githubRepoPicker.owner.description')
+          }
           isDisabled={isDisabled || allowedOwners.length === 1}
           isInvalid={rawErrors?.length > 0 && !owner}
           selectedKey={owner ?? null}
@@ -130,8 +136,10 @@ export const GithubRepoPicker = (
 
     return (
       <BuiAutocomplete
-        label={t('fields.githubRepoPicker.owner.inputTitle')}
-        description={t('fields.githubRepoPicker.owner.description')}
+        label={ownerLabel ?? t('fields.githubRepoPicker.owner.inputTitle')}
+        description={
+          ownerDescription ?? t('fields.githubRepoPicker.owner.description')
+        }
         inputValue={owner ?? ''}
         onInputChange={value => onChange({ owner: value })}
         onSelectionChange={(key: Key | null) => {
@@ -162,7 +170,7 @@ export const GithubRepoPicker = (
           <>
             <MuiSelect
               native
-              label={t('fields.githubRepoPicker.owner.title')}
+              label={ownerLabel ?? t('fields.githubRepoPicker.owner.title')}
               onChange={s =>
                 onChange({ owner: String(Array.isArray(s) ? s[0] : s) })
               }
@@ -181,7 +189,9 @@ export const GithubRepoPicker = (
             renderInput={params => (
               <MuiTextField
                 {...params}
-                label={t('fields.githubRepoPicker.owner.inputTitle')}
+                label={
+                  ownerLabel ?? t('fields.githubRepoPicker.owner.inputTitle')
+                }
                 disabled={isDisabled}
                 required
               />
@@ -192,7 +202,7 @@ export const GithubRepoPicker = (
           />
         )}
         <FormHelperText>
-          {t('fields.githubRepoPicker.owner.description')}
+          {ownerDescription ?? t('fields.githubRepoPicker.owner.description')}
         </FormHelperText>
       </FormControl>
     </>

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/GithubRepoPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/GithubRepoPicker.tsx
@@ -64,12 +64,7 @@ export const GithubRepoPicker = (
     useState<{ owner: string; name: string }[]>([]);
 
   const updateAvailableRepositoriesWithOwner = useCallback(() => {
-    if (
-      disableRepoAutocomplete ||
-      !scaffolderApi.autocomplete ||
-      !accessToken ||
-      !host
-    ) {
+    if (!scaffolderApi.autocomplete || !accessToken || !host) {
       setAvailableRepositoriesWithOwner([]);
       return;
     }
@@ -92,7 +87,7 @@ export const GithubRepoPicker = (
       .catch(() => {
         setAvailableRepositoriesWithOwner([]);
       });
-  }, [disableRepoAutocomplete, scaffolderApi, accessToken, host]);
+  }, [scaffolderApi, accessToken, host]);
 
   useDebounce(updateAvailableRepositoriesWithOwner, 500, [
     updateAvailableRepositoriesWithOwner,
@@ -106,12 +101,24 @@ export const GithubRepoPicker = (
 
   // Update available repositories when available repositories with owner change or when owner changes
   const updateAvailableRepositories = useCallback(() => {
+    // Only surface repository suggestions when repo autocomplete is enabled.
+    // Owner suggestions are still derived from the fetch above.
+    if (disableRepoAutocomplete) {
+      onChange({ availableRepos: [] });
+      return;
+    }
+
     const availableRepos = availableRepositoriesWithOwner.flatMap(r =>
       r.owner === owner ? [{ name: r.name }] : [],
     );
 
     onChange({ availableRepos });
-  }, [availableRepositoriesWithOwner, owner, onChange]);
+  }, [
+    disableRepoAutocomplete,
+    availableRepositoriesWithOwner,
+    owner,
+    onChange,
+  ]);
 
   useDebounce(updateAvailableRepositories, 500, [updateAvailableRepositories]);
 

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/GithubRepoPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/GithubRepoPicker.tsx
@@ -39,6 +39,7 @@ export const GithubRepoPicker = (
     accessToken?: string;
     ownerLabel?: string;
     ownerDescription?: string;
+    disableRepoAutocomplete?: boolean;
   }>,
 ) => {
   const theme = useScaffolderTheme();
@@ -51,6 +52,7 @@ export const GithubRepoPicker = (
     isDisabled,
     ownerLabel,
     ownerDescription,
+    disableRepoAutocomplete,
   } = props;
   const { t } = useTranslationRef(scaffolderTranslationRef);
 
@@ -61,9 +63,13 @@ export const GithubRepoPicker = (
   const [availableRepositoriesWithOwner, setAvailableRepositoriesWithOwner] =
     useState<{ owner: string; name: string }[]>([]);
 
-  // Update available repositories with owner when client is available
   const updateAvailableRepositoriesWithOwner = useCallback(() => {
-    if (!scaffolderApi.autocomplete || !accessToken || !host) {
+    if (
+      disableRepoAutocomplete ||
+      !scaffolderApi.autocomplete ||
+      !accessToken ||
+      !host
+    ) {
       setAvailableRepositoriesWithOwner([]);
       return;
     }
@@ -86,7 +92,7 @@ export const GithubRepoPicker = (
       .catch(() => {
         setAvailableRepositoriesWithOwner([]);
       });
-  }, [scaffolderApi, accessToken, host]);
+  }, [disableRepoAutocomplete, scaffolderApi, accessToken, host]);
 
   useDebounce(updateAvailableRepositoriesWithOwner, 500, [
     updateAvailableRepositoriesWithOwner,

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/GitlabRepoPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/GitlabRepoPicker.tsx
@@ -38,6 +38,7 @@ export const GitlabRepoPicker = (
     accessToken?: string;
     ownerLabel?: string;
     ownerDescription?: string;
+    disableRepoAutocomplete?: boolean;
   }>,
 ) => {
   const theme = useScaffolderTheme();
@@ -50,6 +51,7 @@ export const GitlabRepoPicker = (
     isDisabled,
     ownerLabel,
     ownerDescription,
+    disableRepoAutocomplete,
   } = props;
   const [availableGroups, setAvailableGroups] = useState<
     { title: string; id: string }[]
@@ -88,9 +90,14 @@ export const GitlabRepoPicker = (
 
   useDebounce(updateAvailableGroups, 500, [updateAvailableGroups]);
 
-  // Update available repositories when client is available and group changes
   const updateAvailableRepositories = useCallback(() => {
-    if (!scaffolderApi.autocomplete || !accessToken || !host || !owner) {
+    if (
+      disableRepoAutocomplete ||
+      !scaffolderApi.autocomplete ||
+      !accessToken ||
+      !host ||
+      !owner
+    ) {
       onChange({ availableRepos: [] });
       return;
     }
@@ -115,7 +122,15 @@ export const GitlabRepoPicker = (
       .catch(() => {
         onChange({ availableRepos: [] });
       });
-  }, [scaffolderApi, accessToken, host, owner, onChange, availableGroups]);
+  }, [
+    disableRepoAutocomplete,
+    scaffolderApi,
+    accessToken,
+    host,
+    owner,
+    onChange,
+    availableGroups,
+  ]);
 
   useDebounce(updateAvailableRepositories, 500, [updateAvailableRepositories]);
 

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/GitlabRepoPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/GitlabRepoPicker.tsx
@@ -36,6 +36,8 @@ export const GitlabRepoPicker = (
     allowedOwners?: string[];
     allowedRepos?: string[];
     accessToken?: string;
+    ownerLabel?: string;
+    ownerDescription?: string;
   }>,
 ) => {
   const theme = useScaffolderTheme();
@@ -46,6 +48,8 @@ export const GitlabRepoPicker = (
     rawErrors,
     accessToken,
     isDisabled,
+    ownerLabel,
+    ownerDescription,
   } = props;
   const [availableGroups, setAvailableGroups] = useState<
     { title: string; id: string }[]
@@ -122,8 +126,10 @@ export const GitlabRepoPicker = (
       return (
         <BuiSelect
           className={overrides.select}
-          label={t('fields.gitlabRepoPicker.owner.title')}
-          description={t('fields.gitlabRepoPicker.owner.description')}
+          label={ownerLabel ?? t('fields.gitlabRepoPicker.owner.title')}
+          description={
+            ownerDescription ?? t('fields.gitlabRepoPicker.owner.description')
+          }
           isDisabled={isDisabled || allowedOwners.length === 1}
           isInvalid={rawErrors?.length > 0 && !owner}
           selectedKey={owner ?? null}
@@ -143,8 +149,10 @@ export const GitlabRepoPicker = (
 
     return (
       <BuiAutocomplete
-        label={t('fields.gitlabRepoPicker.owner.inputTitle')}
-        description={t('fields.gitlabRepoPicker.owner.description')}
+        label={ownerLabel ?? t('fields.gitlabRepoPicker.owner.inputTitle')}
+        description={
+          ownerDescription ?? t('fields.gitlabRepoPicker.owner.description')
+        }
         inputValue={owner ?? ''}
         onInputChange={value => onChange({ owner: value })}
         onSelectionChange={(key: Key | null) => {
@@ -175,7 +183,7 @@ export const GitlabRepoPicker = (
           <>
             <MuiSelect
               native
-              label={t('fields.gitlabRepoPicker.owner.title')}
+              label={ownerLabel ?? t('fields.gitlabRepoPicker.owner.title')}
               onChange={selected =>
                 onChange({
                   owner: String(
@@ -198,7 +206,9 @@ export const GitlabRepoPicker = (
             renderInput={params => (
               <MuiTextField
                 {...params}
-                label={t('fields.gitlabRepoPicker.owner.inputTitle')}
+                label={
+                  ownerLabel ?? t('fields.gitlabRepoPicker.owner.inputTitle')
+                }
                 disabled={isDisabled}
                 required
               />
@@ -209,7 +219,7 @@ export const GitlabRepoPicker = (
           />
         )}
         <FormHelperText>
-          {t('fields.gitlabRepoPicker.owner.description')}
+          {ownerDescription ?? t('fields.gitlabRepoPicker.owner.description')}
         </FormHelperText>
       </FormControl>
     </>

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
@@ -242,6 +242,8 @@ export const RepoUrlPicker = (
           onChange={updateLocalState}
           isDisabled={isDisabled}
           accessToken={accessToken}
+          ownerLabel={ownerLabel}
+          ownerDescription={ownerDescription}
         />
       )}
       {hostType === 'azure' && (
@@ -252,6 +254,8 @@ export const RepoUrlPicker = (
           state={state}
           isDisabled={isDisabled}
           onChange={updateLocalState}
+          ownerLabel={ownerLabel}
+          ownerDescription={ownerDescription}
         />
       )}
       {hostType === 'gerrit' && (
@@ -260,6 +264,8 @@ export const RepoUrlPicker = (
           state={state}
           onChange={updateLocalState}
           isDisabled={isDisabled}
+          ownerLabel={ownerLabel}
+          ownerDescription={ownerDescription}
         />
       )}
       <RepoUrlPickerRepoName

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
@@ -85,6 +85,13 @@ export const RepoUrlPicker = (
     () => uiSchema?.['ui:disabled'] ?? false,
     [uiSchema],
   );
+  const ownerLabel = uiSchema?.['ui:options']?.ownerLabel;
+  const ownerDescription = uiSchema?.['ui:options']?.ownerDescription;
+  const repoLabel = uiSchema?.['ui:options']?.repoLabel;
+  const repoDescription = uiSchema?.['ui:options']?.repoDescription;
+  const disableRepoAutocomplete =
+    uiSchema?.['ui:options']?.disableRepoAutocomplete ?? false;
+
   const { owner, organization, project, repoName } = state;
 
   useEffect(() => {
@@ -194,6 +201,8 @@ export const RepoUrlPicker = (
           state={state}
           isDisabled={isDisabled}
           accessToken={accessToken}
+          ownerLabel={ownerLabel}
+          ownerDescription={ownerDescription}
         />
       )}
       {hostType === 'gitea' && (
@@ -204,6 +213,8 @@ export const RepoUrlPicker = (
           state={state}
           isDisabled={isDisabled}
           onChange={updateLocalState}
+          ownerLabel={ownerLabel}
+          ownerDescription={ownerDescription}
         />
       )}
       {hostType === 'gitlab' && (
@@ -214,6 +225,8 @@ export const RepoUrlPicker = (
           onChange={updateLocalState}
           isDisabled={isDisabled}
           accessToken={accessToken}
+          ownerLabel={ownerLabel}
+          ownerDescription={ownerDescription}
         />
       )}
       {(hostType === 'bitbucket' ||
@@ -259,6 +272,9 @@ export const RepoUrlPicker = (
         isDisabled={isDisabled}
         rawErrors={rawErrors}
         availableRepos={state.availableRepos}
+        repoLabel={repoLabel}
+        repoDescription={repoDescription}
+        disableRepoAutocomplete={disableRepoAutocomplete}
       />
     </>
   );

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPicker.tsx
@@ -203,6 +203,7 @@ export const RepoUrlPicker = (
           accessToken={accessToken}
           ownerLabel={ownerLabel}
           ownerDescription={ownerDescription}
+          disableRepoAutocomplete={disableRepoAutocomplete}
         />
       )}
       {hostType === 'gitea' && (
@@ -227,6 +228,7 @@ export const RepoUrlPicker = (
           accessToken={accessToken}
           ownerLabel={ownerLabel}
           ownerDescription={ownerDescription}
+          disableRepoAutocomplete={disableRepoAutocomplete}
         />
       )}
       {(hostType === 'bitbucket' ||

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerRepoName.test.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerRepoName.test.tsx
@@ -17,9 +17,24 @@ import { renderInTestApp } from '@backstage/test-utils';
 import { fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { act } from 'react-dom/test-utils';
+import { useScaffolderTheme } from '@backstage/plugin-scaffolder-react/alpha';
 import { RepoUrlPickerRepoName } from './RepoUrlPickerRepoName';
 
+jest.mock('@backstage/plugin-scaffolder-react/alpha', () => ({
+  ...jest.requireActual('@backstage/plugin-scaffolder-react/alpha'),
+  useScaffolderTheme: jest.fn(),
+}));
+
+const mockUseScaffolderTheme = useScaffolderTheme as jest.Mock;
+
 describe('RepoUrlPickerRepoName', () => {
+  beforeEach(() => {
+    mockUseScaffolderTheme.mockReturnValue('mui');
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
   it('should call onChange with the first allowed repo if there is none set already', async () => {
     const onChange = jest.fn();
 
@@ -189,5 +204,87 @@ describe('RepoUrlPickerRepoName', () => {
 
     // Ensure it's disabled
     expect(textInput).toBeDisabled();
+  });
+
+  describe('bui theme', () => {
+    beforeEach(() => {
+      mockUseScaffolderTheme.mockReturnValue('bui');
+    });
+
+    it('should render a select of all the allowed repos', async () => {
+      const allowedRepos = ['foo', 'bar'];
+      const onChange = jest.fn();
+
+      const { getByRole } = await renderInTestApp(
+        <RepoUrlPickerRepoName
+          onChange={onChange}
+          allowedRepos={allowedRepos}
+          rawErrors={[]}
+        />,
+      );
+
+      // BuiSelect renders a combobox trigger listing the allowed repos
+      expect(getByRole('button')).toBeVisible();
+    });
+
+    it('should render a plain text input when disableRepoAutocomplete is true', async () => {
+      const onChange = jest.fn();
+
+      const { getByRole, queryByRole } = await renderInTestApp(
+        <RepoUrlPickerRepoName
+          onChange={onChange}
+          rawErrors={[]}
+          disableRepoAutocomplete
+        />,
+      );
+
+      const textInput = getByRole('textbox');
+      expect(textInput).toBeVisible();
+
+      // Should be a plain text input, not an autocomplete/combobox
+      expect(queryByRole('combobox')).not.toBeInTheDocument();
+      expect(textInput).not.toHaveAttribute('aria-autocomplete');
+
+      act(() => {
+        textInput.focus();
+        fireEvent.change(textInput, { target: { value: 'new-repo' } });
+      });
+
+      expect(onChange).toHaveBeenCalledWith({ name: 'new-repo' });
+    });
+
+    it('should render custom labels when repoLabel and repoDescription are provided', async () => {
+      const onChange = jest.fn();
+
+      const { getByText, getByRole } = await renderInTestApp(
+        <RepoUrlPickerRepoName
+          onChange={onChange}
+          rawErrors={[]}
+          repoLabel="New Repository Name"
+          repoDescription="Type a new repo name"
+          disableRepoAutocomplete
+        />,
+      );
+
+      expect(getByRole('textbox')).toBeVisible();
+      expect(getByText('New Repository Name')).toBeVisible();
+      expect(getByText('Type a new repo name')).toBeVisible();
+    });
+
+    it('should render an autocomplete of availableRepos when repo autocomplete is enabled', async () => {
+      const availableRepos = [{ name: 'foo' }, { name: 'bar' }];
+      const onChange = jest.fn();
+
+      const { getByRole } = await renderInTestApp(
+        <RepoUrlPickerRepoName
+          onChange={onChange}
+          availableRepos={availableRepos}
+          rawErrors={[]}
+        />,
+      );
+
+      // BuiAutocomplete (Combobox) exposes the combobox role
+      expect(getByRole('combobox')).toBeVisible();
+    });
   });
 });

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerRepoName.test.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerRepoName.test.tsx
@@ -127,6 +127,51 @@ describe('RepoUrlPickerRepoName', () => {
     expect(selectElement).toBeDisabled();
   });
 
+  it('should render a plain text input when disableRepoAutocomplete is true', async () => {
+    const onChange = jest.fn();
+
+    const { getByRole, queryByRole } = await renderInTestApp(
+      <RepoUrlPickerRepoName
+        onChange={onChange}
+        rawErrors={[]}
+        disableRepoAutocomplete
+      />,
+    );
+
+    const textInput = getByRole('textbox');
+    expect(textInput).toBeVisible();
+
+    // Should not have autocomplete behavior
+    expect(queryByRole('combobox')).not.toBeInTheDocument();
+    expect(textInput).not.toHaveAttribute('aria-autocomplete');
+
+    act(() => {
+      textInput.focus();
+      fireEvent.change(textInput, { target: { value: 'new-repo' } });
+    });
+
+    expect(onChange).toHaveBeenCalledWith({ name: 'new-repo' });
+  });
+
+  it('should render custom labels when repoLabel and repoDescription are provided', async () => {
+    const onChange = jest.fn();
+
+    const { getByText, getByRole } = await renderInTestApp(
+      <RepoUrlPickerRepoName
+        onChange={onChange}
+        rawErrors={[]}
+        repoLabel="New Repository Name"
+        repoDescription="Type a new repo name"
+        disableRepoAutocomplete
+      />,
+    );
+
+    const textInput = getByRole('textbox');
+    expect(textInput).toBeVisible();
+    expect(getByText('New Repository Name')).toBeVisible();
+    expect(getByText('Type a new repo name')).toBeVisible();
+  });
+
   it('should disable the text input when no options are passed and isDisabled is true', async () => {
     const onChange = jest.fn();
 

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerRepoName.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerRepoName.tsx
@@ -23,7 +23,7 @@ import { useEffect } from 'react';
 import { scaffolderTranslationRef } from '../../../translation';
 import { AvailableRepositories } from './types';
 import { useScaffolderTheme } from '@backstage/plugin-scaffolder-react/alpha';
-import { Select as BuiSelect } from '@backstage/ui';
+import { TextField as BuiTextField, Select as BuiSelect } from '@backstage/ui';
 import { Autocomplete as BuiAutocomplete } from '../Autocomplete';
 import overrides from '../scaffolderFieldOverrides.module.css';
 import type { Key } from 'react-aria-components';
@@ -88,14 +88,13 @@ export const RepoUrlPickerRepoName = (props: {
 
     if (disableRepoAutocomplete) {
       return (
-        <BuiAutocomplete
+        <BuiTextField
           label={repoLabel ?? t('fields.repoUrlPicker.repository.inputTitle')}
           description={
             repoDescription ?? t('fields.repoUrlPicker.repository.description')
           }
-          inputValue={repoName ?? ''}
-          onInputChange={value => onChange({ name: value })}
-          options={[]}
+          value={repoName ?? ''}
+          onChange={value => onChange({ name: value })}
           isDisabled={isDisabled}
           isRequired
           isInvalid={rawErrors?.length > 0 && !repoName}

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerRepoName.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerRepoName.tsx
@@ -35,6 +35,9 @@ export const RepoUrlPickerRepoName = (props: {
   rawErrors: string[];
   availableRepos?: AvailableRepositories[];
   isDisabled?: boolean;
+  repoLabel?: string;
+  repoDescription?: string;
+  disableRepoAutocomplete?: boolean;
 }) => {
   const theme = useScaffolderTheme();
   const {
@@ -44,6 +47,9 @@ export const RepoUrlPickerRepoName = (props: {
     rawErrors,
     availableRepos,
     isDisabled,
+    repoLabel,
+    repoDescription,
+    disableRepoAutocomplete,
   } = props;
   const { t } = useTranslationRef(scaffolderTranslationRef);
 
@@ -64,8 +70,10 @@ export const RepoUrlPickerRepoName = (props: {
       return (
         <BuiSelect
           className={overrides.select}
-          label={t('fields.repoUrlPicker.repository.title')}
-          description={t('fields.repoUrlPicker.repository.description')}
+          label={repoLabel ?? t('fields.repoUrlPicker.repository.title')}
+          description={
+            repoDescription ?? t('fields.repoUrlPicker.repository.description')
+          }
           isDisabled={isDisabled || allowedRepos.length === 1}
           isInvalid={rawErrors?.length > 0 && !repoName}
           selectedKey={repoName ?? null}
@@ -78,6 +86,23 @@ export const RepoUrlPickerRepoName = (props: {
       );
     }
 
+    if (disableRepoAutocomplete) {
+      return (
+        <BuiAutocomplete
+          label={repoLabel ?? t('fields.repoUrlPicker.repository.inputTitle')}
+          description={
+            repoDescription ?? t('fields.repoUrlPicker.repository.description')
+          }
+          inputValue={repoName ?? ''}
+          onInputChange={value => onChange({ name: value })}
+          options={[]}
+          isDisabled={isDisabled}
+          isRequired
+          isInvalid={rawErrors?.length > 0 && !repoName}
+        />
+      );
+    }
+
     const options = (availableRepos || []).map(r => ({
       label: r.name,
       value: r.name,
@@ -85,8 +110,10 @@ export const RepoUrlPickerRepoName = (props: {
 
     return (
       <BuiAutocomplete
-        label={t('fields.repoUrlPicker.repository.inputTitle')}
-        description={t('fields.repoUrlPicker.repository.description')}
+        label={repoLabel ?? t('fields.repoUrlPicker.repository.inputTitle')}
+        description={
+          repoDescription ?? t('fields.repoUrlPicker.repository.description')
+        }
         inputValue={repoName ?? ''}
         onInputChange={value => {
           const selectedRepo = availableRepos?.find(r => r.name === value);
@@ -112,6 +139,59 @@ export const RepoUrlPickerRepoName = (props: {
     ? allowedRepos.map(i => ({ label: i, value: i }))
     : [{ label: 'Loading...', value: 'loading' }];
 
+  const renderMuiInput = () => {
+    if (allowedRepos?.length) {
+      return (
+        <MuiSelect
+          native
+          label={repoLabel ?? t('fields.repoUrlPicker.repository.title')}
+          onChange={selected =>
+            onChange({
+              name: String(Array.isArray(selected) ? selected[0] : selected),
+            })
+          }
+          disabled={isDisabled || allowedRepos.length === 1}
+          selected={repoName}
+          items={repoItems}
+        />
+      );
+    }
+
+    if (disableRepoAutocomplete) {
+      return (
+        <MuiTextField
+          label={repoLabel ?? t('fields.repoUrlPicker.repository.inputTitle')}
+          value={repoName ?? ''}
+          onChange={e => onChange({ name: e.target.value })}
+          required
+          disabled={isDisabled}
+          error={rawErrors?.length > 0 && !repoName}
+        />
+      );
+    }
+
+    return (
+      <MuiAutocomplete
+        value={repoName}
+        onChange={(_, newValue) => {
+          const selectedRepo = availableRepos?.find(r => r.name === newValue);
+          onChange(selectedRepo || { name: newValue || '' });
+        }}
+        options={(availableRepos || []).map(r => r.name)}
+        renderInput={params => (
+          <MuiTextField
+            {...params}
+            label={repoLabel ?? t('fields.repoUrlPicker.repository.inputTitle')}
+            required
+          />
+        )}
+        freeSolo
+        autoSelect
+        disabled={isDisabled}
+      />
+    );
+  };
+
   return (
     <>
       <FormControl
@@ -119,43 +199,9 @@ export const RepoUrlPickerRepoName = (props: {
         required
         error={rawErrors?.length > 0 && !repoName}
       >
-        {allowedRepos?.length ? (
-          <MuiSelect
-            native
-            label={t('fields.repoUrlPicker.repository.title')}
-            onChange={selected =>
-              onChange({
-                name: String(Array.isArray(selected) ? selected[0] : selected),
-              })
-            }
-            disabled={isDisabled || allowedRepos.length === 1}
-            selected={repoName}
-            items={repoItems}
-          />
-        ) : (
-          <MuiAutocomplete
-            value={repoName}
-            onChange={(_, newValue) => {
-              const selectedRepo = availableRepos?.find(
-                r => r.name === newValue,
-              );
-              onChange(selectedRepo || { name: newValue || '' });
-            }}
-            options={(availableRepos || []).map(r => r.name)}
-            renderInput={params => (
-              <MuiTextField
-                {...params}
-                label={t('fields.repoUrlPicker.repository.inputTitle')}
-                required
-              />
-            )}
-            freeSolo
-            autoSelect
-            disabled={isDisabled}
-          />
-        )}
+        {renderMuiInput()}
         <FormHelperText>
-          {t('fields.repoUrlPicker.repository.description')}
+          {repoDescription ?? t('fields.repoUrlPicker.repository.description')}
         </FormHelperText>
       </FormControl>
     </>

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerRepoName.tsx
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/RepoUrlPickerRepoName.tsx
@@ -134,12 +134,13 @@ export const RepoUrlPickerRepoName = (props: {
     );
   }
 
-  const repoItems: SelectItem[] = allowedRepos
-    ? allowedRepos.map(i => ({ label: i, value: i }))
-    : [{ label: 'Loading...', value: 'loading' }];
-
   const renderMuiInput = () => {
     if (allowedRepos?.length) {
+      const repoItems: SelectItem[] = allowedRepos.map(i => ({
+        label: i,
+        value: i,
+      }));
+
       return (
         <MuiSelect
           native

--- a/plugins/scaffolder/src/components/fields/RepoUrlPicker/schema.ts
+++ b/plugins/scaffolder/src/components/fields/RepoUrlPicker/schema.ts
@@ -43,6 +43,28 @@ export const RepoUrlPickerFieldSchema = makeFieldSchema({
         .array(z.string())
         .optional()
         .describe('List of allowed repos in the given SCM platform'),
+      ownerLabel: z
+        .string()
+        .optional()
+        .describe('Custom label for the owner/namespace field'),
+      ownerDescription: z
+        .string()
+        .optional()
+        .describe('Custom description for the owner/namespace field'),
+      repoLabel: z
+        .string()
+        .optional()
+        .describe('Custom label for the repository name field'),
+      repoDescription: z
+        .string()
+        .optional()
+        .describe('Custom description for the repository name field'),
+      disableRepoAutocomplete: z
+        .boolean()
+        .optional()
+        .describe(
+          'If true, renders a plain text input instead of an autocomplete dropdown for the repository name',
+        ),
       requestUserCredentials: z
         .object({
           secretsKey: z


### PR DESCRIPTION
Adds new ui:options to RepoUrlPicker for per-template customization:
- ownerLabel / ownerDescription: override owner field label and helper text
- repoLabel / repoDescription: override repository name field label and helper text
- disableRepoAutocomplete: render plain text input instead of autocomplete dropdown

Resolves #34893

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

<img width="626" height="334" alt="image" src="https://github.com/user-attachments/assets/0a5a6de9-95b7-4685-987d-811679c6dc8e" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
