### PR TITLE
fix(catalog-client): fall back to POST when filter would produce over…

### DIFF
--- a/.changeset/catalog-client-post-fallback.md
+++ b/.changeset/catalog-client-post-fallback.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-client': patch
+---
+
+Fix `CatalogClient.queryEntities()` to fall back to the POST endpoint when the serialized filter would produce an oversized URL, preventing `ERR_HTTP2_PROTOCOL_ERROR`/414 failures for users belonging to many groups

--- a/.changeset/catalog-client-post-fallback.md
+++ b/.changeset/catalog-client-post-fallback.md
@@ -2,4 +2,4 @@
 '@backstage/catalog-client': patch
 ---
 
-Fix `CatalogClient.queryEntities()` to fall back to the POST endpoint when the serialized filter would produce an oversized URL, preventing `ERR_HTTP2_PROTOCOL_ERROR`/414 failures for users belonging to many groups
+Fix catalog entity queries to fall back to the POST endpoint when filters would produce an oversized URL, preventing `ERR_HTTP2_PROTOCOL_ERROR`/414 failures for users belonging to many groups.

--- a/packages/catalog-client/src/CatalogClient.test.ts
+++ b/packages/catalog-client/src/CatalogClient.test.ts
@@ -488,6 +488,51 @@ describe('CatalogClient', () => {
         'c',
       ]);
     });
+    it('falls back to POST endpoint when filter would produce an oversized URL', async () => {
+      const getMockedEndpoint = jest
+        .fn()
+        .mockImplementation(() =>
+          HttpResponse.json({ items: [], totalItems: 0 }),
+        );
+      const postMockedEndpoint = jest
+        .fn()
+        .mockImplementation(async ({ request }: { request: Request }) => {
+          expect(request.method).toBe('POST');
+          const body = await request.json();
+          expect(body.query).toBeDefined();
+          return HttpResponse.json({ items: [], totalItems: 0 });
+        });
+      server.use(
+        http.get(`${mockBaseUrl}/entities/by-query`, getMockedEndpoint),
+        http.post(`${mockBaseUrl}/entities/by-query`, postMockedEndpoint),
+      );
+      const manyGroups = Array.from(
+        { length: 200 },
+        (_, i) => `group:default/team-${i}`,
+      );
+      const response = await client.queryEntities({
+        filter: {
+          'relations.ownedBy': manyGroups,
+        },
+      });
+      expect(getMockedEndpoint).not.toHaveBeenCalled();
+      expect(postMockedEndpoint).toHaveBeenCalledTimes(1);
+      expect(response).toEqual({ items: [], totalItems: 0 });
+    });
+    it('still uses GET endpoint when filter is small', async () => {
+      const getMockedEndpoint = jest
+        .fn()
+        .mockImplementation(() =>
+          HttpResponse.json({ items: [], totalItems: 0 }),
+        );
+      server.use(
+        http.get(`${mockBaseUrl}/entities/by-query`, getMockedEndpoint),
+      );
+      await client.queryEntities({
+        filter: { 'relations.ownedBy': 'group:default/team-a' },
+      });
+      expect(getMockedEndpoint).toHaveBeenCalledTimes(1);
+    });
 
     it('builds search filters property even those with URL unsafe values', async () => {
       const mockedEndpoint = jest

--- a/packages/catalog-client/src/CatalogClient.ts
+++ b/packages/catalog-client/src/CatalogClient.ts
@@ -335,7 +335,7 @@ export class CatalogClient implements CatalogApi {
       // users belonging to many groups, producing hundreds of `filter=`
       // params).
       const estimatedFilterLength = filterValue.reduce(
-        (sum, f) => sum + f.length + 'filter='.length + 1,
+        (sum, f) => sum + encodeURIComponent(f).length + 'filter='.length + 1,
         0,
       );
       const MAX_FILTER_URL_LENGTH = 2000;

--- a/packages/catalog-client/src/CatalogClient.ts
+++ b/packages/catalog-client/src/CatalogClient.ts
@@ -328,8 +328,26 @@ export class CatalogClient implements CatalogApi {
         fullTextFilter,
         totalItems,
       } = request;
-      params.filter = this.getFilterValue(filter);
+      const filterValue = this.getFilterValue(filter);
 
+      // Fall back to the POST endpoint when the serialized filter would
+      // produce a URL that risks exceeding safe length limits (e.g. for
+      // users belonging to many groups, producing hundreds of `filter=`
+      // params).
+      const estimatedFilterLength = filterValue.reduce(
+        (sum, f) => sum + f.length + 'filter='.length + 1,
+        0,
+      );
+      const MAX_FILTER_URL_LENGTH = 2000;
+
+      if (
+        filter !== undefined &&
+        estimatedFilterLength > MAX_FILTER_URL_LENGTH
+      ) {
+        return this.queryEntitiesByPredicate(request, options);
+      }
+
+      params.filter = filterValue;
       if (limit !== undefined) {
         params.limit = limit;
       }

--- a/packages/catalog-client/src/CatalogClient.ts
+++ b/packages/catalog-client/src/CatalogClient.ts
@@ -334,16 +334,19 @@ export class CatalogClient implements CatalogApi {
       // produce a URL that risks exceeding safe length limits (e.g. for
       // users belonging to many groups, producing hundreds of `filter=`
       // params).
-      const estimatedFilterLength = filterValue.reduce(
-        (sum, f) => sum + encodeURIComponent(f).length + 'filter='.length + 1,
-        0,
-      );
       const MAX_FILTER_URL_LENGTH = 2000;
+      let estimatedFilterLength = 0;
+      let filterExceedsUrlLimit = false;
+      for (const f of filterValue) {
+        estimatedFilterLength +=
+          encodeURIComponent(f).length + 'filter='.length + 1;
+        if (estimatedFilterLength > MAX_FILTER_URL_LENGTH) {
+          filterExceedsUrlLimit = true;
+          break;
+        }
+      }
 
-      if (
-        filter !== undefined &&
-        estimatedFilterLength > MAX_FILTER_URL_LENGTH
-      ) {
+      if (filter !== undefined && filterExceedsUrlLimit) {
         return this.queryEntitiesByPredicate(request, options);
       }
 


### PR DESCRIPTION
Fixes #34881

## What
`CatalogClient.queryEntities()` always serialized `filter` as GET query
parameters, regardless of size. For users belonging to many groups, this
produces hundreds of `filter=relations.ownedBy=...` params, resulting in
`ERR_HTTP2_PROTOCOL_ERROR` / HTTP 414 responses that also kill other
in-flight requests on the same page.

## Fix
When the serialized filter would exceed a safe URL-length threshold
(2000 characters), `queryEntities()` now falls back to the existing
`queryEntitiesByPredicate()` method (POST endpoint), which already
converts `filter` via `convertFilterToPredicate()`. No new backend
routes or conversion logic were needed — this reuses existing,
already-tested infrastructure.

Small filters continue to use GET exactly as before; behavior is
unchanged for all existing callers.

## Testing
- Added a test simulating a user in 200 groups, confirming the request
  falls back to POST and the GET endpoint is never called
- Added a test confirming small filters still use GET as before
- All 144 existing tests in `CatalogClient.test.ts` continue to pass
  (146 total after these additions)

✔️ Checklist
- [x] A changeset describing the change and affected packages
- [x] Tests for new functionality and regression tests for the bug fix
- [x] All commits have a Signed-off-by line
- [ ]