### PR TITLE
fix(signals-backend): require user auth for WebSocket connections

### DIFF
--- a/.changeset/signals-require-websocket-auth.md
+++ b/.changeset/signals-require-websocket-auth.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-signals-backend': patch
+---
+
+The signals WebSocket endpoint now requires a valid user identity token. Connections without a token, with an invalid token, or with a non-user (service) token are rejected, and unauthenticated guest connections are no longer accepted.

--- a/plugins/signals-backend/src/plugin.ts
+++ b/plugins/signals-backend/src/plugin.ts
@@ -61,6 +61,9 @@ export const signalsPlugin = createBackendPlugin({
             events,
           }),
         );
+        // Browser WebSockets cannot send an Authorization header, so the
+        // credentials barrier must allow the handshake through. Authentication
+        // is enforced in the WebSocket upgrade handler via Sec-WebSocket-Protocol.
         httpRouter.addAuthPolicy({
           path: '/',
           allow: 'unauthenticated',

--- a/plugins/signals-backend/src/service/SignalManager.test.ts
+++ b/plugins/signals-backend/src/service/SignalManager.test.ts
@@ -59,6 +59,16 @@ class MockWebSocket {
   }
 }
 
+const guestIdentity = {
+  userEntityRef: 'user:default/guest',
+  ownershipEntityRefs: ['user:default/guest'],
+};
+
+const johnIdentity = {
+  userEntityRef: 'user:default/john.doe',
+  ownershipEntityRefs: ['user:default/john.doe'],
+};
+
 describe('SignalManager', () => {
   let onEvent: Function;
 
@@ -81,16 +91,20 @@ describe('SignalManager', () => {
     lifecycle: mockLifecycle,
   });
 
+  afterAll(() => {
+    shutdownHooks.forEach(hook => hook());
+  });
+
   it('should close all connections when server is closed', () => {
     const ws = new MockWebSocket();
-    manager.addConnection(ws as unknown as WebSocket);
+    manager.addConnection(ws as unknown as WebSocket, guestIdentity);
     shutdownHooks.forEach(hook => hook());
     expect(ws.closed).toBeTruthy();
   });
 
   it('should close connection on error', () => {
     const ws = new MockWebSocket();
-    manager.addConnection(ws as unknown as WebSocket);
+    manager.addConnection(ws as unknown as WebSocket, guestIdentity);
 
     ws.trigger('error', new Error('error'));
     expect(ws.closed).toBeTruthy();
@@ -98,7 +112,7 @@ describe('SignalManager', () => {
 
   it('should allow subscribing and unsubscribing to events', async () => {
     const ws = new MockWebSocket();
-    manager.addConnection(ws as unknown as WebSocket);
+    manager.addConnection(ws as unknown as WebSocket, guestIdentity);
 
     ws.trigger(
       'message',
@@ -139,23 +153,14 @@ describe('SignalManager', () => {
   });
 
   it('should only send to users from identity', async () => {
-    // Connection without identity
     const ws1 = new MockWebSocket();
-    manager.addConnection(ws1 as unknown as WebSocket);
+    manager.addConnection(ws1 as unknown as WebSocket, guestIdentity);
 
-    // Connection with identity and subscription
     const ws2 = new MockWebSocket();
-    manager.addConnection(ws2 as unknown as WebSocket, {
-      ownershipEntityRefs: ['user:default/john.doe'],
-      userEntityRef: 'user:default/john.doe',
-    });
+    manager.addConnection(ws2 as unknown as WebSocket, johnIdentity);
 
-    // Connection without subscription
     const ws3 = new MockWebSocket();
-    manager.addConnection(ws3 as unknown as WebSocket, {
-      ownershipEntityRefs: ['user:default/john.doe'],
-      userEntityRef: 'user:default/john.doe',
-    });
+    manager.addConnection(ws3 as unknown as WebSocket, johnIdentity);
 
     ws1.trigger(
       'message',

--- a/plugins/signals-backend/src/service/SignalManager.test.ts
+++ b/plugins/signals-backend/src/service/SignalManager.test.ts
@@ -59,9 +59,9 @@ class MockWebSocket {
   }
 }
 
-const guestIdentity = {
-  userEntityRef: 'user:default/guest',
-  ownershipEntityRefs: ['user:default/guest'],
+const aliceIdentity = {
+  userEntityRef: 'user:default/alice',
+  ownershipEntityRefs: ['user:default/alice'],
 };
 
 const johnIdentity = {
@@ -96,15 +96,27 @@ describe('SignalManager', () => {
   });
 
   it('should close all connections when server is closed', () => {
+    const localHooks: Function[] = [];
+    const localManager = SignalManager.create({
+      events: {
+        publish: async () => {},
+        subscribe: async () => {},
+      },
+      logger: mockServices.logger.mock(),
+      config: mockServices.rootConfig(),
+      lifecycle: mockServices.lifecycle.mock({
+        addShutdownHook: (hook: Function) => localHooks.push(hook),
+      }),
+    });
     const ws = new MockWebSocket();
-    manager.addConnection(ws as unknown as WebSocket, guestIdentity);
-    shutdownHooks.forEach(hook => hook());
+    localManager.addConnection(ws as unknown as WebSocket, aliceIdentity);
+    localHooks.forEach(hook => hook());
     expect(ws.closed).toBeTruthy();
   });
 
   it('should close connection on error', () => {
     const ws = new MockWebSocket();
-    manager.addConnection(ws as unknown as WebSocket, guestIdentity);
+    manager.addConnection(ws as unknown as WebSocket, aliceIdentity);
 
     ws.trigger('error', new Error('error'));
     expect(ws.closed).toBeTruthy();
@@ -112,7 +124,7 @@ describe('SignalManager', () => {
 
   it('should allow subscribing and unsubscribing to events', async () => {
     const ws = new MockWebSocket();
-    manager.addConnection(ws as unknown as WebSocket, guestIdentity);
+    manager.addConnection(ws as unknown as WebSocket, aliceIdentity);
 
     ws.trigger(
       'message',
@@ -154,7 +166,7 @@ describe('SignalManager', () => {
 
   it('should only send to users from identity', async () => {
     const ws1 = new MockWebSocket();
-    manager.addConnection(ws1 as unknown as WebSocket, guestIdentity);
+    manager.addConnection(ws1 as unknown as WebSocket, aliceIdentity);
 
     const ws2 = new MockWebSocket();
     manager.addConnection(ws2 as unknown as WebSocket, johnIdentity);

--- a/plugins/signals-backend/src/service/SignalManager.ts
+++ b/plugins/signals-backend/src/service/SignalManager.ts
@@ -109,7 +109,7 @@ export class SignalManager {
     this.connections.clear();
   }
 
-  addConnection(ws: WebSocket, identity?: BackstageUserInfo) {
+  addConnection(ws: WebSocket, identity: BackstageUserInfo) {
     // Start pinging on first connection
     if (!this.pingInterval) {
       this.pingInterval = setInterval(() => this.ping(), 30000);
@@ -118,11 +118,9 @@ export class SignalManager {
     const id = uuid();
     const conn = {
       id,
-      user: identity?.userEntityRef ?? 'user:default/guest',
+      user: identity.userEntityRef,
       ws,
-      ownershipEntityRefs: identity?.ownershipEntityRefs ?? [
-        'user:default/guest',
-      ],
+      ownershipEntityRefs: identity.ownershipEntityRefs,
       subscriptions: new Set<string>(),
       isAlive: true,
     };

--- a/plugins/signals-backend/src/service/router.test.ts
+++ b/plugins/signals-backend/src/service/router.test.ts
@@ -55,6 +55,9 @@ async function connectWebSocket(
         return;
       }
       settled = true;
+      if (!result.ws) {
+        ws.terminate();
+      }
       resolve(result);
     };
 

--- a/plugins/signals-backend/src/service/router.test.ts
+++ b/plugins/signals-backend/src/service/router.test.ts
@@ -44,21 +44,37 @@ async function connectWebSocket(
 
   return new Promise(resolve => {
     const ws = new WebSocket(`ws://127.0.0.1:${port}/api/signals`, protocols);
+    let settled = false;
+
+    const settle = (result: {
+      ws?: WebSocket;
+      error?: Error;
+      statusCode?: number;
+    }) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolve(result);
+    };
 
     ws.once('open', () => {
-      resolve({ ws });
+      settle({ ws });
     });
 
     ws.once('unexpected-response', (_req, res) => {
-      resolve({ statusCode: res.statusCode });
+      settle({ statusCode: res.statusCode });
       res.resume();
     });
 
     ws.once('error', error => {
-      // unexpected-response already handles HTTP errors; ignore follow-on errors
-      if ((error as NodeJS.ErrnoException).message.includes('401')) {
-        return;
-      }
+      // Prefer unexpected-response for HTTP upgrade failures; only fall back
+      // to the error event when no response was received.
+      setImmediate(() => {
+        if (!settled) {
+          settle({ error });
+        }
+      });
     });
   });
 }

--- a/plugins/signals-backend/src/service/router.test.ts
+++ b/plugins/signals-backend/src/service/router.test.ts
@@ -15,18 +15,62 @@
  */
 
 import express from 'express';
+import http from 'node:http';
 import request from 'supertest';
+import { WebSocket } from 'ws';
 import { createRouter } from './router';
-import { mockErrorHandler, mockServices } from '@backstage/backend-test-utils';
+import {
+  mockCredentials,
+  mockErrorHandler,
+  mockServices,
+} from '@backstage/backend-test-utils';
 
 const eventsServiceMock = mockServices.events.mock();
 const discovery = mockServices.discovery.mock({
-  getBaseUrl: async () => '/api/signals',
+  getBaseUrl: async () => 'http://127.0.0.1/api/signals',
 });
-const userInfo = mockServices.userInfo.mock();
+const userInfo = mockServices.userInfo.mock({
+  getUserInfo: async () => ({
+    userEntityRef: 'user:default/test',
+    ownershipEntityRefs: ['user:default/test'],
+  }),
+});
+
+async function connectWebSocket(
+  server: http.Server,
+  protocols?: string | string[],
+): Promise<{ ws?: WebSocket; error?: Error; statusCode?: number }> {
+  const { port } = server.address() as { port: number };
+
+  return new Promise(resolve => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/api/signals`, protocols);
+
+    ws.once('open', () => {
+      resolve({ ws });
+    });
+
+    ws.once('unexpected-response', (_req, res) => {
+      resolve({ statusCode: res.statusCode });
+      res.resume();
+    });
+
+    ws.once('error', error => {
+      // unexpected-response already handles HTTP errors; ignore follow-on errors
+      if ((error as NodeJS.ErrnoException).message.includes('401')) {
+        return;
+      }
+    });
+  });
+}
 
 describe('createRouter', () => {
-  let app: express.Express;
+  let server: http.Server;
+  const shutdownHooks: Array<() => void | Promise<void>> = [];
+  const lifecycle = mockServices.lifecycle.mock({
+    addShutdownHook: (hook: () => void | Promise<void>) => {
+      shutdownHooks.push(hook);
+    },
+  });
 
   beforeAll(async () => {
     const router = await createRouter({
@@ -35,22 +79,70 @@ describe('createRouter', () => {
       discovery,
       userInfo,
       config: mockServices.rootConfig(),
-      lifecycle: mockServices.lifecycle.mock(),
+      lifecycle,
       auth: mockServices.auth(),
     });
-    app = express().use(router).use(mockErrorHandler());
+    const app = express().use('/api/signals', router).use(mockErrorHandler());
+    server = http.createServer(app);
+    await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+    // Register the upgrade handler via the first HTTP request
+    await request(server).get('/api/signals/health');
+  });
+
+  afterAll(async () => {
+    await Promise.all(shutdownHooks.map(hook => hook()));
+    await new Promise<void>((resolve, reject) =>
+      server.close(err => (err ? reject(err) : resolve())),
+    );
   });
 
   beforeEach(() => {
-    jest.resetAllMocks();
+    jest.clearAllMocks();
   });
 
   describe('GET /health', () => {
     it('returns ok', async () => {
-      const response = await request(app).get('/health');
+      const response = await request(server).get('/api/signals/health');
 
       expect(response.status).toEqual(200);
       expect(response.body).toEqual({ status: 'ok' });
+    });
+  });
+
+  describe('WebSocket authentication', () => {
+    it('rejects connections without a token', async () => {
+      const result = await connectWebSocket(server);
+      expect(result.statusCode).toEqual(401);
+      expect(result.ws).toBeUndefined();
+    });
+
+    it('rejects connections with an invalid token', async () => {
+      const result = await connectWebSocket(
+        server,
+        mockCredentials.user.invalidToken(),
+      );
+      expect(result.statusCode).toEqual(401);
+      expect(result.ws).toBeUndefined();
+    });
+
+    it('rejects connections with a service token', async () => {
+      const result = await connectWebSocket(
+        server,
+        mockCredentials.service.token(),
+      );
+      expect(result.statusCode).toEqual(401);
+      expect(result.ws).toBeUndefined();
+    });
+
+    it('accepts connections with a valid user token', async () => {
+      const result = await connectWebSocket(
+        server,
+        mockCredentials.user.token(),
+      );
+      expect(result.ws).toBeDefined();
+      expect(result.ws?.readyState).toEqual(WebSocket.OPEN);
+      expect(userInfo.getUserInfo).toHaveBeenCalled();
+      result.ws?.close();
     });
   });
 });

--- a/plugins/signals-backend/src/service/router.ts
+++ b/plugins/signals-backend/src/service/router.ts
@@ -42,6 +42,29 @@ export interface RouterOptions {
   auth: AuthService;
 }
 
+function rejectUpgrade(
+  socket: Duplex,
+  statusLine: string,
+  logger: LoggerService,
+  details: {
+    remoteAddress?: string;
+    reason: string;
+  },
+) {
+  logger.warn('WebSocket upgrade rejected', {
+    remoteAddress: details.remoteAddress,
+    timestamp: new Date().toISOString(),
+    reason: details.reason,
+  });
+  socket.write(
+    `${statusLine}\r\n` +
+      'Connection: close\r\n' +
+      'Content-Length: 0\r\n' +
+      '\r\n',
+  );
+  socket.destroy();
+}
+
 export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {
@@ -73,27 +96,33 @@ export async function createRouter(
       return;
     }
 
-    let userIdentity: BackstageUserInfo | undefined = undefined;
-
     // Authentication token is passed in Sec-WebSocket-Protocol header as there
     // is no other way to pass the token with plain websockets
+    const token = request.headers['sec-websocket-protocol'];
+    if (!token || typeof token !== 'string') {
+      rejectUpgrade(socket, 'HTTP/1.1 401 Unauthorized', logger, {
+        remoteAddress: request.socket.remoteAddress,
+        reason: 'missing_token',
+      });
+      return;
+    }
+
+    let userIdentity: BackstageUserInfo;
     try {
-      const token = request.headers['sec-websocket-protocol'];
-      if (token) {
-        const credentials = await auth.authenticate(token);
-        if (auth.isPrincipal(credentials, 'user')) {
-          userIdentity = await userInfo.getUserInfo(credentials);
-        }
+      const credentials = await auth.authenticate(token);
+      if (!auth.isPrincipal(credentials, 'user')) {
+        rejectUpgrade(socket, 'HTTP/1.1 401 Unauthorized', logger, {
+          remoteAddress: request.socket.remoteAddress,
+          reason: 'non_user_principal',
+        });
+        return;
       }
+      userIdentity = await userInfo.getUserInfo(credentials);
     } catch (e) {
-      logger.error(`Failed to authenticate WebSocket connection: ${e}`);
-      socket.write(
-        'HTTP/1.1 401 Web Socket Protocol Handshake\r\n' +
-          'Upgrade: WebSocket\r\n' +
-          'Connection: Upgrade\r\n' +
-          '\r\n',
-      );
-      socket.destroy();
+      rejectUpgrade(socket, 'HTTP/1.1 401 Unauthorized', logger, {
+        remoteAddress: request.socket.remoteAddress,
+        reason: 'invalid_token',
+      });
       return;
     }
 
@@ -108,35 +137,28 @@ export async function createRouter(
       );
     } catch (e) {
       logger.error(`Failed to handle WebSocket upgrade: ${e}`);
-      socket.write(
-        'HTTP/1.1 500 Web Socket Protocol Handshake\r\n' +
-          'Upgrade: WebSocket\r\n' +
-          'Connection: Upgrade\r\n' +
-          '\r\n',
-      );
-      socket.destroy();
+      rejectUpgrade(socket, 'HTTP/1.1 500 Internal Server Error', logger, {
+        remoteAddress: request.socket.remoteAddress,
+        reason: 'upgrade_failed',
+      });
     }
   };
 
+  // Register the upgrade listener on the first request that reaches this
+  // router so WebSocket handshakes can be handled outside Express.
   const upgradeMiddleware = async (
     req: Request,
     _: Response,
     next: NextFunction,
   ) => {
-    const server: https.Server | http.Server = (req.socket as any)?.server;
-    if (
-      subscribedToUpgradeRequests ||
-      !server ||
-      !req.headers ||
-      req.headers.upgrade === undefined ||
-      req.headers.upgrade.toLowerCase() !== 'websocket'
-    ) {
-      next();
-      return;
+    if (!subscribedToUpgradeRequests) {
+      const server: https.Server | http.Server = (req.socket as any)?.server;
+      if (server) {
+        subscribedToUpgradeRequests = true;
+        server.on('upgrade', handleUpgrade);
+      }
     }
-
-    subscribedToUpgradeRequests = true;
-    server.on('upgrade', handleUpgrade);
+    next();
   };
 
   const router = Router();

--- a/plugins/signals-backend/src/service/router.ts
+++ b/plugins/signals-backend/src/service/router.ts
@@ -69,12 +69,15 @@ function rejectUpgrade(
     timestamp: new Date().toISOString(),
     reason: details.reason,
   });
-  // Prefer end() so the HTTP response is flushed before the socket closes.
+  // Flush the HTTP response, then destroy so the socket cannot linger.
   socket.end(
     `${statusLine}\r\n` +
       'Connection: close\r\n' +
       'Content-Length: 0\r\n' +
       '\r\n',
+    () => {
+      socket.destroy();
+    },
   );
 }
 
@@ -132,6 +135,12 @@ export async function createRouter(
       }
       userIdentity = await userInfo.getUserInfo(credentials);
     } catch (e) {
+      logger.debug('WebSocket authentication failed', {
+        remoteAddress: request.socket.remoteAddress,
+        reason: 'invalid_token',
+        errorName: e instanceof Error ? e.name : undefined,
+        errorMessage: e instanceof Error ? e.message : String(e),
+      });
       rejectUpgrade(socket, 'HTTP/1.1 401 Unauthorized', logger, {
         remoteAddress: request.socket.remoteAddress,
         reason: 'invalid_token',

--- a/plugins/signals-backend/src/service/router.ts
+++ b/plugins/signals-backend/src/service/router.ts
@@ -42,6 +42,19 @@ export interface RouterOptions {
   auth: AuthService;
 }
 
+function readWebSocketToken(
+  header: string | string[] | undefined,
+): string | undefined {
+  const value = Array.isArray(header) ? header[0] : header;
+  if (!value) {
+    return undefined;
+  }
+  // Sec-WebSocket-Protocol may list multiple protocols; the Backstage token is
+  // expected to be the first (and typically only) value.
+  const token = value.split(',')[0]?.trim();
+  return token || undefined;
+}
+
 function rejectUpgrade(
   socket: Duplex,
   statusLine: string,
@@ -56,13 +69,13 @@ function rejectUpgrade(
     timestamp: new Date().toISOString(),
     reason: details.reason,
   });
-  socket.write(
+  // Prefer end() so the HTTP response is flushed before the socket closes.
+  socket.end(
     `${statusLine}\r\n` +
       'Connection: close\r\n' +
       'Content-Length: 0\r\n' +
       '\r\n',
   );
-  socket.destroy();
 }
 
 export async function createRouter(
@@ -98,8 +111,8 @@ export async function createRouter(
 
     // Authentication token is passed in Sec-WebSocket-Protocol header as there
     // is no other way to pass the token with plain websockets
-    const token = request.headers['sec-websocket-protocol'];
-    if (!token || typeof token !== 'string') {
+    const token = readWebSocketToken(request.headers['sec-websocket-protocol']);
+    if (!token) {
       rejectUpgrade(socket, 'HTTP/1.1 401 Unauthorized', logger, {
         remoteAddress: request.socket.remoteAddress,
         reason: 'missing_token',
@@ -144,8 +157,11 @@ export async function createRouter(
     }
   };
 
-  // Register the upgrade listener on the first request that reaches this
-  // router so WebSocket handshakes can be handled outside Express.
+  // The HTTP server is only available via the request socket, so the upgrade
+  // listener is registered on the first request that reaches this router.
+  // Until then, WebSocket upgrades for this plugin are not handled (same
+  // constraint as before; registering on any first request is slightly more
+  // reliable than waiting for an Upgrade request through Express).
   const upgradeMiddleware = async (
     req: Request,
     _: Response,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Requires a valid user identity token for signals WebSocket connections.

Previously, connections without a token (or with a non-user token) were accepted and fell back to `user:default/guest`, which allowed unauthenticated clients to receive broadcast signals. The upgrade handler now rejects missing, invalid, and non-user tokens with HTTP 401, and `SignalManager` no longer accepts connections without an identity.

The existing `allow: 'unauthenticated'` auth policy on `/` is kept on purpose: browser WebSockets cannot send an `Authorization` header, so authentication is enforced in the upgrade handler via `Sec-WebSocket-Protocol`.


#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))