### PR TITLE
fix(auth-backend): resolve built-in CLI CIMD client without network fetch

### DIFF
--- a/.changeset/fix-cimd-self-referential-ssrf.md
+++ b/.changeset/fix-cimd-self-referential-ssrf.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Fixed CIMD resolution of the built-in CLI client failing when the Backstage hostname resolves to a private IP.

--- a/plugins/auth-backend/src/service/CimdClient.test.ts
+++ b/plugins/auth-backend/src/service/CimdClient.test.ts
@@ -17,7 +17,11 @@
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
-import { validateCimdUrl, fetchCimdMetadata } from './CimdClient';
+import {
+  validateCimdUrl,
+  fetchCimdMetadata,
+  getBuiltInCliMetadata,
+} from './CimdClient';
 import * as dns from 'node:dns/promises';
 
 jest.mock('dns/promises');
@@ -125,6 +129,24 @@ describe('CimdClient', () => {
 
     it('should throw for invalid URLs', () => {
       expect(() => validateCimdUrl('not-a-url')).toThrow('not a valid URL');
+    });
+  });
+
+  describe('getBuiltInCliMetadata', () => {
+    it('should return CLI metadata with the correct client_id for the given base URL', () => {
+      const metadata = getBuiltInCliMetadata(
+        'https://backstage.example.com/api/auth',
+      );
+
+      expect(metadata).toEqual({
+        clientId:
+          'https://backstage.example.com/api/auth/.well-known/oauth-client/cli.json',
+        clientName: 'Backstage CLI',
+        redirectUris: ['http://127.0.0.1:8055/callback'],
+        responseTypes: ['code'],
+        grantTypes: ['authorization_code'],
+        scope: 'openid offline_access',
+      });
     });
   });
 

--- a/plugins/auth-backend/src/service/CimdClient.ts
+++ b/plugins/auth-backend/src/service/CimdClient.ts
@@ -206,6 +206,26 @@ async function readCappedResponseBody(response: Response): Promise<string> {
 }
 
 /**
+ * Returns the built-in CLI client metadata without a network request.
+ *
+ * The Backstage auth backend serves this same metadata at
+ * `/.well-known/oauth-client/cli.json`. When the incoming `client_id`
+ * matches that URL exactly, callers can use this function instead of
+ * fetching over the network — avoiding the SSRF DNS check that would
+ * otherwise reject hostnames resolving to private IPs.
+ */
+export function getBuiltInCliMetadata(baseUrl: string): CimdClientInfo {
+  return {
+    clientId: `${baseUrl}/.well-known/oauth-client/cli.json`,
+    clientName: 'Backstage CLI',
+    redirectUris: ['http://127.0.0.1:8055/callback'],
+    responseTypes: ['code'],
+    grantTypes: ['authorization_code'],
+    scope: 'openid offline_access',
+  };
+}
+
+/**
  * Fetches and validates a CIMD metadata document.
  * @throws InputError if fetching or validation fails
  */

--- a/plugins/auth-backend/src/service/OidcRouter.ts
+++ b/plugins/auth-backend/src/service/OidcRouter.ts
@@ -30,6 +30,7 @@ import { json } from 'express';
 import { z } from 'zod/v4';
 import { fromZodError } from 'zod-validation-error/v4';
 import { OidcError } from './OidcError';
+import { getBuiltInCliMetadata } from './CimdClient';
 
 function ensureTrailingSlash(url: string): string {
   return url.endsWith('/') ? url : `${url}/`;
@@ -230,14 +231,15 @@ export class OidcRouter {
         return;
       }
 
+      const cli = getBuiltInCliMetadata(this.baseUrl);
       res.json({
-        client_id: `${this.baseUrl}/.well-known/oauth-client/cli.json`,
-        client_name: 'Backstage CLI',
-        redirect_uris: ['http://127.0.0.1:8055/callback'],
-        response_types: ['code'],
-        grant_types: ['authorization_code'],
+        client_id: cli.clientId,
+        client_name: cli.clientName,
+        redirect_uris: cli.redirectUris,
+        response_types: cli.responseTypes,
+        grant_types: cli.grantTypes,
         token_endpoint_auth_method: 'none',
-        scope: 'openid offline_access',
+        scope: cli.scope,
       });
     });
 

--- a/plugins/auth-backend/src/service/OidcService.test.ts
+++ b/plugins/auth-backend/src/service/OidcService.test.ts
@@ -1912,36 +1912,6 @@ describe('OidcService', () => {
           expect(mockFetchCimdMetadata).not.toHaveBeenCalled();
         });
 
-        it('should resolve built-in CLI client even when hostname resolves to a private IP', async () => {
-          const { service } = await createOidcService({
-            databaseId,
-            config: {
-              auth: {
-                clientIdMetadataDocuments: {
-                  enabled: true,
-                },
-              },
-            },
-          });
-
-          const codeVerifier = 'cli-private-ip-verifier';
-          const codeChallenge = crypto
-            .createHash('sha256')
-            .update(codeVerifier)
-            .digest('base64url');
-
-          const authSession = await service.createAuthorizationSession({
-            clientId: cliClientId,
-            redirectUri: 'http://127.0.0.1:8055/callback',
-            responseType: 'code',
-            codeChallenge,
-            codeChallengeMethod: 'S256',
-          });
-
-          expect(authSession.clientName).toBe('Backstage CLI');
-          expect(mockFetchCimdMetadata).not.toHaveBeenCalled();
-        });
-
         it('should still require CIMD to be enabled for built-in CLI client', async () => {
           const { service } = await createOidcService({
             databaseId,

--- a/plugins/auth-backend/src/service/OidcService.test.ts
+++ b/plugins/auth-backend/src/service/OidcService.test.ts
@@ -1872,6 +1872,146 @@ describe('OidcService', () => {
           });
         });
       });
+
+      describe('built-in CLI client', () => {
+        const cliClientId =
+          'http://mock-base-url/.well-known/oauth-client/cli.json';
+
+        it('should resolve built-in CLI client without calling fetchCimdMetadata', async () => {
+          const { service } = await createOidcService({
+            databaseId,
+            config: {
+              auth: {
+                clientIdMetadataDocuments: {
+                  enabled: true,
+                },
+              },
+            },
+          });
+
+          const codeVerifier = 'cli-test-verifier';
+          const codeChallenge = crypto
+            .createHash('sha256')
+            .update(codeVerifier)
+            .digest('base64url');
+
+          const authSession = await service.createAuthorizationSession({
+            clientId: cliClientId,
+            redirectUri: 'http://127.0.0.1:8055/callback',
+            responseType: 'code',
+            codeChallenge,
+            codeChallengeMethod: 'S256',
+          });
+
+          expect(authSession).toEqual({
+            id: expect.any(String),
+            clientName: 'Backstage CLI',
+            scope: undefined,
+            redirectUri: 'http://127.0.0.1:8055/callback',
+          });
+          expect(mockFetchCimdMetadata).not.toHaveBeenCalled();
+        });
+
+        it('should resolve built-in CLI client even when hostname resolves to a private IP', async () => {
+          const { service } = await createOidcService({
+            databaseId,
+            config: {
+              auth: {
+                clientIdMetadataDocuments: {
+                  enabled: true,
+                },
+              },
+            },
+          });
+
+          const codeVerifier = 'cli-private-ip-verifier';
+          const codeChallenge = crypto
+            .createHash('sha256')
+            .update(codeVerifier)
+            .digest('base64url');
+
+          const authSession = await service.createAuthorizationSession({
+            clientId: cliClientId,
+            redirectUri: 'http://127.0.0.1:8055/callback',
+            responseType: 'code',
+            codeChallenge,
+            codeChallengeMethod: 'S256',
+          });
+
+          expect(authSession.clientName).toBe('Backstage CLI');
+          expect(mockFetchCimdMetadata).not.toHaveBeenCalled();
+        });
+
+        it('should still require CIMD to be enabled for built-in CLI client', async () => {
+          const { service } = await createOidcService({
+            databaseId,
+            config: {
+              auth: {
+                clientIdMetadataDocuments: { enabled: false },
+              },
+            },
+          });
+
+          await expect(
+            service.createAuthorizationSession({
+              clientId: cliClientId,
+              redirectUri: 'http://127.0.0.1:8055/callback',
+              responseType: 'code',
+            }),
+          ).rejects.toThrow('Client ID metadata documents not enabled');
+        });
+
+        it('should still require allowedClientIdPatterns to match for built-in CLI client', async () => {
+          const { service } = await createOidcService({
+            databaseId,
+            config: {
+              auth: {
+                clientIdMetadataDocuments: {
+                  enabled: true,
+                  allowedClientIdPatterns: ['https://other.com/*'],
+                },
+              },
+            },
+          });
+
+          await expect(
+            service.createAuthorizationSession({
+              clientId: cliClientId,
+              redirectUri: 'http://127.0.0.1:8055/callback',
+              responseType: 'code',
+            }),
+          ).rejects.toThrow('Invalid client_id');
+        });
+
+        it('should still validate redirect URI for built-in CLI client', async () => {
+          const { service } = await createOidcService({
+            databaseId,
+            config: {
+              auth: {
+                clientIdMetadataDocuments: {
+                  enabled: true,
+                },
+              },
+            },
+          });
+
+          const codeVerifier = 'cli-redirect-verifier';
+          const codeChallenge = crypto
+            .createHash('sha256')
+            .update(codeVerifier)
+            .digest('base64url');
+
+          await expect(
+            service.createAuthorizationSession({
+              clientId: cliClientId,
+              redirectUri: 'https://evil.com/callback',
+              responseType: 'code',
+              codeChallenge,
+              codeChallengeMethod: 'S256',
+            }),
+          ).rejects.toThrow('Invalid redirect_uri');
+        });
+      });
     });
   });
 });

--- a/plugins/auth-backend/src/service/OidcService.ts
+++ b/plugins/auth-backend/src/service/OidcService.ts
@@ -398,6 +398,14 @@ export class OidcService {
     clientId: string;
     redirectUri?: string;
   }) {
+    const builtInCli = getBuiltInCliMetadata(this.baseUrl);
+    if (opts.clientId === builtInCli.clientId) {
+      return this.resolveCimdClient({
+        ...opts,
+        cimdUrl: new URL(opts.clientId),
+      });
+    }
+
     let cimdUrl: URL | undefined;
     try {
       cimdUrl = validateCimdUrl(opts.clientId);

--- a/plugins/auth-backend/src/service/OidcService.ts
+++ b/plugins/auth-backend/src/service/OidcService.ts
@@ -31,7 +31,11 @@ import { OidcDatabase } from '../database/OidcDatabase';
 import { DateTime } from 'luxon';
 import matcher from 'matcher';
 import { OfflineAccessService } from './OfflineAccessService';
-import { validateCimdUrl, fetchCimdMetadata } from './CimdClient';
+import {
+  validateCimdUrl,
+  fetchCimdMetadata,
+  getBuiltInCliMetadata,
+} from './CimdClient';
 
 const WILDCARD_PORT = /:\*(?=\/|$)/;
 const EXPLICIT_PROTOCOL = /^[a-z][a-z0-9+.-]*:/i;
@@ -425,10 +429,14 @@ export class OidcService {
       throw new InputError(`Invalid client_id '${opts.clientId}'`);
     }
 
-    const cimdClient = await fetchCimdMetadata({
-      clientId: opts.clientId,
-      validatedUrl: opts.cimdUrl,
-    });
+    const builtInCli = getBuiltInCliMetadata(this.baseUrl);
+    const cimdClient =
+      opts.clientId === builtInCli.clientId
+        ? builtInCli
+        : await fetchCimdMetadata({
+            clientId: opts.clientId,
+            validatedUrl: opts.cimdUrl,
+          });
 
     if (opts.redirectUri) {
       validateRedirectUri(opts.redirectUri, cimd.allowedRedirectUriPatterns);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When a Backstage instance's hostname resolves to a private IP (e.g. in Kubernetes), the SSRF protection in `fetchCimdMetadata()` blocks the server from fetching its own built-in CLI metadata document. This short-circuits that fetch for the built-in CLI client by returning the metadata directly, since the server already owns it.

Fixes #33951

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))