### PR TITLE
fix(catalog-backend): isolate Location target failures so one broken target does not drop siblings

### DIFF
--- a/.changeset/location-partial-target-failure.md
+++ b/.changeset/location-partial-target-failure.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Fixed a bug where a single broken target in a Location entity's `spec.targets` would silently drop all other valid targets. Individual target failures are now isolated so that successful targets still produce their entities.

--- a/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.test.ts
+++ b/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.test.ts
@@ -697,8 +697,10 @@ describe('DefaultCatalogProcessingOrchestrator', () => {
         ]),
       });
       // Verify the failed target's entity is not present
-      expect(result.deferredEntities).toBeDefined();
-      const names = result.deferredEntities!.map(d => d.entity.metadata.name);
+      if (!result.ok) {
+        throw new Error('Expected result.ok to be true');
+      }
+      const names = result.deferredEntities.map(d => d.entity.metadata.name);
       expect(names).not.toContain('child2');
     });
 

--- a/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.test.ts
+++ b/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.test.ts
@@ -345,4 +345,407 @@ describe('DefaultCatalogProcessingOrchestrator', () => {
       );
     });
   });
+
+  describe('location target partial failure', () => {
+    const child1: Entity = {
+      apiVersion: '1',
+      kind: 'Component',
+      metadata: { name: 'child1', namespace: 'default' },
+    };
+
+    const child2: Entity = {
+      apiVersion: '1',
+      kind: 'Component',
+      metadata: { name: 'child2', namespace: 'default' },
+    };
+
+    function makeLocationEntity(targets: string[]): LocationEntity {
+      return {
+        apiVersion: 'backstage.io/v1beta1',
+        kind: 'Location',
+        metadata: {
+          name: 'test-location',
+          annotations: {
+            [ANNOTATION_ORIGIN_LOCATION]: 'url:https://example.com/origin.yaml',
+            [ANNOTATION_LOCATION]: 'url:https://example.com/origin.yaml',
+          },
+        },
+        spec: {
+          type: 'url',
+          targets,
+        },
+      };
+    }
+
+    function createOrchestrator(processor: CatalogProcessor) {
+      return new DefaultCatalogProcessingOrchestrator({
+        processors: [processor],
+        integrations: ScmIntegrations.fromConfig(new ConfigReader({})),
+        logger: mockServices.logger.mock(),
+        parser: defaultEntityDataParser,
+        policy: EntityPolicies.allOf([]),
+        rulesEnforcer: { isAllowed: () => true },
+      });
+    }
+
+    it('returns ok with all deferred entities when all targets succeed', async () => {
+      const processor: CatalogProcessor = {
+        getProcessorName: () => 'test',
+        validateEntityKind: async () => true,
+        readLocation: async (location, _optional, emit) => {
+          if (location.target === 'https://example.com/a.yaml') {
+            emit(
+              processingResult.entity(
+                { type: 'url', target: location.target },
+                child1,
+              ),
+            );
+          } else if (location.target === 'https://example.com/b.yaml') {
+            emit(
+              processingResult.entity(
+                { type: 'url', target: location.target },
+                child2,
+              ),
+            );
+          }
+          return true;
+        },
+      };
+
+      const entity = makeLocationEntity([
+        'https://example.com/a.yaml',
+        'https://example.com/b.yaml',
+      ]);
+      const result = await createOrchestrator(processor).process({
+        entity,
+        state: {},
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result).toMatchObject({
+        errors: [],
+        deferredEntities: expect.arrayContaining([
+          expect.objectContaining({
+            entity: expect.objectContaining({
+              metadata: expect.objectContaining({ name: 'child1' }),
+            }),
+          }),
+          expect.objectContaining({
+            entity: expect.objectContaining({
+              metadata: expect.objectContaining({ name: 'child2' }),
+            }),
+          }),
+        ]),
+      });
+    });
+
+    it('returns ok with successful deferred entities when one target emits an error', async () => {
+      const processor: CatalogProcessor = {
+        getProcessorName: () => 'test',
+        validateEntityKind: async () => true,
+        readLocation: async (location, _optional, emit) => {
+          if (location.target === 'https://example.com/good.yaml') {
+            emit(
+              processingResult.entity(
+                { type: 'url', target: location.target },
+                child1,
+              ),
+            );
+          } else if (location.target === 'https://example.com/bad.yaml') {
+            emit(processingResult.notFoundError(location, 'not found'));
+          }
+          return true;
+        },
+      };
+
+      const entity = makeLocationEntity([
+        'https://example.com/good.yaml',
+        'https://example.com/bad.yaml',
+      ]);
+      const result = await createOrchestrator(processor).process({
+        entity,
+        state: {},
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result).toMatchObject({
+        errors: [expect.objectContaining({ message: 'not found' })],
+        deferredEntities: [
+          expect.objectContaining({
+            entity: expect.objectContaining({
+              metadata: expect.objectContaining({ name: 'child1' }),
+            }),
+          }),
+        ],
+      });
+    });
+
+    it('returns ok with successful deferred entities when one target processor throws', async () => {
+      const processor: CatalogProcessor = {
+        getProcessorName: () => 'test',
+        validateEntityKind: async () => true,
+        readLocation: async (location, _optional, emit) => {
+          if (location.target === 'https://example.com/good.yaml') {
+            emit(
+              processingResult.entity(
+                { type: 'url', target: location.target },
+                child1,
+              ),
+            );
+            return true;
+          }
+          throw new Error('connection refused');
+        },
+      };
+
+      const entity = makeLocationEntity([
+        'https://example.com/good.yaml',
+        'https://example.com/throwing.yaml',
+      ]);
+      const result = await createOrchestrator(processor).process({
+        entity,
+        state: {},
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result).toMatchObject({
+        errors: [
+          expect.objectContaining({
+            message: expect.stringContaining('connection refused'),
+          }),
+        ],
+        deferredEntities: [
+          expect.objectContaining({
+            entity: expect.objectContaining({
+              metadata: expect.objectContaining({ name: 'child1' }),
+            }),
+          }),
+        ],
+      });
+    });
+
+    it('returns ok with successful deferred entities when no processor handles one target', async () => {
+      const processor: CatalogProcessor = {
+        getProcessorName: () => 'test',
+        validateEntityKind: async () => true,
+        readLocation: async (location, _optional, emit) => {
+          if (location.target === 'https://example.com/good.yaml') {
+            emit(
+              processingResult.entity(
+                { type: 'url', target: location.target },
+                child1,
+              ),
+            );
+            return true;
+          }
+          return false;
+        },
+      };
+
+      const entity = makeLocationEntity([
+        'https://example.com/good.yaml',
+        'https://example.com/unhandled.yaml',
+      ]);
+      const result = await createOrchestrator(processor).process({
+        entity,
+        state: {},
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result).toMatchObject({
+        errors: [
+          expect.objectContaining({
+            message: expect.stringContaining('No processor was able to handle'),
+          }),
+        ],
+        deferredEntities: [
+          expect.objectContaining({
+            entity: expect.objectContaining({
+              metadata: expect.objectContaining({ name: 'child1' }),
+            }),
+          }),
+        ],
+      });
+    });
+
+    it('returns not ok when all targets fail', async () => {
+      const processor: CatalogProcessor = {
+        getProcessorName: () => 'test',
+        validateEntityKind: async () => true,
+        readLocation: async (location, _optional, emit) => {
+          emit(
+            processingResult.notFoundError(
+              location,
+              `not found: ${location.target}`,
+            ),
+          );
+          return true;
+        },
+      };
+
+      const entity = makeLocationEntity([
+        'https://example.com/bad1.yaml',
+        'https://example.com/bad2.yaml',
+      ]);
+      const result = await createOrchestrator(processor).process({
+        entity,
+        state: {},
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.errors).toHaveLength(2);
+    });
+
+    it('returns not ok when a single target fails', async () => {
+      const processor: CatalogProcessor = {
+        getProcessorName: () => 'test',
+        validateEntityKind: async () => true,
+        readLocation: async () => {
+          throw new Error('boom');
+        },
+      };
+
+      const entity = makeLocationEntity(['https://example.com/only.yaml']);
+      const result = await createOrchestrator(processor).process({
+        entity,
+        state: {},
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].message).toContain('boom');
+    });
+
+    it('returns ok with no deferred entities when targets list is empty', async () => {
+      const processor: CatalogProcessor = {
+        getProcessorName: () => 'test',
+        validateEntityKind: async () => true,
+      };
+
+      const entity = makeLocationEntity([]);
+      const result = await createOrchestrator(processor).process({
+        entity,
+        state: {},
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result).toMatchObject({
+        errors: [],
+        deferredEntities: [],
+      });
+    });
+
+    it('preserves deferred entities from all successful targets when one in the middle fails', async () => {
+      const child3: Entity = {
+        apiVersion: '1',
+        kind: 'Component',
+        metadata: { name: 'child3', namespace: 'default' },
+      };
+
+      const processor: CatalogProcessor = {
+        getProcessorName: () => 'test',
+        validateEntityKind: async () => true,
+        readLocation: async (location, _optional, emit) => {
+          if (location.target === 'https://example.com/a.yaml') {
+            emit(
+              processingResult.entity(
+                { type: 'url', target: location.target },
+                child1,
+              ),
+            );
+            return true;
+          } else if (location.target === 'https://example.com/b.yaml') {
+            throw new Error('404 not found');
+          } else if (location.target === 'https://example.com/c.yaml') {
+            emit(
+              processingResult.entity(
+                { type: 'url', target: location.target },
+                child3,
+              ),
+            );
+            return true;
+          }
+          return false;
+        },
+      };
+
+      const entity = makeLocationEntity([
+        'https://example.com/a.yaml',
+        'https://example.com/b.yaml',
+        'https://example.com/c.yaml',
+      ]);
+      const result = await createOrchestrator(processor).process({
+        entity,
+        state: {},
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0].message).toContain('404 not found');
+      expect(result).toMatchObject({
+        deferredEntities: expect.arrayContaining([
+          expect.objectContaining({
+            entity: expect.objectContaining({
+              metadata: expect.objectContaining({ name: 'child1' }),
+            }),
+          }),
+          expect.objectContaining({
+            entity: expect.objectContaining({
+              metadata: expect.objectContaining({ name: 'child3' }),
+            }),
+          }),
+        ]),
+      });
+      // Verify the failed target's entity is not present
+      const names = (result as any).deferredEntities.map(
+        (d: any) => d.entity.metadata.name,
+      );
+      expect(names).not.toContain('child2');
+    });
+
+    it('does not affect ok flag for non-Location entities with errors', async () => {
+      const nonLocationEntity = {
+        apiVersion: 'my-api/v1',
+        kind: 'FooBar',
+        metadata: {
+          name: 'my-foo-bar',
+          annotations: {
+            [ANNOTATION_LOCATION]: 'url:./here',
+            [ANNOTATION_ORIGIN_LOCATION]: 'url:./there',
+          },
+        },
+      };
+
+      const processor: CatalogProcessor = {
+        getProcessorName: () => 'test',
+        validateEntityKind: async () => true,
+        postProcessEntity: async (e, _location, emit) => {
+          emit(
+            processingResult.generalError(
+              { type: 'url', target: 'foo' },
+              'some error',
+            ),
+          );
+          return e;
+        },
+      };
+
+      const orchestrator = new DefaultCatalogProcessingOrchestrator({
+        processors: [processor],
+        integrations: ScmIntegrations.fromConfig(new ConfigReader({})),
+        logger: mockServices.logger.mock(),
+        parser: defaultEntityDataParser,
+        policy: EntityPolicies.allOf([]),
+        rulesEnforcer: { isAllowed: () => true },
+      });
+
+      const result = await orchestrator.process({
+        entity: nonLocationEntity,
+        state: {},
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.errors).toHaveLength(1);
+    });
+  });
 });

--- a/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.test.ts
+++ b/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.test.ts
@@ -697,9 +697,8 @@ describe('DefaultCatalogProcessingOrchestrator', () => {
         ]),
       });
       // Verify the failed target's entity is not present
-      const names = (result as any).deferredEntities.map(
-        (d: any) => d.entity.metadata.name,
-      );
+      expect(result.deferredEntities).toBeDefined();
+      const names = result.deferredEntities!.map(d => d.entity.metadata.name);
       expect(names).not.toContain('child2');
     });
 

--- a/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.ts
+++ b/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.ts
@@ -158,7 +158,6 @@ export class DefaultCatalogProcessingOrchestrator
       entity = await this.runPreProcessStep(entity, context);
       entity = await this.runPolicyStep(entity);
       await this.runValidateStep(entity, context);
-      const isLocation = isLocationEntity(entity);
       if (isLocationEntity(entity)) {
         await this.runSpecialLocationStep(entity, context);
       }
@@ -191,7 +190,7 @@ export class DefaultCatalogProcessingOrchestrator
       // though other targets may have errored. Errors from failed
       // targets are still recorded and visible in the entity status.
       const ok =
-        isLocation && collectorResults.deferredEntities.length > 0
+        isLocationEntity(entity) && collectorResults.deferredEntities.length > 0
           ? true
           : collectorResults.errors.length === 0;
 
@@ -427,14 +426,16 @@ export class DefaultCatalogProcessingOrchestrator
             );
           }
         } catch (e) {
-          context.collector.generic()(
-            processingResult.generalError(
-              context.location,
-              `Failed to read location target ${type}:${target}, ${
-                toError(e).message
-              }`,
-            ),
+          const originalError = toError(e);
+          const error = new Error(
+            `Failed to read location target ${type}:${target}, ${originalError.message}`,
+            { cause: originalError },
           );
+          context.collector.generic()({
+            type: 'error',
+            location: context.location,
+            error,
+          });
         }
       }
     });

--- a/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.ts
+++ b/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.ts
@@ -158,6 +158,7 @@ export class DefaultCatalogProcessingOrchestrator
       entity = await this.runPreProcessStep(entity, context);
       entity = await this.runPolicyStep(entity);
       await this.runValidateStep(entity, context);
+      const isLocation = isLocationEntity(entity);
       if (isLocationEntity(entity)) {
         await this.runSpecialLocationStep(entity, context);
       }
@@ -185,11 +186,20 @@ export class DefaultCatalogProcessingOrchestrator
         }
       }
 
+      // For Location entities, partial success is acceptable: if at
+      // least one target produced deferred entities, persist them even
+      // though other targets may have errored. Errors from failed
+      // targets are still recorded and visible in the entity status.
+      const ok =
+        isLocation && collectorResults.deferredEntities.length > 0
+          ? true
+          : collectorResults.errors.length === 0;
+
       return {
         ...collectorResults,
         completedEntity: entity,
         state: { cache: cache.collect() },
-        ok: collectorResults.errors.length === 0,
+        ok,
       };
     } catch (error) {
       const err = toError(error);
@@ -375,44 +385,55 @@ export class DefaultCatalogProcessingOrchestrator
           maybeRelativeTarget,
         );
 
-        let didRead = false;
-        for (const processor of this.options.processors) {
-          if (processor.readLocation) {
-            try {
-              const read = await withActiveSpan(
-                tracer,
-                'ProcessingStep',
-                async span => {
-                  addEntityAttributes(span, entity);
-                  addProcessorAttributes(span, 'readLocation', processor);
-                  return await processor.readLocation!(
-                    {
-                      type,
-                      target,
-                      presence,
-                    },
-                    presence === 'optional',
-                    context.collector.forProcessor(processor),
-                    this.options.parser,
-                    context.cache.forProcessor(processor, target),
-                  );
-                },
-              );
-              if (read) {
-                didRead = true;
-                break;
+        try {
+          let didRead = false;
+          for (const processor of this.options.processors) {
+            if (processor.readLocation) {
+              try {
+                const read = await withActiveSpan(
+                  tracer,
+                  'ProcessingStep',
+                  async span => {
+                    addEntityAttributes(span, entity);
+                    addProcessorAttributes(span, 'readLocation', processor);
+                    return await processor.readLocation!(
+                      {
+                        type,
+                        target,
+                        presence,
+                      },
+                      presence === 'optional',
+                      context.collector.forProcessor(processor),
+                      this.options.parser,
+                      context.cache.forProcessor(processor, target),
+                    );
+                  },
+                );
+                if (read) {
+                  didRead = true;
+                  break;
+                }
+              } catch (e) {
+                throw new InputError(
+                  `Processor ${processor.constructor.name} threw an error while reading ${type}:${target}`,
+                  e,
+                );
               }
-            } catch (e) {
-              throw new InputError(
-                `Processor ${processor.constructor.name} threw an error while reading ${type}:${target}`,
-                e,
-              );
             }
           }
-        }
-        if (!didRead) {
-          throw new InputError(
-            `No processor was able to handle reading of ${type}:${target}`,
+          if (!didRead) {
+            throw new InputError(
+              `No processor was able to handle reading of ${type}:${target}`,
+            );
+          }
+        } catch (e) {
+          context.collector.generic()(
+            processingResult.generalError(
+              context.location,
+              `Failed to read location target ${type}:${target}, ${
+                toError(e).message
+              }`,
+            ),
           );
         }
       }

--- a/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.ts
+++ b/plugins/catalog-backend/src/processing/DefaultCatalogProcessingOrchestrator.ts
@@ -158,6 +158,7 @@ export class DefaultCatalogProcessingOrchestrator
       entity = await this.runPreProcessStep(entity, context);
       entity = await this.runPolicyStep(entity);
       await this.runValidateStep(entity, context);
+
       if (isLocationEntity(entity)) {
         await this.runSpecialLocationStep(entity, context);
       }
@@ -185,10 +186,9 @@ export class DefaultCatalogProcessingOrchestrator
         }
       }
 
-      // For Location entities, partial success is acceptable: if at
-      // least one target produced deferred entities, persist them even
-      // though other targets may have errored. Errors from failed
-      // targets are still recorded and visible in the entity status.
+      // Location entities treat partial target success as ok; this covers
+      // all collector errors because results() marks the collector as done,
+      // preventing a before/after snapshot of just target-reading errors.
       const ok =
         isLocationEntity(entity) && collectorResults.deferredEntities.length > 0
           ? true


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When a Location entity has multiple `spec.targets`, a single broken target (e.g. a 404 URL) causes the entire Location to fail — silently dropping all deferred entities from the other valid targets. This wraps each target's processing in a try/catch so failures are isolated: successful targets still produce their entities, while errors from failed targets are recorded in the entity status. The result is only marked as failed when all targets fail.

Fixes #33326

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))