### PR TITLE
feat(mcp-actions): add configurable server instructions

### DIFF
--- a/.changeset/bright-tools-listen.md
+++ b/.changeset/bright-tools-listen.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-mcp-actions-backend': patch
+---
+
+Added support for configuring MCP server instructions for both default and named servers.

--- a/plugins/mcp-actions-backend/README.md
+++ b/plugins/mcp-actions-backend/README.md
@@ -95,6 +95,17 @@ mcpActions:
   namespacedToolNames: false
 ```
 
+### Server Instructions
+
+You can provide instructions that describe how MCP clients should use the server and its tools. The server returns these instructions to clients during initialization.
+
+```yaml
+mcpActions:
+  instructions: 'Inspect existing catalog entities before creating new components.'
+```
+
+For named servers, configure instructions separately for each server.
+
 ### Multiple MCP Servers
 
 By default, the plugin serves a single MCP server at `/api/mcp-actions/v1` that exposes all available actions. You can split actions into multiple focused servers by configuring `mcpActions.servers`, where each key becomes a separate MCP server endpoint.
@@ -105,12 +116,14 @@ mcpActions:
     catalog:
       name: 'Backstage Catalog'
       description: 'Tools for interacting with the software catalog'
+      instructions: 'Inspect catalog entities before making changes.'
       filter:
         include:
           - id: 'catalog:*'
     scaffolder:
       name: 'Backstage Scaffolder'
       description: 'Tools for creating new software from templates'
+      instructions: 'Use this server after checking the catalog.'
       filter:
         include:
           - id: 'scaffolder:*'

--- a/plugins/mcp-actions-backend/config.d.ts
+++ b/plugins/mcp-actions-backend/config.d.ts
@@ -29,6 +29,12 @@ export interface Config {
     description?: string;
 
     /**
+     * Instructions describing how clients should use the MCP server.
+     * Used when running a single bundled server without mcpActions.servers.
+     */
+    instructions?: string;
+
+    /**
      * When true, MCP tool names include the plugin ID prefix to avoid
      * collisions across plugins. For example an action registered as
      * "get-entity" by the catalog plugin becomes "catalog.get-entity".
@@ -61,6 +67,8 @@ export interface Config {
         name: string;
         /** Description of the MCP server. */
         description?: string;
+        /** Instructions describing how clients should use the MCP server. */
+        instructions?: string;
         /** Filter rules to include or exclude specific actions. */
         filter?: {
           include?: Array<{

--- a/plugins/mcp-actions-backend/src/config.ts
+++ b/plugins/mcp-actions-backend/src/config.ts
@@ -27,6 +27,7 @@ export type FilterRule = {
 export type McpServerConfig = {
   name: string;
   description?: string;
+  instructions?: string;
   includeRules: FilterRule[];
   excludeRules: FilterRule[];
 };
@@ -88,6 +89,7 @@ export function parseServerConfigs(
     servers.set(key, {
       name: serverConfig.getString('name'),
       description: serverConfig.getOptionalString('description'),
+      instructions: serverConfig.getOptionalString('instructions'),
       includeRules,
       excludeRules,
     });

--- a/plugins/mcp-actions-backend/src/plugin.test.ts
+++ b/plugins/mcp-actions-backend/src/plugin.test.ts
@@ -50,7 +50,7 @@ describe('Mcp Backend', () => {
     },
   });
 
-  const getContext = async () => {
+  const getContext = async (instructions?: string) => {
     const { server } = await startTestBackend({
       features: [
         mcpPlugin,
@@ -64,6 +64,7 @@ describe('Mcp Backend', () => {
                 pluginSources: ['local'],
               },
             },
+            ...(instructions && { mcpActions: { instructions } }),
           },
         }),
       ],
@@ -129,6 +130,18 @@ describe('Mcp Backend', () => {
       '/api/mcp-actions/v1/sse',
     );
     expect(legacyResponse.status).toBe(404);
+  });
+
+  it('should return configured instructions for the default server', async () => {
+    const instructions = 'Use catalog tools before scaffolder tools.';
+    const { client, serverAddress } = await getContext(instructions);
+    const transport = new StreamableHTTPClientTransport(
+      new URL(`${serverAddress}/api/mcp-actions/v1`),
+    );
+
+    await client.connect(transport);
+
+    expect(client.getInstructions()).toBe(instructions);
   });
 
   describe('multi-server routing', () => {
@@ -197,12 +210,14 @@ describe('Mcp Backend', () => {
                 servers: {
                   catalog: {
                     name: 'Catalog Server',
+                    instructions: 'Use this server to inspect the catalog.',
                     filter: {
                       include: [{ id: 'catalog-actions:*' }],
                     },
                   },
                   scaffolder: {
                     name: 'Scaffolder Server',
+                    instructions: 'Use this server to create components.',
                     filter: {
                       include: [{ id: 'scaffolder-actions:*' }],
                     },
@@ -225,6 +240,9 @@ describe('Mcp Backend', () => {
         new URL(`${serverAddress}/api/mcp-actions/v1/catalog`),
       );
       await catalogClient.connect(catalogTransport);
+      expect(catalogClient.getInstructions()).toBe(
+        'Use this server to inspect the catalog.',
+      );
       const catalogResult = await catalogClient.request(
         { method: 'tools/list' },
         ListToolsResultSchema,
@@ -237,6 +255,9 @@ describe('Mcp Backend', () => {
         new URL(`${serverAddress}/api/mcp-actions/v1/scaffolder`),
       );
       await scaffolderClient.connect(scaffolderTransport);
+      expect(scaffolderClient.getInstructions()).toBe(
+        'Use this server to create components.',
+      );
       const scaffolderResult = await scaffolderClient.request(
         { method: 'tools/list' },
         ListToolsResultSchema,

--- a/plugins/mcp-actions-backend/src/plugin.ts
+++ b/plugins/mcp-actions-backend/src/plugin.ts
@@ -99,6 +99,7 @@ export const mcpPlugin = createBackendPlugin({
           const serverConfig = {
             name: config.getOptionalString('mcpActions.name') ?? 'backstage',
             description: config.getOptionalString('mcpActions.description'),
+            instructions: config.getOptionalString('mcpActions.instructions'),
             includeRules: [],
             excludeRules: [],
           };

--- a/plugins/mcp-actions-backend/src/services/McpService.test.ts
+++ b/plugins/mcp-actions-backend/src/services/McpService.test.ts
@@ -806,7 +806,7 @@ describe('McpService', () => {
     });
   });
 
-  describe('server name and description', () => {
+  describe('server metadata and instructions', () => {
     it('should default server name to backstage when no config is provided', async () => {
       const mcpService = await McpService.create({
         actions: actionsRegistryServiceMock(),
@@ -831,7 +831,7 @@ describe('McpService', () => {
       expect(serverInfo?.description).toBeUndefined();
     });
 
-    it('should use name and description from server config', async () => {
+    it('should use name, description, and instructions from server config', async () => {
       const mcpService = await McpService.create({
         actions: actionsRegistryServiceMock(),
         metrics: metricsServiceMock.mock(),
@@ -843,6 +843,7 @@ describe('McpService', () => {
         serverConfig: {
           name: 'My Custom Server',
           description: 'A custom MCP server for testing',
+          instructions: 'Use this server to test MCP actions.',
           includeRules: [],
           excludeRules: [],
         },
@@ -859,6 +860,9 @@ describe('McpService', () => {
       const serverInfo = client.getServerVersion();
       expect(serverInfo?.name).toBe('My Custom Server');
       expect(serverInfo?.description).toBe('A custom MCP server for testing');
+      expect(client.getInstructions()).toBe(
+        'Use this server to test MCP actions.',
+      );
     });
 
     it('should omit description when not provided in config', async () => {

--- a/plugins/mcp-actions-backend/src/services/McpService.ts
+++ b/plugins/mcp-actions-backend/src/services/McpService.ts
@@ -152,7 +152,12 @@ export class McpService {
           description: serverConfig.description,
         }),
       },
-      { capabilities: { tools: {} } },
+      {
+        capabilities: { tools: {} },
+        ...(serverConfig?.instructions && {
+          instructions: serverConfig.instructions,
+        }),
+      },
     );
 
     server.setRequestHandler(ListToolsRequestSchema, async () => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

## What

Adds optional server instructions for both the default MCP server and named MCP servers. The configured text is returned to clients as part of the MCP initialization response.

## Why

The MCP SDK supports server instructions, but the MCP actions backend did not expose a way to configure them. This lets each Backstage instance describe how clients should use its tools without requiring custom plugin code.

To test:

```sh
CI=1 yarn test plugins/mcp-actions-backend --no-watch
yarn tsc
yarn build:api-reports
```

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
