### PR TITLE
fix(scaffolder): pass scheduler to router so stale task janitor runs

### DIFF
--- a/.changeset/fix-scaffolder-janitor.md
+++ b/.changeset/fix-scaffolder-janitor.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Fixed the stale task janitor not being set up by passing the scheduler service to the router.

--- a/plugins/scaffolder-backend/src/ScaffolderPlugin.ts
+++ b/plugins/scaffolder-backend/src/ScaffolderPlugin.ts
@@ -153,6 +153,7 @@ export const scaffolderPlugin = createBackendPlugin({
         actionsRegistry: actionsServiceRef,
         actionsRegistryService: actionsRegistryServiceRef,
         scaffolderService: scaffolderServiceRef,
+        scheduler: coreServices.scheduler,
         metrics: metricsServiceRef,
       },
       async init({
@@ -172,6 +173,7 @@ export const scaffolderPlugin = createBackendPlugin({
         actionsRegistry,
         actionsRegistryService,
         scaffolderService,
+        scheduler,
         metrics,
       }) {
         const log = loggerToWinstonLogger(logger);
@@ -250,6 +252,7 @@ export const scaffolderPlugin = createBackendPlugin({
           events,
           auditor,
           actionsRegistry,
+          scheduler,
           metrics,
         });
         httpRouter.use(router);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The scaffolder backend plugin was not passing the `scheduler` service to `createRouter`, which meant the stale task janitor (`close_stale_tasks`) was silently never scheduled. Tasks that timed out would remain in a running state indefinitely.

This adds `coreServices.scheduler` to the plugin's deps and threads it through to the router, where it's already wired up to schedule the janitor.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))