### PR TITLE
feat(kubernetes-backend): resolve AWS credentials by account ID for WIF support

### DIFF
--- a/plugins/kubernetes-backend/src/auth/AwsIamStrategy.test.ts
+++ b/plugins/kubernetes-backend/src/auth/AwsIamStrategy.test.ts
@@ -15,18 +15,21 @@
  */
 import { ConfigReader } from '@backstage/config';
 import {
+  ANNOTATION_KUBERNETES_AWS_ACCOUNT_ID,
   ANNOTATION_KUBERNETES_AWS_ASSUME_ROLE,
   ANNOTATION_KUBERNETES_AWS_CLUSTER_ID,
   ANNOTATION_KUBERNETES_AWS_EXTERNAL_ID,
 } from '@backstage/plugin-kubernetes-common';
 import { AwsIamStrategy } from './AwsIamStrategy';
 
+const getCredentialProvider = jest.fn().mockResolvedValue({
+  sdkCredentialProvider: {
+    AccessKeyId: 'asdf',
+  },
+});
+
 const credsManager = {
-  getCredentialProvider: async () => ({
-    sdkCredentialProvider: {
-      AccessKeyId: 'asdf',
-    },
-  }),
+  getCredentialProvider,
 };
 
 jest.mock('@backstage/integration-aws-node', () => ({
@@ -57,6 +60,10 @@ jest.mock('@aws-sdk/credential-providers', () => ({
 describe('AwsIamStrategy#getCredential', () => {
   const config = new ConfigReader({});
 
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('returns a presigned url', async () => {
     const strategy = new AwsIamStrategy({ config });
 
@@ -70,6 +77,7 @@ describe('AwsIamStrategy#getCredential', () => {
       type: 'bearer token',
       token: 'k8s-aws-v1.aHR0cHM6Ly9odHRwczovL2V4YW1wbGUuY29tL2FzZGY_',
     });
+    expect(getCredentialProvider).toHaveBeenCalledWith(undefined);
     expect(signer.presign).toHaveBeenCalledWith(
       expect.objectContaining({
         headers: expect.objectContaining({ 'x-k8s-aws-id': 'test-cluster' }),
@@ -155,6 +163,47 @@ describe('AwsIamStrategy#getCredential', () => {
       params: {
         ExternalId: 'external-id',
         RoleArn: 'SomeRole',
+      },
+    });
+  });
+
+  it('resolves credentials by account ID when specified', async () => {
+    const strategy = new AwsIamStrategy({ config });
+
+    await strategy.getCredential({
+      name: 'test-cluster',
+      url: '',
+      authMetadata: {
+        [ANNOTATION_KUBERNETES_AWS_ACCOUNT_ID]: '123456789012',
+      },
+    });
+
+    expect(getCredentialProvider).toHaveBeenCalledWith({
+      accountId: '123456789012',
+    });
+  });
+
+  it('resolves credentials by account ID and assumes role on top', async () => {
+    const strategy = new AwsIamStrategy({ config });
+
+    await strategy.getCredential({
+      name: 'test-cluster',
+      url: '',
+      authMetadata: {
+        [ANNOTATION_KUBERNETES_AWS_ACCOUNT_ID]: '123456789012',
+        [ANNOTATION_KUBERNETES_AWS_ASSUME_ROLE]: 'SomeOtherRole',
+      },
+    });
+
+    expect(getCredentialProvider).toHaveBeenCalledWith({
+      accountId: '123456789012',
+    });
+    expect(fromTemporaryCredentials).toHaveBeenCalledWith({
+      clientConfig: { region: 'us-east-1' },
+      masterCredentials: { AccessKeyId: 'asdf' },
+      params: {
+        ExternalId: undefined,
+        RoleArn: 'SomeOtherRole',
       },
     });
   });

--- a/plugins/kubernetes-backend/src/auth/AwsIamStrategy.ts
+++ b/plugins/kubernetes-backend/src/auth/AwsIamStrategy.ts
@@ -22,6 +22,7 @@ import {
 } from '@backstage/integration-aws-node';
 import { Config } from '@backstage/config';
 import {
+  ANNOTATION_KUBERNETES_AWS_ACCOUNT_ID,
   ANNOTATION_KUBERNETES_AWS_ASSUME_ROLE,
   ANNOTATION_KUBERNETES_AWS_CLUSTER_ID,
   ANNOTATION_KUBERNETES_AWS_EXTERNAL_ID,
@@ -64,6 +65,7 @@ export class AwsIamStrategy implements AuthenticationStrategy {
       token: await this.getBearerToken(
         clusterDetails.authMetadata[ANNOTATION_KUBERNETES_AWS_CLUSTER_ID] ??
           clusterDetails.name,
+        clusterDetails.authMetadata[ANNOTATION_KUBERNETES_AWS_ACCOUNT_ID],
         clusterDetails.authMetadata[ANNOTATION_KUBERNETES_AWS_ASSUME_ROLE],
         clusterDetails.authMetadata[ANNOTATION_KUBERNETES_AWS_EXTERNAL_ID],
       ),
@@ -76,13 +78,16 @@ export class AwsIamStrategy implements AuthenticationStrategy {
 
   private async getBearerToken(
     clusterId: string,
+    accountId?: string,
     assumeRole?: string,
     externalId?: string,
   ): Promise<string> {
     const region = process.env.AWS_REGION ?? defaultRegion;
 
-    let credentials = (await this.credsManager.getCredentialProvider())
-      .sdkCredentialProvider;
+    const credProvider = await this.credsManager.getCredentialProvider(
+      accountId ? { accountId } : undefined,
+    );
+    let credentials = credProvider.sdkCredentialProvider;
     if (assumeRole) {
       credentials = fromTemporaryCredentials({
         masterCredentials: credentials,

--- a/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.ts
+++ b/plugins/kubernetes-backend/src/cluster-locator/ConfigClusterLocator.ts
@@ -17,6 +17,7 @@
 import { Config } from '@backstage/config';
 import {
   ANNOTATION_KUBERNETES_AUTH_PROVIDER,
+  ANNOTATION_KUBERNETES_AWS_ACCOUNT_ID,
   ANNOTATION_KUBERNETES_AWS_ASSUME_ROLE,
   ANNOTATION_KUBERNETES_AWS_EXTERNAL_ID,
   ANNOTATION_KUBERNETES_OIDC_TOKEN_PROVIDER,
@@ -119,14 +120,22 @@ export class ConfigClusterLocator implements KubernetesClustersSupplier {
     const serviceAccountToken = clusterConfig.getOptionalString(
       'serviceAccountToken',
     );
+    const accountId = clusterConfig.getOptionalString('accountId');
     const assumeRole = clusterConfig.getOptionalString('assumeRole');
     const externalId = clusterConfig.getOptionalString('externalId');
     const oidcTokenProvider =
       clusterConfig.getOptionalString('oidcTokenProvider');
 
-    return serviceAccountToken || assumeRole || externalId || oidcTokenProvider
+    return serviceAccountToken ||
+      accountId ||
+      assumeRole ||
+      externalId ||
+      oidcTokenProvider
       ? {
           ...(serviceAccountToken && { serviceAccountToken }),
+          ...(accountId && {
+            [ANNOTATION_KUBERNETES_AWS_ACCOUNT_ID]: accountId,
+          }),
           ...(assumeRole && {
             [ANNOTATION_KUBERNETES_AWS_ASSUME_ROLE]: assumeRole,
           }),

--- a/plugins/kubernetes-common/src/catalog-entity-constants.ts
+++ b/plugins/kubernetes-common/src/catalog-entity-constants.ts
@@ -131,3 +131,13 @@ export const ANNOTATION_KUBERNETES_AWS_CLUSTER_ID =
  */
 export const ANNOTATION_KUBERNETES_AWS_EXTERNAL_ID =
   'kubernetes.io/aws-external-id';
+
+/**
+ * Annotation for specifying the AWS account ID to resolve credentials for.
+ * When set, credentials are looked up via the `aws.accounts` integration
+ * config instead of falling back to the main account or default chain.
+ *
+ * @public
+ */
+export const ANNOTATION_KUBERNETES_AWS_ACCOUNT_ID =
+  'kubernetes.io/aws-account-id';


### PR DESCRIPTION
The AwsIamStrategy previously called getCredentialProvider() with no arguments, always returning the main account's default credential chain. This ignored per-account configurations in aws.accounts — including webIdentityTokenFile entries used for GCP Workload Identity Federation.

Add an optional accountId field to the cluster config that is passed through to DefaultAwsCredentialsManager.getCredentialProvider({ accountId }). This allows the kubernetes plugin to resolve account-specific credentials, enabling WIF-based authentication to EKS clusters without requiring environment variables.

Backward-compatible: clusters without accountId behave exactly as before.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
