### PR TITLE
docs(cli): expand CLI docs with module system and per-module command pages

### DIFF
--- a/.changeset/cli-docs-fix-readme-link.md
+++ b/.changeset/cli-docs-fix-readme-link.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-dynamic-feature-loader': patch
+---
+
+Updated documentation link to point to the new per-module CLI command pages.

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -117,7 +117,7 @@ CMD ["node", "packages/backend", "--config", "app-config.yaml", "--config", "app
 
 For more details on how the `backend:bundle` command and the `skeleton.tar.gz`
 file works, see the
-[`backend:bundle` command docs](../tooling/cli/03-commands.md#package-bundle).
+[`backend:bundle` command docs](../tooling/cli/module-build.md#package-bundle).
 
 The `Dockerfile` is located at `packages/backend/Dockerfile`, but needs to be
 executed with the root of the repo as the build context, in order to get access

--- a/docs/frontend-system/building-plugins/07-internationalization.md
+++ b/docs/frontend-system/building-plugins/07-internationalization.md
@@ -420,4 +420,4 @@ The exported JSON files are standard key-value pairs compatible with most extern
 3. Download the translated files back into the translations directory
 4. Run `translations import` to regenerate the wiring code
 
-For full command reference, see the [CLI commands documentation](../../tooling/cli/03-commands.md#translations-export).
+For full command reference, see the [CLI commands documentation](../../tooling/cli/module-translations.md#translations-export).

--- a/docs/getting-started/keeping-backstage-updated.md
+++ b/docs/getting-started/keeping-backstage-updated.md
@@ -21,7 +21,7 @@ starting point that's meant to be evolved.
 
 The Backstage CLI has a command to bump all `@backstage` packages and
 dependencies you're using to the latest versions:
-[versions:bump](../tooling/cli/03-commands.md#versionsbump).
+[versions:bump](../tooling/cli/module-migrate.md#versionsbump).
 
 ```bash
 yarn backstage-cli versions:bump

--- a/docs/golden-path/plugins/backend/001-first-steps.md
+++ b/docs/golden-path/plugins/backend/001-first-steps.md
@@ -23,7 +23,7 @@ will be part of the NPM package name, so make it short and containing only
 lowercase characters separated by dashes, for our example, you should provide `todo`. For plugins you may write in the future, this should be an easy to remember indicator of what this plugins does, like if it's a
 package that adds an integration with a system named Carmen, you would want to name it `carmen`.
 
-This will create a new NPM package with a package name something like `@internal/plugin-carmen-backend`, depending on the other flags passed to the `new` command, and your settings for the `new` command in your root `package.json`. For future reference, we also support additional flags and configuration. Learn more at [the CLI docs](../../../tooling/cli/03-commands.md#new).
+This will create a new NPM package with a package name something like `@internal/plugin-carmen-backend`, depending on the other flags passed to the `new` command, and your settings for the `new` command in your root `package.json`. For future reference, we also support additional flags and configuration. Learn more at [the CLI docs](../../../tooling/cli/module-new.md#new).
 
 Creating the plugin will take a little while, so be patient. If it runs with no issues, it will run the initial installation and build commands, so that your package is ready to be hacked on!
 

--- a/docs/golden-path/plugins/frontend/001-first-steps.md
+++ b/docs/golden-path/plugins/frontend/001-first-steps.md
@@ -17,7 +17,7 @@ yarn new --select frontend-plugin --option pluginId=todo --option owner=
 This creates a new NPM package named something like `@internal/plugin-todo`,
 depending on the flags passed to the `new` command and your settings in the root
 `package.json`. For more options, see
-[the CLI docs](../../../tooling/cli/03-commands.md#new).
+[the CLI docs](../../../tooling/cli/module-new.md#new).
 
 Creating the plugin takes a moment. Once the command finishes, a new folder
 appears at `plugins/todo` (the path depends on the plugin ID you chose) with

--- a/docs/integrations/github/github-apps.md
+++ b/docs/integrations/github/github-apps.md
@@ -42,7 +42,7 @@ yarn backstage-cli create-github-app <github org>
 ```
 
 You can read more about the
-[`backstage-cli create-github-app`](../../tooling/cli/03-commands.md#create-github-app) command.
+[`backstage-cli create-github-app`](../../tooling/cli/module-github.md#create-github-app) command.
 
 Once you've gone through the CLI command, it should produce a YAML file in the
 root of the project which you can then use as an `include` in your

--- a/docs/plugins/create-a-plugin.md
+++ b/docs/plugins/create-a-plugin.md
@@ -17,7 +17,7 @@ A Backstage Plugin adds functionality to Backstage.
 To create a new frontend plugin, make sure you've run `yarn install` and installed
 dependencies, then run the following on your command line (a shortcut to
 invoking the
-[`backstage-cli new --select plugin`](../tooling/cli/03-commands.md#new))
+[`backstage-cli new --select plugin`](../tooling/cli/module-new.md#new))
 from the root of your project.
 
 ```bash

--- a/docs/plugins/internationalization.md
+++ b/docs/plugins/internationalization.md
@@ -412,4 +412,4 @@ The exported JSON files are standard key-value pairs compatible with most extern
 3. Download the translated files back into the translations directory
 4. Run `translations import` to regenerate the wiring code
 
-For full command reference, see the [CLI commands documentation](../tooling/cli/03-commands.md#translations-export).
+For full command reference, see the [CLI commands documentation](../tooling/cli/module-translations.md#translations-export).

--- a/docs/tooling/cli/01-overview.md
+++ b/docs/tooling/cli/01-overview.md
@@ -58,10 +58,9 @@ package, which includes the following 12 modules:
 - **Test** (`@backstage/cli-module-test-jest`) — Jest-based testing
 - **Translations** (`@backstage/cli-module-translations`) — Translation message management
 
-You can customize the CLI by adding, removing, or replacing modules. The CLI
-automatically discovers modules from your project's dependencies based on the
-`backstage.role` field in each package's `package.json`. You can also build your
-own modules to extend the CLI with custom commands for your organization.
+You can customize the CLI by replacing default modules or adding your own. The
+CLI discovers modules from your project's dependencies based on the
+`backstage.role` field in each package's `package.json`.
 
 For more details, see the [CLI Modules](./05-modules.md) page and the
 [Building Custom CLI Modules](./building-cli-modules.md) guide.

--- a/docs/tooling/cli/01-overview.md
+++ b/docs/tooling/cli/01-overview.md
@@ -38,29 +38,13 @@ customizing the build process. This is to allow for evolution of the CLI without
 having to take a wide API surface into account. This allows us to iterate and
 improve the tooling, as well as to more easily keep the system up to date.
 
-## Modular Architecture
+## Modular architecture
 
 The CLI is built from a set of independent **CLI modules**, each providing a
-group of related commands. The default set of modules is provided by the
-[`@backstage/cli-defaults`](https://www.npmjs.com/package/@backstage/cli-defaults)
-package, which includes the following 12 modules:
-
-- **Auth** (`@backstage/cli-module-auth`) — Authentication with Backstage instances
-- **Actions** (`@backstage/cli-module-actions`) — Discovering and executing Backstage actions
-- **Build** (`@backstage/cli-module-build`) — Building, starting, and packaging
-- **Config** (`@backstage/cli-module-config`) — Configuration inspection
-- **GitHub** (`@backstage/cli-module-github`) — GitHub App creation
-- **Info** (`@backstage/cli-module-info`) — Environment and dependency information
-- **Lint** (`@backstage/cli-module-lint`) — Linting
-- **Maintenance** (`@backstage/cli-module-maintenance`) — Repository maintenance and deprecation tracking
-- **Migrate** (`@backstage/cli-module-migrate`) — Migration and version management
-- **New** (`@backstage/cli-module-new`) — Scaffolding new plugins and packages
-- **Test** (`@backstage/cli-module-test-jest`) — Jest-based testing
-- **Translations** (`@backstage/cli-module-translations`) — Translation message management
-
-You can customize the CLI by replacing default modules or adding your own. The
-CLI discovers modules from your project's dependencies based on the
-`backstage.role` field in each package's `package.json`.
-
-For more details, see the [CLI Modules](./05-modules.md) page and the
-[Building Custom CLI Modules](./building-cli-modules.md) guide.
+group of related commands. The
+[CLI Modules](./05-modules.md) page lists the default modules and explains
+how module discovery works. You can also
+[customize the defaults](./05-modules.md#customizing-the-default-modules) by
+overriding or removing modules, or
+[build your own](./building-cli-modules.md) to add custom commands for your
+organization.

--- a/docs/tooling/cli/01-overview.md
+++ b/docs/tooling/cli/01-overview.md
@@ -37,3 +37,31 @@ The Backstage CLI intentionally does not provide many hooks for overriding or
 customizing the build process. This is to allow for evolution of the CLI without
 having to take a wide API surface into account. This allows us to iterate and
 improve the tooling, as well as to more easily keep the system up to date.
+
+## Modular Architecture
+
+The CLI is built from a set of independent **CLI modules**, each providing a
+group of related commands. The default set of modules is provided by the
+[`@backstage/cli-defaults`](https://www.npmjs.com/package/@backstage/cli-defaults)
+package, which includes the following 12 modules:
+
+- **Auth** (`@backstage/cli-module-auth`) — Authentication with Backstage instances
+- **Actions** (`@backstage/cli-module-actions`) — Discovering and executing Backstage actions
+- **Build** (`@backstage/cli-module-build`) — Building, starting, and packaging
+- **Config** (`@backstage/cli-module-config`) — Configuration inspection
+- **GitHub** (`@backstage/cli-module-github`) — GitHub App creation
+- **Info** (`@backstage/cli-module-info`) — Environment and dependency information
+- **Lint** (`@backstage/cli-module-lint`) — Linting
+- **Maintenance** (`@backstage/cli-module-maintenance`) — Repository maintenance and deprecation tracking
+- **Migrate** (`@backstage/cli-module-migrate`) — Migration and version management
+- **New** (`@backstage/cli-module-new`) — Scaffolding new plugins and packages
+- **Test** (`@backstage/cli-module-test-jest`) — Jest-based testing
+- **Translations** (`@backstage/cli-module-translations`) — Translation message management
+
+You can customize the CLI by adding, removing, or replacing modules. The CLI
+automatically discovers modules from your project's dependencies based on the
+`backstage.role` field in each package's `package.json`. You can also build your
+own modules to extend the CLI with custom commands for your organization.
+
+For more details, see the [CLI Modules](./05-modules.md) page and the
+[Building Custom CLI Modules](./building-cli-modules.md) guide.

--- a/docs/tooling/cli/03-commands.md
+++ b/docs/tooling/cli/03-commands.md
@@ -23,7 +23,7 @@ config:print [options]                         Print the app configuration for t
 config:check [options]                         Validate that the given configuration loads and matches
                                                 schema
 config:schema [options]                        Print configuration schema
-repo [command]                                 Command that run across an entire Backstage project
+repo [command]                                 Commands that run across an entire Backstage project
 package [command]                              Lifecycle scripts for individual packages
 migrate [command]                              Migration utilities
 versions:bump [options]                        Bump Backstage packages to the latest versions

--- a/docs/tooling/cli/03-commands.md
+++ b/docs/tooling/cli/03-commands.md
@@ -1,11 +1,12 @@
 ---
 id: commands
 title: Commands
-description: Descriptions of all commands available in the CLI.
+description: Index of all commands available in the Backstage CLI.
 ---
 
-This page lists all commands provided by the Backstage CLI, what they're for,
-and where to use them.
+This page lists all commands provided by the Backstage CLI. Each command belongs
+to a [CLI module](./05-modules.md) — follow the links below for detailed
+documentation including options and examples.
 
 ## help
 
@@ -15,6 +16,8 @@ Below is a cleaned up output of `yarn backstage-cli --help`:
 ```text
 new [options]                                  Open up an interactive guide to creating new things in
                                                 your app
+auth [command]                                 Authentication commands
+actions [command]                              Backstage action commands
 config:docs [options]                          Browse the configuration reference documentation
 config:print [options]                         Print the app configuration for the current package
 config:check [options]                         Validate that the given configuration loads and matches
@@ -24,8 +27,8 @@ repo [command]                                 Command that run across an entire
 package [command]                              Lifecycle scripts for individual packages
 migrate [command]                              Migration utilities
 versions:bump [options]                        Bump Backstage packages to the latest versions
+versions:migrate [options]                     Migrate plugins to the @backstage-community namespace
 translations [command]                         Translation message management
-clean                                          Delete cache directories [DEPRECATED]
 build-workspace <workspace-dir> [packages...]  Builds a temporary dist workspace from the provided
                                                 packages
 create-github-app <github-org>                 Create new GitHub App in your organization.
@@ -33,678 +36,107 @@ info                                           Show helpful information for debu
 help [command]                                 display help for command
 ```
 
-The `package` command category, `yarn backstage-cli package --help`:
-
-```text
-start [options]                  Start a package for local development
-build [options]                  Build a package for production deployment or publishing
-lint [options] [directories...]  Lint a package
-test                             Run tests, forwarding args to Jest, defaulting to watch mode
-clean                            Delete cache directories
-prepack                          Prepares a package for packaging before publishing
-postpack                         Restores the changes made by the prepack command
-help [command]                   display help for command
-```
-
-The `repo` command category, `yarn backstage-cli repo --help`:
-
-```text
-start [options] [packageName...]  Starts packages in the repo for local development
-build [options]                   Build packages in the project, excluding bundled app and backend packages.
-test [options]                    Run tests, forwarding args to Jest, defaulting to watch mode
-lint [options]                    Lint all packages in the project
-fix [options]                     Automatically fix packages in the project
-clean                             Delete cache and output directories
-list-deprecations [options]       List deprecations
-help [command]                    display help for command
-```
-
-The `migrate` command category, `yarn backstage-cli migrate --help`:
-
-```text
-package-roles         Add package role field to packages that don't have it
-package-scripts       Set package scripts according to each package role
-package-exports       Synchronize package subpath export definitions
-package-lint-configs  Migrates all packages to use @backstage/cli/config/eslint-factory
-react-router-deps     Migrates the react-router dependencies for all packages to be peer dependencies
-help [command]        display help for command
-```
-
-## repo start
-
-Start a set of packages in the project for local development. If no explicit packages are listed via arguments or options, packages will instead be selected based on their [package role](./02-build-system.md#package-roles). If a single set of frontend and/or backend packages are found, they will be started. If there are multiple matches the directories 'packages/app' and 'packages/backend' will be preferred. If no matches are found the command will fall back to expecting a single plugin frontend and/or backend package to start instead.
-
-Any `--config` options in the `start` script in `package.json` of the selected packages will be picked up and used, unless a `--config` option is provided to this command, in which case it will be used instead.
-
-Any `--require` option in the `start` script in `package.json` of the selected backend package will be picked up and used.
-
-```text
-Usage: backstage-cli repo start [options] [packageNameOrPath...]
-
-Starts packages in the repo for local development
-
-Arguments:
-  packageNameOrPath     Run the specified packages instead of the defaults.
-
-Options:
-  --plugin <pluginId>   Start the dev entry-point for any matching plugin package in the repo (default: [])
-  --config <path>       Config files to load instead of app-config.yaml (default: [])
-  --inspect [host]      Enable debugger in Node.js environments. Applies to backend package only
-  --inspect-brk [host]  Enable debugger in Node.js environments, breaking before code starts. Applies to backend package only
-  --require <path...>   Add a --require argument to the node process. Applies to backend package only
-  --link <path>         Link an external workspace for module resolution
-```
-
-## repo build
-
-Builds all packages in the project, excluding bundled packages by default, i.e. ones
-with the role `'frontend'` or `'backend'`.
-
-```text
-Usage: backstage-cli repo build [options]
-
-Build packages in the project, excluding bundled app and backend packages.
-
-Options:
-  --all          Build all packages, including bundled app and backend packages.
-  --since <ref>  Only build packages and their dev dependents that changed since the specified ref
-```
-
-## repo lint
-
-Lint all packages in the project.
-
-```text
-Usage: backstage-cli repo lint [options]
-
-Lint all packages in the project
-
-Options:
-  --format <format>           Lint report output format (default: "eslint-formatter-friendly")
-  --since <ref>               Only lint packages that changed since the specified ref
-  --success-cache             Enable success caching, which skips running lint for unchanged packages that were successful in the previous run
-  --success-cache-dir <path>  Set the success cache location, (default: node_modules/.cache/backstage-cli)
-  --fix                       Attempt to automatically fix violations
-```
-
-## repo test
-
-Test packages in the project. It is recommended to have this command be used as the `test` script in the root `package.json` in your project:
-
-```json title="package.json in the root of your project"
-{
-  ...
-  "scripts": {
-    ...
-    "test": "backstage-cli repo test"
-  }
-}
-```
-
-If run without any arguments it will default to running changed tests in watch mode, unless the `CI` environment flag is set, in which case it will run all tests without watching:
-
-```sh title="Run changes tests from repo root"
-yarn test
-```
-
-If arguments are provided, they will be forwarded to Jest and used to filter test to execute. If full paths to tests are provided, only those tests will be included, for example:
-
-```sh title="Run specific tests from repo root"
-yarn test packages/app/src/App.test.tsx
-```
-
-If you want to avoid re-running tests that have not changed since the last successful run in CI, you can use the `--success-cache` flag. By default this cache is stored in `node_modules/.cache/backstage-cli`, but you can choose a different directory with the `--success-cache-dir <path>`.
-
-```text
-Usage: backstage-cli repo test [options]
-
-Run tests, forwarding args to Jest, defaulting to watch mode
-
-Options:
-  --since <ref>               Only test packages that changed since the specified ref
-  --success-cache             Enable success caching, which skips running tests for unchanged packages that were successful in the previous run
-  --success-cache-dir <path>  Set the success cache location, (default: node_modules/.cache/backstage-cli)
-  --jest-help                 Show help for Jest CLI options, which are passed through
-  -h, --help                  display help for command
-```
-
-## package start
-
-Starts the package for local development. See the frontend and backend development parts in the build system [bundling](./02-build-system.md#bundling) section for more details.
-
-```text
-Usage: backstage-cli package start [options]
-
-Start a package for local development
-
-Options:
-  --config <path>     Config files to load instead of app-config.yaml (default: [])
-  --role <name>       Run the command with an explicit package role
-  --check             Enable type checking and linting if available
-  --inspect           Enable debugger in Node.js environments
-  --inspect-brk       Enable debugger in Node.js environments, breaking before code starts
-  --entrypoint <path> Entry directory path (uses index file) or entry file path (without extension). Defaults to "dev"
-```
-
-## package build
-
-Build an individual package based on its role. See the build system [building](./02-build-system.md#building) and [bundling](./02-build-system.md#bundling) sections for more details.
-
-```text
-Usage: backstage-cli package build [options]
-
-Build a package for production deployment or publishing
-
-Options:
-  --role <name>              Run the command with an explicit package role
-  --minify                   Minify the generated code. Does not apply to app package (app is minified by default).
-  --skip-build-dependencies  Skip the automatic building of local dependencies. Applies to backend packages only.
-  --stats                    If bundle stats are available, write them to the output directory. Applies to app packages only.
-  --config <path>            Config files to load instead of app-config.yaml. Applies to app packages only. (default: [])
-  --module-federation        Build a package as a module federation remote. Applies to frontend plugin packages only.
-```
-
-## package bundle
-
-:::caution Experimental
-This command is experimental and may receive breaking changes in future releases
-without a deprecation period. It is hidden from the main `--help` output.
-:::
-
-Bundle a plugin for dynamic loading. This creates a self-contained plugin
-package that can be deployed independently and loaded dynamically by a Backstage
-application. Supports both backend and frontend plugins.
-
-Unlike regular builds, the bundle command:
-
-- Creates a fully self-contained plugin deliverable
-
-- Produces module federation assets (frontend) or includes plugin dependencies in the plugin's private `node_modules`, building and packing (with `yarn pack`) the local `workspace:^` dependencies first (backend).
-- Generates a config schema from plugin-related packages only.
-- Validates that the plugin exports valid dynamic loading entry points (backend only)
-
-### Usage
-
-```bash
-# Bundle the current package (output: ./bundle/)
-yarn backstage-cli package bundle
-
-# Bundle to a specific directory (output: ../dynamic-plugins/<mangled-package-name>/)
-yarn backstage-cli package bundle --output-destination ../dynamic-plugins
-
-# Override the bundle subdirectory name
-yarn backstage-cli package bundle --output-name my-plugin-bundle
-
-# Clean output before bundling
-yarn backstage-cli package bundle --clean
-
-# Skip building for the plugin and its local dependencies
-yarn backstage-cli package bundle --no-build
-
-# Skip dependency installation and entrypoint validation
-yarn backstage-cli package bundle --no-install
-
-# Stream detailed output from build, pack, and install steps
-yarn backstage-cli package bundle --verbose
-
-# Use a pre-built dist workspace for batch bundling.
-# First, create the workspace with:
-#   backstage-cli build-workspace <output-dir> [packages...] --alwaysPack
-# Then pass <output-dir> as --pre-packed-dir:
-yarn backstage-cli package bundle --pre-packed-dir ../dist-workspace
-```
-
-### Options
-
-```text
-Usage: backstage-cli package bundle [options]
-
-Bundle a plugin for dynamic loading
-
-Options:
-  --output-destination <dir>  Directory in which the bundle subdirectory is created.
-                              Defaults to the current package directory.
-  --output-name <name>        Name of the bundle subdirectory. Defaults to "bundle" when
-                              output stays in the package directory, or to the mangled
-                              package name (e.g. myorg-plugin-foo) when
-                              --output-destination is specified.
-  --clean                     Clean the output directory before bundling
-  --no-build                  Skip building packages (assumes they are already built)
-  --no-install                Skip dependency installation and entrypoint validation.
-  --verbose                   Stream detailed output from internal steps (build, pack,
-                              install) to the console. Without this flag, output is
-                              captured to per-step log files and only shown on error.
-  --pre-packed-dir <dir>      Path to a pre-built dist workspace (from
-                              build-workspace --alwaysPack). Skips local dependency
-                              packing and uses pre-packed packages directly. For frontend
-                              plugins, this also enables yarn.lock generation for SBOM.
-```
-
-### Output Contract
-
-The bundle output is a directory that can be deployed as a standalone unit.
-Consumers of the bundle (such as `@backstage/backend-dynamic-feature-service`
-or `@backstage/frontend-dynamic-feature-loader`) can rely on the following
-guarantees:
-
-**All bundles:**
-
-- A `package.json` at the bundle root with entry points configured for dynamic
-  loading. The `backstage.role` and `files` fields are preserved from the source package.
-- A `dist/` directory containing the built plugin code.
-- A `dist/.config-schema.json` file (when any config schemas apply) containing
-  gathered schemas from the plugin, its local workspace dependencies, and
-  third-party dependencies. Schemas from unrelated Backstage packages are excluded.
-- No `scripts` or `devDependencies` in `package.json`.
-
-**Backend plugins** (`backend-plugin`, `backend-plugin-module`):
-
-- A `node_modules/` directory with all production dependencies (including local
-  workspace dependencies), pinned to their exact versions from the source lockfile.
-- `bundleDependencies` is set to `true` in `package.json`.
-
-**Frontend plugins** (`frontend-plugin`, `frontend-plugin-module`):
-
-- `main` points to `dist/remoteEntry.js` (the Module Federation remote entry).
-- `types` points to `dist/@mf-types/index.d.ts` when type declarations are
-  available.
-- No embedded `node_modules/` directory.
-
-### Environment Variables
-
-The bundle command supports the same environment variables as the Backstage yarn plugin
-for resolving `backstage:^` version specifiers:
-
-- `BACKSTAGE_MANIFEST_FILE`: Path to a local manifest file (for offline usage)
-- `BACKSTAGE_VERSIONS_BASE_URL`: Custom base URL for fetching release manifests
-
-### Supported Package Roles
-
-The bundle command supports packages with the following roles:
-
-- `backend-plugin`
-- `backend-plugin-module`
-- `frontend-plugin`
-- `frontend-plugin-module`
-
-## package lint
-
-Lint a package. In addition to the default `eslint` behavior, this command will
-include TypeScript files, treat warnings as errors, and default to linting the
-entire directory if no specific files are listed. For more information, see the
-build system [linting](./02-build-system.md#linting) section.
-
-```text
-Usage: backstage-cli package lint [options]
-
-Lint a package
-
-Options:
-  --format <format>        Lint report output format (default: "eslint-formatter-friendly")
-  --fix                    Attempt to automatically fix violations
-  --max-warnings <number>  Fail if more than this number of warnings. -1 allows warnings. (default: -1)
-```
-
-## package test
-
-Run tests, forwarding all unknown options to Jest, and defaulting to watch mode.
-When executing the tests, `process.env.NODE_ENV` will be set to `"test"`.
-
-This command uses a default Jest configuration that is included in the CLI,
-which is set up with similar goals for speed, scale, and working within a
-monorepo. The configuration sets the `src` as the root directory, enforces the
-`.test.` infix for tests, and uses `src/setupTests.ts` as the test setup
-location. The included configuration also supports test execution at the root of
-a yarn workspaces monorepo by automatically creating one grouped configuration
-that includes all packages that have `backstage-cli test` in their package
-`test` script.
-
-For more information about configuration overrides and editor support, see the [Jest Configuration section](./02-build-system.md#jest-configuration) in the build system documentation.
-
-```text
-Usage: backstage-cli package test [options]
-
-Run tests, forwarding args to Jest, defaulting to watch mode
-
-Options:
-  --backstage-cli-help    display help for command
-```
-
-## package clean
-
-Remove cache and output directories.
-
-```text
-Usage: backstage-cli package clean [options]
-
-Delete cache directories
-```
-
-## package prepack
-
-This command should be added as `scripts.prepack` in all packages. It enables
-packaging- and publish-time overrides for fields inside `packages.json`.
-For more details, see the build system [publishing](./02-build-system.md#publishing) section.
-
-```text
-Usage: backstage-cli package prepack [options]
-
-Prepares a package for packaging before publishing
-```
-
-## package postpack
-
-This should be added as `scripts.postpack` in all packages. It restores
-`package.json` to what it looked like before calling the `prepack` command.
-
-```text
-Usage: backstage-cli package postpack [options]
-
-Restores the changes made by the prepack command
-```
-
-## new
-
-The `new` command opens up an interactive guide for you to create new things
-in your app. If you do not pass in any options it is completely interactive, but
-it is possible to pre-select what you want to create using the `--select` flag,
-and provide options using `--option`, for example:
-
-```bash
-backstage-cli new --select frontend-plugin --option pluginId=foo
-```
-
-This command is typically added as script in the root `package.json` to be
-executed with `yarn new`. For example you may have it set up like this:
-
-```json
-{
-  "scripts": {
-    "new": "backstage-cli new"
-  }
-}
-```
-
-The `new` command comes with a default collection of plugins/packages, however,
-you can customize this list and even create your own CLI templates. For more
-information see [CLI Templates](./04-templates.md).
-
-```text
-Usage: backstage-cli new
-
-Options:
-  -h, --help               display help for command
-```
-
-## config\:docs
-
-This commands opens up the reference documentation of your apps local
-configuration schema in the browser. This is useful to get an overview of what
-configuration values are available to use, a description of what they do and
-their format, and where they get sent.
-
-```text
-Usage: backstage-cli config:docs [options]
-
-Browse the configuration reference documentation
-
-Options:
-  --package <name>  Only include the schema that applies to the given package
-  -h, --help        display help for command
-```
-
-## config\:print
-
-Print the static configuration, defaulting to reading `app-config.yaml` in the
-repo root, using schema collected from all local packages in the repo.
-
-For example, to validate that a given configuration value is visible in the
-frontend when building the `my-app` package, you can use the following:
-
-```bash
-yarn backstage-cli config:print --frontend --package my-app
-```
-
-```text
-Usage: backstage-cli config:print [options]
-
-Options:
-  --package <name>   Only load config schema that applies to the given package
-  --lax              Do not require environment variables to be set
-  --frontend         Print only the frontend configuration
-  --with-secrets     Include secrets in the printed configuration
-  --format <format>  Format to print the configuration in, either json or yaml [yaml]
-  --config <path>    Config files to load instead of app-config.yaml (default: [])
-  -h, --help         display help for command
-```
-
-## config\:check
-
-Validate that static configuration loads and matches schema, defaulting to
-reading `app-config.yaml` in the repo root and using schema collected from all
-local packages in the repo.
-
-```text
-Usage: backstage-cli config:check [options]
-
-Options:
-  --package <name>  Only load config schema that applies to the given package
-  --lax             Do not require environment variables to be set
-  --frontend        Only validate the frontend configuration
-  --deprecated      Output deprecated configuration settings
-  --strict          Ensure that the provided config(s) has no errors and does not contain keys not in the schema.
-  --config <path>   Config files to load instead of app-config.yaml (default: [])
-  -h, --help        display help for command
-```
-
-## config\:schema
-
-Dump the configuration schema that was collected from all local packages in the
-repo.
-
-Note: when run by `yarn`, supply the yarn option `--silent` if you are using the
-output in a command line pipe to avoid non schema output in the pipeline.
-
-```text
-Usage: backstage-cli config:schema [options]
-
-Print configuration schema
-
-Options:
-  --package <name>   Only output config schema that applies to the given package
-  --format <format>  Format to print the schema in, either json or yaml [yaml]
-  -h, --help         display help for command
-```
-
-## versions\:bump
-
-Bump all `@backstage` packages to the latest versions. This checks for updates
-in the package registry, and will update entries `package.json` files when necessary. See more how this command can be configured and used [for keeping Backstage updated](../../getting-started/keeping-backstage-updated.md).
-
-```text
-Usage: backstage-cli versions:bump [options]
-
-Options:
-  -h, --help        display help for command
-  --pattern <glob>  Override glob for matching packages to upgrade
-  --release <version|next|main> Bump to a specific Backstage release line or version (default: "main")
-```
-
-## build-workspace
-
-Builds a mirror of the workspace using the packaged production version of each
-package. This essentially calls `yarn pack` in each included package and unpacks
-the resulting archive in the target `workspace-dir`.
-
-```text
-Usage: backstage-cli build-workspace [options] <workspace-dir> [packages...]
-
-Options:
-  --alwaysPack  Force workspace output to be a result of running `yarn pack` on
-                each package (warning: very slow)
-```
-
-When `--alwaysPack` is used, the output directory can be passed to
-`backstage-cli package bundle --pre-packed-dir` to speed up batch bundling of
-multiple plugins from the same monorepo.
-
-## create-github-app
-
-Creates a GitHub App in your GitHub organization. This is an alternative to
-token-based [GitHub integration](../../integrations/github/locations.md). See
-[GitHub Apps for Backstage Authentication](../../integrations/github/github-apps.md).
-
-Launches a browser to create the App through GitHub and saves the result as a
-YAML file that can be referenced in the GitHub integration configuration.
-
-```text
-Usage: backstage-cli create-github-app <github-org>
-```
-
-## translations export
-
-Export translation messages from an app and all of its frontend plugins to JSON
-files. This command must be run from within a package directory (e.g.
-`packages/app`), not from the repository root.
-
-The command discovers all `TranslationRef` definitions in the dependency tree,
-extracts their default messages using the TypeScript type system, and writes
-them as JSON files along with a manifest.
-
-For more details on the translation workflow, see the
-[Internationalization](../../plugins/internationalization.md) documentation.
-
-```text
-Usage: backstage-cli translations export [options]
-
-Options:
-  --output <dir>       Output directory for exported messages and manifest (default: "translations")
-  --pattern <pattern>  File path pattern for message files relative to the output
-                       directory, with {id} and {lang} placeholders
-                       (default: "messages/{id}.{lang}.json")
-  -h, --help           display help for command
-```
-
-### Examples
-
-Export translations with default settings:
-
-```bash
-cd packages/app
-yarn backstage-cli translations export
-```
-
-Export with language-based directory grouping:
-
-```bash
-yarn backstage-cli translations export --pattern '{lang}/{id}.json'
-```
-
-## translations import
-
-Generate translation resource wiring code from translated JSON files. Reads the
-manifest and translated message files produced by `translations export`, and
-generates a TypeScript module that creates `TranslationResource` objects for each
-translated ref.
-
-The file pattern used during export is stored in the manifest and automatically
-used by the import command.
-
-```text
-Usage: backstage-cli translations import [options]
-
-Options:
-  --input <dir>    Input directory containing the manifest and translated message files (default: "translations")
-  --output <path>  Output path for the generated wiring module (default: "src/translations/resources.ts")
-  -h, --help       display help for command
-```
-
-### Examples
-
-Generate wiring code with default settings:
-
-```bash
-cd packages/app
-yarn backstage-cli translations import
-```
-
-## info
-
-Outputs debug information which is useful when opening an issue. Outputs system
-information, node.js and npm versions, CLI version and type (inside backstage
-repo or a created app), all `@backstage/*` package dependency versions, and any
-packages that contain a `backstage` field in their `package.json`.
-
-The command distinguishes between installed packages (from npm) and local
-workspace packages, making it easier to understand your Backstage setup.
-
-```text
-Usage: backstage-cli info [options]
-
-Options:
-  --include <patterns...>  Glob patterns for additional packages to include
-                           (e.g., @mycompany/backstage-*)
-  --format <text|json>     Output format (default: text)
-  -h, --help               display help for command
-```
-
-### Examples
-
-Output debug information to the console:
-
-```bash
-yarn backstage-cli info
-```
-
-Include additional packages matching a glob pattern:
-
-```bash
-yarn backstage-cli info --include "@mycompany/*"
-```
-
-Output as JSON:
-
-```bash
-yarn backstage-cli info --format json
-```
-
-Export JSON to a file for further processing:
-
-```bash
-yarn backstage-cli info --format json > backstage-info.json
-```
-
-Combine options to include custom packages and export to JSON:
-
-```bash
-yarn backstage-cli info --include "@mycompany/backstage-*" --include "@internal/*" --format json > debug-info.json
-```
-
-Export text output to a file:
-
-```bash
-yarn backstage-cli info --format text > backstage-info.txt
-```
-
-### JSON Output Format
-
-When using `--format json`, the output is structured as follows:
-
-```json
-{
-  "system": {
-    "os": "Darwin 23.0.0 - darwin/arm64",
-    "node": "v18.17.0",
-    "yarn": "3.6.0",
-    "cli": { "version": "0.27.0", "local": false },
-    "backstage": "1.20.0"
-  },
-  "dependencies": {
-    "@backstage/core-plugin-api": "1.8.0",
-    "@backstage/plugin-catalog": "1.15.0"
-  },
-  "local": {
-    "@mycompany/backstage-plugin-custom": "0.1.0"
-  }
-}
-```
+## Commands by Module
+
+### [Auth Module](./module-auth.md)
+
+| Command            | Description                               |
+| ------------------ | ----------------------------------------- |
+| `auth login`       | Log in the CLI to a Backstage instance    |
+| `auth logout`      | Log out and clear stored credentials      |
+| `auth show`        | Show details of an authenticated instance |
+| `auth list`        | List authenticated instances              |
+| `auth print-token` | Print an access token to stdout           |
+| `auth select`      | Select the default instance               |
+
+### [Actions Module](./module-actions.md)
+
+| Command                  | Description                                           |
+| ------------------------ | ----------------------------------------------------- |
+| `actions list`           | List available actions from configured plugin sources |
+| `actions execute`        | Execute an action                                     |
+| `actions sources add`    | Add a plugin source for action discovery              |
+| `actions sources list`   | List configured plugin sources                        |
+| `actions sources remove` | Remove a plugin source                                |
+
+### [Build Module](./module-build.md)
+
+| Command            | Description                                             |
+| ------------------ | ------------------------------------------------------- |
+| `repo start`       | Start packages for local development                    |
+| `repo build`       | Build packages in the project                           |
+| `repo clean`       | Delete cache and output directories across the project  |
+| `package start`    | Start a package for local development                   |
+| `package build`    | Build a package for production deployment or publishing |
+| `package bundle`   | Bundle a plugin for dynamic loading (experimental)      |
+| `package clean`    | Delete cache directories                                |
+| `package prepack`  | Prepare a package for packaging before publishing       |
+| `package postpack` | Restore changes made by prepack                         |
+| `build-workspace`  | Build a temporary dist workspace from provided packages |
+
+### [Config Module](./module-config.md)
+
+| Command         | Description                                          |
+| --------------- | ---------------------------------------------------- |
+| `config:docs`   | Browse the configuration reference documentation     |
+| `config:print`  | Print the app configuration                          |
+| `config:check`  | Validate that configuration loads and matches schema |
+| `config:schema` | Print the configuration schema                       |
+
+### [GitHub Module](./module-github.md)
+
+| Command             | Description                                  |
+| ------------------- | -------------------------------------------- |
+| `create-github-app` | Create a new GitHub App in your organization |
+
+### [Info Module](./module-info.md)
+
+| Command | Description                                               |
+| ------- | --------------------------------------------------------- |
+| `info`  | Show helpful information for debugging and reporting bugs |
+
+### [Lint Module](./module-lint.md)
+
+| Command        | Description                      |
+| -------------- | -------------------------------- |
+| `package lint` | Lint a package                   |
+| `repo lint`    | Lint all packages in the project |
+
+### [Maintenance Module](./module-maintenance.md)
+
+| Command                  | Description                               |
+| ------------------------ | ----------------------------------------- |
+| `repo fix`               | Automatically fix packages in the project |
+| `repo list-deprecations` | List deprecations                         |
+
+### [Migrate Module](./module-migrate.md)
+
+| Command                        | Description                                            |
+| ------------------------------ | ------------------------------------------------------ |
+| `versions:bump`                | Bump Backstage packages to the latest versions         |
+| `versions:migrate`             | Migrate plugins to the @backstage-community namespace  |
+| `migrate package-roles`        | Add package role field to packages                     |
+| `migrate package-scripts`      | Set package scripts according to each package role     |
+| `migrate package-exports`      | Synchronize package subpath export definitions         |
+| `migrate package-lint-configs` | Migrate to @backstage/cli/config/eslint-factory        |
+| `migrate react-router-deps`    | Migrate react-router dependencies to peer dependencies |
+
+### [New Module](./module-new.md)
+
+| Command | Description                                                  |
+| ------- | ------------------------------------------------------------ |
+| `new`   | Open an interactive guide to creating new things in your app |
+
+### [Test Module](./module-test.md)
+
+| Command        | Description                    |
+| -------------- | ------------------------------ |
+| `repo test`    | Run tests across the project   |
+| `package test` | Run tests for a single package |
+
+### [Translations Module](./module-translations.md)
+
+| Command               | Description                               |
+| --------------------- | ----------------------------------------- |
+| `translations export` | Export translation messages to JSON files |
+| `translations import` | Generate translation resource wiring code |

--- a/docs/tooling/cli/05-modules.md
+++ b/docs/tooling/cli/05-modules.md
@@ -8,11 +8,11 @@ The Backstage CLI is built from a set of independent **CLI modules**, each
 providing a group of related commands. This modular architecture lets you
 choose which commands are available and add your own.
 
-## Default Modules
+## Default modules
 
 Out of the box the CLI ships with
 [`@backstage/cli-defaults`](https://www.npmjs.com/package/@backstage/cli-defaults),
-which bundles the following 12 modules:
+which bundles the following modules:
 
 | Module                                   | Package                              | Commands                                                                                                                                                                        |
 | ---------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -33,7 +33,7 @@ Each module name links to its dedicated page with full command documentation
 including options and examples. See the [commands](./03-commands.md) page for a
 quick reference index of all commands.
 
-## How Module Discovery Works
+## How module discovery works
 
 When the CLI starts it scans the project root's `package.json` for all
 dependencies and devDependencies. For each dependency it checks whether the
@@ -46,7 +46,7 @@ fallback will be removed in a future release. To avoid the warning, add
 `@backstage/cli-defaults` as a `devDependency` in your root `package.json`, or
 install individual `@backstage/cli-module-*` packages.
 
-## Customizing the Default Modules
+## Customizing the default modules
 
 ### Overriding a module
 

--- a/docs/tooling/cli/05-modules.md
+++ b/docs/tooling/cli/05-modules.md
@@ -41,8 +41,10 @@ package's own `package.json` contains `backstage.role` set to `"cli-module"`. If
 it does, the module is loaded and its commands become available.
 
 If no CLI modules are found among the project's dependencies, the CLI falls back
-to importing `@backstage/cli-defaults`, which provides the full default set of
-modules listed above.
+to importing `@backstage/cli-defaults` and prints a deprecation warning. This
+fallback will be removed in a future release. To avoid the warning, add
+`@backstage/cli-defaults` as a `devDependency` in your root `package.json`, or
+install individual `@backstage/cli-module-*` packages.
 
 ## Customizing the Default Modules
 

--- a/docs/tooling/cli/05-modules.md
+++ b/docs/tooling/cli/05-modules.md
@@ -1,0 +1,111 @@
+---
+id: modules
+title: Overview
+description: Overview of the Backstage CLI module system and the default set of modules.
+---
+
+The Backstage CLI is built from a set of independent **CLI modules**, each
+providing a group of related commands. This modular architecture lets you
+customize which commands are available, override default behavior, or extend the
+CLI with your own commands.
+
+## Default Modules
+
+Out of the box the CLI ships with
+[`@backstage/cli-defaults`](https://www.npmjs.com/package/@backstage/cli-defaults),
+which bundles the following 12 modules:
+
+| Module                                   | Package                              | Commands                                                                                                                                                                        |
+| ---------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Auth](./module-auth.md)                 | `@backstage/cli-module-auth`         | `auth login`, `auth logout`, `auth show`, `auth list`, `auth print-token`, `auth select`                                                                                        |
+| [Actions](./module-actions.md)           | `@backstage/cli-module-actions`      | `actions list`, `actions execute`, `actions sources add`, `actions sources list`, `actions sources remove`                                                                      |
+| [Build](./module-build.md)               | `@backstage/cli-module-build`        | `package build`, `package start`, `package bundle`, `package clean`, `package prepack`, `package postpack`, `repo build`, `repo start`, `repo clean`, `build-workspace`         |
+| [Config](./module-config.md)             | `@backstage/cli-module-config`       | `config:docs`, `config:print`, `config:check`, `config:schema`                                                                                                                  |
+| [GitHub](./module-github.md)             | `@backstage/cli-module-github`       | `create-github-app`                                                                                                                                                             |
+| [Info](./module-info.md)                 | `@backstage/cli-module-info`         | `info`                                                                                                                                                                          |
+| [Lint](./module-lint.md)                 | `@backstage/cli-module-lint`         | `package lint`, `repo lint`                                                                                                                                                     |
+| [Maintenance](./module-maintenance.md)   | `@backstage/cli-module-maintenance`  | `repo fix`, `repo list-deprecations`                                                                                                                                            |
+| [Migrate](./module-migrate.md)           | `@backstage/cli-module-migrate`      | `versions:bump`, `versions:migrate`, `migrate package-roles`, `migrate package-scripts`, `migrate package-exports`, `migrate package-lint-configs`, `migrate react-router-deps` |
+| [New](./module-new.md)                   | `@backstage/cli-module-new`          | `new`                                                                                                                                                                           |
+| [Test](./module-test.md)                 | `@backstage/cli-module-test-jest`    | `repo test`, `package test`                                                                                                                                                     |
+| [Translations](./module-translations.md) | `@backstage/cli-module-translations` | `translations export`, `translations import`                                                                                                                                    |
+
+Each module name links to its dedicated page with full command documentation
+including options and examples. See the [commands](./03-commands.md) page for a
+quick reference index of all commands.
+
+## How Module Discovery Works
+
+When the CLI starts it scans the project root's `package.json` for all
+dependencies and devDependencies. For each dependency it checks whether the
+package's own `package.json` contains `backstage.role` set to `"cli-module"`. If
+it does, the module is loaded and its commands become available.
+
+If no CLI modules are found among the project's dependencies, the CLI falls back
+to importing `@backstage/cli-defaults`, which provides the full default set of
+modules listed above.
+
+## Customizing the Default Modules
+
+### Overriding a module
+
+You can override one or more of the default modules by installing the
+replacement as a direct dependency in your project root. When a module installed
+individually conflicts with a module from `@backstage/cli-defaults`, the
+individually installed module takes precedence and the conflicting default module
+is silently skipped.
+
+For example, if you publish an internal `@mycompany/cli-module-build` that
+registers the same command paths as `@backstage/cli-module-build`, adding it to
+your root `package.json` will cause it to be used instead of the default build
+module:
+
+```json title="package.json"
+{
+  "devDependencies": {
+    "@backstage/cli": "...",
+    "@mycompany/cli-module-build": "..."
+  }
+}
+```
+
+### Using a subset of modules
+
+If you only need certain modules, you can install them individually instead of
+relying on `@backstage/cli-defaults`. The CLI will discover them through the
+same dependency scanning mechanism:
+
+```json title="package.json"
+{
+  "devDependencies": {
+    "@backstage/cli": "...",
+    "@backstage/cli-module-build": "...",
+    "@backstage/cli-module-lint": "...",
+    "@backstage/cli-module-test-jest": "..."
+  }
+}
+```
+
+In this example only the build, lint, and test commands would be available.
+
+### Adding custom modules
+
+You can add your own CLI modules alongside the defaults. Any package with
+`backstage.role` set to `"cli-module"` in its `package.json` that is listed as a
+dependency will be discovered automatically. See
+[Building Custom CLI Modules](./building-cli-modules.md) for a full guide.
+
+## Architecture
+
+The CLI module system is implemented across several packages:
+
+- **`@backstage/cli`** — The main CLI entry point. Contains the `CliInitializer`
+  that discovers modules and the `discoverCliModules` function that scans
+  project dependencies.
+- **`@backstage/cli-node`** — Provides the public API for building CLI modules:
+  `createCliModule`, `runCli`, and the `CliModule`, `CliCommand`, and
+  `CliCommandContext` types.
+- **`@backstage/cli-common`** — Minimal shared utilities for path resolution and
+  child process management, used by the CLI, backend, and `create-app`.
+- **`@backstage/cli-defaults`** — Aggregator package that re-exports all 12
+  default modules as an array.

--- a/docs/tooling/cli/05-modules.md
+++ b/docs/tooling/cli/05-modules.md
@@ -6,8 +6,7 @@ description: Overview of the Backstage CLI module system and the default set of 
 
 The Backstage CLI is built from a set of independent **CLI modules**, each
 providing a group of related commands. This modular architecture lets you
-customize which commands are available, override default behavior, or extend the
-CLI with your own commands.
+choose which commands are available and add your own.
 
 ## Default Modules
 
@@ -57,7 +56,7 @@ is silently skipped.
 
 For example, if you publish an internal `@mycompany/cli-module-build` that
 registers the same command paths as `@backstage/cli-module-build`, adding it to
-your root `package.json` will cause it to be used instead of the default build
+your root `package.json` causes it to be used instead of the default build
 module:
 
 ```json title="package.json"
@@ -72,8 +71,8 @@ module:
 ### Using a subset of modules
 
 If you only need certain modules, you can install them individually instead of
-relying on `@backstage/cli-defaults`. The CLI will discover them through the
-same dependency scanning mechanism:
+relying on `@backstage/cli-defaults`. The CLI discovers them through the same
+dependency scanning mechanism:
 
 ```json title="package.json"
 {
@@ -92,7 +91,7 @@ In this example only the build, lint, and test commands would be available.
 
 You can add your own CLI modules alongside the defaults. Any package with
 `backstage.role` set to `"cli-module"` in its `package.json` that is listed as a
-dependency will be discovered automatically. See
+dependency is discovered automatically. See
 [Building Custom CLI Modules](./building-cli-modules.md) for a full guide.
 
 ## Architecture

--- a/docs/tooling/cli/building-cli-modules.md
+++ b/docs/tooling/cli/building-cli-modules.md
@@ -124,7 +124,7 @@ A short string shown in the help output next to the command name.
 ### Deprecated and experimental flags
 
 Commands can be marked with `deprecated: true` or `experimental: true`. These
-commands are hidden from the `--help` output but remain invocable.
+commands are hidden from the `--help` output but can still be used.
 
 ### Execute function
 

--- a/docs/tooling/cli/building-cli-modules.md
+++ b/docs/tooling/cli/building-cli-modules.md
@@ -11,7 +11,7 @@ in your project, the CLI discovers and loads it automatically.
 
 ## Scaffolding a New Module
 
-The quickest way to get started is to use the built-in template:
+To scaffold a module, use the built-in template:
 
 ```bash
 yarn new
@@ -174,7 +174,8 @@ The execute function receives a `CliCommandContext` with two fields:
   `backstage-cli greet --name World`, the `args` array would be
   `['--name', 'World']`.
 - **`info`** — An object with `usage` (the full command path as shown in help,
-  e.g. `"backstage-cli greet"`) and `name` (the command name, e.g. `"greet"`).
+  for example `"backstage-cli greet"`) and `name` (the command name, for
+  example `"greet"`).
 
 ## Parsing Flags
 

--- a/docs/tooling/cli/building-cli-modules.md
+++ b/docs/tooling/cli/building-cli-modules.md
@@ -9,7 +9,7 @@ modules. A CLI module is a package that registers one or more commands using the
 `createCliModule` API from `@backstage/cli-node`. Once installed as a dependency
 in your project, the CLI discovers and loads it automatically.
 
-## Scaffolding a New Module
+## Scaffolding a new module
 
 To scaffold a module, use the built-in template:
 
@@ -21,7 +21,7 @@ Select the `cli-module` template from the interactive menu. This creates a new
 package with the correct structure, including a sample command, a standalone bin
 script, and all the required configuration.
 
-## Module Structure
+## Module structure
 
 A CLI module package has the following structure:
 
@@ -102,7 +102,7 @@ The `init` callback runs when the module is loaded, not when a command is
 executed. Keep it lightweight and use the deferred loader pattern for commands
 with heavy dependencies.
 
-## Defining Commands
+## Defining commands
 
 Each command is defined by a `CliCommand` object passed to `reg.addCommand`:
 
@@ -176,7 +176,7 @@ export default async ({ args, info }: CliCommandContext) => {
 };
 ```
 
-## Command Context
+## Command context
 
 The execute function receives a `CliCommandContext` with two fields:
 
@@ -188,7 +188,7 @@ The execute function receives a `CliCommandContext` with two fields:
   for example `"backstage-cli greet"`) and `name` (the command name, for
   example `"greet"`).
 
-## Parsing Flags
+## Parsing flags
 
 Commands typically use [`cleye`](https://github.com/privatenumber/cleye) to
 parse flags from the `args` array. This is the same library used by all built-in
@@ -223,7 +223,7 @@ export default async ({ args, info }: CliCommandContext) => {
 };
 ```
 
-## Standalone Execution
+## Standalone execution
 
 Each CLI module can also run as a standalone program, without the full
 `@backstage/cli`. This is useful for distributing a module independently. The
@@ -253,7 +253,7 @@ script. When running from source during development, it registers a Node.js
 transform so TypeScript files can be loaded directly. When running from a
 published package, it loads the compiled output instead.
 
-## Installing Your Module
+## Installing your module
 
 Once your module is published or available as a workspace package, add it as a
 dependency in your project root's `package.json`:

--- a/docs/tooling/cli/building-cli-modules.md
+++ b/docs/tooling/cli/building-cli-modules.md
@@ -1,0 +1,257 @@
+---
+id: building-cli-modules
+title: Custom CLI Modules
+description: Guide to building custom CLI modules that extend the Backstage CLI.
+---
+
+You can extend the Backstage CLI with custom commands by creating your own CLI
+modules. A CLI module is a package that registers one or more commands using the
+`createCliModule` API from `@backstage/cli-node`. Once installed as a dependency
+in your project, the CLI discovers and loads it automatically.
+
+## Scaffolding a New Module
+
+The quickest way to get started is to use the built-in template:
+
+```bash
+yarn new
+```
+
+Select the `cli-module` template from the interactive menu. This creates a new
+package with the correct structure, including a sample command, a standalone bin
+script, and all the required configuration.
+
+## Module Structure
+
+A CLI module package has the following structure:
+
+```text
+packages/cli-module-example/
+  bin/
+    backstage-cli-module-example    # Standalone bin script
+  src/
+    commands/
+      example.ts                    # Command implementation
+    index.ts                        # Module definition
+  package.json
+```
+
+### package.json
+
+The `package.json` must set `backstage.role` to `"cli-module"`. This is how the
+CLI identifies the package as a module during dependency scanning.
+
+```json title="package.json"
+{
+  "name": "@mycompany/cli-module-example",
+  "version": "0.1.0",
+  "backstage": {
+    "role": "cli-module"
+  },
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "dependencies": {
+    "@backstage/cli-node": "...",
+    "cleye": "..."
+  }
+}
+```
+
+### Module definition
+
+The module entry point uses `createCliModule` to register commands:
+
+```ts title="src/index.ts"
+import { createCliModule } from '@backstage/cli-node';
+import packageJson from '../package.json';
+
+export default createCliModule({
+  packageJson,
+  init: async reg => {
+    reg.addCommand({
+      path: ['example'],
+      description: 'An example command',
+      execute: { loader: () => import('./commands/example') },
+    });
+  },
+});
+```
+
+## The `createCliModule` API
+
+The `createCliModule` function accepts an options object with two fields:
+
+- **`packageJson`** — An object with at least a `name` field, typically the
+  imported `package.json`. The name is used in error messages when command
+  conflicts occur.
+- **`init`** — An async callback that receives a registry object. Use the
+  registry's `addCommand` method to register commands.
+
+The `init` callback runs when the module is loaded, not when a command is
+executed. Keep it lightweight and use the deferred loader pattern for commands
+with heavy dependencies.
+
+## Defining Commands
+
+Each command is defined by a `CliCommand` object passed to `reg.addCommand`:
+
+```ts
+reg.addCommand({
+  path: ['my-tool', 'run'],
+  description: 'Run the tool',
+  execute: async ({ args, info }) => {
+    // Command implementation
+  },
+});
+```
+
+### Command path
+
+The `path` array defines how the command is invoked. Each element becomes a
+level in the command hierarchy:
+
+- `['info']` registers `backstage-cli info`
+- `['repo', 'test']` registers `backstage-cli repo test`
+- `['actions', 'sources', 'add']` registers `backstage-cli actions sources add`
+
+Intermediate nodes in the path are created automatically and appear as command
+groups in the help output.
+
+### Description
+
+A short string shown in the help output next to the command name.
+
+### Deprecated and experimental flags
+
+Commands can be marked with `deprecated: true` or `experimental: true`. These
+commands are hidden from the `--help` output but remain invocable.
+
+### Execute function
+
+The `execute` field supports two patterns:
+
+**Direct execution** — an inline async function:
+
+```ts
+reg.addCommand({
+  path: ['greet'],
+  description: 'Print a greeting',
+  execute: async ({ args, info }) => {
+    console.log('Hello!');
+  },
+});
+```
+
+**Deferred loading** — a loader that dynamically imports the command
+implementation. This is the recommended pattern because it avoids loading heavy
+dependencies until the command is actually invoked:
+
+```ts
+reg.addCommand({
+  path: ['greet'],
+  description: 'Print a greeting',
+  execute: { loader: () => import('./commands/greet') },
+});
+```
+
+When using the deferred loader pattern, the command file must export the execute
+function as its default export:
+
+```ts title="src/commands/greet.ts"
+import type { CliCommandContext } from '@backstage/cli-node';
+
+export default async ({ args, info }: CliCommandContext) => {
+  console.log('Hello!');
+};
+```
+
+## Command Context
+
+The execute function receives a `CliCommandContext` with two fields:
+
+- **`args`** — An array of the remaining command-line arguments after the
+  command path has been resolved. For example, if the user runs
+  `backstage-cli greet --name World`, the `args` array would be
+  `['--name', 'World']`.
+- **`info`** — An object with `usage` (the full command path as shown in help,
+  e.g. `"backstage-cli greet"`) and `name` (the command name, e.g. `"greet"`).
+
+## Parsing Flags
+
+Commands typically use [`cleye`](https://github.com/privatenumber/cleye) to
+parse flags from the `args` array. This is the same library used by all built-in
+CLI modules:
+
+```ts title="src/commands/greet.ts"
+import { cli } from 'cleye';
+import type { CliCommandContext } from '@backstage/cli-node';
+
+export default async ({ args, info }: CliCommandContext) => {
+  const { flags } = cli(
+    {
+      name: info.usage,
+      flags: {
+        name: {
+          type: String,
+          description: 'Name to greet',
+          default: 'World',
+        },
+        loud: {
+          type: Boolean,
+          description: 'Shout the greeting',
+        },
+      },
+    },
+    undefined,
+    args,
+  );
+
+  const greeting = `Hello, ${flags.name}!`;
+  console.log(flags.loud ? greeting.toUpperCase() : greeting);
+};
+```
+
+## Standalone Execution
+
+Each CLI module can also run as a standalone program, without the full
+`@backstage/cli`. This is useful for distributing a module independently. The
+scaffolded template includes a bin script that does this:
+
+```js title="bin/backstage-cli-module-example"
+#!/usr/bin/env node
+const { runCli } = require('@backstage/cli-node');
+const cliModule = require('../src').default;
+const pkg = require('../package.json');
+
+runCli({
+  modules: [cliModule],
+  name: pkg.name,
+  version: pkg.version,
+});
+```
+
+The `runCli` function builds a command tree from the provided modules and
+dispatches commands based on the process arguments. It also generates help
+output automatically.
+
+## Installing Your Module
+
+Once your module is published or available as a workspace package, add it as a
+dependency in your project root's `package.json`:
+
+```json title="package.json"
+{
+  "devDependencies": {
+    "@backstage/cli": "...",
+    "@mycompany/cli-module-example": "..."
+  }
+}
+```
+
+The CLI discovers it automatically on the next run. Your custom commands appear
+in the `--help` output alongside the default commands.
+
+If your module registers a command path that conflicts with a default module from
+`@backstage/cli-defaults`, your module takes precedence and the conflicting
+default module is silently skipped. See [CLI Modules](./05-modules.md) for more
+details on conflict resolution.

--- a/docs/tooling/cli/building-cli-modules.md
+++ b/docs/tooling/cli/building-cli-modules.md
@@ -45,14 +45,25 @@ CLI identifies the package as a module during dependency scanning.
 {
   "name": "@mycompany/cli-module-example",
   "version": "0.1.0",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "publishConfig": {
+    "access": "public",
+    "main": "dist/index.cjs.js",
+    "types": "dist/index.d.ts"
+  },
   "backstage": {
     "role": "cli-module"
   },
-  "main": "src/index.ts",
-  "types": "src/index.ts",
+  "bin": "bin/backstage-cli-module-example",
+  "files": ["dist", "bin"],
   "dependencies": {
+    "@backstage/cli-common": "...",
     "@backstage/cli-node": "...",
     "cleye": "..."
+  },
+  "devDependencies": {
+    "@backstage/cli": "..."
   }
 }
 ```
@@ -220,20 +231,27 @@ scaffolded template includes a bin script that does this:
 
 ```js title="bin/backstage-cli-module-example"
 #!/usr/bin/env node
-const { runCli } = require('@backstage/cli-node');
-const cliModule = require('../src').default;
-const pkg = require('../package.json');
+const path = require('node:path');
 
-runCli({
-  modules: [cliModule],
-  name: pkg.name,
-  version: pkg.version,
-});
+/* eslint-disable-next-line no-restricted-syntax */
+const isLocal = require('node:fs').existsSync(
+  path.resolve(__dirname, '../src'),
+);
+
+if (isLocal) {
+  require('@backstage/cli-node/config/nodeTransform.cjs');
+}
+
+const { runCli } = require('@backstage/cli-node');
+const cliModule = require(isLocal ? '../src/index' : '..').default;
+const pkg = require('../package.json');
+runCli({ modules: [cliModule], name: pkg.name, version: pkg.version });
 ```
 
-The `runCli` function builds a command tree from the provided modules and
-dispatches commands based on the process arguments. It also generates help
-output automatically.
+The `isLocal` check detects whether a `src/` directory exists next to the bin
+script. When running from source during development, it registers a Node.js
+transform so TypeScript files can be loaded directly. When running from a
+published package, it loads the compiled output instead.
 
 ## Installing Your Module
 

--- a/docs/tooling/cli/module-actions.md
+++ b/docs/tooling/cli/module-actions.md
@@ -4,9 +4,8 @@ title: Actions Module
 description: CLI commands for discovering and executing Backstage actions.
 ---
 
-The actions module (`@backstage/cli-module-actions`) provides commands for
-discovering and executing Backstage actions directly from the command line. This
-lets you interact with backend plugin actions without using the Backstage UI.
+The actions module (`@backstage/cli-module-actions`) lets you discover and run
+Backstage actions from the command line, without going through the Backstage UI.
 
 For a list of actions that Backstage plugins can expose, see the
 [Well-Known Actions](../../ai/well-known-actions.md) documentation.
@@ -17,7 +16,7 @@ Before using actions commands you must authenticate with a Backstage instance
 using [`auth login`](./module-auth.md#auth-login). Actions commands use the
 stored credentials to communicate with the backend.
 
-All actions commands operate against the currently selected instance by default.
+All actions commands operate against the selected instance by default.
 If you have multiple authenticated instances, use the `--instance` flag with the
 instance name to target a specific one. See
 [Instance Names](./module-auth.md#instance-names) for details on how instance
@@ -177,7 +176,7 @@ yarn backstage-cli actions sources remove scaffolder catalog
 
 ## Workflow Example
 
-Here is a typical workflow for using the actions module:
+A typical workflow looks like this:
 
 ```bash
 # 1. Log in to your Backstage instance

--- a/docs/tooling/cli/module-actions.md
+++ b/docs/tooling/cli/module-actions.md
@@ -1,0 +1,197 @@
+---
+id: module-actions
+title: Actions Module
+description: CLI commands for discovering and executing Backstage actions.
+---
+
+The actions module (`@backstage/cli-module-actions`) provides commands for
+discovering and executing Backstage actions directly from the command line. This
+lets you interact with backend plugin actions without using the Backstage UI.
+
+For a list of actions that Backstage plugins can expose, see the
+[Well-Known Actions](../../ai/well-known-actions.md) documentation.
+
+## Prerequisites
+
+Before using actions commands you must authenticate with a Backstage instance
+using [`auth login`](./module-auth.md#auth-login). Actions commands use the
+stored credentials to communicate with the backend.
+
+All actions commands operate against the currently selected instance by default.
+If you have multiple authenticated instances, use the `--instance` flag with the
+instance name to target a specific one. See
+[Instance Names](./module-auth.md#instance-names) for details on how instance
+names work.
+
+## Plugin Sources
+
+The actions module needs to know which backend plugins to discover actions from.
+These are called **plugin sources** and are stored as metadata on the
+authenticated instance. You manage plugin sources with the `actions sources`
+commands before listing or executing actions.
+
+## actions list
+
+List available actions from all configured plugin sources.
+
+```text
+Usage: backstage-cli actions list [options]
+
+List available actions from configured plugin sources
+
+Options:
+  --instance <name>    Instance name to use (defaults to the selected instance)
+```
+
+If no plugin sources are configured, the command prints a hint to add sources
+with `actions sources add`.
+
+### Examples
+
+List all available actions:
+
+```bash
+yarn backstage-cli actions list
+```
+
+List actions from a named instance:
+
+```bash
+yarn backstage-cli actions list --instance production
+```
+
+## actions execute
+
+Execute an action. The action ID follows the format `<pluginId>:<actionName>`.
+
+```text
+Usage: backstage-cli actions execute [options] <action-id>
+
+Execute an action
+
+Options:
+  --instance <name>    Instance name to use (defaults to the selected instance)
+```
+
+In addition to the `--instance` flag, the command dynamically generates flags
+from the action's input JSON Schema. Each property in the schema becomes a CLI
+flag with automatic type mapping:
+
+- `string` properties become `String` flags
+- `number` and `integer` properties become `Number` flags
+- `boolean` properties become `Boolean` flags
+- Complex types (objects, arrays, unions) become `String` flags that accept JSON
+  input
+
+Use `--help` with an action ID to see the full set of flags available for that
+action, including a rendered description.
+
+### Examples
+
+Show help for a specific action, including its dynamically generated flags:
+
+```bash
+yarn backstage-cli actions execute my-plugin:my-action --help
+```
+
+Execute an action with flags:
+
+```bash
+yarn backstage-cli actions execute my-plugin:create-resource --name my-resource --count 3
+```
+
+Pass complex input as a JSON string:
+
+```bash
+yarn backstage-cli actions execute my-plugin:configure --options '{"timeout": 30, "retries": 3}'
+```
+
+## actions sources add
+
+Add one or more plugin sources for action discovery. Plugin sources are stored as
+metadata on the authenticated instance.
+
+```text
+Usage: backstage-cli actions sources add <plugin-ids...>
+
+Add a plugin source for action discovery
+```
+
+If a plugin source is already configured, it is skipped with a warning.
+
+### Examples
+
+Add a single plugin source:
+
+```bash
+yarn backstage-cli actions sources add scaffolder
+```
+
+Add multiple plugin sources at once:
+
+```bash
+yarn backstage-cli actions sources add scaffolder catalog
+```
+
+## actions sources list
+
+List all configured plugin sources for the current instance.
+
+```text
+Usage: backstage-cli actions sources list
+
+List configured plugin sources
+```
+
+### Examples
+
+```bash
+yarn backstage-cli actions sources list
+```
+
+## actions sources remove
+
+Remove one or more plugin sources from the current instance.
+
+```text
+Usage: backstage-cli actions sources remove <plugin-ids...>
+
+Remove a plugin source
+```
+
+If a plugin source is not configured, it is skipped with a warning.
+
+### Examples
+
+Remove a single plugin source:
+
+```bash
+yarn backstage-cli actions sources remove scaffolder
+```
+
+Remove multiple plugin sources at once:
+
+```bash
+yarn backstage-cli actions sources remove scaffolder catalog
+```
+
+## Workflow Example
+
+Here is a typical workflow for using the actions module:
+
+```bash
+# 1. Log in to your Backstage instance
+yarn backstage-cli auth login --backendUrl https://backstage.example.com
+
+# 2. Add plugin sources to discover actions from
+yarn backstage-cli actions sources add scaffolder
+
+# 3. List available actions
+yarn backstage-cli actions list
+
+# 4. Get help for a specific action
+yarn backstage-cli actions execute scaffolder:create-component --help
+
+# 5. Execute the action
+yarn backstage-cli actions execute scaffolder:create-component --name my-service --owner team-a
+```

--- a/docs/tooling/cli/module-actions.md
+++ b/docs/tooling/cli/module-actions.md
@@ -22,7 +22,7 @@ instance name to target a specific one. See
 [Instance Names](./module-auth.md#instance-names) for details on how instance
 names work.
 
-## Plugin Sources
+## Plugin sources
 
 The actions module needs to know which backend plugins to discover actions from.
 These are called **plugin sources** and are stored as metadata on the
@@ -174,7 +174,7 @@ Remove multiple plugin sources at once:
 yarn backstage-cli actions sources remove scaffolder catalog
 ```
 
-## Workflow Example
+## Workflow example
 
 A typical workflow looks like this:
 

--- a/docs/tooling/cli/module-auth.md
+++ b/docs/tooling/cli/module-auth.md
@@ -1,0 +1,241 @@
+---
+id: module-auth
+title: Auth Module
+description: CLI commands for authenticating with Backstage instances.
+---
+
+The auth module (`@backstage/cli-module-auth`) provides commands for
+authenticating the CLI with Backstage instances. It uses OAuth 2.0 with PKCE to
+securely obtain and manage access tokens, which are then used by other CLI
+commands such as [actions](./module-actions.md).
+
+## Prerequisites
+
+The Backstage instance you are connecting to must have CLI authentication
+support enabled. The CLI checks for this by fetching the OAuth client metadata
+from the instance's well-known endpoint at
+`/api/auth/.well-known/oauth-client/cli.json`.
+
+## Instance Names
+
+Each authenticated Backstage instance is stored under a name that you choose.
+This name is a short label used to refer to the instance in other commands (for
+example `--instance production`). If you do not provide a name when logging in,
+the CLI derives one from the backend URL's hostname (for example
+`backstage.example.com`).
+
+## auth login
+
+Log in the CLI to a Backstage instance. This starts an OAuth authorization flow
+that opens your browser to authenticate and then stores the resulting credentials
+locally.
+
+```text
+Usage: backstage-cli auth login [options]
+
+Log in the CLI to a Backstage instance
+
+Options:
+  --backendUrl <url>   Backend base URL
+  --noBrowser          Do not open browser automatically
+  --instance <name>    A short name for this instance, used to refer to it in
+                       other auth commands. Defaults to the backend URL hostname.
+```
+
+When run without any flags the command prompts you interactively. It scans local
+`app-config.yaml` files to discover backend URLs, lets you pick one or enter a
+URL manually, and derives an instance name from the URL host.
+
+If `--noBrowser` is set, the authorization URL is printed to the terminal so you
+can open it manually.
+
+### Examples
+
+Log in interactively:
+
+```bash
+yarn backstage-cli auth login
+```
+
+Log in to a specific backend URL:
+
+```bash
+yarn backstage-cli auth login --backendUrl https://backstage.example.com
+```
+
+Log in and name the instance for later reference:
+
+```bash
+yarn backstage-cli auth login --backendUrl https://backstage.example.com --instance production
+```
+
+Log in without automatically opening a browser:
+
+```bash
+yarn backstage-cli auth login --backendUrl https://backstage.example.com --noBrowser
+```
+
+## auth logout
+
+Log out of a Backstage instance and clear stored credentials. The command
+revokes the refresh token with the server (best-effort) and removes both tokens
+and instance metadata from local storage.
+
+```text
+Usage: backstage-cli auth logout [options]
+
+Log out the CLI and clear stored credentials
+
+Options:
+  --instance <name>    Name of the instance to log out
+```
+
+If `--instance` is not provided, an interactive prompt lets you pick from the
+list of authenticated instances.
+
+### Examples
+
+Log out of a specific instance:
+
+```bash
+yarn backstage-cli auth logout --instance production
+```
+
+Log out interactively:
+
+```bash
+yarn backstage-cli auth logout
+```
+
+## auth show
+
+Show details of an authenticated instance, including the current user identity
+and ownership entity references.
+
+```text
+Usage: backstage-cli auth show [options]
+
+Show details of an authenticated instance
+
+Options:
+  --instance <name>    Name of the instance to show
+```
+
+The command fetches user information from the instance's `/api/auth/v1/userinfo`
+endpoint, automatically refreshing the access token if needed.
+
+### Examples
+
+Show details for the default instance:
+
+```bash
+yarn backstage-cli auth show
+```
+
+Show details for a named instance:
+
+```bash
+yarn backstage-cli auth show --instance production
+```
+
+## auth list
+
+List all authenticated instances. The currently selected default instance is
+marked with an asterisk (`*`).
+
+```text
+Usage: backstage-cli auth list
+
+List authenticated instances
+```
+
+### Examples
+
+```bash
+yarn backstage-cli auth list
+```
+
+Example output:
+
+```text
+* production - https://backstage.example.com
+  staging - https://backstage-staging.example.com
+```
+
+## auth print-token
+
+Print an access token to stdout. If the token has expired or is about to expire,
+it is refreshed automatically before printing. This command is designed for use
+in scripts and pipelines.
+
+```text
+Usage: backstage-cli auth print-token [options]
+
+Print an access token to stdout (auto-refresh if needed)
+
+Options:
+  --instance <name>    Name of the instance to use
+```
+
+### Examples
+
+Print the access token for the default instance:
+
+```bash
+yarn backstage-cli auth print-token
+```
+
+Use the token in a curl command:
+
+```bash
+curl -H "Authorization: Bearer $(yarn backstage-cli auth print-token)" \
+  https://backstage.example.com/api/catalog/entities
+```
+
+Print the token for a named instance:
+
+```bash
+yarn backstage-cli auth print-token --instance staging
+```
+
+## auth select
+
+Select the default instance. Other auth commands use the default instance when
+no `--instance` flag is provided.
+
+```text
+Usage: backstage-cli auth select [options]
+
+Select the default instance
+
+Options:
+  --instance <name>    Name of the instance to select
+```
+
+If `--instance` is not provided, an interactive prompt lets you pick from the
+list of authenticated instances.
+
+### Examples
+
+Select a specific instance as the default:
+
+```bash
+yarn backstage-cli auth select --instance production
+```
+
+Select interactively:
+
+```bash
+yarn backstage-cli auth select
+```
+
+## Instance Storage
+
+Authentication state is stored in two places:
+
+- **Instance metadata** is stored in a YAML file at
+  `~/.config/backstage-cli/auth-instances.yaml` (or the platform-appropriate
+  equivalent using the XDG config directory). This file contains instance names,
+  backend URLs, token expiration timestamps, and which instance is selected.
+- **Tokens** (access tokens and refresh tokens) are stored in the system secret
+  store, separate from the YAML file.

--- a/docs/tooling/cli/module-auth.md
+++ b/docs/tooling/cli/module-auth.md
@@ -16,7 +16,7 @@ support enabled. The CLI checks for this by fetching the OAuth client metadata
 from the instance's well-known endpoint at
 `/api/auth/.well-known/oauth-client/cli.json`.
 
-## Instance Names
+## Instance names
 
 Each authenticated Backstage instance is stored under a name that you choose.
 This name is a short label used to refer to the instance in other commands (for
@@ -229,7 +229,7 @@ Select interactively:
 yarn backstage-cli auth select
 ```
 
-## Instance Storage
+## Instance storage
 
 Authentication state is stored in two places:
 

--- a/docs/tooling/cli/module-auth.md
+++ b/docs/tooling/cli/module-auth.md
@@ -6,8 +6,8 @@ description: CLI commands for authenticating with Backstage instances.
 
 The auth module (`@backstage/cli-module-auth`) provides commands for
 authenticating the CLI with Backstage instances. It uses OAuth 2.0 with PKCE to
-securely obtain and manage access tokens, which are then used by other CLI
-commands such as [actions](./module-actions.md).
+obtain access tokens, which are then used by other CLI commands such as
+[actions](./module-actions.md).
 
 ## Prerequisites
 
@@ -122,7 +122,7 @@ Options:
 ```
 
 The command fetches user information from the instance's `/api/auth/v1/userinfo`
-endpoint, automatically refreshing the access token if needed.
+endpoint and refreshes the access token if needed.
 
 ### Examples
 
@@ -140,8 +140,8 @@ yarn backstage-cli auth show --instance production
 
 ## auth list
 
-List all authenticated instances. The currently selected default instance is
-marked with an asterisk (`*`).
+List all authenticated instances. The selected default instance is marked with
+an asterisk (`*`).
 
 ```text
 Usage: backstage-cli auth list
@@ -165,8 +165,8 @@ Example output:
 ## auth print-token
 
 Print an access token to stdout. If the token has expired or is about to expire,
-it is refreshed automatically before printing. This command is designed for use
-in scripts and pipelines.
+it is refreshed automatically before printing. Useful for scripting and
+pipelines.
 
 ```text
 Usage: backstage-cli auth print-token [options]

--- a/docs/tooling/cli/module-build.md
+++ b/docs/tooling/cli/module-build.md
@@ -4,11 +4,10 @@ title: Build Module
 description: CLI commands for building, starting, and packaging Backstage packages.
 ---
 
-The build module (`@backstage/cli-module-build`) provides commands for building,
-starting, and packaging Backstage packages. It covers both individual package
-operations and repo-wide builds.
+The build module (`@backstage/cli-module-build`) handles building, starting,
+and packaging Backstage packages, both individually and across the repo.
 
-For a deeper understanding of the underlying build system, see the
+For details on the build system itself, see the
 [Build System](./02-build-system.md) documentation.
 
 ## repo start
@@ -48,8 +47,8 @@ Options:
 
 ## repo build
 
-Builds all packages in the project, excluding bundled packages by default, i.e.
-ones with the role `'frontend'` or `'backend'`.
+Builds all packages in the project, excluding bundled packages by default, that
+is, ones with the role `'frontend'` or `'backend'`.
 
 ```text
 Usage: backstage-cli repo build [options]

--- a/docs/tooling/cli/module-build.md
+++ b/docs/tooling/cli/module-build.md
@@ -241,7 +241,7 @@ The bundle command supports packages with the following roles:
 
 ## package clean
 
-Remove cache and output directories.
+Remove cache directories.
 
 ```text
 Usage: backstage-cli package clean [options]
@@ -252,7 +252,7 @@ Delete cache directories
 ## package prepack
 
 This command should be added as `scripts.prepack` in all packages. It enables
-packaging- and publish-time overrides for fields inside `packages.json`. For
+packaging- and publish-time overrides for fields inside `package.json`. For
 more details, see the build system
 [publishing](./02-build-system.md#publishing) section.
 

--- a/docs/tooling/cli/module-build.md
+++ b/docs/tooling/cli/module-build.md
@@ -1,0 +1,293 @@
+---
+id: module-build
+title: Build Module
+description: CLI commands for building, starting, and packaging Backstage packages.
+---
+
+The build module (`@backstage/cli-module-build`) provides commands for building,
+starting, and packaging Backstage packages. It covers both individual package
+operations and repo-wide builds.
+
+For a deeper understanding of the underlying build system, see the
+[Build System](./02-build-system.md) documentation.
+
+## repo start
+
+Start a set of packages in the project for local development. If no explicit
+packages are listed via arguments or options, packages will instead be selected
+based on their [package role](./02-build-system.md#package-roles). If a single
+set of frontend and/or backend packages are found, they will be started. If
+there are multiple matches the directories `packages/app` and
+`packages/backend` will be preferred. If no matches are found the command will
+fall back to expecting a single plugin frontend and/or backend package to start
+instead.
+
+Any `--config` options in the `start` script in `package.json` of the selected
+packages will be picked up and used, unless a `--config` option is provided to
+this command, in which case it will be used instead.
+
+Any `--require` option in the `start` script in `package.json` of the selected
+backend package will be picked up and used.
+
+```text
+Usage: backstage-cli repo start [options] [packageNameOrPath...]
+
+Starts packages in the repo for local development
+
+Arguments:
+  packageNameOrPath     Run the specified packages instead of the defaults.
+
+Options:
+  --plugin <pluginId>   Start the dev entry-point for any matching plugin package in the repo (default: [])
+  --config <path>       Config files to load instead of app-config.yaml (default: [])
+  --inspect [host]      Enable debugger in Node.js environments. Applies to backend package only
+  --inspect-brk [host]  Enable debugger in Node.js environments, breaking before code starts. Applies to backend package only
+  --require <path...>   Add a --require argument to the node process. Applies to backend package only
+  --link <path>         Link an external workspace for module resolution
+```
+
+## repo build
+
+Builds all packages in the project, excluding bundled packages by default, i.e.
+ones with the role `'frontend'` or `'backend'`.
+
+```text
+Usage: backstage-cli repo build [options]
+
+Build packages in the project, excluding bundled app and backend packages.
+
+Options:
+  --all          Build all packages, including bundled app and backend packages.
+  --since <ref>  Only build packages and their dev dependents that changed since the specified ref
+```
+
+## repo clean
+
+Remove cache and output directories across all packages in the project.
+
+```text
+Usage: backstage-cli repo clean [options]
+
+Delete cache and output directories
+```
+
+## package start
+
+Starts the package for local development. See the frontend and backend
+development parts in the build system
+[bundling](./02-build-system.md#bundling) section for more details.
+
+```text
+Usage: backstage-cli package start [options]
+
+Start a package for local development
+
+Options:
+  --config <path>     Config files to load instead of app-config.yaml (default: [])
+  --role <name>       Run the command with an explicit package role
+  --check             Enable type checking and linting if available
+  --inspect           Enable debugger in Node.js environments
+  --inspect-brk       Enable debugger in Node.js environments, breaking before code starts
+  --entrypoint <path> Entry directory path (uses index file) or entry file path (without extension). Defaults to "dev"
+```
+
+## package build
+
+Build an individual package based on its role. See the build system
+[building](./02-build-system.md#building) and
+[bundling](./02-build-system.md#bundling) sections for more details.
+
+```text
+Usage: backstage-cli package build [options]
+
+Build a package for production deployment or publishing
+
+Options:
+  --role <name>              Run the command with an explicit package role
+  --minify                   Minify the generated code. Does not apply to app package (app is minified by default).
+  --skip-build-dependencies  Skip the automatic building of local dependencies. Applies to backend packages only.
+  --stats                    If bundle stats are available, write them to the output directory. Applies to app packages only.
+  --config <path>            Config files to load instead of app-config.yaml. Applies to app packages only. (default: [])
+  --module-federation        Build a package as a module federation remote. Applies to frontend plugin packages only.
+```
+
+## package bundle
+
+:::caution Experimental
+This command is experimental and may receive breaking changes in future releases
+without a deprecation period. It is hidden from the main `--help` output.
+:::
+
+Bundle a plugin for dynamic loading. This creates a self-contained plugin
+package that can be deployed independently and loaded dynamically by a Backstage
+application. Supports both backend and frontend plugins.
+
+Unlike regular builds, the bundle command:
+
+- Creates a fully self-contained plugin deliverable
+
+- Produces module federation assets (frontend) or includes plugin dependencies
+  in the plugin's private `node_modules`, building and packing (with
+  `yarn pack`) the local `workspace:^` dependencies first (backend).
+- Generates a config schema from plugin-related packages only.
+- Validates that the plugin exports valid dynamic loading entry points (backend
+  only)
+
+### Usage
+
+```bash
+# Bundle the current package (output: ./bundle/)
+yarn backstage-cli package bundle
+
+# Bundle to a specific directory (output: ../dynamic-plugins/<mangled-package-name>/)
+yarn backstage-cli package bundle --output-destination ../dynamic-plugins
+
+# Override the bundle subdirectory name
+yarn backstage-cli package bundle --output-name my-plugin-bundle
+
+# Clean output before bundling
+yarn backstage-cli package bundle --clean
+
+# Skip building for the plugin and its local dependencies
+yarn backstage-cli package bundle --no-build
+
+# Skip dependency installation and entrypoint validation
+yarn backstage-cli package bundle --no-install
+
+# Stream detailed output from build, pack, and install steps
+yarn backstage-cli package bundle --verbose
+
+# Use a pre-built dist workspace for batch bundling.
+# First, create the workspace with:
+#   backstage-cli build-workspace <output-dir> [packages...] --alwaysPack
+# Then pass <output-dir> as --pre-packed-dir:
+yarn backstage-cli package bundle --pre-packed-dir ../dist-workspace
+```
+
+### Options
+
+```text
+Usage: backstage-cli package bundle [options]
+
+Bundle a plugin for dynamic loading
+
+Options:
+  --output-destination <dir>  Directory in which the bundle subdirectory is created.
+                              Defaults to the current package directory.
+  --output-name <name>        Name of the bundle subdirectory. Defaults to "bundle" when
+                              output stays in the package directory, or to the mangled
+                              package name (e.g. myorg-plugin-foo) when
+                              --output-destination is specified.
+  --clean                     Clean the output directory before bundling
+  --no-build                  Skip building packages (assumes they are already built)
+  --no-install                Skip dependency installation and entrypoint validation.
+  --verbose                   Stream detailed output from internal steps (build, pack,
+                              install) to the console. Without this flag, output is
+                              captured to per-step log files and only shown on error.
+  --pre-packed-dir <dir>      Path to a pre-built dist workspace (from
+                              build-workspace --alwaysPack). Skips local dependency
+                              packing and uses pre-packed packages directly. For frontend
+                              plugins, this also enables yarn.lock generation for SBOM.
+```
+
+### Output Contract
+
+The bundle output is a directory that can be deployed as a standalone unit.
+Consumers of the bundle (such as `@backstage/backend-dynamic-feature-service`
+or `@backstage/frontend-dynamic-feature-loader`) can rely on the following
+guarantees:
+
+**All bundles:**
+
+- A `package.json` at the bundle root with entry points configured for dynamic
+  loading. The `backstage.role` and `files` fields are preserved from the source
+  package.
+- A `dist/` directory containing the built plugin code.
+- A `dist/.config-schema.json` file (when any config schemas apply) containing
+  gathered schemas from the plugin, its local workspace dependencies, and
+  third-party dependencies. Schemas from unrelated Backstage packages are
+  excluded.
+- No `scripts` or `devDependencies` in `package.json`.
+
+**Backend plugins** (`backend-plugin`, `backend-plugin-module`):
+
+- A `node_modules/` directory with all production dependencies (including local
+  workspace dependencies), pinned to their exact versions from the source
+  lockfile.
+- `bundleDependencies` is set to `true` in `package.json`.
+
+**Frontend plugins** (`frontend-plugin`, `frontend-plugin-module`):
+
+- `main` points to `dist/remoteEntry.js` (the Module Federation remote entry).
+- `types` points to `dist/@mf-types/index.d.ts` when type declarations are
+  available.
+- No embedded `node_modules/` directory.
+
+### Environment Variables
+
+The bundle command supports the same environment variables as the Backstage yarn
+plugin for resolving `backstage:^` version specifiers:
+
+- `BACKSTAGE_MANIFEST_FILE`: Path to a local manifest file (for offline usage)
+- `BACKSTAGE_VERSIONS_BASE_URL`: Custom base URL for fetching release manifests
+
+### Supported Package Roles
+
+The bundle command supports packages with the following roles:
+
+- `backend-plugin`
+- `backend-plugin-module`
+- `frontend-plugin`
+- `frontend-plugin-module`
+
+## package clean
+
+Remove cache and output directories.
+
+```text
+Usage: backstage-cli package clean [options]
+
+Delete cache directories
+```
+
+## package prepack
+
+This command should be added as `scripts.prepack` in all packages. It enables
+packaging- and publish-time overrides for fields inside `packages.json`. For
+more details, see the build system
+[publishing](./02-build-system.md#publishing) section.
+
+```text
+Usage: backstage-cli package prepack [options]
+
+Prepares a package for packaging before publishing
+```
+
+## package postpack
+
+This should be added as `scripts.postpack` in all packages. It restores
+`package.json` to what it looked like before calling the `prepack` command.
+
+```text
+Usage: backstage-cli package postpack [options]
+
+Restores the changes made by the prepack command
+```
+
+## build-workspace
+
+Builds a mirror of the workspace using the packaged production version of each
+package. This essentially calls `yarn pack` in each included package and unpacks
+the resulting archive in the target `workspace-dir`.
+
+```text
+Usage: backstage-cli build-workspace [options] <workspace-dir> [packages...]
+
+Options:
+  --alwaysPack  Force workspace output to be a result of running `yarn pack` on
+                each package (warning: very slow)
+```
+
+When `--alwaysPack` is used, the output directory can be passed to
+`backstage-cli package bundle --pre-packed-dir` to speed up batch bundling of
+multiple plugins from the same monorepo.

--- a/docs/tooling/cli/module-build.md
+++ b/docs/tooling/cli/module-build.md
@@ -191,7 +191,7 @@ Options:
                               plugins, this also enables yarn.lock generation for SBOM.
 ```
 
-### Output Contract
+### Output contract
 
 The bundle output is a directory that can be deployed as a standalone unit.
 Consumers of the bundle (such as `@backstage/backend-dynamic-feature-service`
@@ -224,7 +224,7 @@ guarantees:
   available.
 - No embedded `node_modules/` directory.
 
-### Environment Variables
+### Environment variables
 
 The bundle command supports the same environment variables as the Backstage yarn
 plugin for resolving `backstage:^` version specifiers:
@@ -232,7 +232,7 @@ plugin for resolving `backstage:^` version specifiers:
 - `BACKSTAGE_MANIFEST_FILE`: Path to a local manifest file (for offline usage)
 - `BACKSTAGE_VERSIONS_BASE_URL`: Custom base URL for fetching release manifests
 
-### Supported Package Roles
+### Supported package roles
 
 The bundle command supports packages with the following roles:
 

--- a/docs/tooling/cli/module-build.md
+++ b/docs/tooling/cli/module-build.md
@@ -41,7 +41,7 @@ Options:
   --config <path>       Config files to load instead of app-config.yaml (default: [])
   --inspect [host]      Enable debugger in Node.js environments. Applies to backend package only
   --inspect-brk [host]  Enable debugger in Node.js environments, breaking before code starts. Applies to backend package only
-  --require <path...>   Add a --require argument to the node process. Applies to backend package only
+  --require <path>      Add a --require argument to the node process. Applies to backend package only
   --link <path>         Link an external workspace for module resolution
 ```
 
@@ -85,9 +85,11 @@ Options:
   --config <path>     Config files to load instead of app-config.yaml (default: [])
   --role <name>       Run the command with an explicit package role
   --check             Enable type checking and linting if available
-  --inspect           Enable debugger in Node.js environments
-  --inspect-brk       Enable debugger in Node.js environments, breaking before code starts
+  --require <path>    Add a --require argument to the node process
+  --link <path>       Link an external workspace for module resolution
   --entrypoint <path> Entry directory path (uses index file) or entry file path (without extension). Defaults to "dev"
+  --inspect [host]    Enable the Node.js inspector, optionally at a specific host:port
+  --inspect-brk [host] Enable the Node.js inspector and break before user code starts
 ```
 
 ## package build

--- a/docs/tooling/cli/module-config.md
+++ b/docs/tooling/cli/module-config.md
@@ -1,0 +1,91 @@
+---
+id: module-config
+title: Config Module
+description: CLI commands for inspecting and validating Backstage configuration.
+---
+
+The config module (`@backstage/cli-module-config`) provides commands for
+inspecting, printing, and validating the Backstage configuration schema and
+resolved values.
+
+## config\:docs
+
+This command opens up the reference documentation of your app's local
+configuration schema in the browser. This is useful to get an overview of what
+configuration values are available to use, a description of what they do and
+their format, and where they get sent.
+
+```text
+Usage: backstage-cli config:docs [options]
+
+Browse the configuration reference documentation
+
+Options:
+  --package <name>  Only include the schema that applies to the given package
+  -h, --help        display help for command
+```
+
+## config\:print
+
+Print the static configuration, defaulting to reading `app-config.yaml` in the
+repo root, using schema collected from all local packages in the repo.
+
+For example, to validate that a given configuration value is visible in the
+frontend when building the `my-app` package, you can use the following:
+
+```bash
+yarn backstage-cli config:print --frontend --package my-app
+```
+
+```text
+Usage: backstage-cli config:print [options]
+
+Options:
+  --package <name>   Only load config schema that applies to the given package
+  --lax              Do not require environment variables to be set
+  --frontend         Print only the frontend configuration
+  --with-secrets     Include secrets in the printed configuration
+  --format <format>  Format to print the configuration in, either json or yaml [yaml]
+  --config <path>    Config files to load instead of app-config.yaml (default: [])
+  -h, --help         display help for command
+```
+
+## config\:check
+
+Validate that static configuration loads and matches schema, defaulting to
+reading `app-config.yaml` in the repo root and using schema collected from all
+local packages in the repo.
+
+```text
+Usage: backstage-cli config:check [options]
+
+Options:
+  --package <name>  Only load config schema that applies to the given package
+  --lax             Do not require environment variables to be set
+  --frontend        Only validate the frontend configuration
+  --deprecated      Output deprecated configuration settings
+  --strict          Ensure that the provided config(s) has no errors and does not contain keys not in the schema.
+  --config <path>   Config files to load instead of app-config.yaml (default: [])
+  -h, --help        display help for command
+```
+
+## config\:schema
+
+Dump the configuration schema that was collected from all local packages in the
+repo.
+
+:::note
+When run by `yarn`, supply the yarn option `--silent` if you are using the
+output in a command line pipe to avoid non-schema output in the pipeline.
+:::
+
+```text
+Usage: backstage-cli config:schema [options]
+
+Print configuration schema
+
+Options:
+  --package <name>   Only output config schema that applies to the given package
+  --format <format>  Format to print the schema in, either json or yaml [yaml]
+  -h, --help         display help for command
+```

--- a/docs/tooling/cli/module-config.md
+++ b/docs/tooling/cli/module-config.md
@@ -10,10 +10,9 @@ resolved values.
 
 ## config\:docs
 
-This command opens up the reference documentation of your app's local
-configuration schema in the browser. This is useful to get an overview of what
-configuration values are available to use, a description of what they do and
-their format, and where they get sent.
+Opens the reference documentation of your app's local configuration schema in
+the browser. Use it to see what configuration values are available, what they
+do, and where they get sent.
 
 ```text
 Usage: backstage-cli config:docs [options]

--- a/docs/tooling/cli/module-github.md
+++ b/docs/tooling/cli/module-github.md
@@ -1,0 +1,22 @@
+---
+id: module-github
+title: GitHub Module
+description: CLI command for creating GitHub Apps for Backstage integration.
+---
+
+The GitHub module (`@backstage/cli-module-github`) provides a command for
+creating GitHub Apps in your organization, as an alternative to token-based
+GitHub integration.
+
+## create-github-app
+
+Creates a GitHub App in your GitHub organization. This is an alternative to
+token-based [GitHub integration](../../integrations/github/locations.md). See
+[GitHub Apps for Backstage Authentication](../../integrations/github/github-apps.md).
+
+Launches a browser to create the App through GitHub and saves the result as a
+YAML file that can be referenced in the GitHub integration configuration.
+
+```text
+Usage: backstage-cli create-github-app <github-org>
+```

--- a/docs/tooling/cli/module-info.md
+++ b/docs/tooling/cli/module-info.md
@@ -60,7 +60,7 @@ Combine options to include custom packages and export to JSON:
 yarn backstage-cli info --include "@mycompany/backstage-*" --include "@internal/*" --format json > debug-info.json
 ```
 
-### JSON Output Format
+### JSON output format
 
 When using `--format json`, the output is structured as follows:
 

--- a/docs/tooling/cli/module-info.md
+++ b/docs/tooling/cli/module-info.md
@@ -1,0 +1,84 @@
+---
+id: module-info
+title: Info Module
+description: CLI command for displaying environment and dependency information.
+---
+
+The info module (`@backstage/cli-module-info`) provides a command for outputting
+debug information about your Backstage setup, useful when opening issues or
+troubleshooting.
+
+## info
+
+Outputs debug information which is useful when opening an issue. Outputs system
+information, Node.js and npm versions, CLI version and type (inside Backstage
+repo or a created app), all `@backstage/*` package dependency versions, and any
+packages that contain a `backstage` field in their `package.json`.
+
+The command distinguishes between installed packages (from npm) and local
+workspace packages, making it easier to understand your Backstage setup.
+
+```text
+Usage: backstage-cli info [options]
+
+Options:
+  --include <patterns...>  Glob patterns for additional packages to include
+                           (e.g., @mycompany/backstage-*)
+  --format <text|json>     Output format (default: text)
+  -h, --help               display help for command
+```
+
+### Examples
+
+Output debug information to the console:
+
+```bash
+yarn backstage-cli info
+```
+
+Include additional packages matching a glob pattern:
+
+```bash
+yarn backstage-cli info --include "@mycompany/*"
+```
+
+Output as JSON:
+
+```bash
+yarn backstage-cli info --format json
+```
+
+Export JSON to a file for further processing:
+
+```bash
+yarn backstage-cli info --format json > backstage-info.json
+```
+
+Combine options to include custom packages and export to JSON:
+
+```bash
+yarn backstage-cli info --include "@mycompany/backstage-*" --include "@internal/*" --format json > debug-info.json
+```
+
+### JSON Output Format
+
+When using `--format json`, the output is structured as follows:
+
+```json
+{
+  "system": {
+    "os": "Darwin 23.0.0 - darwin/arm64",
+    "node": "v18.17.0",
+    "yarn": "3.6.0",
+    "cli": { "version": "0.27.0", "local": false },
+    "backstage": "1.20.0"
+  },
+  "dependencies": {
+    "@backstage/core-plugin-api": "1.8.0",
+    "@backstage/plugin-catalog": "1.15.0"
+  },
+  "local": {
+    "@mycompany/backstage-plugin-custom": "0.1.0"
+  }
+}
+```

--- a/docs/tooling/cli/module-lint.md
+++ b/docs/tooling/cli/module-lint.md
@@ -4,10 +4,9 @@ title: Lint Module
 description: CLI commands for linting Backstage packages.
 ---
 
-The lint module (`@backstage/cli-module-lint`) provides commands for linting
-individual packages and entire repositories. For more information on the
-linting setup, see the build system [linting](./02-build-system.md#linting)
-section.
+The lint module (`@backstage/cli-module-lint`) runs linting on individual
+packages or across the entire repository. For more on the linting setup, see
+the build system [linting](./02-build-system.md#linting) section.
 
 ## package lint
 

--- a/docs/tooling/cli/module-lint.md
+++ b/docs/tooling/cli/module-lint.md
@@ -1,0 +1,44 @@
+---
+id: module-lint
+title: Lint Module
+description: CLI commands for linting Backstage packages.
+---
+
+The lint module (`@backstage/cli-module-lint`) provides commands for linting
+individual packages and entire repositories. For more information on the
+linting setup, see the build system [linting](./02-build-system.md#linting)
+section.
+
+## package lint
+
+Lint a package. In addition to the default `eslint` behavior, this command will
+include TypeScript files, treat warnings as errors, and default to linting the
+entire directory if no specific files are listed.
+
+```text
+Usage: backstage-cli package lint [options]
+
+Lint a package
+
+Options:
+  --format <format>        Lint report output format (default: "eslint-formatter-friendly")
+  --fix                    Attempt to automatically fix violations
+  --max-warnings <number>  Fail if more than this number of warnings. -1 allows warnings. (default: -1)
+```
+
+## repo lint
+
+Lint all packages in the project.
+
+```text
+Usage: backstage-cli repo lint [options]
+
+Lint all packages in the project
+
+Options:
+  --format <format>           Lint report output format (default: "eslint-formatter-friendly")
+  --since <ref>               Only lint packages that changed since the specified ref
+  --success-cache             Enable success caching, which skips running lint for unchanged packages that were successful in the previous run
+  --success-cache-dir <path>  Set the success cache location, (default: node_modules/.cache/backstage-cli)
+  --fix                       Attempt to automatically fix violations
+```

--- a/docs/tooling/cli/module-maintenance.md
+++ b/docs/tooling/cli/module-maintenance.md
@@ -1,0 +1,32 @@
+---
+id: module-maintenance
+title: Maintenance Module
+description: CLI commands for repository maintenance and deprecation tracking.
+---
+
+The maintenance module (`@backstage/cli-module-maintenance`) provides commands
+for automatically fixing common issues in packages and tracking deprecations
+across the project.
+
+## repo fix
+
+Automatically fix packages in the project. This command scans all packages and
+applies automated fixes for common issues such as missing or incorrect
+configuration.
+
+```text
+Usage: backstage-cli repo fix [options]
+
+Automatically fix packages in the project
+```
+
+## repo list-deprecations
+
+List deprecations found across all packages in the project. This is useful for
+tracking usage of deprecated APIs and planning migration work.
+
+```text
+Usage: backstage-cli repo list-deprecations [options]
+
+List deprecations
+```

--- a/docs/tooling/cli/module-maintenance.md
+++ b/docs/tooling/cli/module-maintenance.md
@@ -4,9 +4,8 @@ title: Maintenance Module
 description: CLI commands for repository maintenance and deprecation tracking.
 ---
 
-The maintenance module (`@backstage/cli-module-maintenance`) provides commands
-for automatically fixing common issues in packages and tracking deprecations
-across the project.
+The maintenance module (`@backstage/cli-module-maintenance`) fixes common
+package issues and tracks deprecations across the project.
 
 ## repo fix
 
@@ -22,8 +21,8 @@ Automatically fix packages in the project
 
 ## repo list-deprecations
 
-List deprecations found across all packages in the project. This is useful for
-tracking usage of deprecated APIs and planning migration work.
+List deprecations found across all packages in the project. Use the output to
+track deprecated API usage and plan migration work.
 
 ```text
 Usage: backstage-cli repo list-deprecations [options]

--- a/docs/tooling/cli/module-migrate.md
+++ b/docs/tooling/cli/module-migrate.md
@@ -4,15 +4,14 @@ title: Migrate Module
 description: CLI commands for version management and package migrations.
 ---
 
-The migrate module (`@backstage/cli-module-migrate`) provides commands for
-bumping Backstage package versions, migrating moved packages, and running
-various package migration utilities.
+The migrate module (`@backstage/cli-module-migrate`) bumps Backstage package
+versions, migrates moved packages, and runs package migration utilities.
 
 ## versions\:bump
 
 Bump all `@backstage` packages to the latest versions. This checks for updates
-in the package registry, and will update entries in `package.json` files when
-necessary. See more about how this command can be configured and used
+in the package registry and updates `package.json` files when necessary. See
+more about how this command can be configured and used
 [for keeping Backstage updated](../../getting-started/keeping-backstage-updated.md).
 
 ```text

--- a/docs/tooling/cli/module-migrate.md
+++ b/docs/tooling/cli/module-migrate.md
@@ -1,0 +1,103 @@
+---
+id: module-migrate
+title: Migrate Module
+description: CLI commands for version management and package migrations.
+---
+
+The migrate module (`@backstage/cli-module-migrate`) provides commands for
+bumping Backstage package versions, migrating moved packages, and running
+various package migration utilities.
+
+## versions\:bump
+
+Bump all `@backstage` packages to the latest versions. This checks for updates
+in the package registry, and will update entries in `package.json` files when
+necessary. See more about how this command can be configured and used
+[for keeping Backstage updated](../../getting-started/keeping-backstage-updated.md).
+
+```text
+Usage: backstage-cli versions:bump [options]
+
+Options:
+  -h, --help        display help for command
+  --pattern <glob>  Override glob for matching packages to upgrade
+  --release <version|next|main> Bump to a specific Backstage release line or version (default: "main")
+```
+
+## versions\:migrate
+
+Migrate any plugins that have been moved to the `@backstage-community`
+namespace. This command scans all packages in the project for dependencies that
+have a `backstage.moved` field in their `package.json`, updates the dependency
+names in `package.json` files, and optionally rewrites import paths in source
+files.
+
+After making changes the command runs `yarn install` to update the lockfile.
+
+```text
+Usage: backstage-cli versions:migrate [options]
+
+Options:
+  --pattern <glob>       Override glob for matching packages to upgrade
+  --skip-code-changes    Skip code changes and only update package.json files
+  -h, --help             display help for command
+```
+
+## migrate package-roles
+
+Add the `backstage.role` field to packages that do not already have it. This
+field identifies the purpose of each package and is used by other CLI commands
+to determine the correct build and lint behavior.
+
+```text
+Usage: backstage-cli migrate package-roles
+
+Add package role field to packages that don't have it
+```
+
+## migrate package-scripts
+
+Set package scripts according to each package's role. This ensures that all
+packages have the correct `build`, `test`, `lint`, `prepack`, and `postpack`
+scripts for their role.
+
+```text
+Usage: backstage-cli migrate package-scripts
+
+Set package scripts according to each package role
+```
+
+## migrate package-exports
+
+Synchronize package subpath export definitions. This updates the `exports` field
+in `package.json` to match the expected structure for each package role.
+
+```text
+Usage: backstage-cli migrate package-exports
+
+Synchronize package subpath export definitions
+```
+
+## migrate package-lint-configs
+
+Migrate all packages to use the ESLint configuration factory provided by the
+CLI. This replaces custom ESLint configurations with
+`@backstage/cli/config/eslint-factory`.
+
+```text
+Usage: backstage-cli migrate package-lint-configs
+
+Migrates all packages to use @backstage/cli/config/eslint-factory
+```
+
+## migrate react-router-deps
+
+Migrate the `react-router` dependencies for all packages to be peer
+dependencies. This is part of the migration to support newer versions of React
+Router.
+
+```text
+Usage: backstage-cli migrate react-router-deps
+
+Migrates the react-router dependencies for all packages to be peer dependencies
+```

--- a/docs/tooling/cli/module-new.md
+++ b/docs/tooling/cli/module-new.md
@@ -1,0 +1,41 @@
+---
+id: module-new
+title: New Module
+description: CLI command for scaffolding new plugins and packages.
+---
+
+The new module (`@backstage/cli-module-new`) provides a command for scaffolding
+new plugins, packages, and other components in your Backstage project.
+
+## new
+
+The `new` command opens up an interactive guide for you to create new things in
+your app. If you do not pass in any options it is completely interactive, but it
+is possible to pre-select what you want to create using the `--select` flag, and
+provide options using `--option`, for example:
+
+```bash
+backstage-cli new --select frontend-plugin --option pluginId=foo
+```
+
+This command is typically added as a script in the root `package.json` to be
+executed with `yarn new`. For example you may have it set up like this:
+
+```json
+{
+  "scripts": {
+    "new": "backstage-cli new"
+  }
+}
+```
+
+The `new` command comes with a default collection of plugins/packages, however,
+you can customize this list and even create your own CLI templates. For more
+information see [CLI Templates](./04-templates.md).
+
+```text
+Usage: backstage-cli new
+
+Options:
+  -h, --help               display help for command
+```

--- a/docs/tooling/cli/module-new.md
+++ b/docs/tooling/cli/module-new.md
@@ -15,7 +15,7 @@ is possible to pre-select what you want to create using the `--select` flag, and
 provide options using `--option`, for example:
 
 ```bash
-backstage-cli new --select frontend-plugin --option pluginId=foo
+yarn backstage-cli new --select frontend-plugin --option pluginId=foo
 ```
 
 This command is typically added as a script in the root `package.json` to be

--- a/docs/tooling/cli/module-test.md
+++ b/docs/tooling/cli/module-test.md
@@ -70,8 +70,8 @@ monorepo. The configuration sets the `src` as the root directory, enforces the
 `.test.` infix for tests, and uses `src/setupTests.ts` as the test setup
 location. The included configuration also supports test execution at the root of
 a Yarn workspaces monorepo by automatically creating one grouped configuration
-that includes all packages that have `backstage-cli test` in their package
-`test` script.
+that includes all packages that have `backstage-cli test` or
+`backstage-cli package test` in their package `test` script.
 
 ```text
 Usage: backstage-cli package test [options]

--- a/docs/tooling/cli/module-test.md
+++ b/docs/tooling/cli/module-test.md
@@ -1,0 +1,83 @@
+---
+id: module-test
+title: Test Module
+description: CLI commands for running tests with Jest.
+---
+
+The test module (`@backstage/cli-module-test-jest`) provides commands for
+running tests in individual packages and across the entire repository. Tests are
+run using Jest with a default configuration included in the CLI.
+
+For more information about configuration overrides and editor support, see the
+[Jest Configuration section](./02-build-system.md#jest-configuration) in the
+build system documentation.
+
+## repo test
+
+Test packages in the project. It is recommended to have this command be used as
+the `test` script in the root `package.json` in your project:
+
+```json title="package.json in the root of your project"
+{
+  "scripts": {
+    "test": "backstage-cli repo test"
+  }
+}
+```
+
+If run without any arguments it will default to running changed tests in watch
+mode, unless the `CI` environment flag is set, in which case it will run all
+tests without watching:
+
+```sh title="Run changed tests from repo root"
+yarn test
+```
+
+If arguments are provided, they will be forwarded to Jest and used to filter
+tests to execute. If full paths to tests are provided, only those tests will be
+included, for example:
+
+```sh title="Run specific tests from repo root"
+yarn test packages/app/src/App.test.tsx
+```
+
+If you want to avoid re-running tests that have not changed since the last
+successful run in CI, you can use the `--success-cache` flag. By default this
+cache is stored in `node_modules/.cache/backstage-cli`, but you can choose a
+different directory with the `--success-cache-dir <path>`.
+
+```text
+Usage: backstage-cli repo test [options]
+
+Run tests, forwarding args to Jest, defaulting to watch mode
+
+Options:
+  --since <ref>               Only test packages that changed since the specified ref
+  --success-cache             Enable success caching, which skips running tests for unchanged packages that were successful in the previous run
+  --success-cache-dir <path>  Set the success cache location, (default: node_modules/.cache/backstage-cli)
+  --jest-help                 Show help for Jest CLI options, which are passed through
+  -h, --help                  display help for command
+```
+
+## package test
+
+Run tests, forwarding all unknown options to Jest, and defaulting to watch mode.
+When executing the tests, `process.env.NODE_ENV` will be set to `"test"`.
+
+This command uses a default Jest configuration that is included in the CLI,
+which is set up with similar goals for speed, scale, and working within a
+monorepo. The configuration sets the `src` as the root directory, enforces the
+`.test.` infix for tests, and uses `src/setupTests.ts` as the test setup
+location. The included configuration also supports test execution at the root of
+a Yarn workspaces monorepo by automatically creating one grouped configuration
+that includes all packages that have `backstage-cli test` in their package
+`test` script.
+
+```text
+Usage: backstage-cli package test [options]
+
+Run tests, forwarding args to Jest, defaulting to watch mode
+
+Options:
+  --backstage-cli-help    display help for command
+```

--- a/docs/tooling/cli/module-test.md
+++ b/docs/tooling/cli/module-test.md
@@ -25,17 +25,17 @@ the `test` script in the root `package.json` in your project:
 }
 ```
 
-If run without any arguments it will default to running changed tests in watch
-mode, unless the `CI` environment flag is set, in which case it will run all
-tests without watching:
+If run without any arguments it defaults to running changed tests in watch
+mode, unless the `CI` environment flag is set, in which case it runs all tests
+without watching:
 
 ```sh title="Run changed tests from repo root"
 yarn test
 ```
 
-If arguments are provided, they will be forwarded to Jest and used to filter
-tests to execute. If full paths to tests are provided, only those tests will be
-included, for example:
+If arguments are provided, they are forwarded to Jest and used to filter tests
+to execute. If full paths to tests are provided, only those tests are included,
+for example:
 
 ```sh title="Run specific tests from repo root"
 yarn test packages/app/src/App.test.tsx
@@ -62,7 +62,7 @@ Options:
 ## package test
 
 Run tests, forwarding all unknown options to Jest, and defaulting to watch mode.
-When executing the tests, `process.env.NODE_ENV` will be set to `"test"`.
+When executing the tests, `process.env.NODE_ENV` is set to `"test"`.
 
 This command uses a default Jest configuration that is included in the CLI,
 which is set up with similar goals for speed, scale, and working within a

--- a/docs/tooling/cli/module-translations.md
+++ b/docs/tooling/cli/module-translations.md
@@ -13,7 +13,7 @@ translation workflow, see the
 ## translations export
 
 Export translation messages from an app and all of its frontend plugins to JSON
-files. This command must be run from within a package directory (e.g.
+files. This command must be run from within a package directory (for example
 `packages/app`), not from the repository root.
 
 The command discovers all `TranslationRef` definitions in the dependency tree,

--- a/docs/tooling/cli/module-translations.md
+++ b/docs/tooling/cli/module-translations.md
@@ -1,0 +1,75 @@
+---
+id: module-translations
+title: Translations Module
+description: CLI commands for managing translation messages.
+---
+
+The translations module (`@backstage/cli-module-translations`) provides commands
+for exporting and importing translation messages, supporting the
+internationalization workflow for Backstage apps. For more details on the
+translation workflow, see the
+[Internationalization](../../plugins/internationalization.md) documentation.
+
+## translations export
+
+Export translation messages from an app and all of its frontend plugins to JSON
+files. This command must be run from within a package directory (e.g.
+`packages/app`), not from the repository root.
+
+The command discovers all `TranslationRef` definitions in the dependency tree,
+extracts their default messages using the TypeScript type system, and writes
+them as JSON files along with a manifest.
+
+```text
+Usage: backstage-cli translations export [options]
+
+Options:
+  --output <dir>       Output directory for exported messages and manifest (default: "translations")
+  --pattern <pattern>  File path pattern for message files relative to the output
+                       directory, with {id} and {lang} placeholders
+                       (default: "messages/{id}.{lang}.json")
+  -h, --help           display help for command
+```
+
+### Examples
+
+Export translations with default settings:
+
+```bash
+cd packages/app
+yarn backstage-cli translations export
+```
+
+Export with language-based directory grouping:
+
+```bash
+yarn backstage-cli translations export --pattern '{lang}/{id}.json'
+```
+
+## translations import
+
+Generate translation resource wiring code from translated JSON files. Reads the
+manifest and translated message files produced by `translations export`, and
+generates a TypeScript module that creates `TranslationResource` objects for each
+translated ref.
+
+The file pattern used during export is stored in the manifest and automatically
+used by the import command.
+
+```text
+Usage: backstage-cli translations import [options]
+
+Options:
+  --input <dir>    Input directory containing the manifest and translated message files (default: "translations")
+  --output <path>  Output path for the generated wiring module (default: "src/translations/resources.ts")
+  -h, --help       display help for command
+```
+
+### Examples
+
+Generate wiring code with default settings:
+
+```bash
+cd packages/app
+yarn backstage-cli translations import
+```

--- a/docs/tutorials/package-role-migration.md
+++ b/docs/tutorials/package-role-migration.md
@@ -97,7 +97,7 @@ This will migrate all existing `.eslintrc.js` that extend the old configuration 
 
 ### Step 4 - Use `backstage-cli repo`
 
-The Backstage CLI recently introduced a new `repo` command category, which houses commands that operate on an entire monorepo at once. These commands work particularly well once packages have been migrated to use roles, as that allows for some very effective optimizations. It is typically much faster to use these commands compared to using tools like `lerna`, as they're able to avoid the overhead of calling package scripts through `yarn` and can operate on multiple packages at once. You can read more about the `repo` command in the [CLI command documentation](../tooling/cli/03-commands.md#repo-build).
+The Backstage CLI recently introduced a new `repo` command category, which houses commands that operate on an entire monorepo at once. These commands work particularly well once packages have been migrated to use roles, as that allows for some very effective optimizations. It is typically much faster to use these commands compared to using tools like `lerna`, as they're able to avoid the overhead of calling package scripts through `yarn` and can operate on multiple packages at once. You can read more about the `repo` command in the [CLI command documentation](../tooling/cli/module-build.md#repo-build).
 
 The way to execute this step of the migration is not as well defined as the previous steps, as it depends on what your development and CI/CD setup looks like. Look for the following patterns to replace in your root `package.json` as well as CI/CD setup:
 

--- a/microsite/sidebars.ts
+++ b/microsite/sidebars.ts
@@ -624,6 +624,29 @@ export default {
             'tooling/cli/templates',
             sidebarElementWithIndex(
               {
+                label: 'CLI Modules',
+                description:
+                  'Documentation for each CLI module and its commands.',
+              },
+              [
+                'tooling/cli/modules',
+                'tooling/cli/module-auth',
+                'tooling/cli/module-actions',
+                'tooling/cli/module-build',
+                'tooling/cli/module-config',
+                'tooling/cli/module-github',
+                'tooling/cli/module-info',
+                'tooling/cli/module-lint',
+                'tooling/cli/module-maintenance',
+                'tooling/cli/module-migrate',
+                'tooling/cli/module-new',
+                'tooling/cli/module-test',
+                'tooling/cli/module-translations',
+              ],
+            ),
+            'tooling/cli/building-cli-modules',
+            sidebarElementWithIndex(
+              {
                 label: 'Local Development',
                 description:
                   'Guides for local development using Backstage CLI.',

--- a/packages/frontend-dynamic-feature-loader/README.md
+++ b/packages/frontend-dynamic-feature-loader/README.md
@@ -28,7 +28,7 @@ The frontend feature loader provided in this package works hand-in-hand with the
 
 Adding a frontend plugin (with new frontend system support, possibly in alpha support), is straightforward and consists in:
 
-- bundling the frontend plugin with the [`backstage-cli package bundle`](../../docs/tooling/cli/03-commands.md#package-bundle) command, thus producing a self-contained bundle based on Module Federation.
+- bundling the frontend plugin with the [`backstage-cli package bundle`](../../docs/tooling/cli/module-build.md#package-bundle) command, thus producing a self-contained bundle based on Module Federation.
 - copying the bundle folder into the Backstage installation dynamic plugins root folder for dynamic loading.
 
 So from a `my-backstage-plugin` frontend plugin package folder, you would use the following command:


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The CLI was modularized into 12 independent modules but the docs were not updated. This adds documentation for the module system architecture, dedicated pages for each module's commands, and a guide for building custom CLI modules.

- Updated `01-overview.md` with module system introduction
- Turned `03-commands.md` into an index linking to per-module pages
- Added `05-modules.md` covering module discovery, overriding, and subsetting
- Added per-module command pages for all 12 modules (auth, actions, build, config, github, info, lint, maintenance, migrate, new, test, translations)
- Added `building-cli-modules.md` guide for the `createCliModule` API
- Updated `microsite/sidebars.ts` with CLI Modules subcategory

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))