### PR TITLE
feat(integration-aws-node): support connections for AWS credentials

### DIFF
--- a/.changeset/bright-aws-connections.md
+++ b/.changeset/bright-aws-connections.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration-aws-node': minor
+---
+
+Added support for creating an AWS credentials manager backed by the connections service.

--- a/.changeset/calm-aws-catalog-connections.md
+++ b/.changeset/calm-aws-catalog-connections.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-aws': patch
+---
+
+Use the connections service to resolve credentials for AWS S3 catalog providers.

--- a/packages/integration-aws-node/README.md
+++ b/packages/integration-aws-node/README.md
@@ -26,6 +26,20 @@ following order of precedence:
 See more about the AWS SDK default credentials chain in the
 [AWS SDK for Javascript Developer Guide](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html).
 
+Backend plugins can also create a credentials manager backed by the connections
+service. This resolves access keys, assumed roles, or the AWS SDK default
+credentials chain from an `aws-s3` or `aws-codecommit` connection:
+
+```typescript
+const awsCredentialsManager = DefaultAwsCredentialsManager.fromConnections(
+  connections,
+  {
+    type: 'aws-s3',
+    url: 'https://amazonaws.com',
+  },
+);
+```
+
 Configuration examples:
 
 ```yaml

--- a/packages/integration-aws-node/package.json
+++ b/packages/integration-aws-node/package.json
@@ -42,6 +42,7 @@
     "@aws-sdk/types": "^3.347.0",
     "@aws-sdk/util-arn-parser": "^3.310.0",
     "@backstage/config": "workspace:^",
+    "@backstage/connections": "workspace:^",
     "@backstage/errors": "workspace:^"
   },
   "devDependencies": {

--- a/packages/integration-aws-node/report.api.md
+++ b/packages/integration-aws-node/report.api.md
@@ -5,6 +5,7 @@
 ```ts
 import { AwsCredentialIdentityProvider } from '@aws-sdk/types';
 import { Config } from '@backstage/config';
+import type { ConnectionsService } from '@backstage/connections';
 
 // @public
 export type AwsCredentialProvider = {
@@ -27,9 +28,19 @@ export interface AwsCredentialsManager {
 }
 
 // @public
+export type AwsCredentialsManagerConnectionOptions = {
+  type: 'aws-codecommit' | 'aws-s3';
+  url: string;
+};
+
+// @public
 export class DefaultAwsCredentialsManager implements AwsCredentialsManager {
   // (undocumented)
   static fromConfig(config: Config): DefaultAwsCredentialsManager;
+  static fromConnections(
+    connections: ConnectionsService,
+    options: AwsCredentialsManagerConnectionOptions,
+  ): DefaultAwsCredentialsManager;
   getCredentialProvider(
     opts?: AwsCredentialProviderOptions,
   ): Promise<AwsCredentialProvider>;

--- a/packages/integration-aws-node/src/DefaultAwsCredentialsManager.test.ts
+++ b/packages/integration-aws-node/src/DefaultAwsCredentialsManager.test.ts
@@ -19,6 +19,7 @@ import { mockClient, AwsClientStub } from 'aws-sdk-client-mock';
 import 'aws-sdk-client-mock-jest';
 import { STSClient, GetCallerIdentityCommand } from '@aws-sdk/client-sts';
 import { Config, ConfigReader } from '@backstage/config';
+import { ConnectionsService } from '@backstage/connections';
 import {
   fromNodeProviderChain,
   fromTemporaryCredentials,
@@ -176,6 +177,123 @@ describe('DefaultAwsCredentialsManager', () => {
     if (tmpDir) {
       rmSync(tmpDir, { recursive: true, force: true });
     }
+  });
+
+  describe('.fromConnections', () => {
+    it('creates and reuses access key providers from the connections service', async () => {
+      const find = jest.fn().mockResolvedValue({
+        type: 'aws-s3',
+        title: 'AWS S3',
+        host: 'amazonaws.com',
+        auth: {
+          method: 'accessKey',
+          title: 'Access Key',
+          accessKeyId: 'connection-access-key',
+          secretAccessKey: 'connection-secret-key',
+        },
+      });
+      const provider = DefaultAwsCredentialsManager.fromConnections(
+        { find: find as ConnectionsService['find'] },
+        { type: 'aws-s3', url: 'https://amazonaws.com' },
+      );
+
+      const first = await provider.getCredentialProvider({
+        accountId: '111111111111',
+      });
+      const second = await provider.getCredentialProvider({
+        accountId: '111111111111',
+      });
+
+      expect(find).toHaveBeenCalledWith({
+        type: 'aws-s3',
+        url: 'https://amazonaws.com',
+        authMethods: ['accessKey', 'assumeRole', 'none'],
+      });
+      expect(first).toBe(second);
+      await expect(first.sdkCredentialProvider()).resolves.toEqual({
+        accessKeyId: 'connection-access-key',
+        secretAccessKey: 'connection-secret-key',
+      });
+    });
+
+    it('creates and reuses assume role providers from the connections service', async () => {
+      const find = jest.fn().mockResolvedValue({
+        type: 'aws-codecommit',
+        title: 'AWS CodeCommit',
+        host: 'eu-west-1.console.aws.amazon.com',
+        region: 'eu-west-1',
+        auth: {
+          method: 'assumeRole',
+          title: 'Assume Role',
+          roleArn: 'arn:aws:iam::111111111111:role/hello',
+          externalId: 'connection-external-id',
+        },
+      });
+      const provider = DefaultAwsCredentialsManager.fromConnections(
+        { find: find as ConnectionsService['find'] },
+        {
+          type: 'aws-codecommit',
+          url: 'https://eu-west-1.console.aws.amazon.com',
+        },
+      );
+
+      const first = await provider.getCredentialProvider();
+      const second = await provider.getCredentialProvider();
+
+      expect(find).toHaveBeenCalledWith({
+        type: 'aws-codecommit',
+        url: 'https://eu-west-1.console.aws.amazon.com',
+        authMethods: ['accessKey', 'assumeRole'],
+      });
+      expect(first).toBe(second);
+      expect(first).toEqual(
+        expect.objectContaining({
+          accountId: '111111111111',
+          stsRegion: 'eu-west-1',
+        }),
+      );
+      expect(fromTemporaryCredentials).toHaveBeenCalledTimes(1);
+      expect(fromTemporaryCredentials).toHaveBeenCalledWith(
+        expect.objectContaining({
+          params: {
+            RoleArn: 'arn:aws:iam::111111111111:role/hello',
+            RoleSessionName: 'backstage',
+            ExternalId: 'connection-external-id',
+          },
+          clientConfig: {
+            region: 'eu-west-1',
+            customUserAgent: 'backstage-aws-credentials-manager',
+          },
+        }),
+      );
+    });
+
+    it('uses the default AWS credentials chain for unauthenticated S3 connections', async () => {
+      const find = jest.fn().mockResolvedValue({
+        type: 'aws-s3',
+        title: 'AWS S3',
+        host: 'amazonaws.com',
+        auth: {
+          method: 'none',
+          title: 'None',
+        },
+      });
+      const provider = DefaultAwsCredentialsManager.fromConnections(
+        { find: find as ConnectionsService['find'] },
+        { type: 'aws-s3', url: 'https://amazonaws.com' },
+      );
+
+      const result = await provider.getCredentialProvider();
+
+      await expect(result.sdkCredentialProvider()).resolves.toEqual(
+        expect.objectContaining({
+          accessKeyId: 'ACCESS_KEY_ID_10',
+          secretAccessKey: 'SECRET_ACCESS_KEY_10',
+          sessionToken: 'SESSION_TOKEN_10',
+          expiration: new Date('2022-01-10'),
+        }),
+      );
+    });
   });
 
   describe('#getCredentialProvider', () => {

--- a/packages/integration-aws-node/src/DefaultAwsCredentialsManager.ts
+++ b/packages/integration-aws-node/src/DefaultAwsCredentialsManager.ts
@@ -22,6 +22,7 @@ import {
 } from './config';
 import {
   AwsCredentialsManager,
+  AwsCredentialsManagerConnectionOptions,
   AwsCredentialProvider,
   AwsCredentialProviderOptions,
 } from './types';
@@ -35,6 +36,12 @@ import {
 import { AwsCredentialIdentityProvider } from '@aws-sdk/types';
 import { parse } from '@aws-sdk/util-arn-parser';
 import { Config } from '@backstage/config';
+import type { Connection, ConnectionsService } from '@backstage/connections';
+
+type AwsConnectionCredentialSource = {
+  connections: ConnectionsService;
+  options: AwsCredentialsManagerConnectionOptions;
+};
 
 /**
  * Retrieves the account ID for the given credential provider from STS.
@@ -230,6 +237,27 @@ export class DefaultAwsCredentialsManager implements AwsCredentialsManager {
     );
   }
 
+  /**
+   * Creates a credentials manager backed by the connections service.
+   *
+   * @param connections - The connections service used to resolve AWS credentials.
+   * @param options - The AWS connection type and resource URL to resolve.
+   * @public
+   */
+  static fromConnections(
+    connections: ConnectionsService,
+    options: AwsCredentialsManagerConnectionOptions,
+  ): DefaultAwsCredentialsManager {
+    return new DefaultAwsCredentialsManager(
+      new Map(),
+      {},
+      {
+        sdkCredentialProvider: getDefaultCredentialsChain(),
+      },
+      { connections, options },
+    );
+  }
+
   private readonly accountCredentialProviders: Map<
     string,
     AwsCredentialProvider
@@ -241,6 +269,7 @@ export class DefaultAwsCredentialsManager implements AwsCredentialsManager {
     accountCredentialProviders: Map<string, AwsCredentialProvider>,
     accountDefaults: AwsIntegrationDefaultAccountConfig,
     mainAccountCredentialProvider: AwsCredentialProvider,
+    private readonly connectionCredentialSource?: AwsConnectionCredentialSource,
   ) {
     this.accountCredentialProviders = accountCredentialProviders;
     this.accountDefaults = accountDefaults;
@@ -267,6 +296,10 @@ export class DefaultAwsCredentialsManager implements AwsCredentialsManager {
   async getCredentialProvider(
     opts?: AwsCredentialProviderOptions,
   ): Promise<AwsCredentialProvider> {
+    if (this.connectionCredentialSource) {
+      return this.getConnectionCredentialProvider(opts);
+    }
+
     // If no options provided, fall back to the main account
     if (!opts) {
       return this.mainAccountCredentialProvider;
@@ -323,5 +356,82 @@ export class DefaultAwsCredentialsManager implements AwsCredentialsManager {
     throw new Error(
       `There is no AWS integration that matches ${accountId}. Please add a configuration for this AWS account.`,
     );
+  }
+
+  private async getConnectionCredentialProvider(
+    opts?: AwsCredentialProviderOptions,
+  ): Promise<AwsCredentialProvider> {
+    const { connections, options } = this.connectionCredentialSource!;
+    let connection:
+      | Connection<'aws-codecommit', 'accessKey' | 'assumeRole'>
+      | Connection<'aws-s3', 'accessKey' | 'assumeRole' | 'none'>;
+
+    if (options.type === 'aws-codecommit') {
+      connection = await connections.find({
+        type: 'aws-codecommit',
+        url: options.url,
+        authMethods: ['accessKey', 'assumeRole'],
+      });
+    } else {
+      connection = await connections.find({
+        type: 'aws-s3',
+        url: options.url,
+        authMethods: ['accessKey', 'assumeRole', 'none'],
+      });
+    }
+
+    const { auth } = connection;
+    const requestedAccountId =
+      opts?.accountId ?? (opts?.arn ? parse(opts.arn).accountId : undefined);
+    let authIdentifier = '';
+    if (auth.method === 'accessKey') {
+      authIdentifier = auth.accessKeyId;
+    } else if (auth.method === 'assumeRole') {
+      authIdentifier = auth.roleArn;
+    }
+    const providerKey = `${connection.type}:${connection.host}:${
+      auth.method
+    }:${authIdentifier}:${requestedAccountId ?? ''}`;
+    const cachedProvider = this.accountCredentialProviders.get(providerKey);
+    if (cachedProvider) {
+      return cachedProvider;
+    }
+
+    let credentialProvider: AwsCredentialProvider;
+    if (auth.method === 'accessKey') {
+      credentialProvider = {
+        accountId: requestedAccountId,
+        sdkCredentialProvider: getStaticCredentials(
+          auth.accessKeyId,
+          auth.secretAccessKey,
+        ),
+      };
+    } else if (auth.method === 'assumeRole') {
+      const role = parse(auth.roleArn);
+      const stsRegion =
+        connection.type === 'aws-codecommit' ? connection.region : undefined;
+      credentialProvider = {
+        accountId: role.accountId,
+        stsRegion,
+        sdkCredentialProvider: fromTemporaryCredentials({
+          masterCredentials:
+            this.mainAccountCredentialProvider.sdkCredentialProvider,
+          params: {
+            RoleArn: auth.roleArn,
+            RoleSessionName: 'backstage',
+            ExternalId: auth.externalId,
+          },
+          clientConfig: {
+            region: stsRegion ?? 'us-east-1',
+            customUserAgent: 'backstage-aws-credentials-manager',
+          },
+        }),
+      };
+    } else {
+      credentialProvider = this.mainAccountCredentialProvider;
+    }
+
+    this.accountCredentialProviders.set(providerKey, credentialProvider);
+    return credentialProvider;
   }
 }

--- a/packages/integration-aws-node/src/index.ts
+++ b/packages/integration-aws-node/src/index.ts
@@ -17,6 +17,7 @@
 export { DefaultAwsCredentialsManager } from './DefaultAwsCredentialsManager';
 export type {
   AwsCredentialsManager,
+  AwsCredentialsManagerConnectionOptions,
   AwsCredentialProvider,
   AwsCredentialProviderOptions,
 } from './types';

--- a/packages/integration-aws-node/src/types.ts
+++ b/packages/integration-aws-node/src/types.ts
@@ -54,6 +54,23 @@ export type AwsCredentialProviderOptions = {
 };
 
 /**
+ * The connection to use when resolving AWS credentials.
+ *
+ * @public
+ */
+export type AwsCredentialsManagerConnectionOptions = {
+  /**
+   * The AWS connection type to resolve.
+   */
+  type: 'aws-codecommit' | 'aws-s3';
+
+  /**
+   * The resource URL used to select the connection.
+   */
+  url: string;
+};
+
+/**
  * This allows implementations to be provided to retrieve AWS credentials.
  *
  * @public

--- a/plugins/catalog-backend-module-aws/package.json
+++ b/plugins/catalog-backend-module-aws/package.json
@@ -60,13 +60,16 @@
     "@backstage/backend-plugin-api": "workspace:^",
     "@backstage/catalog-model": "workspace:^",
     "@backstage/config": "workspace:^",
+    "@backstage/connections": "workspace:^",
     "@backstage/errors": "workspace:^",
     "@backstage/integration": "workspace:^",
     "@backstage/integration-aws-node": "workspace:^",
     "@backstage/plugin-catalog-common": "workspace:^",
     "@backstage/plugin-catalog-node": "workspace:^",
     "@backstage/plugin-kubernetes-common": "workspace:^",
-    "p-limit": "^3.0.2"
+    "@backstage/types": "workspace:^",
+    "p-limit": "^3.0.2",
+    "zod": "^3.25.76 || ^4.0.0"
   },
   "devDependencies": {
     "@aws-sdk/util-stream-node": "^3.350.0",

--- a/plugins/catalog-backend-module-aws/report.api.md
+++ b/plugins/catalog-backend-module-aws/report.api.md
@@ -98,6 +98,7 @@ export class AwsS3EntityProvider implements EntityProvider {
       logger: LoggerService;
       schedule?: SchedulerServiceTaskRunner;
       scheduler?: SchedulerService;
+      awsCredentialsManager?: AwsCredentialsManager;
     },
   ): AwsS3EntityProvider[];
   getProviderName(): string;

--- a/plugins/catalog-backend-module-aws/src/module/catalogModuleAwsS3EntityProvider.test.ts
+++ b/plugins/catalog-backend-module-aws/src/module/catalogModuleAwsS3EntityProvider.test.ts
@@ -19,8 +19,13 @@ import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node';
 import { catalogModuleAwsS3EntityProvider } from './catalogModuleAwsS3EntityProvider';
 import { AwsS3EntityProvider } from '../providers';
+import { DefaultAwsCredentialsManager } from '@backstage/integration-aws-node';
 
 describe('catalogModuleAwsS3EntityProvider', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('should register provider at the catalog extension point', async () => {
     let addedProviders: Array<AwsS3EntityProvider> | undefined;
     let usedSchedule: SchedulerServiceTaskScheduleDefinition | undefined;
@@ -37,6 +42,10 @@ describe('catalogModuleAwsS3EntityProvider', () => {
         return { run: runner };
       },
     });
+    const fromConnections = jest.spyOn(
+      DefaultAwsCredentialsManager,
+      'fromConnections',
+    );
 
     const config = {
       catalog: {
@@ -68,5 +77,9 @@ describe('catalogModuleAwsS3EntityProvider', () => {
       'awsS3-provider:default',
     );
     expect(runner).not.toHaveBeenCalled();
+    expect(fromConnections).toHaveBeenCalledWith(expect.anything(), {
+      type: 'aws-s3',
+      url: 'https://amazonaws.com',
+    });
   });
 });

--- a/plugins/catalog-backend-module-aws/src/module/catalogModuleAwsS3EntityProvider.ts
+++ b/plugins/catalog-backend-module-aws/src/module/catalogModuleAwsS3EntityProvider.ts
@@ -18,6 +18,12 @@ import {
   coreServices,
   createBackendModule,
 } from '@backstage/backend-plugin-api';
+import {
+  connectionsServiceRef,
+  declareConnection,
+} from '@backstage/connections-node';
+import { ScmIntegrations } from '@backstage/integration';
+import { DefaultAwsCredentialsManager } from '@backstage/integration-aws-node';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node';
 import { AwsS3EntityProvider } from '../providers';
 
@@ -30,18 +36,36 @@ export const catalogModuleAwsS3EntityProvider = createBackendModule({
   pluginId: 'catalog',
   moduleId: 'aws-s3-entity-provider',
   register(env) {
+    declareConnection(env, {
+      type: 'aws-s3',
+      description: 'Discovers catalog files stored in AWS S3 buckets',
+    });
     env.registerInit({
       deps: {
         config: coreServices.rootConfig,
         catalog: catalogProcessingExtensionPoint,
         logger: coreServices.logger,
         scheduler: coreServices.scheduler,
+        connections: connectionsServiceRef,
       },
-      async init({ config, catalog, logger, scheduler }) {
+      async init({ config, catalog, logger, scheduler, connections }) {
+        const integration = ScmIntegrations.fromConfig(config).awsS3.list()[0];
+        if (!integration) {
+          throw new Error('No integration found for awsS3');
+        }
+        const awsCredentialsManager =
+          DefaultAwsCredentialsManager.fromConnections(connections, {
+            type: 'aws-s3',
+            url:
+              integration.config.endpoint ??
+              `https://${integration.config.host}`,
+          });
+
         catalog.addEntityProvider(
           AwsS3EntityProvider.fromConfig(config, {
             logger,
             scheduler,
+            awsCredentialsManager,
           }),
         );
       },

--- a/plugins/catalog-backend-module-aws/src/providers/AwsS3EntityProvider.ts
+++ b/plugins/catalog-backend-module-aws/src/providers/AwsS3EntityProvider.ts
@@ -62,6 +62,7 @@ export class AwsS3EntityProvider implements EntityProvider {
       logger: LoggerService;
       schedule?: SchedulerServiceTaskRunner;
       scheduler?: SchedulerService;
+      awsCredentialsManager?: AwsCredentialsManager;
     },
   ): AwsS3EntityProvider[] {
     const providerConfigs = readAwsS3Configs(configRoot);
@@ -90,6 +91,7 @@ export class AwsS3EntityProvider implements EntityProvider {
         );
       }
       const awsCredentialsManager =
+        options.awsCredentialsManager ??
         DefaultAwsCredentialsManager.fromConfig(configRoot);
       const taskRunner =
         options.schedule ??

--- a/yarn.lock
+++ b/yarn.lock
@@ -3505,6 +3505,7 @@ __metadata:
     "@backstage/cli": "workspace:^"
     "@backstage/config": "workspace:^"
     "@backstage/config-loader": "workspace:^"
+    "@backstage/connections": "workspace:^"
     "@backstage/errors": "workspace:^"
     "@backstage/test-utils": "workspace:^"
     aws-sdk-client-mock: "npm:^4.0.0"
@@ -4407,16 +4408,19 @@ __metadata:
     "@backstage/catalog-model": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/config": "workspace:^"
+    "@backstage/connections": "workspace:^"
     "@backstage/errors": "workspace:^"
     "@backstage/integration": "workspace:^"
     "@backstage/integration-aws-node": "workspace:^"
     "@backstage/plugin-catalog-common": "workspace:^"
     "@backstage/plugin-catalog-node": "workspace:^"
     "@backstage/plugin-kubernetes-common": "workspace:^"
+    "@backstage/types": "workspace:^"
     aws-sdk-client-mock: "npm:^4.0.0"
     aws-sdk-client-mock-jest: "npm:^4.0.0"
     p-limit: "npm:^3.0.2"
     yaml: "npm:^2.0.0"
+    zod: "npm:^3.25.76 || ^4.0.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds a `DefaultAwsCredentialsManager.fromConnections` factory so consumers can resolve AWS S3 and CodeCommit credentials through `@backstage/connections`. It supports access keys and assumed roles, with the AWS SDK default credentials chain available for unauthenticated S3 connections.

The connections-backed manager reuses credential providers for each resolved host, auth method, and account. The AWS S3 catalog module now declares its connection and routes catalog discovery through the shared manager. This mirrors the GitHub adoption in #34718 and continues dogfooding the connections service before broader use.

Validation:

- `CI=1 yarn test packages/integration-aws-node/src/DefaultAwsCredentialsManager.test.ts`
- `CI=1 yarn test plugins/catalog-backend-module-aws/src/module/catalogModuleAwsS3EntityProvider.test.ts`
- `CI=1 yarn test plugins/catalog-backend-module-aws/src/providers/AwsS3EntityProvider.test.ts`
- `yarn tsc`
- `yarn lint --fix`
- `node scripts/verify-local-dependencies.js`
- `yarn build:api-reports`

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (not applicable)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
