### PR TITLE
fix(backend-defaults,search): resolve account-specific AWS credentials in URL readers and ElasticSearch

### DIFF
--- a/.changeset/aws-url-reader-account-credentials.md
+++ b/.changeset/aws-url-reader-account-credentials.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Fixed `AwsS3UrlReader` and `AwsCodeCommitUrlReader` to resolve account-specific AWS credentials when an assume role ARN is configured, enabling support for `webIdentityTokenFile` and `accountDefaults` in environments without default AWS credentials.

--- a/.changeset/elasticsearch-account-credentials.md
+++ b/.changeset/elasticsearch-account-credentials.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend-module-elasticsearch': patch
+---
+
+Added optional `accountId` config to `search.elasticsearch` for resolving account-specific AWS credentials, enabling support for `webIdentityTokenFile` and `accountDefaults` when using AWS OpenSearch.

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsCodeCommitUrlReader.test.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsCodeCommitUrlReader.test.ts
@@ -660,4 +660,97 @@ describe('AwsCodeCommitUrlReader', () => {
       ).rejects.toThrow('Unsupported search pattern URL');
     });
   });
+
+  describe('buildCredentials with roleArn', () => {
+    const getCredProviderMock = jest.spyOn(
+      DefaultAwsCredentialsManager.prototype,
+      'getCredentialProvider',
+    );
+
+    beforeEach(() => {
+      codeCommitClient.reset();
+      getCredProviderMock.mockReset();
+
+      codeCommitClient.on(GetFileCommand).resolves({
+        fileContent: Buffer.from('site_name: Test\n'),
+        commitId: 'abc123',
+        filePath: 'catalog-info.yaml',
+        fileMode: 'NORMAL',
+        fileSize: 16,
+        blobId: 'blob1',
+      });
+    });
+
+    afterAll(() => {
+      getCredProviderMock.mockRestore();
+    });
+
+    it('uses account-specific credentials as master credentials when account config exists for the role ARN', async () => {
+      const accountCreds = { accessKeyId: 'account-key', secretAccessKey: 'account-secret' };
+      getCredProviderMock.mockImplementation(async (opts?: any) => {
+        if (opts?.arn) {
+          return {
+            accountId: '123456789012',
+            sdkCredentialProvider: async () => accountCreds,
+          };
+        }
+        return {
+          sdkCredentialProvider: async () => ({ accessKeyId: 'default-key', secretAccessKey: 'default-secret' }),
+        };
+      });
+
+      const config = new ConfigReader({
+        host: AMAZON_AWS_CODECOMMIT_HOST,
+        roleArn: 'arn:aws:iam::123456789012:role/MyRole',
+      });
+
+      const credsManager = DefaultAwsCredentialsManager.fromConfig(config);
+      const reader = new AwsCodeCommitUrlReader(
+        credsManager,
+        new AwsCodeCommitIntegration(readAwsCodeCommitIntegrationConfig(config)),
+        { treeResponseFactory },
+      );
+
+      await reader.readUrl(
+        'https://eu-west-1.console.aws.amazon.com/codesuite/codecommit/repositories/my-repo/browse/--/catalog-info.yaml',
+      );
+
+      expect(getCredProviderMock).toHaveBeenCalledWith({
+        arn: 'arn:aws:iam::123456789012:role/MyRole',
+      });
+    });
+
+    it('falls back to default credentials when no account config exists for the role ARN', async () => {
+      const defaultCreds = { accessKeyId: 'default-key', secretAccessKey: 'default-secret' };
+      getCredProviderMock.mockImplementation(async (opts?: any) => {
+        if (opts?.arn) {
+          throw new Error('No matching account');
+        }
+        return {
+          sdkCredentialProvider: async () => defaultCreds,
+        };
+      });
+
+      const config = new ConfigReader({
+        host: AMAZON_AWS_CODECOMMIT_HOST,
+        roleArn: 'arn:aws:iam::123456789012:role/MyRole',
+      });
+
+      const credsManager = DefaultAwsCredentialsManager.fromConfig(config);
+      const reader = new AwsCodeCommitUrlReader(
+        credsManager,
+        new AwsCodeCommitIntegration(readAwsCodeCommitIntegrationConfig(config)),
+        { treeResponseFactory },
+      );
+
+      await reader.readUrl(
+        'https://eu-west-1.console.aws.amazon.com/codesuite/codecommit/repositories/my-repo/browse/--/catalog-info.yaml',
+      );
+
+      expect(getCredProviderMock).toHaveBeenCalledWith({
+        arn: 'arn:aws:iam::123456789012:role/MyRole',
+      });
+      expect(getCredProviderMock).toHaveBeenCalledWith();
+    });
+  });
 });

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsCodeCommitUrlReader.test.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsCodeCommitUrlReader.test.ts
@@ -747,4 +747,97 @@ describe('AwsCodeCommitUrlReader', () => {
       ).rejects.toThrow('Unsupported search pattern URL');
     });
   });
+
+  describe('buildCredentials with roleArn', () => {
+    const getCredProviderMock = jest.spyOn(
+      DefaultAwsCredentialsManager.prototype,
+      'getCredentialProvider',
+    );
+
+    beforeEach(() => {
+      codeCommitClient.reset();
+      getCredProviderMock.mockReset();
+
+      codeCommitClient.on(GetFileCommand).resolves({
+        fileContent: Buffer.from('site_name: Test\n'),
+        commitId: 'abc123',
+        filePath: 'catalog-info.yaml',
+        fileMode: 'NORMAL',
+        fileSize: 16,
+        blobId: 'blob1',
+      });
+    });
+
+    afterAll(() => {
+      getCredProviderMock.mockRestore();
+    });
+
+    it('uses account-specific credentials as master credentials when account config exists for the role ARN', async () => {
+      const accountCreds = { accessKeyId: 'account-key', secretAccessKey: 'account-secret' };
+      getCredProviderMock.mockImplementation(async (opts?: any) => {
+        if (opts?.arn) {
+          return {
+            accountId: '123456789012',
+            sdkCredentialProvider: async () => accountCreds,
+          };
+        }
+        return {
+          sdkCredentialProvider: async () => ({ accessKeyId: 'default-key', secretAccessKey: 'default-secret' }),
+        };
+      });
+
+      const config = new ConfigReader({
+        host: AMAZON_AWS_CODECOMMIT_HOST,
+        roleArn: 'arn:aws:iam::123456789012:role/MyRole',
+      });
+
+      const credsManager = DefaultAwsCredentialsManager.fromConfig(config);
+      const reader = new AwsCodeCommitUrlReader(
+        credsManager,
+        new AwsCodeCommitIntegration(readAwsCodeCommitIntegrationConfig(config)),
+        { treeResponseFactory },
+      );
+
+      await reader.readUrl(
+        'https://eu-west-1.console.aws.amazon.com/codesuite/codecommit/repositories/my-repo/browse/--/catalog-info.yaml',
+      );
+
+      expect(getCredProviderMock).toHaveBeenCalledWith({
+        arn: 'arn:aws:iam::123456789012:role/MyRole',
+      });
+    });
+
+    it('falls back to default credentials when no account config exists for the role ARN', async () => {
+      const defaultCreds = { accessKeyId: 'default-key', secretAccessKey: 'default-secret' };
+      getCredProviderMock.mockImplementation(async (opts?: any) => {
+        if (opts?.arn) {
+          throw new Error('No matching account');
+        }
+        return {
+          sdkCredentialProvider: async () => defaultCreds,
+        };
+      });
+
+      const config = new ConfigReader({
+        host: AMAZON_AWS_CODECOMMIT_HOST,
+        roleArn: 'arn:aws:iam::123456789012:role/MyRole',
+      });
+
+      const credsManager = DefaultAwsCredentialsManager.fromConfig(config);
+      const reader = new AwsCodeCommitUrlReader(
+        credsManager,
+        new AwsCodeCommitIntegration(readAwsCodeCommitIntegrationConfig(config)),
+        { treeResponseFactory },
+      );
+
+      await reader.readUrl(
+        'https://eu-west-1.console.aws.amazon.com/codesuite/codecommit/repositories/my-repo/browse/--/catalog-info.yaml',
+      );
+
+      expect(getCredProviderMock).toHaveBeenCalledWith({
+        arn: 'arn:aws:iam::123456789012:role/MyRole',
+      });
+      expect(getCredProviderMock).toHaveBeenCalledWith();
+    });
+  });
 });

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsCodeCommitUrlReader.test.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsCodeCommitUrlReader.test.ts
@@ -749,31 +749,37 @@ describe('AwsCodeCommitUrlReader', () => {
   });
 
   describe('buildCredentials with roleArn', () => {
-    const getCredProviderMock = jest.spyOn(
-      DefaultAwsCredentialsManager.prototype,
-      'getCredentialProvider',
-    );
+    let getCredProviderMock: jest.SpyInstance;
 
     beforeEach(() => {
-      codeCommitClient.reset();
-      getCredProviderMock.mockReset();
-
-      codeCommitClient.on(GetFileCommand).resolves({
-        fileContent: Buffer.from('site_name: Test\n'),
-        commitId: 'abc123',
-        filePath: 'catalog-info.yaml',
-        fileMode: 'NORMAL',
-        fileSize: 16,
-        blobId: 'blob1',
+      getCredProviderMock = jest.spyOn(
+        DefaultAwsCredentialsManager.prototype,
+        'getCredentialProvider',
+      );
+      jest
+        .spyOn(CodeCommitClient.prototype, 'send')
+        .mockImplementation(codeCommitSendMock);
+      codeCommitSendMock.mockReset();
+      codeCommitSendMock.mockImplementation(async command => {
+        if (command instanceof GetFileCommand) {
+          return {
+            fileContent: Buffer.from('site_name: Test\n'),
+            commitId: 'abc123',
+            filePath: 'catalog-info.yaml',
+            fileMode: 'NORMAL',
+            fileSize: 16,
+            blobId: 'blob1',
+          };
+        }
+        throw new Error(`No mock for ${command.constructor.name}`);
       });
     });
 
-    afterAll(() => {
-      getCredProviderMock.mockRestore();
-    });
-
     it('uses account-specific credentials as master credentials when account config exists for the role ARN', async () => {
-      const accountCreds = { accessKeyId: 'account-key', secretAccessKey: 'account-secret' };
+      const accountCreds = {
+        accessKeyId: 'account-key',
+        secretAccessKey: 'account-secret',
+      };
       getCredProviderMock.mockImplementation(async (opts?: any) => {
         if (opts?.arn) {
           return {
@@ -782,19 +788,25 @@ describe('AwsCodeCommitUrlReader', () => {
           };
         }
         return {
-          sdkCredentialProvider: async () => ({ accessKeyId: 'default-key', secretAccessKey: 'default-secret' }),
+          sdkCredentialProvider: async () => ({
+            accessKeyId: 'default-key',
+            secretAccessKey: 'default-secret',
+          }),
         };
       });
 
       const config = new ConfigReader({
         host: AMAZON_AWS_CODECOMMIT_HOST,
+        region: 'us-east-1',
         roleArn: 'arn:aws:iam::123456789012:role/MyRole',
       });
 
       const credsManager = DefaultAwsCredentialsManager.fromConfig(config);
       const reader = new AwsCodeCommitUrlReader(
         credsManager,
-        new AwsCodeCommitIntegration(readAwsCodeCommitIntegrationConfig(config)),
+        new AwsCodeCommitIntegration(
+          readAwsCodeCommitIntegrationConfig(config),
+        ),
         { treeResponseFactory },
       );
 
@@ -808,7 +820,10 @@ describe('AwsCodeCommitUrlReader', () => {
     });
 
     it('falls back to default credentials when no account config exists for the role ARN', async () => {
-      const defaultCreds = { accessKeyId: 'default-key', secretAccessKey: 'default-secret' };
+      const defaultCreds = {
+        accessKeyId: 'default-key',
+        secretAccessKey: 'default-secret',
+      };
       getCredProviderMock.mockImplementation(async (opts?: any) => {
         if (opts?.arn) {
           throw new Error('No matching account');
@@ -820,13 +835,16 @@ describe('AwsCodeCommitUrlReader', () => {
 
       const config = new ConfigReader({
         host: AMAZON_AWS_CODECOMMIT_HOST,
+        region: 'us-east-1',
         roleArn: 'arn:aws:iam::123456789012:role/MyRole',
       });
 
       const credsManager = DefaultAwsCredentialsManager.fromConfig(config);
       const reader = new AwsCodeCommitUrlReader(
         credsManager,
-        new AwsCodeCommitIntegration(readAwsCodeCommitIntegrationConfig(config)),
+        new AwsCodeCommitIntegration(
+          readAwsCodeCommitIntegrationConfig(config),
+        ),
         { treeResponseFactory },
       );
 

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsCodeCommitUrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsCodeCommitUrlReader.ts
@@ -186,21 +186,40 @@ export class AwsCodeCommitUrlReader implements UrlReaderService {
 
     const accessKeyId = integration.config.accessKeyId;
     const secretAccessKey = integration.config.secretAccessKey;
-    let explicitCredentials: AwsCredentialIdentityProvider;
+    const roleArn = integration.config.roleArn;
+
     if (accessKeyId && secretAccessKey) {
-      explicitCredentials = AwsCodeCommitUrlReader.buildStaticCredentials(
+      const explicitCredentials = AwsCodeCommitUrlReader.buildStaticCredentials(
         accessKeyId,
         secretAccessKey,
       );
-    } else {
-      explicitCredentials = (await credsManager.getCredentialProvider())
-        .sdkCredentialProvider;
+      if (roleArn) {
+        return fromTemporaryCredentials({
+          masterCredentials: explicitCredentials,
+          params: {
+            RoleSessionName: 'backstage-aws-code-commit-url-reader',
+            RoleArn: roleArn,
+            ExternalId: integration.config.externalId,
+          },
+          clientConfig: { region },
+        });
+      }
+      return explicitCredentials;
     }
 
-    const roleArn = integration.config.roleArn;
     if (roleArn) {
+      let masterCredentials: AwsCredentialIdentityProvider;
+      try {
+        masterCredentials = (
+          await credsManager.getCredentialProvider({ arn: roleArn })
+        ).sdkCredentialProvider;
+      } catch {
+        // No account-specific config for this ARN; fall back to default credentials
+        masterCredentials = (await credsManager.getCredentialProvider())
+          .sdkCredentialProvider;
+      }
       return fromTemporaryCredentials({
-        masterCredentials: explicitCredentials,
+        masterCredentials,
         params: {
           RoleSessionName: 'backstage-aws-code-commit-url-reader',
           RoleArn: roleArn,
@@ -210,7 +229,7 @@ export class AwsCodeCommitUrlReader implements UrlReaderService {
       });
     }
 
-    return explicitCredentials;
+    return (await credsManager.getCredentialProvider()).sdkCredentialProvider;
   }
 
   private async buildCodeCommitClient(

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsCodeCommitUrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsCodeCommitUrlReader.ts
@@ -185,21 +185,40 @@ export class AwsCodeCommitUrlReader implements UrlReaderService {
 
     const accessKeyId = integration.config.accessKeyId;
     const secretAccessKey = integration.config.secretAccessKey;
-    let explicitCredentials: AwsCredentialIdentityProvider;
+    const roleArn = integration.config.roleArn;
+
     if (accessKeyId && secretAccessKey) {
-      explicitCredentials = AwsCodeCommitUrlReader.buildStaticCredentials(
+      const explicitCredentials = AwsCodeCommitUrlReader.buildStaticCredentials(
         accessKeyId,
         secretAccessKey,
       );
-    } else {
-      explicitCredentials = (await credsManager.getCredentialProvider())
-        .sdkCredentialProvider;
+      if (roleArn) {
+        return fromTemporaryCredentials({
+          masterCredentials: explicitCredentials,
+          params: {
+            RoleSessionName: 'backstage-aws-code-commit-url-reader',
+            RoleArn: roleArn,
+            ExternalId: integration.config.externalId,
+          },
+          clientConfig: { region },
+        });
+      }
+      return explicitCredentials;
     }
 
-    const roleArn = integration.config.roleArn;
     if (roleArn) {
+      let masterCredentials: AwsCredentialIdentityProvider;
+      try {
+        masterCredentials = (
+          await credsManager.getCredentialProvider({ arn: roleArn })
+        ).sdkCredentialProvider;
+      } catch {
+        // No account-specific config for this ARN; fall back to default credentials
+        masterCredentials = (await credsManager.getCredentialProvider())
+          .sdkCredentialProvider;
+      }
       return fromTemporaryCredentials({
-        masterCredentials: explicitCredentials,
+        masterCredentials,
         params: {
           RoleSessionName: 'backstage-aws-code-commit-url-reader',
           RoleArn: roleArn,
@@ -209,7 +228,7 @@ export class AwsCodeCommitUrlReader implements UrlReaderService {
       });
     }
 
-    return explicitCredentials;
+    return (await credsManager.getCredentialProvider()).sdkCredentialProvider;
   }
 
   private async buildCodeCommitClient(

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.test.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.test.ts
@@ -689,4 +689,100 @@ describe('AwsS3UrlReader', () => {
       ).rejects.toThrow('Unsupported search pattern URL');
     });
   });
+
+  describe('buildCredentials with roleArn', () => {
+    const getCredProviderMock = jest.spyOn(
+      DefaultAwsCredentialsManager.prototype,
+      'getCredentialProvider',
+    );
+
+    beforeEach(() => {
+      s3Client.reset();
+      getCredProviderMock.mockReset();
+
+      s3Client.on(GetObjectCommand).resolves({
+        Body: sdkStreamMixin(
+          fs.createReadStream(
+            path.resolve(
+              __dirname,
+              '__fixtures__/awsS3/awsS3-mock-object.yaml',
+            ),
+          ),
+        ),
+        ETag: '123abc',
+      });
+    });
+
+    afterAll(() => {
+      getCredProviderMock.mockRestore();
+    });
+
+    it('uses account-specific credentials as master credentials when account config exists for the role ARN', async () => {
+      const accountCreds = { accessKeyId: 'account-key', secretAccessKey: 'account-secret' };
+      getCredProviderMock.mockImplementation(async (opts?: any) => {
+        if (opts?.arn) {
+          return {
+            accountId: '123456789012',
+            sdkCredentialProvider: async () => accountCreds,
+          };
+        }
+        return {
+          sdkCredentialProvider: async () => ({ accessKeyId: 'default-key', secretAccessKey: 'default-secret' }),
+        };
+      });
+
+      const config = new ConfigReader({
+        host: 'amazonaws.com',
+        roleArn: 'arn:aws:iam::123456789012:role/MyRole',
+      });
+
+      const credsManager = DefaultAwsCredentialsManager.fromConfig(config);
+      const reader = new AwsS3UrlReader(
+        credsManager,
+        new AwsS3Integration(readAwsS3IntegrationConfig(config)),
+        { treeResponseFactory },
+      );
+
+      await reader.readUrl(
+        'https://test-bucket.s3.us-east-2.amazonaws.com/file.yaml',
+      );
+
+      expect(getCredProviderMock).toHaveBeenCalledWith({
+        arn: 'arn:aws:iam::123456789012:role/MyRole',
+      });
+    });
+
+    it('falls back to default credentials when no account config exists for the role ARN', async () => {
+      const defaultCreds = { accessKeyId: 'default-key', secretAccessKey: 'default-secret' };
+      getCredProviderMock.mockImplementation(async (opts?: any) => {
+        if (opts?.arn) {
+          throw new Error('No matching account');
+        }
+        return {
+          sdkCredentialProvider: async () => defaultCreds,
+        };
+      });
+
+      const config = new ConfigReader({
+        host: 'amazonaws.com',
+        roleArn: 'arn:aws:iam::123456789012:role/MyRole',
+      });
+
+      const credsManager = DefaultAwsCredentialsManager.fromConfig(config);
+      const reader = new AwsS3UrlReader(
+        credsManager,
+        new AwsS3Integration(readAwsS3IntegrationConfig(config)),
+        { treeResponseFactory },
+      );
+
+      await reader.readUrl(
+        'https://test-bucket.s3.us-east-2.amazonaws.com/file.yaml',
+      );
+
+      expect(getCredProviderMock).toHaveBeenCalledWith({
+        arn: 'arn:aws:iam::123456789012:role/MyRole',
+      });
+      expect(getCredProviderMock).toHaveBeenCalledWith();
+    });
+  });
 });

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.test.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.test.ts
@@ -796,4 +796,100 @@ describe('AwsS3UrlReader', () => {
       ).rejects.toThrow('Unsupported search pattern URL');
     });
   });
+
+  describe('buildCredentials with roleArn', () => {
+    const getCredProviderMock = jest.spyOn(
+      DefaultAwsCredentialsManager.prototype,
+      'getCredentialProvider',
+    );
+
+    beforeEach(() => {
+      s3Client.reset();
+      getCredProviderMock.mockReset();
+
+      s3Client.on(GetObjectCommand).resolves({
+        Body: sdkStreamMixin(
+          fs.createReadStream(
+            path.resolve(
+              __dirname,
+              '__fixtures__/awsS3/awsS3-mock-object.yaml',
+            ),
+          ),
+        ),
+        ETag: '123abc',
+      });
+    });
+
+    afterAll(() => {
+      getCredProviderMock.mockRestore();
+    });
+
+    it('uses account-specific credentials as master credentials when account config exists for the role ARN', async () => {
+      const accountCreds = { accessKeyId: 'account-key', secretAccessKey: 'account-secret' };
+      getCredProviderMock.mockImplementation(async (opts?: any) => {
+        if (opts?.arn) {
+          return {
+            accountId: '123456789012',
+            sdkCredentialProvider: async () => accountCreds,
+          };
+        }
+        return {
+          sdkCredentialProvider: async () => ({ accessKeyId: 'default-key', secretAccessKey: 'default-secret' }),
+        };
+      });
+
+      const config = new ConfigReader({
+        host: 'amazonaws.com',
+        roleArn: 'arn:aws:iam::123456789012:role/MyRole',
+      });
+
+      const credsManager = DefaultAwsCredentialsManager.fromConfig(config);
+      const reader = new AwsS3UrlReader(
+        credsManager,
+        new AwsS3Integration(readAwsS3IntegrationConfig(config)),
+        { treeResponseFactory },
+      );
+
+      await reader.readUrl(
+        'https://test-bucket.s3.us-east-2.amazonaws.com/file.yaml',
+      );
+
+      expect(getCredProviderMock).toHaveBeenCalledWith({
+        arn: 'arn:aws:iam::123456789012:role/MyRole',
+      });
+    });
+
+    it('falls back to default credentials when no account config exists for the role ARN', async () => {
+      const defaultCreds = { accessKeyId: 'default-key', secretAccessKey: 'default-secret' };
+      getCredProviderMock.mockImplementation(async (opts?: any) => {
+        if (opts?.arn) {
+          throw new Error('No matching account');
+        }
+        return {
+          sdkCredentialProvider: async () => defaultCreds,
+        };
+      });
+
+      const config = new ConfigReader({
+        host: 'amazonaws.com',
+        roleArn: 'arn:aws:iam::123456789012:role/MyRole',
+      });
+
+      const credsManager = DefaultAwsCredentialsManager.fromConfig(config);
+      const reader = new AwsS3UrlReader(
+        credsManager,
+        new AwsS3Integration(readAwsS3IntegrationConfig(config)),
+        { treeResponseFactory },
+      );
+
+      await reader.readUrl(
+        'https://test-bucket.s3.us-east-2.amazonaws.com/file.yaml',
+      );
+
+      expect(getCredProviderMock).toHaveBeenCalledWith({
+        arn: 'arn:aws:iam::123456789012:role/MyRole',
+      });
+      expect(getCredProviderMock).toHaveBeenCalledWith();
+    });
+  });
 });

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.test.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.test.ts
@@ -798,34 +798,38 @@ describe('AwsS3UrlReader', () => {
   });
 
   describe('buildCredentials with roleArn', () => {
-    const getCredProviderMock = jest.spyOn(
-      DefaultAwsCredentialsManager.prototype,
-      'getCredentialProvider',
-    );
+    let getCredProviderMock: jest.SpyInstance;
 
     beforeEach(() => {
-      s3Client.reset();
-      getCredProviderMock.mockReset();
-
-      s3Client.on(GetObjectCommand).resolves({
-        Body: sdkStreamMixin(
-          fs.createReadStream(
-            path.resolve(
-              __dirname,
-              '__fixtures__/awsS3/awsS3-mock-object.yaml',
+      getCredProviderMock = jest.spyOn(
+        DefaultAwsCredentialsManager.prototype,
+        'getCredentialProvider',
+      );
+      jest.spyOn(S3Client.prototype, 'send').mockImplementation(s3SendMock);
+      s3SendMock.mockReset();
+      s3SendMock.mockImplementation(async command => {
+        if (command instanceof GetObjectCommand) {
+          return {
+            Body: sdkStreamMixin(
+              fs.createReadStream(
+                path.resolve(
+                  __dirname,
+                  '__fixtures__/awsS3/awsS3-mock-object.yaml',
+                ),
+              ),
             ),
-          ),
-        ),
-        ETag: '123abc',
+            ETag: '123abc',
+          };
+        }
+        throw new Error(`No mock for ${command.constructor.name}`);
       });
     });
 
-    afterAll(() => {
-      getCredProviderMock.mockRestore();
-    });
-
     it('uses account-specific credentials as master credentials when account config exists for the role ARN', async () => {
-      const accountCreds = { accessKeyId: 'account-key', secretAccessKey: 'account-secret' };
+      const accountCreds = {
+        accessKeyId: 'account-key',
+        secretAccessKey: 'account-secret',
+      };
       getCredProviderMock.mockImplementation(async (opts?: any) => {
         if (opts?.arn) {
           return {
@@ -834,7 +838,10 @@ describe('AwsS3UrlReader', () => {
           };
         }
         return {
-          sdkCredentialProvider: async () => ({ accessKeyId: 'default-key', secretAccessKey: 'default-secret' }),
+          sdkCredentialProvider: async () => ({
+            accessKeyId: 'default-key',
+            secretAccessKey: 'default-secret',
+          }),
         };
       });
 
@@ -860,7 +867,10 @@ describe('AwsS3UrlReader', () => {
     });
 
     it('falls back to default credentials when no account config exists for the role ARN', async () => {
-      const defaultCreds = { accessKeyId: 'default-key', secretAccessKey: 'default-secret' };
+      const defaultCreds = {
+        accessKeyId: 'default-key',
+        secretAccessKey: 'default-secret',
+      };
       getCredProviderMock.mockImplementation(async (opts?: any) => {
         if (opts?.arn) {
           throw new Error('No matching account');

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.ts
@@ -234,21 +234,40 @@ export class AwsS3UrlReader implements UrlReaderService {
 
     const accessKeyId = integration.config.accessKeyId;
     const secretAccessKey = integration.config.secretAccessKey;
-    let explicitCredentials: AwsCredentialIdentityProvider;
+    const roleArn = integration.config.roleArn;
+
     if (accessKeyId && secretAccessKey) {
-      explicitCredentials = AwsS3UrlReader.buildStaticCredentials(
+      const explicitCredentials = AwsS3UrlReader.buildStaticCredentials(
         accessKeyId,
         secretAccessKey,
       );
-    } else {
-      explicitCredentials = (await credsManager.getCredentialProvider())
-        .sdkCredentialProvider;
+      if (roleArn) {
+        return fromTemporaryCredentials({
+          masterCredentials: explicitCredentials,
+          params: {
+            RoleSessionName: 'backstage-aws-s3-url-reader',
+            RoleArn: roleArn,
+            ExternalId: integration.config.externalId,
+          },
+          clientConfig: { region },
+        });
+      }
+      return explicitCredentials;
     }
 
-    const roleArn = integration.config.roleArn;
     if (roleArn) {
+      let masterCredentials: AwsCredentialIdentityProvider;
+      try {
+        masterCredentials = (
+          await credsManager.getCredentialProvider({ arn: roleArn })
+        ).sdkCredentialProvider;
+      } catch {
+        // No account-specific config for this ARN; fall back to default credentials
+        masterCredentials = (await credsManager.getCredentialProvider())
+          .sdkCredentialProvider;
+      }
       return fromTemporaryCredentials({
-        masterCredentials: explicitCredentials,
+        masterCredentials,
         params: {
           RoleSessionName: 'backstage-aws-s3-url-reader',
           RoleArn: roleArn,
@@ -258,7 +277,7 @@ export class AwsS3UrlReader implements UrlReaderService {
       });
     }
 
-    return explicitCredentials;
+    return (await credsManager.getCredentialProvider()).sdkCredentialProvider;
   }
 
   private async buildS3Client(

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/AwsS3UrlReader.ts
@@ -243,21 +243,40 @@ export class AwsS3UrlReader implements UrlReaderService {
 
     const accessKeyId = integration.config.accessKeyId;
     const secretAccessKey = integration.config.secretAccessKey;
-    let explicitCredentials: AwsCredentialIdentityProvider;
+    const roleArn = integration.config.roleArn;
+
     if (accessKeyId && secretAccessKey) {
-      explicitCredentials = AwsS3UrlReader.buildStaticCredentials(
+      const explicitCredentials = AwsS3UrlReader.buildStaticCredentials(
         accessKeyId,
         secretAccessKey,
       );
-    } else {
-      explicitCredentials = (await credsManager.getCredentialProvider())
-        .sdkCredentialProvider;
+      if (roleArn) {
+        return fromTemporaryCredentials({
+          masterCredentials: explicitCredentials,
+          params: {
+            RoleSessionName: 'backstage-aws-s3-url-reader',
+            RoleArn: roleArn,
+            ExternalId: integration.config.externalId,
+          },
+          clientConfig: { region },
+        });
+      }
+      return explicitCredentials;
     }
 
-    const roleArn = integration.config.roleArn;
     if (roleArn) {
+      let masterCredentials: AwsCredentialIdentityProvider;
+      try {
+        masterCredentials = (
+          await credsManager.getCredentialProvider({ arn: roleArn })
+        ).sdkCredentialProvider;
+      } catch {
+        // No account-specific config for this ARN; fall back to default credentials
+        masterCredentials = (await credsManager.getCredentialProvider())
+          .sdkCredentialProvider;
+      }
       return fromTemporaryCredentials({
-        masterCredentials: explicitCredentials,
+        masterCredentials,
         params: {
           RoleSessionName: 'backstage-aws-s3-url-reader',
           RoleArn: roleArn,
@@ -267,7 +286,7 @@ export class AwsS3UrlReader implements UrlReaderService {
       });
     }
 
-    return explicitCredentials;
+    return (await credsManager.getCredentialProvider()).sdkCredentialProvider;
   }
 
   private async buildS3Client(

--- a/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngine.ts
+++ b/plugins/search-backend-module-elasticsearch/src/engines/ElasticSearchSearchEngine.ts
@@ -201,9 +201,13 @@ export class ElasticSearchSearchEngine implements SearchEngine {
       authProvider,
     } = options;
     const credentialProvider = DefaultAwsCredentialsManager.fromConfig(config);
+    const esConfig = config.getConfig('search.elasticsearch');
+    const awsAccountId = esConfig.getOptionalString('accountId');
     const clientOptions = await this.createElasticSearchClientOptions(
-      await credentialProvider?.getCredentialProvider(),
-      config.getConfig('search.elasticsearch'),
+      await credentialProvider?.getCredentialProvider(
+        awsAccountId ? { accountId: awsAccountId } : undefined,
+      ),
+      esConfig,
       authProvider,
     );
     if (clientOptions.provider === 'elastic') {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

`AwsS3UrlReader` and `AwsCodeCommitUrlReader` now pass the integration's role ARN to `getCredentialProvider()`, enabling them to resolve account-specific credentials (e.g. `webIdentityTokenFile` via `aws.accounts` or `aws.accountDefaults`). Previously they always used the main account's default credential chain, which fails in environments without ambient AWS credentials (such as GCP).

Falls back to existing behavior (main account + `fromTemporaryCredentials`) when no account-specific config is found.

`ElasticSearchSearchEngine` adds an optional `search.elasticsearch.accountId` config key and passes it to `getCredentialProvider()`, enabling the same account-specific credential resolution for AWS OpenSearch.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
