### PR TITLE
fix(catalog-react): guard replaceState in entity list to prevent Safari SecurityError

### DIFF
--- a/.changeset/catalog-replacestate-guard.md
+++ b/.changeset/catalog-replacestate-guard.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Fixed the catalog entity list re-writing the URL on every render, which spammed `history.replaceState` and crashed Safari with a `SecurityError`. The URL is now only updated when it actually changes.

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.test.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.test.tsx
@@ -339,6 +339,46 @@ describe('<EntityListProvider />', () => {
     expect(mockCatalogApi.getEntities).toHaveBeenCalledTimes(1);
   });
 
+  it('does not rewrite the URL when the serialized filters are unchanged', async () => {
+    // Delegate to the real implementation so window.location actually
+    // reflects the rewritten URL, which is what the guard compares against.
+    const replaceStateSpy = jest.fn(
+      (...args: Parameters<History['replaceState']>) =>
+        origReplaceState.apply(window.history, args),
+    );
+    window.history.replaceState = replaceStateSpy;
+
+    const { result } = renderHook(() => useEntityList(), {
+      wrapper: createWrapper({ pagination }),
+    });
+
+    // Applying the user filter changes the URL, so the URL is rewritten once.
+    act(() => {
+      result.current.updateFilters({ user: EntityUserFilter.all() });
+    });
+
+    await waitFor(() => {
+      expect(replaceStateSpy).toHaveBeenCalled();
+    });
+    const callsAfterChange = replaceStateSpy.mock.calls.length;
+
+    // Re-applying an equivalent filter produces a fresh requestedFilters
+    // object that serializes to the same URL (mirrors the UserListPicker
+    // `?filters[user]=all` churn). The URL must not be rewritten again,
+    // since repeated replaceState calls crash Safari with a SecurityError.
+    act(() => {
+      result.current.updateFilters({ user: EntityUserFilter.all() });
+    });
+
+    await expect(
+      waitFor(() => {
+        expect(replaceStateSpy.mock.calls.length).toBeGreaterThan(
+          callsAfterChange,
+        );
+      }),
+    ).rejects.toThrow();
+  });
+
   it('returns an error on catalogApi failure', async () => {
     const { result } = renderHook(() => useEntityList(), {
       wrapper: createWrapper({ pagination }),

--- a/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
+++ b/plugins/catalog-react/src/hooks/useEntityListProvider.tsx
@@ -426,7 +426,15 @@ export const EntityListProvider = <EntityFilters extends DefaultEntityFilters>(
       { addQueryPrefix: true, arrayFormat: 'repeat' },
     );
     const newUrl = `${window.location.pathname}${newParams}`;
-    window.history?.replaceState(null, document.title, newUrl);
+    const currentUrl = `${window.location.pathname}${window.location.search}`;
+    // Only rewrite the URL when it actually changes. Some filters (e.g. the
+    // user filter with `?filters[user]=all`) produce a new requestedFilters
+    // object on every render while serializing to the same URL; without this
+    // guard replaceState is called repeatedly, which crashes Safari with a
+    // SecurityError once it exceeds its replaceState rate limit.
+    if (newUrl !== currentUrl) {
+      window.history?.replaceState(null, document.title, newUrl);
+    }
   }, [
     cursor,
     isMounted,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Safari crashes on the catalog index page with `SecurityError: Attempt to use history.replaceState() more than 100 times per 10 seconds`.

Cause: the effect in `useEntityListProvider` that mirrors filter state into the URL called `window.history.replaceState(...)` on every `requestedFilters` change. With `?filters[user]=all`, `UserListPicker` produces a fresh `EntityUserFilter.all()` on each render, so the same URL was rewritten in a tight loop. Chrome/Firefox don't rate-limit `replaceState`, so it only surfaced in Safari.

Fix: only call `replaceState` when the computed URL actually differs from the current one.

Fixes #34941

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
