### PR TITLE
Add ScaleQuality to the plugin directory

### DIFF
--- a/microsite/data/plugins/scalequality.yaml
+++ b/microsite/data/plugins/scalequality.yaml
@@ -1,0 +1,10 @@
+title: ScaleQuality
+author: ScaleQuality
+authorUrl: https://scalequality.io
+category: Code Quality
+description: Surface ScaleQuality's measured quality signals (AI code durability, engineering maturity, code maturity, tech radar) on any entity in your catalog.
+documentation: https://github.com/scalequality-io/backstage-plugin#readme
+iconUrl: https://raw.githubusercontent.com/scalequality-io/backstage-plugin/main/assets/scalequality-icon.png
+npmPackageName: '@scalequality/backstage-plugin'
+addedDate: '2026-07-22'
+status: active


### PR DESCRIPTION
## Description

Adds **ScaleQuality** to the plugin directory.

[`@scalequality/backstage-plugin`](https://www.npmjs.com/package/@scalequality/backstage-plugin) is a frontend entity plugin that surfaces ScaleQuality's measured quality signals (AI code durability, engineering maturity, code maturity, and tech radar) on any catalog entity, sourced from ScaleQuality's read-only `/v1` API via the Backstage proxy.

- **npm:** https://www.npmjs.com/package/@scalequality/backstage-plugin
- **Source & docs:** https://github.com/scalequality-io/backstage-plugin

This PR only adds `microsite/data/plugins/scalequality.yaml`, following the existing directory format and validated against the `scripts/verify-plugin-directory.js` schema.
