### PR TITLE
fix(ui): make Dialog panel opaque in dark mode

### DIFF
--- a/.changeset/dialog-dark-opaque-panel.md
+++ b/.changeset/dialog-dark-opaque-panel.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed the Dialog surface becoming semi-transparent in dark mode, which let content behind the dialog show through and made its own content hard to read. The dialog panel is now fully opaque in dark mode, matching light mode.

--- a/packages/ui/src/components/Dialog/Dialog.module.css
+++ b/packages/ui/src/components/Dialog/Dialog.module.css
@@ -30,10 +30,6 @@
     z-index: 1000;
   }
 
-  [data-theme-mode='dark'] .bui-Dialog {
-    background: rgba(0, 0, 0, 0.5);
-  }
-
   .bui-DialogOverlay[data-entering] {
     animation: fade-in 200ms ease-out forwards;
   }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

In dark mode, the `Dialog` panel rendered at 50% opacity, so content behind the dialog showed through and the dialog's own content was hard to read.

The dark-mode rule `[data-theme-mode='dark'] .bui-Dialog { background: rgba(0, 0, 0, 0.5) }` targets the panel (`.bui-Dialog`), but the panel already has an opaque base (`background: var(--bui-bg-app)`), so the override just made it translucent. It appears to be a leftover from #33785 (which separated the overlay from the modal and lifted the classes up one layer, so `.bui-Dialog` went from being the overlay to being the panel) that was then activated by #33898 (which corrected the selector from `[data-theme='dark']` to `[data-theme-mode='dark']`). The fix removes the stray override; the overlay keeps its own scrim and the panel stays opaque in both themes.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
