### PR TITLE
fix(mcp): advertise OAuth resource metadata

### DIFF
--- a/.changeset/calm-cats-challenge.md
+++ b/.changeset/calm-cats-challenge.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-mcp-actions-backend': patch
+---
+
+Added RFC 9728 `WWW-Authenticate` challenges to MCP endpoints when OAuth support is enabled, allowing clients to discover protected resource metadata and recover from rejected access tokens.

--- a/docs/ai/mcp-actions.md
+++ b/docs/ai/mcp-actions.md
@@ -134,6 +134,12 @@ mcpActions:
 
 By default, the Backstage backend requires authentication for all requests.
 
+When OAuth support is enabled through Dynamic Client Registration or Client ID
+Metadata Documents, unauthenticated MCP requests return an RFC 9728
+`WWW-Authenticate` challenge. The challenge points clients to the protected
+resource metadata for the requested MCP server. Rejected Bearer tokens include
+`error="invalid_token"` so clients can refresh or restart authorization.
+
 ### External Access with Static Tokens
 
 :::warning

--- a/plugins/mcp-actions-backend/src/plugin.test.ts
+++ b/plugins/mcp-actions-backend/src/plugin.test.ts
@@ -24,7 +24,11 @@ import {
 } from '@backstage/backend-test-utils/alpha';
 import { mcpPlugin } from './plugin';
 import { actionsRegistryServiceRef } from '@backstage/backend-plugin-api/alpha';
-import { createBackendPlugin } from '@backstage/backend-plugin-api';
+import {
+  coreServices,
+  createBackendPlugin,
+  createServiceFactory,
+} from '@backstage/backend-plugin-api';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { ListToolsResultSchema } from '@modelcontextprotocol/sdk/types.js';
@@ -523,12 +527,19 @@ describe('Mcp Backend', () => {
           getExternalBaseUrl: async pluginId =>
             `${externalBaseUrl}/${pluginId}`,
         });
+        const mockAuditor = mockServices.auditor.mock();
+        const mockAuditorFactory = createServiceFactory({
+          service: coreServices.auditor,
+          deps: {},
+          factory: async () => mockAuditor,
+        });
 
         const { server } = await startTestBackend({
           features: [
             mcpPlugin,
             mockPluginWithActions,
             mockDiscovery.factory,
+            mockAuditorFactory,
             mockServices.httpAuth.factory({
               defaultCredentials: mockCredentials.none(),
             }),
@@ -585,6 +596,7 @@ describe('Mcp Backend', () => {
         expect(invalidCredentials.header['www-authenticate']).toBe(
           `Bearer resource_metadata="${resourceMetadataUrl}", error="invalid_token"`,
         );
+        expect(mockAuditor.createEvent).not.toHaveBeenCalled();
 
         const validCredentials = await request(server)
           .post(path)

--- a/plugins/mcp-actions-backend/src/plugin.test.ts
+++ b/plugins/mcp-actions-backend/src/plugin.test.ts
@@ -13,7 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
+import {
+  mockCredentials,
+  mockServices,
+  startTestBackend,
+} from '@backstage/backend-test-utils';
 import {
   metricsServiceMock,
   tracingServiceMock,
@@ -489,6 +493,144 @@ describe('Mcp Backend', () => {
       await request(server)
         .get('/.well-known/oauth-protected-resource/api/mcp-actions/v1')
         .expect(200);
+    });
+
+    const challengeTestCases = [
+      {
+        name: 'default server',
+        suffix: '/v1',
+        mcpActions: undefined,
+      },
+      {
+        name: 'named server',
+        suffix: '/v1/catalog',
+        mcpActions: {
+          servers: {
+            catalog: {
+              name: 'Catalog',
+              filter: { include: [] },
+            },
+          },
+        },
+      },
+    ];
+
+    it.each(challengeTestCases)(
+      'should advertise OAuth metadata and still require credentials for the $name',
+      async ({ suffix, mcpActions }) => {
+        const externalBaseUrl = 'https://backstage.example.com/api';
+        const mockDiscovery = mockServices.discovery.mock({
+          getExternalBaseUrl: async pluginId =>
+            `${externalBaseUrl}/${pluginId}`,
+        });
+
+        const { server } = await startTestBackend({
+          features: [
+            mcpPlugin,
+            mockPluginWithActions,
+            mockDiscovery.factory,
+            mockServices.httpAuth.factory({
+              defaultCredentials: mockCredentials.none(),
+            }),
+            mockServices.rootConfig.factory({
+              data: {
+                backend: {
+                  actions: {
+                    pluginSources: ['local'],
+                  },
+                },
+                auth: {
+                  experimentalDynamicClientRegistration: {
+                    enabled: true,
+                  },
+                },
+                ...(mcpActions && { mcpActions }),
+              },
+            }),
+          ],
+        });
+
+        const path = `/api/mcp-actions${suffix}`;
+        const resourceMetadataUrl = `${externalBaseUrl.replace(
+          /\/api$/,
+          '',
+        )}/.well-known/oauth-protected-resource${path}`;
+        const initializeRequest = {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'initialize',
+          params: {
+            protocolVersion: '2025-06-18',
+            capabilities: {},
+            clientInfo: { name: 'test client', version: '1.0' },
+          },
+        };
+
+        const missingCredentials = await request(server)
+          .post(path)
+          .set('Host', 'untrusted.example.com')
+          .set('Accept', 'application/json, text/event-stream')
+          .send(initializeRequest);
+        expect(missingCredentials.status).toBe(401);
+        expect(missingCredentials.header['www-authenticate']).toBe(
+          `Bearer resource_metadata="${resourceMetadataUrl}"`,
+        );
+
+        const invalidCredentials = await request(server)
+          .post(path)
+          .set('Authorization', 'Bearer invalid-token')
+          .set('Accept', 'application/json, text/event-stream')
+          .send(initializeRequest);
+        expect(invalidCredentials.status).toBe(401);
+        expect(invalidCredentials.header['www-authenticate']).toBe(
+          `Bearer resource_metadata="${resourceMetadataUrl}", error="invalid_token"`,
+        );
+
+        const validCredentials = await request(server)
+          .post(path)
+          .set('Authorization', mockCredentials.user.header())
+          .set('Accept', 'application/json, text/event-stream')
+          .send(initializeRequest);
+        expect(validCredentials.status).toBe(200);
+      },
+    );
+
+    it('should keep the default authentication policy when OAuth is disabled', async () => {
+      const { server } = await startTestBackend({
+        features: [
+          mcpPlugin,
+          mockPluginWithActions,
+          mockServices.httpAuth.factory({
+            defaultCredentials: mockCredentials.none(),
+          }),
+          mockServices.rootConfig.factory({
+            data: {
+              backend: {
+                actions: {
+                  pluginSources: ['local'],
+                },
+              },
+            },
+          }),
+        ],
+      });
+
+      const response = await request(server)
+        .post('/api/mcp-actions/v1')
+        .set('Accept', 'application/json, text/event-stream')
+        .send({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'initialize',
+          params: {
+            protocolVersion: '2025-06-18',
+            capabilities: {},
+            clientInfo: { name: 'test client', version: '1.0' },
+          },
+        });
+
+      expect(response.status).toBe(401);
+      expect(response.header['www-authenticate']).toBeUndefined();
     });
   });
 });

--- a/plugins/mcp-actions-backend/src/plugin.ts
+++ b/plugins/mcp-actions-backend/src/plugin.ts
@@ -71,6 +71,26 @@ export const mcpPlugin = createBackendPlugin({
         const captureToolPayloads =
           config.getOptionalBoolean('mcpActions.tracing.capture.toolPayload') ??
           false;
+        const cimdConfigPath = config.has('auth.clientIdMetadataDocuments')
+          ? 'auth.clientIdMetadataDocuments'
+          : 'auth.experimentalClientIdMetadataDocuments';
+        const oauthEnabled =
+          config.getOptionalBoolean(
+            'auth.experimentalDynamicClientRegistration.enabled',
+          ) || config.getOptionalBoolean(`${cimdConfigPath}.enabled`);
+        const externalMcpBaseUrl = oauthEnabled
+          ? new URL(await discovery.getExternalBaseUrl('mcp-actions'))
+          : undefined;
+        const getResourceMetadataUrl = (suffix: string) =>
+          externalMcpBaseUrl
+            ? new URL(
+                `/.well-known/oauth-protected-resource${externalMcpBaseUrl.pathname.replace(
+                  /\/$/,
+                  '',
+                )}${suffix}`,
+                externalMcpBaseUrl.origin,
+              ).href
+            : undefined;
 
         const mcpService = await McpService.create({
           actions,
@@ -87,6 +107,14 @@ export const mcpPlugin = createBackendPlugin({
 
         if (serverConfigs && serverConfigs.size > 0) {
           for (const [key, serverConfig] of serverConfigs) {
+            const suffix = `/v1/${key}`;
+            if (oauthEnabled) {
+              httpRouter.addAuthPolicy({
+                path: suffix,
+                allow: 'unauthenticated',
+              });
+            }
+
             const streamableRouter = createStreamableRouter({
               mcpService,
               httpAuth,
@@ -95,11 +123,20 @@ export const mcpPlugin = createBackendPlugin({
               tracing,
               auditor,
               serverConfig,
+              resourceMetadataUrl: getResourceMetadataUrl(suffix),
             });
 
-            router.use(`/v1/${key}`, streamableRouter);
+            router.use(suffix, streamableRouter);
           }
         } else {
+          const suffix = '/v1';
+          if (oauthEnabled) {
+            httpRouter.addAuthPolicy({
+              path: suffix,
+              allow: 'unauthenticated',
+            });
+          }
+
           const serverConfig = {
             name: config.getOptionalString('mcpActions.name') ?? 'backstage',
             description: config.getOptionalString('mcpActions.description'),
@@ -116,20 +153,13 @@ export const mcpPlugin = createBackendPlugin({
             tracing,
             auditor,
             serverConfig,
+            resourceMetadataUrl: getResourceMetadataUrl(suffix),
           });
 
-          router.use('/v1', streamableRouter);
+          router.use(suffix, streamableRouter);
         }
 
         httpRouter.use(router);
-
-        const cimdConfigPath = config.has('auth.clientIdMetadataDocuments')
-          ? 'auth.clientIdMetadataDocuments'
-          : 'auth.experimentalClientIdMetadataDocuments';
-        const oauthEnabled =
-          config.getOptionalBoolean(
-            'auth.experimentalDynamicClientRegistration.enabled',
-          ) || config.getOptionalBoolean(`${cimdConfigPath}.enabled`);
 
         if (oauthEnabled) {
           // OAuth Authorization Server Metadata (RFC 8414)

--- a/plugins/mcp-actions-backend/src/routers/createStreamableRouter.ts
+++ b/plugins/mcp-actions-backend/src/routers/createStreamableRouter.ts
@@ -71,8 +71,79 @@ export const createStreamableRouter = ({
       'network.protocol.name': 'http',
     };
 
+    const handleError = async ({
+      error,
+      connectionEvent,
+      authenticationAttempt = false,
+    }: {
+      error: unknown;
+      connectionEvent?: AuditorServiceEvent;
+      authenticationAttempt?: boolean;
+    }) => {
+      const err = toError(error);
+      const errorType = err.name;
+
+      logger.error(err.message);
+
+      if (!res.headersSent) {
+        if (
+          authenticationAttempt &&
+          err.name === 'AuthenticationError' &&
+          resourceMetadataUrl
+        ) {
+          const hasBearerToken =
+            typeof req.headers.authorization === 'string' &&
+            /^Bearer[ ]+\S+$/i.test(req.headers.authorization);
+          res.setHeader(
+            'WWW-Authenticate',
+            `Bearer resource_metadata="${resourceMetadataUrl}"${
+              hasBearerToken ? ', error="invalid_token"' : ''
+            }`,
+          );
+          res.status(401).json({
+            jsonrpc: '2.0',
+            error: {
+              code: -32001,
+              message: 'Authentication required',
+            },
+            id: null,
+          });
+        } else {
+          res.status(500).json({
+            jsonrpc: '2.0',
+            error: {
+              code: -32603,
+              message: 'Internal server error',
+            },
+            id: null,
+          });
+        }
+      }
+
+      const durationSeconds = (performance.now() - sessionStart) / 1000;
+
+      sessionDuration.record(durationSeconds, {
+        ...baseAttributes,
+        'error.type': errorType,
+      });
+
+      await connectionEvent?.fail({ error: err });
+    };
+
+    const credentials = await httpAuth
+      .credentials(req, {
+        allow: ['user', 'service'],
+      })
+      .catch(async error => {
+        await handleError({ error, authenticationAttempt: true });
+        return undefined;
+      });
+
+    if (!credentials) {
+      return;
+    }
+
     let connectionEvent: AuditorServiceEvent | undefined;
-    let authenticating = true;
 
     try {
       connectionEvent = await auditor.createEvent({
@@ -80,11 +151,6 @@ export const createStreamableRouter = ({
         request: req,
         meta: { transport: 'streamable', actionType: 'established' },
       });
-
-      const credentials = await httpAuth.credentials(req, {
-        allow: ['user', 'service'],
-      });
-      authenticating = false;
 
       const server = mcpService.getServer({
         credentials,
@@ -126,54 +192,7 @@ export const createStreamableRouter = ({
         await e.success();
       });
     } catch (error) {
-      const err = toError(error);
-      const errorType = err.name;
-
-      logger.error(err.message);
-
-      if (!res.headersSent) {
-        if (
-          authenticating &&
-          err.name === 'AuthenticationError' &&
-          resourceMetadataUrl
-        ) {
-          const hasBearerToken =
-            typeof req.headers.authorization === 'string' &&
-            /^Bearer[ ]+\S+$/i.test(req.headers.authorization);
-          res.setHeader(
-            'WWW-Authenticate',
-            `Bearer resource_metadata="${resourceMetadataUrl}"${
-              hasBearerToken ? ', error="invalid_token"' : ''
-            }`,
-          );
-          res.status(401).json({
-            jsonrpc: '2.0',
-            error: {
-              code: -32001,
-              message: 'Authentication required',
-            },
-            id: null,
-          });
-        } else {
-          res.status(500).json({
-            jsonrpc: '2.0',
-            error: {
-              code: -32603,
-              message: 'Internal server error',
-            },
-            id: null,
-          });
-        }
-      }
-
-      const durationSeconds = (performance.now() - sessionStart) / 1000;
-
-      sessionDuration.record(durationSeconds, {
-        ...baseAttributes,
-        'error.type': errorType,
-      });
-
-      await connectionEvent?.fail({ error: toError(error) });
+      await handleError({ error, connectionEvent });
     }
   });
 

--- a/plugins/mcp-actions-backend/src/routers/createStreamableRouter.ts
+++ b/plugins/mcp-actions-backend/src/routers/createStreamableRouter.ts
@@ -23,6 +23,7 @@ import { toError } from '@backstage/errors';
 import { TracingService } from '@backstage/backend-plugin-api/alpha';
 import {
   AuditorService,
+  AuditorServiceEvent,
   HttpAuthService,
   LoggerService,
 } from '@backstage/backend-plugin-api';
@@ -38,6 +39,7 @@ export const createStreamableRouter = ({
   tracing,
   auditor,
   serverConfig,
+  resourceMetadataUrl,
 }: {
   mcpService: McpService;
   logger: LoggerService;
@@ -46,6 +48,7 @@ export const createStreamableRouter = ({
   tracing: TracingService;
   auditor: AuditorService;
   serverConfig?: McpServerConfig;
+  resourceMetadataUrl?: string;
 }): Router => {
   const router = PromiseRouter();
 
@@ -68,15 +71,23 @@ export const createStreamableRouter = ({
       'network.protocol.name': 'http',
     };
 
-    const connectionEvent = await auditor.createEvent({
-      eventId: 'connection',
-      request: req,
-      meta: { transport: 'streamable', actionType: 'established' },
-    });
+    let connectionEvent: AuditorServiceEvent | undefined;
+    let authenticating = true;
 
     try {
+      connectionEvent = await auditor.createEvent({
+        eventId: 'connection',
+        request: req,
+        meta: { transport: 'streamable', actionType: 'established' },
+      });
+
+      const credentials = await httpAuth.credentials(req, {
+        allow: ['user', 'service'],
+      });
+      authenticating = false;
+
       const server = mcpService.getServer({
-        credentials: await httpAuth.credentials(req),
+        credentials,
         serverConfig,
         req,
       });
@@ -121,14 +132,38 @@ export const createStreamableRouter = ({
       logger.error(err.message);
 
       if (!res.headersSent) {
-        res.status(500).json({
-          jsonrpc: '2.0',
-          error: {
-            code: -32603,
-            message: 'Internal server error',
-          },
-          id: null,
-        });
+        if (
+          authenticating &&
+          err.name === 'AuthenticationError' &&
+          resourceMetadataUrl
+        ) {
+          const hasBearerToken =
+            typeof req.headers.authorization === 'string' &&
+            /^Bearer[ ]+\S+$/i.test(req.headers.authorization);
+          res.setHeader(
+            'WWW-Authenticate',
+            `Bearer resource_metadata="${resourceMetadataUrl}"${
+              hasBearerToken ? ', error="invalid_token"' : ''
+            }`,
+          );
+          res.status(401).json({
+            jsonrpc: '2.0',
+            error: {
+              code: -32001,
+              message: 'Authentication required',
+            },
+            id: null,
+          });
+        } else {
+          res.status(500).json({
+            jsonrpc: '2.0',
+            error: {
+              code: -32603,
+              message: 'Internal server error',
+            },
+            id: null,
+          });
+        }
       }
 
       const durationSeconds = (performance.now() - sessionStart) / 1000;
@@ -138,7 +173,7 @@ export const createStreamableRouter = ({
         'error.type': errorType,
       });
 
-      await connectionEvent.fail({ error: toError(error) });
+      await connectionEvent?.fail({ error: toError(error) });
     }
   });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

MCP clients need the RFC 9728 WWW-Authenticate challenge before they can discover how to authorize against a protected MCP endpoint. The MCP Actions backend currently publishes protected-resource metadata, but its unauthenticated response does not point clients to it.

This adds the challenge when Dynamic Client Registration or Client ID Metadata Documents are enabled. Missing credentials advertise the endpoint-specific resource metadata URL, while rejected Bearer tokens additionally report invalid_token. Authentication remains mandatory inside the MCP router for both user and service credentials, and the metadata URL comes from Backstage discovery rather than the request Host header.

This addresses the missing WWW-Authenticate portion of #33750.

AI assistance disclosure: Codex was used extensively to investigate, implement, and test this contribution. The behavior was validated with the complete MCP Actions backend test suite, repository type checking, linting, formatting, and API-report generation.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (not applicable; no UI changes)
- [x] All your commits have a Signed-off-by line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))