### PR TITLE
feat(notifications-backend-module-slack): add a target resolver extension point

### DIFF
--- a/.changeset/slack-notification-target-resolver.md
+++ b/.changeset/slack-notification-target-resolver.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications-backend-module-slack': patch
+---
+
+Added a target resolver extension point (`notificationsSlackTargetResolverExtensionPoint`) that lets you override which Slack channel an entity-addressed notification is delivered to, for example to route notifications to different channels based on their topic. When no resolver is registered, or the resolver returns `undefined`, delivery falls back to the recipient entity's `slack.com/bot-notify` annotation exactly as before.

--- a/plugins/notifications-backend-module-slack/report.api.md
+++ b/plugins/notifications-backend-module-slack/report.api.md
@@ -24,8 +24,29 @@ export interface NotificationsSlackBlockKitExtensionPoint {
 // @public (undocumented)
 export const notificationsSlackBlockKitExtensionPoint: ExtensionPoint<NotificationsSlackBlockKitExtensionPoint>;
 
+// @public
+export interface NotificationsSlackTargetResolverExtensionPoint {
+  // (undocumented)
+  setTargetResolver(resolver: SlackNotificationTargetResolver): void;
+}
+
+// @public (undocumented)
+export const notificationsSlackTargetResolverExtensionPoint: ExtensionPoint<NotificationsSlackTargetResolverExtensionPoint>;
+
 // @public (undocumented)
 export type SlackBlockKitRenderer = (
   payload: NotificationPayload,
 ) => KnownBlock[];
+
+// @public
+export interface SlackNotificationTargetContext {
+  // (undocumented)
+  payload: NotificationPayload;
+}
+
+// @public
+export type SlackNotificationTargetResolver = (
+  entityRef: string,
+  context: SlackNotificationTargetContext,
+) => Promise<string | undefined>;
 ```

--- a/plugins/notifications-backend-module-slack/src/extensions.ts
+++ b/plugins/notifications-backend-module-slack/src/extensions.ts
@@ -41,3 +41,44 @@ export const notificationsSlackBlockKitExtensionPoint =
   createExtensionPoint<NotificationsSlackBlockKitExtensionPoint>({
     id: 'notifications.slack.blockkit',
   });
+
+/**
+ * @public
+ *
+ * Context passed to a {@link SlackNotificationTargetResolver}, describing the
+ * notification whose target is being resolved.
+ */
+export interface SlackNotificationTargetContext {
+  payload: NotificationPayload;
+}
+
+/**
+ * @public
+ *
+ * Resolves the Slack channel for an entity-addressed notification. Return a
+ * Slack channel ID to override where the notification is sent; return
+ * `undefined` to fall back to the entity's `slack.com/bot-notify` annotation
+ * (the default behaviour).
+ */
+export type SlackNotificationTargetResolver = (
+  entityRef: string,
+  context: SlackNotificationTargetContext,
+) => Promise<string | undefined>;
+
+/**
+ * @public
+ *
+ * Extension point for overriding how entity-addressed notifications are mapped
+ * to a Slack channel, for example to route by notification topic.
+ */
+export interface NotificationsSlackTargetResolverExtensionPoint {
+  setTargetResolver(resolver: SlackNotificationTargetResolver): void;
+}
+
+/**
+ * @public
+ */
+export const notificationsSlackTargetResolverExtensionPoint =
+  createExtensionPoint<NotificationsSlackTargetResolverExtensionPoint>({
+    id: 'notifications.slack.target',
+  });

--- a/plugins/notifications-backend-module-slack/src/lib/SlackNotificationProcessor.test.ts
+++ b/plugins/notifications-backend-module-slack/src/lib/SlackNotificationProcessor.test.ts
@@ -156,6 +156,62 @@ describe('SlackNotificationProcessor', () => {
     mockedPThrottle.mockClear();
   });
 
+  describe('target resolver', () => {
+    it('routes to the channel returned by the resolver, overriding bot-notify', async () => {
+      const slack = new WebClient();
+      const targetResolver = jest.fn(async () => 'C_DEPLOYS');
+
+      const processor = SlackNotificationProcessor.fromConfig(config, {
+        auth,
+        logger,
+        catalog: catalogServiceMock({
+          entities: DEFAULT_ENTITIES_RESPONSE.items,
+        }),
+        metrics,
+        slack,
+        targetResolver,
+      })[0];
+
+      await processor.processOptions({
+        recipients: { type: 'entity', entityRef: 'group:default/mock' },
+        payload: { title: 'notification', topic: 'deployment:deploy' },
+      });
+
+      expect(targetResolver).toHaveBeenCalledWith('group:default/mock', {
+        payload: expect.objectContaining({ topic: 'deployment:deploy' }),
+      });
+      expect(slack.chat.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ channel: 'C_DEPLOYS' }),
+      );
+    });
+
+    it('falls back to the bot-notify annotation when the resolver returns undefined', async () => {
+      const slack = new WebClient();
+      const targetResolver = jest.fn(async () => undefined);
+
+      const processor = SlackNotificationProcessor.fromConfig(config, {
+        auth,
+        logger,
+        catalog: catalogServiceMock({
+          entities: DEFAULT_ENTITIES_RESPONSE.items,
+        }),
+        metrics,
+        slack,
+        targetResolver,
+      })[0];
+
+      await processor.processOptions({
+        recipients: { type: 'entity', entityRef: 'group:default/mock' },
+        payload: { title: 'notification', topic: 'unknown:topic' },
+      });
+
+      expect(targetResolver).toHaveBeenCalled();
+      expect(slack.chat.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ channel: 'C12345678' }),
+      );
+    });
+  });
+
   it('should send a notification to a group', async () => {
     const slack = new WebClient();
 

--- a/plugins/notifications-backend-module-slack/src/lib/SlackNotificationProcessor.ts
+++ b/plugins/notifications-backend-module-slack/src/lib/SlackNotificationProcessor.ts
@@ -46,7 +46,11 @@ import { ANNOTATION_SLACK_BOT_NOTIFY } from './constants';
 import { BroadcastRoute } from './types';
 import { ExpiryMap, toChatPostMessageArgs } from './util';
 import { CatalogService } from '@backstage/plugin-catalog-node';
-import { SlackBlockKitRenderer } from '../extensions';
+import {
+  SlackBlockKitRenderer,
+  SlackNotificationTargetContext,
+  SlackNotificationTargetResolver,
+} from '../extensions';
 
 interface ScopeContext {
   origin: string;
@@ -74,6 +78,7 @@ export class SlackNotificationProcessor implements NotificationProcessor {
   private readonly concurrencyLimit: number;
   private readonly throttleInterval: number;
   private readonly blockKitRenderer?: SlackBlockKitRenderer;
+  private readonly targetResolver?: SlackNotificationTargetResolver;
 
   static fromConfig(
     config: Config,
@@ -85,6 +90,7 @@ export class SlackNotificationProcessor implements NotificationProcessor {
       slack?: WebClient;
       broadcastChannels?: string[];
       blockKitRenderer?: SlackBlockKitRenderer;
+      targetResolver?: SlackNotificationTargetResolver;
     },
   ): SlackNotificationProcessor[] {
     const slackConfig =
@@ -128,6 +134,7 @@ export class SlackNotificationProcessor implements NotificationProcessor {
     concurrencyLimit?: number;
     throttleInterval?: number;
     blockKitRenderer?: SlackBlockKitRenderer;
+    targetResolver?: SlackNotificationTargetResolver;
   }) {
     const {
       auth,
@@ -141,6 +148,7 @@ export class SlackNotificationProcessor implements NotificationProcessor {
       concurrencyLimit,
       throttleInterval,
       blockKitRenderer,
+      targetResolver,
     } = options;
     this.logger = logger;
     this.catalog = catalog;
@@ -153,6 +161,7 @@ export class SlackNotificationProcessor implements NotificationProcessor {
     this.throttleInterval =
       throttleInterval ?? durationToMilliseconds({ minutes: 1 });
     this.blockKitRenderer = blockKitRenderer;
+    this.targetResolver = targetResolver;
 
     this.entityLoader = new DataLoader<string, Entity | undefined>(
       async entityRefs => {
@@ -271,7 +280,9 @@ export class SlackNotificationProcessor implements NotificationProcessor {
 
         let channel;
         try {
-          channel = await this.getSlackNotificationTarget(entityRef);
+          channel = await this.getSlackNotificationTarget(entityRef, {
+            payload: options.payload,
+          });
         } catch (error) {
           this.logger.error(
             `Failed to get Slack channel for entity: ${toError(error).message}`,
@@ -427,7 +438,15 @@ export class SlackNotificationProcessor implements NotificationProcessor {
 
   async getSlackNotificationTarget(
     entityRef: string,
+    context?: SlackNotificationTargetContext,
   ): Promise<string | undefined> {
+    if (this.targetResolver && context) {
+      const resolved = await this.targetResolver(entityRef, context);
+      if (resolved) {
+        return resolved;
+      }
+    }
+
     const entity = await this.entityLoader.load(entityRef);
     if (!entity) {
       throw new NotFoundError(`Entity not found: ${entityRef}`);

--- a/plugins/notifications-backend-module-slack/src/module.ts
+++ b/plugins/notifications-backend-module-slack/src/module.ts
@@ -25,7 +25,9 @@ import { SlackNotificationProcessor } from './lib/SlackNotificationProcessor';
 import { catalogServiceRef } from '@backstage/plugin-catalog-node';
 import {
   notificationsSlackBlockKitExtensionPoint,
+  notificationsSlackTargetResolverExtensionPoint,
   SlackBlockKitRenderer,
+  SlackNotificationTargetResolver,
 } from './extensions';
 
 const MIGRATIONS_DIR = resolvePackagePath(
@@ -65,6 +67,18 @@ export const notificationsModuleSlack = createBackendModule({
       },
     });
 
+    let targetResolver: SlackNotificationTargetResolver | undefined;
+    reg.registerExtensionPoint(notificationsSlackTargetResolverExtensionPoint, {
+      setTargetResolver(resolver) {
+        if (targetResolver) {
+          throw new Error(
+            `Slack notification target resolver was already registered`,
+          );
+        }
+        targetResolver = resolver;
+      },
+    });
+
     reg.registerInit({
       deps: {
         auth: coreServices.auth,
@@ -92,6 +106,7 @@ export const notificationsModuleSlack = createBackendModule({
           catalog,
           metrics,
           blockKitRenderer,
+          targetResolver,
         });
 
         if (processors.length === 0) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds a target resolver extension point to `@backstage/plugin-notifications-backend-module-slack` that lets adopters override **which Slack channel an entity-addressed notification is delivered to**.

Today, for `{ type: 'entity' }` recipients the channel is derived solely from the recipient entity's `slack.com/bot-notify` annotation — one entity always maps to one channel, with no awareness of the notification itself. This makes it impossible to route, say, deploy notifications and general team notifications for the same team to different channels.

This change mirrors the existing `notificationsSlackBlockKitExtensionPoint`:

- New `notificationsSlackTargetResolverExtensionPoint` with `setTargetResolver((entityRef, { payload }) => Promise<string | undefined>)`.
- `SlackNotificationProcessor` consults the resolver first in `getSlackNotificationTarget`; if it returns a channel ID that is used, otherwise it **falls back to the existing `slack.com/bot-notify` behaviour unchanged**.
- The resolver receives the `NotificationPayload`, so adopters can route on `topic`, `scope`, or `metadata`.

Fully backwards compatible: when no resolver is registered, behaviour is identical to today.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation (TSDoc on the new public API)
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes) — n/a, backend only
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
