### PR TITLE
Coerce string limit and offset in query-catalog-entities action

### DIFF
--- a/.changeset/query-catalog-entities-string-pagination.md
+++ b/.changeset/query-catalog-entities-string-pagination.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+The `catalog:query-catalog-entities` action now accepts `limit` and `offset` when they are passed as strings, coercing them to numbers before validation. Previously the action failed with a validation error when a client sent these pagination arguments as strings, which is common for MCP/LLM clients.

--- a/plugins/catalog-backend/src/actions/createQueryCatalogEntitiesAction.test.ts
+++ b/plugins/catalog-backend/src/actions/createQueryCatalogEntitiesAction.test.ts
@@ -275,6 +275,20 @@ describe('createQueryCatalogEntitiesAction', () => {
     expect(output.nextPageCursor).toBeDefined();
   });
 
+  it('should coerce string limit and offset into numbers', async () => {
+    const { invoke } = createCatalogQueryAction();
+    const result = await invoke({
+      id: 'test:query-catalog-entities',
+      input: { limit: '2', offset: '0' } as any,
+    });
+
+    const output = result.output as any;
+    expect(output.items).toHaveLength(2);
+    expect(output.totalItems).toBe(4);
+    expect(output.hasMoreEntities).toBe(true);
+    expect(output.nextPageCursor).toBeDefined();
+  });
+
   it('should support cursor-based pagination', async () => {
     const { invoke } = createCatalogQueryAction();
 

--- a/plugins/catalog-backend/src/actions/createQueryCatalogEntitiesAction.test.ts
+++ b/plugins/catalog-backend/src/actions/createQueryCatalogEntitiesAction.test.ts
@@ -306,7 +306,7 @@ describe('createQueryCatalogEntitiesAction', () => {
           id: 'test:query-catalog-entities',
           input: badInput as any,
         }),
-      ).rejects.toThrow();
+      ).rejects.toThrow('Invalid input to action');
     }
   });
 

--- a/plugins/catalog-backend/src/actions/createQueryCatalogEntitiesAction.test.ts
+++ b/plugins/catalog-backend/src/actions/createQueryCatalogEntitiesAction.test.ts
@@ -289,6 +289,25 @@ describe('createQueryCatalogEntitiesAction', () => {
     expect(output.nextPageCursor).toBeDefined();
   });
 
+  it('should reject non-numeric-string limit and offset values', async () => {
+    const { invoke } = createCatalogQueryAction();
+
+    for (const badInput of [
+      { limit: true },
+      { limit: '' },
+      { limit: 'abc' },
+      { offset: null },
+      { offset: false },
+    ]) {
+      await expect(
+        invoke({
+          id: 'test:query-catalog-entities',
+          input: badInput as any,
+        }),
+      ).rejects.toThrow();
+    }
+  });
+
   it('should support cursor-based pagination', async () => {
     const { invoke } = createCatalogQueryAction();
 

--- a/plugins/catalog-backend/src/actions/createQueryCatalogEntitiesAction.test.ts
+++ b/plugins/catalog-backend/src/actions/createQueryCatalogEntitiesAction.test.ts
@@ -289,7 +289,7 @@ describe('createQueryCatalogEntitiesAction', () => {
     expect(output.nextPageCursor).toBeDefined();
   });
 
-  it('should reject non-numeric-string limit and offset values', async () => {
+  it('should reject invalid limit and offset values', async () => {
     const { invoke } = createCatalogQueryAction();
 
     for (const badInput of [
@@ -298,6 +298,8 @@ describe('createQueryCatalogEntitiesAction', () => {
       { limit: 'abc' },
       { offset: null },
       { offset: false },
+      { offset: '' },
+      { offset: 'abc' },
     ]) {
       await expect(
         invoke({

--- a/plugins/catalog-backend/src/actions/createQueryCatalogEntitiesAction.ts
+++ b/plugins/catalog-backend/src/actions/createQueryCatalogEntitiesAction.ts
@@ -141,13 +141,13 @@ export const createQueryCatalogEntitiesAction = ({
             .describe(
               'Specific fields to include in the response. If not provided, all fields are returned. Each entry is a dot separated path into an entity, e.g. `spec.type`.',
             ),
-          limit: z
+          limit: z.coerce
             .number()
             .int()
             .positive()
             .optional()
             .describe('Maximum number of entities to return at a time.'),
-          offset: z
+          offset: z.coerce
             .number()
             .int()
             .min(0)

--- a/plugins/catalog-backend/src/actions/createQueryCatalogEntitiesAction.ts
+++ b/plugins/catalog-backend/src/actions/createQueryCatalogEntitiesAction.ts
@@ -129,13 +129,17 @@ export const createQueryCatalogEntitiesAction = ({
       : INLINE_MODEL_DESCRIPTION,
     schema: {
       input: z => {
-        // MCP/LLM clients often send numeric arguments as strings. Coerce numeric
-        // strings to numbers, but leave other types untouched so they still fail
-        // validation instead of being silently converted (e.g. true -> 1, '' -> 0).
-        const numericFromString = (value: unknown) =>
-          typeof value === 'string' && value.trim() !== ''
-            ? Number(value)
-            : value;
+        // MCP/LLM clients often send numeric arguments as strings. Convert numeric
+        // strings to numbers, but leave everything else untouched so Zod rejects the
+        // original value (e.g. reports "received string" for 'abc' rather than
+        // "received NaN", and doesn't silently turn true/null/'' into 1/0/0).
+        const numericFromString = (value: unknown) => {
+          if (typeof value === 'string' && value.trim() !== '') {
+            const parsed = Number(value);
+            return Number.isFinite(parsed) ? parsed : value;
+          }
+          return value;
+        };
 
         return z.object({
           query: createZodV3FilterPredicateSchema(z)

--- a/plugins/catalog-backend/src/actions/createQueryCatalogEntitiesAction.ts
+++ b/plugins/catalog-backend/src/actions/createQueryCatalogEntitiesAction.ts
@@ -128,8 +128,16 @@ export const createQueryCatalogEntitiesAction = ({
       ? MODEL_REFERENCE_DESCRIPTION
       : INLINE_MODEL_DESCRIPTION,
     schema: {
-      input: z =>
-        z.object({
+      input: z => {
+        // MCP/LLM clients often send numeric arguments as strings. Coerce numeric
+        // strings to numbers, but leave other types untouched so they still fail
+        // validation instead of being silently converted (e.g. true -> 1, '' -> 0).
+        const numericFromString = (value: unknown) =>
+          typeof value === 'string' && value.trim() !== ''
+            ? Number(value)
+            : value;
+
+        return z.object({
           query: createZodV3FilterPredicateSchema(z)
             .optional()
             .describe(
@@ -141,16 +149,12 @@ export const createQueryCatalogEntitiesAction = ({
             .describe(
               'Specific fields to include in the response. If not provided, all fields are returned. Each entry is a dot separated path into an entity, e.g. `spec.type`.',
             ),
-          limit: z.coerce
-            .number()
-            .int()
-            .positive()
+          limit: z
+            .preprocess(numericFromString, z.number().int().positive())
             .optional()
             .describe('Maximum number of entities to return at a time.'),
-          offset: z.coerce
-            .number()
-            .int()
-            .min(0)
+          offset: z
+            .preprocess(numericFromString, z.number().int().min(0))
             .optional()
             .describe('Number of entities to skip before returning results.'),
           orderFields: z
@@ -196,7 +200,8 @@ export const createQueryCatalogEntitiesAction = ({
             .describe(
               'Cursor for pagination. This can be used only after the first request with a response containing a cursor. If a cursor is given it takes precedence over `offset`.',
             ),
-        }),
+        });
+      },
       output: z =>
         z.object({
           items: z


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `catalog:query-catalog-entities` MCP action validated `limit` and `offset` with `z.number()`, which rejected values passed as strings. MCP/LLM clients commonly emit numeric arguments as JSON strings, so the action failed with `Expected number, received string`. This switches both fields to `z.coerce.number()` so string values are converted before validation.

Fixes #34778

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
