### PR TITLE
feat(auth-backend): support Codex CIMD authentication

### DIFF
--- a/.changeset/friendly-codex-auth.md
+++ b/.changeset/friendly-codex-auth.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Added a built-in Client ID Metadata Document for connecting Codex to MCP Actions without Dynamic Client Registration.

--- a/docs/ai/mcp-actions.md
+++ b/docs/ai/mcp-actions.md
@@ -192,7 +192,11 @@ Follow these steps to install and configure the new `@backstage/plugin-auth` fro
 
 The [November 2025 MCP specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization) outlined a new authorization method to replace Dynamic Client Registration called [Client ID Metadata Documents (CIMD)](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#client-id-metadata-documents).
 
-Using Client ID Metadata Documents means you do not need to manually configure a token in your MCP client settings. Instead, a client can request a token on your behalf. When adding the MCP server to an MCP client like Cursor or Claude, a popup requiring your approval will open in your Backstage instance (powered by the `auth` plugin).
+Using Client ID Metadata Documents means you do not need to manually configure
+a token in your MCP client settings. Instead, a client can request a token on
+your behalf. When adding the MCP server to an MCP client like Codex or Claude,
+a popup requiring your approval opens in your Backstage instance (powered by
+the `auth` plugin).
 
 This can be enabled in the `auth-backend` plugin by using the `auth.clientIdMetadataDocuments.enabled` flag in config:
 
@@ -201,10 +205,11 @@ auth:
   clientIdMetadataDocuments:
     enabled: true
     # Optional: override which client_id URLs are allowed.
-    # Defaults to Claude, VS Code, and the built-in Backstage CLI.
+    # Defaults to Claude, VS Code, and the built-in Backstage CLI and Codex
+    # metadata documents.
     # Note: setting this replaces the defaults entirely. The built-in
-    # CLI pattern is derived from your auth backend's base URL and
-    # must be re-added manually if you override this list.
+    # CLI and Codex patterns are derived from your auth backend's base URL
+    # and must be re-added manually if you override this list.
     # allowedClientIdPatterns:
     #   - 'https://claude.ai/*'
     #   - 'https://vscode.dev/*'
@@ -262,6 +267,26 @@ The default endpoint is `http://localhost:7007/api/mcp-actions/v1`.
 ```
 
 The `${MCP_TOKEN}` environment variable would be an [external access static token](#external-access-with-static-tokens).
+
+### Connect from Codex
+
+When Client ID Metadata Documents are enabled, configure Codex with the
+built-in client metadata URL:
+
+```shell
+codex mcp add backstage-actions \
+  --url https://backstage.example.com/api/mcp-actions/v1 \
+  --oauth-client-id https://backstage.example.com/api/auth/.well-known/oauth-client/codex
+```
+
+Replace `https://backstage.example.com` with the external URL of your Backstage
+instance. Codex opens the Backstage authorization page so that you can approve
+the requested access. To restart authorization for an existing entry, run
+`codex mcp login backstage-actions`.
+
+For a named MCP server, append the server key to both the MCP URL and client
+metadata URL. For example, use `/api/mcp-actions/v1/catalog` with
+`/api/auth/.well-known/oauth-client/codex/catalog`.
 
 ### Multiple Servers
 

--- a/plugins/auth-backend/config.d.ts
+++ b/plugins/auth-backend/config.d.ts
@@ -194,8 +194,9 @@ export interface Config {
       /**
        * A list of allowed URI patterns for client_id URLs.
        * Uses glob-style pattern matching where `*` matches any characters.
-       * Defaults to `['https://claude.ai/*', 'https://vscode.dev/*', '{baseUrl}/.well-known/oauth-client/cli.json']`
-       * where `{baseUrl}` is the auth backend's base URL.
+       * Defaults to Claude, VS Code, and the built-in Backstage CLI and Codex
+       * metadata documents. The built-in documents are derived from the auth
+       * backend's base URL.
        *
        * @example ['https://example.com/*', 'https://*.trusted-domain.com/*']
        */

--- a/plugins/auth-backend/src/service/OidcRouter.test.ts
+++ b/plugins/auth-backend/src/service/OidcRouter.test.ts
@@ -1623,11 +1623,20 @@ describe('OidcRouter', () => {
           ],
         });
 
-        const response = await request(server)
+        const cliResponse = await request(server)
           .get('/api/auth/.well-known/oauth-client/cli.json')
           .expect(404);
 
-        expect(response.body).toEqual({
+        expect(cliResponse.body).toEqual({
+          error: 'not_found',
+          error_description: 'Client ID metadata documents not enabled',
+        });
+
+        const codexResponse = await request(server)
+          .get('/api/auth/.well-known/oauth-client/codex')
+          .expect(404);
+
+        expect(codexResponse.body).toEqual({
           error: 'not_found',
           error_description: 'Client ID metadata documents not enabled',
         });
@@ -1664,6 +1673,7 @@ describe('OidcRouter', () => {
           auth: mockServices.auth.mock(),
           tokenIssuer: mockTokenIssuer,
           baseUrl: 'http://localhost:7007/api/auth',
+          mcpActionsBaseUrl: 'http://localhost:7007/api/mcp-actions',
           appUrl: 'http://localhost:3000',
           logger: mockServices.logger.mock(),
           userInfo: userInfoDatabase,
@@ -1702,15 +1712,45 @@ describe('OidcRouter', () => {
           ],
         });
 
-        const response = await request(server)
+        const cliResponse = await request(server)
           .get('/api/auth/.well-known/oauth-client/cli.json')
           .expect(200);
 
-        expect(response.body).toEqual({
+        expect(cliResponse.body).toEqual({
           client_id:
             'http://localhost:7007/api/auth/.well-known/oauth-client/cli.json',
           client_name: 'Backstage CLI',
           redirect_uris: ['http://127.0.0.1:8055/callback'],
+          response_types: ['code'],
+          grant_types: ['authorization_code'],
+          token_endpoint_auth_method: 'none',
+          scope: 'openid offline_access',
+        });
+
+        const codexResponse = await request(server)
+          .get('/api/auth/.well-known/oauth-client/codex')
+          .expect(200);
+
+        expect(codexResponse.body).toEqual({
+          client_id:
+            'http://localhost:7007/api/auth/.well-known/oauth-client/codex',
+          client_name: 'Codex',
+          redirect_uris: ['http://127.0.0.1/callback/tTgaGrtgqoQ1'],
+          response_types: ['code'],
+          grant_types: ['authorization_code'],
+          token_endpoint_auth_method: 'none',
+          scope: 'openid offline_access',
+        });
+
+        const namedCodexResponse = await request(server)
+          .get('/api/auth/.well-known/oauth-client/codex/catalog')
+          .expect(200);
+
+        expect(namedCodexResponse.body).toEqual({
+          client_id:
+            'http://localhost:7007/api/auth/.well-known/oauth-client/codex/catalog',
+          client_name: 'Codex',
+          redirect_uris: ['http://127.0.0.1/callback/mcRpJqaqysHB'],
           response_types: ['code'],
           grant_types: ['authorization_code'],
           token_endpoint_auth_method: 'none',

--- a/plugins/auth-backend/src/service/OidcRouter.ts
+++ b/plugins/auth-backend/src/service/OidcRouter.ts
@@ -27,12 +27,26 @@ import { UserInfoDatabase } from '../database/UserInfoDatabase';
 import { OidcDatabase } from '../database/OidcDatabase';
 import { OfflineAccessService } from './OfflineAccessService';
 import { json } from 'express';
+import type { Response } from 'express';
 import { z } from 'zod/v4';
 import { fromZodError } from 'zod-validation-error/v4';
 import { OidcError } from './OidcError';
+import crypto from 'node:crypto';
 
 function ensureTrailingSlash(url: string): string {
   return url.endsWith('/') ? url : `${url}/`;
+}
+
+function codexCallbackId(serverUrl: string): string {
+  const normalizedUrl = new URL(serverUrl);
+  normalizedUrl.hash = '';
+
+  return crypto
+    .createHash('sha256')
+    .update(normalizedUrl.toString())
+    .digest()
+    .subarray(0, 9)
+    .toString('base64url');
 }
 
 const authorizeQuerySchema = z.object({
@@ -155,6 +169,7 @@ export class OidcRouter {
   private readonly httpAuth: HttpAuthService;
   private readonly config: RootConfigService;
   private readonly baseUrl: string;
+  private readonly mcpActionsBaseUrl: string;
 
   private constructor(
     oidc: OidcService,
@@ -164,6 +179,7 @@ export class OidcRouter {
     httpAuth: HttpAuthService,
     config: RootConfigService,
     baseUrl: string,
+    mcpActionsBaseUrl: string,
   ) {
     this.oidc = oidc;
     this.logger = logger;
@@ -172,12 +188,14 @@ export class OidcRouter {
     this.httpAuth = httpAuth;
     this.config = config;
     this.baseUrl = baseUrl;
+    this.mcpActionsBaseUrl = mcpActionsBaseUrl;
   }
 
   static create(options: {
     auth: AuthService;
     tokenIssuer: TokenIssuer;
     baseUrl: string;
+    mcpActionsBaseUrl?: string;
     appUrl: string;
     logger: LoggerService;
     userInfo: UserInfoDatabase;
@@ -194,6 +212,8 @@ export class OidcRouter {
       options.httpAuth,
       options.config,
       options.baseUrl,
+      options.mcpActionsBaseUrl ??
+        `${new URL(options.baseUrl).origin}/api/mcp-actions`,
     );
   }
 
@@ -239,6 +259,49 @@ export class OidcRouter {
         token_endpoint_auth_method: 'none',
         scope: 'openid offline_access',
       });
+    });
+
+    const baseUrl = this.baseUrl;
+    const mcpActionsBaseUrl = this.mcpActionsBaseUrl;
+
+    function sendCodexClientMetadata(res: Response, serverName?: string): void {
+      if (!cimdEnabled) {
+        res.status(404).json({
+          error: 'not_found',
+          error_description: 'Client ID metadata documents not enabled',
+        });
+        return;
+      }
+
+      const suffix = serverName ? `/${encodeURIComponent(serverName)}` : '';
+      const clientId = new URL(
+        `.well-known/oauth-client/codex${suffix}`,
+        ensureTrailingSlash(baseUrl),
+      ).toString();
+      const mcpServerUrl = new URL(
+        `v1${suffix}`,
+        ensureTrailingSlash(mcpActionsBaseUrl),
+      ).toString();
+
+      res.json({
+        client_id: clientId,
+        client_name: 'Codex',
+        redirect_uris: [
+          `http://127.0.0.1/callback/${codexCallbackId(mcpServerUrl)}`,
+        ],
+        response_types: ['code'],
+        grant_types: ['authorization_code'],
+        token_endpoint_auth_method: 'none',
+        scope: 'openid offline_access',
+      });
+    }
+
+    router.get('/.well-known/oauth-client/codex', (_req, res) => {
+      sendCodexClientMetadata(res);
+    });
+
+    router.get('/.well-known/oauth-client/codex/:serverName', (req, res) => {
+      sendCodexClientMetadata(res, req.params.serverName);
     });
 
     // UserInfo endpoint

--- a/plugins/auth-backend/src/service/OidcService.test.ts
+++ b/plugins/auth-backend/src/service/OidcService.test.ts
@@ -53,12 +53,18 @@ describe('OidcService', () => {
 
   interface CreateOidcServiceOptions {
     databaseId: TestDatabaseId;
+    baseUrl?: string;
     config?: JsonObject;
     offlineAccess?: OfflineAccessService;
   }
 
   async function createOidcService(options: CreateOidcServiceOptions) {
-    const { databaseId, config: configData = {}, offlineAccess } = options;
+    const {
+      databaseId,
+      baseUrl = 'http://mock-base-url',
+      config: configData = {},
+      offlineAccess,
+    } = options;
 
     const knex = await databases.init(databaseId);
 
@@ -92,7 +98,7 @@ describe('OidcService', () => {
       service: OidcService.create({
         auth: mockAuth,
         tokenIssuer: mockTokenIssuer,
-        baseUrl: 'http://mock-base-url',
+        baseUrl,
         userInfo: mockUserInfo,
         oidc: oidcDatabase,
         config,
@@ -1217,6 +1223,47 @@ describe('OidcService', () => {
       });
 
       describe('createAuthorizationSession with CIMD', () => {
+        it('should accept the built-in Codex client with default CIMD patterns', async () => {
+          const baseUrl = 'https://backstage.example.com/api/auth';
+          const clientId = `${baseUrl}/.well-known/oauth-client/codex`;
+          const redirectUri = 'http://127.0.0.1:54321/callback/tTgaGrtgqoQ1';
+          mockFetchCimdMetadata.mockResolvedValue({
+            clientId,
+            clientName: 'Codex',
+            redirectUris: ['http://127.0.0.1/callback/tTgaGrtgqoQ1'],
+            responseTypes: ['code'],
+            grantTypes: ['authorization_code'],
+            scope: 'openid offline_access',
+          });
+
+          const { service } = await createOidcService({
+            databaseId,
+            baseUrl,
+            config: {
+              auth: {
+                clientIdMetadataDocuments: {
+                  enabled: true,
+                },
+              },
+            },
+          });
+
+          const authSession = await service.createAuthorizationSession({
+            clientId,
+            redirectUri,
+            responseType: 'code',
+            scope: 'openid',
+            ...pkceParams,
+          });
+
+          expect(authSession).toEqual({
+            id: expect.any(String),
+            clientName: 'Codex',
+            scope: 'openid',
+            redirectUri,
+          });
+        });
+
         it('should accept loopback redirect URIs with default CIMD patterns', async () => {
           const { service } = await createOidcService({
             databaseId,

--- a/plugins/auth-backend/src/service/OidcService.ts
+++ b/plugins/auth-backend/src/service/OidcService.ts
@@ -377,12 +377,19 @@ export class OidcService {
       this.config.getOptionalBoolean(`${configPath}.enabled`) ?? false;
 
     const cliClientId = `${this.baseUrl}/.well-known/oauth-client/cli.json`;
+    const codexClientId = `${this.baseUrl}/.well-known/oauth-client/codex`;
 
     return {
       enabled,
       allowedClientIdPatterns: this.config.getOptionalStringArray(
         `${configPath}.allowedClientIdPatterns`,
-      ) ?? ['https://claude.ai/*', 'https://vscode.dev/*', cliClientId],
+      ) ?? [
+        'https://claude.ai/*',
+        'https://vscode.dev/*',
+        cliClientId,
+        codexClientId,
+        `${codexClientId}/*`,
+      ],
       allowedRedirectUriPatterns:
         this.config.getOptionalStringArray(
           `${configPath}.allowedRedirectUriPatterns`,

--- a/plugins/auth-backend/src/service/router.ts
+++ b/plugins/auth-backend/src/service/router.ts
@@ -75,6 +75,7 @@ export async function createRouter(
 
   const appUrl = config.getString('app.baseUrl');
   const authUrl = await discovery.getExternalBaseUrl('auth');
+  const mcpActionsBaseUrl = await discovery.getExternalBaseUrl('mcp-actions');
   const backstageTokenExpiration = readBackstageTokenExpiration(config);
   const database = AuthDatabase.create(db);
 
@@ -158,6 +159,7 @@ export async function createRouter(
     auth: options.auth,
     tokenIssuer,
     baseUrl: authUrl,
+    mcpActionsBaseUrl,
     appUrl,
     userInfo,
     oidc,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

## What

Adds a built-in Client ID Metadata Document for connecting Codex to MCP
Actions. It supports the default MCP endpoint as well as named servers and
derives the loopback callback expected for each server URL.

The default CIMD allowlist now includes these built-in client IDs, and the MCP
Actions documentation includes the Codex setup command.

## Why

Codex otherwise falls back to Dynamic Client Registration, which is not
available in the recommended Backstage CIMD setup. This gives adopters a stable
client metadata URL that works with the existing authorization and consent
flow.

To test:

1. Enable `auth.clientIdMetadataDocuments.enabled`.
2. Start the example app and backend.
3. Add the MCP server:

   ```shell
   codex mcp add backstage-actions \
     --url http://localhost:7007/api/mcp-actions/v1 \
     --oauth-client-id http://localhost:7007/api/auth/.well-known/oauth-client/codex
   ```

4. Run `codex mcp login backstage-actions` and approve the request in Backstage.
5. Start Codex and call a read-only catalog tool through `backstage-actions`.

I verified the complete login and authenticated tool-call flow locally. The
focused OIDC test suites pass with 97 tests, along with the full typecheck,
affected-package lint, and API reports.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

