### PR TITLE
feat(auth-backend): skip SSRF check for exact CIMD allowedClientIdPatterns

### DIFF
--- a/.changeset/cimd-allow-private-network-access.md
+++ b/.changeset/cimd-allow-private-network-access.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Added `dangerouslyAllowPrivateNetworkAccess` option to the CIMD configuration. When enabled, CIMD metadata fetches are allowed to resolve to private network addresses (RFC 1918), which is needed for CIMD clients hosted on internal networks. The `allowedClientIdPatterns` allowlist still applies.

--- a/.changeset/cimd-allow-private-network-access.md
+++ b/.changeset/cimd-allow-private-network-access.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-auth-backend': patch
 ---
 
-Added `dangerouslyAllowPrivateNetworkAccess` option to the CIMD configuration. When enabled, CIMD metadata fetches are allowed to resolve to private network addresses (RFC 1918), which is needed for CIMD clients hosted on internal networks. The `allowedClientIdPatterns` allowlist still applies.
+Skip SSRF protection for CIMD metadata fetches when the `client_id` matches an exact (non-wildcard) entry in `allowedClientIdPatterns`. Exact patterns mean the administrator explicitly listed a specific URL, so the DNS resolution is trusted. Wildcard patterns still enforce the SSRF check to protect against attacker-controlled subdomains resolving to internal addresses.

--- a/plugins/auth-backend/config.d.ts
+++ b/plugins/auth-backend/config.d.ts
@@ -209,19 +209,6 @@ export interface Config {
        * @example ['http://localhost:*', 'http://127.0.0.1:*\/callback']
        */
       allowedRedirectUriPatterns?: string[];
-
-      /**
-       * Disables SSRF protection for CIMD metadata fetches, allowing
-       * client_id URLs that resolve to private network addresses
-       * (10.x.x.x, 172.16-31.x.x, 192.168.x.x, etc.).
-       *
-       * Only enable this if you need CIMD clients hosted on your
-       * internal network. The `allowedClientIdPatterns` allowlist
-       * still applies when this is enabled.
-       *
-       * @default false
-       */
-      dangerouslyAllowPrivateNetworkAccess?: boolean;
     };
 
     /**
@@ -263,19 +250,6 @@ export interface Config {
        * @example ['http://localhost:*\/*', 'http://127.0.0.1:*\/callback']
        */
       allowedRedirectUriPatterns?: string[];
-
-      /**
-       * Disables SSRF protection for CIMD metadata fetches, allowing
-       * client_id URLs that resolve to private network addresses
-       * (10.x.x.x, 172.16-31.x.x, 192.168.x.x, etc.).
-       *
-       * Only enable this if you need CIMD clients hosted on your
-       * internal network. The `allowedClientIdPatterns` allowlist
-       * still applies when this is enabled.
-       *
-       * @default false
-       */
-      dangerouslyAllowPrivateNetworkAccess?: boolean;
     };
   };
 }

--- a/plugins/auth-backend/config.d.ts
+++ b/plugins/auth-backend/config.d.ts
@@ -209,6 +209,19 @@ export interface Config {
        * @example ['http://localhost:*', 'http://127.0.0.1:*\/callback']
        */
       allowedRedirectUriPatterns?: string[];
+
+      /**
+       * Disables SSRF protection for CIMD metadata fetches, allowing
+       * client_id URLs that resolve to private network addresses
+       * (10.x.x.x, 172.16-31.x.x, 192.168.x.x, etc.).
+       *
+       * Only enable this if you need CIMD clients hosted on your
+       * internal network. The `allowedClientIdPatterns` allowlist
+       * still applies when this is enabled.
+       *
+       * @default false
+       */
+      dangerouslyAllowPrivateNetworkAccess?: boolean;
     };
 
     /**
@@ -250,6 +263,19 @@ export interface Config {
        * @example ['http://localhost:*\/*', 'http://127.0.0.1:*\/callback']
        */
       allowedRedirectUriPatterns?: string[];
+
+      /**
+       * Disables SSRF protection for CIMD metadata fetches, allowing
+       * client_id URLs that resolve to private network addresses
+       * (10.x.x.x, 172.16-31.x.x, 192.168.x.x, etc.).
+       *
+       * Only enable this if you need CIMD clients hosted on your
+       * internal network. The `allowedClientIdPatterns` allowlist
+       * still applies when this is enabled.
+       *
+       * @default false
+       */
+      dangerouslyAllowPrivateNetworkAccess?: boolean;
     };
   };
 }

--- a/plugins/auth-backend/src/service/CimdClient.test.ts
+++ b/plugins/auth-backend/src/service/CimdClient.test.ts
@@ -234,7 +234,7 @@ describe('CimdClient', () => {
         ).rejects.toThrow('Invalid client_id URL');
       });
 
-      it('should allow private IPs when dangerouslyAllowPrivateNetworkAccess is set', async () => {
+      it('should allow private IPs when skipSsrfCheck is set', async () => {
         mockDnsLookup.mockResolvedValue([
           { address: '10.0.0.1', family: 4 },
         ] as any);
@@ -253,14 +253,14 @@ describe('CimdClient', () => {
 
         const result = await fetchCimdMetadata({
           clientId: 'https://internal.example.com/metadata',
-          dangerouslyAllowPrivateNetworkAccess: true,
+          skipSsrfCheck: true,
         });
 
         expect(result.clientId).toBe('https://internal.example.com/metadata');
         expect(result.clientName).toBe('Internal Client');
       });
 
-      it('should still block private IPs when dangerouslyAllowPrivateNetworkAccess is false', async () => {
+      it('should still block private IPs when skipSsrfCheck is false', async () => {
         mockDnsLookup.mockResolvedValue([
           { address: '10.0.0.1', family: 4 },
         ] as any);
@@ -268,7 +268,7 @@ describe('CimdClient', () => {
         await expect(
           fetchCimdMetadata({
             clientId: 'https://internal.example.com/metadata',
-            dangerouslyAllowPrivateNetworkAccess: false,
+            skipSsrfCheck: false,
           }),
         ).rejects.toThrow('Invalid client_id URL');
       });

--- a/plugins/auth-backend/src/service/CimdClient.test.ts
+++ b/plugins/auth-backend/src/service/CimdClient.test.ts
@@ -233,6 +233,45 @@ describe('CimdClient', () => {
           }),
         ).rejects.toThrow('Invalid client_id URL');
       });
+
+      it('should allow private IPs when dangerouslyAllowPrivateNetworkAccess is set', async () => {
+        mockDnsLookup.mockResolvedValue([
+          { address: '10.0.0.1', family: 4 },
+        ] as any);
+
+        const metadata = {
+          client_id: 'https://internal.example.com/metadata',
+          client_name: 'Internal Client',
+          redirect_uris: ['http://localhost:8080/callback'],
+        };
+
+        server.use(
+          http.get('https://internal.example.com/metadata', () =>
+            HttpResponse.json(metadata),
+          ),
+        );
+
+        const result = await fetchCimdMetadata({
+          clientId: 'https://internal.example.com/metadata',
+          dangerouslyAllowPrivateNetworkAccess: true,
+        });
+
+        expect(result.clientId).toBe('https://internal.example.com/metadata');
+        expect(result.clientName).toBe('Internal Client');
+      });
+
+      it('should still block private IPs when dangerouslyAllowPrivateNetworkAccess is false', async () => {
+        mockDnsLookup.mockResolvedValue([
+          { address: '10.0.0.1', family: 4 },
+        ] as any);
+
+        await expect(
+          fetchCimdMetadata({
+            clientId: 'https://internal.example.com/metadata',
+            dangerouslyAllowPrivateNetworkAccess: false,
+          }),
+        ).rejects.toThrow('Invalid client_id URL');
+      });
     });
 
     describe('redirect protection', () => {

--- a/plugins/auth-backend/src/service/CimdClient.ts
+++ b/plugins/auth-backend/src/service/CimdClient.ts
@@ -212,17 +212,16 @@ async function readCappedResponseBody(response: Response): Promise<string> {
 export async function fetchCimdMetadata(opts: {
   clientId: string;
   validatedUrl?: URL;
-  dangerouslyAllowPrivateNetworkAccess?: boolean;
+  skipSsrfCheck?: boolean;
 }): Promise<CimdClientInfo> {
   const url = opts.validatedUrl ?? validateCimdUrl(opts.clientId);
 
-  // Skip SSRF validation for localhost in development, or when the
-  // administrator has explicitly opted in to private network access
-  // for CIMD clients that already passed the allowedClientIdPatterns check.
+  // Skip SSRF validation for localhost in development, or when the caller
+  // has determined the client_id matched an exact (non-wildcard) pattern.
   const isLocalhostDev =
     (url.hostname === 'localhost' || url.hostname === '127.0.0.1') &&
     process.env.NODE_ENV === 'development';
-  if (!isLocalhostDev && !opts.dangerouslyAllowPrivateNetworkAccess) {
+  if (!isLocalhostDev && !opts.skipSsrfCheck) {
     await validateHostNotPrivate(url.hostname);
   }
 

--- a/plugins/auth-backend/src/service/CimdClient.ts
+++ b/plugins/auth-backend/src/service/CimdClient.ts
@@ -212,14 +212,17 @@ async function readCappedResponseBody(response: Response): Promise<string> {
 export async function fetchCimdMetadata(opts: {
   clientId: string;
   validatedUrl?: URL;
+  dangerouslyAllowPrivateNetworkAccess?: boolean;
 }): Promise<CimdClientInfo> {
   const url = opts.validatedUrl ?? validateCimdUrl(opts.clientId);
 
-  // Skip SSRF validation for localhost in development only
+  // Skip SSRF validation for localhost in development, or when the
+  // administrator has explicitly opted in to private network access
+  // for CIMD clients that already passed the allowedClientIdPatterns check.
   const isLocalhostDev =
     (url.hostname === 'localhost' || url.hostname === '127.0.0.1') &&
     process.env.NODE_ENV === 'development';
-  if (!isLocalhostDev) {
+  if (!isLocalhostDev && !opts.dangerouslyAllowPrivateNetworkAccess) {
     await validateHostNotPrivate(url.hostname);
   }
 

--- a/plugins/auth-backend/src/service/OidcRouter.test.ts
+++ b/plugins/auth-backend/src/service/OidcRouter.test.ts
@@ -1833,7 +1833,7 @@ describe('OidcRouter', () => {
         expect(mockFetchCimdMetadata).toHaveBeenCalledWith({
           clientId: cimdClientId,
           validatedUrl: expect.any(URL),
-          dangerouslyAllowPrivateNetworkAccess: false,
+          skipSsrfCheck: false,
         });
         const location = new URL(authorizeResponse.header.location);
         expect(location.origin).toBe('http://localhost:3000');

--- a/plugins/auth-backend/src/service/OidcRouter.test.ts
+++ b/plugins/auth-backend/src/service/OidcRouter.test.ts
@@ -1833,6 +1833,7 @@ describe('OidcRouter', () => {
         expect(mockFetchCimdMetadata).toHaveBeenCalledWith({
           clientId: cimdClientId,
           validatedUrl: expect.any(URL),
+          dangerouslyAllowPrivateNetworkAccess: false,
         });
         const location = new URL(authorizeResponse.header.location);
         expect(location.origin).toBe('http://localhost:3000');

--- a/plugins/auth-backend/src/service/OidcService.test.ts
+++ b/plugins/auth-backend/src/service/OidcService.test.ts
@@ -1300,6 +1300,37 @@ describe('OidcService', () => {
           expect(mockFetchCimdMetadata).toHaveBeenCalledWith({
             clientId: cimdClientId,
             validatedUrl: expect.any(URL),
+            dangerouslyAllowPrivateNetworkAccess: false,
+          });
+        });
+
+        it('should pass dangerouslyAllowPrivateNetworkAccess to fetchCimdMetadata', async () => {
+          const { service } = await createOidcService({
+            databaseId,
+            config: {
+              auth: {
+                clientIdMetadataDocuments: {
+                  enabled: true,
+                  allowedClientIdPatterns: ['*'],
+                  allowedRedirectUriPatterns: ['*'],
+                  dangerouslyAllowPrivateNetworkAccess: true,
+                },
+              },
+            },
+          });
+
+          await service.createAuthorizationSession({
+            clientId: cimdClientId,
+            redirectUri: 'http://localhost:8080/callback',
+            responseType: 'code',
+            scope: 'openid',
+            ...pkceParams,
+          });
+
+          expect(mockFetchCimdMetadata).toHaveBeenCalledWith({
+            clientId: cimdClientId,
+            validatedUrl: expect.any(URL),
+            dangerouslyAllowPrivateNetworkAccess: true,
           });
         });
 
@@ -1869,6 +1900,7 @@ describe('OidcService', () => {
           expect(mockFetchCimdMetadata).toHaveBeenCalledWith({
             clientId: cimdClientId,
             validatedUrl: expect.any(URL),
+            dangerouslyAllowPrivateNetworkAccess: false,
           });
         });
       });

--- a/plugins/auth-backend/src/service/OidcService.test.ts
+++ b/plugins/auth-backend/src/service/OidcService.test.ts
@@ -1300,20 +1300,19 @@ describe('OidcService', () => {
           expect(mockFetchCimdMetadata).toHaveBeenCalledWith({
             clientId: cimdClientId,
             validatedUrl: expect.any(URL),
-            dangerouslyAllowPrivateNetworkAccess: false,
+            skipSsrfCheck: false,
           });
         });
 
-        it('should pass dangerouslyAllowPrivateNetworkAccess to fetchCimdMetadata', async () => {
+        it('should skip SSRF check for exact (non-wildcard) client_id patterns', async () => {
           const { service } = await createOidcService({
             databaseId,
             config: {
               auth: {
                 clientIdMetadataDocuments: {
                   enabled: true,
-                  allowedClientIdPatterns: ['*'],
+                  allowedClientIdPatterns: [cimdClientId],
                   allowedRedirectUriPatterns: ['*'],
-                  dangerouslyAllowPrivateNetworkAccess: true,
                 },
               },
             },
@@ -1330,7 +1329,7 @@ describe('OidcService', () => {
           expect(mockFetchCimdMetadata).toHaveBeenCalledWith({
             clientId: cimdClientId,
             validatedUrl: expect.any(URL),
-            dangerouslyAllowPrivateNetworkAccess: true,
+            skipSsrfCheck: true,
           });
         });
 
@@ -1900,7 +1899,7 @@ describe('OidcService', () => {
           expect(mockFetchCimdMetadata).toHaveBeenCalledWith({
             clientId: cimdClientId,
             validatedUrl: expect.any(URL),
-            dangerouslyAllowPrivateNetworkAccess: false,
+            skipSsrfCheck: false,
           });
         });
       });

--- a/plugins/auth-backend/src/service/OidcService.ts
+++ b/plugins/auth-backend/src/service/OidcService.ts
@@ -387,6 +387,10 @@ export class OidcService {
         this.config.getOptionalStringArray(
           `${configPath}.allowedRedirectUriPatterns`,
         ) ?? LOOPBACK_REDIRECT_PATTERNS,
+      dangerouslyAllowPrivateNetworkAccess:
+        this.config.getOptionalBoolean(
+          `${configPath}.dangerouslyAllowPrivateNetworkAccess`,
+        ) ?? false,
     };
   }
 
@@ -428,6 +432,8 @@ export class OidcService {
     const cimdClient = await fetchCimdMetadata({
       clientId: opts.clientId,
       validatedUrl: opts.cimdUrl,
+      dangerouslyAllowPrivateNetworkAccess:
+        cimd.dangerouslyAllowPrivateNetworkAccess,
     });
 
     if (opts.redirectUri) {

--- a/plugins/auth-backend/src/service/OidcService.ts
+++ b/plugins/auth-backend/src/service/OidcService.ts
@@ -387,10 +387,6 @@ export class OidcService {
         this.config.getOptionalStringArray(
           `${configPath}.allowedRedirectUriPatterns`,
         ) ?? LOOPBACK_REDIRECT_PATTERNS,
-      dangerouslyAllowPrivateNetworkAccess:
-        this.config.getOptionalBoolean(
-          `${configPath}.dangerouslyAllowPrivateNetworkAccess`,
-        ) ?? false,
     };
   }
 
@@ -422,18 +418,24 @@ export class OidcService {
       throw new InputError('Client ID metadata documents not enabled');
     }
 
-    const clientIdMatchers = cimd.allowedClientIdPatterns.map(
-      createUrlPatternMatcher,
-    );
-    if (!clientIdMatchers.some(matches => matches(opts.cimdUrl))) {
+    const matchingPattern = cimd.allowedClientIdPatterns.find(pattern => {
+      const matches = createUrlPatternMatcher(pattern);
+      return matches(opts.cimdUrl);
+    });
+    if (!matchingPattern) {
       throw new InputError(`Invalid client_id '${opts.clientId}'`);
     }
+
+    // Exact patterns (no wildcards) mean the admin explicitly listed this
+    // URL, so we can skip the SSRF check. Wildcard patterns could match
+    // attacker-controlled subdomains that resolve to internal IPs.
+    const isExactPattern =
+      !matchingPattern.includes('*') && !matchingPattern.includes('?');
 
     const cimdClient = await fetchCimdMetadata({
       clientId: opts.clientId,
       validatedUrl: opts.cimdUrl,
-      dangerouslyAllowPrivateNetworkAccess:
-        cimd.dangerouslyAllowPrivateNetworkAccess,
+      skipSsrfCheck: isExactPattern,
     });
 
     if (opts.redirectUri) {


### PR DESCRIPTION
## Summary

- Skips the SSRF IP validation for CIMD metadata fetches when the `client_id` matches an exact (non-wildcard) entry in `allowedClientIdPatterns`
- Wildcard patterns still enforce the SSRF check to protect against attacker-controlled subdomains resolving to internal addresses

## Motivation

CIMD clients hosted on internal networks have `client_id` URLs that resolve to private addresses. The SSRF protection in `fetchCimdMetadata` blocks these fetches even when the administrator has explicitly listed the exact URL in `allowedClientIdPatterns`. This makes CIMD unusable for internal services.

Exact patterns mean the administrator explicitly trusts a specific URL, so the DNS resolution is also trusted. Wildcard patterns like `https://*.example.com/*` could match attacker-controlled subdomains that resolve to internal infrastructure, so the SSRF check remains for those.

## How it works

When resolving a CIMD client, the code now tracks which `allowedClientIdPatterns` entry matched. If the matching pattern contains no glob characters (`*` or `?`), it passes `skipSsrfCheck: true` to `fetchCimdMetadata`, bypassing the `validateHostNotPrivate` call.

```yaml
auth:
  clientIdMetadataDocuments:
    enabled: true
    allowedClientIdPatterns:
      # Exact URL — SSRF check skipped (admin explicitly trusts this)
      - 'https://internal-service.example.net/.well-known/oauth-client.json'
      # Wildcard — SSRF check enforced (could match attacker subdomains)
      - 'https://*.example.com/*'
```

## Test plan

- [x] `CimdClient`: allows private addresses when `skipSsrfCheck` is set
- [x] `CimdClient`: still blocks private addresses when `skipSsrfCheck` is false
- [x] `OidcService`: passes `skipSsrfCheck: true` for exact patterns
- [x] `OidcService`: passes `skipSsrfCheck: false` for wildcard patterns
- [x] `OidcRouter`: updated assertion passes
- [x] All 129 existing tests pass (32 CimdClient + 64 OidcService + 33 OidcRouter)