### PR TITLE
Replace hierarchy links in BUI entity header with EntityRefLinks in order to display titles

### DIFF
--- a/.changeset/weak-carrots-wash.md
+++ b/.changeset/weak-carrots-wash.md
@@ -1,5 +1,6 @@
 ---
-'@backstage/plugin-catalog': patch
+'@backstage/plugin-catalog': minor
+'@backstage/plugin-catalog-react': minor
 ---
 
-Fetch entities for hierarchy links in BUI entity header in order to display titles
+Replace hierarchy links in BUI entity header with EntityRefLinks in order to display titles

--- a/.changeset/weak-carrots-wash.md
+++ b/.changeset/weak-carrots-wash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Fetch entities for hierarchy links in BUI entity header in order to display titles

--- a/plugins/catalog-react/report.api.md
+++ b/plugins/catalog-react/report.api.md
@@ -19,7 +19,7 @@ import IconButton from '@material-ui/core/IconButton';
 import { IconComponent } from '@backstage/core-plugin-api';
 import { InfoCardVariants } from '@backstage/core-components';
 import { JSX as JSX_2 } from 'react/jsx-runtime';
-import { LinkProps } from '@backstage/core-components';
+import { LinkProps } from '@backstage/ui';
 import { Observable } from '@backstage/types';
 import { OutlinedTextFieldProps } from '@material-ui/core/TextField';
 import { Overrides } from '@material-ui/core/styles/overrides';
@@ -641,7 +641,7 @@ export type EntityRefLinkProps = {
   children?: ReactNode;
   hideIcon?: boolean;
   disableTooltip?: boolean;
-} & Omit<LinkProps, 'to'>;
+} & Omit<LinkProps, 'href'>;
 
 // @public
 export function EntityRefLinks<
@@ -657,7 +657,7 @@ export type EntityRefLinksProps<
   hideIcons?: boolean;
   fetchEntities?: boolean;
   getTitle?(entity: TRef): string | undefined;
-} & Omit<LinkProps, 'to'>;
+} & Omit<LinkProps, 'href'>;
 
 // @public
 export interface EntityRefPresentation {

--- a/plugins/catalog-react/src/components/EntityRefLink/EntityRefLink.tsx
+++ b/plugins/catalog-react/src/components/EntityRefLink/EntityRefLink.tsx
@@ -15,7 +15,7 @@
  */
 
 import { CompoundEntityRef, Entity } from '@backstage/catalog-model';
-import { Link, LinkProps } from '@backstage/core-components';
+import { Link, LinkProps } from '@backstage/ui';
 import { useRouteRef } from '@backstage/core-plugin-api';
 import { ReactNode, forwardRef, useCallback } from 'react';
 import { entityRouteParams, entityRouteRef } from '../../routes';
@@ -35,7 +35,7 @@ export type EntityRefLinkProps = {
   children?: ReactNode;
   hideIcon?: boolean;
   disableTooltip?: boolean;
-} & Omit<LinkProps, 'to'>;
+} & Omit<LinkProps, 'href'>;
 
 /**
  * Shows a clickable link to an entity.
@@ -67,7 +67,12 @@ export const EntityRefLink = forwardRef<any, EntityRefLinkProps>(
     );
 
     return (
-      <Link {...linkProps} ref={ref} to={entityLink(props.entityRef)}>
+      <Link
+        {...linkProps}
+        ref={ref}
+        href={entityLink(props.entityRef)}
+        standalone
+      >
         {content}
       </Link>
     );

--- a/plugins/catalog-react/src/components/EntityRefLink/EntityRefLinks.tsx
+++ b/plugins/catalog-react/src/components/EntityRefLink/EntityRefLinks.tsx
@@ -20,7 +20,7 @@ import {
 } from '@backstage/catalog-model';
 import { Fragment } from 'react';
 import { EntityRefLink } from './EntityRefLink';
-import { LinkProps } from '@backstage/core-components';
+import { LinkProps } from '@backstage/ui';
 
 /**
  * Props for {@link EntityRefLink}.
@@ -37,7 +37,7 @@ export type EntityRefLinksProps<
   fetchEntities?: boolean;
   /** @deprecated This option is no longer used; presentation is handled by entityPresentationApiRef instead */
   getTitle?(entity: TRef): string | undefined;
-} & Omit<LinkProps, 'to'>;
+} & Omit<LinkProps, 'href'>;
 
 /**
  * Shows a list of clickable links to entities.

--- a/plugins/catalog/src/alpha/components/EntityHeader/EntityHeaderBui.test.tsx
+++ b/plugins/catalog/src/alpha/components/EntityHeader/EntityHeaderBui.test.tsx
@@ -55,16 +55,6 @@ const ownerEntity: Entity = {
   spec: { profile: { picture: 'https://example.com/team-a.png' } },
 };
 
-const systemEntity: Entity = {
-  apiVersion: 'backstage.io/v1alpha1',
-  kind: 'System',
-  metadata: {
-    namespace: 'default',
-    name: 'artist-engagement-portal',
-    title: 'Artist Engagement Portal',
-  },
-};
-
 function createDeferred<T>() {
   let resolve!: (value: T) => void;
   const promise = new Promise<T>(resolver => {
@@ -101,7 +91,7 @@ describe('EntityHeaderBui', () => {
   it('renders rich entity data from canonical relations', async () => {
     await renderHeader({
       entity: componentEntity,
-      catalogEntities: [componentEntity, ownerEntity, systemEntity],
+      catalogEntities: [componentEntity, ownerEntity],
     });
 
     expect(
@@ -112,7 +102,7 @@ describe('EntityHeaderBui', () => {
     expect(screen.getByText('experimental')).toBeInTheDocument();
     expect(await screen.findByText('Team A')).toBeInTheDocument();
     expect(
-      screen.getByRole('link', { name: 'Artist Engagement Portal' }),
+      screen.getByRole('link', { name: 'artist-engagement-portal' }),
     ).toHaveAttribute(
       'href',
       '/catalog/default/system/artist-engagement-portal',
@@ -130,11 +120,7 @@ describe('EntityHeaderBui', () => {
     await renderHeader({
       entity: componentEntity,
       catalogApi: catalogApiMock.mock({
-        getEntitiesByRefs: jest.fn(({ entityRefs }) =>
-          entityRefs.every(ref => ref.startsWith('group:'))
-            ? ownerResponse.promise
-            : Promise.reject(),
-        ),
+        getEntitiesByRefs: jest.fn(() => ownerResponse.promise),
       }),
     });
 
@@ -143,30 +129,6 @@ describe('EntityHeaderBui', () => {
       ownerResponse.resolve({ items: [ownerEntity] });
     });
     expect(await screen.findByText('Team A')).toBeInTheDocument();
-  });
-
-  it('keeps a useful hierarchy link fallback while catalog hierarchy resolution is pending', async () => {
-    const hierarchyResponse = createDeferred<{ items: Entity[] }>();
-    await renderHeader({
-      entity: componentEntity,
-      catalogApi: catalogApiMock.mock({
-        getEntitiesByRefs: jest.fn(({ entityRefs }) =>
-          entityRefs.every(ref => ref.startsWith('system:'))
-            ? hierarchyResponse.promise
-            : Promise.reject(),
-        ),
-      }),
-    });
-
-    expect(
-      await screen.findByText('artist-engagement-portal'),
-    ).toBeInTheDocument();
-    await act(async () => {
-      hierarchyResponse.resolve({ items: [systemEntity] });
-    });
-    expect(
-      await screen.findByText('Artist Engagement Portal'),
-    ).toBeInTheDocument();
   });
 
   it('renders a route-ref title while the entity is loading', async () => {

--- a/plugins/catalog/src/alpha/components/EntityHeader/EntityHeaderBui.test.tsx
+++ b/plugins/catalog/src/alpha/components/EntityHeader/EntityHeaderBui.test.tsx
@@ -55,6 +55,16 @@ const ownerEntity: Entity = {
   spec: { profile: { picture: 'https://example.com/team-a.png' } },
 };
 
+const systemEntity: Entity = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'System',
+  metadata: {
+    namespace: 'default',
+    name: 'artist-engagement-portal',
+    title: 'Artist Engagement Portal',
+  },
+};
+
 function createDeferred<T>() {
   let resolve!: (value: T) => void;
   const promise = new Promise<T>(resolver => {
@@ -91,7 +101,7 @@ describe('EntityHeaderBui', () => {
   it('renders rich entity data from canonical relations', async () => {
     await renderHeader({
       entity: componentEntity,
-      catalogEntities: [componentEntity, ownerEntity],
+      catalogEntities: [componentEntity, ownerEntity, systemEntity],
     });
 
     expect(
@@ -102,7 +112,7 @@ describe('EntityHeaderBui', () => {
     expect(screen.getByText('experimental')).toBeInTheDocument();
     expect(await screen.findByText('Team A')).toBeInTheDocument();
     expect(
-      screen.getByRole('link', { name: 'artist-engagement-portal' }),
+      screen.getByRole('link', { name: 'Artist Engagement Portal' }),
     ).toHaveAttribute(
       'href',
       '/catalog/default/system/artist-engagement-portal',
@@ -120,7 +130,11 @@ describe('EntityHeaderBui', () => {
     await renderHeader({
       entity: componentEntity,
       catalogApi: catalogApiMock.mock({
-        getEntitiesByRefs: jest.fn(() => ownerResponse.promise),
+        getEntitiesByRefs: jest.fn(({ entityRefs }) =>
+          entityRefs.every(ref => ref.startsWith('group:'))
+            ? ownerResponse.promise
+            : Promise.reject(),
+        ),
       }),
     });
 
@@ -129,6 +143,30 @@ describe('EntityHeaderBui', () => {
       ownerResponse.resolve({ items: [ownerEntity] });
     });
     expect(await screen.findByText('Team A')).toBeInTheDocument();
+  });
+
+  it('keeps a useful hierarchy link fallback while catalog hierarchy resolution is pending', async () => {
+    const hierarchyResponse = createDeferred<{ items: Entity[] }>();
+    await renderHeader({
+      entity: componentEntity,
+      catalogApi: catalogApiMock.mock({
+        getEntitiesByRefs: jest.fn(({ entityRefs }) =>
+          entityRefs.every(ref => ref.startsWith('system:'))
+            ? hierarchyResponse.promise
+            : Promise.reject(),
+        ),
+      }),
+    });
+
+    expect(
+      await screen.findByText('artist-engagement-portal'),
+    ).toBeInTheDocument();
+    await act(async () => {
+      hierarchyResponse.resolve({ items: [systemEntity] });
+    });
+    expect(
+      await screen.findByText('Artist Engagement Portal'),
+    ).toBeInTheDocument();
   });
 
   it('renders a route-ref title while the entity is loading', async () => {

--- a/plugins/catalog/src/alpha/components/EntityHeader/EntityHeaderBui.tsx
+++ b/plugins/catalog/src/alpha/components/EntityHeader/EntityHeaderBui.tsx
@@ -16,11 +16,9 @@
 
 import { useMemo } from 'react';
 import {
-  Box,
   ButtonIcon,
   Header,
   HeaderMetadataUsers,
-  Link,
   type HeaderMetadataItem,
   type HeaderMetadataUser,
   type HeaderNavTabItem,
@@ -37,6 +35,7 @@ import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import {
   catalogApiRef,
   catalogReactTranslationRef,
+  EntityRefLinks,
   entityRouteRef,
   getEntityRelations,
   useAsyncEntity,
@@ -91,40 +90,6 @@ function useOwnerUsers(entity: Entity | undefined): HeaderMetadataUser[] {
   });
 }
 
-function HierarchyLinks(props: { refs: CompoundEntityRef[] }) {
-  const catalogApi = useApi(catalogApiRef);
-  const entityLink = useEntityRefLink();
-  const refStrings = useMemo(
-    () => props.refs.map(ref => stringifyEntityRef(ref)),
-    [props.refs],
-  );
-  const { value: hierarchyEntities } = useAsync(async () => {
-    if (refStrings.length === 0) return [];
-    return (
-      await catalogApi.getEntitiesByRefs({
-        entityRefs: refStrings,
-        fields: ['metadata.name', 'metadata.title'],
-      })
-    ).items;
-  }, [catalogApi, refStrings]);
-
-  return (
-    <Box as="ul" display="inline" m="0" p="0" style={{ listStyle: 'none' }}>
-      {props.refs.map((ref, index) => {
-        const entity = hierarchyEntities?.[index];
-        return (
-          <Box as="li" display="inline" key={stringifyEntityRef(ref)}>
-            {index > 0 ? ', ' : null}
-            <Link href={entityLink(ref)} standalone>
-              {entity?.metadata.title ?? entity?.metadata.name ?? ref.name}
-            </Link>
-          </Box>
-        );
-      })}
-    </Box>
-  );
-}
-
 function hierarchyLabel(
   ref: CompoundEntityRef,
 ): 'systemLabel' | 'domainLabel' | 'partOfLabel' {
@@ -174,7 +139,7 @@ function useMetadata(entity: Entity | undefined): HeaderMetadataItem[] {
             | 'entityLabels.domainLabel'
             | 'entityLabels.partOfLabel',
         ),
-        value: <HierarchyLinks refs={refs} />,
+        value: <EntityRefLinks entityRefs={refs} />,
       });
     }
     return metadata;

--- a/plugins/catalog/src/alpha/components/EntityHeader/EntityHeaderBui.tsx
+++ b/plugins/catalog/src/alpha/components/EntityHeader/EntityHeaderBui.tsx
@@ -92,17 +92,35 @@ function useOwnerUsers(entity: Entity | undefined): HeaderMetadataUser[] {
 }
 
 function HierarchyLinks(props: { refs: CompoundEntityRef[] }) {
+  const catalogApi = useApi(catalogApiRef);
   const entityLink = useEntityRefLink();
+  const refStrings = useMemo(
+    () => props.refs.map(ref => stringifyEntityRef(ref)),
+    [props.refs],
+  );
+  const { value: hierarchyEntities } = useAsync(async () => {
+    if (refStrings.length === 0) return [];
+    return (
+      await catalogApi.getEntitiesByRefs({
+        entityRefs: refStrings,
+        fields: ['metadata.name', 'metadata.title'],
+      })
+    ).items;
+  }, [catalogApi, refStrings]);
+
   return (
     <Box as="ul" display="inline" m="0" p="0" style={{ listStyle: 'none' }}>
-      {props.refs.map((ref, index) => (
-        <Box as="li" display="inline" key={stringifyEntityRef(ref)}>
-          {index > 0 ? ', ' : null}
-          <Link href={entityLink(ref)} standalone>
-            {ref.name}
-          </Link>
-        </Box>
-      ))}
+      {props.refs.map((ref, index) => {
+        const entity = hierarchyEntities?.[index];
+        return (
+          <Box as="li" display="inline" key={stringifyEntityRef(ref)}>
+            {index > 0 ? ', ' : null}
+            <Link href={entityLink(ref)} standalone>
+              {entity?.metadata.title ?? entity?.metadata.name ?? ref.name}
+            </Link>
+          </Box>
+        );
+      })}
     </Box>
   );
 }

--- a/plugins/catalog/src/alpha/components/EntityLabels/EntityLabels.tsx
+++ b/plugins/catalog/src/alpha/components/EntityLabels/EntityLabels.tsx
@@ -38,11 +38,7 @@ export function EntityLabels(props: EntityLabelsProps) {
           label={t('entityLabels.ownerLabel')}
           contentTypograpyRootComponent="p"
           value={
-            <EntityRefLinks
-              entityRefs={ownedByRelations}
-              defaultKind="Group"
-              color="inherit"
-            />
+            <EntityRefLinks entityRefs={ownedByRelations} defaultKind="Group" />
           }
         />
       )}

--- a/plugins/catalog/src/components/EntityLayout/EntityLayout.tsx
+++ b/plugins/catalog/src/components/EntityLayout/EntityLayout.tsx
@@ -141,11 +141,7 @@ function EntityLabels(props: { entity: Entity }) {
           label={t('entityLabels.ownerLabel')}
           contentTypograpyRootComponent="p"
           value={
-            <EntityRefLinks
-              entityRefs={ownedByRelations}
-              defaultKind="Group"
-              color="inherit"
-            />
+            <EntityRefLinks entityRefs={ownedByRelations} defaultKind="Group" />
           }
         />
       )}

--- a/plugins/techdocs/src/reader/components/TechDocsReaderPageHeader/TechDocsReaderPageHeader.tsx
+++ b/plugins/techdocs/src/reader/components/TechDocsReaderPageHeader/TechDocsReaderPageHeader.tsx
@@ -93,23 +93,13 @@ export const TechDocsReaderPageHeader = (
     <>
       <HeaderLabel
         label={capitalize(entityMetadata?.kind || 'entity')}
-        value={
-          <EntityRefLink
-            color="inherit"
-            entityRef={entityRef}
-            defaultKind="Component"
-          />
-        }
+        value={<EntityRefLink entityRef={entityRef} defaultKind="Component" />}
       />
       {ownedByRelations.length > 0 && (
         <HeaderLabel
           label={t('readerPageHeader.owner')}
           value={
-            <EntityRefLinks
-              color="inherit"
-              entityRefs={ownedByRelations}
-              defaultKind="group"
-            />
+            <EntityRefLinks entityRefs={ownedByRelations} defaultKind="group" />
           }
         />
       )}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fetch entities for hierarchy links (labeled System, Domain or Part of) in BUI entity header in order to display titles.

Before:
<img width="1120" height="76" alt="image" src="https://github.com/user-attachments/assets/efa97809-d0c6-48ce-b888-94eaa20619ca" />

After:
<img width="900" height="72" alt="image" src="https://github.com/user-attachments/assets/a26ecb15-69d7-42f1-9352-684db94154cc" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
