### PR TITLE
Add TechDocs Editor to microsite plugin catalog

### DIFF
--- a/microsite/data/plugins/techdocs-editor.yaml
+++ b/microsite/data/plugins/techdocs-editor.yaml
@@ -1,0 +1,11 @@
+---
+title: TechDocs Editor
+author: Estehsan
+authorUrl: https://github.com/Estehsan
+category: Documentation
+description: Edit TechDocs directly in Backstage with WYSIWYG/Markdown modes and open GitHub or GitLab pull/merge requests from the portal.
+documentation: https://github.com/Estehsan/backstage-techdoc-editor/tree/main/workspaces/techdocs-editor/plugins/techdocs-editor\#readme
+iconUrl: https://github.com/Estehsan/Portfolio/blob/main/public/tech-doc-editor.png\?raw\=true
+npmPackageName: '@estehsaan/backstage-plugin-techdocs-editor'
+addedDate: '2026-07-20'
+status: active

--- a/microsite/data/plugins/techdocs-editor.yaml
+++ b/microsite/data/plugins/techdocs-editor.yaml
@@ -4,8 +4,8 @@ author: Estehsan
 authorUrl: https://github.com/Estehsan
 category: Documentation
 description: Edit TechDocs directly in Backstage with WYSIWYG/Markdown modes and open GitHub or GitLab pull/merge requests from the portal.
-documentation: https://github.com/Estehsan/backstage-techdoc-editor/tree/main/workspaces/techdocs-editor/plugins/techdocs-editor\#readme
-iconUrl: https://github.com/Estehsan/Portfolio/blob/main/public/tech-doc-editor.png\?raw\=true
+documentation: https://github.com/Estehsan/backstage-techdoc-editor/tree/main/workspaces/techdocs-editor/plugins/techdocs-editor#readme
+iconUrl: https://github.com/Estehsan/Portfolio/blob/main/public/tech-doc-editor.png?raw=true
 npmPackageName: '@estehsaan/backstage-plugin-techdocs-editor'
 addedDate: '2026-07-20'
 status: active


### PR DESCRIPTION
Add a new plugin metadata entry so TechDocs Editor appears in the Backstage plugin listing with author info, docs link, icon, npm package name, and active status.

## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
