### PR TITLE
Bitbucket server expect slug, not username on some API calls

### DIFF
--- a/.changeset/fix-bitbucket-server-username-slug.md
+++ b/.changeset/fix-bitbucket-server-username-slug.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-bitbucket-server-provider': patch
+---
+
+Fixed sign-in failing for users whose Bitbucket Server username differs from their user slug (for example when authenticated via SSO or LDAP). The provider now resolves the logged-in user's slug before fetching their profile, instead of assuming the username reported by Bitbucket Server can be used directly.

--- a/plugins/auth-backend-module-bitbucket-server-provider/src/helpers.ts
+++ b/plugins/auth-backend-module-bitbucket-server-provider/src/helpers.ts
@@ -37,15 +37,44 @@ export async function fetchProfile(options: {
   }
 
   // A response.ok check here would be worthless as the Bitbucket API always returns 200 OK for this call
-  const username = whoAmIResponse.headers.get('X-Ausername');
+  const username = decodeURIComponent(
+    whoAmIResponse.headers.get('X-Ausername') ?? '',
+  ).trim();
   if (!username) {
     throw new Error(`Failed to retrieve the username of the logged in user`);
+  }
+
+  // Resolve slug that might be different from the username
+  let userLookupResponse;
+  try {
+    userLookupResponse = await fetch(
+      `https://${host}/rest/api/latest/users?filter=${username}`,
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+    );
+  } catch (e) {
+    throw new Error(`Failed to lookup the user '${username}'`);
+  }
+
+  if (!userLookupResponse.ok) {
+    throw new Error(`Failed to lookup the user '${username}'`);
+  }
+
+  const userLookup = await userLookupResponse.json();
+  const userSlug = userLookup.values.find(
+    (u: { name: string; slug: string }) => u.name === username,
+  )?.slug;
+  if (!userSlug) {
+    throw new Error(`Failed to lookup the user '${username}'`);
   }
 
   let userResponse;
   try {
     userResponse = await fetch(
-      `https://${host}/rest/api/latest/users/${username}?avatarSize=256`,
+      `https://${host}/rest/api/latest/users/${userSlug}?avatarSize=256`,
       {
         headers: {
           Authorization: `Bearer ${accessToken}`,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

https://developer.atlassian.com/server/bitbucket/rest/v1004/api-group-system-maintenance/#api-api-latest-users-userslug-get expect a `slug`. Not username

> The user matching the supplied userSlug. Note, this may not be the user's username, always use the user.slug property.

I'm not a frontend develop, but I was able to test this change on my local Backstage and confirmed that I can now link my identity (email + different slug) to Backstage

I didn't added tests, I didn't saw any for this code

It's an AI assisted PR, but I understand everyline of it

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
