### PR TITLE
fix(ui): Realignment of Spotify theme TextField 

### DIFF
--- a/.storybook/themes/spotify.css
+++ b/.storybook/themes/spotify.css
@@ -184,7 +184,24 @@
   }
 
   .bui-Input {
-    border-radius: var(--bui-radius-3);
+    box-shadow: inset 0 0 0 1px var(--bui-input-border-color);
+
+    &:hover:not([data-disabled]):not([data-focused]):not([data-invalid]) {
+      box-shadow: inset 0 0 0 1px var(--bui-input-border-color-hover);
+    }
+
+    &[data-focused] {
+      box-shadow: inset 0 0 0 1px var(--bui-ring);
+    }
+
+    &[data-invalid] {
+      box-shadow: inset 0 0 0 1px var(--bui-border-danger);
+    }
+  }
+
+  .bui-InputWrapper[data-size='medium'] .bui-Input {
+    height: 48px;
+    font-size: 1rem;
   }
 
   .bui-Tag {
@@ -193,6 +210,8 @@
 }
 
 [data-theme-mode='light'][data-theme-name='spotify'] {
+  --bui-input-border-color: #818181;
+  --bui-input-border-color-hover: #000000;
   --bui-ring: rgba(0, 0, 0, 0.2);
   --bui-accent-bg: #1ed760;
   --bui-accent-bg-hover: #3be477;
@@ -213,6 +232,8 @@
 }
 
 [data-theme-mode='dark'][data-theme-name='spotify'] {
+  --bui-input-border-color: #7c7c7c;
+  --bui-input-border-color-hover: #ffffff;
   --bui-bg-app: var(--bui-black);
   --bui-bg-neutral-1: #121212;
   --bui-bg-neutral-2: #2a2a2a;


### PR DESCRIPTION
- Remove border-radius override (8px) 
- Add 1px inset resting form-control (--essential-subdued: #818181 light, #7c7c7c dark)
- Add hover border darkening (--essential-base: #000 light, #fff dark), excluded when disabled/focused/invalid
- Bump medium input height from 40px to 48px to match --encore-control-size-base
- Bump medium input font-size from 14px to 16px (1rem)
- Re-specify focus/invalid box-shadow states so the un-layered spotify.css resting border doesn't clobber BUI's @layer declarations

Cross-cutting items deferred to Phase 1 (global improvements):
  - Focus ring mechanism (box-shadow → outline)
  - Disabled opacity (0.5 → 0.3)
  - Error border color (#f87a7a → #e91429)


