### PR TITLE
fix(ui): align Spotify theme TextArea with Encore FormTextarea

### DIFF
--- a/.storybook/themes/spotify.css
+++ b/.storybook/themes/spotify.css
@@ -184,7 +184,24 @@
   }
 
   .bui-Input {
-    border-radius: var(--bui-radius-3);
+    box-shadow: inset 0 0 0 1px var(--bui-input-border-color);
+
+    &:hover:not([data-disabled]):not([data-focused]):not([data-invalid]) {
+      box-shadow: inset 0 0 0 1px var(--bui-input-border-color-hover);
+    }
+
+    &[data-focused] {
+      box-shadow: inset 0 0 0 1px var(--bui-ring);
+    }
+
+    &[data-invalid] {
+      box-shadow: inset 0 0 0 1px var(--bui-border-danger);
+    }
+  }
+
+  .bui-InputWrapper[data-size='medium'] .bui-Input {
+    height: 48px;
+    font-size: 1rem;
   }
 
   .bui-Tag {
@@ -193,6 +210,8 @@
 }
 
 [data-theme-mode='light'][data-theme-name='spotify'] {
+  --bui-input-border-color: #818181;
+  --bui-input-border-color-hover: #000000;
   --bui-ring: rgba(0, 0, 0, 0.2);
   --bui-accent-bg: #1ed760;
   --bui-accent-bg-hover: #3be477;
@@ -213,6 +232,8 @@
 }
 
 [data-theme-mode='dark'][data-theme-name='spotify'] {
+  --bui-input-border-color: #7c7c7c;
+  --bui-input-border-color-hover: #ffffff;
   --bui-bg-app: var(--bui-black);
   --bui-bg-neutral-1: #121212;
   --bui-bg-neutral-2: #2a2a2a;

--- a/.storybook/themes/spotify.css
+++ b/.storybook/themes/spotify.css
@@ -204,6 +204,31 @@
     font-size: 1rem;
   }
 
+  .bui-TextArea {
+    box-shadow: inset 0 0 0 1px var(--bui-input-border-color);
+
+    &:hover:not([data-disabled]):not([data-focused]):not([data-invalid]) {
+      box-shadow: inset 0 0 0 1px var(--bui-input-border-color-hover);
+    }
+
+    &[data-focused] {
+      box-shadow: inset 0 0 0 1px var(--bui-ring);
+    }
+
+    &[data-invalid] {
+      box-shadow: inset 0 0 0 1px var(--bui-border-danger);
+    }
+
+    &[data-size='medium'] {
+      padding: 12px;
+      font-size: 1rem;
+    }
+
+    &[data-size='small'] {
+      padding: 8px;
+    }
+  }
+
   .bui-Tag {
     border-radius: var(--bui-radius-full);
   }


### PR DESCRIPTION
## Summary
- Adds 1px inset resting border and hover darkening to `.bui-TextArea` in the Spotify theme, matching Encore's `form-control` treatment
- Bumps medium padding from 8px/12px to 12px uniform (`--encore-spacing-tighter`) and small padding from 6px/12px to 8px uniform (`--encore-spacing-tighter-2`)
- Bumps medium font-size from 14px to 16px to match Encore's `bodyMedium` text style
- Re-specifies focus/invalid states so un-layered `spotify.css` doesn't clobber BUI's `@layer` declarations
- Depends on #34965 (TextField parity) for the `--bui-input-border-color` custom property definitions

Cross-cutting items deferred to a separate Phase 1 commit: focus ring mechanism, disabled opacity.

## Test plan
- [ ] Run BUI Storybook (`yarn storybook`) and navigate to TextAreaField stories
- [ ] Toggle to Spotify theme (`?globals=themeName:spotify`)
- [ ] Verify resting border, hover darkening, padding, and font-size match Encore's FormTextarea
- [ ] Verify focus and invalid states still render correctly
- [ ] Check both light and dark modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)