### PR TITLE
feat(notifications-slack): allow metadata.slackChannel to override entity annotation

### DIFF
--- a/.changeset/slack-metadata-channel-override.md
+++ b/.changeset/slack-metadata-channel-override.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications-backend-module-slack': patch
+---
+
+Added support for routing notifications to a specific Slack channel via `payload.metadata.slackChannel`, with the existing entity annotation lookup as a fallback.

--- a/plugins/notifications-backend-module-slack/src/lib/SlackNotificationProcessor.ts
+++ b/plugins/notifications-backend-module-slack/src/lib/SlackNotificationProcessor.ts
@@ -259,6 +259,9 @@ export class SlackNotificationProcessor implements NotificationProcessor {
     }
 
     const entityRefs = [options.recipients.entityRef].flat();
+    const metadataChannel = options.payload.metadata?.slackChannel as
+      | string
+      | undefined;
 
     const outbound: ChatPostMessageArguments[] = [];
     await Promise.all(
@@ -269,14 +272,18 @@ export class SlackNotificationProcessor implements NotificationProcessor {
           return;
         }
 
-        let channel;
-        try {
-          channel = await this.getSlackNotificationTarget(entityRef);
-        } catch (error) {
-          this.logger.error(
-            `Failed to get Slack channel for entity: ${toError(error).message}`,
-          );
-          return;
+        let channel = metadataChannel;
+        if (!channel) {
+          try {
+            channel = await this.getSlackNotificationTarget(entityRef);
+          } catch (error) {
+            this.logger.error(
+              `Failed to get Slack channel for entity: ${
+                toError(error).message
+              }`,
+            );
+            return;
+          }
         }
 
         if (!channel) {


### PR DESCRIPTION
## Summary
- Adds support for `payload.metadata.slackChannel` in `processOptions` to allow callers to route notifications to a specific Slack channel without requiring an entity annotation.
- The `metadata.slackChannel` override allows targeting a Slack channel without requiring any `slack.com/bot-notify annotation` annotation changes on the entity.
- The existing annotation-based lookup remains as a fallback when no metadata channel is provided.

## Test plan
- [ ] Send a notification with `metadata.slackChannel` set — verify it routes to that channel
- [ ] Send a notification without `metadata.slackChannel` — verify it falls back to the entity annotation lookup
- [ ] Send a notification for an entity with no annotation and no metadata channel — verify the "No Slack channel found" debug log

🤖 Generated with [Claude Code](https://claude.com/claude-code)