### PR TITLE
fix(ui): enable Spotify theme mode in Chromatic snapshots

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -107,6 +107,8 @@ export default definePreview({
       modes: {
         'light backstage': allModes['light backstage'],
         'light spotify': allModes['light spotify'],
+        // 'dark backstage': allModes['dark backstage'],
+        // 'dark spotify': allModes['dark spotify'],
       },
     },
 

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -106,10 +106,7 @@ export default definePreview({
     chromatic: {
       modes: {
         'light backstage': allModes['light backstage'],
-        // TODO: Enable these modes when we have more Chromatic snapshots.
-        // 'dark backstage': allModes['dark backstage'],
-        // 'light spotify': allModes['light spotify'],
-        // 'dark spotify': allModes['dark spotify'],
+        'light spotify': allModes['light spotify'],
       },
     },
 


### PR DESCRIPTION
Chromatic was only capturing the default Backstage theme (`light backstage`), so visual changes to the Spotify theme CSS went undetected. This enables the `light spotify` mode so every story is now snapshotted in both themes, catching regressions to the Spotify-themed appearance of BUI components.

Dark mode variants (`dark backstage`, `dark spotify`) are left commented out for future enablement.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. — *Not needed; this only touches Storybook config, not published package output.*
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))