### PR TITLE
refactor(catalog-backend)!: remove relations compatibility mode

### DIFF
--- a/.changeset/remove-relations-compatibility.md
+++ b/.changeset/remove-relations-compatibility.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': major
+---
+
+Removed the deprecated `catalog.enableRelationsCompatibility` config option and its associated compatibility layer. Entity relations are now always returned in the standard format with only `targetRef`. If you were relying on the `target` field in relations, update your code to use `targetRef` instead.

--- a/.changeset/remove-relations-compatibility.md
+++ b/.changeset/remove-relations-compatibility.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend': major
 ---
 
-Removed the deprecated `catalog.enableRelationsCompatibility` config option and its associated compatibility layer. Entity relations are now always returned in the standard format with only `targetRef`. If you were relying on the `target` field in relations, update your code to use `targetRef` instead.
+**BREAKING**: Removed the deprecated `catalog.enableRelationsCompatibility` config option and its associated compatibility layer. Entity relations are now always returned in the standard format with only `targetRef`. If you were relying on the `target` field in relations, update your code to use `targetRef` instead.

--- a/docs/features/software-catalog/api.md
+++ b/docs/features/software-catalog/api.md
@@ -37,6 +37,14 @@ process, not the raw originally ingested entity data. See
 [The Life of an Entity](./life-of-an-entity.md) for more details about this process and
 distinction.
 
+### Relation response format
+
+Catalog API responses represent relation targets using the `targetRef` field.
+The deprecated `target` object and the `catalog.enableRelationsCompatibility`
+setting have been removed. If an external catalog API consumer reads
+`relation.target`, update it to use `relation.targetRef` instead. The
+`targetRef` value is a full [entity reference](references.md).
+
 ### `GET /entities/by-query`
 
 Query entities. Supports the following query parameters, described in the section below:

--- a/plugins/catalog-backend/config.d.ts
+++ b/plugins/catalog-backend/config.d.ts
@@ -142,16 +142,6 @@ export interface Config {
     }>;
 
     /**
-     * Enables the compatibility layer for relations in returned entities that
-     * ensures that all relations objects have both `target` and `targetRef`.
-     *
-     * Enabling this option significantly increases the memory usage of the
-     * catalog, and slightly reduces performance, but may avoid breaking consumers that
-     * rely on the existence of `target` in the relations objects.
-     */
-    enableRelationsCompatibility?: boolean;
-
-    /**
      * Disables the default backstage processors.
      *
      * Enabling this option allows more complete control of which processors are included

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -394,10 +394,6 @@ export class CatalogBuilder {
       metrics,
     } = this.env;
 
-    const enableRelationsCompatibility = Boolean(
-      config.getOptionalBoolean('catalog.enableRelationsCompatibility'),
-    );
-
     const policy = this.buildEntityPolicy();
     const processors = this.buildProcessors();
     const parser = this.parser || defaultEntityDataParser;
@@ -435,7 +431,6 @@ export class CatalogBuilder {
     const unauthorizedEntitiesCatalog = new DefaultEntitiesCatalog({
       database: dbClient,
       logger,
-      enableRelationsCompatibility,
     });
 
     const orchestrator = new DefaultCatalogProcessingOrchestrator({
@@ -553,7 +548,6 @@ export class CatalogBuilder {
       httpAuth,
       permissionsService: permissions,
       auditor,
-      enableRelationsCompatibility,
     });
 
     await connectEntityProviders(providerDatabase, enabledProviderEntries);

--- a/plugins/catalog-backend/src/service/CatalogBuilder.ts
+++ b/plugins/catalog-backend/src/service/CatalogBuilder.ts
@@ -394,10 +394,6 @@ export class CatalogBuilder {
       metrics,
     } = this.env;
 
-    const enableRelationsCompatibility = Boolean(
-      config.getOptionalBoolean('catalog.enableRelationsCompatibility'),
-    );
-
     const policy = this.buildEntityPolicy();
     const processors = this.buildProcessors();
     const parser = this.parser || defaultEntityDataParser;
@@ -435,7 +431,6 @@ export class CatalogBuilder {
     const unauthorizedEntitiesCatalog = new DefaultEntitiesCatalog({
       database: dbClient,
       logger,
-      enableRelationsCompatibility,
     });
 
     const orchestrator = new DefaultCatalogProcessingOrchestrator({
@@ -552,7 +547,6 @@ export class CatalogBuilder {
       httpAuth,
       permissionsService: permissions,
       auditor,
-      enableRelationsCompatibility,
     });
 
     await connectEntityProviders(providerDatabase, enabledProviderEntries);

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
@@ -460,63 +460,6 @@ describe.each(databases.eachSupportedId())(
         expect(entities.length).toBe(0);
       });
 
-      it('should return both target and targetRef for entities in compat mode', async () => {
-        await createDatabase();
-        await addEntity(
-          {
-            apiVersion: 'a',
-            kind: 'k',
-            metadata: { name: 'one' },
-            spec: {},
-            relations: [{ type: 'r', targetRef: 'x:y/z' } as any],
-          },
-          [],
-        );
-        await addEntity(
-          {
-            apiVersion: 'a',
-            kind: 'k',
-            metadata: { name: 'two' },
-            spec: {},
-            relations: [
-              {
-                type: 'r',
-                target: { kind: 'x', namespace: 'y', name: 'z' },
-              } as any,
-            ],
-          },
-          [],
-        );
-        const catalog = new DefaultEntitiesCatalog({
-          database: knex,
-          logger: mockServices.logger.mock(),
-
-          enableRelationsCompatibility: true,
-        });
-
-        const res = await catalog.entities();
-        const entities = entitiesResponseToObjects(res.entities);
-
-        expect(
-          entities.find(e => e?.metadata.name === 'one')!.relations,
-        ).toEqual([
-          {
-            type: 'r',
-            targetRef: 'x:y/z',
-            target: { kind: 'x', namespace: 'y', name: 'z' },
-          },
-        ]);
-        expect(
-          entities.find(e => e?.metadata.name === 'two')!.relations,
-        ).toEqual([
-          {
-            type: 'r',
-            targetRef: 'x:y/z',
-            target: { kind: 'x', namespace: 'y', name: 'z' },
-          },
-        ]);
-      });
-
       it('handles inversion both for existing and missing keys', async () => {
         await createDatabase();
 

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
@@ -484,63 +484,6 @@ describe.each(databases.eachSupportedId())(
         expect(entities.length).toBe(0);
       });
 
-      it('should return both target and targetRef for entities in compat mode', async () => {
-        await createDatabase();
-        await addEntity(
-          {
-            apiVersion: 'a',
-            kind: 'k',
-            metadata: { name: 'one' },
-            spec: {},
-            relations: [{ type: 'r', targetRef: 'x:y/z' } as any],
-          },
-          [],
-        );
-        await addEntity(
-          {
-            apiVersion: 'a',
-            kind: 'k',
-            metadata: { name: 'two' },
-            spec: {},
-            relations: [
-              {
-                type: 'r',
-                target: { kind: 'x', namespace: 'y', name: 'z' },
-              } as any,
-            ],
-          },
-          [],
-        );
-        const catalog = new DefaultEntitiesCatalog({
-          database: knex,
-          logger: mockServices.logger.mock(),
-
-          enableRelationsCompatibility: true,
-        });
-
-        const res = await catalog.entities();
-        const entities = entitiesResponseToObjects(res.entities);
-
-        expect(
-          entities.find(e => e?.metadata.name === 'one')!.relations,
-        ).toEqual([
-          {
-            type: 'r',
-            targetRef: 'x:y/z',
-            target: { kind: 'x', namespace: 'y', name: 'z' },
-          },
-        ]);
-        expect(
-          entities.find(e => e?.metadata.name === 'two')!.relations,
-        ).toEqual([
-          {
-            type: 'r',
-            targetRef: 'x:y/z',
-            target: { kind: 'x', namespace: 'y', name: 'z' },
-          },
-        ]);
-      });
-
       it('handles inversion both for existing and missing keys', async () => {
         await createDatabase();
 

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -45,7 +45,6 @@ import {
 import { markForStitching } from '../database/operations/stitcher/markForStitching';
 
 import {
-  expandLegacyCompoundRelationsInEntity,
   isQueryEntitiesCursorRequest,
   isQueryEntitiesInitialRequest,
 } from './util';
@@ -104,18 +103,10 @@ function stringifyPagination(
 export class DefaultEntitiesCatalog implements EntitiesCatalog {
   private readonly database: Knex;
   private readonly logger: LoggerService;
-  private readonly enableRelationsCompatibility: boolean;
 
-  constructor(options: {
-    database: Knex;
-    logger: LoggerService;
-    enableRelationsCompatibility?: boolean;
-  }) {
+  constructor(options: { database: Knex; logger: LoggerService }) {
     this.database = options.database;
     this.logger = options.logger;
-    this.enableRelationsCompatibility = Boolean(
-      options.enableRelationsCompatibility,
-    );
   }
 
   async entities(request?: EntitiesRequest): Promise<EntitiesResponse> {
@@ -221,15 +212,7 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
     return {
       entities: processRawEntitiesResult(
         rows.map(r => r.final_entity!),
-        this.enableRelationsCompatibility
-          ? e => {
-              expandLegacyCompoundRelationsInEntity(e);
-              if (request?.fields) {
-                return request.fields(e);
-              }
-              return e;
-            }
-          : request?.fields,
+        request?.fields,
       ),
       pageInfo,
     };

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -45,7 +45,6 @@ import {
 import { markForStitching } from '../database/operations/stitcher/markForStitching';
 
 import {
-  expandLegacyCompoundRelationsInEntity,
   isQueryEntitiesCursorRequest,
   isQueryEntitiesInitialRequest,
 } from './util';
@@ -103,18 +102,10 @@ function stringifyPagination(
 export class DefaultEntitiesCatalog implements EntitiesCatalog {
   private readonly database: Knex;
   private readonly logger: LoggerService;
-  private readonly enableRelationsCompatibility: boolean;
 
-  constructor(options: {
-    database: Knex;
-    logger: LoggerService;
-    enableRelationsCompatibility?: boolean;
-  }) {
+  constructor(options: { database: Knex; logger: LoggerService }) {
     this.database = options.database;
     this.logger = options.logger;
-    this.enableRelationsCompatibility = Boolean(
-      options.enableRelationsCompatibility,
-    );
   }
 
   async entities(request?: EntitiesRequest): Promise<EntitiesResponse> {
@@ -220,15 +211,7 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
     return {
       entities: processRawEntitiesResult(
         rows.map(r => r.final_entity!),
-        this.enableRelationsCompatibility
-          ? e => {
-              expandLegacyCompoundRelationsInEntity(e);
-              if (request?.fields) {
-                return request.fields(e);
-              }
-              return e;
-            }
-          : request?.fields,
+        request?.fields,
       ),
       pageInfo,
     };

--- a/plugins/catalog-backend/src/service/createRouter.test.ts
+++ b/plugins/catalog-backend/src/service/createRouter.test.ts
@@ -152,38 +152,6 @@ describe('createRouter readonly disabled', () => {
       expect(response.body).toEqual(entities);
     });
 
-    it('happy path: lists entities with relations compat', async () => {
-      const router = await createRouter({
-        entitiesCatalog,
-        locationService,
-        orchestrator,
-        logger: mockServices.logger.mock(),
-        refreshService,
-        config: new ConfigReader(undefined),
-        auth: mockServices.auth(),
-        httpAuth: mockServices.httpAuth(),
-        locationAnalyzer,
-        permissionsService,
-        enableRelationsCompatibility: true, // added
-        auditor: mockServices.auditor.mock(),
-      });
-
-      app = await wrapServer(express().use(router));
-      const entities: Entity[] = [
-        { apiVersion: 'a', kind: 'b', metadata: { name: 'n' } },
-      ];
-
-      entitiesCatalog.entities.mockResolvedValueOnce({
-        entities: { type: 'object', entities: [entities[0]] },
-        pageInfo: { hasNextPage: false },
-      });
-
-      const response = await request(app).get('/entities');
-
-      expect(response.status).toEqual(200);
-      expect(response.body).toEqual(entities);
-    });
-
     it('parses single and multiple request parameters and passes them down', async () => {
       entitiesCatalog.queryEntities.mockResolvedValueOnce({
         items: { type: 'object', entities: [] },
@@ -208,45 +176,6 @@ describe('createRouter readonly disabled', () => {
         limit: 10000,
         credentials: mockCredentials.user(),
         totalItems: 'exclude',
-      });
-    });
-
-    it('parses single and multiple request parameters and passes them down with relations compat', async () => {
-      const router = await createRouter({
-        entitiesCatalog,
-        locationService,
-        orchestrator,
-        logger: mockServices.logger.mock(),
-        refreshService,
-        config: new ConfigReader(undefined),
-        auth: mockServices.auth(),
-        httpAuth: mockServices.httpAuth(),
-        locationAnalyzer,
-        permissionsService,
-        enableRelationsCompatibility: true,
-        auditor: mockServices.auditor.mock(),
-      });
-      app = await wrapServer(express().use(router));
-      entitiesCatalog.entities.mockResolvedValueOnce({
-        entities: { type: 'object', entities: [] },
-        pageInfo: { hasNextPage: false },
-      });
-      const response = await request(app).get(
-        '/entities?filter=a=1,a=2,b=3&filter=c=4',
-      );
-
-      expect(response.status).toEqual(200);
-      expect(entitiesCatalog.entities).toHaveBeenCalledTimes(1);
-      expect(entitiesCatalog.entities).toHaveBeenCalledWith({
-        filter: {
-          $any: [
-            {
-              $all: [{ a: { $in: ['1', '2'] } }, { b: '3' }],
-            },
-            { c: '4' },
-          ],
-        },
-        credentials: mockCredentials.user(),
       });
     });
   });

--- a/plugins/catalog-backend/src/service/createRouter.test.ts
+++ b/plugins/catalog-backend/src/service/createRouter.test.ts
@@ -152,38 +152,6 @@ describe('createRouter readonly disabled', () => {
       expect(response.body).toEqual(entities);
     });
 
-    it('happy path: lists entities with relations compat', async () => {
-      const router = await createRouter({
-        entitiesCatalog,
-        locationService,
-        orchestrator,
-        logger: mockServices.logger.mock(),
-        refreshService,
-        config: new ConfigReader(undefined),
-        auth: mockServices.auth(),
-        httpAuth: mockServices.httpAuth(),
-        locationAnalyzer,
-        permissionsService,
-        enableRelationsCompatibility: true, // added
-        auditor: mockServices.auditor.mock(),
-      });
-
-      app = await wrapServer(express().use(router));
-      const entities: Entity[] = [
-        { apiVersion: 'a', kind: 'b', metadata: { name: 'n' } },
-      ];
-
-      entitiesCatalog.entities.mockResolvedValueOnce({
-        entities: { type: 'object', entities: [entities[0]] },
-        pageInfo: { hasNextPage: false },
-      });
-
-      const response = await request(app).get('/entities');
-
-      expect(response.status).toEqual(200);
-      expect(response.body).toEqual(entities);
-    });
-
     it('parses single and multiple request parameters and passes them down', async () => {
       entitiesCatalog.queryEntities.mockResolvedValueOnce({
         items: { type: 'object', entities: [] },
@@ -211,48 +179,6 @@ describe('createRouter readonly disabled', () => {
         limit: 10000,
         credentials: mockCredentials.user(),
         totalItems: 'exclude',
-      });
-    });
-
-    it('parses single and multiple request parameters and passes them down with relations compat', async () => {
-      const router = await createRouter({
-        entitiesCatalog,
-        locationService,
-        orchestrator,
-        logger: mockServices.logger.mock(),
-        refreshService,
-        config: new ConfigReader(undefined),
-        auth: mockServices.auth(),
-        httpAuth: mockServices.httpAuth(),
-        locationAnalyzer,
-        permissionsService,
-        enableRelationsCompatibility: true,
-        auditor: mockServices.auditor.mock(),
-      });
-      app = await wrapServer(express().use(router));
-      entitiesCatalog.entities.mockResolvedValueOnce({
-        entities: { type: 'object', entities: [] },
-        pageInfo: { hasNextPage: false },
-      });
-      const response = await request(app).get(
-        '/entities?filter=a=1,a=2,b=3&filter=c=4',
-      );
-
-      expect(response.status).toEqual(200);
-      expect(entitiesCatalog.entities).toHaveBeenCalledTimes(1);
-      expect(entitiesCatalog.entities).toHaveBeenCalledWith({
-        filter: {
-          anyOf: [
-            {
-              allOf: [
-                { key: 'a', values: ['1', '2'] },
-                { key: 'b', values: ['3'] },
-              ],
-            },
-            { key: 'c', values: ['4'] },
-          ],
-        },
-        credentials: mockCredentials.user(),
       });
     });
   });

--- a/plugins/catalog-backend/src/service/createRouter.ts
+++ b/plugins/catalog-backend/src/service/createRouter.ts
@@ -83,8 +83,6 @@ export interface RouterOptions {
   httpAuth: HttpAuthService;
   permissionsService: PermissionsService;
   auditor: AuditorService;
-  /** @deprecated This option will be removed in a future release. */
-  enableRelationsCompatibility?: boolean;
 }
 
 /**
@@ -112,7 +110,6 @@ export async function createRouter(
     auth,
     httpAuth,
     auditor,
-    enableRelationsCompatibility = false,
   } = options;
 
   const readonlyEnabled =
@@ -174,7 +171,7 @@ export async function createRouter(
         // When pagination parameters are passed in, use the legacy slow path
         // that loads all entities into memory
 
-        if (pagination || enableRelationsCompatibility === true) {
+        if (pagination) {
           const { entities, pageInfo } = await entitiesCatalog.entities({
             filter,
             fields,
@@ -196,7 +193,6 @@ export async function createRouter(
           await writeEntitiesResponse({
             res,
             items: entities,
-            alwaysUseObjectMode: enableRelationsCompatibility,
           });
           return;
         }
@@ -291,7 +287,6 @@ export async function createRouter(
         await writeEntitiesResponse({
           res,
           items,
-          alwaysUseObjectMode: enableRelationsCompatibility,
           responseWrapper: entities => ({
             items: entities,
             ...meta,
@@ -340,7 +335,6 @@ export async function createRouter(
         await writeEntitiesResponse({
           res,
           items,
-          alwaysUseObjectMode: enableRelationsCompatibility,
           responseWrapper: entities => ({
             items: entities,
             ...meta,
@@ -532,7 +526,6 @@ export async function createRouter(
         await writeEntitiesResponse({
           res,
           items,
-          alwaysUseObjectMode: enableRelationsCompatibility,
           responseWrapper: entities => ({
             items: entities,
           }),

--- a/plugins/catalog-backend/src/service/createRouter.ts
+++ b/plugins/catalog-backend/src/service/createRouter.ts
@@ -83,8 +83,6 @@ export interface RouterOptions {
   httpAuth: HttpAuthService;
   permissionsService: PermissionsService;
   auditor: AuditorService;
-  /** @deprecated This option will be removed in a future release. */
-  enableRelationsCompatibility?: boolean;
 }
 
 /**
@@ -112,7 +110,6 @@ export async function createRouter(
     auth,
     httpAuth,
     auditor,
-    enableRelationsCompatibility = false,
   } = options;
 
   const readonlyEnabled =
@@ -174,7 +171,7 @@ export async function createRouter(
         // When pagination parameters are passed in, use the legacy slow path
         // that loads all entities into memory
 
-        if (pagination || enableRelationsCompatibility === true) {
+        if (pagination) {
           const { entities, pageInfo } = await entitiesCatalog.entities({
             filter,
             fields,
@@ -196,7 +193,6 @@ export async function createRouter(
           await writeEntitiesResponse({
             res,
             items: entities,
-            alwaysUseObjectMode: enableRelationsCompatibility,
           });
           return;
         }
@@ -291,7 +287,7 @@ export async function createRouter(
         await writeEntitiesResponse({
           res,
           items,
-          alwaysUseObjectMode: enableRelationsCompatibility,
+
           responseWrapper: entities => ({
             items: entities,
             ...meta,
@@ -340,7 +336,7 @@ export async function createRouter(
         await writeEntitiesResponse({
           res,
           items,
-          alwaysUseObjectMode: enableRelationsCompatibility,
+
           responseWrapper: entities => ({
             items: entities,
             ...meta,
@@ -528,7 +524,7 @@ export async function createRouter(
         await writeEntitiesResponse({
           res,
           items,
-          alwaysUseObjectMode: enableRelationsCompatibility,
+
           responseWrapper: entities => ({
             items: entities,
           }),

--- a/plugins/catalog-backend/src/service/response/index.ts
+++ b/plugins/catalog-backend/src/service/response/index.ts
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-export {
-  processRawEntitiesResult,
-  processEntitiesResponseItems,
-  entitiesResponseToObjects,
-} from './process';
+export { processRawEntitiesResult, entitiesResponseToObjects } from './process';
 export { writeSingleEntityResponse, writeEntitiesResponse } from './write';
 export { createEntityArrayJsonStream } from './createEntityArrayJsonStream';

--- a/plugins/catalog-backend/src/service/response/process.test.ts
+++ b/plugins/catalog-backend/src/service/response/process.test.ts
@@ -15,11 +15,7 @@
  */
 
 import { Entity } from '@backstage/catalog-model';
-import {
-  entitiesResponseToObjects,
-  processEntitiesResponseItems,
-  processRawEntitiesResult,
-} from './process';
+import { entitiesResponseToObjects, processRawEntitiesResult } from './process';
 
 const mockTransform = (entity: Entity): Entity => ({
   ...entity,
@@ -35,58 +31,6 @@ describe('processRawEntitiesResult', () => {
 
     expect(
       processRawEntitiesResult(['{"kind":"test"}', null], mockTransform),
-    ).toEqual({
-      type: 'object',
-      entities: [{ kind: 'transformed-test' }, null],
-    });
-  });
-});
-
-describe('processEntitiesResponseItems', () => {
-  it('should transform entities in object form', () => {
-    expect(
-      processEntitiesResponseItems({
-        type: 'object',
-        entities: [{ kind: 'test' } as Entity, null],
-      }),
-    ).toEqual({
-      type: 'object',
-      entities: [{ kind: 'test' }, null],
-    });
-
-    expect(
-      processEntitiesResponseItems(
-        {
-          type: 'object',
-          entities: [{ kind: 'test' } as Entity, null],
-        },
-        mockTransform,
-      ),
-    ).toEqual({
-      type: 'object',
-      entities: [{ kind: 'transformed-test' }, null],
-    });
-  });
-
-  it('should transform entities in raw form', () => {
-    expect(
-      processEntitiesResponseItems({
-        type: 'raw',
-        entities: ['{"kind":"test"}', null],
-      }),
-    ).toEqual({
-      type: 'raw',
-      entities: ['{"kind":"test"}', null],
-    });
-
-    expect(
-      processEntitiesResponseItems(
-        {
-          type: 'raw',
-          entities: ['{"kind":"test"}', null],
-        },
-        mockTransform,
-      ),
     ).toEqual({
       type: 'object',
       entities: [{ kind: 'transformed-test' }, null],

--- a/plugins/catalog-backend/src/service/response/process.ts
+++ b/plugins/catalog-backend/src/service/response/process.ts
@@ -36,22 +36,6 @@ export function processRawEntitiesResult(
   };
 }
 
-export function processEntitiesResponseItems(
-  response: EntitiesResponseItems,
-  transform?: (entity: Entity) => Entity,
-): EntitiesResponseItems {
-  if (!transform) {
-    return response;
-  }
-  if (response.type === 'raw') {
-    return processRawEntitiesResult(response.entities, transform);
-  }
-  return {
-    type: 'object',
-    entities: response.entities.map(e => (e !== null ? transform(e) : e)),
-  };
-}
-
 export function entitiesResponseToObjects(
   response: EntitiesResponseItems,
 ): (Entity | null)[] {

--- a/plugins/catalog-backend/src/service/response/write.test.ts
+++ b/plugins/catalog-backend/src/service/response/write.test.ts
@@ -131,14 +131,12 @@ describe('writeEntitiesResponse', () => {
     writeEntitiesResponse({
       res,
       items: req.body,
-      alwaysUseObjectMode: Boolean(req.query.object),
     });
   });
   app.get('/wrapped', (req, res) => {
     writeEntitiesResponse({
       res,
       items: req.body,
-      alwaysUseObjectMode: Boolean(req.query.object),
       responseWrapper: entities => ({
         page: 1,
         items: entities,
@@ -325,118 +323,6 @@ describe('writeEntitiesResponse', () => {
         'application/json; charset=utf-8',
       );
       expect(res.header['content-length']).not.toBeDefined();
-      expect(res.body).toEqual({
-        page: 1,
-        items: expect.any(Array),
-        totalItems: 1337,
-      });
-      expect(res.body.items).toHaveLength(300);
-    });
-  });
-
-  describe('in raw form forced to object', () => {
-    it('should return empty list', async () => {
-      const res = await request(app).get('/echo?object=true').send({
-        type: 'raw',
-        entities: [],
-      });
-
-      expect(res.status).toBe(200);
-      expect(res.type).toBe('application/json');
-      expect(res.header['content-type']).toBe(
-        'application/json; charset=utf-8',
-      );
-      expect(res.header['content-length']).toBeDefined();
-      expect(res.body).toEqual([]);
-    });
-
-    it('should return mixed objects', async () => {
-      const res = await request(app)
-        .get('/echo?object=true')
-        .send({
-          type: 'raw',
-          entities: ['{"kind":"Component"}', null, '{"kind":"User"}', null],
-        });
-
-      expect(res.status).toBe(200);
-      expect(res.type).toBe('application/json');
-      expect(res.header['content-type']).toBe(
-        'application/json; charset=utf-8',
-      );
-      expect(res.header['content-length']).toBeDefined();
-      expect(res.body).toEqual([
-        { kind: 'Component' },
-        null,
-        { kind: 'User' },
-        null,
-      ]);
-    });
-
-    it('should wrap response of empty list', async () => {
-      const res = await request(app)
-        .get('/wrapped?object=true')
-        .send({ type: 'raw', entities: [] });
-
-      expect(res.status).toBe(200);
-      expect(res.type).toBe('application/json');
-      expect(res.header['content-type']).toBe(
-        'application/json; charset=utf-8',
-      );
-      expect(res.header['content-length']).toBeDefined();
-      expect(res.body).toEqual({ page: 1, items: [], totalItems: 1337 });
-    });
-
-    it('should wrap response of mixed list', async () => {
-      const res = await request(app)
-        .get('/wrapped?object=true')
-        .send({
-          type: 'raw',
-          entities: ['{"kind":"Component"}', null, '{"kind":"User"}', null],
-        });
-
-      expect(res.status).toBe(200);
-      expect(res.type).toBe('application/json');
-      expect(res.header['content-type']).toBe(
-        'application/json; charset=utf-8',
-      );
-      expect(res.header['content-length']).toBeDefined();
-      expect(res.body).toEqual({
-        page: 1,
-        items: [{ kind: 'Component' }, null, { kind: 'User' }, null],
-        totalItems: 1337,
-      });
-    });
-
-    it('should write a large wrapped response', async () => {
-      const entityMock = JSON.stringify({
-        apiVersion: 'backstage.io/v1alpha1',
-        kind: 'Component',
-        metadata: {
-          name: 'my-component',
-          namespace: 'default',
-          annotations: {
-            'backstage.io/managed-by-location': 'url:https://example.com',
-          },
-        },
-        spec: {
-          type: 'service',
-          owner: 'me',
-          lifecycle: 'production',
-        },
-      });
-      const res = await request(app)
-        .get('/wrapped?object=true')
-        .send({
-          type: 'raw',
-          entities: Array(300).fill(entityMock),
-        });
-
-      expect(res.status).toBe(200);
-      expect(res.type).toBe('application/json');
-      expect(res.header['content-type']).toBe(
-        'application/json; charset=utf-8',
-      );
-      expect(res.header['content-length']).toBeDefined();
       expect(res.body).toEqual({
         page: 1,
         items: expect.any(Array),

--- a/plugins/catalog-backend/src/service/response/write.ts
+++ b/plugins/catalog-backend/src/service/response/write.ts
@@ -18,7 +18,6 @@ import { Response } from 'express';
 import { EntitiesResponseItems } from '../../catalog/types';
 import { createDeferred, DeferredPromise, JsonValue } from '@backstage/types';
 import { NotFoundError } from '@backstage/errors';
-import { processEntitiesResponseItems } from './process';
 
 const JSON_CONTENT_TYPE = 'application/json; charset=utf-8';
 
@@ -47,14 +46,9 @@ export async function writeEntitiesResponse(options: {
   res: Response;
   items: EntitiesResponseItems;
   responseWrapper?: (entities: JsonValue) => JsonValue;
-  alwaysUseObjectMode?: boolean;
 }) {
-  const { res, responseWrapper, alwaysUseObjectMode } = options;
+  const { res, items, responseWrapper } = options;
   const writer = createResponseDataWriter(res);
-
-  const items = alwaysUseObjectMode
-    ? processEntitiesResponseItems(options.items, e => e)
-    : options.items;
 
   if (items.type === 'object') {
     res.json(

--- a/plugins/catalog-backend/src/service/response/write.ts
+++ b/plugins/catalog-backend/src/service/response/write.ts
@@ -18,7 +18,6 @@ import { Response } from 'express';
 import { EntitiesResponseItems } from '../../catalog/types';
 import { createDeferred, DeferredPromise, JsonValue } from '@backstage/types';
 import { NotFoundError } from '@backstage/errors';
-import { processEntitiesResponseItems } from './process';
 
 const JSON_CONTENT_TYPE = 'application/json; charset=utf-8';
 
@@ -47,14 +46,11 @@ export async function writeEntitiesResponse(options: {
   res: Response;
   items: EntitiesResponseItems;
   responseWrapper?: (entities: JsonValue) => JsonValue;
-  alwaysUseObjectMode?: boolean;
 }) {
-  const { res, responseWrapper, alwaysUseObjectMode } = options;
+  const { res, responseWrapper } = options;
   const writer = createResponseDataWriter(res);
 
-  const items = alwaysUseObjectMode
-    ? processEntitiesResponseItems(options.items, e => e)
-    : options.items;
+  const items = options.items;
 
   if (items.type === 'object') {
     res.json(

--- a/plugins/catalog-backend/src/service/util.ts
+++ b/plugins/catalog-backend/src/service/util.ts
@@ -26,11 +26,6 @@ import {
   QueryEntitiesRequest,
 } from '../catalog/types';
 import { CatalogProcessor, EntityFilter } from '@backstage/plugin-catalog-node';
-import {
-  Entity,
-  parseEntityRef,
-  stringifyEntityRef,
-} from '@backstage/catalog-model';
 import { Config } from '@backstage/config';
 import type { EntityProviderEntry } from '../processing/connectEntityProviders';
 
@@ -147,29 +142,6 @@ export function decodeCursor(encodedCursor: string) {
   } catch (e) {
     throw new InputError(`Malformed cursor: ${e}`);
   }
-}
-
-// TODO(freben): This is added as a compatibility guarantee, until we can be
-// sure that all adopters have re-stitched their entities so that the new
-// targetRef field is present on them, and that they have stopped consuming
-// the now-removed old field
-// TODO(patriko): Remove this in catalog 2.0
-export function expandLegacyCompoundRelationsInEntity(entity: Entity): Entity {
-  if (entity.relations) {
-    for (const relation of entity.relations as any) {
-      if (!relation.targetRef && relation.target) {
-        // This is the case where an old-form entity, not yet stitched with
-        // the updated code, was in the database
-        relation.targetRef = stringifyEntityRef(relation.target);
-      } else if (!relation.target && relation.targetRef) {
-        // This is the case where a new-form entity, stitched with the
-        // updated code, was in the database but we still want to produce
-        // the old data shape as well for compatibility reasons
-        relation.target = parseEntityRef(relation.targetRef);
-      }
-    }
-  }
-  return entity;
 }
 
 /**

--- a/plugins/catalog-backend/src/tests/integration.test.ts
+++ b/plugins/catalog-backend/src/tests/integration.test.ts
@@ -209,7 +209,6 @@ class TestHarness {
   readonly #db: Knex;
 
   static async create(options: {
-    enableRelationsCompatibility?: boolean;
     logger?: LoggerService;
     db: Knex;
     permissions?: PermissionEvaluator;
@@ -283,7 +282,6 @@ class TestHarness {
     const catalog = new DefaultEntitiesCatalog({
       database: options.db,
       logger,
-      enableRelationsCompatibility: options?.enableRelationsCompatibility,
     });
     const proxyProgressTracker = new ProxyProgressTracker(
       new NoopProgressTracker(),


### PR DESCRIPTION
This compatibility path was introduced in February 2022 with an original removal target of April 2022. The legacy target field was removed from the public type in March 2022, and compatibility output has been disabled by default since July 2025. Removing the remaining opt-in compatibility mode now concludes a migration that has been available for more than four years and disabled by default for over a year.

## Summary

- Removed the deprecated `catalog.enableRelationsCompatibility` config option and all associated code
- Entity relations are now always returned in the standard format with only `targetRef`
- Removed `expandLegacyCompoundRelationsInEntity` and the `alwaysUseObjectMode` response option
- Follows up on #34758, which deprecated the compatibility option

## Verification

- Full `@backstage/plugin-catalog-backend` suite: 79 suites and 729 tests passed
- Focused affected suites: 4 suites and 142 tests passed
- Repository TypeScript compilation passed
- Catalog backend package build passed
- Catalog backend lint passed
- Prettier and diff checks passed
- Branch rebased onto current `master`

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
