### PR TITLE
fix(core-components): avoid jarring pile-up animation on DependencyGraph initial render

### DIFF
--- a/.changeset/smooth-graph-settle.md
+++ b/.changeset/smooth-graph-settle.md
@@ -1,0 +1,7 @@
+---
+'@backstage/core-components': patch
+---
+
+Fixed the `DependencyGraph` component to avoid a jarring initial render where nodes briefly pile up at overlapping positions before animating into place. The graph content is now hidden until node measurements are complete and the layout has fully settled, then revealed at the correct positions with transitions suppressed for the first frame.
+
+Also fixed a `containerRef` recreation chain where every graph dimension change caused the container measurement callback to be recreated and re-triggered, producing unnecessary re-renders during initial layout.

--- a/packages/core-components/src/components/DependencyGraph/DependencyGraph.test.tsx
+++ b/packages/core-components/src/components/DependencyGraph/DependencyGraph.test.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { waitFor } from '@testing-library/react';
 import { DependencyGraph } from './DependencyGraph';
 import { DependencyGraphTypes as Types } from './types';
 import { EDGE_TEST_ID, LABEL_TEST_ID, NODE_TEST_ID } from './constants';
@@ -124,5 +125,51 @@ describe('<DependencyGraph />', () => {
     expect(node).toBeInTheDocument();
     expect(container.querySelector('circle')).toBeInTheDocument();
     expect(getByText(labeledEdge[0].label)).toBeInTheDocument();
+  });
+
+  it('settles graph layout so nodes are visible after initial render', async () => {
+    const { container, findAllByTestId } = await renderInTestApp(
+      <DependencyGraph nodes={nodes} edges={edges} />,
+    );
+    await findAllByTestId(NODE_TEST_ID);
+
+    const outerSvg = container.querySelector('#dependency-graph')!;
+    const containerDiv = outerSvg.parentElement!;
+    await waitFor(() => {
+      expect(containerDiv).toHaveStyle({ visibility: 'visible' });
+      expect(outerSvg.querySelector('style')).toBeNull();
+    });
+  });
+
+  it('settles graph layout even when measurements return zero dimensions', async () => {
+    const originalGetBBox = Object.getOwnPropertyDescriptor(
+      window.SVGElement.prototype,
+      'getBBox',
+    )!;
+
+    Object.defineProperty(window.SVGElement.prototype, 'getBBox', {
+      value: () => ({ width: 0, height: 0, x: 0, y: 0 }),
+      configurable: true,
+    });
+
+    try {
+      const { container, findAllByTestId } = await renderInTestApp(
+        <DependencyGraph nodes={nodes} edges={edges} />,
+      );
+      await findAllByTestId(NODE_TEST_ID);
+
+      const outerSvg = container.querySelector('#dependency-graph')!;
+      const containerDiv = outerSvg.parentElement!;
+      await waitFor(() => {
+        expect(containerDiv).toHaveStyle({ visibility: 'visible' });
+        expect(outerSvg.querySelector('style')).toBeNull();
+      });
+    } finally {
+      Object.defineProperty(
+        window.SVGElement.prototype,
+        'getBBox',
+        originalGetBBox,
+      );
+    }
   });
 });

--- a/packages/core-components/src/components/DependencyGraph/DependencyGraphContent.tsx
+++ b/packages/core-components/src/components/DependencyGraph/DependencyGraphContent.tsx
@@ -280,9 +280,53 @@ export function DependencyGraph<NodeData, EdgeData>(
   );
   const [graphNodes, setGraphNodes] = useState<string[]>([]);
   const [graphEdges, setGraphEdges] = useState<dagre.Edge[]>([]);
+  const [settled, setSettled] = useState(false);
+  const [transitionsReady, setTransitionsReady] = useState(false);
+  const settledRef = useRef(false);
+  const pendingInitialFlush = useRef(false);
+  const measuredLayoutCount = useRef(0);
+
+  useEffect(() => {
+    if (settled && !transitionsReady) {
+      const frame = requestAnimationFrame(() => {
+        setTransitionsReady(true);
+      });
+      return () => cancelAnimationFrame(frame);
+    }
+    return undefined;
+  }, [settled, transitionsReady]);
+
+  // Fallback: if getBBox() returns zero dimensions (e.g. in jsdom or hidden
+  // containers), setNode is never called and the normal settlement path never
+  // triggers. This timeout ensures the graph still becomes visible.
+  useEffect(() => {
+    if (graphNodes.length > 0 && !settledRef.current) {
+      const timeout = setTimeout(() => {
+        if (!settledRef.current) {
+          settledRef.current = true;
+          setSettled(true);
+        }
+      }, 500);
+      return () => clearTimeout(timeout);
+    }
+    return undefined;
+  }, [graphNodes]);
 
   const maxWidth = Math.max(graphWidth, containerWidth);
   const maxHeight = Math.max(graphHeight, containerHeight);
+
+  const dimensionsRef = useRef({
+    containerWidth,
+    containerHeight,
+    maxWidth,
+    maxHeight,
+  });
+  dimensionsRef.current = {
+    containerWidth,
+    containerHeight,
+    maxWidth,
+    maxHeight,
+  };
 
   const [_measureRef] = useMeasure();
   const measureRef = once(_measureRef);
@@ -314,18 +358,19 @@ export function DependencyGraph<NodeData, EdgeData>(
               .zoom<SVGSVGElement, null>()
               .scaleExtent([1, Infinity])
               .on('zoom', event => {
+                const dims = dimensionsRef.current;
                 event.transform.x = Math.min(
                   0,
                   Math.max(
                     event.transform.x,
-                    maxWidth - maxWidth * event.transform.k,
+                    dims.maxWidth - dims.maxWidth * event.transform.k,
                   ),
                 );
                 event.transform.y = Math.min(
                   0,
                   Math.max(
                     event.transform.y,
-                    maxHeight - maxHeight * event.transform.k,
+                    dims.maxHeight - dims.maxHeight * event.transform.k,
                   ),
                 );
                 workspace.attr('transform', event.transform);
@@ -341,20 +386,21 @@ export function DependencyGraph<NodeData, EdgeData>(
 
         const { width: newContainerWidth, height: newContainerHeight } =
           root.getBoundingClientRect();
+        const dims = dimensionsRef.current;
         if (
-          containerWidth !== newContainerWidth &&
-          newContainerWidth <= maxWidth
+          dims.containerWidth !== newContainerWidth &&
+          newContainerWidth <= dims.maxWidth
         ) {
           setContainerWidth(newContainerWidth);
         }
         if (
-          containerHeight !== newContainerHeight &&
-          newContainerHeight <= maxHeight
+          dims.containerHeight !== newContainerHeight &&
+          newContainerHeight <= dims.maxHeight
         ) {
           setContainerHeight(newContainerHeight);
         }
       }, 100),
-    [measureRef, containerHeight, containerWidth, maxWidth, maxHeight, zoom],
+    [measureRef, zoom],
   );
 
   const setNodesAndEdges = useCallback(() => {
@@ -419,6 +465,23 @@ export function DependencyGraph<NodeData, EdgeData>(
 
           setGraphNodes(graph.current.nodes());
           setGraphEdges(graph.current.edges());
+
+          if (!settledRef.current) {
+            const nodeIds = graph.current.nodes();
+            const hasMeasuredNodes =
+              nodeIds.length > 0 &&
+              nodeIds.some(id => {
+                const n = graph.current.node(id);
+                return n && n.width > 0 && n.height > 0;
+              });
+            if (hasMeasuredNodes) {
+              measuredLayoutCount.current += 1;
+            }
+            if (measuredLayoutCount.current >= 2 || nodeIds.length === 0) {
+              settledRef.current = true;
+              setSettled(true);
+            }
+          }
         },
         250,
         { leading: true },
@@ -461,6 +524,13 @@ export function DependencyGraph<NodeData, EdgeData>(
     (id: string, node: Types.DependencyNode<NodeData>) => {
       graph.current.setNode(id, node);
       updateGraph();
+      if (!settledRef.current && !pendingInitialFlush.current) {
+        pendingInitialFlush.current = true;
+        queueMicrotask(() => {
+          pendingInitialFlush.current = false;
+          updateGraph.flush();
+        });
+      }
       return graph.current;
     },
     [updateGraph],
@@ -501,7 +571,14 @@ export function DependencyGraph<NodeData, EdgeData>(
         </Tooltip>
       )}
 
-      <div ref={containerRef} style={{ width: '100%', height: '100%' }}>
+      <div
+        ref={containerRef}
+        style={{
+          width: '100%',
+          height: '100%',
+          visibility: settled ? 'visible' : 'hidden',
+        }}
+      >
         <svg
           {...svgProps}
           width="100%"
@@ -527,6 +604,9 @@ export function DependencyGraph<NodeData, EdgeData>(
             </marker>
             {defs}
           </defs>
+          {!transitionsReady && (
+            <style>{`#${DEPENDENCY_GRAPH_SVG} * { transition: none !important; }`}</style>
+          )}
           <g id={WORKSPACE_ID}>
             <svg
               width={graphWidth}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

BEFORE:

https://github.com/user-attachments/assets/67f012b8-3746-4d08-97ab-2eb319a2e94b

AFTER:

https://github.com/user-attachments/assets/d2b7d1a8-d8a0-4d66-9717-e08c6fa1bbcb

The `DependencyGraph` component uses a multi-pass layout cycle with dagre: first with unmeasured (0x0) nodes, then with real dimensions after `getBBox()` measurements. Custom render nodes (like the catalog graph's `DefaultRenderNode`) add further passes as they measure their own text content internally. Previously this caused all nodes to pile up at overlapping positions and then animate apart, which was visually jarring — especially on the entity relations card.

The fix has three parts:

1. **Hide during measurement** — the container div uses `visibility: hidden` during the measurement phase and becomes visible only after the layout has settled. Settlement is detected by counting layout passes that include measured (non-zero) node dimensions — requiring at least two passes ensures custom render nodes have completed their internal measurement cycles.

2. **Suppress transitions** — an inline SVG `<style>` element (`#dependency-graph * { transition: none !important; }`) is injected during settlement and removed one animation frame after the settled positions are painted. This prevents any residual animation when the graph first becomes visible.

3. **Break containerRef chain** — the `containerRef` useMemo previously depended on `maxWidth`/`maxHeight`/`containerWidth`/`containerHeight`, causing it to be recreated on every dimension change. Each recreation re-triggered the container measurement callback, producing a cascade of unnecessary re-renders during initial layout. Now these values are read from a ref instead.

A microtask-based debounce flush in `setNode` bypasses the 250ms debounce wait for the initial measurement passes, so the graph appears in ~32ms (two frames) instead of ~250ms. A fallback timeout ensures the graph still becomes visible if `getBBox()` returns zero dimensions (e.g., in jsdom or hidden containers).

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))