### PR TITLE
Add Akeyless to the plugin directory

### DIFF
--- a/microsite/data/plugins/akeyless.yaml
+++ b/microsite/data/plugins/akeyless.yaml
@@ -1,0 +1,11 @@
+---
+title: Akeyless
+author: Akeyless
+authorUrl: https://www.akeyless.io
+category: Security
+description: Browse Akeyless secrets linked to catalog entities, with optional static-secret CRUD via the companion backend plugin.
+documentation: https://github.com/backstage/community-plugins/tree/main/workspaces/akeyless/plugins/akeyless
+iconUrl: /img/logo-gradient-on-dark.svg
+npmPackageName: '@backstage-community/plugin-akeyless'
+addedDate: '2026-07-28'
+status: active


### PR DESCRIPTION
## Description

Adds **Akeyless** to the Backstage plugin directory.

[`@backstage-community/plugin-akeyless`](https://www.npmjs.com/package/@backstage-community/plugin-akeyless) is the frontend plugin for Akeyless secrets discovery on catalog entities. It requires the companion backend package [`@backstage-community/plugin-akeyless-backend`](https://www.npmjs.com/package/@backstage-community/plugin-akeyless-backend) (also published; shared types in [`@backstage-community/plugin-akeyless-common`](https://www.npmjs.com/package/@backstage-community/plugin-akeyless-common)).

- **npm:** https://www.npmjs.com/package/@backstage-community/plugin-akeyless
- **Source & docs:** https://github.com/backstage/community-plugins/tree/main/workspaces/akeyless/plugins/akeyless
- **Merged into community-plugins:** https://github.com/backstage/community-plugins/pull/9436

This PR only adds `microsite/data/plugins/akeyless.yaml`, following the existing directory format (`status: active`). Uses the default Backstage icon until a cleared brand asset is available.

## Checklist

- [x] Package published publicly on npm (`0.1.0`)
- [x] Documentation link points at the frontend plugin README (backend install called out there)
- [x] YAML matches `scripts/verify-plugin-directory.js` schema


Made with [Cursor](https://cursor.com)