### PR TITLE
fix(core-components): remove DependencyGraph CSS transitions

### DIFF
--- a/.changeset/dep-graph-transition-suppress.md
+++ b/.changeset/dep-graph-transition-suppress.md
@@ -2,4 +2,4 @@
 '@backstage/core-components': patch
 ---
 
-Improved `DependencyGraph` animation behavior. Topology changes (adding or removing nodes) now appear instantly without jarring intermediate layout flashes. Layout parameter changes (such as switching direction) smoothly animate existing nodes to their new positions. The settlement mechanism that determines when the graph is ready to display has been reworked to be more robust, avoiding premature settlement that could cause visible position corrections.
+Removed CSS transitions from `DependencyGraph` nodes and edges to eliminate jarring animation artifacts when the graph layout changes. The graph now renders layout changes instantly.

--- a/.changeset/dep-graph-transition-suppress.md
+++ b/.changeset/dep-graph-transition-suppress.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Improved `DependencyGraph` animation behavior. Topology changes (adding or removing nodes) now appear instantly without jarring intermediate layout flashes. Layout parameter changes (such as switching direction) smoothly animate existing nodes to their new positions. The settlement mechanism that determines when the graph is ready to display has been reworked to be more robust, avoiding premature settlement that could cause visible position corrections.

--- a/packages/core-components/src/components/DependencyGraph/DependencyGraphContent.tsx
+++ b/packages/core-components/src/components/DependencyGraph/DependencyGraphContent.tsx
@@ -283,8 +283,9 @@ export function DependencyGraph<NodeData, EdgeData>(
   const [settled, setSettled] = useState(false);
   const [transitionsReady, setTransitionsReady] = useState(false);
   const settledRef = useRef(false);
+  const hasSettledOnceRef = useRef(false);
   const pendingInitialFlush = useRef(false);
-  const measuredLayoutCount = useRef(0);
+  const measurementsDirty = useRef(false);
 
   useEffect(() => {
     if (settled && !transitionsReady) {
@@ -296,6 +297,30 @@ export function DependencyGraph<NodeData, EdgeData>(
     return undefined;
   }, [settled, transitionsReady]);
 
+  // Settlement: after each render, useLayoutEffect in Node/Edge fires any
+  // measurements (setting measurementsDirty). This useEffect runs afterward.
+  // If no measurements happened, all nodes are measured, and we haven't
+  // settled yet, the layout is stable and we can settle.
+  useEffect(() => {
+    if (settledRef.current) return;
+    if (measurementsDirty.current) {
+      measurementsDirty.current = false;
+      return;
+    }
+    const nodeIds = graph.current.nodes();
+    const allMeasured =
+      nodeIds.length > 0 &&
+      nodeIds.every(id => {
+        const n = graph.current.node(id);
+        return n && n.width > 0 && n.height > 0;
+      });
+    if (allMeasured) {
+      settledRef.current = true;
+      hasSettledOnceRef.current = true;
+      setSettled(true);
+    }
+  }, [graphNodes, graphEdges]);
+
   // Fallback: if getBBox() returns zero dimensions (e.g. in jsdom or hidden
   // containers), setNode is never called and the normal settlement path never
   // triggers. This timeout ensures the graph still becomes visible.
@@ -304,6 +329,7 @@ export function DependencyGraph<NodeData, EdgeData>(
       const timeout = setTimeout(() => {
         if (!settledRef.current) {
           settledRef.current = true;
+          hasSettledOnceRef.current = true;
           setSettled(true);
         }
       }, 500);
@@ -439,11 +465,12 @@ export function DependencyGraph<NodeData, EdgeData>(
     });
 
     edges.forEach(e => {
+      const existing = graph.current.edge(e.from, e.to);
       graph.current.setEdge(e.from, e.to, {
         ...e,
         label: e.label,
-        width: 0,
-        height: 0,
+        width: (e.label && existing?.width) || 0,
+        height: (e.label && existing?.height) || 0,
         labelpos: labelPosition,
         labeloffset: labelOffset,
         weight: edgeWeight,
@@ -466,22 +493,7 @@ export function DependencyGraph<NodeData, EdgeData>(
           setGraphNodes(graph.current.nodes());
           setGraphEdges(graph.current.edges());
 
-          if (!settledRef.current) {
-            const nodeIds = graph.current.nodes();
-            const hasMeasuredNodes =
-              nodeIds.length > 0 &&
-              nodeIds.some(id => {
-                const n = graph.current.node(id);
-                return n && n.width > 0 && n.height > 0;
-              });
-            if (hasMeasuredNodes) {
-              measuredLayoutCount.current += 1;
-            }
-            if (measuredLayoutCount.current >= 2 || nodeIds.length === 0) {
-              settledRef.current = true;
-              setSettled(true);
-            }
-          }
+          // Settlement is handled by a useEffect — see below
         },
         250,
         { leading: true },
@@ -502,7 +514,35 @@ export function DependencyGraph<NodeData, EdgeData>(
       ranker,
     });
 
+    const nodesBefore = new Set(graph.current.nodes());
+    const edgesBefore = graph.current.edges().length;
     setNodesAndEdges();
+    const nodesAfter = new Set(graph.current.nodes());
+    const edgesAfter = graph.current.edges().length;
+
+    if (settledRef.current) {
+      const hasUnmeasured =
+        graph.current.nodes().some(id => {
+          const n = graph.current.node(id);
+          return n && n.width === 0 && n.height === 0;
+        }) ||
+        graph.current.edges().some(e => {
+          const edge = graph.current.edge(e);
+          return edge && edge.label && edge.width === 0 && edge.height === 0;
+        });
+      const topologyChanged =
+        hasUnmeasured ||
+        nodesAfter.size !== nodesBefore.size ||
+        edgesAfter !== edgesBefore ||
+        [...nodesAfter].some(id => !nodesBefore.has(id));
+
+      if (topologyChanged) {
+        settledRef.current = false;
+        setSettled(false);
+        setTransitionsReady(false);
+      }
+    }
+
     updateGraph();
 
     return updateGraph.cancel;
@@ -522,6 +562,7 @@ export function DependencyGraph<NodeData, EdgeData>(
 
   const setNode = useCallback(
     (id: string, node: Types.DependencyNode<NodeData>) => {
+      measurementsDirty.current = true;
       graph.current.setNode(id, node);
       updateGraph();
       if (!settledRef.current && !pendingInitialFlush.current) {
@@ -538,8 +579,16 @@ export function DependencyGraph<NodeData, EdgeData>(
 
   const setEdge = useCallback(
     (id: dagre.Edge, edge: Types.DependencyEdge<EdgeData>) => {
+      measurementsDirty.current = true;
       graph.current.setEdge(id, edge);
       updateGraph();
+      if (!settledRef.current && !pendingInitialFlush.current) {
+        pendingInitialFlush.current = true;
+        queueMicrotask(() => {
+          pendingInitialFlush.current = false;
+          updateGraph.flush();
+        });
+      }
       return graph.current;
     },
     [updateGraph],

--- a/packages/core-components/src/components/DependencyGraph/DependencyGraphContent.tsx
+++ b/packages/core-components/src/components/DependencyGraph/DependencyGraphContent.tsx
@@ -281,21 +281,9 @@ export function DependencyGraph<NodeData, EdgeData>(
   const [graphNodes, setGraphNodes] = useState<string[]>([]);
   const [graphEdges, setGraphEdges] = useState<dagre.Edge[]>([]);
   const [settled, setSettled] = useState(false);
-  const [transitionsReady, setTransitionsReady] = useState(false);
   const settledRef = useRef(false);
-  const hasSettledOnceRef = useRef(false);
   const pendingInitialFlush = useRef(false);
   const measurementsDirty = useRef(false);
-
-  useEffect(() => {
-    if (settled && !transitionsReady) {
-      const frame = requestAnimationFrame(() => {
-        setTransitionsReady(true);
-      });
-      return () => cancelAnimationFrame(frame);
-    }
-    return undefined;
-  }, [settled, transitionsReady]);
 
   // Settlement: after each render, useLayoutEffect in Node/Edge fires any
   // measurements (setting measurementsDirty). This useEffect runs afterward.
@@ -316,7 +304,6 @@ export function DependencyGraph<NodeData, EdgeData>(
       });
     if (allMeasured) {
       settledRef.current = true;
-      hasSettledOnceRef.current = true;
       setSettled(true);
     }
   }, [graphNodes, graphEdges]);
@@ -329,7 +316,6 @@ export function DependencyGraph<NodeData, EdgeData>(
       const timeout = setTimeout(() => {
         if (!settledRef.current) {
           settledRef.current = true;
-          hasSettledOnceRef.current = true;
           setSettled(true);
         }
       }, 500);
@@ -492,8 +478,6 @@ export function DependencyGraph<NodeData, EdgeData>(
 
           setGraphNodes(graph.current.nodes());
           setGraphEdges(graph.current.edges());
-
-          // Settlement is handled by a useEffect — see below
         },
         250,
         { leading: true },
@@ -514,33 +498,11 @@ export function DependencyGraph<NodeData, EdgeData>(
       ranker,
     });
 
-    const nodesBefore = new Set(graph.current.nodes());
-    const edgesBefore = graph.current.edges().length;
     setNodesAndEdges();
-    const nodesAfter = new Set(graph.current.nodes());
-    const edgesAfter = graph.current.edges().length;
 
     if (settledRef.current) {
-      const hasUnmeasured =
-        graph.current.nodes().some(id => {
-          const n = graph.current.node(id);
-          return n && n.width === 0 && n.height === 0;
-        }) ||
-        graph.current.edges().some(e => {
-          const edge = graph.current.edge(e);
-          return edge && edge.label && edge.width === 0 && edge.height === 0;
-        });
-      const topologyChanged =
-        hasUnmeasured ||
-        nodesAfter.size !== nodesBefore.size ||
-        edgesAfter !== edgesBefore ||
-        [...nodesAfter].some(id => !nodesBefore.has(id));
-
-      if (topologyChanged) {
-        settledRef.current = false;
-        setSettled(false);
-        setTransitionsReady(false);
-      }
+      settledRef.current = false;
+      setSettled(false);
     }
 
     updateGraph();
@@ -653,9 +615,6 @@ export function DependencyGraph<NodeData, EdgeData>(
             </marker>
             {defs}
           </defs>
-          {!transitionsReady && (
-            <style>{`#${DEPENDENCY_GRAPH_SVG} * { transition: none !important; }`}</style>
-          )}
           <g id={WORKSPACE_ID}>
             <svg
               width={graphWidth}

--- a/packages/core-components/src/components/DependencyGraph/Edge.tsx
+++ b/packages/core-components/src/components/DependencyGraph/Edge.tsx
@@ -18,6 +18,7 @@ import { useRef, useLayoutEffect, useMemo } from 'react';
 import * as d3Shape from 'd3-shape';
 import isFinite from 'lodash/isFinite';
 import makeStyles from '@material-ui/core/styles/makeStyles';
+import useTheme from '@material-ui/core/styles/useTheme';
 import { DependencyGraphTypes as Types } from './types';
 import { ARROW_MARKER_ID, EDGE_TEST_ID, LABEL_TEST_ID } from './constants';
 import { DefaultLabel } from './DefaultLabel';
@@ -48,9 +49,7 @@ const useStyles = makeStyles(
       fill: 'none',
       transition: `${theme.transitions.duration.shortest}ms`,
     },
-    label: {
-      transition: `${theme.transitions.duration.shortest}ms`,
-    },
+    label: {},
   }),
   { name: 'BackstageDependencyGraphEdge' },
 );
@@ -85,6 +84,7 @@ export function Edge<EdgeData>({
   const { x = 0, y = 0, width, height, points } = edge;
   const labelProps: Types.DependencyEdge<EdgeData> = edge;
   const classes = useStyles();
+  const theme = useTheme();
 
   const labelRef = useRef<SVGGElement>(null);
 
@@ -141,6 +141,9 @@ export function Edge<EdgeData>({
           data-testid={LABEL_TEST_ID}
           className={classes.label}
           transform={`translate(${x},${y})`}
+          style={{
+            transition: `transform ${theme.transitions.duration.shortest}ms`,
+          }}
         >
           {render({ edge: labelProps })}
         </g>

--- a/packages/core-components/src/components/DependencyGraph/Edge.tsx
+++ b/packages/core-components/src/components/DependencyGraph/Edge.tsx
@@ -18,7 +18,6 @@ import { useRef, useLayoutEffect, useMemo } from 'react';
 import * as d3Shape from 'd3-shape';
 import isFinite from 'lodash/isFinite';
 import makeStyles from '@material-ui/core/styles/makeStyles';
-import useTheme from '@material-ui/core/styles/useTheme';
 import { DependencyGraphTypes as Types } from './types';
 import { ARROW_MARKER_ID, EDGE_TEST_ID, LABEL_TEST_ID } from './constants';
 import { DefaultLabel } from './DefaultLabel';
@@ -47,7 +46,6 @@ const useStyles = makeStyles(
       strokeWidth: 1.3,
       stroke: theme.palette.textSubtle,
       fill: 'none',
-      transition: `${theme.transitions.duration.shortest}ms`,
     },
     label: {},
   }),
@@ -84,7 +82,6 @@ export function Edge<EdgeData>({
   const { x = 0, y = 0, width, height, points } = edge;
   const labelProps: Types.DependencyEdge<EdgeData> = edge;
   const classes = useStyles();
-  const theme = useTheme();
 
   const labelRef = useRef<SVGGElement>(null);
 
@@ -141,9 +138,6 @@ export function Edge<EdgeData>({
           data-testid={LABEL_TEST_ID}
           className={classes.label}
           transform={`translate(${x},${y})`}
-          style={{
-            transition: `transform ${theme.transitions.duration.shortest}ms`,
-          }}
         >
           {render({ edge: labelProps })}
         </g>

--- a/packages/core-components/src/components/DependencyGraph/Node.tsx
+++ b/packages/core-components/src/components/DependencyGraph/Node.tsx
@@ -25,11 +25,9 @@ import dagre from '@dagrejs/dagre';
 export type DependencyGraphNodeClassKey = 'node';
 
 const useStyles = makeStyles(
-  theme => ({
-    node: {
-      transition: `${theme.transitions.duration.shortest}ms`,
-    },
-  }),
+  {
+    node: {},
+  },
   { name: 'BackstageDependencyGraphNode' },
 );
 


### PR DESCRIPTION
Removes CSS transitions from `DependencyGraph` nodes and edges. The transitions
caused jarring animation artifacts — labels jumping to corners, nodes sliding
into place — when layout parameters changed after the initial render. The graph
now renders layout changes instantly, and the settlement/animation-gating logic
that was added to work around the transition issues has been cleaned up.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))