### PR TITLE
fix(catalog-backend): fix missing promise return in migration rollback

### DIFF
--- a/.changeset/fix-catalog-migration-promises.md
+++ b/.changeset/fix-catalog-migration-promises.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Fixed a missing promise return in a database migration rollback function.

--- a/plugins/catalog-backend/migrations/20200527114117_location_update_log_latest_view.js
+++ b/plugins/catalog-backend/migrations/20200527114117_location_update_log_latest_view.js
@@ -41,5 +41,5 @@ exports.up = async function up(knex) {
  * @param {import('knex').Knex} knex
  */
 exports.down = async function down(knex) {
-  return knex.schema.raw(`DROP VIEW location_update_log_latest;`);
+  await knex.schema.raw(`DROP VIEW IF EXISTS location_update_log_latest;`);
 };

--- a/plugins/catalog-backend/migrations/20200721115244_location_update_log_latest_deduplicate.js
+++ b/plugins/catalog-backend/migrations/20200721115244_location_update_log_latest_deduplicate.js
@@ -19,8 +19,9 @@
 /**
  * @param {import('knex').Knex} knex
  */
-exports.up = function up(knex) {
-  return knex.schema.raw(`DROP VIEW location_update_log_latest;`).raw(`
+exports.up = async function up(knex) {
+  await knex.schema.raw(`DROP VIEW location_update_log_latest;`);
+  await knex.schema.raw(`
   CREATE VIEW location_update_log_latest AS
   SELECT t1.* FROM location_update_log t1
   JOIN
@@ -39,6 +40,6 @@ exports.up = function up(knex) {
 /**
  * @param {import('knex').Knex} knex
  */
-exports.down = function down(knex) {
-  knex.schema.raw(`DROP VIEW location_update_log_latest;`);
+exports.down = async function down(knex) {
+  await knex.schema.raw(`DROP VIEW IF EXISTS location_update_log_latest;`);
 };


### PR DESCRIPTION
The `down` function in `20200721115244_location_update_log_latest_deduplicate.js`
was missing its `return`, causing a "did not return a promise" warning during
`yarn build:api-reports`. Converted to async/await for consistency.

Both this migration and the earlier `20200527114117_location_update_log_latest_view.js`
now use `DROP VIEW IF EXISTS` in their rollbacks, since both target the same view
and the later migration's rollback runs first.

No changeset needed — internal migration fix with no effect on published packages.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))