### PR TITLE
fix(catalog-backend): fix flaky stitcher test on MySQL

### DIFF
--- a/plugins/catalog-backend/src/stitching/DefaultStitcher.test.ts
+++ b/plugins/catalog-backend/src/stitching/DefaultStitcher.test.ts
@@ -95,7 +95,12 @@ describe.each(databases.eachSupportedId())('Stitcher, %p', databaseId => {
     // Wait for stitching to complete
     await waitForCondition(async () => {
       const entities = await db<DbFinalEntitiesRow>('final_entities');
-      return entities.length === 1 && entities[0].final_entity !== null;
+      const searchRows = await db<DbSearchRow>('search');
+      return (
+        entities.length === 1 &&
+        entities[0].final_entity !== null &&
+        searchRows.length > 0
+      );
     });
 
     await stitcher.stop();


### PR DESCRIPTION
The `waitForCondition` in the stitcher happy-path test only checked
`final_entities`, but `search` rows are written in a separate step after.
On MySQL the search sync uses temp tables and multiple DML operations,
making the window wider — `stitcher.stop()` could race against it and
the subsequent assertion would find an empty `search` table.

Fixed by also waiting for `search` rows before proceeding.

No changeset needed — test-only change.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))