### PR TITLE
fix(auth-backend): always allow the built-in CLI client_id for CIMD

### DIFF
--- a/.changeset/olive-donkeys-repeat.md
+++ b/.changeset/olive-donkeys-repeat.md
@@ -3,7 +3,3 @@
 ---
 
 Fixed the built-in CLI client being rejected when `allowedClientIdPatterns` is configured for Client ID Metadata Documents.
-
-Enabling CIMD makes the auth backend serve a client metadata document for the Backstage CLI at `/.well-known/oauth-client/cli.json`, and its `client_id` is one of the default `allowedClientIdPatterns`. Because configuring that key replaced the defaults outright, any deployment that allowlisted an additional client silently stopped accepting the CLI, which then failed with `Invalid client_id` even though the backend kept serving the document at 200.
-
-The derived CLI pattern is now always allowed. Configuring `allowedClientIdPatterns` still replaces the Claude and VS Code defaults.

--- a/.changeset/olive-donkeys-repeat.md
+++ b/.changeset/olive-donkeys-repeat.md
@@ -1,0 +1,9 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Fixed the built-in CLI client being rejected when `allowedClientIdPatterns` is configured for Client ID Metadata Documents.
+
+Enabling CIMD makes the auth backend serve a client metadata document for the Backstage CLI at `/.well-known/oauth-client/cli.json`, and its `client_id` is one of the default `allowedClientIdPatterns`. Because configuring that key replaced the defaults outright, any deployment that allowlisted an additional client silently stopped accepting the CLI, which then failed with `Invalid client_id` even though the backend kept serving the document at 200.
+
+The derived CLI pattern is now always allowed. Configuring `allowedClientIdPatterns` still replaces the Claude and VS Code defaults.

--- a/docs/ai/mcp-actions.md
+++ b/docs/ai/mcp-actions.md
@@ -202,9 +202,9 @@ auth:
     enabled: true
     # Optional: override which client_id URLs are allowed.
     # Defaults to Claude, VS Code, and the built-in Backstage CLI.
-    # Note: setting this replaces the defaults entirely. The built-in
-    # CLI pattern is derived from your auth backend's base URL and
-    # must be re-added manually if you override this list.
+    # Note: setting this replaces the Claude and VS Code defaults entirely.
+    # The built-in CLI client is always allowed, since this backend serves
+    # its metadata document itself.
     # allowedClientIdPatterns:
     #   - 'https://claude.ai/*'
     #   - 'https://vscode.dev/*'

--- a/plugins/auth-backend/config.d.ts
+++ b/plugins/auth-backend/config.d.ts
@@ -197,6 +197,10 @@ export interface Config {
        * Defaults to `['https://claude.ai/*', 'https://vscode.dev/*', '{baseUrl}/.well-known/oauth-client/cli.json']`
        * where `{baseUrl}` is the auth backend's base URL.
        *
+       * Setting this replaces the Claude and VS Code defaults. The built-in
+       * CLI client is always allowed, since this backend serves its metadata
+       * document itself.
+       *
        * @example ['https://example.com/*', 'https://*.trusted-domain.com/*']
        */
       allowedClientIdPatterns?: string[];
@@ -231,6 +235,10 @@ export interface Config {
        *
        * Defaults to `['https://claude.ai/*', 'https://vscode.dev/*', '{baseUrl}/.well-known/oauth-client/cli.json']`
        * where `{baseUrl}` is the auth backend's base URL.
+       *
+       * Setting this replaces the Claude and VS Code defaults. The built-in
+       * CLI client is always allowed, since this backend serves its metadata
+       * document itself.
        *
        * @example ['https://example.com/*', 'https://*.trusted-domain.com/*']
        */

--- a/plugins/auth-backend/src/service/OidcService.test.ts
+++ b/plugins/auth-backend/src/service/OidcService.test.ts
@@ -55,10 +55,16 @@ describe('OidcService', () => {
     databaseId: TestDatabaseId;
     config?: JsonObject;
     offlineAccess?: OfflineAccessService;
+    baseUrl?: string;
   }
 
   async function createOidcService(options: CreateOidcServiceOptions) {
-    const { databaseId, config: configData = {}, offlineAccess } = options;
+    const {
+      databaseId,
+      config: configData = {},
+      offlineAccess,
+      baseUrl = 'http://mock-base-url',
+    } = options;
 
     const knex = await databases.init(databaseId);
 
@@ -92,7 +98,7 @@ describe('OidcService', () => {
       service: OidcService.create({
         auth: mockAuth,
         tokenIssuer: mockTokenIssuer,
-        baseUrl: 'http://mock-base-url',
+        baseUrl,
         userInfo: mockUserInfo,
         oidc: oidcDatabase,
         config,
@@ -1374,6 +1380,46 @@ describe('OidcService', () => {
             expect.objectContaining({
               id: expect.any(String),
               clientName: 'CIMD Test Client',
+            }),
+          );
+        });
+
+        it('should allow the built-in CLI client_id when allowedClientIdPatterns is set', async () => {
+          const authBaseUrl = 'https://backstage.example.com/api/auth';
+          const cliClientId = `${authBaseUrl}/.well-known/oauth-client/cli.json`;
+
+          const { service } = await createOidcService({
+            databaseId,
+            baseUrl: authBaseUrl,
+            config: {
+              auth: {
+                clientIdMetadataDocuments: {
+                  enabled: true,
+                  allowedClientIdPatterns: ['https://*.trusted.com/*'],
+                },
+              },
+            },
+          });
+
+          mockFetchCimdMetadata.mockResolvedValue({
+            clientId: cliClientId,
+            clientName: 'Backstage CLI',
+            redirectUris: ['http://127.0.0.1:8055/callback'],
+            responseTypes: ['code'],
+            grantTypes: ['authorization_code'],
+          });
+
+          const authSession = await service.createAuthorizationSession({
+            clientId: cliClientId,
+            redirectUri: 'http://127.0.0.1:8055/callback',
+            responseType: 'code',
+            ...pkceParams,
+          });
+
+          expect(authSession).toEqual(
+            expect.objectContaining({
+              id: expect.any(String),
+              clientName: 'Backstage CLI',
             }),
           );
         });

--- a/plugins/auth-backend/src/service/OidcService.ts
+++ b/plugins/auth-backend/src/service/OidcService.ts
@@ -378,11 +378,20 @@ export class OidcService {
 
     const cliClientId = `${this.baseUrl}/.well-known/oauth-client/cli.json`;
 
+    // This backend serves the CLI client metadata document itself at
+    // /.well-known/oauth-client/cli.json whenever CIMD is enabled, so its
+    // client_id is always accepted. Configuring allowedClientIdPatterns
+    // narrows which third-party clients are allowed, it does not turn off the
+    // built-in CLI.
+    const configuredClientIdPatterns = this.config.getOptionalStringArray(
+      `${configPath}.allowedClientIdPatterns`,
+    );
+
     return {
       enabled,
-      allowedClientIdPatterns: this.config.getOptionalStringArray(
-        `${configPath}.allowedClientIdPatterns`,
-      ) ?? ['https://claude.ai/*', 'https://vscode.dev/*', cliClientId],
+      allowedClientIdPatterns: configuredClientIdPatterns
+        ? [...new Set([...configuredClientIdPatterns, cliClientId])]
+        : ['https://claude.ai/*', 'https://vscode.dev/*', cliClientId],
       allowedRedirectUriPatterns:
         this.config.getOptionalStringArray(
           `${configPath}.allowedRedirectUriPatterns`,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Enabling Client ID Metadata Documents makes the auth backend serve a client metadata document for the Backstage CLI at `/.well-known/oauth-client/cli.json`, and that document's URL is one of the default `allowedClientIdPatterns`. Because configuring that key replaced the defaults outright, any deployment that allowlisted one extra client silently stopped accepting its own CLI.

The result is a server that is inconsistent with itself: `GET /.well-known/oauth-client/cli.json` still returns the document with `200`, while `GET /v1/authorize?client_id=<that same URL>` returns `400 Invalid client_id`.

```yaml
auth:
  clientIdMetadataDocuments:
    enabled: true
    allowedClientIdPatterns:
      - 'https://my-client.example.com/*' # <- also disables the built-in CLI
```

This is easy to hit because the reason is invisible: nothing warns, and the CLI pattern is derived from `baseUrl` rather than written down anywhere in config. We hit it on our internal instance, where adding a single allowlist entry broke Claude Code, VS Code Copilot, and the CLI at once, and it took a while to trace back to this key.

### Change

`getCimdConfig` now always includes the derived CLI `client_id`, whether or not `allowedClientIdPatterns` is configured. Configuring the key still replaces the `https://claude.ai/*` and `https://vscode.dev/*` defaults, so the security hardening from 0.29.0 is unchanged for third-party clients. Only the pattern that points back at this backend's own endpoint is now unconditional.

Also updates `config.d.ts` and `docs/ai/mcp-actions.md`, which currently tell you to re-add the CLI pattern by hand.

Happy to switch this to a startup warning instead if you would rather keep the list strictly literal. That felt weaker, since the endpoint is enabled by the same flag that enables CIMD, so there is no configuration in which serving the document but refusing it is the intended behaviour.

:heavy_check_mark: **Checklist**

- [x] A changeset describing the change and affected packages
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes) — n/a
- [x] All your commits have a `Signed-off-by` line in the message
