### PR TITLE
fix(catalog-backend): use entity_ref instead of entity_id for default ordering

### DIFF
--- a/.changeset/catalog-default-order-by-entity-ref.md
+++ b/.changeset/catalog-default-order-by-entity-ref.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Changed the default entity ordering and cursor pagination anchor from `entity_id` to `entity_ref`. This produces a stable, meaningful sort order (by kind/namespace/name) that is resilient to future leader-promotion scenarios where `entity_id` may change for a given ref.

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.test.ts
@@ -20,6 +20,7 @@ import {
   mockServices,
 } from '@backstage/backend-test-utils';
 import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
+import { EntityFilter } from '@backstage/plugin-catalog-node';
 import { Knex } from 'knex';
 import { randomUUID as uuid } from 'node:crypto';
 import {
@@ -1569,7 +1570,7 @@ describe.each(databases.eachSupportedId())(
           logger: mockServices.logger.mock(),
         });
 
-        const filter = {
+        const filter: EntityFilter = {
           key: 'spec.should_include_this',
         };
 
@@ -1585,10 +1586,10 @@ describe.each(databases.eachSupportedId())(
         const response = await catalog.queryEntities(request);
 
         expect(entitiesResponseToObjects(response.items)).toEqual([
-          entityFrom('KingOfTheJungle', { uid: 'id0', title: 'lion' }),
-          entityFrom('NotKingOfTheJungle', { uid: 'id1', title: 'cat' }),
-          entityFrom('NotACatKing', { uid: 'id2', title: 'atcatss' }),
           entityFrom('123', { uid: 'id3', title: 'king' }),
+          entityFrom('KingOfTheJungle', { uid: 'id0', title: 'lion' }),
+          entityFrom('NotACatKing', { uid: 'id2', title: 'atcatss' }),
+          entityFrom('NotKingOfTheJungle', { uid: 'id1', title: 'cat' }),
         ]);
         expect(response.pageInfo.nextCursor).toBeUndefined();
         expect(response.pageInfo.prevCursor).toBeUndefined();
@@ -1599,8 +1600,8 @@ describe.each(databases.eachSupportedId())(
           limit: 2,
         });
         expect(entitiesResponseToObjects(paginatedResponse.items)).toEqual([
+          entityFrom('123', { uid: 'id3', title: 'king' }),
           entityFrom('KingOfTheJungle', { uid: 'id0', title: 'lion' }),
-          entityFrom('NotKingOfTheJungle', { uid: 'id1', title: 'cat' }),
         ]);
         expect(paginatedResponse.pageInfo.nextCursor).not.toBeUndefined();
         expect(paginatedResponse.pageInfo.prevCursor).toBeUndefined();
@@ -1612,7 +1613,7 @@ describe.each(databases.eachSupportedId())(
         });
         expect(entitiesResponseToObjects(paginatedResponseNext.items)).toEqual([
           entityFrom('NotACatKing', { uid: 'id2', title: 'atcatss' }),
-          entityFrom('123', { uid: 'id3', title: 'king' }),
+          entityFrom('NotKingOfTheJungle', { uid: 'id1', title: 'cat' }),
         ]);
         expect(paginatedResponseNext.pageInfo.nextCursor).toBeUndefined();
         expect(paginatedResponseNext.pageInfo.prevCursor).not.toBeUndefined();

--- a/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
+++ b/plugins/catalog-backend/src/service/DefaultEntitiesCatalog.ts
@@ -185,7 +185,7 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
             ]);
           }
         });
-        entitiesQuery.orderBy('final_entities.entity_id', 'asc');
+        entitiesQuery.orderBy('final_entities.entity_ref', 'asc');
       } else {
         entitiesQuery = entitiesQuery.orderBy(
           'final_entities.entity_ref',
@@ -283,12 +283,12 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
     withField = isPg
       ? withField.orderBy([
           { column: 'order_0.value', order: primaryOrder.order, nulls: 'last' },
-          { column: 'final_entities.entity_id', order: 'asc' },
+          { column: 'final_entities.entity_ref', order: 'asc' },
         ])
       : withField.orderBy([
           { column: 'order_0.value', order: undefined, nulls: 'last' },
           { column: 'order_0.value', order: primaryOrder.order },
-          { column: 'final_entities.entity_id', order: 'asc' },
+          { column: 'final_entities.entity_ref', order: 'asc' },
         ]);
     if (wantedRows < Number.MAX_SAFE_INTEGER) {
       withField = withField.limit(wantedRows);
@@ -316,7 +316,7 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
       );
     withoutField = applyFilter(withoutField);
     withoutField = withoutField.orderBy(
-      'final_entities.entity_id',
+      'final_entities.entity_ref',
       'asc', // NULL group always stable-sorted ASC regardless of primary direction
     );
     if (limit !== undefined) {
@@ -468,7 +468,12 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
     // the set reachable through cursor pagination.
     const dbQuery = this.database.with(
       'filtered',
-      ['entity_id', 'final_entity', ...(sortField ? ['value'] : [])],
+      [
+        'entity_id',
+        'entity_ref',
+        'final_entity',
+        ...(sortField ? ['value'] : []),
+      ],
       inner => {
         if (sortField) {
           inner
@@ -483,6 +488,7 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
             .whereNotNull('final_entities.final_entity')
             .select({
               entity_id: 'final_entities.entity_id',
+              entity_ref: 'final_entities.entity_ref',
               final_entity: 'final_entities.final_entity',
               value: 'search.value',
             });
@@ -492,6 +498,7 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
             .whereNotNull('final_entity')
             .select({
               entity_id: 'final_entities.entity_id',
+              entity_ref: 'final_entities.entity_ref',
               final_entity: 'final_entities.final_entity',
             });
         }
@@ -530,7 +537,7 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
     // Move forward (or backward) in the set to the correct cursor position
     if (cursor.orderFieldValues) {
       if (cursor.orderFieldValues.length === 2) {
-        // The first will be the sortField value, the second the entity_id
+        // The first will be the sortField value, the second the entity_ref
         const [first, second] = cursor.orderFieldValues;
         dbQuery.andWhere(function nested() {
           this.where(
@@ -540,15 +547,15 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
           )
             .orWhere('filtered.value', '=', first)
             .andWhere(
-              'filtered.entity_id',
+              'filtered.entity_ref',
               isFetchingBackwards !== isOrderingDescending ? '<' : '>',
               second,
             );
         });
       } else if (cursor.orderFieldValues.length === 1) {
-        // This will be the entity_id
+        // This will be the entity_ref
         const [first] = cursor.orderFieldValues;
-        dbQuery.andWhere('entity_id', isFetchingBackwards ? '<' : '>', first);
+        dbQuery.andWhere('entity_ref', isFetchingBackwards ? '<' : '>', first);
       }
     }
 
@@ -558,7 +565,7 @@ export class DefaultEntitiesCatalog implements EntitiesCatalog {
     }
     dbQuery.orderBy([
       ...(sortField ? [{ column: 'filtered.value', order }] : []),
-      { column: 'filtered.entity_id', order },
+      { column: 'filtered.entity_ref', order },
     ]);
 
     // Apply a manually set initial offset
@@ -901,5 +908,5 @@ function sortFieldsFromRow(
   row: DbSearchRow & DbFinalEntitiesRow,
   sortField?: EntityOrder | undefined,
 ) {
-  return sortField ? [row?.value, row?.entity_id] : [row?.entity_id];
+  return sortField ? [row?.value, row?.entity_ref] : [row?.entity_ref];
 }


### PR DESCRIPTION
## Summary

Switches the default sort column and cursor pagination tiebreaker from
`entity_id` to `entity_ref` across all catalog query paths:

- **`entities()` slow path** — tiebreaker after user-specified order fields
- **`runOrderedEntitiesQuery()` fast path** — tiebreaker in both the "has sort
  field" and "lacks sort field" phases
- **`queryEntities()`** — the `filtered` CTE now includes `entity_ref`, used
  as the ORDER BY tiebreaker/sole sort and cursor seek column
- **`sortFieldsFromRow()`** — cursor values encode `entity_ref` instead of
  `entity_id`

### Why

`entity_ref` is the correct pagination anchor because:

- **Meaningful sort order** — entities sort by kind/namespace/name, which is
  what users expect when no explicit sort is requested
- **Stable across leader promotions** — future bucketing changes will allow
  `entity_id` to change for a given ref when a new winner is elected;
  `entity_ref` is the stable external identity
- **No double-counting or skipping** — `entity_ref` is unique in
  `final_entities`, so cursor pagination remains correct during concurrent
  mutations

The no-sort-field default in `entities()` already used `entity_ref`; this
change makes `queryEntities()` and the tiebreaker paths consistent.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))