### PR TITLE
Add delay to github publish action

### DIFF
--- a/.changeset/add-delay-to-publish-github.md
+++ b/.changeset/add-delay-to-publish-github.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-github': patch
+---
+
+Adding delay to publish:github action. In some organizations adding delay can prevent failure of this action. It can happen after repository is created and when collaborators are being added.

--- a/plugins/scaffolder-backend-module-github/report.api.md
+++ b/plugins/scaffolder-backend-module-github/report.api.md
@@ -308,6 +308,7 @@ export function createGithubRepoCreateAction(options: {
     token?: string | undefined;
     topics?: string[] | undefined;
     workflowAccess?: 'none' | 'organization' | 'user' | undefined;
+    delay?: number | undefined;
   },
   {
     remoteUrl: string;
@@ -467,6 +468,7 @@ export function createPublishGithubAction(options: {
     requiredLinearHistory?: boolean | undefined;
     customProperties?: Record<string, string | string[]> | undefined;
     subscribe?: boolean | undefined;
+    delay?: number | undefined;
   },
   {
     remoteUrl: string;

--- a/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/github.test.ts
@@ -1888,6 +1888,37 @@ describe('publish:github', () => {
     });
   });
 
+  it('waits for the configured delay before continuing', async () => {
+    jest.useFakeTimers();
+
+    try {
+      mockOctokit.rest.users.getByUsername.mockResolvedValue({
+        data: { type: 'User' },
+      });
+
+      mockOctokit.rest.repos.createForAuthenticatedUser.mockResolvedValue({
+        data: {},
+      });
+
+      const handlerPromise = action.handler({
+        ...mockContext,
+        input: {
+          ...mockContext.input,
+          delay: 1,
+        },
+      });
+
+      expect(initRepoAndPush).not.toHaveBeenCalled();
+
+      await jest.advanceTimersByTimeAsync(1000);
+      await handlerPromise;
+
+      expect(initRepoAndPush).toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   describe('GraphQL API fallback', () => {
     let readdirSpy: jest.SpyInstance;
     let readFileSpy: jest.SpyInstance;

--- a/plugins/scaffolder-backend-module-github/src/actions/github.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/github.ts
@@ -97,6 +97,7 @@ export function createPublishGithubAction(options: {
         requiredLinearHistory: inputProps.requiredLinearHistory,
         customProperties: inputProps.customProperties,
         subscribe: inputProps.subscribe,
+        delay: inputProps.delay,
       },
       output: {
         remoteUrl: outputProps.remoteUrl,
@@ -147,6 +148,7 @@ export function createPublishGithubAction(options: {
         subscribe = false,
         requiredCommitSigning = false,
         requiredLinearHistory = false,
+        delay = 0,
       } = ctx.input;
 
       const { host, owner, repo } = parseRepoUrl(repoUrl, integrations);
@@ -198,6 +200,9 @@ export function createPublishGithubAction(options: {
             customProperties,
             subscribe,
             ctx.logger,
+            undefined,
+            undefined,
+            delay,
           );
 
           return {

--- a/plugins/scaffolder-backend-module-github/src/actions/githubRepoCreate.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubRepoCreate.ts
@@ -82,6 +82,7 @@ export function createGithubRepoCreateAction(options: {
         token: providedToken,
         autoInit = undefined,
         workflowAccess,
+        delay = 0,
       } = ctx.input;
 
       const { host, owner, repo } = parseRepoUrl(repoUrl, integrations);
@@ -135,6 +136,7 @@ export function createGithubRepoCreateAction(options: {
             ctx.logger,
             autoInit,
             workflowAccess,
+            delay,
           );
           return newRepo.clone_url;
         },

--- a/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/helpers.ts
@@ -82,6 +82,7 @@ export async function createGithubRepoWithCollaboratorsAndTopics(
   logger: LoggerService,
   autoInit?: boolean | undefined,
   workflowAccess?: 'none' | 'organization' | 'user',
+  delay: number = 0,
 ) {
   const user = await client.rest.users.getByUsername({
     username: owner,
@@ -136,6 +137,10 @@ export async function createGithubRepoWithCollaboratorsAndTopics(
         toError(e).message
       }`,
     );
+  }
+
+  if (delay > 0) {
+    await new Promise(resolve => setTimeout(resolve, delay * 1000)); // wait for GitHub to finish creating the repository
   }
 
   if (access?.startsWith(`${owner}/`)) {

--- a/plugins/scaffolder-backend-module-github/src/actions/inputProperties.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/inputProperties.ts
@@ -429,6 +429,14 @@ const workflowAccess = (z: typeof zod) =>
     })
     .optional();
 
+const delay = (z: typeof zod) =>
+  z
+    .number({
+      description: `Delay in seconds to wait after creating the repository before performing other operations.  In some organizations adding delay can prevent failure of this action. It can happen after repository is created and when collaborators are being added. Default is 0.`,
+    })
+    .default(0)
+    .optional();
+
 export {
   access,
   allowAutoMerge,
@@ -476,4 +484,5 @@ export {
   token,
   topics,
   workflowAccess,
+  delay,
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This is adding possibility to have a delay between repository creation and other operations that are performed in github:publish action. This change is based on my observation I have described here:
https://github.com/backstage/backstage/issues/33809#issuecomment-4246727665

Parameter is not mandatory and by default 0 in which case there is no delay as before the change.

I have experienced this issue few times and then it disappeared. We have quite large github org in our company and I am suspecting bigger delays in github API then other companies may experience. It might be good to have this possibility at least until the proper solution by @adobejmong is implemented.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
