### PR TITLE
frontend-app-api: restore explicit API ownership

### DIFF
--- a/.changeset/restore-api-ref-ownership.md
+++ b/.changeset/restore-api-ref-ownership.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-app-api': patch
+---
+
+Respect explicit API reference plugin ownership when resolving conflicting API factories.

--- a/packages/frontend-app-api/src/wiring/apiFactories.ts
+++ b/packages/frontend-app-api/src/wiring/apiFactories.ts
@@ -22,7 +22,7 @@ import {
   FrontendFeature,
   featureFlagsApiRef,
 } from '@backstage/frontend-plugin-api';
-import { OpaqueFrontendPlugin } from '@internal/frontend';
+import { OpaqueApiRef, OpaqueFrontendPlugin } from '@internal/frontend';
 import { instantiateAppNodeSubtree } from '../tree/instantiateAppNodeTree';
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import {
@@ -250,14 +250,14 @@ export function collectApiFactoryEntries(options: {
     );
     if (apiFactory) {
       const apiRefId = apiFactory.api.id;
-      const ownerId = getApiOwnerId(apiRefId);
+      const ownerId = getApiOwnerId(apiFactory.api);
       const pluginId = apiNode.spec.plugin.pluginId ?? 'app';
       const existingFactory = factoriesById.get(apiRefId);
 
       // This allows modules to override factories provided by the plugin, but
       // it rejects API overrides from other plugins. In the event of a
-      // conflict, the owning plugin is attempted to be inferred from the API
-      // reference ID.
+      // conflict, the owning plugin is inferred from explicit ownership
+      // metadata or the API reference ID.
       if (existingFactory && existingFactory.pluginId !== pluginId) {
         const shouldReplace =
           ownerId === pluginId && existingFactory.pluginId !== ownerId;
@@ -309,7 +309,15 @@ export function collectApiFactoryEntries(options: {
 
 // TODO(Rugvip): It would be good if this was more explicit, but I think that
 //               might need to wait for some future update for API factories.
-function getApiOwnerId(apiRefId: string): string {
+function getApiOwnerId(apiRef: { id: string }): string {
+  if (OpaqueApiRef.isType(apiRef)) {
+    const { pluginId } = OpaqueApiRef.toInternal(apiRef);
+    if (pluginId) {
+      return pluginId;
+    }
+  }
+
+  const apiRefId = apiRef.id;
   const [prefix, ...rest] = apiRefId.split('.');
   if (!prefix) {
     return apiRefId;

--- a/packages/frontend-app-api/src/wiring/createSpecializedApp.test.tsx
+++ b/packages/frontend-app-api/src/wiring/createSpecializedApp.test.tsx
@@ -294,8 +294,122 @@ describe('createSpecializedApp', () => {
     expect(mockAnalyticsApi).toHaveBeenCalled();
   });
 
-  it('should select the API factory from the owning plugin on conflict', () => {
-    const testApiRef = createApiRef<{ value: string }>({ id: 'test.api' });
+  it.each([
+    [
+      'first ID segment',
+      createApiRef<{ value: string }>({ id: 'test.api' }),
+      'test',
+    ],
+    [
+      'plugin-prefixed ID',
+      createApiRef<{ value: string }>({ id: 'plugin.test.api' }),
+      'test',
+    ],
+    [
+      'core-prefixed ID',
+      createApiRef<{ value: string }>({ id: 'core.test-api' }),
+      'app',
+    ],
+  ])(
+    'should select the API factory from the owning plugin on conflict using the %s',
+    (_ownershipType, testApiRef, ownerPluginId) => {
+      const appRootPlugin = createFrontendPlugin({
+        pluginId: 'app',
+        extensions: [
+          createExtension({
+            attachTo: { id: 'root', input: 'app' },
+            output: [coreExtensionData.reactElement],
+            factory: ({ apis }) => [
+              coreExtensionData.reactElement(
+                <div>Selected API: {apis.get(testApiRef)!.value}</div>,
+              ),
+            ],
+          }),
+        ],
+      });
+      const ownerFeature =
+        ownerPluginId === 'app'
+          ? createFrontendModule({
+              pluginId: ownerPluginId,
+              extensions: [
+                ApiBlueprint.make({
+                  params: defineParams =>
+                    defineParams({
+                      api: testApiRef,
+                      deps: {},
+                      factory: () => ({ value: 'owner' }),
+                    }),
+                }),
+              ],
+            })
+          : createFrontendPlugin({
+              pluginId: ownerPluginId,
+              extensions: [
+                ApiBlueprint.make({
+                  params: defineParams =>
+                    defineParams({
+                      api: testApiRef,
+                      deps: {},
+                      factory: () => ({ value: 'owner' }),
+                    }),
+                }),
+              ],
+            });
+
+      const app = createSpecializedApp({
+        features: [
+          appRootPlugin,
+          createFrontendPlugin({
+            pluginId: 'other-before',
+            extensions: [
+              ApiBlueprint.make({
+                params: defineParams =>
+                  defineParams({
+                    api: testApiRef,
+                    deps: {},
+                    factory: () => ({ value: 'other' }),
+                  }),
+              }),
+            ],
+          }),
+          ownerFeature,
+          createFrontendPlugin({
+            pluginId: 'other-after',
+            extensions: [
+              ApiBlueprint.make({
+                params: defineParams =>
+                  defineParams({
+                    api: testApiRef,
+                    deps: {},
+                    factory: () => ({ value: 'other' }),
+                  }),
+              }),
+            ],
+          }),
+        ],
+      });
+
+      expect(app.errors).toEqual([
+        expect.objectContaining({
+          code: 'API_FACTORY_CONFLICT',
+          message: expect.stringContaining(`API '${testApiRef.id}'`),
+        }),
+        expect.objectContaining({
+          code: 'API_FACTORY_CONFLICT',
+          message: expect.stringContaining(`API '${testApiRef.id}'`),
+        }),
+      ]);
+
+      render(app.element);
+      expect(screen.getByText('Selected API: owner')).toBeInTheDocument();
+    },
+  );
+
+  it('should prefer explicit API ownership regardless of registration order', () => {
+    const testApiRef = createApiRef<{ value: string }>().with({
+      id: 'shared.api',
+      pluginId: 'owner',
+    });
     const appRootPlugin = createFrontendPlugin({
       pluginId: 'app',
       extensions: [
@@ -322,13 +436,13 @@ describe('createSpecializedApp', () => {
                 defineParams({
                   api: testApiRef,
                   deps: {},
-                  factory: () => ({ value: 'other' }),
+                  factory: () => ({ value: 'other-before' }),
                 }),
             }),
           ],
         }),
         createFrontendPlugin({
-          pluginId: 'test',
+          pluginId: 'owner',
           extensions: [
             ApiBlueprint.make({
               params: defineParams =>
@@ -348,7 +462,7 @@ describe('createSpecializedApp', () => {
                 defineParams({
                   api: testApiRef,
                   deps: {},
-                  factory: () => ({ value: 'other' }),
+                  factory: () => ({ value: 'other-after' }),
                 }),
             }),
           ],
@@ -359,11 +473,23 @@ describe('createSpecializedApp', () => {
     expect(app.errors).toEqual([
       expect.objectContaining({
         code: 'API_FACTORY_CONFLICT',
-        message: expect.stringContaining("API 'test.api'"),
+        message:
+          "API 'shared.api' is already provided by plugin 'owner', cannot also be provided by 'other-before'.",
+        context: expect.objectContaining({
+          apiRefId: 'shared.api',
+          pluginId: 'other-before',
+          existingPluginId: 'owner',
+        }),
       }),
       expect.objectContaining({
         code: 'API_FACTORY_CONFLICT',
-        message: expect.stringContaining("API 'test.api'"),
+        message:
+          "API 'shared.api' is already provided by plugin 'owner', cannot also be provided by 'other-after'.",
+        context: expect.objectContaining({
+          apiRefId: 'shared.api',
+          pluginId: 'other-after',
+          existingPluginId: 'owner',
+        }),
       }),
     ]);
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes https://github.com/backstage/backstage/issues/34999.

Restores explicit `pluginId` ownership during API factory conflict resolution. Ownership is now read from the API ref before falling back to the existing ID conventions, ensuring that factories from non-owning plugins are rejected regardless of registration order.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))