### PR TITLE
fix(ui): align Spotify theme Radio with Encore FormRadio

### DIFF
--- a/.storybook/themes/spotify.css
+++ b/.storybook/themes/spotify.css
@@ -251,6 +251,10 @@
   --bui-border-danger: #f87a7a;
   --bui-border-warning: #e36d05;
   --bui-border-success: #53db83;
+
+  .bui-Radio::before {
+    border-color: #818181;
+  }
 }
 
 [data-theme-mode='dark'][data-theme-name='spotify'] {
@@ -285,4 +289,8 @@
   --bui-border-danger: #f87a7a;
   --bui-border-warning: #e36d05;
   --bui-border-success: #53db83;
+
+  .bui-Radio::before {
+    border-color: #7c7c7c;
+  }
 }

--- a/.storybook/themes/spotify.css
+++ b/.storybook/themes/spotify.css
@@ -190,6 +190,47 @@
   .bui-Tag {
     border-radius: var(--bui-radius-full);
   }
+
+  /* ── Radio: align with Encore FormRadio ──────────────────── */
+
+  .bui-Radio {
+    font-size: var(--bui-font-size-3);
+    gap: 0.75rem;
+    min-height: 2rem;
+    padding-block: 0.25rem;
+  }
+
+  .bui-Radio::before {
+    border-width: 1px;
+  }
+
+  .bui-Radio[data-selected]::before {
+    background-color: var(--bui-bg-solid);
+    border-color: var(--bui-bg-solid);
+    border-width: 1px;
+  }
+
+  .bui-Radio[data-selected]::after {
+    content: '';
+    position: absolute;
+    left: 0.25rem;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 0.5rem;
+    height: 0.5rem;
+    background-color: var(--bui-bg-neutral-1);
+    border-radius: 50%;
+    pointer-events: none;
+  }
+
+  .bui-Radio:not([data-selected]):not([data-disabled]):hover::before {
+    border-color: var(--bui-bg-solid);
+  }
+
+  .bui-Radio:not([data-selected]):not([data-disabled])[data-pressed]::before {
+    border-color: var(--bui-bg-solid);
+    box-shadow: inset 0 0 0 1px var(--bui-bg-solid);
+  }
 }
 
 [data-theme-mode='light'][data-theme-name='spotify'] {


### PR DESCRIPTION
## Summary

- Aligns BUI's Radio component under the Spotify theme with Encore's FormRadio
- Changes are CSS-only in `.storybook/themes/spotify.css` — no BUI component or prop changes
- Selected state switches from thick-border indication to filled background + inner dot (matching Encore)
- Adds hover and pressed interaction states on unselected radios
- Adjusts label font-size (12px → 14px), indicator-to-label gap (8px → 12px), row height (min 32px), and border-width (2px → 1px)
- Aligns unselected border color per theme with Encore's `essential-subdued` token (light: `#818181`, dark: `#7c7c7c`)

Cross-cutting items (disabled opacity, focus ring) intentionally excluded — those are RFC 3 Phase 1 global scope.

## Test plan

- [ ] Open BUI Storybook locally (`yarn storybook` at `localhost:6006`)
- [ ] Navigate to RadioGroup stories with `?globals=themeName:spotify`
- [ ] Verify unselected radio: thin 1px border, correct gray per light/dark
- [ ] Verify selected radio: filled green circle with contrasting inner dot
- [ ] Verify hover on unselected: border turns green
- [ ] Verify pressed on unselected: green border + inset shadow
- [ ] Verify label text is 14px with 12px gap from indicator
- [ ] Toggle light/dark mode and confirm both look correct
- [ ] Compare side-by-side with Encore FormRadio in Encore Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)