### PR TITLE
fix(plugin-app): preserve query string and fragment through config-driven redirects

### DIFF
--- a/.changeset/redirect-preserve-query-hash.md
+++ b/.changeset/redirect-preserve-query-hash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-app': patch
+---
+
+Fixed config-driven route redirects to preserve the query string and fragment from the original URL. Previously, redirects declared under `app.extensions[].app/routes.config.redirects` silently dropped everything after `?` or `#` in the incoming URL.

--- a/plugins/app/src/extensions/AppRoutes.test.tsx
+++ b/plugins/app/src/extensions/AppRoutes.test.tsx
@@ -586,6 +586,280 @@ describe('AppRoutes', () => {
     });
   });
 
+  it('should preserve query string through a redirect', async () => {
+    const LocationDisplay = () => {
+      const location = useLocation();
+      return (
+        <div>
+          <div data-testid="location">{location.pathname}</div>
+          <div data-testid="search">{location.search}</div>
+        </div>
+      );
+    };
+
+    const catalogPage = PageBlueprint.make({
+      name: 'catalog',
+      params: {
+        path: '/catalog',
+        loader: async () => (
+          <div>
+            Catalog Page
+            <LocationDisplay />
+          </div>
+        ),
+      },
+    });
+
+    renderTestApp({
+      extensions: [catalogPage],
+      initialRouteEntries: ['/old-catalog?id=abc&view=detail'],
+      config: {
+        ...DEFAULT_CONFIG,
+        app: {
+          ...DEFAULT_CONFIG.app,
+          extensions: [
+            {
+              'app/routes': {
+                config: {
+                  redirects: [{ from: '/old-catalog', to: '/catalog' }],
+                },
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Catalog Page')).toBeInTheDocument();
+      expect(screen.getByTestId('location')).toHaveTextContent('/catalog');
+      expect(screen.getByTestId('search')).toHaveTextContent(
+        '?id=abc&view=detail',
+      );
+    });
+  });
+
+  it('should preserve fragment through a redirect', async () => {
+    const LocationDisplay = () => {
+      const location = useLocation();
+      return (
+        <div>
+          <div data-testid="location">{location.pathname}</div>
+          <div data-testid="hash">{location.hash}</div>
+        </div>
+      );
+    };
+
+    const catalogPage = PageBlueprint.make({
+      name: 'catalog',
+      params: {
+        path: '/catalog',
+        loader: async () => (
+          <div>
+            Catalog Page
+            <LocationDisplay />
+          </div>
+        ),
+      },
+    });
+
+    renderTestApp({
+      extensions: [catalogPage],
+      initialRouteEntries: ['/old-catalog#section'],
+      config: {
+        ...DEFAULT_CONFIG,
+        app: {
+          ...DEFAULT_CONFIG.app,
+          extensions: [
+            {
+              'app/routes': {
+                config: {
+                  redirects: [{ from: '/old-catalog', to: '/catalog' }],
+                },
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Catalog Page')).toBeInTheDocument();
+      expect(screen.getByTestId('location')).toHaveTextContent('/catalog');
+      expect(screen.getByTestId('hash')).toHaveTextContent('#section');
+    });
+  });
+
+  it('should preserve both query and fragment through a redirect', async () => {
+    const LocationDisplay = () => {
+      const location = useLocation();
+      return (
+        <div>
+          <div data-testid="location">{location.pathname}</div>
+          <div data-testid="search">{location.search}</div>
+          <div data-testid="hash">{location.hash}</div>
+        </div>
+      );
+    };
+
+    const catalogPage = PageBlueprint.make({
+      name: 'catalog',
+      params: {
+        path: '/catalog',
+        loader: async () => (
+          <div>
+            Catalog Page
+            <LocationDisplay />
+          </div>
+        ),
+      },
+    });
+
+    renderTestApp({
+      extensions: [catalogPage],
+      initialRouteEntries: ['/old-catalog?id=abc&q=hello?world#section'],
+      config: {
+        ...DEFAULT_CONFIG,
+        app: {
+          ...DEFAULT_CONFIG.app,
+          extensions: [
+            {
+              'app/routes': {
+                config: {
+                  redirects: [{ from: '/old-catalog', to: '/catalog' }],
+                },
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Catalog Page')).toBeInTheDocument();
+      expect(screen.getByTestId('location')).toHaveTextContent('/catalog');
+      expect(screen.getByTestId('search')).toHaveTextContent(
+        '?id=abc&q=hello?world',
+      );
+      expect(screen.getByTestId('hash')).toHaveTextContent('#section');
+    });
+  });
+
+  it('should preserve query through a redirect with named params and splat', async () => {
+    const LocationDisplay = () => {
+      const location = useLocation();
+      return (
+        <div>
+          <div data-testid="location">{location.pathname}</div>
+          <div data-testid="search">{location.search}</div>
+        </div>
+      );
+    };
+
+    const catalogPage = PageBlueprint.make({
+      name: 'catalog',
+      params: {
+        path: '/catalog',
+        loader: async () => (
+          <div>
+            Catalog Page
+            <LocationDisplay />
+          </div>
+        ),
+      },
+    });
+
+    renderTestApp({
+      extensions: [catalogPage],
+      initialRouteEntries: [
+        '/apps/my-service/crashes/info?id=c1ccbebaffb4919d',
+      ],
+      config: {
+        ...DEFAULT_CONFIG,
+        app: {
+          ...DEFAULT_CONFIG.app,
+          extensions: [
+            {
+              'app/routes': {
+                config: {
+                  redirects: [
+                    {
+                      from: '/apps/:name',
+                      to: '/catalog/default/component/:name/*',
+                    },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Catalog Page')).toBeInTheDocument();
+      expect(screen.getByTestId('location')).toHaveTextContent(
+        '/catalog/default/component/my-service/crashes/info',
+      );
+      expect(screen.getByTestId('search')).toHaveTextContent(
+        '?id=c1ccbebaffb4919d',
+      );
+    });
+  });
+
+  it('should prefer the query from the redirect template over the incoming one', async () => {
+    const LocationDisplay = () => {
+      const location = useLocation();
+      return (
+        <div>
+          <div data-testid="location">{location.pathname}</div>
+          <div data-testid="search">{location.search}</div>
+        </div>
+      );
+    };
+
+    const catalogPage = PageBlueprint.make({
+      name: 'catalog',
+      params: {
+        path: '/catalog',
+        loader: async () => (
+          <div>
+            Catalog Page
+            <LocationDisplay />
+          </div>
+        ),
+      },
+    });
+
+    renderTestApp({
+      extensions: [catalogPage],
+      initialRouteEntries: ['/old-catalog?view=list'],
+      config: {
+        ...DEFAULT_CONFIG,
+        app: {
+          ...DEFAULT_CONFIG.app,
+          extensions: [
+            {
+              'app/routes': {
+                config: {
+                  redirects: [
+                    { from: '/old-catalog', to: '/catalog?view=table' },
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Catalog Page')).toBeInTheDocument();
+      expect(screen.getByTestId('location')).toHaveTextContent('/catalog');
+      expect(screen.getByTestId('search')).toHaveTextContent('?view=table');
+    });
+  });
+
   it('should not interfere with normal routes when redirects are configured', async () => {
     const homePage = PageBlueprint.make({
       name: 'home',

--- a/plugins/app/src/extensions/AppRoutes.tsx
+++ b/plugins/app/src/extensions/AppRoutes.tsx
@@ -47,7 +47,11 @@ function RedirectWithParams({ to }: { to: string }) {
 
   return (
     <Navigate
-      to={`${path}${targetSearch || search}${targetHash || hash}`}
+      to={{
+        pathname: path,
+        search: targetSearch || search,
+        hash: targetHash || hash,
+      }}
       replace
     />
   );

--- a/plugins/app/src/extensions/AppRoutes.tsx
+++ b/plugins/app/src/extensions/AppRoutes.tsx
@@ -21,10 +21,12 @@ import {
   createExtensionInput,
   NotFoundErrorPage,
 } from '@backstage/frontend-plugin-api';
-import { Navigate, useParams, useRoutes } from 'react-router-dom';
+import { Navigate, useLocation, useParams, useRoutes } from 'react-router-dom';
 
 function RedirectWithParams({ to }: { to: string }) {
   const params = useParams() as Record<string, string>;
+  const { search, hash } = useLocation();
+
   let target = to;
   for (const [name, value] of Object.entries(params)) {
     // Use \b (word boundary) for named params so that `:a` doesn't
@@ -34,7 +36,21 @@ function RedirectWithParams({ to }: { to: string }) {
       value ?? '',
     );
   }
-  return <Navigate to={target} replace />;
+
+  const hashIndex = target.indexOf('#');
+  const beforeHash = hashIndex === -1 ? target : target.slice(0, hashIndex);
+  const targetHash = hashIndex === -1 ? '' : target.slice(hashIndex);
+
+  const queryIndex = beforeHash.indexOf('?');
+  const path = queryIndex === -1 ? beforeHash : beforeHash.slice(0, queryIndex);
+  const targetSearch = queryIndex === -1 ? '' : beforeHash.slice(queryIndex);
+
+  return (
+    <Navigate
+      to={`${path}${targetSearch || search}${targetHash || hash}`}
+      replace
+    />
+  );
 }
 
 export const AppRoutes = createExtension({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`RedirectWithParams` builds its navigation target by substituting React Router params into the `to` template from config, but it never reads `useLocation()`. Since `<Navigate to={string}>` does not carry the current `search` or `hash` over, every redirect declared under `app.extensions[].app/routes.config.redirects` silently discards anything after `?` or `#`.

The fix reads `search` and `hash` from `useLocation()` and appends them to the navigation target. A `to` template that specifies its own query or fragment takes precedence over the incoming one.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))