### PR TITLE
fix(core-app-api): don't prompt login on transient auth refresh network errors

### DIFF
--- a/.changeset/oauth-refresh-network-error.md
+++ b/.changeset/oauth-refresh-network-error.md
@@ -1,0 +1,7 @@
+---
+'@backstage/core-app-api': patch
+---
+
+Fixed the OAuth "Login Required" popup (`OAuthRequestDialog`) appearing after a transient network failure during a background token refresh — for example right after the machine wakes from sleep, when the session has not actually expired.
+
+`DefaultAuthConnector` now throws an `AuthConnectionError` when a refresh request fails to reach the backend (a rejected `fetch`, as opposed to the backend rejecting the session). `RefreshingAuthSessionManager` treats that as a retryable transient failure: it no longer wipes the session or opens an interactive login popup for it, and instead surfaces the error so a later call can refresh silently once connectivity returns. Optional session requests continue to resolve with `undefined`.

--- a/packages/core-app-api/src/lib/AuthConnector/DefaultAuthConnector.test.ts
+++ b/packages/core-app-api/src/lib/AuthConnector/DefaultAuthConnector.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { DefaultAuthConnector } from './DefaultAuthConnector';
+import { AuthConnectionError } from './errors';
 import MockOAuthApi from '../../apis/implementations/OAuthRequestApi/MockOAuthApi';
 import * as loginPopup from '../loginPopup';
 import { UrlPatternDiscovery } from '../../apis';
@@ -103,6 +104,15 @@ describe('DefaultAuthConnector', () => {
     const connector = new DefaultAuthConnector(defaultOptions);
     await expect(connector.refreshSession()).rejects.toThrow(
       'Auth refresh request failed, NOPE',
+    );
+  });
+
+  it('should throw an AuthConnectionError when the refresh request cannot reach the backend', async () => {
+    server.use(rest.get('*', (_req, res) => res.networkError('offline')));
+
+    const connector = new DefaultAuthConnector(defaultOptions);
+    await expect(connector.refreshSession()).rejects.toThrow(
+      AuthConnectionError,
     );
   });
 

--- a/packages/core-app-api/src/lib/AuthConnector/DefaultAuthConnector.ts
+++ b/packages/core-app-api/src/lib/AuthConnector/DefaultAuthConnector.ts
@@ -21,6 +21,7 @@ import {
   OAuthRequester,
 } from '@backstage/core-plugin-api';
 import { openLoginPopup } from '../loginPopup';
+import { AuthConnectionError } from './errors';
 import {
   AuthConnector,
   AuthConnectorCreateSessionOptions,
@@ -143,6 +144,10 @@ export class DefaultAuthConnector<AuthSession>
   async refreshSession(
     options?: AuthConnectorRefreshSessionOptions,
   ): Promise<any> {
+    // A rejected `fetch` means the request never reached the backend (network
+    // down, CORS, aborted), which is transient and distinct from the backend
+    // rejecting the session. Flag it as an AuthConnectionError so session
+    // managers can retry instead of prompting for an interactive login.
     const res = await fetch(
       await this.buildUrl('/refresh', {
         optional: true,
@@ -155,7 +160,10 @@ export class DefaultAuthConnector<AuthSession>
         credentials: 'include',
       },
     ).catch(error => {
-      throw new Error(`Auth refresh request failed, ${error}`);
+      throw new AuthConnectionError(
+        `Auth refresh request failed, ${error}`,
+        error,
+      );
     });
 
     if (!res.ok) {

--- a/packages/core-app-api/src/lib/AuthConnector/errors.ts
+++ b/packages/core-app-api/src/lib/AuthConnector/errors.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Thrown by an AuthConnector when a session refresh could not reach the backend
+ * because of a network/connectivity problem, as opposed to the backend actively
+ * rejecting the session.
+ *
+ * The browser can briefly lose connectivity — most commonly right after the
+ * machine wakes from sleep — which makes the refresh `fetch` reject even though
+ * the session is still valid. Session managers use this to tell a retryable
+ * transient failure apart from an authentication failure, so they don't wipe
+ * the session or escalate to an interactive login prompt for something that
+ * will succeed on the next attempt.
+ */
+export class AuthConnectionError extends Error {
+  constructor(message: string, cause?: unknown) {
+    super(message);
+    this.name = 'AuthConnectionError';
+    if (cause !== undefined) {
+      (this as Error & { cause?: unknown }).cause = cause;
+    }
+  }
+}
+
+/**
+ * Type guard for {@link AuthConnectionError}. Also matches by name so it keeps
+ * working across module/realm boundaries where `instanceof` can be unreliable.
+ */
+export function isAuthConnectionError(
+  error: unknown,
+): error is AuthConnectionError {
+  return (
+    error instanceof AuthConnectionError ||
+    (error instanceof Error && error.name === 'AuthConnectionError')
+  );
+}

--- a/packages/core-app-api/src/lib/AuthConnector/index.ts
+++ b/packages/core-app-api/src/lib/AuthConnector/index.ts
@@ -16,4 +16,5 @@
 
 export { DefaultAuthConnector } from './DefaultAuthConnector';
 export { DirectAuthConnector } from './DirectAuthConnector';
+export { AuthConnectionError, isAuthConnectionError } from './errors';
 export * from './types';

--- a/packages/core-app-api/src/lib/AuthSessionManager/RefreshingAuthSessionManager.test.ts
+++ b/packages/core-app-api/src/lib/AuthSessionManager/RefreshingAuthSessionManager.test.ts
@@ -16,7 +16,10 @@
 
 import { RefreshingAuthSessionManager } from './RefreshingAuthSessionManager';
 import { SessionState } from '@backstage/core-plugin-api';
-import { AuthConnectorRefreshSessionOptions } from '../AuthConnector';
+import {
+  AuthConnectionError,
+  AuthConnectorRefreshSessionOptions,
+} from '../AuthConnector';
 
 const defaultOptions = {
   sessionScopes: (session: { scopes: Set<string> }) => session.scopes,
@@ -296,5 +299,77 @@ describe('RefreshingAuthSessionManager', () => {
     // call refresh session only once
     expect(refreshSession).toHaveBeenCalledTimes(2);
     expect(createSession).toHaveBeenCalledTimes(2);
+  });
+
+  it('should not open a login popup when a refresh fails with a network error', async () => {
+    const createSession = jest.fn();
+    const refreshSession = jest
+      .fn()
+      .mockRejectedValue(new AuthConnectionError('offline'));
+    const manager = new RefreshingAuthSessionManager({
+      connector: { createSession, refreshSession },
+      ...defaultOptions,
+    } as any);
+
+    await expect(
+      manager.getSession({ scopes: new Set(['a']) }),
+    ).rejects.toThrow('offline');
+    expect(createSession).toHaveBeenCalledTimes(0);
+  });
+
+  it('should return undefined for an optional session when a refresh fails with a network error', async () => {
+    const createSession = jest.fn();
+    const refreshSession = jest
+      .fn()
+      .mockRejectedValue(new AuthConnectionError('offline'));
+    const manager = new RefreshingAuthSessionManager({
+      connector: { createSession, refreshSession },
+      ...defaultOptions,
+    } as any);
+
+    expect(await manager.getSession({ optional: true })).toBe(undefined);
+    expect(createSession).toHaveBeenCalledTimes(0);
+  });
+
+  it('should keep the existing session on a transient network error and recover on the next call', async () => {
+    const createSession = jest
+      .fn()
+      .mockResolvedValue({ scopes: new Set(['a']), expired: true });
+    const refreshSession = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('NOPE')) // seed a session via createSession
+      .mockRejectedValueOnce(new AuthConnectionError('offline')) // transient failure
+      .mockResolvedValue({ scopes: new Set(['a']), expired: false }); // recovery
+    const manager = new RefreshingAuthSessionManager({
+      connector: { createSession, refreshSession },
+      ...defaultOptions,
+    } as any);
+
+    const stateSubscriber = jest.fn();
+    manager.sessionState$().subscribe(stateSubscriber);
+    await Promise.resolve();
+
+    // Seed a signed-in (but expired) session.
+    await manager.getSession({ scopes: new Set(['a']) });
+    expect(createSession).toHaveBeenCalledTimes(1);
+    expect(stateSubscriber.mock.calls).toEqual([
+      [SessionState.SignedOut],
+      [SessionState.SignedIn],
+    ]);
+
+    // Transient network error: no popup, error surfaced, session not wiped.
+    await expect(
+      manager.getSession({ scopes: new Set(['a']) }),
+    ).rejects.toThrow('offline');
+    expect(createSession).toHaveBeenCalledTimes(1);
+    expect(stateSubscriber.mock.calls).toEqual([
+      [SessionState.SignedOut],
+      [SessionState.SignedIn],
+    ]);
+
+    // Connectivity is back: the next call refreshes silently, no popup.
+    const session = await manager.getSession({ scopes: new Set(['a']) });
+    expect(session).toEqual({ scopes: new Set(['a']), expired: false });
+    expect(createSession).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core-app-api/src/lib/AuthSessionManager/RefreshingAuthSessionManager.ts
+++ b/packages/core-app-api/src/lib/AuthSessionManager/RefreshingAuthSessionManager.ts
@@ -20,7 +20,7 @@ import {
   SessionShouldRefreshFunc,
   GetSessionOptions,
 } from './types';
-import { AuthConnector } from '../AuthConnector';
+import { AuthConnector, isAuthConnectionError } from '../AuthConnector';
 import { SessionScopeHelper, hasScopes } from './common';
 import { SessionStateTracker } from './SessionStateTracker';
 
@@ -86,6 +86,17 @@ export class RefreshingAuthSessionManager<T> implements SessionManager<T> {
         }
         return refreshedSession;
       } catch (error) {
+        // A transient connectivity failure doesn't mean the session is invalid.
+        // Keep it so a later call can refresh once connectivity returns, and
+        // never open an interactive login popup for it — surface the error to
+        // an optional-less caller so it can retry.
+        if (isAuthConnectionError(error)) {
+          if (options.optional) {
+            return undefined;
+          }
+          throw error;
+        }
+
         this.removeLocalSession();
 
         if (options.optional) {
@@ -109,7 +120,12 @@ export class RefreshingAuthSessionManager<T> implements SessionManager<T> {
         this.currentSession = newSession;
         // The session might not have the scopes requested so go back and check again
         return this.getSession(options);
-      } catch {
+      } catch (error) {
+        // As above, a transient connectivity failure must not trigger an
+        // interactive login popup; surface it so the caller can retry.
+        if (isAuthConnectionError(error) && !options.optional) {
+          throw error;
+        }
         this.removeLocalSession();
         // If the refresh attempt fails we assume we don't have a session, so continue to create one.
       }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Summary

The OAuth "Login Required" popup (`OAuthRequestDialog`) can appear during an active session — most commonly right after the machine wakes from sleep — even though the user's session hasn't actually expired. Reloading the page clears it without a real re-login.

**Root cause:** `RefreshingAuthSessionManager.getSession` runs a silent `/refresh` first, but if that refresh *throws* and the caller is non-optional, it falls straight through to `connector.createSession(...)` — the interactive popup. It doesn't distinguish a transient network failure (a rejected `fetch` — network briefly unreachable on wake) from the backend actually rejecting the session. Background callers like the signals `SignalClient` reconnect, the fetch middleware, and the permission API all read credentials non-optionally, so a momentary connectivity blip surfaces as a disruptive modal for a condition that self-heals on the very next call.

### Change

- `DefaultAuthConnector.refreshSession` now throws a new internal `AuthConnectionError` when the refresh `fetch` is *rejected* (network down / CORS / aborted — the request never reached the backend). HTTP errors and `authInfo.error` responses are unchanged, so a genuine backend rejection behaves exactly as before.
- `RefreshingAuthSessionManager` treats an `AuthConnectionError` as a retryable transient failure: it no longer wipes the local session or opens the interactive login popup. It surfaces the error to non-optional callers (so the operation can retry) and continues to resolve `undefined` for optional requests. Since the local session is preserved, the next call refreshes silently once connectivity returns.

`navigator.onLine` is intentionally not used to detect this — it reports `true` in exactly this scenario (observed live: a `TypeError` fetch rejection with `navigator.onLine === true` right after wake).

`AuthConnectionError` is kept internal (not exported from the package entry point), so there's no public API change. Happy to promote it to `@public` if maintainers would like custom `AuthConnector` implementations to opt into this behavior.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation (no doc change needed)
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes) (n/a)
- [x] All your commits have a `Signed-off-by` line in the message.