### PR TITLE
feat(core-components): add onCopyLog prop to LogViewer

### DIFF
--- a/.changeset/add-logviewer-copy-button.md
+++ b/.changeset/add-logviewer-copy-button.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Added an `onCopyLog` prop to the `LogViewer` component that renders a copy button in the toolbar, allowing users to copy all log content to the clipboard.

--- a/packages/core-components/report-alpha.api.md
+++ b/packages/core-components/report-alpha.api.md
@@ -65,6 +65,7 @@ export const coreComponentsTranslationRef: TranslationRef<
     readonly 'proxiedSignInPage.title': 'You do not appear to be signed in. Please try reloading the browser page.';
     readonly 'logViewer.searchField.placeholder': 'Search';
     readonly 'logViewer.downloadBtn.tooltip': 'Download logs';
+    readonly 'logViewer.copyBtn.tooltip': 'Copy logs to clipboard';
   }
 >;
 

--- a/packages/core-components/report.api.md
+++ b/packages/core-components/report.api.md
@@ -283,6 +283,7 @@ export const coreComponentsTranslationRef: TranslationRef<
     readonly 'proxiedSignInPage.title': 'You do not appear to be signed in. Please try reloading the browser page.';
     readonly 'logViewer.searchField.placeholder': 'Search';
     readonly 'logViewer.downloadBtn.tooltip': 'Download logs';
+    readonly 'logViewer.copyBtn.tooltip': 'Copy logs to clipboard';
   }
 >;
 
@@ -883,6 +884,7 @@ export interface LogViewerProps {
   classes?: {
     root?: string;
   };
+  onCopyLog?: () => void | Promise<void>;
   onDownloadLog?: () => void;
   text: string;
   textWrap?: boolean;

--- a/packages/core-components/src/components/LogViewer/LogViewer.tsx
+++ b/packages/core-components/src/components/LogViewer/LogViewer.tsx
@@ -32,6 +32,10 @@ export interface LogViewerProps {
    */
   onDownloadLog?: () => void;
   /**
+   * Callback function to handle the copy log action, and show the copy button.
+   */
+  onCopyLog?: () => void | Promise<void>;
+  /**
    * The text of the logs to display.
    *
    * The LogViewer component is optimized for appending content at the end of the text.

--- a/packages/core-components/src/components/LogViewer/LogViewerControls.tsx
+++ b/packages/core-components/src/components/LogViewer/LogViewerControls.tsx
@@ -23,12 +23,14 @@ import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import FilterListIcon from '@material-ui/icons/FilterList';
 import GetApp from '@material-ui/icons/GetApp';
+import FileCopyIcon from '@material-ui/icons/FileCopy';
 import ToolTip from '@material-ui/core/Tooltip';
 import { coreComponentsTranslationRef } from '../../translation';
 import { LogViewerSearch } from './useLogViewerSearch';
 
 export interface LogViewerControlsProps extends LogViewerSearch {
   onDownloadLog?: () => void;
+  onCopyLog?: () => void;
 }
 
 export function LogViewerControls(props: LogViewerControlsProps) {
@@ -78,8 +80,23 @@ export function LogViewerControls(props: LogViewerControlsProps) {
       </IconButton>
       {Boolean(props?.onDownloadLog) ? (
         <ToolTip title={t('logViewer.downloadBtn.tooltip')}>
-          <IconButton size="small" onClick={props.onDownloadLog}>
+          <IconButton
+            aria-label={t('logViewer.downloadBtn.tooltip')}
+            size="small"
+            onClick={props.onDownloadLog}
+          >
             <GetApp />
+          </IconButton>
+        </ToolTip>
+      ) : null}
+      {Boolean(props?.onCopyLog) ? (
+        <ToolTip title={t('logViewer.copyBtn.tooltip')}>
+          <IconButton
+            aria-label={t('logViewer.copyBtn.tooltip')}
+            size="small"
+            onClick={props.onCopyLog}
+          >
+            <FileCopyIcon />
           </IconButton>
         </ToolTip>
       ) : null}

--- a/packages/core-components/src/components/LogViewer/LogViewerControls.tsx
+++ b/packages/core-components/src/components/LogViewer/LogViewerControls.tsx
@@ -78,17 +78,6 @@ export function LogViewerControls(props: LogViewerControlsProps) {
           <FilterListIcon color="disabled" />
         )}
       </IconButton>
-      {Boolean(props?.onDownloadLog) ? (
-        <ToolTip title={t('logViewer.downloadBtn.tooltip')}>
-          <IconButton
-            aria-label={t('logViewer.downloadBtn.tooltip')}
-            size="small"
-            onClick={props.onDownloadLog}
-          >
-            <GetApp />
-          </IconButton>
-        </ToolTip>
-      ) : null}
       {Boolean(props?.onCopyLog) ? (
         <ToolTip title={t('logViewer.copyBtn.tooltip')}>
           <IconButton
@@ -97,6 +86,17 @@ export function LogViewerControls(props: LogViewerControlsProps) {
             onClick={props.onCopyLog}
           >
             <FileCopyIcon />
+          </IconButton>
+        </ToolTip>
+      ) : null}
+      {Boolean(props?.onDownloadLog) ? (
+        <ToolTip title={t('logViewer.downloadBtn.tooltip')}>
+          <IconButton
+            aria-label={t('logViewer.downloadBtn.tooltip')}
+            size="small"
+            onClick={props.onDownloadLog}
+          >
+            <GetApp />
           </IconButton>
         </ToolTip>
       ) : null}

--- a/packages/core-components/src/components/LogViewer/RealLogViewer.test.tsx
+++ b/packages/core-components/src/components/LogViewer/RealLogViewer.test.tsx
@@ -93,6 +93,39 @@ describe('RealLogViewer', () => {
     expect(onDownloadLog).toHaveBeenCalledTimes(1);
   });
 
+  it('should render copy button and show copy confirmation', async () => {
+    const onCopyLog = jest.fn();
+    const rendered = await renderInTestApp(
+      <RealLogViewer text={testText} onCopyLog={onCopyLog} />,
+    );
+
+    const copyButton = rendered.getByRole('button', {
+      name: /copy logs to clipboard/i,
+    });
+    await userEvent.click(copyButton);
+
+    expect(onCopyLog).toHaveBeenCalledTimes(1);
+    expect(
+      await rendered.findByText('Lines copied to clipboard'),
+    ).toBeInTheDocument();
+  });
+
+  it('should not show copy confirmation when copying fails', async () => {
+    const onCopyLog = jest.fn().mockRejectedValue(new Error('Copy failed'));
+    const rendered = await renderInTestApp(
+      <RealLogViewer text={testText} onCopyLog={onCopyLog} />,
+    );
+
+    await userEvent.click(
+      rendered.getByRole('button', { name: /copy logs to clipboard/i }),
+    );
+
+    expect(onCopyLog).toHaveBeenCalledTimes(1);
+    expect(
+      rendered.queryByText('Lines copied to clipboard'),
+    ).not.toBeInTheDocument();
+  });
+
   it('should not render download button when showDownloadButton is false', async () => {
     const rendered = await renderInTestApp(
       <RealLogViewer text={testText} showDownloadButton={false} />,

--- a/packages/core-components/src/components/LogViewer/RealLogViewer.tsx
+++ b/packages/core-components/src/components/LogViewer/RealLogViewer.tsx
@@ -34,6 +34,7 @@ import Snackbar from '@material-ui/core/Snackbar';
 export interface RealLogViewerProps {
   showDownloadButton?: boolean;
   onDownloadLog?: () => void;
+  onCopyLog?: () => void | Promise<void>;
   text: string;
   textWrap?: boolean;
   classes?: { root?: string };
@@ -106,6 +107,15 @@ export function RealLogViewer(props: RealLogViewerProps) {
   const handleCopySelection = (line: number) => {
     selection.copySelection(line);
     setShowCopyInfo(true);
+  };
+
+  const handleCopyLog = async () => {
+    try {
+      await props.onCopyLog?.();
+      setShowCopyInfo(true);
+    } catch {
+      // The callback owns error reporting; only show confirmation on success.
+    }
   };
 
   function setRowHeight(index: number, size: number) {
@@ -192,6 +202,7 @@ export function RealLogViewer(props: RealLogViewerProps) {
                 <LogViewerControls
                   {...search}
                   onDownloadLog={props.onDownloadLog}
+                  onCopyLog={props.onCopyLog ? handleCopyLog : undefined}
                 />
               </Box>
               {shouldTextWrap ? (

--- a/packages/core-components/src/translation.ts
+++ b/packages/core-components/src/translation.ts
@@ -131,6 +131,9 @@ export const coreComponentsTranslationRef = createTranslationRef({
       downloadBtn: {
         tooltip: 'Download logs',
       },
+      copyBtn: {
+        tooltip: 'Copy logs to clipboard',
+      },
       searchField: {
         placeholder: 'Search',
       },


### PR DESCRIPTION
## Summary

<img width="1226" height="887" alt="image" src="https://github.com/user-attachments/assets/9d82417e-0c1a-489b-a305-382e9be4452d" />


Adds an `onCopyLog` callback prop to the `LogViewer` component. When provided, a copy icon button appears in the toolbar alongside the existing search, filter, and download controls. Clicking it invokes the callback and shows the same "Lines copied to clipboard" Snackbar that line-selection copy already uses, so the feedback is consistent and theme-aware (no dark-mode styling issues).

### Changes

- Added `onCopyLog` optional prop to `LogViewerProps`, `RealLogViewerProps`, and `LogViewerControlsProps`
- Added `FileCopy` icon button in `LogViewerControls` (renders after the download button when `onCopyLog` is provided)
- Copy triggers the existing Snackbar confirmation via `handleCopyLog` in `RealLogViewer`
- Added `aria-label` to both the download and copy icon buttons for accessibility
- Added `logViewer.copyBtn.tooltip` translation key ("Copy logs to clipboard")
- Added a test that clicks the copy button and verifies the callback fires and the Snackbar appears
- Updated API reports

### Usage

Copy all visible log text to the clipboard:

```tsx
<LogViewer
  text={logText}
  onCopyLog={() => navigator.clipboard.writeText(logText)}
/>
```

Combined with download — both icons appear in the toolbar:

```tsx
const handleCopy = async () => {
  await navigator.clipboard.writeText(logText);
};

const handleDownload = () => {
  const blob = new Blob([logText], { type: 'text/plain' });
  const url = URL.createObjectURL(blob);
  const a = document.createElement('a');
  a.href = url;
  a.download = 'logs.txt';
  a.click();
  URL.revokeObjectURL(url);
};

<LogViewer
  text={logText}
  onCopyLog={handleCopy}
  onDownloadLog={handleDownload}
/>
```

Copy filtered/transformed content instead of raw text:

```tsx
const filteredText = logs
  .filter(l => l.level === 'error')
  .map(l => `[${l.timestamp}] ${l.message}`)
  .join('\n');

<LogViewer
  text={formattedLogText}
  onCopyLog={() => navigator.clipboard.writeText(filteredText)}
/>
```

Without the prop, no copy button renders (backward-compatible):

```tsx
<LogViewer text={logText} />
```

## Checklist

- [x] I've read the [contributor guidelines](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md)
- [x] I've added a changeset
- [x] I've updated API reports (`yarn build:api-reports`)
- [x] Existing tests pass (`yarn test packages/core-components/src/components/LogViewer`)