### PR TITLE
fix(auth): honor configured token expiration

### DIFF
--- a/.changeset/bright-tokens-expire.md
+++ b/.changeset/bright-tokens-expire.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Fixed OAuth token responses to report the configured Backstage token lifetime instead of always reporting one hour.

--- a/plugins/auth-backend/README.md
+++ b/plugins/auth-backend/README.md
@@ -168,7 +168,7 @@ To try out SAML, you can use the mock identity provider:
 
 ## Configuring Token Expiration in App Config
 
-If you need to change Backstage token expiration from the default value of one hour you can do so through configuration. Note that this is **not** the session duration, but rather the duration that the short-term cryptographic tokens are valid for. The expiration can not be set lower than 10 minutes or above 24 hours.
+If you need to change Backstage token expiration from the default value of one hour you can do so through configuration. Note that this is **not** the session duration, but rather the duration that the short-term cryptographic tokens are valid for. OAuth token responses report this duration through `expires_in`. The expiration can not be set lower than 10 minutes or above 24 hours.
 
 This is what the configuration looks like:
 

--- a/plugins/auth-backend/src/service/OidcService.test.ts
+++ b/plugins/auth-backend/src/service/OidcService.test.ts
@@ -930,6 +930,66 @@ describe('OidcService', () => {
         });
       });
 
+      it('should use configured expiration for access tokens', async () => {
+        const mockOfflineAccess = {
+          refreshAccessToken: jest.fn().mockResolvedValue({
+            accessToken: 'refreshed-access-token',
+            refreshToken: 'refreshed-refresh-token',
+          }),
+        } as unknown as OfflineAccessService;
+        const { service, mocks } = await createOidcService({
+          databaseId,
+          config: {
+            auth: {
+              backstageTokenExpiration: { hours: 2 },
+            },
+          },
+          offlineAccess: mockOfflineAccess,
+        });
+        mocks.tokenIssuer.issueToken.mockResolvedValue({
+          token: 'mock-jwt-token',
+        });
+
+        const client = await service.registerClient({
+          clientName: 'Test Client',
+          redirectUris: ['http://localhost:8080/callback'],
+        });
+        const authSession = await service.createAuthorizationSession({
+          clientId: client.clientId,
+          redirectUri: 'http://localhost:8080/callback',
+          responseType: 'code',
+          scope: 'openid',
+        });
+        const authResult = await service.approveAuthorizationSession({
+          sessionId: authSession.id,
+          userEntityRef: 'user:default/test',
+        });
+        const code = new URL(authResult.redirectUrl).searchParams.get('code')!;
+
+        const tokenResult = await service.exchangeCodeForToken({
+          code,
+          redirectUri: 'http://localhost:8080/callback',
+          grantType: 'authorization_code',
+        });
+        const refreshResult = await service.refreshAccessToken({
+          refreshToken: 'refresh-token',
+          clientId: client.clientId,
+        });
+
+        expect(tokenResult.expiresIn).toBe(7200);
+        expect(refreshResult).toEqual({
+          accessToken: 'refreshed-access-token',
+          tokenType: 'Bearer',
+          expiresIn: 7200,
+          refreshToken: 'refreshed-refresh-token',
+        });
+        expect(mockOfflineAccess.refreshAccessToken).toHaveBeenCalledWith({
+          refreshToken: 'refresh-token',
+          tokenIssuer: mocks.tokenIssuer,
+          clientId: client.clientId,
+        });
+      });
+
       it('should throw error for invalid grant type', async () => {
         const { service } = await createOidcService({ databaseId });
 

--- a/plugins/auth-backend/src/service/OidcService.ts
+++ b/plugins/auth-backend/src/service/OidcService.ts
@@ -32,6 +32,7 @@ import { DateTime } from 'luxon';
 import matcher from 'matcher';
 import { OfflineAccessService } from './OfflineAccessService';
 import { validateCimdUrl, fetchCimdMetadata } from './CimdClient';
+import { readBackstageTokenExpiration } from './readTokenExpiration';
 
 const WILDCARD_PORT = /:\*(?=\/|$)/;
 const EXPLICIT_PROTOCOL = /^[a-z][a-z0-9+.-]*:/i;
@@ -150,6 +151,7 @@ export class OidcService {
   private readonly config: RootConfigService;
   private readonly logger: LoggerService;
   private readonly offlineAccess?: OfflineAccessService;
+  private readonly backstageTokenExpiration: number;
 
   private constructor(
     auth: AuthService,
@@ -169,6 +171,7 @@ export class OidcService {
     this.config = config;
     this.logger = logger;
     this.offlineAccess = offlineAccess;
+    this.backstageTokenExpiration = readBackstageTokenExpiration(config);
   }
 
   static create(options: {
@@ -648,7 +651,7 @@ export class OidcService {
     return {
       accessToken: token,
       tokenType: 'Bearer',
-      expiresIn: 3600,
+      expiresIn: this.backstageTokenExpiration,
       idToken: token,
       scope: session.scope || 'openid',
       refreshToken,
@@ -678,7 +681,7 @@ export class OidcService {
     return {
       accessToken,
       tokenType: 'Bearer',
-      expiresIn: 3600,
+      expiresIn: this.backstageTokenExpiration,
       refreshToken,
     };
   }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #34985. OAuth clients use `expires_in` to decide when to discard an access token. Report the same configured lifetime that Backstage uses when issuing the token, so non-default expiration settings no longer contradict the JWT.

AI-assisted: I reviewed the implementation and ran the project checks listed below.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (not applicable; backend-only change)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

Validation:
- `CI=1 yarn test plugins/auth-backend/src/service/OidcService.test.ts` (256 passed)
- `yarn prettier --check ...`
- `yarn tsc`
- `yarn build:api-reports`