### PR TITLE
plugin(kubernetes-backend): add bounded proxy middleware cache with TTL and cluster-detail invalidation

### DIFF
--- a/.changeset/real-houses-spend.md
+++ b/.changeset/real-houses-spend.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+The Kubernetes API proxy now refreshes cached middleware when cluster details change, after a configurable TTL, or when the cache reaches its size limit. At startup, the backend logs a warning for each cluster configured with `skipTLSVerify: true`. Invalid cache configuration values fall back to defaults. Optional configuration is available under `kubernetes.proxy.middlewareCache`.

--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -612,6 +612,28 @@ If the configuration-based cluster locators do not work for your use-case,
 it is also possible to implement a
 [custom `KubernetesClustersSupplier`](installation.md#custom-cluster-discovery).
 
+### `proxy` (optional)
+
+Options for the Kubernetes API proxy (`/api/kubernetes/proxy`).
+
+#### `proxy.middlewareCache` (optional)
+
+The proxy caches one `http-proxy-middleware` instance per cluster. Entries are refreshed when cluster details change, after a configurable TTL, or when the cache reaches its size limit.
+
+Clusters from **config** are loaded when the backend starts; changing `app-config` still requires a restart for those values to refresh. Catalog and other dynamic cluster sources can pick up cluster detail changes without a restart once the cluster supplier returns new details.
+
+```yaml
+kubernetes:
+  proxy:
+    middlewareCache:
+      maxSize: 100
+      ttl:
+        milliseconds: 60000
+```
+
+- `maxSize` — maximum cached middleware instances (default `100`).
+- `ttl.milliseconds` — cache entry lifetime in milliseconds (default `60000`).
+
 ### `customResources` (optional)
 
 Configures which [custom resources][3] to look for by default when returning an entity's

--- a/plugins/kubernetes-backend/config.d.ts
+++ b/plugins/kubernetes-backend/config.d.ts
@@ -142,5 +142,19 @@ export interface Config {
       statefulsets?: string;
       daemonsets?: string;
     } & { [pluralKind: string]: string };
+
+    /**
+     * Options for the Kubernetes API proxy middleware cache.
+     */
+    proxy?: {
+      middlewareCache?: {
+        /** Maximum number of cached middleware instances. Defaults to 100. */
+        maxSize?: number;
+        ttl?: {
+          /** Time-to-live for cached middleware in milliseconds. Defaults to 60000. */
+          milliseconds?: number;
+        };
+      };
+    };
   };
 }

--- a/plugins/kubernetes-backend/report.api.md
+++ b/plugins/kubernetes-backend/report.api.md
@@ -163,6 +163,10 @@ export type KubernetesProxyOptions = {
   discovery: DiscoveryService;
   httpAuth: HttpAuthService;
   auditor?: AuditorService;
+  middlewareCache?: {
+    ttlMs?: number;
+    maxSize?: number;
+  };
 };
 
 // @public (undocumented)

--- a/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
@@ -31,6 +31,7 @@ import {
 } from '@backstage/plugin-kubernetes-common';
 import { getMockReq, getMockRes } from '@jest-mock/express';
 import express from 'express';
+import * as httpProxyMiddleware from 'http-proxy-middleware';
 import Router from 'express-promise-router';
 import { Server } from 'node:http';
 import { rest } from 'msw';
@@ -815,6 +816,37 @@ describe('KubernetesProxy', () => {
     const response = await requestPromise;
 
     expect(response.status).toEqual(299);
+    expect(response.body).toStrictEqual(apiResponse);
+  });
+
+  it('rewrites paths when the proxy mount contains regex metacharacters', async () => {
+    const apiResponse = { kind: 'PodList', items: [] };
+
+    clusterSupplier.getClusters.mockResolvedValue([
+      {
+        name: 'cluster1',
+        url: 'https://localhost:9999/api',
+        authMetadata: {},
+      },
+    ]);
+
+    worker.use(
+      rest.get(
+        'https://localhost:9999/api/v1/pods',
+        (_: any, res: any, ctx: any) =>
+          res(ctx.status(200), ctx.json(apiResponse)),
+      ),
+    );
+
+    const requestPromise = setupProxyPromise({
+      proxyPath: '/mount.path',
+      requestPath: '/v1/pods',
+      headers: { [HEADER_KUBERNETES_CLUSTER]: 'cluster1' },
+    });
+
+    const response = await requestPromise;
+
+    expect(response.status).toEqual(200);
     expect(response.body).toStrictEqual(apiResponse);
   });
 
@@ -1729,6 +1761,62 @@ describe('KubernetesProxy', () => {
         kind: 'NamespaceList',
         apiVersion: 'v1',
         items: [],
+      });
+    });
+  });
+
+  describe('middleware cache', () => {
+    let createProxyMiddlewareSpy: jest.SpiedFunction<
+      typeof httpProxyMiddleware.createProxyMiddleware
+    >;
+
+    beforeEach(() => {
+      createProxyMiddlewareSpy = jest
+        .spyOn(httpProxyMiddleware, 'createProxyMiddleware')
+        .mockImplementation((() => jest.fn()) as any);
+      proxy = new KubernetesProxy({
+        logger,
+        clusterSupplier,
+        authStrategy,
+        discovery: mockDiscoveryApi,
+        httpAuth: mockServices.httpAuth.mock(),
+        auditor,
+        middlewareCache: { ttlMs: 60_000, maxSize: 10 },
+      });
+    });
+
+    afterEach(() => {
+      createProxyMiddlewareSpy.mockRestore();
+    });
+
+    it('recreates middleware when skipTLSVerify changes', async () => {
+      const baseCluster: ClusterDetails = {
+        name: 'cluster1',
+        url: 'https://localhost:9999',
+        authMetadata: {},
+        skipTLSVerify: true,
+      };
+
+      clusterSupplier.getClusters
+        .mockResolvedValueOnce([baseCluster])
+        .mockResolvedValueOnce([{ ...baseCluster, skipTLSVerify: false }]);
+
+      const handler = proxy.createRequestHandler({ permissionApi });
+
+      const req1 = buildMockRequest('cluster1', 'api');
+      const { res: res1, next: next1 } = getMockRes();
+      await handler(req1, res1, next1);
+
+      const req2 = buildMockRequest('cluster1', 'api');
+      const { res: res2, next: next2 } = getMockRes();
+      await handler(req2, res2, next2);
+
+      expect(createProxyMiddlewareSpy).toHaveBeenCalledTimes(2);
+      expect(createProxyMiddlewareSpy.mock.calls[0][0]).toMatchObject({
+        secure: false,
+      });
+      expect(createProxyMiddlewareSpy.mock.calls[1][0]).toMatchObject({
+        secure: true,
       });
     });
   });

--- a/plugins/kubernetes-backend/src/service/KubernetesProxy.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesProxy.ts
@@ -37,6 +37,11 @@ import {
   KubernetesClustersSupplier,
 } from '@backstage/plugin-kubernetes-node';
 
+import {
+  ProxyMiddlewareCache,
+  resolveProxyMiddlewareCacheOptions,
+} from './ProxyMiddlewareCache';
+
 import type { NextFunction, Request, Response } from 'express';
 import { IncomingHttpHeaders } from 'node:http';
 import {
@@ -92,6 +97,10 @@ export type KubernetesProxyOptions = {
   discovery: DiscoveryService;
   httpAuth: HttpAuthService;
   auditor?: AuditorService;
+  middlewareCache?: {
+    ttlMs?: number;
+    maxSize?: number;
+  };
 };
 
 /**
@@ -100,7 +109,7 @@ export type KubernetesProxyOptions = {
  * @public
  */
 export class KubernetesProxy {
-  private readonly middlewareForClusterName = new Map<string, RequestHandler>();
+  private readonly middlewareCache: ProxyMiddlewareCache;
   private readonly logger: LoggerService;
   private readonly clusterSupplier: KubernetesClustersSupplier;
   private readonly authStrategy: AuthenticationStrategy;
@@ -113,6 +122,9 @@ export class KubernetesProxy {
     this.authStrategy = options.authStrategy;
     this.httpAuth = options.httpAuth;
     this.auditor = options.auditor;
+    this.middlewareCache = new ProxyMiddlewareCache(
+      resolveProxyMiddlewareCacheOptions(options.middlewareCache),
+    );
   }
 
   public createRequestHandler(
@@ -265,7 +277,9 @@ export class KubernetesProxy {
 
     const requestPath = req.originalUrl || req.url || '';
     const rewrittenPath = requestPath.replace(
-      new RegExp(`^${req.baseUrl || ''}`),
+      new RegExp(
+        `^${(req.baseUrl || '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`,
+      ),
       url.pathname || '',
     );
 
@@ -274,11 +288,12 @@ export class KubernetesProxy {
 
   // We create one middleware per remote cluster and hold on to them, because
   // the secure property isn't possible to decide on a per-request basis with a
-  // single middleware instance - and we don't expect it to change over time.
-  // Target resolution and path rewriting are handled per-request via the
-  // PROXY_PREPARED_TARGET symbol stashed on each req by prepareProxyTarget.
+  // single middleware instance. Target resolution and path rewriting are handled
+  // per-request via the PROXY_PREPARED_TARGET symbol stashed on each req by
+  // prepareProxyTarget. Entries are refreshed after a TTL or when cluster details
+  // change.
   private getOrCreateMiddleware(cluster: ClusterDetails): RequestHandler {
-    let middleware = this.middlewareForClusterName.get(cluster.name);
+    let middleware = this.middlewareCache.get(cluster);
     if (!middleware) {
       const logger = this.logger.child({ cluster: cluster.name });
       middleware = createProxyMiddleware({
@@ -324,7 +339,7 @@ export class KubernetesProxy {
         },
         onProxyReqWs: ProxyAuditSession.handleWebSocketProxyReq,
       });
-      this.middlewareForClusterName.set(cluster.name, middleware);
+      this.middlewareCache.set(cluster, middleware);
     }
     return middleware;
   }

--- a/plugins/kubernetes-backend/src/service/KubernetesRouter.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesRouter.ts
@@ -27,7 +27,7 @@ import express from 'express';
 import Router from 'express-promise-router';
 
 import { DispatchStrategy } from '../auth';
-import { NotAllowedError } from '@backstage/errors';
+import { NotAllowedError, toError } from '@backstage/errors';
 
 import {
   AuthService,
@@ -52,6 +52,7 @@ import { KubernetesProxy } from './KubernetesProxy';
 import { requirePermission } from '../auth/requirePermission';
 import { CatalogService } from '@backstage/plugin-catalog-node';
 import { stringifyEntityRef } from '@backstage/catalog-model';
+import { resolveProxyMiddlewareCacheOptions } from './ProxyMiddlewareCache';
 
 export interface KubernetesEnvironment {
   logger: LoggerService;
@@ -107,6 +108,8 @@ export class KubernetesRouter {
       return Router();
     }
 
+    await this.warnForClustersWithSkipTLSVerify(logger, clusterSupplier);
+
     const proxy = this.buildProxy(
       logger,
       clusterSupplier,
@@ -153,6 +156,14 @@ export class KubernetesRouter {
     const authStrategy = new DispatchStrategy({
       authStrategyMap,
     });
+    const middlewareCacheConfig = this.env.config.getOptionalConfig(
+      'kubernetes.proxy.middlewareCache',
+    );
+    const { ttlMs, maxSize } = resolveProxyMiddlewareCacheOptions({
+      ttlMs: middlewareCacheConfig?.getOptionalNumber('ttl.milliseconds'),
+      maxSize: middlewareCacheConfig?.getOptionalNumber('maxSize'),
+    });
+
     return new KubernetesProxy({
       logger,
       clusterSupplier,
@@ -160,6 +171,7 @@ export class KubernetesRouter {
       discovery,
       httpAuth,
       auditor: this.env.auditor,
+      middlewareCache: { ttlMs, maxSize },
     });
   }
 
@@ -319,5 +331,29 @@ export class KubernetesRouter {
     );
 
     return clusterDetails;
+  }
+
+  private async warnForClustersWithSkipTLSVerify(
+    logger: LoggerService,
+    clusterSupplier: KubernetesClustersSupplier,
+  ): Promise<void> {
+    try {
+      const credentials = await this.env.auth.getOwnServiceCredentials();
+      const clusters = await clusterSupplier.getClusters({ credentials });
+
+      for (const cluster of clusters) {
+        if (cluster.skipTLSVerify) {
+          logger.warn(
+            `Cluster '${cluster.name}' is configured with skipTLSVerify: true; TLS certificate verification is disabled for Kubernetes API traffic to this cluster`,
+          );
+        }
+      }
+    } catch (error) {
+      logger.warn(
+        `Failed to log skipTLSVerify warnings at startup: ${
+          toError(error).message
+        }`,
+      );
+    }
   }
 }

--- a/plugins/kubernetes-backend/src/service/ProxyMiddlewareCache.test.ts
+++ b/plugins/kubernetes-backend/src/service/ProxyMiddlewareCache.test.ts
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ClusterDetails } from '@backstage/plugin-kubernetes-node';
+import type { RequestHandler } from 'http-proxy-middleware';
+import {
+  buildProxyMiddlewareFingerprint,
+  ProxyMiddlewareCache,
+  resolveProxyMiddlewareCacheOptions,
+} from './ProxyMiddlewareCache';
+
+const cluster = (overrides: Partial<ClusterDetails> = {}): ClusterDetails => ({
+  name: 'cluster-a',
+  url: 'https://example.com:6443',
+  authMetadata: {},
+  ...overrides,
+});
+
+const stubMiddleware = (): RequestHandler =>
+  jest.fn() as unknown as RequestHandler;
+
+describe('resolveProxyMiddlewareCacheOptions', () => {
+  it('falls back to defaults for invalid ttl and maxSize', () => {
+    expect(
+      resolveProxyMiddlewareCacheOptions({ ttlMs: 0, maxSize: 0 }),
+    ).toEqual({
+      ttlMs: 60_000,
+      maxSize: 100,
+    });
+  });
+});
+
+describe('buildProxyMiddlewareFingerprint', () => {
+  it('includes cluster detail fields that affect the fingerprint', () => {
+    expect(
+      buildProxyMiddlewareFingerprint(
+        cluster({
+          skipTLSVerify: true,
+          caData: 'abc',
+          caFile: '/tmp/ca',
+        }),
+      ),
+    ).toBe('https://example.com:6443|true|abc|/tmp/ca');
+  });
+});
+
+describe('ProxyMiddlewareCache', () => {
+  it('returns cached middleware when fingerprint matches and TTL has not expired', () => {
+    let now = 1_000;
+    const cache = new ProxyMiddlewareCache({
+      ttlMs: 10_000,
+      maxSize: 10,
+      now: () => now,
+    });
+    const details = cluster();
+    const middleware = stubMiddleware();
+
+    cache.set(details, middleware);
+    now += 5_000;
+
+    expect(cache.get(details)).toBe(middleware);
+  });
+
+  it('invalidates when skipTLSVerify changes', () => {
+    const cache = new ProxyMiddlewareCache({ ttlMs: 60_000, maxSize: 10 });
+    const details = cluster({ skipTLSVerify: true });
+    const middleware = stubMiddleware();
+
+    cache.set(details, middleware);
+
+    expect(cache.get(cluster({ skipTLSVerify: false }))).toBeUndefined();
+    expect(cache.get(details)).toBeUndefined();
+  });
+
+  it('invalidates after TTL expires', () => {
+    let now = 0;
+    const cache = new ProxyMiddlewareCache({
+      ttlMs: 1_000,
+      maxSize: 10,
+      now: () => now,
+    });
+    const details = cluster();
+    cache.set(details, stubMiddleware());
+
+    now = 1_001;
+    expect(cache.get(details)).toBeUndefined();
+  });
+
+  it('does not evict other clusters when replacing an existing cache entry at capacity', () => {
+    let now = 0;
+    const cache = new ProxyMiddlewareCache({
+      ttlMs: 60_000,
+      maxSize: 2,
+      now: () => now,
+    });
+
+    const first = stubMiddleware();
+    const second = stubMiddleware();
+    const secondReplacement = stubMiddleware();
+
+    cache.set(cluster({ name: 'first' }), first);
+    now += 100;
+    cache.set(cluster({ name: 'second', skipTLSVerify: true }), second);
+    now += 100;
+    cache.set(
+      cluster({ name: 'second', skipTLSVerify: false }),
+      secondReplacement,
+    );
+
+    expect(cache.get(cluster({ name: 'first' }))).toBe(first);
+    expect(cache.get(cluster({ name: 'second', skipTLSVerify: false }))).toBe(
+      secondReplacement,
+    );
+  });
+
+  it('evicts the oldest entry when maxSize is exceeded', () => {
+    let now = 0;
+    const cache = new ProxyMiddlewareCache({
+      ttlMs: 60_000,
+      maxSize: 2,
+      now: () => now,
+    });
+
+    const first = stubMiddleware();
+    const second = stubMiddleware();
+    const third = stubMiddleware();
+
+    cache.set(cluster({ name: 'first' }), first);
+    now += 100;
+    cache.set(cluster({ name: 'second' }), second);
+    now += 100;
+    cache.set(cluster({ name: 'third' }), third);
+
+    expect(cache.get(cluster({ name: 'first' }))).toBeUndefined();
+    expect(cache.get(cluster({ name: 'second' }))).toBe(second);
+    expect(cache.get(cluster({ name: 'third' }))).toBe(third);
+  });
+});

--- a/plugins/kubernetes-backend/src/service/ProxyMiddlewareCache.ts
+++ b/plugins/kubernetes-backend/src/service/ProxyMiddlewareCache.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { RequestHandler } from 'http-proxy-middleware';
+import type { ClusterDetails } from '@backstage/plugin-kubernetes-node';
+
+export const DEFAULT_PROXY_MIDDLEWARE_CACHE_TTL_MS = 60_000;
+export const DEFAULT_PROXY_MIDDLEWARE_CACHE_MAX_SIZE = 100;
+
+/**
+ * @internal
+ */
+export function resolveProxyMiddlewareCacheOptions(options?: {
+  ttlMs?: number;
+  maxSize?: number;
+}): { ttlMs: number; maxSize: number } {
+  const ttlMs =
+    options?.ttlMs !== undefined && options.ttlMs > 0
+      ? options.ttlMs
+      : DEFAULT_PROXY_MIDDLEWARE_CACHE_TTL_MS;
+  const maxSize =
+    options?.maxSize !== undefined && options.maxSize >= 1
+      ? options.maxSize
+      : DEFAULT_PROXY_MIDDLEWARE_CACHE_MAX_SIZE;
+
+  return { ttlMs, maxSize };
+}
+
+type CacheEntry = {
+  middleware: RequestHandler;
+  fingerprint: string;
+  createdAtMs: number;
+};
+
+/**
+ * Builds a cache fingerprint from cluster details that affect cached proxy middleware.
+ *
+ * @internal
+ */
+export function buildProxyMiddlewareFingerprint(
+  cluster: ClusterDetails,
+): string {
+  return `${cluster.url}|${cluster.skipTLSVerify ?? false}|${
+    cluster.caData ?? ''
+  }|${cluster.caFile ?? ''}`;
+}
+
+/**
+ * Bounded TTL cache for per-cluster http-proxy-middleware instances.
+ *
+ * @internal
+ */
+export class ProxyMiddlewareCache {
+  readonly #ttlMs: number;
+  readonly #maxSize: number;
+  readonly #entries = new Map<string, CacheEntry>();
+  readonly #now: () => number;
+
+  constructor(options: {
+    ttlMs?: number;
+    maxSize?: number;
+    now?: () => number;
+  }) {
+    const resolved = resolveProxyMiddlewareCacheOptions(options);
+    this.#ttlMs = resolved.ttlMs;
+    this.#maxSize = resolved.maxSize;
+    this.#now = options.now ?? (() => Date.now());
+  }
+
+  get(cluster: ClusterDetails): RequestHandler | undefined {
+    const entry = this.#entries.get(cluster.name);
+    if (!entry) {
+      return undefined;
+    }
+
+    const fingerprint = buildProxyMiddlewareFingerprint(cluster);
+    if (
+      entry.fingerprint !== fingerprint ||
+      this.#now() - entry.createdAtMs > this.#ttlMs
+    ) {
+      this.#entries.delete(cluster.name);
+      return undefined;
+    }
+
+    return entry.middleware;
+  }
+
+  set(cluster: ClusterDetails, middleware: RequestHandler): void {
+    this.#entries.delete(cluster.name);
+
+    while (this.#entries.size >= this.#maxSize) {
+      const oldestKey = this.#findOldestKey();
+      if (!oldestKey) {
+        break;
+      }
+      this.#entries.delete(oldestKey);
+    }
+
+    this.#entries.set(cluster.name, {
+      middleware,
+      fingerprint: buildProxyMiddlewareFingerprint(cluster),
+      createdAtMs: this.#now(),
+    });
+  }
+
+  #findOldestKey(): string | undefined {
+    let oldestKey: string | undefined;
+    let oldestTime = Number.POSITIVE_INFINITY;
+
+    for (const [key, entry] of this.#entries) {
+      if (entry.createdAtMs < oldestTime) {
+        oldestTime = entry.createdAtMs;
+        oldestKey = key;
+      }
+    }
+
+    return oldestKey;
+  }
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR replaces the Kubernetes API proxy’s unbounded per-cluster middleware map with a bounded cache (`ProxyMiddlewareCache`) that refreshes entries when cluster details change, after a configurable TTL, or when the cache reaches its size limit. It also adds an optional `kubernetes.proxy.middlewareCache` config to configure the cache's maxSize and TTL. 


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))