### PR TITLE
docs: to improve document with clarity and American English

### DIFF
--- a/.changeset/itchy-toys-tan.md
+++ b/.changeset/itchy-toys-tan.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+standardized and improved grammar in doc ui

--- a/.changeset/itchy-toys-tan.md
+++ b/.changeset/itchy-toys-tan.md
@@ -1,5 +1,0 @@
----
-'@backstage/ui': patch
----
-
-standardized and improved grammar in doc ui

--- a/docs-ui/src/app/components/header/page.mdx
+++ b/docs-ui/src/app/components/header/page.mdx
@@ -78,7 +78,7 @@ Use `HeaderMetadataUsers` as the metadata value to display users as avatars. A s
 
 ### Metadata with status
 
-Use `HeaderMetadataStatus` as the metadata value to display a status indicator. The dot colour is driven by the `color` prop which maps to BUI status tokens. Pass an `href` to make the label a link.
+Use `HeaderMetadataStatus` as the metadata value to display a status indicator. The dot color is driven by the `color` prop which maps to BUI status tokens. Pass an `href` to make the label a link.
 
 <Snippet open preview={<WithMetadataStatus />} code={withMetadataStatus} />
 

--- a/docs-ui/src/app/tokens/page.mdx
+++ b/docs-ui/src/app/tokens/page.mdx
@@ -376,7 +376,7 @@ overlapping element needs to match its surrounding bg without hardcoding a level
 
 ## Foreground colors
 
-Foreground colours are meant to work in pair with a background colours. Typically this would work
+Foreground colors are meant to be paired with background colors. Typically this would work
 for icons, texts, shapes, ... Use a matching name to know what foreground color to use. These colors
 are prefixed with `fg` to make it easier to identify.
 

--- a/packages/ui/src/components/Header/HeaderMetadataStatus.tsx
+++ b/packages/ui/src/components/Header/HeaderMetadataStatus.tsx
@@ -20,7 +20,7 @@ import { Link } from '../Link';
 import styles from './HeaderMetadataStatus.module.css';
 
 /**
- * Displays a single status indicator as a coloured dot with a label inside a
+ * Displays a single status indicator as a colored dot with a label inside a
  * Header metadata value. Optionally renders the label as a link when href is provided.
  *
  * @public


### PR DESCRIPTION
## Hey, I just made a Pull Request!
This PR is to standardizes the documentation by replacing the British English Spelling "colour/colours/coloured" with the American English spelling "color/colors/colored" for consistency with existing documentations, also did a grammar fix from `Foreground colours are meant to work in pair with a background colours` to  `Foreground colors are meant to be paired with background colors. Typically this would work` in [tokens/page.mdx](https://github.com/backstage/backstage/blob/master/docs-ui/src/app/tokens/page.mdx).

Reference: [Backstage Documentation Style Guide](https://backstage.io/docs/contribute/doc-style-guide/#language)

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
