### PR TITLE
feat(auth-backend-module-azure-easyauth-provider): add Azure Container Apps support

### DIFF
--- a/.changeset/azure-easyauth-aca-support.md
+++ b/.changeset/azure-easyauth-aca-support.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-azure-easyauth-provider': patch
+---
+
+Added support for Azure Container Apps (ACA) in the Azure EasyAuth authentication provider, allowing it to parse client principal headers and work without Azure App Services environment variables.

--- a/plugins/auth-backend-module-azure-easyauth-provider/src/authenticator.test.ts
+++ b/plugins/auth-backend-module-azure-easyauth-provider/src/authenticator.test.ts
@@ -18,6 +18,9 @@ import {
   azureEasyAuthAuthenticator,
   ID_TOKEN_HEADER,
   ACCESS_TOKEN_HEADER,
+  ACA_PRINCIPAL_ID_HEADER,
+  ACA_PRINCIPAL_NAME_HEADER,
+  ACA_CLIENT_PRINCIPAL_HEADER,
 } from './authenticator';
 import { mockServices } from '@backstage/backend-test-utils';
 import { Request } from 'express';
@@ -111,6 +114,114 @@ describe('EasyAuthAuthProvider', () => {
       await expect(
         azureEasyAuthAuthenticator.authenticate({ req: request }, ctx),
       ).rejects.toThrow('id_token is not version 2.0');
+    });
+  });
+
+  describe('Azure Container Apps support', () => {
+    const acaPrincipal = {
+      auth_typ: 'aad',
+      name_typ: 'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name',
+      role_typ: 'http://schemas.microsoft.com/ws/2008/06/identity/claims/role',
+      claims: [
+        {
+          typ: 'http://schemas.microsoft.com/identity/claims/objectidentifier',
+          val: 'c43063d4-0650-4f3e-ba6b-307473d24dfd',
+        },
+        {
+          typ: 'name',
+          val: 'Alice Bob',
+        },
+        {
+          typ: 'preferred_username',
+          val: 'Another name',
+        },
+        {
+          typ: 'email',
+          val: 'alice@bob.com',
+        },
+      ],
+    };
+    const encodedPrincipal = Buffer.from(JSON.stringify(acaPrincipal)).toString(
+      'base64',
+    );
+
+    it('should succeed with valid client principal header and claims', async () => {
+      const request = mockRequest({
+        [ACA_CLIENT_PRINCIPAL_HEADER]: encodedPrincipal,
+        [ACA_PRINCIPAL_ID_HEADER]: 'c43063d4-0650-4f3e-ba6b-307473d24dfd',
+        [ACA_PRINCIPAL_NAME_HEADER]: 'alice@bob.com',
+        [ACCESS_TOKEN_HEADER]: 'ACCESS_TOKEN',
+      });
+
+      await expect(
+        azureEasyAuthAuthenticator.authenticate({ req: request }, ctx),
+      ).resolves.toEqual({
+        result: {
+          fullProfile: {
+            provider: 'easyauth',
+            id: 'c43063d4-0650-4f3e-ba6b-307473d24dfd',
+            displayName: 'Alice Bob',
+            emails: [{ value: 'alice@bob.com' }],
+            username: 'Another name',
+          },
+          accessToken: 'ACCESS_TOKEN',
+        },
+        providerInfo: {
+          accessToken: 'ACCESS_TOKEN',
+        },
+      });
+    });
+
+    it('should succeed and fallback when client principal header is missing but id/name are present', async () => {
+      const request = mockRequest({
+        [ACA_PRINCIPAL_ID_HEADER]: 'c43063d4-0650-4f3e-ba6b-307473d24dfd',
+        [ACA_PRINCIPAL_NAME_HEADER]: 'alice@bob.com',
+      });
+
+      await expect(
+        azureEasyAuthAuthenticator.authenticate({ req: request }, ctx),
+      ).resolves.toEqual({
+        result: {
+          fullProfile: {
+            provider: 'easyauth',
+            id: 'c43063d4-0650-4f3e-ba6b-307473d24dfd',
+            displayName: 'alice@bob.com',
+            emails: [{ value: 'alice@bob.com' }],
+            username: 'alice@bob.com',
+          },
+          accessToken: undefined,
+        },
+        providerInfo: {
+          accessToken: undefined,
+        },
+      });
+    });
+
+    it('should fail when principal ID is missing and client principal claims lack ID', async () => {
+      const invalidPrincipal = Buffer.from(
+        JSON.stringify({
+          claims: [{ typ: 'name', val: 'Alice Bob' }],
+        }),
+      ).toString('base64');
+      const request = mockRequest({
+        [ACA_CLIENT_PRINCIPAL_HEADER]: invalidPrincipal,
+      });
+
+      await expect(
+        azureEasyAuthAuthenticator.authenticate({ req: request }, ctx),
+      ).rejects.toThrow(
+        'Missing user identity in Azure Container Apps authentication headers',
+      );
+    });
+
+    it('should fail when client principal header is malformed base64/JSON', async () => {
+      const request = mockRequest({
+        [ACA_CLIENT_PRINCIPAL_HEADER]: 'not-base64-json!',
+      });
+
+      await expect(
+        azureEasyAuthAuthenticator.authenticate({ req: request }, ctx),
+      ).rejects.toThrow(/Invalid x-ms-client-principal header/);
     });
   });
 });

--- a/plugins/auth-backend-module-azure-easyauth-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-azure-easyauth-provider/src/authenticator.ts
@@ -23,6 +23,9 @@ import { decodeJwt } from 'jose';
 
 export const ID_TOKEN_HEADER = 'x-ms-token-aad-id-token';
 export const ACCESS_TOKEN_HEADER = 'x-ms-token-aad-access-token';
+export const ACA_PRINCIPAL_ID_HEADER = 'x-ms-client-principal-id';
+export const ACA_PRINCIPAL_NAME_HEADER = 'x-ms-client-principal-name';
+export const ACA_CLIENT_PRINCIPAL_HEADER = 'x-ms-client-principal';
 
 /** @public */
 export const azureEasyAuthAuthenticator = createProxyAuthenticator({
@@ -48,6 +51,23 @@ export const azureEasyAuthAuthenticator = createProxyAuthenticator({
 });
 
 async function getResult(req: Request): Promise<AzureEasyAuthResult> {
+  const acaPrincipalId = req.header(ACA_PRINCIPAL_ID_HEADER);
+  const acaPrincipalName = req.header(ACA_PRINCIPAL_NAME_HEADER);
+  const acaClientPrincipal = req.header(ACA_CLIENT_PRINCIPAL_HEADER);
+
+  if (acaPrincipalId !== undefined || acaClientPrincipal !== undefined) {
+    const fullProfile = clientPrincipalToProfile(
+      acaPrincipalId,
+      acaPrincipalName,
+      acaClientPrincipal,
+    );
+    const accessToken = req.header(ACCESS_TOKEN_HEADER);
+    return {
+      fullProfile,
+      accessToken,
+    };
+  }
+
   const idToken = req.header(ID_TOKEN_HEADER);
   const accessToken = req.header(ACCESS_TOKEN_HEADER);
   if (idToken === undefined) {
@@ -58,6 +78,77 @@ async function getResult(req: Request): Promise<AzureEasyAuthResult> {
     fullProfile: idTokenToProfile(idToken),
     accessToken: accessToken,
   };
+}
+
+function clientPrincipalToProfile(
+  principalId: string | undefined,
+  principalName: string | undefined,
+  clientPrincipalBase64: string | undefined,
+): Profile {
+  let id = principalId;
+  let displayName = principalName;
+  let username = principalName;
+  let email = principalName;
+
+  if (clientPrincipalBase64) {
+    try {
+      const decodedJson = Buffer.from(clientPrincipalBase64, 'base64').toString(
+        'utf-8',
+      );
+      const principal = JSON.parse(decodedJson);
+      const claims: Record<string, string> = {};
+      if (principal && Array.isArray(principal.claims)) {
+        for (const claim of principal.claims) {
+          if (claim && claim.typ && claim.val) {
+            claims[claim.typ] = claim.val;
+          }
+        }
+      }
+
+      id =
+        id ||
+        claims[
+          'http://schemas.microsoft.com/identity/claims/objectidentifier'
+        ] ||
+        claims.oid;
+      displayName =
+        claims.name ||
+        claims['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name'] ||
+        displayName;
+      username =
+        claims.preferred_username ||
+        claims['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/upn'] ||
+        claims.upn ||
+        username;
+      email =
+        claims.email ||
+        claims[
+          'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress'
+        ] ||
+        claims.preferred_username ||
+        email;
+    } catch (error) {
+      throw new AuthenticationError(
+        `Invalid x-ms-client-principal header: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+
+  if (!id) {
+    throw new AuthenticationError(
+      `Missing user identity in Azure Container Apps authentication headers`,
+    );
+  }
+
+  return {
+    id,
+    displayName: displayName || id,
+    provider: 'easyauth',
+    emails: email ? [{ value: email }] : undefined,
+    username,
+  } as Profile;
 }
 
 function idTokenToProfile(idToken: string) {

--- a/plugins/auth-backend-module-azure-easyauth-provider/src/module.test.ts
+++ b/plugins/auth-backend-module-azure-easyauth-provider/src/module.test.ts
@@ -47,9 +47,9 @@ describe('authModuleAzureEasyAuthProvider', () => {
     process.env = env;
   });
 
-  it('should fail when run outside of Azure App Services', async () => {
+  it('should fail when run outside of Azure App Services or Azure Container Apps', async () => {
     await expect(startTestBackend({ features })).rejects.toThrow(
-      'Backstage is not running on Azure App Services',
+      'Backstage is not running on Azure App Services or Azure Container Apps',
     );
   });
 
@@ -85,6 +85,13 @@ describe('authModuleAzureEasyAuthProvider', () => {
     process.env.WEBSITE_AUTH_ENABLED = 'True';
     process.env.WEBSITE_AUTH_DEFAULT_PROVIDER = 'AzureActiveDirectory';
     process.env.WEBSITE_AUTH_TOKEN_STORE = 'True';
+    await expect(startTestBackend({ features })).resolves.toBeInstanceOf(
+      Object,
+    );
+  });
+
+  it('should start successfully when running in Azure Container Apps', async () => {
+    process.env.CONTAINER_APP_NAME = 'my-container-app';
     await expect(startTestBackend({ features })).resolves.toBeInstanceOf(
       Object,
     );

--- a/plugins/auth-backend-module-azure-easyauth-provider/src/module.ts
+++ b/plugins/auth-backend-module-azure-easyauth-provider/src/module.ts
@@ -52,11 +52,17 @@ export const authModuleAzureEasyAuthProvider = createBackendModule({
 function validateAppServiceConfiguration(env: NodeJS.ProcessEnv) {
   // Based on https://github.com/AzureAD/microsoft-identity-web/blob/f7403779d1a91f4a3fec0ed0993bd82f50f299e1/src/Microsoft.Identity.Web/AppServicesAuth/AppServicesAuthenticationInformation.cs#L38-L59
   //
-  // It's critical to validate we're really running in a correctly configured Azure App Services,
-  // As we rely on App Services to manage & validate the ID and Access Token headers
-  // Without that, this users can be trivially impersonated.
+  // It's critical to validate we're really running in a correctly configured Azure App Services or Azure Container Apps,
+  // As we rely on them to manage & validate the identity headers.
+  // Without that, users can be trivially impersonated.
+  if (env.CONTAINER_APP_NAME !== undefined) {
+    return;
+  }
+
   if (env.WEBSITE_SKU === undefined) {
-    throw new Error('Backstage is not running on Azure App Services');
+    throw new Error(
+      'Backstage is not running on Azure App Services or Azure Container Apps',
+    );
   }
   if (env.WEBSITE_AUTH_ENABLED?.toLocaleLowerCase('en-US') !== 'true') {
     throw new Error('Azure App Services does not have authentication enabled');


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Description
This PR adds support for Azure Container Apps (ACA) in the EasyAuth authentication provider (`@backstage/plugin-auth-backend-module-azure-easyauth-provider`).

- Relaxed/extended environment variable validation to support `CONTAINER_APP_NAME` alongside Azure App Service checks.
- Added base64 decoding and JSON claim parsing for `x-ms-client-principal`, as well as support for `x-ms-client-principal-id` and `x-ms-client-principal-name` request headers.
- Added comprehensive unit test coverage for Azure Container Apps header processing and error handling.

Fixes #34110

#### ✔ Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.