### PR TITLE
Fix New Adopters Form to follow the application theme

### DIFF
--- a/microsite/src/pages/home/hubSpotNewAdoptersForm.module.scss
+++ b/microsite/src/pages/home/hubSpotNewAdoptersForm.module.scss
@@ -28,7 +28,9 @@ $page-header-height: 44px;
 .hubSpotNewAdopterFormContent {
   max-width: 500px;
   border-radius: 8px 0 0 8px;
-  background-color: var(--ifm-color-white);
+  background-color: var(--ifm-background-surface-color);
+  color: var(--ifm-front-color-base);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
 
   form {
     width: 100%;
@@ -37,10 +39,26 @@ $page-header-height: 44px;
 
     padding-right: 2rem;
   }
-  select[class*='hs-input'] {
-    color: black;
+
+  :global(.hs-form-field) label,
+  :global(.hs-form-field) legend,
+  :global(.hs-richtext),
+  :global(.hs-richtext) p {
+    color: var(--ifm-front-color-base);
   }
-  input[class*='hs-button'] {
-    color: black;
+
+  :global(.hs-input) {
+    color: var(--ifm-front-color-base);
+    background-color: var(--ifm-background-color);
+    border: 1px solid var(--ifm-color-emphasis-300);
+
+    &::placeholder {
+      color: var(--ifm-front-emphasis-500);
+    }
+  }
+
+  :global(.hs-error-msgs) label,
+  :global(.hs-error-msg) {
+    color: var(--ifm-color-danger);
   }
 }

--- a/microsite/src/pages/home/hubSpotNewAdoptersForm.module.scss
+++ b/microsite/src/pages/home/hubSpotNewAdoptersForm.module.scss
@@ -29,7 +29,7 @@ $page-header-height: 44px;
   max-width: 500px;
   border-radius: 8px 0 0 8px;
   background-color: var(--ifm-background-surface-color);
-  color: var(--ifm-front-color-base);
+  color: var(--ifm-font-color-base);
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
 
   form {
@@ -44,16 +44,16 @@ $page-header-height: 44px;
   :global(.hs-form-field) legend,
   :global(.hs-richtext),
   :global(.hs-richtext) p {
-    color: var(--ifm-front-color-base);
+    color: var(--ifm-font-color-base);
   }
 
   :global(.hs-input) {
-    color: var(--ifm-front-color-base);
+    color: var(--ifm-font-color-base);
     background-color: var(--ifm-background-color);
     border: 1px solid var(--ifm-color-emphasis-300);
 
     &::placeholder {
-      color: var(--ifm-front-emphasis-500);
+      color: var(--ifm-font-emphasis-500);
     }
   }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This PR update the New Adopters Form to follow the application's active theme instead of using fixed light background style.

### Existing Behaviour
<img width="1882" height="906" alt="ExistingBehaviour" src="https://github.com/user-attachments/assets/cc4246ac-6cb5-47f0-9ea6-b5d9ed01a175" />

### Expected Behaviour
<img width="1876" height="912" alt="ExpecterBehaviour" src="https://github.com/user-attachments/assets/ee20e2f0-0b25-4781-bb1e-07ab5364b573" />


Closes #35024 

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
