### PR TITLE
Fix config:check --strict complaining about additional properties in open-ended objects

### DIFF
--- a/.changeset/witty-radios-scream.md
+++ b/.changeset/witty-radios-scream.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-catalog-backend-module-backstage-openapi': patch
+'@backstage/plugin-search-backend-module-catalog': patch
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Fix issue where `backstage-cli config:check --strict` would complain about open-ended configuration fields having additional properties.

--- a/plugins/catalog-backend-module-backstage-openapi/config.d.ts
+++ b/plugins/catalog-backend-module-backstage-openapi/config.d.ts
@@ -31,7 +31,7 @@ export interface Config {
         /**
          * Properties to override on the final entity object.
          */
-        entityOverrides?: object;
+        entityOverrides?: { [key: string]: unknown };
         /**
          * The format of the definition.
          * @defaultValue json

--- a/plugins/kubernetes-backend/config.d.ts
+++ b/plugins/kubernetes-backend/config.d.ts
@@ -59,7 +59,7 @@ export interface Config {
             /** @visibility frontend */
             authProvider?: string;
             /** @visibility secret  */
-            authMetadata?: object;
+            authMetadata?: { [key: string]: unknown };
             /** @visibility frontend */
             oidcTokenProvider?: string;
             /** @visibility frontend */

--- a/plugins/search-backend-module-catalog/config.d.ts
+++ b/plugins/search-backend-module-catalog/config.d.ts
@@ -36,7 +36,7 @@ export interface Config {
          *
          * Defaults to no filter, ie indexing all entities.
          */
-        filter?: object | object[];
+        filter?: { [key: string]: unknown } | { [key: string]: unknown }[];
         /**
          * The number of entities to process at a time. Keep this at a
          * reasonable number to avoid overloading either the catalog or the


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

While updating to backstage v1.53, we hit an issue with our config checks (run with `--strict`):

```
  Error: Configuration does not match schema
  
    Config must NOT have additional properties { additionalProperty=metadata } at /catalog/providers/backstageOpenapi/entityOverrides
    Config must NOT have additional properties { additionalProperty=spec } at /catalog/providers/backstageOpenapi/entityOverrides
    Config must NOT have additional properties { additionalProperty=kind } at /search/collators/catalog/filter
    Config must be array { type=array } at /search/collators/catalog/filter
    Config must match a schema in anyOf {  } at /search/collators/catalog/filter
```

I believe that this may have been a side-effect of https://github.com/backstage/backstage/commit/87af6cee13f5597e3ee3d2e0d1b2af432de8d0b3.

These two config options are "open-ended". They're meant to be objects with any properties. The issue is that generated schema for them is:

```json
{ "type": "object" }
```

With `--strict`, this turns into:

```json
{
  "type": "object",
  "additionalProperties": false
}
```

This defeats the purpose of these options.

My fix (switching from `foo: object` to `foo: {[key: string]: unknown}`) changes the output schema to be:

```json
{
  "type": "object",
  "additionalProperties": {}
}
```

This allows arbitrary values in those options.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
