### PR TITLE
Migrate sign-in resolver factories to Standard Schema

### DIFF
--- a/.changeset/atlassian-sign-in-zod-v4.md
+++ b/.changeset/atlassian-sign-in-zod-v4.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-atlassian-provider': patch
+---
+
+Updated the Atlassian sign-in resolver option schema to use Zod v4.

--- a/.changeset/aws-alb-sign-in-zod-v4.md
+++ b/.changeset/aws-alb-sign-in-zod-v4.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-aws-alb-provider': patch
+---
+
+Updated the AWS Application Load Balancer sign-in resolver option schema to use Zod v4.

--- a/.changeset/azure-easyauth-sign-in-zod-v4.md
+++ b/.changeset/azure-easyauth-sign-in-zod-v4.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-azure-easyauth-provider': patch
+---
+
+Updated the Azure Easy Auth sign-in resolver option schema to use Zod v4.

--- a/.changeset/bitbucket-server-sign-in-zod-v4.md
+++ b/.changeset/bitbucket-server-sign-in-zod-v4.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-bitbucket-server-provider': patch
+---
+
+Updated the Bitbucket Server sign-in resolver option schema to use Zod v4.

--- a/.changeset/bitbucket-sign-in-zod-v4.md
+++ b/.changeset/bitbucket-sign-in-zod-v4.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-bitbucket-provider': patch
+---
+
+Updated the Bitbucket sign-in resolver option schemas to use Zod v4.

--- a/.changeset/cloudflare-access-sign-in-zod-v4.md
+++ b/.changeset/cloudflare-access-sign-in-zod-v4.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-cloudflare-access-provider': patch
+---
+
+Updated the Cloudflare Access sign-in resolver option schema to use Zod v4.

--- a/.changeset/gcp-iap-sign-in-zod-v4.md
+++ b/.changeset/gcp-iap-sign-in-zod-v4.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-gcp-iap-provider': patch
+---
+
+Updated the Google Cloud Identity-Aware Proxy sign-in resolver option schemas to use Zod v4.

--- a/.changeset/github-sign-in-zod-v4.md
+++ b/.changeset/github-sign-in-zod-v4.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-github-provider': patch
+---
+
+Updated the GitHub sign-in resolver option schemas to use Zod v4.

--- a/.changeset/gitlab-sign-in-zod-v4.md
+++ b/.changeset/gitlab-sign-in-zod-v4.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-gitlab-provider': patch
+---
+
+Updated the GitLab sign-in resolver option schemas to use Zod v4.

--- a/.changeset/google-sign-in-zod-v4.md
+++ b/.changeset/google-sign-in-zod-v4.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-google-provider': patch
+---
+
+Updated the Google sign-in resolver option schema to use Zod v4.

--- a/.changeset/microsoft-sign-in-zod-v4.md
+++ b/.changeset/microsoft-sign-in-zod-v4.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-microsoft-provider': patch
+---
+
+Updated the Microsoft sign-in resolver option schemas to use Zod v4.

--- a/.changeset/oauth2-proxy-sign-in-zod-v4.md
+++ b/.changeset/oauth2-proxy-sign-in-zod-v4.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-oauth2-proxy-provider': patch
+---
+
+Updated the OAuth 2 Proxy sign-in resolver option schemas to use Zod v4.

--- a/.changeset/oauth2-sign-in-zod-v4.md
+++ b/.changeset/oauth2-sign-in-zod-v4.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-oauth2-provider': patch
+---
+
+Updated the OAuth 2 sign-in resolver option schema to use Zod v4.

--- a/.changeset/oidc-sign-in-schema-dependency.md
+++ b/.changeset/oidc-sign-in-schema-dependency.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-oidc-provider': patch
+---
+
+Removed an unused Zod dependency after the shared OIDC sign-in resolver option schemas migrated to Standard Schema.

--- a/.changeset/okta-sign-in-zod-v4.md
+++ b/.changeset/okta-sign-in-zod-v4.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-okta-provider': patch
+---
+
+Updated the Okta sign-in resolver option schema to use Zod v4.

--- a/.changeset/onelogin-sign-in-zod-v4.md
+++ b/.changeset/onelogin-sign-in-zod-v4.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-onelogin-provider': patch
+---
+
+Updated the OneLogin sign-in resolver option schema to use Zod v4.

--- a/.changeset/openshift-sign-in-zod-v4.md
+++ b/.changeset/openshift-sign-in-zod-v4.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-openshift-provider': patch
+---
+
+Updated the OpenShift sign-in resolver option schema to use Zod v4.

--- a/.changeset/standard-sign-in-schemas.md
+++ b/.changeset/standard-sign-in-schemas.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-node': minor
+---
+
+**BREAKING**: Sign-in resolver factory option schemas now use Standard Schema and Standard JSON Schema instead of Zod v3. When using Zod, provide a schema from the full Zod v4 package by importing from `zod`; Zod v3 schemas and the `zod/v4` compatibility export from a Zod v3 installation are not supported because they cannot provide the required JSON Schema metadata. Other schema libraries can be used when they implement both standards and validate synchronously.

--- a/docs/auth/add-auth-provider.md
+++ b/docs/auth/add-auth-provider.md
@@ -173,6 +173,55 @@ export const authModuleFoobarProvider = createBackendModule({
 });
 ```
 
+You can expose provider-specific configurable sign-in resolvers with the
+`createSignInResolverFactory` function. Pass the options schema directly. The
+schema must support synchronous [Standard Schema](https://standardschema.dev/)
+validation and Standard JSON Schema conversion. If you use Zod, install the
+full Zod v4 package and import from `zod`:
+
+```ts
+import {
+  createSignInResolverFactory,
+  OAuthAuthenticatorResult,
+  PassportProfile,
+  SignInInfo,
+} from '@backstage/plugin-auth-node';
+import { z } from 'zod';
+
+export const usernameMatchingUserEntityName = createSignInResolverFactory({
+  optionsSchema: z
+    .object({
+      dangerouslyAllowSignInWithoutUserInCatalog: z.boolean().optional(),
+    })
+    .optional(),
+  create(options = {}) {
+    return async (
+      info: SignInInfo<OAuthAuthenticatorResult<PassportProfile>>,
+      ctx,
+    ) => {
+      const username = info.result.fullProfile.username;
+      if (!username) {
+        throw new Error('User profile does not contain a username');
+      }
+
+      return ctx.signInWithCatalogUser(
+        { entityRef: { name: username } },
+        {
+          dangerousEntityRefFallback:
+            options.dangerouslyAllowSignInWithoutUserInCatalog
+              ? { entityRef: { name: username } }
+              : undefined,
+        },
+      );
+    };
+  },
+});
+```
+
+Add the resolver factory to the `signInResolverFactories` option of your auth
+provider factory so that adopters can select and configure it through
+`app-config.yaml`.
+
 Now let's implement the actual authenticator for our provider using `Strategy` from a passport package.
 The authenticator is responsible for creating the passport strategy and handling the authentication flow using secrets from the config file.
 

--- a/plugins/auth-backend-module-atlassian-provider/package.json
+++ b/plugins/auth-backend-module-atlassian-provider/package.json
@@ -39,7 +39,7 @@
     "express": "^4.22.0",
     "passport": "^0.7.0",
     "passport-atlassian-oauth2": "^2.1.0",
-    "zod": "^3.25.76 || ^4.0.0"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@backstage/backend-defaults": "workspace:^",

--- a/plugins/auth-backend-module-atlassian-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-atlassian-provider/src/resolvers.ts
@@ -20,7 +20,7 @@ import {
   PassportProfile,
   SignInInfo,
 } from '@backstage/plugin-auth-node';
-import { z } from 'zod/v3';
+import { z } from 'zod';
 
 /**
  * Available sign-in resolvers for the Atlassian auth provider.

--- a/plugins/auth-backend-module-aws-alb-provider/package.json
+++ b/plugins/auth-backend-module-aws-alb-provider/package.json
@@ -43,7 +43,7 @@
     "@backstage/plugin-auth-node": "workspace:^",
     "jose": "^5.0.0",
     "node-cache": "^5.1.2",
-    "zod": "^3.25.76 || ^4.0.0"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "workspace:^",

--- a/plugins/auth-backend-module-aws-alb-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-aws-alb-provider/src/resolvers.ts
@@ -19,7 +19,7 @@ import {
   SignInInfo,
 } from '@backstage/plugin-auth-node';
 import { AwsAlbResult } from './types';
-import { z } from 'zod/v3';
+import { z } from 'zod';
 
 /**
  * Available sign-in resolvers for the AWS ALB auth provider.

--- a/plugins/auth-backend-module-azure-easyauth-provider/package.json
+++ b/plugins/auth-backend-module-azure-easyauth-provider/package.json
@@ -41,7 +41,7 @@
     "express": "^4.22.0",
     "jose": "^5.0.0",
     "passport": "^0.7.0",
-    "zod": "^3.25.76 || ^4.0.0"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "workspace:^",

--- a/plugins/auth-backend-module-azure-easyauth-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-azure-easyauth-provider/src/resolvers.ts
@@ -19,7 +19,7 @@ import {
   SignInInfo,
 } from '@backstage/plugin-auth-node';
 import { AzureEasyAuthResult } from './types';
-import { z } from 'zod/v3';
+import { z } from 'zod';
 
 /** @public */
 export namespace azureEasyAuthSignInResolvers {

--- a/plugins/auth-backend-module-bitbucket-provider/package.json
+++ b/plugins/auth-backend-module-bitbucket-provider/package.json
@@ -39,7 +39,7 @@
     "express": "^4.22.0",
     "passport": "^0.7.0",
     "passport-bitbucket-oauth2": "^0.1.2",
-    "zod": "^3.25.76 || ^4.0.0"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@backstage/backend-defaults": "workspace:^",

--- a/plugins/auth-backend-module-bitbucket-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-bitbucket-provider/src/resolvers.ts
@@ -20,7 +20,7 @@ import {
   PassportProfile,
   SignInInfo,
 } from '@backstage/plugin-auth-node';
-import { z } from 'zod/v3';
+import { z } from 'zod';
 
 /**
  * Available sign-in resolvers for the Bitbucket auth provider.

--- a/plugins/auth-backend-module-bitbucket-server-provider/package.json
+++ b/plugins/auth-backend-module-bitbucket-server-provider/package.json
@@ -38,7 +38,7 @@
     "@backstage/plugin-auth-node": "workspace:^",
     "passport": "^0.7.0",
     "passport-oauth2": "^1.6.1",
-    "zod": "^3.25.76 || ^4.0.0"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@backstage/backend-defaults": "workspace:^",

--- a/plugins/auth-backend-module-bitbucket-server-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-bitbucket-server-provider/src/resolvers.ts
@@ -19,7 +19,7 @@ import {
   PassportProfile,
   SignInInfo,
 } from '@backstage/plugin-auth-node';
-import { z } from 'zod/v3';
+import { z } from 'zod';
 
 /**
  * Available sign-in resolvers for the Bitbucket Server auth provider.

--- a/plugins/auth-backend-module-cloudflare-access-provider/package.json
+++ b/plugins/auth-backend-module-cloudflare-access-provider/package.json
@@ -40,7 +40,7 @@
     "@backstage/plugin-auth-node": "workspace:^",
     "express": "^4.22.0",
     "jose": "^5.0.0",
-    "zod": "^3.25.76 || ^4.0.0"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@backstage/backend-defaults": "workspace:^",

--- a/plugins/auth-backend-module-cloudflare-access-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-cloudflare-access-provider/src/resolvers.ts
@@ -19,7 +19,7 @@ import {
   SignInInfo,
 } from '@backstage/plugin-auth-node';
 import { CloudflareAccessResult } from './types';
-import { z } from 'zod/v3';
+import { z } from 'zod';
 
 /**
  * Available sign-in resolvers for the Cloudflare Access auth provider.

--- a/plugins/auth-backend-module-gcp-iap-provider/package.json
+++ b/plugins/auth-backend-module-gcp-iap-provider/package.json
@@ -43,7 +43,7 @@
     "@backstage/plugin-auth-node": "workspace:^",
     "@backstage/types": "workspace:^",
     "google-auth-library": "^9.0.0",
-    "zod": "^3.25.76 || ^4.0.0"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "workspace:^",

--- a/plugins/auth-backend-module-gcp-iap-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-gcp-iap-provider/src/resolvers.ts
@@ -19,7 +19,7 @@ import {
   SignInInfo,
 } from '@backstage/plugin-auth-node';
 import { GcpIapResult } from './types';
-import { z } from 'zod/v3';
+import { z } from 'zod';
 
 /**
  * Available sign-in resolvers for the Google auth provider.

--- a/plugins/auth-backend-module-github-provider/package.json
+++ b/plugins/auth-backend-module-github-provider/package.json
@@ -37,7 +37,7 @@
     "@backstage/backend-plugin-api": "workspace:^",
     "@backstage/plugin-auth-node": "workspace:^",
     "passport-github2": "^0.1.12",
-    "zod": "^3.25.76 || ^4.0.0"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@backstage/backend-defaults": "workspace:^",

--- a/plugins/auth-backend-module-github-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-github-provider/src/resolvers.ts
@@ -19,7 +19,7 @@ import {
   OAuthAuthenticatorResult,
   SignInInfo,
 } from '@backstage/plugin-auth-node';
-import { z } from 'zod/v3';
+import { z } from 'zod';
 
 import { GithubProfile } from './authenticator';
 

--- a/plugins/auth-backend-module-gitlab-provider/package.json
+++ b/plugins/auth-backend-module-gitlab-provider/package.json
@@ -39,7 +39,7 @@
     "express": "^4.22.0",
     "passport": "^0.7.0",
     "passport-gitlab2": "^5.0.0",
-    "zod": "^3.25.76 || ^4.0.0"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@backstage/backend-defaults": "workspace:^",

--- a/plugins/auth-backend-module-gitlab-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-gitlab-provider/src/resolvers.ts
@@ -19,7 +19,7 @@ import {
   OAuthAuthenticatorResult,
   SignInInfo,
 } from '@backstage/plugin-auth-node';
-import { z } from 'zod/v3';
+import { z } from 'zod';
 
 import { GitlabProfile } from './authenticator';
 

--- a/plugins/auth-backend-module-google-provider/package.json
+++ b/plugins/auth-backend-module-google-provider/package.json
@@ -42,7 +42,7 @@
     "@backstage/plugin-auth-node": "workspace:^",
     "google-auth-library": "^9.0.0",
     "passport-google-oauth20": "^2.0.0",
-    "zod": "^3.25.76 || ^4.0.0"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "workspace:^",

--- a/plugins/auth-backend-module-google-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-google-provider/src/resolvers.ts
@@ -20,7 +20,7 @@ import {
   PassportProfile,
   SignInInfo,
 } from '@backstage/plugin-auth-node';
-import { z } from 'zod/v3';
+import { z } from 'zod';
 
 /**
  * Available sign-in resolvers for the Google auth provider.

--- a/plugins/auth-backend-module-microsoft-provider/package.json
+++ b/plugins/auth-backend-module-microsoft-provider/package.json
@@ -39,7 +39,7 @@
     "express": "^4.22.0",
     "jose": "^5.0.0",
     "passport-microsoft": "^1.0.0",
-    "zod": "^3.25.76 || ^4.0.0"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@backstage/backend-defaults": "workspace:^",

--- a/plugins/auth-backend-module-microsoft-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-microsoft-provider/src/resolvers.ts
@@ -20,7 +20,7 @@ import {
   PassportProfile,
   SignInInfo,
 } from '@backstage/plugin-auth-node';
-import { z } from 'zod/v3';
+import { z } from 'zod';
 
 /**
  * Available sign-in resolvers for the Microsoft auth provider.

--- a/plugins/auth-backend-module-oauth2-provider/package.json
+++ b/plugins/auth-backend-module-oauth2-provider/package.json
@@ -38,7 +38,7 @@
     "@backstage/plugin-auth-node": "workspace:^",
     "passport": "^0.7.0",
     "passport-oauth2": "^1.6.1",
-    "zod": "^3.25.76 || ^4.0.0"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@backstage/backend-defaults": "workspace:^",

--- a/plugins/auth-backend-module-oauth2-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-oauth2-provider/src/resolvers.ts
@@ -20,7 +20,7 @@ import {
   PassportProfile,
   SignInInfo,
 } from '@backstage/plugin-auth-node';
-import { z } from 'zod/v3';
+import { z } from 'zod';
 
 /**
  * Available sign-in resolvers for the oauth2 auth provider.

--- a/plugins/auth-backend-module-oauth2-proxy-provider/package.json
+++ b/plugins/auth-backend-module-oauth2-proxy-provider/package.json
@@ -37,7 +37,7 @@
     "@backstage/errors": "workspace:^",
     "@backstage/plugin-auth-node": "workspace:^",
     "jose": "^5.0.0",
-    "zod": "^3.25.76 || ^4.0.0"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@backstage/backend-test-utils": "workspace:^",

--- a/plugins/auth-backend-module-oauth2-proxy-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-oauth2-proxy-provider/src/resolvers.ts
@@ -19,7 +19,7 @@ import {
   SignInInfo,
 } from '@backstage/plugin-auth-node';
 import { OAuth2ProxyResult } from './types';
-import { z } from 'zod/v3';
+import { z } from 'zod';
 
 /**
  * @public

--- a/plugins/auth-backend-module-oidc-provider/package.json
+++ b/plugins/auth-backend-module-oidc-provider/package.json
@@ -41,8 +41,7 @@
     "@backstage/types": "workspace:^",
     "express": "^4.22.0",
     "openid-client": "^5.5.0",
-    "passport": "^0.7.0",
-    "zod": "^3.25.76 || ^4.0.0"
+    "passport": "^0.7.0"
   },
   "devDependencies": {
     "@backstage/backend-defaults": "workspace:^",

--- a/plugins/auth-backend-module-okta-provider/package.json
+++ b/plugins/auth-backend-module-okta-provider/package.json
@@ -39,7 +39,7 @@
     "@davidzemon/passport-okta-oauth": "^0.0.7",
     "express": "^4.22.0",
     "passport": "^0.7.0",
-    "zod": "^3.25.76 || ^4.0.0"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@backstage/backend-defaults": "workspace:^",

--- a/plugins/auth-backend-module-okta-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-okta-provider/src/resolvers.ts
@@ -20,7 +20,7 @@ import {
   PassportProfile,
   SignInInfo,
 } from '@backstage/plugin-auth-node';
-import { z } from 'zod/v3';
+import { z } from 'zod';
 
 /**
  * Available sign-in resolvers for the Okta auth provider.

--- a/plugins/auth-backend-module-onelogin-provider/package.json
+++ b/plugins/auth-backend-module-onelogin-provider/package.json
@@ -39,7 +39,7 @@
     "express": "^4.22.0",
     "passport": "^0.7.0",
     "passport-onelogin-oauth": "^0.0.1",
-    "zod": "^3.25.76 || ^4.0.0"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@backstage/backend-defaults": "workspace:^",

--- a/plugins/auth-backend-module-onelogin-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-onelogin-provider/src/resolvers.ts
@@ -20,7 +20,7 @@ import {
   PassportProfile,
   SignInInfo,
 } from '@backstage/plugin-auth-node';
-import { z } from 'zod/v3';
+import { z } from 'zod';
 
 /**
  * Available sign-in resolvers for the OneLogin auth provider.

--- a/plugins/auth-backend-module-openshift-provider/package.json
+++ b/plugins/auth-backend-module-openshift-provider/package.json
@@ -39,7 +39,7 @@
     "@backstage/plugin-auth-node": "workspace:^",
     "@backstage/types": "workspace:^",
     "passport-oauth2": "^1.8.0",
-    "zod": "^3.25.76 || ^4.0.0"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@backstage/backend-defaults": "workspace:^",

--- a/plugins/auth-backend-module-openshift-provider/src/resolvers.ts
+++ b/plugins/auth-backend-module-openshift-provider/src/resolvers.ts
@@ -25,7 +25,7 @@ import {
   DEFAULT_NAMESPACE,
   stringifyEntityRef,
 } from '@backstage/catalog-model';
-import { z } from 'zod/v3';
+import { z } from 'zod';
 
 export namespace openshiftSignInResolvers {
   export const displayNameMatchingUserEntityName = createSignInResolverFactory({

--- a/plugins/auth-node/package.json
+++ b/plugins/auth-node/package.json
@@ -44,15 +44,14 @@
     "@backstage/config": "workspace:^",
     "@backstage/errors": "workspace:^",
     "@backstage/types": "workspace:^",
+    "@standard-schema/spec": "^1.1.0",
     "@types/express": "^4.17.6",
     "@types/passport": "^1.0.3",
     "express": "^4.22.0",
     "jose": "^5.0.0",
     "lodash": "^4.17.21",
     "passport": "^0.7.0",
-    "zod": "^3.25.76 || ^4.0.0",
-    "zod-to-json-schema": "^3.25.1",
-    "zod-validation-error": "^5.0.0"
+    "zod": "^4.0.0"
   },
   "devDependencies": {
     "@backstage/backend-defaults": "workspace:^",

--- a/plugins/auth-node/report.api.md
+++ b/plugins/auth-node/report.api.md
@@ -15,9 +15,9 @@ import { LoggerService } from '@backstage/backend-plugin-api';
 import { Profile } from 'passport';
 import { Request as Request_2 } from 'express';
 import { Response as Response_2 } from 'express';
+import type { StandardJSONSchemaV1 } from '@standard-schema/spec';
+import type { StandardSchemaV1 } from '@standard-schema/spec';
 import { Strategy } from 'passport';
-import type { z } from 'zod/v3';
-import type { ZodType } from 'zod/v3';
 
 // @public (undocumented)
 export interface AuthOwnershipResolutionExtensionPoint {
@@ -224,13 +224,14 @@ export function createProxyAuthRouteHandlers<TResult>(
   options: ProxyAuthRouteHandlersOptions<TResult>,
 ): AuthProviderRouteHandlers;
 
-// @public (undocumented)
+// @public
 export function createSignInResolverFactory<
   TAuthResult,
-  TSchema extends ZodType = ZodType<unknown>,
+  TSchema extends StandardSchemaV1 & StandardJSONSchemaV1 = StandardSchemaV1 &
+    StandardJSONSchemaV1,
 >(
   options: SignInResolverFactoryOptions<TAuthResult, TSchema>,
-): SignInResolverFactory<TAuthResult, z.input<TSchema>>;
+): SignInResolverFactory<TAuthResult, StandardSchemaV1.InferInput<TSchema>>;
 
 // @public (undocumented)
 export function decodeOAuthState(encodedState: string): OAuthState;
@@ -679,11 +680,13 @@ export interface SignInResolverFactory<TAuthResult = any, TOptions = any> {
 // @public (undocumented)
 export interface SignInResolverFactoryOptions<
   TAuthResult,
-  TSchema extends ZodType = ZodType<unknown>,
+  TSchema extends StandardSchemaV1 & StandardJSONSchemaV1 = StandardSchemaV1 &
+    StandardJSONSchemaV1,
 > {
   // (undocumented)
-  create(options: z.output<TSchema>): SignInResolver<TAuthResult>;
-  // (undocumented)
+  create(
+    options: StandardSchemaV1.InferOutput<TSchema>,
+  ): SignInResolver<TAuthResult>;
   optionsSchema?: TSchema;
 }
 

--- a/plugins/auth-node/src/sign-in/commonSignInResolvers.ts
+++ b/plugins/auth-node/src/sign-in/commonSignInResolvers.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { z } from 'zod/v3';
+import { z } from 'zod';
 import { createSignInResolverFactory } from './createSignInResolverFactory';
 import { NotAllowedError } from '@backstage/errors';
 

--- a/plugins/auth-node/src/sign-in/createSignInResolverFactory.test.ts
+++ b/plugins/auth-node/src/sign-in/createSignInResolverFactory.test.ts
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { InputError } from '@backstage/errors';
+import type {
+  StandardJSONSchemaV1,
+  StandardSchemaV1,
+} from '@standard-schema/spec';
+import { z } from 'zod';
+import { createSignInResolverFactory } from './createSignInResolverFactory';
+
+describe('createSignInResolverFactory', () => {
+  it('validates options synchronously and passes transformed output to create', () => {
+    const create = jest.fn(() => jest.fn());
+    const factory = createSignInResolverFactory({
+      optionsSchema: z
+        .object({
+          name: z.string(),
+          enabled: z.boolean().default(true),
+        })
+        .transform(options => ({
+          displayName: options.name.trim(),
+          active: options.enabled,
+        })),
+      create,
+    });
+
+    factory({ name: ' Example ' });
+
+    expect(create).toHaveBeenCalledWith({
+      displayName: 'Example',
+      active: true,
+    });
+    expect(factory.optionsJsonSchema).toMatchObject({
+      properties: {
+        name: { type: 'string' },
+        enabled: { default: true, type: 'boolean' },
+      },
+      required: ['name'],
+    });
+  });
+
+  it('uses the Standard JSON Schema input converter targeting draft-07', () => {
+    const input = jest.fn(() => ({
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['name'],
+    }));
+    const schema: StandardSchemaV1<{ name: string }, { name: string }> &
+      StandardJSONSchemaV1<{ name: string }, { name: string }> = {
+      '~standard': {
+        version: 1,
+        vendor: 'test',
+        validate(value) {
+          return { value: value as { name: string } };
+        },
+        jsonSchema: {
+          input,
+          output() {
+            return {};
+          },
+        },
+      },
+    };
+
+    const factory = createSignInResolverFactory({
+      optionsSchema: schema,
+      create: () => jest.fn(),
+    });
+
+    expect(input).toHaveBeenCalledWith({ target: 'draft-07' });
+    expect(factory.optionsJsonSchema).toEqual({
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['name'],
+    });
+  });
+
+  it('reports Standard Schema issues with normalized paths', () => {
+    const schema: StandardSchemaV1<object> & StandardJSONSchemaV1<object> = {
+      '~standard': {
+        version: 1,
+        vendor: 'test',
+        validate() {
+          return {
+            issues: [
+              {
+                message: 'Must be a valid email address',
+                path: [{ key: 'profile' }, 'emails', 0],
+              },
+              { message: 'Must be a boolean', path: [{ key: 'enabled' }] },
+            ],
+          };
+        },
+        jsonSchema: {
+          input() {
+            return { type: 'object' };
+          },
+          output() {
+            return { type: 'object' };
+          },
+        },
+      },
+    };
+    const factory = createSignInResolverFactory({
+      optionsSchema: schema,
+      create: () => jest.fn(),
+    });
+    const createResolver = () => factory({});
+
+    expect(createResolver).toThrow(InputError);
+    expect(createResolver).toThrow(
+      "Invalid sign-in resolver options, Must be a valid email address at 'profile.emails.0'; Must be a boolean at 'enabled'",
+    );
+  });
+
+  it('rejects asynchronous schemas immediately', () => {
+    const schema: StandardSchemaV1<string> & StandardJSONSchemaV1<string> = {
+      '~standard': {
+        version: 1,
+        vendor: 'test',
+        async validate(value) {
+          return { value: String(value) };
+        },
+        jsonSchema: {
+          input() {
+            return { type: 'string' };
+          },
+          output() {
+            return { type: 'string' };
+          },
+        },
+      },
+    };
+    const create = jest.fn(() => jest.fn());
+    const factory = createSignInResolverFactory({
+      optionsSchema: schema,
+      create,
+    });
+    const createResolver = () => factory('value');
+
+    expect(createResolver).toThrow(InputError);
+    expect(createResolver).toThrow(
+      'Sign-in resolver option schemas must validate synchronously; asynchronous schemas are not supported by sign-in resolver factories',
+    );
+    expect(create).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/auth-node/src/sign-in/createSignInResolverFactory.ts
+++ b/plugins/auth-node/src/sign-in/createSignInResolverFactory.ts
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-import type { z, ZodType } from 'zod/v3';
-import { SignInResolver } from '../types';
-import zodToJsonSchema from 'zod-to-json-schema';
-import { JsonObject } from '@backstage/types';
-import { fromError } from 'zod-validation-error/v3';
 import { InputError } from '@backstage/errors';
+import { JsonObject } from '@backstage/types';
+import type {
+  StandardJSONSchemaV1,
+  StandardSchemaV1,
+} from '@standard-schema/spec';
+import { SignInResolver } from '../types';
 
 /** @public */
 export interface SignInResolverFactory<TAuthResult = any, TOptions = any> {
@@ -34,22 +35,39 @@ export interface SignInResolverFactory<TAuthResult = any, TOptions = any> {
 /** @public */
 export interface SignInResolverFactoryOptions<
   TAuthResult,
-  TSchema extends ZodType = ZodType<unknown>,
+  TSchema extends StandardSchemaV1 & StandardJSONSchemaV1 = StandardSchemaV1 &
+    StandardJSONSchemaV1,
 > {
+  /**
+   * A schema that supports synchronous Standard Schema validation and Standard
+   * JSON Schema conversion.
+   */
   optionsSchema?: TSchema;
-  create(options: z.output<TSchema>): SignInResolver<TAuthResult>;
+  create(
+    options: StandardSchemaV1.InferOutput<TSchema>,
+  ): SignInResolver<TAuthResult>;
 }
 
-/** @public */
+/**
+ * Creates a configurable sign-in resolver factory.
+ *
+ * The options schema must validate synchronously and provide a Standard JSON
+ * Schema input converter. When using Zod, pass a schema from the full Zod v4
+ * package, for example `optionsSchema: z.object({ ... })` after importing
+ * `z` from `zod`.
+ *
+ * @public
+ */
 export function createSignInResolverFactory<
   TAuthResult,
-  TSchema extends ZodType = ZodType<unknown>,
+  TSchema extends StandardSchemaV1 & StandardJSONSchemaV1 = StandardSchemaV1 &
+    StandardJSONSchemaV1,
 >(
   options: SignInResolverFactoryOptions<TAuthResult, TSchema>,
-): SignInResolverFactory<TAuthResult, z.input<TSchema>> {
+): SignInResolverFactory<TAuthResult, StandardSchemaV1.InferInput<TSchema>> {
   const { optionsSchema } = options;
   if (!optionsSchema) {
-    return (resolverOptions?: z.input<TSchema>) => {
+    return (resolverOptions?: StandardSchemaV1.InferInput<TSchema>) => {
       if (resolverOptions) {
         throw new InputError('sign-in resolver does not accept options');
       }
@@ -57,21 +75,47 @@ export function createSignInResolverFactory<
     };
   }
   const factory = (
-    ...[resolverOptions]: undefined extends z.input<TSchema>
-      ? [options?: z.input<TSchema>]
-      : [options: z.input<TSchema>]
+    ...[resolverOptions]: undefined extends StandardSchemaV1.InferInput<TSchema>
+      ? [options?: StandardSchemaV1.InferInput<TSchema>]
+      : [options: StandardSchemaV1.InferInput<TSchema>]
   ) => {
-    let parsedOptions;
+    let result;
     try {
-      parsedOptions = optionsSchema.parse(resolverOptions);
+      result = optionsSchema['~standard'].validate(resolverOptions);
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
       throw new InputError(
-        `Invalid sign-in resolver options, ${fromError(error)}`,
+        `Invalid sign-in resolver options, validation failed: ${message}`,
       );
     }
-    return options.create(parsedOptions);
+
+    if (result instanceof Promise) {
+      result.catch(() => {});
+      throw new InputError(
+        'Sign-in resolver option schemas must validate synchronously; asynchronous schemas are not supported by sign-in resolver factories',
+      );
+    }
+
+    if (result.issues) {
+      const issues = result.issues.map(issue => {
+        const path = issue.path
+          ?.map(segment =>
+            typeof segment === 'object' ? segment.key : segment,
+          )
+          .map(String)
+          .join('.');
+        return path ? `${issue.message} at '${path}'` : issue.message;
+      });
+      throw new InputError(
+        `Invalid sign-in resolver options, ${issues.join('; ')}`,
+      );
+    }
+
+    return options.create(result.value);
   };
 
-  factory.optionsJsonSchema = zodToJsonSchema(optionsSchema) as JsonObject;
+  factory.optionsJsonSchema = optionsSchema['~standard'].jsonSchema.input({
+    target: 'draft-07',
+  }) as JsonObject;
   return factory;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3837,7 +3837,7 @@ __metadata:
     passport: "npm:^0.7.0"
     passport-atlassian-oauth2: "npm:^2.1.0"
     supertest: "npm:^7.0.0"
-    zod: "npm:^3.25.76 || ^4.0.0"
+    zod: "npm:^4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -3881,7 +3881,7 @@ __metadata:
     jose: "npm:^5.0.0"
     msw: "npm:^2.0.8"
     node-cache: "npm:^5.1.2"
-    zod: "npm:^3.25.76 || ^4.0.0"
+    zod: "npm:^4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -3900,7 +3900,7 @@ __metadata:
     express: "npm:^4.22.0"
     jose: "npm:^5.0.0"
     passport: "npm:^0.7.0"
-    zod: "npm:^3.25.76 || ^4.0.0"
+    zod: "npm:^4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -3919,7 +3919,7 @@ __metadata:
     passport: "npm:^0.7.0"
     passport-bitbucket-oauth2: "npm:^0.1.2"
     supertest: "npm:^7.0.0"
-    zod: "npm:^3.25.76 || ^4.0.0"
+    zod: "npm:^4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -3938,7 +3938,7 @@ __metadata:
     passport: "npm:^0.7.0"
     passport-oauth2: "npm:^1.6.1"
     supertest: "npm:^7.0.0"
-    zod: "npm:^3.25.76 || ^4.0.0"
+    zod: "npm:^4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -3959,7 +3959,7 @@ __metadata:
     jose: "npm:^5.0.0"
     msw: "npm:^2.0.0"
     node-mocks-http: "npm:^1.0.0"
-    zod: "npm:^3.25.76 || ^4.0.0"
+    zod: "npm:^4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -3975,7 +3975,7 @@ __metadata:
     "@backstage/types": "workspace:^"
     express: "npm:^4.22.0"
     google-auth-library: "npm:^9.0.0"
-    zod: "npm:^3.25.76 || ^4.0.0"
+    zod: "npm:^4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -3993,7 +3993,7 @@ __metadata:
     "@types/passport-github2": "npm:^1.2.4"
     passport-github2: "npm:^0.1.12"
     supertest: "npm:^7.0.0"
-    zod: "npm:^3.25.76 || ^4.0.0"
+    zod: "npm:^4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4012,7 +4012,7 @@ __metadata:
     passport: "npm:^0.7.0"
     passport-gitlab2: "npm:^5.0.0"
     supertest: "npm:^7.0.0"
-    zod: "npm:^3.25.76 || ^4.0.0"
+    zod: "npm:^4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4030,7 +4030,7 @@ __metadata:
     google-auth-library: "npm:^9.0.0"
     passport-google-oauth20: "npm:^2.0.0"
     supertest: "npm:^7.0.0"
-    zod: "npm:^3.25.76 || ^4.0.0"
+    zod: "npm:^4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4068,7 +4068,7 @@ __metadata:
     msw: "npm:^2.0.0"
     passport-microsoft: "npm:^1.0.0"
     supertest: "npm:^7.0.0"
-    zod: "npm:^3.25.76 || ^4.0.0"
+    zod: "npm:^4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4086,7 +4086,7 @@ __metadata:
     passport: "npm:^0.7.0"
     passport-oauth2: "npm:^1.6.1"
     supertest: "npm:^7.0.0"
-    zod: "npm:^3.25.76 || ^4.0.0"
+    zod: "npm:^4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4100,7 +4100,7 @@ __metadata:
     "@backstage/errors": "workspace:^"
     "@backstage/plugin-auth-node": "workspace:^"
     jose: "npm:^5.0.0"
-    zod: "npm:^3.25.76 || ^4.0.0"
+    zod: "npm:^4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4125,7 +4125,6 @@ __metadata:
     openid-client: "npm:^5.5.0"
     passport: "npm:^0.7.0"
     supertest: "npm:^7.0.0"
-    zod: "npm:^3.25.76 || ^4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4144,7 +4143,7 @@ __metadata:
     express: "npm:^4.22.0"
     passport: "npm:^0.7.0"
     supertest: "npm:^7.0.0"
-    zod: "npm:^3.25.76 || ^4.0.0"
+    zod: "npm:^4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4163,7 +4162,7 @@ __metadata:
     passport: "npm:^0.7.0"
     passport-onelogin-oauth: "npm:^0.0.1"
     supertest: "npm:^7.0.0"
-    zod: "npm:^3.25.76 || ^4.0.0"
+    zod: "npm:^4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4184,7 +4183,7 @@ __metadata:
     msw: "npm:^2.7.3"
     passport-oauth2: "npm:^1.8.0"
     supertest: "npm:^7.1.0"
-    zod: "npm:^3.25.76 || ^4.0.0"
+    zod: "npm:^4.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4288,6 +4287,7 @@ __metadata:
     "@backstage/config": "workspace:^"
     "@backstage/errors": "workspace:^"
     "@backstage/types": "workspace:^"
+    "@standard-schema/spec": "npm:^1.1.0"
     "@types/express": "npm:^4.17.6"
     "@types/passport": "npm:^1.0.3"
     cookie-parser: "npm:^1.4.6"
@@ -4298,9 +4298,7 @@ __metadata:
     msw: "npm:^2.0.0"
     passport: "npm:^0.7.0"
     supertest: "npm:^7.0.0"
-    zod: "npm:^3.25.76 || ^4.0.0"
-    zod-to-json-schema: "npm:^3.25.1"
-    zod-validation-error: "npm:^5.0.0"
+    zod: "npm:^4.0.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Migrates the public sign-in resolver factory contract from Zod v3 to Standard Schema and Standard JSON Schema. Resolver options remain synchronously validated, transformed output is passed to resolver creation, and draft-07 metadata continues to describe caller input.

Built-in common and provider resolver schemas now use the full Zod v4 package. The auth provider authoring documentation, package dependencies, API report, and adopter-facing changesets are updated alongside focused compatibility coverage.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

<!-- mana-workspace:doEorvbh6d4 -->