### PR TITLE
fix(catalog-backend): ignore location.moved events for untracked locations

### DIFF
--- a/.changeset/fix-untracked-location-moved.md
+++ b/.changeset/fix-untracked-location-moved.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Fixed an issue where SCM `location.moved` events would generate new locations in the database for files that were not actively tracked.

--- a/plugins/catalog-backend/src/providers/DefaultLocationStore.test.ts
+++ b/plugins/catalog-backend/src/providers/DefaultLocationStore.test.ts
@@ -627,6 +627,58 @@ describe.each(databases.eachSupportedId())(
         });
       });
 
+      it('ignores location.moved for untracked locations', async () => {
+        const { store, knex, connection } = await createLocationStore();
+        expect(subscriber).not.toBeUndefined();
+
+        // Prepare
+        const untrackedTarget =
+          'https://github.com/backstage/demo/blob/master/untracked/catalog-info.yaml';
+        const trackedTarget =
+          'https://github.com/backstage/other/blob/master/folder/catalog-info.yaml';
+
+        await store.createLocation({
+          type: 'url',
+          target: trackedTarget,
+        });
+
+        // Act
+        await subscriber!.onEvents([
+          {
+            type: 'location.moved',
+            fromUrl: untrackedTarget,
+            toUrl:
+              'https://github.com/backstage/demo/blob/master/new-location/catalog-info.yaml',
+          },
+        ]);
+
+        // Verify
+        await waitFor(async () => {
+          await expect(
+            knex<DbLocationsRow>('locations')
+              .where('type', 'url')
+              .orderBy('target', 'asc'),
+          ).resolves.toEqual([
+            {
+              id: expect.any(String),
+              type: 'url',
+              target: trackedTarget,
+              location_entity_ref: expect.any(String),
+            },
+          ]);
+        });
+
+        expect(connection.applyMutation).not.toHaveBeenCalledWith(
+          expect.objectContaining({
+            added: expect.arrayContaining([
+              expect.objectContaining({
+                locationKey: expect.stringContaining('new-location'),
+              }),
+            ]),
+          }),
+        );
+      });
+
       it('handles repository.deleted', async () => {
         const { store, knex, connection } = await createLocationStore();
         expect(subscriber).not.toBeUndefined();

--- a/plugins/catalog-backend/src/providers/DefaultLocationStore.ts
+++ b/plugins/catalog-backend/src/providers/DefaultLocationStore.ts
@@ -405,6 +405,24 @@ export class DefaultLocationStore implements LocationStore, EntityProvider {
     const exactLocationsToCreate = new Set<string>();
     const locationPrefixesToMove = new Map<string, string>();
 
+    const movedFromUrls = new Set<string>();
+    for (const event of events) {
+      if (event.type === 'location.moved' && this.scmEventHandlingConfig.move) {
+        movedFromUrls.add(event.fromUrl);
+      }
+    }
+
+    const trackedFromUrls = new Set<string>();
+    if (movedFromUrls.size > 0) {
+      const existing = await this.db<DbLocationsRow>('locations')
+        .where('type', '=', 'url')
+        .whereIn('target', Array.from(movedFromUrls))
+        .select('target');
+      for (const row of existing) {
+        trackedFromUrls.add(row.target);
+      }
+    }
+
     for (const event of events) {
       if (
         event.type === 'location.deleted' &&
@@ -415,10 +433,12 @@ export class DefaultLocationStore implements LocationStore, EntityProvider {
         event.type === 'location.moved' &&
         this.scmEventHandlingConfig.move
       ) {
-        // Since Location entities are named after their target URL, these
-        // unfortunately have to be translated into deletion and creation
-        exactLocationsToDelete.add(event.fromUrl);
-        exactLocationsToCreate.add(event.toUrl);
+        if (trackedFromUrls.has(event.fromUrl)) {
+          // Since Location entities are named after their target URL, these
+          // unfortunately have to be translated into deletion and creation
+          exactLocationsToDelete.add(event.fromUrl);
+          exactLocationsToCreate.add(event.toUrl);
+        }
       } else if (
         event.type === 'repository.deleted' &&
         this.scmEventHandlingConfig.unregister


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Description
Fixes #34962.

When SCM `location.moved` events occur for files/locations that are not actively tracked in the catalog location store, Backstage previously created new `Location` entities pointing to `toUrl`. This caused non-entity YAML files (e.g. Helm charts, CI configs) to flood the DevTools **Unprocessed Entities** tab with `apiVersion` missing errors.

This change updates `DefaultLocationStore` so that `location.moved` events only trigger location mutations if `fromUrl` is already an actively tracked URL location in the database store.

### Changes Made
- **`DefaultLocationStore.ts`**: Batch-queries existing location records for `fromUrl` candidates and ignores `location.moved` events for untracked files.
- **`DefaultLocationStore.test.ts`**: Added unit test verifying that `location.moved` events with untracked `fromUrl` targets do not mutate or create location records.
- Added a patch changeset for `@backstage/plugin-catalog-backend`.

### Checklist
- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.