### PR TITLE
Remove the main/module/types specifications from publishConfig  at plugin-app-module-user-settings

### DIFF
--- a/.changeset/shaggy-hornets-ask.md
+++ b/.changeset/shaggy-hornets-ask.md
@@ -1,5 +1,6 @@
 ---
 '@backstage/plugin-app-module-user-settings': patch
+'@backstage/cli-module-new': patch
 ---
 
-Fix published entry points so it can be imported reliably in Jest/Node resolution.
+Fixes published entry point configurations so it can be imported reliably in Jest/Node resolution.

--- a/.changeset/shaggy-hornets-ask.md
+++ b/.changeset/shaggy-hornets-ask.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-app-module-user-settings': patch
+---
+
+Fix published entry points so it can be imported reliably in Jest/Node resolution.

--- a/packages/cli-module-new/templates/frontend-plugin-module/package.json.hbs
+++ b/packages/cli-module-new/templates/frontend-plugin-module/package.json.hbs
@@ -4,10 +4,7 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {
-    "access": "public",
-    "main": "dist/index.cjs.js",
-    "module": "dist/index.esm.js",
-    "types": "dist/index.d.ts"
+    "access": "public"
   },
   "backstage": {
     "role": "frontend-plugin-module",

--- a/packages/cli-module-new/templates/frontend-plugin/package.json.hbs
+++ b/packages/cli-module-new/templates/frontend-plugin/package.json.hbs
@@ -3,9 +3,7 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {
-    "access": "public",
-    "main": "dist/index.esm.js",
-    "types": "dist/index.d.ts"
+    "access": "public"
   },
   "backstage": {
     "role": "frontend-plugin",

--- a/packages/cli-module-new/templates/scaffolder-field-extension-module/package.json.hbs
+++ b/packages/cli-module-new/templates/scaffolder-field-extension-module/package.json.hbs
@@ -4,10 +4,7 @@
   "main": "src/index.ts",
   "types": "src/index.ts",
   "publishConfig": {
-    "access": "public",
-    "main": "dist/index.cjs.js",
-    "module": "dist/index.esm.js",
-    "types": "dist/index.d.ts"
+    "access": "public"
   },
   "backstage": {
     "role": "frontend-plugin-module",

--- a/plugins/app-module-user-settings/package.json
+++ b/plugins/app-module-user-settings/package.json
@@ -8,10 +8,7 @@
     "pluginPackage": "@backstage/plugin-app"
   },
   "publishConfig": {
-    "access": "public",
-    "main": "dist/index.cjs.js",
-    "module": "dist/index.esm.js",
-    "types": "dist/index.d.ts"
+    "access": "public"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Hey, I just made a Pull Request!

"dist/index.cjs.js" was specified at publishConfig.main, but this plugin does not have cjs.
And I think we don't need to specify these value.

This changes is for fixes #35035  

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
