### PR TITLE
feat(techdocs): preserve source Markdown alongside generated HTML

### DIFF
--- a/.changeset/techdocs-source-storage-backend.md
+++ b/.changeset/techdocs-source-storage-backend.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-backend': minor
+---
+
+Added support for preserving source Markdown files alongside generated HTML in TechDocs storage. You can enable this globally via `techdocs.generator.preserveSources.enabled` in `app-config.yaml`, or per entity with the `backstage.io/techdocs-source-storage` annotation. Source files are stored under `_sources/` and served through the existing static docs API.

--- a/.changeset/techdocs-source-storage-cli.md
+++ b/.changeset/techdocs-source-storage-cli.md
@@ -1,0 +1,5 @@
+---
+'@techdocs/cli': minor
+---
+
+Added `--include-sources` and `--source-excludes` flags to `techdocs-cli generate`. When `--include-sources` is set, the original Markdown source files are preserved in a `_sources/` directory alongside the generated HTML output. Use `--source-excludes` to filter out files by name or extension pattern, for example `--source-excludes "*.png" "*.jpg"`.

--- a/.changeset/techdocs-source-storage-cli.md
+++ b/.changeset/techdocs-source-storage-cli.md
@@ -2,4 +2,4 @@
 '@techdocs/cli': minor
 ---
 
-Added `--include-sources` and `--source-excludes` flags to `techdocs-cli generate`. When `--include-sources` is set, the original Markdown source files are preserved in a `_sources/` directory alongside the generated HTML output. Use `--source-excludes` to filter out files by name or extension pattern, for example `--source-excludes "*.png" "*.jpg"`.
+Added `--include-sources`, `--source-excludes`, and `--source-additional-files` flags to `techdocs-cli generate`. When `--include-sources` is set, the original Markdown source files are preserved in a `_sources/` directory alongside the generated HTML output. Use `--source-excludes` to filter out files by name or extension pattern, and `--source-additional-files` to include extra root files beyond the default `README.md`.

--- a/.changeset/techdocs-source-storage-node.md
+++ b/.changeset/techdocs-source-storage-node.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-node': minor
+---
+
+Added source storage support to the TechDocs generator. When `preserveSources` is set in `GeneratorRunOptions`, the generator copies `mkdocs.yml` and the documentation source directory into a `_sources/` folder in the output alongside the generated HTML. Files matching built-in exclude patterns (`.git/`, `node_modules/`, etc.) are filtered out, and additional patterns can be provided via `sourceExcludes`.

--- a/docs/features/software-catalog/well-known-annotations.md
+++ b/docs/features/software-catalog/well-known-annotations.md
@@ -128,6 +128,25 @@ The value of this annotation informs of the path to this component's TechDocs wi
 In conjunction with [backstage.io/techdocs-entity](#backstageiotechdocs-entity) this allows for deep linking into the TechDocs of
 another entity, not just linking to the root of another entity's TechDocs.
 
+### backstage.io/techdocs-source-storage
+
+```yaml
+# Example:
+metadata:
+  annotations:
+    backstage.io/techdocs-ref: dir:.
+    backstage.io/techdocs-source-storage: enabled
+```
+
+Controls whether the original Markdown source files are preserved alongside the
+generated HTML in TechDocs storage. Accepts `enabled` or `disabled`. When this
+annotation is absent, the entity falls back to the global
+`techdocs.generator.preserveSources.enabled` configuration setting (which
+defaults to `false`).
+
+See the [TechDocs Source Storage configuration](../techdocs/configuration.md#source-storage)
+for more details.
+
 ### backstage.io/view-url, backstage.io/edit-url
 
 ```yaml

--- a/docs/features/techdocs/cli.md
+++ b/docs/features/techdocs/cli.md
@@ -152,9 +152,24 @@ Options:
   --disableExternalFonts          Disable external font downloads for all TechDocs sites. Useful for air-gapped environments
                                   where Google fonts cannot be accessed. (default: false)
   --runAsDefaultUser              Bypass setting the container user as the same user and group id as host for Linux and MacOS (default: false)
+  --include-sources               Include source Markdown files in the generated output under _sources/. (default: false)
+  --source-excludes <PATTERNS>    Patterns to exclude from _sources/. Supports exact names and extension patterns
+                                  (for example, "*.png" "*.jpg"). Only applies when --include-sources is set. (default: [])
+  --source-additional-files <FILES>  Additional files from the source root to include in _sources/ (for example,
+                                  "README.md" "CONTRIBUTING.md"). Only applies when --include-sources is set. (default: [])
   -v, --verbose                   Enable verbose output. (default: false)
   -h, --help                      display help for command
 ```
+
+When `--include-sources` is set, the generator copies the documentation source
+directory into a `_sources/` folder in the output. This
+preserves the original Markdown alongside the generated HTML, which is useful
+for MCP tools and other AI integrations that consume documentation content. Use
+`--source-excludes` to filter out files you do not want stored, for example
+large images. By default, `README.md` is included automatically if it exists
+in the source root. Use `--source-additional-files` to specify a different set
+of root files to include, or add `README.md` to `--source-excludes` to suppress
+the default.
 
 ### Publish generated TechDocs sites
 

--- a/docs/features/techdocs/concepts.md
+++ b/docs/features/techdocs/concepts.md
@@ -25,7 +25,11 @@ There are two kinds of preparers available -
 
 Generating is the second step after preparing the markdown source files. This
 step either runs the TechDocs container (defined below) or runs `mkdocs` CLI to
-generate static HTML files and its assets.
+generate static HTML files and its assets. Optionally, the generator can also
+preserve the original source Markdown files alongside the generated HTML by
+copying them into a `_sources/` directory in the output. This is controlled by
+the `techdocs.generator.preserveSources` configuration option or the `--include-sources` CLI flag.
+See [Source Storage](./configuration.md#source-storage) for details.
 
 ### TechDocs Publisher
 

--- a/docs/features/techdocs/configuration.md
+++ b/docs/features/techdocs/configuration.md
@@ -141,6 +141,125 @@ techdocs:
       defaultPlugins: ['techdocs-core']
 ```
 
+### Source storage
+
+`techdocs.generator.preserveSources`
+
+(Optional) Preserves source Markdown files alongside the generated HTML
+output. When enabled, the documentation source directory is copied into a
+`_sources/` directory in TechDocs storage and served through the existing
+static docs API.
+
+This is useful for Model Context Protocol (MCP) tools and other AI
+integrations that consume documentation. Markdown uses fewer tokens and
+produces better results than converted HTML when used as input to large
+language models.
+
+**Configuration:**
+
+```yaml
+techdocs:
+  generator:
+    preserveSources:
+      enabled: true # default: false
+      excludes: # optional, patterns to exclude from _sources/
+        - '*.png'
+        - '*.jpg'
+        - '*.gif'
+        - '*.svg'
+      additionalFiles: # optional, files from the repo root to include
+        - README.md
+        - CONTRIBUTING.md
+```
+
+A set of built-in excludes is always applied regardless of configuration:
+`.git/`, `node_modules/`, `__pycache__/`, `.venv/`, and `*.pyc`.
+Adopter-provided `excludes` extend the built-in list.
+
+Use `additionalFiles` to include files from the input directory root
+alongside the docs directory. By default, `README.md` is included
+automatically if it exists in the input directory root. To include
+other files, list them explicitly:
+
+```yaml
+techdocs:
+  generator:
+    preserveSources:
+      enabled: true
+      additionalFiles:
+        - README.md
+        - CONTRIBUTING.md
+        - CHANGELOG.md
+```
+
+Additional files are copied into the `_sources/` root using their base
+filename only. If two entries share the same filename (e.g. `README.md`
+and `docs/README.md`), the last one wins.
+
+Setting `additionalFiles` replaces the default list. To disable the
+default `README.md` inclusion without adding other files, add
+`README.md` to the `excludes` list instead:
+
+```yaml
+techdocs:
+  generator:
+    preserveSources:
+      enabled: true
+      excludes:
+        - README.md
+```
+
+Individual entities can override the global default using the
+`backstage.io/techdocs-source-storage` annotation with a value of `enabled`
+or `disabled`. See
+[Well-known Annotations](../software-catalog/well-known-annotations.md#backstageiotechdocs-source-storage)
+for details.
+
+When using the TechDocs CLI, use the `--include-sources` and
+`--source-excludes` flags instead. See the
+[CLI documentation](./cli.md) for details.
+
+**Structure for tool authors**
+
+When source storage is enabled, the `_sources/` directory in TechDocs
+storage has the following structure:
+
+```
+_sources/
+  manifest.json
+  docs/
+    index.md
+    getting-started.md
+    guides/
+      setup.md
+  README.md
+```
+
+`manifest.json` contains a machine-readable index of all stored source
+files:
+
+```json
+{
+  "generatedAt": 1722700000000,
+  "files": [
+    "README.md",
+    "docs/getting-started.md",
+    "docs/guides/setup.md",
+    "docs/index.md"
+  ]
+}
+```
+
+- `generatedAt` — Unix timestamp (milliseconds) of when the sources
+  were stored.
+- `files` — sorted list of all source file paths relative to
+  `_sources/`, using forward slashes.
+
+MCP servers and other tools can fetch `manifest.json` through the
+existing static docs API to discover available sources without
+directory listing. Site metadata such as `site_name` and
+`site_description` is available separately in `techdocs_metadata.json`.
+
 ## Builder Configuration
 
 `techdocs.builder`

--- a/docs/features/techdocs/configuration.md
+++ b/docs/features/techdocs/configuration.md
@@ -176,6 +176,33 @@ A set of built-in excludes is always applied regardless of configuration:
 `.git/`, `node_modules/`, `__pycache__/`, `.venv/`, and `*.pyc`.
 Adopter-provided `excludes` extend the built-in list.
 
+:::caution Why `mkdocs.yml` is not included by default
+
+Source storage is designed to be build-tool agnostic — it captures
+documentation content, not build configuration. The `mkdocs.yml` file
+can also contain plugin configurations, environment variable
+references, or custom hook paths that may expose internal details
+about your infrastructure.
+
+If your use case requires storing `mkdocs.yml` alongside the source
+files, you can add it to `additionalFiles`:
+
+```yaml
+techdocs:
+  generator:
+    preserveSources:
+      enabled: true
+      additionalFiles:
+        - README.md
+        - mkdocs.yml
+```
+
+This applies to any file added through `additionalFiles` — by
+including files explicitly, you accept responsibility for reviewing
+their contents and ensuring they do not expose sensitive information.
+
+:::
+
 Use `additionalFiles` to include files from the input directory root
 alongside the docs directory. By default, `README.md` is included
 automatically if it exists in the input directory root. To include

--- a/packages/techdocs-cli/cli-report.md
+++ b/packages/techdocs-cli/cli-report.md
@@ -30,6 +30,7 @@ Options:
   --disableExternalFonts
   --docker-image <DOCKER_IMAGE>
   --etag <ETAG>
+  --include-sources
   --legacyCopyReadmeMdToIndexMd
   --no-docker
   --no-pull
@@ -37,7 +38,9 @@ Options:
   --output-dir <PATH>
   --runAsDefaultUser
   --site-name
+  --source-additional-files <FILES...>
   --source-dir <PATH>
+  --source-excludes <PATTERNS...>
   --techdocs-ref <HOST_TYPE:URL>
   -h, --help
   -v, --verbose

--- a/packages/techdocs-cli/src/commands/generate/generate.test.ts
+++ b/packages/techdocs-cli/src/commands/generate/generate.test.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { resolve } from 'node:path';
+import { TechdocsGenerator } from '@backstage/plugin-techdocs-node';
+
+const mockRun = jest.fn();
+
+jest.mock('@backstage/plugin-techdocs-node');
+jest.mock('fs-extra');
+jest.mock('../../lib/utility');
+
+import generate from './generate';
+
+describe('generate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    const { getMkdocsYml } = require('@backstage/plugin-techdocs-node');
+    getMkdocsYml.mockResolvedValue({
+      path: '/tmp/mkdocs.yml',
+      configIsTemporary: false,
+    });
+
+    (TechdocsGenerator.fromConfig as jest.Mock).mockReturnValue({
+      run: mockRun,
+    });
+
+    const { createLogger, getLogStream } = require('../../lib/utility');
+    createLogger.mockReturnValue({
+      info: jest.fn(),
+      verbose: jest.fn(),
+      error: jest.fn(),
+    });
+    getLogStream.mockReturnValue({});
+
+    const fsExtra = require('fs-extra');
+    fsExtra.ensureDir.mockResolvedValue(undefined);
+  });
+
+  it('should pass preserveSources when --include-sources is set', async () => {
+    await generate({
+      sourceDir: '.',
+      outputDir: './site',
+      docker: false,
+      verbose: false,
+      includeSources: true,
+      sourceExcludes: [],
+    });
+
+    expect(mockRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        inputDir: resolve('.'),
+        outputDir: resolve('./site'),
+        preserveSources: true,
+        sourceExcludes: [],
+      }),
+    );
+  });
+
+  it('should not set preserveSources when --include-sources is not set', async () => {
+    await generate({
+      sourceDir: '.',
+      outputDir: './site',
+      docker: false,
+      verbose: false,
+      includeSources: false,
+      sourceExcludes: [],
+    });
+
+    expect(mockRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        preserveSources: false,
+        sourceExcludes: [],
+      }),
+    );
+  });
+
+  it('should pass sourceExcludes from --source-excludes flag', async () => {
+    await generate({
+      sourceDir: '.',
+      outputDir: './site',
+      docker: false,
+      verbose: false,
+      includeSources: true,
+      sourceExcludes: ['*.png', '*.jpg'],
+    });
+
+    expect(mockRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        preserveSources: true,
+        sourceExcludes: ['*.png', '*.jpg'],
+      }),
+    );
+  });
+
+  it('should pass sourceAdditionalFiles from --source-additional-files flag', async () => {
+    await generate({
+      sourceDir: '.',
+      outputDir: './site',
+      docker: false,
+      verbose: false,
+      includeSources: true,
+      sourceExcludes: [],
+      sourceAdditionalFiles: ['README.md', 'CONTRIBUTING.md'],
+    });
+
+    expect(mockRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        preserveSources: true,
+        sourceAdditionalFiles: ['README.md', 'CONTRIBUTING.md'],
+      }),
+    );
+  });
+});

--- a/packages/techdocs-cli/src/commands/generate/generate.test.ts
+++ b/packages/techdocs-cli/src/commands/generate/generate.test.ts
@@ -66,7 +66,7 @@ describe('generate', () => {
         inputDir: resolve('.'),
         outputDir: resolve('./site'),
         preserveSources: true,
-        sourceExcludes: [],
+        sourceExcludes: undefined,
       }),
     );
   });
@@ -84,7 +84,7 @@ describe('generate', () => {
     expect(mockRun).toHaveBeenCalledWith(
       expect.objectContaining({
         preserveSources: false,
-        sourceExcludes: [],
+        sourceExcludes: undefined,
       }),
     );
   });

--- a/packages/techdocs-cli/src/commands/generate/generate.ts
+++ b/packages/techdocs-cli/src/commands/generate/generate.ts
@@ -104,8 +104,12 @@ export default async function generate(opts: OptionValues) {
     siteOptions: { name: opts.siteName },
     runAsDefaultUser: opts.runAsDefaultUser,
     preserveSources: opts.includeSources,
-    sourceExcludes: opts.sourceExcludes,
-    sourceAdditionalFiles: opts.sourceAdditionalFiles,
+    sourceExcludes: opts.sourceExcludes?.length
+      ? opts.sourceExcludes
+      : undefined,
+    sourceAdditionalFiles: opts.sourceAdditionalFiles?.length
+      ? opts.sourceAdditionalFiles
+      : undefined,
   });
 
   if (configIsTemporary) {

--- a/packages/techdocs-cli/src/commands/generate/generate.ts
+++ b/packages/techdocs-cli/src/commands/generate/generate.ts
@@ -103,6 +103,9 @@ export default async function generate(opts: OptionValues) {
     logStream: getLogStream(logger),
     siteOptions: { name: opts.siteName },
     runAsDefaultUser: opts.runAsDefaultUser,
+    preserveSources: opts.includeSources,
+    sourceExcludes: opts.sourceExcludes,
+    sourceAdditionalFiles: opts.sourceAdditionalFiles,
   });
 
   if (configIsTemporary) {

--- a/packages/techdocs-cli/src/commands/index.ts
+++ b/packages/techdocs-cli/src/commands/index.ts
@@ -85,6 +85,21 @@ export function registerCommands(program: Command) {
       'Bypass setting the container user as the same user and group id as host for Linux and MacOS',
       false,
     )
+    .option(
+      '--include-sources',
+      'Include source Markdown files in the generated output under _sources/.',
+      false,
+    )
+    .option(
+      '--source-excludes <PATTERNS...>',
+      'Patterns to exclude from _sources/. Supports exact names (e.g. "build") and extension patterns (e.g. "*.png" "*.jpg"). Only applies when --include-sources is set.',
+      [],
+    )
+    .option(
+      '--source-additional-files <FILES...>',
+      'Additional files from the source root to include in _sources/ (e.g. "README.md" "CONTRIBUTING.md"). Only applies when --include-sources is set.',
+      [],
+    )
     .alias('build')
     .action(lazy(() => import('./generate/generate'), 'default'));
 

--- a/plugins/techdocs-backend/config.d.ts
+++ b/plugins/techdocs-backend/config.d.ts
@@ -48,6 +48,37 @@ export interface Config {
       pullImage?: boolean;
 
       /**
+       * Preserve source Markdown files alongside the generated HTML output.
+       * When enabled, source files are stored under a `_sources/` directory
+       * in TechDocs storage and served through the existing static docs API.
+       */
+      preserveSources?: {
+        /**
+         * Enable source storage globally for all entities.
+         * Individual entities can override this with the
+         * `backstage.io/techdocs-source-storage` annotation.
+         * Defaults to false.
+         */
+        enabled?: boolean;
+
+        /**
+         * Patterns for files to exclude from source storage.
+         * Supports exact names (e.g. "build") and extension patterns (e.g. "*.png").
+         * These are additive with built-in excludes (.git, node_modules, etc.).
+         */
+        excludes?: string[];
+
+        /**
+         * Additional files from the input directory root to include in
+         * source storage alongside the docs directory. Defaults to
+         * including README.md if not specified. Setting this replaces
+         * the default list. To suppress the default README.md, add it
+         * to the excludes list instead.
+         */
+        additionalFiles?: string[];
+      };
+
+      /**
        * Override behavior specific to mkdocs.
        */
       mkdocs?: {

--- a/plugins/techdocs-backend/src/DocsBuilder/builder.test.ts
+++ b/plugins/techdocs-backend/src/DocsBuilder/builder.test.ts
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity } from '@backstage/catalog-model';
+import { ConfigReader } from '@backstage/config';
+import { DocsBuilder } from './builder';
+
+const mockGeneratorRun = jest.fn().mockResolvedValue(undefined);
+const mockPublisherPublish = jest.fn().mockResolvedValue({ objects: [] });
+const mockPublisherHasDocsBeenGenerated = jest.fn().mockResolvedValue(false);
+const mockPreparerPrepare = jest.fn().mockResolvedValue({
+  preparedDir: '/tmp/prepared',
+  etag: 'test-etag',
+});
+const mockPreparerShouldClean = jest.fn().mockReturnValue(false);
+
+jest.mock('@backstage/plugin-techdocs-node', () => ({
+  ...jest.requireActual('@backstage/plugin-techdocs-node'),
+  getLocationForEntity: jest.fn().mockReturnValue({
+    type: 'url',
+    target: 'https://github.com/org/repo',
+  }),
+}));
+
+jest.mock('fs-extra', () => ({
+  mkdtemp: jest.fn().mockResolvedValue('/tmp/techdocs-tmp-123'),
+  realpathSync: jest.fn().mockImplementation((p: string) => p),
+  remove: jest.fn().mockResolvedValue(undefined),
+}));
+
+function createMockLogger() {
+  return {
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  } as any;
+}
+
+function createEntity(annotations?: Record<string, string>): Entity {
+  return {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Component',
+    metadata: {
+      uid: 'test-uid',
+      name: 'test-component',
+      annotations: {
+        'backstage.io/techdocs-ref': 'dir:.',
+        ...annotations,
+      },
+    },
+    spec: { type: 'service' },
+  };
+}
+
+function createDocsBuilder(
+  entity: Entity,
+  configData: Record<string, any> = {},
+) {
+  const logger = createMockLogger();
+  const builder = new DocsBuilder({
+    preparers: {
+      get: jest.fn().mockReturnValue({
+        prepare: mockPreparerPrepare,
+        shouldCleanPreparedDirectory: mockPreparerShouldClean,
+      }),
+    } as any,
+    generators: {
+      get: jest.fn().mockReturnValue({ run: mockGeneratorRun }),
+    } as any,
+    publisher: {
+      publish: mockPublisherPublish,
+      hasDocsBeenGenerated: mockPublisherHasDocsBeenGenerated,
+      getReadiness: jest.fn().mockResolvedValue({ isAvailable: true }),
+      fetchTechDocsMetadata: jest.fn().mockResolvedValue({}),
+    } as any,
+    entity,
+    logger,
+    config: new ConfigReader(configData),
+    scmIntegrations: {} as any,
+  });
+  return { builder, logger };
+}
+
+describe('DocsBuilder', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPreparerPrepare.mockResolvedValue({
+      preparedDir: '/tmp/prepared',
+      etag: 'test-etag',
+    });
+    mockPublisherHasDocsBeenGenerated.mockResolvedValue(false);
+    mockPublisherPublish.mockResolvedValue({ objects: [] });
+    mockGeneratorRun.mockResolvedValue(undefined);
+  });
+
+  describe('preserveSources resolution', () => {
+    it('should default preserveSources to false when no config or annotation', async () => {
+      const { builder } = createDocsBuilder(createEntity());
+      await builder.build();
+
+      expect(mockGeneratorRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          preserveSources: false,
+        }),
+      );
+    });
+
+    it('should set preserveSources to true when global config is enabled', async () => {
+      const { builder } = createDocsBuilder(createEntity(), {
+        techdocs: {
+          generator: {
+            preserveSources: { enabled: true },
+          },
+        },
+      });
+      await builder.build();
+
+      expect(mockGeneratorRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          preserveSources: true,
+        }),
+      );
+    });
+
+    it('should override global config when annotation is set to enabled', async () => {
+      const entity = createEntity({
+        'backstage.io/techdocs-source-storage': 'enabled',
+      });
+      const { builder } = createDocsBuilder(entity);
+      await builder.build();
+
+      expect(mockGeneratorRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          preserveSources: true,
+        }),
+      );
+    });
+
+    it('should override global config when annotation is set to disabled', async () => {
+      const entity = createEntity({
+        'backstage.io/techdocs-source-storage': 'disabled',
+      });
+      const { builder } = createDocsBuilder(entity, {
+        techdocs: {
+          generator: {
+            preserveSources: { enabled: true },
+          },
+        },
+      });
+      await builder.build();
+
+      expect(mockGeneratorRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          preserveSources: false,
+        }),
+      );
+    });
+
+    it('should warn and fall back to config for unrecognized annotation values', async () => {
+      const entity = createEntity({
+        'backstage.io/techdocs-source-storage': 'true',
+      });
+      const { builder, logger } = createDocsBuilder(entity);
+      await builder.build();
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "Ignoring unrecognized backstage.io/techdocs-source-storage annotation value 'true'",
+        ),
+      );
+      expect(mockGeneratorRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          preserveSources: false,
+        }),
+      );
+    });
+
+    it('should pass sourceExcludes from config', async () => {
+      const { builder } = createDocsBuilder(createEntity(), {
+        techdocs: {
+          generator: {
+            preserveSources: {
+              enabled: true,
+              excludes: ['*.png', '*.jpg'],
+            },
+          },
+        },
+      });
+      await builder.build();
+
+      expect(mockGeneratorRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          preserveSources: true,
+          sourceExcludes: ['*.png', '*.jpg'],
+        }),
+      );
+    });
+
+    it('should pass undefined sourceExcludes when not configured', async () => {
+      const { builder } = createDocsBuilder(createEntity(), {
+        techdocs: {
+          generator: {
+            preserveSources: { enabled: true },
+          },
+        },
+      });
+      await builder.build();
+
+      expect(mockGeneratorRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          preserveSources: true,
+          sourceExcludes: undefined,
+        }),
+      );
+    });
+
+    it('should pass additionalFiles from config', async () => {
+      const { builder } = createDocsBuilder(createEntity(), {
+        techdocs: {
+          generator: {
+            preserveSources: {
+              enabled: true,
+              additionalFiles: ['README.md', 'CONTRIBUTING.md'],
+            },
+          },
+        },
+      });
+      await builder.build();
+
+      expect(mockGeneratorRun).toHaveBeenCalledWith(
+        expect.objectContaining({
+          preserveSources: true,
+          sourceAdditionalFiles: ['README.md', 'CONTRIBUTING.md'],
+        }),
+      );
+    });
+  });
+});

--- a/plugins/techdocs-backend/src/DocsBuilder/builder.ts
+++ b/plugins/techdocs-backend/src/DocsBuilder/builder.ts
@@ -82,6 +82,25 @@ export class DocsBuilder {
     this.cache = cache;
   }
 
+  private resolvePreserveSources(): boolean {
+    const annotation =
+      this.entity.metadata.annotations?.[
+        'backstage.io/techdocs-source-storage'
+      ];
+    if (annotation === 'enabled') return true;
+    if (annotation === 'disabled') return false;
+    if (annotation) {
+      this.logger.warn(
+        `Ignoring unrecognized backstage.io/techdocs-source-storage annotation value '${annotation}', expected 'enabled' or 'disabled'`,
+      );
+    }
+    return (
+      this.config.getOptionalBoolean(
+        'techdocs.generator.preserveSources.enabled',
+      ) ?? false
+    );
+  }
+
   /**
    * Build the docs and return whether they have been newly generated or have been cached
    * @returns true, if the docs have been built. false, if the cached docs are still up-to-date.
@@ -191,6 +210,13 @@ export class DocsBuilder {
         siteOptions: {
           name: this.entity.metadata.title ?? this.entity.metadata.name,
         },
+        preserveSources: this.resolvePreserveSources(),
+        sourceExcludes: this.config.getOptionalStringArray(
+          'techdocs.generator.preserveSources.excludes',
+        ),
+        sourceAdditionalFiles: this.config.getOptionalStringArray(
+          'techdocs.generator.preserveSources.additionalFiles',
+        ),
       });
 
       /**

--- a/plugins/techdocs-node/report.api.md
+++ b/plugins/techdocs-node/report.api.md
@@ -63,6 +63,9 @@ export type GeneratorRunOptions = {
     name?: string;
   };
   runAsDefaultUser?: boolean;
+  preserveSources?: boolean;
+  sourceExcludes?: string[];
+  sourceAdditionalFiles?: string[];
 };
 
 // @public

--- a/plugins/techdocs-node/src/stages/generate/techdocs.test.ts
+++ b/plugins/techdocs-node/src/stages/generate/techdocs.test.ts
@@ -15,7 +15,10 @@
  */
 
 import { ConfigReader } from '@backstage/config';
-import { readGeneratorConfig } from './techdocs';
+import fs from 'fs-extra';
+import path from 'node:path';
+import os from 'node:os';
+import { readGeneratorConfig, createSourceExcludeFilter } from './techdocs';
 
 const mockLogger = {
   warn: jest.fn(),
@@ -176,5 +179,90 @@ describe('readGeneratorConfig', () => {
       pullImage: false,
       defaultPlugins: ['mkdocs-custom-plugin'],
     });
+  });
+});
+
+describe('createSourceExcludeFilter', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'techdocs-filter-'));
+    await fs.ensureDir(path.join(tmpDir, '.git'));
+    await fs.ensureDir(path.join(tmpDir, 'node_modules'));
+    await fs.ensureDir(path.join(tmpDir, '__pycache__'));
+    await fs.ensureDir(path.join(tmpDir, '.venv'));
+    await fs.writeFile(path.join(tmpDir, 'module.pyc'), '');
+    await fs.writeFile(path.join(tmpDir, 'index.md'), '');
+    await fs.writeFile(path.join(tmpDir, 'guide.md'), '');
+    await fs.writeFile(path.join(tmpDir, 'mkdocs.yml'), '');
+    await fs.writeFile(path.join(tmpDir, 'diagram.png'), '');
+    await fs.writeFile(path.join(tmpDir, 'photo.jpg'), '');
+    await fs.writeFile(path.join(tmpDir, 'icon.svg'), '');
+    await fs.ensureDir(path.join(tmpDir, 'build'));
+    await fs.ensureDir(path.join(tmpDir, 'docs'));
+    await fs.writeFile(path.join(tmpDir, 'real-target.md'), '');
+    await fs.symlink(
+      path.join(tmpDir, 'real-target.md'),
+      path.join(tmpDir, 'symlinked.md'),
+    );
+  });
+
+  afterEach(async () => {
+    await fs.remove(tmpDir);
+  });
+
+  it('should exclude built-in patterns by default', () => {
+    const filter = createSourceExcludeFilter();
+
+    expect(filter(path.join(tmpDir, '.git'))).toBe(false);
+    expect(filter(path.join(tmpDir, 'node_modules'))).toBe(false);
+    expect(filter(path.join(tmpDir, '__pycache__'))).toBe(false);
+    expect(filter(path.join(tmpDir, '.venv'))).toBe(false);
+    expect(filter(path.join(tmpDir, 'module.pyc'))).toBe(false);
+  });
+
+  it('should allow non-excluded files', () => {
+    const filter = createSourceExcludeFilter();
+
+    expect(filter(path.join(tmpDir, 'index.md'))).toBe(true);
+    expect(filter(path.join(tmpDir, 'guide.md'))).toBe(true);
+    expect(filter(path.join(tmpDir, 'mkdocs.yml'))).toBe(true);
+    expect(filter(path.join(tmpDir, 'diagram.png'))).toBe(true);
+  });
+
+  it('should apply custom extension excludes', () => {
+    const filter = createSourceExcludeFilter(['*.png', '*.jpg']);
+
+    expect(filter(path.join(tmpDir, 'diagram.png'))).toBe(false);
+    expect(filter(path.join(tmpDir, 'photo.jpg'))).toBe(false);
+    expect(filter(path.join(tmpDir, 'index.md'))).toBe(true);
+  });
+
+  it('should apply custom directory excludes', () => {
+    const filter = createSourceExcludeFilter(['build']);
+
+    expect(filter(path.join(tmpDir, 'build'))).toBe(false);
+    expect(filter(path.join(tmpDir, 'docs'))).toBe(true);
+  });
+
+  it('should combine built-in and custom excludes', () => {
+    const filter = createSourceExcludeFilter(['*.svg']);
+
+    expect(filter(path.join(tmpDir, '.git'))).toBe(false);
+    expect(filter(path.join(tmpDir, 'icon.svg'))).toBe(false);
+    expect(filter(path.join(tmpDir, 'index.md'))).toBe(true);
+  });
+
+  it('should exclude symbolic links', () => {
+    const filter = createSourceExcludeFilter();
+
+    expect(filter(path.join(tmpDir, 'symlinked.md'))).toBe(false);
+    expect(filter(path.join(tmpDir, 'real-target.md'))).toBe(true);
+  });
+
+  it('should return false for paths that do not exist', () => {
+    const filter = createSourceExcludeFilter();
+
+    expect(filter('/nonexistent/path/file.md')).toBe(false);
   });
 });

--- a/plugins/techdocs-node/src/stages/generate/techdocs.ts
+++ b/plugins/techdocs-node/src/stages/generate/techdocs.ts
@@ -16,6 +16,7 @@
 
 import { Config } from '@backstage/config';
 import path from 'node:path';
+import fs from 'fs-extra';
 import {
   ScmIntegrationRegistry,
   ScmIntegrations,
@@ -29,6 +30,7 @@ import {
   validateDocsDirectory,
   validateMkdocsYaml,
 } from './helpers';
+import { getFileTreeRecursively } from '../publish/helpers';
 
 import {
   patchMkdocsYmlPreBuild,
@@ -45,7 +47,7 @@ import {
 } from './types';
 import { ForwardedError } from '@backstage/errors';
 import { DockerContainerRunner } from './DockerContainerRunner';
-import { LoggerService } from '@backstage/backend-plugin-api';
+import { isChildPath, LoggerService } from '@backstage/backend-plugin-api';
 import { TechDocsContainerRunner } from './types';
 
 /**
@@ -91,6 +93,80 @@ export class TechdocsGenerator implements GeneratorBase {
     this.options = readGeneratorConfig(options.config, options.logger);
     this.containerRunner = options.containerRunner;
     this.scmIntegrations = options.scmIntegrations;
+  }
+
+  private async copySources(options: {
+    inputDir: string;
+    outputDir: string;
+    docsDir: string | undefined;
+    sourceExcludes?: string[];
+    sourceAdditionalFiles?: string[];
+    logger: LoggerService;
+  }): Promise<void> {
+    const {
+      inputDir,
+      outputDir,
+      docsDir,
+      sourceExcludes,
+      sourceAdditionalFiles,
+      logger,
+    } = options;
+    const resolvedDocsDir = docsDir ?? 'docs';
+    const docsSource = path.resolve(inputDir, resolvedDocsDir);
+    if (docsSource === path.resolve(inputDir)) {
+      logger.warn(
+        'Skipping source storage: docs_dir resolves to the input directory, which may contain non-documentation files',
+      );
+      return;
+    }
+
+    const sourcesDir = path.join(outputDir, '_sources');
+    await fs.ensureDir(sourcesDir);
+
+    const filter = createSourceExcludeFilter(sourceExcludes);
+
+    if (await fs.pathExists(docsSource)) {
+      await fs.copy(docsSource, path.join(sourcesDir, resolvedDocsDir), {
+        filter,
+      });
+    }
+
+    const additionalFiles = sourceAdditionalFiles ?? ['README.md'];
+    for (const fileName of additionalFiles) {
+      const basename = path.basename(fileName);
+      const source = path.resolve(inputDir, fileName);
+      if (!filter(source)) {
+        continue;
+      }
+      if (!isChildPath(path.resolve(inputDir), source)) {
+        logger.warn(
+          `Skipping additional source file '${fileName}': path resolves outside the input directory`,
+        );
+        continue;
+      }
+      if (await fs.pathExists(source)) {
+        const fileStat = await fs.lstat(source);
+        if (fileStat.isSymbolicLink()) {
+          logger.warn(
+            `Skipping additional source file '${fileName}': file is a symbolic link`,
+          );
+          continue;
+        }
+        await fs.copy(source, path.join(sourcesDir, basename));
+      }
+    }
+
+    const fileTree = await getFileTreeRecursively(sourcesDir);
+    const files = fileTree
+      .map(f => path.relative(sourcesDir, f).split(path.sep).join('/'))
+      .sort();
+
+    await fs.writeJson(path.join(sourcesDir, 'manifest.json'), {
+      generatedAt: Date.now(),
+      files,
+    });
+
+    logger.info(`Preserved source files in ${sourcesDir}`);
   }
 
   /** {@inheritDoc GeneratorBase.run} */
@@ -217,6 +293,18 @@ export class TechdocsGenerator implements GeneratorBase {
      * Post Generate steps
      */
 
+    // Optionally preserve source files alongside the generated output
+    if (options.preserveSources) {
+      await this.copySources({
+        inputDir,
+        outputDir,
+        docsDir,
+        sourceExcludes: options.sourceExcludes,
+        sourceAdditionalFiles: options.sourceAdditionalFiles,
+        logger: childLogger,
+      });
+    }
+
     // Add build timestamp and files to techdocs_metadata.json
     // Creates techdocs_metadata.json if file does not exist.
     await createOrUpdateMetadata(
@@ -233,6 +321,38 @@ export class TechdocsGenerator implements GeneratorBase {
       );
     }
   }
+}
+
+const BUILT_IN_EXCLUDES = [
+  '.git',
+  'node_modules',
+  '__pycache__',
+  '.venv',
+  '*.pyc',
+];
+
+/** @internal */
+export function createSourceExcludeFilter(
+  sourceExcludes?: string[],
+): (filePath: string) => boolean {
+  const allExcludes = [...BUILT_IN_EXCLUDES, ...(sourceExcludes ?? [])];
+  return (filePath: string): boolean => {
+    try {
+      const stat = fs.lstatSync(filePath);
+      if (stat.isSymbolicLink()) {
+        return false;
+      }
+    } catch {
+      return false;
+    }
+    const basename = path.basename(filePath);
+    return !allExcludes.some(pattern => {
+      if (pattern.startsWith('*.')) {
+        return basename.endsWith(pattern.slice(1));
+      }
+      return basename === pattern;
+    });
+  };
 }
 
 export function readGeneratorConfig(

--- a/plugins/techdocs-node/src/stages/generate/types.ts
+++ b/plugins/techdocs-node/src/stages/generate/types.ts
@@ -70,6 +70,9 @@ export type GeneratorRunOptions = {
   logStream?: Writable;
   siteOptions?: { name?: string };
   runAsDefaultUser?: boolean;
+  preserveSources?: boolean;
+  sourceExcludes?: string[];
+  sourceAdditionalFiles?: string[];
 };
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds opt-in source storage to the TechDocs generator. When enabled, source Markdown files are copied into a `_sources/` directory alongside generated HTML and served through the existing static docs API. See #35038 for the full design rationale.

**Control mechanisms (annotation overrides config):**

- `techdocs.generator.preserveSources.enabled` in `app-config.yaml` (global, off by default)
- `backstage.io/techdocs-source-storage` annotation per entity (`enabled` / `disabled`)
- `--include-sources`, `--source-excludes`, `--source-additional-files` CLI flags

Copies `docs_dir` + configurable root files (default: `README.md`) and generates a `manifest.json`. Built-in excludes filter `.git/`, `node_modules/`, symlinks, etc. No publisher, API route, or frontend changes.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))