### PR TITLE
fix(search-backend): mark query action as non-destructive

### DIFF
--- a/.changeset/calm-search-actions.md
+++ b/.changeset/calm-search-actions.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-search-backend': patch
+---
+
+Marked search query actions as non-destructive so action clients can run searches without destructive-operation confirmation.

--- a/docs/ai/well-known-actions.md
+++ b/docs/ai/well-known-actions.md
@@ -37,4 +37,4 @@ This is a (non-exhaustive) list of actions that are known to be part of the Acti
 
 ### Search
 
-- `search.query` (Query Search Engine): Query the Backstage search engine for documents across all or selected document types.
+- `search.query` (Query Search Engine): Performs a read-only, non-destructive query across all or selected document types.

--- a/docs/ai/well-known-actions.md
+++ b/docs/ai/well-known-actions.md
@@ -37,4 +37,4 @@ This is a (non-exhaustive) list of actions that are known to be part of the Acti
 
 ### Search
 
-- `search.query` (Query Search Engine): Performs a read-only, non-destructive query across all or selected document types.
+- `search.query` (Query Search Engine): Query the Backstage search engine for documents across all or selected document types.

--- a/plugins/search-backend/src/actions/createQueryAction.test.ts
+++ b/plugins/search-backend/src/actions/createQueryAction.test.ts
@@ -25,6 +25,30 @@ describe('createQueryAction', () => {
     child: jest.fn(),
   } as any;
 
+  it('registers as a non-destructive read-only action', async () => {
+    const mockActionsRegistry = actionsRegistryServiceMock();
+
+    createQueryAction({
+      engine: { query: jest.fn() } as any,
+      actionsRegistry: mockActionsRegistry,
+      searchIndexService: {
+        getDocumentTypes: jest.fn().mockReturnValue({}),
+      } as any,
+      logger: mockLogger,
+    });
+
+    await expect(mockActionsRegistry.list()).resolves.toMatchObject({
+      actions: [
+        {
+          attributes: {
+            destructive: false,
+            readOnly: true,
+          },
+        },
+      ],
+    });
+  });
+
   it('returns results from the search engine', async () => {
     const mockActionsRegistry = actionsRegistryServiceMock();
     const mockGetDocumentTypes = jest.fn().mockReturnValue({

--- a/plugins/search-backend/src/actions/createQueryAction.ts
+++ b/plugins/search-backend/src/actions/createQueryAction.ts
@@ -64,6 +64,7 @@ Results are returned in a paginated format, along with \`pageCursor\` for naviga
     `,
     attributes: {
       readOnly: true,
+      destructive: false,
     },
     schema: {
       input: z =>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes search query actions being exposed to action clients as destructive operations.

## Root Cause

The search backend query action declares itself read-only but omitted an explicit `destructive: false` hint. The actions registry defaults an omitted destructive hint to `true`, so clients can require destructive-operation confirmation before running a search.

This came from [#31010](https://github.com/backstage/backstage/pull/31010), which introduced the query action without the explicit destructive hint.

## Fix

Marks the query action as non-destructive and adds regression coverage for the exposed action metadata.

To test:

```sh
CI=1 yarn test plugins/search-backend/src/actions/createQueryAction.test.ts --no-watch
yarn workspace @backstage/plugin-search-backend lint
yarn tsc
yarn build:api-reports
```

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
