### PR TITLE
fix(backend-defaults): default read-only actions to non-destructive

### DIFF
--- a/.changeset/calm-actions-defaults.md
+++ b/.changeset/calm-actions-defaults.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Read-only actions now default to non-destructive when the destructive attribute is omitted.

--- a/.changeset/document-action-defaults.md
+++ b/.changeset/document-action-defaults.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-plugin-api': patch
+---
+
+Documented the default destructive and read-only action attribute values.

--- a/.changeset/gentle-action-mocks.md
+++ b/.changeset/gentle-action-mocks.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-test-utils': patch
+---
+
+Aligned mocked action attributes so read-only actions default to non-destructive.

--- a/docs/ai/mcp-actions.md
+++ b/docs/ai/mcp-actions.md
@@ -42,7 +42,7 @@ For details on filtering actions, see the [filtering actions documentation](../b
 
 When registering an action, set the `attributes` field to describe the action's behavior. This allows clients to make informed decisions, for example: warning users before invoking a destructive action, or allowing a read-only action to run without confirmation.
 
-The defaults are conservative. When unset, an action is assumed to be destructive, non-idempotent, and not read-only. **Always set these explicitly so clients can correctly represent the action's capabilities.**
+The defaults are conservative. When unset, an action is assumed to be non-idempotent and not read-only. `destructive` defaults to `true` unless `readOnly` is `true`, in which case it defaults to `false`. **Set these explicitly when the defaults do not represent the action's capabilities.**
 See the [Action Attributes Reference](../backend-system/core-services/actions-registry.md#action-attributes-reference) for the full attribute definitions and defaults.
 
 ## Single MCP Server Name & Description

--- a/docs/backend-system/core-services/actions-registry.md
+++ b/docs/backend-system/core-services/actions-registry.md
@@ -300,10 +300,10 @@ actionsRegistry.register({
 
 ## Action Attributes Reference
 
-| Attribute     | Type    | Default | Description                                                         |
-| ------------- | ------- | ------- | ------------------------------------------------------------------- |
-| `destructive` | boolean | `true`  | Indicates the action modifies or deletes data. Use with caution.    |
-| `idempotent`  | boolean | `false` | Indicates the action can be run multiple times with the same result |
-| `readOnly`    | boolean | `false` | Indicates the action only reads data without making modifications   |
+| Attribute     | Type    | Default                                | Description                                                         |
+| ------------- | ------- | -------------------------------------- | ------------------------------------------------------------------- |
+| `destructive` | boolean | `false` if read-only, otherwise `true` | Indicates the action modifies or deletes data. Use with caution.    |
+| `idempotent`  | boolean | `false`                                | Indicates the action can be run multiple times with the same result |
+| `readOnly`    | boolean | `false`                                | Indicates the action only reads data without making modifications   |
 
 These attributes help consumers of actions understand their behavior and implement appropriate safeguards, retries, or optimizations based on the action's characteristics.

--- a/packages/backend-defaults/config.d.ts
+++ b/packages/backend-defaults/config.d.ts
@@ -189,7 +189,8 @@ export interface Config {
           attributes?: {
             /**
              * If specified, only match actions where destructive matches this value.
-             * Actions default to destructive: true if not explicitly set.
+             * Actions default to destructive: false when readOnly is true,
+             * and destructive: true otherwise.
              */
             destructive?: boolean;
 
@@ -234,7 +235,8 @@ export interface Config {
           attributes?: {
             /**
              * If specified, only match actions where destructive matches this value.
-             * Actions default to destructive: true if not explicitly set.
+             * Actions default to destructive: false when readOnly is true,
+             * and destructive: true otherwise.
              */
             destructive?: boolean;
 

--- a/packages/backend-defaults/src/alpha/entrypoints/actionsRegistry/DefaultActionsRegistryService.ts
+++ b/packages/backend-defaults/src/alpha/entrypoints/actionsRegistry/DefaultActionsRegistryService.ts
@@ -111,7 +111,8 @@ export class DefaultActionsRegistryService implements ActionsRegistryService {
           attributes: {
             // Inspired by the @modelcontextprotocol/sdk defaults for the hints.
             // https://github.com/modelcontextprotocol/typescript-sdk/blob/dd69efa1de8646bb6b195ff8d5f52e13739f4550/src/types.ts#L777-L812
-            destructive: action.attributes?.destructive ?? true,
+            destructive:
+              action.attributes?.destructive ?? !action.attributes?.readOnly,
             idempotent: action.attributes?.idempotent ?? false,
             readOnly: action.attributes?.readOnly ?? false,
           },

--- a/packages/backend-defaults/src/alpha/entrypoints/actionsRegistry/actionsRegistryServiceFactory.test.ts
+++ b/packages/backend-defaults/src/alpha/entrypoints/actionsRegistry/actionsRegistryServiceFactory.test.ts
@@ -314,6 +314,19 @@ describe('actionsRegistryServiceFactory', () => {
                 },
                 action: async () => ({ output: { ok: true } }),
               });
+              actionsRegistry.register({
+                name: 'read-only',
+                title: 'Read Only',
+                description: 'Read Only',
+                attributes: {
+                  readOnly: true,
+                },
+                schema: {
+                  input: z => z.object({}),
+                  output: z => z.object({}),
+                },
+                action: async () => ({ output: { ok: true } }),
+              });
             },
           });
         },
@@ -339,6 +352,14 @@ describe('actionsRegistryServiceFactory', () => {
               readOnly: false,
             },
           },
+          {
+            name: 'read-only',
+            attributes: {
+              destructive: false,
+              idempotent: false,
+              readOnly: true,
+            },
+          },
         ],
       });
     });
@@ -359,6 +380,20 @@ describe('actionsRegistryServiceFactory', () => {
                 attributes: {
                   destructive: false,
                   idempotent: true,
+                  readOnly: false,
+                },
+                schema: {
+                  input: z => z.object({}),
+                  output: z => z.object({}),
+                },
+                action: async () => ({ output: { ok: true } }),
+              });
+              actionsRegistry.register({
+                name: 'read-only',
+                title: 'Read Only',
+                description: 'Read Only',
+                attributes: {
+                  destructive: true,
                   readOnly: true,
                 },
                 schema: {
@@ -391,6 +426,14 @@ describe('actionsRegistryServiceFactory', () => {
             attributes: {
               destructive: false,
               idempotent: true,
+              readOnly: false,
+            },
+          },
+          {
+            name: 'read-only',
+            attributes: {
+              destructive: true,
+              idempotent: false,
               readOnly: true,
             },
           },

--- a/packages/backend-plugin-api/src/alpha/ActionsRegistryService.ts
+++ b/packages/backend-plugin-api/src/alpha/ActionsRegistryService.ts
@@ -71,8 +71,13 @@ export type ActionsRegistryActionOptions<
   examples?: Array<ActionsRegistryActionExample<TInputSchema, TOutputSchema>>;
   visibilityPermission?: BasicPermission;
   attributes?: {
+    /**
+     * Whether the action may perform destructive updates. Defaults to `false`
+     * when `readOnly` is `true`, and `true` otherwise.
+     */
     destructive?: boolean;
     idempotent?: boolean;
+    /** Whether the action only reads from its environment. Defaults to `false`. */
     readOnly?: boolean;
   };
   action: (

--- a/packages/backend-test-utils/src/alpha/services/MockActionsRegistry.test.ts
+++ b/packages/backend-test-utils/src/alpha/services/MockActionsRegistry.test.ts
@@ -135,6 +135,46 @@ describe('MockActionsRegistry', () => {
       },
       action: async ({ input }) => ({ output: { name: input.name } }),
     });
+    registry.register({
+      name: 'explicit-non-destructive-action',
+      title: 'Explicitly Non-Destructive',
+      description: 'Explicitly Non-Destructive',
+      attributes: {
+        destructive: false,
+      },
+      schema: {
+        input: z => z.object({}),
+        output: z => z.object({}),
+      },
+      action: async () => ({ output: {} }),
+    });
+    registry.register({
+      name: 'read-only-action',
+      title: 'Read Only',
+      description: 'Read Only',
+      attributes: {
+        readOnly: true,
+      },
+      schema: {
+        input: z => z.object({}),
+        output: z => z.object({}),
+      },
+      action: async () => ({ output: {} }),
+    });
+    registry.register({
+      name: 'explicit-destructive-read-only-action',
+      title: 'Explicitly Destructive Read Only',
+      description: 'Explicitly Destructive Read Only',
+      attributes: {
+        destructive: true,
+        readOnly: true,
+      },
+      schema: {
+        input: z => z.object({}),
+        output: z => z.object({}),
+      },
+      action: async () => ({ output: {} }),
+    });
 
     const result = await registry.list();
 
@@ -163,6 +203,33 @@ describe('MockActionsRegistry', () => {
                 name: { type: 'string' },
               },
             },
+          },
+        },
+        {
+          id: 'test:explicit-non-destructive-action',
+          name: 'explicit-non-destructive-action',
+          attributes: {
+            destructive: false,
+            idempotent: false,
+            readOnly: false,
+          },
+        },
+        {
+          id: 'test:read-only-action',
+          name: 'read-only-action',
+          attributes: {
+            destructive: false,
+            idempotent: false,
+            readOnly: true,
+          },
+        },
+        {
+          id: 'test:explicit-destructive-read-only-action',
+          name: 'explicit-destructive-read-only-action',
+          attributes: {
+            destructive: true,
+            idempotent: false,
+            readOnly: true,
           },
         },
       ],

--- a/packages/backend-test-utils/src/alpha/services/MockActionsRegistry.ts
+++ b/packages/backend-test-utils/src/alpha/services/MockActionsRegistry.ts
@@ -87,7 +87,8 @@ export class MockActionsRegistry
         title: action.title,
         description: action.description,
         attributes: {
-          destructive: action.attributes?.destructive ?? true,
+          destructive:
+            action.attributes?.destructive ?? !action.attributes?.readOnly,
           idempotent: action.attributes?.idempotent ?? false,
           readOnly: action.attributes?.readOnly ?? false,
         },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Actions that set `readOnly: true` currently receive `destructive: true` when the destructive attribute is omitted. Although MCP defines `destructiveHint` as meaningful only for actions that are not read-only, clients still use the value when deciding how to present or approve a tool call.

This updates the actions registry to default omitted destructive attributes to `false` for read-only actions, while preserving the MCP default of `true` for all other actions. Explicit destructive attributes remain authoritative. The mock actions registry now follows the same behavior, and the public action attributes document the conditional default.

This supersedes #35040 and implements the central default suggested in [review](https://github.com/backstage/backstage/pull/35040#discussion_r3703308599). The behavior follows the [MCP tool annotation contract](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/schema/2025-06-18/schema.ts#L894-L902).

Validation:

- `CI=1 yarn test packages/backend-defaults/src/alpha/entrypoints/actionsRegistry/actionsRegistryServiceFactory.test.ts packages/backend-test-utils/src/alpha/services/MockActionsRegistry.test.ts --no-watch`
- Package lint for `@backstage/backend-defaults`, `@backstage/backend-test-utils`, and `@backstage/backend-plugin-api`
- `yarn tsc`
- `yarn build:api-reports`

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (not applicable; backend-only change)
- [x] All commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
