### PR TITLE
Fix strict config check rejecting valid open-ended schemas

### DIFF
--- a/.changeset/cruel-squids-tie.md
+++ b/.changeset/cruel-squids-tie.md
@@ -1,0 +1,5 @@
+---
+'@backstage/config-loader': patch
+---
+
+Fix issue where `backstage-cli config:check --strict` would incorrectly reject valid configuration for open-ended object schemas, such as plain objects or map-like structures.

--- a/packages/config-loader/src/schema/compile.test.ts
+++ b/packages/config-loader/src/schema/compile.test.ts
@@ -459,4 +459,211 @@ describe('deepVisibility', () => {
       `Config schema visibility is both 'frontend' and 'secret' for /properties/a`,
     );
   });
+
+  describe('noUndeclaredProperties', () => {
+    it('should add additionalProperties: false to objects', () => {
+      const validate = compileConfigSchemas(
+        [
+          {
+            path: 'a1',
+            packageName: 'a1',
+            value: {
+              type: 'object',
+              properties: {
+                a: {
+                  type: 'object',
+                  properties: {
+                    a: { type: 'string' },
+                  },
+                },
+                b: { type: 'string' },
+                d: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      a: { type: 'string' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+        { noUndeclaredProperties: true },
+      );
+      expect(
+        validate([
+          {
+            data: {
+              bonus: 'nope',
+              a: {
+                bonus: 'nope',
+              },
+              d: [{ bonus: 'nope' }],
+            },
+            context: 'test',
+          },
+        ]),
+      ).toEqual({
+        errors: [
+          {
+            instancePath: '',
+            keyword: 'additionalProperties',
+            message: 'must NOT have additional properties',
+            params: {
+              additionalProperty: 'bonus',
+            },
+            schemaPath: '#/additionalProperties',
+          },
+          {
+            instancePath: '/a',
+            keyword: 'additionalProperties',
+            message: 'must NOT have additional properties',
+            params: {
+              additionalProperty: 'bonus',
+            },
+            schemaPath: '#/properties/a/additionalProperties',
+          },
+          {
+            instancePath: '/d/0',
+            keyword: 'additionalProperties',
+            message: 'must NOT have additional properties',
+            params: {
+              additionalProperty: 'bonus',
+            },
+            schemaPath: '#/properties/d/items/additionalProperties',
+          },
+        ],
+        visibilityByDataPath: new Map(),
+        deepVisibilityByDataPath: new Map(),
+        visibilityBySchemaPath: new Map(),
+        deprecationByDataPath: new Map(),
+      });
+    });
+
+    it('should preserve existing additionalProperties', () => {
+      const validate = compileConfigSchemas(
+        [
+          {
+            path: 'a1',
+            packageName: 'a1',
+            value: {
+              type: 'object',
+              properties: {
+                a: {
+                  type: 'object',
+                  properties: {
+                    a: { type: 'string' },
+                  },
+                  additionalProperties: true,
+                },
+                b: { type: 'string' },
+                d: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      a: { type: 'string' },
+                    },
+                    additionalProperties: { type: 'string' },
+                  },
+                },
+              },
+              additionalProperties: {},
+            },
+          },
+        ],
+        { noUndeclaredProperties: true },
+      );
+      expect(
+        validate([
+          {
+            data: {
+              bonus: 'nope',
+              a: {
+                bonus: 'nope',
+              },
+              d: [{ bonus: 'nope' }],
+            },
+            context: 'test',
+          },
+        ]),
+      ).toEqual({
+        visibilityByDataPath: new Map(),
+        deepVisibilityByDataPath: new Map(),
+        visibilityBySchemaPath: new Map(),
+        deprecationByDataPath: new Map(),
+      });
+    });
+
+    it('should skip objects with no properties', () => {
+      const validate = compileConfigSchemas(
+        [
+          {
+            path: 'a1',
+            packageName: 'a1',
+            value: {
+              type: 'object',
+              properties: {
+                a: {
+                  type: 'object',
+                  properties: {
+                    a: { type: 'string' },
+                  },
+                },
+                b: {
+                  type: 'object',
+                  patternProperties: {
+                    a: { type: 'string' },
+                  },
+                },
+                c: {
+                  type: 'object',
+                },
+              },
+            },
+          },
+        ],
+        { noUndeclaredProperties: true },
+      );
+      expect(
+        validate([
+          {
+            data: {
+              a: { bonus: 'nope' },
+              b: { bonus: 'nope' },
+              c: { bonus: 'nope' },
+            },
+            context: 'test',
+          },
+        ]),
+      ).toEqual({
+        errors: [
+          {
+            instancePath: '/a',
+            keyword: 'additionalProperties',
+            message: 'must NOT have additional properties',
+            params: {
+              additionalProperty: 'bonus',
+            },
+            schemaPath: '#/properties/a/additionalProperties',
+          },
+          {
+            instancePath: '/b',
+            keyword: 'additionalProperties',
+            message: 'must NOT have additional properties',
+            params: {
+              additionalProperty: 'bonus',
+            },
+            schemaPath: '#/properties/b/additionalProperties',
+          },
+        ],
+        visibilityByDataPath: new Map(),
+        deepVisibilityByDataPath: new Map(),
+        visibilityBySchemaPath: new Map(),
+        deprecationByDataPath: new Map(),
+      });
+    });
+  });
 });

--- a/packages/config-loader/src/schema/compile.test.ts
+++ b/packages/config-loader/src/schema/compile.test.ts
@@ -459,211 +459,211 @@ describe('deepVisibility', () => {
       `Config schema visibility is both 'frontend' and 'secret' for /properties/a`,
     );
   });
+});
 
-  describe('noUndeclaredProperties', () => {
-    it('should add additionalProperties: false to objects', () => {
-      const validate = compileConfigSchemas(
-        [
-          {
-            path: 'a1',
-            packageName: 'a1',
-            value: {
-              type: 'object',
-              properties: {
-                a: {
-                  type: 'object',
-                  properties: {
-                    a: { type: 'string' },
-                  },
-                },
-                b: { type: 'string' },
-                d: {
-                  type: 'array',
-                  items: {
-                    type: 'object',
-                    properties: {
-                      a: { type: 'string' },
-                    },
-                  },
-                },
-              },
-            },
-          },
-        ],
-        { noUndeclaredProperties: true },
-      );
-      expect(
-        validate([
-          {
-            data: {
-              bonus: 'nope',
+describe('noUndeclaredProperties', () => {
+  it('should add additionalProperties: false to objects', () => {
+    const validate = compileConfigSchemas(
+      [
+        {
+          path: 'a1',
+          packageName: 'a1',
+          value: {
+            type: 'object',
+            properties: {
               a: {
-                bonus: 'nope',
+                type: 'object',
+                properties: {
+                  a: { type: 'string' },
+                },
               },
-              d: [{ bonus: 'nope' }],
-            },
-            context: 'test',
-          },
-        ]),
-      ).toEqual({
-        errors: [
-          {
-            instancePath: '',
-            keyword: 'additionalProperties',
-            message: 'must NOT have additional properties',
-            params: {
-              additionalProperty: 'bonus',
-            },
-            schemaPath: '#/additionalProperties',
-          },
-          {
-            instancePath: '/a',
-            keyword: 'additionalProperties',
-            message: 'must NOT have additional properties',
-            params: {
-              additionalProperty: 'bonus',
-            },
-            schemaPath: '#/properties/a/additionalProperties',
-          },
-          {
-            instancePath: '/d/0',
-            keyword: 'additionalProperties',
-            message: 'must NOT have additional properties',
-            params: {
-              additionalProperty: 'bonus',
-            },
-            schemaPath: '#/properties/d/items/additionalProperties',
-          },
-        ],
-        visibilityByDataPath: new Map(),
-        deepVisibilityByDataPath: new Map(),
-        visibilityBySchemaPath: new Map(),
-        deprecationByDataPath: new Map(),
-      });
-    });
-
-    it('should preserve existing additionalProperties', () => {
-      const validate = compileConfigSchemas(
-        [
-          {
-            path: 'a1',
-            packageName: 'a1',
-            value: {
-              type: 'object',
-              properties: {
-                a: {
+              b: { type: 'string' },
+              d: {
+                type: 'array',
+                items: {
                   type: 'object',
                   properties: {
                     a: { type: 'string' },
                   },
-                  additionalProperties: true,
-                },
-                b: { type: 'string' },
-                d: {
-                  type: 'array',
-                  items: {
-                    type: 'object',
-                    properties: {
-                      a: { type: 'string' },
-                    },
-                    additionalProperties: { type: 'string' },
-                  },
                 },
               },
-              additionalProperties: {},
             },
           },
-        ],
-        { noUndeclaredProperties: true },
-      );
-      expect(
-        validate([
-          {
-            data: {
+        },
+      ],
+      { noUndeclaredProperties: true },
+    );
+    expect(
+      validate([
+        {
+          data: {
+            bonus: 'nope',
+            a: {
               bonus: 'nope',
-              a: {
-                bonus: 'nope',
-              },
-              d: [{ bonus: 'nope' }],
             },
-            context: 'test',
+            d: [{ bonus: 'nope' }],
           },
-        ]),
-      ).toEqual({
-        visibilityByDataPath: new Map(),
-        deepVisibilityByDataPath: new Map(),
-        visibilityBySchemaPath: new Map(),
-        deprecationByDataPath: new Map(),
-      });
+          context: 'test',
+        },
+      ]),
+    ).toEqual({
+      errors: [
+        {
+          instancePath: '',
+          keyword: 'additionalProperties',
+          message: 'must NOT have additional properties',
+          params: {
+            additionalProperty: 'bonus',
+          },
+          schemaPath: '#/additionalProperties',
+        },
+        {
+          instancePath: '/a',
+          keyword: 'additionalProperties',
+          message: 'must NOT have additional properties',
+          params: {
+            additionalProperty: 'bonus',
+          },
+          schemaPath: '#/properties/a/additionalProperties',
+        },
+        {
+          instancePath: '/d/0',
+          keyword: 'additionalProperties',
+          message: 'must NOT have additional properties',
+          params: {
+            additionalProperty: 'bonus',
+          },
+          schemaPath: '#/properties/d/items/additionalProperties',
+        },
+      ],
+      visibilityByDataPath: new Map(),
+      deepVisibilityByDataPath: new Map(),
+      visibilityBySchemaPath: new Map(),
+      deprecationByDataPath: new Map(),
     });
+  });
 
-    it('should skip objects with no properties', () => {
-      const validate = compileConfigSchemas(
-        [
-          {
-            path: 'a1',
-            packageName: 'a1',
-            value: {
-              type: 'object',
-              properties: {
-                a: {
+  it('should preserve existing additionalProperties', () => {
+    const validate = compileConfigSchemas(
+      [
+        {
+          path: 'a1',
+          packageName: 'a1',
+          value: {
+            type: 'object',
+            properties: {
+              a: {
+                type: 'object',
+                properties: {
+                  a: { type: 'string' },
+                },
+                additionalProperties: true,
+              },
+              b: { type: 'string' },
+              d: {
+                type: 'array',
+                items: {
                   type: 'object',
                   properties: {
                     a: { type: 'string' },
                   },
-                },
-                b: {
-                  type: 'object',
-                  patternProperties: {
-                    a: { type: 'string' },
-                  },
-                },
-                c: {
-                  type: 'object',
+                  additionalProperties: { type: 'string' },
                 },
               },
             },
+            additionalProperties: {},
           },
-        ],
-        { noUndeclaredProperties: true },
-      );
-      expect(
-        validate([
-          {
-            data: {
-              a: { bonus: 'nope' },
-              b: { bonus: 'nope' },
-              c: { bonus: 'nope' },
+        },
+      ],
+      { noUndeclaredProperties: true },
+    );
+    expect(
+      validate([
+        {
+          data: {
+            bonus: 'nope',
+            a: {
+              bonus: 'nope',
             },
-            context: 'test',
+            d: [{ bonus: 'nope' }],
           },
-        ]),
-      ).toEqual({
-        errors: [
-          {
-            instancePath: '/a',
-            keyword: 'additionalProperties',
-            message: 'must NOT have additional properties',
-            params: {
-              additionalProperty: 'bonus',
+          context: 'test',
+        },
+      ]),
+    ).toEqual({
+      visibilityByDataPath: new Map(),
+      deepVisibilityByDataPath: new Map(),
+      visibilityBySchemaPath: new Map(),
+      deprecationByDataPath: new Map(),
+    });
+  });
+
+  it('should skip objects with no properties', () => {
+    const validate = compileConfigSchemas(
+      [
+        {
+          path: 'a1',
+          packageName: 'a1',
+          value: {
+            type: 'object',
+            properties: {
+              a: {
+                type: 'object',
+                properties: {
+                  a: { type: 'string' },
+                },
+              },
+              b: {
+                type: 'object',
+                patternProperties: {
+                  a: { type: 'string' },
+                },
+              },
+              c: {
+                type: 'object',
+              },
             },
-            schemaPath: '#/properties/a/additionalProperties',
           },
-          {
-            instancePath: '/b',
-            keyword: 'additionalProperties',
-            message: 'must NOT have additional properties',
-            params: {
-              additionalProperty: 'bonus',
-            },
-            schemaPath: '#/properties/b/additionalProperties',
+        },
+      ],
+      { noUndeclaredProperties: true },
+    );
+    expect(
+      validate([
+        {
+          data: {
+            a: { bonus: 'nope' },
+            b: { bonus: 'nope' },
+            c: { bonus: 'nope' },
           },
-        ],
-        visibilityByDataPath: new Map(),
-        deepVisibilityByDataPath: new Map(),
-        visibilityBySchemaPath: new Map(),
-        deprecationByDataPath: new Map(),
-      });
+          context: 'test',
+        },
+      ]),
+    ).toEqual({
+      errors: [
+        {
+          instancePath: '/a',
+          keyword: 'additionalProperties',
+          message: 'must NOT have additional properties',
+          params: {
+            additionalProperty: 'bonus',
+          },
+          schemaPath: '#/properties/a/additionalProperties',
+        },
+        {
+          instancePath: '/b',
+          keyword: 'additionalProperties',
+          message: 'must NOT have additional properties',
+          params: {
+            additionalProperty: 'bonus',
+          },
+          schemaPath: '#/properties/b/additionalProperties',
+        },
+      ],
+      visibilityByDataPath: new Map(),
+      deepVisibilityByDataPath: new Map(),
+      visibilityBySchemaPath: new Map(),
+      deprecationByDataPath: new Map(),
     });
   });
 });

--- a/packages/config-loader/src/schema/compile.ts
+++ b/packages/config-loader/src/schema/compile.ts
@@ -27,7 +27,7 @@ import {
 } from './types';
 import { SchemaObject } from 'json-schema-traverse';
 import { normalizeAjvPath } from './utils';
-import { cloneDeep } from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 // Used to keep track of the internal deepVisibility inherited through the schema.
 const inheritedVisibility = Symbol('inherited-visibility');
@@ -187,16 +187,23 @@ export function compileConfigSchemas(
       }
 
       if (options?.noUndeclaredProperties) {
+        const hasProperties =
+          typeof schema.properties === 'object' &&
+          schema.properties !== null &&
+          Object.keys(schema.properties).length > 0;
+        const hasPatternProperties =
+          typeof schema.patternProperties === 'object' &&
+          schema.patternProperties !== null &&
+          Object.keys(schema.patternProperties).length > 0;
         /**
-         * The `additionalProperties` key can only be applied to `type: object` in the JSON
-         *  schema.
+         * The `additionalProperties` key can only be applied to `type: object`
+         * in the JSON schema. It's only applied to objects that specify
+         * properties. Otherwise, we end up with nonsensical schemas that don't
+         * allow any properties at all.
          */
         if (
           schema?.type === 'object' &&
-          // Only restrict schemas that have properties otherwise we're left
-          // with `{type: object, additionalProperties: false}` which never
-          // makes sense.
-          ('properties' in schema || 'patternProperties' in schema)
+          (hasProperties || hasPatternProperties)
         ) {
           schema.additionalProperties ||= false;
         }

--- a/packages/config-loader/src/schema/compile.ts
+++ b/packages/config-loader/src/schema/compile.ts
@@ -27,6 +27,7 @@ import {
 } from './types';
 import { SchemaObject } from 'json-schema-traverse';
 import { normalizeAjvPath } from './utils';
+import { cloneDeep } from 'lodash';
 
 // Used to keep track of the internal deepVisibility inherited through the schema.
 const inheritedVisibility = Symbol('inherited-visibility');
@@ -129,7 +130,27 @@ export function compileConfigSchemas(
     }
   }
 
-  const merged = mergeConfigSchemas(schemas.map(_ => _.value));
+  const merged = mergeConfigSchemas(
+    schemas.map(_ => {
+      const copy = cloneDeep(_.value as JSONSchema);
+      traverse(copy, s => {
+        // We convert `additionalProperties: {}` to `additionalProperties: true`
+        // because `mergeAllOf` drops `additionalProperties: {}` during merging.
+        // According to JSON Schema, these two forms are equivalent. Without this
+        // conversion, the dropped value is treated as unset, which causes
+        // `noUndeclaredProperties` to incorrectly add `additionalProperties: false`
+        // and reject valid configuration.
+        if (
+          typeof s.additionalProperties === 'object' &&
+          s.additionalProperties !== null &&
+          Object.keys(s.additionalProperties).length === 0
+        ) {
+          s.additionalProperties = true;
+        }
+      });
+      return copy;
+    }),
+  );
 
   traverse(
     merged,
@@ -170,7 +191,13 @@ export function compileConfigSchemas(
          * The `additionalProperties` key can only be applied to `type: object` in the JSON
          *  schema.
          */
-        if (schema?.type === 'object') {
+        if (
+          schema?.type === 'object' &&
+          // Only restrict schemas that have properties otherwise we're left
+          // with `{type: object, additionalProperties: false}` which never
+          // makes sense.
+          ('properties' in schema || 'patternProperties' in schema)
+        ) {
           schema.additionalProperties ||= false;
         }
       }

--- a/packages/config-loader/src/schema/compile.ts
+++ b/packages/config-loader/src/schema/compile.ts
@@ -187,14 +187,10 @@ export function compileConfigSchemas(
       }
 
       if (options?.noUndeclaredProperties) {
-        const hasProperties =
-          typeof schema.properties === 'object' &&
-          schema.properties !== null &&
-          Object.keys(schema.properties).length > 0;
-        const hasPatternProperties =
-          typeof schema.patternProperties === 'object' &&
-          schema.patternProperties !== null &&
-          Object.keys(schema.patternProperties).length > 0;
+        const hasPropertyWithKey = (key: string) =>
+          typeof schema[key] === 'object' &&
+          schema[key] !== null &&
+          Object.keys(schema[key]).length > 0;
         /**
          * The `additionalProperties` key can only be applied to `type: object`
          * in the JSON schema. It's only applied to objects that specify
@@ -203,7 +199,8 @@ export function compileConfigSchemas(
          */
         if (
           schema?.type === 'object' &&
-          (hasProperties || hasPatternProperties)
+          (hasPropertyWithKey('properties') ||
+            hasPropertyWithKey('patternProperties'))
         ) {
           schema.additionalProperties ||= false;
         }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR makes it so that `backstage-cli config:check --strict` no longer rejects "open-ended" schemas:
- `foo: object` (TS)
- `foo: { [key: string]: unknown }` (TS)
- `{"type": "object"}` (JSON Schema)

Such schemas should allow additional properties even in strict mode. They're open by nature and restricting them makes them unusable (only accept `{}` as a valid value).

### Context

While updating to backstage v1.53, we hit an issue with our config checks (run with `--strict`):

```
  Error: Configuration does not match schema
  
    Config must NOT have additional properties { additionalProperty=metadata } at /catalog/providers/backstageOpenapi/entityOverrides
    Config must NOT have additional properties { additionalProperty=spec } at /catalog/providers/backstageOpenapi/entityOverrides
    Config must NOT have additional properties { additionalProperty=kind } at /search/collators/catalog/filter
    Config must be array { type=array } at /search/collators/catalog/filter
    Config must match a schema in anyOf {  } at /search/collators/catalog/filter
```

I believe that this may have been a side-effect of https://github.com/backstage/backstage/commit/87af6cee13f5597e3ee3d2e0d1b2af432de8d0b3.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
