### PR TITLE
fix: use persistent slot counter for scheduled PR sync

### DIFF
--- a/.github/workflows/sync_pull-requests-scheduled.yml
+++ b/.github/workflows/sync_pull-requests-scheduled.yml
@@ -12,6 +12,7 @@ jobs:
   plan:
     permissions:
       pull-requests: read
+      actions: write
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -28,21 +29,36 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
-            // 48 slots per day (one per 30-minute cron window).
+            // 48 slots (one per 30-minute cron window across a day).
             // Each PR is assigned a fixed slot via pr.number % 48, so
             // opening/closing other PRs never shifts the assignment.
             //
-            // GitHub Actions cron jobs can be delayed 15-30+ minutes,
-            // which can push execution past the next 30-minute boundary
-            // and cause a slot to be permanently skipped. To prevent
-            // this, we process both the current slot and the previous
-            // one. Each PR may be processed twice per day as a result,
-            // but the downstream action is idempotent.
+            // Instead of deriving the slot from wall-clock time (which
+            // breaks when cron is delayed past the next boundary), we
+            // persist a counter in a repository variable and advance it
+            // by one on each run. This guarantees every slot is visited
+            // exactly once regardless of scheduling jitter.
             const totalSlots = 48;
-            const now = new Date();
-            const currentSlot =
-              now.getUTCHours() * 2 + (now.getUTCMinutes() >= 30 ? 1 : 0);
-            const prevSlot = (currentSlot + totalSlots - 1) % totalSlots;
+            const varName = 'SYNC_PR_LAST_SLOT';
+
+            let lastSlot = -1;
+            try {
+              const { data } = await github.rest.actions.getRepoVariable({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: varName,
+              });
+              lastSlot = parseInt(data.value, 10);
+              if (Number.isNaN(lastSlot)) {
+                lastSlot = -1;
+              }
+            } catch (e) {
+              // Variable doesn't exist yet — bootstrap from slot -1
+              // so the first run processes slot 0.
+              core.info('No slot variable found, bootstrapping from slot 0');
+            }
+
+            const currentSlot = (lastSlot + 1) % totalSlots;
 
             const prs = await github.paginate(github.rest.pulls.list, {
               owner: context.repo.owner,
@@ -51,15 +67,32 @@ jobs:
               per_page: 100,
             });
 
-            const batch = prs.filter(pr => {
-              const prSlot = pr.number % totalSlots;
-              return prSlot === currentSlot || prSlot === prevSlot;
-            });
+            const batch = prs.filter(
+              pr => pr.number % totalSlots === currentSlot,
+            );
 
             core.info(
-              `Slots ${prevSlot},${currentSlot}/${totalSlots}: ` +
+              `Slot ${currentSlot}/${totalSlots}: ` +
               `${batch.length} PRs to process out of ${prs.length} open`,
             );
+
+            // Persist the slot counter for the next run
+            try {
+              await github.rest.actions.updateRepoVariable({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: varName,
+                value: String(currentSlot),
+              });
+            } catch (e) {
+              // Variable doesn't exist yet — create it
+              await github.rest.actions.createRepoVariable({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: varName,
+                value: String(currentSlot),
+              });
+            }
 
             const matrix = {
               include: batch.map(pr => ({ prNumber: String(pr.number) })),

--- a/.github/workflows/sync_pull-requests-scheduled.yml
+++ b/.github/workflows/sync_pull-requests-scheduled.yml
@@ -31,10 +31,18 @@ jobs:
             // 48 slots per day (one per 30-minute cron window).
             // Each PR is assigned a fixed slot via pr.number % 48, so
             // opening/closing other PRs never shifts the assignment.
+            //
+            // GitHub Actions cron jobs can be delayed 15-30+ minutes,
+            // which can push execution past the next 30-minute boundary
+            // and cause a slot to be permanently skipped. To prevent
+            // this, we process both the current slot and the previous
+            // one. Each PR may be processed twice per day as a result,
+            // but the downstream action is idempotent.
             const totalSlots = 48;
             const now = new Date();
             const currentSlot =
               now.getUTCHours() * 2 + (now.getUTCMinutes() >= 30 ? 1 : 0);
+            const prevSlot = (currentSlot + totalSlots - 1) % totalSlots;
 
             const prs = await github.paginate(github.rest.pulls.list, {
               owner: context.repo.owner,
@@ -43,12 +51,13 @@ jobs:
               per_page: 100,
             });
 
-            const batch = prs.filter(
-              pr => pr.number % totalSlots === currentSlot,
-            );
+            const batch = prs.filter(pr => {
+              const prSlot = pr.number % totalSlots;
+              return prSlot === currentSlot || prSlot === prevSlot;
+            });
 
             core.info(
-              `Slot ${currentSlot}/${totalSlots}: ` +
+              `Slots ${prevSlot},${currentSlot}/${totalSlots}: ` +
               `${batch.length} PRs to process out of ${prs.length} open`,
             );
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Replaces the wall-clock-derived slot calculation with a persistent counter stored in a repository variable (`SYNC_PR_LAST_SLOT`). The counter advances by one on each run, guaranteeing every slot is visited exactly once regardless of cron scheduling jitter.

Previously, the slot was computed from the current UTC time, which meant GitHub Actions cron delays (commonly 15-30+ minutes) could push execution past the next 30-minute boundary and permanently skip a slot. The workaround was processing two adjacent slots per run, but that doubled the work and still couldn't handle delays longer than one window.

The variable is auto-created on the first run and handles missing or malformed values gracefully by bootstrapping from slot 0.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))