### PR TITLE
Fix flaky catalog tests: metrics cache timing and MySQL deadlock

### DIFF
--- a/.changeset/fix-mysql-deadlock-retry.md
+++ b/.changeset/fix-mysql-deadlock-retry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Fixed a potential MySQL deadlock during concurrent entity processing by retrying the `updateProcessedEntity` transaction on deadlock errors.

--- a/plugins/catalog-backend/src/database/metrics.test.ts
+++ b/plugins/catalog-backend/src/database/metrics.test.ts
@@ -93,7 +93,7 @@ describe.each(databases.eachSupportedId())('metrics, %p', databaseId => {
   describe('createEntitiesCountByKind', () => {
     it('serves cached results within the TTL and refreshes after', async () => {
       const knex = await createDatabase();
-      const getCount = createEntitiesCountByKind(knex, { ttlMs: 50 });
+      const getCount = createEntitiesCountByKind(knex, { ttlMs: 500 });
 
       await insertEntity(knex, {
         entityRef: 'component:default/one',
@@ -111,15 +111,18 @@ describe.each(databases.eachSupportedId())('metrics, %p', databaseId => {
       const cached = await getCount();
       expect(Object.fromEntries(cached)).toEqual({ component: 1 });
 
-      // After the TTL elapses the next call hits the database again.
-      await new Promise(resolve => setTimeout(resolve, 80));
-      const refreshed = await getCount();
+      // Poll until the TTL elapses and the cache refreshes.
+      let refreshed;
+      do {
+        await new Promise(resolve => setTimeout(resolve, 50));
+        refreshed = await getCount();
+      } while (refreshed.get('component') === 1);
       expect(Object.fromEntries(refreshed)).toEqual({ component: 2 });
     });
 
     it('coalesces overlapping callers into a single underlying query', async () => {
       const knex = await createDatabase();
-      const getCount = createEntitiesCountByKind(knex, { ttlMs: 50 });
+      const getCount = createEntitiesCountByKind(knex, { ttlMs: 500 });
 
       await insertEntity(knex, {
         entityRef: 'component:default/one',

--- a/plugins/catalog-backend/src/database/metrics.test.ts
+++ b/plugins/catalog-backend/src/database/metrics.test.ts
@@ -20,6 +20,7 @@ import { randomUUID as uuid } from 'node:crypto';
 import { applyDatabaseMigrations } from './migrations';
 import { DbFinalEntitiesRow, DbRefreshStateRow } from './tables';
 import { createEntitiesCountByKind, queryEntitiesCountByKind } from './metrics';
+import waitForExpect from 'wait-for-expect';
 
 jest.setTimeout(60_000);
 
@@ -111,13 +112,11 @@ describe.each(databases.eachSupportedId())('metrics, %p', databaseId => {
       const cached = await getCount();
       expect(Object.fromEntries(cached)).toEqual({ component: 1 });
 
-      // Poll until the TTL elapses and the cache refreshes.
-      let refreshed;
-      do {
-        await new Promise(resolve => setTimeout(resolve, 50));
-        refreshed = await getCount();
-      } while (refreshed.get('component') === 1);
-      expect(Object.fromEntries(refreshed)).toEqual({ component: 2 });
+      // After the TTL elapses the next call hits the database again.
+      await waitForExpect(async () => {
+        const refreshed = await getCount();
+        expect(Object.fromEntries(refreshed)).toEqual({ component: 2 });
+      });
     });
 
     it('coalesces overlapping callers into a single underlying query', async () => {

--- a/plugins/catalog-backend/src/database/util.ts
+++ b/plugins/catalog-backend/src/database/util.ts
@@ -71,6 +71,9 @@ function isDeadlockError(
     return isError(e) && e.code === '40P01';
   }
 
-  // Add more database engine checks here as needed
+  if (knex.client.config.client.includes('mysql')) {
+    return isError(e) && (e as any).errno === 1213;
+  }
+
   return false;
 }

--- a/plugins/catalog-backend/src/processing/DefaultCatalogProcessingEngine.ts
+++ b/plugins/catalog-backend/src/processing/DefaultCatalogProcessingEngine.ts
@@ -38,6 +38,7 @@ import {
 import { deleteOrphanedEntities } from '../database/operations/util/deleteOrphanedEntities';
 import { EventsService } from '@backstage/plugin-events-node';
 import { CATALOG_ERRORS_TOPIC } from '../constants';
+import { retryOnDeadlock } from '../database/util';
 import { LoggerService, SchedulerService } from '@backstage/backend-plugin-api';
 import { MetricsService } from '@backstage/backend-plugin-api/alpha';
 
@@ -291,25 +292,29 @@ export class DefaultCatalogProcessingEngine {
 
             result.completedEntity.metadata.uid = id;
             let oldRelationSources: Map<string, string>;
-            await this.processingDatabase.transaction(async tx => {
-              const { previous } =
-                await this.processingDatabase.updateProcessedEntity(tx, {
-                  id,
-                  processedEntity: result.completedEntity,
-                  resultHash,
-                  errors: errorsString,
-                  relations: result.relations,
-                  deferredEntities: result.deferredEntities,
-                  locationKey,
-                  refreshKeys: result.refreshKeys,
-                });
-              oldRelationSources = new Map(
-                previous.relations.map(r => [
-                  `${r.source_entity_ref}:${r.type}->${r.target_entity_ref}`,
-                  r.source_entity_ref,
-                ]),
-              );
-            });
+            await retryOnDeadlock(
+              () =>
+                this.processingDatabase.transaction(async tx => {
+                  const { previous } =
+                    await this.processingDatabase.updateProcessedEntity(tx, {
+                      id,
+                      processedEntity: result.completedEntity,
+                      resultHash,
+                      errors: errorsString,
+                      relations: result.relations,
+                      deferredEntities: result.deferredEntities,
+                      locationKey,
+                      refreshKeys: result.refreshKeys,
+                    });
+                  oldRelationSources = new Map(
+                    previous.relations.map(r => [
+                      `${r.source_entity_ref}:${r.type}->${r.target_entity_ref}`,
+                      r.source_entity_ref,
+                    ]),
+                  );
+                }),
+              this.knex,
+            );
 
             const newRelationSources = new Map<string, string>(
               result.relations.map(relation => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Two fixes for intermittent catalog-backend test failures:

**Metrics cache test flake** — `createEntitiesCountByKind` cache test used a 50ms TTL with a fixed 80ms sleep to verify cache expiry, but the database insert between cache checks could take longer than 50ms on a loaded runner — expiring the cache early and returning `{component: 2}` where `{component: 1}` was expected. Increased TTL to 500ms and replaced the fixed sleep with `waitForExpect`.

**MySQL deadlock in processing engine** — Concurrent processing of parent/child entities can deadlock on MySQL when `updateProcessedEntity` and `addUnprocessedEntities` acquire `refresh_state` row locks in opposite order across transactions. Wrapped the transaction with the existing `retryOnDeadlock` utility and added MySQL `errno 1213` detection to `isDeadlockError` (previously only handled PostgreSQL).

> **Note:** The deadlock root cause is the OR-scoped DELETE on `refresh_state_references` in `addUnprocessedEntities`, which causes InnoDB gap-lock conflicts between concurrent processing transactions. #34606 eliminates this by replacing the delete-all + reinsert with a diff-based sync scoped to a single source. Once that lands, the `retryOnDeadlock` added here becomes defense-in-depth rather than a primary fix.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))