### PR TITLE
fix(cli-module-build): defer auto-discovered plugin entry points until after the app's target entry

### DIFF
--- a/.changeset/defer-discovered-plugin-entry.md
+++ b/.changeset/defer-discovered-plugin-entry.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli-module-build': patch
+---
+
+Fixed a bug where plugin packages installed through feature discovery were loaded before the app's own code ran. This could cause bootstrap-order-sensitive setup code in the app, such as configuring MUI 5's class name prefix, to be skipped if a discovered plugin's dependencies loaded MUI 5 components first. Discovered plugin packages are now loaded after the app's own code instead.

--- a/packages/cli-module-build/src/lib/bundler/bundle.ts
+++ b/packages/cli-module-build/src/lib/bundler/bundle.ts
@@ -74,9 +74,9 @@ export async function buildBundle(options: BuildOptions) {
       await createConfig(paths, {
         ...commonConfigOptions,
         additionalEntryPoints: [
-          ...detectedModulesEntryPoint,
           ...moduleFederationSharedDependenciesEntryPoint,
         ],
+        deferredEntryPoints: [...detectedModulesEntryPoint],
         appMode: publicPaths ? 'protected' : 'public',
       }),
     );

--- a/packages/cli-module-build/src/lib/bundler/config.test.ts
+++ b/packages/cli-module-build/src/lib/bundler/config.test.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ConfigReader } from '@backstage/config';
+import { createConfig } from './config';
+import { BundlingPaths } from './paths';
+import { BundlingOptions } from './types';
+
+const paths: BundlingPaths = {
+  targetHtml: '/fake/app/public/index.html',
+  targetPublic: undefined,
+  targetPath: '/fake/app',
+  targetRunFile: undefined,
+  targetDist: '/fake/app/dist',
+  targetAssets: '/fake/app/assets',
+  targetSrc: '/fake/app/src',
+  targetDev: '/fake/app/dev',
+  targetEntry: '/fake/app/src/index.tsx',
+  targetTsConfig: '/fake/tsconfig.json',
+  targetPackageJson: '/fake/app/package.json',
+  rootNodeModules: '/fake/node_modules',
+  root: '/fake',
+};
+
+function createOptions(
+  overrides: Partial<BundlingOptions> = {},
+): BundlingOptions {
+  return {
+    checksEnabled: false,
+    isDev: false,
+    frontendConfig: new ConfigReader({}),
+    getFrontendAppConfigs: () => [],
+    ...overrides,
+  };
+}
+
+describe('createConfig', () => {
+  it('places deferredEntryPoints after targetEntry, and targetEntry after additionalEntryPoints', async () => {
+    const options = createOptions({
+      additionalEntryPoints: ['additional-entry-package'],
+      deferredEntryPoints: ['deferred-entry-package'],
+    });
+
+    const { entry } = await createConfig(paths, options);
+    const entryArray = entry as string[];
+
+    const additionalIndex = entryArray.indexOf('additional-entry-package');
+    const targetEntryIndex = entryArray.indexOf(paths.targetEntry);
+    const deferredIndex = entryArray.indexOf('deferred-entry-package');
+
+    expect(additionalIndex).toBeGreaterThan(-1);
+    expect(targetEntryIndex).toBeGreaterThan(-1);
+    expect(deferredIndex).toBeGreaterThan(-1);
+
+    expect(additionalIndex).toBeLessThan(targetEntryIndex);
+    expect(targetEntryIndex).toBeLessThan(deferredIndex);
+  });
+
+  it('produces an entry array with only targetEntry when no additional or deferred entry points are configured', async () => {
+    const options = createOptions();
+
+    const { entry } = await createConfig(paths, options);
+    const entryArray = entry as string[];
+
+    expect(entryArray).toContain(paths.targetEntry);
+    expect(entryArray).toHaveLength(2); // webpack-public-path + targetEntry
+  });
+});

--- a/packages/cli-module-build/src/lib/bundler/config.ts
+++ b/packages/cli-module-build/src/lib/bundler/config.ts
@@ -335,6 +335,7 @@ export async function createConfig(
       findOwnPaths(__dirname).resolve('config/webpack-public-path'),
       ...(options.additionalEntryPoints ?? []),
       paths.targetEntry,
+      ...(options.deferredEntryPoints ?? []),
     ],
     resolve: {
       extensions: ['.ts', '.tsx', '.mjs', '.js', '.jsx', '.json', '.wasm'],

--- a/packages/cli-module-build/src/lib/bundler/server.ts
+++ b/packages/cli-module-build/src/lib/bundler/server.ts
@@ -150,10 +150,8 @@ DEPRECATION WARNING: React Router Beta is deprecated and support for it will be 
 
   const config = await createConfig(paths, {
     ...commonConfigOptions,
-    additionalEntryPoints: [
-      ...detectedModulesEntryPoint,
-      ...moduleFederationSharedDependenciesEntryPoint,
-    ],
+    additionalEntryPoints: [...moduleFederationSharedDependenciesEntryPoint],
+    deferredEntryPoints: [...detectedModulesEntryPoint],
     moduleFederationRemote: options.moduleFederationRemote,
   });
 

--- a/packages/cli-module-build/src/lib/bundler/types.ts
+++ b/packages/cli-module-build/src/lib/bundler/types.ts
@@ -37,6 +37,10 @@ export type BundlingOptions = {
   frontendConfig: Config;
   getFrontendAppConfigs(): AppConfig[];
   additionalEntryPoints?: string[];
+  // Entry points that should load after the app's own target entry, e.g.
+  // auto-discovered plugin packages. Unlike additionalEntryPoints, these are
+  // not evaluated before the app gets a chance to run its own bootstrap code.
+  deferredEntryPoints?: string[];
   // Path to append to the detected public path, e.g. '/public'
   publicSubPath?: string;
   // Mode that the app is running in, 'protected' or 'public', default is 'public'


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix for an issue where auto-discovered plugin packages could load before the app's own bootstrap code which can break styling for plugins that use MUI v5 components. Apps using feature discovery can intermittently render MUI v5 components with unprefixed class names (e.g. `MuiTouchRipple-root` instead of the app's configured `v5-MuiTouchRipple-root`), breaking styling for those components. 

Let me know if I might've missed anything in my evaluation.

### Root cause
`@backstage/cli-module-build` bundles the app with a single multi-entry array:
https://github.com/backstage/backstage/blob/750b214a478c39429019dba42ec1b008ea3d8638/packages/cli-module-build/src/lib/bundler/config.ts#L333-L338

All entries in this array are required synchronously in order where the auto discovered plugins are defined in `additionalEntryPoints` and the app index.tsx is defined in `targetEntry`.

Meanwhile, `@backstage/theme`'s `UnifiedThemeProvider` configures MUI v5's global class-name prefix as an import-time side effect via `unstable_ClassNameGenerator`:
https://github.com/backstage/backstage/blob/8ec59ea11f30c832e2a661be4227c73cd059646b/packages/theme/src/unified/UnifiedThemeProvider.tsx#L49-L54

`unstable_ClassNameGenerator` is a module-level singleton. Some MUI utility-class call sites (e.g. [`touchRippleClasses.js`'s default export](https://github.com/mui/material-ui/blob/6b50143dcfc2aad56a37c9f2e1f14256e9a65c4e/packages/mui-material/src/ButtonBase/touchRippleClasses.ts#L27-L37)) cache their generated class name in a frozen constant the *first* time the module is evaluated — before or after `configure()` has run determines whether that constant is ever prefixed.

Whether the race is won or lost depends on whether any auto-discovered plugin's dependency graph transitively imports an MUI component (e.g. `Button`/`ButtonBase`) that uses `touchRippleClasses` before `targetEntry` (and therefore the app's theme provider) gets a chance to run `configure()`.

### Intermittent reproduction in prod vs dev
This issue is consistently reproduced when running the local dev server (`yarn dev`) where tree-shaking is disabled by default so unused `require()` edges are not pruned from the compiled module graph — any plugin that merely imports something MUI-adjacent drags in `touchRippleClasses.js` early, freezing the unprefixed class name for the rest of the session. In production builds, tree shaking prunes those edges more aggressively so if no MUI v5 plugins utilize any components that are associated with `touchRippleClasses.js`, this bug can be masked by a false negative reproduction. 

### Proposed fix

Give the bundler a second, later entry-point slot — `deferredEntryPoints` — that's appended after `targetEntry` instead of before it, and move the auto-discovery module into it. This guarantees the app's own code — and any import-time setup it performs, such as the theme's `configure()` call — always finishes evaluating before any auto-discovered plugin package is required, regardless of tree-shaking behavior or build mode.

This order shift should also be safe because auto-discovered modules are consumed via `appLoader` which is wrapped in `React.lazy()` so `appLoader` only runs during React's render phase — strictly after every entry in the webpack/Rspack entry array (including the new deferred one) has finished evaluating synchronously. So moving the auto-discovery module to the end of the entry array doesn't change *when* discovery is consumed, only *when* its module graph is required relative to the app's own code:
https://github.com/backstage/backstage/blob/b805889bd21c76fda029d3cda2d79461eb7b0eaa/packages/frontend-defaults/src/createApp.tsx#L135-L143

### Current workaround
App owners are able to workaround this issue today by excluding the affected MUI v5 plugins from `packages` auto-discovery in `app-config.yaml` and installing them manually instead via `createApp`. This sidesteps the bug because manually-installed plugins are imported directly by the app's own `targetEntry` module rather than through the generated auto-discovery entry point, so they can never be required ahead of the theme's `configure()` call.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
