### PR TITLE
Preserve Backstage CLI cache after test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,6 +288,7 @@ jobs:
         run: yarn backstage-cli repo lint --since origin/master --success-cache --success-cache-dir .cache/backstage-cli
 
       - name: test changed packages
+        id: test
         run: yarn backstage-cli repo test --maxWorkers=3 --workerIdleMemoryLimit=1300M --since origin/master --success-cache --success-cache-dir .cache/backstage-cli
         env:
           BACKSTAGE_TEST_DISABLE_DOCKER: 1
@@ -296,10 +297,10 @@ jobs:
           BACKSTAGE_TEST_DATABASE_MYSQL8_CONNECTION_STRING: mysql://root:root@localhost:${{ job.services.mysql8.ports[3306] }}/ignored
           BACKSTAGE_TEST_CACHE_REDIS7_CONNECTION_STRING: redis://localhost:${{ job.services.redis.ports[6379] }}
 
-      # Always save success cache even if there were failures, that way it can be used in re-triggered builds
+      # Save successful test results even if other tests failed
       - name: save backstage-cli cache
         uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        if: always()
+        if: ${{ !cancelled() && steps.test.outcome != 'skipped' }}
         with:
           path: .cache/backstage-cli
           key: ${{ runner.os }}-v${{ matrix.node-version }}-backstage-cli-${{ github.run_id }}

--- a/.github/workflows/deploy_packages.yml
+++ b/.github/workflows/deploy_packages.yml
@@ -93,8 +93,9 @@ jobs:
       - name: validate config
         run: yarn backstage-cli config:check --lax
 
-      - name: backstage-cli cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      - name: Restore backstage-cli cache
+        id: backstage-cli-cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: .cache/backstage-cli
           key: ${{ runner.os }}-v${{ matrix.node-version }}-backstage-cli-${{ github.run_id }}
@@ -114,6 +115,7 @@ jobs:
         run: yarn lint:type-deps
 
       - name: test (and upload coverage)
+        id: test
         run: |
           yarn backstage-cli repo test --maxWorkers=3 --workerIdleMemoryLimit=1300M --coverage --success-cache --success-cache-dir .cache/backstage-cli
         env:
@@ -122,6 +124,13 @@ jobs:
           BACKSTAGE_TEST_DATABASE_POSTGRES14_CONNECTION_STRING: postgresql://postgres:postgres@localhost:${{ job.services.postgres14.ports[5432] }}
           BACKSTAGE_TEST_DATABASE_MYSQL8_CONNECTION_STRING: mysql://root:root@localhost:${{ job.services.mysql8.ports[3306] }}/ignored
           BACKSTAGE_TEST_CACHE_REDIS7_CONNECTION_STRING: redis://localhost:${{ job.services.redis.ports[6379] }}
+
+      - name: Save backstage-cli cache
+        if: ${{ !cancelled() && steps.test.outcome != 'skipped' }}
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: .cache/backstage-cli
+          key: ${{ steps.backstage-cli-cache.outputs.cache-primary-key }}
 
       - name: Discord notification
         if: ${{ failure() }}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Preserve successful Backstage CLI package cache entries when the test step fails, so a flaky package does not force later master runs to repeat work that already passed.

This splits cache restoration and saving, and saves only after the test step has run and the job was not cancelled. Failed package hashes are excluded by the Backstage CLI success cache.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
