### PR TITLE
fix(ci): allow safe fork PR checkout in pull_request_target workflows

### DIFF
--- a/.github/workflows/automate_changeset_feedback.yml
+++ b/.github/workflows/automate_changeset_feedback.yml
@@ -32,6 +32,9 @@ jobs:
           # Fetch the commit that's merged into the base rather than the target ref
           # This will let us diff only the contents of the PR, without fetching more history
           ref: 'refs/pull/${{ github.event.pull_request.number }}/merge'
+          # Safe to allow: the checkout is only ever diffed, never built or
+          # executed, and the app credentials used below are scoped to posting comments.
+          allow-unsafe-pr-checkout: true
       - name: fetch base
         run: git fetch --depth 1 origin ${{ github.base_ref }}
       - uses: backstage/actions/changeset-feedback@2cd6978b476cbdc39fec48346f8b6ca13199dd6a # v0.7.8

--- a/.github/workflows/automate_merge_message.yml
+++ b/.github/workflows/automate_merge_message.yml
@@ -31,6 +31,9 @@ jobs:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: '${{ github.event.pull_request.merge_commit_sha }}'
+          # Safe to allow: this job only runs after the PR has already been merged
+          # into master, so the checked-out code is no longer untrusted fork content.
+          allow-unsafe-pr-checkout: true
 
       - name: fetch head & base
         run: git fetch --depth 1 origin ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/automate_yarn-lock-changes.yml
+++ b/.github/workflows/automate_yarn-lock-changes.yml
@@ -22,6 +22,9 @@ jobs:
           # Fetch the commit that's merged into the base rather than the target ref.
           ref: 'refs/pull/${{ github.event.pull_request.number }}/merge'
           persist-credentials: false
+          # Safe to allow: contents is read-only and the checkout is only ever
+          # diffed for yarn.lock changes, never built or executed.
+          allow-unsafe-pr-checkout: true
 
       - name: Yarn Lock Changes
         uses: Simek/yarn-lock-changes@59f47ee499424d2c2437c5aebf863b5c6d50a5bc # v0.14.1


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`actions/checkout` v6.1.0 (backported from v7) now refuses to check out fork pull request code in `pull_request_target` workflows — by head SHA, `merge_commit_sha`, or `refs/pull/*/{head,merge}` — unless `allow-unsafe-pr-checkout: true` is set. This broke three of our `pull_request_target` workflows that use exactly those checkout patterns:

- `automate_yarn-lock-changes.yml`
- `automate_changeset_feedback.yml`
- `automate_merge_message.yml`

None of them execute the checked-out fork code (no install/build/run steps against it — they only diff it or run trusted scripts fetched from `master`), and `automate_merge_message.yml` only runs after the PR is already merged. So opting back in with `allow-unsafe-pr-checkout: true` is safe for these, and each has a comment explaining why.

See https://github.com/actions/checkout/pull/2500 and https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/ for background.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
