### PR TITLE
fix(catalog): prevent theme typography overrides from breaking AboutField labels

### DIFF
--- a/.changeset/fix-about-field-label-variant.md
+++ b/.changeset/fix-about-field-label-variant.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Fixed the `AboutField` label in the About card using `variant="inherit"` instead of `variant="h2"` to prevent theme typography overrides from changing the intended 10px label size.

--- a/plugins/catalog/src/components/AboutCard/AboutField.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutField.tsx
@@ -70,7 +70,7 @@ export function AboutField(props: AboutFieldProps) {
     );
   return (
     <div className={className}>
-      <Typography variant="h2" className={classes.label}>
+      <Typography variant="inherit" component="h2" className={classes.label}>
         {label}
       </Typography>
       {content}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `AboutField` component in the catalog About card renders metadata labels (DESCRIPTION, OWNER, SYSTEM, TAGS, KIND, LIFECYCLE) in Portal using `<Typography variant="h2">` with a `makeStyles` class that sets `font-size: 10px`.

Because `variant="h2"` causes MUI to emit the global `.MuiTypography-h2` class, any theme that maps the `h2` variant to a different font-size competes with the label's intended size. Both selectors are single-class (equal specificity), so the winner depends on stylesheet insertion order in `<head>`.

This is fragile and breaks when a second copy of the `Typography` component is loaded from a separately built bundle (e.g. a Module Federation remote). The duplicate registers its `MuiTypography` sheet later in the shared JSS registry, so it is inserted after the label's sheet and wins the specificity tie — rendering the labels as large 24px headings instead of small 10px metadata labels.

The fix switches to `variant="inherit"` so MUI skips the variant class entirely (see `Typography.js` — variant classes are only added when `variant !== 'inherit'`), and adds `component="h2"` to preserve the `<h2>` tag for heading semantics.

Before:
```html
<h2 class="MuiTypography-root jss4-45 MuiTypography-h2">Owner</h2>
<!-- .jss4-45 { font-size: 10px } loses to .MuiTypography-h2 { font-size: 24px } -->
```

After:
```html
<h2 class="MuiTypography-root jss4-45">Owner</h2>
<!-- .jss4-45 { font-size: 10px } is the only font-size rule — nothing to compete with -->
```

Related: https://github.com/backstage/backstage/issues/31467 (MUI to BUI Migration Tracking)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))