### PR TITLE
ci: skip redundant approvals on Renovate lockfile PRs

### DIFF
--- a/.github/workflows/sync_renovate-changesets.yml
+++ b/.github/workflows/sync_renovate-changesets.yml
@@ -35,6 +35,19 @@ jobs:
               return;
             }
 
+            const { data: reviews } = await github.rest.pulls.listReviews({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+            const hasActiveApproval = reviews.some(
+              r => r.user.login === 'backstage-service' && r.state === 'APPROVED'
+            );
+            if (hasActiveApproval) {
+              console.log("Already approved by backstage-service, skipping");
+              return;
+            }
+
             await github.rest.pulls.createReview({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/sync_renovate-changesets.yml
+++ b/.github/workflows/sync_renovate-changesets.yml
@@ -35,7 +35,7 @@ jobs:
               return;
             }
 
-            const { data: reviews } = await github.rest.pulls.listReviews({
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.payload.pull_request.number,


### PR DESCRIPTION
The `sync_renovate-changesets` workflow unconditionally approves yarn.lock-only Renovate PRs on every `pull_request_target` event. When Renovate repeatedly rebases a branch (e.g. PR #34236 was force-pushed ~20 times), this produces a pile-up of identical approval reviews.

This adds an idempotency check before approving: list existing reviews and skip if `backstage-service` already has an active `APPROVED` review. When "Dismiss stale reviews on push" is enabled in branch protection, dismissed approvals have state `DISMISSED`, so re-approval still happens correctly in that case.

#### :heavy_check_mark: Checklist

- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

🤖 Generated with [Claude Code](https://claude.com/claude-code)