### PR TITLE
fix: retry on deadlock in DefaultRefreshService test helper

### DIFF
--- a/plugins/catalog-backend/src/service/DefaultRefreshService.test.ts
+++ b/plugins/catalog-backend/src/service/DefaultRefreshService.test.ts
@@ -34,6 +34,7 @@ import { ProcessingDatabase } from '../database/types';
 import { DefaultCatalogProcessingEngine } from '../processing/DefaultCatalogProcessingEngine';
 import { EntityProcessingRequest } from '../processing/types';
 import { DefaultRefreshService } from './DefaultRefreshService';
+import { retryOnDeadlock } from '../database/util';
 import { ConfigReader } from '@backstage/config';
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { metricsServiceMock } from '@backstage/backend-test-utils/alpha';
@@ -175,13 +176,19 @@ describe.each(databases.eachSupportedId())(
           ? (JSON.parse(result.processed_entity) as Entity)
           : undefined;
         if (entity?.metadata?.annotations?.['refresh-completed']) {
-          // Reset the annotation so that we can run another verification
+          // Reset the annotation so that we can run another verification.
+          // This update can race with the processing engine writing to the
+          // same row, causing a deadlock on MySQL.
           delete entity.metadata.annotations['refresh-completed'];
-          await knex<DbRefreshStateRow>('refresh_state')
-            .update({
-              processed_entity: JSON.stringify(entity),
-            })
-            .where('entity_ref', entityRef);
+          await retryOnDeadlock(
+            () =>
+              knex<DbRefreshStateRow>('refresh_state')
+                .update({
+                  processed_entity: JSON.stringify(entity),
+                })
+                .where('entity_ref', entityRef),
+            knex,
+          );
           return true;
         }
         await new Promise(resolve => setTimeout(resolve, 500));


### PR DESCRIPTION
The `waitForRefresh` test helper in `DefaultRefreshService.test.ts` writes to `processed_entity` to reset a marker annotation after detecting a refresh. This races with the processing engine's concurrent write to the same row, causing a MySQL deadlock (errno 1213) that flakes CI.

Wrap the update with `retryOnDeadlock` so the test retries instead of failing. This is a test-only change — the production `DefaultRefreshService` is unaffected (it only writes `next_update_at`, not `processed_entity`).

#### :heavy_check_mark: Checklist

- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

🤖 Generated with [Claude Code](https://claude.com/claude-code)