### PR TITLE
ci: use blobless full-history checkout instead of large fetch-depth

### DIFF
--- a/.github/workflows/sync_code-formatting.yml
+++ b/.github/workflows/sync_code-formatting.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           # Fetch changes to previous commit - required for 'only_changed' in Prettier action
           fetch-depth: 0
+          filter: blob:none
 
       - name: use node.js ${{ matrix.node-version }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/sync_patch-cleanup.yml
+++ b/.github/workflows/sync_patch-cleanup.yml
@@ -26,7 +26,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
-          fetch-depth: 20000
+          fetch-depth: 0
+          filter: blob:none
           fetch-tags: true
           ref: master
           token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}

--- a/.github/workflows/sync_patch-release.yml
+++ b/.github/workflows/sync_patch-release.yml
@@ -27,7 +27,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
-          fetch-depth: 20000
+          fetch-depth: 0
+          filter: blob:none
           fetch-tags: true
           token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}
 

--- a/.github/workflows/sync_version-packages.yml
+++ b/.github/workflows/sync_version-packages.yml
@@ -25,7 +25,8 @@ jobs:
 
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
-          fetch-depth: 20000
+          fetch-depth: 0
+          filter: blob:none
           fetch-tags: true
           token: ${{ secrets.GH_SERVICE_ACCOUNT_TOKEN }}
 

--- a/.github/workflows/verify_chromatic.yml
+++ b/.github/workflows/verify_chromatic.yml
@@ -31,7 +31,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
-          fetch-depth: 10000 # Required to retrieve git history
+          fetch-depth: 0 # Required to retrieve git history
+          filter: blob:none
 
       - name: Use node.js ${{ matrix.node-version }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Speeds up CI checkouts that need deep git history (release/patch syncing, Chromatic, Prettier's `only_changed` check). These previously used a large fixed `fetch-depth` (10000-20000), which is slow because the git server has to negotiate the shallow boundary out to that depth. Switched to `fetch-depth: 0` (full history) combined with `filter: blob:none` (partial clone), which fetches full commit/tree metadata without downloading historical blob content — avoiding the shallow negotiation cost while staying cheap on data transferred.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
