### PR TITLE
ci: make previous-commit fetch shallow and blobless in deploy_packages

### DIFF
--- a/.github/workflows/deploy_packages.yml
+++ b/.github/workflows/deploy_packages.yml
@@ -81,7 +81,7 @@ jobs:
           cache-prefix: ${{ runner.os }}-v${{ matrix.node-version }}
 
       - name: Fetch previous commit for release check
-        run: git fetch origin '${{ github.event.before }}'
+        run: git fetch --depth 1 --filter=blob:none origin '${{ github.event.before }}'
 
       - name: Check if release
         if: inputs.force_release != true

--- a/.github/workflows/deploy_packages.yml
+++ b/.github/workflows/deploy_packages.yml
@@ -69,6 +69,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          filter: blob:none
 
       - name: use node.js ${{ matrix.node-version }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/deploy_packages.yml
+++ b/.github/workflows/deploy_packages.yml
@@ -83,7 +83,7 @@ jobs:
           cache-prefix: ${{ runner.os }}-v${{ matrix.node-version }}
 
       - name: Fetch previous commit for release check
-        run: git fetch --depth 1 --filter=blob:none origin '${{ github.event.before }}'
+        run: git fetch --depth 1 origin '${{ github.event.before }}'
 
       - name: Check if release
         if: inputs.force_release != true


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Speeds up the `Deploy Packages` workflow's release-check step. It ran `git fetch origin '${{ github.event.before }}'` against a shallow (`fetch-depth: 1`) checkout with no depth or filter limit — since that commit isn't part of the shallow history, git had to transfer the entire history and full blob content back to it, which was taking upwards of 10 minutes. The release-check script only diffs trees and reads a couple of files at that commit, so `--depth 1 --filter=blob:none` is sufficient and avoids the full transfer.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
