### PR TITLE
ci: skip unnecessary blob transfers in git fetches/checkouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,13 +249,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+        # Only trees and paths are needed here, to check the release and to scope
+        # linting and testing to changed packages, so skip historical blob
+        # content rather than transferring the whole branch.
       - name: fetch master branch
-        run: git fetch origin master
+        run: git fetch --filter=blob:none origin master
 
         # Need to fetch the base branch to be able to verify the release
       - name: fetch base branch
         if: github.event.pull_request.base.ref != 'master'
-        run: git fetch origin ${{ github.event.pull_request.base.ref }}
+        run: git fetch --filter=blob:none origin ${{ github.event.pull_request.base.ref }}
 
       - name: use node.js ${{ matrix.node-version }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/deploy_packages.yml
+++ b/.github/workflows/deploy_packages.yml
@@ -80,8 +80,10 @@ jobs:
         with:
           cache-prefix: ${{ runner.os }}-v${{ matrix.node-version }}
 
+      # Only the tree of the previous commit is needed to diff package versions,
+      # so keep this shallow rather than fetching its entire ancestry.
       - name: Fetch previous commit for release check
-        run: git fetch origin '${{ github.event.before }}'
+        run: git fetch --depth 1 origin '${{ github.event.before }}'
 
       - name: Check if release
         if: inputs.force_release != true


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Follow-up to #35094: adds `--filter=blob:none` / `filter: blob:none` to the remaining CI git fetches and checkouts that don't need broad blob content.

- `ci.yml`: fetches `master`/the base branch for `backstage-cli repo lint/test --since`, which calls `git merge-base` and needs full ancestry, so no `--depth` change — but the diff itself is path-only and only reads `yarn.lock` at the merge base, so the filter is safe.
- `api-breaking-changes.yml`, `automate_changeset_feedback.yml`, `automate_merge_message.yml`, `deploy_microsite.yml`, `verify_microsite.yml`: already use `--depth 1`, but still pulled the full blob content of the fetched commit's tree even though downstream only reads a handful of specific files (`openapi.yaml`, `.changeset/*`, `docs/releases/*`, or pure diff/log metadata).
- `deploy_packages.yml`: the release-check step fetched an arbitrary commit SHA (`github.event.before`) with no depth or filter limit against a shallow checkout, which could take upwards of 10 minutes since git had to transfer the full history and blob content back to that commit. Made the checkout itself a blobless partial clone (`filter: blob:none`) and the follow-up fetch shallow (`--depth 1`); the filter is inherited from the checkout so it doesn't need to be repeated on the fetch.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
