### PR TITLE
fix: apply catalog graph page configuration

### DIFF
--- a/.changeset/fuzzy-pandas-graph.md
+++ b/.changeset/fuzzy-pandas-graph.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-graph': patch
+---
+
+Fixed the catalog graph page so configured filter and graph defaults are applied when the page opens.

--- a/plugins/catalog-graph/src/alpha.test.tsx
+++ b/plugins/catalog-graph/src/alpha.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { renderTestApp } from '@backstage/frontend-test-utils';
 import { ComponentEntity, Entity } from '@backstage/catalog-model';
 import {
@@ -25,12 +25,111 @@ import catalogGraphPlugin from './alpha';
 import { catalogGraphRouteRef } from './routes';
 import { catalogGraphApiRef, DefaultCatalogGraphApi } from './api';
 
+jest.mock('./components/CatalogGraphPage', () => {
+  const { useCatalogGraphPage } = jest.requireActual<
+    typeof import('./components/CatalogGraphPage/useCatalogGraphPage')
+  >('./components/CatalogGraphPage/useCatalogGraphPage');
+  const { useLocation } =
+    jest.requireActual<typeof import('react-router-dom')>('react-router-dom');
+
+  return {
+    CatalogGraphPage: (
+      props: Parameters<typeof useCatalogGraphPage>[0] &
+        Record<string, unknown>,
+    ) => {
+      const state = useCatalogGraphPage(props);
+      const location = useLocation();
+
+      return (
+        <output data-testid="catalog-graph-page-state">
+          {JSON.stringify({ props, state, search: location.search })}
+        </output>
+      );
+    },
+  };
+});
+
 const CatalogGraphEntityCard = catalogGraphPlugin.getExtension(
   'entity-card:catalog-graph/relations',
 );
 const CatalogGraphApi = catalogGraphPlugin.getExtension('api:catalog-graph');
+const CatalogGraphPage = catalogGraphPlugin.getExtension('page:catalog-graph');
 
 describe('catalog-graph alpha plugin', () => {
+  describe('CatalogGraphPage', () => {
+    it('should apply page configuration to the initial state and URL', async () => {
+      const config = {
+        selectedKinds: ['Component'],
+        selectedRelations: ['dependsOn'],
+        rootEntityRefs: ['component:default/my-service'],
+        maxDepth: 3,
+        unidirectional: false,
+        mergeRelations: false,
+        showArrowHeads: true,
+        direction: 'RL',
+        showFilters: false,
+        curve: 'curveStepBefore',
+        kinds: ['component'],
+        relations: ['dependsOn'],
+        relationPairs: [['dependsOn', 'dependencyOf']],
+        zoom: 'disabled',
+      };
+
+      renderTestApp({
+        extensions: [CatalogGraphPage],
+        initialRouteEntries: ['/catalog-graph'],
+        config: {
+          app: {
+            baseUrl: 'http://localhost:3000',
+            extensions: [{ 'page:catalog-graph': { config } }],
+          },
+          backend: { baseUrl: 'http://localhost:7007' },
+        },
+      });
+
+      await waitFor(() => {
+        const snapshot = JSON.parse(
+          screen.getByTestId('catalog-graph-page-state').textContent!,
+        );
+
+        expect(snapshot.props).toMatchObject({
+          ...config,
+          initialState: config,
+        });
+        expect(snapshot.state).toMatchObject({
+          rootEntityNames: [
+            {
+              kind: 'component',
+              namespace: 'default',
+              name: 'my-service',
+            },
+          ],
+          maxDepth: 3,
+          selectedKinds: ['component'],
+          selectedRelations: ['dependsOn'],
+          unidirectional: false,
+          mergeRelations: false,
+          direction: 'RL',
+          showFilters: false,
+          curve: 'curveStepBefore',
+        });
+
+        const search = new URLSearchParams(snapshot.search);
+        expect(search.getAll('rootEntityRefs[]')).toEqual([
+          'component:default/my-service',
+        ]);
+        expect(search.get('maxDepth')).toBe('3');
+        expect(search.getAll('selectedKinds[]')).toEqual(['component']);
+        expect(search.getAll('selectedRelations[]')).toEqual(['dependsOn']);
+        expect(search.get('unidirectional')).toBe('false');
+        expect(search.get('mergeRelations')).toBe('false');
+        expect(search.get('direction')).toBe('RL');
+        expect(search.get('showFilters')).toBe('false');
+        expect(search.get('curve')).toBe('curveStepBefore');
+      });
+    });
+  });
+
   describe('CatalogGraphEntityCard', () => {
     it('should render with Relations title', async () => {
       const entity: ComponentEntity = {

--- a/plugins/catalog-graph/src/alpha.tsx
+++ b/plugins/catalog-graph/src/alpha.tsx
@@ -80,7 +80,7 @@ const CatalogGraphPage = PageBlueprint.makeWithOverrides({
       routeRef: catalogGraphRouteRef,
       loader: () =>
         import('./components/CatalogGraphPage').then(m => (
-          <m.CatalogGraphPage {...config} />
+          <m.CatalogGraphPage {...config} initialState={config} />
         )),
     });
   },


### PR DESCRIPTION
Fixes #35027.

The new frontend system accepts `page:catalog-graph` configuration, but the page route was not forwarding that configuration to `CatalogGraphPage`. As a result, configured initial filters and graph settings were ignored when the page first loaded. This connects the existing configuration contract to the page and adds regression coverage for both the initial hook state and URL.

Verification:

- `CI=1 yarn test plugins/catalog-graph/src/alpha.test.tsx --runInBand` (4/4 passed)
- `yarn workspace @backstage/plugin-catalog-graph lint`
- `yarn tsc`
- `yarn build:api-reports plugins/catalog-graph`

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected package
- [ ] Added or updated documentation (not needed for this bug fix)
- [x] Regression tests for the bug fix
- [ ] Screenshots attached (no visual UI change)
- [x] All commits have a `Signed-off-by` line

Developed with help from Codex. I reviewed and understand the change.
