### PR TITLE
feat(ui): add destructive ButtonIcon state

### DIFF
--- a/.changeset/quick-icons-warn.md
+++ b/.changeset/quick-icons-warn.md
@@ -1,0 +1,7 @@
+---
+'@backstage/ui': patch
+---
+
+Added destructive styling to `ButtonIcon` for dangerous icon-only actions.
+
+**Affected components:** ButtonIcon

--- a/docs-ui/src/app/components/button-icon/components.tsx
+++ b/docs-ui/src/app/components/button-icon/components.tsx
@@ -56,6 +56,31 @@ export const Disabled = () => {
   );
 };
 
+export const Destructive = () => {
+  return (
+    <Flex align="center" gap="2">
+      <ButtonIcon
+        destructive
+        icon={<RiCloudLine />}
+        variant="primary"
+        aria-label="Cloud"
+      />
+      <ButtonIcon
+        destructive
+        icon={<RiCloudLine />}
+        variant="secondary"
+        aria-label="Cloud"
+      />
+      <ButtonIcon
+        destructive
+        icon={<RiCloudLine />}
+        variant="tertiary"
+        aria-label="Cloud"
+      />
+    </Flex>
+  );
+};
+
 export const Pending = () => {
   return (
     <ButtonIcon

--- a/docs-ui/src/app/components/button-icon/page.mdx
+++ b/docs-ui/src/app/components/button-icon/page.mdx
@@ -7,9 +7,10 @@ import {
   variantsSnippet,
   sizesSnippet,
   disabledSnippet,
+  destructiveSnippet,
   isPendingSnippet,
 } from './snippets';
-import { Variants, Sizes, Disabled, Pending } from './components';
+import { Variants, Sizes, Disabled, Destructive, Pending } from './components';
 import { PageTitle } from '@/components/PageTitle';
 import { Theming } from '@/components/Theming';
 import { ButtonIconDefinition } from '../../../utils/definitions';
@@ -22,7 +23,7 @@ export const reactAriaUrls = {
 
 <PageTitle
   title="ButtonIcon"
-  description="An icon-only button with primary, secondary, and tertiary variants."
+  description="An icon-only button with primary, secondary, and tertiary variants, destructive styling, and pending state."
 />
 
 <Snippet align="center" py={4} preview={<Variants />} code={variantsSnippet} />
@@ -61,6 +62,18 @@ export const reactAriaUrls = {
   open
   preview={<Disabled />}
   code={disabledSnippet}
+/>
+
+### Destructive
+
+Use the `destructive` prop for dangerous actions like delete or remove.
+
+<Snippet
+  align="center"
+  py={4}
+  open
+  preview={<Destructive />}
+  code={destructiveSnippet}
 />
 
 ### Pending

--- a/docs-ui/src/app/components/button-icon/props-definition.tsx
+++ b/docs-ui/src/app/components/button-icon/props-definition.tsx
@@ -19,6 +19,12 @@ export const buttonIconPropDefs: Record<string, PropDef> = {
       </>
     ),
   },
+  destructive: {
+    type: 'boolean',
+    default: 'false',
+    description:
+      'Applies destructive styling for dangerous actions like delete or remove.',
+  },
   size: {
     type: 'enum',
     values: ['small', 'medium'],

--- a/docs-ui/src/app/components/button-icon/snippets.ts
+++ b/docs-ui/src/app/components/button-icon/snippets.ts
@@ -20,4 +20,10 @@ export const disabledSnippet = `<Flex direction="row" gap="2">
   <ButtonIcon isDisabled icon={<RiCloudLine />} variant="tertiary" aria-label="Cloud" />
 </Flex>`;
 
+export const destructiveSnippet = `<Flex align="center" gap="2">
+  <ButtonIcon destructive icon={<RiCloudLine />} variant="primary" aria-label="Cloud" />
+  <ButtonIcon destructive icon={<RiCloudLine />} variant="secondary" aria-label="Cloud" />
+  <ButtonIcon destructive icon={<RiCloudLine />} variant="tertiary" aria-label="Cloud" />
+</Flex>`;
+
 export const isPendingSnippet = `<ButtonIcon icon={<RiCloudLine />} variant="primary" isPending aria-label="Cloud" />`;

--- a/packages/ui/report.api.md
+++ b/packages/ui/report.api.md
@@ -574,6 +574,9 @@ export const ButtonIconDefinition: {
       readonly dataAttribute: true;
       readonly default: 'primary';
     };
+    readonly destructive: {
+      readonly dataAttribute: true;
+    };
     readonly isPending: {
       readonly dataAttribute: true;
     };
@@ -589,6 +592,7 @@ export const ButtonIconDefinition: {
 export type ButtonIconOwnProps = {
   size?: Responsive<'small' | 'medium'>;
   variant?: Responsive<'primary' | 'secondary' | 'tertiary'>;
+  destructive?: boolean;
   icon?: ReactElement;
   isPending?: boolean;
   loading?: boolean;

--- a/packages/ui/src/components/ButtonIcon/ButtonIcon.module.css
+++ b/packages/ui/src/components/ButtonIcon/ButtonIcon.module.css
@@ -79,6 +79,39 @@
     }
   }
 
+  .bui-ButtonIcon[data-variant='primary'][data-destructive='true'] {
+    /* Custom properties matching future token names (without bui- prefix) */
+    --bg-solid-danger: #dc2626;
+    --bg-solid-danger-hover: #b91c1c;
+    --bg-solid-danger-pressed: #991b1b;
+    --bg-solid-danger-disabled: #fca5a5;
+    --fg-solid-danger: var(--bui-white);
+
+    [data-theme-mode='dark'] & {
+      --bg-solid-danger: #ef4444;
+      --bg-solid-danger-hover: #dc2626;
+      --bg-solid-danger-pressed: #b91c1c;
+      --bg-solid-danger-disabled: #7f1d1d;
+    }
+
+    --bg: var(--bg-solid-danger);
+    --bg-hover: var(--bg-solid-danger-hover);
+    --bg-active: var(--bg-solid-danger-pressed);
+    --fg: var(--fg-solid-danger);
+
+    &[data-disabled='true'],
+    &[data-ispending='true'] {
+      --bg: var(--bg-solid-danger-disabled);
+      --bg-hover: var(--bg-solid-danger-disabled);
+      --bg-active: var(--bg-solid-danger-disabled);
+    }
+
+    &[data-focus-visible] {
+      outline: 2px solid var(--bui-border-danger);
+      outline-offset: 2px;
+    }
+  }
+
   .bui-ButtonIcon[data-variant='secondary'] {
     --bg: var(--bui-bg-neutral-1);
     --bg-hover: var(--bui-bg-neutral-1-hover);
@@ -117,6 +150,33 @@
     }
   }
 
+  .bui-ButtonIcon[data-variant='secondary'][data-destructive='true'] {
+    /* Custom properties for hover/active states (no tokens exist yet) */
+    --bg-danger-hover: #fecaca;
+    --bg-danger-pressed: #fca5a5;
+
+    [data-theme-mode='dark'] & {
+      --bg-danger-hover: #450a0a;
+      --bg-danger-pressed: #7f1d1d;
+    }
+
+    --bg: var(--bui-bg-danger);
+    --bg-hover: var(--bg-danger-hover);
+    --bg-active: var(--bg-danger-pressed);
+    --fg: var(--bui-fg-danger);
+
+    &[data-disabled='true'],
+    &[data-ispending='true'] {
+      --bg-hover: var(--bg);
+      --bg-active: var(--bg);
+      --fg: var(--bui-fg-disabled);
+    }
+
+    &[data-focus-visible] {
+      box-shadow: inset 0 0 0 2px var(--bui-border-danger);
+    }
+  }
+
   .bui-ButtonIcon[data-variant='tertiary'] {
     --bg-hover: var(--bui-bg-neutral-1-hover);
     --bg-active: var(--bui-bg-neutral-1-pressed);
@@ -148,6 +208,32 @@
       outline: none;
       transition: none;
       box-shadow: inset 0 0 0 2px var(--bui-ring);
+    }
+  }
+
+  .bui-ButtonIcon[data-variant='tertiary'][data-destructive='true'] {
+    /* Custom properties for hover/active states (no tokens exist yet) */
+    --bg-danger-hover: #fecaca;
+    --bg-danger-pressed: #fca5a5;
+
+    [data-theme-mode='dark'] & {
+      --bg-danger-hover: #450a0a;
+      --bg-danger-pressed: #7f1d1d;
+    }
+
+    --bg-hover: var(--bui-bg-danger);
+    --bg-active: var(--bg-danger-pressed);
+    --fg: var(--bui-fg-danger);
+
+    &[data-disabled='true'],
+    &[data-ispending='true'] {
+      --bg-hover: var(--bg);
+      --bg-active: var(--bg);
+      --fg: var(--bui-fg-disabled);
+    }
+
+    &[data-focus-visible] {
+      box-shadow: inset 0 0 0 2px var(--bui-border-danger);
     }
   }
 

--- a/packages/ui/src/components/ButtonIcon/ButtonIcon.stories.tsx
+++ b/packages/ui/src/components/ButtonIcon/ButtonIcon.stories.tsx
@@ -17,7 +17,7 @@ import preview from '../../../../../.storybook/preview';
 import { ButtonIcon } from './ButtonIcon';
 import { Flex } from '../Flex';
 import { Text } from '../Text';
-import { RiCloudLine } from '@remixicon/react';
+import { RiCloudLine, RiDeleteBinLine } from '@remixicon/react';
 import { useState } from 'react';
 
 const meta = preview.meta({
@@ -30,7 +30,10 @@ const meta = preview.meta({
     },
     variant: {
       control: 'select',
-      options: ['primary', 'secondary'],
+      options: ['primary', 'secondary', 'tertiary'],
+    },
+    destructive: {
+      control: 'boolean',
     },
   },
 });
@@ -45,6 +48,31 @@ export const Variants = meta.story({
       <ButtonIcon icon={<RiCloudLine />} variant="primary" />
       <ButtonIcon icon={<RiCloudLine />} variant="secondary" />
       <ButtonIcon icon={<RiCloudLine />} variant="tertiary" />
+    </Flex>
+  ),
+});
+
+export const Destructive = meta.story({
+  render: () => (
+    <Flex align="center" gap="2">
+      <ButtonIcon
+        aria-label="Delete"
+        destructive
+        icon={<RiDeleteBinLine />}
+        variant="primary"
+      />
+      <ButtonIcon
+        aria-label="Delete"
+        destructive
+        icon={<RiDeleteBinLine />}
+        variant="secondary"
+      />
+      <ButtonIcon
+        aria-label="Delete"
+        destructive
+        icon={<RiDeleteBinLine />}
+        variant="tertiary"
+      />
     </Flex>
   ),
 });

--- a/packages/ui/src/components/ButtonIcon/ButtonIcon.test.tsx
+++ b/packages/ui/src/components/ButtonIcon/ButtonIcon.test.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { RiDeleteBinLine } from '@remixicon/react';
+import { ButtonIcon } from './ButtonIcon';
+
+describe('ButtonIcon', () => {
+  it('marks destructive actions', () => {
+    render(
+      <ButtonIcon aria-label="Delete" destructive icon={<RiDeleteBinLine />} />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Delete' })).toHaveAttribute(
+      'data-destructive',
+      'true',
+    );
+  });
+});

--- a/packages/ui/src/components/ButtonIcon/ButtonIcon.tsx
+++ b/packages/ui/src/components/ButtonIcon/ButtonIcon.tsx
@@ -22,7 +22,7 @@ import { useDefinition } from '../../hooks/useDefinition';
 import { ButtonIconDefinition } from './definition';
 
 /**
- * An icon-only button that supports a loading state and requires an accessible label.
+ * An icon-only button that supports destructive and loading states and requires an accessible label.
  *
  * @public
  */

--- a/packages/ui/src/components/ButtonIcon/definition.ts
+++ b/packages/ui/src/components/ButtonIcon/definition.ts
@@ -33,6 +33,7 @@ export const ButtonIconDefinition = defineComponent<ButtonIconOwnProps>()({
   propDefs: {
     size: { dataAttribute: true, default: 'small' },
     variant: { dataAttribute: true, default: 'primary' },
+    destructive: { dataAttribute: true },
     isPending: { dataAttribute: true },
     loading: { dataAttribute: true },
     icon: {},

--- a/packages/ui/src/components/ButtonIcon/types.ts
+++ b/packages/ui/src/components/ButtonIcon/types.ts
@@ -22,6 +22,7 @@ import type { Responsive } from '../../types';
 export type ButtonIconOwnProps = {
   size?: Responsive<'small' | 'medium'>;
   variant?: Responsive<'primary' | 'secondary' | 'tertiary'>;
+  destructive?: boolean;
   icon?: ReactElement;
   isPending?: boolean;
   /** @deprecated Use `isPending` instead. */


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #35023.

`ButtonIcon` now supports the same `destructive` state as `Button`:

- adds the optional public prop and generated `data-destructive` attribute
- matches `Button` danger colors for primary, secondary, and tertiary variants, including disabled, pending, focus, and dark-theme states
- documents the state in TSDoc and a dedicated Storybook story
- updates the API report and adds the required `@backstage/ui` changeset

The focused regression failed on `master` because the rendered button had no `data-destructive` attribute, then passed after the component-definition change.

AI assistance: this PR was implemented with OpenAI Codex. I reviewed the resulting diff against `Button`'s existing public API and state styles and ran the validation below.

Validation on Node 24:

- `CI=1 yarn test packages/ui/src/components/ButtonIcon/ButtonIcon.test.tsx`
- `CI=1 yarn test packages/ui/src` — 17 suites, 254 tests passed
- `yarn tsc`
- `yarn lint --fix` — checked 335 files in `packages/ui`
- `yarn build:api-reports`
- `yarn prettier --write <changed paths>`
- `yarn install --immutable`
- local Storybook compiled and served the new story

A screenshot is not attached because this execution session had no available browser surface. The dedicated `Destructive` story renders all three variants for visual review.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
