### PR TITLE
ci: fix permission for slot counter variable

### DIFF
--- a/.github/workflows/sync_pull-requests-scheduled.yml
+++ b/.github/workflows/sync_pull-requests-scheduled.yml
@@ -12,7 +12,6 @@ jobs:
   plan:
     permissions:
       pull-requests: read
-      actions: write
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -24,10 +23,18 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Generate app token
+        id: token
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        with:
+          app-id: ${{ secrets.BACKSTAGE_GOALIE_APPLICATION_ID }}
+          private-key: ${{ secrets.BACKSTAGE_GOALIE_PRIVATE_KEY }}
+
       - name: Determine PR batch
         id: batch
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
+          github-token: ${{ steps.token.outputs.token }}
           script: |
             // 48 slots (one per 30-minute cron window across a day).
             // Each PR is assigned a fixed slot via pr.number % 48, so


### PR DESCRIPTION
Every run of `sync_pull-requests-scheduled` since #35044 merged has failed with:

```
RequestError [HttpError]: Resource not accessible by integration
url: 'https://api.github.com/repos/backstage/backstage/actions/variables'
x-accepted-github-permissions: 'actions_variables=write'
```

The job had `actions: write` which covers workflow runs/artifacts, but repository variables need `variables: write`.

#### :heavy_check_mark: Checklist

- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

🤖 Generated with [Claude Code](https://claude.com/claude-code)