### PR TITLE
fix(ui): add destructive prop to ButtonIcon

### DIFF
--- a/.changeset/buttonicon-destructive-prop.md
+++ b/.changeset/buttonicon-destructive-prop.md
@@ -1,0 +1,7 @@
+---
+'@backstage/ui': patch
+---
+
+Add `destructive` prop to `ButtonIcon` for danger/delete icon buttons.
+
+**Affected components:** ButtonIcon

--- a/packages/ui/report.api.md
+++ b/packages/ui/report.api.md
@@ -574,6 +574,9 @@ export const ButtonIconDefinition: {
       readonly dataAttribute: true;
       readonly default: 'primary';
     };
+    readonly destructive: {
+      readonly dataAttribute: true;
+    };
     readonly isPending: {
       readonly dataAttribute: true;
     };
@@ -589,6 +592,7 @@ export const ButtonIconDefinition: {
 export type ButtonIconOwnProps = {
   size?: Responsive<'small' | 'medium'>;
   variant?: Responsive<'primary' | 'secondary' | 'tertiary'>;
+  destructive?: boolean;
   icon?: ReactElement;
   isPending?: boolean;
   loading?: boolean;

--- a/packages/ui/src/components/ButtonIcon/ButtonIcon.module.css
+++ b/packages/ui/src/components/ButtonIcon/ButtonIcon.module.css
@@ -79,6 +79,38 @@
     }
   }
 
+  .bui-ButtonIcon[data-variant='primary'][data-destructive='true'] {
+    --bg-solid-danger: #dc2626;
+    --bg-solid-danger-hover: #b91c1c;
+    --bg-solid-danger-pressed: #991b1b;
+    --bg-solid-danger-disabled: #fca5a5;
+    --fg-solid-danger: var(--bui-white);
+
+    [data-theme-mode='dark'] & {
+      --bg-solid-danger: #ef4444;
+      --bg-solid-danger-hover: #dc2626;
+      --bg-solid-danger-pressed: #b91c1c;
+      --bg-solid-danger-disabled: #7f1d1d;
+    }
+
+    --bg: var(--bg-solid-danger);
+    --bg-hover: var(--bg-solid-danger-hover);
+    --bg-active: var(--bg-solid-danger-pressed);
+    --fg: var(--fg-solid-danger);
+
+    &[data-disabled='true'],
+    &[data-ispending='true'] {
+      --bg: var(--bg-solid-danger-disabled);
+      --bg-hover: var(--bg-solid-danger-disabled);
+      --bg-active: var(--bg-solid-danger-disabled);
+    }
+
+    &[data-focus-visible] {
+      outline: 2px solid var(--bui-border-danger);
+      outline-offset: 2px;
+    }
+  }
+
   .bui-ButtonIcon[data-variant='secondary'] {
     --bg: var(--bui-bg-neutral-1);
     --bg-hover: var(--bui-bg-neutral-1-hover);
@@ -117,6 +149,32 @@
     }
   }
 
+  .bui-ButtonIcon[data-variant='secondary'][data-destructive='true'] {
+    --bg-danger-hover: #fecaca;
+    --bg-danger-pressed: #fca5a5;
+
+    [data-theme-mode='dark'] & {
+      --bg-danger-hover: #450a0a;
+      --bg-danger-pressed: #7f1d1d;
+    }
+
+    --bg: var(--bui-bg-danger);
+    --bg-hover: var(--bg-danger-hover);
+    --bg-active: var(--bg-danger-pressed);
+    --fg: var(--bui-fg-danger);
+
+    &[data-disabled='true'],
+    &[data-ispending='true'] {
+      --bg-hover: var(--bg);
+      --bg-active: var(--bg);
+      --fg: var(--bui-fg-disabled);
+    }
+
+    &[data-focus-visible] {
+      box-shadow: inset 0 0 0 2px var(--bui-border-danger);
+    }
+  }
+
   .bui-ButtonIcon[data-variant='tertiary'] {
     --bg-hover: var(--bui-bg-neutral-1-hover);
     --bg-active: var(--bui-bg-neutral-1-pressed);
@@ -148,6 +206,31 @@
       outline: none;
       transition: none;
       box-shadow: inset 0 0 0 2px var(--bui-ring);
+    }
+  }
+
+  .bui-ButtonIcon[data-variant='tertiary'][data-destructive='true'] {
+    --bg-danger-hover: #fecaca;
+    --bg-danger-pressed: #fca5a5;
+
+    [data-theme-mode='dark'] & {
+      --bg-danger-hover: #450a0a;
+      --bg-danger-pressed: #7f1d1d;
+    }
+
+    --bg-hover: var(--bui-bg-danger);
+    --bg-active: var(--bg-danger-pressed);
+    --fg: var(--bui-fg-danger);
+
+    &[data-disabled='true'],
+    &[data-ispending='true'] {
+      --bg-hover: var(--bg);
+      --bg-active: var(--bg);
+      --fg: var(--bui-fg-disabled);
+    }
+
+    &[data-focus-visible] {
+      box-shadow: inset 0 0 0 2px var(--bui-border-danger);
     }
   }
 

--- a/packages/ui/src/components/ButtonIcon/definition.ts
+++ b/packages/ui/src/components/ButtonIcon/definition.ts
@@ -33,6 +33,7 @@ export const ButtonIconDefinition = defineComponent<ButtonIconOwnProps>()({
   propDefs: {
     size: { dataAttribute: true, default: 'small' },
     variant: { dataAttribute: true, default: 'primary' },
+    destructive: { dataAttribute: true },
     isPending: { dataAttribute: true },
     loading: { dataAttribute: true },
     icon: {},

--- a/packages/ui/src/components/ButtonIcon/types.ts
+++ b/packages/ui/src/components/ButtonIcon/types.ts
@@ -22,6 +22,7 @@ import type { Responsive } from '../../types';
 export type ButtonIconOwnProps = {
   size?: Responsive<'small' | 'medium'>;
   variant?: Responsive<'primary' | 'secondary' | 'tertiary'>;
+  destructive?: boolean;
   icon?: ReactElement;
   isPending?: boolean;
   /** @deprecated Use `isPending` instead. */


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds the `destructive` prop to `ButtonIcon`, matching the existing behavior in `Button`. This enables red/danger styling on icon-only buttons (e.g., a delete icon that visually signals a destructive action).

The fix adds the prop to the type definition, the component definition (data attribute mapping), and the CSS module (destructive styles for primary, secondary, and tertiary variants, including dark mode and disabled states).

**Affected components:** ButtonIcon

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message.

Fixes #35023