### PR TITLE
fix(microsoft-provider): fetch profile via Graph on resource-scoped refresh

### DIFF
--- a/.changeset/fix-microsoft-refresh-profile.md
+++ b/.changeset/fix-microsoft-refresh-profile.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-microsoft-provider': patch
+---
+
+Fixed an issue where refreshing tokens with non-Graph scopes (such as Azure Management API) would crash the sign-in resolver because the user profile was unavailable. The Microsoft authenticator now makes a separate Graph API call to fetch the profile when the primary token targets a different resource.

--- a/.changeset/fix-microsoft-refresh-profile.md
+++ b/.changeset/fix-microsoft-refresh-profile.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-auth-backend-module-microsoft-provider': patch
 ---
 
-Fixed an issue where refreshing tokens with non-Graph scopes (such as Azure Management API) would crash the sign-in resolver because the user profile was unavailable. The Microsoft authenticator now makes a separate Graph API call to fetch the profile when the primary token targets a different resource.
+Fixed an issue where acquiring tokens with non-Graph scopes (such as Azure Management API) would crash the sign-in resolver because the user profile was unavailable. This affected both the initial sign-in and later token refreshes. The Microsoft authenticator now makes a separate Graph API call to fetch the profile when the primary token targets a different resource. Setting the `skipUserProfile` configuration option to true disables this extra call.

--- a/docs/auth/microsoft/provider.md
+++ b/docs/auth/microsoft/provider.md
@@ -83,7 +83,7 @@ The Microsoft provider is a structure with three mandatory configuration keys:
   When specified, this reduces login friction for users with accounts in multiple tenants by automatically filtering away accounts from other tenants.
   For more details, see [Home Realm Discovery](https://learn.microsoft.com/en-us/azure/active-directory/manage-apps/home-realm-discovery-policy)
 - `additionalScopes` (optional): List of scopes for the App Registration, to be requested in addition to the required ones.
-- `skipUserProfile` (optional): If true, skips loading the user profile even if the `User.Read` scope is present. This is a performance optimization during login and can be used with resolvers that only needs the email address in `spec.profile.email` obtained when the `email` OAuth2 scope is present.
+- `skipUserProfile` (optional): If true, skips loading the user profile even if the `User.Read` scope is present. This also disables the separate Microsoft Graph call that is otherwise made to fetch the profile when acquiring tokens for non-Graph resources (for example the Azure Management API). This is a performance optimization and can be used with resolvers that only needs the email address in `spec.profile.email` obtained when the `email` OAuth2 scope is present.
 - `sessionDuration` (optional): Lifespan of the user session.
 
 ### Resolvers

--- a/plugins/auth-backend-module-microsoft-provider/report.api.md
+++ b/plugins/auth-backend-module-microsoft-provider/report.api.md
@@ -22,6 +22,7 @@ export const microsoftAuthenticator: OAuthAuthenticator<
   {
     helper: PassportOAuthAuthenticatorHelper;
     domainHint: string | undefined;
+    skipUserProfile: boolean;
   },
   PassportProfile
 >;

--- a/plugins/auth-backend-module-microsoft-provider/src/__testUtils__/fake.ts
+++ b/plugins/auth-backend-module-microsoft-provider/src/__testUtils__/fake.ts
@@ -37,11 +37,14 @@ export class FakeMicrosoftAPI {
     id_token?: string;
   } {
     const scopeParameter = formData.get('scope');
-    const claims =
-      (scopeParameter && this.allClaimsForScope(scopeParameter)) ??
-      formData.get('grant_type') === 'refresh_token'
-        ? this.decodeClaims(formData.get('refresh_token')!)
-        : this.decodeClaims(formData.get('code')!);
+    let claims: Claims;
+    if (scopeParameter) {
+      claims = this.allClaimsForScope(scopeParameter);
+    } else if (formData.get('grant_type') === 'refresh_token') {
+      claims = this.decodeClaims(formData.get('refresh_token')!);
+    } else {
+      claims = this.decodeClaims(formData.get('code')!);
+    }
     return {
       ...this.tokenWithClaims(claims),
       ...(this.hasScope(claims, 'offline_access') && {

--- a/plugins/auth-backend-module-microsoft-provider/src/authenticator.test.ts
+++ b/plugins/auth-backend-module-microsoft-provider/src/authenticator.test.ts
@@ -48,6 +48,7 @@ describe('microsoftAuthenticator', () => {
   let implementation: {
     domainHint: string | undefined;
     helper: PassportOAuthAuthenticatorHelper;
+    skipUserProfile: boolean;
   };
 
   beforeEach(() => {
@@ -259,14 +260,15 @@ describe('microsoftAuthenticator', () => {
       expect(profile.photos).toStrictEqual([{ value: photo }]);
     });
 
-    it('returns access token for non-microsoft graph scope', async () => {
+    it('fetches profile via Graph when refreshing with non-Graph scopes', async () => {
       const foreignScope = 'aks-audience/user.read';
       const refreshResponse = await microsoftAuthenticator.refresh(
         createRefreshRequest(foreignScope),
         implementation,
       );
 
-      expect(refreshResponse.fullProfile).toBeUndefined();
+      expect(refreshResponse.fullProfile).toBeDefined();
+      expect(refreshResponse.fullProfile!.displayName).toBe('Conrad');
       expect(refreshResponse.session.accessToken).toBe(
         microsoftApi.generateAccessToken(foreignScope),
       );

--- a/plugins/auth-backend-module-microsoft-provider/src/authenticator.test.ts
+++ b/plugins/auth-backend-module-microsoft-provider/src/authenticator.test.ts
@@ -182,7 +182,26 @@ describe('microsoftAuthenticator', () => {
       expect(profile.photos).toStrictEqual([{ value: photo }]);
     });
 
-    it('returns access token for non-microsoft graph scope', async () => {
+    it('fetches profile via Graph when signing in with non-Graph scopes', async () => {
+      const foreignScope = 'aks-audience/user.read offline_access';
+      const authenticateResponse = await microsoftAuthenticator.authenticate(
+        createAuthenticateRequest(foreignScope),
+        implementation,
+      );
+
+      expect(authenticateResponse.fullProfile).toBeDefined();
+      expect(authenticateResponse.fullProfile!.displayName).toBe('Conrad');
+      expect(authenticateResponse.session.accessToken).toBe(
+        microsoftApi.generateAccessToken(foreignScope),
+      );
+      expect(authenticateResponse.session.refreshToken).toBe(
+        microsoftApi.generateRefreshToken(
+          'openid email User.Read offline_access',
+        ),
+      );
+    });
+
+    it('returns no profile for non-Graph scopes when no refresh token is granted', async () => {
       const foreignScope = 'aks-audience/user.read';
       const authenticateResponse = await microsoftAuthenticator.authenticate(
         createAuthenticateRequest(foreignScope),
@@ -271,6 +290,51 @@ describe('microsoftAuthenticator', () => {
       expect(refreshResponse.fullProfile!.displayName).toBe('Conrad');
       expect(refreshResponse.session.accessToken).toBe(
         microsoftApi.generateAccessToken(foreignScope),
+      );
+    });
+
+    it('chains the rotated refresh token into the Graph profile call', async () => {
+      const tokenRequests: URLSearchParams[] = [];
+      server.use(
+        http.post(
+          'https://login.microsoftonline.com/tenantId/oauth2/v2.0/token',
+          async ({ request }) => {
+            const formData = new URLSearchParams(await request.text());
+            tokenRequests.push(formData);
+            return HttpResponse.json({
+              ...microsoftApi.token(formData),
+              token_type: 'Bearer',
+              expires_in: 123,
+              ext_expires_in: 123,
+            });
+          },
+        ),
+      );
+
+      const foreignScope = 'aks-audience/user.read offline_access';
+      const refreshResponse = await microsoftAuthenticator.refresh(
+        {
+          scope: foreignScope,
+          // An old refresh token that the first refresh call will rotate
+          refreshToken: microsoftApi.generateRefreshToken(
+            'aks-audience/user.read',
+          ),
+          req: {} as unknown as express.Request,
+        },
+        implementation,
+      );
+
+      // The Graph profile call must use the rotated refresh token from the
+      // first call, not the incoming one
+      expect(tokenRequests).toHaveLength(2);
+      expect(tokenRequests[1].get('refresh_token')).toBe(
+        microsoftApi.generateRefreshToken(foreignScope),
+      );
+      expect(refreshResponse.fullProfile!.displayName).toBe('Conrad');
+      expect(refreshResponse.session.refreshToken).toBe(
+        microsoftApi.generateRefreshToken(
+          'openid email User.Read offline_access',
+        ),
       );
     });
 

--- a/plugins/auth-backend-module-microsoft-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-microsoft-provider/src/authenticator.ts
@@ -16,11 +16,52 @@
 
 import {
   createOAuthAuthenticator,
+  OAuthAuthenticatorRefreshInput,
+  OAuthAuthenticatorResult,
   PassportOAuthAuthenticatorHelper,
   PassportOAuthDoneCallback,
   PassportProfile,
 } from '@backstage/plugin-auth-node';
 import { ExtendedMicrosoftStrategy } from './strategy';
+
+const GRAPH_PROFILE_SCOPE = 'openid email User.Read offline_access';
+
+/**
+ * When the acquired access token targets a non-Graph resource, it can't be
+ * used to fetch the user profile from the Microsoft Graph API. In that case,
+ * make a separate refresh call with Graph scopes to get a token for profile
+ * fetching, so that the sign-in resolver always receives a valid profile.
+ * This is possible because Microsoft refresh tokens are resource-agnostic:
+ * a single refresh token can produce access tokens for different resources.
+ * The access token from the original result is preserved - only the profile
+ * is taken from the Graph-scoped call.
+ */
+async function withProfileFetchedViaGraph(
+  result: OAuthAuthenticatorResult<PassportProfile>,
+  input: { req: OAuthAuthenticatorRefreshInput['req']; refreshToken?: string },
+  ctx: { helper: PassportOAuthAuthenticatorHelper; skipUserProfile: boolean },
+): Promise<OAuthAuthenticatorResult<PassportProfile>> {
+  if (result.fullProfile || ctx.skipUserProfile) {
+    return result;
+  }
+  const refreshToken = result.session.refreshToken ?? input.refreshToken;
+  if (!refreshToken) {
+    return result;
+  }
+  const graphResult = await ctx.helper.refresh({
+    req: input.req,
+    scope: GRAPH_PROFILE_SCOPE,
+    refreshToken,
+  });
+  return {
+    ...result,
+    fullProfile: graphResult.fullProfile,
+    session: {
+      ...result.session,
+      refreshToken: graphResult.session.refreshToken ?? refreshToken,
+    },
+  };
+}
 
 /** @public */
 export const microsoftAuthenticator = createOAuthAuthenticator({
@@ -89,31 +130,12 @@ export const microsoftAuthenticator = createOAuthAuthenticator({
   },
 
   async authenticate(input, ctx) {
-    return ctx.helper.authenticate(input);
+    const result = await ctx.helper.authenticate(input);
+    return withProfileFetchedViaGraph(result, input, ctx);
   },
 
   async refresh(input, ctx) {
     const result = await ctx.helper.refresh(input);
-    if (result.fullProfile || ctx.skipUserProfile) {
-      return result;
-    }
-    // When the requested scopes target a non-Graph resource, the access
-    // token can't be used to fetch the user profile. Make a second
-    // refresh to get a Graph-scoped token for profile fetching, so the
-    // sign-in resolver always receives a valid profile.
-    const graphResult = await ctx.helper.refresh({
-      ...input,
-      refreshToken: result.session.refreshToken ?? input.refreshToken,
-      scope: 'openid email User.Read offline_access',
-    });
-    return {
-      ...result,
-      fullProfile: graphResult.fullProfile,
-      session: {
-        ...result.session,
-        refreshToken:
-          graphResult.session.refreshToken ?? result.session.refreshToken,
-      },
-    };
+    return withProfileFetchedViaGraph(result, input, ctx);
   },
 });

--- a/plugins/auth-backend-module-microsoft-provider/src/authenticator.ts
+++ b/plugins/auth-backend-module-microsoft-provider/src/authenticator.ts
@@ -72,6 +72,7 @@ export const microsoftAuthenticator = createOAuthAuthenticator({
     return {
       helper,
       domainHint,
+      skipUserProfile,
     };
   },
 
@@ -92,6 +93,27 @@ export const microsoftAuthenticator = createOAuthAuthenticator({
   },
 
   async refresh(input, ctx) {
-    return ctx.helper.refresh(input);
+    const result = await ctx.helper.refresh(input);
+    if (result.fullProfile || ctx.skipUserProfile) {
+      return result;
+    }
+    // When the requested scopes target a non-Graph resource, the access
+    // token can't be used to fetch the user profile. Make a second
+    // refresh to get a Graph-scoped token for profile fetching, so the
+    // sign-in resolver always receives a valid profile.
+    const graphResult = await ctx.helper.refresh({
+      ...input,
+      refreshToken: result.session.refreshToken ?? input.refreshToken,
+      scope: 'openid email User.Read offline_access',
+    });
+    return {
+      ...result,
+      fullProfile: graphResult.fullProfile,
+      session: {
+        ...result.session,
+        refreshToken:
+          graphResult.session.refreshToken ?? result.session.refreshToken,
+      },
+    };
   },
 });


### PR DESCRIPTION
Fixes #28002

## Alternative approach to #34378

Instead of adding framework-level support for skipping the sign-in resolver when a profile is unavailable, this fixes the problem at the provider level: the Microsoft authenticator now always provides a profile.

### The problem

When refreshing tokens with non-Graph scopes (e.g. `https://management.azure.com/.default`), the access token can't call the Microsoft Graph user info endpoint. The profile comes back as `undefined`, and the sign-in resolver crashes with `Cannot read properties of undefined (reading 'id')`.

### The fix

When the primary refresh produces no profile (because the scopes target a different resource), the authenticator makes a second refresh call with Graph scopes (`openid email User.Read offline_access`) specifically to fetch the profile. The access token from the original request is preserved — only the profile is taken from the Graph-scoped call.

This is possible because Microsoft's refresh tokens are scope-agnostic: a single refresh token can produce access tokens for different resources.

### Why this over #34378

PR #34378 added `OAuthAuthenticatorResponse` (optional profile) and `hasFullProfile` guards to skip the resolver at the framework level. [Rugvip raised a concern](https://github.com/backstage/backstage/pull/34378#issuecomment-5192134529) that this is unsafe: the `/refresh` endpoint is also used to re-establish identity on page reload, and skipping the resolver based on profile absence can't distinguish "intentionally no profile" from "bug that prevents profile fetching" — it fails open.

This approach keeps the security model intact: the sign-in resolver always runs, always receives a profile, and always re-validates the user.

### Trade-off

The second Graph call adds latency to resource-scoped refreshes. Microsoft's user info endpoint can be slow, especially when fetching avatar data. In practice this happens in background token refreshes and shouldn't noticeably affect UX.

### Also fixes

A pre-existing operator precedence bug in the test mock's `token()` method where the `scope` parameter was ignored for `refresh_token` grants due to ternary vs nullish coalescing precedence.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)