### PR TITLE
docs: Strict mdx cleanup and linting fixes

### DIFF
--- a/docs/accessibility/index.md
+++ b/docs/accessibility/index.md
@@ -47,7 +47,7 @@ If you want to use the Lighthouse CLI and run the checks based on the config you
 yarn dlx @lhci/cli@0.11.x autorun
 ```
 
-:::note Note
+:::note
 Running this command will use the [Lighthouse config](https://github.com/backstage/backstage/blob/39ba2284d73885b7ca8290cb38e2b1e4d983c8d6/lighthouserc.js#L19-L34) so make sure to adjust it to your needs if needed.
 
 :::

--- a/docs/architecture-decisions/adr003-avoid-default-exports.md
+++ b/docs/architecture-decisions/adr003-avoid-default-exports.md
@@ -23,7 +23,7 @@ as `import { default as localName } from 'the-module';`.
 However, there are numerous reasons to avoid default exports, as documented by
 others before:
 
-- [https://humanwhocodes.com/blog/2019/01/stop-using-default-exports-javascript-module/](https://humanwhocodes.com/blog/2019/01/stop-using-default-exports-javascript-module/)
+- <https://humanwhocodes.com/blog/2019/01/stop-using-default-exports-javascript-module/>
 
 A summary:
 

--- a/docs/architecture-decisions/adr003-avoid-default-exports.md
+++ b/docs/architecture-decisions/adr003-avoid-default-exports.md
@@ -23,7 +23,7 @@ as `import { default as localName } from 'the-module';`.
 However, there are numerous reasons to avoid default exports, as documented by
 others before:
 
-- https://humanwhocodes.com/blog/2019/01/stop-using-default-exports-javascript-module/
+- [https://humanwhocodes.com/blog/2019/01/stop-using-default-exports-javascript-module/](https://humanwhocodes.com/blog/2019/01/stop-using-default-exports-javascript-module/)
 
 A summary:
 

--- a/docs/architecture-decisions/adr007-use-msw-to-mock-service-requests.md
+++ b/docs/architecture-decisions/adr007-use-msw-to-mock-service-requests.md
@@ -13,7 +13,7 @@ library to mock network requests by using an express style declaration for
 routes. react-testing-library suggests using this library instead of mocking
 fetch directly whether this be in a browser or in node.
 
-https://github.com/mswjs/msw
+[https://github.com/mswjs/msw](https://github.com/mswjs/msw)
 
 ## Decision
 

--- a/docs/architecture-decisions/adr007-use-msw-to-mock-service-requests.md
+++ b/docs/architecture-decisions/adr007-use-msw-to-mock-service-requests.md
@@ -13,7 +13,7 @@ library to mock network requests by using an express style declaration for
 routes. react-testing-library suggests using this library instead of mocking
 fetch directly whether this be in a browser or in node.
 
-[https://github.com/mswjs/msw](https://github.com/mswjs/msw)
+<https://github.com/mswjs/msw>
 
 ## Decision
 

--- a/docs/architecture-decisions/adr009-entity-references.md
+++ b/docs/architecture-decisions/adr009-entity-references.md
@@ -21,7 +21,7 @@ made.
 The textual format, as written by humans, to reference entities by name is on
 the following form, where square brackets denote optionality:
 
-```
+```text
 [<kind>:][<namespace>/]<name>
 ```
 
@@ -56,7 +56,7 @@ A full description of the format can be found
 Where entities are referenced by name in the Backstage frontend, the URL
 containing the reference shall take the following form:
 
-```
+```text
 :namespace/:kind/:name
 ```
 

--- a/docs/architecture-decisions/adr013-use-node-fetch.md
+++ b/docs/architecture-decisions/adr013-use-node-fetch.md
@@ -4,7 +4,7 @@ title: 'ADR013: [superseded] Proper use of HTTP fetching libraries'
 description: Architecture Decision Record (ADR) for the proper use of fetchApiRef, node-fetch, and cross-fetch for data fetching.
 ---
 
-:::note Superseded
+:::note[Superseded]
 
 This ADR has been superseded by [ADR014](./adr014-use-fetch.md) and no longer applies.
 

--- a/docs/auth/add-auth-provider.md
+++ b/docs/auth/add-auth-provider.md
@@ -21,7 +21,7 @@ interface consists of four methods. Each of these methods is hosted at an
 endpoint (by default) `/api/auth/[provider]/method`, where `method` performs a
 certain operation as follows:
 
-```
+```text
   /auth/[provider]/start -> Initiate a login from the web page
   /auth/[provider]/handler/frame -> Handle a finished authentication operation
   /auth/[provider]/refresh -> Refresh the validity of a login

--- a/docs/auth/add-auth-provider.md
+++ b/docs/auth/add-auth-provider.md
@@ -260,7 +260,7 @@ The implementation is similar to the OAuth provider, but the `authenticator` fun
 > done should be invoked with false instead of a user to indicate an
 > authentication failure.
 >
-> http://www.passportjs.org/docs/configure/
+> [http://www.passportjs.org/docs/configure/](http://www.passportjs.org/docs/configure/)
 
 ### Add the provider to the backend
 

--- a/docs/auth/add-auth-provider.md
+++ b/docs/auth/add-auth-provider.md
@@ -260,7 +260,7 @@ The implementation is similar to the OAuth provider, but the `authenticator` fun
 > done should be invoked with false instead of a user to indicate an
 > authentication failure.
 >
-> [http://www.passportjs.org/docs/configure/](http://www.passportjs.org/docs/configure/)
+> <http://www.passportjs.org/docs/configure/>
 
 ### Add the provider to the backend
 

--- a/docs/auth/add-auth-provider.md
+++ b/docs/auth/add-auth-provider.md
@@ -4,7 +4,7 @@ title: Contributing New Provider Modules
 description: Documentation on adding new authentication providers
 ---
 
-:::note Note
+:::note
 
 The primary audience for this documentation are contributors that want to add support for new authentication providers.
 While you can follow it to implement your own custom providers it is much

--- a/docs/auth/atlassian/provider.md
+++ b/docs/auth/atlassian/provider.md
@@ -81,7 +81,7 @@ This provider includes several resolvers out of the box that you can use:
 - `emailLocalPartMatchingUserEntityName`: Matches the [local part](https://en.wikipedia.org/wiki/Email_address#Local-part) of the email address from the auth provider with the User entity that has a matching `name`. If no match is found, it will throw a `NotFoundError`.
 - `usernameMatchingUserEntityName`: Matches the username from the auth provider with the User entity that has a matching `name`. If no match is found, it will throw a `NotFoundError`.
 
-:::note Note
+:::note
 
 The resolvers will be tried in order but will only be skipped if they throw a `NotFoundError`.
 

--- a/docs/auth/auth0/provider.md
+++ b/docs/auth/auth0/provider.md
@@ -77,7 +77,7 @@ This provider includes several resolvers out of the box that you can use:
 - `emailMatchingUserEntityProfileEmail`: Matches the email address from the auth provider with the User entity that has a matching `spec.profile.email`. If no match is found, it will throw a `NotFoundError`.
 - `emailLocalPartMatchingUserEntityName`: Matches the [local part](https://en.wikipedia.org/wiki/Email_address#Local-part) of the email address from the auth provider with the User entity that has a matching `name`. If no match is found, it will throw a `NotFoundError`.
 
-:::note Note
+:::note
 
 The resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
 

--- a/docs/auth/autologout.md
+++ b/docs/auth/autologout.md
@@ -42,7 +42,7 @@ export default app.createRoot(
 );
 ```
 
-## Configuration
+## Configuration
 
 You can further adjust the Auto Logout settings by tweaking the available `<AutoLogout>` properties:
 

--- a/docs/auth/aws-alb/provider.md
+++ b/docs/auth/aws-alb/provider.md
@@ -44,7 +44,7 @@ This provider includes several resolvers out of the box that you can use:
 - `emailMatchingUserEntityProfileEmail`: Matches the email address from the auth provider with the User entity that has a matching `spec.profile.email`. If no match is found, it will throw a `NotFoundError`.
 - `emailLocalPartMatchingUserEntityName`: Matches the [local part](https://en.wikipedia.org/wiki/Email_address#Local-part) of the email address from the auth provider with the User entity that has a matching `name`. If no match is found, it will throw a `NotFoundError`.
 
-:::note Note
+:::note
 
 The resolvers will be tried in order but will only be skipped if they throw a `NotFoundError`.
 

--- a/docs/auth/bitbucket/provider.md
+++ b/docs/auth/bitbucket/provider.md
@@ -64,7 +64,7 @@ This provider includes several resolvers out of the box that you can use:
 - `userIdMatchingUserEntityAnnotation`: Matches the `userId` from the auth provider with the User entity that has a matching `bitbucket.org/user-id` annotation. If no match is found, it will throw a `NotFoundError`.
 - `usernameMatchingUserEntityAnnotation`: Matches the `username` from the auth provider with the User entity that has a matching `bitbucket.org/username` annotation. If no match is found, it will throw a `NotFoundError`.
 
-:::note Note
+:::note
 
 The resolvers will be tried in order but will only be skipped if they throw a `NotFoundError`.
 

--- a/docs/auth/bitbucketServer/provider.md
+++ b/docs/auth/bitbucketServer/provider.md
@@ -47,7 +47,7 @@ This provider includes several resolvers out of the box that you can use:
 - `emailMatchingUserEntityProfileEmail`: Matches the email address from the auth provider with the User entity that has a matching `spec.profile.email`. If no match is found, it will throw a `NotFoundError`.
 - `emailLocalPartMatchingUserEntityName`: Matches the [local part](https://en.wikipedia.org/wiki/Email_address#Local-part) of the email address from the auth provider with the User entity that has a matching `name`. If no match is found, it will throw a `NotFoundError`.
 
-:::note Note
+:::note
 
 The resolvers will be tried in order but will only be skipped if they throw a `NotFoundError`.
 

--- a/docs/auth/cloudflare/provider.md
+++ b/docs/auth/cloudflare/provider.md
@@ -60,7 +60,7 @@ This provider includes several resolvers out of the box that you can use:
 - `emailMatchingUserEntityProfileEmail`: Matches the email address from the auth provider with the User entity that has a matching `spec.profile.email`. If no match is found, it will throw a `NotFoundError`.
 - `emailLocalPartMatchingUserEntityName`: Matches the [local part](https://en.wikipedia.org/wiki/Email_address#Local-part) of the email address from the auth provider with the User entity that has a matching `name`. If no match is found, it will throw a `NotFoundError`.
 
-:::note Note
+:::note
 
 The resolvers will be tried in order but will only be skipped if they throw a `NotFoundError`.
 

--- a/docs/auth/github/provider.md
+++ b/docs/auth/github/provider.md
@@ -82,7 +82,7 @@ This provider includes several resolvers out of the box that you can use:
 - `usernameMatchingUserEntityName`: Matches the username from the auth provider with the User entity that has a matching `name`. If no match is found, it will throw a `NotFoundError`.
 - `userIdMatchingUserEntityAnnotation`: Matches the GitHub user ID with the User entity that has a matching `github.com/user-id`. If no match is found, it will throw a `NotFoundError`.
 
-:::note Note
+:::note
 
 The resolvers will be tried in order but will only be skipped if they throw a `NotFoundError`.
 

--- a/docs/auth/gitlab/provider.md
+++ b/docs/auth/gitlab/provider.md
@@ -74,7 +74,7 @@ This provider includes several resolvers out of the box that you can use:
 - `usernameMatchingUserEntityName`: Matches the username from the auth provider with the User entity that has a matching `name`. If no match is found, it will throw a `NotFoundError`.
 - `userIdMatchingUserEntityAnnotation`: Matches the GitLab user ID with the User entity that has a matching `gitlab.com/user-id` annotation (or `{integration-host}/user-id` for self-hosted GitLab instances). If no match is found, it will throw a `NotFoundError`.
 
-:::note Note
+:::note
 
 The resolvers will be tried in order but will only be skipped if they throw a `NotFoundError`.
 

--- a/docs/auth/google/gcp-iap-auth.md
+++ b/docs/auth/google/gcp-iap-auth.md
@@ -47,7 +47,7 @@ This provider includes several resolvers out of the box that you can use:
 - `emailLocalPartMatchingUserEntityName`: Matches the [local part](https://en.wikipedia.org/wiki/Email_address#Local-part) of the email address from the auth provider with the User entity that has a matching `name`. If no match is found it will throw a `NotFoundError`.
 - `emailMatchingUserEntityAnnotation`: Matches the email address from the auth provider with the User entity where the value of the `google.com/email` annotation matches. If no match is found it will throw a `NotFoundError`.
 
-:::note Note
+:::note
 
 The resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
 

--- a/docs/auth/google/provider.md
+++ b/docs/auth/google/provider.md
@@ -24,9 +24,9 @@ To support Google authentication, you must create OAuth credentials:
    - Add yourself as a test user, if using External user type
 6. Set **Application Type** to `Web Application` with these settings:
    - `Name`: Backstage (or your custom app name)
-   - `Authorized JavaScript origins`: <http://localhost:3000>
+   - `Authorized JavaScript origins`: [http://localhost:3000](http://localhost:3000)
    - `Authorized Redirect URIs`:
-     <http://localhost:7007/api/auth/google/handler/frame>
+     [http://localhost:7007/api/auth/google/handler/frame](http://localhost:7007/api/auth/google/handler/frame)
 7. Click Create
 
 ## Configuration

--- a/docs/auth/google/provider.md
+++ b/docs/auth/google/provider.md
@@ -24,9 +24,9 @@ To support Google authentication, you must create OAuth credentials:
    - Add yourself as a test user, if using External user type
 6. Set **Application Type** to `Web Application` with these settings:
    - `Name`: Backstage (or your custom app name)
-   - `Authorized JavaScript origins`: [http://localhost:3000](http://localhost:3000)
+   - `Authorized JavaScript origins`: <http://localhost:3000>
    - `Authorized Redirect URIs`:
-     [http://localhost:7007/api/auth/google/handler/frame](http://localhost:7007/api/auth/google/handler/frame)
+     <http://localhost:7007/api/auth/google/handler/frame>
 7. Click Create
 
 ## Configuration

--- a/docs/auth/google/provider.md
+++ b/docs/auth/google/provider.md
@@ -68,7 +68,7 @@ This provider includes several resolvers out of the box that you can use:
 - `emailLocalPartMatchingUserEntityName`: Matches the [local part](https://en.wikipedia.org/wiki/Email_address#Local-part) of the email address from the auth provider with the User entity that has a matching `name`. If no match is found it will throw a `NotFoundError`.
 - `emailMatchingUserEntityAnnotation`: Matches the email address from the auth provider with the User entity where the value of the `google.com/email` annotation matches. If no match is found it will throw a `NotFoundError`.
 
-:::note Note
+:::note
 
 The resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
 

--- a/docs/auth/index--old.md
+++ b/docs/auth/index--old.md
@@ -14,7 +14,7 @@ configure Backstage to have any number of authentication providers, but only
 one of these will typically be used for sign-in, with the rest being used to provide
 access to external resources.
 
-:::note Note
+:::note
 
 Identity management and the Sign-In page in Backstage will block external access by default, without setting `backend.auth.dangerouslyDisableDefaultAuthPolicy` in configuration. Even so, the frontend bundle is not protected from external access, protecting it requires the use of the [experimental public entry point](../tutorials/enable-public-entry.md). You can learn more about this in the [Threat Model](../overview/threat-model.md#operator-responsibilities).
 
@@ -115,7 +115,7 @@ const app = createApp({
 });
 ```
 
-:::note Note
+:::note
 
 You can configure sign-in to use a redirect flow with no pop-up by adding
 `enableExperimentalRedirectFlow: true` to the root of your `app-config.yaml`

--- a/docs/auth/index.md
+++ b/docs/auth/index.md
@@ -10,7 +10,7 @@ This documentation is written for [the new frontend system](../frontend-system/i
 
 The authentication system in Backstage serves two distinct purposes: sign-in and identification of users, as well as delegating access to third-party resources. It is possible to configure Backstage to have any number of authentication providers, but only one of these will typically be used for sign-in, with the rest being used to provide access to external resources.
 
-:::note Note
+:::note
 
 Identity management and the Sign-In page in Backstage will only block external access when using the new backend system, without setting `backend.auth.dangerouslyDisableDefaultAuthPolicy` in configuration. Even so, the frontend bundle is not protected from external access, protecting it requires the use of the [experimental public entry point](../tutorials/enable-public-entry.md). You can learn more about this in the [Threat Model](../overview/threat-model.md#operator-responsibilities).
 
@@ -111,7 +111,7 @@ export default createApp({
 });
 ```
 
-:::note Note
+:::note
 
 You can configure sign-in to use a redirect flow with no pop-up by adding `enableExperimentalRedirectFlow: true` to the root of your `app-config.yaml`
 

--- a/docs/auth/microsoft/azure-easyauth.md
+++ b/docs/auth/microsoft/azure-easyauth.md
@@ -78,7 +78,7 @@ This provider includes several resolvers out of the box that you can use:
 - `emailLocalPartMatchingUserEntityName`: Matches the [local part](https://en.wikipedia.org/wiki/Email_address#Local-part) of the email address from the auth provider with the User entity that has a matching `name`. If no match is found it will throw a `NotFoundError`.
 - `idMatchingUserEntityAnnotation`: Matches the user Id from the auth provider with the User entity that has a matching `graph.microsoft.com/user-id` annotation. If no match is found it will throw a `NotFoundError`.
 
-:::note Note
+:::note
 
 The resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
 

--- a/docs/auth/microsoft/provider.md
+++ b/docs/auth/microsoft/provider.md
@@ -95,7 +95,7 @@ This provider includes several resolvers out of the box that you can use:
 - `emailMatchingUserEntityAnnotation`: Matches the email address from the auth provider with the User entity where the value of the `microsoft.com/email` annotation matches. If no match is found it will throw a `NotFoundError`.
 - `userIdMatchingUserEntityAnnotation`: Matches the user profile ID from the auth provider with the User entity where the value of the `graph.microsoft.com/user-id` annotation matches. This resolver is recommended to resolve users without an email in their profile. If no match is found it will throw a `NotFoundError`.
 
-:::note Note
+:::note
 
 The resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
 

--- a/docs/auth/oauth2-proxy/provider.md
+++ b/docs/auth/oauth2-proxy/provider.md
@@ -13,7 +13,7 @@ a cluster. In general the `oauth2-proxy` supports all OpenID Connect providers,
 for more details check this
 [list of supported providers](https://oauth2-proxy.github.io/oauth2-proxy/configuration/providers/).
 
-:::note Note
+:::note
 
 OAuth2 Proxy does not provide a way to authenticate requests, you must instead ensure that your Backstage instance is only accessible through the OAuth2 Proxy. If you need more strict validation, consider using a different provider.
 
@@ -44,7 +44,7 @@ This provider includes several resolvers out of the box that you can use:
 - `forwardedUserMatchingUserEntityName`: Matches the value in the `x-forwarded-user` header from the auth provider with the User entity that has a matching `name`. If no match is found it will throw a `NotFoundError`.
 - `forwardedPreferredUsernameMatchingUserEntityName`: Matches the value in the `x-forwarded-preferred-username` header from the auth provider with the User entity that has a matching `name`. If no match is found it will throw a `NotFoundError`.
 
-:::note Note
+:::note
 
 The resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
 

--- a/docs/auth/oidc--old.md
+++ b/docs/auth/oidc--old.md
@@ -51,7 +51,7 @@ export const keycloakAuthApiRef: ApiRef<
 
 The `id` of the API ref can be anything you want, as long as it doesn't conflict with other refs. Backstage recommends to use a custom name that references your custom provider.
 
-:::note TypeScript Note
+:::note[TypeScript Note]
 As we're exporting this API reference, as well as the TypeScript types, we need to
 be able to import this reference anywhere in the app. The types will tell TypeScript
 what instance we're getting from DI when injecting the API. In this case we are defining
@@ -62,7 +62,8 @@ interfaces:
 - Profile API for requesting user profile info from the auth provider in question.
 - Backstage identity API to handle and associate the user profile with backstage identity.
 - Session API, to handle the session the user will have while signed in.
-  :::
+
+:::
 
 ### The API Factory (and auth provider)
 
@@ -259,7 +260,7 @@ These parameters have implicit default values. Don't override them unless you kn
   start URL is controlled by the browser, so this feature is only for improving the
   Backstage user experience.
 
-:::note Config Reloading
+:::note[Config Reloading]
 Backstage does not yet support hot reloading of auth provider configuration. Any changes to this YAML file require a restart of Backstage.
 :::
 
@@ -281,7 +282,7 @@ export const providers = [
 ];
 ```
 
-:::note Note
+:::note
 These steps apply to most auth providers. The main
 difference between providers will be the contents of the API factory, the code
 in the Auth Provider Factory, the resolver, and the different variables each provider

--- a/docs/auth/oidc.md
+++ b/docs/auth/oidc.md
@@ -101,7 +101,7 @@ email` scopes. Do not configure `scope` directly, as the OIDC provider will reje
   start URL is controlled by the browser, so this feature is only for improving the
   Backstage user experience.
 
-:::note Config Reloading
+:::note[Config Reloading]
 Backstage does not yet support hot reloading of auth provider configuration. Any changes to this YAML file require a restart of Backstage.
 :::
 
@@ -273,7 +273,7 @@ export default createApp({
 
 The `id` of the API ref (e.g. `'auth.keycloak'`) and the `id` used in the `SignInPage` provider configuration (e.g. `'keycloak-auth-provider'`) can be customized. However, the `provider.id` passed to `OAuth2.create` must remain `'oidc'` to match Backstage's generic OIDC auth strategy on the backend.
 
-:::note Note
+:::note
 You can configure sign-in to use a redirect flow with no pop-up by adding `enableExperimentalRedirectFlow: true` to the root of your `app-config.yaml`.
 :::
 

--- a/docs/auth/okta/provider.md
+++ b/docs/auth/okta/provider.md
@@ -76,7 +76,7 @@ This provider includes several resolvers out of the box that you can use:
 - `emailLocalPartMatchingUserEntityName`: Matches the [local part](https://en.wikipedia.org/wiki/Email_address#Local-part) of the email address from the auth provider with the User entity that has a matching `name`. If no match is found it will throw a `NotFoundError`.
 - `emailMatchingUserEntityAnnotation`: Matches the email address from the auth provider with the User entity where the value of the `okta.com/email` annotation matches. If no match is found it will throw a `NotFoundError`.
 
-:::note Note
+:::note
 
 The resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
 

--- a/docs/auth/onelogin/provider.md
+++ b/docs/auth/onelogin/provider.md
@@ -65,7 +65,7 @@ This provider includes several resolvers out of the box that you can use:
 - `emailLocalPartMatchingUserEntityName`: Matches the [local part](https://en.wikipedia.org/wiki/Email_address#Local-part) of the email address from the auth provider with the User entity that has a matching `name`. If no match is found it will throw a `NotFoundError`.
 - `usernameMatchingUserEntityName`: Matches the username from the auth provider with the User entity that has a matching `name`. If no match is found it will throw a `NotFoundError`.
 
-:::note Note
+:::note
 
 The resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
 

--- a/docs/auth/openshift/provider.md
+++ b/docs/auth/openshift/provider.md
@@ -58,7 +58,7 @@ export const apis: AnyApiFactory[] = [
 ];
 ```
 
-:::note Note
+:::note
 
 The OpenShift auth API does **not** implement the `OpenIdConnectApi` interface. In other words, it does **not** return an ID token.
 Instead, it returns an **access token**, which is used by the Kubernetes integration in place of an ID token.

--- a/docs/auth/service-to-service-auth.md
+++ b/docs/auth/service-to-service-auth.md
@@ -244,7 +244,7 @@ make access with the CICD token, they will be rejected if they try to contact
 anything but the `events` backend plugin. You could add additional entries to
 the array that allow targeting more plugins if that's what you want.
 
-:::note Note
+:::note
 
 If no `accessRestrictions` are added, the access method has unlimited access to
 all functionality of all plugins. It is recommended that you try to specify
@@ -353,7 +353,7 @@ The `externalTokenHandlersServiceRef` can be used to add custom external token h
 
 Your service factory must return an object with a `type` property that matches the token type in your configuration (e.g., 'custom', 'api-key'). When Backstage encounters tokens of this type, it calls your `initialize` method with all the configuration entries that match this type. Your factory can return either a single token handler or an array of handlers to process and validate these tokens.
 
-:::note Note
+:::note
 
 During token verification, all the token handlers are tested. Consider this when adding many token handlers, as it may impact performance.
 

--- a/docs/auth/vmware-cloud/provider.md
+++ b/docs/auth/vmware-cloud/provider.md
@@ -59,7 +59,7 @@ Where `APP_ID` refers to the ID retrieved when creating the OAuth App, and
 `ORG_ID` is the [long ID of the Organization](https://docs.vmware.com/en/VMware-Cloud-services/services/Using-VMware-Cloud-Services/GUID-CF9E9318-B811-48CF-8499-9419997DC1F8.html#view-the-organization-id-1)
 in VMware Cloud for which you wish to enable sign-in.
 
-:::note Note
+:::note
 
 VMware Cloud requires OAuth Apps to use
 [PKCE](https://oauth.net/2/pkce/) when performing authorization code flows; the
@@ -81,7 +81,7 @@ This provider includes several resolvers out of the box that you can use:
 - `emailMatchingUserEntityProfileEmail`: Matches the email address from the auth provider with the User entity that has a matching `spec.profile.email`. If no match is found it will throw a `NotFoundError`.
 - `emailLocalPartMatchingUserEntityName`: Matches the [local part](https://en.wikipedia.org/wiki/Email_address#Local-part) of the email address from the auth provider with the User entity that has a matching `name`. If no match is found it will throw a `NotFoundError`.
 
-:::note Note
+:::note
 
 The resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
 

--- a/docs/backend-system/architecture/01-index.md
+++ b/docs/backend-system/architecture/01-index.md
@@ -18,7 +18,7 @@ The diagram below provides an overview of the different building blocks, and the
 
 ![backend system building blocks diagram](../../assets/backend-system/architecture-building-blocks.drawio.svg)
 
-:::note Note
+:::note
 
 These are all concepts that existed in our old backend system in one way or another, but they have now all been lifted up to be first class concerns.
 

--- a/docs/backend-system/architecture/03-services.md
+++ b/docs/backend-system/architecture/03-services.md
@@ -254,7 +254,7 @@ deps: {fooServices: fooServiceRef},
 
 ## Service Factory Options Pattern
 
-:::note Note
+:::note
 
 This pattern is discouraged, only use it when necessary. If possible you should prefer to make services configurable via static configuration or re-implementation instead.
 

--- a/docs/backend-system/building-backends/01-index.md
+++ b/docs/backend-system/building-backends/01-index.md
@@ -5,7 +5,7 @@ sidebar_label: Overview
 description: Building backends using the backend system
 ---
 
-:::note Note
+:::note
 
 If you have an existing backend that is not yet using the new backend
 system, see [migrating](./08-migrating.md).

--- a/docs/backend-system/building-backends/08-migrating.md
+++ b/docs/backend-system/building-backends/08-migrating.md
@@ -217,7 +217,7 @@ These are the deprecation messages for the most common replacements:
 
 - `createLegacyAuthAdapters` - Migrate to use the new backend system and auth services instead.
 - `errorHandler` - Use `MiddlewareFactory.create.error` from `@backstage/backend-defaults/rootHttpRouter` instead.
-- `getRootLogger` - This function will be removed in the future. If you need to get the root logger in the new system, please check out this documentation: [https://backstage.io/docs/backend-system/core-services/logger](https://backstage.io/docs/backend-system/core-services/logger)
+- `getRootLogger` - This function will be removed in the future. If you need to get the root logger in the new system, please check out this documentation: <https://backstage.io/docs/backend-system/core-services/logger>
 - `getVoidLogger` - This function will be removed in the future. If you need to mock the root logger in the new system, please use `mockServices.logger.mock()` from `@backstage/backend-test-utils` instead.
 - `legacyPlugin` - Fully use the new backend system instead.
 - `loadBackendConfig` - Please migrate to the new backend system and use `coreServices.rootConfig` instead, or the [@backstage/config-loader#ConfigSources](https://backstage.io/api/stable/classes/_backstage_config-loader.ConfigSources.html) facilities if required.

--- a/docs/backend-system/building-backends/08-migrating.md
+++ b/docs/backend-system/building-backends/08-migrating.md
@@ -200,7 +200,7 @@ const legacyPlugin = makeLegacyPlugin(
 After this, your backend will know how to instantiate your thing on demand and
 place it in the legacy plugin environment.
 
-:::note Note
+:::note
 
 If you happen to be dealing with a service ref that does NOT have a
 default implementation, but rather has a separate service factory, then you
@@ -238,7 +238,7 @@ maintained by the Backstage maintainers, you may find that they have already
 been migrated to the new backend system. This section describes some specific
 such migrations you can make.
 
-:::note Note
+:::note
 
 For each of these, note that your backend still needs to have a
 dependency (e.g. in `packages/backend/package.json`) to those plugin packages,
@@ -902,7 +902,7 @@ auth:
             - resolver: emailMatchingUserEntityProfileEmail
 ```
 
-:::note Note
+:::note
 
 The resolvers will be tried in order, but will only be skipped if they throw a `NotFoundError`.
 
@@ -1163,7 +1163,7 @@ backend.add(import('@backstage/plugin-search-backend'));
 /* highlight-add-end */
 ```
 
-:::note Note
+:::note
 
 This will use the Lunr search engine which stores its index in memory.
 
@@ -1254,7 +1254,7 @@ backend.add(
 /* highlight-add-end */
 ```
 
-:::note Note
+:::note
 
 The above example includes a default allow-all policy. If that is not what you want, do not add the second line and instead investigate one of the options below.
 

--- a/docs/backend-system/building-backends/08-migrating.md
+++ b/docs/backend-system/building-backends/08-migrating.md
@@ -217,7 +217,7 @@ These are the deprecation messages for the most common replacements:
 
 - `createLegacyAuthAdapters` - Migrate to use the new backend system and auth services instead.
 - `errorHandler` - Use `MiddlewareFactory.create.error` from `@backstage/backend-defaults/rootHttpRouter` instead.
-- `getRootLogger` - This function will be removed in the future. If you need to get the root logger in the new system, please check out this documentation: https://backstage.io/docs/backend-system/core-services/logger
+- `getRootLogger` - This function will be removed in the future. If you need to get the root logger in the new system, please check out this documentation: [https://backstage.io/docs/backend-system/core-services/logger](https://backstage.io/docs/backend-system/core-services/logger)
 - `getVoidLogger` - This function will be removed in the future. If you need to mock the root logger in the new system, please use `mockServices.logger.mock()` from `@backstage/backend-test-utils` instead.
 - `legacyPlugin` - Fully use the new backend system instead.
 - `loadBackendConfig` - Please migrate to the new backend system and use `coreServices.rootConfig` instead, or the [@backstage/config-loader#ConfigSources](https://backstage.io/api/stable/classes/_backstage_config-loader.ConfigSources.html) facilities if required.

--- a/docs/backend-system/core-services/auth.md
+++ b/docs/backend-system/core-services/auth.md
@@ -51,7 +51,7 @@ const { token } = await auth.getPluginRequestToken({
 });
 ```
 
-:::note Note
+:::note
 
 Never store and reuse tokens. Always call `getPluginRequestToken` immediately
 before making a request. Otherwise you run the risk of running into permission
@@ -116,7 +116,7 @@ if (auth.isPrincipal(credentials, 'user')) {
 
 ## Configuring the service
 
-:::note Note
+:::note
 
 The `auth` service is not suitable for having its implementation replaced
 entirely in your private repo. If you desire additional service auth related

--- a/docs/backend-system/core-services/http-auth.md
+++ b/docs/backend-system/core-services/http-auth.md
@@ -61,7 +61,7 @@ The default is to accept both service and user credentials (excluding limited
 access), but in the example above, any attempt to call this endpoint with
 service credentials will result in an Unauthorized error being thrown.
 
-:::note Note
+:::note
 
 You don't need to call `httpAuth.credentials` _just_ to ensure that incoming
 credentials are valid in the first place; only use this method if you actually
@@ -93,7 +93,7 @@ Due to the above, we do not document the `httpAuth.issueUserCookie` method here.
 
 ## Configuring the service
 
-:::note Note
+:::note
 
 The `httpAuth` service is not suitable for having its implementation replaced
 entirely in your private repo. If you desire additional service auth related

--- a/docs/backend-system/core-services/identity.md
+++ b/docs/backend-system/core-services/identity.md
@@ -5,7 +5,7 @@ sidebar_label: Identity
 description: Documentation for the Identity service
 ---
 
-:::note Note
+:::note
 
 This service is deprecated, you are likely looking for the [Auth Service](./auth.md) instead. If you're wondering how to get the user's entity ref and ownership claims in your backend plugin, you should see the [User Info Service](./user-info.md) documentation.
 

--- a/docs/backend-system/core-services/root-instance-metadata.md
+++ b/docs/backend-system/core-services/root-instance-metadata.md
@@ -7,7 +7,7 @@ description: Documentation for the Root Instance Metadata service
 
 The root instance metadata service provides information about the running Backstage backend instance. Currently, it provides a list of all installed backend plugins.
 
-:::note Note
+:::note
 
 The root instance metadata service only provides information about the specific Backstage instance you're running on. In more complex deployments with multiple Backstage instances, this service will not provide a complete list of all plugins across all instances.
 

--- a/docs/backend-system/core-services/user-info.md
+++ b/docs/backend-system/core-services/user-info.md
@@ -9,7 +9,7 @@ This service lets you extract more information about a set of user credentials.
 Specifically, it can be used to extract the ownership entity refs for a user
 principal.
 
-:::note Note
+:::note
 
 Please also refer to [`auth`](./auth.md) and [`httpAuth`](./http-auth.md) services for
 general credentials handling which is a prerequisite for the below examples.

--- a/docs/conf/reading.md
+++ b/docs/conf/reading.md
@@ -119,7 +119,7 @@ The [ConfigApi](https://backstage.io/api/stable/types/_backstage_frontend-plugin
 [UtilityApi](../api/utility-apis.md). It's accessible as usual via the
 `configApiRef` exported from `@backstage/core-plugin-api`:
 
-```
+```ts
 import { useApi, configApiRef } from '@backstage/core-plugin-api';
 ...
 const MyReactComponent = (...) => {

--- a/docs/contribute/doc-style-guide.md
+++ b/docs/contribute/doc-style-guide.md
@@ -238,6 +238,17 @@ helps downstream localization.
 | :------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------- |
 | Write hyperlinks with descriptive text. For example: See [Getting Started](../getting-started/index.md) for details. | Use ambiguous link text. For example: See [here](../getting-started/index.md) for details. |
 | Write Markdown-style links: `[link text](./index.md)`.                                                               | Write HTML-style links or create links that open in new tabs.                              |
+| Give a plain address some markup: `<https://example.com>`.                                                           | Paste a bare address: `https://example.com`.                                               |
+
+A link with descriptive text is the better choice wherever you can write one.
+People using a screen reader often navigate a page by listing its links, so link
+text such as `the Kubernetes configuration` tells them where it goes while a raw
+address does not.
+
+When the address itself is what you want to show, the syntax depends on the file
+extension. In `.md` files, use either angle brackets or a Markdown link. In
+`.mdx` files, use a Markdown link: angle brackets are not valid there and the
+build fails.
 
 ### Lists
 

--- a/docs/contribute/doc-style-guide.md
+++ b/docs/contribute/doc-style-guide.md
@@ -148,6 +148,19 @@ Use `:::note` for supplementary information, `:::tip` for helpful suggestions,
 `:::caution` for potential pitfalls, and `:::danger` for actions that could
 cause data loss or security issues.
 
+To give an admonition a custom title, put the title in square brackets. Writing
+the title after the type without brackets no longer works, and the admonition
+renders as plain text instead.
+
+```markdown
+:::tip[Browser window didn't open]
+Navigate to `http://localhost:3000` yourself.
+:::
+```
+
+Only add a title when it says something the type doesn't. A `:::note` titled
+`Note` is noise, so leave it off.
+
 Keep admonitions short and focused. Each admonition should contain a single,
 clear point. If you find yourself writing multiple paragraphs inside an
 admonition, consider whether the content belongs in the main text instead.

--- a/docs/contribute/doc-style-guide.md
+++ b/docs/contribute/doc-style-guide.md
@@ -116,7 +116,7 @@ yarn start
 
 The output is similar to this:
 
-```console
+```log
 [0] webpack output is served from /
 [1] Loaded config from app-config.yaml
 ```
@@ -124,8 +124,15 @@ The output is similar to this:
 ### Use appropriate language tags for code blocks
 
 Use the correct language identifier for fenced code blocks: `ts` or `typescript`
-for TypeScript, `yaml` for YAML configuration, `shell` for shell commands,
-`console` for command output, and `diff` for changesets.
+for TypeScript, `yaml` for YAML configuration, `shell` for shell commands, `log`
+for command output, `shell-session` for a transcript that mixes prompts and
+output, and `diff` for changesets. Use `text` when nothing else fits, such as a
+directory tree.
+
+Every identifier must be a language Prism recognizes, and anything outside the
+set Docusaurus bundles by default has to be listed in `additionalLanguages` in
+`microsite/docusaurus.config.ts`. An unrecognized identifier is not an error —
+the block simply renders unhighlighted, which is easy to miss.
 
 ## Admonitions
 

--- a/docs/contribute/doc-style-guide.md
+++ b/docs/contribute/doc-style-guide.md
@@ -132,7 +132,7 @@ directory tree.
 Every identifier must be a language Prism recognizes, and anything outside the
 set Docusaurus bundles by default has to be listed in `additionalLanguages` in
 `microsite/docusaurus.config.ts`. An unrecognized identifier is not an error —
-the block simply renders unhighlighted, which is easy to miss.
+the block simply loses its syntax highlighting, which is easy to miss.
 
 ## Admonitions
 

--- a/docs/contribute/project-structure.md
+++ b/docs/contribute/project-structure.md
@@ -37,7 +37,7 @@ the code.
 
 - [`docs/`](https://github.com/backstage/backstage/tree/master/docs) - This is
   where we keep all of our documentation Markdown files. These end up on
-  https://backstage.io/docs. Just keep in mind that changes to the
+  [https://backstage.io/docs](https://backstage.io/docs). Just keep in mind that changes to the
   [`sidebars.ts`](https://github.com/backstage/backstage/blob/master/microsite/sidebars.ts)
   file may be needed as sections are added/removed.
 

--- a/docs/contribute/project-structure.md
+++ b/docs/contribute/project-structure.md
@@ -37,7 +37,7 @@ the code.
 
 - [`docs/`](https://github.com/backstage/backstage/tree/master/docs) - This is
   where we keep all of our documentation Markdown files. These end up on
-  [https://backstage.io/docs](https://backstage.io/docs). Just keep in mind that changes to the
+  <https://backstage.io/docs>. Just keep in mind that changes to the
   [`sidebars.ts`](https://github.com/backstage/backstage/blob/master/microsite/sidebars.ts)
   file may be needed as sections are added/removed.
 

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -144,7 +144,7 @@ browser at `http://localhost:7007`
 
 ## Multi-stage Build
 
-:::note Note
+:::note
 
 The `.dockerignore` is different in this setup, read on for more
 details.
@@ -299,7 +299,7 @@ browser at `http://localhost:7007`
 
 ## Separate Frontend
 
-:::note Note
+:::note
 
 This is an optional step, and you will lose out on the features of the
 `@backstage/plugin-app-backend` plugin. Most notably the frontend configuration

--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -13,7 +13,7 @@ This documentation shows common examples that may be useful when deploying
 Backstage for the first time, or for those without established deployment
 practices.
 
-:::note Note
+:::note
 
 The _easiest_ way to explore Backstage is to visit the
 [live demo site](https://demo.backstage.io).

--- a/docs/deployment/k8s.md
+++ b/docs/deployment/k8s.md
@@ -107,7 +107,7 @@ $ echo -n "backstage" | base64
 YmFja3N0YWdl
 ```
 
-:::note Note
+:::note
 
 Secrets are base64-encoded, but not encrypted. Be sure to enable
 [Encryption at Rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/)

--- a/docs/dls/contributing-to-storybook.md
+++ b/docs/dls/contributing-to-storybook.md
@@ -46,7 +46,7 @@ want to document on Storybook.
 
 See below an example of the structure:
 
-```
+```text
 core
 └── src
     └── components

--- a/docs/dls/contributing-to-storybook.md
+++ b/docs/dls/contributing-to-storybook.md
@@ -55,7 +55,7 @@ core
             └── Progress.stories.tsx
 ```
 
-:::note Note
+:::note
 
 Make sure your component story file has the following format
 componentName.stories.tsx

--- a/docs/features/kubernetes/authenticationstrategy.md
+++ b/docs/features/kubernetes/authenticationstrategy.md
@@ -165,7 +165,7 @@ Notice that this guide assumes that you already installed the [Kubernetes Plugin
 
 To create the Backend module, run `yarn new`, select `backend-module`. Then fill out:
 
-```
+```text
 ? What do you want to create? backend-module - A new backend module
 ? Enter the ID of the plugin [required] kubernetes
 ? Enter the ID of the module [required] pinniped

--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -414,7 +414,7 @@ clusterLinksFormatters.myDashboard = (options) => ...;
 ```
 
 See also
-[https://github.com/backstage/backstage/tree/master/plugins/kubernetes-react/src/api/formatters](https://github.com/backstage/backstage/tree/master/plugins/kubernetes-react/src/api/formatters)
+<https://github.com/backstage/backstage/tree/master/plugins/kubernetes-react/src/api/formatters>
 for real examples.
 
 ##### `clusters.\*.dashboardParameters` (optional)
@@ -471,7 +471,7 @@ gcloud container clusters describe <YOUR_CLUSTER_NAME> \
 ```
 
 See also
-[https://cloud.google.com/kubernetes-engine/docs/how-to/api-server-authentication#environments-without-gcloud](https://cloud.google.com/kubernetes-engine/docs/how-to/api-server-authentication#environments-without-gcloud)
+<https://cloud.google.com/kubernetes-engine/docs/how-to/api-server-authentication#environments-without-gcloud>
 for complete docs about GKE without `gcloud`.
 
 ##### `clusters.\*.caFile` (optional)
@@ -573,7 +573,7 @@ about resources.
 Defaults to `google` which leverages the logged in user's Google OAuth credentials.
 
 Set to `googleServiceAccount` to leverage
-Application Default Credentials ([https://cloud.google.com/docs/authentication/application-default-credentials](https://cloud.google.com/docs/authentication/application-default-credentials)).
+Application Default Credentials (<https://cloud.google.com/docs/authentication/application-default-credentials>).
 To use a service account JSON key (not recommended), set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable
 on the Backstage backend to the path of the service account key file.
 

--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -414,7 +414,7 @@ clusterLinksFormatters.myDashboard = (options) => ...;
 ```
 
 See also
-[https://github.com/backstage/backstage/tree/master/plugins/kubernetes/src/utils/clusterLinks/formatters](https://github.com/backstage/backstage/tree/master/plugins/kubernetes/src/utils/clusterLinks/formatters)
+[https://github.com/backstage/backstage/tree/master/plugins/kubernetes-react/src/api/formatters](https://github.com/backstage/backstage/tree/master/plugins/kubernetes-react/src/api/formatters)
 for real examples.
 
 ##### `clusters.\*.dashboardParameters` (optional)

--- a/docs/features/kubernetes/configuration.md
+++ b/docs/features/kubernetes/configuration.md
@@ -414,7 +414,7 @@ clusterLinksFormatters.myDashboard = (options) => ...;
 ```
 
 See also
-https://github.com/backstage/backstage/tree/master/plugins/kubernetes/src/utils/clusterLinks/formatters
+[https://github.com/backstage/backstage/tree/master/plugins/kubernetes/src/utils/clusterLinks/formatters](https://github.com/backstage/backstage/tree/master/plugins/kubernetes/src/utils/clusterLinks/formatters)
 for real examples.
 
 ##### `clusters.\*.dashboardParameters` (optional)
@@ -464,14 +464,14 @@ This value could be obtained via inspecting the `kubeconfig` file (usually
 at `~/.kube/config`) under `clusters[*].cluster.certificate-authority-data`. For
 GKE, execute the following command to obtain the value
 
-```
+```shell
 gcloud container clusters describe <YOUR_CLUSTER_NAME> \
     --zone=<YOUR_COMPUTE_ZONE> \
     --format="value(masterAuth.clusterCaCertificate)"
 ```
 
 See also
-https://cloud.google.com/kubernetes-engine/docs/how-to/api-server-authentication#environments-without-gcloud
+[https://cloud.google.com/kubernetes-engine/docs/how-to/api-server-authentication#environments-without-gcloud](https://cloud.google.com/kubernetes-engine/docs/how-to/api-server-authentication#environments-without-gcloud)
 for complete docs about GKE without `gcloud`.
 
 ##### `clusters.\*.caFile` (optional)
@@ -573,7 +573,7 @@ about resources.
 Defaults to `google` which leverages the logged in user's Google OAuth credentials.
 
 Set to `googleServiceAccount` to leverage
-Application Default Credentials (https://cloud.google.com/docs/authentication/application-default-credentials).
+Application Default Credentials ([https://cloud.google.com/docs/authentication/application-default-credentials](https://cloud.google.com/docs/authentication/application-default-credentials)).
 To use a service account JSON key (not recommended), set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable
 on the Backstage backend to the path of the service account key file.
 

--- a/docs/features/kubernetes/installation.md
+++ b/docs/features/kubernetes/installation.md
@@ -140,7 +140,7 @@ backend.add(kubernetesModuleCustomClusterDiscovery);
 backend.start();
 ```
 
-:::note Note
+:::note
 
 This example uses items from the `@backstage/plugin-kubernetes-node` and `luxon` packages, you'll need to add those for this example to work as is.
 

--- a/docs/features/search/declarative-integration.md
+++ b/docs/features/search/declarative-integration.md
@@ -31,7 +31,7 @@ Only one step is required to start using the `Search` plugin within declarative 
 yarn add @backstage/plugin-catalog @backstage/plugin-search
 ```
 
-The `Search` plugin depends on the `Catalog API`, that's the reason we have to install the ` @backstage/plugin-catalog` package too.
+The `Search` plugin depends on the `Catalog API`, that's the reason we have to install the `@backstage/plugin-catalog` package too.
 
 ### Extensions
 

--- a/docs/features/search/getting-started--old.md
+++ b/docs/features/search/getting-started--old.md
@@ -306,7 +306,7 @@ indexBuilder.addCollator({
 });
 ```
 
-:::note Note
+:::note
 
 if you are using the in-memory Lunr search engine, you probably want to
 implement a non-distributed `SchedulerServiceTaskRunner` like the following to ensure consistency

--- a/docs/features/search/getting-started.md
+++ b/docs/features/search/getting-started.md
@@ -211,7 +211,7 @@ indexBuilder.addCollator({
 });
 ```
 
-:::note Note
+:::note
 
 if you are using the in-memory Lunr search engine, you probably want to
 implement a non-distributed `SchedulerServiceTaskRunner` like the following to ensure consistency

--- a/docs/features/search/search-engines.md
+++ b/docs/features/search/search-engines.md
@@ -31,7 +31,7 @@ backend.add(import('@backstage/plugin-search-backend'));
 backend.start();
 ```
 
-:::note Note
+:::note
 
 Lunr is appropriate as a zero-config search engine when developing
 other parts of Backstage locally, however its use is highly discouraged when
@@ -348,7 +348,7 @@ backend.start();
 
 The `getAuthHeaders` method is called before each request, allowing for just-in-time token retrieval and automatic rotation. When an auth provider is configured, it takes precedence over any static authentication in `app-config.yaml`.
 
-:::note Note
+:::note
 
 Custom authentication is supported for the `elastic`, `opensearch`, and default providers. The `aws` provider uses AWS SigV4 request signing and does not support custom auth providers.
 

--- a/docs/features/software-catalog/api.md
+++ b/docs/features/software-catalog/api.md
@@ -190,7 +190,7 @@ Some more real world usable examples:
 
   `/entities/by-query?filter=kind=component,relations.ownedBy=group:default/my-team&fullTextFilterTerm=api&fullTextFilterFields=metadata.name`
 
-:::note Note
+:::note
 
 Full text filtering is mutually exclusive with cursor-based pagination. When a
 `cursor` is provided, `fullTextFilterTerm` and `fullTextFilterFields` are
@@ -446,7 +446,7 @@ meaning.
 
 Lists entities.
 
-:::note Note
+:::note
 
 This endpoint is deprecated in favor of `GET /entities/by-query`, which provides a more efficient implementation and cursor based pagination.
 

--- a/docs/features/software-catalog/catalog-customization--old.md
+++ b/docs/features/software-catalog/catalog-customization--old.md
@@ -367,7 +367,7 @@ const myColumnsFunc: CatalogTableColumnsFunc = entityListContext => {
 <Route path="/catalog" element={<CatalogIndexPage columns={myColumnsFunc} />} />
 ```
 
-:::note Note
+:::note
 
 In the examples above, the contents of the files have been shortened for simplicity.
 
@@ -438,7 +438,7 @@ const customActions: TableProps<CatalogTableRow>['actions'] = [
 <Route path="/catalog" element={<CatalogIndexPage actions={customActions} />} />
 ```
 
-:::note Note
+:::note
 
 In the example above, the contents of `App.tsx` has been shortened for simplicity.
 
@@ -675,7 +675,7 @@ export const CustomCatalogPage = () => {
 
 The above is a very basic version of a fully custom `CatalogIndexPage`, you'll want to explore the various props to see what you can all do with them. This was built off the building blocks seen in the [`DefaultCatalogPage`](https://github.com/backstage/backstage/blob/master/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx)
 
-:::note Note
+:::note
 
 The catalog index page is designed to have a minimal code footprint to support easy customization, but creating a replica does introduce a possibility of drifting out of date over time. Be sure to check the catalog [CHANGELOG](https://github.com/backstage/backstage/blob/master/plugins/catalog/CHANGELOG.md) periodically.
 

--- a/docs/features/software-catalog/catalog-customization.md
+++ b/docs/features/software-catalog/catalog-customization.md
@@ -306,7 +306,7 @@ export const CustomCatalogPage = () => {
 };
 ```
 
-:::note Note
+:::note
 
 The catalog index page is designed to have a minimal code footprint to support
 easy customization, but creating a replica does introduce a possibility of

--- a/docs/features/software-catalog/configuration.md
+++ b/docs/features/software-catalog/configuration.md
@@ -286,7 +286,7 @@ This will log errors with a level of `warn`.
 
 You should now see logs as the catalog emits events. Example:
 
-```
+```log
 [1] 2024-06-07T00:00:28.787Z events warn Policy check failed for user:default/guest; caused by Error: Malformed envelope, /metadata/tags must be array entity=user:default/guest location=file:/Users/foobar/code/backstage-demo-instance/examples/org.yaml
 ```
 

--- a/docs/features/software-catalog/creating-the-catalog-graph.md
+++ b/docs/features/software-catalog/creating-the-catalog-graph.md
@@ -10,7 +10,7 @@ It is worth noting that the Backstage Software Catalog should not be considered 
 
 [**Entities:**](https://backstage.io/docs/features/software-catalog/system-model) An entity refers to a node in the graph that represents a distinct object, concept, or thing. Nodes are the fundamental building blocks of a graph database and are used to represent entities and their properties.
 
-![](../../assets/software-catalog/entity.drawio.svg)
+![Diagram of an entity envelope and its apiVersion, kind, metadata and spec fields](../../assets/software-catalog/entity.drawio.svg)
 
 [**Kinds:**](https://backstage.io/docs/features/software-catalog/descriptor-format#contents) These are broad categories used to group related entities. Kinds are used to provide a high-level categorization of entities, such as "service", "database", or "team". Kinds are often used to provide a way to filter entities in the catalog and to provide a high-level overview of the types of entities that are being managed.
 

--- a/docs/features/software-catalog/descriptor-format.md
+++ b/docs/features/software-catalog/descriptor-format.md
@@ -389,7 +389,7 @@ Fields of a link are:
 | `icon`  | String | [Optional] A key representing a visual icon to be displayed in the UI.               |
 | `type`  | String | [Optional] An optional value to categorize links into specific groups.               |
 
-:::note Note
+:::note
 
 The `icon` field value is meant to be a semantic key that will map to a
 specific icon that may be provided by an icon library (e.g. `material-ui`

--- a/docs/features/software-catalog/external-integrations/entity-providers.md
+++ b/docs/features/software-catalog/external-integrations/entity-providers.md
@@ -37,7 +37,7 @@ yarn new --select catalog-provider-module
 The CLI prompts for a module ID (for example, `frobs`). This generates a
 backend module package in the `plugins` folder with the following structure:
 
-```
+```text
 plugins/catalog-backend-module-frobs-provider/
 ├── config.d.ts
 ├── package.json

--- a/docs/features/software-catalog/external-integrations/processors.md
+++ b/docs/features/software-catalog/external-integrations/processors.md
@@ -58,7 +58,7 @@ yarn new --select catalog-processor-module
 The CLI prompts for a module ID (for example, `team-name`). This generates a
 backend module package in the `plugins` folder:
 
-```
+```text
 plugins/catalog-backend-module-team-name-processor/
 ├── package.json
 ├── src/

--- a/docs/features/software-catalog/life-of-an-entity.md
+++ b/docs/features/software-catalog/life-of-an-entity.md
@@ -125,7 +125,7 @@ all of the processors' contributions to one step are run in the order that the
 processors were registered, then all of their contributions to the next step in
 the same order, and so on.
 
-:::note Technical note
+:::note[Technical note]
 
 Processors registered from the same catalog module always run
 in the registration order, but this does not apply over multiple catalog modules as
@@ -174,7 +174,7 @@ steps and merging them into the final object which is what is visible from the
 catalog API. As the final entity itself gets updated, the stitcher makes sure
 that the search table gets refreshed accordingly as well.
 
-:::note Note
+:::note
 
 The search table mentioned here is not related to the core Search
 feature of Backstage. It's rather the table that backs the ability to filter
@@ -195,7 +195,7 @@ The diagram shows how the stitcher reads from several sources:
 The last part is noteworthy: This is how the stitcher is able to collect all of
 the relation edges, both incoming and outgoing, no matter who produced them.
 
-:::note Technical note
+:::note[Technical note]
 
 Whether the entity will be stitched depends on the entity hash value,
 which is calculated based on the entity body, relations, errors, referred entities,

--- a/docs/features/software-catalog/life-of-an-entity.md
+++ b/docs/features/software-catalog/life-of-an-entity.md
@@ -286,7 +286,7 @@ The default behavior of the catalog is to automatically remove orphaned
 entities. However, if you want to keep them instead, you can disable the
 automated cleanup with the following app-config option.
 
-```
+```yaml
 catalog:
   orphanStrategy: keep
 ```

--- a/docs/features/software-catalog/system-model.md
+++ b/docs/features/software-catalog/system-model.md
@@ -23,7 +23,7 @@ We model software in the Backstage catalogue using these three core entities
 - **Resources** are physical or virtual infrastructure needed to operate a
   component
 
-![](../../assets/software-catalog/software-model-core-entities.drawio.svg)
+![Diagram of the core entities, showing a Component that provides and consumes APIs and depends on Resources](../../assets/software-catalog/software-model-core-entities.drawio.svg)
 
 ### Component
 
@@ -84,7 +84,7 @@ these entities using the following (optional) concepts:
   function
 - **Domains** relate entities and systems to part of the business
 
-![](../../assets/software-catalog/software-model-entities.drawio.svg)
+![Diagram showing how Components, APIs and Resources are grouped into Systems, and Systems into Domains](../../assets/software-catalog/software-model-entities.drawio.svg)
 
 ### System
 

--- a/docs/features/software-templates/adding-templates.md
+++ b/docs/features/software-templates/adding-templates.md
@@ -86,7 +86,7 @@ contains more information about the required fields.
 Once we have a `template.yaml` ready, we can then add it to the software catalog
 for use by the scaffolder.
 
-:::note Note
+:::note
 
 When you add or modify a template, you will need to refresh the location entity.
 Otherwise, Backstage won't display the template in the available templates,

--- a/docs/features/software-templates/configuration.md
+++ b/docs/features/software-templates/configuration.md
@@ -12,7 +12,7 @@ This is done in your `app-config.yaml` by adding
 [Backstage integrations](https://backstage.io/docs/integrations/) for the
 appropriate source code repository for your organization.
 
-:::note Note
+:::note
 
 Integrations may already be set up as part of your `app-config.yaml`.
 

--- a/docs/features/software-templates/index.md
+++ b/docs/features/software-templates/index.md
@@ -10,7 +10,7 @@ Components inside Backstage. By default, it has the ability to load skeletons of
 code, template in some variables, and then publish the template to some
 locations like GitHub or GitLab.
 
-:::warning Important
+:::warning[Important]
 
 When creating custom scaffolder actions, **use camelCase for action IDs** instead of kebab-case. Action IDs with dashes (like `fetch-component-id`) will cause template expressions like `${{ steps.fetch-component-id.output.componentId }}` to return `NaN` because the dashes are evaluated as subtraction operators in JavaScript expressions.
 

--- a/docs/features/software-templates/templating-extensions.md
+++ b/docs/features/software-templates/templating-extensions.md
@@ -127,7 +127,7 @@ be accelerated using the Backstage CLI.
 
 Start by using the `yarn backstage-cli new` command to generate a scaffolder module. This command sets up the necessary boilerplate code, providing a smooth start:
 
-```
+```shell-session
 $ yarn backstage-cli new
 ? What do you want to create?
   frontend-plugin - A new frontend plugin
@@ -143,7 +143,7 @@ When prompted, use the arrow keys to select the option to generate a `backend-pl
 Since we want to extend the Scaffolder backend, enter `scaffolder` when prompted for the ID of the plugin to extend.
 Next, enter the ID (name) of your module. This will be appended to the `scaffolder-backend-module-` prefix. The CLI will then generate the required files and directory structure, for example:
 
-```
+```text
 ? Enter the ID of the plugin [required] scaffolder
 ? Enter the ID of the module [required] foo-bar
   templating    plugins/scaffolder-backend-module-foo-bar ✔
@@ -156,7 +156,7 @@ Next, enter the ID (name) of your module. This will be appended to the `scaffold
 
 **Directory Structure**
 
-```
+```text
 plugins
 ├── README.md
 ├── scaffolder-backend-module-foo-bar

--- a/docs/features/software-templates/writing-templates.md
+++ b/docs/features/software-templates/writing-templates.md
@@ -713,7 +713,7 @@ template. These follow the same standard format:
       name: ${{ parameters.name }}
 ```
 
-:::warning Action ID Naming
+:::warning[Action ID Naming]
 
 When using custom actions, **use camelCase for action IDs** to avoid issues with template expressions. Action IDs with dashes will cause expressions like `${{ steps.my-action.output.value }}` to return `NaN` instead of the expected value.
 

--- a/docs/features/techdocs/architecture.md
+++ b/docs/features/techdocs/architecture.md
@@ -13,7 +13,7 @@ out-of-the box experience.
 
 ![TechDocs Architecture diagram](../../assets/techdocs/architecture-basic.drawio.svg)
 
-:::note Note
+:::note
 
 See below for our recommended deployment architecture which takes care
 of stability, scalability and speed. Also look at the

--- a/docs/features/techdocs/cli.md
+++ b/docs/features/techdocs/cli.md
@@ -7,7 +7,7 @@ description: TechDocs CLI - a utility command line interface for managing TechDo
 Utility command line interface for managing TechDocs sites in
 [Backstage](https://github.com/backstage/backstage).
 
-[https://backstage.io/docs/features/techdocs/](https://backstage.io/docs/features/techdocs/)
+<https://backstage.io/docs/features/techdocs/>
 
 ## Features
 

--- a/docs/features/techdocs/cli.md
+++ b/docs/features/techdocs/cli.md
@@ -7,7 +7,7 @@ description: TechDocs CLI - a utility command line interface for managing TechDo
 Utility command line interface for managing TechDocs sites in
 [Backstage](https://github.com/backstage/backstage).
 
-https://backstage.io/docs/features/techdocs/
+[https://backstage.io/docs/features/techdocs/](https://backstage.io/docs/features/techdocs/)
 
 ## Features
 

--- a/docs/features/techdocs/configuration.md
+++ b/docs/features/techdocs/configuration.md
@@ -86,7 +86,7 @@ techdocs:
 
 (Optional and not recommended) Configures the techdocs generator to attempt to ensure an index.md exists falling back to using `<docs-dir>/README.md` or `README.md` in case a default `<docs-dir>/index.md` is not provided.
 
-**Note:** [https://www.mkdocs.org/user-guide/configuration/#edit_uri](https://www.mkdocs.org/user-guide/configuration/#edit_uri) behavior will be broken in these scenarios.
+**Note:** <https://www.mkdocs.org/user-guide/configuration/#edit_uri> behavior will be broken in these scenarios.
 
 **Example:**
 
@@ -261,7 +261,7 @@ techdocs:
 `techdocs.publisher.googleGcs.credentials`
 
 (Optional) An API key required to write to a storage bucket.
-If missing `GOOGLE_APPLICATION_CREDENTIALS` environment variable will be used. [https://cloud.google.com/docs/authentication/production](https://cloud.google.com/docs/authentication/production)
+If missing `GOOGLE_APPLICATION_CREDENTIALS` environment variable will be used. <https://cloud.google.com/docs/authentication/production>
 
 **Example:**
 
@@ -324,8 +324,8 @@ The AWS account ID where the storage bucket is located. Credentials for the acco
 
 If account ID is not set and no credentials are set, environment variables or AWS config file will be used to authenticate.
 
-[https://www.npmjs.com/package/@aws-sdk/credential-provider-node](https://www.npmjs.com/package/@aws-sdk/credential-provider-node)
-[https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html)
+<https://www.npmjs.com/package/@aws-sdk/credential-provider-node>
+<https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html>
 
 **Example:**
 
@@ -346,8 +346,8 @@ techdocs:
 
 If credentials are not set and no account ID is set, environment variables or AWS config file will be used to authenticate.
 
-[https://www.npmjs.com/package/@aws-sdk/credential-provider-node](https://www.npmjs.com/package/@aws-sdk/credential-provider-node)
-[https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html)
+<https://www.npmjs.com/package/@aws-sdk/credential-provider-node>
+<https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html>
 
 **Example:**
 
@@ -369,7 +369,7 @@ techdocs:
 (Optional) The AWS Region of the bucket.
 If not set, `AWS_REGION` environment variable or AWS config file will be used.
 
-[https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-region.html](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-region.html)
+<https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-region.html>
 
 **Example:**
 
@@ -389,7 +389,7 @@ techdocs:
 (Optional) The Endpoint URI to send requests to.
 If not set, the default endpoint is built from the configured region.
 
-[https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-s3/interfaces/s3clientconfig.html#endpoint](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-s3/interfaces/s3clientconfig.html#endpoint)
+<https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-s3/interfaces/s3clientconfig.html#endpoint>
 
 **Example:**
 
@@ -442,7 +442,7 @@ techdocs:
 
 (Optional) AWS Server Side Encryption. Defaults to undefined. If not set, encrypted buckets will fail to publish.
 
-[https://docs.aws.amazon.com/AmazonS3/latest/userguide/specifying-s3-encryption.html](https://docs.aws.amazon.com/AmazonS3/latest/userguide/specifying-s3-encryption.html)
+<https://docs.aws.amazon.com/AmazonS3/latest/userguide/specifying-s3-encryption.html>
 
 **Options:** `'aws:kms'` or `'AES256'`
 
@@ -502,11 +502,11 @@ techdocs:
 
 (Required) An account name to write to a storage blob container.
 
-[https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key](https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key)
+<https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key>
 
 (Optional) An account key is required to write to a storage container. If missing, `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` environment variables will be used.
 
-[https://docs.microsoft.com/en-us/azure/storage/common/storage-auth?toc=/azure/storage/blobs/toc.json](https://docs.microsoft.com/en-us/azure/storage/common/storage-auth?toc=/azure/storage/blobs/toc.json)
+<https://docs.microsoft.com/en-us/azure/storage/common/storage-auth?toc=/azure/storage/blobs/toc.json>
 
 **Example:**
 

--- a/docs/features/techdocs/configuration.md
+++ b/docs/features/techdocs/configuration.md
@@ -86,7 +86,7 @@ techdocs:
 
 (Optional and not recommended) Configures the techdocs generator to attempt to ensure an index.md exists falling back to using `<docs-dir>/README.md` or `README.md` in case a default `<docs-dir>/index.md` is not provided.
 
-**Note:** https://www.mkdocs.org/user-guide/configuration/#edit_uri behavior will be broken in these scenarios.
+**Note:** [https://www.mkdocs.org/user-guide/configuration/#edit_uri](https://www.mkdocs.org/user-guide/configuration/#edit_uri) behavior will be broken in these scenarios.
 
 **Example:**
 
@@ -261,7 +261,7 @@ techdocs:
 `techdocs.publisher.googleGcs.credentials`
 
 (Optional) An API key required to write to a storage bucket.
-If missing `GOOGLE_APPLICATION_CREDENTIALS` environment variable will be used. https://cloud.google.com/docs/authentication/production
+If missing `GOOGLE_APPLICATION_CREDENTIALS` environment variable will be used. [https://cloud.google.com/docs/authentication/production](https://cloud.google.com/docs/authentication/production)
 
 **Example:**
 
@@ -324,8 +324,8 @@ The AWS account ID where the storage bucket is located. Credentials for the acco
 
 If account ID is not set and no credentials are set, environment variables or AWS config file will be used to authenticate.
 
-https://www.npmjs.com/package/@aws-sdk/credential-provider-node
-https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html
+[https://www.npmjs.com/package/@aws-sdk/credential-provider-node](https://www.npmjs.com/package/@aws-sdk/credential-provider-node)
+[https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html)
 
 **Example:**
 
@@ -346,8 +346,8 @@ techdocs:
 
 If credentials are not set and no account ID is set, environment variables or AWS config file will be used to authenticate.
 
-https://www.npmjs.com/package/@aws-sdk/credential-provider-node
-https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html
+[https://www.npmjs.com/package/@aws-sdk/credential-provider-node](https://www.npmjs.com/package/@aws-sdk/credential-provider-node)
+[https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html)
 
 **Example:**
 
@@ -369,7 +369,7 @@ techdocs:
 (Optional) The AWS Region of the bucket.
 If not set, `AWS_REGION` environment variable or AWS config file will be used.
 
-https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-region.html
+[https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-region.html](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-region.html)
 
 **Example:**
 
@@ -389,7 +389,7 @@ techdocs:
 (Optional) The Endpoint URI to send requests to.
 If not set, the default endpoint is built from the configured region.
 
-https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-s3/interfaces/s3clientconfig.html#endpoint
+[https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-s3/interfaces/s3clientconfig.html#endpoint](https://docs.aws.amazon.com/AWSJavaScriptSDK/v3/latest/clients/client-s3/interfaces/s3clientconfig.html#endpoint)
 
 **Example:**
 
@@ -442,7 +442,7 @@ techdocs:
 
 (Optional) AWS Server Side Encryption. Defaults to undefined. If not set, encrypted buckets will fail to publish.
 
-https://docs.aws.amazon.com/AmazonS3/latest/userguide/specifying-s3-encryption.html
+[https://docs.aws.amazon.com/AmazonS3/latest/userguide/specifying-s3-encryption.html](https://docs.aws.amazon.com/AmazonS3/latest/userguide/specifying-s3-encryption.html)
 
 **Options:** `'aws:kms'` or `'AES256'`
 
@@ -502,11 +502,11 @@ techdocs:
 
 (Required) An account name to write to a storage blob container.
 
-https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key
+[https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key](https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key)
 
 (Optional) An account key is required to write to a storage container. If missing, `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` environment variables will be used.
 
-https://docs.microsoft.com/en-us/azure/storage/common/storage-auth?toc=/azure/storage/blobs/toc.json
+[https://docs.microsoft.com/en-us/azure/storage/common/storage-auth?toc=/azure/storage/blobs/toc.json](https://docs.microsoft.com/en-us/azure/storage/common/storage-auth?toc=/azure/storage/blobs/toc.json)
 
 **Example:**
 

--- a/docs/features/techdocs/creating-and-publishing.md
+++ b/docs/features/techdocs/creating-and-publishing.md
@@ -106,7 +106,7 @@ To add documentation to an existing entity:
     :::note
     Although `docs` is a popular directory name for storing documentation,
     it can be renamed to something else and can be configured by `mkdocs.yml`. See
-    [https://www.mkdocs.org/user-guide/configuration/#docs_dir](https://www.mkdocs.org/user-guide/configuration/#docs_dir)
+    <https://www.mkdocs.org/user-guide/configuration/#docs_dir>
     :::
 
 4.  Create a `docs/index.md` file, as a minimum. For example:

--- a/docs/features/techdocs/creating-and-publishing.md
+++ b/docs/features/techdocs/creating-and-publishing.md
@@ -159,7 +159,7 @@ published as a standalone part of TechDocs.
 3. Add your `index.md` Markdown file, in a folder named `docs/` with your desired
    documentation in Markdown. Your file structure should now look like this:
 
-   ```
+   ```text
    your-great-documentation/
      docs/
        index.md

--- a/docs/features/techdocs/creating-and-publishing.md
+++ b/docs/features/techdocs/creating-and-publishing.md
@@ -106,7 +106,7 @@ To add documentation to an existing entity:
     :::note
     Although `docs` is a popular directory name for storing documentation,
     it can be renamed to something else and can be configured by `mkdocs.yml`. See
-    https://www.mkdocs.org/user-guide/configuration/#docs_dir
+    [https://www.mkdocs.org/user-guide/configuration/#docs_dir](https://www.mkdocs.org/user-guide/configuration/#docs_dir)
     :::
 
 4.  Create a `docs/index.md` file, as a minimum. For example:

--- a/docs/features/techdocs/how-to-guides--old.md
+++ b/docs/features/techdocs/how-to-guides--old.md
@@ -546,7 +546,7 @@ Start writing your documentation by adding more markdown (.md) files to this
 folder (/docs) or replace the content in this file.
 ```
 
-:::note Note
+:::note
 
 The values of `site_name`, `component_id` and `site_description` depends
 on how you have configured your `template.yaml`.
@@ -565,7 +565,7 @@ theme:
   font: false
 ```
 
-:::note Note
+:::note
 
 The addition `name: material` is necessary. Otherwise it will not work
 
@@ -721,7 +721,7 @@ plugins:
   - kroki
 ```
 
-:::note Note
+:::note
 
 You will very likely want to set a `kroki` `ServerURL` configuration in your
 `mkdocs.yml` as well. The default value is the publicly hosted `kroki.io`. If
@@ -903,7 +903,7 @@ backend.add(techdocsCustomBuildStrategy);
 backend.start();
 ```
 
-:::note Note
+:::note
 
 You may need to add the `@backstage/plugin-techdocs-node` package to your backend `package.json` if it's not been imported already.
 

--- a/docs/features/techdocs/how-to-guides--old.md
+++ b/docs/features/techdocs/how-to-guides--old.md
@@ -66,7 +66,7 @@ When you see `dir:.`, you can translate it to mean:
 
 The directory tree of the entity would look something like this:
 
-```
+```text
 ├── catalog-info.yaml
 ├── mkdocs.yml
 └── docs
@@ -77,7 +77,7 @@ If, for example, you wanted to keep a lean root directory, you could place your
 `mkdocs.yml` file in a subdirectory and update the `backstage.io/techdocs-ref`
 annotation value accordingly, e.g. to `dir:./sub-folder`:
 
-```
+```text
 ├── catalog-info.yaml
 └── sub-folder
     ├── mkdocs.yml
@@ -1007,7 +1007,7 @@ You may want to make files available for download by your users such as PDF
 documents, images, or code templates. Download links for files included in your
 docs directory can be made by adding `{: download }` after a markdown link.
 
-```
+```markdown
 [Link text](https://example.com/foo.jpg){: download }
 ```
 
@@ -1017,6 +1017,6 @@ clicked.
 Specify a file name to control the name the file will be given when it is
 downloaded:
 
-```
+```markdown
 [Link text](https://example.com/foo.jpg){: download="foo.jpg" }
 ```

--- a/docs/features/techdocs/how-to-guides.md
+++ b/docs/features/techdocs/how-to-guides.md
@@ -364,7 +364,7 @@ Start writing your documentation by adding more markdown (.md) files to this
 folder (/docs) or replace the content in this file.
 ```
 
-:::note Note
+:::note
 
 The values of `site_name`, `component_id` and `site_description` depends
 on how you have configured your `template.yaml`.
@@ -562,7 +562,7 @@ plugins:
   - kroki
 ```
 
-:::note Note
+:::note
 
 You will very likely want to set a `kroki` `ServerURL` configuration in your
 `mkdocs.yml` as well. The default value is the publicly hosted `kroki.io`. If
@@ -744,7 +744,7 @@ backend.add(techdocsCustomBuildStrategy);
 backend.start();
 ```
 
-:::note Note
+:::note
 
 You may need to add the `@backstage/plugin-techdocs-node` package to your backend `package.json` if it's not been imported already.
 

--- a/docs/features/techdocs/how-to-guides.md
+++ b/docs/features/techdocs/how-to-guides.md
@@ -67,7 +67,7 @@ When you see `dir:.`, you can translate it to mean:
 
 The directory tree of the entity would look something like this:
 
-```
+```text
 ├── catalog-info.yaml
 ├── mkdocs.yml
 └── docs
@@ -78,7 +78,7 @@ If, for example, you wanted to keep a lean root directory, you could place your
 `mkdocs.yml` file in a subdirectory and update the `backstage.io/techdocs-ref`
 annotation value accordingly, e.g. to `dir:./sub-folder`:
 
-```
+```text
 ├── catalog-info.yaml
 └── sub-folder
     ├── mkdocs.yml
@@ -848,7 +848,7 @@ You may want to make files available for download by your users such as PDF
 documents, images, or code templates. Download links for files included in your
 docs directory can be made by adding `{: download }` after a markdown link.
 
-```
+```markdown
 [Link text](https://example.com/foo.jpg){: download }
 ```
 
@@ -858,6 +858,6 @@ clicked.
 Specify a file name to control the name the file will be given when it is
 downloaded:
 
-```
+```markdown
 [Link text](https://example.com/foo.jpg){: download="foo.jpg" }
 ```

--- a/docs/features/techdocs/troubleshooting.md
+++ b/docs/features/techdocs/troubleshooting.md
@@ -31,14 +31,14 @@ troubleshoot MkDocs build issues locally. Note this requires you have Docker
 available to launch images. First, `git clone` the target repository locally,
 then in the root of the repository, run:
 
-```
+```shell
 npx @techdocs/cli serve
 ```
 
 For example, if you have forgotten to put an MkDocs configuration file in your
 repo, the resulting error will be:
 
-```
+```log
 npx: installed 278 in 9.089s
 [techdocs-preview-bundle] Running local version of Backstage at http://localhost:3000
 INFO    -  Building documentation...
@@ -49,7 +49,7 @@ Config file '/content/mkdocs.yml' does not exist.
 When it works, a local copy of both Backstage and your site will be launched
 locally:
 
-```
+```log
 npx: installed 278 in 9.682s
 [techdocs-preview-bundle] Running local version of Backstage at http://localhost:3000
 INFO    -  Building documentation...

--- a/docs/features/techdocs/using-cloud-storage.md
+++ b/docs/features/techdocs/using-cloud-storage.md
@@ -56,7 +56,7 @@ techdocs:
 The GCS Node.js client will automatically use the environment variable
 `GOOGLE_APPLICATION_CREDENTIALS` to authenticate with Google Cloud. It might
 already be set in Compute Engine, Google Kubernetes Engine, etc. Read
-[https://cloud.google.com/docs/authentication/production](https://cloud.google.com/docs/authentication/production) for more details.
+<https://cloud.google.com/docs/authentication/production> for more details.
 
 **3b. Authentication using app-config.yaml**
 
@@ -68,7 +68,7 @@ service account, use "Storage Object Admin".
 
 If you want to create a custom role, make sure to include both `get` and
 `create` permissions for both "Objects" and "Buckets". See
-[https://cloud.google.com/storage/docs/access-control/iam-permissions](https://cloud.google.com/storage/docs/access-control/iam-permissions)
+<https://cloud.google.com/storage/docs/access-control/iam-permissions>
 
 A service account can have many keys. Open your newly created account's page (in
 IAM & Admin console), and create a new key. Use JSON format for the key.
@@ -446,7 +446,7 @@ follow these steps.
 
 To get credentials, access the Azure Portal and go to "Settings > Access Keys",
 and get your Storage account name and Primary Key.
-[https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key](https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key)
+<https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key>
 for more details.
 
 ```yaml
@@ -514,7 +514,7 @@ techdocs:
 
 Set the configs in your `app-config.yaml` to point to your container name.
 
-[https://docs.openstack.org/api-ref/identity/v3/?expanded=password-authentication-with-unscoped-authorization-detail,authenticating-with-an-application-credential-detail#authenticating-with-an-application-credential](https://docs.openstack.org/api-ref/identity/v3/?expanded=password-authentication-with-unscoped-authorization-detail,authenticating-with-an-application-credential-detail#authenticating-with-an-application-credential)
+<https://docs.openstack.org/api-ref/identity/v3/?expanded=password-authentication-with-unscoped-authorization-detail,authenticating-with-an-application-credential-detail#authenticating-with-an-application-credential>
 for more details.
 
 ```yaml

--- a/docs/features/techdocs/using-cloud-storage.md
+++ b/docs/features/techdocs/using-cloud-storage.md
@@ -56,7 +56,7 @@ techdocs:
 The GCS Node.js client will automatically use the environment variable
 `GOOGLE_APPLICATION_CREDENTIALS` to authenticate with Google Cloud. It might
 already be set in Compute Engine, Google Kubernetes Engine, etc. Read
-https://cloud.google.com/docs/authentication/production for more details.
+[https://cloud.google.com/docs/authentication/production](https://cloud.google.com/docs/authentication/production) for more details.
 
 **3b. Authentication using app-config.yaml**
 
@@ -68,7 +68,7 @@ service account, use "Storage Object Admin".
 
 If you want to create a custom role, make sure to include both `get` and
 `create` permissions for both "Objects" and "Buckets". See
-https://cloud.google.com/storage/docs/access-control/iam-permissions
+[https://cloud.google.com/storage/docs/access-control/iam-permissions](https://cloud.google.com/storage/docs/access-control/iam-permissions)
 
 A service account can have many keys. Open your newly created account's page (in
 IAM & Admin console), and create a new key. Use JSON format for the key.
@@ -446,7 +446,7 @@ follow these steps.
 
 To get credentials, access the Azure Portal and go to "Settings > Access Keys",
 and get your Storage account name and Primary Key.
-https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key
+[https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key](https://docs.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key)
 for more details.
 
 ```yaml
@@ -514,7 +514,7 @@ techdocs:
 
 Set the configs in your `app-config.yaml` to point to your container name.
 
-https://docs.openstack.org/api-ref/identity/v3/?expanded=password-authentication-with-unscoped-authorization-detail,authenticating-with-an-application-credential-detail#authenticating-with-an-application-credential
+[https://docs.openstack.org/api-ref/identity/v3/?expanded=password-authentication-with-unscoped-authorization-detail,authenticating-with-an-application-credential-detail#authenticating-with-an-application-credential](https://docs.openstack.org/api-ref/identity/v3/?expanded=password-authentication-with-unscoped-authorization-detail,authenticating-with-an-application-credential-detail#authenticating-with-an-application-credential)
 for more details.
 
 ```yaml

--- a/docs/features/techdocs/using-cloud-storage.md
+++ b/docs/features/techdocs/using-cloud-storage.md
@@ -201,7 +201,7 @@ permissions to:
 - `s3:ListBucket` - To retrieve bucket metadata
 - `s3:GetObject` - To retrieve files from the bucket
 
-:::note Note
+:::note
 
 If you need to migrate documentation objects from an older-style path
 format including case-sensitive entity metadata, you will need to add some

--- a/docs/frontend-system/building-plugins/05-migrating.md
+++ b/docs/frontend-system/building-plugins/05-migrating.md
@@ -11,7 +11,7 @@ The main concept is that routes, components, apis are now extensions. You can us
 
 ## Migrating the plugin
 
-:::note Note
+:::note
 
 Unless you are migrating a plugin that is only used within your own project, we recommend all plugins to keep support for the old system intact. The code added in these examples should be added to a new `src/alpha.tsx` entry point of your plugin.
 

--- a/docs/getting-started/config/authentication--old.md
+++ b/docs/getting-started/config/authentication--old.md
@@ -16,7 +16,7 @@ We'll be walking you through how to setup authentication for your Backstage app 
 
 There are multiple authentication providers available for you to use with Backstage, feel free to follow [their instructions for adding authentication](../../auth/index--old.md).
 
-:::note Note
+:::note
 
 The default Backstage app comes with a guest Sign In Resolver. This resolver makes all users share a single "guest" identity and is only intended as a minimum requirement to quickly get up and running. You can read more about how [Sign In Resolvers](../../auth/identity-resolver.md#sign-in-resolvers) play a role in creating a [Backstage User Identity](../../auth/identity-resolver.md#backstage-user-identity) for logged in users.
 
@@ -134,7 +134,7 @@ backend.add(import('@backstage/plugin-auth-backend-module-github-provider'));
 
 Restart Backstage from the terminal, by stopping it with `Ctrl+C`, and starting it with `yarn start`. You should be welcomed by a login prompt! If you try to login at this point you will get a "Failed to sign-in, unable to resolve user identity" message, read on as we'll fix that next.
 
-:::note Note
+:::note
 
 Sometimes the frontend starts before the backend resulting in errors on the sign in page. Wait for the backend to start and then reload Backstage to proceed.
 
@@ -201,7 +201,7 @@ integrations:
       token: ${GITHUB_TOKEN} # this will use the environment variable GITHUB_TOKEN
 ```
 
-:::note Note
+:::note
 
 If you've updated the configuration for your integration, it's likely that the backend will need a restart to apply these changes. To do this, stop the running instance in your terminal with `Control-C`, then start it again with `yarn start`. Once the backend has restarted, retry the operation.
 

--- a/docs/getting-started/config/authentication.md
+++ b/docs/getting-started/config/authentication.md
@@ -16,7 +16,7 @@ We'll be walking you through how to setup authentication for your Backstage app 
 
 There are multiple authentication providers available for you to use with Backstage, feel free to follow [their instructions for adding authentication](../../auth/index.md).
 
-:::note Note
+:::note
 
 The default Backstage app comes with a guest Sign In Resolver. This resolver makes all users share a single "guest" identity and is only intended as a minimum requirement to quickly get up and running. You can read more about how [Sign In Resolvers](../../auth/identity-resolver.md#sign-in-resolvers) play a role in creating a [Backstage User Identity](../../auth/identity-resolver.md#backstage-user-identity) for logged in users.
 
@@ -160,7 +160,7 @@ backend.add(import('@backstage/plugin-auth-backend-module-github-provider'));
 
 Restart Backstage from the terminal, by stopping it with `Ctrl+C`, and starting it with `yarn start`. You should be welcomed by a login prompt! If you try to login at this point you will get a "Failed to sign-in, unable to resolve user identity" message, read on as we'll fix that next.
 
-:::note Note
+:::note
 
 Sometimes the frontend starts before the backend resulting in errors on the sign in page. Wait for the backend to start and then reload Backstage to proceed.
 
@@ -227,7 +227,7 @@ integrations:
       token: ${GITHUB_TOKEN} # this will use the environment variable GITHUB_TOKEN
 ```
 
-:::note Note
+:::note
 
 If you've updated the configuration for your integration, it's likely that the backend will need a restart to apply these changes. To do this, stop the running instance in your terminal with `Control-C`, then start it again with `yarn start`. Once the backend has restarted, retry the operation.
 

--- a/docs/getting-started/config/database.md
+++ b/docs/getting-started/config/database.md
@@ -25,7 +25,7 @@ This guide assumes a basic understanding of working on a Linux based operating s
 
 ## 1. Install and Configure PostgreSQL
 
-:::tip Already configured your database?
+:::tip[Already configured your database?]
 
 If you've already installed PostgreSQL and created a schema and user, you can skip to [Step 2](#2-configuring-backstage-pg-client).
 

--- a/docs/getting-started/configure-app-with-plugins--old.md
+++ b/docs/getting-started/configure-app-with-plugins--old.md
@@ -12,7 +12,7 @@ system. If your app uses the new frontend system, read the
 
 Audience: Developers
 
-:::note Note
+:::note
 Backstage plugins are primarily written using [TypeScript](https://www.typescriptlang.org), [Node.js](https://nodejs.org) and [React](https://reactjs.org). Having an understanding of these technologies will be beneficial on your journey to customizing Backstage!
 :::
 

--- a/docs/getting-started/configure-app-with-plugins.md
+++ b/docs/getting-started/configure-app-with-plugins.md
@@ -13,7 +13,7 @@ instead.
 
 Audience: Developers
 
-:::note Note
+:::note
 Backstage plugins are primarily written using [TypeScript](https://www.typescriptlang.org), [Node.js](https://nodejs.org) and [React](https://reactjs.org). Having an understanding of these technologies will be beneficial on your journey to customizing Backstage!
 :::
 

--- a/docs/getting-started/create-a-component.md
+++ b/docs/getting-started/create-a-component.md
@@ -58,15 +58,15 @@ Selecting `REPOSITORY` displays the `catalog-info.yaml`file and other project se
 
 The `catalog-info.yaml` file describes the entity for the Software Catalog. [Descriptor Format of Catalog Entities](../features/software-catalog/descriptor-format.md) provides additional information.
 
-```
- apiVersion: backstage.io/v1alpha1
- kind: Component
- metadata:
-   name: "tutorial"
- spec:
-   type: service
-   owner: user:guest
-   lifecycle: experimental
+```yaml
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: 'tutorial'
+spec:
+  type: service
+  owner: user:guest
+  lifecycle: experimental
 ```
 
 Selecting `OPEN IN CATALOG` displays details of the new component, such as its relationships, links, and subcomponents.

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -106,7 +106,7 @@ To create the application:
 
 2. If this is the first time that you are installing a Backstage application on this device, the following question is displayed. Enter `y` and select `Enter` to proceed with the installation.
 
-   ```console
+   ```text
    Need to install the following packages:
    @backstage/create-app@<version>
    ok to proceed? (y)
@@ -114,7 +114,7 @@ To create the application:
 
 3. Enter the name for your application and select `Enter`. This is the root directory of your application. In this example, the name is set to `my-backstage-app`.
 
-   ```console
+   ```text
    ? Enter a name for the app [required] my-backstage-app
 
    Creating the app...

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -7,7 +7,7 @@ description: How to create and run a Standalone Backstage.
 
 Audience: Developers and Admins
 
-:::note Note
+:::note
 It is not required, although recommended to have a basic understanding of [Yarn](https://www.pluralsight.com/guides/yarn-a-package-manager-for-node-js) and [npm](https://docs.npmjs.com/about-npm) before starting this guide.
 :::
 
@@ -17,7 +17,7 @@ This guide walks through how to create your own Backstage customizable app. This
 
 By the end of this guide, you will have a standalone Backstage installation running locally with an in-memory `SQLite` database and demo content. To be clear, this is not a production-ready installation, and it does not contain information specific to your organization until you set up integrations with your specific data sources!
 
-:::note Contributors
+:::note[Contributors]
 
 If you are planning to contribute a new feature or bug fix to the Backstage project, we advise you to follow the [Contributors](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#get-started) guide instead to do a repository-based installation.
 
@@ -180,7 +180,7 @@ Rspack compiled successfully
 
 Once the Backstage UI is displayed, you can start exploring the demo immediately.
 
-:::tip Browser window didn't open with yarn start
+:::tip[Browser window didn't open with yarn start]
 
 When you see the message `Rspack compiled successfully`, you can navigate directly to `http://localhost:3000` to see your Backstage app.
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -34,7 +34,7 @@ needed for you to run your app.
 
 Below is a simplified layout of the files and folders generated when creating an app.
 
-```
+```text
 app
 ├── app-config.yaml
 ├── catalog-info.yaml
@@ -159,7 +159,7 @@ To run the application:
 
 As the frontend and backend are starting, you will see output similar to the following. The output shows that the app and backend are starting up with the configuration coming from `app-config.yaml`. You will see the plugins being initialized, and authorization and permissions being setup. In addition you will see a series of REST API calls for those plugins that use a service backend, such as the service catalog.
 
-```
+```log
 Starting app, backend
 Loaded config from app-config.yaml
 .

--- a/docs/getting-started/keeping-backstage-updated.md
+++ b/docs/getting-started/keeping-backstage-updated.md
@@ -6,7 +6,7 @@ description: How to keep your Backstage App updated
 
 Audience: Developers and Admins
 
-:::note Note
+:::note
 To better understand the concepts in this section, it's recommended to have an understanding of [Monorepos](https://semaphoreci.com/blog/what-is-monorepo), [Semantic Versioning](https://semver.org) and [CHANGELOGs](https://keepachangelog.com).
 :::
 

--- a/docs/getting-started/register-a-component.md
+++ b/docs/getting-started/register-a-component.md
@@ -6,7 +6,7 @@ description: Start populating your Backstage app with your data.
 
 Audience: Developers
 
-:::note Note
+:::note
 Entity files are stored in YAML format, if you are not familiar with YAML, you can learn more about it [here](https://yaml.org).
 
 [Descriptor Format of Catalog Entities](../features/software-catalog/descriptor-format.md) provides additional information on the format of the YAML entity files.
@@ -22,7 +22,7 @@ When registering a component, you can:
 
 - Link to a repository: All `catalog-info.yaml` files are discovered in the repository and their defined entities are added to the Scaffolded Backstage App Catalog. For example, `https://github.com/backstage/backstage`.
 
-  :::note Note
+  :::note
   If no entities are found, a Pull Request is created that adds an example `catalog-info.yaml` file to the repository. When the Pull Request is merged, the Scaffolded Backstage App Catalog loads all of the defined entities.
 
   :::

--- a/docs/golden-path/adoption/001-getting-started.md
+++ b/docs/golden-path/adoption/001-getting-started.md
@@ -9,7 +9,7 @@ The adoption journey is a bit different than the other Golden Paths. The goal of
 
 :::info
 
-I'd highly recommend poking around [https://demo.backstage.io/](https://demo.backstage.io/) before continuing with this guide. It's a test instance of Backstage that provides a good foundation for what to expect from the tool as a user.
+I'd highly recommend poking around <https://demo.backstage.io/> before continuing with this guide. It's a test instance of Backstage that provides a good foundation for what to expect from the tool as a user.
 
 :::
 
@@ -64,10 +64,10 @@ If you're non-technical, it is highly recommended to find a technical partner fo
 
 ### Software Catalog
 
-Let's go to [https://demo.backstage.io/](https://demo.backstage.io/) together. When you first navigate to the page, you will be brought to the Software Catalog page. This is a view of all projects currently registered with the (Demo) Backstage instance. There are a series of filters that you can play around with. If you're _really_ interested, we recommend reading through [the software catalog system model](../../features/software-catalog/system-model.md).
+Let's go to <https://demo.backstage.io/> together. When you first navigate to the page, you will be brought to the Software Catalog page. This is a view of all projects currently registered with the (Demo) Backstage instance. There are a series of filters that you can play around with. If you're _really_ interested, we recommend reading through [the software catalog system model](../../features/software-catalog/system-model.md).
 
 Let's click into a Component, say "artist-lookup". This will bring you to a specialized view for that Component. Across the top, you can see tabs for "CI/CD", "API", "Dependencies", "Docs" and "TODOs". For your company, you can change this as you see fit. The important takeaway is that all of these tabs are automatically filtered for this Component which makes it easy to see how this could start to replace many navigation to other tools.
 
 ### Scaffolder
 
-Let's go to [https://demo.backstage.io/create](https://demo.backstage.io/create) now. This is the Scaffolder, a place to store reusable templates. Click the "Choose" button in the "Demo template". This will bring you to a form with some information to input. You don't need to fill this out. The main takeaway here is that this form is generated from YAML and doesn't require a frontend team to implement a custom form for each template you want to create.
+Let's go to <https://demo.backstage.io/create> now. This is the Scaffolder, a place to store reusable templates. Click the "Choose" button in the "Demo template". This will bring you to a form with some information to input. You don't need to fill this out. The main takeaway here is that this form is generated from YAML and doesn't require a frontend team to implement a custom form for each template you want to create.

--- a/docs/golden-path/adoption/001-getting-started.md
+++ b/docs/golden-path/adoption/001-getting-started.md
@@ -9,7 +9,7 @@ The adoption journey is a bit different than the other Golden Paths. The goal of
 
 :::info
 
-I'd highly recommend poking around https://demo.backstage.io/ before continuing with this guide. It's a test instance of Backstage that provides a good foundation for what to expect from the tool as a user.
+I'd highly recommend poking around [https://demo.backstage.io/](https://demo.backstage.io/) before continuing with this guide. It's a test instance of Backstage that provides a good foundation for what to expect from the tool as a user.
 
 :::
 
@@ -64,10 +64,10 @@ If you're non-technical, it is highly recommended to find a technical partner fo
 
 ### Software Catalog
 
-Let's go to https://demo.backstage.io/ together. When you first navigate to the page, you will be brought to the Software Catalog page. This is a view of all projects currently registered with the (Demo) Backstage instance. There are a series of filters that you can play around with. If you're _really_ interested, we recommend reading through [the software catalog system model](../../features/software-catalog/system-model.md).
+Let's go to [https://demo.backstage.io/](https://demo.backstage.io/) together. When you first navigate to the page, you will be brought to the Software Catalog page. This is a view of all projects currently registered with the (Demo) Backstage instance. There are a series of filters that you can play around with. If you're _really_ interested, we recommend reading through [the software catalog system model](../../features/software-catalog/system-model.md).
 
 Let's click into a Component, say "artist-lookup". This will bring you to a specialized view for that Component. Across the top, you can see tabs for "CI/CD", "API", "Dependencies", "Docs" and "TODOs". For your company, you can change this as you see fit. The important takeaway is that all of these tabs are automatically filtered for this Component which makes it easy to see how this could start to replace many navigation to other tools.
 
 ### Scaffolder
 
-Let's go to https://demo.backstage.io/create now. This is the Scaffolder, a place to store reusable templates. Click the "Choose" button in the "Demo template". This will bring you to a form with some information to input. You don't need to fill this out. The main takeaway here is that this form is generated from YAML and doesn't require a frontend team to implement a custom form for each template you want to create.
+Let's go to [https://demo.backstage.io/create](https://demo.backstage.io/create) now. This is the Scaffolder, a place to store reusable templates. Click the "Choose" button in the "Demo template". This will bring you to a form with some information to input. You don't need to fill this out. The main takeaway here is that this form is generated from YAML and doesn't require a frontend team to implement a custom form for each template you want to create.

--- a/docs/golden-path/adoption/005-customizing-your-instance.md
+++ b/docs/golden-path/adoption/005-customizing-your-instance.md
@@ -9,7 +9,7 @@ You now have the knowledge of what your users want and the go from leadership to
 
 ## Open Source or Build it yourself?
 
-There's a huge community of plugins available for easy installation at https://backstage.io/plugins. We would recommend that you start here for any needs you may be trying to solve. Building a plugin yourself requires significant effort and can be hard to justify early on in your adoption story. If there is a clear gap in the existing offerings for your company, you should build something yourself - otherwise, save yourself the maintenance overhead.
+There's a huge community of plugins available for easy installation at [https://backstage.io/plugins](https://backstage.io/plugins). We would recommend that you start here for any needs you may be trying to solve. Building a plugin yourself requires significant effort and can be hard to justify early on in your adoption story. If there is a clear gap in the existing offerings for your company, you should build something yourself - otherwise, save yourself the maintenance overhead.
 
 ## Customizing the theme
 

--- a/docs/golden-path/adoption/005-customizing-your-instance.md
+++ b/docs/golden-path/adoption/005-customizing-your-instance.md
@@ -9,7 +9,7 @@ You now have the knowledge of what your users want and the go from leadership to
 
 ## Open Source or Build it yourself?
 
-There's a huge community of plugins available for easy installation at [https://backstage.io/plugins](https://backstage.io/plugins). We would recommend that you start here for any needs you may be trying to solve. Building a plugin yourself requires significant effort and can be hard to justify early on in your adoption story. If there is a clear gap in the existing offerings for your company, you should build something yourself - otherwise, save yourself the maintenance overhead.
+There's a huge community of plugins available for easy installation at <https://backstage.io/plugins>. We would recommend that you start here for any needs you may be trying to solve. Building a plugin yourself requires significant effort and can be hard to justify early on in your adoption story. If there is a clear gap in the existing offerings for your company, you should build something yourself - otherwise, save yourself the maintenance overhead.
 
 ## Customizing the theme
 

--- a/docs/golden-path/create-app/customize-theme--old.md
+++ b/docs/golden-path/create-app/customize-theme--old.md
@@ -34,7 +34,7 @@ export const myTheme = createUnifiedTheme({
 });
 ```
 
-:::note Note
+:::note
 
 we recommend creating a `theme` folder in `packages/app/src` to place your theme file to keep things nicely organized.
 
@@ -514,7 +514,7 @@ You can add more icons, if the [default icons](https://github.com/backstage/back
 
    You might want to use this method if you have an icon you want to use in several locations.
 
-:::note Note
+:::note
 
 If the icon is not available as one of the default icons or one you've added then it will fall back to Material UI's `LanguageIcon`
 

--- a/docs/golden-path/create-app/customize-theme.md
+++ b/docs/golden-path/create-app/customize-theme.md
@@ -35,7 +35,7 @@ export const myTheme = createUnifiedTheme({
 });
 ```
 
-:::note Note
+:::note
 
 We recommend creating a `theme` folder in `packages/app/src` to place your theme file to keep things nicely organized.
 
@@ -521,7 +521,7 @@ const alertIcon = app.getSystemIcon('alert');
 
 You might want to use this method if you have an icon you want to use in several locations.
 
-:::note Note
+:::note
 
 If the icon is not available as one of the default icons or one you've added then it will fall back to Material UI's `LanguageIcon`
 

--- a/docs/golden-path/create-app/installing-plugins.md
+++ b/docs/golden-path/create-app/installing-plugins.md
@@ -43,8 +43,8 @@ In both cases, you'll want to find the plugin's installation documentation. For 
 
 Generally, installing a backend plugin is really easy - you just add a
 
-```
-backend.import(`@scope/package`)
+```ts
+backend.import(`@scope/package`);
 ```
 
 to your `packages/backend/src/index.ts` file alongside the other entries. Saving the file will trigger a hot reload and just like that your new plugin is available and usable. For advanced cases, there may be required config for the plugin that you'll have to set. That config will (or should) be documented by the plugin in their `README`.

--- a/docs/golden-path/create-app/installing-plugins.md
+++ b/docs/golden-path/create-app/installing-plugins.md
@@ -11,7 +11,7 @@ Now that you have a working Backstage app, let's walk through the most valuable 
 
 A Backstage plugin usually consists of frontend and backend functionality. Some examples of Backstage plugins are our Software Catalog, Search, and Software Templates plugins! Each plugin provides a series of well-contained focused features, for example - the Software Catalog contains an entity ingestion engine, an optimized query layer for fetching entity information and a series of UI elements that provide list and detail functionality for entities. Some plugins allow modules which supplement existing plugin-level functionality, customizing it for specific use cases - a good example here are catalog processor modules which allow for ingesting data from common sources into the catalog.
 
-:::note Backstage Plugin Naming
+:::note[Backstage Plugin Naming]
 
 The `backstage-cli new` command scaffolds plugins automatically with the expected naming conventions. We describe the naming conventions below for users who are installing external plugins.
 

--- a/docs/golden-path/create-app/keeping-backstage-updated.md
+++ b/docs/golden-path/create-app/keeping-backstage-updated.md
@@ -7,7 +7,7 @@ description: How to keep your Backstage instance up to date with the latest rele
 
 Audience: Developers and Admins
 
-:::note Note
+:::note
 To better understand the concepts in this section, it's recommended to have an understanding of [Monorepos](https://semaphoreci.com/blog/what-is-monorepo), [Semantic Versioning](https://semver.org) and [CHANGELOGs](https://keepachangelog.com).
 :::
 

--- a/docs/golden-path/create-app/local-development.md
+++ b/docs/golden-path/create-app/local-development.md
@@ -45,13 +45,13 @@ Speaking of hot reloads, these are supported for both the frontend and backend.
 
 In the frontend, whenever you save a file used by your React app, after a slight delay, you should see a message like
 
-```
+```text
 Rspack compiled successfully
 ```
 
 In the backend, you should see a
 
-```
+```text
 Change detected, restarting the development server...
 ```
 

--- a/docs/golden-path/create-app/local-development.md
+++ b/docs/golden-path/create-app/local-development.md
@@ -15,7 +15,7 @@ yarn start
 
 Here again, there's a small wait for the frontend to start up. Once the frontend is built, your browser window should automatically open.
 
-:::tip Browser window didn't open
+:::tip[Browser window didn't open]
 
 When you see the message `[0] webpack compiled successfully`, you can navigate directly to `http://localhost:3000` to see your Backstage app.
 
@@ -27,7 +27,7 @@ Once its spun up, you should see something similar to the below.
 
 ## Architecture of local development
 
-:::note Deploy architecture
+:::note[Deploy architecture]
 
 This section only touches on local development, we'll walk through what a Golden Path production architecture looks like in the `deployment` Golden Path.
 

--- a/docs/golden-path/create-app/npx-create-app.md
+++ b/docs/golden-path/create-app/npx-create-app.md
@@ -56,7 +56,7 @@ The wizard for this command will ask what name you want to have for your new app
 
 When you run the command, you'll see an output like this.
 
-```console
+```text
 
 ? Enter a name for the app [required] my-backstage-app
 

--- a/docs/golden-path/create-app/npx-create-app.md
+++ b/docs/golden-path/create-app/npx-create-app.md
@@ -6,7 +6,7 @@ description: How to scaffold a new Backstage app using create-app
 
 Audience: Developers and Admins
 
-:::note Note
+:::note
 It is not required, although recommended to have a basic understanding of [Yarn](https://www.pluralsight.com/guides/yarn-a-package-manager-for-node-js) and [npm](https://docs.npmjs.com/about-npm) before starting this guide.
 :::
 
@@ -16,7 +16,7 @@ This guide walks through how to get started creating your very own Backstage cus
 
 By the end of this guide, you will have a standalone Backstage installation running locally with a `SQLite` database and demo content.
 
-:::caution Organization customization
+:::caution[Organization customization]
 
 To be clear, this is not a production-ready installation, and it does not contain information specific to your organization. You will learn how to customize Backstage for your use case through this guide.
 

--- a/docs/golden-path/create-app/npx-create-app.md
+++ b/docs/golden-path/create-app/npx-create-app.md
@@ -100,7 +100,7 @@ This may take a few minutes to fully install everything. Don't stress if the loa
 
 Below is a simplified layout of the files and folders generated when creating an app.
 
-```
+```text
 app
 ├── app-config.yaml
 ├── catalog-info.yaml

--- a/docs/golden-path/deployment/001-docker.md
+++ b/docs/golden-path/deployment/001-docker.md
@@ -60,7 +60,7 @@ docker run -it -p 7007:7007 backstage
 You should see logs in your terminal and be able to open `http://localhost:7007`
 in your browser.
 
-:::tip Troubleshooting
+:::tip[Troubleshooting]
 
 If you run into build issues, two Docker flags can help:
 

--- a/docs/golden-path/deployment/005-config-first.md
+++ b/docs/golden-path/deployment/005-config-first.md
@@ -24,7 +24,7 @@ merges them together. Files loaded later override values from earlier files.
 The Docker image built in the [first step](./001-docker.md) starts with this
 command:
 
-```
+```shell
 node packages/backend --config app-config.yaml --config app-config.production.yaml
 ```
 

--- a/docs/golden-path/plugins/backend/001-first-steps.md
+++ b/docs/golden-path/plugins/backend/001-first-steps.md
@@ -29,7 +29,7 @@ Creating the plugin will take a little while, so be patient. If it runs with no 
 
 Once the commands complete, you should see a new folder `plugins/todo-backend` with content like the below tree:
 
-```
+```text
 / <- your Backstage app's root directory
     /plugins/
         /todo-backend/

--- a/docs/golden-path/plugins/backend/002-poking-around.md
+++ b/docs/golden-path/plugins/backend/002-poking-around.md
@@ -24,7 +24,7 @@ Before we jump in to making this plugin ready to ship, let's walk through how to
 
 If you run `yarn start`, you should see a custom backend for just your plugin start up. This will simplify plugin development and iteration for you or your team by easily testing out new features in just your plugin - just make sure you add what you need to the global `packages/backend`. The important log for us to look for is
 
-```
+```log
 2025-06-08T16:14:53.229Z rootHttpRouter info Listening on :7007
 ```
 

--- a/docs/golden-path/plugins/frontend/001-first-steps.md
+++ b/docs/golden-path/plugins/frontend/001-first-steps.md
@@ -23,7 +23,7 @@ Creating the plugin takes a moment. Once the command finishes, a new folder
 appears at `plugins/todo` (the path depends on the plugin ID you chose) with
 a structure like this:
 
-```
+```text
 plugins/todo/
 ├── dev/          # Standalone dev server setup
 ├── src/

--- a/docs/integrations/aws-codecommit/locations.md
+++ b/docs/integrations/aws-codecommit/locations.md
@@ -24,19 +24,16 @@ integrations:
 
 This most basic example can only be used if you are running Backstage on an instance that has an IAM identity with the following policies:
 
-```
+```json
 {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Action": [
-                "codecommit:GetFile",
-                "codecommit:GetFolder"
-            ],
-            "Resource": "*",
-            "Effect": "Allow"
-        }
-    ]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": ["codecommit:GetFile", "codecommit:GetFolder"],
+      "Resource": "*",
+      "Effect": "Allow"
+    }
+  ]
 }
 ```
 

--- a/docs/integrations/azure/discovery.md
+++ b/docs/integrations/azure/discovery.md
@@ -74,7 +74,7 @@ The parameters available are:
   - **`scope`** _(optional)_:
     `'global'` or `'local'`. Sets the scope of concurrency control.
 
-:::note Note
+:::note
 
 - The path parameter follows the same rules as the search on Azure DevOps web interface. For more details visit the [official search documentation](https://docs.microsoft.com/en-us/azure/devops/project/search/get-started-search?view=azure-devops).
 - To use branch parameters, it is necessary that the desired branch be added to the "Searchable branches" list within Azure DevOps Repositories. To do this, follow the instructions below:

--- a/docs/integrations/azure/locations.md
+++ b/docs/integrations/azure/locations.md
@@ -161,7 +161,7 @@ If you need to authenticate against an Azure DevOps organization in a different 
 - [Create a multi-tenant application in Entra ID](https://learn.microsoft.com/en-us/entra/identity-platform/single-and-multi-tenant-apps).
 - [Convert the existing application to a multi-tenant application](https://learn.microsoft.com/en-gb/entra/identity-platform/howto-convert-app-to-be-multi-tenant#update-registration-to-be-multitenant).
 
-:::note Note
+:::note
 
 Make sure that your application requests at least one Graph API permission. This is required to be able to install the application in another tenant. The least privileged permission you can request is the [`email` permission](https://learn.microsoft.com/en-us/graph/permissions-reference#email) with type `Delegated`. This allows the application to read the e-mail address of the signed-in user, but without the [`openid` permission](https://learn.microsoft.com/en-us/graph/permissions-reference#openid) users cannot actually sign in.
 
@@ -189,7 +189,7 @@ integrations:
 
 Where `${APP_REGISTRATION_CLIENT_ID}` is the client ID of the multi-tenant app registration in you created in your own tenant, and `${OTHER_TENANT_ID}` is the tenant ID of the other tenant where you .
 
-:::note Note
+:::note
 
 The example above uses a [system-assigned managed identity to generate the client assertion](#using-a-system-assigned-managed-identity-to-generate-the-client-assertion). You can also use a [user-assigned managed identity to generate the client assertion](#using-a-user-assigned-managed-identity-to-generate-the-client-assertion) or a client secret to authenticate for the application.
 
@@ -266,7 +266,7 @@ The `credentials` element is an array where each entry is a structure with exact
 - For personal access token:
   - `personalAccessToken`: The personal access token
 
-:::note Note
+:::note
 
 - You cannot use a service principal or managed identity for Azure DevOps Server (on-premises) organizations
 - You can only use a service principal or managed identity for Microsoft Entra ID (formerly Azure Active Directory) backed Azure DevOps organizations

--- a/docs/integrations/bitbucketCloud/discovery.md
+++ b/docs/integrations/bitbucketCloud/discovery.md
@@ -59,9 +59,9 @@ You need to decide how you want to receive events from external sources like
 
 Further documentation:
 
-- [https://github.com/backstage/backstage/tree/master/plugins/events-backend/README.md](https://github.com/backstage/backstage/tree/master/plugins/events-backend/README.md)
-- [https://github.com/backstage/backstage/tree/master/plugins/events-backend-module-aws-sqs/README.md](https://github.com/backstage/backstage/tree/master/plugins/events-backend-module-aws-sqs/README.md)
-- [https://github.com/backstage/backstage/tree/master/plugins/events-backend-module-bitbucket-cloud/README.md](https://github.com/backstage/backstage/tree/master/plugins/events-backend-module-bitbucket-cloud/README.md)
+- <https://github.com/backstage/backstage/tree/master/plugins/events-backend/README.md>
+- <https://github.com/backstage/backstage/tree/master/plugins/events-backend-module-aws-sqs/README.md>
+- <https://github.com/backstage/backstage/tree/master/plugins/events-backend-module-bitbucket-cloud/README.md>
 
 ## Configuration
 

--- a/docs/integrations/bitbucketCloud/discovery.md
+++ b/docs/integrations/bitbucketCloud/discovery.md
@@ -59,9 +59,9 @@ You need to decide how you want to receive events from external sources like
 
 Further documentation:
 
-- <https://github.com/backstage/backstage/tree/master/plugins/events-backend/README.md>
-- <https://github.com/backstage/backstage/tree/master/plugins/events-backend-module-aws-sqs/README.md>
-- <https://github.com/backstage/backstage/tree/master/plugins/events-backend-module-bitbucket-cloud/README.md>
+- [https://github.com/backstage/backstage/tree/master/plugins/events-backend/README.md](https://github.com/backstage/backstage/tree/master/plugins/events-backend/README.md)
+- [https://github.com/backstage/backstage/tree/master/plugins/events-backend-module-aws-sqs/README.md](https://github.com/backstage/backstage/tree/master/plugins/events-backend-module-aws-sqs/README.md)
+- [https://github.com/backstage/backstage/tree/master/plugins/events-backend-module-bitbucket-cloud/README.md](https://github.com/backstage/backstage/tree/master/plugins/events-backend-module-bitbucket-cloud/README.md)
 
 ## Configuration
 

--- a/docs/integrations/bitbucketCloud/discovery.md
+++ b/docs/integrations/bitbucketCloud/discovery.md
@@ -88,7 +88,7 @@ catalog:
         workspace: workspace-name
 ```
 
-:::note Note
+:::note
 
 It is possible but certainly not recommended to skip the provider ID level.
 

--- a/docs/integrations/bitbucketCloud/locations.md
+++ b/docs/integrations/bitbucketCloud/locations.md
@@ -41,14 +41,14 @@ integrations:
       clientSecret: client-secret
 ```
 
-:::note Note
+:::note
 
 A public Bitbucket Cloud provider is added automatically at startup for
 convenience, so you only need to list it if you want to supply credentials.
 
 :::
 
-:::note Note
+:::note
 
 The credential required for this type is either an [Api token](https://support.atlassian.com/bitbucket-cloud/docs/using-api-tokens/), an [App Password](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/) or an [OAuth 2.0 client credentials](https://support.atlassian.com/bitbucket-cloud/docs/use-oauth-on-bitbucket-cloud/). An Atlassian Account API key will not work.
 

--- a/docs/integrations/bitbucketServer/discovery.md
+++ b/docs/integrations/bitbucketServer/discovery.md
@@ -43,9 +43,9 @@ You need to decide how you want to receive events from external sources like
 
 Further documentation:
 
-- [https://github.com/backstage/backstage/tree/master/plugins/events-backend/README.md](https://github.com/backstage/backstage/tree/master/plugins/events-backend/README.md)
-- [https://github.com/backstage/backstage/tree/master/plugins/events-backend-module-aws-sqs/README.md](https://github.com/backstage/backstage/tree/master/plugins/events-backend-module-aws-sqs/README.md)
-- [https://github.com/backstage/backstage/tree/master/plugins/events-backend-module-bitbucket-server/README.md](https://github.com/backstage/backstage/tree/master/plugins/events-backend-module-bitbucket-server/README.md)
+- <https://github.com/backstage/backstage/tree/master/plugins/events-backend/README.md>
+- <https://github.com/backstage/backstage/tree/master/plugins/events-backend-module-aws-sqs/README.md>
+- <https://github.com/backstage/backstage/tree/master/plugins/events-backend-module-bitbucket-server/README.md>
 
 ## Configuration
 

--- a/docs/integrations/bitbucketServer/discovery.md
+++ b/docs/integrations/bitbucketServer/discovery.md
@@ -43,9 +43,9 @@ You need to decide how you want to receive events from external sources like
 
 Further documentation:
 
-- <https://github.com/backstage/backstage/tree/master/plugins/events-backend/README.md>
-- <https://github.com/backstage/backstage/tree/master/plugins/events-backend-module-aws-sqs/README.md>
-- <https://github.com/backstage/backstage/tree/master/plugins/events-backend-module-bitbucket-server/README.md>
+- [https://github.com/backstage/backstage/tree/master/plugins/events-backend/README.md](https://github.com/backstage/backstage/tree/master/plugins/events-backend/README.md)
+- [https://github.com/backstage/backstage/tree/master/plugins/events-backend-module-aws-sqs/README.md](https://github.com/backstage/backstage/tree/master/plugins/events-backend-module-aws-sqs/README.md)
+- [https://github.com/backstage/backstage/tree/master/plugins/events-backend-module-bitbucket-server/README.md](https://github.com/backstage/backstage/tree/master/plugins/events-backend-module-bitbucket-server/README.md)
 
 ## Configuration
 

--- a/docs/integrations/datadog-rum/installation.md
+++ b/docs/integrations/datadog-rum/installation.md
@@ -72,6 +72,8 @@ In case after a proper configuration, the events still are not being captured: C
 <% } %>
 ```
 
+:::
+
 The `clientToken` and `applicationId` are generated from the Datadog RUM page
 following
 [these instructions](https://docs.datadoghq.com/real_user_monitoring/browser/).

--- a/docs/integrations/github/discovery.md
+++ b/docs/integrations/github/discovery.md
@@ -101,7 +101,7 @@ events:
       - github
 ```
 
-This will then expose an endpoint like this: [http://localhost/api/events/http/github](http://localhost/api/events/http/github)
+This will then expose an endpoint like this: <http://localhost/api/events/http/github>
 
 ### Events Setup using AWS SQS module
 

--- a/docs/integrations/github/discovery.md
+++ b/docs/integrations/github/discovery.md
@@ -101,7 +101,7 @@ events:
       - github
 ```
 
-This will then expose an endpoint like this: <http://localhost/api/events/http/github>
+This will then expose an endpoint like this: [http://localhost/api/events/http/github](http://localhost/api/events/http/github)
 
 ### Events Setup using AWS SQS module
 

--- a/docs/integrations/github/discovery.md
+++ b/docs/integrations/github/discovery.md
@@ -298,7 +298,7 @@ catalog:
 
 This provider supports multiple organizations and apps via unique provider IDs.
 
-:::note Note
+:::note
 
 It is possible but certainly not recommended to skip the provider ID level.
 If you do so, `default` will be used as provider ID.

--- a/docs/integrations/github/github-apps.md
+++ b/docs/integrations/github/github-apps.md
@@ -37,7 +37,7 @@ You can use the `backstage-cli` to create a GitHub App using a manifest file
 that we provide. This gives us a way to automate some of the work required to
 create a GitHub app.
 
-```console
+```shell
 yarn backstage-cli create-github-app <github org>
 ```
 

--- a/docs/integrations/github/locations.md
+++ b/docs/integrations/github/locations.md
@@ -28,7 +28,7 @@ integrations:
       token: ${GHE_TOKEN}
 ```
 
-:::note Note
+:::note
 
 A public GitHub provider is added automatically at startup for convenience, so you only need to list it if you want to supply a [token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token).
 

--- a/docs/integrations/github/org.md
+++ b/docs/integrations/github/org.md
@@ -12,7 +12,7 @@ is a hierarchy of
 [`Group`](../../features/software-catalog/descriptor-format.md#kind-group) kind
 entities that mirror your org setup.
 
-:::note Note
+:::note
 
 This adds `User` and `Group` entities to the catalog, but does not
 provide authentication. See the

--- a/docs/integrations/gitlab/discovery.md
+++ b/docs/integrations/gitlab/discovery.md
@@ -99,7 +99,7 @@ events:
       - gitlab
 ```
 
-This will then expose an endpoint like this: <http://localhost/api/events/http/gitlab>
+This will then expose an endpoint like this: [http://localhost/api/events/http/gitlab](http://localhost/api/events/http/gitlab)
 
 ### Events Setup using AWS SQS module
 

--- a/docs/integrations/gitlab/discovery.md
+++ b/docs/integrations/gitlab/discovery.md
@@ -227,7 +227,7 @@ To use the discovery provider, you'll need a GitLab integration
 [set up](locations.md) with a `token`. Then you can add a provider config per group
 to the catalog configuration.
 
-:::note Note
+:::note
 
 The `schedule` has to be setup in the config, as shown below.
 

--- a/docs/integrations/gitlab/discovery.md
+++ b/docs/integrations/gitlab/discovery.md
@@ -99,7 +99,7 @@ events:
       - gitlab
 ```
 
-This will then expose an endpoint like this: [http://localhost/api/events/http/gitlab](http://localhost/api/events/http/gitlab)
+This will then expose an endpoint like this: <http://localhost/api/events/http/gitlab>
 
 ### Events Setup using AWS SQS module
 

--- a/docs/integrations/gitlab/locations.md
+++ b/docs/integrations/gitlab/locations.md
@@ -19,7 +19,7 @@ integrations:
       token: ${GITLAB_TOKEN}
 ```
 
-:::note Note
+:::note
 
 A public GitLab provider is added automatically at startup for convenience, so you only need to list it if you want to supply a [token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html).
 

--- a/docs/integrations/gitlab/org.md
+++ b/docs/integrations/gitlab/org.md
@@ -90,7 +90,7 @@ amount of data, this can take significant time and resources.
 The token used must have the `read_api` scope, and the Users and Groups fetched
 will be those visible to the account which provisioned the token.
 
-:::note Note
+:::note
 
 The `schedule` has to be setup in the config, as shown below.
 

--- a/docs/integrations/harness/locations.md
+++ b/docs/integrations/harness/locations.md
@@ -26,7 +26,7 @@ integrations:
 Directly under the `harness` key is a list of provider configurations, where you
 can list the Harness instances you want to be able to fetch
 
-check out [https://developer.harness.io/docs/platform/automation/api/add-and-manage-api-keys/](https://developer.harness.io/docs/platform/automation/api/add-and-manage-api-keys/) for more information
+check out <https://developer.harness.io/docs/platform/automation/api/add-and-manage-api-keys/> for more information
 
 - `host`: The host of the Harness Code instance that you want to match on.
 - `token` (optional): The password or api token to authenticate with.

--- a/docs/integrations/harness/locations.md
+++ b/docs/integrations/harness/locations.md
@@ -26,7 +26,7 @@ integrations:
 Directly under the `harness` key is a list of provider configurations, where you
 can list the Harness instances you want to be able to fetch
 
-check out https://developer.harness.io/docs/platform/automation/api/add-and-manage-api-keys/ for more information
+check out [https://developer.harness.io/docs/platform/automation/api/add-and-manage-api-keys/](https://developer.harness.io/docs/platform/automation/api/add-and-manage-api-keys/) for more information
 
 - `host`: The host of the Harness Code instance that you want to match on.
 - `token` (optional): The password or api token to authenticate with.

--- a/docs/integrations/ldap/org--old.md
+++ b/docs/integrations/ldap/org--old.md
@@ -27,7 +27,7 @@ to `@backstage/plugin-catalog-backend-module-ldap` to your backend package.
 yarn --cwd packages/backend add @backstage/plugin-catalog-backend-module-ldap
 ```
 
-:::note Note
+:::note
 
 When configuring to use a Provider instead of a Processor you do not
 need to add a _location_ pointing to your LDAP server

--- a/docs/integrations/ldap/org.md
+++ b/docs/integrations/ldap/org.md
@@ -85,7 +85,7 @@ catalog:
 
 These config blocks have a lot of options in them, so we will describe each "root" key within the block separately.
 
-:::note Note
+:::note
 
 If you want to import users and groups from different LDAP servers, you can define multiple providers with different names.
 If they should come from the same server, you can define multiple users and groups blocks within the same provider using an array of users / groups.

--- a/docs/landing-page/doc-landing-page.md
+++ b/docs/landing-page/doc-landing-page.md
@@ -18,13 +18,13 @@ description: Documentation landing page.
       <ul>
         <li><a href='https://backstage.io/docs/overview/what-is-backstage'>What is Backstage?</a></li>
         <li><a href='https://backstage.io/docs/overview/technical-overview'>Technical Overview</a></li>
-        <li><a href='https://backstage.io/docs/overview/architecture-overview'>Architecture overview</a></li> 
+        <li><a href='https://backstage.io/docs/overview/architecture-overview'>Architecture overview</a></li>
         <li><a href='https://backstage.io/docs/plugins/'>Introduction to Plugins</a></li>
         <li><a href='https://backstage.io/docs/features/software-catalog/'>Software Catalog Overview</a></li>
         <li><a href='https://backstage.io/docs/features/software-catalog/system-model'>System Model</a></li>
         <li><a href='https://backstage.io/docs/auth/'>Authentication in Backstage</a></li>
         <li><a href='https://backstage.io/docs/backend-system/'>Backend System Overview</a></li>
-        <li><a href='https://backstage.io/docs/frontend-system/architecture/index'>New Frontend System Overview</a></li> 
+        <li><a href='https://backstage.io/docs/frontend-system/architecture/index'>New Frontend System Overview</a></li>
         <li><a href='https://backstage.io/docs/overview/threat-model'>Security & Threat Model</a></li>
         <li><a href='https://backstage.io/docs/overview/versioning-policy'>Release & Versioning Policy</a></li>
       </ul>
@@ -53,8 +53,8 @@ description: Documentation landing page.
         <li><a href='https://backstage.io/docs/features/software-templates/adding-templates'>Creating a Software Template</a></li>
         <li><a href='https://backstage.io/docs/features/kubernetes/'>Check health of services with Kubernetes</a></li>
         <li><a href='https://backstage.io/docs/tooling/cli/overview/'>Backstage CLI</a></li>
-      </ul>           
-    </td> 
+      </ul>
+    </td>
     <td valign='top'><i>Configure, Deploy, & Upgrade.</i><br><br>
       <ul>
         <li><a href='https://backstage.io/docs/getting-started/config/authentication'>Setup Authentication</a></li>

--- a/docs/notifications/processors.md
+++ b/docs/notifications/processors.md
@@ -104,7 +104,7 @@ Apart from STMP, the email processor also supports the following transmissions:
 - sendmail
 - stream (only for debugging purposes)
 
-See more information at [https://github.com/backstage/backstage/blob/master/plugins/notifications-backend-module-email/README.md](https://github.com/backstage/backstage/blob/master/plugins/notifications-backend-module-email/README.md)
+See more information at <https://github.com/backstage/backstage/blob/master/plugins/notifications-backend-module-email/README.md>
 
 ### Slack Processor
 

--- a/docs/notifications/processors.md
+++ b/docs/notifications/processors.md
@@ -104,7 +104,7 @@ Apart from STMP, the email processor also supports the following transmissions:
 - sendmail
 - stream (only for debugging purposes)
 
-See more information at <https://github.com/backstage/backstage/blob/master/plugins/notifications-backend-module-email/README.md>
+See more information at [https://github.com/backstage/backstage/blob/master/plugins/notifications-backend-module-email/README.md](https://github.com/backstage/backstage/blob/master/plugins/notifications-backend-module-email/README.md)
 
 ### Slack Processor
 

--- a/docs/openapi/01-getting-started.md
+++ b/docs/openapi/01-getting-started.md
@@ -28,12 +28,13 @@ This tutorial assumes that you're already familiar with the following,
 2. `Express.js` and `Typescript`
 3. OpenAPI 3.1 schemas
 
-:::note OpenAPI Version Support
+:::note[OpenAPI Version Support]
 Backstage supports both OpenAPI 3.0 and 3.1 specifications. If you have existing OpenAPI 3.0 specs, we recommend that you migrate them to 3.1. You can use `oasdiff upgrade spec.yaml` to automate this conversion. The main changes are:
 
 - Replace `nullable: true` with `type: ['string', 'null']` or use `anyOf`/`oneOf`
 - Remove `allowReserved` from path parameters (only valid on query/cookie parameters in 3.1)
-  :::
+
+:::
 
 ### Setting up
 

--- a/docs/overview/adopting.md
+++ b/docs/overview/adopting.md
@@ -155,7 +155,7 @@ Backstage as _the_ platform:
 Again, any feedback is appreciated. Please use the Edit button at the bottom of the
 page to make a suggestion.
 
-:::note Note
+:::note
 
 It might be tempting to try to optimize Backstage usage and
 "engagement". Even though you want to consolidate all your tooling and technical

--- a/docs/overview/architecture-overview.md
+++ b/docs/overview/architecture-overview.md
@@ -278,7 +278,7 @@ backend:
 #### Extended configuration
 
 - Unlike Redis, Infinispan will **not** create the cache for you. It's expected you've configured the cache in your infinispan server prior to configuration here.
-- A full list of configuration items are available: https://docs.jboss.org/infinispan/hotrod-clients/javascript/1.0/apidocs/module-infinispan.html including support for backup clusters.
+- A full list of configuration items are available: [https://docs.jboss.org/infinispan/hotrod-clients/javascript/1.0/apidocs/module-infinispan.html](https://docs.jboss.org/infinispan/hotrod-clients/javascript/1.0/apidocs/module-infinispan.html) including support for backup clusters.
 
 ```yaml
 backend:

--- a/docs/overview/architecture-overview.md
+++ b/docs/overview/architecture-overview.md
@@ -170,7 +170,7 @@ Third-party backend plugins are similar to service backend plugins. The main dif
 
 The CircleCI plugin is an example of a third-party backend plugin. CircleCI is a SaaS service which can be used without any knowledge of Backstage. It has an API which a Backstage plugin consumes to display content.
 
-Requests going to CircleCI from the user's browser are passed through a proxy service that Backstage provides. Without this, the requests would be blocked by Cross Origin Resource Sharing policies which prevent a browser page served at [https://example.com](https://example.com) from serving resources hosted at https://circleci.com.
+Requests going to CircleCI from the user's browser are passed through a proxy service that Backstage provides. Without this, the requests would be blocked by Cross Origin Resource Sharing policies which prevent a browser page served at [https://example.com](https://example.com) from serving resources hosted at [https://circleci.com](https://circleci.com).
 
 > **NOTE:**
 > The following diagram does not show the detailed contents of the frontend and backend, in order to highlight the changes that pertain to the addition of the specified plugin.

--- a/docs/overview/architecture-overview.md
+++ b/docs/overview/architecture-overview.md
@@ -170,7 +170,7 @@ Third-party backend plugins are similar to service backend plugins. The main dif
 
 The CircleCI plugin is an example of a third-party backend plugin. CircleCI is a SaaS service which can be used without any knowledge of Backstage. It has an API which a Backstage plugin consumes to display content.
 
-Requests going to CircleCI from the user's browser are passed through a proxy service that Backstage provides. Without this, the requests would be blocked by Cross Origin Resource Sharing policies which prevent a browser page served at [https://example.com](https://example.com) from serving resources hosted at [https://circleci.com](https://circleci.com).
+Requests going to CircleCI from the user's browser are passed through a proxy service that Backstage provides. Without this, the requests would be blocked by Cross Origin Resource Sharing policies which prevent a browser page served at <https://example.com> from serving resources hosted at <https://circleci.com>.
 
 > **NOTE:**
 > The following diagram does not show the detailed contents of the frontend and backend, in order to highlight the changes that pertain to the addition of the specified plugin.
@@ -278,7 +278,7 @@ backend:
 #### Extended configuration
 
 - Unlike Redis, Infinispan will **not** create the cache for you. It's expected you've configured the cache in your infinispan server prior to configuration here.
-- A full list of configuration items are available: [https://docs.jboss.org/infinispan/hotrod-clients/javascript/1.0/apidocs/module-infinispan.html](https://docs.jboss.org/infinispan/hotrod-clients/javascript/1.0/apidocs/module-infinispan.html) including support for backup clusters.
+- A full list of configuration items are available: <https://docs.jboss.org/infinispan/hotrod-clients/javascript/1.0/apidocs/module-infinispan.html> including support for backup clusters.
 
 ```yaml
 backend:

--- a/docs/overview/logos.md
+++ b/docs/overview/logos.md
@@ -8,4 +8,4 @@ description: Guidelines for how to use the Backstage logos and icons
 Guidelines for how to use the Backstage logo and icon can be found
 [here](https://backstage.io/logo_assets/Backstage_Identity_Assets_Overview.pdf).
 
-You can find the assets at [https://github.com/cncf/artwork/tree/main/projects/backstage](https://github.com/cncf/artwork/tree/main/projects/backstage).
+You can find the assets at <https://github.com/cncf/artwork/tree/main/projects/backstage>.

--- a/docs/overview/logos.md
+++ b/docs/overview/logos.md
@@ -8,4 +8,4 @@ description: Guidelines for how to use the Backstage logos and icons
 Guidelines for how to use the Backstage logo and icon can be found
 [here](https://backstage.io/logo_assets/Backstage_Identity_Assets_Overview.pdf).
 
-You can find the assets at https://github.com/cncf/artwork/tree/main/projects/backstage.
+You can find the assets at [https://github.com/cncf/artwork/tree/main/projects/backstage](https://github.com/cncf/artwork/tree/main/projects/backstage).

--- a/docs/overview/vision.md
+++ b/docs/overview/vision.md
@@ -12,7 +12,7 @@ engineers. Our belief is that engineers should not have to be experts in various
 infrastructure tools to be productive. Infrastructure should be abstracted away
 so that you can return to building and scaling, quickly and safely.
 
-![](https://backstage.io/animations/backstage-logos-hero-8.gif)
+![Animated Backstage logo](https://backstage.io/animations/backstage-logos-hero-8.gif)
 
 We are working on making Backstage the trusted standard toolbox (read: UX layer)
 for the open source infrastructure landscape. Think of it like Kubernetes for

--- a/docs/permissions/custom-rules.md
+++ b/docs/permissions/custom-rules.md
@@ -103,7 +103,7 @@ export class CustomPolicy implements PermissionPolicy {
 
 Now that we have a custom rule defined and added to our policy, we need provide it to the catalog plugin. This step is important because the catalog plugin will use the rule's `toQuery` and `apply` methods while evaluating conditional authorize results. There's no guarantee that the catalog and permission backends are running on the same server, so we must explicitly link the rule to ensure that it's available at runtime.
 
-:::warning Warning
+:::warning
 
 The `PermissionsRegistryService` is a fairly new addition and not yet supported by all plugins as they might still be using the old `createPermissionIntegrationRouter` that cannot be extended. If you encounter errors when installing custom rules for a plugin, the plugin may need to be switched to using the `PermissionsRegistryService` first.
 

--- a/docs/permissions/plugin-authors/02-adding-a-basic-permission-check.md
+++ b/docs/permissions/plugin-authors/02-adding-a-basic-permission-check.md
@@ -47,7 +47,7 @@ We use a separate `todo-list-common` package since all permissions authorized by
 
 Install the following module:
 
-```
+```shell
 $ yarn workspace @internal/plugin-todo-list-backend \
   add @backstage/plugin-permission-common @backstage/plugin-permission-node @internal/plugin-todo-list-common
 ```

--- a/docs/permissions/plugin-authors/02-adding-a-basic-permission-check.md
+++ b/docs/permissions/plugin-authors/02-adding-a-basic-permission-check.md
@@ -37,7 +37,7 @@ export const todoListPermissions = [todoListCreatePermission];
 
 For this tutorial, we've automatically exported all permissions from this file (see `plugins/todo-list-common/src/index.ts`).
 
-:::note Note
+:::note
 
 We use a separate `todo-list-common` package since all permissions authorized by your plugin should be exported from a ["common-library" package](https://backstage.io/docs/tooling/cli/build-system#package-roles). This allows Backstage integrators to reference them in frontend components as well as permission policies.
 

--- a/docs/permissions/plugin-authors/03-adding-a-resource-permission-check.md
+++ b/docs/permissions/plugin-authors/03-adding-a-resource-permission-check.md
@@ -160,7 +160,7 @@ export const rules = { isOwner };
 
 The `todoListPermissionResourceRef` is a utility that encapsulates the types and constants related to the resource type. It ensures that the resource and query types are consistent across all rules created for this resource.
 
-:::note Note
+:::note
 
 To support custom rules defined by Backstage integrators, you must export `todoListPermissionResourceRef` from the backend package, or a `*-node` package if you want to enable the creation of third-party modules.
 

--- a/docs/permissions/plugin-authors/04-authorizing-access-to-paginated-data.md
+++ b/docs/permissions/plugin-authors/04-authorizing-access-to-paginated-data.md
@@ -37,7 +37,7 @@ This approach will work for simple cases, but it has a downside: it forces us to
 
 To avoid this situation, the permissions framework has support for filtering items in the data source itself. In this part of the tutorial, we'll describe the steps required to use that behavior.
 
-:::note Note
+:::note
 
 In order to perform authorization filtering in this way, the data source must allow filters to be logically combined with AND, OR, and NOT operators. The conditional decisions returned by the permissions framework use a [nested object](https://backstage.io/api/stable/types/_backstage_plugin-permission-common.PermissionCriteria.html) to combine conditions. If you're implementing a filter API from scratch, we recommend using the same shape for ease of interoperability. If not, you'll need to implement a function which transforms the nested object into your own format.
 

--- a/docs/permissions/plugin-authors/05-frontend-authorization.md
+++ b/docs/permissions/plugin-authors/05-frontend-authorization.md
@@ -8,7 +8,7 @@ In the previous sections, we learned how to protect our plugin's backend API rou
 
 Take, for example, the "Add" button in our todo list application. When a user clicks this button, the frontend makes a `POST` request to the `/todos` route of our backend. If a user tries to add a todo but is not authorized, they will have no way of knowing this until they perform the action and are faced with an error. This is a poor user experience. We can do better by disabling the add button.
 
-:::note Note
+:::note
 
 Placing frontend components behind authorization cannot take the place of placing your backend routes behind authorization. Authorization checks on the frontend should be used in _addition_ to the corresponding backend authorization, as an improvement to the user experience. If you do not place your backend route behind authorization, a malicious actor can still send a request to the route even if you disabled the corresponding frontend component.
 

--- a/docs/permissions/writing-a-policy.md
+++ b/docs/permissions/writing-a-policy.md
@@ -196,7 +196,7 @@ export class CustomPolicy implements PermissionPolicy {
 
 In this example, we use [`isResourcePermission`](https://backstage.io/api/stable/functions/_backstage_plugin-permission-common.isResourcePermission.html) to match all permissions with a resource type of `catalog-entity`. Just like `isPermission`, this helper will "narrow" the type of `request.permission` and enable the use of `createCatalogConditionalDecision`. In addition to the behavior you observed before, you should also see that catalog entities are no longer visible unless you are the owner - success!
 
-:::note Note
+:::note
 
 Some catalog permissions do not have the `'catalog-entity'` resource type, such as [`catalogEntityCreatePermission`](https://github.com/backstage/backstage/blob/1e5e9fb9de9856a49e60fc70c38a4e4e94c69570/plugins/catalog-common/src/permissions.ts#L49). In those cases, a definitive decision is required because conditions can't be applied to an entity that does not exist yet.
 

--- a/docs/plugins/add-to-directory.md
+++ b/docs/plugins/add-to-directory.md
@@ -4,7 +4,7 @@ title: Add to Directory
 description: Documentation on Adding Plugin to Plugin Directory
 ---
 
-:::caution Legacy Documentation
+:::caution[Legacy Documentation]
 
 This section is part of the legacy plugins documentation. The process for adding plugins to the directory described here is still current.
 

--- a/docs/plugins/analytics.md
+++ b/docs/plugins/analytics.md
@@ -4,7 +4,7 @@ title: Plugin Analytics
 description: Measuring usage of your Backstage instance.
 ---
 
-:::caution Legacy Documentation
+:::caution[Legacy Documentation]
 
 This section is part of the legacy plugins documentation. For the new frontend system version, see [Plugin Analytics](../frontend-system/building-plugins/08-analytics.md). The concepts and events described here apply to both the old and new frontend systems.
 

--- a/docs/plugins/backend-plugin.md
+++ b/docs/plugins/backend-plugin.md
@@ -4,7 +4,7 @@ title: Backend plugins
 description: Creating and Developing Backend plugins
 ---
 
-:::caution Legacy Documentation
+:::caution[Legacy Documentation]
 
 This section is part of the legacy plugins documentation. While this page already describes the new backend system patterns, the canonical documentation for building backend plugins has moved to [Building Backend Plugins and Modules](../backend-system/building-plugins-and-modules/01-index.md).
 
@@ -59,7 +59,9 @@ You should see the following response:
 }
 ```
 
-:::note Note: The route shown here matches the default in the current backend plugin template. If you want a `/health` endpoint for health checks, you can add it to your router yourself.
+:::note
+
+The route shown here matches the default in the current backend plugin template. If you want a `/health` endpoint for health checks, you can add it to your router yourself.
 
 :::
 

--- a/docs/plugins/call-existing-api.md
+++ b/docs/plugins/call-existing-api.md
@@ -4,7 +4,7 @@ title: Call Existing API
 description: Describes the various options that Backstage frontend plugins have, in communicating with service APIs that already exist
 ---
 
-:::caution Legacy Documentation
+:::caution[Legacy Documentation]
 
 This section is part of the legacy plugins documentation. The frontend code examples on this page use the old frontend system APIs (`discoveryApiRef`, `fetchApiRef` from `@backstage/core-plugin-api`). The same APIs are available in the new frontend system via `@backstage/frontend-plugin-api`. The general guidance on when to use direct requests vs. the proxy vs. a backend plugin remains valid for both systems.
 

--- a/docs/plugins/composability.md
+++ b/docs/plugins/composability.md
@@ -4,7 +4,7 @@ title: Composability System
 description: Documentation for the Backstage plugin composability APIs.
 ---
 
-:::caution Legacy Documentation
+:::caution[Legacy Documentation]
 
 This page describes the composability system for the **old frontend system**, including `createRoutableExtension`, `createComponentExtension`, `RouteRef`, `ExternalRouteRef`, and component data. For the new frontend system, see [Extensions](../frontend-system/architecture/20-extensions.md), [Extension Blueprints](../frontend-system/architecture/23-extension-blueprints.md), and [Routes](../frontend-system/architecture/36-routes.md).
 

--- a/docs/plugins/create-a-plugin.md
+++ b/docs/plugins/create-a-plugin.md
@@ -4,7 +4,7 @@ title: Create a Backstage Plugin
 description: Documentation on How to Create a Backstage Plugin
 ---
 
-:::caution Legacy Documentation
+:::caution[Legacy Documentation]
 
 This page describes creating plugins for the **old frontend system**. For creating plugins using the new frontend system, see [Building Frontend Plugins](../frontend-system/building-plugins/01-index.md). For creating backend plugins, see [Building Backend Plugins and Modules](../backend-system/building-plugins-and-modules/01-index.md).
 

--- a/docs/plugins/feature-flags.md
+++ b/docs/plugins/feature-flags.md
@@ -4,7 +4,7 @@ title: Feature Flags
 description: Details the process of defining setting and reading a feature flag.
 ---
 
-:::caution Legacy Documentation
+:::caution[Legacy Documentation]
 
 This page describes feature flags using the **old frontend system** APIs (`createPlugin` from `@backstage/core-plugin-api` and `createApp` from `@backstage/app-defaults`). For the new frontend system version, see [Feature Flags](../frontend-system/building-plugins/09-feature-flags.md). The `FeatureFlagged` component and `featureFlagsApiRef` work the same way in both systems.
 

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -4,7 +4,7 @@ title: Introduction to Plugins (Legacy)
 description: Legacy documentation for integrating various infrastructure and software development tools into Backstage through plugins using the old frontend system.
 ---
 
-:::caution Legacy Documentation
+:::caution[Legacy Documentation]
 
 This section covers plugin development using the **old frontend system**. For new development, please refer to the [new frontend system](../frontend-system/index.md) and [new backend system](../backend-system/index.md) documentation. The content here is kept for reference and for maintaining existing plugins that have not yet been migrated.
 

--- a/docs/plugins/integrating-plugin-into-software-catalog.md
+++ b/docs/plugins/integrating-plugin-into-software-catalog.md
@@ -4,7 +4,7 @@ title: Integrate into the Software Catalog
 description: How to integrate a plugin into software catalog
 ---
 
-:::caution Legacy Documentation
+:::caution[Legacy Documentation]
 
 This page describes integrating plugins into the Software Catalog using the **old frontend system** patterns (`EntitySwitch`, `EntityLayout`, `EntityLayout.Route`). For the new frontend system, entity page integrations are done using `EntityCardBlueprint` and `EntityContentBlueprint` — see [Common Extension Blueprints](../frontend-system/building-plugins/03-common-extension-blueprints.md).
 

--- a/docs/plugins/integrating-plugin-into-software-catalog.md
+++ b/docs/plugins/integrating-plugin-into-software-catalog.md
@@ -26,7 +26,7 @@ should have a separate package in a folder, which represents your plugin.
 
 Example:
 
-```
+```shell-session
 $ yarn new
 # Select `frontend-plugin`
 > ? Enter an ID for the plugin [required] my-plugin

--- a/docs/plugins/integrating-search-into-plugins.md
+++ b/docs/plugins/integrating-search-into-plugins.md
@@ -256,7 +256,7 @@ Run `yarn start` in the root folder of your Backstage project and look for logs 
 [backend]: YYYY-MM-DDTHH:MM:SS.000Z search info Collating documents for faq-snippets succeeded documentType=faq-snippets
 ```
 
-It means that the collator task was started and completed successfully. Visit [http://localhost:3000](http://localhost:3000), log in, select the 'All' tab, and type in one of your snippets title in the search box.
+It means that the collator task was started and completed successfully. Visit <http://localhost:3000>, log in, select the 'All' tab, and type in one of your snippets title in the search box.
 
 Results should appear for snippets.
 

--- a/docs/plugins/integrating-search-into-plugins.md
+++ b/docs/plugins/integrating-search-into-plugins.md
@@ -256,7 +256,7 @@ Run `yarn start` in the root folder of your Backstage project and look for logs 
 [backend]: YYYY-MM-DDTHH:MM:SS.000Z search info Collating documents for faq-snippets succeeded documentType=faq-snippets
 ```
 
-It means that the collator task was started and completed successfully. Visit http://localhost:3000, log in, select the 'All' tab, and type in one of your snippets title in the search box.
+It means that the collator task was started and completed successfully. Visit [http://localhost:3000](http://localhost:3000), log in, select the 'All' tab, and type in one of your snippets title in the search box.
 
 Results should appear for snippets.
 

--- a/docs/plugins/integrating-search-into-plugins.md
+++ b/docs/plugins/integrating-search-into-plugins.md
@@ -4,7 +4,7 @@ title: Integrating Search into a plugin
 description: How to integrate Search into a Backstage plugin
 ---
 
-:::caution Legacy Documentation
+:::caution[Legacy Documentation]
 
 This section is part of the legacy plugins documentation. The backend search collator patterns described here use the new backend system and are still current. The frontend search experience examples use the old frontend system APIs.
 

--- a/docs/plugins/internationalization.md
+++ b/docs/plugins/internationalization.md
@@ -4,7 +4,7 @@ title: Internationalization
 description: Documentation on adding internationalization to plugins and apps
 ---
 
-:::caution Legacy Documentation
+:::caution[Legacy Documentation]
 
 This section is part of the legacy plugins documentation. For the new frontend system version, see [Internationalization](../frontend-system/building-plugins/07-internationalization.md). The i18n APIs (`createTranslationRef`, `useTranslationRef`) work the same way in both the old and new frontend systems.
 

--- a/docs/plugins/new-backend-system.md
+++ b/docs/plugins/new-backend-system.md
@@ -4,7 +4,7 @@ title: New Backend System
 description: Details of the new backend system
 ---
 
-:::caution Legacy Documentation
+:::caution[Legacy Documentation]
 
 This section is part of the legacy plugins documentation. The canonical documentation for the backend system has moved to the [Backend System](../backend-system/index.md) section, which includes more detailed and up-to-date guides for [building plugins and modules](../backend-system/building-plugins-and-modules/01-index.md), [architecture](../backend-system/architecture/01-index.md), and [core services](../backend-system/core-services/01-index.md).
 

--- a/docs/plugins/observability.md
+++ b/docs/plugins/observability.md
@@ -4,7 +4,7 @@ title: Observability
 description: Adding Observability to Your Plugin
 ---
 
-:::caution Legacy Documentation
+:::caution[Legacy Documentation]
 
 This section is part of the legacy plugins documentation. For new backend system logging, see the [Logger](../backend-system/core-services/logger.md) and [Root Logger](../backend-system/core-services/root-logger.md) core service documentation. For health checks, see [Root Health](../backend-system/core-services/root-health.md).
 

--- a/docs/plugins/plugin-development.md
+++ b/docs/plugins/plugin-development.md
@@ -4,7 +4,7 @@ title: Plugin Development
 description: Documentation on Plugin Development
 ---
 
-:::caution Legacy Documentation
+:::caution[Legacy Documentation]
 
 This page covers plugin development patterns for the **old frontend system**, including `createPlugin`, `createRoutableExtension`, and `RouteRef` from `@backstage/core-plugin-api`. For the new frontend system equivalents, see [Building Frontend Plugins](../frontend-system/building-plugins/01-index.md) and [Routes](../frontend-system/architecture/36-routes.md).
 

--- a/docs/plugins/plugin-directory-audit.md
+++ b/docs/plugins/plugin-directory-audit.md
@@ -4,7 +4,7 @@ title: Plugin Directory Audit
 description: Details about the process for auditing plugins in the directory
 ---
 
-:::caution Legacy Documentation
+:::caution[Legacy Documentation]
 
 This section is part of the legacy plugins documentation. The audit process described here is still current.
 

--- a/docs/plugins/proxying.md
+++ b/docs/plugins/proxying.md
@@ -4,7 +4,7 @@ title: Proxying
 description: Documentation on Proxying
 ---
 
-:::caution Legacy Documentation
+:::caution[Legacy Documentation]
 
 This section is part of the legacy plugins documentation. The proxy configuration and usage described here applies to both the old and new backend systems. For creating backend plugins and modules, see [Building Backend Plugins and Modules](../backend-system/building-plugins-and-modules/01-index.md).
 

--- a/docs/plugins/structure-of-a-plugin.md
+++ b/docs/plugins/structure-of-a-plugin.md
@@ -4,7 +4,7 @@ title: Structure of a Plugin
 description: Details about structure of a plugin
 ---
 
-:::caution Legacy Documentation
+:::caution[Legacy Documentation]
 
 This page describes the structure of a plugin for the **old frontend system**. For the new frontend system, see [Building Frontend Plugins](../frontend-system/building-plugins/01-index.md). The general folder structure is similar, but the plugin wiring in `plugin.ts` differs significantly.
 

--- a/docs/plugins/structure-of-a-plugin.md
+++ b/docs/plugins/structure-of-a-plugin.md
@@ -17,7 +17,7 @@ great things. But first off, let's look at what we get out of the box.
 
 The new plugin should look something like:
 
-```
+```text
 new-plugin/
     dev/
         index.ts

--- a/docs/plugins/testing.md
+++ b/docs/plugins/testing.md
@@ -28,15 +28,21 @@ frameworks and libraries like [Mocha](https://mochajs.org/),
 
 Running all tests:
 
-    yarn test
+```shell
+yarn test
+```
 
 Running an individual test (e.g. `MyComponent.test.tsx`):
 
-    yarn test MyComponent
+```shell
+yarn test MyComponent
+```
 
 To run both `MyComponent.test.tsx` and `MyControl.test.tsx` suite of tests:
 
-    yarn test MyComponent MyControl
+```shell
+yarn test MyComponent MyControl
+```
 
 :::note
 
@@ -369,13 +375,15 @@ functions:
 
 **`wrapInTestApp`**
 
-    import { wrapInTestApp } from '../../test-utils';
-    ...
-    it('Definitely is not a coconut', () => {
-      const mangoWrapper = mount(wrapInTestApp(<Mango />));
+```tsx
+import { wrapInTestApp } from '../../test-utils';
+...
+it('Definitely is not a coconut', () => {
+  const mangoWrapper = mount(wrapInTestApp(<Mango />));
 
-      expect(mangoWrapper.context().store).toBeDefined();
-    });
+  expect(mangoWrapper.context().store).toBeDefined();
+});
+```
 
 Note: wrapping in the test application **requires** you to do a `find()` or
 `dive()` since the wrapped component is now the application.

--- a/docs/plugins/testing.md
+++ b/docs/plugins/testing.md
@@ -4,13 +4,13 @@ title: Testing with Jest
 description: Documentation on How to do unit testing with Jest
 ---
 
-:::caution Legacy Documentation
+:::caution[Legacy Documentation]
 
 This section is part of the legacy plugins documentation. The general testing principles described here still apply, but for system-specific testing guides, see [Testing Frontend Plugins](../frontend-system/building-plugins/02-testing.md) and [Testing Backend Plugins and Modules](../backend-system/building-plugins-and-modules/02-testing.md).
 
 :::
 
-:::note Note
+:::note
 
 You may want to consider migrating to Jest 30, to do this, you can follow this guide: [Migrating to Jest 30](../tutorials/jest30-migration.md)
 
@@ -38,7 +38,7 @@ To run both `MyComponent.test.tsx` and `MyControl.test.tsx` suite of tests:
 
     yarn test MyComponent MyControl
 
-:::note Note
+:::note
 
 if `console.log`s are not appearing, run only the individual test you are
 working on.

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -23,7 +23,7 @@ PR is merged. This is typically done every Tuesday around noon CET.
 - Check [`Version Packages (next)` Pull Request](https://github.com/backstage/backstage/pulls?q=is%3Aopen+is%3Apr+in%3Atitle+%22Version+Packages+%28next%29%22)
   - Verify the version we are shipping is correct, by looking at the version packages PR title. It should be "Version Packages (next)"
   - Check `pre.json` in [the `.changeset` folder](https://github.com/backstage/backstage/blob/master/.changeset) - it should have `"mode": "pre"` near the top. If you encounter `"mode": "exit"` or if the file doesn't exist, it indicates a mainline release.
-- Verify that there are no active/unfinished `sync_version-packages` actions running ([https://github.com/backstage/backstage/actions/workflows/sync_version-packages.yml](https://github.com/backstage/backstage/actions/workflows/sync_version-packages.yml))
+- Verify that there are no active/unfinished `sync_version-packages` actions running (<https://github.com/backstage/backstage/actions/workflows/sync_version-packages.yml>)
   - Locking the main branch will prevent new ones to be created, but be sure to check for running actions again after unlocking, since it may cause pending auto-merge PRs to be merged.
 - Check [`Version Packages (next)` Pull Request](https://github.com/backstage/backstage/pulls?q=is%3Aopen+is%3Apr+in%3Atitle+%22Version+Packages+%28next%29%22) for sufficient approval to be merged
   - Check generated `changelog` in the changed files of the pull request under `docs/releases` to see if there are any unexpected major bumps e.g. by searching the file

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -23,7 +23,7 @@ PR is merged. This is typically done every Tuesday around noon CET.
 - Check [`Version Packages (next)` Pull Request](https://github.com/backstage/backstage/pulls?q=is%3Aopen+is%3Apr+in%3Atitle+%22Version+Packages+%28next%29%22)
   - Verify the version we are shipping is correct, by looking at the version packages PR title. It should be "Version Packages (next)"
   - Check `pre.json` in [the `.changeset` folder](https://github.com/backstage/backstage/blob/master/.changeset) - it should have `"mode": "pre"` near the top. If you encounter `"mode": "exit"` or if the file doesn't exist, it indicates a mainline release.
-- Verify that there are no active/unfinished `sync_version-packages` actions running (https://github.com/backstage/backstage/actions/workflows/sync_version-packages.yml)
+- Verify that there are no active/unfinished `sync_version-packages` actions running ([https://github.com/backstage/backstage/actions/workflows/sync_version-packages.yml](https://github.com/backstage/backstage/actions/workflows/sync_version-packages.yml))
   - Locking the main branch will prevent new ones to be created, but be sure to check for running actions again after unlocking, since it may cause pending auto-merge PRs to be merged.
 - Check [`Version Packages (next)` Pull Request](https://github.com/backstage/backstage/pulls?q=is%3Aopen+is%3Apr+in%3Atitle+%22Version+Packages+%28next%29%22) for sufficient approval to be merged
   - Check generated `changelog` in the changed files of the pull request under `docs/releases` to see if there are any unexpected major bumps e.g. by searching the file

--- a/docs/tooling/cli/02-build-system.md
+++ b/docs/tooling/cli/02-build-system.md
@@ -630,7 +630,7 @@ With that in mind, here are some IDEs configurations to run backstage components
     1.  Click on "Edit Configurations" on top panel
     2.  In the modal dialog click on link "Edit configuration templates..." located in the bottom left corner.
     3.  "Configuration file": leave empty (`backstage-cli` adds the config)
-    4.  "Node options": ` --experimental-vm-modules`
+    4.  "Node options": `--experimental-vm-modules`
     5.  "Jest package": `~/workspace/backstage/node_modules/@backstage/cli` - the location of the backstage cli package.
     6.  "Working directory": `~/workspace/backstage`
     7.  "Jest Options": `repo test --runInBand --watch=false`

--- a/docs/tooling/cli/module-build.md
+++ b/docs/tooling/cli/module-build.md
@@ -114,7 +114,7 @@ Options:
 
 ## package bundle
 
-:::caution Experimental
+:::caution[Experimental]
 This command is experimental and may receive breaking changes in future releases
 without a deprecation period. It is hidden from the main `--help` output.
 :::

--- a/docs/tutorials/enable-public-entry--old.md
+++ b/docs/tutorials/enable-public-entry--old.md
@@ -97,7 +97,7 @@ With that, Backstage's cli and backend will detect public entry point and serve 
    yarn start-backend
    ```
 
-4. Visit http://localhost:7007 to see the public app and validate that the _index.html_ response only contains a minimal application.
+4. Visit [http://localhost:7007](http://localhost:7007) to see the public app and validate that the _index.html_ response only contains a minimal application.
    :::note
    Regular app serving will always serve protected apps without authenticating.
    :::

--- a/docs/tutorials/enable-public-entry--old.md
+++ b/docs/tutorials/enable-public-entry--old.md
@@ -97,7 +97,7 @@ With that, Backstage's cli and backend will detect public entry point and serve 
    yarn start-backend
    ```
 
-4. Visit [http://localhost:7007](http://localhost:7007) to see the public app and validate that the _index.html_ response only contains a minimal application.
+4. Visit <http://localhost:7007> to see the public app and validate that the _index.html_ response only contains a minimal application.
    :::note
    Regular app serving will always serve protected apps without authenticating.
    :::

--- a/docs/tutorials/enable-public-entry.md
+++ b/docs/tutorials/enable-public-entry.md
@@ -68,7 +68,7 @@ With that, Backstage's cli and backend will detect public entry point and serve 
    yarn start-backend
    ```
 
-4. Visit http://localhost:7007 to see the public app and validate that the _index.html_ response only contains a minimal application.
+4. Visit [http://localhost:7007](http://localhost:7007) to see the public app and validate that the _index.html_ response only contains a minimal application.
    :::note
    Regular app serving will always serve protected apps without authenticating.
    :::

--- a/docs/tutorials/enable-public-entry.md
+++ b/docs/tutorials/enable-public-entry.md
@@ -68,7 +68,7 @@ With that, Backstage's cli and backend will detect public entry point and serve 
    yarn start-backend
    ```
 
-4. Visit [http://localhost:7007](http://localhost:7007) to see the public app and validate that the _index.html_ response only contains a minimal application.
+4. Visit <http://localhost:7007> to see the public app and validate that the _index.html_ response only contains a minimal application.
    :::note
    Regular app serving will always serve protected apps without authenticating.
    :::

--- a/docs/tutorials/integrating-event-driven-updates-with-entity-providers.md
+++ b/docs/tutorials/integrating-event-driven-updates-with-entity-providers.md
@@ -22,7 +22,7 @@ The `@backstage/plugin-events-backend` plugin provides out-of-the-box support fo
 
 To create HTTP endpoints for specific topics, you need to configure them in your app-config.yaml:
 
-```
+```yaml
 events:
   http:
     topics:

--- a/docs/tutorials/setup-opentelemetry.md
+++ b/docs/tutorials/setup-opentelemetry.md
@@ -112,7 +112,7 @@ For local development, you can add the required flag in your `packages/backend/p
   ...
 ```
 
-You can now start your Backstage instance as usual, using `yarn start` and you'll be able to see your metrics at: <http://localhost:9464/metrics>
+You can now start your Backstage instance as usual, using `yarn start` and you'll be able to see your metrics at: [http://localhost:9464/metrics](http://localhost:9464/metrics)
 
 ### Troubleshooting
 

--- a/docs/tutorials/setup-opentelemetry.md
+++ b/docs/tutorials/setup-opentelemetry.md
@@ -112,7 +112,7 @@ For local development, you can add the required flag in your `packages/backend/p
   ...
 ```
 
-You can now start your Backstage instance as usual, using `yarn start` and you'll be able to see your metrics at: [http://localhost:9464/metrics](http://localhost:9464/metrics)
+You can now start your Backstage instance as usual, using `yarn start` and you'll be able to see your metrics at: <http://localhost:9464/metrics>
 
 ### Troubleshooting
 

--- a/docs/tutorials/using-backstage-proxy-within-plugin.md
+++ b/docs/tutorials/using-backstage-proxy-within-plugin.md
@@ -30,7 +30,7 @@ If your plugin requires access to an API, backstage offers
 
 ## Setting up the backstage proxy
 
-Let's say your plugin's API is hosted at _[https://api.myawesomeservice.com/v1_](https://api.myawesomeservice.com/v1_),
+Let's say your plugin's API is hosted at _[https://api.myawesomeservice.com/v1](https://api.myawesomeservice.com/v1)_,
 and you want to be able to access it within backstage at
 `/api/proxy/<your-proxy-uri>`, and add a default header called
 `X-Custom-Source`. You will need to add the following to `app-config.yaml`:
@@ -110,7 +110,7 @@ This section describes the steps to wrap your API client in a [Utility API](../a
 ### Defining the API client interface
 
 Continuing from the previous example, let's assume that
-_[https://api.myawesomeservice.com/v1_](https://api.myawesomeservice.com/v1_) has the following endpoints:
+_[https://api.myawesomeservice.com/v1](https://api.myawesomeservice.com/v1)_ has the following endpoints:
 
 | Method                   | Description             |
 | :----------------------- | :---------------------- |

--- a/docs/tutorials/using-backstage-proxy-within-plugin.md
+++ b/docs/tutorials/using-backstage-proxy-within-plugin.md
@@ -30,7 +30,7 @@ If your plugin requires access to an API, backstage offers
 
 ## Setting up the backstage proxy
 
-Let's say your plugin's API is hosted at _https://api.myawesomeservice.com/v1_,
+Let's say your plugin's API is hosted at _[https://api.myawesomeservice.com/v1_](https://api.myawesomeservice.com/v1_),
 and you want to be able to access it within backstage at
 `/api/proxy/<your-proxy-uri>`, and add a default header called
 `X-Custom-Source`. You will need to add the following to `app-config.yaml`:
@@ -110,7 +110,7 @@ This section describes the steps to wrap your API client in a [Utility API](../a
 ### Defining the API client interface
 
 Continuing from the previous example, let's assume that
-_https://api.myawesomeservice.com/v1_ has the following endpoints:
+_[https://api.myawesomeservice.com/v1_](https://api.myawesomeservice.com/v1_) has the following endpoints:
 
 | Method                   | Description             |
 | :----------------------- | :---------------------- |

--- a/docs/tutorials/using-backstage-proxy-within-plugin.md
+++ b/docs/tutorials/using-backstage-proxy-within-plugin.md
@@ -30,7 +30,7 @@ If your plugin requires access to an API, backstage offers
 
 ## Setting up the backstage proxy
 
-Let's say your plugin's API is hosted at _[https://api.myawesomeservice.com/v1](https://api.myawesomeservice.com/v1)_,
+Let's say your plugin's API is hosted at _<https://api.myawesomeservice.com/v1>_,
 and you want to be able to access it within backstage at
 `/api/proxy/<your-proxy-uri>`, and add a default header called
 `X-Custom-Source`. You will need to add the following to `app-config.yaml`:
@@ -110,7 +110,7 @@ This section describes the steps to wrap your API client in a [Utility API](../a
 ### Defining the API client interface
 
 Continuing from the previous example, let's assume that
-_[https://api.myawesomeservice.com/v1](https://api.myawesomeservice.com/v1)_ has the following endpoints:
+_<https://api.myawesomeservice.com/v1>_ has the following endpoints:
 
 | Method                   | Description             |
 | :----------------------- | :---------------------- |

--- a/microsite/README.md
+++ b/microsite/README.md
@@ -45,7 +45,7 @@ This command generates static content into the `build` directory, which is what 
 
 Your project file structure should look something like this
 
-```
+```plaintext
 my-docusaurus/
   docs/
     doc-1.md

--- a/microsite/README.md
+++ b/microsite/README.md
@@ -45,7 +45,7 @@ This command generates static content into the `build` directory, which is what 
 
 Your project file structure should look something like this
 
-```plaintext
+```text
 my-docusaurus/
   docs/
     doc-1.md

--- a/microsite/blog/2020-03-18-what-is-backstage.mdx
+++ b/microsite/blog/2020-03-18-what-is-backstage.mdx
@@ -83,6 +83,6 @@ Similar to how Backstage ties together all of Spotify’s infrastructure, our am
 
 We are envisioning [three phases](https://github.com/backstage/backstage/milestones) of the project (so far), and we have already begun work on various aspects of these phases. The best way to track the work and see where you can jump in and help out is:
 
-https://github.com/backstage/backstage/milestones
+[https://github.com/backstage/backstage/milestones](https://github.com/backstage/backstage/milestones)
 
 Want to discuss the project or need support? Join us on [Discord](https://discord.gg/backstage-687207715902193673) or reach out on [backstage-interest@spotify.com](mailto:backstage-interest@spotify.com).

--- a/microsite/blog/2020-04-30-how-to-quickly-set-up-backstage.mdx
+++ b/microsite/blog/2020-04-30-how-to-quickly-set-up-backstage.mdx
@@ -15,7 +15,7 @@ In this blog post we’ll look at what a Backstage app is and how to create one 
 
 ## What is a Backstage app?
 
-![](assets/4/welcome.png)
+![The welcome page of a newly created Backstage app](assets/4/welcome.png)
 
 A Backstage app is a modern monorepo web project that is built using Backstage packages. It includes all the configuration and architecture you need to run Backstage so that you don’t have to worry about setting everything up by yourself.
 
@@ -39,7 +39,7 @@ npx @backstage/create-app
 
 Name your app, and we will create everything you need:
 
-![](assets/4/create-app.png)
+![The create-app command prompting for an app name](assets/4/create-app.png)
 
 The only thing you need to do is to start the app:
 

--- a/microsite/blog/2020-07-01-how-to-enable-authentication-in-backstage-using-passport.mdx
+++ b/microsite/blog/2020-07-01-how-to-enable-authentication-in-backstage-using-passport.mdx
@@ -23,7 +23,7 @@ Passport has allowed us to leverage an existing open-source authentication frame
 
 First, check out the provided Google and GitHub implementations! [Spin up a local copy of Backstage](https://backstage.io/blog/2020/04/30/how-to-quickly-set-up-backstage) along with our example-backend. You can find more documentation on setting up the example backend [here](https://github.com/backstage/backstage/tree/master/packages/backend), but be sure to include the relevant client IDs and secrets when running `yarn start`:
 
-```
+```shell
 AUTH_GOOGLE_CLIENT_ID=x AUTH_GOOGLE_CLIENT_SECRET=x AUTH_GITHUB_CLIENT_ID=x AUTH_GITHUB_CLIENT_SECRET=x SENTRY_TOKEN=x LOG_LEVEL=debug yarn start
 ```
 

--- a/microsite/blog/2020-09-30-backstage-design-system.mdx
+++ b/microsite/blog/2020-09-30-backstage-design-system.mdx
@@ -25,7 +25,7 @@ As Backstage has gained traction, we’ve seen the importance of creating a scal
 
 ## Anatomy of a plugin
 
-![](https://backstage.io/img/cards-plugins.png)
+![Backstage plugin cards](https://backstage.io/img/cards-plugins.png)
 
 Plugins are what provide the feature functionality in Backstage, allowing you to customize it to fit your infrastructure. They are integrated into Backstage's frontend, so that no matter what tool or service is being accessed, users are guaranteed a seamless experience.
 
@@ -84,13 +84,13 @@ There are a lot of exciting things that we’re envisioning for Backstage and op
 
 - Expanding our Backstage Design System by building on the UI kit and component library in Figma and Storybook
 
-* Collaborating with more of our amazing contributors to ensure our Backstage Design System works for everyone
+- Collaborating with more of our amazing contributors to ensure our Backstage Design System works for everyone
 
-* Featuring rad plugins that folks have created, using our design system, in our Figma Community space
+- Featuring rad plugins that folks have created, using our design system, in our Figma Community space
 
-* Building up our Guidelines by continuing to creating robust design documentation
+- Building up our Guidelines by continuing to creating robust design documentation
 
-* Ensuring that we maintain accessible practices throughout our experience
+- Ensuring that we maintain accessible practices throughout our experience
 
 ![img](assets/backstage-world-DS.png)
 

--- a/microsite/blog/2022-03-16-backstage-turns-two.mdx
+++ b/microsite/blog/2022-03-16-backstage-turns-two.mdx
@@ -60,7 +60,7 @@ We asked a few contributors and maintainers to share their thoughts around this 
 
 Warms the heart, doesn’t it? Thanks again to all our contributors for making this possible. Seriously. We’re proud of what the community has accomplished and how we’ve accomplished it. All along, it’s your enthusiasm and warm/collaborative/positive vibes that have carried us and this project through.
 
-## Version 1.0 and beyond
+## Version 1.0 and beyond
 
 Tomorrow, we’ll be releasing version 1.0 of the Backstage core framework, including Software Catalog, Software Templates, TechDocs, and API Reference. With Backstage 1.0, the project’s core components are coming out of beta and into production with regular versioning and release cycle commitments (check back on this blog for more details!).
 

--- a/microsite/blog/2023-11-15-backstagecon-kubecon-23.mdx
+++ b/microsite/blog/2023-11-15-backstagecon-kubecon-23.mdx
@@ -12,9 +12,9 @@ tl;dr BackstageCon North America is officially in the books! We had a blast in C
 
 Obviously we're biased, but Backstage was definitely one of the big topics at [KubeCon + CloudNativeCon North America](https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/) this year. Recently, the CNCF announced that Backstage was the [third fastest-growing project](https://www.cncf.io/blog/2023/10/27/october-2023-where-we-are-with-velocity-of-cncf-lf-and-top-30-open-source-projects/) of the year (up from the fifth last year). And you could confirm it with your own eyes during BackstageCon and KubeCon: hundreds of people flocked through the event, talks, and the project booth sharing their enthusiasm and asking more questions about the project.
 
-### BackstageCon: A growing community 
+### BackstageCon: A growing community
 
-With a whopping peak attendance of 400+ people, the crowd nearly doubled from last year,[ taking the center stage of the conference](https://www.forbes.com/sites/janakirammsv/2023/11/14/backstage-project-takes-center-stage-at-kubecon-north-america-2023/?sh=1972303a6539), as reported by Forbes. For some, BackstageCon was their first entry point into the community, but the event also boasted lots of  familiar faces, mostly from some of the most mature adopters such as Dynatrace, Lunar, and US Bank. We also got to hear from new voices in the community like Comcast and Grafana Labs.
+With a whopping peak attendance of 400+ people, the crowd nearly doubled from last year, [taking the center stage of the conference](https://www.forbes.com/sites/janakirammsv/2023/11/14/backstage-project-takes-center-stage-at-kubecon-north-america-2023/?sh=1972303a6539), as reported by Forbes. For some, BackstageCon was their first entry point into the community, but the event also boasted lots of  familiar faces, mostly from some of the most mature adopters such as Dynatrace, Lunar, and US Bank. We also got to hear from new voices in the community like Comcast and Grafana Labs.
 
 We hear a lot of great questions such as:
 
@@ -68,4 +68,4 @@ And to close the event, Ritesh Patel, Nirmata and David Murphy, Upbound, introdu
 
 ### See you next year!
 
-The next KubeCon Europe is scheduled for March 18-22 in Paris. We're looking forward to meeting you all there! [KubeCon EU](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/program/cfp/) and[ BackstageCon EU](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/co-located-events/backstagecon/) are accepting CFPs, submit your proposal now!
+The next KubeCon Europe is scheduled for March 18-22 in Paris. We're looking forward to meeting you all there! [KubeCon EU](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/program/cfp/) and [BackstageCon EU](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/co-located-events/backstagecon/) are accepting CFPs, submit your proposal now!

--- a/microsite/blog/2024-09-24-dynatrace-adopter-spotlight.mdx
+++ b/microsite/blog/2024-09-24-dynatrace-adopter-spotlight.mdx
@@ -21,10 +21,9 @@ A few years ago, Dynatrace developers worked with large monolithic repositories 
 
 Dynatrace decided to move towards the current Dynatrace platform model as the next evolutionary step of our product. This decision led to an architectural change of splitting the monolithic repository into multiple projects. The platform is designed to enable the development of apps on top of platform capabilities to unlock faster innovations and decouple them from the release cycles of other components. Based on this decision, it became apparent that the number of platform components and individual apps would increase significantly, eliminating the option of a single repository to unify all processes. Besides, the risk of increasing cognitive load in software development was high due to development being spread across multiple touchpoints, a challenge discussed in research for years ([Sweller, 1988](<https://doi.org/10.1016/0364-0213(88)90023-7>), [Robert, 2008](https://dl.acm.org/doi/10.5555/1388398)). Consequently, the need to standardize project creation became crucial to ensure corporate governance and compliance even before the first commit was pushed.
 
-{/* References:
-[^1]: John Sweller, Cognitive load during problem solving: Effects on learning, Cognitive Science, Volume 12, Issue 2, 1988, Pages 257-285, ISSN 0364-0213, https://doi.org/10.1016/0364-0213(88)90023-7.
-[^2]: Robert C. Martin Series, Clean Code: A Handbook of Agile Software Craftsmanship (Robert C. Martin Series), 2008, ISBN 9780132350884.
-*/}
+{/* References: */}
+{/* [^1]: John Sweller, Cognitive load during problem solving: Effects on learning, Cognitive Science, Volume 12, Issue 2, 1988, Pages 257-285, ISSN 0364-0213, https://doi.org/10.1016/0364-0213(88)90023-7. */}
+{/* [^2]: Robert C. Martin Series, Clean Code: A Handbook of Agile Software Craftsmanship (Robert C. Martin Series), 2008, ISBN 9780132350884. */}
 
 Therefore, the Dynatrace Platform Engineering team initiated a project to standardize and simplify the process for starting service or application development. This effort was initially named “project initializer” and launched around the same time Backstage joined the CNCF. Although the platform engineering team saw initial success with the project initializer, we quickly realized that there was a greater demand for centralizing development activities and providing appropriate guidelines. For example, we noted that the complexity of integrating new code had shifted from the build phase to the deployment phase, transferring relatively complex integration tasks from continuous integration to continuous deployment. Overall, the main requirements and focal points were:
 

--- a/microsite/blog/2024-09-24-dynatrace-adopter-spotlight.mdx
+++ b/microsite/blog/2024-09-24-dynatrace-adopter-spotlight.mdx
@@ -90,6 +90,6 @@ Second, we enhanced the developer experience by integrating observability and se
 
 ## What`s next?
 
-Backstage is a crucial element for Dynatrace's developer experience, providing out-of-the-box core functionality for every developer and supporting extensibility where needed. Our Backstage extension is maintained as an open-source project and is available for every Backstage user. Don't hesitate to utilize it or to contribute: https://github.com/Dynatrace/backstage-plugin
+Backstage is a crucial element for Dynatrace's developer experience, providing out-of-the-box core functionality for every developer and supporting extensibility where needed. Our Backstage extension is maintained as an open-source project and is available for every Backstage user. Don't hesitate to utilize it or to contribute: [https://github.com/Dynatrace/backstage-plugin](https://github.com/Dynatrace/backstage-plugin)
 
 If you have a great Backstage story to tell, please share your experience with us to the variety of use case areas.

--- a/microsite/blog/2024-09-24-dynatrace-adopter-spotlight.mdx
+++ b/microsite/blog/2024-09-24-dynatrace-adopter-spotlight.mdx
@@ -21,10 +21,10 @@ A few years ago, Dynatrace developers worked with large monolithic repositories 
 
 Dynatrace decided to move towards the current Dynatrace platform model as the next evolutionary step of our product. This decision led to an architectural change of splitting the monolithic repository into multiple projects. The platform is designed to enable the development of apps on top of platform capabilities to unlock faster innovations and decouple them from the release cycles of other components. Based on this decision, it became apparent that the number of platform components and individual apps would increase significantly, eliminating the option of a single repository to unify all processes. Besides, the risk of increasing cognitive load in software development was high due to development being spread across multiple touchpoints, a challenge discussed in research for years ([Sweller, 1988](<https://doi.org/10.1016/0364-0213(88)90023-7>), [Robert, 2008](https://dl.acm.org/doi/10.5555/1388398)). Consequently, the need to standardize project creation became crucial to ensure corporate governance and compliance even before the first commit was pushed.
 
-<!-- References:
+{/* References:
 [^1]: John Sweller, Cognitive load during problem solving: Effects on learning, Cognitive Science, Volume 12, Issue 2, 1988, Pages 257-285, ISSN 0364-0213, https://doi.org/10.1016/0364-0213(88)90023-7.
 [^2]: Robert C. Martin Series, Clean Code: A Handbook of Agile Software Craftsmanship (Robert C. Martin Series), 2008, ISBN 9780132350884.
--->
+*/}
 
 Therefore, the Dynatrace Platform Engineering team initiated a project to standardize and simplify the process for starting service or application development. This effort was initially named “project initializer” and launched around the same time Backstage joined the CNCF. Although the platform engineering team saw initial success with the project initializer, we quickly realized that there was a greater demand for centralizing development activities and providing appropriate guidelines. For example, we noted that the complexity of integrating new code had shifted from the build phase to the deployment phase, transferring relatively complex integration tasks from continuous integration to continuous deployment. Overall, the main requirements and focal points were:
 

--- a/microsite/blog/2025-05-12-from-zero-to-maintainer-my-opensource-journey-with-backstage.mdx
+++ b/microsite/blog/2025-05-12-from-zero-to-maintainer-my-opensource-journey-with-backstage.mdx
@@ -40,10 +40,10 @@ These two tasks were a significant step up from my initial contributions. They r
 ## Stage 4: Becoming an active community member
 
 ![Engaging with the Open Source Community at the CNCF meetup in Toronto](assets/2025-05-12/cncf_1.jpeg)
-_(Source: https://www.linkedin.com/posts/mwijay_you-totally-missed-last-nights-first-cncf-ugcPost-7311005210628235264-8BES)_
+_(Source: [https://www.linkedin.com/posts/mwijay_you-totally-missed-last-nights-first-cncf-ugcPost-7311005210628235264-8BES](https://www.linkedin.com/posts/mwijay_you-totally-missed-last-nights-first-cncf-ugcPost-7311005210628235264-8BES))_
 
 ![Engaging with the Open Source Community at the CNCF meetup in Toronto](assets/2025-05-12/cncf_2.png)
-_Engaging with the Open Source Community at the CNCF meetup in Toronto (Source: https://community.cncf.io/events/details/cncf-cloud-native-toronto-presents-cncf-2025-kickoff-at-shopify/)_
+_Engaging with the Open Source Community at the CNCF meetup in Toronto (Source: [https://community.cncf.io/events/details/cncf-cloud-native-toronto-presents-cncf-2025-kickoff-at-shopify/](https://community.cncf.io/events/details/cncf-cloud-native-toronto-presents-cncf-2025-kickoff-at-shopify/))_
 
 One of the ways I got more involved was by helping with the maintenance of the [community-plugins repository](https://github.com/backstage/community-plugins). For instance, I helped address a security vulnerability — specifically, that the `@backstage/backend-common package` relied on a vulnerable version of `jsonpath-plus` through `@kubernetes/client-node`. I proactively removed this vulnerable dependency from eight plugins, effectively safeguarding those plugins from potential risks. I also focused on improving dependency management by implementing Knip reports. These reports help us identify and remove unused dependencies, keeping the repository clean and efficient.
 
@@ -54,7 +54,7 @@ This marked a turning point in my journey, as I transitioned from a contributor 
 ## What’s next: future steps as a maintainer
 
 ![Presenting "From Zero to Contributor: My Open Source Journey with Backstage" at the CNCF 2025 Kickoff event at Shopify, Toronto](assets/2025-05-12/cncf_3.jpeg)
-_Presenting "From Zero to Contributor: My Open Source Journey with Backstage" at the CNCF 2025 Kickoff event at Shopify, Toronto (Source: https://www.linkedin.com/posts/mwijay_you-totally-missed-last-nights-first-cncf-ugcPost-7311005210628235264-8BES)_
+_Presenting "From Zero to Contributor: My Open Source Journey with Backstage" at the CNCF 2025 Kickoff event at Shopify, Toronto (Source: [https://www.linkedin.com/posts/mwijay_you-totally-missed-last-nights-first-cncf-ugcPost-7311005210628235264-8BES](https://www.linkedin.com/posts/mwijay_you-totally-missed-last-nights-first-cncf-ugcPost-7311005210628235264-8BES))_
 
 As a maintainer, my focus is on supporting others in their open source journey and improving the overall contributor experience. I actively review PRs, guide new contributors through constructive reviews, and point them to good first issues to help them get started.
 Furthermore, I aim to actively contribute to the community-plugins SIG meetings, offering suggestions and participating in discussions to help guide the project’s direction.

--- a/microsite/docusaurus.config.ts
+++ b/microsite/docusaurus.config.ts
@@ -214,18 +214,6 @@ const config: Config = {
     ],
   ],
   markdown: {
-    preprocessor({ fileContent }) {
-      // Replace all HTML comments with empty strings as these are not supported by MDXv2.
-      function removeHtmlComments(input) {
-        let previous;
-        do {
-          previous = input;
-          input = input.replace(/<!--.*?-->/gs, '');
-        } while (input !== previous);
-        return input;
-      }
-      return removeHtmlComments(fileContent);
-    },
     format: 'detect',
     hooks: {
       onBrokenMarkdownLinks: 'log',

--- a/microsite/docusaurus.config.ts
+++ b/microsite/docusaurus.config.ts
@@ -678,7 +678,7 @@ const config: Config = {
       theme: backstageTheme,
       // Supported languages: https://prismjs.com/#supported-languages
       // Default languages: https://github.com/FormidableLabs/prism-react-renderer/blob/master/packages/generate-prism-languages/index.ts#L9-L23
-      additionalLanguages: ['docker', 'bash'],
+      additionalLanguages: ['docker', 'bash', 'log', 'shell-session'],
       magicComments: [
         // Extend the default highlight class name
         {


### PR DESCRIPTION
Follow-up on #33790 

## Hey, I just made a Pull Request!

Background: https://docusaurus.io/blog/releases/3.10#strict-mdx

The microsite already runs with `future.v4: true`, which turns off the MDX v1 compatibility shims. One of those shims rewrote the legacy `:::note My Title` admonition syntax, so without it 152 admonitions across 110 pages render as literal `:::note` text.

- **Bracketed admonition titles.** `:::note My Title` → `:::note[My Title]`. Where the title only repeated the type (`:::note Note`), it is dropped. Also closes an admonition in the Datadog RUM guide that was missing its closing fence and had been swallowing the rest of the page.
- **Dropped the HTML comment preprocessor.** It stripped every HTML comment from every Markdown file on each build to work around one blog post. That post now uses `{/* */}`, so the preprocessor is gone.
- **No bare URLs.** A bare URL only becomes a link because of a Markdown extension. In `.md` files they are now angle brackets, `<https://…>`; in `.mdx` files, where angle brackets are not valid, they are `[url](url)`. Existing `<https://…>` links are untouched.
- **Markup that rendered wrong.** Two headings were followed by a non-breaking space, so they were never headings — `## Configuration` shows up as literal text on the page with no anchor. Plus two code spans and a link that had absorbed a neighbouring space.
- **The `console` code-block language.** It is not a Prism language or alias, so those blocks were never highlighted. They are retagged `log`, `shell-session`, `shell` or `
text`, and `log` / `shell-session` are registered in `additionalLanguages`.
- **Language tags and alt text** on the code blocks and images that had none.

Rendering is unchanged except where it was already wrong. `docs/` and `microsite/` are clean under [rumdl](https://github.com/rvben/rumdl) (except some opinionated rules that doesn't fit in this PR) and Prettier. `docs/releases/` is also untouched since they doesn't break the build or generate warnings.

The doc style guide now covers the bracketed title syntax and which language tags to use, since both are easy to get wrong in a way that fails silently.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))


