### PR TITLE
fix(catalog): prevent Entity not found flash during entity navigation

### DIFF
--- a/.changeset/ripe-vans-obey.md
+++ b/.changeset/ripe-vans-obey.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Fixed a brief "Entity not found" flash when navigating between catalog entity pages.

--- a/plugins/catalog/src/alpha/pages.test.tsx
+++ b/plugins/catalog/src/alpha/pages.test.tsx
@@ -30,6 +30,7 @@ import {
 } from '@backstage/plugin-catalog-react/alpha';
 import { catalogApiMock } from '@backstage/plugin-catalog-react/testUtils';
 import {
+  EntityRefLink,
   entityRouteRef,
   MockStarredEntitiesApi,
   starredEntitiesApiRef,
@@ -37,10 +38,57 @@ import {
 } from '@backstage/plugin-catalog-react';
 import { convertLegacyRouteRef } from '@backstage/core-compat-api';
 import { rootRouteRef } from '../routes';
-import { Entity } from '@backstage/catalog-model';
+import {
+  CompoundEntityRef,
+  Entity,
+  parseEntityRef,
+  stringifyEntityRef,
+} from '@backstage/catalog-model';
 import { useAppNode } from '@backstage/frontend-plugin-api';
 
 jest.setTimeout(30_000);
+
+const mockEntityProviderStatuses: Array<{
+  hasEntity: boolean;
+  loading: boolean;
+  hasError: boolean;
+}> = [];
+let mockRecordEntityProviderStatuses = false;
+
+jest.mock('./components/EntityLayout/EntityLayoutBui', () => {
+  const actual = jest.requireActual(
+    './components/EntityLayout/EntityLayoutBui',
+  ) as typeof import('./components/EntityLayout/EntityLayoutBui');
+  const { useAsyncEntity: useAsyncEntityMocked } =
+    require('@backstage/plugin-catalog-react') as typeof import('@backstage/plugin-catalog-react');
+
+  function EntityLayoutBuiWithProbe(
+    props: Parameters<typeof actual.EntityLayoutBui>[0],
+  ) {
+    function EntityProviderStatusProbe() {
+      const { entity, loading, error } = useAsyncEntityMocked();
+      if (mockRecordEntityProviderStatuses) {
+        mockEntityProviderStatuses.push({
+          hasEntity: Boolean(entity),
+          loading,
+          hasError: Boolean(error),
+        });
+      }
+      return null;
+    }
+    return (
+      <>
+        <EntityProviderStatusProbe />
+        <actual.EntityLayoutBui {...props} />
+      </>
+    );
+  }
+
+  return {
+    ...actual,
+    EntityLayoutBui: EntityLayoutBuiWithProbe,
+  };
+});
 
 // The entity page extension uses React.lazy (via ExtensionBoundary.lazy) to
 // dynamically import EntityLayout and its large dependency tree. Pre-warming
@@ -712,6 +760,105 @@ describe('Entity page', () => {
       expect(screen.getByText('Refresh header')).toBeInTheDocument();
       expect(mounts).toBe(1);
       expect(unmounts).toBe(0);
+    });
+
+    it('does not flash Entity not found when navigating to another entity', async () => {
+      mockEntityProviderStatuses.length = 0;
+      mockRecordEntityProviderStatuses = true;
+
+      const entityB: Entity = {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: {
+          name: 'www-artist',
+          namespace: 'default',
+        },
+        spec: {
+          type: 'website',
+          lifecycle: 'production',
+          owner: 'team-a',
+        },
+      };
+
+      let resolveEntityB!: (entity: Entity | undefined) => void;
+      const entityBResponse = new Promise<Entity | undefined>(resolve => {
+        resolveEntityB = resolve;
+      });
+      const getEntityByRef = jest.fn((ref: string | CompoundEntityRef) => {
+        const entityRef = stringifyEntityRef(parseEntityRef(ref));
+        if (entityRef === stringifyEntityRef(entityMock)) {
+          return Promise.resolve(entityMock);
+        }
+        if (entityRef === stringifyEntityRef(entityB)) {
+          return entityBResponse;
+        }
+        return Promise.resolve(undefined);
+      });
+
+      function RelatedEntityNavContent() {
+        const { entity } = useAsyncEntity();
+        return (
+          <div>
+            <div>Current entity: {entity?.metadata.name}</div>
+            <EntityRefLink entityRef={entityB}>Go to entity B</EntityRefLink>
+          </div>
+        );
+      }
+
+      const navContent = EntityContentBlueprint.make({
+        name: 'nav',
+        params: {
+          // Index route so EntityRefLink's entity-root href still matches.
+          path: '/',
+          title: 'Nav',
+          loader: async () => <RelatedEntityNavContent />,
+        },
+      });
+      const tester = createExtensionTester(
+        Object.assign({ namespace: 'catalog' }, catalogEntityPage),
+      ).add(navContent);
+
+      try {
+        await renderInTestApp(tester.reactElement(), {
+          apis: [
+            catalogApiMock.mock({ getEntityByRef }),
+            [starredEntitiesApiRef, mockStarredEntitiesApi],
+          ],
+          mountPath: '/catalog/:namespace/:kind/:name',
+          initialRouteEntries: [entityPath],
+          config: {
+            app: { title: 'Custom app' },
+            backend: { baseUrl: 'http://localhost:7000' },
+          },
+          mountedRoutes: {
+            '/catalog': convertLegacyRouteRef(rootRouteRef),
+            '/catalog/:namespace/:kind/:name':
+              convertLegacyRouteRef(entityRouteRef),
+          },
+        });
+
+        expect(
+          await screen.findByText('Current entity: artist-lookup'),
+        ).toBeInTheDocument();
+
+        await userEvent.click(
+          screen.getByRole('link', { name: 'Go to entity B' }),
+        );
+
+        expect(
+          mockEntityProviderStatuses.some(
+            status => !status.loading && !status.hasError && !status.hasEntity,
+          ),
+        ).toBe(false);
+
+        await act(async () => resolveEntityB(entityB));
+        expect(
+          await screen.findByText('Current entity: www-artist'),
+        ).toBeInTheDocument();
+      } finally {
+        mockRecordEntityProviderStatuses = false;
+        mockEntityProviderStatuses.length = 0;
+      }
     });
 
     it('Should use the default header', async () => {

--- a/plugins/catalog/src/alpha/pages.tsx
+++ b/plugins/catalog/src/alpha/pages.tsx
@@ -274,13 +274,18 @@ export const catalogEntityPage = PageBlueprint.makeWithOverrides({
         const Component = () => {
           const routeParams = useRouteRefParams(entityRouteRef);
           const entityFromUrl = useEntityFromUrl();
-          const entity =
-            entityFromUrl.entity &&
+          const matchesRoute =
+            !!entityFromUrl.entity &&
             stringifyEntityRef(entityFromUrl.entity) ===
-              stringifyEntityRef(routeParams)
-              ? entityFromUrl.entity
-              : undefined;
-          const entityProviderProps = { ...entityFromUrl, entity };
+              stringifyEntityRef(routeParams);
+          const entity = matchesRoute ? entityFromUrl.entity : undefined;
+          const entityProviderProps = {
+            ...entityFromUrl,
+            entity,
+            loading:
+              entityFromUrl.loading ||
+              (!!entityFromUrl.entity && !matchesRoute),
+          };
           const filteredMenuItems = entity
             ? menuItems
                 .filter(i => i.filter(entity))


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #35126.

Sometimes, when navigating between entities using direct links, the new entity briefly shows "Entity not found".

This is caused by Entity pages clearing the previously viewed entity as soon as the route no longer matches, while "useEntityFromUrl"'s loading indicator does not become true until the next render due to "useAsyncRetry"'s retry logic, creating a frame where the entity is neither present nor loading, which EntityLayout displays as not-found.

CatalogEntityPage does not clear the entity upon route change, so it is not affected.

The fix is to set the entity to loading state as it is cleared for being on a different route; this is safe as a real not-found scenario would not have cleared the entity in the first place, and a route change within the same entity does not require changing the entity. Only affects the new Entity page.

While it would be more logical to fix this in "useEntityFromUrl", this hook is used in CatalogEntityPage, which does not have this issue, so it should not be modified.

The test for this is non-trivial, as the flash happens as part of a single render cycle between unmounting the old entity and mounting the new one. Checking page content directly is not reliable for this. Instead, the test captures the entity-provider status (entity/loading/error) on every render during a click-through navigation, and asserts it never reaches a not-found state (no entity, not loading, no error). It uses click navigation through a related entity link, matching the Relations card repro. Fails without the fix, passes with it.

Tested with "yarn test", passes (25/25). "yarn jest" fails to parse this repo's TS for me, even on unrelated pre-existing files, unrelated to this change, but it's why I used "yarn test" instead.

Used AI tooling to help investigate and draft this. I reviewed and understood the full change before submitting.Let me know if you'd like me to clarify anything further.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes) - one-frame timing issue, doesn't show in a static screenshot; can add a recording if useful
- [x] All your commits have a `Signed-off-by` line in the message.