### PR TITLE
fix(home): rename top-visited widget to most-visited

### DIFF
--- a/docs/getting-started/homepage.md
+++ b/docs/getting-started/homepage.md
@@ -98,7 +98,7 @@ These widgets come from `@backstage/plugin-home`:
 | Starred Entities | `home-page-widget:home/starred-entities` | Shows entities you have starred in the catalog.                    |
 | Toolkit          | `home-page-widget:home/toolkit`          | A collection of configurable links and tools.                      |
 | World Clocks     | `home-page-widget:home/world-clock`      | Displays clocks for configured time zones.                         |
-| Most Visited     | `home-page-widget:home/top-visited`      | Shows your most frequently visited pages. Requires visit tracking. |
+| Most Visited     | `home-page-widget:home/most-visited`     | Shows your most frequently visited pages. Requires visit tracking. |
 | Recently Visited | `home-page-widget:home/recently-visited` | Shows pages you have recently visited. Requires visit tracking.    |
 | Random Joke      | `home-page-widget:home/random-joke`      | Shows a random programming joke.                                   |
 

--- a/plugins/home/report-alpha.api.md
+++ b/plugins/home/report-alpha.api.md
@@ -53,6 +53,15 @@ const _default: OverridableFrontendPlugin<
         element: JSX.Element;
       };
     }>;
+    'home-page-widget:home/most-visited': OverridableExtensionDefinition<{
+      kind: 'home-page-widget';
+      name: 'most-visited';
+      config: {};
+      configInput: {};
+      output: ExtensionDataRef<HomePageWidgetData, 'home.widget.data', {}>;
+      inputs: {};
+      params: HomePageWidgetBlueprintParams;
+    }>;
     'home-page-widget:home/random-joke': OverridableExtensionDefinition<{
       kind: 'home-page-widget';
       name: 'random-joke';
@@ -101,15 +110,6 @@ const _default: OverridableFrontendPlugin<
       inputs: {};
       kind: 'home-page-widget';
       name: 'toolkit';
-      params: HomePageWidgetBlueprintParams;
-    }>;
-    'home-page-widget:home/top-visited': OverridableExtensionDefinition<{
-      kind: 'home-page-widget';
-      name: 'top-visited';
-      config: {};
-      configInput: {};
-      output: ExtensionDataRef<HomePageWidgetData, 'home.widget.data', {}>;
-      inputs: {};
       params: HomePageWidgetBlueprintParams;
     }>;
     'home-page-widget:home/world-clock': OverridableExtensionDefinition<{

--- a/plugins/home/src/alpha.tsx
+++ b/plugins/home/src/alpha.tsx
@@ -226,7 +226,7 @@ const homePageRandomJokeWidget = HomePageWidgetBlueprint.make({
 });
 
 const homePageTopVisitedWidget = HomePageWidgetBlueprint.make({
-  name: 'top-visited',
+  name: 'most-visited',
   params: {
     name: 'HomePageTopVisited',
     title: 'Most Visited',

--- a/plugins/home/src/alpha.tsx
+++ b/plugins/home/src/alpha.tsx
@@ -225,7 +225,7 @@ const homePageRandomJokeWidget = HomePageWidgetBlueprint.make({
   },
 });
 
-const homePageTopVisitedWidget = HomePageWidgetBlueprint.make({
+const homePageMostVisitedWidget = HomePageWidgetBlueprint.make({
   name: 'most-visited',
   params: {
     name: 'HomePageTopVisited',
@@ -318,7 +318,7 @@ export default createFrontendPlugin({
     homePageToolkitWidget,
     homePageStarredEntitiesWidget,
     homePageRandomJokeWidget,
-    homePageTopVisitedWidget,
+    homePageMostVisitedWidget,
     homePageRecentlyVisitedWidget,
     homePageWorldClockWidget,
   ],

--- a/plugins/home/src/alpha.tsx
+++ b/plugins/home/src/alpha.tsx
@@ -228,7 +228,7 @@ const homePageRandomJokeWidget = HomePageWidgetBlueprint.make({
 const homePageMostVisitedWidget = HomePageWidgetBlueprint.make({
   name: 'most-visited',
   params: {
-    name: 'HomePageTopVisited',
+    name: 'HomePageMostVisited',
     title: 'Most Visited',
     description: 'Shows your most frequently visited pages',
     components: () =>


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Rename the `top-visited` home page widget extension to `most-visited` to avoid an extension ID conflict.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))