### PR TITLE
fix: memoize entity and analytics context values to stop page-wide rerender cascades

### DIFF
--- a/.changeset/fix-analytics-context-rerender.md
+++ b/.changeset/fix-analytics-context-rerender.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-plugin-api': patch
+---
+
+Fixed a performance issue where all components using analytics, including every link, would rerender unnecessarily whenever a surrounding analytics context rendered again without its attributes having changed, for example when a URL query parameter changed on an entity page.

--- a/.changeset/fix-entity-page-rerender-cascade.md
+++ b/.changeset/fix-entity-page-rerender-cascade.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Fixed a performance issue where all components reading the entity context on an entity page would rerender unnecessarily whenever the page rendered again without the entity data having changed, for example when a URL query parameter changed. This was particularly noticeable when switching tabs in the entity inspector dialog, which caused the entire underlying page to rerender.

--- a/packages/core-plugin-api/src/analytics/AnalyticsContext.test.tsx
+++ b/packages/core-plugin-api/src/analytics/AnalyticsContext.test.tsx
@@ -67,6 +67,34 @@ describe('AnalyticsContext', () => {
       expect(result.getByTestId('route-ref')).toHaveTextContent('unknown');
     });
 
+    it('does not rerender consumers when rerendered with unchanged attributes', () => {
+      let consumerRenderCount = 0;
+      const Consumer = () => {
+        useAnalyticsContext();
+        consumerRenderCount++;
+        return null;
+      };
+      // The consumer element and attributes must be identity-stable across
+      // rerenders, so that any rerenders of the consumer are caused by the
+      // context value changing
+      const consumerElement = <Consumer />;
+      const attributes = { pluginId: 'custom' };
+
+      const { rerender } = render(
+        <AnalyticsContext attributes={attributes}>
+          {consumerElement}
+        </AnalyticsContext>,
+      );
+      expect(consumerRenderCount).toBe(1);
+
+      rerender(
+        <AnalyticsContext attributes={attributes}>
+          {consumerElement}
+        </AnalyticsContext>,
+      );
+      expect(consumerRenderCount).toBe(1);
+    });
+
     it('uses nested analytics context', () => {
       const result = render(
         <AnalyticsContext attributes={{ pluginId: 'custom' }}>

--- a/packages/core-plugin-api/src/analytics/AnalyticsContext.tsx
+++ b/packages/core-plugin-api/src/analytics/AnalyticsContext.tsx
@@ -25,11 +25,11 @@ const AnalyticsReactContext = createVersionedContext<{
   1: AnalyticsContextValue;
 }>('analytics-context');
 
-const defaultAnalyticsContext: AnalyticsContextValue = {
+const defaultAnalyticsContext: AnalyticsContextValue = Object.freeze({
   routeRef: 'unknown',
   pluginId: 'root',
   extension: 'App',
-};
+});
 
 /**
  * A "private" (to this package) hook that enables context inheritance and a

--- a/packages/core-plugin-api/src/analytics/AnalyticsContext.tsx
+++ b/packages/core-plugin-api/src/analytics/AnalyticsContext.tsx
@@ -18,12 +18,18 @@ import {
   createVersionedContext,
   createVersionedValueMap,
 } from '@backstage/version-bridge';
-import { ComponentType, ReactNode, useContext } from 'react';
+import { ComponentType, ReactNode, useContext, useMemo } from 'react';
 import { AnalyticsContextValue } from './types';
 
 const AnalyticsReactContext = createVersionedContext<{
   1: AnalyticsContextValue;
 }>('analytics-context');
+
+const defaultAnalyticsContext: AnalyticsContextValue = {
+  routeRef: 'unknown',
+  pluginId: 'root',
+  extension: 'App',
+};
 
 /**
  * A "private" (to this package) hook that enables context inheritance and a
@@ -36,11 +42,7 @@ export const useAnalyticsContext = (): AnalyticsContextValue => {
 
   // Provide a default value if no value exists.
   if (theContext === undefined) {
-    return {
-      routeRef: 'unknown',
-      pluginId: 'root',
-      extension: 'App',
-    };
+    return defaultAnalyticsContext;
   }
 
   // This should probably never happen, but check for it.
@@ -70,12 +72,14 @@ export const AnalyticsContext = (options: {
   const { attributes, children } = options;
 
   const parentValues = useAnalyticsContext();
-  const combinedValue = {
-    ...parentValues,
-    ...attributes,
-  };
-
-  const versionedCombinedValue = createVersionedValueMap({ 1: combinedValue });
+  // The versioned value is memoized so that context consumers don't get
+  // rerendered when this provider rerenders without the attributes having
+  // changed. Note that this requires callers to pass a stable attributes
+  // object for the memoization to be effective.
+  const versionedCombinedValue = useMemo(
+    () => createVersionedValueMap({ 1: { ...parentValues, ...attributes } }),
+    [parentValues, attributes],
+  );
   return (
     <AnalyticsReactContext.Provider value={versionedCombinedValue}>
       {children}

--- a/plugins/catalog-react/src/hooks/useEntity.test.tsx
+++ b/plugins/catalog-react/src/hooks/useEntity.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import { PropsWithChildren } from 'react';
-import { renderHook } from '@testing-library/react';
+import { render, renderHook } from '@testing-library/react';
 import {
   useEntity,
   useAsyncEntity,
@@ -54,6 +54,33 @@ describe('useEntity', () => {
     });
 
     expect(result.current.entity).toBe(entity);
+  });
+
+  it('should not rerender consumers when the provider rerenders with unchanged values', () => {
+    let consumerRenderCount = 0;
+    const Consumer = () => {
+      useEntity();
+      consumerRenderCount++;
+      return null;
+    };
+    // The consumer element must be identity-stable across rerenders, so that
+    // any rerenders of it are caused by the context value changing
+    const consumerElement = <Consumer />;
+    const refresh = () => {};
+
+    const { rerender } = render(
+      <AsyncEntityProvider entity={entity} loading={false} refresh={refresh}>
+        {consumerElement}
+      </AsyncEntityProvider>,
+    );
+    expect(consumerRenderCount).toBe(1);
+
+    rerender(
+      <AsyncEntityProvider entity={entity} loading={false} refresh={refresh}>
+        {consumerElement}
+      </AsyncEntityProvider>,
+    );
+    expect(consumerRenderCount).toBe(1);
   });
 
   it('should provide entityRef analytics context', () => {

--- a/plugins/catalog-react/src/hooks/useEntity.tsx
+++ b/plugins/catalog-react/src/hooks/useEntity.tsx
@@ -70,8 +70,6 @@ export const AsyncEntityProvider = (props: AsyncEntityProviderProps) => {
     }),
     [entity],
   );
-  // We provide both the old and the new context, since
-  // consumers might be doing things like `useContext(EntityContext)`
   return (
     <NewEntityContext.Provider value={value}>
       <AnalyticsContext attributes={attributes}>{children}</AnalyticsContext>

--- a/plugins/catalog-react/src/hooks/useEntity.tsx
+++ b/plugins/catalog-react/src/hooks/useEntity.tsx
@@ -20,7 +20,7 @@ import {
   createVersionedValueMap,
   useVersionedContext,
 } from '@backstage/version-bridge';
-import { ReactNode } from 'react';
+import { ReactNode, useMemo } from 'react';
 
 /** @public */
 export type EntityLoadingStatus<TEntity extends Entity = Entity> = {
@@ -57,18 +57,24 @@ export interface AsyncEntityProviderProps {
  */
 export const AsyncEntityProvider = (props: AsyncEntityProviderProps) => {
   const { children, entity, loading, error, refresh } = props;
-  const value = { entity, loading, error, refresh };
+  // The versioned value is memoized so that context consumers don't get
+  // rerendered when this provider rerenders without any of the actual
+  // values changing, e.g. as a result of URL query parameter updates.
+  const value = useMemo(
+    () => createVersionedValueMap({ 1: { entity, loading, error, refresh } }),
+    [entity, loading, error, refresh],
+  );
+  const attributes = useMemo(
+    () => ({
+      ...(entity ? { entityRef: stringifyEntityRef(entity) } : undefined),
+    }),
+    [entity],
+  );
   // We provide both the old and the new context, since
   // consumers might be doing things like `useContext(EntityContext)`
   return (
-    <NewEntityContext.Provider value={createVersionedValueMap({ 1: value })}>
-      <AnalyticsContext
-        attributes={{
-          ...(entity ? { entityRef: stringifyEntityRef(entity) } : undefined),
-        }}
-      >
-        {children}
-      </AnalyticsContext>
+    <NewEntityContext.Provider value={value}>
+      <AnalyticsContext attributes={attributes}>{children}</AnalyticsContext>
     </NewEntityContext.Provider>
   );
 };

--- a/plugins/catalog/src/components/EntityLayout/EntityLayout.test.tsx
+++ b/plugins/catalog/src/components/EntityLayout/EntityLayout.test.tsx
@@ -20,7 +20,11 @@ import {
   RELATION_OWNED_BY,
 } from '@backstage/catalog-model';
 import { ApiProvider } from '@backstage/core-app-api';
-import { AlertApi, alertApiRef } from '@backstage/core-plugin-api';
+import {
+  AlertApi,
+  alertApiRef,
+  useAnalytics,
+} from '@backstage/core-plugin-api';
 import {
   AsyncEntityProvider,
   catalogApiRef,
@@ -28,6 +32,7 @@ import {
   entityRouteRef,
   starredEntitiesApiRef,
   MockStarredEntitiesApi,
+  useEntity,
 } from '@backstage/plugin-catalog-react';
 import { catalogApiMock } from '@backstage/plugin-catalog-react/testUtils';
 import { permissionApiRef } from '@backstage/plugin-permission-react';
@@ -40,7 +45,8 @@ import { mockApis } from '@backstage/frontend-test-utils';
 import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { EntityLayout } from './EntityLayout';
 import { rootRouteRef, unregisterRedirectRouteRef } from '../../routes';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, useNavigate } from 'react-router-dom';
+import { ReactNode, useEffect } from 'react';
 
 describe('EntityLayout', () => {
   const mockEntity = {
@@ -450,5 +456,95 @@ describe('EntityLayout - CleanUpAfterRemoval', () => {
     await waitFor(() => {
       expect(screen.getByText('catalog-page')).toBeInTheDocument();
     });
+  });
+});
+
+describe('EntityLayout - inspect dialog', () => {
+  const mockEntity = {
+    apiVersion: 'backstage.io/v1alpha1',
+    kind: 'Component',
+    metadata: {
+      name: 'my-entity',
+      namespace: 'default',
+    },
+  } as Entity;
+
+  const apis = TestApiRegistry.from(
+    [catalogApiRef, catalogApiMock()],
+    [alertApiRef, mockApis.alert()],
+    [starredEntitiesApiRef, new MockStarredEntitiesApi()],
+    [permissionApiRef, mockApis.permission()],
+  );
+
+  // Mimics CatalogEntityPage: subscribes to location updates the same way
+  // that useEntityFromUrl does (useNavigate calls useLocation internally),
+  // and renders the AsyncEntityProvider with stable prop values.
+  const FakeCatalogEntityPage = (props: { children: ReactNode }) => {
+    useNavigate();
+    return (
+      <AsyncEntityProvider entity={mockEntity} loading={false}>
+        {props.children}
+      </AsyncEntityProvider>
+    );
+  };
+
+  it('does not rerender or remount tab content when switching inspector tabs', async () => {
+    let mountCount = 0;
+    let renderCount = 0;
+    let analyticsRenderCount = 0;
+
+    const Probe = () => {
+      useEntity();
+      renderCount++;
+      useEffect(() => {
+        mountCount++;
+      }, []);
+      return <div>probe-content</div>;
+    };
+
+    const AnalyticsProbe = () => {
+      useAnalytics();
+      analyticsRenderCount++;
+      return <div>analytics-probe-content</div>;
+    };
+
+    const children = (
+      <EntityLayout>
+        <EntityLayout.Route path="/" title="tabbed-test-title">
+          <>
+            <Probe />
+            <AnalyticsProbe />
+          </>
+        </EntityLayout.Route>
+      </EntityLayout>
+    );
+
+    await renderInTestApp(
+      <ApiProvider apis={apis}>
+        <FakeCatalogEntityPage children={children} />
+      </ApiProvider>,
+      {
+        routeEntries: ['/?inspect=overview'],
+        mountedRoutes: {
+          '/catalog/:namespace/:kind/:name': entityRouteRef,
+          '/catalog': rootRouteRef,
+        },
+      },
+    );
+
+    expect(await screen.findByText('probe-content')).toBeInTheDocument();
+    expect(await screen.findByText('Entity Inspector')).toBeInTheDocument();
+
+    const mountsBefore = mountCount;
+    const rendersBefore = renderCount;
+    const analyticsRendersBefore = analyticsRenderCount;
+    expect(mountsBefore).toBe(1);
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Ancestry' }));
+
+    expect(await screen.findByText('probe-content')).toBeInTheDocument();
+    expect(mountCount).toBe(mountsBefore);
+    expect(renderCount).toBe(rendersBefore);
+    expect(analyticsRenderCount).toBe(analyticsRendersBefore);
   });
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Entity pages rerender in their entirety whenever any part of the URL changes, including query-parameter-only changes such as the entity inspector dialog updating `?inspect=` when switching tabs.

The trigger is that the entity page component subscribes to all location changes (`useNavigate` calls `useLocation` internally). Two context providers then amplify that single cheap rerender into a page-wide one:

- `AsyncEntityProvider` rebuilt its versioned context value object on every render, so every `useEntity`/`useAsyncEntity` consumer rerendered.
- `AnalyticsContext` did the same, so every `useAnalytics` consumer rerendered too — which includes every `Link`.

This PR memoizes both context values (and the analytics attributes object), so unrelated rerenders of the providers no longer cascade. With the fix, switching inspector tabs no longer rerenders the page content at all, verified by mount/render-counting probe tests that fail without the fix. On heavy entity pages with many cards the cascade was visibly janky.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

🤖 Generated with [Claude Code](https://claude.com/claude-code)