### PR TITLE
fix(catalog): show loading state instead of not-found flash when navigating between entities

### DIFF
--- a/.changeset/fix-entity-not-found-flash.md
+++ b/.changeset/fix-entity-not-found-flash.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Fixed a brief flash of the "Entity not found" warning when navigating between entity pages. When the URL changes to a different entity, there is a short window where the new route params have taken effect but the old entity data is still loaded. The entity page now reports a loading state during this window instead of an empty not-found state.

--- a/plugins/catalog/src/alpha/pages.tsx
+++ b/plugins/catalog/src/alpha/pages.tsx
@@ -274,13 +274,18 @@ export const catalogEntityPage = PageBlueprint.makeWithOverrides({
         const Component = () => {
           const routeParams = useRouteRefParams(entityRouteRef);
           const entityFromUrl = useEntityFromUrl();
-          const entity =
+          const entityMatchesRoute =
             entityFromUrl.entity &&
             stringifyEntityRef(entityFromUrl.entity) ===
-              stringifyEntityRef(routeParams)
-              ? entityFromUrl.entity
-              : undefined;
-          const entityProviderProps = { ...entityFromUrl, entity };
+              stringifyEntityRef(routeParams);
+          const entity = entityMatchesRoute ? entityFromUrl.entity : undefined;
+          const entityProviderProps = {
+            ...entityFromUrl,
+            entity,
+            loading:
+              entityFromUrl.loading ||
+              (!!entityFromUrl.entity && !entityMatchesRoute),
+          };
           const filteredMenuItems = entity
             ? menuItems
                 .filter(i => i.filter(entity))


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When navigating between entity pages (e.g. from `group/team-a` to `component/artist-lookup`), the "Entity not found" warning briefly flashes before the new entity loads.

### Root cause

The new-frontend-system entity page has a ref-mismatch guard that clears the stale entity when the route params no longer match the loaded data — this prevents showing `team-a`'s content under `artist-lookup`'s URL. But the guard only cleared `entity` to `undefined` without also setting `loading: true`, creating a single rendered frame where `entity` is `undefined` and `loading` is `false`. `EntityLayoutBui` interprets that as "entity genuinely not found" and renders the warning panel.

The fetch starts on the next effect cycle and `loading` flips to `true`, but in a browser the intermediate frame has already painted.

### Fix

When the entity is cleared due to the ref mismatch, the provider now also reports `loading: true`, so the page shows a progress indicator instead of the not-found warning during the transition.

One-line change in the alpha entity page wiring (`pages.tsx`).

### Testing

This is a paint-timing issue — React batches the state transitions in jsdom so the intermediate `!entity && !loading` frame never occurs in tests. The fix is verified by visual inspection in the browser. Existing test suite (24 tests) passes unchanged.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

🤖 Generated with [Claude Code](https://claude.com/claude-code)