### PR TITLE
Added tooltips to the icon buttons in the top toolbar BUI Page

### DIFF
--- a/docs-ui/src/components/Toolbar/Toolbar.module.css
+++ b/docs-ui/src/components/Toolbar/Toolbar.module.css
@@ -168,6 +168,72 @@
   }
 }
 
+.tooltipWrapper {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+
+  &[data-hide-tablet] {
+    display: none;
+  }
+
+  @media (min-width: 1024px) {
+    &[data-hide-tablet] {
+      display: inline-flex;
+    }
+  }
+
+  &[data-tooltip]::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: var(--color-gray-900, #111);
+    color: var(--color-gray-50, #fafafa);
+    font-size: 0.75rem;
+    font-weight: 500;
+    white-space: nowrap;
+    padding: 4px 8px;
+    border-radius: 6px;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s ease-in-out;
+    z-index: 100;
+  }
+
+  &[data-tooltip]:hover::after {
+    opacity: 1;
+  }
+}
+
+.buttonGroup button[data-tooltip] {
+  position: relative;
+
+  &::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    top: calc(100% + 12px);
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: var(--color-gray-900, #111);
+    color: var(--color-gray-50, #fafafa);
+    font-size: 0.75rem;
+    font-weight: 500;
+    white-space: nowrap;
+    padding: 4px 8px;
+    border-radius: 6px;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s ease-in-out;
+    z-index: 100;
+  }
+
+  &:hover::after {
+    opacity: 1;
+  }
+}
+
 .Popup {
   box-sizing: border-box;
   padding-block: 0.25rem;

--- a/docs-ui/src/components/Toolbar/Toolbar.tsx
+++ b/docs-ui/src/components/Toolbar/Toolbar.tsx
@@ -103,26 +103,36 @@ export const Toolbar = ({ version }: ToolbarProps) => {
         >
           Version {version}
         </a>
-        <a
-          href="https://github.com/backstage/backstage/tree/master/packages/ui"
-          target="_blank"
-          rel="noopener noreferrer"
-          className={styles.bubble}
+        <span
+          className={styles.tooltipWrapper}
+          data-tooltip="GitHub"
           data-hide-tablet
-          aria-label="View source on GitHub"
         >
-          <RiGithubLine size={16} />
-        </a>
-        <a
-          href="https://discord.gg/backstage-687207715902193673"
-          target="_blank"
-          rel="noopener noreferrer"
-          className={styles.bubble}
+          <a
+            href="https://github.com/backstage/backstage/tree/master/packages/ui"
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.bubble}
+            aria-label="View source on GitHub"
+          >
+            <RiGithubLine size={16} />
+          </a>
+        </span>
+        <span
+          className={styles.tooltipWrapper}
+          data-tooltip="Discord"
           data-hide-tablet
-          aria-label="Join Backstage on Discord"
         >
-          <RiDiscordLine size={16} />
-        </a>
+          <a
+            href="https://discord.gg/backstage-687207715902193673"
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.bubble}
+            aria-label="Join Backstage on Discord"
+          >
+            <RiDiscordLine size={16} />
+          </a>
+        </span>
         <ToggleButtonGroup
           defaultSelectedKeys={['light']}
           selectedKeys={selectedTheme}
@@ -131,10 +141,18 @@ export const Toolbar = ({ version }: ToolbarProps) => {
           className={styles.buttonGroup}
           aria-label="Color scheme"
         >
-          <ToggleButton id="light" aria-label="Light theme">
+          <ToggleButton
+            id="light"
+            aria-label="Light theme"
+            data-tooltip="Light theme"
+          >
             <RiSunLine aria-hidden="true" size={16} />
           </ToggleButton>
-          <ToggleButton id="dark" aria-label="Dark theme">
+          <ToggleButton
+            id="dark"
+            aria-label="Dark theme"
+            data-tooltip="Dark theme"
+          >
             <RiMoonLine aria-hidden="true" size={16} />
           </ToggleButton>
         </ToggleButtonGroup>


### PR DESCRIPTION
## What's changed

Added tooltips to the icon buttons in the top toolbar so users know what each icon does when they hover over it.


<img width="1902" height="423" alt="image" src="https://github.com/user-attachments/assets/f4376a0a-e360-436e-988a-abb658f341b6" />
<img width="1900" height="399" alt="image" src="https://github.com/user-attachments/assets/e55002a3-bd46-4655-8ce9-6f58009aced4" />


## Which icons now have tooltips

- **GitHub** — links to the Backstage UI source code
- **Discord** — links to the Backstage Discord community
- **Sun icon** — Light theme toggle
- **Moon icon** — Dark theme toggle

## How it looks

Tooltips appear just below each icon on hover with a smooth fade-in effect.

## Why

The toolbar had icon-only buttons with no visible labels, making it unclear what they did at a glance. Tooltips make the UI more discoverable without changing the layout.