### PR TITLE
Add query limit for team members in github organization

### DIFF
--- a/.changeset/github-org-max-team-size.md
+++ b/.changeset/github-org-max-team-size.md
@@ -1,0 +1,33 @@
+---
+'@backstage/plugin-catalog-backend-module-github-org': minor
+'@backstage/plugin-catalog-backend-module-github': minor
+---
+
+Adds a new `queryLimits.teamMembers` configuration option for the GitHub Org provider, which caps the number of team members fetched and imported into the catalog. This helps avoid catalog refresh timeouts for organizations with teams that have thousands of members.
+
+```yaml title="app-config.yaml"
+catalog:
+  providers:
+    githubOrg:
+      - id: github
+        githubUrl: https://github.com
+        orgs: ['organization-1', 'organization-2', 'organization-3']
+        schedule:
+          initialDelay: { seconds: 30 }
+          frequency: { hours: 1 }
+          timeout: { minutes: 50 }
+        pageSizes:
+          teams: 25
+          teamMembers: 50
+          organizationMembers: 50
++       queryLimits:
++         teamMembers: 300
+      - id: ghe
+        githubUrl: https://ghe.mycompany.com
+        orgs: ['internal-1', 'internal-2', 'internal-3']
+        schedule:
+          initialDelay: { seconds: 30 }
+          frequency: { hours: 1 }
+          timeout: { minutes: 50 }
+        excludeSuspendedUsers: true
+```

--- a/docs/integrations/github/org.md
+++ b/docs/integrations/github/org.md
@@ -105,9 +105,9 @@ Directly under the `githubOrg` is a list of configurations, each entry is a stru
 
   Reducing page sizes will result in more API calls and slightly longer sync times, but will prevent API resource limits for organizations with large number of teams and members.
 
-- `queryLimits` (optional): Configure maximum item limits for GitHub GraphQL API queries. Use this if the catalog refresh job times out because your organization has teams with thousands of members — the job's request headers timeout is 60 minutes, so very large teams can cause it to fail.
+- `queryLimits` (optional): Configure limits for GitHub GraphQL API queries to make sure catalog jobs do not time out. This can happen if you have large organization and too many GraphQL request are executed in one session. Request headers timeout is 60 minutes, check if your jobs are reaching this limit.
 
-  - `teamMembers`: Maximum number of members a team can have before it's excluded from the catalog (default: undefined, no limit)
+  - `teamMembers`: Maximum number of members a team can have before it's excluded from the catalog. Use this if the job times out because your organization has teams with thousands of members which take too long to fetch (default: undefined, no limit)
 
   If you set this, teams with more members than the limit will not appear in the catalog.
 

--- a/docs/integrations/github/org.md
+++ b/docs/integrations/github/org.md
@@ -79,6 +79,8 @@ catalog:
           teams: 25
           teamMembers: 50
           organizationMembers: 50
+        queryLimits:
+          teamMembers: 300
       - id: ghe
         githubUrl: https://ghe.mycompany.com
         orgs: ['internal-1', 'internal-2', 'internal-3']
@@ -102,6 +104,12 @@ Directly under the `githubOrg` is a list of configurations, each entry is a stru
   - `organizationMembers`: Number of organization members to fetch per page (default: 50)
 
   Reducing page sizes will result in more API calls and slightly longer sync times, but will prevent API resource limits for organizations with large number of teams and members.
+
+- `queryLimits` (optional): Configure maximum item limits for GitHub GraphQL API queries. Use this if the catalog refresh job times out because your organization has teams with thousands of members — the job's request headers timeout is 60 minutes, so very large teams can cause it to fail.
+
+  - `teamMembers`: Maximum number of members a team can have before it's excluded from the catalog (default: undefined, no limit)
+
+  If you set this, teams with more members than the limit will not appear in the catalog.
 
 - `excludeSuspendedUsers` (optional): Whether to exclude suspended users when querying organization users. Only for GitHub Enterprise instances. Will error if used against GitHub.com API.
 

--- a/plugins/catalog-backend-module-github-org/src/module.test.ts
+++ b/plugins/catalog-backend-module-github-org/src/module.test.ts
@@ -127,6 +127,57 @@ describe('catalogModuleGithubOrgEntityProvider', () => {
     );
   });
 
+  it('should register provider with custom query limits', async () => {
+    let addedProviders: Array<EntityProvider> | undefined;
+
+    const extensionPoint = {
+      addEntityProvider: (...providers: any) => {
+        addedProviders = providers;
+      },
+    };
+    const runner = jest.fn();
+    const scheduler = mockServices.scheduler.mock({
+      createScheduledTaskRunner() {
+        return { run: runner };
+      },
+    });
+
+    const config = {
+      catalog: {
+        providers: {
+          githubOrg: [
+            {
+              id: 'default',
+              githubUrl: 'https://github.com',
+              orgs: ['backstage'],
+              schedule: {
+                frequency: 'P1M',
+                timeout: 'PT3M',
+              },
+              queryLimits: {
+                teamMembers: 100,
+              },
+            },
+          ],
+        },
+      },
+    };
+
+    await startTestBackend({
+      extensionPoints: [[catalogProcessingExtensionPoint, extensionPoint]],
+      features: [
+        catalogModuleGithubOrgEntityProvider,
+        mockServices.rootConfig.factory({ data: config }),
+        scheduler.factory,
+      ],
+    });
+
+    expect(addedProviders?.length).toEqual(1);
+    expect(addedProviders![0].getProviderName()).toEqual(
+      'GithubMultiOrgEntityProvider:default',
+    );
+  });
+
   it('should register provider without page sizes configuration', async () => {
     let addedProviders: Array<EntityProvider> | undefined;
 

--- a/plugins/catalog-backend-module-github-org/src/module.ts
+++ b/plugins/catalog-backend-module-github-org/src/module.ts
@@ -127,6 +127,7 @@ export const catalogModuleGithubOrgEntityProvider = createBackendModule({
               alwaysUseDefaultNamespace:
                 definitions.length === 1 && definition.orgs?.length === 1,
               pageSizes: definition.pageSizes,
+              queryLimits: definition.queryLimits,
               excludeSuspendedUsers: definition.excludeSuspendedUsers,
               cache,
               experimental_checkForSuspendedUsersWithRest:
@@ -148,6 +149,9 @@ function readDefinitionsFromConfig(rootConfig: Config): Array<{
     teams?: number;
     teamMembers?: number;
     organizationMembers?: number;
+  };
+  queryLimits?: {
+    teamMembers?: number;
   };
   excludeSuspendedUsers?: boolean;
   experimental_checkForSuspendedUsersWithRest?: boolean;
@@ -177,6 +181,11 @@ function readDefinitionsFromConfig(rootConfig: Config): Array<{
           organizationMembers: c.getOptionalNumber(
             'pageSizes.organizationMembers',
           ),
+        }
+      : undefined,
+    queryLimits: c.has('queryLimits')
+      ? {
+          teamMembers: c.getOptionalNumber('queryLimits.teamMembers'),
         }
       : undefined,
     excludeSuspendedUsers:

--- a/plugins/catalog-backend-module-github/config.d.ts
+++ b/plugins/catalog-backend-module-github/config.d.ts
@@ -322,6 +322,14 @@ export interface Config {
                */
               organizationMembers?: number;
             };
+
+            queryLimits?: {
+              /**
+               * (Optional) Maximum number of team members to fetch per team when querying team members.
+               * Default: `undefined` (no limit).
+               */
+              teamMembers?: number;
+            };
           }
         | Array<{
             /**

--- a/plugins/catalog-backend-module-github/report.api.md
+++ b/plugins/catalog-backend-module-github/report.api.md
@@ -158,6 +158,7 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
     teamTransformer?: TeamTransformer;
     alwaysUseDefaultNamespace?: boolean;
     pageSizes?: Partial<GithubPageSizes>;
+    queryLimits?: Partial<GithubQueryLimits>;
     excludeSuspendedUsers?: boolean;
     cache?: CacheService;
     experimental_checkForSuspendedUsersWithRest?: boolean;
@@ -185,6 +186,7 @@ export interface GithubMultiOrgEntityProviderOptions {
   logger: LoggerService;
   orgs?: string[];
   pageSizes?: Partial<GithubPageSizes>;
+  queryLimits?: Partial<GithubQueryLimits>;
   schedule?: 'manual' | SchedulerServiceTaskRunner;
   teamTransformer?: TeamTransformer;
   userTransformer?: UserTransformer;
@@ -241,6 +243,7 @@ export class GithubOrgEntityProvider implements EntityProvider {
     userTransformer?: UserTransformer;
     teamTransformer?: TeamTransformer;
     pageSizes?: Partial<GithubPageSizes>;
+    queryLimits?: Partial<GithubQueryLimits>;
     excludeSuspendedUsers?: boolean;
     cache?: CacheService;
     experimental_checkForSuspendedUsersWithRest?: boolean;
@@ -269,6 +272,7 @@ export interface GithubOrgEntityProviderOptions {
   logger: LoggerService;
   orgUrl: string;
   pageSizes?: Partial<GithubPageSizes>;
+  queryLimits?: Partial<GithubQueryLimits>;
   schedule?: 'manual' | SchedulerServiceTaskRunner;
   teamTransformer?: TeamTransformer;
   userTransformer?: UserTransformer;
@@ -305,6 +309,11 @@ export type GithubPageSizes = {
   teamMembers: number;
   organizationMembers: number;
   repositories: number;
+};
+
+// @public
+export type GithubQueryLimits = {
+  teamMembers?: number;
 };
 
 // @public

--- a/plugins/catalog-backend-module-github/src/index.ts
+++ b/plugins/catalog-backend-module-github/src/index.ts
@@ -43,6 +43,7 @@ export {
   defaultOrganizationTeamTransformer,
   type TransformerContext,
   type GithubPageSizes,
+  type GithubQueryLimits,
 } from './lib';
 
 export * from './deprecated';

--- a/plugins/catalog-backend-module-github/src/lib/github.test.ts
+++ b/plugins/catalog-backend-module-github/src/lib/github.test.ts
@@ -34,6 +34,7 @@ import {
   QueryResponse,
   GithubUser,
   GithubTeam,
+  DEFAULT_PAGE_SIZES,
   createAddEntitiesOperation,
   createRemoveEntitiesOperation,
   createReplaceEntitiesOperation,
@@ -892,6 +893,64 @@ describe('github', () => {
       );
 
       await expect(getTeamMembers(graphql, 'a', 'b')).resolves.toEqual(output);
+    });
+
+    it('returns empty members when teamMembers query limit is reached', async () => {
+      const input: QueryResponse = {
+        organization: {
+          team: {
+            slug: '',
+            combinedSlug: '',
+            members: {
+              pageInfo: { hasNextPage: false },
+              nodes: [{ login: 'user1' }, { login: 'user2' }],
+            },
+          },
+        },
+      };
+
+      server.use(
+        graphqlMsw.query('members', () => HttpResponse.json({ data: input })),
+      );
+
+      await expect(
+        getTeamMembers(graphql, 'a', 'b', DEFAULT_PAGE_SIZES, {
+          teamMembers: 1,
+        }),
+      ).resolves.toEqual({ members: [] });
+    });
+
+    it('returns all members when count is below teamMembers query limit', async () => {
+      const input: QueryResponse = {
+        organization: {
+          team: {
+            slug: '',
+            combinedSlug: '',
+            members: {
+              pageInfo: { hasNextPage: false },
+              nodes: [{ login: 'user1' }],
+            },
+          },
+        },
+      };
+
+      server.use(
+        graphqlMsw.query('members', () => HttpResponse.json({ data: input })),
+      );
+
+      await expect(
+        getTeamMembers(graphql, 'a', 'b', DEFAULT_PAGE_SIZES, {
+          teamMembers: 2,
+        }),
+      ).resolves.toEqual({ members: [{ login: 'user1' }] });
+    });
+
+    it('throws when teamMembers query limit is negative', async () => {
+      await expect(
+        getTeamMembers(graphql, 'a', 'b', DEFAULT_PAGE_SIZES, {
+          teamMembers: -1,
+        }),
+      ).rejects.toThrow('Invalid maxItems (-1): must be >= 0');
     });
   });
 
@@ -1815,6 +1874,72 @@ describe('github', () => {
       );
 
       await getOrganizationTeams(graphql as any, org);
+    });
+  });
+
+  describe('Query limits configuration', () => {
+    const org = 'my-org';
+
+    it('passes queryLimits through getOrganizationTeams when members paginate', async () => {
+      server.use(
+        graphqlMsw.query('teams', () =>
+          HttpResponse.json({
+            data: {
+              organization: {
+                teams: {
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                  nodes: [
+                    {
+                      slug: 'team1',
+                      combinedSlug: 'my-org/team1',
+                      name: 'Team 1',
+                      description: 'desc',
+                      avatarUrl: '',
+                      editTeamUrl: '',
+                      parentTeam: null,
+                      members: {
+                        pageInfo: { hasNextPage: true },
+                        nodes: [{ login: 'user1' }],
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          }),
+        ),
+        graphqlMsw.query('members', () =>
+          HttpResponse.json({
+            data: {
+              organization: {
+                team: {
+                  slug: 'team1',
+                  combinedSlug: 'my-org/team1',
+                  members: {
+                    pageInfo: { hasNextPage: false },
+                    nodes: [{ login: 'user1' }, { login: 'user2' }],
+                  },
+                },
+              },
+            },
+          }),
+        ),
+      );
+
+      const { teams } = await getOrganizationTeams(
+        graphql as any,
+        org,
+        undefined,
+        DEFAULT_PAGE_SIZES,
+        { teamMembers: 1 },
+      );
+
+      expect(teams).toHaveLength(1);
+      expect(teams[0]).toEqual(
+        expect.objectContaining({
+          spec: expect.objectContaining({ members: [] }),
+        }),
+      );
     });
   });
 });

--- a/plugins/catalog-backend-module-github/src/lib/github.ts
+++ b/plugins/catalog-backend-module-github/src/lib/github.ts
@@ -67,7 +67,7 @@ export type GithubPageSizes = {
 };
 
 /**
- * Configuration for Github GraphQL API paging options
+ * Configuration for GitHub GraphQL API paging options
  *
  * @public
  */
@@ -885,7 +885,7 @@ export async function queryWithPaging<
       });
       if (transformedNode) {
         result.push(transformedNode);
-        if (result.length >= maxResultItems) {
+        if (result.length > maxResultItems) {
           maxItemsReached = true;
           break;
         }

--- a/plugins/catalog-backend-module-github/src/lib/github.ts
+++ b/plugins/catalog-backend-module-github/src/lib/github.ts
@@ -67,6 +67,15 @@ export type GithubPageSizes = {
 };
 
 /**
+ * Configuration for Github GraphQL API paging options
+ *
+ * @public
+ */
+export type GithubQueryLimits = {
+  teamMembers?: number;
+};
+
+/**
  * Default page sizes for GitHub GraphQL API queries.
  * These values are reduced to prevent RESOURCE_LIMITS_EXCEEDED errors with large organizations.
  *
@@ -77,6 +86,10 @@ export const DEFAULT_PAGE_SIZES: GithubPageSizes = {
   teamMembers: 50,
   organizationMembers: 50,
   repositories: 25,
+};
+
+export const DEFAULT_QUERY_LIMITS: GithubQueryLimits = {
+  teamMembers: undefined,
 };
 
 // Graphql types
@@ -267,12 +280,14 @@ export async function getOrganizationUsers(
  * @param org - The slug of the org to read
  * @param teamTransformer - Optional transformer for team entities
  * @param pageSizes - Optional page sizes configuration
+ * @param queryLimits - Optional limit for number of items in GitHub graphql queries
  */
 export async function getOrganizationTeams(
   client: typeof graphql,
   org: string,
   teamTransformer: TeamTransformer = defaultOrganizationTeamTransformer,
   pageSizes: GithubPageSizes = DEFAULT_PAGE_SIZES,
+  queryLimits: GithubQueryLimits = DEFAULT_QUERY_LIMITS,
 ): Promise<{
   teams: Entity[];
 }> {
@@ -325,6 +340,7 @@ export async function getOrganizationTeams(
         ctx.org,
         item.slug,
         pageSizes,
+        queryLimits,
       );
       for (const userLogin of members) {
         memberNames.push(userLogin);
@@ -361,6 +377,7 @@ export async function getOrganizationTeamsFromUsers(
   userLogins: string[],
   teamTransformer: TeamTransformer = defaultOrganizationTeamTransformer,
   pageSizes: GithubPageSizes = DEFAULT_PAGE_SIZES,
+  queryLimits: GithubQueryLimits = DEFAULT_QUERY_LIMITS,
 ): Promise<{
   teams: Entity[];
 }> {
@@ -420,6 +437,7 @@ export async function getOrganizationTeamsFromUsers(
         ctx.org,
         item.slug,
         pageSizes,
+        queryLimits,
       );
       for (const userLogin of members) {
         memberNames.push(userLogin);
@@ -539,6 +557,7 @@ export async function getOrganizationTeam(
   teamSlug: string,
   teamTransformer: TeamTransformer = defaultOrganizationTeamTransformer,
   pageSizes: GithubPageSizes = DEFAULT_PAGE_SIZES,
+  queryLimits: GithubQueryLimits = DEFAULT_QUERY_LIMITS,
 ): Promise<{
   team: Entity;
 }> {
@@ -580,6 +599,7 @@ export async function getOrganizationTeam(
         ctx.org,
         item.slug,
         pageSizes,
+        queryLimits,
       );
       for (const userLogin of members) {
         memberNames.push(userLogin);
@@ -757,6 +777,7 @@ export async function getTeamMembers(
   org: string,
   teamSlug: string,
   pageSizes: GithubPageSizes = DEFAULT_PAGE_SIZES,
+  queryLimits: GithubQueryLimits = DEFAULT_QUERY_LIMITS,
 ): Promise<{ members: GithubUser[] }> {
   const query = `
     query members($org: String!, $teamSlug: String!, $cursor: String, $membersPageSize: Int!) {
@@ -777,6 +798,7 @@ export async function getTeamMembers(
     connection: r => r.organization?.team?.members,
     transformer: async user => user,
     variables: { org, teamSlug, membersPageSize: pageSizes.teamMembers },
+    maxItems: queryLimits.teamMembers,
   });
 
   return { members };
@@ -801,6 +823,7 @@ export async function getTeamMembers(
  *               returns the model mapped form of it
  * @param params.variables - The variable values that the query needs, minus the cursor
  * @param params.filter - An optional filter function to filter the nodes before transforming them
+ * @param params.maxItems - Optional cap on the number of transformed items returned
  */
 export async function queryWithPaging<
   GraphqlType,
@@ -818,13 +841,28 @@ export async function queryWithPaging<
   ) => Promise<OutputType | undefined>;
   variables: Variables;
   filter?: (item: GraphqlType) => Promise<boolean> | boolean;
+  maxItems?: number;
 }): Promise<OutputType[]> {
-  const { client, query, org, connection, transformer, variables, filter } =
-    params;
+  const {
+    client,
+    query,
+    org,
+    connection,
+    transformer,
+    variables,
+    filter,
+    maxItems,
+  } = params;
   const result: OutputType[] = [];
   const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));
+  const maxResultItems = maxItems ?? Infinity;
+
+  if (maxResultItems < 0) {
+    throw new Error(`Invalid maxItems (${maxResultItems}): must be >= 0`);
+  }
 
   let cursor: string | undefined = undefined;
+  let maxItemsReached = false;
   for (let j = 0; j < 1000 /* just for sanity */; ++j) {
     const response: Response = await client(query, {
       ...variables,
@@ -847,7 +885,17 @@ export async function queryWithPaging<
       });
       if (transformedNode) {
         result.push(transformedNode);
+        if (result.length >= maxResultItems) {
+          maxItemsReached = true;
+          break;
+        }
       }
+    }
+
+    // when we reach max allowed items, we return empty array not to confuse users with incomplete data,
+    // when this happens during fetching members of big teams, the team then does not appear in the catalog at all
+    if (maxItemsReached) {
+      return [];
     }
 
     if (!conn.pageInfo.hasNextPage) {

--- a/plugins/catalog-backend-module-github/src/lib/index.ts
+++ b/plugins/catalog-backend-module-github/src/lib/index.ts
@@ -24,7 +24,9 @@ export {
   type GithubUser,
   type GithubTeam,
   type GithubPageSizes,
+  type GithubQueryLimits,
   DEFAULT_PAGE_SIZES,
+  DEFAULT_QUERY_LIMITS,
 } from './github';
 export {
   type UserTransformer,

--- a/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.test.ts
@@ -980,6 +980,98 @@ describe('GithubMultiOrgEntityProvider', () => {
 
       expect(entityProviderConnection.applyMutation).not.toHaveBeenCalled();
     });
+
+    it('should apply queryLimits when reading specified orgs', async () => {
+      entityProvider = new GithubMultiOrgEntityProvider({
+        id: 'my-id',
+        gitHubConfig,
+        githubCredentialsProvider: {
+          getCredentials: mockGetCredentials,
+        },
+        githubUrl: 'https://github.com',
+        logger,
+        orgs: ['orgA'],
+        queryLimits: { teamMembers: 1 },
+      });
+
+      await entityProvider.connect(entityProviderConnection);
+
+      mockClient
+        .mockResolvedValueOnce({
+          organization: {
+            membersWithRole: {
+              pageInfo: { hasNextPage: false },
+              nodes: [
+                {
+                  login: 'a',
+                  id: 'f',
+                  name: 'b',
+                  bio: 'c',
+                  email: 'd',
+                  avatarUrl: 'e',
+                },
+              ],
+            },
+          },
+        })
+        .mockResolvedValueOnce({
+          organization: {
+            teams: {
+              pageInfo: { hasNextPage: false },
+              nodes: [
+                {
+                  slug: 'team',
+                  combinedSlug: 'orgA/team',
+                  name: 'Team',
+                  description: 'The one and only team',
+                  avatarUrl: 'http://example.com/team.jpeg',
+                  parentTeam: {
+                    slug: 'parent',
+                    combinedSlug: '',
+                    members: { pageInfo: { hasNextPage: false }, nodes: [] },
+                  },
+                  members: {
+                    pageInfo: { hasNextPage: true },
+                    nodes: [{ login: 'a', id: 'f' }],
+                  },
+                },
+              ],
+            },
+          },
+        })
+        .mockResolvedValueOnce({
+          organization: {
+            team: {
+              slug: 'team',
+              combinedSlug: 'orgA/team',
+              members: {
+                pageInfo: { hasNextPage: false },
+                nodes: [
+                  { login: 'a', id: 'f' },
+                  { login: 'b', id: 'g' },
+                ],
+              },
+            },
+          },
+        });
+
+      (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
+
+      await entityProvider.read();
+
+      expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          entities: expect.arrayContaining([
+            expect.objectContaining({
+              entity: expect.objectContaining({
+                kind: 'Group',
+                spec: expect.objectContaining({ members: [] }),
+              }),
+            }),
+          ]),
+        }),
+      );
+    });
   });
 
   describe('withLocations', () => {

--- a/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
@@ -68,7 +68,9 @@ import {
   TransformerContext,
   UserTransformer,
   GithubPageSizes,
+  GithubQueryLimits,
   DEFAULT_PAGE_SIZES,
+  DEFAULT_QUERY_LIMITS,
 } from '../lib';
 import {
   ANNOTATION_GITHUB_TEAM_SLUG,
@@ -181,6 +183,12 @@ export interface GithubMultiOrgEntityProviderOptions {
   pageSizes?: Partial<GithubPageSizes>;
 
   /**
+   * Optionally configure query limits for GitHub GraphQL API queries.
+   * Add these max amounts if the job runs for so long that it times out (request headers timeout is 60 minutes)
+   */
+  queryLimits?: Partial<GithubQueryLimits>;
+
+  /**
    * Optionally exclude suspended users when querying organization users.
    * @defaultValue false
    * @remarks
@@ -249,6 +257,7 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       events: options.events,
       alwaysUseDefaultNamespace: options.alwaysUseDefaultNamespace,
       pageSizes: options.pageSizes,
+      queryLimits: options.queryLimits,
       excludeSuspendedUsers: options.excludeSuspendedUsers,
       cache: options.cache,
       experimental_checkForSuspendedUsersWithRest:
@@ -273,6 +282,7 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       teamTransformer?: TeamTransformer;
       alwaysUseDefaultNamespace?: boolean;
       pageSizes?: Partial<GithubPageSizes>;
+      queryLimits?: Partial<GithubQueryLimits>;
       excludeSuspendedUsers?: boolean;
       cache?: CacheService;
       experimental_checkForSuspendedUsersWithRest?: boolean;
@@ -289,6 +299,27 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       ...DEFAULT_PAGE_SIZES,
       ...this.options.pageSizes,
     };
+  }
+
+  private getQueryLimits(): GithubQueryLimits {
+    return {
+      ...DEFAULT_QUERY_LIMITS,
+      ...this.options.queryLimits,
+    };
+  }
+
+  private async getOrgGraphqlClient(org: string) {
+    const { headers, type: tokenType } =
+      await this.options.githubCredentialsProvider.getCredentials({
+        url: `${this.options.githubUrl}/${org}`,
+      });
+
+    const client = graphql.defaults({
+      baseUrl: this.options.gitHubConfig.apiBaseUrl,
+      headers,
+    });
+
+    return { client, tokenType };
   }
 
   private get useRestSuspendedCheck(): boolean {
@@ -355,25 +386,17 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
 
     const allUsersMap = new Map();
     const allTeams: Entity[] = [];
+    const pageSizes = this.getPageSizes();
+    const queryLimits = this.getQueryLimits();
 
     const orgsToProcess = this.options.orgs?.length
       ? this.options.orgs
       : await this.getAllOrgs(this.options.gitHubConfig);
 
     for (const org of orgsToProcess) {
-      const { headers, type: tokenType } =
-        await this.options.githubCredentialsProvider.getCredentials({
-          url: `${this.options.githubUrl}/${org}`,
-        });
-      const client = graphql.defaults({
-        baseUrl: this.options.gitHubConfig.apiBaseUrl,
-        headers,
-      });
-
       logger.info(`Reading GitHub users and teams for org: ${org}`);
 
-      const pageSizes = this.getPageSizes();
-
+      const { client, tokenType } = await this.getOrgGraphqlClient(org);
       const { users } = await getOrganizationUsers(
         client,
         org,
@@ -389,6 +412,7 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
         org,
         this.defaultMultiOrgTeamTransformer.bind(this),
         pageSizes,
+        queryLimits,
       );
 
       // Grab current users from `allUsersMap` if they already exist in our

--- a/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.test.ts
@@ -194,6 +194,115 @@ describe('GithubOrgEntityProvider', () => {
       });
     });
 
+    it('should apply queryLimits when reading org data', async () => {
+      const logger = mockServices.logger.mock();
+      const gitHubConfig = {
+        host: 'https://github.com',
+      };
+
+      const mockGetCredentials = jest.fn().mockReturnValue({
+        headers: { token: 'blah' },
+        type: 'app',
+      });
+
+      const githubCredentialsProvider = {
+        getCredentials: mockGetCredentials,
+      };
+
+      const provider = new GithubOrgEntityProvider({
+        id: 'my-id',
+        githubCredentialsProvider,
+        orgUrl: 'https://github.com/backstage',
+        gitHubConfig,
+        logger,
+        queryLimits: { teamMembers: 1 },
+      });
+
+      const connection: EntityProviderConnection = {
+        applyMutation: jest.fn(),
+        refresh: jest.fn(),
+      };
+
+      await provider.connect(connection);
+
+      mockClient = jest
+        .fn()
+        // getOrganizationUsers
+        .mockResolvedValueOnce({
+          organization: {
+            membersWithRole: {
+              pageInfo: { hasNextPage: false },
+              nodes: [
+                {
+                  login: 'a',
+                  id: 'f',
+                  name: 'b',
+                  bio: 'c',
+                  email: 'd',
+                  avatarUrl: 'e',
+                },
+              ],
+            },
+          },
+        })
+        // getOrganizationTeams (initial teams query, members paginate)
+        .mockResolvedValueOnce({
+          organization: {
+            teams: {
+              pageInfo: { hasNextPage: false },
+              nodes: [
+                {
+                  slug: 'team',
+                  combinedSlug: 'blah/team',
+                  name: 'Team',
+                  description: 'The one and only team',
+                  avatarUrl: 'http://example.com/team.jpeg',
+                  parentTeam: {
+                    slug: 'parent',
+                    combinedSlug: '',
+                    members: { pageInfo: { hasNextPage: false }, nodes: [] },
+                  },
+                  members: {
+                    pageInfo: { hasNextPage: true },
+                    nodes: [{ login: 'a' }],
+                  },
+                },
+              ],
+            },
+          },
+        })
+        // getTeamMembers (members query returns more than the limit)
+        .mockResolvedValueOnce({
+          organization: {
+            team: {
+              slug: 'team',
+              combinedSlug: 'blah/team',
+              members: {
+                pageInfo: { hasNextPage: false },
+                nodes: [{ login: 'a' }, { login: 'b' }],
+              },
+            },
+          },
+        });
+
+      (createGraphqlClient as jest.Mock).mockReturnValue(mockClient);
+
+      await provider.read();
+
+      expect(connection.applyMutation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          entities: expect.arrayContaining([
+            expect.objectContaining({
+              entity: expect.objectContaining({
+                kind: 'Group',
+                spec: expect.objectContaining({ members: [] }),
+              }),
+            }),
+          ]),
+        }),
+      );
+    });
+
     it('should not apply mutation if a request fails', async () => {
       setupMocks(() => Promise.reject(new Error('Network error')));
 

--- a/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubOrgEntityProvider.ts
@@ -56,6 +56,7 @@ import {
   createRemoveEntitiesOperation,
   createRestClient,
   DEFAULT_PAGE_SIZES,
+  DEFAULT_QUERY_LIMITS,
   DeferredEntitiesBuilder,
   getOrganizationTeam,
   getOrganizationTeams,
@@ -63,6 +64,7 @@ import {
   getOrganizationTeamsFromUsers,
   getOrganizationUsers,
   GithubPageSizes,
+  GithubQueryLimits,
   GithubTeam,
   isGitHubEnterprise,
   isSuspended,
@@ -150,6 +152,12 @@ export interface GithubOrgEntityProviderOptions {
   pageSizes?: Partial<GithubPageSizes>;
 
   /**
+   * Optionally configure query limits for GitHub GraphQL API queries.
+   * Add these max amounts if the job runs for so long that it times out (request headers timeout is 60 minutes)
+   */
+  queryLimits?: Partial<GithubQueryLimits>;
+
+  /**
    * Optionally exclude suspended users when querying organization users.
    * @defaultValue false
    * @remarks
@@ -210,6 +218,7 @@ export class GithubOrgEntityProvider implements EntityProvider {
       teamTransformer: options.teamTransformer,
       events: options.events,
       pageSizes: options.pageSizes,
+      queryLimits: options.queryLimits,
       excludeSuspendedUsers: options.excludeSuspendedUsers,
       cache: options.cache,
       experimental_checkForSuspendedUsersWithRest:
@@ -232,6 +241,7 @@ export class GithubOrgEntityProvider implements EntityProvider {
       userTransformer?: UserTransformer;
       teamTransformer?: TeamTransformer;
       pageSizes?: Partial<GithubPageSizes>;
+      queryLimits?: Partial<GithubQueryLimits>;
       excludeSuspendedUsers?: boolean;
       cache?: CacheService;
       experimental_checkForSuspendedUsersWithRest?: boolean;
@@ -251,6 +261,13 @@ export class GithubOrgEntityProvider implements EntityProvider {
     return {
       ...DEFAULT_PAGE_SIZES,
       ...this.options.pageSizes,
+    };
+  }
+
+  private getQueryLimits(): GithubQueryLimits {
+    return {
+      ...DEFAULT_QUERY_LIMITS,
+      ...this.options.queryLimits,
     };
   }
 
@@ -325,7 +342,7 @@ export class GithubOrgEntityProvider implements EntityProvider {
 
     const { org } = parseGithubOrgUrl(this.options.orgUrl);
     const pageSizes = this.getPageSizes();
-
+    const queryLimits = this.getQueryLimits();
     const { users } = await getOrganizationUsers(
       client,
       org,
@@ -340,6 +357,7 @@ export class GithubOrgEntityProvider implements EntityProvider {
       org,
       this.options.teamTransformer,
       pageSizes,
+      queryLimits,
     );
 
     if (areGroupEntities(teams)) {
@@ -450,6 +468,7 @@ export class GithubOrgEntityProvider implements EntityProvider {
 
     const { org } = parseGithubOrgUrl(this.options.orgUrl);
     const pageSizes = this.getPageSizes();
+    const queryLimits = this.getQueryLimits();
     const { team } = await getOrganizationTeam(
       client,
       org,
@@ -482,6 +501,7 @@ export class GithubOrgEntityProvider implements EntityProvider {
       usersToRebuild.map(u => u.metadata.name),
       this.options.teamTransformer,
       pageSizes,
+      queryLimits,
     );
 
     if (areGroupEntities(teams)) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds a new `queryLimits.teamMembers` configuration option for the GitHub Org provider, which caps the number of team members fetched and imported into the catalog. This helps avoid catalog refresh timeouts for organizations with teams that have thousands of members.

I have experienced this in our GitHub organization - we have several thousands of users and there around 10 teams that contain all users (some administrative ones, not really needed to be in our backstage catalog). Our organization grew over time and at one point, the job that syncs teams and users started to timeout due to 1 hour headers time out. This lets easily filter out those few large teams.

Main logic is in `github.ts` file, the rest is just definition of that new configuration option.

This PR is related to [35202](https://github.com/backstage/backstage/pull/35202) as it also solves issue for large organizations.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
