### PR TITLE
fix(techdocs-cli): explicitly enable mkdocs live reload on serve

### DIFF
--- a/.changeset/silver-pandas-battle.md
+++ b/.changeset/silver-pandas-battle.md
@@ -1,0 +1,5 @@
+---
+'@techdocs/cli': patch
+---
+
+Fixed an issue where `techdocs-cli serve` would silently stop detecting documentation changes and no longer refresh the browser when the Python environment (TechDocs container image or local) contains `click` 8.3.x. The CLI now explicitly enables MkDocs live reload when serving.

--- a/docs/features/techdocs/cli.md
+++ b/docs/features/techdocs/cli.md
@@ -64,6 +64,11 @@ By default, Docker and
 make sure all the dependencies are installed. However, Docker can be disabled
 with `--no-docker` flag.
 
+Note that the `serve` command does not pull the Docker image and keeps using the
+one available locally. If serving misbehaves, for example changes to
+documentation files are no longer detected, update the image with
+`docker pull spotify/techdocs`.
+
 The command starts two local servers - an MkDocs preview server on port 8000 and
 a Backstage app server on port 3000. The Backstage app has a custom TechDocs API
 implementation, which uses the MkDocs preview server as a proxy to fetch the

--- a/packages/techdocs-cli/src/lib/mkdocsServer.test.ts
+++ b/packages/techdocs-cli/src/lib/mkdocsServer.test.ts
@@ -41,6 +41,7 @@ describe('runMkdocsServer', () => {
           'serve',
           '--dev-addr',
           '0.0.0.0:8000',
+          '--livereload',
           'spotify/techdocs',
         ]),
         expect.objectContaining({}),
@@ -91,6 +92,7 @@ describe('runMkdocsServer', () => {
           'serve',
           '--dev-addr',
           '0.0.0.0:8000',
+          '--livereload',
         ]),
         expect.objectContaining({}),
       );
@@ -107,6 +109,7 @@ describe('runMkdocsServer', () => {
           'serve',
           '--dev-addr',
           '0.0.0.0:8000',
+          '--livereload',
           '--clean',
           '--strict',
         ]),
@@ -125,6 +128,7 @@ describe('runMkdocsServer', () => {
           'serve',
           '--dev-addr',
           '127.0.0.1:8000',
+          '--livereload',
         ]),
         expect.objectContaining({}),
       );

--- a/packages/techdocs-cli/src/lib/mkdocsServer.ts
+++ b/packages/techdocs-cli/src/lib/mkdocsServer.ts
@@ -54,6 +54,7 @@ export const runMkdocsServer = (options: {
         'serve',
         '--dev-addr',
         `0.0.0.0:${port}`,
+        '--livereload',
         ...(options.mkdocsConfigFileName
           ? ['--config-file', options.mkdocsConfigFileName]
           : []),
@@ -74,6 +75,7 @@ export const runMkdocsServer = (options: {
       'serve',
       '--dev-addr',
       `127.0.0.1:${port}`,
+      '--livereload',
       ...(options.mkdocsConfigFileName
         ? ['--config-file', options.mkdocsConfigFileName]
         : []),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Click 8.3.x changes the default resolution of mkdocs' `--livereload`/`--no-livereload` flag pair, silently disabling file watching (pallets/click#3403). Pass `--livereload` explicitly so serve is immune to click's version in the environment.

Fixes #34983

Alternative approach: forbid click 8.3.* with mkdocs-techdocs-core package. While it was done in https://github.com/backstage/mkdocs-techdocs-core/pull/321, Renovate bumps could have quietly allowedinstalling click 8.3.* if using a local python environment ore custom image which had other dependencies that restricted click's range.
Belt and suspenders with https://github.com/backstage/mkdocs-techdocs-core/pull/365 and this PR.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
