### PR TITLE
feat(techdocs-node)!: Avoid installing unused cloud provider SDKs

### DIFF
--- a/.changeset/techdocs-cli-optional-cloud-sdks.md
+++ b/.changeset/techdocs-cli-optional-cloud-sdks.md
@@ -1,0 +1,8 @@
+---
+'@techdocs/cli': patch
+---
+
+Declare cloud storage SDKs used by `techdocs-cli publish` (AWS S3, Google Cloud Storage,
+Azure Blob Storage, OpenStack Swift) as optional dependencies. They are still installed by default, but
+installations that only need a subset of providers can now use `--omit=optional` and install just
+the packages they need.

--- a/.changeset/techdocs-node-lazy-cloud-publishers.md
+++ b/.changeset/techdocs-node-lazy-cloud-publishers.md
@@ -1,0 +1,11 @@
+---
+'@backstage/plugin-techdocs-node': major
+---
+
+**BREAKING** Cloud storage SDKs (AWS S3, Google Cloud Storage, Azure Blob Storage, OpenStack Swift)
+are no longer installed automatically with this package, to avoid installing unused dependencies.
+If your `techdocs.publisher.type` is set to `googleGcs`, `awsS3`, `azureBlobStorage`, or
+`openStackSwift`, you must now install the corresponding packages in your backend.
+
+See [Using Cloud Storage for TechDocs generated files](https://backstage.io/docs/features/techdocs/using-cloud-storage)
+for details.

--- a/docs/features/techdocs/cli.md
+++ b/docs/features/techdocs/cli.md
@@ -49,6 +49,15 @@ npm install -g @techdocs/cli
 techdocs-cli [command]
 ```
 
+By default, this installs the SDKs for all cloud storage providers (`awsS3`, `googleGcs`,
+`azureBlobStorage`, `openStackSwift`). If you only publish to one provider,
+you can skip them and add back just the one you need:
+
+```bash
+npm install -g @techdocs/cli --omit=optional
+npm install -g @azure/identity @azure/storage-blob   # Azure only, for example
+```
+
 ## Usage
 
 ### Preview TechDocs site locally in a Backstage like environment

--- a/docs/features/techdocs/configuration.md
+++ b/docs/features/techdocs/configuration.md
@@ -191,6 +191,12 @@ techdocs:
     type: 'local'
 ```
 
+Any option other than `'local'` requires installing the corresponding cloud storage SDK as an
+explicit dependency in your backend package, since these are optional peer dependencies of
+`@backstage/plugin-techdocs-node`. See
+[Using Cloud Storage for TechDocs generated files](./using-cloud-storage.md) for
+the packages to install for each provider.
+
 ### Local Storage
 
 `techdocs.publisher.local`

--- a/docs/features/techdocs/using-cloud-storage.md
+++ b/docs/features/techdocs/using-cloud-storage.md
@@ -20,7 +20,15 @@ Follow the
 [official Google Cloud documentation](https://googleapis.dev/nodejs/storage/latest/index.html#quickstart)
 for the latest instructions on the following steps involving GCP.
 
-**1. Set `techdocs.publisher.type` config in your `app-config.yaml`**
+**1. Install Google Cloud's related packages**
+
+Add `@google-cloud/storage` in your backend package
+
+```shell
+yarn --cwd packages/backend add @google-cloud/storage
+```
+
+**2. Set `techdocs.publisher.type` config in your `app-config.yaml`**
 
 Set `techdocs.publisher.type` to `'googleGcs'`.
 
@@ -30,7 +38,7 @@ techdocs:
     type: 'googleGcs'
 ```
 
-**2. Create a GCS Bucket**
+**3. Create a GCS Bucket**
 
 Create a dedicated Google Cloud Storage bucket for TechDocs sites.
 techdocs-backend will publish documentation to this bucket. TechDocs will fetch
@@ -51,16 +59,16 @@ techdocs:
       projectId: 'name-of-project'
 ```
 
-**3a. (Recommended) Authentication using environment variable**
+**4a. (Recommended) Authentication using environment variable**
 
 The GCS Node.js client will automatically use the environment variable
 `GOOGLE_APPLICATION_CREDENTIALS` to authenticate with Google Cloud. It might
 already be set in Compute Engine, Google Kubernetes Engine, etc. Read
 https://cloud.google.com/docs/authentication/production for more details.
 
-**3b. Authentication using app-config.yaml**
+**4b. Authentication using app-config.yaml**
 
-If you do not prefer (3a) and optionally like to use a service account, you can
+If you do not prefer (4a) and optionally like to use a service account, you can
 follow these steps.
 
 Create a new Service Account and a key associated with it. In roles of the
@@ -115,7 +123,7 @@ techdocs:
       projectId: 'name-of-project'
 ```
 
-**4. That's it!**
+**5. That's it!**
 
 Your Backstage app is now ready to use Google Cloud Storage for TechDocs, to
 store and read the static generated documentation files.
@@ -128,6 +136,8 @@ You can register custom `StorageOptions` that will be used to configure the clie
 need to register publisher settings inside your module init, like in the following example:
 
 ```typescript
+import type { StorageOptions } from '@google-cloud/storage';
+
 export const gcsPublisherCustomizer = createBackendModule({
   pluginId: 'techdocs',
   moduleId: 'gcs-publisher-customizer',
@@ -152,7 +162,22 @@ export const gcsPublisherCustomizer = createBackendModule({
 
 ## Configuring AWS S3 Bucket with TechDocs
 
-**1. Set `techdocs.publisher.type` config in your `app-config.yaml`**
+**1. Install AWS S3's related packages**
+
+Add the AWS S3 packages in your backend package
+
+```
+yarn --cwd packages/backend add \
+  @aws-sdk/client-s3 \
+  @aws-sdk/credential-providers \
+  @aws-sdk/lib-storage \
+  @aws-sdk/types \
+  @backstage/integration-aws-node \
+  @smithy/node-http-handler \
+  hpagent
+```
+
+**2. Set `techdocs.publisher.type` config in your `app-config.yaml`**
 
 Set `techdocs.publisher.type` to `'awsS3'`.
 
@@ -162,7 +187,7 @@ techdocs:
     type: 'awsS3'
 ```
 
-**2. Create an S3 Bucket**
+**3. Create an S3 Bucket**
 
 Create a dedicated AWS S3 bucket for the storage of TechDocs sites.
 [Refer to the official documentation](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/create-bucket.html).
@@ -185,7 +210,7 @@ techdocs:
 /* highlight-add-end */
 ```
 
-**3. Create minimal AWS IAM policies to manage TechDocs**
+**4. Create minimal AWS IAM policies to manage TechDocs**
 
 To _write_ TechDocs into the S3 bucket the IAM policy needs to have at a minimum
 permissions to:
@@ -238,7 +263,7 @@ well as all resources under the bucket. See the example policy below.
 }
 ```
 
-**4a. (Recommended) Setup authentication the AWS way, using environment
+**5a. (Recommended) Setup authentication the AWS way, using environment
 variables**
 
 You should follow the
@@ -254,7 +279,7 @@ If the environment variables
 - `AWS_SECRET_ACCESS_KEY`
 - `AWS_REGION`
 
-are set and can be used to access the bucket you created in step 2, they will be
+are set and can be used to access the bucket you created in step 3, they will be
 used by the AWS SDK V3 Node.js client for authentication.
 [Refer to the official documentation for loading credentials in Node.js from environment variables](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/loading-node-credentials-environment.html).
 
@@ -268,7 +293,7 @@ environment automatically by defining appropriate IAM role with access to the
 bucket. Read more in the
 [official AWS documentation for using IAM roles](https://docs.aws.amazon.com/general/latest/gr/aws-access-keys-best-practices.html#use-roles).
 
-**4b. Authentication using app-config.yaml via aws.accounts**
+**5b. Authentication using app-config.yaml via aws.accounts**
 
 AWS credentials and region can be provided to the AWS SDK via `app-config.yaml`.
 If the configs below are present, they will be used over existing `AWS_*`
@@ -292,7 +317,7 @@ aws:
 Refer to the
 [official AWS documentation for obtaining the credentials](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html).
 
-**4c. Authentication using app-config.yaml via integrations.awsS3**
+**5c. Authentication using app-config.yaml via integrations.awsS3**
 
 If you already have an [AWS S3 integration](../../integrations/aws-s3/locations.md), you can use it to authenticate with AWS S3:
 
@@ -330,7 +355,7 @@ integrations:
       secretAccessKey: ${AWS_SECRET_ACCESS_KEY_2}
 ```
 
-**4d. Authentication using an assumed role** Users with multiple AWS accounts
+**5d. Authentication using an assumed role** Users with multiple AWS accounts
 may want to use a role for S3 storage that is in a different AWS account. Using
 the `roleArn` parameter as seen below, you can instruct the TechDocs publisher
 to assume a role before accessing S3.
@@ -350,7 +375,7 @@ Note: Assuming a role requires that primary credentials are already configured
 at `AWS.config.credentials`. Read more about
 [assuming roles in AWS](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html).
 
-**5. That's it!**
+**6. That's it!**
 
 Your Backstage app is now ready to use AWS S3 for TechDocs, to store and read
 the static generated documentation files. When you start the backend of the app,
@@ -363,7 +388,15 @@ Follow the
 [official Azure Blob Storage documentation](https://docs.microsoft.com/en-us/azure/storage/common/storage-auth?toc=/azure/storage/blobs/toc.json)
 for the latest instructions on the following steps involving Azure Blob Storage.
 
-**1. Set `techdocs.publisher.type` config in your `app-config.yaml`**
+**1. Install Azure Blob Storage related packages**
+
+Add the Azure Blob Storage packages in your backend package
+
+```shell
+yarn --cwd packages/backend add @azure/identity @azure/storage-blob
+```
+
+**2. Set `techdocs.publisher.type` config in your `app-config.yaml`**
 
 Set `techdocs.publisher.type` to `'azureBlobStorage'`.
 
@@ -373,7 +406,7 @@ techdocs:
     type: 'azureBlobStorage'
 ```
 
-**2. Create an Azure Blob Storage Container**
+**3. Create an Azure Blob Storage Container**
 
 Create a dedicated container for TechDocs sites.
 [Refer to the official documentation](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-portal).
@@ -393,7 +426,7 @@ techdocs:
       containerName: 'name-of-techdocs-storage-container'
 ```
 
-**3a. (Recommended) Authentication using environment variable**
+**4a. (Recommended) Authentication using environment variable**
 
 The Azure Blob Storage client in Backstage supports all credential types
 provided by
@@ -439,9 +472,9 @@ For more details, see the
 and
 [Workload Identity Federation for Kubernetes](https://learn.microsoft.com/en-us/azure/active-directory/workload-identities/workload-identity-federation-overview).
 
-**3b. Authentication using app-config.yaml**
+**4b. Authentication using app-config.yaml**
 
-If you do not prefer (3a) and optionally like to use key-based access, you can
+If you do not prefer (4a) and optionally like to use key-based access, you can
 follow these steps.
 
 To get credentials, access the Azure Portal and go to "Settings > Access Keys",
@@ -466,7 +499,7 @@ applied, in order to read, write, and delete objects as needed, unless you use
 an external publisher, in this case the `Storage Blob Data Reader` role is
 sufficient.
 
-**4. That's it!**
+**5. That's it!**
 
 Your Backstage app is now ready to use Azure Blob Storage for TechDocs, to store
 and read the static generated documentation files. When you start the backend of
@@ -480,7 +513,15 @@ Follow the
 [official OpenStack Api documentation](https://docs.openstack.org/api-ref/identity/v3/)
 for the latest instructions on the following steps involving OpenStack Storage.
 
-**1. Set `techdocs.publisher.type` config in your `app-config.yaml`**
+**1. Install OpenStack Swift related packages**
+
+Add the OpenStack Swift packages in your backend package
+
+```shell
+yarn --cwd packages/backend add @trendyol-js/openstack-swift-sdk
+```
+
+**2. Set `techdocs.publisher.type` config in your `app-config.yaml`**
 
 Set `techdocs.publisher.type` to `'openStackSwift'`.
 
@@ -490,7 +531,7 @@ techdocs:
     type: 'openStackSwift'
 ```
 
-**2. Create an OpenStack Swift Storage Container**
+**3. Create an OpenStack Swift Storage Container**
 
 Create a dedicated container for TechDocs sites.
 [Refer to the official documentation](https://docs.openstack.org/mitaka/user-guide/dashboard_manage_containers.html).
@@ -510,7 +551,7 @@ techdocs:
       containerName: 'name-of-techdocs-storage-container'
 ```
 
-**3. Authentication using app-config.yaml**
+**4. Authentication using app-config.yaml**
 
 Set the configs in your `app-config.yaml` to point to your container name.
 
@@ -530,7 +571,7 @@ techdocs:
       swiftUrl: ${OPENSTACK_SWIFT_STORAGE_SWIFT_URL}
 ```
 
-**4. That's it!**
+**5. That's it!**
 
 Your Backstage app is now ready to use OpenStack Swift Storage for TechDocs, to
 store and read the static generated documentation files. When you start the

--- a/packages/techdocs-cli/package.json
+++ b/packages/techdocs-cli/package.json
@@ -66,5 +66,18 @@
     "find-process": "^2.0.0",
     "nodemon": "^3.0.1",
     "techdocs-cli-embedded-app": "link:../techdocs-cli-embedded-app"
+  },
+  "optionalDependencies": {
+    "@aws-sdk/client-s3": "^3.350.0",
+    "@aws-sdk/credential-providers": "^3.350.0",
+    "@aws-sdk/lib-storage": "^3.350.0",
+    "@aws-sdk/types": "^3.347.0",
+    "@azure/identity": "^4.0.0",
+    "@azure/storage-blob": "^12.5.0",
+    "@backstage/integration-aws-node": "workspace:^",
+    "@google-cloud/storage": "^7.0.0",
+    "@smithy/node-http-handler": "^3.0.0",
+    "@trendyol-js/openstack-swift-sdk": "^0.0.7",
+    "hpagent": "^1.2.0"
   }
 }

--- a/plugins/techdocs-node/package.json
+++ b/plugins/techdocs-node/package.json
@@ -47,29 +47,18 @@
     "test": "backstage-cli package test"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.350.0",
-    "@aws-sdk/credential-providers": "^3.350.0",
-    "@aws-sdk/lib-storage": "^3.350.0",
-    "@aws-sdk/types": "^3.347.0",
-    "@azure/identity": "^4.0.0",
-    "@azure/storage-blob": "^12.5.0",
     "@backstage/backend-plugin-api": "workspace:^",
     "@backstage/catalog-model": "workspace:^",
     "@backstage/config": "workspace:^",
     "@backstage/errors": "workspace:^",
     "@backstage/integration": "workspace:^",
-    "@backstage/integration-aws-node": "workspace:^",
     "@backstage/plugin-search-common": "workspace:^",
     "@backstage/plugin-techdocs-common": "workspace:^",
-    "@google-cloud/storage": "^7.0.0",
-    "@smithy/node-http-handler": "^3.0.0",
-    "@trendyol-js/openstack-swift-sdk": "^0.0.7",
     "@types/express": "^4.17.6",
     "dockerode": "^4.0.0",
     "express": "^4.22.0",
     "fs-extra": "^11.2.0",
     "git-url-parse": "^15.0.0",
-    "hpagent": "^1.2.0",
     "js-yaml": "^4.3.0",
     "json5": "^2.1.3",
     "mime-types": "^2.1.27",
@@ -78,13 +67,72 @@
     "winston": "^3.2.1"
   },
   "devDependencies": {
+    "@aws-sdk/client-s3": "^3.350.0",
+    "@aws-sdk/credential-providers": "^3.350.0",
+    "@aws-sdk/lib-storage": "^3.350.0",
+    "@aws-sdk/types": "^3.347.0",
+    "@azure/identity": "^4.0.0",
+    "@azure/storage-blob": "^12.5.0",
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
+    "@backstage/integration-aws-node": "workspace:^",
+    "@google-cloud/storage": "^7.0.0",
+    "@smithy/node-http-handler": "^3.0.0",
+    "@trendyol-js/openstack-swift-sdk": "^0.0.7",
     "@types/fs-extra": "^11.0.0",
     "@types/js-yaml": "^4.0.0",
     "@types/mime-types": "^2.1.0",
     "@types/recursive-readdir": "^2.2.0",
     "@types/supertest": "^2.0.8",
+    "hpagent": "^1.2.0",
     "supertest": "^7.0.0"
+  },
+  "peerDependencies": {
+    "@aws-sdk/client-s3": "^3.350.0",
+    "@aws-sdk/credential-providers": "^3.350.0",
+    "@aws-sdk/lib-storage": "^3.350.0",
+    "@aws-sdk/types": "^3.347.0",
+    "@azure/identity": "^4.0.0",
+    "@azure/storage-blob": "^12.5.0",
+    "@backstage/integration-aws-node": "workspace:^",
+    "@google-cloud/storage": "^7.0.0",
+    "@smithy/node-http-handler": "^3.0.0",
+    "@trendyol-js/openstack-swift-sdk": "^0.0.7",
+    "hpagent": "^1.2.0"
+  },
+  "peerDependenciesMeta": {
+    "@aws-sdk/client-s3": {
+      "optional": true
+    },
+    "@aws-sdk/credential-providers": {
+      "optional": true
+    },
+    "@aws-sdk/lib-storage": {
+      "optional": true
+    },
+    "@aws-sdk/types": {
+      "optional": true
+    },
+    "@azure/identity": {
+      "optional": true
+    },
+    "@azure/storage-blob": {
+      "optional": true
+    },
+    "@backstage/integration-aws-node": {
+      "optional": true
+    },
+    "@google-cloud/storage": {
+      "optional": true
+    },
+    "@smithy/node-http-handler": {
+      "optional": true
+    },
+    "@trendyol-js/openstack-swift-sdk": {
+      "optional": true
+    },
+    "hpagent": {
+      "optional": true
+    }
   }
 }

--- a/plugins/techdocs-node/report.api.md
+++ b/plugins/techdocs-node/report.api.md
@@ -13,7 +13,6 @@ import { IndexableDocument } from '@backstage/plugin-search-common';
 import { Logger } from 'winston';
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { ScmIntegrationRegistry } from '@backstage/integration';
-import { StorageOptions } from '@google-cloud/storage';
 import { UrlReaderService } from '@backstage/backend-plugin-api';
 import * as winston from 'winston';
 import { Writable } from 'node:stream';
@@ -219,8 +218,7 @@ export type PublisherFactory = {
 
 // @public
 export interface PublisherSettings {
-  // (undocumented)
-  googleGcs?: StorageOptions;
+  googleGcs?: unknown;
 }
 
 // @public

--- a/plugins/techdocs-node/src/stages/publish/googleStorage.ts
+++ b/plugins/techdocs-node/src/stages/publish/googleStorage.ts
@@ -71,7 +71,7 @@ export class GoogleGCSPublish implements PublisherBase {
   static fromConfig(
     config: Config,
     logger: LoggerService,
-    options?: StorageOptions,
+    options?: unknown,
   ): PublisherBase {
     let bucketName = '';
     try {
@@ -107,7 +107,7 @@ export class GoogleGCSPublish implements PublisherBase {
       }
     }
 
-    const clientOpts: StorageOptions = options ?? {};
+    const clientOpts = (options ?? {}) as StorageOptions;
     if (projectId) {
       clientOpts.projectId = projectId;
     }

--- a/plugins/techdocs-node/src/stages/publish/publish.test.ts
+++ b/plugins/techdocs-node/src/stages/publish/publish.test.ts
@@ -35,10 +35,6 @@ jest.mock('@azure/identity', () => ({
 }));
 
 describe('Publisher', () => {
-  beforeEach(() => {
-    jest.resetModules(); // clear the cache
-  });
-
   it('should create local publisher by default', async () => {
     const mockConfig = new ConfigReader({});
 

--- a/plugins/techdocs-node/src/stages/publish/publish.ts
+++ b/plugins/techdocs-node/src/stages/publish/publish.ts
@@ -15,11 +15,8 @@
  */
 
 import { Config } from '@backstage/config';
-import { AwsS3Publish } from './awsS3';
-import { AzureBlobStoragePublish } from './azureBlobStorage';
-import { GoogleGCSPublish } from './googleStorage';
+import { ForwardedError } from '@backstage/errors';
 import { LocalPublish } from './local';
-import { OpenStackSwiftPublish } from './openStackSwift';
 import {
   PublisherFactory,
   PublisherBase,
@@ -82,8 +79,18 @@ export class Publisher implements PublisherBuilder {
     ) ?? 'local') as PublisherType;
 
     switch (publisherType) {
-      case 'googleGcs':
+      case 'googleGcs': {
         logger.info('Creating Google Storage Bucket publisher for TechDocs');
+        const { GoogleGCSPublish } = await import('./googleStorage').catch(
+          error => {
+            throw new ForwardedError(
+              `Failed to load the Google Cloud Storage TechDocs publisher, which requires ` +
+                `'@google-cloud/storage'. It must be installed as an explicit dependency in ` +
+                `your project`,
+              error,
+            );
+          },
+        );
         publishers.register(
           publisherType,
           GoogleGCSPublish.fromConfig(
@@ -93,31 +100,64 @@ export class Publisher implements PublisherBuilder {
           ),
         );
         break;
-      case 'awsS3':
+      }
+      case 'awsS3': {
         logger.info('Creating AWS S3 Bucket publisher for TechDocs');
+        const { AwsS3Publish } = await import('./awsS3').catch(error => {
+          throw new ForwardedError(
+            `Failed to load the AWS S3 TechDocs publisher, which requires ` +
+              `'@aws-sdk/client-s3', '@aws-sdk/credential-providers', '@aws-sdk/lib-storage', ` +
+              `'@aws-sdk/types', '@backstage/integration-aws-node', '@smithy/node-http-handler' ` +
+              `and 'hpagent'. They must be installed as explicit dependencies in your project`,
+            error,
+          );
+        });
         publishers.register(
           publisherType,
           await AwsS3Publish.fromConfig(config, logger),
         );
         break;
-      case 'azureBlobStorage':
+      }
+      case 'azureBlobStorage': {
         logger.info(
           'Creating Azure Blob Storage Container publisher for TechDocs',
         );
+        const { AzureBlobStoragePublish } = await import(
+          './azureBlobStorage'
+        ).catch(error => {
+          throw new ForwardedError(
+            `Failed to load the Azure Blob Storage TechDocs publisher, which requires ` +
+              `'@azure/identity' and '@azure/storage-blob'. They must be installed as ` +
+              `explicit dependencies in your project`,
+            error,
+          );
+        });
         publishers.register(
           publisherType,
           AzureBlobStoragePublish.fromConfig(config, logger),
         );
         break;
-      case 'openStackSwift':
+      }
+      case 'openStackSwift': {
         logger.info(
           'Creating OpenStack Swift Container publisher for TechDocs',
         );
+        const { OpenStackSwiftPublish } = await import(
+          './openStackSwift'
+        ).catch(error => {
+          throw new ForwardedError(
+            `Failed to load the OpenStack Swift TechDocs publisher, which requires ` +
+              `'@trendyol-js/openstack-swift-sdk'. It must be installed as an explicit ` +
+              `dependency in your project`,
+            error,
+          );
+        });
         publishers.register(
           publisherType,
           OpenStackSwiftPublish.fromConfig(config, logger),
         );
         break;
+      }
       case 'local':
         logger.info('Creating Local publisher for TechDocs');
         publishers.register(

--- a/plugins/techdocs-node/src/stages/publish/types.ts
+++ b/plugins/techdocs-node/src/stages/publish/types.ts
@@ -17,7 +17,6 @@ import express from 'express';
 import { Config } from '@backstage/config';
 import { DiscoveryService, LoggerService } from '@backstage/backend-plugin-api';
 import { Entity, CompoundEntityRef } from '@backstage/catalog-model';
-import { StorageOptions } from '@google-cloud/storage';
 
 /**
  * Options for building publishers
@@ -35,7 +34,12 @@ export type PublisherFactory = {
  * @public
  */
 export interface PublisherSettings {
-  googleGcs?: StorageOptions;
+  /**
+   * Intentionally typed as `unknown` rather than `StorageOptions`, to
+   * avoid exposing a type from `@google-cloud/storage` in this package's
+   * public API.
+   */
+  googleGcs?: unknown;
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -7301,6 +7301,41 @@ __metadata:
     recursive-readdir: "npm:^2.2.2"
     supertest: "npm:^7.0.0"
     winston: "npm:^3.2.1"
+  peerDependencies:
+    "@aws-sdk/client-s3": ^3.350.0
+    "@aws-sdk/credential-providers": ^3.350.0
+    "@aws-sdk/lib-storage": ^3.350.0
+    "@aws-sdk/types": ^3.347.0
+    "@azure/identity": ^4.0.0
+    "@azure/storage-blob": ^12.5.0
+    "@backstage/integration-aws-node": "workspace:^"
+    "@google-cloud/storage": ^7.0.0
+    "@smithy/node-http-handler": ^3.0.0
+    "@trendyol-js/openstack-swift-sdk": ^0.0.7
+    hpagent: ^1.2.0
+  peerDependenciesMeta:
+    "@aws-sdk/client-s3":
+      optional: true
+    "@aws-sdk/credential-providers":
+      optional: true
+    "@aws-sdk/lib-storage":
+      optional: true
+    "@aws-sdk/types":
+      optional: true
+    "@azure/identity":
+      optional: true
+    "@azure/storage-blob":
+      optional: true
+    "@backstage/integration-aws-node":
+      optional: true
+    "@google-cloud/storage":
+      optional: true
+    "@smithy/node-http-handler":
+      optional: true
+    "@trendyol-js/openstack-swift-sdk":
+      optional: true
+    hpagent:
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -18341,12 +18376,22 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@techdocs/cli@workspace:packages/techdocs-cli"
   dependencies:
+    "@aws-sdk/client-s3": "npm:^3.350.0"
+    "@aws-sdk/credential-providers": "npm:^3.350.0"
+    "@aws-sdk/lib-storage": "npm:^3.350.0"
+    "@aws-sdk/types": "npm:^3.347.0"
+    "@azure/identity": "npm:^4.0.0"
+    "@azure/storage-blob": "npm:^12.5.0"
     "@backstage/backend-defaults": "workspace:^"
     "@backstage/catalog-model": "workspace:^"
     "@backstage/cli": "workspace:^"
     "@backstage/cli-common": "workspace:^"
     "@backstage/config": "workspace:^"
+    "@backstage/integration-aws-node": "workspace:^"
     "@backstage/plugin-techdocs-node": "workspace:^"
+    "@google-cloud/storage": "npm:^7.0.0"
+    "@smithy/node-http-handler": "npm:^3.0.0"
+    "@trendyol-js/openstack-swift-sdk": "npm:^0.0.7"
     "@types/fs-extra": "npm:^11.0.0"
     "@types/http-proxy": "npm:^1.17.4"
     "@types/node": "npm:^22.13.14"
@@ -18355,12 +18400,36 @@ __metadata:
     commander: "npm:^14.0.3"
     find-process: "npm:^2.0.0"
     fs-extra: "npm:^11.0.0"
+    hpagent: "npm:^1.2.0"
     http-proxy: "npm:^1.18.1"
     nodemon: "npm:^3.0.1"
     react-dev-utils: "npm:^12.0.0-next.60"
     serve-handler: "npm:^6.1.3"
     techdocs-cli-embedded-app: "link:../techdocs-cli-embedded-app"
     winston: "npm:^3.2.1"
+  dependenciesMeta:
+    "@aws-sdk/client-s3":
+      optional: true
+    "@aws-sdk/credential-providers":
+      optional: true
+    "@aws-sdk/lib-storage":
+      optional: true
+    "@aws-sdk/types":
+      optional: true
+    "@azure/identity":
+      optional: true
+    "@azure/storage-blob":
+      optional: true
+    "@backstage/integration-aws-node":
+      optional: true
+    "@google-cloud/storage":
+      optional: true
+    "@smithy/node-http-handler":
+      optional: true
+    "@trendyol-js/openstack-swift-sdk":
+      optional: true
+    hpagent:
+      optional: true
   bin:
     techdocs-cli: bin/techdocs-cli
   languageName: unknown


### PR DESCRIPTION
## Hey, I just made a Pull Request!

After the chat with @awanlin in #33577, this attempts to follow [their guidance](https://github.com/backstage/backstage/issues/33577#issuecomment-5174418524).

Techdocs should not depend on all cloud provider SDKs by default: allow the users to install only the required dependencies directly.

There are some implementation parts where I guessed the approach, but I'd really appreciate if a maintainer could verify those, or course correct. Highlighting them for visibility:
- `techdocs-cli` now requires (duplicates?) `techdocs-node`'s dependencies, to avoid a breaking change in the cli. I don't like having the list of dependencies in 2 places though.
- Some sdk's are easier to install than others: Amazon's S3 requires 7-8 libraries, and it doesn't look right to add all of that as a list of peerDependencies. I thought about creating a package (`techdocs-node-aws-s3`) and just listing that dependency, but that looked like a larger change, and I wanted to align on an approach first.
- PR #26836 exposed google cloud's `StorageOptions` in the package public API, as a type. I've change that to `undefined` and updated the docs to exemplify how typing can still be enforced. But I'm unsure if we want to go down this route or you have any other ideas.


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
