### PR TITLE
fix(scaffolder): validate example template component name against entity-name format

### DIFF
--- a/.changeset/shaky-beers-shave.md
+++ b/.changeset/shaky-beers-shave.md
@@ -1,0 +1,5 @@
+---
+'@backstage/create-app': patch
+---
+
+Fixed the example scaffolder template so the component name field validates against the allowed entity-name format, preventing names with spaces that would fail catalog registration.

--- a/packages/create-app/templates/default-app/examples/template/template.yaml
+++ b/packages/create-app/templates/default-app/examples/template/template.yaml
@@ -20,9 +20,8 @@ spec:
           title: Name
           type: string
           description: Unique name of the component
+          ui:field: EntityNamePicker
           ui:autofocus: true
-          ui:options:
-            rows: 5
     - title: Choose a location
       required:
         - repoUrl

--- a/packages/create-app/templates/legacy-app/examples/template/template.yaml
+++ b/packages/create-app/templates/legacy-app/examples/template/template.yaml
@@ -20,9 +20,8 @@ spec:
           title: Name
           type: string
           description: Unique name of the component
+          ui:field: EntityNamePicker
           ui:autofocus: true
-          ui:options:
-            rows: 5
     - title: Choose a location
       required:
         - repoUrl


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The `name` field in the example scaffolder template was a plain string input with no validation, so the form accepted values containing spaces. That value is templated straight into `metadata.name` of the generated `catalog-info.yaml`, which the catalog backend validates against the entity-name format (`isValidObjectName` - alphanumerics plus `-`, `_`, `.`, must start/end alphanumeric, max 63 chars). A name with spaces passes the form but then fails at the `catalog:register` step - and because `publish` runs before `register`, the user is left with a created repo and a failed registration.

This switches the `name` field to `ui:field: EntityNamePicker`, which validates input in the form against the same rule the backend enforces, so invalid names are caught immediately with a clear message. It also removes the leftover `ui:options.rows: 5` textarea config, which doesn't belong on a single-line name field.

Applied to both the `default-app` and `legacy-app` templates so they stay consistent.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

<img width="1413" height="766" alt="Screenshot 2026-08-08 at 22 50 36" src="https://github.com/user-attachments/assets/4578f212-2bf5-44c6-85dc-2c3c6a31fe63" />

