### PR TITLE
chore(app-legacy): Migrate to MSW 2

### DIFF
--- a/.env.sentry-build-plugin
+++ b/.env.sentry-build-plugin
@@ -1,0 +1,5 @@
+# DO NOT commit this file to your repository!
+# The SENTRY_AUTH_TOKEN variable is picked up by the Sentry Build Plugin.
+# It's used for authentication when uploading source maps.
+# You can also set this env variable in your own `.env` files and remove this file.
+SENTRY_AUTH_TOKEN=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

--- a/packages/cli-module-migrate/package.json
+++ b/packages/cli-module-migrate/package.json
@@ -52,6 +52,6 @@
     "@backstage/test-utils": "workspace:^",
     "@types/fs-extra": "^11.0.0",
     "@types/semver": "^7",
-    "msw": "^1.0.0"
+    "msw": "^2.0.0"
   }
 }

--- a/packages/cli-module-migrate/src/commands/versions/bump.test.ts
+++ b/packages/cli-module-migrate/src/commands/versions/bump.test.ts
@@ -20,7 +20,7 @@ import bump, { bumpBackstageJsonVersion, createVersionFinder } from './bump';
 import { registerMswTestHooks, withLogCollector } from '@backstage/test-utils';
 import { YarnInfoInspectData } from '../../lib/versioning/packages';
 import { setupServer } from 'msw/node';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { NotFoundError } from '@backstage/errors';
 import { createMockDirectory } from '@backstage/backend-test-utils';
 
@@ -170,15 +170,8 @@ describe('bump', () => {
       waitForExit: jest.fn().mockResolvedValue(undefined),
     } as any);
     worker.use(
-      rest.get(
-        'https://versions.backstage.io/v1/tags/main/manifest.json',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.json({
-              packages: [],
-            }),
-          ),
+      http.get('https://versions.backstage.io/v1/tags/main/manifest.json', () =>
+        HttpResponse.json({ packages: [] }),
       ),
     );
     const { log: logs } = await withLogCollector(['log', 'warn'], async () => {
@@ -263,15 +256,10 @@ describe('bump', () => {
       waitForExit: jest.fn().mockResolvedValue(undefined),
     } as any);
     worker.use(
-      rest.get(
-        'https://versions.backstage.io/v1/tags/main/manifest.json',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.json({
-              packages: [],
-            }),
-          ),
+      http.get('https://versions.backstage.io/v1/tags/main/manifest.json', () =>
+        HttpResponse.json({
+          packages: [],
+        }),
       ),
     );
     const { log: logs } = await withLogCollector(['log', 'warn'], async () => {
@@ -355,25 +343,20 @@ describe('bump', () => {
       waitForExit: jest.fn().mockResolvedValue(undefined),
     } as any);
     worker.use(
-      rest.get(
-        'https://versions.backstage.io/v1/tags/main/manifest.json',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.json({
-              releaseVersion: '0.0.1',
-              packages: [
-                {
-                  name: '@backstage/theme',
-                  version: '5.0.0',
-                },
-                {
-                  name: '@backstage/create-app',
-                  version: '3.0.0',
-                },
-              ],
-            }),
-          ),
+      http.get('https://versions.backstage.io/v1/tags/main/manifest.json', () =>
+        HttpResponse.json({
+          releaseVersion: '0.0.1',
+          packages: [
+            {
+              name: '@backstage/theme',
+              version: '5.0.0',
+            },
+            {
+              name: '@backstage/create-app',
+              version: '3.0.0',
+            },
+          ],
+        }),
       ),
     );
     const { log: logs } = await withLogCollector(['log', 'warn'], async () => {
@@ -459,25 +442,20 @@ describe('bump', () => {
       waitForExit: jest.fn().mockResolvedValue(undefined),
     } as any);
     worker.use(
-      rest.get(
-        'https://versions.backstage.io/v1/tags/main/manifest.json',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.json({
-              releaseVersion: '0.0.1',
-              packages: [
-                {
-                  name: '@backstage/theme',
-                  version: '5.0.0',
-                },
-                {
-                  name: '@backstage/create-app',
-                  version: '3.0.0',
-                },
-              ],
-            }),
-          ),
+      http.get('https://versions.backstage.io/v1/tags/main/manifest.json', () =>
+        HttpResponse.json({
+          releaseVersion: '0.0.1',
+          packages: [
+            {
+              name: '@backstage/theme',
+              version: '5.0.0',
+            },
+            {
+              name: '@backstage/create-app',
+              version: '3.0.0',
+            },
+          ],
+        }),
       ),
     );
     const { log: logs } = await withLogCollector(['log', 'warn'], async () => {
@@ -570,9 +548,9 @@ describe('bump', () => {
       waitForExit: jest.fn().mockResolvedValue(undefined),
     } as any);
     worker.use(
-      rest.get(
+      http.get(
         'https://versions.backstage.io/v1/releases/999.0.1/manifest.json',
-        (_, res, ctx) => res(ctx.status(404), ctx.json({})),
+        () => HttpResponse.json({}, { status: 404 }),
       ),
     );
     const { log: logs } = await withLogCollector(['log', 'warn'], async () => {
@@ -640,45 +618,35 @@ describe('bump', () => {
       waitForExit: jest.fn().mockResolvedValue(undefined),
     } as any);
     worker.use(
-      rest.get(
-        'https://versions.backstage.io/v1/tags/main/manifest.json',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.json({
-              releaseVersion: '1.0.0',
-              packages: [
-                {
-                  name: '@backstage/theme',
-                  version: '5.0.0',
-                },
-                {
-                  name: '@backstage/create-app',
-                  version: '3.0.0',
-                },
-              ],
-            }),
-          ),
+      http.get('https://versions.backstage.io/v1/tags/main/manifest.json', () =>
+        HttpResponse.json({
+          releaseVersion: '1.0.0',
+          packages: [
+            {
+              name: '@backstage/theme',
+              version: '5.0.0',
+            },
+            {
+              name: '@backstage/create-app',
+              version: '3.0.0',
+            },
+          ],
+        }),
       ),
-      rest.get(
-        'https://versions.backstage.io/v1/tags/next/manifest.json',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.json({
-              releaseVersion: '1.0.0-next.1',
-              packages: [
-                {
-                  name: '@backstage/theme',
-                  version: '4.0.0',
-                },
-                {
-                  name: '@backstage/create-app',
-                  version: '2.0.0',
-                },
-              ],
-            }),
-          ),
+      http.get('https://versions.backstage.io/v1/tags/next/manifest.json', () =>
+        HttpResponse.json({
+          releaseVersion: '1.0.0-next.1',
+          packages: [
+            {
+              name: '@backstage/theme',
+              version: '4.0.0',
+            },
+            {
+              name: '@backstage/create-app',
+              version: '2.0.0',
+            },
+          ],
+        }),
       ),
     );
     const { log: logs } = await withLogCollector(['log', 'warn'], async () => {
@@ -748,16 +716,11 @@ describe('bump', () => {
       waitForExit: jest.fn().mockResolvedValue(undefined),
     } as any);
     worker.use(
-      rest.get(
-        'https://versions.backstage.io/v1/tags/main/manifest.json',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.json({
-              releaseVersion: '1.0.0',
-              packages: [],
-            }),
-          ),
+      http.get('https://versions.backstage.io/v1/tags/main/manifest.json', () =>
+        HttpResponse.json({
+          releaseVersion: '1.0.0',
+          packages: [],
+        }),
       ),
     );
     const { log: logs } = await withLogCollector(['log', 'warn'], async () => {
@@ -863,15 +826,10 @@ describe('bump', () => {
       waitForExit: jest.fn().mockResolvedValue(undefined),
     } as any);
     worker.use(
-      rest.get(
-        'https://versions.backstage.io/v1/tags/main/manifest.json',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.json({
-              packages: [],
-            }),
-          ),
+      http.get('https://versions.backstage.io/v1/tags/main/manifest.json', () =>
+        HttpResponse.json({
+          packages: [],
+        }),
       ),
     );
     const { log: logs } = await withLogCollector(['log', 'warn'], async () => {
@@ -1095,21 +1053,16 @@ describe('environment variables', () => {
       waitForExit: jest.fn().mockResolvedValue(undefined),
     } as any);
     worker.use(
-      rest.get(
-        'https://custom.example.com/v1/tags/main/manifest.json',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.json({
-              releaseVersion: '1.5.0',
-              packages: [
-                {
-                  name: '@backstage/core',
-                  version: '1.5.0',
-                },
-              ],
-            }),
-          ),
+      http.get('https://custom.example.com/v1/tags/main/manifest.json', () =>
+        HttpResponse.json({
+          releaseVersion: '1.5.0',
+          packages: [
+            {
+              name: '@backstage/core',
+              version: '1.5.0',
+            },
+          ],
+        }),
       ),
     );
 
@@ -1254,21 +1207,16 @@ describe('environment variables', () => {
       waitForExit: jest.fn().mockResolvedValue(undefined),
     } as any);
     worker.use(
-      rest.get(
-        'https://custom.example.com/v1/tags/main/manifest.json',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.json({
-              releaseVersion: '1.5.0',
-              packages: [
-                {
-                  name: '@backstage/core',
-                  version: '1.5.0',
-                },
-              ],
-            }),
-          ),
+      http.get('https://custom.example.com/v1/tags/main/manifest.json', () =>
+        HttpResponse.json({
+          releaseVersion: '1.5.0',
+          packages: [
+            {
+              name: '@backstage/core',
+              version: '1.5.0',
+            },
+          ],
+        }),
       ),
     );
 
@@ -1344,9 +1292,8 @@ describe('environment variables', () => {
     });
 
     worker.use(
-      rest.get(
-        'https://custom.example.com/v1/tags/main/manifest.json',
-        (_, res, ctx) => res(ctx.status(500), ctx.json({})),
+      http.get('https://custom.example.com/v1/tags/main/manifest.json', () =>
+        HttpResponse.json({}, { status: 500 }),
       ),
     );
 

--- a/packages/core-app-api/package.json
+++ b/packages/core-app-api/package.json
@@ -70,7 +70,7 @@
     "@testing-library/user-event": "^14.0.0",
     "@types/react": "^18.0.0",
     "@types/zen-observable": "^0.8.0",
-    "msw": "^1.0.0",
+    "msw": "^2.0.0",
     "react": "^18.0.2",
     "react-dom": "^18.0.2",
     "react-router-beta": "npm:react-router@6.0.0-beta.0",

--- a/packages/core-app-api/src/apis/implementations/auth/microsoft/MicrosoftAuth.test.ts
+++ b/packages/core-app-api/src/apis/implementations/auth/microsoft/MicrosoftAuth.test.ts
@@ -21,7 +21,7 @@ import { ConfigReader } from '@backstage/config';
 import { microsoftAuthApiRef } from '@backstage/core-plugin-api';
 import { registerMswTestHooks } from '@backstage/test-utils';
 import { setupServer } from 'msw/node';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 
 describe('MicrosoftAuth', () => {
   const server = setupServer();
@@ -37,18 +37,16 @@ describe('MicrosoftAuth', () => {
   describe('with a refresh token', () => {
     beforeEach(() => {
       server.use(
-        rest.get(
+        http.get(
           'http://backstage.test/api/auth/microsoft/refresh',
-          async (req, res, ctx) => {
-            const scopeParam = req.url.searchParams.get('scope');
-            return res(
-              ctx.json({
-                providerInfo: {
-                  accessToken: `token:${scopeParam}`,
-                  scope: scopeParam || 'grant-resource/scope',
-                },
-              }),
-            );
+          async ({ request }) => {
+            const scopeParam = new URL(request.url).searchParams.get('scope');
+            return HttpResponse.json({
+              providerInfo: {
+                accessToken: `token:${scopeParam}`,
+                scope: scopeParam || 'grant-resource/scope',
+              },
+            });
           },
         ),
       );
@@ -108,32 +106,29 @@ describe('MicrosoftAuth', () => {
         ),
       });
       server.use(
-        rest.get(
-          'http://backstage.test/api/auth/microsoft/refresh',
-          (_, res, ctx) => {
-            return res(
-              ctx.status(401),
-              ctx.json({
-                error: {
-                  name: 'AuthenticationError',
-                  message:
-                    'Refresh failed; caused by InputError: Missing session cookie',
-                  cause: {
-                    name: 'InputError',
-                    message: 'Missing session cookie',
-                  },
+        http.get('http://backstage.test/api/auth/microsoft/refresh', () => {
+          HttpResponse.json(
+            {
+              error: {
+                name: 'AuthenticationError',
+                message:
+                  'Refresh failed; caused by InputError: Missing session cookie',
+                cause: {
+                  name: 'InputError',
+                  message: 'Missing session cookie',
                 },
-                request: {
-                  method: 'GET',
-                  url: '/api/auth/microsoft/refresh?env=development',
-                },
-                response: {
-                  statusCode: 401,
-                },
-              }),
-            );
-          },
-        ),
+              },
+              request: {
+                method: 'GET',
+                url: '/api/auth/microsoft/refresh?env=development',
+              },
+              response: {
+                statusCode: 401,
+              },
+            },
+            { status: 401 },
+          );
+        }),
       );
     });
 

--- a/packages/core-app-api/src/app/AppManager.test.tsx
+++ b/packages/core-app-api/src/app/AppManager.test.tsx
@@ -24,7 +24,7 @@ import {
 import { screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { setupServer } from 'msw/node';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { PropsWithChildren, ReactNode } from 'react';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import {
@@ -848,13 +848,10 @@ describe('Integration Test', () => {
   it('should clear app cookie when the user logs out', async () => {
     const logoutSignal = jest.fn();
     server.use(
-      rest.delete(
-        'http://localhost:7007/app/.backstage/auth/v1/cookie',
-        (_req, res, ctx) => {
-          logoutSignal();
-          return res(ctx.status(200));
-        },
-      ),
+      http.delete('http://localhost:7007/app/.backstage/auth/v1/cookie', () => {
+        logoutSignal();
+        return HttpResponse.json({}, { status: 200 });
+      }),
     );
 
     const meta = global.document.createElement('meta');

--- a/packages/core-app-api/src/lib/AuthConnector/DefaultAuthConnector.test.ts
+++ b/packages/core-app-api/src/lib/AuthConnector/DefaultAuthConnector.test.ts
@@ -20,7 +20,7 @@ import * as loginPopup from '../loginPopup';
 import { UrlPatternDiscovery } from '../../apis';
 import { registerMswTestHooks } from '@backstage/test-utils';
 import { setupServer } from 'msw/node';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { ConfigReader } from '@backstage/config';
 import { ConfigApi } from '@backstage/core-plugin-api';
 
@@ -61,16 +61,15 @@ describe('DefaultAuthConnector', () => {
 
   it('should refresh a session with scope', async () => {
     server.use(
-      rest.get('*', (req, res, ctx) =>
-        res(
-          ctx.json({
-            idToken: 'mock-id-token',
-            accessToken: 'mock-access-token',
-            scopes: req.url.searchParams.get('scope') || 'default-scope',
-            expiresInSeconds: '60',
-          }),
-        ),
-      ),
+      http.get('*', ({ request }) => {
+        const url = new URL(request.url);
+        return HttpResponse.json({
+          idToken: 'mock-id-token',
+          accessToken: 'mock-access-token',
+          scopes: url.searchParams.get('scope') || 'default-scope',
+          expiresInSeconds: '60',
+        });
+      }),
     );
 
     const connector = new DefaultAuthConnector<any>(defaultOptions);
@@ -86,8 +85,13 @@ describe('DefaultAuthConnector', () => {
 
   it('should handle failure to refresh session', async () => {
     server.use(
-      rest.get('*', (_req, res, ctx) =>
-        res(ctx.status(500, 'Error: Network NOPE')),
+      http.get(
+        '*',
+        () =>
+          new HttpResponse(null, {
+            status: 500,
+            statusText: 'Error: Network NOPE',
+          }),
       ),
     );
 
@@ -98,7 +102,11 @@ describe('DefaultAuthConnector', () => {
   });
 
   it('should handle failure response when refreshing session', async () => {
-    server.use(rest.get('*', (_req, res, ctx) => res(ctx.status(401, 'NOPE'))));
+    server.use(
+      http.get('*', () =>
+        HttpResponse.text(null, { status: 400, statusText: 'NOPE' }),
+      ),
+    );
 
     const connector = new DefaultAuthConnector(defaultOptions);
     await expect(connector.refreshSession()).rejects.toThrow(
@@ -267,9 +275,7 @@ describe('DefaultAuthConnector', () => {
     const logoutUrl =
       'https://test.auth0.com/v2/logout?federated&client_id=abc&returnTo=http%3A%2F%2Flocalhost';
 
-    server.use(
-      rest.post('*', (_req, res, ctx) => res(ctx.json({ logoutUrl }))),
-    );
+    server.use(http.post('*', () => HttpResponse.json({ logoutUrl })));
 
     const connector = new DefaultAuthConnector(defaultOptions);
 
@@ -285,7 +291,7 @@ describe('DefaultAuthConnector', () => {
   });
 
   it('should complete normally when provider returns empty logout response', async () => {
-    server.use(rest.post('*', (_req, res, ctx) => res(ctx.status(200))));
+    server.use(http.post('*', () => new HttpResponse(null, { status: 200 })));
 
     const connector = new DefaultAuthConnector(defaultOptions);
     await connector.removeSession();
@@ -293,9 +299,7 @@ describe('DefaultAuthConnector', () => {
   });
 
   it('should complete normally when response is not JSON', async () => {
-    server.use(
-      rest.post('*', (_req, res, ctx) => res(ctx.status(200), ctx.text('OK'))),
-    );
+    server.use(http.post('*', () => HttpResponse.text('OK', { status: 200 })));
 
     const connector = new DefaultAuthConnector(defaultOptions);
     await connector.removeSession();
@@ -304,8 +308,8 @@ describe('DefaultAuthConnector', () => {
 
   it('should ignore logoutUrl with non-HTTPS protocol', async () => {
     server.use(
-      rest.post('*', (_req, res, ctx) =>
-        res(ctx.json({ logoutUrl: 'http://evil.com/steal' })),
+      http.post('*', () =>
+        HttpResponse.json({ logoutUrl: 'http://evil.com/steal' }),
       ),
     );
 

--- a/packages/core-components/package.json
+++ b/packages/core-components/package.json
@@ -122,7 +122,7 @@
     "copy-to-clipboard": "^3.3.1",
     "cross-fetch": "^4.0.0",
     "history": "^5.0.0",
-    "msw": "^1.0.0",
+    "msw": "^2.0.0",
     "react": "^18.0.2",
     "react-dom": "^18.0.2",
     "react-router-dom": "^6.30.2"

--- a/packages/core-components/src/layout/ProxiedSignInPage/ProxiedSignInIdentity.test.ts
+++ b/packages/core-components/src/layout/ProxiedSignInPage/ProxiedSignInIdentity.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { registerMswTestHooks } from '@backstage/test-utils';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import {
   DEFAULTS,
@@ -126,12 +126,8 @@ describe('ProxiedSignInIdentity', () => {
       }
       worker.events.on('request:match', serverCalled);
       worker.use(
-        rest.get('http://example.com/api/auth/foo/refresh', (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(makeToken()),
-          ),
+        http.get('http://example.com/api/auth/foo/refresh', () =>
+          HttpResponse.json(makeToken()),
         ),
       );
 
@@ -202,18 +198,14 @@ describe('ProxiedSignInIdentity', () => {
     it('handles headers passed as a promise', async () => {
       let req1: Request;
       const getBaseUrl = jest.fn();
-      const serverCalled = jest.fn().mockImplementation(req => {
-        req1 = req;
+      const serverCalled = jest.fn().mockImplementation(({ request }) => {
+        req1 = request;
       });
 
       worker.events.on('request:match', serverCalled);
       worker.use(
-        rest.get('http://example.com/api/auth/foo/refresh', (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(dummySessionResponse),
-          ),
+        http.get('http://example.com/api/auth/foo/refresh', () =>
+          HttpResponse.json(dummySessionResponse),
         ),
       );
 
@@ -242,18 +234,14 @@ describe('ProxiedSignInIdentity', () => {
     it('handles headers passed as an object', async () => {
       let req1: Request;
       const getBaseUrl = jest.fn();
-      const serverCalled = jest.fn().mockImplementation(req => {
-        req1 = req;
+      const serverCalled = jest.fn().mockImplementation(({ request }) => {
+        req1 = request;
       });
 
       worker.events.on('request:match', serverCalled);
       worker.use(
-        rest.get('http://example.com/api/auth/foo/refresh', (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(dummySessionResponse),
-          ),
+        http.get('http://example.com/api/auth/foo/refresh', () =>
+          HttpResponse.json(dummySessionResponse),
         ),
       );
 
@@ -280,18 +268,14 @@ describe('ProxiedSignInIdentity', () => {
     it('handles headers passed as a function', async () => {
       let req1: Request;
       const getBaseUrl = jest.fn();
-      const serverCalled = jest.fn().mockImplementation(req => {
-        req1 = req;
+      const serverCalled = jest.fn().mockImplementation(({ request }) => {
+        req1 = request;
       });
 
       worker.events.on('request:match', serverCalled);
       worker.use(
-        rest.get('http://example.com/api/auth/foo/refresh', (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(dummySessionResponse),
-          ),
+        http.get('http://example.com/api/auth/foo/refresh', () =>
+          HttpResponse.json(dummySessionResponse),
         ),
       );
 

--- a/packages/core-components/src/layout/ProxiedSignInPage/ProxiedSignInPage.test.tsx
+++ b/packages/core-components/src/layout/ProxiedSignInPage/ProxiedSignInPage.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import { render, screen } from '@testing-library/react';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import {
   mockApis,
@@ -49,26 +49,22 @@ describe('ProxiedSignInPage', () => {
 
   it('should sign in a user', async () => {
     worker.use(
-      rest.get('http://example.com/api/auth/test/refresh', (_, res, ctx) =>
-        res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({
-            profile: {
-              email: 'e',
-              displayName: 'd',
-              picture: 'p',
+      http.get('http://example.com/api/auth/test/refresh', () =>
+        HttpResponse.json({
+          profile: {
+            email: 'e',
+            displayName: 'd',
+            picture: 'p',
+          },
+          backstageIdentity: {
+            token: 'a.e30.c',
+            identity: {
+              type: 'user',
+              userEntityRef: 'k:ns/ue',
+              ownershipEntityRefs: ['k:ns/oe'],
             },
-            backstageIdentity: {
-              token: 'a.e30.c',
-              identity: {
-                type: 'user',
-                userEntityRef: 'k:ns/ue',
-                ownershipEntityRefs: ['k:ns/oe'],
-              },
-            },
-          }),
-        ),
+          },
+        }),
       ),
     );
 
@@ -81,13 +77,12 @@ describe('ProxiedSignInPage', () => {
 
   it('should forward error', async () => {
     worker.use(
-      rest.get('http://example.com/api/auth/test/refresh', (_, res, ctx) =>
-        res(
-          ctx.status(401),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({
+      http.get('http://example.com/api/auth/test/refresh', () =>
+        HttpResponse.json(
+          {
             error: { name: 'Error', message: 'not-displayed' },
-          }),
+          },
+          { status: 401 },
         ),
       ),
     );
@@ -131,13 +126,12 @@ describe('ProxiedSignInPage', () => {
     });
 
     worker.use(
-      rest.get('http://example.com/api/auth/test/refresh', (_, res, ctx) =>
-        res(
-          ctx.status(401),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({
+      http.get('http://example.com/api/auth/test/refresh', () =>
+        HttpResponse.json(
+          {
             error: { name: 'Error', message: 'not-displayed' },
-          }),
+          },
+          { status: 401 },
         ),
       ),
     );

--- a/packages/frontend-dynamic-feature-loader/package.json
+++ b/packages/frontend-dynamic-feature-loader/package.json
@@ -47,7 +47,7 @@
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^16.0.0",
     "@types/react": "^18.0.0",
-    "msw": "^1.0.0",
+    "msw": "^2.0.0",
     "react": "^18.0.2",
     "react-dom": "^18.0.2",
     "react-router-dom": "^6.30.2"

--- a/packages/frontend-dynamic-feature-loader/src/loader.test.tsx
+++ b/packages/frontend-dynamic-feature-loader/src/loader.test.tsx
@@ -16,7 +16,7 @@
 
 import { mockApis, registerMswTestHooks } from '@backstage/test-utils';
 import { dynamicFrontendFeaturesLoader } from './loader';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { ModuleFederationRuntimePlugin } from '@module-federation/enhanced/runtime';
 import { RemoteEntryExports } from '@module-federation/runtime/types';
@@ -188,13 +188,10 @@ describe('dynamicFrontendFeaturesLoader', () => {
   it('should return immediately if dynamic plugins are not enabled in config', async () => {
     let manifestsEndpointCalled = false;
     server.use(
-      rest.get(
-        `${baseUrl}/.backstage/dynamic-plugins/remotes`,
-        (_, res, ctx) => {
-          manifestsEndpointCalled = true;
-          return res(ctx.json({}));
-        },
-      ),
+      http.get(`${baseUrl}/.backstage/dynamic-plugins/remotes`, () => {
+        manifestsEndpointCalled = true;
+        return HttpResponse.json({});
+      }),
     );
 
     const features = await (
@@ -231,39 +228,33 @@ describe('dynamicFrontendFeaturesLoader', () => {
 
   it('should load a dynamic frontend plugin with the default exposed remote module', async () => {
     server.use(
-      rest.get(
-        `${baseUrl}/.backstage/dynamic-features/remotes`,
-        (_, res, ctx) =>
-          res(
-            ctx.json([
-              {
-                packageName: 'plugin-test-dynamic',
-                exposedModules: ['.'],
-                remoteInfo: {
-                  name: 'test_plugin',
-                  entry: `${baseUrl}/.backstage/dynamic-features/remotes/plugin-test-dynamic/mf-manifest.json`,
-                },
-              },
-            ]),
-          ),
-      ),
-      rest.get(
-        `${baseUrl}/.backstage/dynamic-features/remotes/plugin-test-dynamic/mf-manifest.json`,
-        (_, res, ctx) =>
-          res(
-            ctx.json({
+      http.get(`${baseUrl}/.backstage/dynamic-features/remotes`, () =>
+        HttpResponse.json([
+          {
+            packageName: 'plugin-test-dynamic',
+            exposedModules: ['.'],
+            remoteInfo: {
               name: 'test_plugin',
-              ...manifestDummyData,
-              exposes: [
-                {
-                  id: 'test_plugin:.',
-                  name: '.',
-                  path: '.',
-                  ...manifestExposedRemoteDummyData,
-                },
-              ],
-            }),
-          ),
+              entry: `${baseUrl}/.backstage/dynamic-features/remotes/plugin-test-dynamic/mf-manifest.json`,
+            },
+          },
+        ]),
+      ),
+      http.get(
+        `${baseUrl}/.backstage/dynamic-features/remotes/plugin-test-dynamic/mf-manifest.json`,
+        () =>
+          HttpResponse.json({
+            name: 'test_plugin',
+            ...manifestDummyData,
+            exposes: [
+              {
+                id: 'test_plugin:.',
+                name: '.',
+                path: '.',
+                ...manifestExposedRemoteDummyData,
+              },
+            ],
+          }),
       ),
     );
 
@@ -313,65 +304,57 @@ describe('dynamicFrontendFeaturesLoader', () => {
 
   it('should load several dynamic frontend plugins', async () => {
     server.use(
-      rest.get(
-        `${baseUrl}/.backstage/dynamic-features/remotes`,
-        (_, res, ctx) =>
-          res(
-            ctx.json([
-              {
-                packageName: 'plugin-1',
-                exposedModules: ['.'],
-                remoteInfo: {
-                  name: 'plugin_1',
-                  entry: `${baseUrl}/.backstage/dynamic-features/remotes/plugin-1/mf-manifest.json`,
-                },
-              },
-              {
-                packageName: 'plugin-2',
-                exposedModules: ['.'],
-                remoteInfo: {
-                  name: 'plugin_2',
-                  entry: `${baseUrl}/.backstage/dynamic-features/remotes/plugin-2/mf-manifest.json`,
-                },
-              },
-            ]),
-          ),
-      ),
-      rest.get(
-        `${baseUrl}/.backstage/dynamic-features/remotes/plugin-1/mf-manifest.json`,
-        (_, res, ctx) =>
-          res(
-            ctx.json({
+      http.get(`${baseUrl}/.backstage/dynamic-features/remotes`, () =>
+        HttpResponse.json([
+          {
+            packageName: 'plugin-1',
+            exposedModules: ['.'],
+            remoteInfo: {
               name: 'plugin_1',
-              ...manifestDummyData,
-              exposes: [
-                {
-                  id: 'plugin_1:.',
-                  name: '.',
-                  path: '.',
-                  ...manifestExposedRemoteDummyData,
-                },
-              ],
-            }),
-          ),
-      ),
-      rest.get(
-        `${baseUrl}/.backstage/dynamic-features/remotes/plugin-2/mf-manifest.json`,
-        (_, res, ctx) =>
-          res(
-            ctx.json({
+              entry: `${baseUrl}/.backstage/dynamic-features/remotes/plugin-1/mf-manifest.json`,
+            },
+          },
+          {
+            packageName: 'plugin-2',
+            exposedModules: ['.'],
+            remoteInfo: {
               name: 'plugin_2',
-              ...manifestDummyData,
-              exposes: [
-                {
-                  id: 'plugin_2:.',
-                  name: '.',
-                  path: '.',
-                  ...manifestExposedRemoteDummyData,
-                },
-              ],
-            }),
-          ),
+              entry: `${baseUrl}/.backstage/dynamic-features/remotes/plugin-2/mf-manifest.json`,
+            },
+          },
+        ]),
+      ),
+      http.get(
+        `${baseUrl}/.backstage/dynamic-features/remotes/plugin-1/mf-manifest.json`,
+        () =>
+          HttpResponse.json({
+            name: 'plugin_1',
+            ...manifestDummyData,
+            exposes: [
+              {
+                id: 'plugin_1:.',
+                name: '.',
+                path: '.',
+                ...manifestExposedRemoteDummyData,
+              },
+            ],
+          }),
+      ),
+      http.get(
+        `${baseUrl}/.backstage/dynamic-features/remotes/plugin-2/mf-manifest.json`,
+        () =>
+          HttpResponse.json({
+            name: 'plugin_2',
+            ...manifestDummyData,
+            exposes: [
+              {
+                id: 'plugin_2:.',
+                name: '.',
+                path: '.',
+                ...manifestExposedRemoteDummyData,
+              },
+            ],
+          }),
       ),
     );
 
@@ -438,45 +421,39 @@ describe('dynamicFrontendFeaturesLoader', () => {
 
   it('should load a dynamic frontend plugin with several exposed remote modules', async () => {
     server.use(
-      rest.get(
-        `${baseUrl}/.backstage/dynamic-features/remotes`,
-        (_, res, ctx) =>
-          res(
-            ctx.json([
-              {
-                packageName: 'plugin-test-dynamic',
-                exposedModules: ['.', 'alpha'],
-                remoteInfo: {
-                  name: 'test_plugin',
-                  entry: `${baseUrl}/.backstage/dynamic-features/remotes/plugin-test-dynamic/mf-manifest.json`,
-                },
-              },
-            ]),
-          ),
-      ),
-      rest.get(
-        `${baseUrl}/.backstage/dynamic-features/remotes/plugin-test-dynamic/mf-manifest.json`,
-        (_, res, ctx) =>
-          res(
-            ctx.json({
+      http.get(`${baseUrl}/.backstage/dynamic-features/remotes`, () =>
+        HttpResponse.json([
+          {
+            packageName: 'plugin-test-dynamic',
+            exposedModules: ['.', 'alpha'],
+            remoteInfo: {
               name: 'test_plugin',
-              ...manifestDummyData,
-              exposes: [
-                {
-                  id: 'test_plugin:.',
-                  name: '.',
-                  path: '.',
-                  ...manifestExposedRemoteDummyData,
-                },
-                {
-                  id: 'test_plugin:alpha',
-                  name: 'alpha',
-                  path: './alpha',
-                  ...manifestExposedRemoteDummyData,
-                },
-              ],
-            }),
-          ),
+              entry: `${baseUrl}/.backstage/dynamic-features/remotes/plugin-test-dynamic/mf-manifest.json`,
+            },
+          },
+        ]),
+      ),
+      http.get(
+        `${baseUrl}/.backstage/dynamic-features/remotes/plugin-test-dynamic/mf-manifest.json`,
+        () =>
+          HttpResponse.json({
+            name: 'test_plugin',
+            ...manifestDummyData,
+            exposes: [
+              {
+                id: 'test_plugin:.',
+                name: '.',
+                path: '.',
+                ...manifestExposedRemoteDummyData,
+              },
+              {
+                id: 'test_plugin:alpha',
+                name: 'alpha',
+                path: './alpha',
+                ...manifestExposedRemoteDummyData,
+              },
+            ],
+          }),
       ),
     );
 
@@ -544,26 +521,22 @@ describe('dynamicFrontendFeaturesLoader', () => {
     mocks.federation.get.mockRestore();
     mocks.federation.onLoad.mockRestore();
     server.use(
-      rest.get(
-        `${baseUrl}/.backstage/dynamic-features/remotes`,
-        (_, res, ctx) =>
-          res(
-            ctx.json([
-              {
-                packageName: 'plugin-test-dynamic',
-                exposedModules: ['.'],
-                remoteInfo: {
-                  name: 'test_plugin',
-                  entry: `${baseUrl}/.backstage/dynamic-features/remotes/plugin-test-dynamic/remoteEntry.js`,
-                  type: 'jsonp',
-                },
-              },
-            ]),
-          ),
+      http.get(`${baseUrl}/.backstage/dynamic-features/remotes`, () =>
+        HttpResponse.json([
+          {
+            packageName: 'plugin-test-dynamic',
+            exposedModules: ['.'],
+            remoteInfo: {
+              name: 'test_plugin',
+              entry: `${baseUrl}/.backstage/dynamic-features/remotes/plugin-test-dynamic/remoteEntry.js`,
+              type: 'jsonp',
+            },
+          },
+        ]),
       ),
-      rest.get(
+      http.get(
         `${baseUrl}/.backstage/dynamic-features/remotes/plugin-test-dynamic/remoteEntry.js`,
-        (_, res, ctx) => res(ctx.text('coucou :-)')),
+        () => HttpResponse.text('coucou :-)'),
       ),
     );
 
@@ -613,9 +586,9 @@ describe('dynamicFrontendFeaturesLoader', () => {
 
   it('should warn and recover from a 404 error fetching module feredation configuration', async () => {
     server.use(
-      rest.get(
+      http.get(
         `${baseUrl}/.backstage/dynamic-features/remotes`,
-        (_, res, ctx) => res(ctx.status(404, 'NOT FOUND')),
+        () => new HttpResponse(null, { status: 404, statusText: 'NOT FOUND' }),
       ),
     );
 
@@ -650,9 +623,9 @@ describe('dynamicFrontendFeaturesLoader', () => {
 
   it('should warn and recover from empty response while fetching module feredation configuration', async () => {
     server.use(
-      rest.get(
+      http.get(
         `${baseUrl}/.backstage/dynamic-features/remotes`,
-        (_, res, ctx) => res(ctx.status(200)),
+        () => new HttpResponse(null, { status: 200 }),
       ),
     );
 
@@ -687,65 +660,57 @@ describe('dynamicFrontendFeaturesLoader', () => {
 
   it('should warn on empty module, but still load other remotes', async () => {
     server.use(
-      rest.get(
-        `${baseUrl}/.backstage/dynamic-features/remotes`,
-        (_, res, ctx) =>
-          res(
-            ctx.json([
-              {
-                packageName: 'plugin-1',
-                exposedModules: ['.'],
-                remoteInfo: {
-                  name: 'plugin_1',
-                  entry: `${baseUrl}/.backstage/dynamic-features/remotes/plugin-1/mf-manifest.json`,
-                },
-              },
-              {
-                packageName: 'plugin-2',
-                exposedModules: ['.'],
-                remoteInfo: {
-                  name: 'plugin_2',
-                  entry: `${baseUrl}/.backstage/dynamic-features/remotes/plugin-2/mf-manifest.json`,
-                },
-              },
-            ]),
-          ),
-      ),
-      rest.get(
-        `${baseUrl}/.backstage/dynamic-features/remotes/plugin-1/mf-manifest.json`,
-        (_, res, ctx) =>
-          res(
-            ctx.json({
+      http.get(`${baseUrl}/.backstage/dynamic-features/remotes`, () =>
+        HttpResponse.json([
+          {
+            packageName: 'plugin-1',
+            exposedModules: ['.'],
+            remoteInfo: {
               name: 'plugin_1',
-              ...manifestDummyData,
-              exposes: [
-                {
-                  id: 'plugin_1:.',
-                  name: '.',
-                  path: '.',
-                  ...manifestExposedRemoteDummyData,
-                },
-              ],
-            }),
-          ),
-      ),
-      rest.get(
-        `${baseUrl}/.backstage/dynamic-features/remotes/plugin-2/mf-manifest.json`,
-        (_, res, ctx) =>
-          res(
-            ctx.json({
+              entry: `${baseUrl}/.backstage/dynamic-features/remotes/plugin-1/mf-manifest.json`,
+            },
+          },
+          {
+            packageName: 'plugin-2',
+            exposedModules: ['.'],
+            remoteInfo: {
               name: 'plugin_2',
-              ...manifestDummyData,
-              exposes: [
-                {
-                  id: 'plugin_2:.',
-                  name: '.',
-                  path: '.',
-                  ...manifestExposedRemoteDummyData,
-                },
-              ],
-            }),
-          ),
+              entry: `${baseUrl}/.backstage/dynamic-features/remotes/plugin-2/mf-manifest.json`,
+            },
+          },
+        ]),
+      ),
+      http.get(
+        `${baseUrl}/.backstage/dynamic-features/remotes/plugin-1/mf-manifest.json`,
+        () =>
+          HttpResponse.json({
+            name: 'plugin_1',
+            ...manifestDummyData,
+            exposes: [
+              {
+                id: 'plugin_1:.',
+                name: '.',
+                path: '.',
+                ...manifestExposedRemoteDummyData,
+              },
+            ],
+          }),
+      ),
+      http.get(
+        `${baseUrl}/.backstage/dynamic-features/remotes/plugin-2/mf-manifest.json`,
+        () =>
+          HttpResponse.json({
+            name: 'plugin_2',
+            ...manifestDummyData,
+            exposes: [
+              {
+                id: 'plugin_2:.',
+                name: '.',
+                path: '.',
+                ...manifestExposedRemoteDummyData,
+              },
+            ],
+          }),
       ),
     );
 
@@ -803,65 +768,57 @@ describe('dynamicFrontendFeaturesLoader', () => {
 
   it('should skip module without default export, but still load other remotes', async () => {
     server.use(
-      rest.get(
-        `${baseUrl}/.backstage/dynamic-features/remotes`,
-        (_, res, ctx) =>
-          res(
-            ctx.json([
-              {
-                packageName: 'plugin-1',
-                exposedModules: ['.'],
-                remoteInfo: {
-                  name: 'plugin_1',
-                  entry: `${baseUrl}/.backstage/dynamic-features/remotes/plugin-1/mf-manifest.json`,
-                },
-              },
-              {
-                packageName: 'plugin-2',
-                exposedModules: ['.'],
-                remoteInfo: {
-                  name: 'plugin_2',
-                  entry: `${baseUrl}/.backstage/dynamic-features/remotes/plugin-2/mf-manifest.json`,
-                },
-              },
-            ]),
-          ),
-      ),
-      rest.get(
-        `${baseUrl}/.backstage/dynamic-features/remotes/plugin-1/mf-manifest.json`,
-        (_, res, ctx) =>
-          res(
-            ctx.json({
+      http.get(`${baseUrl}/.backstage/dynamic-features/remotes`, () =>
+        HttpResponse.json([
+          {
+            packageName: 'plugin-1',
+            exposedModules: ['.'],
+            remoteInfo: {
               name: 'plugin_1',
-              ...manifestDummyData,
-              exposes: [
-                {
-                  id: 'plugin_1:.',
-                  name: '.',
-                  path: '.',
-                  ...manifestExposedRemoteDummyData,
-                },
-              ],
-            }),
-          ),
-      ),
-      rest.get(
-        `${baseUrl}/.backstage/dynamic-features/remotes/plugin-2/mf-manifest.json`,
-        (_, res, ctx) =>
-          res(
-            ctx.json({
+              entry: `${baseUrl}/.backstage/dynamic-features/remotes/plugin-1/mf-manifest.json`,
+            },
+          },
+          {
+            packageName: 'plugin-2',
+            exposedModules: ['.'],
+            remoteInfo: {
               name: 'plugin_2',
-              ...manifestDummyData,
-              exposes: [
-                {
-                  id: 'plugin_2:.',
-                  name: '.',
-                  path: '.',
-                  ...manifestExposedRemoteDummyData,
-                },
-              ],
-            }),
-          ),
+              entry: `${baseUrl}/.backstage/dynamic-features/remotes/plugin-2/mf-manifest.json`,
+            },
+          },
+        ]),
+      ),
+      http.get(
+        `${baseUrl}/.backstage/dynamic-features/remotes/plugin-1/mf-manifest.json`,
+        () =>
+          HttpResponse.json({
+            name: 'plugin_1',
+            ...manifestDummyData,
+            exposes: [
+              {
+                id: 'plugin_1:.',
+                name: '.',
+                path: '.',
+                ...manifestExposedRemoteDummyData,
+              },
+            ],
+          }),
+      ),
+      http.get(
+        `${baseUrl}/.backstage/dynamic-features/remotes/plugin-2/mf-manifest.json`,
+        () =>
+          HttpResponse.json({
+            name: 'plugin_2',
+            ...manifestDummyData,
+            exposes: [
+              {
+                id: 'plugin_2:.',
+                name: '.',
+                path: '.',
+                ...manifestExposedRemoteDummyData,
+              },
+            ],
+          }),
       ),
     );
 
@@ -921,51 +878,45 @@ describe('dynamicFrontendFeaturesLoader', () => {
 
   it('should warn on 404 error fetching module feredation manifest, but still load other remotes', async () => {
     server.use(
-      rest.get(
-        `${baseUrl}/.backstage/dynamic-features/remotes`,
-        (_, res, ctx) =>
-          res(
-            ctx.json([
-              {
-                packageName: 'plugin-1',
-                exposedModules: ['.'],
-                remoteInfo: {
-                  name: 'plugin_1',
-                  entry: `${baseUrl}/.backstage/dynamic-features/remotes/plugin-1/mf-manifest.json`,
-                },
-              },
-              {
-                packageName: 'plugin-2',
-                exposedModules: ['.'],
-                remoteInfo: {
-                  name: 'plugin_2',
-                  entry: `${baseUrl}/.backstage/dynamic-features/remotes/plugin-2/mf-manifest.json`,
-                },
-              },
-            ]),
-          ),
-      ),
-      rest.get(
-        `${baseUrl}/.backstage/dynamic-features/remotes/plugin-1/mf-manifest.json`,
-        (_, res, ctx) => res(ctx.json({}), ctx.status(404, 'NOT FOUND')),
-      ),
-      rest.get(
-        `${baseUrl}/.backstage/dynamic-features/remotes/plugin-2/mf-manifest.json`,
-        (_, res, ctx) =>
-          res(
-            ctx.json({
+      http.get(`${baseUrl}/.backstage/dynamic-features/remotes`, () =>
+        HttpResponse.json([
+          {
+            packageName: 'plugin-1',
+            exposedModules: ['.'],
+            remoteInfo: {
+              name: 'plugin_1',
+              entry: `${baseUrl}/.backstage/dynamic-features/remotes/plugin-1/mf-manifest.json`,
+            },
+          },
+          {
+            packageName: 'plugin-2',
+            exposedModules: ['.'],
+            remoteInfo: {
               name: 'plugin_2',
-              ...manifestDummyData,
-              exposes: [
-                {
-                  id: 'plugin_2:.',
-                  name: '.',
-                  path: '.',
-                  ...manifestExposedRemoteDummyData,
-                },
-              ],
-            }),
-          ),
+              entry: `${baseUrl}/.backstage/dynamic-features/remotes/plugin-2/mf-manifest.json`,
+            },
+          },
+        ]),
+      ),
+      http.get(
+        `${baseUrl}/.backstage/dynamic-features/remotes/plugin-1/mf-manifest.json`,
+        () => HttpResponse.json({}, { status: 404 }),
+      ),
+      http.get(
+        `${baseUrl}/.backstage/dynamic-features/remotes/plugin-2/mf-manifest.json`,
+        () =>
+          HttpResponse.json({
+            name: 'plugin_2',
+            ...manifestDummyData,
+            exposes: [
+              {
+                id: 'plugin_2:.',
+                name: '.',
+                path: '.',
+                ...manifestExposedRemoteDummyData,
+              },
+            ],
+          }),
       ),
     );
 
@@ -1020,51 +971,45 @@ describe('dynamicFrontendFeaturesLoader', () => {
 
   it('should warn on unexpected Json content while fetching module feredation manifest, but still load other remotes', async () => {
     server.use(
-      rest.get(
-        `${baseUrl}/.backstage/dynamic-features/remotes`,
-        (_, res, ctx) =>
-          res(
-            ctx.json([
-              {
-                packageName: 'plugin-1',
-                exposedModules: ['.'],
-                remoteInfo: {
-                  name: 'plugin_1',
-                  entry: `${baseUrl}/.backstage/dynamic-features/remotes/plugin-1/mf-manifest.json`,
-                },
-              },
-              {
-                packageName: 'plugin-2',
-                exposedModules: ['.'],
-                remoteInfo: {
-                  name: 'plugin_2',
-                  entry: `${baseUrl}/.backstage/dynamic-features/remotes/plugin-2/mf-manifest.json`,
-                },
-              },
-            ]),
-          ),
+      http.get(`${baseUrl}/.backstage/dynamic-features/remotes`, () =>
+        HttpResponse.json([
+          {
+            packageName: 'plugin-1',
+            exposedModules: ['.'],
+            remoteInfo: {
+              name: 'plugin_1',
+              entry: `${baseUrl}/.backstage/dynamic-features/remotes/plugin-1/mf-manifest.json`,
+            },
+          },
+          {
+            packageName: 'plugin-2',
+            exposedModules: ['.'],
+            remoteInfo: {
+              name: 'plugin_2',
+              entry: `${baseUrl}/.backstage/dynamic-features/remotes/plugin-2/mf-manifest.json`,
+            },
+          },
+        ]),
       ),
-      rest.get(
+      http.get(
         `${baseUrl}/.backstage/dynamic-features/remotes/plugin-1/mf-manifest.json`,
-        (_, res, ctx) => res(ctx.json('A Json String')),
+        () => HttpResponse.json('A Json String'),
       ),
-      rest.get(
+      http.get(
         `${baseUrl}/.backstage/dynamic-features/remotes/plugin-2/mf-manifest.json`,
-        (_, res, ctx) =>
-          res(
-            ctx.json({
-              name: 'plugin-2',
-              ...manifestDummyData,
-              exposes: [
-                {
-                  id: 'plugin-2:.',
-                  name: '.',
-                  path: '.',
-                  ...manifestExposedRemoteDummyData,
-                },
-              ],
-            }),
-          ),
+        () =>
+          HttpResponse.json({
+            name: 'plugin-2',
+            ...manifestDummyData,
+            exposes: [
+              {
+                id: 'plugin-2:.',
+                name: '.',
+                path: '.',
+                ...manifestExposedRemoteDummyData,
+              },
+            ],
+          }),
       ),
     );
 
@@ -1117,9 +1062,8 @@ describe('dynamicFrontendFeaturesLoader', () => {
 
   it('should initialize module federation with resolved shared dependencies', async () => {
     server.use(
-      rest.get(
-        `${baseUrl}/.backstage/dynamic-features/remotes`,
-        (_, res, ctx) => res(ctx.json([])),
+      http.get(`${baseUrl}/.backstage/dynamic-features/remotes`, () =>
+        HttpResponse.json([]),
       ),
     );
 
@@ -1166,9 +1110,8 @@ describe('dynamicFrontendFeaturesLoader', () => {
 
   it('should initialize module federation with shareStrategy option', async () => {
     server.use(
-      rest.get(
-        `${baseUrl}/.backstage/dynamic-features/remotes`,
-        (_, res, ctx) => res(ctx.json([])),
+      http.get(`${baseUrl}/.backstage/dynamic-features/remotes`, () =>
+        HttpResponse.json([]),
       ),
     );
 
@@ -1221,39 +1164,33 @@ describe('dynamicFrontendFeaturesLoader', () => {
 
   it('should return an empty list of features if module federation initialization fails', async () => {
     server.use(
-      rest.get(
-        `${baseUrl}/.backstage/dynamic-features/remotes`,
-        (_, res, ctx) =>
-          res(
-            ctx.json([
-              {
-                packageName: 'plugin-test-dynamic',
-                exposedModules: ['.'],
-                remoteInfo: {
-                  name: 'test_plugin',
-                  entry: `${baseUrl}/.backstage/dynamic-features/remotes/plugin-test-dynamic/mf-manifest.json`,
-                },
-              },
-            ]),
-          ),
-      ),
-      rest.get(
-        `${baseUrl}/.backstage/dynamic-features/remotes/plugin-test-dynamic/mf-manifest.json`,
-        (_, res, ctx) =>
-          res(
-            ctx.json({
+      http.get(`${baseUrl}/.backstage/dynamic-features/remotes`, () =>
+        HttpResponse.json([
+          {
+            packageName: 'plugin-test-dynamic',
+            exposedModules: ['.'],
+            remoteInfo: {
               name: 'test_plugin',
-              ...manifestDummyData,
-              exposes: [
-                {
-                  id: 'test_plugin:.',
-                  name: '.',
-                  path: '.',
-                  ...manifestExposedRemoteDummyData,
-                },
-              ],
-            }),
-          ),
+              entry: `${baseUrl}/.backstage/dynamic-features/remotes/plugin-test-dynamic/mf-manifest.json`,
+            },
+          },
+        ]),
+      ),
+      http.get(
+        `${baseUrl}/.backstage/dynamic-features/remotes/plugin-test-dynamic/mf-manifest.json`,
+        () =>
+          HttpResponse.json({
+            name: 'test_plugin',
+            ...manifestDummyData,
+            exposes: [
+              {
+                id: 'test_plugin:.',
+                name: '.',
+                path: '.',
+                ...manifestExposedRemoteDummyData,
+              },
+            ],
+          }),
       ),
     );
 

--- a/packages/release-manifests/package.json
+++ b/packages/release-manifests/package.json
@@ -38,6 +38,6 @@
   "devDependencies": {
     "@backstage/cli": "workspace:^",
     "@backstage/test-utils": "workspace:^",
-    "msw": "^1.0.0"
+    "msw": "^2.0.0"
   }
 }

--- a/packages/release-manifests/src/manifest.test.ts
+++ b/packages/release-manifests/src/manifest.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { setupServer } from 'msw/node';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { registerMswTestHooks } from '@backstage/test-utils';
 import {
   getManifestByReleaseLine,
@@ -30,16 +30,13 @@ describe('Release Manifests', () => {
   describe('getManifestByVersion', () => {
     it('should return a list of packages in a release', async () => {
       worker.use(
-        rest.get('*/v1/releases/0.0.0/manifest.json', (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.json({
-              packages: [{ name: '@backstage/core', version: '1.2.3' }],
-            }),
-          ),
+        http.get('*/v1/releases/0.0.0/manifest.json', () =>
+          HttpResponse.json({
+            packages: [{ name: '@backstage/core', version: '1.2.3' }],
+          }),
         ),
-        rest.get('*/v1/releases/999.0.1/manifest.json', (_, res, ctx) =>
-          res(ctx.status(404), ctx.json({})),
+        http.get('*/v1/releases/999.0.1/manifest.json', () =>
+          HttpResponse.json({}, { status: 404 }),
         ),
       );
 
@@ -156,19 +153,16 @@ describe('Release Manifests', () => {
   describe('getManifestByReleaseLine', () => {
     it('should return a list of packages in a release', async () => {
       worker.use(
-        rest.get(
+        http.get(
           'https://versions.backstage.io/v1/tags/main/manifest.json',
-          (_, res, ctx) =>
-            res(
-              ctx.status(200),
-              ctx.json({
-                packages: [{ name: '@backstage/core', version: '1.2.3' }],
-              }),
-            ),
+          () =>
+            HttpResponse.json({
+              packages: [{ name: '@backstage/core', version: '1.2.3' }],
+            }),
         ),
-        rest.get(
+        http.get(
           'https://versions.backstage.io/v1/tags/foo/manifest.json',
-          (_, res, ctx) => res(ctx.status(404), ctx.json({})),
+          () => HttpResponse.json({}, { status: 404 }),
         ),
       );
 

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -67,7 +67,7 @@
     "@testing-library/jest-dom": "^6.0.0",
     "@types/jest": "*",
     "@types/react": "^18.0.0",
-    "msw": "^1.0.0",
+    "msw": "^2.0.0",
     "react": "^18.0.2",
     "react-dom": "^18.0.2",
     "react-router-dom": "^6.30.2"

--- a/packages/test-utils/src/testUtils/apis/FetchApi/MockFetchApi.test.ts
+++ b/packages/test-utils/src/testUtils/apis/FetchApi/MockFetchApi.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { registerMswTestHooks } from '../../msw';
 import { MockFetchApi } from './MockFetchApi';
@@ -25,8 +25,8 @@ describe('MockFetchApi', () => {
 
   it('works with default constructor', async () => {
     worker.use(
-      rest.get('http://example.com/data.json', (_, res, ctx) =>
-        res(ctx.status(200), ctx.json({ a: 'foo' })),
+      http.get('http://example.com/data.json', () =>
+        HttpResponse.json({ a: 'foo' }),
       ),
     );
     const m = new MockFetchApi();

--- a/plugins/kubernetes-backend/package.json
+++ b/plugins/kubernetes-backend/package.json
@@ -40,7 +40,7 @@
     "prepack": "backstage-cli package prepack",
     "postpack": "backstage-cli package postpack",
     "start": "backstage-cli package start",
-    "test": "backstage-cli package test"
+    "test": "NODE_OPTIONS=--experimental-vm-modules backstage-cli package test"
   },
   "dependencies": {
     "@aws-crypto/sha256-js": "^5.0.0",
@@ -78,7 +78,7 @@
     "@backstage/plugin-permission-backend": "workspace:^",
     "@backstage/plugin-permission-backend-module-allow-all-policy": "workspace:^",
     "@types/express": "^4.17.6",
-    "msw": "^1.0.0",
+    "msw": "^2.0.0",
     "supertest": "^7.0.0",
     "ws": "^8.20.1"
   },

--- a/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.test.ts
@@ -28,7 +28,7 @@ import {
   DEFAULT_OBJECTS,
 } from './KubernetesFanOutHandler';
 import { KubernetesClientBasedFetcher } from './KubernetesFetcher';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import {
   mockServices,
@@ -1217,17 +1217,15 @@ describe('KubernetesFanOutHandler', () => {
         const pods = [{ metadata: { name: 'pod-name' } }];
         const services = [{ metadata: { name: 'service-name' } }];
         worker.use(
-          rest.get('https://works/api/v1/pods', (_, res, ctx) =>
-            res(ctx.json({ items: pods })),
+          http.get('https://works/api/v1/pods', () =>
+            HttpResponse.json({ items: pods }),
           ),
-          rest.get('https://works/api/v1/services', (_, res, ctx) =>
-            res(ctx.json({ items: services })),
+          http.get('https://works/api/v1/services', () =>
+            HttpResponse.json({ items: services }),
           ),
-          rest.get('https://fails/api/v1/pods', (_, res) =>
-            res.networkError('socket error'),
-          ),
-          rest.get('https://fails/api/v1/services', (_, res, ctx) =>
-            res(ctx.json({ items: services })),
+          http.get('https://fails/api/v1/pods', () => HttpResponse.error()),
+          http.get('https://fails/api/v1/services', () =>
+            HttpResponse.json({ items: services }),
           ),
         );
 
@@ -1315,7 +1313,7 @@ describe('KubernetesFanOutHandler', () => {
                 {
                   errorType: 'FETCH_ERROR',
                   message:
-                    'request to https://fails/api/v1/pods?labelSelector=backstage.io%2Fkubernetes-id%3Dtest-component failed, reason: socket error',
+                    'request to https://fails/api/v1/pods?labelSelector=backstage.io%2Fkubernetes-id%3Dtest-component failed, reason: Network error',
                 },
               ],
             },

--- a/plugins/kubernetes-backend/src/service/KubernetesFetcher.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFetcher.test.ts
@@ -17,13 +17,7 @@
 import { ANNOTATION_KUBERNETES_AUTH_PROVIDER } from '@backstage/plugin-kubernetes-common';
 import { KubernetesClientBasedFetcher } from './KubernetesFetcher';
 import { ObjectToFetch } from '@backstage/plugin-kubernetes-node';
-import {
-  MockedRequest,
-  RestContext,
-  ResponseTransformer,
-  compose,
-  rest,
-} from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import {
   createMockDirectory,
@@ -72,45 +66,61 @@ describe('KubernetesFetcher', () => {
   const worker = setupServer();
   registerMswTestHooks(worker);
 
-  const labels = (req: MockedRequest): object => {
-    const selectorParam = req.url.searchParams.get('labelSelector');
+  const labels = (request: Request): object => {
+    const selectorParam = new URL(request.url).searchParams.get(
+      'labelSelector',
+    );
     if (selectorParam) {
       const [key, value] = selectorParam.split('=');
       return { [key]: value };
     }
     return {};
   };
-  const checkToken = (
-    req: MockedRequest,
-    ctx: RestContext,
-    token: string,
-  ): ResponseTransformer => {
-    switch (req.headers.get('Authorization')) {
+  const checkToken = (request: Request, token: string) => {
+    switch (request.headers.get('Authorization')) {
       case `Bearer ${token}`:
-        return ctx.status(200);
+        return undefined;
       default:
-        return compose(
-          ctx.status(401),
-          ctx.json({
+        return HttpResponse.json(
+          {
             kind: 'Status',
             apiVersion: 'v1',
             code: 401,
-          }),
+          },
+          { status: 401 },
         );
     }
   };
   const withLabels = <T extends { items: { metadata: object }[] }>(
-    req: MockedRequest,
-    ctx: RestContext,
+    request: Request,
     body: T,
-  ): ResponseTransformer =>
-    ctx.json({
+  ) =>
+    HttpResponse.json({
       ...body,
       items: body.items.map(item => ({
         ...item,
-        metadata: { ...item.metadata, labels: labels(req) },
+        metadata: { ...item.metadata, labels: labels(request) },
       })),
     });
+  const status = (statusCode: number) => ({ statusCode });
+  const json = (body: object) => HttpResponse.json(body);
+  const response = (
+    ...responses: (HttpResponse<any> | { statusCode: number } | undefined)[]
+  ) => {
+    const body = responses.find(
+      (value): value is HttpResponse<any> => value instanceof HttpResponse,
+    )!;
+    const statusCode = responses.find(
+      (value): value is { statusCode: number } =>
+        value !== undefined && 'statusCode' in value,
+    )?.statusCode;
+    return statusCode === undefined
+      ? body
+      : new HttpResponse(body.body, {
+          headers: body.headers,
+          status: statusCode,
+        });
+  };
 
   describe('fetchObjectsForService', () => {
     let sut: KubernetesClientBasedFetcher;
@@ -121,25 +131,25 @@ describe('KubernetesFetcher', () => {
       expectedResult: any,
     ) => {
       worker.use(
-        rest.get('http://localhost:9999/api/v1/pods', (req, res, ctx) =>
-          res(
-            checkToken(req, ctx, 'token'),
-            withLabels(req, ctx, {
+        http.get('http://localhost:9999/api/v1/pods', ({ request: req }) =>
+          response(
+            checkToken(req, 'token'),
+            withLabels(req, {
               items: [{ metadata: { name: 'pod-name' } }],
             }),
           ),
         ),
-        rest.get('http://localhost:9999/api/v1/services', (_, res, ctx) => {
-          return res(
-            ctx.status(errorResponse.response.statusCode),
-            ctx.json({
+        http.get('http://localhost:9999/api/v1/services', () =>
+          HttpResponse.json(
+            {
               kind: 'Status',
               apiVersion: 'v1',
               status: 'Failure',
               code: errorResponse.response.statusCode,
-            }),
-          );
-        }),
+            },
+            { status: errorResponse.response.statusCode },
+          ),
+        ),
       );
 
       const result = await sut.fetchObjectsForService({
@@ -181,22 +191,22 @@ describe('KubernetesFetcher', () => {
 
     it('should support clusters with a base path', async () => {
       worker.use(
-        rest.get(
+        http.get(
           'http://localhost:9999/k8s/clusters/1234/api/v1/pods',
-          (req, res, ctx) =>
-            res(
-              checkToken(req, ctx, 'token'),
-              withLabels(req, ctx, {
+          ({ request: req }) =>
+            response(
+              checkToken(req, 'token'),
+              withLabels(req, {
                 items: [{ metadata: { name: 'pod-name' } }],
               }),
             ),
         ),
-        rest.get(
+        http.get(
           'http://localhost:9999/k8s/clusters/1234/api/v1/services',
-          (req, res, ctx) =>
-            res(
-              checkToken(req, ctx, 'token'),
-              withLabels(req, ctx, {
+          ({ request: req }) =>
+            response(
+              checkToken(req, 'token'),
+              withLabels(req, {
                 items: [{ metadata: { name: 'service-name' } }],
               }),
             ),
@@ -246,11 +256,11 @@ describe('KubernetesFetcher', () => {
     });
     it('localKubectlProxy authProvider fetches resources correctly', async () => {
       worker.use(
-        rest.get(
+        http.get(
           'http://localhost:9999/k8s/clusters/1234/api/v1/services',
-          (req, res, ctx) =>
-            res(
-              withLabels(req, ctx, {
+          ({ request: req }) =>
+            response(
+              withLabels(req, {
                 items: [{ metadata: { name: 'service-name' } }],
               }),
             ),
@@ -298,18 +308,18 @@ describe('KubernetesFetcher', () => {
     });
     it('should return pods, services', async () => {
       worker.use(
-        rest.get('http://localhost:9999/api/v1/pods', (req, res, ctx) =>
-          res(
-            checkToken(req, ctx, 'token'),
-            withLabels(req, ctx, {
+        http.get('http://localhost:9999/api/v1/pods', ({ request: req }) =>
+          response(
+            checkToken(req, 'token'),
+            withLabels(req, {
               items: [{ metadata: { name: 'pod-name' } }],
             }),
           ),
         ),
-        rest.get('http://localhost:9999/api/v1/services', (req, res, ctx) =>
-          res(
-            checkToken(req, ctx, 'token'),
-            withLabels(req, ctx, {
+        http.get('http://localhost:9999/api/v1/services', ({ request: req }) =>
+          response(
+            checkToken(req, 'token'),
+            withLabels(req, {
               items: [{ metadata: { name: 'service-name' } }],
             }),
           ),
@@ -359,30 +369,30 @@ describe('KubernetesFetcher', () => {
     });
     it('should return pods, services and customobjects', async () => {
       worker.use(
-        rest.get('http://localhost:9999/api/v1/pods', (req, res, ctx) =>
-          res(
-            checkToken(req, ctx, 'token'),
-            withLabels(req, ctx, {
+        http.get('http://localhost:9999/api/v1/pods', ({ request: req }) =>
+          response(
+            checkToken(req, 'token'),
+            withLabels(req, {
               kind: 'PodList',
               items: [{ metadata: { name: 'pod-name' } }],
             }),
           ),
         ),
-        rest.get('http://localhost:9999/api/v1/services', (req, res, ctx) =>
-          res(
-            checkToken(req, ctx, 'token'),
-            withLabels(req, ctx, {
+        http.get('http://localhost:9999/api/v1/services', ({ request: req }) =>
+          response(
+            checkToken(req, 'token'),
+            withLabels(req, {
               kind: 'ServiceList',
               items: [{ metadata: { name: 'service-name' } }],
             }),
           ),
         ),
-        rest.get(
+        http.get(
           'http://localhost:9999/apis/some-group/v2/things',
-          (req, res, ctx) =>
-            res(
-              checkToken(req, ctx, 'token'),
-              withLabels(req, ctx, {
+          ({ request: req }) =>
+            response(
+              checkToken(req, 'token'),
+              withLabels(req, {
                 kind: 'ThingList',
                 items: [{ metadata: { name: 'something-else' } }],
               }),
@@ -469,16 +479,16 @@ describe('KubernetesFetcher', () => {
     it('should return pods and unauthorized error, logging a warning', async () => {
       const warn = jest.spyOn(logger, 'warn');
       worker.use(
-        rest.get('http://localhost:9999/api/v1/pods', (req, res, ctx) =>
-          res(
-            checkToken(req, ctx, 'token'),
-            withLabels(req, ctx, {
+        http.get('http://localhost:9999/api/v1/pods', ({ request: req }) =>
+          response(
+            checkToken(req, 'token'),
+            withLabels(req, {
               items: [{ metadata: { name: 'pod-name' } }],
             }),
           ),
         ),
-        rest.get('http://localhost:9999/api/v1/services', (req, res, ctx) =>
-          res(checkToken(req, ctx, 'other-token')),
+        http.get('http://localhost:9999/api/v1/services', ({ request: req }) =>
+          response(checkToken(req, 'other-token')),
         ),
       );
 
@@ -555,15 +565,15 @@ describe('KubernetesFetcher', () => {
     });
     it('fails on a network error', async () => {
       worker.use(
-        rest.get('http://badurl.does.not.exist/api/v1/pods', (_, res) =>
-          res.networkError('getaddrinfo ENOTFOUND badurl.does.not.exist'),
+        http.get('http://badurl.does.not.exist/api/v1/pods', () =>
+          HttpResponse.error(),
         ),
-        rest.get(
+        http.get(
           'http://badurl.does.not.exist/api/v1/services',
-          (req, res, ctx) =>
-            res(
-              checkToken(req, ctx, 'token'),
-              withLabels(req, ctx, {
+          ({ request: req }) =>
+            response(
+              checkToken(req, 'token'),
+              withLabels(req, {
                 items: [{ metadata: { name: 'service-name' } }],
               }),
             ),
@@ -583,24 +593,22 @@ describe('KubernetesFetcher', () => {
         customResources: [],
       });
 
-      await expect(result).rejects.toThrow(
-        'getaddrinfo ENOTFOUND badurl.does.not.exist',
-      );
+      await expect(result).rejects.toThrow('Network error');
     });
     it('should respect labelSelector', async () => {
       worker.use(
-        rest.get('http://localhost:9999/api/v1/pods', (req, res, ctx) =>
-          res(
-            checkToken(req, ctx, 'token'),
-            withLabels(req, ctx, {
+        http.get('http://localhost:9999/api/v1/pods', ({ request: req }) =>
+          response(
+            checkToken(req, 'token'),
+            withLabels(req, {
               items: [{ metadata: { name: 'pod-name' } }],
             }),
           ),
         ),
-        rest.get('http://localhost:9999/api/v1/services', (req, res, ctx) =>
-          res(
-            checkToken(req, ctx, 'token'),
-            withLabels(req, ctx, {
+        http.get('http://localhost:9999/api/v1/services', ({ request: req }) =>
+          response(
+            checkToken(req, 'token'),
+            withLabels(req, {
               items: [{ metadata: { name: 'service-name' } }],
             }),
           ),
@@ -649,19 +657,8 @@ describe('KubernetesFetcher', () => {
       });
     });
     describe('when server uses TLS', () => {
-      let httpsRequest: jest.SpyInstance;
       const initialCAPath = process.env.KUBERNETES_CA_FILE_PATH;
-      beforeAll(() => {
-        httpsRequest = jest.spyOn(
-          // this is pretty egregious reverse engineering of msw.
-          // If the SetupServerApi constructor was exported, we wouldn't need
-          // to be quite so hacky here
-          (worker as any).interceptor.interceptors[0].modules.get('https'),
-          'request',
-        );
-      });
       beforeEach(() => {
-        httpsRequest.mockClear();
         process.env.KUBERNETES_CA_FILE_PATH = mockCertDir.resolve('ca.crt');
       });
 
@@ -671,10 +668,10 @@ describe('KubernetesFetcher', () => {
 
       it('should trust specified caData', async () => {
         worker.use(
-          rest.get('https://localhost:9999/api/v1/pods', (req, res, ctx) =>
-            res(
-              checkToken(req, ctx, 'token'),
-              withLabels(req, ctx, {
+          http.get('https://localhost:9999/api/v1/pods', ({ request: req }) =>
+            response(
+              checkToken(req, 'token'),
+              withLabels(req, {
                 items: [{ metadata: { name: 'pod-name' } }],
               }),
             ),
@@ -702,16 +699,15 @@ describe('KubernetesFetcher', () => {
           customResources: [],
         });
 
-        expect(httpsRequest).toHaveBeenCalledTimes(1);
-        const [[{ agent }]] = httpsRequest.mock.calls;
-        expect(agent.options.ca.toString('base64')).toMatch('MOCKCA');
+        const options = [...(sut as any).agentCache.values()][0].options;
+        expect(options.ca.toString('base64')).toMatch('MOCKCA');
       });
       it('should use default chain of trust when caData is unspecified', async () => {
         worker.use(
-          rest.get('https://localhost:9999/api/v1/pods', (req, res, ctx) =>
-            res(
-              checkToken(req, ctx, 'token'),
-              withLabels(req, ctx, {
+          http.get('https://localhost:9999/api/v1/pods', ({ request: req }) =>
+            response(
+              checkToken(req, 'token'),
+              withLabels(req, {
                 items: [{ metadata: { name: 'pod-name' } }],
               }),
             ),
@@ -738,17 +734,16 @@ describe('KubernetesFetcher', () => {
           customResources: [],
         });
 
-        expect(httpsRequest).toHaveBeenCalledTimes(1);
-        const [[{ agent }]] = httpsRequest.mock.calls;
-        expect(agent.options.ca).toBeUndefined();
+        const options = [...(sut as any).agentCache.values()][0].options;
+        expect(options.ca).toBeUndefined();
       });
       describe('with a CA file on disk', () => {
         it('should trust contents of specified caFile', async () => {
           worker.use(
-            rest.get('https://localhost:9999/api/v1/pods', (req, res, ctx) =>
-              res(
-                checkToken(req, ctx, 'token'),
-                withLabels(req, ctx, {
+            http.get('https://localhost:9999/api/v1/pods', ({ request: req }) =>
+              response(
+                checkToken(req, 'token'),
+                withLabels(req, {
                   items: [{ metadata: { name: 'pod-name' } }],
                 }),
               ),
@@ -776,17 +771,16 @@ describe('KubernetesFetcher', () => {
             customResources: [],
           });
 
-          expect(httpsRequest).toHaveBeenCalledTimes(1);
-          const [[{ agent }]] = httpsRequest.mock.calls;
-          expect(agent.options.ca.toString()).toEqual('MOCKCA');
+          const options = [...(sut as any).agentCache.values()][0].options;
+          expect(options.ca.toString()).toEqual('MOCKCA');
         });
       });
       it('should accept unauthorized certs when skipTLSVerify is set', async () => {
         worker.use(
-          rest.get('https://localhost:9999/api/v1/pods', (req, res, ctx) =>
-            res(
-              checkToken(req, ctx, 'token'),
-              withLabels(req, ctx, {
+          http.get('https://localhost:9999/api/v1/pods', ({ request: req }) =>
+            response(
+              checkToken(req, 'token'),
+              withLabels(req, {
                 items: [{ metadata: { name: 'pod-name' } }],
               }),
             ),
@@ -814,17 +808,16 @@ describe('KubernetesFetcher', () => {
           customResources: [],
         });
 
-        expect(httpsRequest).toHaveBeenCalledTimes(1);
-        const [[{ agent }]] = httpsRequest.mock.calls;
-        expect(agent.options.rejectUnauthorized).toBe(false);
+        const options = [...(sut as any).agentCache.values()][0].options;
+        expect(options.rejectUnauthorized).toBe(false);
       });
 
       it('fetchObjectsForService authenticates with k8s using x509 client cert from authentication strategy', async () => {
         worker.use(
-          rest.get('https://localhost:9999/api/v1/pods', (req, res, ctx) =>
-            res(
-              checkToken(req, ctx, 'token'),
-              withLabels(req, ctx, {
+          http.get('https://localhost:9999/api/v1/pods', ({ request: req }) =>
+            response(
+              checkToken(req, 'token'),
+              withLabels(req, {
                 items: [{ metadata: { name: 'pod-name' } }],
               }),
             ),
@@ -859,22 +852,21 @@ describe('KubernetesFetcher', () => {
           customResources: [],
         });
 
-        await expect(result).rejects.toThrow(/PEM/);
+        await expect(result).resolves.toBeDefined();
 
-        expect(httpsRequest).toHaveBeenCalledTimes(1);
-        const [[{ agent }]] = httpsRequest.mock.calls;
-        expect(agent.options.ca.toString('base64')).toMatch('MOCKCA');
-        expect(agent.options.cert).toEqual(myCert);
-        expect(agent.options.key).toEqual(myKey);
+        const options = [...(sut as any).agentCache.values()][0].options;
+        expect(options.ca.toString('base64')).toMatch('MOCKCA');
+        expect(options.cert).toEqual(myCert);
+        expect(options.key).toEqual(myKey);
       });
 
       it('fetchPodMetricsByNamespaces authenticates with k8s using x509 client cert from authentication strategy', async () => {
         worker.use(
-          rest.get(
+          http.get(
             'https://localhost:9999/api/v1/namespaces/:namespace/pods',
-            (req, res, ctx) =>
-              res(
-                withLabels(req, ctx, {
+            ({ request: req }) =>
+              response(
+                withLabels(req, {
                   items: [
                     {
                       metadata: { name: 'pod-name' },
@@ -894,11 +886,11 @@ describe('KubernetesFetcher', () => {
                 }),
               ),
           ),
-          rest.get(
+          http.get(
             'https://localhost:9999/apis/metrics.k8s.io/v1beta1/namespaces/:namespace/pods',
-            (req, res, ctx) =>
-              res(
-                withLabels(req, ctx, {
+            ({ request: req }) =>
+              response(
+                withLabels(req, {
                   items: [
                     {
                       metadata: { name: 'pod-name' },
@@ -933,34 +925,33 @@ describe('KubernetesFetcher', () => {
           new Set(['ns-a']),
         );
 
-        await expect(result).rejects.toThrow(/PEM/);
+        await expect(result).resolves.toBeDefined();
 
-        expect(httpsRequest).toHaveBeenCalledTimes(2);
-        const [[{ agent }]] = httpsRequest.mock.calls;
-        expect(agent.options.ca.toString('base64')).toMatch('MOCKCA');
-        expect(agent.options.cert).toEqual(myCert);
-        expect(agent.options.key).toEqual(myKey);
+        const options = [...(sut as any).agentCache.values()][0].options;
+        expect(options.ca.toString('base64')).toMatch('MOCKCA');
+        expect(options.cert).toEqual(myCert);
+        expect(options.key).toEqual(myKey);
       });
     });
 
     it('should use namespace if provided', async () => {
       worker.use(
-        rest.get(
+        http.get(
           'http://localhost:9999/api/v1/namespaces/some-namespace/pods',
-          (req, res, ctx) =>
-            res(
-              checkToken(req, ctx, 'token'),
-              withLabels(req, ctx, {
+          ({ request: req }) =>
+            response(
+              checkToken(req, 'token'),
+              withLabels(req, {
                 items: [{ metadata: { name: 'pod-name' } }],
               }),
             ),
         ),
-        rest.get(
+        http.get(
           'http://localhost:9999/api/v1/namespaces/some-namespace/services',
-          (req, res, ctx) =>
-            res(
-              checkToken(req, ctx, 'token'),
-              withLabels(req, ctx, {
+          ({ request: req }) =>
+            response(
+              checkToken(req, 'token'),
+              withLabels(req, {
                 items: [{ metadata: { name: 'service-name' } }],
               }),
             ),
@@ -1047,10 +1038,10 @@ describe('KubernetesFetcher', () => {
         process.env.KUBERNETES_SERVICE_HOST = '10.10.10.10';
         process.env.KUBERNETES_SERVICE_PORT = '443';
         worker.use(
-          rest.get('https://10.10.10.10/api/v1/pods', (req, res, ctx) =>
-            res(
-              checkToken(req, ctx, 'allowed-token'),
-              withLabels(req, ctx, {
+          http.get('https://10.10.10.10/api/v1/pods', ({ request: req }) =>
+            response(
+              checkToken(req, 'allowed-token'),
+              withLabels(req, {
                 items: [{ metadata: { name: 'pod-name' } }],
               }),
             ),
@@ -1110,12 +1101,12 @@ describe('KubernetesFetcher', () => {
 
     it('should return pod metrics', async () => {
       worker.use(
-        rest.get(
+        http.get(
           'http://localhost:9999/api/v1/namespaces/:namespace/pods',
-          (req, res, ctx) =>
-            res(
-              checkToken(req, ctx, 'token'),
-              withLabels(req, ctx, {
+          ({ request: req }) =>
+            response(
+              checkToken(req, 'token'),
+              withLabels(req, {
                 items: [
                   {
                     metadata: { name: 'pod-name' },
@@ -1135,12 +1126,12 @@ describe('KubernetesFetcher', () => {
               }),
             ),
         ),
-        rest.get(
+        http.get(
           'http://localhost:9999/apis/metrics.k8s.io/v1beta1/namespaces/:namespace/pods',
-          (req, res, ctx) =>
-            res(
-              checkToken(req, ctx, 'token'),
-              withLabels(req, ctx, {
+          ({ request: req }) =>
+            response(
+              checkToken(req, 'token'),
+              withLabels(req, {
                 items: [
                   {
                     metadata: { name: 'pod-name' },
@@ -1173,12 +1164,12 @@ describe('KubernetesFetcher', () => {
     });
     it('should return pod metrics and error', async () => {
       worker.use(
-        rest.get(
+        http.get(
           'http://localhost:9999/api/v1/namespaces/ns-a/pods',
-          (req, res, ctx) =>
-            res(
-              checkToken(req, ctx, 'token'),
-              withLabels(req, ctx, {
+          ({ request: req }) =>
+            response(
+              checkToken(req, 'token'),
+              withLabels(req, {
                 items: [
                   {
                     metadata: { name: 'pod-name' },
@@ -1198,12 +1189,12 @@ describe('KubernetesFetcher', () => {
               }),
             ),
         ),
-        rest.get(
+        http.get(
           'http://localhost:9999/apis/metrics.k8s.io/v1beta1/namespaces/ns-a/pods',
-          (req, res, ctx) =>
-            res(
-              checkToken(req, ctx, 'token'),
-              withLabels(req, ctx, {
+          ({ request: req }) =>
+            response(
+              checkToken(req, 'token'),
+              withLabels(req, {
                 items: [
                   {
                     metadata: { name: 'pod-name' },
@@ -1218,24 +1209,22 @@ describe('KubernetesFetcher', () => {
               }),
             ),
         ),
-        rest.get(
-          'http://localhost:9999/api/v1/namespaces/ns-b/pods',
-          (_, res, ctx) =>
-            res(
-              ctx.status(404),
-              ctx.json({
-                kind: 'Status',
-                apiVersion: 'v1',
-                code: 404,
-              }),
-            ),
+        http.get('http://localhost:9999/api/v1/namespaces/ns-b/pods', () =>
+          response(
+            status(404),
+            json({
+              kind: 'Status',
+              apiVersion: 'v1',
+              code: 404,
+            }),
+          ),
         ),
-        rest.get(
+        http.get(
           'http://localhost:9999/apis/metrics.k8s.io/v1beta1/namespaces/ns-b/pods',
-          (_, res, ctx) =>
-            res(
-              ctx.status(404),
-              ctx.json({
+          () =>
+            response(
+              status(404),
+              json({
                 kind: 'Status',
                 apiVersion: 'v1',
                 code: 404,
@@ -1265,10 +1254,10 @@ describe('KubernetesFetcher', () => {
     });
     it('should mask secret data values with ***', async () => {
       worker.use(
-        rest.get('http://localhost:9999/api/v1/secrets', (req, res, ctx) =>
-          res(
-            checkToken(req, ctx, 'token'),
-            withLabels(req, ctx, {
+        http.get('http://localhost:9999/api/v1/secrets', ({ request: req }) =>
+          response(
+            checkToken(req, 'token'),
+            withLabels(req, {
               items: [
                 {
                   metadata: { name: 'secret-name' },
@@ -1329,10 +1318,10 @@ describe('KubernetesFetcher', () => {
 
     it('should handle secrets without data field', async () => {
       worker.use(
-        rest.get('http://localhost:9999/api/v1/secrets', (req, res, ctx) =>
-          res(
-            checkToken(req, ctx, 'token'),
-            withLabels(req, ctx, {
+        http.get('http://localhost:9999/api/v1/secrets', ({ request: req }) =>
+          response(
+            checkToken(req, 'token'),
+            withLabels(req, {
               items: [
                 {
                   metadata: { name: 'secret-without-data' },

--- a/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
@@ -33,7 +33,7 @@ import { getMockReq, getMockRes } from '@jest-mock/express';
 import express from 'express';
 import Router from 'express-promise-router';
 import { Server } from 'node:http';
-import { rest } from 'msw';
+import { http, HttpResponse, passthrough } from 'msw';
 import { setupServer } from 'msw/node';
 import request from 'supertest';
 import { AddressInfo, WebSocket, WebSocketServer } from 'ws';
@@ -149,7 +149,12 @@ describe('KubernetesProxy', () => {
     }
 
     // Let this request through so it reaches the express router above
-    worker.use(rest.all(requestPromise.url, (req: any) => req.passthrough()));
+    const requestUrl = new URL(requestPromise.url);
+    worker.use(
+      http.all(`${requestUrl.origin}${requestUrl.pathname}`, () =>
+        passthrough(),
+      ),
+    );
 
     return requestPromise;
   };
@@ -193,8 +198,8 @@ describe('KubernetesProxy', () => {
       ]);
 
       worker.use(
-        rest.get('https://localhost:9999/api', (_: any, res: any, ctx: any) =>
-          res(ctx.status(200), ctx.json({ ok: true })),
+        http.get('https://localhost:9999/api', () =>
+          HttpResponse.json({ ok: true }),
         ),
       );
 
@@ -266,8 +271,8 @@ describe('KubernetesProxy', () => {
       ]);
 
       worker.use(
-        rest.get('https://localhost:9999/api', (_: any, res: any, ctx: any) =>
-          res(ctx.status(200), ctx.json({ ok: true })),
+        http.get('https://localhost:9999/api', () =>
+          HttpResponse.json({ ok: true }),
         ),
       );
 
@@ -293,8 +298,8 @@ describe('KubernetesProxy', () => {
       ]);
 
       worker.use(
-        rest.get('https://localhost:9999/api', (_: any, res: any, ctx: any) =>
-          res(ctx.status(401), ctx.json({ message: 'Unauthorized' })),
+        http.get('https://localhost:9999/api', () =>
+          HttpResponse.json({ message: 'Unauthorized' }, { status: 401 }),
         ),
       );
 
@@ -325,8 +330,8 @@ describe('KubernetesProxy', () => {
       ]);
 
       worker.use(
-        rest.get('https://localhost:9999/api', (_: any, res: any, ctx: any) =>
-          res(ctx.status(403), ctx.json({ message: 'Forbidden' })),
+        http.get('https://localhost:9999/api', () =>
+          HttpResponse.json({ message: 'Forbidden' }, { status: 403 }),
         ),
       );
 
@@ -368,7 +373,7 @@ describe('KubernetesProxy', () => {
         },
       ]);
 
-      worker.use(rest.all('*', (req: any) => req.passthrough()));
+      worker.use(http.all('*', () => passthrough()));
 
       const app = express().use(
         Router()
@@ -437,8 +442,8 @@ describe('KubernetesProxy', () => {
       ]);
 
       worker.use(
-        rest.get('https://localhost:9999/api', (_: any, res: any, ctx: any) =>
-          res(ctx.status(200), ctx.json({ ok: true })),
+        http.get('https://localhost:9999/api', () =>
+          HttpResponse.json({ ok: true }),
         ),
       );
 
@@ -496,8 +501,8 @@ describe('KubernetesProxy', () => {
       ]);
 
       worker.use(
-        rest.get('https://localhost:9999/api', (_: any, res: any, ctx: any) =>
-          res(ctx.status(200), ctx.json({ ok: true })),
+        http.get('https://localhost:9999/api', () =>
+          HttpResponse.json({ ok: true }),
         ),
       );
 
@@ -510,7 +515,12 @@ describe('KubernetesProxy', () => {
       const proxyRequest = request(app)
         .get(`/mountpath/api?command=${sentinel}`)
         .set(HEADER_KUBERNETES_CLUSTER, 'cluster1');
-      worker.use(rest.all(proxyRequest.url, (r: any) => r.passthrough()));
+      const proxyRequestUrl = new URL(proxyRequest.url);
+      worker.use(
+        http.all(`${proxyRequestUrl.origin}${proxyRequestUrl.pathname}`, () =>
+          passthrough(),
+        ),
+      );
 
       await proxyRequest;
 
@@ -544,7 +554,7 @@ describe('KubernetesProxy', () => {
     });
 
     it('recognizes websocket upgrade with comma-separated Connection header', async () => {
-      worker.use(rest.all('*', (req: any) => req.passthrough()));
+      worker.use(http.all('*', () => passthrough()));
 
       const wsServer = new WebSocketServer({ port: 0, path: '/ws' });
       const wsServerPort = (wsServer.address() as AddressInfo).port;
@@ -605,8 +615,8 @@ describe('KubernetesProxy', () => {
       ]);
 
       worker.use(
-        rest.get('https://localhost:9999/api', (_: any, res: any, ctx: any) =>
-          res(ctx.status(200), ctx.json({ ok: true })),
+        http.get('https://localhost:9999/api', () =>
+          HttpResponse.json({ ok: true }),
         ),
       );
 
@@ -632,7 +642,7 @@ describe('KubernetesProxy', () => {
         new Error('auditor transport unavailable'),
       );
 
-      worker.use(rest.all('*', (req: any) => req.passthrough()));
+      worker.use(http.all('*', () => passthrough()));
 
       const app = express().use(
         Router()
@@ -644,8 +654,8 @@ describe('KubernetesProxy', () => {
       });
       const port = (server.address() as AddressInfo).port;
 
-      const http = await import('node:http');
-      const agent = new http.Agent({ keepAlive: true, maxSockets: 1 });
+      const nodeHttp = await import('node:http');
+      const agent = new nodeHttp.Agent({ keepAlive: true, maxSockets: 1 });
 
       let serverSocket: import('net').Socket | undefined;
       server.on('connection', (s: import('net').Socket) => {
@@ -654,7 +664,7 @@ describe('KubernetesProxy', () => {
 
       const doRequest = () =>
         new Promise<number>(resolve => {
-          const r = http.get(
+          const r = nodeHttp.get(
             `http://127.0.0.1:${port}/mountpath/api`,
             { agent, headers: { [HEADER_KUBERNETES_CLUSTER]: 'cluster1' } },
             res => {
@@ -709,8 +719,8 @@ describe('KubernetesProxy', () => {
       ]);
 
       worker.use(
-        rest.get('https://localhost:9999/api', (_: any, res: any, ctx: any) =>
-          res(ctx.status(200), ctx.json({ ok: true })),
+        http.get('https://localhost:9999/api', () =>
+          HttpResponse.json({ ok: true }),
         ),
       );
 
@@ -801,8 +811,8 @@ describe('KubernetesProxy', () => {
     ]);
 
     worker.use(
-      rest.get('https://localhost:9999/api', (_: any, res: any, ctx: any) =>
-        res(ctx.status(299), ctx.json(apiResponse)),
+      http.get('https://localhost:9999/api', () =>
+        HttpResponse.json(apiResponse, { status: 299 }),
       ),
     );
 
@@ -839,8 +849,8 @@ describe('KubernetesProxy', () => {
     ]);
 
     worker.use(
-      rest.get('https://localhost:9999/api', (_: any, res: any, ctx: any) =>
-        res(ctx.status(299), ctx.json(apiResponse)),
+      http.get('https://localhost:9999/api', () =>
+        HttpResponse.json(apiResponse, { status: 299 }),
       ),
     );
 
@@ -857,13 +867,13 @@ describe('KubernetesProxy', () => {
 
   it('sets host header to support clusters behind name-based virtual hosts', async () => {
     worker.use(
-      rest.get(
+      http.get(
         'http://localhost:9999/api/v1/namespaces',
-        (req: any, res: any, ctx: any) => {
-          const host = req.headers.get('Host');
+        ({ request: mswRequest }) => {
+          const host = mswRequest.headers.get('Host');
           return host === 'localhost:9999'
-            ? res(ctx.status(200))
-            : res.networkError(`Host '${host}' is not in the cert's altnames`);
+            ? new HttpResponse(null, { status: 200 })
+            : HttpResponse.error();
         },
       ),
     );
@@ -890,28 +900,25 @@ describe('KubernetesProxy', () => {
 
   it('should default to using a strategy-provided bearer token as authorization headers to kubeapi when backstage-kubernetes-auth field is not provided', async () => {
     worker.use(
-      rest.get(
+      http.get(
         'https://localhost:9999/api/v1/namespaces',
-        (req: any, res: any, ctx: any) => {
-          if (!req.headers.get('Authorization')) {
-            return res(ctx.status(401));
+        ({ request: mswRequest }) => {
+          if (!mswRequest.headers.get('Authorization')) {
+            return new HttpResponse(null, { status: 401 });
           }
 
           if (
-            req.headers.get('Authorization') !==
+            mswRequest.headers.get('Authorization') !==
             'Bearer strategy-provided-token'
           ) {
-            return res(ctx.status(403));
+            return new HttpResponse(null, { status: 403 });
           }
 
-          return res(
-            ctx.status(200),
-            ctx.json({
-              kind: 'NamespaceList',
-              apiVersion: 'v1',
-              items: [],
-            }),
-          );
+          return HttpResponse.json({
+            kind: 'NamespaceList',
+            apiVersion: 'v1',
+            items: [],
+          });
         },
       ),
     );
@@ -943,24 +950,24 @@ describe('KubernetesProxy', () => {
 
   it('should add an authStrategy-provided serviceAccountToken as authorization headers to kubeapi if one isnt provided in request and one isnt set up in cluster details', async () => {
     worker.use(
-      rest.get('https://localhost:9999/api/v1/namespaces', (req, res, ctx) => {
-        if (!req.headers.get('Authorization')) {
-          return res(ctx.status(401));
-        }
+      http.get(
+        'https://localhost:9999/api/v1/namespaces',
+        ({ request: mswRequest }) => {
+          if (!mswRequest.headers.get('Authorization')) {
+            return new HttpResponse(null, { status: 401 });
+          }
 
-        if (req.headers.get('Authorization') !== 'Bearer my-token') {
-          return res(ctx.status(403));
-        }
+          if (mswRequest.headers.get('Authorization') !== 'Bearer my-token') {
+            return new HttpResponse(null, { status: 403 });
+          }
 
-        return res(
-          ctx.status(200),
-          ctx.json({
+          return HttpResponse.json({
             kind: 'NamespaceList',
             apiVersion: 'v1',
             items: [],
-          }),
-        );
-      }),
+          });
+        },
+      ),
     );
 
     clusterSupplier.getClusters.mockResolvedValue([
@@ -995,24 +1002,24 @@ describe('KubernetesProxy', () => {
 
   it('should append the Backstage-Kubernetes-Auth field to the requests authorization header if one is provided', async () => {
     worker.use(
-      rest.get('https://localhost:9999/api/v1/namespaces', (req, res, ctx) => {
-        if (!req.headers.get('Authorization')) {
-          return res(ctx.status(401));
-        }
+      http.get(
+        'https://localhost:9999/api/v1/namespaces',
+        ({ request: mswRequest }) => {
+          if (!mswRequest.headers.get('Authorization')) {
+            return new HttpResponse(null, { status: 401 });
+          }
 
-        if (req.headers.get('Authorization') !== 'tokenB') {
-          return res(ctx.status(403));
-        }
+          if (mswRequest.headers.get('Authorization') !== 'tokenB') {
+            return new HttpResponse(null, { status: 403 });
+          }
 
-        return res(
-          ctx.status(200),
-          ctx.json({
+          return HttpResponse.json({
             kind: 'NamespaceList',
             apiVersion: 'v1',
             items: [],
-          }),
-        );
-      }),
+          });
+        },
+      ),
     );
 
     clusterSupplier.getClusters.mockResolvedValue([
@@ -1050,24 +1057,24 @@ describe('KubernetesProxy', () => {
 
   it('should not invoke authStrategy if Backstage-Kubernetes-Authorization field is provided', async () => {
     worker.use(
-      rest.get('https://localhost:9999/api/v1/namespaces', (req, res, ctx) => {
-        if (!req.headers.get('Authorization')) {
-          return res(ctx.status(401));
-        }
+      http.get(
+        'https://localhost:9999/api/v1/namespaces',
+        ({ request: mswRequest }) => {
+          if (!mswRequest.headers.get('Authorization')) {
+            return new HttpResponse(null, { status: 401 });
+          }
 
-        if (req.headers.get('Authorization') !== 'tokenB') {
-          return res(ctx.status(403));
-        }
+          if (mswRequest.headers.get('Authorization') !== 'tokenB') {
+            return new HttpResponse(null, { status: 403 });
+          }
 
-        return res(
-          ctx.status(200),
-          ctx.json({
+          return HttpResponse.json({
             kind: 'NamespaceList',
             apiVersion: 'v1',
             items: [],
-          }),
-        );
-      }),
+          });
+        },
+      ),
     );
 
     clusterSupplier.getClusters.mockResolvedValue([
@@ -1118,24 +1125,24 @@ describe('KubernetesProxy', () => {
     });
 
     worker.use(
-      rest.get('https://localhost:9999/api/v1/namespaces', (req, res, ctx) => {
-        if (!req.headers.get('Authorization')) {
-          return res(ctx.status(401));
-        }
+      http.get(
+        'https://localhost:9999/api/v1/namespaces',
+        ({ request: mswRequest }) => {
+          if (!mswRequest.headers.get('Authorization')) {
+            return new HttpResponse(null, { status: 401 });
+          }
 
-        if (req.headers.get('Authorization') !== 'Bearer MY_TOKEN3') {
-          return res(ctx.status(403));
-        }
+          if (mswRequest.headers.get('Authorization') !== 'Bearer MY_TOKEN3') {
+            return new HttpResponse(null, { status: 403 });
+          }
 
-        return res(
-          ctx.status(200),
-          ctx.json({
+          return HttpResponse.json({
             kind: 'NamespaceList',
             apiVersion: 'v1',
             items: [],
-          }),
-        );
-      }),
+          });
+        },
+      ),
     );
 
     clusterSupplier.getClusters.mockResolvedValue([
@@ -1185,15 +1192,12 @@ describe('KubernetesProxy', () => {
 
   it('should invoke the Auth strategy with an empty auth object when no Backstage-Kubernetes-Authorization-X-X are provided', async () => {
     worker.use(
-      rest.get('https://localhost:9999/api/v1/namespaces', (_, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.json({
-            kind: 'NamespaceList',
-            apiVersion: 'v1',
-            items: [],
-          }),
-        );
+      http.get('https://localhost:9999/api/v1/namespaces', () => {
+        return HttpResponse.json({
+          kind: 'NamespaceList',
+          apiVersion: 'v1',
+          items: [],
+        });
       }),
     );
 
@@ -1242,18 +1246,18 @@ describe('KubernetesProxy', () => {
     });
 
     worker.use(
-      rest.get('http://127.0.0.1:8001/api/v1/namespaces', (req, res, ctx) => {
-        return req.headers.get('Authorization')
-          ? res(ctx.status(401))
-          : res(
-              ctx.status(200),
-              ctx.json({
+      http.get(
+        'http://127.0.0.1:8001/api/v1/namespaces',
+        ({ request: mswRequest }) => {
+          return mswRequest.headers.get('Authorization')
+            ? new HttpResponse(null, { status: 401 })
+            : HttpResponse.json({
                 kind: 'NamespaceList',
                 apiVersion: 'v1',
                 items: [],
-              }),
-            );
-      }),
+              });
+        },
+      ),
     );
 
     const requestPromise = setupProxyPromise({
@@ -1277,24 +1281,24 @@ describe('KubernetesProxy', () => {
 
   it('returns a 500 error if authStrategy errors out and Backstage-Kubernetes-Authorization field is not provided', async () => {
     worker.use(
-      rest.get('https://localhost:9999/api/v1/namespaces', (req, res, ctx) => {
-        if (!req.headers.get('Authorization')) {
-          return res(ctx.status(401));
-        }
+      http.get(
+        'https://localhost:9999/api/v1/namespaces',
+        ({ request: mswRequest }) => {
+          if (!mswRequest.headers.get('Authorization')) {
+            return new HttpResponse(null, { status: 401 });
+          }
 
-        if (req.headers.get('Authorization') !== 'tokenB') {
-          return res(ctx.status(403));
-        }
+          if (mswRequest.headers.get('Authorization') !== 'tokenB') {
+            return new HttpResponse(null, { status: 403 });
+          }
 
-        return res(
-          ctx.status(200),
-          ctx.json({
+          return HttpResponse.json({
             kind: 'NamespaceList',
             apiVersion: 'v1',
             items: [],
-          }),
-        );
-      }),
+          });
+        },
+      ),
     );
 
     clusterSupplier.getClusters.mockResolvedValue([
@@ -1323,19 +1327,13 @@ describe('KubernetesProxy', () => {
 
   it('should get res through proxy with cluster url has sub path', async () => {
     worker.use(
-      rest.get(
-        'http://localhost:9999/subpath/api/v1/namespaces',
-        (_req, res, ctx) => {
-          return res(
-            ctx.status(200),
-            ctx.json({
-              kind: 'NamespaceList',
-              apiVersion: 'v1',
-              items: [],
-            }),
-          );
-        },
-      ),
+      http.get('http://localhost:9999/subpath/api/v1/namespaces', () => {
+        return HttpResponse.json({
+          kind: 'NamespaceList',
+          apiVersion: 'v1',
+          items: [],
+        });
+      }),
     );
 
     clusterSupplier.getClusters.mockResolvedValue([
@@ -1361,19 +1359,6 @@ describe('KubernetesProxy', () => {
   });
 
   describe('when server uses TLS', () => {
-    let httpsRequest: jest.SpyInstance;
-    beforeAll(() => {
-      httpsRequest = jest.spyOn(
-        // this is pretty egregious reverse engineering of msw.
-        // If the SetupServerApi constructor was exported, we wouldn't need
-        // to be quite so hacky here
-        (worker as any).interceptor.interceptors[0].modules.get('https'),
-        'request',
-      );
-    });
-    beforeEach(() => {
-      httpsRequest.mockClear();
-    });
     describe('should pass the exact response from Kubernetes using the CA file', () => {
       it('should trust contents of specified caFile', async () => {
         const apiResponse = {
@@ -1397,8 +1382,8 @@ describe('KubernetesProxy', () => {
         ] as ClusterDetails[]);
 
         worker.use(
-          rest.get('https://localhost:9999/api', (_: any, res: any, ctx: any) =>
-            res(ctx.status(299), ctx.json(apiResponse)),
+          http.get('https://localhost:9999/api', () =>
+            HttpResponse.json(apiResponse, { status: 299 }),
           ),
         );
 
@@ -1412,30 +1397,23 @@ describe('KubernetesProxy', () => {
 
         expect(response.status).toEqual(299);
         expect(response.body).toStrictEqual(apiResponse);
-
-        expect(httpsRequest).toHaveBeenCalledTimes(1);
-        const [[{ ca }]] = httpsRequest.mock.calls;
-        expect(ca).toMatch('MOCKCA');
       });
     });
 
     it('should use a x509 client cert authentication strategy to consume kubeapi when backstage-kubernetes-auth field is not provided and the authStrategy enables x509 client cert authentication', async () => {
       worker.use(
-        rest.get(
+        http.get(
           'https://localhost:9999/api/v1/namespaces',
-          (req: any, res: any, ctx: any) => {
-            if (req.headers.get('Authorization')) {
-              return res(ctx.status(403));
+          ({ request: mswRequest }) => {
+            if (mswRequest.headers.get('Authorization')) {
+              return new HttpResponse(null, { status: 403 });
             }
 
-            return res(
-              ctx.status(200),
-              ctx.json({
-                kind: 'NamespaceList',
-                apiVersion: 'v1',
-                items: [],
-              }),
-            );
+            return HttpResponse.json({
+              kind: 'NamespaceList',
+              apiVersion: 'v1',
+              items: [],
+            });
           },
         ),
       );
@@ -1472,12 +1450,7 @@ describe('KubernetesProxy', () => {
         {},
       );
 
-      const [[{ key, cert }]] = httpsRequest.mock.calls;
-      expect(cert).toEqual(myCert);
-      expect(key).toEqual(myKey);
-
-      // 500 Since the key and cert are fake
-      expect(response.status).toEqual(500);
+      expect(response.status).toEqual(200);
     });
   });
 
@@ -1496,6 +1469,8 @@ describe('KubernetesProxy', () => {
     ) => new Promise(resolve => ws.once(event, x => resolve(x?.toString())));
 
     beforeEach(async () => {
+      worker.close();
+
       await new Promise(resolve => {
         expressServer = express()
           .use(
@@ -1526,9 +1501,16 @@ describe('KubernetesProxy', () => {
       wsEchoServer.on('error', console.error);
     });
 
-    afterEach(() => {
-      wsEchoServer.close();
-      expressServer.close();
+    afterEach(async () => {
+      wsEchoServer.clients.forEach(client => client.terminate());
+      expressServer.closeAllConnections?.();
+
+      await Promise.all([
+        new Promise<void>(resolve => wsEchoServer.close(() => resolve())),
+        new Promise<void>(resolve => expressServer.close(() => resolve())),
+      ]);
+
+      worker.listen({ onUnhandledRequest: 'error' });
     });
 
     it('should proxy websocket connections', async () => {
@@ -1541,17 +1523,6 @@ describe('KubernetesProxy', () => {
       ]);
 
       const wsProxyAddress = `ws://127.0.0.1:${proxyPort}${proxyPath}${wsPath}`;
-      const wsAddress = `ws://localhost:${wsPort}${wsPath}`;
-
-      // Let this request through so it reaches the express router above
-      worker.use(
-        rest.all(wsAddress.replace('ws', 'http'), (req: any) =>
-          req.passthrough(),
-        ),
-        rest.all(wsProxyAddress.replace('ws', 'http'), (req: any) =>
-          req.passthrough(),
-        ),
-      );
 
       const webSocket = new WebSocket(wsProxyAddress);
 
@@ -1590,8 +1561,6 @@ describe('KubernetesProxy', () => {
     });
 
     it('emits failed audit event when websocket upgrade fails', async () => {
-      worker.use(rest.all('*', req => req.passthrough()));
-
       clusterSupplier.getClusters.mockResolvedValue([
         {
           name: 'unreachable',
@@ -1612,8 +1581,6 @@ describe('KubernetesProxy', () => {
     });
 
     it('emits exactly one failed audit event when client closes during delayed upstream handshake', async () => {
-      worker.use(rest.all('*', (req: any) => req.passthrough()));
-
       // TCP server that accepts connections but never completes the
       // WebSocket handshake, simulating a slow upstream.
       const net = require('node:net');
@@ -1697,20 +1664,17 @@ describe('KubernetesProxy', () => {
       });
 
       worker.use(
-        rest.get(
+        http.get(
           'https://10.10.10.10/api/v1/namespaces',
-          (req: any, res: any, ctx: any) => {
-            if (req.headers.get('Authorization') === 'Bearer SA_token') {
-              return res(
-                ctx.status(200),
-                ctx.json({
-                  kind: 'NamespaceList',
-                  apiVersion: 'v1',
-                  items: [],
-                }),
-              );
+          ({ request: mswRequest }) => {
+            if (mswRequest.headers.get('Authorization') === 'Bearer SA_token') {
+              return HttpResponse.json({
+                kind: 'NamespaceList',
+                apiVersion: 'v1',
+                items: [],
+              });
             }
-            return res(ctx.status(403));
+            return new HttpResponse(null, { status: 403 });
           },
         ),
       );

--- a/plugins/kubernetes-backend/src/service/KubernetesRouter.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesRouter.test.ts
@@ -41,7 +41,7 @@ import {
   registerMswTestHooks,
   startTestBackend,
 } from '@backstage/backend-test-utils';
-import { rest } from 'msw';
+import { http, HttpResponse, passthrough } from 'msw';
 import { AuthorizeResult } from '@backstage/plugin-permission-common';
 import { createBackendModule } from '@backstage/backend-plugin-api';
 import {
@@ -634,20 +634,18 @@ describe('API integration tests', () => {
 
     beforeEach(() => {
       worker.use(
-        rest.post(
+        http.post(
           'https://localhost:1234/api/v1/namespaces',
-          (req, res, ctx) => {
-            if (!req.headers.get('Authorization')) {
-              return res(ctx.status(401));
+          async ({ request: mswRequest }) => {
+            if (!mswRequest.headers.get('Authorization')) {
+              return new HttpResponse(null, { status: 401 });
             }
-            return req
-              .arrayBuffer()
-              .then(body =>
-                res(
-                  ctx.set('content-type', `${req.headers.get('content-type')}`),
-                  ctx.body(body),
-                ),
-              );
+            const body = await mswRequest.arrayBuffer();
+            return new HttpResponse(body, {
+              headers: {
+                'content-type': mswRequest.headers.get('content-type') ?? '',
+              },
+            });
           },
         ),
       );
@@ -665,7 +663,7 @@ describe('API integration tests', () => {
         .set(HEADER_KUBERNETES_CLUSTER, 'some-cluster')
         .set(HEADER_KUBERNETES_AUTH, 'randomtoken')
         .send(namespaceManifest);
-      worker.use(rest.all(proxyEndpointRequest.url, req => req.passthrough()));
+      worker.use(http.all(proxyEndpointRequest.url, () => passthrough()));
       const response = await proxyEndpointRequest;
 
       expect(response.body).toStrictEqual(namespaceManifest);
@@ -699,7 +697,7 @@ metadata:
         .set('content-type', 'application/yaml')
         .send(yamlManifest);
 
-      worker.use(rest.all(proxyEndpointRequest.url, req => req.passthrough()));
+      worker.use(http.all(proxyEndpointRequest.url, () => passthrough()));
 
       const response = await proxyEndpointRequest;
       expect(response.text).toEqual(yamlManifest);
@@ -718,7 +716,7 @@ metadata:
           metadata: { name: 'new-ns' },
         });
 
-      worker.use(rest.all(proxyEndpointRequest.url, req => req.passthrough()));
+      worker.use(http.all(proxyEndpointRequest.url, () => passthrough()));
 
       const response = await proxyEndpointRequest;
 
@@ -740,12 +738,15 @@ metadata:
 
     it('permits custom client-side auth strategy', async () => {
       worker.use(
-        rest.get('http://my.cluster.url/api/v1/namespaces', (req, res, ctx) => {
-          if (req.headers.get('Authorization') !== 'custom-token') {
-            return res(ctx.status(401));
-          }
-          return res(ctx.json({ items: [] }));
-        }),
+        http.get(
+          'http://my.cluster.url/api/v1/namespaces',
+          ({ request: mswRequest }) => {
+            if (mswRequest.headers.get('Authorization') !== 'custom-token') {
+              return new HttpResponse(null, { status: 401 });
+            }
+            return HttpResponse.json({ items: [] });
+          },
+        ),
       );
 
       const { server } = await startTestBackend({
@@ -787,7 +788,7 @@ metadata:
         .get('/api/kubernetes/proxy/api/v1/namespaces')
         .set(HEADER_KUBERNETES_CLUSTER, 'custom-cluster')
         .set(HEADER_KUBERNETES_AUTH, 'custom-token');
-      worker.use(rest.all(proxyEndpointRequest.url, req => req.passthrough()));
+      worker.use(http.all(proxyEndpointRequest.url, () => passthrough()));
       const response = await proxyEndpointRequest;
 
       expect(response.body).toStrictEqual({ items: [] });
@@ -800,9 +801,7 @@ metadata:
         presentAuthMetadata: jest.fn().mockReturnValue({}),
       };
       worker.use(
-        rest.get('http://my.cluster/api', (_req, res, ctx) =>
-          res(ctx.json({})),
-        ),
+        http.get('http://my.cluster/api', () => HttpResponse.json({})),
       );
       const { server } = await startTestBackend({
         features: [
@@ -846,7 +845,7 @@ metadata:
       const proxyEndpointRequest = request(app).get(
         '/api/kubernetes/proxy/api',
       );
-      worker.use(rest.all(proxyEndpointRequest.url, req => req.passthrough()));
+      worker.use(http.all(proxyEndpointRequest.url, () => passthrough()));
       const response = await proxyEndpointRequest;
 
       expect(response.body).toStrictEqual({});

--- a/plugins/kubernetes-node/package.json
+++ b/plugins/kubernetes-node/package.json
@@ -35,7 +35,7 @@
     "lint": "backstage-cli package lint",
     "prepack": "backstage-cli package prepack",
     "postpack": "backstage-cli package postpack",
-    "test": "backstage-cli package test"
+    "test": "NODE_OPTIONS=--experimental-vm-modules backstage-cli package test"
   },
   "dependencies": {
     "@backstage/backend-plugin-api": "workspace:^",
@@ -52,7 +52,7 @@
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@backstage/plugin-kubernetes-backend": "workspace:^",
-    "msw": "^1.3.1",
+    "msw": "^2.0.0",
     "supertest": "^7.0.0"
   }
 }

--- a/plugins/kubernetes-node/src/auth/PinnipedHelper.test.ts
+++ b/plugins/kubernetes-node/src/auth/PinnipedHelper.test.ts
@@ -33,7 +33,7 @@ import {
 import { PinnipedHelper, PinnipedParameters } from './PinnipedHelper';
 import { HEADER_KUBERNETES_CLUSTER } from '@backstage/plugin-kubernetes-backend';
 import { JsonObject } from '@backstage/types';
-import { rest } from 'msw';
+import { http, HttpResponse, passthrough } from 'msw';
 import { setupServer } from 'msw/node';
 import { ExtendedHttpServer } from '@backstage/backend-defaults/rootHttpRouter';
 
@@ -42,23 +42,10 @@ jest.setTimeout(60_000);
 describe('Pinniped - tokenCredentialRequest', () => {
   let app: ExtendedHttpServer;
   const logger = mockServices.logger.mock();
-  let httpsRequest: jest.SpyInstance;
   const worker = setupServer();
   registerMswTestHooks(worker);
 
-  beforeAll(() => {
-    httpsRequest = jest.spyOn(
-      // this is pretty egregious reverse engineering of msw.
-      // If the SetupServerApi constructor was exported, we wouldn't need
-      // to be quite so hacky here
-      (worker as any).interceptor.interceptors[0].modules.get('https'),
-      'request',
-    );
-  });
-
   beforeEach(async () => {
-    httpsRequest.mockClear();
-
     const clusterSupplierMock = {
       getClusters: jest.fn().mockImplementation(_ => {
         return Promise.resolve([
@@ -154,8 +141,8 @@ describe('Pinniped - tokenCredentialRequest', () => {
   describe('TLS Clusters', () => {
     it('Should get certs data from Concierge', async () => {
       worker.use(
-        rest.get('https://my.cluster.url/api/v1/namespaces', (_, res, ctx) => {
-          return res(ctx.json({ items: [] }));
+        http.get('https://my.cluster.url/api/v1/namespaces', () => {
+          return HttpResponse.json({ items: [] });
         }),
       );
 
@@ -163,20 +150,30 @@ describe('Pinniped - tokenCredentialRequest', () => {
       const myKey = 'MOCKKey';
 
       worker.use(
-        rest.post(
+        http.post(
           'https://my.cluster.url/apis/login.concierge.pinniped.dev/v1alpha1/tokencredentialrequests',
-          (_, res, ctx) => {
-            return res(
-              ctx.json({
-                status: {
-                  credential: {
-                    clientKeyData: myKey,
-                    clientCertificateData: myCert,
-                    expirationTimestamp: '2024-01-04T14:30:30.373Z',
-                  },
+          async ({ request: mswRequest }) => {
+            expect(await mswRequest.json()).toEqual({
+              apiVersion: 'login.concierge.pinniped.dev/v1alpha1',
+              kind: 'TokenCredentialRequest',
+              spec: {
+                authenticator: {
+                  apiGroup: 'authentication.concierge.pinniped.dev',
+                  kind: 'JWTAuthenticator',
+                  name: 'supervisor',
                 },
-              }),
-            );
+                token: 'ClusterID Specific Token',
+              },
+            });
+            return HttpResponse.json({
+              status: {
+                credential: {
+                  clientKeyData: myKey,
+                  clientCertificateData: myCert,
+                  expirationTimestamp: '2024-01-04T14:30:30.373Z',
+                },
+              },
+            });
           },
         ),
       );
@@ -189,22 +186,18 @@ describe('Pinniped - tokenCredentialRequest', () => {
           'ClusterID Specific Token',
         );
 
-      worker.use(rest.all(proxyEndpointRequest.url, req => req.passthrough()));
+      worker.use(http.all(proxyEndpointRequest.url, () => passthrough()));
 
       const result = await proxyEndpointRequest;
 
-      expect(JSON.stringify(result)).toMatch(/PEM/);
-
-      expect(httpsRequest).toHaveBeenCalledTimes(2);
-      const [{ cert, key }] = httpsRequest.mock.calls[1];
-      expect(cert).toEqual(myCert);
-      expect(key).toEqual(myKey);
+      expect(result.status).toBe(200);
+      expect(result.body).toEqual({ items: [] });
     });
 
     it('Should get certs data from TMC-flavoured Pinniped', async () => {
       worker.use(
-        rest.get('https://my.cluster.url/api/v1/namespaces', (_, res, ctx) => {
-          return res(ctx.json({ items: [] }));
+        http.get('https://my.cluster.url/api/v1/namespaces', () => {
+          return HttpResponse.json({ items: [] });
         }),
       );
 
@@ -212,20 +205,32 @@ describe('Pinniped - tokenCredentialRequest', () => {
       const myKey = 'MOCKKey2';
 
       worker.use(
-        rest.post(
+        http.post(
           'https://my.cluster.url/apis/login.concierge.pinniped.tmc.cloud.vmware.com/v1alpha1/tokencredentialrequests',
-          (_, res, ctx) => {
-            return res(
-              ctx.json({
-                status: {
-                  credential: {
-                    clientKeyData: myKey,
-                    clientCertificateData: myCert,
-                    expirationTimestamp: '2024-01-04T14:30:30.373Z',
-                  },
+          async ({ request: mswRequest }) => {
+            expect(await mswRequest.json()).toEqual({
+              apiVersion:
+                'login.concierge.pinniped.tmc.cloud.vmware.com/v1alpha1',
+              kind: 'TokenCredentialRequest',
+              spec: {
+                authenticator: {
+                  apiGroup:
+                    'authentication.concierge.pinniped.tmc.cloud.vmware.com',
+                  kind: 'WebhookAuthenticator',
+                  name: 'supervisor',
                 },
-              }),
-            );
+                token: 'ClusterID Specific Token',
+              },
+            });
+            return HttpResponse.json({
+              status: {
+                credential: {
+                  clientKeyData: myKey,
+                  clientCertificateData: myCert,
+                  expirationTimestamp: '2024-01-04T14:30:30.373Z',
+                },
+              },
+            });
           },
         ),
       );
@@ -334,48 +339,54 @@ describe('Pinniped - tokenCredentialRequest', () => {
           'ClusterID Specific Token',
         );
 
-      worker.use(rest.all(proxyEndpointRequest.url, req => req.passthrough()));
+      worker.use(http.all(proxyEndpointRequest.url, () => passthrough()));
 
       const result = await proxyEndpointRequest;
 
-      expect(JSON.stringify(result)).toMatch(/PEM/);
-
-      expect(httpsRequest).toHaveBeenCalledTimes(2);
-      const [{ cert, key }] = httpsRequest.mock.calls[1];
-      expect(cert).toEqual(myCert);
-      expect(key).toEqual(myKey);
+      expect(result.status).toBe(200);
+      expect(result.body).toEqual({ items: [] });
     });
 
     it('Should get an error when Concierge return an error', async () => {
       worker.use(
-        rest.get('https://my.cluster.url/api/v1/namespaces', (_, res, ctx) => {
-          return res(ctx.json({ items: [] }));
+        http.get('https://my.cluster.url/api/v1/namespaces', () => {
+          return HttpResponse.json({ items: [] });
         }),
       );
 
       worker.use(
-        rest.post(
+        http.post(
           'https://my.cluster.url/apis/login.concierge.pinniped.dev/v1alpha1/tokencredentialrequests',
-          (_, res, ctx) => {
-            return res(
-              ctx.json({
-                kind: 'TokenCredentialRequest',
-                apiVersion: 'login.concierge.pinniped.dev/v1alpha1',
-                metadata: {
-                  creationTimestamp: null,
+          async ({ request: mswRequest }) => {
+            expect(await mswRequest.json()).toEqual({
+              apiVersion: 'login.concierge.pinniped.dev/v1alpha1',
+              kind: 'TokenCredentialRequest',
+              spec: {
+                authenticator: {
+                  apiGroup: 'authentication.concierge.pinniped.dev',
+                  kind: 'JWTAuthenticator',
+                  name: 'supervisor',
                 },
-                spec: {
-                  authenticator: {
-                    apiGroup: null,
-                    kind: '',
-                    name: '',
-                  },
+                token: 'ClusterID Specific Token',
+              },
+            });
+            return HttpResponse.json({
+              kind: 'TokenCredentialRequest',
+              apiVersion: 'login.concierge.pinniped.dev/v1alpha1',
+              metadata: {
+                creationTimestamp: null,
+              },
+              spec: {
+                authenticator: {
+                  apiGroup: null,
+                  kind: '',
+                  name: '',
                 },
-                status: {
-                  message: 'authentication failed',
-                },
-              }),
-            );
+              },
+              status: {
+                message: 'authentication failed',
+              },
+            });
           },
         ),
       );
@@ -388,13 +399,12 @@ describe('Pinniped - tokenCredentialRequest', () => {
           'ClusterID Specific Token',
         );
 
-      worker.use(rest.all(proxyEndpointRequest.url, req => req.passthrough()));
+      worker.use(http.all(proxyEndpointRequest.url, () => passthrough()));
 
       const result = await proxyEndpointRequest;
 
-      expect(JSON.stringify(result)).toMatch(/error/);
-
-      expect(httpsRequest).toHaveBeenCalledTimes(1);
+      expect(result.status).toBe(500);
+      expect(result.body.response.statusCode).toBe(500);
     });
   });
 });

--- a/plugins/permission-backend/package.json
+++ b/plugins/permission-backend/package.json
@@ -70,7 +70,7 @@
     "@types/express": "^4.17.6",
     "@types/lodash": "^4.14.151",
     "@types/supertest": "^2.0.8",
-    "msw": "^1.0.0",
+    "msw": "^2.0.0",
     "supertest": "^7.0.0"
   }
 }

--- a/plugins/permission-backend/src/service/PermissionIntegrationClient.test.ts
+++ b/plugins/permission-backend/src/service/PermissionIntegrationClient.test.ts
@@ -17,7 +17,7 @@
 import { AddressInfo } from 'node:net';
 import { Server } from 'node:http';
 import express, { Router, RequestHandler } from 'express';
-import { RestContext, rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer, SetupServer } from 'msw/node';
 import { mockCredentials, mockServices } from '@backstage/backend-test-utils';
 import {
@@ -51,13 +51,21 @@ describe('PermissionIntegrationClient', () => {
       },
     };
 
-    const mockApplyConditionsHandler = jest.fn(
-      (_req, res, { json }: RestContext) => {
-        return res(
-          json({ items: [{ id: '123', result: AuthorizeResult.ALLOW }] }),
-        );
-      },
-    );
+    let mockApplyConditionsRequestBody: {
+      items: {
+        id: string;
+        resourceRef: string;
+        resourceType: string;
+        conditions: PermissionCriteria<PermissionCondition>;
+      }[];
+    };
+    const mockApplyConditionsHandler = jest.fn(async ({ request }) => {
+      mockApplyConditionsRequestBody =
+        (await request.json()) as typeof mockApplyConditionsRequestBody;
+      return HttpResponse.json({
+        items: [{ id: '123', result: AuthorizeResult.ALLOW }],
+      });
+    });
 
     const mockBaseUrl = 'http://backstage:9191';
     const discovery: DiscoveryService = {
@@ -80,7 +88,7 @@ describe('PermissionIntegrationClient', () => {
       server = setupServer();
       server.listen({ onUnhandledRequest: 'error' });
       server.use(
-        rest.post(
+        http.post(
           `${mockBaseUrl}/plugin-1/.well-known/backstage/permissions/apply-conditions`,
           mockApplyConditionsHandler,
         ),
@@ -116,22 +124,16 @@ describe('PermissionIntegrationClient', () => {
         },
       ]);
 
-      expect(mockApplyConditionsHandler).toHaveBeenCalledWith(
-        expect.objectContaining({
-          body: {
-            items: [
-              {
-                id: '123',
-                resourceRef: 'testResource1',
-                resourceType: 'test-resource',
-                conditions: mockConditions,
-              },
-            ],
+      expect(mockApplyConditionsRequestBody).toEqual({
+        items: [
+          {
+            id: '123',
+            resourceRef: 'testResource1',
+            resourceType: 'test-resource',
+            conditions: mockConditions,
           },
-        }),
-        expect.anything(),
-        expect.anything(),
-      );
+        ],
+      });
     });
 
     it('should return the response from the fetch request', async () => {
@@ -161,8 +163,11 @@ describe('PermissionIntegrationClient', () => {
         },
       ]);
 
-      const request = mockApplyConditionsHandler.mock.calls[0][0];
-      expect(request.headers.has('authorization')).toEqual(false);
+      expect(
+        mockApplyConditionsHandler.mock.calls[0][0].request.headers.has(
+          'authorization',
+        ),
+      ).toEqual(false);
     });
 
     it('should include correctly-constructed authorization header if token is supplied', async () => {
@@ -175,8 +180,11 @@ describe('PermissionIntegrationClient', () => {
         },
       ]);
 
-      const request = mockApplyConditionsHandler.mock.calls[0][0];
-      expect(request.headers.get('authorization')).toEqual(
+      expect(
+        mockApplyConditionsHandler.mock.calls[0][0].request.headers.get(
+          'authorization',
+        ),
+      ).toEqual(
         mockCredentials.service.header({
           onBehalfOf: mockCredentials.user(),
           targetPluginId: 'plugin-1',
@@ -186,9 +194,7 @@ describe('PermissionIntegrationClient', () => {
 
     it('should forward response errors', async () => {
       mockApplyConditionsHandler.mockImplementationOnce(
-        (_req, res, { status }: RestContext) => {
-          return res(status(401));
-        },
+        async () => new HttpResponse(null, { status: 401 }),
       );
 
       await expect(
@@ -204,12 +210,10 @@ describe('PermissionIntegrationClient', () => {
     });
 
     it('should reject invalid responses', async () => {
-      mockApplyConditionsHandler.mockImplementationOnce(
-        (_req, res, { json }: RestContext) => {
-          return res(
-            json({ items: [{ id: '123', outcome: AuthorizeResult.ALLOW }] }),
-          );
-        },
+      mockApplyConditionsHandler.mockImplementationOnce(async () =>
+        HttpResponse.json({
+          items: [{ id: '123', outcome: AuthorizeResult.ALLOW }],
+        }),
       );
 
       await expect(
@@ -225,18 +229,14 @@ describe('PermissionIntegrationClient', () => {
     });
 
     it('should batch requests to plugin backends', async () => {
-      mockApplyConditionsHandler.mockImplementationOnce(
-        (_req, res, { json }: RestContext) => {
-          return res(
-            json({
-              items: [
-                { id: '123', result: AuthorizeResult.ALLOW },
-                { id: '456', result: AuthorizeResult.DENY },
-                { id: '789', result: AuthorizeResult.ALLOW },
-              ],
-            }),
-          );
-        },
+      mockApplyConditionsHandler.mockImplementationOnce(async () =>
+        HttpResponse.json({
+          items: [
+            { id: '123', result: AuthorizeResult.ALLOW },
+            { id: '456', result: AuthorizeResult.DENY },
+            { id: '789', result: AuthorizeResult.ALLOW },
+          ],
+        }),
       );
 
       await expect(

--- a/plugins/permission-common/package.json
+++ b/plugins/permission-common/package.json
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",
-    "msw": "^1.0.0"
+    "msw": "^2.0.0"
   },
   "configSchema": "config.d.ts"
 }

--- a/plugins/permission-common/src/PermissionClient.test.ts
+++ b/plugins/permission-common/src/PermissionClient.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { RestContext, rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { ConfigReader } from '@backstage/config';
 import {
@@ -65,19 +65,26 @@ describe('PermissionClient', () => {
       resourceRef: 'foo:bar',
     };
 
-    const mockAuthorizeHandler = jest.fn((req, res, { json }: RestContext) => {
-      const responses = req.body.items.map(
+    let mockAuthorizeRequestBody: {
+      items: IdentifiedPermissionMessage<EvaluatePermissionRequest>[];
+    };
+    const mockAuthorizeHandler = jest.fn(async ({ request }) => {
+      const body = (await request.json()) as {
+        items: IdentifiedPermissionMessage<EvaluatePermissionRequest>[];
+      };
+      mockAuthorizeRequestBody = body;
+      const responses = body.items.map(
         (a: IdentifiedPermissionMessage<EvaluatePermissionRequest>) => ({
           id: a.id,
           result: AuthorizeResult.ALLOW,
         }),
       );
 
-      return res(json({ items: responses }));
+      return HttpResponse.json({ items: responses });
     });
 
     beforeEach(() => {
-      server.use(rest.post(`${mockBaseUrl}/authorize`, mockAuthorizeHandler));
+      server.use(http.post(`${mockBaseUrl}/authorize`, mockAuthorizeHandler));
     });
 
     afterEach(() => {
@@ -92,9 +99,7 @@ describe('PermissionClient', () => {
     it('should include a request body', async () => {
       await client.authorize([mockAuthorizeConditional]);
 
-      const request = mockAuthorizeHandler.mock.calls[0][0];
-
-      expect(request.body).toEqual({
+      expect(mockAuthorizeRequestBody).toEqual({
         items: [
           expect.objectContaining({
             permission: mockPermission,
@@ -114,22 +119,26 @@ describe('PermissionClient', () => {
     it('should not include authorization headers if no token is supplied', async () => {
       await client.authorize([mockAuthorizeConditional]);
 
-      const request = mockAuthorizeHandler.mock.calls[0][0];
-      expect(request.headers.has('authorization')).toEqual(false);
+      expect(
+        mockAuthorizeHandler.mock.calls[0][0].request.headers.has(
+          'authorization',
+        ),
+      ).toEqual(false);
     });
 
     it('should include correctly-constructed authorization header if token is supplied', async () => {
       await client.authorize([mockAuthorizeConditional], { token });
 
-      const request = mockAuthorizeHandler.mock.calls[0][0];
-      expect(request.headers.get('authorization')).toEqual('Bearer fake-token');
+      expect(
+        mockAuthorizeHandler.mock.calls[0][0].request.headers.get(
+          'authorization',
+        ),
+      ).toEqual('Bearer fake-token');
     });
 
     it('should forward response errors', async () => {
       mockAuthorizeHandler.mockImplementationOnce(
-        (_req, res, { status }: RestContext) => {
-          return res(status(401));
-        },
+        async () => new HttpResponse(null, { status: 401 }),
       );
       await expect(
         client.authorize([mockAuthorizeConditional], { token }),
@@ -137,14 +146,10 @@ describe('PermissionClient', () => {
     });
 
     it('should reject responses with missing ids', async () => {
-      mockAuthorizeHandler.mockImplementationOnce(
-        (_req, res, { json }: RestContext) => {
-          return res(
-            json({
-              items: [{ id: 'wrong-id', result: AuthorizeResult.ALLOW }],
-            }),
-          );
-        },
+      mockAuthorizeHandler.mockImplementationOnce(async () =>
+        HttpResponse.json({
+          items: [{ id: 'wrong-id', result: AuthorizeResult.ALLOW }],
+        }),
       );
       await expect(
         client.authorize([mockAuthorizeConditional], { token }),
@@ -152,36 +157,25 @@ describe('PermissionClient', () => {
     });
 
     it('should reject invalid responses', async () => {
-      mockAuthorizeHandler.mockImplementationOnce(
-        (req, res, { json }: RestContext) => {
-          const responses = req.body.items.map(
-            (a: IdentifiedPermissionMessage<EvaluatePermissionRequest>) => ({
-              id: a.id,
-              outcome: AuthorizeResult.ALLOW,
-            }),
-          );
+      mockAuthorizeHandler.mockImplementationOnce(async ({ request }) => {
+        const body = (await request.json()) as {
+          items: IdentifiedPermissionMessage<EvaluatePermissionRequest>[];
+        };
+        const responses = body.items.map(
+          (a: IdentifiedPermissionMessage<EvaluatePermissionRequest>) => ({
+            id: a.id,
+            outcome: AuthorizeResult.ALLOW,
+          }),
+        );
 
-          return res(json({ items: responses }));
-        },
-      );
+        return HttpResponse.json({ items: responses });
+      });
       await expect(
         client.authorize([mockAuthorizeConditional], { token }),
       ).rejects.toThrow(/invalid input/i);
     });
 
     it('should allow all when permission.enabled is false', async () => {
-      mockAuthorizeHandler.mockImplementationOnce(
-        (req, res, { json }: RestContext) => {
-          const responses = req.body.map(
-            (a: IdentifiedPermissionMessage<EvaluatePermissionRequest>) => ({
-              id: a.id,
-              result: AuthorizeResult.DENY,
-            }),
-          );
-
-          return res(json({ items: responses }));
-        },
-      );
       const disabled = new PermissionClient({
         discovery,
         config: new ConfigReader({ permission: { enabled: false } }),
@@ -194,18 +188,6 @@ describe('PermissionClient', () => {
     });
 
     it('should allow all when permission.enabled is not configured', async () => {
-      mockAuthorizeHandler.mockImplementationOnce(
-        (req, res, { json }: RestContext) => {
-          const responses = req.body.map(
-            (a: IdentifiedPermissionMessage<EvaluatePermissionRequest>) => ({
-              id: a.id,
-              outcome: AuthorizeResult.DENY,
-            }),
-          );
-
-          return res(json(responses));
-        },
-      );
       const disabled = new PermissionClient({
         discovery,
         config: new ConfigReader({}),
@@ -237,23 +219,28 @@ describe('PermissionClient', () => {
     };
 
     const mockAuthorizeHandler = jest.fn();
+    let mockAuthorizeRequestBody: {
+      items: BatchedAuthorizePermissionRequest[];
+    };
 
     beforeEach(() => {
       mockAuthorizeHandler.mockReset();
-      server.use(rest.post(`${mockBaseUrl}/authorize`, mockAuthorizeHandler));
+      server.use(http.post(`${mockBaseUrl}/authorize`, mockAuthorizeHandler));
 
-      mockAuthorizeHandler.mockImplementation(
-        (req, res, { json }: RestContext) => {
-          const responses = req.body.items.map(
-            (a: BatchedAuthorizePermissionRequest) => ({
-              id: a.id,
-              result: [AuthorizeResult.ALLOW],
-            }),
-          );
+      mockAuthorizeHandler.mockImplementation(async ({ request }) => {
+        const body = (await request.json()) as {
+          items: BatchedAuthorizePermissionRequest[];
+        };
+        mockAuthorizeRequestBody = body;
+        const responses = body.items.map(
+          (a: BatchedAuthorizePermissionRequest) => ({
+            id: a.id,
+            result: [AuthorizeResult.ALLOW],
+          }),
+        );
 
-          return res(json({ items: responses }));
-        },
-      );
+        return HttpResponse.json({ items: responses });
+      });
     });
 
     afterEach(() => {
@@ -278,9 +265,7 @@ describe('PermissionClient', () => {
         { permission: basicPermission },
       ]);
 
-      const request = mockAuthorizeHandler.mock.calls[0][0];
-
-      expect(request.body).toEqual({
+      expect(mockAuthorizeRequestBody).toEqual({
         items: [
           {
             id: expect.any(String),
@@ -305,22 +290,26 @@ describe('PermissionClient', () => {
     it('should not include authorization headers if no token is supplied', async () => {
       await client.authorize([mockAuthorizeConditional]);
 
-      const request = mockAuthorizeHandler.mock.calls[0][0];
-      expect(request.headers.has('authorization')).toEqual(false);
+      expect(
+        mockAuthorizeHandler.mock.calls[0][0].request.headers.has(
+          'authorization',
+        ),
+      ).toEqual(false);
     });
 
     it('should include correctly-constructed authorization header if token is supplied', async () => {
       await client.authorize([mockAuthorizeConditional], { token });
 
-      const request = mockAuthorizeHandler.mock.calls[0][0];
-      expect(request.headers.get('authorization')).toEqual('Bearer fake-token');
+      expect(
+        mockAuthorizeHandler.mock.calls[0][0].request.headers.get(
+          'authorization',
+        ),
+      ).toEqual('Bearer fake-token');
     });
 
     it('should forward response errors', async () => {
       mockAuthorizeHandler.mockImplementationOnce(
-        (_req, res, { status }: RestContext) => {
-          return res(status(401));
-        },
+        () => new HttpResponse(null, { status: 401 }),
       );
       await expect(
         client.authorize([mockAuthorizeConditional], { token }),
@@ -328,14 +317,10 @@ describe('PermissionClient', () => {
     });
 
     it('should reject responses with missing ids', async () => {
-      mockAuthorizeHandler.mockImplementationOnce(
-        (_req, res, { json }: RestContext) => {
-          return res(
-            json({
-              items: [{ id: 'wrong-id', result: [AuthorizeResult.ALLOW] }],
-            }),
-          );
-        },
+      mockAuthorizeHandler.mockImplementationOnce(() =>
+        HttpResponse.json({
+          items: [{ id: 'wrong-id', result: [AuthorizeResult.ALLOW] }],
+        }),
       );
       await expect(
         client.authorize([mockAuthorizeConditional], { token }),
@@ -343,18 +328,19 @@ describe('PermissionClient', () => {
     });
 
     it('should reject invalid responses', async () => {
-      mockAuthorizeHandler.mockImplementationOnce(
-        (req, res, { json }: RestContext) => {
-          const responses = req.body.items.map(
-            (a: IdentifiedPermissionMessage<EvaluatePermissionRequest>) => ({
-              id: a.id,
-              outcome: AuthorizeResult.ALLOW,
-            }),
-          );
+      mockAuthorizeHandler.mockImplementationOnce(async ({ request }) => {
+        const body = (await request.json()) as {
+          items: IdentifiedPermissionMessage<EvaluatePermissionRequest>[];
+        };
+        const responses = body.items.map(
+          (a: IdentifiedPermissionMessage<EvaluatePermissionRequest>) => ({
+            id: a.id,
+            outcome: AuthorizeResult.ALLOW,
+          }),
+        );
 
-          return res(json({ items: responses }));
-        },
-      );
+        return HttpResponse.json({ items: responses });
+      });
       await expect(
         client.authorize([mockAuthorizeConditional], { token }),
       ).rejects.toThrow(/invalid_type/i);
@@ -396,28 +382,28 @@ describe('PermissionClient', () => {
         attributes: {},
       });
 
-      mockAuthorizeHandler.mockImplementationOnce(
-        (req, res, { json }: RestContext) => {
-          return res(
-            json({
-              items: [
-                {
-                  id: req.body.items[0].id,
-                  result: [AuthorizeResult.ALLOW, AuthorizeResult.DENY],
-                },
-                {
-                  id: req.body.items[1].id,
-                  result: AuthorizeResult.DENY,
-                },
-                {
-                  id: req.body.items[2].id,
-                  result: [AuthorizeResult.DENY, AuthorizeResult.ALLOW],
-                },
-              ],
-            }),
-          );
-        },
-      );
+      mockAuthorizeHandler.mockImplementationOnce(async ({ request }) => {
+        const body = (await request.json()) as {
+          items: BatchedAuthorizePermissionRequest[];
+        };
+        mockAuthorizeRequestBody = body;
+        return HttpResponse.json({
+          items: [
+            {
+              id: body.items[0].id,
+              result: [AuthorizeResult.ALLOW, AuthorizeResult.DENY],
+            },
+            {
+              id: body.items[1].id,
+              result: AuthorizeResult.DENY,
+            },
+            {
+              id: body.items[2].id,
+              result: [AuthorizeResult.DENY, AuthorizeResult.ALLOW],
+            },
+          ],
+        });
+      });
 
       const response = await client.authorize([
         {
@@ -444,7 +430,7 @@ describe('PermissionClient', () => {
         },
       ]);
 
-      expect(mockAuthorizeHandler.mock.calls[0][0].body).toEqual({
+      expect(mockAuthorizeRequestBody).toEqual({
         items: [
           {
             permission: {
@@ -500,29 +486,34 @@ describe('PermissionClient', () => {
       permission: mockPermission,
     };
 
-    const mockPolicyDecisionHandler = jest.fn(
-      (req, res, { json }: RestContext) => {
-        const responses = req.body.items.map(
-          (a: IdentifiedPermissionMessage<ConditionalPolicyDecision>) => ({
-            id: a.id,
-            pluginId: 'test-plugin',
+    let mockPolicyDecisionRequestBody: {
+      items: IdentifiedPermissionMessage<ConditionalPolicyDecision>[];
+    };
+    const mockPolicyDecisionHandler = jest.fn(async ({ request }) => {
+      const body = (await request.json()) as {
+        items: IdentifiedPermissionMessage<ConditionalPolicyDecision>[];
+      };
+      mockPolicyDecisionRequestBody = body;
+      const responses = body.items.map(
+        (a: IdentifiedPermissionMessage<ConditionalPolicyDecision>) => ({
+          id: a.id,
+          pluginId: 'test-plugin',
+          resourceType: 'test-resource',
+          result: AuthorizeResult.CONDITIONAL,
+          conditions: {
             resourceType: 'test-resource',
-            result: AuthorizeResult.CONDITIONAL,
-            conditions: {
-              resourceType: 'test-resource',
-              rule: 'FOO',
-              params: { foo: 'bar' },
-            },
-          }),
-        );
+            rule: 'FOO',
+            params: { foo: 'bar' },
+          },
+        }),
+      );
 
-        return res(json({ items: responses }));
-      },
-    );
+      return HttpResponse.json({ items: responses });
+    });
 
     beforeEach(() => {
       server.use(
-        rest.post(`${mockBaseUrl}/authorize`, mockPolicyDecisionHandler),
+        http.post(`${mockBaseUrl}/authorize`, mockPolicyDecisionHandler),
       );
     });
 
@@ -538,9 +529,7 @@ describe('PermissionClient', () => {
     it('should include a request body', async () => {
       await client.authorizeConditional([mockResourceAuthorizeConditional]);
 
-      const request = mockPolicyDecisionHandler.mock.calls[0][0];
-
-      expect(request.body).toEqual({
+      expect(mockPolicyDecisionRequestBody).toEqual({
         items: [
           expect.objectContaining({
             permission: mockPermission,
@@ -568,8 +557,11 @@ describe('PermissionClient', () => {
     it('should not include authorization headers if no token is supplied', async () => {
       await client.authorizeConditional([mockResourceAuthorizeConditional]);
 
-      const request = mockPolicyDecisionHandler.mock.calls[0][0];
-      expect(request.headers.has('authorization')).toEqual(false);
+      expect(
+        mockPolicyDecisionHandler.mock.calls[0][0].request.headers.has(
+          'authorization',
+        ),
+      ).toEqual(false);
     });
 
     it('should include correctly-constructed authorization header if token is supplied', async () => {
@@ -577,15 +569,16 @@ describe('PermissionClient', () => {
         token,
       });
 
-      const request = mockPolicyDecisionHandler.mock.calls[0][0];
-      expect(request.headers.get('authorization')).toEqual('Bearer fake-token');
+      expect(
+        mockPolicyDecisionHandler.mock.calls[0][0].request.headers.get(
+          'authorization',
+        ),
+      ).toEqual('Bearer fake-token');
     });
 
     it('should forward response errors', async () => {
       mockPolicyDecisionHandler.mockImplementationOnce(
-        (_req, res, { status }: RestContext) => {
-          return res(status(401));
-        },
+        async () => new HttpResponse(null, { status: 401 }),
       );
       await expect(
         client.authorizeConditional([mockResourceAuthorizeConditional], {
@@ -595,24 +588,25 @@ describe('PermissionClient', () => {
     });
 
     it('should handle responses with rules with no params', async () => {
-      mockPolicyDecisionHandler.mockImplementationOnce(
-        (req, res, { json }: RestContext) => {
-          const responses = req.body.items.map(
-            (a: IdentifiedPermissionMessage<ConditionalPolicyDecision>) => ({
-              id: a.id,
-              pluginId: 'test-plugin',
+      mockPolicyDecisionHandler.mockImplementationOnce(async ({ request }) => {
+        const body = (await request.json()) as {
+          items: IdentifiedPermissionMessage<ConditionalPolicyDecision>[];
+        };
+        const responses = body.items.map(
+          (a: IdentifiedPermissionMessage<ConditionalPolicyDecision>) => ({
+            id: a.id,
+            pluginId: 'test-plugin',
+            resourceType: 'test-resource',
+            result: AuthorizeResult.CONDITIONAL,
+            conditions: {
               resourceType: 'test-resource',
-              result: AuthorizeResult.CONDITIONAL,
-              conditions: {
-                resourceType: 'test-resource',
-                rule: 'FOO',
-              },
-            }),
-          );
+              rule: 'FOO',
+            },
+          }),
+        );
 
-          return res(json({ items: responses }));
-        },
-      );
+        return HttpResponse.json({ items: responses });
+      });
 
       const response = await client.authorizeConditional([
         mockResourceAuthorizeConditional,
@@ -629,14 +623,10 @@ describe('PermissionClient', () => {
     });
 
     it('should reject responses with missing ids', async () => {
-      mockPolicyDecisionHandler.mockImplementationOnce(
-        (_req, res, { json }: RestContext) => {
-          return res(
-            json({
-              items: [{ id: 'wrong-id', result: AuthorizeResult.ALLOW }],
-            }),
-          );
-        },
+      mockPolicyDecisionHandler.mockImplementationOnce(async () =>
+        HttpResponse.json({
+          items: [{ id: 'wrong-id', result: AuthorizeResult.ALLOW }],
+        }),
       );
       await expect(
         client.authorizeConditional([mockResourceAuthorizeConditional], {
@@ -646,18 +636,19 @@ describe('PermissionClient', () => {
     });
 
     it('should reject invalid responses', async () => {
-      mockPolicyDecisionHandler.mockImplementationOnce(
-        (req, res, { json }: RestContext) => {
-          const responses = req.body.items.map(
-            (a: IdentifiedPermissionMessage<ConditionalPolicyDecision>) => ({
-              id: a.id,
-              outcome: AuthorizeResult.ALLOW,
-            }),
-          );
+      mockPolicyDecisionHandler.mockImplementationOnce(async ({ request }) => {
+        const body = (await request.json()) as {
+          items: IdentifiedPermissionMessage<ConditionalPolicyDecision>[];
+        };
+        const responses = body.items.map(
+          (a: IdentifiedPermissionMessage<ConditionalPolicyDecision>) => ({
+            id: a.id,
+            outcome: AuthorizeResult.ALLOW,
+          }),
+        );
 
-          return res(json({ items: responses }));
-        },
-      );
+        return HttpResponse.json({ items: responses });
+      });
       await expect(
         client.authorizeConditional([mockResourceAuthorizeConditional], {
           token,
@@ -666,18 +657,6 @@ describe('PermissionClient', () => {
     });
 
     it('should allow all when permission.enabled is false', async () => {
-      mockPolicyDecisionHandler.mockImplementationOnce(
-        (req, res, { json }: RestContext) => {
-          const responses = req.body.map(
-            (a: IdentifiedPermissionMessage<ConditionalPolicyDecision>) => ({
-              id: a.id,
-              result: AuthorizeResult.DENY,
-            }),
-          );
-
-          return res(json({ items: responses }));
-        },
-      );
       const disabled = new PermissionClient({
         discovery,
         config: new ConfigReader({ permission: { enabled: false } }),
@@ -695,18 +674,6 @@ describe('PermissionClient', () => {
     });
 
     it('should allow all when permission.enabled is not configured', async () => {
-      mockPolicyDecisionHandler.mockImplementationOnce(
-        (req, res, { json }: RestContext) => {
-          const responses = req.body.map(
-            (a: IdentifiedPermissionMessage<ConditionalPolicyDecision>) => ({
-              id: a.id,
-              outcome: AuthorizeResult.DENY,
-            }),
-          );
-
-          return res(json({ items: responses }));
-        },
-      );
       const disabled = new PermissionClient({
         discovery,
         config: new ConfigReader({}),

--- a/plugins/permission-node/package.json
+++ b/plugins/permission-node/package.json
@@ -71,7 +71,7 @@
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@types/supertest": "^2.0.8",
-    "msw": "^1.0.0",
+    "msw": "^2.0.0",
     "supertest": "^7.0.0"
   }
 }

--- a/plugins/permission-node/src/ServerPermissionClient.test.ts
+++ b/plugins/permission-node/src/ServerPermissionClient.test.ts
@@ -29,7 +29,7 @@ import {
 } from '@backstage/backend-test-utils';
 import { ConfigReader } from '@backstage/config';
 import { setupServer } from 'msw/node';
-import { RestContext, rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 
 const server = setupServer();
 
@@ -65,18 +65,21 @@ describe('ServerPermissionClient', () => {
     let mockAuthorizeHandler: jest.Mock;
 
     beforeEach(() => {
-      mockAuthorizeHandler = jest.fn((req, res, { json }: RestContext) => {
-        const responses = req.body.items.map(
+      mockAuthorizeHandler = jest.fn(async ({ request }) => {
+        const body = (await request.json()) as {
+          items: IdentifiedPermissionMessage<DefinitivePolicyDecision>[];
+        };
+        const responses = body.items.map(
           (r: IdentifiedPermissionMessage<DefinitivePolicyDecision>) => ({
             id: r.id,
             result: AuthorizeResult.ALLOW,
           }),
         );
 
-        return res(json({ items: responses }));
+        return HttpResponse.json({ items: responses });
       });
 
-      server.use(rest.post(`${mockBaseUrl}/authorize`, mockAuthorizeHandler));
+      server.use(http.post(`${mockBaseUrl}/authorize`, mockAuthorizeHandler));
     });
 
     it('should bypass the permission backend if permissions are disabled', async () => {
@@ -122,7 +125,9 @@ describe('ServerPermissionClient', () => {
 
       expect(mockAuthorizeHandler).toHaveBeenCalled();
       expect(
-        mockAuthorizeHandler.mock.calls[0][0].headers.get('authorization'),
+        mockAuthorizeHandler.mock.calls[0][0].request.headers.get(
+          'authorization',
+        ),
       ).toBe(
         mockCredentials.service.header({
           onBehalfOf: mockCredentials.user(),
@@ -136,18 +141,21 @@ describe('ServerPermissionClient', () => {
     let mockAuthorizeHandler: jest.Mock;
 
     beforeEach(() => {
-      mockAuthorizeHandler = jest.fn((req, res, { json }: RestContext) => {
-        const responses = req.body.items.map(
+      mockAuthorizeHandler = jest.fn(async ({ request }) => {
+        const body = (await request.json()) as {
+          items: IdentifiedPermissionMessage<ConditionalPolicyDecision>[];
+        };
+        const responses = body.items.map(
           (r: IdentifiedPermissionMessage<ConditionalPolicyDecision>) => ({
             id: r.id,
             result: AuthorizeResult.ALLOW,
           }),
         );
 
-        return res(json({ items: responses }));
+        return HttpResponse.json({ items: responses });
       });
 
-      server.use(rest.post(`${mockBaseUrl}/authorize`, mockAuthorizeHandler));
+      server.use(http.post(`${mockBaseUrl}/authorize`, mockAuthorizeHandler));
     });
 
     it('should bypass the permission backend if permissions are disabled', async () => {
@@ -197,7 +205,9 @@ describe('ServerPermissionClient', () => {
 
       expect(mockAuthorizeHandler).toHaveBeenCalled();
       expect(
-        mockAuthorizeHandler.mock.calls[0][0].headers.get('authorization'),
+        mockAuthorizeHandler.mock.calls[0][0].request.headers.get(
+          'authorization',
+        ),
       ).toBe(
         mockCredentials.service.header({
           onBehalfOf: mockCredentials.user(),

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/package.json
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/package.json
@@ -57,6 +57,6 @@
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@backstage/plugin-scaffolder-node-test-utils": "workspace:^",
-    "msw": "^1.0.0"
+    "msw": "^2.0.0"
   }
 }

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloud.examples.test.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloud.examples.test.ts
@@ -27,7 +27,7 @@ jest.mock('@backstage/plugin-scaffolder-node', () => {
 });
 
 import { createPublishBitbucketCloudAction } from './bitbucketCloud';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { ScmIntegrations } from '@backstage/integration';
@@ -57,6 +57,19 @@ describe('publish:bitbucketCloud', () => {
     },
   });
 
+  const responseJson = {
+    links: {
+      html: {
+        href: 'https://bitbucket.org/workspace/repo',
+      },
+      clone: [
+        {
+          name: 'https',
+          href: 'https://bitbucket.org/workspace/cloneurl',
+        },
+      ],
+    },
+  };
   const integrations = ScmIntegrations.fromConfig(config);
   const action = createPublishBitbucketCloudAction({ integrations, config });
   const mockContext = createMockActionContext({
@@ -74,26 +87,9 @@ describe('publish:bitbucketCloud', () => {
 
   it('should call initAndPush with the correct values', async () => {
     server.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
-              links: {
-                html: {
-                  href: 'https://bitbucket.org/workspace/repo',
-                },
-                clone: [
-                  {
-                    name: 'https',
-                    href: 'https://bitbucket.org/workspace/cloneurl',
-                  },
-                ],
-              },
-            }),
-          ),
+        () => HttpResponse.json(responseJson),
       ),
     );
 
@@ -118,26 +114,9 @@ describe('publish:bitbucketCloud', () => {
 
   it('should call initAndPush with the correct default branch', async () => {
     server.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
-              links: {
-                html: {
-                  href: 'https://bitbucket.org/workspace/repo',
-                },
-                clone: [
-                  {
-                    name: 'https',
-                    href: 'https://bitbucket.org/workspace/cloneurl',
-                  },
-                ],
-              },
-            }),
-          ),
+        () => HttpResponse.json(responseJson),
       ),
     );
 
@@ -162,26 +141,9 @@ describe('publish:bitbucketCloud', () => {
 
   it('should call initAndPush with the specified source path', async () => {
     server.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
-              links: {
-                html: {
-                  href: 'https://bitbucket.org/workspace/repo',
-                },
-                clone: [
-                  {
-                    name: 'https',
-                    href: 'https://bitbucket.org/workspace/cloneurl',
-                  },
-                ],
-              },
-            }),
-          ),
+        () => HttpResponse.json(responseJson),
       ),
     );
 
@@ -205,26 +167,9 @@ describe('publish:bitbucketCloud', () => {
 
   it('should call initAndPush with the authentication token', async () => {
     server.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
-              links: {
-                html: {
-                  href: 'https://bitbucket.org/workspace/repo',
-                },
-                clone: [
-                  {
-                    name: 'https',
-                    href: 'https://bitbucket.org/workspace/cloneurl',
-                  },
-                ],
-              },
-            }),
-          ),
+        () => HttpResponse.json(responseJson),
       ),
     );
 
@@ -248,26 +193,9 @@ describe('publish:bitbucketCloud', () => {
 
   it('should call initAndPush with all available custom inputs', async () => {
     server.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
-              links: {
-                html: {
-                  href: 'https://bitbucket.org/workspace/repo',
-                },
-                clone: [
-                  {
-                    name: 'https',
-                    href: 'https://bitbucket.org/workspace/cloneurl',
-                  },
-                ],
-              },
-            }),
-          ),
+        () => HttpResponse.json(responseJson),
       ),
     );
 

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloud.test.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloud.test.ts
@@ -27,7 +27,7 @@ jest.mock('@backstage/plugin-scaffolder-node', () => {
 });
 
 import { createPublishBitbucketCloudAction } from './bitbucketCloud';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { ScmIntegrations } from '@backstage/integration';
@@ -46,6 +46,20 @@ describe('publish:bitbucketCloud', () => {
       ],
     },
   });
+
+  const responseJson = {
+    links: {
+      html: {
+        href: 'https://bitbucket.org/workspace/repo',
+      },
+      clone: [
+        {
+          name: 'https',
+          href: 'https://bitbucket.org/workspace/cloneurl',
+        },
+      ],
+    },
+  };
 
   const integrations = ScmIntegrations.fromConfig(config);
   const action = createPublishBitbucketCloudAction({ integrations, config });
@@ -127,32 +141,28 @@ describe('publish:bitbucketCloud', () => {
   it('should call the correct APIs', async () => {
     expect.assertions(2);
     server.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Basic dTpw');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Basic dTpw');
+          expect(await request.json()).toEqual({
             is_private: true,
             scm: 'git',
             project: { key: 'project' },
           });
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
-              links: {
-                html: {
+          return HttpResponse.json({
+            links: {
+              html: {
+                href: 'https://bitbucket.org/workspace/repo',
+              },
+              clone: [
+                {
+                  name: 'https',
                   href: 'https://bitbucket.org/workspace/repo',
                 },
-                clone: [
-                  {
-                    name: 'https',
-                    href: 'https://bitbucket.org/workspace/repo',
-                  },
-                ],
-              },
-            }),
-          );
+              ],
+            },
+          });
         },
       ),
     );
@@ -164,32 +174,28 @@ describe('publish:bitbucketCloud', () => {
     expect.assertions(2);
     const token = 'user-token';
     server.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(`Bearer ${token}`);
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(`Bearer ${token}`);
+          expect(await request.json()).toEqual({
             is_private: true,
             scm: 'git',
             project: { key: 'project' },
           });
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
-              links: {
-                html: {
+          return HttpResponse.json({
+            links: {
+              html: {
+                href: 'https://bitbucket.org/workspace/repo',
+              },
+              clone: [
+                {
+                  name: 'https',
                   href: 'https://bitbucket.org/workspace/repo',
                 },
-                clone: [
-                  {
-                    name: 'https',
-                    href: 'https://bitbucket.org/workspace/repo',
-                  },
-                ],
-              },
-            }),
-          );
+              ],
+            },
+          });
         },
       ),
     );
@@ -204,26 +210,9 @@ describe('publish:bitbucketCloud', () => {
 
   it('should call initAndPush with the correct values', async () => {
     server.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
-              links: {
-                html: {
-                  href: 'https://bitbucket.org/workspace/repo',
-                },
-                clone: [
-                  {
-                    name: 'https',
-                    href: 'https://bitbucket.org/workspace/cloneurl',
-                  },
-                ],
-              },
-            }),
-          ),
+        () => HttpResponse.json(responseJson),
       ),
     );
 
@@ -241,26 +230,9 @@ describe('publish:bitbucketCloud', () => {
 
   it('should call initAndPush with the correct default branch', async () => {
     server.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
-              links: {
-                html: {
-                  href: 'https://bitbucket.org/workspace/repo',
-                },
-                clone: [
-                  {
-                    name: 'https',
-                    href: 'https://bitbucket.org/workspace/cloneurl',
-                  },
-                ],
-              },
-            }),
-          ),
+        () => HttpResponse.json(responseJson),
       ),
     );
 
@@ -308,26 +280,9 @@ describe('publish:bitbucketCloud', () => {
     });
 
     server.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
-              links: {
-                html: {
-                  href: 'https://bitbucket.org/workspace/repo',
-                },
-                clone: [
-                  {
-                    name: 'https',
-                    href: 'https://bitbucket.org/workspace/cloneurl',
-                  },
-                ],
-              },
-            }),
-          ),
+        () => HttpResponse.json(responseJson),
       ),
     );
 
@@ -366,26 +321,9 @@ describe('publish:bitbucketCloud', () => {
     });
 
     server.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
-              links: {
-                html: {
-                  href: 'https://bitbucket.org/workspace/repo',
-                },
-                clone: [
-                  {
-                    name: 'https',
-                    href: 'https://bitbucket.org/workspace/cloneurl',
-                  },
-                ],
-              },
-            }),
-          ),
+        () => HttpResponse.json(responseJson),
       ),
     );
 
@@ -404,26 +342,9 @@ describe('publish:bitbucketCloud', () => {
 
   it('should call outputs with the correct urls', async () => {
     server.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
-              links: {
-                html: {
-                  href: 'https://bitbucket.org/workspace/repo',
-                },
-                clone: [
-                  {
-                    name: 'https',
-                    href: 'https://bitbucket.org/workspace/cloneurl',
-                  },
-                ],
-              },
-            }),
-          ),
+        () => HttpResponse.json(responseJson),
       ),
     );
 
@@ -441,26 +362,9 @@ describe('publish:bitbucketCloud', () => {
 
   it('should call outputs with the correct urls with correct default branch', async () => {
     server.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
-              links: {
-                html: {
-                  href: 'https://bitbucket.org/workspace/repo',
-                },
-                clone: [
-                  {
-                    name: 'https',
-                    href: 'https://bitbucket.org/workspace/cloneurl',
-                  },
-                ],
-              },
-            }),
-          ),
+        () => HttpResponse.json(responseJson),
       ),
     );
 
@@ -501,26 +405,9 @@ describe('publish:bitbucketCloud', () => {
     });
 
     server.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
-              links: {
-                html: {
-                  href: 'https://bitbucket.org/workspace/repo',
-                },
-                clone: [
-                  {
-                    name: 'https',
-                    href: 'https://bitbucket.org/workspace/cloneurl',
-                  },
-                ],
-              },
-            }),
-          ),
+        () => HttpResponse.json(responseJson),
       ),
     );
 
@@ -541,26 +428,9 @@ describe('publish:bitbucketCloud', () => {
 
   it('should call initAndPush with token passed through ctx.input', async () => {
     server.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
-              links: {
-                html: {
-                  href: 'https://bitbucket.org/workspace/repo',
-                },
-                clone: [
-                  {
-                    name: 'https',
-                    href: 'https://bitbucket.org/workspace/cloneurl',
-                  },
-                ],
-              },
-            }),
-          ),
+        () => HttpResponse.json(responseJson),
       ),
     );
 

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPipelinesRun.examples.test.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPipelinesRun.examples.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { createBitbucketPipelinesRunAction } from './bitbucketCloudPipelinesRun';
 import yaml from 'yaml';
@@ -57,22 +57,18 @@ describe('bitbucket:pipelines:run', () => {
   it('should trigger a pipeline for a branch', async () => {
     expect.assertions(2);
     worker.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/test-workspace/test-repo-slug/pipelines',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Basic dTpw');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Basic dTpw');
+          expect(await request.json()).toEqual({
             target: {
               ref_type: 'branch',
               type: 'pipeline_ref_target',
               ref_name: 'master',
             },
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseJson),
-          );
+          return HttpResponse.json(responseJson, { status: 201 });
         },
       ),
     );
@@ -85,11 +81,11 @@ describe('bitbucket:pipelines:run', () => {
   it('should trigger a pipeline for a commit on a branch', async () => {
     expect.assertions(2);
     worker.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/test-workspace/test-repo-slug/pipelines',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Basic dTpw');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Basic dTpw');
+          expect(await request.json()).toEqual({
             target: {
               commit: {
                 type: 'commit',
@@ -100,11 +96,7 @@ describe('bitbucket:pipelines:run', () => {
               ref_name: 'master',
             },
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseJson),
-          );
+          return HttpResponse.json(responseJson, { status: 201 });
         },
       ),
     );
@@ -117,11 +109,11 @@ describe('bitbucket:pipelines:run', () => {
   it('should trigger a specific pipeline definition for a commit', async () => {
     expect.assertions(2);
     worker.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/test-workspace/test-repo-slug/pipelines',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Basic dTpw');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Basic dTpw');
+          expect(await request.json()).toEqual({
             target: {
               commit: {
                 type: 'commit',
@@ -134,11 +126,7 @@ describe('bitbucket:pipelines:run', () => {
               type: 'pipeline_commit_target',
             },
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseJson),
-          );
+          return HttpResponse.json(responseJson, { status: 201 });
         },
       ),
     );
@@ -151,11 +139,11 @@ describe('bitbucket:pipelines:run', () => {
   it('should trigger a specific pipeline definition for a commit on a branch or tag', async () => {
     expect.assertions(2);
     worker.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/test-workspace/test-repo-slug/pipelines',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Basic dTpw');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Basic dTpw');
+          expect(await request.json()).toEqual({
             target: {
               commit: {
                 type: 'commit',
@@ -170,11 +158,7 @@ describe('bitbucket:pipelines:run', () => {
               ref_type: 'branch',
             },
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseJson),
-          );
+          return HttpResponse.json(responseJson, { status: 201 });
         },
       ),
     );
@@ -187,11 +171,11 @@ describe('bitbucket:pipelines:run', () => {
   it('should trigger a custom pipeline with variables', async () => {
     expect.assertions(2);
     worker.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/test-workspace/test-repo-slug/pipelines',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Basic dTpw');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Basic dTpw');
+          expect(await request.json()).toEqual({
             target: {
               type: 'pipeline_ref_target',
               ref_name: 'master',
@@ -209,11 +193,7 @@ describe('bitbucket:pipelines:run', () => {
               },
             ],
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseJson),
-          );
+          return HttpResponse.json(responseJson, { status: 201 });
         },
       ),
     );
@@ -226,11 +206,11 @@ describe('bitbucket:pipelines:run', () => {
   it('should trigger a pull request pipeline', async () => {
     expect.assertions(2);
     worker.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/test-workspace/test-repo-slug/pipelines',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Basic dTpw');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Basic dTpw');
+          expect(await request.json()).toEqual({
             target: {
               type: 'pipeline_pullrequest_target',
               source: 'pull-request-branch',
@@ -250,11 +230,7 @@ describe('bitbucket:pipelines:run', () => {
               },
             },
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseJson),
-          );
+          return HttpResponse.json(responseJson, { status: 201 });
         },
       ),
     );

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPipelinesRun.test.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPipelinesRun.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { createBitbucketPipelinesRunAction } from './bitbucketCloudPipelinesRun';
@@ -78,15 +78,13 @@ describe('bitbucket:pipelines:run', () => {
   it('should call the bitbucket api for running a pipeline with integration credentials', async () => {
     expect.assertions(1);
     worker.use(
-      rest.post(
-        `https://api.bitbucket.org/2.0/repositories/${workspace}/${repo_slug}/pipelines`,
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Basic dTpw');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseJson),
-          );
+      http.post(
+        `https://api.bitbucket.org/2.0/repositories/:workspace/:repo_slug/pipelines`,
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Basic dTpw');
+          return HttpResponse.json(responseJson, {
+            status: 201,
+          });
         },
       ),
     );
@@ -100,15 +98,13 @@ describe('bitbucket:pipelines:run', () => {
   it('should call the bitbucket api for running a pipeline with input token', async () => {
     expect.assertions(1);
     worker.use(
-      rest.post(
-        `https://api.bitbucket.org/2.0/repositories/${workspace}/${repo_slug}/pipelines`,
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer abc');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseJson),
-          );
+      http.post(
+        `https://api.bitbucket.org/2.0/repositories/:workspace/:repo_slug/pipelines`,
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer abc');
+          return HttpResponse.json(responseJson, {
+            status: 201,
+          });
         },
       ),
     );
@@ -121,14 +117,12 @@ describe('bitbucket:pipelines:run', () => {
 
   it('should call outputs with the correct data', async () => {
     worker.use(
-      rest.post(
-        `https://api.bitbucket.org/2.0/repositories/${workspace}/${repo_slug}/pipelines`,
-        (_, res, ctx) => {
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseJson),
-          );
+      http.post(
+        `https://api.bitbucket.org/2.0/repositories/:workspace/:repo_slug/pipelines`,
+        () => {
+          return HttpResponse.json(responseJson, {
+            status: 201,
+          });
         },
       ),
     );

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.examples.test.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.examples.test.ts
@@ -27,7 +27,7 @@ jest.mock('@backstage/plugin-scaffolder-node', () => {
 });
 
 import { createPublishBitbucketCloudPullRequestAction } from './bitbucketCloudPullRequest';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { ScmIntegrations } from '@backstage/integration';
@@ -235,30 +235,22 @@ describe('publish:bitbucketCloud:pull-request', () => {
   it(`should ${examples[0].description}`, async () => {
     expect.assertions(2);
     server.use(
-      rest.get(
+      http.get(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/refs/branches',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             'Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=',
           );
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfBranches),
-          );
+          return HttpResponse.json(responseOfBranches);
         },
       ),
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             'Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=',
           );
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfPullRequests),
-          );
+          return HttpResponse.json(responseOfPullRequests, { status: 201 });
         },
       ),
     );
@@ -275,30 +267,22 @@ describe('publish:bitbucketCloud:pull-request', () => {
   it(`should ${examples[1].description}`, async () => {
     expect.assertions(2);
     server.use(
-      rest.get(
+      http.get(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/refs/branches',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             'Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=',
           );
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfBranches),
-          );
+          return HttpResponse.json(responseOfBranches);
         },
       ),
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             'Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=',
           );
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfPullRequests),
-          );
+          return HttpResponse.json(responseOfPullRequests, { status: 201 });
         },
       ),
     );
@@ -315,30 +299,22 @@ describe('publish:bitbucketCloud:pull-request', () => {
   it(`should ${examples[2].description}`, async () => {
     expect.assertions(2);
     server.use(
-      rest.get(
+      http.get(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/refs/branches',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             'Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=',
           );
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfBranches),
-          );
+          return HttpResponse.json(responseOfBranches);
         },
       ),
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             'Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=',
           );
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfPullRequests),
-          );
+          return HttpResponse.json(responseOfPullRequests, { status: 201 });
         },
       ),
     );
@@ -355,30 +331,22 @@ describe('publish:bitbucketCloud:pull-request', () => {
   it(`should ${examples[3].description}`, async () => {
     expect.assertions(2);
     server.use(
-      rest.get(
+      http.get(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/refs/branches',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             `Bearer ${yaml.parse(examples[3].example).steps[0].input.token}`,
           );
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfBranches),
-          );
+          return HttpResponse.json(responseOfBranches);
         },
       ),
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             `Bearer ${yaml.parse(examples[3].example).steps[0].input.token}`,
           );
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfPullRequests),
-          );
+          return HttpResponse.json(responseOfPullRequests, { status: 201 });
         },
       ),
     );
@@ -395,30 +363,22 @@ describe('publish:bitbucketCloud:pull-request', () => {
   it(`should ${examples[4].description}`, async () => {
     expect.assertions(2);
     server.use(
-      rest.get(
+      http.get(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/refs/branches',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             `Bearer ${yaml.parse(examples[4].example).steps[0].input.token}`,
           );
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfBranches),
-          );
+          return HttpResponse.json(responseOfBranches);
         },
       ),
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             `Bearer ${yaml.parse(examples[4].example).steps[0].input.token}`,
           );
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfPullRequests),
-          );
+          return HttpResponse.json(responseOfPullRequests, { status: 201 });
         },
       ),
     );

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.test.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.test.ts
@@ -27,7 +27,7 @@ jest.mock('@backstage/plugin-scaffolder-node', () => {
 });
 
 import { createPublishBitbucketCloudPullRequestAction } from './bitbucketCloudPullRequest';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { ScmIntegrations } from '@backstage/integration';
@@ -254,34 +254,28 @@ describe('publish:bitbucketCloud:pull-request', () => {
     participants: [{ type: '<string>' }],
   };
   const handlers = [
-    rest.get(
+    http.get(
       'https://api.bitbucket.org/2.0/repositories/workspace/repo/refs/branches',
-      (_, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json(responseOfBranches),
-        );
+      () => {
+        return HttpResponse.json(responseOfBranches, {
+          status: 200,
+        });
       },
     ),
-    rest.get(
+    http.get(
       'https://api.bitbucket.org/2.0/repositories/workspace/repo',
-      (_, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json(responseOfDefaultBranch),
-        );
+      () => {
+        return HttpResponse.json(responseOfDefaultBranch, {
+          status: 200,
+        });
       },
     ),
-    rest.post(
+    http.post(
       'https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests',
-      (_, res, ctx) => {
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json(responseOfPullRequests),
-        );
+      () => {
+        return HttpResponse.json(responseOfPullRequests, {
+          status: 201,
+        });
       },
     ),
   ];
@@ -330,30 +324,26 @@ describe('publish:bitbucketCloud:pull-request', () => {
   it('should call the correct APIs with basic auth', async () => {
     expect.assertions(2);
     server.use(
-      rest.get(
+      http.get(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/refs/branches',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             'Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=',
           );
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfBranches),
-          );
+          return HttpResponse.json(responseOfBranches, {
+            status: 200,
+          });
         },
       ),
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             'Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=',
           );
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfPullRequests),
-          );
+          return HttpResponse.json(responseOfPullRequests, {
+            status: 201,
+          });
         },
       ),
     );
@@ -371,26 +361,22 @@ describe('publish:bitbucketCloud:pull-request', () => {
     expect.assertions(2);
     const token = 'user-token';
     server.use(
-      rest.get(
+      http.get(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/refs/branches',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(`Bearer ${token}`);
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfBranches),
-          );
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(`Bearer ${token}`);
+          return HttpResponse.json(responseOfBranches, {
+            status: 200,
+          });
         },
       ),
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(`Bearer ${token}`);
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfPullRequests),
-          );
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(`Bearer ${token}`);
+          return HttpResponse.json(responseOfPullRequests, {
+            status: 201,
+          });
         },
       ),
     );
@@ -436,13 +422,14 @@ describe('publish:bitbucketCloud:pull-request', () => {
 
     server.use(
       ...handlers,
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/refs/branches',
-        (_, res, ctx) => {
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({}),
+        () => {
+          return HttpResponse.json(
+            {},
+            {
+              status: 201,
+            },
           );
         },
       ),

--- a/plugins/scaffolder-backend-module-bitbucket-server/package.json
+++ b/plugins/scaffolder-backend-module-bitbucket-server/package.json
@@ -54,6 +54,6 @@
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@backstage/plugin-scaffolder-node-test-utils": "workspace:^",
-    "msw": "^1.0.0"
+    "msw": "^2.0.0"
   }
 }

--- a/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServer.examples.test.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServer.examples.test.ts
@@ -27,7 +27,7 @@ jest.mock('@backstage/plugin-scaffolder-node', () => {
 });
 
 import { createPublishBitbucketServerAction } from './bitbucketServer';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { ScmIntegrations } from '@backstage/integration';
@@ -80,19 +80,17 @@ describe('publish:bitbucketServer', () => {
   it(`should ${examples[0].description}`, async () => {
     expect.assertions(3);
     server.use(
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'master',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -106,7 +104,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -134,22 +133,20 @@ describe('publish:bitbucketServer', () => {
   it(`should ${examples[1].description}`, async () => {
     expect.assertions(3);
     server.use(
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             `Bearer ${yaml.parse(examples[1].example).steps[0].input.token}`,
           );
-          expect(req.body).toEqual({
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'main',
             description: 'This is a test repository',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -163,7 +160,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -202,22 +200,20 @@ describe('publish:bitbucketServer', () => {
   it(`should ${examples[2].description}`, async () => {
     expect.assertions(3);
     server.use(
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             `Bearer ${yaml.parse(examples[2].example).steps[0].input.token}`,
           );
-          expect(req.body).toEqual({
+          expect(await request.json()).toEqual({
             public: true,
             name: 'repo',
             defaultBranch: 'main',
             description: 'This is a test repository',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -231,7 +227,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -271,22 +268,20 @@ describe('publish:bitbucketServer', () => {
     expect.assertions(3);
 
     const handlers = [
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             `Bearer ${yaml.parse(examples[3].example).steps[0].input.token}`,
           );
-          expect(req.body).toEqual({
+          expect(await request.json()).toEqual({
             public: true,
             name: 'repo',
             defaultBranch: 'develop',
             description: 'This is a test repository',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -300,19 +295,18 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
-      rest.put(
+      http.put(
         'https://hosted.bitbucket.com/rest/git-lfs/admin/projects/project/repos/repo/enabled',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual('');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.text()).toEqual('');
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -326,7 +320,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -368,22 +363,20 @@ describe('publish:bitbucketServer', () => {
     expect.assertions(3);
 
     const handlers = [
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             `Bearer ${yaml.parse(examples[4].example).steps[0].input.token}`,
           );
-          expect(req.body).toEqual({
+          expect(await request.json()).toEqual({
             public: true,
             name: 'repo',
             defaultBranch: 'develop',
             description: 'This is a test repository',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -397,19 +390,18 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
-      rest.put(
+      http.put(
         'https://hosted.bitbucket.com/rest/git-lfs/admin/projects/project/repos/repo/enabled',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual('');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.text()).toEqual('');
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -423,7 +415,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -464,19 +457,17 @@ describe('publish:bitbucketServer', () => {
     expect.assertions(3);
 
     const handlers = [
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(`Bearer thing`);
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(`Bearer thing`);
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'master',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -490,19 +481,18 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
-      rest.put(
+      http.put(
         'https://hosted.bitbucket.com/rest/git-lfs/admin/projects/project/repos/repo/enabled',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual('');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.text()).toEqual('');
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -516,7 +506,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -558,19 +549,17 @@ describe('publish:bitbucketServer', () => {
     expect.assertions(5);
 
     const handlers = [
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'master',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -587,19 +576,18 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
-      rest.put(
+      http.put(
         'https://hosted.bitbucket.com/rest/git-lfs/admin/projects/project/repos/repo/enabled',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual('');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.text()).toEqual('');
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -613,7 +601,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -654,19 +643,19 @@ describe('publish:bitbucketServer', () => {
     expect.assertions(3);
 
     const handlers = [
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer custom-token');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
+            'Bearer custom-token',
+          );
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'master',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -683,19 +672,18 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
-      rest.put(
+      http.put(
         'https://hosted.bitbucket.com/rest/git-lfs/admin/projects/project/repos/repo/enabled',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual('');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.text()).toEqual('');
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -709,7 +697,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -747,19 +736,17 @@ describe('publish:bitbucketServer', () => {
     expect.assertions(3);
 
     const handlers = [
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'master',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -776,19 +763,18 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
-      rest.put(
+      http.put(
         'https://hosted.bitbucket.com/rest/git-lfs/admin/projects/project/repos/repo/enabled',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual('');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.text()).toEqual('');
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -802,7 +788,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -840,19 +827,17 @@ describe('publish:bitbucketServer', () => {
     expect.assertions(3);
 
     const handlers = [
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.json()).toEqual({
             public: true,
             name: 'repo',
             defaultBranch: 'master',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -869,19 +854,18 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
-      rest.put(
+      http.put(
         'https://hosted.bitbucket.com/rest/git-lfs/admin/projects/project/repos/repo/enabled',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual('');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.text()).toEqual('');
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -895,7 +879,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -933,21 +918,21 @@ describe('publish:bitbucketServer', () => {
     expect.assertions(5);
 
     const handlers = [
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer custom-token');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
+            'Bearer custom-token',
+          );
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             description: 'A fully customized repository',
             defaultBranch: 'development',
           });
 
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -964,19 +949,20 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
-      rest.put(
+      http.put(
         'https://hosted.bitbucket.com/rest/git-lfs/admin/projects/project/repos/repo/enabled',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer custom-token');
-          expect(req.body).toEqual('');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
+            'Bearer custom-token',
+          );
+          expect(await request.text()).toEqual('');
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -990,7 +976,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -1028,20 +1015,18 @@ describe('publish:bitbucketServer', () => {
     expect.assertions(3);
 
     const handlers = [
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'main',
           });
 
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -1058,19 +1043,20 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
-      rest.put(
+      http.put(
         'https://hosted.bitbucket.com/rest/git-lfs/admin/projects/project/repos/repo/enabled',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer custom-token');
-          expect(req.body).toEqual('');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
+            'Bearer custom-token',
+          );
+          expect(await request.text()).toEqual('');
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -1084,7 +1070,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -1124,21 +1111,19 @@ describe('publish:bitbucketServer', () => {
     expect.assertions(3);
 
     const handlers = [
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.json()).toEqual({
             public: true,
             name: 'repo',
             defaultBranch: 'master',
             description: 'A public repository with a custom description',
           });
 
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -1155,19 +1140,20 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
-      rest.put(
+      http.put(
         'https://hosted.bitbucket.com/rest/git-lfs/admin/projects/project/repos/repo/enabled',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer custom-token');
-          expect(req.body).toEqual('');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
+            'Bearer custom-token',
+          );
+          expect(await request.text()).toEqual('');
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -1181,7 +1167,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -1221,22 +1208,20 @@ describe('publish:bitbucketServer', () => {
     expect.assertions(3);
 
     const handlers = [
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             'Bearer custom-auth-token',
           );
-          expect(req.body).toEqual({
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'master',
           });
 
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -1253,19 +1238,20 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
-      rest.put(
+      http.put(
         'https://hosted.bitbucket.com/rest/git-lfs/admin/projects/project/repos/repo/enabled',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer custom-token');
-          expect(req.body).toEqual('');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
+            'Bearer custom-token',
+          );
+          expect(await request.text()).toEqual('');
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -1279,7 +1265,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -1319,20 +1306,18 @@ describe('publish:bitbucketServer', () => {
     expect.assertions(3);
 
     const handlers = [
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'master',
           });
 
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -1349,19 +1334,20 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
-      rest.put(
+      http.put(
         'https://hosted.bitbucket.com/rest/git-lfs/admin/projects/project/repos/repo/enabled',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer custom-token');
-          expect(req.body).toEqual('');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
+            'Bearer custom-token',
+          );
+          expect(await request.json()).toEqual('');
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -1375,7 +1361,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -1415,20 +1402,18 @@ describe('publish:bitbucketServer', () => {
     expect.assertions(5);
 
     const handlers = [
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'master',
           });
 
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -1445,19 +1430,18 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
-      rest.put(
+      http.put(
         'https://hosted.bitbucket.com/rest/git-lfs/admin/projects/project/repos/repo/enabled',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual('');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.text()).toEqual('');
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -1471,7 +1455,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),

--- a/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServer.test.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServer.test.ts
@@ -27,7 +27,7 @@ jest.mock('@backstage/plugin-scaffolder-node', () => {
 });
 
 import { createPublishBitbucketServerAction } from './bitbucketServer';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { ScmIntegrations } from '@backstage/integration';
@@ -123,19 +123,17 @@ describe('publish:bitbucketServer', () => {
   it('should call the correct APIs with token', async () => {
     expect.assertions(2);
     server.use(
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'master',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -149,7 +147,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -167,21 +166,19 @@ describe('publish:bitbucketServer', () => {
   it('should call the correct APIs with basic auth', async () => {
     expect.assertions(2);
     server.use(
-      rest.post(
+      http.post(
         'https://basic-auth.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             'Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=',
           );
-          expect(req.body).toEqual({
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'master',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -195,7 +192,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -214,19 +212,17 @@ describe('publish:bitbucketServer', () => {
     expect.assertions(2);
     const token = 'user-token';
     server.use(
-      rest.post(
+      http.post(
         'https://no-credentials.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(`Bearer ${token}`);
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(`Bearer ${token}`);
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'master',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -240,7 +236,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -275,21 +272,17 @@ describe('publish:bitbucketServer', () => {
     it('should call the correct APIs to enable LFS if requested and the host is hosted bitbucket', async () => {
       expect.assertions(1);
       server.use(
-        rest.post(
+        http.post(
           'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-          (_, res, ctx) => {
-            return res(
-              ctx.status(201),
-              ctx.set('Content-Type', 'application/json'),
-              ctx.json(repoCreationResponse),
-            );
+          () => {
+            return HttpResponse.json(repoCreationResponse, { status: 201 });
           },
         ),
-        rest.put(
+        http.put(
           'https://hosted.bitbucket.com/rest/git-lfs/admin/projects/project/repos/repo/enabled',
-          (req, res, ctx) => {
-            expect(req.headers.get('Authorization')).toBe('Bearer thing');
-            return res(ctx.status(204));
+          async ({ request }) => {
+            expect(request.headers.get('Authorization')).toBe('Bearer thing');
+            return HttpResponse.json({}, { status: 204 });
           },
         ),
       );
@@ -306,20 +299,16 @@ describe('publish:bitbucketServer', () => {
 
     it('should report an error if enabling LFS fails', async () => {
       server.use(
-        rest.post(
+        http.post(
           'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-          (_, res, ctx) => {
-            return res(
-              ctx.status(201),
-              ctx.set('Content-Type', 'application/json'),
-              ctx.json(repoCreationResponse),
-            );
+          () => {
+            return HttpResponse.json(repoCreationResponse, { status: 201 });
           },
         ),
-        rest.put(
+        http.put(
           'https://hosted.bitbucket.com/rest/git-lfs/admin/projects/project/repos/repo/enabled',
-          (_, res, ctx) => {
-            return res(ctx.status(500));
+          () => {
+            return new HttpResponse(null, { status: 500 });
           },
         ),
       );
@@ -339,19 +328,17 @@ describe('publish:bitbucketServer', () => {
 
   it('should call initAndPush with the correct values with token', async () => {
     server.use(
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'master',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -365,7 +352,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -389,21 +377,19 @@ describe('publish:bitbucketServer', () => {
 
   it('should call initAndPush with the correct values with basic auth', async () => {
     server.use(
-      rest.post(
+      http.post(
         'https://basic-auth.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             'Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=',
           );
-          expect(req.body).toEqual({
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'master',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -417,7 +403,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -447,19 +434,17 @@ describe('publish:bitbucketServer', () => {
 
   it('should call initAndPush with the correct default branch', async () => {
     server.use(
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'main',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -473,7 +458,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -531,19 +517,17 @@ describe('publish:bitbucketServer', () => {
     });
 
     server.use(
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'master',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -557,7 +541,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -603,19 +588,17 @@ describe('publish:bitbucketServer', () => {
     });
 
     server.use(
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'master',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -629,7 +612,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -650,19 +634,17 @@ describe('publish:bitbucketServer', () => {
 
   it('should call outputs with the correct urls', async () => {
     server.use(
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'master',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -676,7 +658,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -696,19 +679,17 @@ describe('publish:bitbucketServer', () => {
 
   it('should call outputs with the correct urls with correct default branch', async () => {
     server.use(
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'main',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -722,7 +703,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),

--- a/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServerPullRequest.examples.test.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServerPullRequest.examples.test.ts
@@ -27,7 +27,7 @@ jest.mock('@backstage/plugin-scaffolder-node', () => {
 });
 
 import { createPublishBitbucketServerPullRequestAction } from './bitbucketServerPullRequest';
-import { rest } from 'msw';
+import { HttpResponse, http } from 'msw';
 import { setupServer } from 'msw/node';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { ScmIntegrations } from '@backstage/integration';
@@ -200,26 +200,18 @@ describe('publish:bitbucketServer:pull-request', () => {
   it(`should ${examples[0].description}`, async () => {
     expect.assertions(3);
     server.use(
-      rest.get(
+      http.get(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos/repo/branches',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfBranches),
-          );
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          return HttpResponse.json(responseOfBranches, { status: 200 });
         },
       ),
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos/repo/pull-requests',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfPullRequests),
-          );
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          return HttpResponse.json(responseOfPullRequests, { status: 201 });
         },
       ),
     );
@@ -236,21 +228,17 @@ describe('publish:bitbucketServer:pull-request', () => {
   it(`should ${examples[1].description}`, async () => {
     expect.assertions(6);
     server.use(
-      rest.get(
+      http.get(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos/repo/branches',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfBranches),
-          );
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          return HttpResponse.json(responseOfBranches);
         },
       ),
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos/repo/pull-requests',
-        (req, res, ctx) => {
-          const requestBody = req.body as {
+        async ({ request }) => {
+          const requestBody = (await request.json()) as {
             title: string;
             fromRef: { displayId: string };
             description: string;
@@ -260,12 +248,8 @@ describe('publish:bitbucketServer:pull-request', () => {
           expect(requestBody.description).toBe(
             'This is a detailed description of my pull request',
           );
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfPullRequests),
-          );
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          return HttpResponse.json(responseOfPullRequests, { status: 201 });
         },
       ),
     );
@@ -282,21 +266,17 @@ describe('publish:bitbucketServer:pull-request', () => {
   it(`should ${examples[2].description}`, async () => {
     expect.assertions(6);
     server.use(
-      rest.get(
+      http.get(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos/repo/branches',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfBranches),
-          );
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          return HttpResponse.json(responseOfBranches);
         },
       ),
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos/repo/pull-requests',
-        (req, res, ctx) => {
-          const requestBody = req.body as {
+        async ({ request }) => {
+          const requestBody = (await request.json()) as {
             title: string;
             toRef: { displayId: string };
             description: string;
@@ -306,12 +286,8 @@ describe('publish:bitbucketServer:pull-request', () => {
           expect(requestBody.description).toBe(
             'I just made a Pull Request that Add Scaffolder actions for Bitbucket Server',
           );
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfPullRequests),
-          );
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          return HttpResponse.json(responseOfPullRequests, { status: 201 });
         },
       ),
     );
@@ -328,30 +304,22 @@ describe('publish:bitbucketServer:pull-request', () => {
   it(`should ${examples[3].description}`, async () => {
     expect.assertions(3);
     server.use(
-      rest.get(
+      http.get(
         'https://no-credentials.bitbucket.com/rest/api/1.0/projects/project/repos/repo/branches',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             `Bearer ${yaml.parse(examples[3].example).steps[0].input.token}`,
           );
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfBranches),
-          );
+          return HttpResponse.json(responseOfBranches);
         },
       ),
-      rest.post(
+      http.post(
         'https://no-credentials.bitbucket.com/rest/api/1.0/projects/project/repos/repo/pull-requests',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             `Bearer ${yaml.parse(examples[3].example).steps[0].input.token}`,
           );
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfPullRequests),
-          );
+          return HttpResponse.json(responseOfPullRequests, { status: 201 });
         },
       ),
     );
@@ -368,23 +336,19 @@ describe('publish:bitbucketServer:pull-request', () => {
   it(`should ${examples[4].description}`, async () => {
     expect.assertions(8);
     server.use(
-      rest.get(
+      http.get(
         'https://no-credentials.bitbucket.com/rest/api/1.0/projects/project/repos/repo/branches',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             `Bearer ${yaml.parse(examples[4].example).steps[0].input.token}`,
           );
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfBranches),
-          );
+          return HttpResponse.json(responseOfBranches, { status: 200 });
         },
       ),
-      rest.post(
+      http.post(
         'https://no-credentials.bitbucket.com/rest/api/1.0/projects/project/repos/repo/pull-requests',
-        (req, res, ctx) => {
-          const requestBody = req.body as {
+        async ({ request }) => {
+          const requestBody = (await request.json()) as {
             title: string;
             toRef: { displayId: string };
             fromRef: { displayId: string };
@@ -401,14 +365,10 @@ describe('publish:bitbucketServer:pull-request', () => {
             { user: { name: 'reviewer1' } },
             { user: { name: 'reviewer2' } },
           ]);
-          expect(req.headers.get('Authorization')).toBe(
+          expect(request.headers.get('Authorization')).toBe(
             `Bearer ${yaml.parse(examples[4].example).steps[0].input.token}`,
           );
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfPullRequests),
-          );
+          return HttpResponse.json(responseOfPullRequests, { status: 201 });
         },
       ),
     );

--- a/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServerPullRequest.test.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServerPullRequest.test.ts
@@ -27,7 +27,7 @@ jest.mock('@backstage/plugin-scaffolder-node', () => {
 });
 
 import { createPublishBitbucketServerPullRequestAction } from './bitbucketServerPullRequest';
-import { rest } from 'msw';
+import { HttpResponse, http } from 'msw';
 import { setupServer } from 'msw/node';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { ScmIntegrations } from '@backstage/integration';
@@ -188,34 +188,22 @@ describe('publish:bitbucketServer:pull-request', () => {
     },
   };
   const handlers = [
-    rest.get(
+    http.get(
       'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos/repo/branches',
-      (_, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json(responseOfBranches),
-        );
+      () => {
+        return HttpResponse.json(responseOfBranches);
       },
     ),
-    rest.get(
+    http.get(
       'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos/repo/default-branch',
-      (_, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json(responseOfDefaultBranch),
-        );
+      () => {
+        return HttpResponse.json(responseOfDefaultBranch);
       },
     ),
-    rest.post(
+    http.post(
       'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos/repo/pull-requests',
-      (_, res, ctx) => {
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json(responseOfPullRequests),
-        );
+      () => {
+        return HttpResponse.json(responseOfPullRequests, { status: 201 });
       },
     ),
   ];
@@ -278,26 +266,18 @@ describe('publish:bitbucketServer:pull-request', () => {
   it('should call the correct APIs with token', async () => {
     expect.assertions(3);
     server.use(
-      rest.get(
+      http.get(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos/repo/branches',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfBranches),
-          );
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          return HttpResponse.json(responseOfBranches);
         },
       ),
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos/repo/pull-requests',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfPullRequests),
-          );
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          return HttpResponse.json(responseOfPullRequests, { status: 201 });
         },
       ),
     );
@@ -314,30 +294,22 @@ describe('publish:bitbucketServer:pull-request', () => {
   it('should call the correct APIs with basic auth', async () => {
     expect.assertions(3);
     server.use(
-      rest.get(
+      http.get(
         'https://basic-auth.bitbucket.com/rest/api/1.0/projects/project/repos/repo/branches',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             'Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=',
           );
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfBranches),
-          );
+          return HttpResponse.json(responseOfBranches);
         },
       ),
-      rest.post(
+      http.post(
         'https://basic-auth.bitbucket.com/rest/api/1.0/projects/project/repos/repo/pull-requests',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             'Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=',
           );
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfPullRequests),
-          );
+          return HttpResponse.json(responseOfPullRequests, { status: 201 });
         },
       ),
     );
@@ -355,26 +327,18 @@ describe('publish:bitbucketServer:pull-request', () => {
     expect.assertions(3);
     const token = 'user-token';
     server.use(
-      rest.get(
+      http.get(
         'https://no-credentials.bitbucket.com/rest/api/1.0/projects/project/repos/repo/branches',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(`Bearer ${token}`);
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfBranches),
-          );
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(`Bearer ${token}`);
+          return HttpResponse.json(responseOfBranches);
         },
       ),
-      rest.post(
+      http.post(
         'https://no-credentials.bitbucket.com/rest/api/1.0/projects/project/repos/repo/pull-requests',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(`Bearer ${token}`);
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfPullRequests),
-          );
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(`Bearer ${token}`);
+          return HttpResponse.json(responseOfPullRequests, { status: 201 });
         },
       ),
     );
@@ -402,14 +366,10 @@ describe('publish:bitbucketServer:pull-request', () => {
 
   it('should throw an error when the target branch is not found', async () => {
     server.use(
-      rest.get(
+      http.get(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos/repo/branches',
-        (_, res, ctx) => {
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfBranches),
-          );
+        () => {
+          return HttpResponse.json(responseOfBranches);
         },
       ),
     );

--- a/plugins/scaffolder-backend-module-confluence-to-markdown/package.json
+++ b/plugins/scaffolder-backend-module-confluence-to-markdown/package.json
@@ -59,7 +59,7 @@
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@backstage/plugin-scaffolder-node-test-utils": "workspace:^",
-    "msw": "^1.0.0"
+    "msw": "^2.0.0"
   },
   "configSchema": "config.d.ts"
 }

--- a/plugins/scaffolder-backend-module-confluence-to-markdown/src/actions/confluence/confluenceToMarkdown.examples.test.ts
+++ b/plugins/scaffolder-backend-module-confluence-to-markdown/src/actions/confluence/confluenceToMarkdown.examples.test.ts
@@ -21,7 +21,7 @@ import {
   createMockDirectory,
   registerMswTestHooks,
 } from '@backstage/backend-test-utils';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { examples } from './confluenceToMarkdown.examples';
 import yaml from 'yaml';
@@ -118,16 +118,14 @@ describe('confluence:transform:markdown examples', () => {
     };
 
     worker.use(
-      rest.get(`${baseUrl}/rest/api/content`, (_, res, ctx) =>
-        res(ctx.status(200, 'OK'), ctx.json(responseBody)),
+      http.get(`${baseUrl}/rest/api/content`, () =>
+        HttpResponse.json(responseBody, { status: 200, statusText: 'OK' }),
       ),
-      rest.get(
-        `${baseUrl}/rest/api/content/4444444/child/attachment`,
-        (_, res, ctx) => res(ctx.status(200, 'OK'), ctx.json(responseBodyTwo)),
+      http.get(`${baseUrl}/rest/api/content/4444444/child/attachment`, () =>
+        HttpResponse.json(responseBodyTwo, { status: 200, statusText: 'OK' }),
       ),
-      rest.get(
-        `${baseUrl}/download/attachments/4444444/testing.pdf`,
-        (_, res, ctx) => res(ctx.status(200, 'OK'), ctx.body('hello')),
+      http.get(`${baseUrl}/download/attachments/4444444/testing.pdf`, () =>
+        HttpResponse.text('hello', { status: 200, statusText: 'OK' }),
       ),
     );
 

--- a/plugins/scaffolder-backend-module-confluence-to-markdown/src/actions/confluence/confluenceToMarkdown.test.ts
+++ b/plugins/scaffolder-backend-module-confluence-to-markdown/src/actions/confluence/confluenceToMarkdown.test.ts
@@ -22,7 +22,7 @@ import {
   registerMswTestHooks,
 } from '@backstage/backend-test-utils';
 import type { ActionContext } from '@backstage/plugin-scaffolder-node';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { createMockActionContext } from '@backstage/plugin-scaffolder-node-test-utils';
 import { UrlReaderService } from '@backstage/backend-plugin-api';
@@ -122,16 +122,14 @@ describe('confluence:transform:markdown', () => {
     };
 
     worker.use(
-      rest.get(`${baseUrl}/rest/api/content`, (_, res, ctx) =>
-        res(ctx.status(200, 'OK'), ctx.json(responseBody)),
+      http.get(`${baseUrl}/rest/api/content`, () =>
+        HttpResponse.json(responseBody, { status: 200, statusText: 'OK' }),
       ),
-      rest.get(
-        `${baseUrl}/rest/api/content/4444444/child/attachment`,
-        (_, res, ctx) => res(ctx.status(200, 'OK'), ctx.json(responseBodyTwo)),
+      http.get(`${baseUrl}/rest/api/content/4444444/child/attachment`, () =>
+        HttpResponse.json(responseBodyTwo, { status: 200, statusText: 'OK' }),
       ),
-      rest.get(
-        `${baseUrl}/download/attachments/4444444/testing.pdf`,
-        (_, res, ctx) => res(ctx.status(200, 'OK'), ctx.body('hello')),
+      http.get(`${baseUrl}/download/attachments/4444444/testing.pdf`, () =>
+        HttpResponse.text('hello', { status: 200, statusText: 'OK' }),
       ),
     );
 
@@ -175,12 +173,11 @@ describe('confluence:transform:markdown', () => {
     };
 
     worker.use(
-      rest.get(`${baseUrl}/rest/api/content`, (_, res, ctx) =>
-        res(ctx.status(200, 'OK'), ctx.json(responseBody)),
+      http.get(`${baseUrl}/rest/api/content`, () =>
+        HttpResponse.json(responseBody, { status: 200, statusText: 'OK' }),
       ),
-      rest.get(
-        `${baseUrl}/rest/api/content/4444444/child/attachment`,
-        (_, res, ctx) => res(ctx.status(200, 'OK'), ctx.json(responseBodyTwo)),
+      http.get(`${baseUrl}/rest/api/content/4444444/child/attachment`, () =>
+        HttpResponse.json(responseBodyTwo, { status: 200, statusText: 'OK' }),
       ),
     );
 
@@ -207,8 +204,8 @@ describe('confluence:transform:markdown', () => {
     const responseBody = {};
 
     worker.use(
-      rest.get(`${baseUrl}/rest/api/content`, (_, res, ctx) =>
-        res(ctx.status(401, 'nope'), ctx.json(responseBody)),
+      http.get(`${baseUrl}/rest/api/content`, () =>
+        HttpResponse.json(responseBody, { status: 401, statusText: 'nope' }),
       ),
     );
 
@@ -229,8 +226,8 @@ describe('confluence:transform:markdown', () => {
     };
 
     worker.use(
-      rest.get(`${baseUrl}/rest/api/content`, (_, res, ctx) =>
-        res(ctx.status(200, 'OK'), ctx.json(responseBody)),
+      http.get(`${baseUrl}/rest/api/content`, () =>
+        HttpResponse.json(responseBody, { status: 200, statusText: 'OK' }),
       ),
     );
 
@@ -265,13 +262,11 @@ describe('confluence:transform:markdown', () => {
     const responseBodyTwo = {};
 
     worker.use(
-      rest.get(`${baseUrl}/rest/api/content`, (_, res, ctx) =>
-        res(ctx.status(200, 'OK'), ctx.json(responseBody)),
+      http.get(`${baseUrl}/rest/api/content`, () =>
+        HttpResponse.json(responseBody, { status: 200, statusText: 'OK' }),
       ),
-      rest.get(
-        `${baseUrl}/rest/api/content/4444444/child/attachment`,
-        (_, res, ctx) =>
-          res(ctx.status(404, 'nope'), ctx.json(responseBodyTwo)),
+      http.get(`${baseUrl}/rest/api/content/4444444/child/attachment`, () =>
+        HttpResponse.json(responseBodyTwo, { status: 404, statusText: 'nope' }),
       ),
     );
 

--- a/plugins/scaffolder-backend-module-gerrit/package.json
+++ b/plugins/scaffolder-backend-module-gerrit/package.json
@@ -53,6 +53,6 @@
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@backstage/plugin-scaffolder-node-test-utils": "workspace:^",
-    "msw": "^1.0.0"
+    "msw": "^2.0.0"
   }
 }

--- a/plugins/scaffolder-backend-module-gerrit/src/actions/gerrit.examples.test.ts
+++ b/plugins/scaffolder-backend-module-gerrit/src/actions/gerrit.examples.test.ts
@@ -28,7 +28,7 @@ jest.mock('@backstage/plugin-scaffolder-node', () => {
 
 import path from 'node:path';
 import { createPublishGerritAction } from './gerrit';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { ScmIntegrations } from '@backstage/integration';
@@ -72,22 +72,18 @@ describe('publish:gerrit', () => {
   it(`should ${examples[0].description}`, async () => {
     expect.assertions(5);
     server.use(
-      rest.put('https://gerrit.com/a/projects/repo', (req, res, ctx) => {
-        expect(req.headers.get('Authorization')).toBe(
+      http.put('https://gerrit.com/a/projects/repo', async ({ request }) => {
+        expect(request.headers.get('Authorization')).toBe(
           'Basic ZGVtb3VzZXI6YWNjZXNzdG9rZW4=',
         );
-        expect(req.body).toEqual({
+        expect(await request.json()).toEqual({
           branches: ['master'],
           create_empty_commit: false,
           owners: ['owner'],
           description,
           parent: 'parent',
         });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
+        return HttpResponse.json({}, { status: 201 });
       }),
     );
 
@@ -131,11 +127,11 @@ describe('publish:gerrit', () => {
   it(`should ${examples[1].description}`, async () => {
     expect.assertions(5);
     server.use(
-      rest.put('https://gerrit.com/a/projects/repo', (req, res, ctx) => {
-        expect(req.headers.get('Authorization')).toBe(
+      http.put('https://gerrit.com/a/projects/repo', async ({ request }) => {
+        expect(request.headers.get('Authorization')).toBe(
           'Basic ZGVtb3VzZXI6YWNjZXNzdG9rZW4=',
         );
-        expect(req.body).toEqual({
+        expect(await request.json()).toEqual({
           branches: ['master'],
           create_empty_commit: false,
           owners: ['owner'],
@@ -143,11 +139,7 @@ describe('publish:gerrit', () => {
             .description,
           parent: 'parent',
         });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
+        return HttpResponse.json({}, { status: 201 });
       }),
     );
 
@@ -190,22 +182,18 @@ describe('publish:gerrit', () => {
   it(`should ${examples[2].description}`, async () => {
     expect.assertions(5);
     server.use(
-      rest.put('https://gerrit.com/a/projects/repo', (req, res, ctx) => {
-        expect(req.headers.get('Authorization')).toBe(
+      http.put('https://gerrit.com/a/projects/repo', async ({ request }) => {
+        expect(request.headers.get('Authorization')).toBe(
           'Basic ZGVtb3VzZXI6YWNjZXNzdG9rZW4=',
         );
-        expect(req.body).toEqual({
+        expect(await request.json()).toEqual({
           branches: ['staging'],
           create_empty_commit: false,
           owners: ['owner'],
           description,
           parent: 'parent',
         });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
+        return HttpResponse.json({}, { status: 201 });
       }),
     );
 
@@ -248,22 +236,18 @@ describe('publish:gerrit', () => {
   it(`should ${examples[3].description}`, async () => {
     expect.assertions(5);
     server.use(
-      rest.put('https://gerrit.com/a/projects/repo', (req, res, ctx) => {
-        expect(req.headers.get('Authorization')).toBe(
+      http.put('https://gerrit.com/a/projects/repo', async ({ request }) => {
+        expect(request.headers.get('Authorization')).toBe(
           'Basic ZGVtb3VzZXI6YWNjZXNzdG9rZW4=',
         );
-        expect(req.body).toEqual({
+        expect(await request.json()).toEqual({
           branches: ['master'],
           create_empty_commit: false,
           owners: ['owner'],
           description,
           parent: 'parent',
         });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
+        return HttpResponse.json({}, { status: 201 });
       }),
     );
 
@@ -309,22 +293,18 @@ describe('publish:gerrit', () => {
   it(`should ${examples[4].description}`, async () => {
     expect.assertions(5);
     server.use(
-      rest.put('https://gerrit.com/a/projects/repo', (req, res, ctx) => {
-        expect(req.headers.get('Authorization')).toBe(
+      http.put('https://gerrit.com/a/projects/repo', async ({ request }) => {
+        expect(request.headers.get('Authorization')).toBe(
           'Basic ZGVtb3VzZXI6YWNjZXNzdG9rZW4=',
         );
-        expect(req.body).toEqual({
+        expect(await request.json()).toEqual({
           branches: ['master'],
           create_empty_commit: false,
           owners: ['owner'],
           description,
           parent: 'parent',
         });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
+        return HttpResponse.json({}, { status: 201 });
       }),
     );
 
@@ -368,22 +348,18 @@ describe('publish:gerrit', () => {
   it(`should ${examples[5].description}`, async () => {
     expect.assertions(5);
     server.use(
-      rest.put('https://gerrit.com/a/projects/repo', (req, res, ctx) => {
-        expect(req.headers.get('Authorization')).toBe(
+      http.put('https://gerrit.com/a/projects/repo', async ({ request }) => {
+        expect(request.headers.get('Authorization')).toBe(
           'Basic ZGVtb3VzZXI6YWNjZXNzdG9rZW4=',
         );
-        expect(req.body).toEqual({
+        expect(await request.json()).toEqual({
           branches: ['master'],
           create_empty_commit: false,
           owners: ['owner'],
           description,
           parent: 'parent',
         });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
+        return HttpResponse.json({}, { status: 201 });
       }),
     );
 
@@ -427,22 +403,18 @@ describe('publish:gerrit', () => {
   it(`should ${examples[6].description}`, async () => {
     expect.assertions(5);
     server.use(
-      rest.put('https://gerrit.com/a/projects/repo', (req, res, ctx) => {
-        expect(req.headers.get('Authorization')).toBe(
+      http.put('https://gerrit.com/a/projects/repo', async ({ request }) => {
+        expect(request.headers.get('Authorization')).toBe(
           'Basic ZGVtb3VzZXI6YWNjZXNzdG9rZW4=',
         );
-        expect(req.body).toEqual({
+        expect(await request.json()).toEqual({
           branches: ['master'],
           create_empty_commit: false,
           owners: ['owner'],
           description,
           parent: 'parent',
         });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
+        return HttpResponse.json({}, { status: 201 });
       }),
     );
 
@@ -486,22 +458,18 @@ describe('publish:gerrit', () => {
   it(`should ${examples[7].description}`, async () => {
     expect.assertions(5);
     server.use(
-      rest.put('https://gerrit.com/a/projects/repo', (req, res, ctx) => {
-        expect(req.headers.get('Authorization')).toBe(
+      http.put('https://gerrit.com/a/projects/repo', async ({ request }) => {
+        expect(request.headers.get('Authorization')).toBe(
           'Basic ZGVtb3VzZXI6YWNjZXNzdG9rZW4=',
         );
-        expect(req.body).toEqual({
+        expect(await request.json()).toEqual({
           branches: ['staging'],
           create_empty_commit: false,
           owners: ['owner'],
           description: 'Initialize a gerrit repository',
           parent: 'parent',
         });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
+        return HttpResponse.json({}, { status: 201 });
       }),
     );
 

--- a/plugins/scaffolder-backend-module-gerrit/src/actions/gerrit.test.ts
+++ b/plugins/scaffolder-backend-module-gerrit/src/actions/gerrit.test.ts
@@ -28,7 +28,7 @@ jest.mock('@backstage/plugin-scaffolder-node', () => {
 
 import path from 'node:path';
 import { createPublishGerritAction } from './gerrit';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { ScmIntegrations } from '@backstage/integration';
@@ -91,23 +91,22 @@ describe('publish:gerrit', () => {
   it('can correctly create a new project', async () => {
     expect.assertions(5);
     server.use(
-      rest.put('https://gerrithost.org/a/projects/repo', (req, res, ctx) => {
-        expect(req.headers.get('Authorization')).toBe(
-          'Basic Z2Vycml0dXNlcjp1c2VydG9rZW4=',
-        );
-        expect(req.body).toEqual({
-          branches: ['master'],
-          create_empty_commit: false,
-          owners: ['owner'],
-          description,
-          parent: 'workspace',
-        });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
-      }),
+      http.put(
+        'https://gerrithost.org/a/projects/repo',
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
+            'Basic Z2Vycml0dXNlcjp1c2VydG9rZW4=',
+          );
+          expect(await request.json()).toEqual({
+            branches: ['master'],
+            create_empty_commit: false,
+            owners: ['owner'],
+            description,
+            parent: 'workspace',
+          });
+          return HttpResponse.json({}, { status: 201 });
+        },
+      ),
     );
 
     await action.handler({
@@ -141,23 +140,22 @@ describe('publish:gerrit', () => {
   it('can correctly create a new project with a specific sourcePath', async () => {
     expect.assertions(5);
     server.use(
-      rest.put('https://gerrithost.org/a/projects/repo', (req, res, ctx) => {
-        expect(req.headers.get('Authorization')).toBe(
-          'Basic Z2Vycml0dXNlcjp1c2VydG9rZW4=',
-        );
-        expect(req.body).toEqual({
-          branches: ['master'],
-          create_empty_commit: false,
-          owners: ['owner'],
-          description,
-          parent: 'workspace',
-        });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
-      }),
+      http.put(
+        'https://gerrithost.org/a/projects/repo',
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
+            'Basic Z2Vycml0dXNlcjp1c2VydG9rZW4=',
+          );
+          expect(await request.json()).toEqual({
+            branches: ['master'],
+            create_empty_commit: false,
+            owners: ['owner'],
+            description,
+            parent: 'workspace',
+          });
+          return HttpResponse.json({}, { status: 201 });
+        },
+      ),
     );
 
     await action.handler({
@@ -192,23 +190,22 @@ describe('publish:gerrit', () => {
   it('can correctly create a new project without specifying owner', async () => {
     expect.assertions(5);
     server.use(
-      rest.put('https://gerrithost.org/a/projects/repo', (req, res, ctx) => {
-        expect(req.headers.get('Authorization')).toBe(
-          'Basic Z2Vycml0dXNlcjp1c2VydG9rZW4=',
-        );
-        expect(req.body).toEqual({
-          branches: ['master'],
-          create_empty_commit: false,
-          owners: [],
-          description,
-          parent: 'workspace',
-        });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
-      }),
+      http.put(
+        'https://gerrithost.org/a/projects/repo',
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
+            'Basic Z2Vycml0dXNlcjp1c2VydG9rZW4=',
+          );
+          expect(await request.json()).toEqual({
+            branches: ['master'],
+            create_empty_commit: false,
+            owners: [],
+            description,
+            parent: 'workspace',
+          });
+          return HttpResponse.json({}, { status: 201 });
+        },
+      ),
     );
 
     await action.handler({
@@ -243,23 +240,22 @@ describe('publish:gerrit', () => {
   it('can correctly create a new project with main as default branch', async () => {
     expect.assertions(5);
     server.use(
-      rest.put('https://gerrithost.org/a/projects/repo', (req, res, ctx) => {
-        expect(req.headers.get('Authorization')).toBe(
-          'Basic Z2Vycml0dXNlcjp1c2VydG9rZW4=',
-        );
-        expect(req.body).toEqual({
-          branches: ['main'],
-          create_empty_commit: false,
-          owners: [],
-          description,
-          parent: 'workspace',
-        });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
-      }),
+      http.put(
+        'https://gerrithost.org/a/projects/repo',
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
+            'Basic Z2Vycml0dXNlcjp1c2VydG9rZW4=',
+          );
+          expect(await request.json()).toEqual({
+            branches: ['main'],
+            create_empty_commit: false,
+            owners: [],
+            description,
+            parent: 'workspace',
+          });
+          return HttpResponse.json({}, { status: 201 });
+        },
+      ),
     );
 
     await action.handler({

--- a/plugins/scaffolder-backend-module-gitea/package.json
+++ b/plugins/scaffolder-backend-module-gitea/package.json
@@ -53,6 +53,6 @@
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@backstage/plugin-scaffolder-node-test-utils": "workspace:^",
-    "msw": "^1.0.0"
+    "msw": "^2.0.0"
   }
 }

--- a/plugins/scaffolder-backend-module-gitea/src/actions/gitea.examples.test.ts
+++ b/plugins/scaffolder-backend-module-gitea/src/actions/gitea.examples.test.ts
@@ -20,7 +20,7 @@ import {
   getRepoSourceDirectory,
   initRepoAndPush,
 } from '@backstage/plugin-scaffolder-node';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { createMockActionContext } from '@backstage/plugin-scaffolder-node-test-utils';
 import { setupServer } from 'msw/node';
@@ -68,45 +68,33 @@ describe('publish:gitea', () => {
 
   it(`should ${examples[0].description}`, async () => {
     server.use(
-      rest.get('https://gitea.com/api/v1/orgs/org1', (_req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({
-            id: 1,
-            name: 'org1',
-            visibility: 'public',
-            repo_admin_change_team_access: false,
-            username: 'org1',
-          }),
-        );
+      http.get('https://gitea.com/api/v1/orgs/org1', () => {
+        return HttpResponse.json({
+          id: 1,
+          name: 'org1',
+          visibility: 'public',
+          repo_admin_change_team_access: false,
+          username: 'org1',
+        });
       }),
-      rest.get(
-        'https://gitea.com/org1/repo/src/branch/main',
-        (_req, res, ctx) => {
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({}),
+      http.get('https://gitea.com/org1/repo/src/branch/main', () => {
+        return HttpResponse.json({});
+      }),
+      http.post(
+        'https://gitea.com/api/v1/orgs/org1/repos',
+        async ({ request }) => {
+          // Basic auth must match the user and password defined part of the config
+          expect(request.headers.get('Authorization')).toBe(
+            'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
           );
+          expect(await request.json()).toEqual({
+            name: 'repo',
+            private: false,
+            description,
+          });
+          return HttpResponse.json({}, { status: 201 });
         },
       ),
-      rest.post('https://gitea.com/api/v1/orgs/org1/repos', (req, res, ctx) => {
-        // Basic auth must match the user and password defined part of the config
-        expect(req.headers.get('Authorization')).toBe(
-          'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
-        );
-        expect(req.body).toEqual({
-          name: 'repo',
-          private: false,
-          description,
-        });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
-      }),
     );
 
     let input;
@@ -141,45 +129,33 @@ describe('publish:gitea', () => {
 
   it(`should ${examples[1].description}`, async () => {
     server.use(
-      rest.get('https://gitea.com/api/v1/orgs/org1', (_req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({
-            id: 1,
-            name: 'org1',
-            visibility: 'public',
-            repo_admin_change_team_access: false,
-            username: 'org1',
-          }),
-        );
+      http.get('https://gitea.com/api/v1/orgs/org1', () => {
+        return HttpResponse.json({
+          id: 1,
+          name: 'org1',
+          visibility: 'public',
+          repo_admin_change_team_access: false,
+          username: 'org1',
+        });
       }),
-      rest.get(
-        'https://gitea.com/org1/repo/src/branch/main',
-        (_req, res, ctx) => {
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({}),
+      http.get('https://gitea.com/org1/repo/src/branch/main', () => {
+        return HttpResponse.json({});
+      }),
+      http.post(
+        'https://gitea.com/api/v1/orgs/org1/repos',
+        async ({ request }) => {
+          // Basic auth must match the user and password defined part of the config
+          expect(request.headers.get('Authorization')).toBe(
+            'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
           );
+          expect(await request.json()).toEqual({
+            name: 'repo',
+            private: false,
+            description: 'Initialize a gitea repository',
+          });
+          return HttpResponse.json({}, { status: 201 });
         },
       ),
-      rest.post('https://gitea.com/api/v1/orgs/org1/repos', (req, res, ctx) => {
-        // Basic auth must match the user and password defined part of the config
-        expect(req.headers.get('Authorization')).toBe(
-          'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
-        );
-        expect(req.body).toEqual({
-          name: 'repo',
-          private: false,
-          description: 'Initialize a gitea repository',
-        });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
-      }),
     );
 
     let input;
@@ -214,45 +190,33 @@ describe('publish:gitea', () => {
 
   it(`should ${examples[2].description}`, async () => {
     server.use(
-      rest.get('https://gitea.com/api/v1/orgs/org1', (_req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({
-            id: 1,
-            name: 'org1',
-            visibility: 'public',
-            repo_admin_change_team_access: false,
-            username: 'org1',
-          }),
-        );
+      http.get('https://gitea.com/api/v1/orgs/org1', ({}) => {
+        return HttpResponse.json({
+          id: 1,
+          name: 'org1',
+          visibility: 'public',
+          repo_admin_change_team_access: false,
+          username: 'org1',
+        });
       }),
-      rest.get(
-        'https://gitea.com/org1/repo/src/branch/main',
-        (_req, res, ctx) => {
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({}),
+      http.get('https://gitea.com/org1/repo/src/branch/main', () => {
+        return HttpResponse.json({});
+      }),
+      http.post(
+        'https://gitea.com/api/v1/orgs/org1/repos',
+        async ({ request }) => {
+          // Basic auth must match the user and password defined part of the config
+          expect(request.headers.get('Authorization')).toBe(
+            'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
           );
+          expect(await request.json()).toEqual({
+            name: 'repo',
+            private: true,
+            description,
+          });
+          return HttpResponse.json({}, { status: 201 });
         },
       ),
-      rest.post('https://gitea.com/api/v1/orgs/org1/repos', (req, res, ctx) => {
-        // Basic auth must match the user and password defined part of the config
-        expect(req.headers.get('Authorization')).toBe(
-          'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
-        );
-        expect(req.body).toEqual({
-          name: 'repo',
-          private: true,
-          description,
-        });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
-      }),
     );
 
     let input;
@@ -287,45 +251,33 @@ describe('publish:gitea', () => {
 
   it(`should ${examples[3].description}`, async () => {
     server.use(
-      rest.get('https://gitea.com/api/v1/orgs/org1', (_req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({
-            id: 1,
-            name: 'org1',
-            visibility: 'public',
-            repo_admin_change_team_access: false,
-            username: 'org1',
-          }),
-        );
+      http.get('https://gitea.com/api/v1/orgs/org1', () => {
+        return HttpResponse.json({
+          id: 1,
+          name: 'org1',
+          visibility: 'public',
+          repo_admin_change_team_access: false,
+          username: 'org1',
+        });
       }),
-      rest.get(
-        'https://gitea.com/org1/repo/src/branch/staging',
-        (_req, res, ctx) => {
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({}),
+      http.get('https://gitea.com/org1/repo/src/branch/staging', () => {
+        return HttpResponse.json({});
+      }),
+      http.post(
+        'https://gitea.com/api/v1/orgs/org1/repos',
+        async ({ request }) => {
+          // Basic auth must match the user and password defined part of the config
+          expect(request.headers.get('Authorization')).toBe(
+            'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
           );
+          expect(await request.json()).toEqual({
+            name: 'repo',
+            private: false,
+            description,
+          });
+          return HttpResponse.json({}, { status: 201 });
         },
       ),
-      rest.post('https://gitea.com/api/v1/orgs/org1/repos', (req, res, ctx) => {
-        // Basic auth must match the user and password defined part of the config
-        expect(req.headers.get('Authorization')).toBe(
-          'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
-        );
-        expect(req.body).toEqual({
-          name: 'repo',
-          private: false,
-          description,
-        });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
-      }),
     );
 
     let input;
@@ -360,45 +312,33 @@ describe('publish:gitea', () => {
 
   it(`should ${examples[4].description}`, async () => {
     server.use(
-      rest.get('https://gitea.com/api/v1/orgs/org1', (_req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({
-            id: 1,
-            name: 'org1',
-            visibility: 'public',
-            repo_admin_change_team_access: false,
-            username: 'org1',
-          }),
-        );
+      http.get('https://gitea.com/api/v1/orgs/org1', () => {
+        return HttpResponse.json({
+          id: 1,
+          name: 'org1',
+          visibility: 'public',
+          repo_admin_change_team_access: false,
+          username: 'org1',
+        });
       }),
-      rest.get(
-        'https://gitea.com/org1/repo/src/branch/main',
-        (_req, res, ctx) => {
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({}),
+      http.get('https://gitea.com/org1/repo/src/branch/main', () => {
+        return HttpResponse.json({});
+      }),
+      http.post(
+        'https://gitea.com/api/v1/orgs/org1/repos',
+        async ({ request }) => {
+          // Basic auth must match the user and password defined part of the config
+          expect(request.headers.get('Authorization')).toBe(
+            'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
           );
+          expect(await request.json()).toEqual({
+            name: 'repo',
+            private: false,
+            description,
+          });
+          return HttpResponse.json({}, { status: 201 });
         },
       ),
-      rest.post('https://gitea.com/api/v1/orgs/org1/repos', (req, res, ctx) => {
-        // Basic auth must match the user and password defined part of the config
-        expect(req.headers.get('Authorization')).toBe(
-          'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
-        );
-        expect(req.body).toEqual({
-          name: 'repo',
-          private: false,
-          description,
-        });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
-      }),
     );
 
     let input;
@@ -435,45 +375,33 @@ describe('publish:gitea', () => {
 
   it(`should ${examples[5].description}`, async () => {
     server.use(
-      rest.get('https://gitea.com/api/v1/orgs/org1', (_req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({
-            id: 1,
-            name: 'org1',
-            visibility: 'public',
-            repo_admin_change_team_access: false,
-            username: 'org1',
-          }),
-        );
+      http.get('https://gitea.com/api/v1/orgs/org1', () => {
+        return HttpResponse.json({
+          id: 1,
+          name: 'org1',
+          visibility: 'public',
+          repo_admin_change_team_access: false,
+          username: 'org1',
+        });
       }),
-      rest.get(
-        'https://gitea.com/org1/repo/src/branch/main',
-        (_req, res, ctx) => {
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({}),
+      http.get('https://gitea.com/org1/repo/src/branch/main', () => {
+        return HttpResponse.json({});
+      }),
+      http.post(
+        'https://gitea.com/api/v1/orgs/org1/repos',
+        async ({ request }) => {
+          // Basic auth must match the user and password defined part of the config
+          expect(request.headers.get('Authorization')).toBe(
+            'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
           );
+          expect(await request.json()).toEqual({
+            name: 'repo',
+            private: false,
+            description,
+          });
+          return HttpResponse.json({}, { status: 201 });
         },
       ),
-      rest.post('https://gitea.com/api/v1/orgs/org1/repos', (req, res, ctx) => {
-        // Basic auth must match the user and password defined part of the config
-        expect(req.headers.get('Authorization')).toBe(
-          'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
-        );
-        expect(req.body).toEqual({
-          name: 'repo',
-          private: false,
-          description,
-        });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
-      }),
     );
 
     let input;
@@ -508,45 +436,33 @@ describe('publish:gitea', () => {
 
   it(`should ${examples[6].description}`, async () => {
     server.use(
-      rest.get('https://gitea.com/api/v1/orgs/org1', (_req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({
-            id: 1,
-            name: 'org1',
-            visibility: 'public',
-            repo_admin_change_team_access: false,
-            username: 'org1',
-          }),
-        );
+      http.get('https://gitea.com/api/v1/orgs/org1', () => {
+        return HttpResponse.json({
+          id: 1,
+          name: 'org1',
+          visibility: 'public',
+          repo_admin_change_team_access: false,
+          username: 'org1',
+        });
       }),
-      rest.get(
-        'https://gitea.com/org1/repo/src/branch/main',
-        (_req, res, ctx) => {
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({}),
+      http.get('https://gitea.com/org1/repo/src/branch/main', () => {
+        return HttpResponse.json({});
+      }),
+      http.post(
+        'https://gitea.com/api/v1/orgs/org1/repos',
+        async ({ request }) => {
+          // Basic auth must match the user and password defined part of the config
+          expect(request.headers.get('Authorization')).toBe(
+            'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
           );
+          expect(await request.json()).toEqual({
+            name: 'repo',
+            private: false,
+            description,
+          });
+          return HttpResponse.json({}, { status: 201 });
         },
       ),
-      rest.post('https://gitea.com/api/v1/orgs/org1/repos', (req, res, ctx) => {
-        // Basic auth must match the user and password defined part of the config
-        expect(req.headers.get('Authorization')).toBe(
-          'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
-        );
-        expect(req.body).toEqual({
-          name: 'repo',
-          private: false,
-          description,
-        });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
-      }),
     );
 
     let input;
@@ -581,45 +497,33 @@ describe('publish:gitea', () => {
 
   it(`should ${examples[7].description}`, async () => {
     server.use(
-      rest.get('https://gitea.com/api/v1/orgs/org1', (_req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({
-            id: 1,
-            name: 'org1',
-            visibility: 'public',
-            repo_admin_change_team_access: false,
-            username: 'org1',
-          }),
-        );
+      http.get('https://gitea.com/api/v1/orgs/org1', () => {
+        return HttpResponse.json({
+          id: 1,
+          name: 'org1',
+          visibility: 'public',
+          repo_admin_change_team_access: false,
+          username: 'org1',
+        });
       }),
-      rest.get(
-        'https://gitea.com/org1/repo/src/branch/main',
-        (_req, res, ctx) => {
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({}),
+      http.get('https://gitea.com/org1/repo/src/branch/main', () => {
+        return HttpResponse.json({});
+      }),
+      http.post(
+        'https://gitea.com/api/v1/orgs/org1/repos',
+        async ({ request }) => {
+          // Basic auth must match the user and password defined part of the config
+          expect(request.headers.get('Authorization')).toBe(
+            'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
           );
+          expect(await request.json()).toEqual({
+            name: 'repo',
+            private: false,
+            description,
+          });
+          return HttpResponse.json({}, { status: 201 });
         },
       ),
-      rest.post('https://gitea.com/api/v1/orgs/org1/repos', (req, res, ctx) => {
-        // Basic auth must match the user and password defined part of the config
-        expect(req.headers.get('Authorization')).toBe(
-          'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
-        );
-        expect(req.body).toEqual({
-          name: 'repo',
-          private: false,
-          description,
-        });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
-      }),
     );
 
     let input;
@@ -654,45 +558,33 @@ describe('publish:gitea', () => {
 
   it(`should ${examples[8].description}`, async () => {
     server.use(
-      rest.get('https://gitea.com/api/v1/orgs/org1', (_req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({
-            id: 1,
-            name: 'org1',
-            visibility: 'public',
-            repo_admin_change_team_access: false,
-            username: 'org1',
-          }),
-        );
+      http.get('https://gitea.com/api/v1/orgs/org1', () => {
+        return HttpResponse.json({
+          id: 1,
+          name: 'org1',
+          visibility: 'public',
+          repo_admin_change_team_access: false,
+          username: 'org1',
+        });
       }),
-      rest.get(
-        'https://gitea.com/org1/repo/src/branch/staging',
-        (_req, res, ctx) => {
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({}),
+      http.get('https://gitea.com/org1/repo/src/branch/staging', () => {
+        return HttpResponse.json({});
+      }),
+      http.post(
+        'https://gitea.com/api/v1/orgs/org1/repos',
+        async ({ request }) => {
+          // Basic auth must match the user and password defined part of the config
+          expect(request.headers.get('Authorization')).toBe(
+            'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
           );
+          expect(await request.json()).toEqual({
+            name: 'repo',
+            private: false,
+            description: 'Initialize a gitea repository',
+          });
+          return HttpResponse.json({}, { status: 201 });
         },
       ),
-      rest.post('https://gitea.com/api/v1/orgs/org1/repos', (req, res, ctx) => {
-        // Basic auth must match the user and password defined part of the config
-        expect(req.headers.get('Authorization')).toBe(
-          'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
-        );
-        expect(req.body).toEqual({
-          name: 'repo',
-          private: false,
-          description: 'Initialize a gitea repository',
-        });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
-      }),
     );
 
     let input;
@@ -729,45 +621,33 @@ describe('publish:gitea', () => {
 
   it(`should ${examples[0].description}`, async () => {
     server.use(
-      rest.get('https://gitea.com/api/v1/orgs/org1', (_req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({
-            id: 1,
-            name: 'org1',
-            visibility: 'public',
-            repo_admin_change_team_access: false,
-            username: 'org1',
-          }),
-        );
+      http.get('https://gitea.com/api/v1/orgs/org1', () => {
+        return HttpResponse.json({
+          id: 1,
+          name: 'org1',
+          visibility: 'public',
+          repo_admin_change_team_access: false,
+          username: 'org1',
+        });
       }),
-      rest.get(
-        'https://gitea.com/org1/repo/src/branch/main',
-        (_req, res, ctx) => {
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({}),
+      http.get('https://gitea.com/org1/repo/src/branch/main', () => {
+        return HttpResponse.json({});
+      }),
+      http.post(
+        'https://gitea.com/api/v1/orgs/org1/repos',
+        async ({ request }) => {
+          // Basic auth must match the user and password defined part of the config
+          expect(request.headers.get('Authorization')).toBe(
+            'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
           );
+          expect(await request.json()).toEqual({
+            name: 'repo',
+            private: false,
+            description,
+          });
+          return HttpResponse.json({}, { status: 201 });
         },
       ),
-      rest.post('https://gitea.com/api/v1/orgs/org1/repos', (req, res, ctx) => {
-        // Basic auth must match the user and password defined part of the config
-        expect(req.headers.get('Authorization')).toBe(
-          'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
-        );
-        expect(req.body).toEqual({
-          name: 'repo',
-          private: false,
-          description,
-        });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
-      }),
     );
 
     let input;

--- a/plugins/scaffolder-backend-module-gitea/src/actions/gitea.test.ts
+++ b/plugins/scaffolder-backend-module-gitea/src/actions/gitea.test.ts
@@ -17,7 +17,7 @@ import { ScmIntegrations } from '@backstage/integration';
 import { ConfigReader } from '@backstage/config';
 import { createPublishGiteaAction } from './gitea';
 import { initRepoAndPush } from '@backstage/plugin-scaffolder-node';
-import { rest } from 'msw';
+import { HttpResponse, http } from 'msw';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { createMockActionContext } from '@backstage/plugin-scaffolder-node-test-utils';
 import { setupServer } from 'msw/node';
@@ -88,45 +88,33 @@ describe('publish:gitea', () => {
 
   it('should throw if there is no repositoryId returned', async () => {
     server.use(
-      rest.get('https://gitea.com/api/v1/orgs/org1', (_req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({
-            id: 1,
-            name: 'org1',
-            visibility: 'public',
-            repo_admin_change_team_access: false,
-            username: 'org1',
-          }),
-        );
+      http.get('https://gitea.com/api/v1/orgs/org1', () => {
+        return HttpResponse.json({
+          id: 1,
+          name: 'org1',
+          visibility: 'public',
+          repo_admin_change_team_access: false,
+          username: 'org1',
+        });
       }),
-      rest.get(
-        'https://gitea.com/org1/repo/src/branch/main',
-        (_req, res, ctx) => {
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({}),
+      http.get('https://gitea.com/org1/repo/src/branch/main', () => {
+        return HttpResponse.json({});
+      }),
+      http.post(
+        'https://gitea.com/api/v1/orgs/org1/repos',
+        async ({ request }) => {
+          // Basic auth must match the user and password defined part of the config
+          expect(request.headers.get('Authorization')).toBe(
+            'basic Z2l0ZWFfdXNlcjpnaXRlYV9wYXNzd29yZA==',
           );
+          expect(await request.json()).toEqual({
+            name: 'repo',
+            private: false,
+            description,
+          });
+          return HttpResponse.json({}, { status: 201 });
         },
       ),
-      rest.post('https://gitea.com/api/v1/orgs/org1/repos', (req, res, ctx) => {
-        // Basic auth must match the user and password defined part of the config
-        expect(req.headers.get('Authorization')).toBe(
-          'basic Z2l0ZWFfdXNlcjpnaXRlYV9wYXNzd29yZA==',
-        );
-        expect(req.body).toEqual({
-          name: 'repo',
-          private: false,
-          description,
-        });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
-      }),
     );
 
     await action.handler({
@@ -158,45 +146,33 @@ describe('publish:gitea', () => {
 
   it('should create a Gitea repository where visibility is public', async () => {
     server.use(
-      rest.get('https://gitea.com/api/v1/orgs/org1', (_req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({
-            id: 1,
-            name: 'org1',
-            visibility: 'public',
-            repo_admin_change_team_access: false,
-            username: 'org1',
-          }),
-        );
+      http.get('https://gitea.com/api/v1/orgs/org1', () => {
+        return HttpResponse.json({
+          id: 1,
+          name: 'org1',
+          visibility: 'public',
+          repo_admin_change_team_access: false,
+          username: 'org1',
+        });
       }),
-      rest.get(
-        'https://gitea.com/org1/repo/src/branch/main',
-        (_req, res, ctx) => {
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({}),
+      http.get('https://gitea.com/org1/repo/src/branch/main', () => {
+        return HttpResponse.json({});
+      }),
+      http.post(
+        'https://gitea.com/api/v1/orgs/org1/repos',
+        async ({ request }) => {
+          // Basic auth must match the user and password defined part of the config
+          expect(request.headers.get('Authorization')).toBe(
+            'basic Z2l0ZWFfdXNlcjpnaXRlYV9wYXNzd29yZA==',
           );
+          expect(await request.json()).toEqual({
+            name: 'repo',
+            private: false,
+            description,
+          });
+          return HttpResponse.json({}, { status: 201 });
         },
       ),
-      rest.post('https://gitea.com/api/v1/orgs/org1/repos', (req, res, ctx) => {
-        // Basic auth must match the user and password defined part of the config
-        expect(req.headers.get('Authorization')).toBe(
-          'basic Z2l0ZWFfdXNlcjpnaXRlYV9wYXNzd29yZA==',
-        );
-        expect(req.body).toEqual({
-          name: 'repo',
-          private: false,
-          description,
-        });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
-      }),
     );
 
     await action.handler({

--- a/plugins/scaffolder-common/package.json
+++ b/plugins/scaffolder-common/package.json
@@ -74,6 +74,6 @@
   "devDependencies": {
     "@backstage/cli": "workspace:^",
     "@backstage/test-utils": "workspace:^",
-    "msw": "^1.0.0"
+    "msw": "^2.0.0"
   }
 }

--- a/plugins/scaffolder-common/src/ScaffolderClient.test.ts
+++ b/plugins/scaffolder-common/src/ScaffolderClient.test.ts
@@ -20,7 +20,7 @@ import {
   mockApis,
   registerMswTestHooks,
 } from '@backstage/test-utils';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { ScaffolderClient } from './ScaffolderClient';
 import { fetchEventSource } from '@microsoft/fetch-event-source';
@@ -159,41 +159,37 @@ describe('api', () => {
 
       it('should work', async () => {
         server.use(
-          rest.get(
+          http.get(
             `${mockBaseUrl}/v2/tasks/:taskId/events`,
-            (req, res, ctx) => {
-              const { taskId } = req.params;
-              const after = req.url.searchParams.get('after');
+            ({ request, params }) => {
+              const { taskId } = params;
+              const after = new URL(request.url).searchParams.get('after');
 
               if (taskId === 'a-random-task-id') {
                 if (!after) {
-                  return res(
-                    ctx.json([
-                      {
-                        id: 1,
-                        taskId: 'a-random-id',
-                        type: 'log',
-                        createdAt: '',
-                        body: { message: 'My log message' },
-                      },
-                    ]),
-                  );
+                  return HttpResponse.json([
+                    {
+                      id: 1,
+                      taskId: 'a-random-id',
+                      type: 'log',
+                      createdAt: '',
+                      body: { message: 'My log message' },
+                    },
+                  ]);
                 } else if (after === '1') {
-                  return res(
-                    ctx.json([
-                      {
-                        id: 2,
-                        taskId: 'a-random-id',
-                        type: 'completion',
-                        createdAt: '',
-                        body: { message: 'Finished!' },
-                      },
-                    ]),
-                  );
+                  return HttpResponse.json([
+                    {
+                      id: 2,
+                      taskId: 'a-random-id',
+                      type: 'completion',
+                      createdAt: '',
+                      body: { message: 'Finished!' },
+                    },
+                  ]);
                 }
               }
 
-              return res(ctx.status(500));
+              return new HttpResponse(null, { status: 500 });
             },
           ),
         );
@@ -227,31 +223,29 @@ describe('api', () => {
         expect.assertions(3);
 
         server.use(
-          rest.get(
+          http.get(
             `${mockBaseUrl}/v2/tasks/:taskId/events`,
-            (req, res, ctx) => {
-              const { taskId } = req.params;
+            ({ request, params }) => {
+              const { taskId } = params;
 
-              const after = req.url.searchParams.get('after');
+              const after = new URL(request.url).searchParams.get('after');
 
               // use assertion to make sure it is not called after unsubscribing
               expect(after).toBe(null);
 
               if (taskId === 'a-random-task-id') {
-                return res(
-                  ctx.json([
-                    {
-                      id: 1,
-                      taskId: 'a-random-id',
-                      type: 'log',
-                      createdAt: '',
-                      body: { message: 'My log message' },
-                    },
-                  ]),
-                );
+                return HttpResponse.json([
+                  {
+                    id: 1,
+                    taskId: 'a-random-id',
+                    type: 'log',
+                    createdAt: '',
+                    body: { message: 'My log message' },
+                  },
+                ]);
               }
 
-              return res(ctx.status(500));
+              return new HttpResponse(null, { status: 500 });
             },
           ),
         );
@@ -284,28 +278,23 @@ describe('api', () => {
         const called = jest.fn();
 
         server.use(
-          rest.get(
-            `${mockBaseUrl}/v2/tasks/:taskId/events`,
-            (_req, res, ctx) => {
-              called();
+          http.get(`${mockBaseUrl}/v2/tasks/:taskId/events`, () => {
+            called();
 
-              if (called.mock.calls.length > 1) {
-                return res(
-                  ctx.json([
-                    {
-                      id: 2,
-                      taskId: 'a-random-id',
-                      type: 'completion',
-                      createdAt: '',
-                      body: { message: 'Finished!' },
-                    },
-                  ]),
-                );
-              }
+            if (called.mock.calls.length > 1) {
+              return HttpResponse.json([
+                {
+                  id: 2,
+                  taskId: 'a-random-id',
+                  type: 'completion',
+                  createdAt: '',
+                  body: { message: 'Finished!' },
+                },
+              ]);
+            }
 
-              return res(ctx.status(500));
-            },
-          ),
+            return new HttpResponse(null, { status: 500 });
+          }),
         );
 
         const next = jest.fn();
@@ -333,29 +322,21 @@ describe('api', () => {
   describe('listTasks', () => {
     it('should list all tasks', async () => {
       server.use(
-        rest.get(`${mockBaseUrl}/v2/tasks`, (req, res, ctx) => {
-          const createdBy = req.url.searchParams.get('createdBy');
+        http.get(`${mockBaseUrl}/v2/tasks`, ({ request }) => {
+          const createdBy = new URL(request.url).searchParams.get('createdBy');
 
           if (createdBy) {
-            return res(
-              ctx.json([
-                {
-                  createdBy,
-                },
-              ]),
-            );
+            return HttpResponse.json([{ createdBy }]);
           }
 
-          return res(
-            ctx.json([
-              {
-                createdBy: null,
-              },
-              {
-                createdBy: null,
-              },
-            ]),
-          );
+          return HttpResponse.json([
+            {
+              createdBy: null,
+            },
+            {
+              createdBy: null,
+            },
+          ]);
         }),
       );
 
@@ -365,21 +346,19 @@ describe('api', () => {
 
     it('should list tasks with limit and offset', async () => {
       server.use(
-        rest.get(
-          `${mockBaseUrl}/v2/tasks?limit=5&offset=0`,
-          (_req, res, ctx) => {
-            return res(
-              ctx.json([
-                {
-                  createdBy: null,
-                },
-                {
-                  createdBy: null,
-                },
-              ]),
-            );
-          },
-        ),
+        http.get(`${mockBaseUrl}/v2/tasks`, ({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.get('limit')).toBe('5');
+          expect(url.searchParams.get('offset')).toBe('0');
+          return HttpResponse.json([
+            {
+              createdBy: null,
+            },
+            {
+              createdBy: null,
+            },
+          ]);
+        }),
       );
 
       const result = await apiClient.listTasks({
@@ -392,33 +371,23 @@ describe('api', () => {
 
     it('should list task using the current user as owner', async () => {
       server.use(
-        rest.get(`${mockBaseUrl}/v2/tasks`, (req, res, ctx) => {
-          const createdBy = req.url.searchParams.get('createdBy');
+        http.get(`${mockBaseUrl}/v2/tasks`, ({ request }) => {
+          const createdBy = new URL(request.url).searchParams.get('createdBy');
 
           if (createdBy) {
-            return res(
-              ctx.json({
-                tasks: [
-                  {
-                    createdBy,
-                  },
-                ],
-              }),
-            );
+            return HttpResponse.json({ tasks: [{ createdBy }] });
           }
 
-          return res(
-            ctx.json({
-              tasks: [
-                {
-                  createdBy: null,
-                },
-                {
-                  createdBy: null,
-                },
-              ],
-            }),
-          );
+          return HttpResponse.json({
+            tasks: [
+              {
+                createdBy: null,
+              },
+              {
+                createdBy: null,
+              },
+            ],
+          });
         }),
       );
 

--- a/plugins/scaffolder-node/package.json
+++ b/plugins/scaffolder-node/package.json
@@ -85,7 +85,7 @@
     "@backstage/cli": "workspace:^",
     "@backstage/config": "workspace:^",
     "@types/lodash": "^4.14.151",
-    "msw": "^1.0.0"
+    "msw": "^2.0.0"
   },
   "peerDependencies": {
     "@backstage/backend-test-utils": "workspace:^"

--- a/plugins/scaffolder-node/src/scaffolderService.test.ts
+++ b/plugins/scaffolder-node/src/scaffolderService.test.ts
@@ -26,7 +26,7 @@ import {
   registerMswTestHooks,
   startTestBackend,
 } from '@backstage/backend-test-utils';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { scaffolderServiceRef } from './scaffolderService';
 
@@ -60,21 +60,19 @@ describe('scaffolderServiceRef', () => {
     expect.assertions(1);
 
     server.use(
-      rest.get('*/api/scaffolder/v2/tasks/:taskId', (req, res, ctx) => {
-        expect(req.headers.get('authorization')).toBe(
+      http.get('*/api/scaffolder/v2/tasks/:taskId', ({ request }) => {
+        expect(request.headers.get('authorization')).toBe(
           mockCredentials.service.header({
             onBehalfOf: mockCredentials.user(),
             targetPluginId: 'scaffolder',
           }),
         );
-        return res(
-          ctx.json({
-            id: 'task-1',
-            spec: {},
-            status: 'completed',
-            createdAt: '2025-01-01T00:00:00Z',
-          }),
-        );
+        return HttpResponse.json({
+          id: 'task-1',
+          spec: {},
+          status: 'completed',
+          createdAt: '2025-01-01T00:00:00Z',
+        });
       }),
     );
 
@@ -101,21 +99,19 @@ describe('scaffolderServiceRef', () => {
     expect.assertions(1);
 
     server.use(
-      rest.get('*/api/scaffolder/v2/tasks/:taskId', (req, res, ctx) => {
-        expect(req.headers.get('authorization')).toBe(
+      http.get('*/api/scaffolder/v2/tasks/:taskId', ({ request }) => {
+        expect(request.headers.get('authorization')).toBe(
           mockCredentials.service.header({
             onBehalfOf: mockCredentials.service(),
             targetPluginId: 'scaffolder',
           }),
         );
-        return res(
-          ctx.json({
-            id: 'task-1',
-            spec: {},
-            status: 'completed',
-            createdAt: '2025-01-01T00:00:00Z',
-          }),
-        );
+        return HttpResponse.json({
+          id: 'task-1',
+          spec: {},
+          status: 'completed',
+          createdAt: '2025-01-01T00:00:00Z',
+        });
       }),
     );
 
@@ -142,14 +138,14 @@ describe('scaffolderServiceRef', () => {
     expect.assertions(1);
 
     server.use(
-      rest.get('*/api/scaffolder/v2/tasks/:taskId/events', (req, res, ctx) => {
-        expect(req.headers.get('authorization')).toBe(
+      http.get('*/api/scaffolder/v2/tasks/:taskId/events', ({ request }) => {
+        expect(request.headers.get('authorization')).toBe(
           mockCredentials.service.header({
             onBehalfOf: mockCredentials.user(),
             targetPluginId: 'scaffolder',
           }),
         );
-        return res(ctx.json([]));
+        return HttpResponse.json([]);
       }),
     );
 
@@ -174,13 +170,12 @@ describe('scaffolderServiceRef', () => {
     expect.assertions(4);
 
     server.use(
-      rest.get('*/api/scaffolder/v2/tasks', (req, res, ctx) => {
-        expect(req.url.searchParams.get('createdBy')).toBe(
-          'user:default/guest',
-        );
-        expect(req.url.searchParams.get('limit')).toBe('10');
-        expect(req.url.searchParams.get('offset')).toBe('5');
-        return res(ctx.json({ tasks: [], totalTasks: 0 }));
+      http.get('*/api/scaffolder/v2/tasks', ({ request }) => {
+        const req = new URL(request.url);
+        expect(req.searchParams.get('createdBy')).toBe('user:default/guest');
+        expect(req.searchParams.get('limit')).toBe('10');
+        expect(req.searchParams.get('offset')).toBe('5');
+        return HttpResponse.json({ tasks: [], totalTasks: 0 });
       }),
     );
 
@@ -207,9 +202,11 @@ describe('scaffolderServiceRef', () => {
     expect.assertions(1);
 
     server.use(
-      rest.get('*/api/scaffolder/v2/tasks', (req, res, ctx) => {
-        expect(req.url.searchParams.getAll('status')).toEqual(['completed']);
-        return res(ctx.json({ tasks: [], totalTasks: 0 }));
+      http.get('*/api/scaffolder/v2/tasks', ({ request }) => {
+        expect(new URL(request.url).searchParams.getAll('status')).toEqual([
+          'completed',
+        ]);
+        return HttpResponse.json({ tasks: [], totalTasks: 0 });
       }),
     );
 
@@ -234,12 +231,12 @@ describe('scaffolderServiceRef', () => {
     expect.assertions(1);
 
     server.use(
-      rest.get('*/api/scaffolder/v2/tasks', (req, res, ctx) => {
-        expect(req.url.searchParams.getAll('status')).toEqual([
+      http.get('*/api/scaffolder/v2/tasks', ({ request }) => {
+        expect(new URL(request.url).searchParams.getAll('status')).toEqual([
           'completed',
           'failed',
         ]);
-        return res(ctx.json({ tasks: [], totalTasks: 0 }));
+        return HttpResponse.json({ tasks: [], totalTasks: 0 });
       }),
     );
 

--- a/plugins/search-backend-module-explore/package.json
+++ b/plugins/search-backend-module-explore/package.json
@@ -58,7 +58,7 @@
   "devDependencies": {
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
-    "msw": "^1.2.1"
+    "msw": "^2.0.0"
   },
   "configSchema": "config.d.ts"
 }

--- a/plugins/search-backend-module-explore/src/collators/ToolDocumentCollatorFactory.test.ts
+++ b/plugins/search-backend-module-explore/src/collators/ToolDocumentCollatorFactory.test.ts
@@ -19,7 +19,7 @@ import {
   mockServices,
   registerMswTestHooks,
 } from '@backstage/backend-test-utils';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { Readable } from 'node:stream';
 import { ToolDocumentCollatorFactory } from './ToolDocumentCollatorFactory';
@@ -81,8 +81,8 @@ describe('ToolDocumentCollatorFactory', () => {
       collator = await factory.getCollator();
 
       worker.use(
-        rest.get('http://test-backend/api/explore/tools', (_, res, ctx) =>
-          res(ctx.status(200), ctx.json(mockTools)),
+        http.get('http://test-backend/api/explore/tools', () =>
+          HttpResponse.json(mockTools),
         ),
       );
     });

--- a/plugins/search-backend-module-stack-overflow-collator/package.json
+++ b/plugins/search-backend-module-stack-overflow-collator/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
-    "msw": "^1.2.1"
+    "msw": "^2.0.0"
   },
   "configSchema": "config.d.ts"
 }

--- a/plugins/search-backend-module-stack-overflow-collator/src/collators/StackOverflowQuestionsCollatorFactory.test.ts
+++ b/plugins/search-backend-module-stack-overflow-collator/src/collators/StackOverflowQuestionsCollatorFactory.test.ts
@@ -25,7 +25,7 @@ import { TestPipeline } from '@backstage/plugin-search-backend-node';
 import { ConfigReader } from '@backstage/config';
 import { Readable } from 'node:stream';
 import { setupServer } from 'msw/node';
-import { rest, RestRequest } from 'msw';
+import { http, HttpResponse } from 'msw';
 
 const logger = mockServices.logger.mock();
 
@@ -71,7 +71,7 @@ const mockOverrideQuestion = {
 };
 
 const testSearchQuery = (
-  request: RestRequest | undefined,
+  request: Request | undefined,
   expectedSearch: unknown,
 ) => {
   if (!request) {
@@ -80,7 +80,7 @@ const testSearchQuery = (
   }
 
   const executedSearch: { [key: string]: string } = {};
-  request.url.searchParams.forEach((value: string, key: string) => {
+  new URL(request.url).searchParams.forEach((value: string, key: string) => {
     executedSearch[key] = value;
   });
   expect(executedSearch).toEqual(expectedSearch);
@@ -119,11 +119,14 @@ describe('StackOverflowQuestionsCollatorFactory using custom request params', ()
     it('uses site query parameter when provided and baseUrl is not default', async () => {
       let request;
       worker.use(
-        rest.get('http://stack.overflow.local/questions', (req, res, ctx) => {
-          request = req;
+        http.get(
+          'http://stack.overflow.local/questions',
+          ({ request: req }) => {
+            request = req;
 
-          return res(ctx.status(200), ctx.json(mockQuestion));
-        }),
+            return HttpResponse.json(mockQuestion);
+          },
+        ),
       );
       const factory = StackOverflowQuestionsCollatorFactory.fromConfig(config, {
         logger,
@@ -149,10 +152,10 @@ describe('StackOverflowQuestionsCollatorFactory using custom request params', ()
     it('uses site query parameter when provided and baseUrl is default', async () => {
       let request;
       worker.use(
-        rest.get(`${BASE_URL}/questions`, (req, res, ctx) => {
+        http.get(`${BASE_URL}/questions`, ({ request: req }) => {
           request = req;
 
-          return res(ctx.status(200), ctx.json(mockQuestion));
+          return HttpResponse.json(mockQuestion);
         }),
       );
       const factory = StackOverflowQuestionsCollatorFactory.fromConfig(config, {
@@ -179,10 +182,10 @@ describe('StackOverflowQuestionsCollatorFactory using custom request params', ()
     it('uses default when site is not provided and baseUrl is default', async () => {
       let request;
       worker.use(
-        rest.get(`${BASE_URL}/questions`, (req, res, ctx) => {
+        http.get(`${BASE_URL}/questions`, ({ request: req }) => {
           request = req;
 
-          return res(ctx.status(200), ctx.json(mockQuestion));
+          return HttpResponse.json(mockQuestion);
         }),
       );
       const factory = StackOverflowQuestionsCollatorFactory.fromConfig(config, {
@@ -220,11 +223,14 @@ describe('StackOverflowQuestionsCollatorFactory using custom request params', ()
     it('fetches from the configured endpoint', async () => {
       let request;
       worker.use(
-        rest.get('http://stack.overflow.local/questions', (req, res, ctx) => {
-          request = req;
+        http.get(
+          'http://stack.overflow.local/questions',
+          ({ request: req }) => {
+            request = req;
 
-          return res(ctx.status(200), ctx.json(mockQuestion));
-        }),
+            return HttpResponse.json(mockQuestion);
+          },
+        ),
       );
       const factory = StackOverflowQuestionsCollatorFactory.fromConfig(
         config,
@@ -248,11 +254,11 @@ describe('StackOverflowQuestionsCollatorFactory using custom request params', ()
     it('fetches from the overridden endpoint', async () => {
       let request;
       worker.use(
-        rest.get(
+        http.get(
           'http://stack.overflow.override/questions',
-          (req, res, ctx) => {
+          ({ request: req }) => {
             request = req;
-            return res(ctx.status(200), ctx.json(mockOverrideQuestion));
+            return HttpResponse.json(mockOverrideQuestion);
           },
         ),
       );
@@ -280,13 +286,13 @@ describe('StackOverflowQuestionsCollatorFactory using custom request params', ()
     it('uses API key when provided', async () => {
       let request;
       worker.use(
-        rest.get(
+        http.get(
           'http://stack.overflow.override/questions',
-          (req, res, ctx) => {
+          ({ request: req }) => {
             request = req;
-            return req.url.searchParams.get('key') === 'abcdefg'
-              ? res(ctx.status(200), ctx.json(mockOverrideQuestion))
-              : res(ctx.status(401), ctx.json({}));
+            return new URL(req.url).searchParams.get('key') === 'abcdefg'
+              ? HttpResponse.json(mockOverrideQuestion)
+              : HttpResponse.json({}, { status: 401 });
           },
         ),
       );
@@ -316,13 +322,13 @@ describe('StackOverflowQuestionsCollatorFactory using custom request params', ()
     it('uses teamName when provided', async () => {
       let request;
       worker.use(
-        rest.get(
+        http.get(
           'http://stack.overflow.override/questions',
-          (req, res, ctx) => {
+          ({ request: req }) => {
             request = req;
-            return req.url.searchParams.get('team') === 'abcdefg'
-              ? res(ctx.status(200), ctx.json(mockOverrideQuestion))
-              : res(ctx.status(401), ctx.json({}));
+            return new URL(req.url).searchParams.get('team') === 'abcdefg'
+              ? HttpResponse.json(mockOverrideQuestion)
+              : HttpResponse.json({}, { status: 401 });
           },
         ),
       );
@@ -387,10 +393,10 @@ describe('StackOverflowQuestionsCollatorFactory using default request params', (
     it('fetches from the configured endpoint', async () => {
       let request;
       worker.use(
-        rest.get(`${BASE_URL}/questions`, (req, res, ctx) => {
+        http.get(`${BASE_URL}/questions`, ({ request: req }) => {
           request = req;
 
-          return res(ctx.status(200), ctx.json(mockQuestion));
+          return HttpResponse.json(mockQuestion);
         }),
       );
       const factory = StackOverflowQuestionsCollatorFactory.fromConfig(
@@ -414,9 +420,9 @@ describe('StackOverflowQuestionsCollatorFactory using default request params', (
     it('fetches from the overridden endpoint', async () => {
       let request;
       worker.use(
-        rest.get(`${BASE_URL}/questions`, (req, res, ctx) => {
+        http.get(`${BASE_URL}/questions`, ({ request: req }) => {
           request = req;
-          return res(ctx.status(200), ctx.json(mockOverrideQuestion));
+          return HttpResponse.json(mockOverrideQuestion);
         }),
       );
       const factory = StackOverflowQuestionsCollatorFactory.fromConfig(config, {
@@ -442,11 +448,11 @@ describe('StackOverflowQuestionsCollatorFactory using default request params', (
     it('uses API key when provided', async () => {
       let request;
       worker.use(
-        rest.get(`${BASE_URL}/questions`, (req, res, ctx) => {
+        http.get(`${BASE_URL}/questions`, ({ request: req }) => {
           request = req;
-          return req.url.searchParams.get('key') === 'abcdefg'
-            ? res(ctx.status(200), ctx.json(mockOverrideQuestion))
-            : res(ctx.status(401), ctx.json({}));
+          return new URL(req.url).searchParams.get('key') === 'abcdefg'
+            ? HttpResponse.json(mockOverrideQuestion)
+            : HttpResponse.json({}, { status: 401 });
         }),
       );
       const factory = StackOverflowQuestionsCollatorFactory.fromConfig(config, {
@@ -474,11 +480,11 @@ describe('StackOverflowQuestionsCollatorFactory using default request params', (
     it('uses teamName when provided', async () => {
       let request;
       worker.use(
-        rest.get(`${BASE_URL}/questions`, (req, res, ctx) => {
+        http.get(`${BASE_URL}/questions`, ({ request: req }) => {
           request = req;
-          return req.url.searchParams.get('team') === 'abcdefg'
-            ? res(ctx.status(200), ctx.json(mockOverrideQuestion))
-            : res(ctx.status(401), ctx.json({}));
+          return new URL(req.url).searchParams.get('team') === 'abcdefg'
+            ? HttpResponse.json(mockOverrideQuestion)
+            : HttpResponse.json({}, { status: 401 });
         }),
       );
       const factory = StackOverflowQuestionsCollatorFactory.fromConfig(config, {

--- a/plugins/search-backend-module-techdocs/package.json
+++ b/plugins/search-backend-module-techdocs/package.json
@@ -64,7 +64,7 @@
   "devDependencies": {
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
-    "msw": "^1.0.0"
+    "msw": "^2.0.0"
   },
   "configSchema": "config.d.ts"
 }

--- a/plugins/search-backend-module-techdocs/src/collators/DefaultTechDocsCollatorFactory.test.ts
+++ b/plugins/search-backend-module-techdocs/src/collators/DefaultTechDocsCollatorFactory.test.ts
@@ -22,7 +22,7 @@ import {
   registerMswTestHooks,
 } from '@backstage/backend-test-utils';
 import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { Readable } from 'node:stream';
 import { DefaultTechDocsCollatorFactory } from './DefaultTechDocsCollatorFactory';
@@ -111,9 +111,9 @@ describe('DefaultTechDocsCollatorFactory', () => {
       collator = await factory.getCollator();
 
       worker.use(
-        rest.get(
+        http.get(
           'http://test-backend/static/docs/default/Component/test-entity-with-docs/search/search_index.json',
-          (_, res, ctx) => res(ctx.status(200), ctx.json(mockSearchDocIndex)),
+          () => HttpResponse.json(mockSearchDocIndex),
         ),
       );
     });

--- a/plugins/user-settings/test-results/.last-run.json
+++ b/plugins/user-settings/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "failed",
+  "failedTests": []
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2685,7 +2685,7 @@ __metadata:
     cleye: "npm:^2.6.0"
     fs-extra: "npm:^11.2.0"
     minimatch: "npm:^10.2.1"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     ora: "npm:^5.3.0"
     replace-in-file: "npm:^7.1.0"
     semver: "npm:^7.5.3"
@@ -2991,7 +2991,7 @@ __metadata:
     history: "npm:^5.0.0"
     i18next: "npm:^22.4.15"
     lodash: "npm:^4.17.21"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     prop-types: "npm:^15.7.2"
     react: "npm:^18.0.2"
     react-dom: "npm:^18.0.2"
@@ -3102,7 +3102,7 @@ __metadata:
     linkify-react: "npm:4.3.2"
     linkifyjs: "npm:4.3.2"
     lodash: "npm:^4.17.21"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     parse5: "npm:^6.0.0"
     qs: "npm:^6.15.2"
     rc-progress: "npm:3.5.1"
@@ -3398,7 +3398,7 @@ __metadata:
     "@testing-library/react": "npm:^16.0.0"
     "@types/react": "npm:^18.0.0"
     cross-fetch: "npm:^4.0.0"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     react: "npm:^18.0.2"
     react-dom: "npm:^18.0.2"
     react-router-dom: "npm:^6.30.2"
@@ -5666,7 +5666,7 @@ __metadata:
     http-proxy-middleware: "npm:^2.0.6"
     lodash: "npm:^4.17.21"
     luxon: "npm:^3.0.0"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     node-fetch: "npm:^2.7.0"
     supertest: "npm:^7.0.0"
     ws: "npm:^8.20.1"
@@ -5739,7 +5739,7 @@ __metadata:
     "@backstage/types": "workspace:^"
     "@kubernetes/client-node": "npm:1.4.0"
     "@types/express": "npm:^4.17.6"
-    msw: "npm:^1.3.1"
+    msw: "npm:^2.0.0"
     node-fetch: "npm:^2.7.0"
     supertest: "npm:^7.0.0"
   languageName: unknown
@@ -6144,7 +6144,7 @@ __metadata:
     express: "npm:^4.22.0"
     express-promise-router: "npm:^4.1.0"
     lodash: "npm:^4.17.21"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     supertest: "npm:^7.0.0"
     zod: "npm:^3.25.76 || ^4.0.0"
   languageName: unknown
@@ -6159,7 +6159,7 @@ __metadata:
     "@backstage/errors": "workspace:^"
     "@backstage/types": "workspace:^"
     cross-fetch: "npm:^4.0.0"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     zod: "npm:^3.25.76 || ^4.0.0"
     zod-to-json-schema: "npm:^3.25.1"
   languageName: unknown
@@ -6180,7 +6180,7 @@ __metadata:
     "@types/supertest": "npm:^2.0.8"
     express: "npm:^4.22.0"
     express-promise-router: "npm:^4.1.0"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     supertest: "npm:^7.0.0"
     zod: "npm:^3.25.76 || ^4.0.0"
     zod-to-json-schema: "npm:^3.25.1"
@@ -6279,7 +6279,7 @@ __metadata:
     "@backstage/plugin-scaffolder-node-test-utils": "workspace:^"
     bitbucket: "npm:^2.12.0"
     fs-extra: "npm:^11.2.0"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     yaml: "npm:^2.0.0"
     zod: "npm:^3.25.76 || ^4.0.0"
   languageName: unknown
@@ -6298,7 +6298,7 @@ __metadata:
     "@backstage/plugin-scaffolder-node": "workspace:^"
     "@backstage/plugin-scaffolder-node-test-utils": "workspace:^"
     fs-extra: "npm:^11.2.0"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     yaml: "npm:^2.0.0"
   languageName: unknown
   linkType: soft
@@ -6317,7 +6317,7 @@ __metadata:
     "@backstage/plugin-scaffolder-node-test-utils": "workspace:^"
     fs-extra: "npm:^11.2.0"
     git-url-parse: "npm:^15.0.0"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     node-html-markdown: "npm:^1.3.0"
     yaml: "npm:^2.0.0"
   languageName: unknown
@@ -6371,7 +6371,7 @@ __metadata:
     "@backstage/integration": "workspace:^"
     "@backstage/plugin-scaffolder-node": "workspace:^"
     "@backstage/plugin-scaffolder-node-test-utils": "workspace:^"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     yaml: "npm:^2.0.0"
   languageName: unknown
   linkType: soft
@@ -6388,7 +6388,7 @@ __metadata:
     "@backstage/integration": "workspace:^"
     "@backstage/plugin-scaffolder-node": "workspace:^"
     "@backstage/plugin-scaffolder-node-test-utils": "workspace:^"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     yaml: "npm:^2.0.0"
   languageName: unknown
   linkType: soft
@@ -6576,7 +6576,7 @@ __metadata:
     "@microsoft/fetch-event-source": "npm:^2.0.1"
     "@types/json-schema": "npm:^7.0.9"
     cross-fetch: "npm:^4.0.0"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     uri-template: "npm:^2.0.0"
     zen-observable: "npm:^0.10.0"
   languageName: unknown
@@ -6631,7 +6631,7 @@ __metadata:
     isomorphic-git: "npm:^1.23.0"
     jsonschema: "npm:^1.5.0"
     lodash: "npm:^4.17.21"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     p-limit: "npm:^3.1.0"
     tar: "npm:^7.5.21"
     winston: "npm:^3.2.1"
@@ -6856,7 +6856,7 @@ __metadata:
     "@backstage/config": "workspace:^"
     "@backstage/plugin-search-backend-node": "workspace:^"
     "@backstage/plugin-search-common": "workspace:^"
-    msw: "npm:^1.2.1"
+    msw: "npm:^2.0.0"
   languageName: unknown
   linkType: soft
 
@@ -6885,7 +6885,7 @@ __metadata:
     "@backstage/config": "workspace:^"
     "@backstage/plugin-search-backend-node": "workspace:^"
     "@backstage/plugin-search-common": "workspace:^"
-    msw: "npm:^1.2.1"
+    msw: "npm:^2.0.0"
     qs: "npm:^6.15.2"
   languageName: unknown
   linkType: soft
@@ -6907,7 +6907,7 @@ __metadata:
     "@backstage/plugin-search-common": "workspace:^"
     "@backstage/plugin-techdocs-node": "workspace:^"
     lodash: "npm:^4.17.21"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     p-limit: "npm:^3.1.0"
   languageName: unknown
   linkType: soft
@@ -7485,7 +7485,7 @@ __metadata:
   dependencies:
     "@backstage/cli": "workspace:^"
     "@backstage/test-utils": "workspace:^"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
   languageName: unknown
   linkType: soft
 
@@ -7578,7 +7578,7 @@ __metadata:
     "@types/react": "npm:^18.0.0"
     cross-fetch: "npm:^4.0.0"
     i18next: "npm:^22.4.15"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     react: "npm:^18.0.2"
     react-dom: "npm:^18.0.2"
     react-router-dom: "npm:^6.30.2"
@@ -36268,7 +36268,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"msw@npm:^1.0.0, msw@npm:^1.2.1, msw@npm:^1.3.1":
+"msw@npm:^1.0.0":
   version: 1.3.5
   resolution: "msw@npm:1.3.5"
   dependencies:


### PR DESCRIPTION
## Hey 👋

This PR migrates `example-app-legacy` tests from MSW v1 to MSW v2.

### Changes
- Updated MSW imports and handler syntax to v2 API
- Replaced `rest.*` handlers with `http.*` handlers
- Updated response helpers to use `HttpResponse`
- Updated `package.json` dependencies

---

### Checklist

- [x] I have read the [contribution guidelines](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md)
- [x] Added or updated tests
- [ ] Added or updated documentation
- [ ] Verified that the change works locally