### PR TITLE
chore(cli-module-migrate): Migrate to MSW 2

### DIFF
--- a/packages/cli-module-migrate/package.json
+++ b/packages/cli-module-migrate/package.json
@@ -52,6 +52,6 @@
     "@backstage/test-utils": "workspace:^",
     "@types/fs-extra": "^11.0.0",
     "@types/semver": "^7",
-    "msw": "^1.0.0"
+    "msw": "^2.0.0"
   }
 }

--- a/packages/cli-module-migrate/src/commands/versions/bump.test.ts
+++ b/packages/cli-module-migrate/src/commands/versions/bump.test.ts
@@ -20,7 +20,7 @@ import bump, { bumpBackstageJsonVersion, createVersionFinder } from './bump';
 import { registerMswTestHooks, withLogCollector } from '@backstage/test-utils';
 import { YarnInfoInspectData } from '../../lib/versioning/packages';
 import { setupServer } from 'msw/node';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { NotFoundError } from '@backstage/errors';
 import { createMockDirectory } from '@backstage/backend-test-utils';
 
@@ -170,15 +170,8 @@ describe('bump', () => {
       waitForExit: jest.fn().mockResolvedValue(undefined),
     } as any);
     worker.use(
-      rest.get(
-        'https://versions.backstage.io/v1/tags/main/manifest.json',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.json({
-              packages: [],
-            }),
-          ),
+      http.get('https://versions.backstage.io/v1/tags/main/manifest.json', () =>
+        HttpResponse.json({ packages: [] }),
       ),
     );
     const { log: logs } = await withLogCollector(['log', 'warn'], async () => {
@@ -263,15 +256,10 @@ describe('bump', () => {
       waitForExit: jest.fn().mockResolvedValue(undefined),
     } as any);
     worker.use(
-      rest.get(
-        'https://versions.backstage.io/v1/tags/main/manifest.json',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.json({
-              packages: [],
-            }),
-          ),
+      http.get('https://versions.backstage.io/v1/tags/main/manifest.json', () =>
+        HttpResponse.json({
+          packages: [],
+        }),
       ),
     );
     const { log: logs } = await withLogCollector(['log', 'warn'], async () => {
@@ -355,25 +343,20 @@ describe('bump', () => {
       waitForExit: jest.fn().mockResolvedValue(undefined),
     } as any);
     worker.use(
-      rest.get(
-        'https://versions.backstage.io/v1/tags/main/manifest.json',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.json({
-              releaseVersion: '0.0.1',
-              packages: [
-                {
-                  name: '@backstage/theme',
-                  version: '5.0.0',
-                },
-                {
-                  name: '@backstage/create-app',
-                  version: '3.0.0',
-                },
-              ],
-            }),
-          ),
+      http.get('https://versions.backstage.io/v1/tags/main/manifest.json', () =>
+        HttpResponse.json({
+          releaseVersion: '0.0.1',
+          packages: [
+            {
+              name: '@backstage/theme',
+              version: '5.0.0',
+            },
+            {
+              name: '@backstage/create-app',
+              version: '3.0.0',
+            },
+          ],
+        }),
       ),
     );
     const { log: logs } = await withLogCollector(['log', 'warn'], async () => {
@@ -459,25 +442,20 @@ describe('bump', () => {
       waitForExit: jest.fn().mockResolvedValue(undefined),
     } as any);
     worker.use(
-      rest.get(
-        'https://versions.backstage.io/v1/tags/main/manifest.json',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.json({
-              releaseVersion: '0.0.1',
-              packages: [
-                {
-                  name: '@backstage/theme',
-                  version: '5.0.0',
-                },
-                {
-                  name: '@backstage/create-app',
-                  version: '3.0.0',
-                },
-              ],
-            }),
-          ),
+      http.get('https://versions.backstage.io/v1/tags/main/manifest.json', () =>
+        HttpResponse.json({
+          releaseVersion: '0.0.1',
+          packages: [
+            {
+              name: '@backstage/theme',
+              version: '5.0.0',
+            },
+            {
+              name: '@backstage/create-app',
+              version: '3.0.0',
+            },
+          ],
+        }),
       ),
     );
     const { log: logs } = await withLogCollector(['log', 'warn'], async () => {
@@ -570,9 +548,9 @@ describe('bump', () => {
       waitForExit: jest.fn().mockResolvedValue(undefined),
     } as any);
     worker.use(
-      rest.get(
+      http.get(
         'https://versions.backstage.io/v1/releases/999.0.1/manifest.json',
-        (_, res, ctx) => res(ctx.status(404), ctx.json({})),
+        () => HttpResponse.json({}, { status: 404 }),
       ),
     );
     const { log: logs } = await withLogCollector(['log', 'warn'], async () => {
@@ -640,45 +618,35 @@ describe('bump', () => {
       waitForExit: jest.fn().mockResolvedValue(undefined),
     } as any);
     worker.use(
-      rest.get(
-        'https://versions.backstage.io/v1/tags/main/manifest.json',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.json({
-              releaseVersion: '1.0.0',
-              packages: [
-                {
-                  name: '@backstage/theme',
-                  version: '5.0.0',
-                },
-                {
-                  name: '@backstage/create-app',
-                  version: '3.0.0',
-                },
-              ],
-            }),
-          ),
+      http.get('https://versions.backstage.io/v1/tags/main/manifest.json', () =>
+        HttpResponse.json({
+          releaseVersion: '1.0.0',
+          packages: [
+            {
+              name: '@backstage/theme',
+              version: '5.0.0',
+            },
+            {
+              name: '@backstage/create-app',
+              version: '3.0.0',
+            },
+          ],
+        }),
       ),
-      rest.get(
-        'https://versions.backstage.io/v1/tags/next/manifest.json',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.json({
-              releaseVersion: '1.0.0-next.1',
-              packages: [
-                {
-                  name: '@backstage/theme',
-                  version: '4.0.0',
-                },
-                {
-                  name: '@backstage/create-app',
-                  version: '2.0.0',
-                },
-              ],
-            }),
-          ),
+      http.get('https://versions.backstage.io/v1/tags/next/manifest.json', () =>
+        HttpResponse.json({
+          releaseVersion: '1.0.0-next.1',
+          packages: [
+            {
+              name: '@backstage/theme',
+              version: '4.0.0',
+            },
+            {
+              name: '@backstage/create-app',
+              version: '2.0.0',
+            },
+          ],
+        }),
       ),
     );
     const { log: logs } = await withLogCollector(['log', 'warn'], async () => {
@@ -748,16 +716,11 @@ describe('bump', () => {
       waitForExit: jest.fn().mockResolvedValue(undefined),
     } as any);
     worker.use(
-      rest.get(
-        'https://versions.backstage.io/v1/tags/main/manifest.json',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.json({
-              releaseVersion: '1.0.0',
-              packages: [],
-            }),
-          ),
+      http.get('https://versions.backstage.io/v1/tags/main/manifest.json', () =>
+        HttpResponse.json({
+          releaseVersion: '1.0.0',
+          packages: [],
+        }),
       ),
     );
     const { log: logs } = await withLogCollector(['log', 'warn'], async () => {
@@ -863,15 +826,10 @@ describe('bump', () => {
       waitForExit: jest.fn().mockResolvedValue(undefined),
     } as any);
     worker.use(
-      rest.get(
-        'https://versions.backstage.io/v1/tags/main/manifest.json',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.json({
-              packages: [],
-            }),
-          ),
+      http.get('https://versions.backstage.io/v1/tags/main/manifest.json', () =>
+        HttpResponse.json({
+          packages: [],
+        }),
       ),
     );
     const { log: logs } = await withLogCollector(['log', 'warn'], async () => {
@@ -1095,21 +1053,16 @@ describe('environment variables', () => {
       waitForExit: jest.fn().mockResolvedValue(undefined),
     } as any);
     worker.use(
-      rest.get(
-        'https://custom.example.com/v1/tags/main/manifest.json',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.json({
-              releaseVersion: '1.5.0',
-              packages: [
-                {
-                  name: '@backstage/core',
-                  version: '1.5.0',
-                },
-              ],
-            }),
-          ),
+      http.get('https://custom.example.com/v1/tags/main/manifest.json', () =>
+        HttpResponse.json({
+          releaseVersion: '1.5.0',
+          packages: [
+            {
+              name: '@backstage/core',
+              version: '1.5.0',
+            },
+          ],
+        }),
       ),
     );
 
@@ -1254,21 +1207,16 @@ describe('environment variables', () => {
       waitForExit: jest.fn().mockResolvedValue(undefined),
     } as any);
     worker.use(
-      rest.get(
-        'https://custom.example.com/v1/tags/main/manifest.json',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.json({
-              releaseVersion: '1.5.0',
-              packages: [
-                {
-                  name: '@backstage/core',
-                  version: '1.5.0',
-                },
-              ],
-            }),
-          ),
+      http.get('https://custom.example.com/v1/tags/main/manifest.json', () =>
+        HttpResponse.json({
+          releaseVersion: '1.5.0',
+          packages: [
+            {
+              name: '@backstage/core',
+              version: '1.5.0',
+            },
+          ],
+        }),
       ),
     );
 
@@ -1344,9 +1292,8 @@ describe('environment variables', () => {
     });
 
     worker.use(
-      rest.get(
-        'https://custom.example.com/v1/tags/main/manifest.json',
-        (_, res, ctx) => res(ctx.status(500), ctx.json({})),
+      http.get('https://custom.example.com/v1/tags/main/manifest.json', () =>
+        HttpResponse.json({}, { status: 500 }),
       ),
     );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2685,7 +2685,7 @@ __metadata:
     cleye: "npm:^2.6.0"
     fs-extra: "npm:^11.2.0"
     minimatch: "npm:^10.2.1"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     ora: "npm:^5.3.0"
     replace-in-file: "npm:^7.1.0"
     semver: "npm:^7.5.3"


### PR DESCRIPTION
## Hey 👋

This PR migrates `@backstage/cli-module-migrate` tests from MSW v1 to MSW v2.

### Changes
- Updated MSW imports and handler syntax to v2 API
- Replaced `rest.*` handlers with `http.*` handlers
- Updated response helpers to use `HttpResponse`
- Updated `package.json` dependencies

---

### Checklist

- [x] I have read the [contribution guidelines](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md)
- [x] Added or updated tests
- [ ] Added or updated documentation
- [x] Verified that the change works locally