### PR TITLE
chore(core-app-api): Migrate to MSW 2

### DIFF
--- a/packages/core-app-api/package.json
+++ b/packages/core-app-api/package.json
@@ -70,7 +70,7 @@
     "@testing-library/user-event": "^14.0.0",
     "@types/react": "^18.0.0",
     "@types/zen-observable": "^0.8.0",
-    "msw": "^1.0.0",
+    "msw": "^2.0.0",
     "react": "^18.0.2",
     "react-dom": "^18.0.2",
     "react-router-beta": "npm:react-router@6.0.0-beta.0",

--- a/packages/core-app-api/src/apis/implementations/auth/microsoft/MicrosoftAuth.test.ts
+++ b/packages/core-app-api/src/apis/implementations/auth/microsoft/MicrosoftAuth.test.ts
@@ -21,7 +21,7 @@ import { ConfigReader } from '@backstage/config';
 import { microsoftAuthApiRef } from '@backstage/core-plugin-api';
 import { registerMswTestHooks } from '@backstage/test-utils';
 import { setupServer } from 'msw/node';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 
 describe('MicrosoftAuth', () => {
   const server = setupServer();
@@ -37,18 +37,16 @@ describe('MicrosoftAuth', () => {
   describe('with a refresh token', () => {
     beforeEach(() => {
       server.use(
-        rest.get(
+        http.get(
           'http://backstage.test/api/auth/microsoft/refresh',
-          async (req, res, ctx) => {
-            const scopeParam = req.url.searchParams.get('scope');
-            return res(
-              ctx.json({
-                providerInfo: {
-                  accessToken: `token:${scopeParam}`,
-                  scope: scopeParam || 'grant-resource/scope',
-                },
-              }),
-            );
+          async ({ request }) => {
+            const scopeParam = new URL(request.url).searchParams.get('scope');
+            return HttpResponse.json({
+              providerInfo: {
+                accessToken: `token:${scopeParam}`,
+                scope: scopeParam || 'grant-resource/scope',
+              },
+            });
           },
         ),
       );
@@ -108,32 +106,29 @@ describe('MicrosoftAuth', () => {
         ),
       });
       server.use(
-        rest.get(
-          'http://backstage.test/api/auth/microsoft/refresh',
-          (_, res, ctx) => {
-            return res(
-              ctx.status(401),
-              ctx.json({
-                error: {
-                  name: 'AuthenticationError',
-                  message:
-                    'Refresh failed; caused by InputError: Missing session cookie',
-                  cause: {
-                    name: 'InputError',
-                    message: 'Missing session cookie',
-                  },
+        http.get('http://backstage.test/api/auth/microsoft/refresh', () => {
+          HttpResponse.json(
+            {
+              error: {
+                name: 'AuthenticationError',
+                message:
+                  'Refresh failed; caused by InputError: Missing session cookie',
+                cause: {
+                  name: 'InputError',
+                  message: 'Missing session cookie',
                 },
-                request: {
-                  method: 'GET',
-                  url: '/api/auth/microsoft/refresh?env=development',
-                },
-                response: {
-                  statusCode: 401,
-                },
-              }),
-            );
-          },
-        ),
+              },
+              request: {
+                method: 'GET',
+                url: '/api/auth/microsoft/refresh?env=development',
+              },
+              response: {
+                statusCode: 401,
+              },
+            },
+            { status: 401 },
+          );
+        }),
       );
     });
 

--- a/packages/core-app-api/src/app/AppManager.test.tsx
+++ b/packages/core-app-api/src/app/AppManager.test.tsx
@@ -24,7 +24,7 @@ import {
 import { screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { setupServer } from 'msw/node';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { PropsWithChildren, ReactNode } from 'react';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import {
@@ -848,13 +848,10 @@ describe('Integration Test', () => {
   it('should clear app cookie when the user logs out', async () => {
     const logoutSignal = jest.fn();
     server.use(
-      rest.delete(
-        'http://localhost:7007/app/.backstage/auth/v1/cookie',
-        (_req, res, ctx) => {
-          logoutSignal();
-          return res(ctx.status(200));
-        },
-      ),
+      http.delete('http://localhost:7007/app/.backstage/auth/v1/cookie', () => {
+        logoutSignal();
+        return HttpResponse.json({}, { status: 200 });
+      }),
     );
 
     const meta = global.document.createElement('meta');

--- a/packages/core-app-api/src/lib/AuthConnector/DefaultAuthConnector.test.ts
+++ b/packages/core-app-api/src/lib/AuthConnector/DefaultAuthConnector.test.ts
@@ -20,7 +20,7 @@ import * as loginPopup from '../loginPopup';
 import { UrlPatternDiscovery } from '../../apis';
 import { registerMswTestHooks } from '@backstage/test-utils';
 import { setupServer } from 'msw/node';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { ConfigReader } from '@backstage/config';
 import { ConfigApi } from '@backstage/core-plugin-api';
 
@@ -61,16 +61,15 @@ describe('DefaultAuthConnector', () => {
 
   it('should refresh a session with scope', async () => {
     server.use(
-      rest.get('*', (req, res, ctx) =>
-        res(
-          ctx.json({
-            idToken: 'mock-id-token',
-            accessToken: 'mock-access-token',
-            scopes: req.url.searchParams.get('scope') || 'default-scope',
-            expiresInSeconds: '60',
-          }),
-        ),
-      ),
+      http.get('*', ({ request }) => {
+        const url = new URL(request.url);
+        return HttpResponse.json({
+          idToken: 'mock-id-token',
+          accessToken: 'mock-access-token',
+          scopes: url.searchParams.get('scope') || 'default-scope',
+          expiresInSeconds: '60',
+        });
+      }),
     );
 
     const connector = new DefaultAuthConnector<any>(defaultOptions);
@@ -86,8 +85,13 @@ describe('DefaultAuthConnector', () => {
 
   it('should handle failure to refresh session', async () => {
     server.use(
-      rest.get('*', (_req, res, ctx) =>
-        res(ctx.status(500, 'Error: Network NOPE')),
+      http.get(
+        '*',
+        () =>
+          new HttpResponse(null, {
+            status: 500,
+            statusText: 'Error: Network NOPE',
+          }),
       ),
     );
 
@@ -98,7 +102,11 @@ describe('DefaultAuthConnector', () => {
   });
 
   it('should handle failure response when refreshing session', async () => {
-    server.use(rest.get('*', (_req, res, ctx) => res(ctx.status(401, 'NOPE'))));
+    server.use(
+      http.get('*', () =>
+        HttpResponse.text(null, { status: 400, statusText: 'NOPE' }),
+      ),
+    );
 
     const connector = new DefaultAuthConnector(defaultOptions);
     await expect(connector.refreshSession()).rejects.toThrow(
@@ -267,9 +275,7 @@ describe('DefaultAuthConnector', () => {
     const logoutUrl =
       'https://test.auth0.com/v2/logout?federated&client_id=abc&returnTo=http%3A%2F%2Flocalhost';
 
-    server.use(
-      rest.post('*', (_req, res, ctx) => res(ctx.json({ logoutUrl }))),
-    );
+    server.use(http.post('*', () => HttpResponse.json({ logoutUrl })));
 
     const connector = new DefaultAuthConnector(defaultOptions);
 
@@ -285,7 +291,7 @@ describe('DefaultAuthConnector', () => {
   });
 
   it('should complete normally when provider returns empty logout response', async () => {
-    server.use(rest.post('*', (_req, res, ctx) => res(ctx.status(200))));
+    server.use(http.post('*', () => new HttpResponse(null, { status: 200 })));
 
     const connector = new DefaultAuthConnector(defaultOptions);
     await connector.removeSession();
@@ -293,9 +299,7 @@ describe('DefaultAuthConnector', () => {
   });
 
   it('should complete normally when response is not JSON', async () => {
-    server.use(
-      rest.post('*', (_req, res, ctx) => res(ctx.status(200), ctx.text('OK'))),
-    );
+    server.use(http.post('*', () => HttpResponse.text('OK', { status: 200 })));
 
     const connector = new DefaultAuthConnector(defaultOptions);
     await connector.removeSession();
@@ -304,8 +308,8 @@ describe('DefaultAuthConnector', () => {
 
   it('should ignore logoutUrl with non-HTTPS protocol', async () => {
     server.use(
-      rest.post('*', (_req, res, ctx) =>
-        res(ctx.json({ logoutUrl: 'http://evil.com/steal' })),
+      http.post('*', () =>
+        HttpResponse.json({ logoutUrl: 'http://evil.com/steal' }),
       ),
     );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2991,7 +2991,7 @@ __metadata:
     history: "npm:^5.0.0"
     i18next: "npm:^22.4.15"
     lodash: "npm:^4.17.21"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     prop-types: "npm:^15.7.2"
     react: "npm:^18.0.2"
     react-dom: "npm:^18.0.2"


### PR DESCRIPTION
## Hey 👋

This PR migrates `@backstage/core-app-api` tests from MSW v1 to MSW v2.

### Changes
- Updated MSW imports and handler syntax to v2 API
- Replaced `rest.*` handlers with `http.*` handlers
- Updated response helpers to use `HttpResponse`
- Updated `package.json` dependencies

---

### Checklist

- [x] I have read the [contribution guidelines](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md)
- [x] Added or updated tests
- [ ] Added or updated documentation
- [x] Verified that the change works locally