### PR TITLE
chore: Migrate scaffolder and user-settings packages to MSW 2

### DIFF
--- a/.changeset/migrate-msw2-scaffolder-user-settings.md
+++ b/.changeset/migrate-msw2-scaffolder-user-settings.md
@@ -1,0 +1,12 @@
+---
+'@backstage/plugin-scaffolder-backend-module-bitbucket-cloud': patch
+'@backstage/plugin-scaffolder-backend-module-bitbucket-server': patch
+'@backstage/plugin-scaffolder-backend-module-confluence-to-markdown': patch
+'@backstage/plugin-scaffolder-backend-module-gerrit': patch
+'@backstage/plugin-scaffolder-backend-module-gitea': patch
+'@backstage/plugin-scaffolder-common': patch
+'@backstage/plugin-scaffolder-node': patch
+'@backstage/plugin-user-settings': patch
+---
+
+Migrated tests from MSW v1 to MSW v2.

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/package.json
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/package.json
@@ -57,6 +57,6 @@
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@backstage/plugin-scaffolder-node-test-utils": "workspace:^",
-    "msw": "^1.0.0"
+    "msw": "^2.0.0"
   }
 }

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloud.examples.test.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloud.examples.test.ts
@@ -27,7 +27,7 @@ jest.mock('@backstage/plugin-scaffolder-node', () => {
 });
 
 import { createPublishBitbucketCloudAction } from './bitbucketCloud';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { ScmIntegrations } from '@backstage/integration';
@@ -57,6 +57,19 @@ describe('publish:bitbucketCloud', () => {
     },
   });
 
+  const responseJson = {
+    links: {
+      html: {
+        href: 'https://bitbucket.org/workspace/repo',
+      },
+      clone: [
+        {
+          name: 'https',
+          href: 'https://bitbucket.org/workspace/cloneurl',
+        },
+      ],
+    },
+  };
   const integrations = ScmIntegrations.fromConfig(config);
   const action = createPublishBitbucketCloudAction({ integrations, config });
   const mockContext = createMockActionContext({
@@ -74,26 +87,9 @@ describe('publish:bitbucketCloud', () => {
 
   it('should call initAndPush with the correct values', async () => {
     server.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
-              links: {
-                html: {
-                  href: 'https://bitbucket.org/workspace/repo',
-                },
-                clone: [
-                  {
-                    name: 'https',
-                    href: 'https://bitbucket.org/workspace/cloneurl',
-                  },
-                ],
-              },
-            }),
-          ),
+        () => HttpResponse.json(responseJson),
       ),
     );
 
@@ -118,26 +114,9 @@ describe('publish:bitbucketCloud', () => {
 
   it('should call initAndPush with the correct default branch', async () => {
     server.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
-              links: {
-                html: {
-                  href: 'https://bitbucket.org/workspace/repo',
-                },
-                clone: [
-                  {
-                    name: 'https',
-                    href: 'https://bitbucket.org/workspace/cloneurl',
-                  },
-                ],
-              },
-            }),
-          ),
+        () => HttpResponse.json(responseJson),
       ),
     );
 
@@ -162,26 +141,9 @@ describe('publish:bitbucketCloud', () => {
 
   it('should call initAndPush with the specified source path', async () => {
     server.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
-              links: {
-                html: {
-                  href: 'https://bitbucket.org/workspace/repo',
-                },
-                clone: [
-                  {
-                    name: 'https',
-                    href: 'https://bitbucket.org/workspace/cloneurl',
-                  },
-                ],
-              },
-            }),
-          ),
+        () => HttpResponse.json(responseJson),
       ),
     );
 
@@ -205,26 +167,9 @@ describe('publish:bitbucketCloud', () => {
 
   it('should call initAndPush with the authentication token', async () => {
     server.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
-              links: {
-                html: {
-                  href: 'https://bitbucket.org/workspace/repo',
-                },
-                clone: [
-                  {
-                    name: 'https',
-                    href: 'https://bitbucket.org/workspace/cloneurl',
-                  },
-                ],
-              },
-            }),
-          ),
+        () => HttpResponse.json(responseJson),
       ),
     );
 
@@ -248,26 +193,9 @@ describe('publish:bitbucketCloud', () => {
 
   it('should call initAndPush with all available custom inputs', async () => {
     server.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
-              links: {
-                html: {
-                  href: 'https://bitbucket.org/workspace/repo',
-                },
-                clone: [
-                  {
-                    name: 'https',
-                    href: 'https://bitbucket.org/workspace/cloneurl',
-                  },
-                ],
-              },
-            }),
-          ),
+        () => HttpResponse.json(responseJson),
       ),
     );
 

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloud.test.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloud.test.ts
@@ -27,7 +27,7 @@ jest.mock('@backstage/plugin-scaffolder-node', () => {
 });
 
 import { createPublishBitbucketCloudAction } from './bitbucketCloud';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { ScmIntegrations } from '@backstage/integration';
@@ -46,6 +46,20 @@ describe('publish:bitbucketCloud', () => {
       ],
     },
   });
+
+  const responseJson = {
+    links: {
+      html: {
+        href: 'https://bitbucket.org/workspace/repo',
+      },
+      clone: [
+        {
+          name: 'https',
+          href: 'https://bitbucket.org/workspace/cloneurl',
+        },
+      ],
+    },
+  };
 
   const integrations = ScmIntegrations.fromConfig(config);
   const action = createPublishBitbucketCloudAction({ integrations, config });
@@ -127,32 +141,28 @@ describe('publish:bitbucketCloud', () => {
   it('should call the correct APIs', async () => {
     expect.assertions(2);
     server.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Basic dTpw');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Basic dTpw');
+          expect(await request.json()).toEqual({
             is_private: true,
             scm: 'git',
             project: { key: 'project' },
           });
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
-              links: {
-                html: {
+          return HttpResponse.json({
+            links: {
+              html: {
+                href: 'https://bitbucket.org/workspace/repo',
+              },
+              clone: [
+                {
+                  name: 'https',
                   href: 'https://bitbucket.org/workspace/repo',
                 },
-                clone: [
-                  {
-                    name: 'https',
-                    href: 'https://bitbucket.org/workspace/repo',
-                  },
-                ],
-              },
-            }),
-          );
+              ],
+            },
+          });
         },
       ),
     );
@@ -164,32 +174,28 @@ describe('publish:bitbucketCloud', () => {
     expect.assertions(2);
     const token = 'user-token';
     server.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(`Bearer ${token}`);
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(`Bearer ${token}`);
+          expect(await request.json()).toEqual({
             is_private: true,
             scm: 'git',
             project: { key: 'project' },
           });
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
-              links: {
-                html: {
+          return HttpResponse.json({
+            links: {
+              html: {
+                href: 'https://bitbucket.org/workspace/repo',
+              },
+              clone: [
+                {
+                  name: 'https',
                   href: 'https://bitbucket.org/workspace/repo',
                 },
-                clone: [
-                  {
-                    name: 'https',
-                    href: 'https://bitbucket.org/workspace/repo',
-                  },
-                ],
-              },
-            }),
-          );
+              ],
+            },
+          });
         },
       ),
     );
@@ -204,26 +210,9 @@ describe('publish:bitbucketCloud', () => {
 
   it('should call initAndPush with the correct values', async () => {
     server.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
-              links: {
-                html: {
-                  href: 'https://bitbucket.org/workspace/repo',
-                },
-                clone: [
-                  {
-                    name: 'https',
-                    href: 'https://bitbucket.org/workspace/cloneurl',
-                  },
-                ],
-              },
-            }),
-          ),
+        () => HttpResponse.json(responseJson),
       ),
     );
 
@@ -241,26 +230,9 @@ describe('publish:bitbucketCloud', () => {
 
   it('should call initAndPush with the correct default branch', async () => {
     server.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
-              links: {
-                html: {
-                  href: 'https://bitbucket.org/workspace/repo',
-                },
-                clone: [
-                  {
-                    name: 'https',
-                    href: 'https://bitbucket.org/workspace/cloneurl',
-                  },
-                ],
-              },
-            }),
-          ),
+        () => HttpResponse.json(responseJson),
       ),
     );
 
@@ -308,26 +280,9 @@ describe('publish:bitbucketCloud', () => {
     });
 
     server.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
-              links: {
-                html: {
-                  href: 'https://bitbucket.org/workspace/repo',
-                },
-                clone: [
-                  {
-                    name: 'https',
-                    href: 'https://bitbucket.org/workspace/cloneurl',
-                  },
-                ],
-              },
-            }),
-          ),
+        () => HttpResponse.json(responseJson),
       ),
     );
 
@@ -366,26 +321,9 @@ describe('publish:bitbucketCloud', () => {
     });
 
     server.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
-              links: {
-                html: {
-                  href: 'https://bitbucket.org/workspace/repo',
-                },
-                clone: [
-                  {
-                    name: 'https',
-                    href: 'https://bitbucket.org/workspace/cloneurl',
-                  },
-                ],
-              },
-            }),
-          ),
+        () => HttpResponse.json(responseJson),
       ),
     );
 
@@ -404,26 +342,9 @@ describe('publish:bitbucketCloud', () => {
 
   it('should call outputs with the correct urls', async () => {
     server.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
-              links: {
-                html: {
-                  href: 'https://bitbucket.org/workspace/repo',
-                },
-                clone: [
-                  {
-                    name: 'https',
-                    href: 'https://bitbucket.org/workspace/cloneurl',
-                  },
-                ],
-              },
-            }),
-          ),
+        () => HttpResponse.json(responseJson),
       ),
     );
 
@@ -441,26 +362,9 @@ describe('publish:bitbucketCloud', () => {
 
   it('should call outputs with the correct urls with correct default branch', async () => {
     server.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
-              links: {
-                html: {
-                  href: 'https://bitbucket.org/workspace/repo',
-                },
-                clone: [
-                  {
-                    name: 'https',
-                    href: 'https://bitbucket.org/workspace/cloneurl',
-                  },
-                ],
-              },
-            }),
-          ),
+        () => HttpResponse.json(responseJson),
       ),
     );
 
@@ -501,26 +405,9 @@ describe('publish:bitbucketCloud', () => {
     });
 
     server.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
-              links: {
-                html: {
-                  href: 'https://bitbucket.org/workspace/repo',
-                },
-                clone: [
-                  {
-                    name: 'https',
-                    href: 'https://bitbucket.org/workspace/cloneurl',
-                  },
-                ],
-              },
-            }),
-          ),
+        () => HttpResponse.json(responseJson),
       ),
     );
 
@@ -541,26 +428,9 @@ describe('publish:bitbucketCloud', () => {
 
   it('should call initAndPush with token passed through ctx.input', async () => {
     server.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo',
-        (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
-              links: {
-                html: {
-                  href: 'https://bitbucket.org/workspace/repo',
-                },
-                clone: [
-                  {
-                    name: 'https',
-                    href: 'https://bitbucket.org/workspace/cloneurl',
-                  },
-                ],
-              },
-            }),
-          ),
+        () => HttpResponse.json(responseJson),
       ),
     );
 

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPipelinesRun.examples.test.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPipelinesRun.examples.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { createBitbucketPipelinesRunAction } from './bitbucketCloudPipelinesRun';
 import yaml from 'yaml';
@@ -57,22 +57,18 @@ describe('bitbucket:pipelines:run', () => {
   it('should trigger a pipeline for a branch', async () => {
     expect.assertions(2);
     worker.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/test-workspace/test-repo-slug/pipelines',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Basic dTpw');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Basic dTpw');
+          expect(await request.json()).toEqual({
             target: {
               ref_type: 'branch',
               type: 'pipeline_ref_target',
               ref_name: 'master',
             },
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseJson),
-          );
+          return HttpResponse.json(responseJson, { status: 201 });
         },
       ),
     );
@@ -85,11 +81,11 @@ describe('bitbucket:pipelines:run', () => {
   it('should trigger a pipeline for a commit on a branch', async () => {
     expect.assertions(2);
     worker.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/test-workspace/test-repo-slug/pipelines',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Basic dTpw');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Basic dTpw');
+          expect(await request.json()).toEqual({
             target: {
               commit: {
                 type: 'commit',
@@ -100,11 +96,7 @@ describe('bitbucket:pipelines:run', () => {
               ref_name: 'master',
             },
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseJson),
-          );
+          return HttpResponse.json(responseJson, { status: 201 });
         },
       ),
     );
@@ -117,11 +109,11 @@ describe('bitbucket:pipelines:run', () => {
   it('should trigger a specific pipeline definition for a commit', async () => {
     expect.assertions(2);
     worker.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/test-workspace/test-repo-slug/pipelines',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Basic dTpw');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Basic dTpw');
+          expect(await request.json()).toEqual({
             target: {
               commit: {
                 type: 'commit',
@@ -134,11 +126,7 @@ describe('bitbucket:pipelines:run', () => {
               type: 'pipeline_commit_target',
             },
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseJson),
-          );
+          return HttpResponse.json(responseJson, { status: 201 });
         },
       ),
     );
@@ -151,11 +139,11 @@ describe('bitbucket:pipelines:run', () => {
   it('should trigger a specific pipeline definition for a commit on a branch or tag', async () => {
     expect.assertions(2);
     worker.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/test-workspace/test-repo-slug/pipelines',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Basic dTpw');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Basic dTpw');
+          expect(await request.json()).toEqual({
             target: {
               commit: {
                 type: 'commit',
@@ -170,11 +158,7 @@ describe('bitbucket:pipelines:run', () => {
               ref_type: 'branch',
             },
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseJson),
-          );
+          return HttpResponse.json(responseJson, { status: 201 });
         },
       ),
     );
@@ -187,11 +171,11 @@ describe('bitbucket:pipelines:run', () => {
   it('should trigger a custom pipeline with variables', async () => {
     expect.assertions(2);
     worker.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/test-workspace/test-repo-slug/pipelines',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Basic dTpw');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Basic dTpw');
+          expect(await request.json()).toEqual({
             target: {
               type: 'pipeline_ref_target',
               ref_name: 'master',
@@ -209,11 +193,7 @@ describe('bitbucket:pipelines:run', () => {
               },
             ],
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseJson),
-          );
+          return HttpResponse.json(responseJson, { status: 201 });
         },
       ),
     );
@@ -226,11 +206,11 @@ describe('bitbucket:pipelines:run', () => {
   it('should trigger a pull request pipeline', async () => {
     expect.assertions(2);
     worker.use(
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/test-workspace/test-repo-slug/pipelines',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Basic dTpw');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Basic dTpw');
+          expect(await request.json()).toEqual({
             target: {
               type: 'pipeline_pullrequest_target',
               source: 'pull-request-branch',
@@ -250,11 +230,7 @@ describe('bitbucket:pipelines:run', () => {
               },
             },
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseJson),
-          );
+          return HttpResponse.json(responseJson, { status: 201 });
         },
       ),
     );

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPipelinesRun.test.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPipelinesRun.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { createBitbucketPipelinesRunAction } from './bitbucketCloudPipelinesRun';
@@ -78,15 +78,13 @@ describe('bitbucket:pipelines:run', () => {
   it('should call the bitbucket api for running a pipeline with integration credentials', async () => {
     expect.assertions(1);
     worker.use(
-      rest.post(
-        `https://api.bitbucket.org/2.0/repositories/${workspace}/${repo_slug}/pipelines`,
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Basic dTpw');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseJson),
-          );
+      http.post(
+        `https://api.bitbucket.org/2.0/repositories/:workspace/:repo_slug/pipelines`,
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Basic dTpw');
+          return HttpResponse.json(responseJson, {
+            status: 201,
+          });
         },
       ),
     );
@@ -100,15 +98,13 @@ describe('bitbucket:pipelines:run', () => {
   it('should call the bitbucket api for running a pipeline with input token', async () => {
     expect.assertions(1);
     worker.use(
-      rest.post(
-        `https://api.bitbucket.org/2.0/repositories/${workspace}/${repo_slug}/pipelines`,
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer abc');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseJson),
-          );
+      http.post(
+        `https://api.bitbucket.org/2.0/repositories/:workspace/:repo_slug/pipelines`,
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer abc');
+          return HttpResponse.json(responseJson, {
+            status: 201,
+          });
         },
       ),
     );
@@ -121,14 +117,12 @@ describe('bitbucket:pipelines:run', () => {
 
   it('should call outputs with the correct data', async () => {
     worker.use(
-      rest.post(
-        `https://api.bitbucket.org/2.0/repositories/${workspace}/${repo_slug}/pipelines`,
-        (_, res, ctx) => {
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseJson),
-          );
+      http.post(
+        `https://api.bitbucket.org/2.0/repositories/:workspace/:repo_slug/pipelines`,
+        () => {
+          return HttpResponse.json(responseJson, {
+            status: 201,
+          });
         },
       ),
     );

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.examples.test.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.examples.test.ts
@@ -27,7 +27,7 @@ jest.mock('@backstage/plugin-scaffolder-node', () => {
 });
 
 import { createPublishBitbucketCloudPullRequestAction } from './bitbucketCloudPullRequest';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { ScmIntegrations } from '@backstage/integration';
@@ -235,30 +235,22 @@ describe('publish:bitbucketCloud:pull-request', () => {
   it(`should ${examples[0].description}`, async () => {
     expect.assertions(2);
     server.use(
-      rest.get(
+      http.get(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/refs/branches',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             'Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=',
           );
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfBranches),
-          );
+          return HttpResponse.json(responseOfBranches);
         },
       ),
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             'Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=',
           );
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfPullRequests),
-          );
+          return HttpResponse.json(responseOfPullRequests, { status: 201 });
         },
       ),
     );
@@ -275,30 +267,22 @@ describe('publish:bitbucketCloud:pull-request', () => {
   it(`should ${examples[1].description}`, async () => {
     expect.assertions(2);
     server.use(
-      rest.get(
+      http.get(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/refs/branches',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             'Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=',
           );
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfBranches),
-          );
+          return HttpResponse.json(responseOfBranches);
         },
       ),
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             'Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=',
           );
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfPullRequests),
-          );
+          return HttpResponse.json(responseOfPullRequests, { status: 201 });
         },
       ),
     );
@@ -315,30 +299,22 @@ describe('publish:bitbucketCloud:pull-request', () => {
   it(`should ${examples[2].description}`, async () => {
     expect.assertions(2);
     server.use(
-      rest.get(
+      http.get(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/refs/branches',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             'Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=',
           );
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfBranches),
-          );
+          return HttpResponse.json(responseOfBranches);
         },
       ),
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             'Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=',
           );
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfPullRequests),
-          );
+          return HttpResponse.json(responseOfPullRequests, { status: 201 });
         },
       ),
     );
@@ -355,30 +331,22 @@ describe('publish:bitbucketCloud:pull-request', () => {
   it(`should ${examples[3].description}`, async () => {
     expect.assertions(2);
     server.use(
-      rest.get(
+      http.get(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/refs/branches',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             `Bearer ${yaml.parse(examples[3].example).steps[0].input.token}`,
           );
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfBranches),
-          );
+          return HttpResponse.json(responseOfBranches);
         },
       ),
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             `Bearer ${yaml.parse(examples[3].example).steps[0].input.token}`,
           );
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfPullRequests),
-          );
+          return HttpResponse.json(responseOfPullRequests, { status: 201 });
         },
       ),
     );
@@ -395,30 +363,22 @@ describe('publish:bitbucketCloud:pull-request', () => {
   it(`should ${examples[4].description}`, async () => {
     expect.assertions(2);
     server.use(
-      rest.get(
+      http.get(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/refs/branches',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             `Bearer ${yaml.parse(examples[4].example).steps[0].input.token}`,
           );
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfBranches),
-          );
+          return HttpResponse.json(responseOfBranches);
         },
       ),
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             `Bearer ${yaml.parse(examples[4].example).steps[0].input.token}`,
           );
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfPullRequests),
-          );
+          return HttpResponse.json(responseOfPullRequests, { status: 201 });
         },
       ),
     );

--- a/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.test.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-cloud/src/actions/bitbucketCloudPullRequest.test.ts
@@ -27,7 +27,7 @@ jest.mock('@backstage/plugin-scaffolder-node', () => {
 });
 
 import { createPublishBitbucketCloudPullRequestAction } from './bitbucketCloudPullRequest';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { ScmIntegrations } from '@backstage/integration';
@@ -254,34 +254,28 @@ describe('publish:bitbucketCloud:pull-request', () => {
     participants: [{ type: '<string>' }],
   };
   const handlers = [
-    rest.get(
+    http.get(
       'https://api.bitbucket.org/2.0/repositories/workspace/repo/refs/branches',
-      (_, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json(responseOfBranches),
-        );
+      () => {
+        return HttpResponse.json(responseOfBranches, {
+          status: 200,
+        });
       },
     ),
-    rest.get(
+    http.get(
       'https://api.bitbucket.org/2.0/repositories/workspace/repo',
-      (_, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json(responseOfDefaultBranch),
-        );
+      () => {
+        return HttpResponse.json(responseOfDefaultBranch, {
+          status: 200,
+        });
       },
     ),
-    rest.post(
+    http.post(
       'https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests',
-      (_, res, ctx) => {
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json(responseOfPullRequests),
-        );
+      () => {
+        return HttpResponse.json(responseOfPullRequests, {
+          status: 201,
+        });
       },
     ),
   ];
@@ -330,30 +324,26 @@ describe('publish:bitbucketCloud:pull-request', () => {
   it('should call the correct APIs with basic auth', async () => {
     expect.assertions(2);
     server.use(
-      rest.get(
+      http.get(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/refs/branches',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             'Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=',
           );
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfBranches),
-          );
+          return HttpResponse.json(responseOfBranches, {
+            status: 200,
+          });
         },
       ),
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             'Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=',
           );
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfPullRequests),
-          );
+          return HttpResponse.json(responseOfPullRequests, {
+            status: 201,
+          });
         },
       ),
     );
@@ -371,26 +361,22 @@ describe('publish:bitbucketCloud:pull-request', () => {
     expect.assertions(2);
     const token = 'user-token';
     server.use(
-      rest.get(
+      http.get(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/refs/branches',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(`Bearer ${token}`);
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfBranches),
-          );
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(`Bearer ${token}`);
+          return HttpResponse.json(responseOfBranches, {
+            status: 200,
+          });
         },
       ),
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(`Bearer ${token}`);
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfPullRequests),
-          );
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(`Bearer ${token}`);
+          return HttpResponse.json(responseOfPullRequests, {
+            status: 201,
+          });
         },
       ),
     );
@@ -436,13 +422,14 @@ describe('publish:bitbucketCloud:pull-request', () => {
 
     server.use(
       ...handlers,
-      rest.post(
+      http.post(
         'https://api.bitbucket.org/2.0/repositories/workspace/repo/refs/branches',
-        (_, res, ctx) => {
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({}),
+        () => {
+          return HttpResponse.json(
+            {},
+            {
+              status: 201,
+            },
           );
         },
       ),

--- a/plugins/scaffolder-backend-module-bitbucket-server/package.json
+++ b/plugins/scaffolder-backend-module-bitbucket-server/package.json
@@ -54,6 +54,6 @@
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@backstage/plugin-scaffolder-node-test-utils": "workspace:^",
-    "msw": "^1.0.0"
+    "msw": "^2.0.0"
   }
 }

--- a/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServer.examples.test.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServer.examples.test.ts
@@ -27,7 +27,7 @@ jest.mock('@backstage/plugin-scaffolder-node', () => {
 });
 
 import { createPublishBitbucketServerAction } from './bitbucketServer';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { ScmIntegrations } from '@backstage/integration';
@@ -80,19 +80,17 @@ describe('publish:bitbucketServer', () => {
   it(`should ${examples[0].description}`, async () => {
     expect.assertions(3);
     server.use(
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'master',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -106,7 +104,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -134,22 +133,20 @@ describe('publish:bitbucketServer', () => {
   it(`should ${examples[1].description}`, async () => {
     expect.assertions(3);
     server.use(
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             `Bearer ${yaml.parse(examples[1].example).steps[0].input.token}`,
           );
-          expect(req.body).toEqual({
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'main',
             description: 'This is a test repository',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -163,7 +160,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -202,22 +200,20 @@ describe('publish:bitbucketServer', () => {
   it(`should ${examples[2].description}`, async () => {
     expect.assertions(3);
     server.use(
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             `Bearer ${yaml.parse(examples[2].example).steps[0].input.token}`,
           );
-          expect(req.body).toEqual({
+          expect(await request.json()).toEqual({
             public: true,
             name: 'repo',
             defaultBranch: 'main',
             description: 'This is a test repository',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -231,7 +227,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -271,22 +268,20 @@ describe('publish:bitbucketServer', () => {
     expect.assertions(3);
 
     const handlers = [
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             `Bearer ${yaml.parse(examples[3].example).steps[0].input.token}`,
           );
-          expect(req.body).toEqual({
+          expect(await request.json()).toEqual({
             public: true,
             name: 'repo',
             defaultBranch: 'develop',
             description: 'This is a test repository',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -300,19 +295,18 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
-      rest.put(
+      http.put(
         'https://hosted.bitbucket.com/rest/git-lfs/admin/projects/project/repos/repo/enabled',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual('');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.text()).toEqual('');
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -326,7 +320,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -368,22 +363,20 @@ describe('publish:bitbucketServer', () => {
     expect.assertions(3);
 
     const handlers = [
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             `Bearer ${yaml.parse(examples[4].example).steps[0].input.token}`,
           );
-          expect(req.body).toEqual({
+          expect(await request.json()).toEqual({
             public: true,
             name: 'repo',
             defaultBranch: 'develop',
             description: 'This is a test repository',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -397,19 +390,18 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
-      rest.put(
+      http.put(
         'https://hosted.bitbucket.com/rest/git-lfs/admin/projects/project/repos/repo/enabled',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual('');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.text()).toEqual('');
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -423,7 +415,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -464,19 +457,17 @@ describe('publish:bitbucketServer', () => {
     expect.assertions(3);
 
     const handlers = [
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(`Bearer thing`);
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(`Bearer thing`);
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'master',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -490,19 +481,18 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
-      rest.put(
+      http.put(
         'https://hosted.bitbucket.com/rest/git-lfs/admin/projects/project/repos/repo/enabled',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual('');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.text()).toEqual('');
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -516,7 +506,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -558,19 +549,17 @@ describe('publish:bitbucketServer', () => {
     expect.assertions(5);
 
     const handlers = [
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'master',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -587,19 +576,18 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
-      rest.put(
+      http.put(
         'https://hosted.bitbucket.com/rest/git-lfs/admin/projects/project/repos/repo/enabled',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual('');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.text()).toEqual('');
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -613,7 +601,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -654,19 +643,19 @@ describe('publish:bitbucketServer', () => {
     expect.assertions(3);
 
     const handlers = [
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer custom-token');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
+            'Bearer custom-token',
+          );
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'master',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -683,19 +672,18 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
-      rest.put(
+      http.put(
         'https://hosted.bitbucket.com/rest/git-lfs/admin/projects/project/repos/repo/enabled',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual('');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.text()).toEqual('');
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -709,7 +697,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -747,19 +736,17 @@ describe('publish:bitbucketServer', () => {
     expect.assertions(3);
 
     const handlers = [
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'master',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -776,19 +763,18 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
-      rest.put(
+      http.put(
         'https://hosted.bitbucket.com/rest/git-lfs/admin/projects/project/repos/repo/enabled',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual('');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.text()).toEqual('');
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -802,7 +788,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -840,19 +827,17 @@ describe('publish:bitbucketServer', () => {
     expect.assertions(3);
 
     const handlers = [
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.json()).toEqual({
             public: true,
             name: 'repo',
             defaultBranch: 'master',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -869,19 +854,18 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
-      rest.put(
+      http.put(
         'https://hosted.bitbucket.com/rest/git-lfs/admin/projects/project/repos/repo/enabled',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual('');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.text()).toEqual('');
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -895,7 +879,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -933,21 +918,21 @@ describe('publish:bitbucketServer', () => {
     expect.assertions(5);
 
     const handlers = [
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer custom-token');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
+            'Bearer custom-token',
+          );
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             description: 'A fully customized repository',
             defaultBranch: 'development',
           });
 
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -964,19 +949,20 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
-      rest.put(
+      http.put(
         'https://hosted.bitbucket.com/rest/git-lfs/admin/projects/project/repos/repo/enabled',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer custom-token');
-          expect(req.body).toEqual('');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
+            'Bearer custom-token',
+          );
+          expect(await request.text()).toEqual('');
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -990,7 +976,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -1028,20 +1015,18 @@ describe('publish:bitbucketServer', () => {
     expect.assertions(3);
 
     const handlers = [
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'main',
           });
 
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -1058,19 +1043,20 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
-      rest.put(
+      http.put(
         'https://hosted.bitbucket.com/rest/git-lfs/admin/projects/project/repos/repo/enabled',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer custom-token');
-          expect(req.body).toEqual('');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
+            'Bearer custom-token',
+          );
+          expect(await request.text()).toEqual('');
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -1084,7 +1070,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -1124,21 +1111,19 @@ describe('publish:bitbucketServer', () => {
     expect.assertions(3);
 
     const handlers = [
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.json()).toEqual({
             public: true,
             name: 'repo',
             defaultBranch: 'master',
             description: 'A public repository with a custom description',
           });
 
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -1155,19 +1140,20 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
-      rest.put(
+      http.put(
         'https://hosted.bitbucket.com/rest/git-lfs/admin/projects/project/repos/repo/enabled',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer custom-token');
-          expect(req.body).toEqual('');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
+            'Bearer custom-token',
+          );
+          expect(await request.text()).toEqual('');
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -1181,7 +1167,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -1221,22 +1208,20 @@ describe('publish:bitbucketServer', () => {
     expect.assertions(3);
 
     const handlers = [
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             'Bearer custom-auth-token',
           );
-          expect(req.body).toEqual({
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'master',
           });
 
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -1253,19 +1238,20 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
-      rest.put(
+      http.put(
         'https://hosted.bitbucket.com/rest/git-lfs/admin/projects/project/repos/repo/enabled',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer custom-token');
-          expect(req.body).toEqual('');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
+            'Bearer custom-token',
+          );
+          expect(await request.text()).toEqual('');
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -1279,7 +1265,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -1319,20 +1306,18 @@ describe('publish:bitbucketServer', () => {
     expect.assertions(3);
 
     const handlers = [
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'master',
           });
 
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -1349,19 +1334,20 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
-      rest.put(
+      http.put(
         'https://hosted.bitbucket.com/rest/git-lfs/admin/projects/project/repos/repo/enabled',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer custom-token');
-          expect(req.body).toEqual('');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
+            'Bearer custom-token',
+          );
+          expect(await request.text()).toEqual('');
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -1375,7 +1361,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -1415,20 +1402,18 @@ describe('publish:bitbucketServer', () => {
     expect.assertions(5);
 
     const handlers = [
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'master',
           });
 
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -1445,19 +1430,18 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
-      rest.put(
+      http.put(
         'https://hosted.bitbucket.com/rest/git-lfs/admin/projects/project/repos/repo/enabled',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual('');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.text()).toEqual('');
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -1471,7 +1455,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),

--- a/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServer.test.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServer.test.ts
@@ -27,7 +27,7 @@ jest.mock('@backstage/plugin-scaffolder-node', () => {
 });
 
 import { createPublishBitbucketServerAction } from './bitbucketServer';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { ScmIntegrations } from '@backstage/integration';
@@ -123,19 +123,17 @@ describe('publish:bitbucketServer', () => {
   it('should call the correct APIs with token', async () => {
     expect.assertions(2);
     server.use(
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'master',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -149,7 +147,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -167,21 +166,19 @@ describe('publish:bitbucketServer', () => {
   it('should call the correct APIs with basic auth', async () => {
     expect.assertions(2);
     server.use(
-      rest.post(
+      http.post(
         'https://basic-auth.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             'Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=',
           );
-          expect(req.body).toEqual({
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'master',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -195,7 +192,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -214,19 +212,17 @@ describe('publish:bitbucketServer', () => {
     expect.assertions(2);
     const token = 'user-token';
     server.use(
-      rest.post(
+      http.post(
         'https://no-credentials.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(`Bearer ${token}`);
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(`Bearer ${token}`);
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'master',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -240,7 +236,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -275,21 +272,17 @@ describe('publish:bitbucketServer', () => {
     it('should call the correct APIs to enable LFS if requested and the host is hosted bitbucket', async () => {
       expect.assertions(1);
       server.use(
-        rest.post(
+        http.post(
           'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-          (_, res, ctx) => {
-            return res(
-              ctx.status(201),
-              ctx.set('Content-Type', 'application/json'),
-              ctx.json(repoCreationResponse),
-            );
+          () => {
+            return HttpResponse.json(repoCreationResponse, { status: 201 });
           },
         ),
-        rest.put(
+        http.put(
           'https://hosted.bitbucket.com/rest/git-lfs/admin/projects/project/repos/repo/enabled',
-          (req, res, ctx) => {
-            expect(req.headers.get('Authorization')).toBe('Bearer thing');
-            return res(ctx.status(204));
+          async ({ request }) => {
+            expect(request.headers.get('Authorization')).toBe('Bearer thing');
+            return new HttpResponse(null, { status: 204 });
           },
         ),
       );
@@ -306,20 +299,16 @@ describe('publish:bitbucketServer', () => {
 
     it('should report an error if enabling LFS fails', async () => {
       server.use(
-        rest.post(
+        http.post(
           'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-          (_, res, ctx) => {
-            return res(
-              ctx.status(201),
-              ctx.set('Content-Type', 'application/json'),
-              ctx.json(repoCreationResponse),
-            );
+          () => {
+            return HttpResponse.json(repoCreationResponse, { status: 201 });
           },
         ),
-        rest.put(
+        http.put(
           'https://hosted.bitbucket.com/rest/git-lfs/admin/projects/project/repos/repo/enabled',
-          (_, res, ctx) => {
-            return res(ctx.status(500));
+          () => {
+            return new HttpResponse(null, { status: 500 });
           },
         ),
       );
@@ -339,19 +328,17 @@ describe('publish:bitbucketServer', () => {
 
   it('should call initAndPush with the correct values with token', async () => {
     server.use(
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'master',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -365,7 +352,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -389,21 +377,19 @@ describe('publish:bitbucketServer', () => {
 
   it('should call initAndPush with the correct values with basic auth', async () => {
     server.use(
-      rest.post(
+      http.post(
         'https://basic-auth.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             'Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=',
           );
-          expect(req.body).toEqual({
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'master',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -417,7 +403,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -447,19 +434,17 @@ describe('publish:bitbucketServer', () => {
 
   it('should call initAndPush with the correct default branch', async () => {
     server.use(
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'main',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -473,7 +458,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -531,19 +517,17 @@ describe('publish:bitbucketServer', () => {
     });
 
     server.use(
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'master',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -557,7 +541,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -603,19 +588,17 @@ describe('publish:bitbucketServer', () => {
     });
 
     server.use(
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'master',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -629,7 +612,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -650,19 +634,17 @@ describe('publish:bitbucketServer', () => {
 
   it('should call outputs with the correct urls', async () => {
     server.use(
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'master',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -676,7 +658,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),
@@ -696,19 +679,17 @@ describe('publish:bitbucketServer', () => {
 
   it('should call outputs with the correct urls with correct default branch', async () => {
     server.use(
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          expect(req.body).toEqual({
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          expect(await request.json()).toEqual({
             public: false,
             name: 'repo',
             defaultBranch: 'main',
           });
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({
+          return HttpResponse.json(
+            {
               links: {
                 self: [
                   {
@@ -722,7 +703,8 @@ describe('publish:bitbucketServer', () => {
                   },
                 ],
               },
-            }),
+            },
+            { status: 201 },
           );
         },
       ),

--- a/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServerPullRequest.examples.test.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServerPullRequest.examples.test.ts
@@ -27,7 +27,7 @@ jest.mock('@backstage/plugin-scaffolder-node', () => {
 });
 
 import { createPublishBitbucketServerPullRequestAction } from './bitbucketServerPullRequest';
-import { rest } from 'msw';
+import { HttpResponse, http } from 'msw';
 import { setupServer } from 'msw/node';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { ScmIntegrations } from '@backstage/integration';
@@ -200,26 +200,18 @@ describe('publish:bitbucketServer:pull-request', () => {
   it(`should ${examples[0].description}`, async () => {
     expect.assertions(3);
     server.use(
-      rest.get(
+      http.get(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos/repo/branches',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfBranches),
-          );
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          return HttpResponse.json(responseOfBranches, { status: 200 });
         },
       ),
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos/repo/pull-requests',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfPullRequests),
-          );
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          return HttpResponse.json(responseOfPullRequests, { status: 201 });
         },
       ),
     );
@@ -236,21 +228,17 @@ describe('publish:bitbucketServer:pull-request', () => {
   it(`should ${examples[1].description}`, async () => {
     expect.assertions(6);
     server.use(
-      rest.get(
+      http.get(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos/repo/branches',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfBranches),
-          );
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          return HttpResponse.json(responseOfBranches);
         },
       ),
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos/repo/pull-requests',
-        (req, res, ctx) => {
-          const requestBody = req.body as {
+        async ({ request }) => {
+          const requestBody = (await request.json()) as {
             title: string;
             fromRef: { displayId: string };
             description: string;
@@ -260,12 +248,8 @@ describe('publish:bitbucketServer:pull-request', () => {
           expect(requestBody.description).toBe(
             'This is a detailed description of my pull request',
           );
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfPullRequests),
-          );
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          return HttpResponse.json(responseOfPullRequests, { status: 201 });
         },
       ),
     );
@@ -282,21 +266,17 @@ describe('publish:bitbucketServer:pull-request', () => {
   it(`should ${examples[2].description}`, async () => {
     expect.assertions(6);
     server.use(
-      rest.get(
+      http.get(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos/repo/branches',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfBranches),
-          );
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          return HttpResponse.json(responseOfBranches);
         },
       ),
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos/repo/pull-requests',
-        (req, res, ctx) => {
-          const requestBody = req.body as {
+        async ({ request }) => {
+          const requestBody = (await request.json()) as {
             title: string;
             toRef: { displayId: string };
             description: string;
@@ -306,12 +286,8 @@ describe('publish:bitbucketServer:pull-request', () => {
           expect(requestBody.description).toBe(
             'I just made a Pull Request that Add Scaffolder actions for Bitbucket Server',
           );
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfPullRequests),
-          );
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          return HttpResponse.json(responseOfPullRequests, { status: 201 });
         },
       ),
     );
@@ -328,30 +304,22 @@ describe('publish:bitbucketServer:pull-request', () => {
   it(`should ${examples[3].description}`, async () => {
     expect.assertions(3);
     server.use(
-      rest.get(
+      http.get(
         'https://no-credentials.bitbucket.com/rest/api/1.0/projects/project/repos/repo/branches',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             `Bearer ${yaml.parse(examples[3].example).steps[0].input.token}`,
           );
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfBranches),
-          );
+          return HttpResponse.json(responseOfBranches);
         },
       ),
-      rest.post(
+      http.post(
         'https://no-credentials.bitbucket.com/rest/api/1.0/projects/project/repos/repo/pull-requests',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             `Bearer ${yaml.parse(examples[3].example).steps[0].input.token}`,
           );
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfPullRequests),
-          );
+          return HttpResponse.json(responseOfPullRequests, { status: 201 });
         },
       ),
     );
@@ -368,23 +336,19 @@ describe('publish:bitbucketServer:pull-request', () => {
   it(`should ${examples[4].description}`, async () => {
     expect.assertions(8);
     server.use(
-      rest.get(
+      http.get(
         'https://no-credentials.bitbucket.com/rest/api/1.0/projects/project/repos/repo/branches',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             `Bearer ${yaml.parse(examples[4].example).steps[0].input.token}`,
           );
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfBranches),
-          );
+          return HttpResponse.json(responseOfBranches, { status: 200 });
         },
       ),
-      rest.post(
+      http.post(
         'https://no-credentials.bitbucket.com/rest/api/1.0/projects/project/repos/repo/pull-requests',
-        (req, res, ctx) => {
-          const requestBody = req.body as {
+        async ({ request }) => {
+          const requestBody = (await request.json()) as {
             title: string;
             toRef: { displayId: string };
             fromRef: { displayId: string };
@@ -401,14 +365,10 @@ describe('publish:bitbucketServer:pull-request', () => {
             { user: { name: 'reviewer1' } },
             { user: { name: 'reviewer2' } },
           ]);
-          expect(req.headers.get('Authorization')).toBe(
+          expect(request.headers.get('Authorization')).toBe(
             `Bearer ${yaml.parse(examples[4].example).steps[0].input.token}`,
           );
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfPullRequests),
-          );
+          return HttpResponse.json(responseOfPullRequests, { status: 201 });
         },
       ),
     );

--- a/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServerPullRequest.test.ts
+++ b/plugins/scaffolder-backend-module-bitbucket-server/src/actions/bitbucketServerPullRequest.test.ts
@@ -27,7 +27,7 @@ jest.mock('@backstage/plugin-scaffolder-node', () => {
 });
 
 import { createPublishBitbucketServerPullRequestAction } from './bitbucketServerPullRequest';
-import { rest } from 'msw';
+import { HttpResponse, http } from 'msw';
 import { setupServer } from 'msw/node';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { ScmIntegrations } from '@backstage/integration';
@@ -188,34 +188,22 @@ describe('publish:bitbucketServer:pull-request', () => {
     },
   };
   const handlers = [
-    rest.get(
+    http.get(
       'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos/repo/branches',
-      (_, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json(responseOfBranches),
-        );
+      () => {
+        return HttpResponse.json(responseOfBranches);
       },
     ),
-    rest.get(
+    http.get(
       'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos/repo/default-branch',
-      (_, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json(responseOfDefaultBranch),
-        );
+      () => {
+        return HttpResponse.json(responseOfDefaultBranch);
       },
     ),
-    rest.post(
+    http.post(
       'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos/repo/pull-requests',
-      (_, res, ctx) => {
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json(responseOfPullRequests),
-        );
+      () => {
+        return HttpResponse.json(responseOfPullRequests, { status: 201 });
       },
     ),
   ];
@@ -278,26 +266,18 @@ describe('publish:bitbucketServer:pull-request', () => {
   it('should call the correct APIs with token', async () => {
     expect.assertions(3);
     server.use(
-      rest.get(
+      http.get(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos/repo/branches',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfBranches),
-          );
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          return HttpResponse.json(responseOfBranches);
         },
       ),
-      rest.post(
+      http.post(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos/repo/pull-requests',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe('Bearer thing');
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfPullRequests),
-          );
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe('Bearer thing');
+          return HttpResponse.json(responseOfPullRequests, { status: 201 });
         },
       ),
     );
@@ -314,30 +294,22 @@ describe('publish:bitbucketServer:pull-request', () => {
   it('should call the correct APIs with basic auth', async () => {
     expect.assertions(3);
     server.use(
-      rest.get(
+      http.get(
         'https://basic-auth.bitbucket.com/rest/api/1.0/projects/project/repos/repo/branches',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             'Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=',
           );
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfBranches),
-          );
+          return HttpResponse.json(responseOfBranches);
         },
       ),
-      rest.post(
+      http.post(
         'https://basic-auth.bitbucket.com/rest/api/1.0/projects/project/repos/repo/pull-requests',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
             'Basic dGVzdC11c2VyOnRlc3QtcGFzc3dvcmQ=',
           );
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfPullRequests),
-          );
+          return HttpResponse.json(responseOfPullRequests, { status: 201 });
         },
       ),
     );
@@ -355,26 +327,18 @@ describe('publish:bitbucketServer:pull-request', () => {
     expect.assertions(3);
     const token = 'user-token';
     server.use(
-      rest.get(
+      http.get(
         'https://no-credentials.bitbucket.com/rest/api/1.0/projects/project/repos/repo/branches',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(`Bearer ${token}`);
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfBranches),
-          );
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(`Bearer ${token}`);
+          return HttpResponse.json(responseOfBranches);
         },
       ),
-      rest.post(
+      http.post(
         'https://no-credentials.bitbucket.com/rest/api/1.0/projects/project/repos/repo/pull-requests',
-        (req, res, ctx) => {
-          expect(req.headers.get('Authorization')).toBe(`Bearer ${token}`);
-          return res(
-            ctx.status(201),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfPullRequests),
-          );
+        ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(`Bearer ${token}`);
+          return HttpResponse.json(responseOfPullRequests, { status: 201 });
         },
       ),
     );
@@ -402,14 +366,10 @@ describe('publish:bitbucketServer:pull-request', () => {
 
   it('should throw an error when the target branch is not found', async () => {
     server.use(
-      rest.get(
+      http.get(
         'https://hosted.bitbucket.com/rest/api/1.0/projects/project/repos/repo/branches',
-        (_, res, ctx) => {
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json(responseOfBranches),
-          );
+        () => {
+          return HttpResponse.json(responseOfBranches);
         },
       ),
     );

--- a/plugins/scaffolder-backend-module-confluence-to-markdown/package.json
+++ b/plugins/scaffolder-backend-module-confluence-to-markdown/package.json
@@ -59,7 +59,7 @@
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@backstage/plugin-scaffolder-node-test-utils": "workspace:^",
-    "msw": "^1.0.0"
+    "msw": "^2.0.0"
   },
   "configSchema": "config.d.ts"
 }

--- a/plugins/scaffolder-backend-module-confluence-to-markdown/src/actions/confluence/confluenceToMarkdown.examples.test.ts
+++ b/plugins/scaffolder-backend-module-confluence-to-markdown/src/actions/confluence/confluenceToMarkdown.examples.test.ts
@@ -21,7 +21,7 @@ import {
   createMockDirectory,
   registerMswTestHooks,
 } from '@backstage/backend-test-utils';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { examples } from './confluenceToMarkdown.examples';
 import yaml from 'yaml';
@@ -118,16 +118,14 @@ describe('confluence:transform:markdown examples', () => {
     };
 
     worker.use(
-      rest.get(`${baseUrl}/rest/api/content`, (_, res, ctx) =>
-        res(ctx.status(200, 'OK'), ctx.json(responseBody)),
+      http.get(`${baseUrl}/rest/api/content`, () =>
+        HttpResponse.json(responseBody, { status: 200, statusText: 'OK' }),
       ),
-      rest.get(
-        `${baseUrl}/rest/api/content/4444444/child/attachment`,
-        (_, res, ctx) => res(ctx.status(200, 'OK'), ctx.json(responseBodyTwo)),
+      http.get(`${baseUrl}/rest/api/content/4444444/child/attachment`, () =>
+        HttpResponse.json(responseBodyTwo, { status: 200, statusText: 'OK' }),
       ),
-      rest.get(
-        `${baseUrl}/download/attachments/4444444/testing.pdf`,
-        (_, res, ctx) => res(ctx.status(200, 'OK'), ctx.body('hello')),
+      http.get(`${baseUrl}/download/attachments/4444444/testing.pdf`, () =>
+        HttpResponse.text('hello', { status: 200, statusText: 'OK' }),
       ),
     );
 

--- a/plugins/scaffolder-backend-module-confluence-to-markdown/src/actions/confluence/confluenceToMarkdown.test.ts
+++ b/plugins/scaffolder-backend-module-confluence-to-markdown/src/actions/confluence/confluenceToMarkdown.test.ts
@@ -22,7 +22,7 @@ import {
   registerMswTestHooks,
 } from '@backstage/backend-test-utils';
 import type { ActionContext } from '@backstage/plugin-scaffolder-node';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { createMockActionContext } from '@backstage/plugin-scaffolder-node-test-utils';
 import { UrlReaderService } from '@backstage/backend-plugin-api';
@@ -122,16 +122,14 @@ describe('confluence:transform:markdown', () => {
     };
 
     worker.use(
-      rest.get(`${baseUrl}/rest/api/content`, (_, res, ctx) =>
-        res(ctx.status(200, 'OK'), ctx.json(responseBody)),
+      http.get(`${baseUrl}/rest/api/content`, () =>
+        HttpResponse.json(responseBody, { status: 200, statusText: 'OK' }),
       ),
-      rest.get(
-        `${baseUrl}/rest/api/content/4444444/child/attachment`,
-        (_, res, ctx) => res(ctx.status(200, 'OK'), ctx.json(responseBodyTwo)),
+      http.get(`${baseUrl}/rest/api/content/4444444/child/attachment`, () =>
+        HttpResponse.json(responseBodyTwo, { status: 200, statusText: 'OK' }),
       ),
-      rest.get(
-        `${baseUrl}/download/attachments/4444444/testing.pdf`,
-        (_, res, ctx) => res(ctx.status(200, 'OK'), ctx.body('hello')),
+      http.get(`${baseUrl}/download/attachments/4444444/testing.pdf`, () =>
+        HttpResponse.text('hello', { status: 200, statusText: 'OK' }),
       ),
     );
 
@@ -175,12 +173,11 @@ describe('confluence:transform:markdown', () => {
     };
 
     worker.use(
-      rest.get(`${baseUrl}/rest/api/content`, (_, res, ctx) =>
-        res(ctx.status(200, 'OK'), ctx.json(responseBody)),
+      http.get(`${baseUrl}/rest/api/content`, () =>
+        HttpResponse.json(responseBody, { status: 200, statusText: 'OK' }),
       ),
-      rest.get(
-        `${baseUrl}/rest/api/content/4444444/child/attachment`,
-        (_, res, ctx) => res(ctx.status(200, 'OK'), ctx.json(responseBodyTwo)),
+      http.get(`${baseUrl}/rest/api/content/4444444/child/attachment`, () =>
+        HttpResponse.json(responseBodyTwo, { status: 200, statusText: 'OK' }),
       ),
     );
 
@@ -207,8 +204,8 @@ describe('confluence:transform:markdown', () => {
     const responseBody = {};
 
     worker.use(
-      rest.get(`${baseUrl}/rest/api/content`, (_, res, ctx) =>
-        res(ctx.status(401, 'nope'), ctx.json(responseBody)),
+      http.get(`${baseUrl}/rest/api/content`, () =>
+        HttpResponse.json(responseBody, { status: 401, statusText: 'nope' }),
       ),
     );
 
@@ -229,8 +226,8 @@ describe('confluence:transform:markdown', () => {
     };
 
     worker.use(
-      rest.get(`${baseUrl}/rest/api/content`, (_, res, ctx) =>
-        res(ctx.status(200, 'OK'), ctx.json(responseBody)),
+      http.get(`${baseUrl}/rest/api/content`, () =>
+        HttpResponse.json(responseBody, { status: 200, statusText: 'OK' }),
       ),
     );
 
@@ -265,13 +262,11 @@ describe('confluence:transform:markdown', () => {
     const responseBodyTwo = {};
 
     worker.use(
-      rest.get(`${baseUrl}/rest/api/content`, (_, res, ctx) =>
-        res(ctx.status(200, 'OK'), ctx.json(responseBody)),
+      http.get(`${baseUrl}/rest/api/content`, () =>
+        HttpResponse.json(responseBody, { status: 200, statusText: 'OK' }),
       ),
-      rest.get(
-        `${baseUrl}/rest/api/content/4444444/child/attachment`,
-        (_, res, ctx) =>
-          res(ctx.status(404, 'nope'), ctx.json(responseBodyTwo)),
+      http.get(`${baseUrl}/rest/api/content/4444444/child/attachment`, () =>
+        HttpResponse.json(responseBodyTwo, { status: 404, statusText: 'nope' }),
       ),
     );
 

--- a/plugins/scaffolder-backend-module-gerrit/package.json
+++ b/plugins/scaffolder-backend-module-gerrit/package.json
@@ -53,6 +53,6 @@
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@backstage/plugin-scaffolder-node-test-utils": "workspace:^",
-    "msw": "^1.0.0"
+    "msw": "^2.0.0"
   }
 }

--- a/plugins/scaffolder-backend-module-gerrit/src/actions/gerrit.examples.test.ts
+++ b/plugins/scaffolder-backend-module-gerrit/src/actions/gerrit.examples.test.ts
@@ -28,7 +28,7 @@ jest.mock('@backstage/plugin-scaffolder-node', () => {
 
 import path from 'node:path';
 import { createPublishGerritAction } from './gerrit';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { ScmIntegrations } from '@backstage/integration';
@@ -72,22 +72,18 @@ describe('publish:gerrit', () => {
   it(`should ${examples[0].description}`, async () => {
     expect.assertions(5);
     server.use(
-      rest.put('https://gerrit.com/a/projects/repo', (req, res, ctx) => {
-        expect(req.headers.get('Authorization')).toBe(
+      http.put('https://gerrit.com/a/projects/repo', async ({ request }) => {
+        expect(request.headers.get('Authorization')).toBe(
           'Basic ZGVtb3VzZXI6YWNjZXNzdG9rZW4=',
         );
-        expect(req.body).toEqual({
+        expect(await request.json()).toEqual({
           branches: ['master'],
           create_empty_commit: false,
           owners: ['owner'],
           description,
           parent: 'parent',
         });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
+        return HttpResponse.json({}, { status: 201 });
       }),
     );
 
@@ -131,11 +127,11 @@ describe('publish:gerrit', () => {
   it(`should ${examples[1].description}`, async () => {
     expect.assertions(5);
     server.use(
-      rest.put('https://gerrit.com/a/projects/repo', (req, res, ctx) => {
-        expect(req.headers.get('Authorization')).toBe(
+      http.put('https://gerrit.com/a/projects/repo', async ({ request }) => {
+        expect(request.headers.get('Authorization')).toBe(
           'Basic ZGVtb3VzZXI6YWNjZXNzdG9rZW4=',
         );
-        expect(req.body).toEqual({
+        expect(await request.json()).toEqual({
           branches: ['master'],
           create_empty_commit: false,
           owners: ['owner'],
@@ -143,11 +139,7 @@ describe('publish:gerrit', () => {
             .description,
           parent: 'parent',
         });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
+        return HttpResponse.json({}, { status: 201 });
       }),
     );
 
@@ -190,22 +182,18 @@ describe('publish:gerrit', () => {
   it(`should ${examples[2].description}`, async () => {
     expect.assertions(5);
     server.use(
-      rest.put('https://gerrit.com/a/projects/repo', (req, res, ctx) => {
-        expect(req.headers.get('Authorization')).toBe(
+      http.put('https://gerrit.com/a/projects/repo', async ({ request }) => {
+        expect(request.headers.get('Authorization')).toBe(
           'Basic ZGVtb3VzZXI6YWNjZXNzdG9rZW4=',
         );
-        expect(req.body).toEqual({
+        expect(await request.json()).toEqual({
           branches: ['staging'],
           create_empty_commit: false,
           owners: ['owner'],
           description,
           parent: 'parent',
         });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
+        return HttpResponse.json({}, { status: 201 });
       }),
     );
 
@@ -248,22 +236,18 @@ describe('publish:gerrit', () => {
   it(`should ${examples[3].description}`, async () => {
     expect.assertions(5);
     server.use(
-      rest.put('https://gerrit.com/a/projects/repo', (req, res, ctx) => {
-        expect(req.headers.get('Authorization')).toBe(
+      http.put('https://gerrit.com/a/projects/repo', async ({ request }) => {
+        expect(request.headers.get('Authorization')).toBe(
           'Basic ZGVtb3VzZXI6YWNjZXNzdG9rZW4=',
         );
-        expect(req.body).toEqual({
+        expect(await request.json()).toEqual({
           branches: ['master'],
           create_empty_commit: false,
           owners: ['owner'],
           description,
           parent: 'parent',
         });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
+        return HttpResponse.json({}, { status: 201 });
       }),
     );
 
@@ -309,22 +293,18 @@ describe('publish:gerrit', () => {
   it(`should ${examples[4].description}`, async () => {
     expect.assertions(5);
     server.use(
-      rest.put('https://gerrit.com/a/projects/repo', (req, res, ctx) => {
-        expect(req.headers.get('Authorization')).toBe(
+      http.put('https://gerrit.com/a/projects/repo', async ({ request }) => {
+        expect(request.headers.get('Authorization')).toBe(
           'Basic ZGVtb3VzZXI6YWNjZXNzdG9rZW4=',
         );
-        expect(req.body).toEqual({
+        expect(await request.json()).toEqual({
           branches: ['master'],
           create_empty_commit: false,
           owners: ['owner'],
           description,
           parent: 'parent',
         });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
+        return HttpResponse.json({}, { status: 201 });
       }),
     );
 
@@ -368,22 +348,18 @@ describe('publish:gerrit', () => {
   it(`should ${examples[5].description}`, async () => {
     expect.assertions(5);
     server.use(
-      rest.put('https://gerrit.com/a/projects/repo', (req, res, ctx) => {
-        expect(req.headers.get('Authorization')).toBe(
+      http.put('https://gerrit.com/a/projects/repo', async ({ request }) => {
+        expect(request.headers.get('Authorization')).toBe(
           'Basic ZGVtb3VzZXI6YWNjZXNzdG9rZW4=',
         );
-        expect(req.body).toEqual({
+        expect(await request.json()).toEqual({
           branches: ['master'],
           create_empty_commit: false,
           owners: ['owner'],
           description,
           parent: 'parent',
         });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
+        return HttpResponse.json({}, { status: 201 });
       }),
     );
 
@@ -427,22 +403,18 @@ describe('publish:gerrit', () => {
   it(`should ${examples[6].description}`, async () => {
     expect.assertions(5);
     server.use(
-      rest.put('https://gerrit.com/a/projects/repo', (req, res, ctx) => {
-        expect(req.headers.get('Authorization')).toBe(
+      http.put('https://gerrit.com/a/projects/repo', async ({ request }) => {
+        expect(request.headers.get('Authorization')).toBe(
           'Basic ZGVtb3VzZXI6YWNjZXNzdG9rZW4=',
         );
-        expect(req.body).toEqual({
+        expect(await request.json()).toEqual({
           branches: ['master'],
           create_empty_commit: false,
           owners: ['owner'],
           description,
           parent: 'parent',
         });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
+        return HttpResponse.json({}, { status: 201 });
       }),
     );
 
@@ -486,22 +458,18 @@ describe('publish:gerrit', () => {
   it(`should ${examples[7].description}`, async () => {
     expect.assertions(5);
     server.use(
-      rest.put('https://gerrit.com/a/projects/repo', (req, res, ctx) => {
-        expect(req.headers.get('Authorization')).toBe(
+      http.put('https://gerrit.com/a/projects/repo', async ({ request }) => {
+        expect(request.headers.get('Authorization')).toBe(
           'Basic ZGVtb3VzZXI6YWNjZXNzdG9rZW4=',
         );
-        expect(req.body).toEqual({
+        expect(await request.json()).toEqual({
           branches: ['staging'],
           create_empty_commit: false,
           owners: ['owner'],
           description: 'Initialize a gerrit repository',
           parent: 'parent',
         });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
+        return HttpResponse.json({}, { status: 201 });
       }),
     );
 

--- a/plugins/scaffolder-backend-module-gerrit/src/actions/gerrit.test.ts
+++ b/plugins/scaffolder-backend-module-gerrit/src/actions/gerrit.test.ts
@@ -28,7 +28,7 @@ jest.mock('@backstage/plugin-scaffolder-node', () => {
 
 import path from 'node:path';
 import { createPublishGerritAction } from './gerrit';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { ScmIntegrations } from '@backstage/integration';
@@ -91,23 +91,22 @@ describe('publish:gerrit', () => {
   it('can correctly create a new project', async () => {
     expect.assertions(5);
     server.use(
-      rest.put('https://gerrithost.org/a/projects/repo', (req, res, ctx) => {
-        expect(req.headers.get('Authorization')).toBe(
-          'Basic Z2Vycml0dXNlcjp1c2VydG9rZW4=',
-        );
-        expect(req.body).toEqual({
-          branches: ['master'],
-          create_empty_commit: false,
-          owners: ['owner'],
-          description,
-          parent: 'workspace',
-        });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
-      }),
+      http.put(
+        'https://gerrithost.org/a/projects/repo',
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
+            'Basic Z2Vycml0dXNlcjp1c2VydG9rZW4=',
+          );
+          expect(await request.json()).toEqual({
+            branches: ['master'],
+            create_empty_commit: false,
+            owners: ['owner'],
+            description,
+            parent: 'workspace',
+          });
+          return HttpResponse.json({}, { status: 201 });
+        },
+      ),
     );
 
     await action.handler({
@@ -141,23 +140,22 @@ describe('publish:gerrit', () => {
   it('can correctly create a new project with a specific sourcePath', async () => {
     expect.assertions(5);
     server.use(
-      rest.put('https://gerrithost.org/a/projects/repo', (req, res, ctx) => {
-        expect(req.headers.get('Authorization')).toBe(
-          'Basic Z2Vycml0dXNlcjp1c2VydG9rZW4=',
-        );
-        expect(req.body).toEqual({
-          branches: ['master'],
-          create_empty_commit: false,
-          owners: ['owner'],
-          description,
-          parent: 'workspace',
-        });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
-      }),
+      http.put(
+        'https://gerrithost.org/a/projects/repo',
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
+            'Basic Z2Vycml0dXNlcjp1c2VydG9rZW4=',
+          );
+          expect(await request.json()).toEqual({
+            branches: ['master'],
+            create_empty_commit: false,
+            owners: ['owner'],
+            description,
+            parent: 'workspace',
+          });
+          return HttpResponse.json({}, { status: 201 });
+        },
+      ),
     );
 
     await action.handler({
@@ -192,23 +190,22 @@ describe('publish:gerrit', () => {
   it('can correctly create a new project without specifying owner', async () => {
     expect.assertions(5);
     server.use(
-      rest.put('https://gerrithost.org/a/projects/repo', (req, res, ctx) => {
-        expect(req.headers.get('Authorization')).toBe(
-          'Basic Z2Vycml0dXNlcjp1c2VydG9rZW4=',
-        );
-        expect(req.body).toEqual({
-          branches: ['master'],
-          create_empty_commit: false,
-          owners: [],
-          description,
-          parent: 'workspace',
-        });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
-      }),
+      http.put(
+        'https://gerrithost.org/a/projects/repo',
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
+            'Basic Z2Vycml0dXNlcjp1c2VydG9rZW4=',
+          );
+          expect(await request.json()).toEqual({
+            branches: ['master'],
+            create_empty_commit: false,
+            owners: [],
+            description,
+            parent: 'workspace',
+          });
+          return HttpResponse.json({}, { status: 201 });
+        },
+      ),
     );
 
     await action.handler({
@@ -243,23 +240,22 @@ describe('publish:gerrit', () => {
   it('can correctly create a new project with main as default branch', async () => {
     expect.assertions(5);
     server.use(
-      rest.put('https://gerrithost.org/a/projects/repo', (req, res, ctx) => {
-        expect(req.headers.get('Authorization')).toBe(
-          'Basic Z2Vycml0dXNlcjp1c2VydG9rZW4=',
-        );
-        expect(req.body).toEqual({
-          branches: ['main'],
-          create_empty_commit: false,
-          owners: [],
-          description,
-          parent: 'workspace',
-        });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
-      }),
+      http.put(
+        'https://gerrithost.org/a/projects/repo',
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
+            'Basic Z2Vycml0dXNlcjp1c2VydG9rZW4=',
+          );
+          expect(await request.json()).toEqual({
+            branches: ['main'],
+            create_empty_commit: false,
+            owners: [],
+            description,
+            parent: 'workspace',
+          });
+          return HttpResponse.json({}, { status: 201 });
+        },
+      ),
     );
 
     await action.handler({
@@ -294,22 +290,21 @@ describe('publish:gerrit', () => {
   it('can correctly create a new project without description', async () => {
     expect.assertions(5);
     server.use(
-      rest.put('https://gerrithost.org/a/projects/repo', (req, res, ctx) => {
-        expect(req.headers.get('Authorization')).toBe(
-          'Basic Z2Vycml0dXNlcjp1c2VydG9rZW4=',
-        );
-        expect(req.body).toEqual({
-          branches: ['master'],
-          create_empty_commit: false,
-          owners: [],
-          parent: 'workspace',
-        });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
-      }),
+      http.put(
+        'https://gerrithost.org/a/projects/repo',
+        async ({ request }) => {
+          expect(request.headers.get('Authorization')).toBe(
+            'Basic Z2Vycml0dXNlcjp1c2VydG9rZW4=',
+          );
+          expect(await request.json()).toEqual({
+            branches: ['master'],
+            create_empty_commit: false,
+            owners: [],
+            parent: 'workspace',
+          });
+          return HttpResponse.json({}, { status: 201 });
+        },
+      ),
     );
 
     await action.handler({

--- a/plugins/scaffolder-backend-module-gitea/package.json
+++ b/plugins/scaffolder-backend-module-gitea/package.json
@@ -53,6 +53,6 @@
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@backstage/plugin-scaffolder-node-test-utils": "workspace:^",
-    "msw": "^1.0.0"
+    "msw": "^2.0.0"
   }
 }

--- a/plugins/scaffolder-backend-module-gitea/src/actions/gitea.examples.test.ts
+++ b/plugins/scaffolder-backend-module-gitea/src/actions/gitea.examples.test.ts
@@ -20,7 +20,7 @@ import {
   getRepoSourceDirectory,
   initRepoAndPush,
 } from '@backstage/plugin-scaffolder-node';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { createMockActionContext } from '@backstage/plugin-scaffolder-node-test-utils';
 import { setupServer } from 'msw/node';
@@ -68,45 +68,33 @@ describe('publish:gitea', () => {
 
   it(`should ${examples[0].description}`, async () => {
     server.use(
-      rest.get('https://gitea.com/api/v1/orgs/org1', (_req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({
-            id: 1,
-            name: 'org1',
-            visibility: 'public',
-            repo_admin_change_team_access: false,
-            username: 'org1',
-          }),
-        );
+      http.get('https://gitea.com/api/v1/orgs/org1', () => {
+        return HttpResponse.json({
+          id: 1,
+          name: 'org1',
+          visibility: 'public',
+          repo_admin_change_team_access: false,
+          username: 'org1',
+        });
       }),
-      rest.get(
-        'https://gitea.com/org1/repo/src/branch/main',
-        (_req, res, ctx) => {
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({}),
+      http.get('https://gitea.com/org1/repo/src/branch/main', () => {
+        return HttpResponse.json({});
+      }),
+      http.post(
+        'https://gitea.com/api/v1/orgs/org1/repos',
+        async ({ request }) => {
+          // Basic auth must match the user and password defined part of the config
+          expect(request.headers.get('Authorization')).toBe(
+            'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
           );
+          expect(await request.json()).toEqual({
+            name: 'repo',
+            private: false,
+            description,
+          });
+          return HttpResponse.json({}, { status: 201 });
         },
       ),
-      rest.post('https://gitea.com/api/v1/orgs/org1/repos', (req, res, ctx) => {
-        // Basic auth must match the user and password defined part of the config
-        expect(req.headers.get('Authorization')).toBe(
-          'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
-        );
-        expect(req.body).toEqual({
-          name: 'repo',
-          private: false,
-          description,
-        });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
-      }),
     );
 
     let input;
@@ -141,45 +129,33 @@ describe('publish:gitea', () => {
 
   it(`should ${examples[1].description}`, async () => {
     server.use(
-      rest.get('https://gitea.com/api/v1/orgs/org1', (_req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({
-            id: 1,
-            name: 'org1',
-            visibility: 'public',
-            repo_admin_change_team_access: false,
-            username: 'org1',
-          }),
-        );
+      http.get('https://gitea.com/api/v1/orgs/org1', () => {
+        return HttpResponse.json({
+          id: 1,
+          name: 'org1',
+          visibility: 'public',
+          repo_admin_change_team_access: false,
+          username: 'org1',
+        });
       }),
-      rest.get(
-        'https://gitea.com/org1/repo/src/branch/main',
-        (_req, res, ctx) => {
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({}),
+      http.get('https://gitea.com/org1/repo/src/branch/main', () => {
+        return HttpResponse.json({});
+      }),
+      http.post(
+        'https://gitea.com/api/v1/orgs/org1/repos',
+        async ({ request }) => {
+          // Basic auth must match the user and password defined part of the config
+          expect(request.headers.get('Authorization')).toBe(
+            'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
           );
+          expect(await request.json()).toEqual({
+            name: 'repo',
+            private: false,
+            description: 'Initialize a gitea repository',
+          });
+          return HttpResponse.json({}, { status: 201 });
         },
       ),
-      rest.post('https://gitea.com/api/v1/orgs/org1/repos', (req, res, ctx) => {
-        // Basic auth must match the user and password defined part of the config
-        expect(req.headers.get('Authorization')).toBe(
-          'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
-        );
-        expect(req.body).toEqual({
-          name: 'repo',
-          private: false,
-          description: 'Initialize a gitea repository',
-        });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
-      }),
     );
 
     let input;
@@ -214,45 +190,33 @@ describe('publish:gitea', () => {
 
   it(`should ${examples[2].description}`, async () => {
     server.use(
-      rest.get('https://gitea.com/api/v1/orgs/org1', (_req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({
-            id: 1,
-            name: 'org1',
-            visibility: 'public',
-            repo_admin_change_team_access: false,
-            username: 'org1',
-          }),
-        );
+      http.get('https://gitea.com/api/v1/orgs/org1', ({}) => {
+        return HttpResponse.json({
+          id: 1,
+          name: 'org1',
+          visibility: 'public',
+          repo_admin_change_team_access: false,
+          username: 'org1',
+        });
       }),
-      rest.get(
-        'https://gitea.com/org1/repo/src/branch/main',
-        (_req, res, ctx) => {
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({}),
+      http.get('https://gitea.com/org1/repo/src/branch/main', () => {
+        return HttpResponse.json({});
+      }),
+      http.post(
+        'https://gitea.com/api/v1/orgs/org1/repos',
+        async ({ request }) => {
+          // Basic auth must match the user and password defined part of the config
+          expect(request.headers.get('Authorization')).toBe(
+            'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
           );
+          expect(await request.json()).toEqual({
+            name: 'repo',
+            private: true,
+            description,
+          });
+          return HttpResponse.json({}, { status: 201 });
         },
       ),
-      rest.post('https://gitea.com/api/v1/orgs/org1/repos', (req, res, ctx) => {
-        // Basic auth must match the user and password defined part of the config
-        expect(req.headers.get('Authorization')).toBe(
-          'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
-        );
-        expect(req.body).toEqual({
-          name: 'repo',
-          private: true,
-          description,
-        });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
-      }),
     );
 
     let input;
@@ -287,45 +251,33 @@ describe('publish:gitea', () => {
 
   it(`should ${examples[3].description}`, async () => {
     server.use(
-      rest.get('https://gitea.com/api/v1/orgs/org1', (_req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({
-            id: 1,
-            name: 'org1',
-            visibility: 'public',
-            repo_admin_change_team_access: false,
-            username: 'org1',
-          }),
-        );
+      http.get('https://gitea.com/api/v1/orgs/org1', () => {
+        return HttpResponse.json({
+          id: 1,
+          name: 'org1',
+          visibility: 'public',
+          repo_admin_change_team_access: false,
+          username: 'org1',
+        });
       }),
-      rest.get(
-        'https://gitea.com/org1/repo/src/branch/staging',
-        (_req, res, ctx) => {
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({}),
+      http.get('https://gitea.com/org1/repo/src/branch/staging', () => {
+        return HttpResponse.json({});
+      }),
+      http.post(
+        'https://gitea.com/api/v1/orgs/org1/repos',
+        async ({ request }) => {
+          // Basic auth must match the user and password defined part of the config
+          expect(request.headers.get('Authorization')).toBe(
+            'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
           );
+          expect(await request.json()).toEqual({
+            name: 'repo',
+            private: false,
+            description,
+          });
+          return HttpResponse.json({}, { status: 201 });
         },
       ),
-      rest.post('https://gitea.com/api/v1/orgs/org1/repos', (req, res, ctx) => {
-        // Basic auth must match the user and password defined part of the config
-        expect(req.headers.get('Authorization')).toBe(
-          'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
-        );
-        expect(req.body).toEqual({
-          name: 'repo',
-          private: false,
-          description,
-        });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
-      }),
     );
 
     let input;
@@ -360,45 +312,33 @@ describe('publish:gitea', () => {
 
   it(`should ${examples[4].description}`, async () => {
     server.use(
-      rest.get('https://gitea.com/api/v1/orgs/org1', (_req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({
-            id: 1,
-            name: 'org1',
-            visibility: 'public',
-            repo_admin_change_team_access: false,
-            username: 'org1',
-          }),
-        );
+      http.get('https://gitea.com/api/v1/orgs/org1', () => {
+        return HttpResponse.json({
+          id: 1,
+          name: 'org1',
+          visibility: 'public',
+          repo_admin_change_team_access: false,
+          username: 'org1',
+        });
       }),
-      rest.get(
-        'https://gitea.com/org1/repo/src/branch/main',
-        (_req, res, ctx) => {
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({}),
+      http.get('https://gitea.com/org1/repo/src/branch/main', () => {
+        return HttpResponse.json({});
+      }),
+      http.post(
+        'https://gitea.com/api/v1/orgs/org1/repos',
+        async ({ request }) => {
+          // Basic auth must match the user and password defined part of the config
+          expect(request.headers.get('Authorization')).toBe(
+            'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
           );
+          expect(await request.json()).toEqual({
+            name: 'repo',
+            private: false,
+            description,
+          });
+          return HttpResponse.json({}, { status: 201 });
         },
       ),
-      rest.post('https://gitea.com/api/v1/orgs/org1/repos', (req, res, ctx) => {
-        // Basic auth must match the user and password defined part of the config
-        expect(req.headers.get('Authorization')).toBe(
-          'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
-        );
-        expect(req.body).toEqual({
-          name: 'repo',
-          private: false,
-          description,
-        });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
-      }),
     );
 
     let input;
@@ -435,45 +375,33 @@ describe('publish:gitea', () => {
 
   it(`should ${examples[5].description}`, async () => {
     server.use(
-      rest.get('https://gitea.com/api/v1/orgs/org1', (_req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({
-            id: 1,
-            name: 'org1',
-            visibility: 'public',
-            repo_admin_change_team_access: false,
-            username: 'org1',
-          }),
-        );
+      http.get('https://gitea.com/api/v1/orgs/org1', () => {
+        return HttpResponse.json({
+          id: 1,
+          name: 'org1',
+          visibility: 'public',
+          repo_admin_change_team_access: false,
+          username: 'org1',
+        });
       }),
-      rest.get(
-        'https://gitea.com/org1/repo/src/branch/main',
-        (_req, res, ctx) => {
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({}),
+      http.get('https://gitea.com/org1/repo/src/branch/main', () => {
+        return HttpResponse.json({});
+      }),
+      http.post(
+        'https://gitea.com/api/v1/orgs/org1/repos',
+        async ({ request }) => {
+          // Basic auth must match the user and password defined part of the config
+          expect(request.headers.get('Authorization')).toBe(
+            'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
           );
+          expect(await request.json()).toEqual({
+            name: 'repo',
+            private: false,
+            description,
+          });
+          return HttpResponse.json({}, { status: 201 });
         },
       ),
-      rest.post('https://gitea.com/api/v1/orgs/org1/repos', (req, res, ctx) => {
-        // Basic auth must match the user and password defined part of the config
-        expect(req.headers.get('Authorization')).toBe(
-          'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
-        );
-        expect(req.body).toEqual({
-          name: 'repo',
-          private: false,
-          description,
-        });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
-      }),
     );
 
     let input;
@@ -508,45 +436,33 @@ describe('publish:gitea', () => {
 
   it(`should ${examples[6].description}`, async () => {
     server.use(
-      rest.get('https://gitea.com/api/v1/orgs/org1', (_req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({
-            id: 1,
-            name: 'org1',
-            visibility: 'public',
-            repo_admin_change_team_access: false,
-            username: 'org1',
-          }),
-        );
+      http.get('https://gitea.com/api/v1/orgs/org1', () => {
+        return HttpResponse.json({
+          id: 1,
+          name: 'org1',
+          visibility: 'public',
+          repo_admin_change_team_access: false,
+          username: 'org1',
+        });
       }),
-      rest.get(
-        'https://gitea.com/org1/repo/src/branch/main',
-        (_req, res, ctx) => {
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({}),
+      http.get('https://gitea.com/org1/repo/src/branch/main', () => {
+        return HttpResponse.json({});
+      }),
+      http.post(
+        'https://gitea.com/api/v1/orgs/org1/repos',
+        async ({ request }) => {
+          // Basic auth must match the user and password defined part of the config
+          expect(request.headers.get('Authorization')).toBe(
+            'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
           );
+          expect(await request.json()).toEqual({
+            name: 'repo',
+            private: false,
+            description,
+          });
+          return HttpResponse.json({}, { status: 201 });
         },
       ),
-      rest.post('https://gitea.com/api/v1/orgs/org1/repos', (req, res, ctx) => {
-        // Basic auth must match the user and password defined part of the config
-        expect(req.headers.get('Authorization')).toBe(
-          'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
-        );
-        expect(req.body).toEqual({
-          name: 'repo',
-          private: false,
-          description,
-        });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
-      }),
     );
 
     let input;
@@ -581,45 +497,33 @@ describe('publish:gitea', () => {
 
   it(`should ${examples[7].description}`, async () => {
     server.use(
-      rest.get('https://gitea.com/api/v1/orgs/org1', (_req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({
-            id: 1,
-            name: 'org1',
-            visibility: 'public',
-            repo_admin_change_team_access: false,
-            username: 'org1',
-          }),
-        );
+      http.get('https://gitea.com/api/v1/orgs/org1', () => {
+        return HttpResponse.json({
+          id: 1,
+          name: 'org1',
+          visibility: 'public',
+          repo_admin_change_team_access: false,
+          username: 'org1',
+        });
       }),
-      rest.get(
-        'https://gitea.com/org1/repo/src/branch/main',
-        (_req, res, ctx) => {
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({}),
+      http.get('https://gitea.com/org1/repo/src/branch/main', () => {
+        return HttpResponse.json({});
+      }),
+      http.post(
+        'https://gitea.com/api/v1/orgs/org1/repos',
+        async ({ request }) => {
+          // Basic auth must match the user and password defined part of the config
+          expect(request.headers.get('Authorization')).toBe(
+            'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
           );
+          expect(await request.json()).toEqual({
+            name: 'repo',
+            private: false,
+            description,
+          });
+          return HttpResponse.json({}, { status: 201 });
         },
       ),
-      rest.post('https://gitea.com/api/v1/orgs/org1/repos', (req, res, ctx) => {
-        // Basic auth must match the user and password defined part of the config
-        expect(req.headers.get('Authorization')).toBe(
-          'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
-        );
-        expect(req.body).toEqual({
-          name: 'repo',
-          private: false,
-          description,
-        });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
-      }),
     );
 
     let input;
@@ -654,45 +558,33 @@ describe('publish:gitea', () => {
 
   it(`should ${examples[8].description}`, async () => {
     server.use(
-      rest.get('https://gitea.com/api/v1/orgs/org1', (_req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({
-            id: 1,
-            name: 'org1',
-            visibility: 'public',
-            repo_admin_change_team_access: false,
-            username: 'org1',
-          }),
-        );
+      http.get('https://gitea.com/api/v1/orgs/org1', () => {
+        return HttpResponse.json({
+          id: 1,
+          name: 'org1',
+          visibility: 'public',
+          repo_admin_change_team_access: false,
+          username: 'org1',
+        });
       }),
-      rest.get(
-        'https://gitea.com/org1/repo/src/branch/staging',
-        (_req, res, ctx) => {
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({}),
+      http.get('https://gitea.com/org1/repo/src/branch/staging', () => {
+        return HttpResponse.json({});
+      }),
+      http.post(
+        'https://gitea.com/api/v1/orgs/org1/repos',
+        async ({ request }) => {
+          // Basic auth must match the user and password defined part of the config
+          expect(request.headers.get('Authorization')).toBe(
+            'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
           );
+          expect(await request.json()).toEqual({
+            name: 'repo',
+            private: false,
+            description: 'Initialize a gitea repository',
+          });
+          return HttpResponse.json({}, { status: 201 });
         },
       ),
-      rest.post('https://gitea.com/api/v1/orgs/org1/repos', (req, res, ctx) => {
-        // Basic auth must match the user and password defined part of the config
-        expect(req.headers.get('Authorization')).toBe(
-          'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
-        );
-        expect(req.body).toEqual({
-          name: 'repo',
-          private: false,
-          description: 'Initialize a gitea repository',
-        });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
-      }),
     );
 
     let input;
@@ -729,45 +621,33 @@ describe('publish:gitea', () => {
 
   it(`should ${examples[0].description}`, async () => {
     server.use(
-      rest.get('https://gitea.com/api/v1/orgs/org1', (_req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({
-            id: 1,
-            name: 'org1',
-            visibility: 'public',
-            repo_admin_change_team_access: false,
-            username: 'org1',
-          }),
-        );
+      http.get('https://gitea.com/api/v1/orgs/org1', () => {
+        return HttpResponse.json({
+          id: 1,
+          name: 'org1',
+          visibility: 'public',
+          repo_admin_change_team_access: false,
+          username: 'org1',
+        });
       }),
-      rest.get(
-        'https://gitea.com/org1/repo/src/branch/main',
-        (_req, res, ctx) => {
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({}),
+      http.get('https://gitea.com/org1/repo/src/branch/main', () => {
+        return HttpResponse.json({});
+      }),
+      http.post(
+        'https://gitea.com/api/v1/orgs/org1/repos',
+        async ({ request }) => {
+          // Basic auth must match the user and password defined part of the config
+          expect(request.headers.get('Authorization')).toBe(
+            'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
           );
+          expect(await request.json()).toEqual({
+            name: 'repo',
+            private: false,
+            description,
+          });
+          return HttpResponse.json({}, { status: 201 });
         },
       ),
-      rest.post('https://gitea.com/api/v1/orgs/org1/repos', (req, res, ctx) => {
-        // Basic auth must match the user and password defined part of the config
-        expect(req.headers.get('Authorization')).toBe(
-          'basic c2FtcGxlX3VzZXI6cGFzc3dvcmRfdG9rZW4=',
-        );
-        expect(req.body).toEqual({
-          name: 'repo',
-          private: false,
-          description,
-        });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
-      }),
     );
 
     let input;

--- a/plugins/scaffolder-backend-module-gitea/src/actions/gitea.test.ts
+++ b/plugins/scaffolder-backend-module-gitea/src/actions/gitea.test.ts
@@ -17,7 +17,7 @@ import { ScmIntegrations } from '@backstage/integration';
 import { ConfigReader } from '@backstage/config';
 import { createPublishGiteaAction } from './gitea';
 import { initRepoAndPush } from '@backstage/plugin-scaffolder-node';
-import { rest } from 'msw';
+import { HttpResponse, http } from 'msw';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { createMockActionContext } from '@backstage/plugin-scaffolder-node-test-utils';
 import { setupServer } from 'msw/node';
@@ -88,45 +88,33 @@ describe('publish:gitea', () => {
 
   it('should throw if there is no repositoryId returned', async () => {
     server.use(
-      rest.get('https://gitea.com/api/v1/orgs/org1', (_req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({
-            id: 1,
-            name: 'org1',
-            visibility: 'public',
-            repo_admin_change_team_access: false,
-            username: 'org1',
-          }),
-        );
+      http.get('https://gitea.com/api/v1/orgs/org1', () => {
+        return HttpResponse.json({
+          id: 1,
+          name: 'org1',
+          visibility: 'public',
+          repo_admin_change_team_access: false,
+          username: 'org1',
+        });
       }),
-      rest.get(
-        'https://gitea.com/org1/repo/src/branch/main',
-        (_req, res, ctx) => {
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({}),
+      http.get('https://gitea.com/org1/repo/src/branch/main', () => {
+        return HttpResponse.json({});
+      }),
+      http.post(
+        'https://gitea.com/api/v1/orgs/org1/repos',
+        async ({ request }) => {
+          // Basic auth must match the user and password defined part of the config
+          expect(request.headers.get('Authorization')).toBe(
+            'basic Z2l0ZWFfdXNlcjpnaXRlYV9wYXNzd29yZA==',
           );
+          expect(await request.json()).toEqual({
+            name: 'repo',
+            private: false,
+            description,
+          });
+          return HttpResponse.json({}, { status: 201 });
         },
       ),
-      rest.post('https://gitea.com/api/v1/orgs/org1/repos', (req, res, ctx) => {
-        // Basic auth must match the user and password defined part of the config
-        expect(req.headers.get('Authorization')).toBe(
-          'basic Z2l0ZWFfdXNlcjpnaXRlYV9wYXNzd29yZA==',
-        );
-        expect(req.body).toEqual({
-          name: 'repo',
-          private: false,
-          description,
-        });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
-      }),
     );
 
     await action.handler({
@@ -158,45 +146,33 @@ describe('publish:gitea', () => {
 
   it('should create a Gitea repository where visibility is public', async () => {
     server.use(
-      rest.get('https://gitea.com/api/v1/orgs/org1', (_req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({
-            id: 1,
-            name: 'org1',
-            visibility: 'public',
-            repo_admin_change_team_access: false,
-            username: 'org1',
-          }),
-        );
+      http.get('https://gitea.com/api/v1/orgs/org1', () => {
+        return HttpResponse.json({
+          id: 1,
+          name: 'org1',
+          visibility: 'public',
+          repo_admin_change_team_access: false,
+          username: 'org1',
+        });
       }),
-      rest.get(
-        'https://gitea.com/org1/repo/src/branch/main',
-        (_req, res, ctx) => {
-          return res(
-            ctx.status(200),
-            ctx.set('Content-Type', 'application/json'),
-            ctx.json({}),
+      http.get('https://gitea.com/org1/repo/src/branch/main', () => {
+        return HttpResponse.json({});
+      }),
+      http.post(
+        'https://gitea.com/api/v1/orgs/org1/repos',
+        async ({ request }) => {
+          // Basic auth must match the user and password defined part of the config
+          expect(request.headers.get('Authorization')).toBe(
+            'basic Z2l0ZWFfdXNlcjpnaXRlYV9wYXNzd29yZA==',
           );
+          expect(await request.json()).toEqual({
+            name: 'repo',
+            private: false,
+            description,
+          });
+          return HttpResponse.json({}, { status: 201 });
         },
       ),
-      rest.post('https://gitea.com/api/v1/orgs/org1/repos', (req, res, ctx) => {
-        // Basic auth must match the user and password defined part of the config
-        expect(req.headers.get('Authorization')).toBe(
-          'basic Z2l0ZWFfdXNlcjpnaXRlYV9wYXNzd29yZA==',
-        );
-        expect(req.body).toEqual({
-          name: 'repo',
-          private: false,
-          description,
-        });
-        return res(
-          ctx.status(201),
-          ctx.set('Content-Type', 'application/json'),
-          ctx.json({}),
-        );
-      }),
     );
 
     await action.handler({

--- a/plugins/scaffolder-common/package.json
+++ b/plugins/scaffolder-common/package.json
@@ -74,6 +74,6 @@
   "devDependencies": {
     "@backstage/cli": "workspace:^",
     "@backstage/test-utils": "workspace:^",
-    "msw": "^1.0.0"
+    "msw": "^2.0.0"
   }
 }

--- a/plugins/scaffolder-common/src/ScaffolderClient.test.ts
+++ b/plugins/scaffolder-common/src/ScaffolderClient.test.ts
@@ -20,7 +20,7 @@ import {
   mockApis,
   registerMswTestHooks,
 } from '@backstage/test-utils';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { ScaffolderClient } from './ScaffolderClient';
 import { fetchEventSource } from '@microsoft/fetch-event-source';
@@ -159,41 +159,37 @@ describe('api', () => {
 
       it('should work', async () => {
         server.use(
-          rest.get(
+          http.get(
             `${mockBaseUrl}/v2/tasks/:taskId/events`,
-            (req, res, ctx) => {
-              const { taskId } = req.params;
-              const after = req.url.searchParams.get('after');
+            ({ request, params }) => {
+              const { taskId } = params;
+              const after = new URL(request.url).searchParams.get('after');
 
               if (taskId === 'a-random-task-id') {
                 if (!after) {
-                  return res(
-                    ctx.json([
-                      {
-                        id: 1,
-                        taskId: 'a-random-id',
-                        type: 'log',
-                        createdAt: '',
-                        body: { message: 'My log message' },
-                      },
-                    ]),
-                  );
+                  return HttpResponse.json([
+                    {
+                      id: 1,
+                      taskId: 'a-random-id',
+                      type: 'log',
+                      createdAt: '',
+                      body: { message: 'My log message' },
+                    },
+                  ]);
                 } else if (after === '1') {
-                  return res(
-                    ctx.json([
-                      {
-                        id: 2,
-                        taskId: 'a-random-id',
-                        type: 'completion',
-                        createdAt: '',
-                        body: { message: 'Finished!' },
-                      },
-                    ]),
-                  );
+                  return HttpResponse.json([
+                    {
+                      id: 2,
+                      taskId: 'a-random-id',
+                      type: 'completion',
+                      createdAt: '',
+                      body: { message: 'Finished!' },
+                    },
+                  ]);
                 }
               }
 
-              return res(ctx.status(500));
+              return new HttpResponse(null, { status: 500 });
             },
           ),
         );
@@ -227,31 +223,29 @@ describe('api', () => {
         expect.assertions(3);
 
         server.use(
-          rest.get(
+          http.get(
             `${mockBaseUrl}/v2/tasks/:taskId/events`,
-            (req, res, ctx) => {
-              const { taskId } = req.params;
+            ({ request, params }) => {
+              const { taskId } = params;
 
-              const after = req.url.searchParams.get('after');
+              const after = new URL(request.url).searchParams.get('after');
 
               // use assertion to make sure it is not called after unsubscribing
               expect(after).toBe(null);
 
               if (taskId === 'a-random-task-id') {
-                return res(
-                  ctx.json([
-                    {
-                      id: 1,
-                      taskId: 'a-random-id',
-                      type: 'log',
-                      createdAt: '',
-                      body: { message: 'My log message' },
-                    },
-                  ]),
-                );
+                return HttpResponse.json([
+                  {
+                    id: 1,
+                    taskId: 'a-random-id',
+                    type: 'log',
+                    createdAt: '',
+                    body: { message: 'My log message' },
+                  },
+                ]);
               }
 
-              return res(ctx.status(500));
+              return new HttpResponse(null, { status: 500 });
             },
           ),
         );
@@ -284,28 +278,23 @@ describe('api', () => {
         const called = jest.fn();
 
         server.use(
-          rest.get(
-            `${mockBaseUrl}/v2/tasks/:taskId/events`,
-            (_req, res, ctx) => {
-              called();
+          http.get(`${mockBaseUrl}/v2/tasks/:taskId/events`, () => {
+            called();
 
-              if (called.mock.calls.length > 1) {
-                return res(
-                  ctx.json([
-                    {
-                      id: 2,
-                      taskId: 'a-random-id',
-                      type: 'completion',
-                      createdAt: '',
-                      body: { message: 'Finished!' },
-                    },
-                  ]),
-                );
-              }
+            if (called.mock.calls.length > 1) {
+              return HttpResponse.json([
+                {
+                  id: 2,
+                  taskId: 'a-random-id',
+                  type: 'completion',
+                  createdAt: '',
+                  body: { message: 'Finished!' },
+                },
+              ]);
+            }
 
-              return res(ctx.status(500));
-            },
-          ),
+            return new HttpResponse(null, { status: 500 });
+          }),
         );
 
         const next = jest.fn();
@@ -333,29 +322,21 @@ describe('api', () => {
   describe('listTasks', () => {
     it('should list all tasks', async () => {
       server.use(
-        rest.get(`${mockBaseUrl}/v2/tasks`, (req, res, ctx) => {
-          const createdBy = req.url.searchParams.get('createdBy');
+        http.get(`${mockBaseUrl}/v2/tasks`, ({ request }) => {
+          const createdBy = new URL(request.url).searchParams.get('createdBy');
 
           if (createdBy) {
-            return res(
-              ctx.json([
-                {
-                  createdBy,
-                },
-              ]),
-            );
+            return HttpResponse.json([{ createdBy }]);
           }
 
-          return res(
-            ctx.json([
-              {
-                createdBy: null,
-              },
-              {
-                createdBy: null,
-              },
-            ]),
-          );
+          return HttpResponse.json([
+            {
+              createdBy: null,
+            },
+            {
+              createdBy: null,
+            },
+          ]);
         }),
       );
 
@@ -365,21 +346,19 @@ describe('api', () => {
 
     it('should list tasks with limit and offset', async () => {
       server.use(
-        rest.get(
-          `${mockBaseUrl}/v2/tasks?limit=5&offset=0`,
-          (_req, res, ctx) => {
-            return res(
-              ctx.json([
-                {
-                  createdBy: null,
-                },
-                {
-                  createdBy: null,
-                },
-              ]),
-            );
-          },
-        ),
+        http.get(`${mockBaseUrl}/v2/tasks`, ({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.get('limit')).toBe('5');
+          expect(url.searchParams.get('offset')).toBe('0');
+          return HttpResponse.json([
+            {
+              createdBy: null,
+            },
+            {
+              createdBy: null,
+            },
+          ]);
+        }),
       );
 
       const result = await apiClient.listTasks({
@@ -392,33 +371,23 @@ describe('api', () => {
 
     it('should list task using the current user as owner', async () => {
       server.use(
-        rest.get(`${mockBaseUrl}/v2/tasks`, (req, res, ctx) => {
-          const createdBy = req.url.searchParams.get('createdBy');
+        http.get(`${mockBaseUrl}/v2/tasks`, ({ request }) => {
+          const createdBy = new URL(request.url).searchParams.get('createdBy');
 
           if (createdBy) {
-            return res(
-              ctx.json({
-                tasks: [
-                  {
-                    createdBy,
-                  },
-                ],
-              }),
-            );
+            return HttpResponse.json({ tasks: [{ createdBy }] });
           }
 
-          return res(
-            ctx.json({
-              tasks: [
-                {
-                  createdBy: null,
-                },
-                {
-                  createdBy: null,
-                },
-              ],
-            }),
-          );
+          return HttpResponse.json({
+            tasks: [
+              {
+                createdBy: null,
+              },
+              {
+                createdBy: null,
+              },
+            ],
+          });
         }),
       );
 

--- a/plugins/scaffolder-node/package.json
+++ b/plugins/scaffolder-node/package.json
@@ -85,7 +85,7 @@
     "@backstage/cli": "workspace:^",
     "@backstage/config": "workspace:^",
     "@types/lodash": "^4.14.151",
-    "msw": "^1.0.0"
+    "msw": "^2.0.0"
   },
   "peerDependencies": {
     "@backstage/backend-test-utils": "workspace:^"

--- a/plugins/scaffolder-node/src/scaffolderService.test.ts
+++ b/plugins/scaffolder-node/src/scaffolderService.test.ts
@@ -26,7 +26,7 @@ import {
   registerMswTestHooks,
   startTestBackend,
 } from '@backstage/backend-test-utils';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { scaffolderServiceRef } from './scaffolderService';
 
@@ -60,21 +60,19 @@ describe('scaffolderServiceRef', () => {
     expect.assertions(1);
 
     server.use(
-      rest.get('*/api/scaffolder/v2/tasks/:taskId', (req, res, ctx) => {
-        expect(req.headers.get('authorization')).toBe(
+      http.get('*/api/scaffolder/v2/tasks/:taskId', ({ request }) => {
+        expect(request.headers.get('authorization')).toBe(
           mockCredentials.service.header({
             onBehalfOf: mockCredentials.user(),
             targetPluginId: 'scaffolder',
           }),
         );
-        return res(
-          ctx.json({
-            id: 'task-1',
-            spec: {},
-            status: 'completed',
-            createdAt: '2025-01-01T00:00:00Z',
-          }),
-        );
+        return HttpResponse.json({
+          id: 'task-1',
+          spec: {},
+          status: 'completed',
+          createdAt: '2025-01-01T00:00:00Z',
+        });
       }),
     );
 
@@ -101,21 +99,19 @@ describe('scaffolderServiceRef', () => {
     expect.assertions(1);
 
     server.use(
-      rest.get('*/api/scaffolder/v2/tasks/:taskId', (req, res, ctx) => {
-        expect(req.headers.get('authorization')).toBe(
+      http.get('*/api/scaffolder/v2/tasks/:taskId', ({ request }) => {
+        expect(request.headers.get('authorization')).toBe(
           mockCredentials.service.header({
             onBehalfOf: mockCredentials.service(),
             targetPluginId: 'scaffolder',
           }),
         );
-        return res(
-          ctx.json({
-            id: 'task-1',
-            spec: {},
-            status: 'completed',
-            createdAt: '2025-01-01T00:00:00Z',
-          }),
-        );
+        return HttpResponse.json({
+          id: 'task-1',
+          spec: {},
+          status: 'completed',
+          createdAt: '2025-01-01T00:00:00Z',
+        });
       }),
     );
 
@@ -142,14 +138,14 @@ describe('scaffolderServiceRef', () => {
     expect.assertions(1);
 
     server.use(
-      rest.get('*/api/scaffolder/v2/tasks/:taskId/events', (req, res, ctx) => {
-        expect(req.headers.get('authorization')).toBe(
+      http.get('*/api/scaffolder/v2/tasks/:taskId/events', ({ request }) => {
+        expect(request.headers.get('authorization')).toBe(
           mockCredentials.service.header({
             onBehalfOf: mockCredentials.user(),
             targetPluginId: 'scaffolder',
           }),
         );
-        return res(ctx.json([]));
+        return HttpResponse.json([]);
       }),
     );
 
@@ -174,13 +170,12 @@ describe('scaffolderServiceRef', () => {
     expect.assertions(4);
 
     server.use(
-      rest.get('*/api/scaffolder/v2/tasks', (req, res, ctx) => {
-        expect(req.url.searchParams.get('createdBy')).toBe(
-          'user:default/guest',
-        );
-        expect(req.url.searchParams.get('limit')).toBe('10');
-        expect(req.url.searchParams.get('offset')).toBe('5');
-        return res(ctx.json({ tasks: [], totalTasks: 0 }));
+      http.get('*/api/scaffolder/v2/tasks', ({ request }) => {
+        const req = new URL(request.url);
+        expect(req.searchParams.get('createdBy')).toBe('user:default/guest');
+        expect(req.searchParams.get('limit')).toBe('10');
+        expect(req.searchParams.get('offset')).toBe('5');
+        return HttpResponse.json({ tasks: [], totalTasks: 0 });
       }),
     );
 
@@ -207,9 +202,11 @@ describe('scaffolderServiceRef', () => {
     expect.assertions(1);
 
     server.use(
-      rest.get('*/api/scaffolder/v2/tasks', (req, res, ctx) => {
-        expect(req.url.searchParams.getAll('status')).toEqual(['completed']);
-        return res(ctx.json({ tasks: [], totalTasks: 0 }));
+      http.get('*/api/scaffolder/v2/tasks', ({ request }) => {
+        expect(new URL(request.url).searchParams.getAll('status')).toEqual([
+          'completed',
+        ]);
+        return HttpResponse.json({ tasks: [], totalTasks: 0 });
       }),
     );
 
@@ -234,12 +231,12 @@ describe('scaffolderServiceRef', () => {
     expect.assertions(1);
 
     server.use(
-      rest.get('*/api/scaffolder/v2/tasks', (req, res, ctx) => {
-        expect(req.url.searchParams.getAll('status')).toEqual([
+      http.get('*/api/scaffolder/v2/tasks', ({ request }) => {
+        expect(new URL(request.url).searchParams.getAll('status')).toEqual([
           'completed',
           'failed',
         ]);
-        return res(ctx.json({ tasks: [], totalTasks: 0 }));
+        return HttpResponse.json({ tasks: [], totalTasks: 0 });
       }),
     );
 

--- a/plugins/user-settings/package.json
+++ b/plugins/user-settings/package.json
@@ -84,7 +84,7 @@
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.0.0",
     "@types/react": "^18.0.0",
-    "msw": "^1.0.0",
+    "msw": "^2.0.0",
     "react": "^18.0.2",
     "react-dom": "^18.0.2",
     "react-router-dom": "^6.30.2"

--- a/plugins/user-settings/src/apis/StorageApi/UserSettingsStorage.test.ts
+++ b/plugins/user-settings/src/apis/StorageApi/UserSettingsStorage.test.ts
@@ -26,7 +26,7 @@ import {
   registerMswTestHooks,
 } from '@backstage/test-utils';
 import { createDeferred } from '@backstage/types';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { UserSettingsStorage } from './UserSettingsStorage';
 
@@ -97,15 +97,15 @@ describe('Persistent Storage API', () => {
     const dummyValue = 'a';
 
     server.use(
-      rest.put(
+      http.put(
         `${mockBaseUrl}/buckets/:bucket/keys/:key`,
-        async (req, res, ctx) => {
-          const body = await req.json();
+        async ({ request }) => {
+          const body = await request.json();
           const data = { value: dummyValue };
 
           expect(body).toEqual(data);
 
-          return res(ctx.json(data));
+          return HttpResponse.json(data);
         },
       ),
     );
@@ -121,14 +121,14 @@ describe('Persistent Storage API', () => {
     };
 
     server.use(
-      rest.put(
+      http.put(
         `${mockBaseUrl}/buckets/:bucket/keys/:key`,
-        async (req, res, ctx) => {
-          const body = await req.json();
+        async ({ request }) => {
+          const body = await request.json();
           const data = { value: dummyValue };
           expect(body).toEqual(data);
 
-          return res(ctx.json(data));
+          return HttpResponse.json(data);
         },
       ),
     );
@@ -175,19 +175,19 @@ describe('Persistent Storage API', () => {
     const serverCall = createDeferred();
 
     server.use(
-      rest.put(
+      http.put(
         `${mockBaseUrl}/buckets/:bucket/keys/:key`,
-        async (req, res, ctx) => {
-          const body = await req.json();
+        async ({ request }) => {
+          const body = await request.json();
           const data = { value: mockData };
           expect(body).toEqual(data);
 
-          return res(ctx.json(data));
+          return HttpResponse.json(data);
         },
       ),
-      rest.post(`${mockBaseUrl}/multiget`, async (_req, res, ctx) => {
+      http.post(`${mockBaseUrl}/multiget`, async () => {
         serverCall.resolve();
-        return res(ctx.json([]));
+        return HttpResponse.json([]);
       }),
     );
 
@@ -226,15 +226,12 @@ describe('Persistent Storage API', () => {
     const serverCall = createDeferred();
 
     server.use(
-      rest.delete(
-        `${mockBaseUrl}/buckets/:bucket/keys/:key`,
-        async (_req, res, ctx) => {
-          return res(ctx.status(204));
-        },
-      ),
-      rest.post(`${mockBaseUrl}/multiget`, async (_req, res, ctx) => {
+      http.delete(`${mockBaseUrl}/buckets/:bucket/keys/:key`, async () => {
+        return new HttpResponse(null, { status: 204 });
+      }),
+      http.post(`${mockBaseUrl}/multiget`, async () => {
         serverCall.resolve();
-        return res(ctx.json([]));
+        return HttpResponse.json([]);
       }),
     );
 
@@ -269,26 +266,28 @@ describe('Persistent Storage API', () => {
     const selectedKeyNextHandler = jest.fn();
 
     server.use(
-      rest.put(
+      http.put(
         `${mockBaseUrl}/buckets/:bucket/keys/:key`,
-        async (req, res, ctx) => {
-          const { bucket, key } = req.params;
-          const { value } = await req.json();
+        async ({ request, params }) => {
+          const { bucket, key } = params;
+          const value = await request.json();
 
           expect(bucket).toEqual('clash.profile.something.deep');
           expect(key).toEqual('test2');
 
-          return res(ctx.json({ value }));
+          return HttpResponse.json(value);
         },
       ),
-      rest.post(`${mockBaseUrl}/multiget`, async (req, res, ctx) => {
-        const payload = await req.json();
+      http.post(`${mockBaseUrl}/multiget`, async ({ request }) => {
+        const payload = (await request.json()) as {
+          items: { bucket: string; key: string }[];
+        };
         const { bucket, key } = payload.items[0];
 
         expect(bucket).toEqual('clash.profile/something');
         expect(key).toEqual('deep/test2');
 
-        return res(ctx.status(404));
+        return new HttpResponse(null, { status: 404 });
       }),
     );
 
@@ -330,12 +329,12 @@ describe('Persistent Storage API', () => {
     });
 
     server.use(
-      rest.post(`${mockBaseUrl}/multiget`, async (req, res, ctx) => {
-        const payload = await req.json();
+      http.post(`${mockBaseUrl}/multiget`, async ({ request }) => {
+        const payload = await request.json();
         expect(payload).toEqual({
           items: [{ bucket: 'Test.Mock.Thing', key: 'key' }],
         });
-        return res(ctx.text('{ invalid: json string }'));
+        return HttpResponse.text('{ invalid: json string }');
       }),
     );
 
@@ -365,8 +364,8 @@ describe('Persistent Storage API', () => {
     const data = { foo: 'bar', baz: [{ foo: 'bar' }] };
 
     server.use(
-      rest.post(`${mockBaseUrl}/multiget`, async (_req, res, ctx) => {
-        return res(ctx.json({ items: [{ value: data }] }));
+      http.post(`${mockBaseUrl}/multiget`, async () => {
+        return HttpResponse.json({ items: [{ value: data }] });
       }),
     );
 
@@ -411,9 +410,9 @@ describe('Persistent Storage API', () => {
     let serverCalls = 0;
 
     server.use(
-      rest.post(`${mockBaseUrl}/multiget`, async (req, res, ctx) => {
+      http.post(`${mockBaseUrl}/multiget`, async ({ request }) => {
         ++serverCalls;
-        const payload = (await req.json()) as {
+        const payload = (await request.json()) as {
           items: { bucket: string; key: string }[];
         };
         const result = payload.items.map(item => {
@@ -425,7 +424,7 @@ describe('Persistent Storage API', () => {
           return null;
         });
 
-        return res(ctx.json({ items: result }));
+        return HttpResponse.json({ items: result });
       }),
     );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6279,7 +6279,7 @@ __metadata:
     "@backstage/plugin-scaffolder-node-test-utils": "workspace:^"
     bitbucket: "npm:^2.12.0"
     fs-extra: "npm:^11.2.0"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     yaml: "npm:^2.0.0"
     zod: "npm:^3.25.76 || ^4.0.0"
   languageName: unknown
@@ -6298,7 +6298,7 @@ __metadata:
     "@backstage/plugin-scaffolder-node": "workspace:^"
     "@backstage/plugin-scaffolder-node-test-utils": "workspace:^"
     fs-extra: "npm:^11.2.0"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     yaml: "npm:^2.0.0"
   languageName: unknown
   linkType: soft
@@ -6317,7 +6317,7 @@ __metadata:
     "@backstage/plugin-scaffolder-node-test-utils": "workspace:^"
     fs-extra: "npm:^11.2.0"
     git-url-parse: "npm:^15.0.0"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     node-html-markdown: "npm:^1.3.0"
     yaml: "npm:^2.0.0"
   languageName: unknown
@@ -6371,7 +6371,7 @@ __metadata:
     "@backstage/integration": "workspace:^"
     "@backstage/plugin-scaffolder-node": "workspace:^"
     "@backstage/plugin-scaffolder-node-test-utils": "workspace:^"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     yaml: "npm:^2.0.0"
   languageName: unknown
   linkType: soft
@@ -6388,7 +6388,7 @@ __metadata:
     "@backstage/integration": "workspace:^"
     "@backstage/plugin-scaffolder-node": "workspace:^"
     "@backstage/plugin-scaffolder-node-test-utils": "workspace:^"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     yaml: "npm:^2.0.0"
   languageName: unknown
   linkType: soft
@@ -6576,7 +6576,7 @@ __metadata:
     "@microsoft/fetch-event-source": "npm:^2.0.1"
     "@types/json-schema": "npm:^7.0.9"
     cross-fetch: "npm:^4.0.0"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     uri-template: "npm:^2.0.0"
     zen-observable: "npm:^0.10.0"
   languageName: unknown
@@ -6631,7 +6631,7 @@ __metadata:
     isomorphic-git: "npm:^1.23.0"
     jsonschema: "npm:^1.5.0"
     lodash: "npm:^4.17.21"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     p-limit: "npm:^3.1.0"
     tar: "npm:^7.5.21"
     winston: "npm:^3.2.1"
@@ -7462,7 +7462,7 @@ __metadata:
     "@testing-library/user-event": "npm:^14.0.0"
     "@types/react": "npm:^18.0.0"
     dataloader: "npm:^2.0.0"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     react: "npm:^18.0.2"
     react-dom: "npm:^18.0.2"
     react-router-dom: "npm:^6.30.2"


### PR DESCRIPTION
## Hey 👋

This PR migrates the following packages owned by `@backstage/maintainers` from MSW v1 to MSW v2:

- `@backstage/plugin-scaffolder-backend-module-bitbucket-cloud`
- `@backstage/plugin-scaffolder-backend-module-bitbucket-server`
- `@backstage/plugin-scaffolder-backend-module-confluence-to-markdown`
- `@backstage/plugin-scaffolder-backend-module-gerrit`
- `@backstage/plugin-scaffolder-backend-module-gitea`
- `@backstage/plugin-scaffolder-common`
- `@backstage/plugin-scaffolder-node`
- `@backstage/plugin-user-settings`

### Changes
- Updated MSW imports and handler syntax to v2 API
- Replaced `rest.*` handlers with `http.*` handlers
- Updated response helpers to use `HttpResponse`
- Updated `package.json` dependencies

---

### Checklist

- [x] I have read the [contribution guidelines](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md)
- [x] Added or updated tests
- [ ] Added or updated documentation
- [x] Verified that the change works locally