### PR TITLE
chore(search): Migrate search packages to MSW 2

### DIFF
--- a/.changeset/migrate-msw2-search.md
+++ b/.changeset/migrate-msw2-search.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-search-backend-module-explore': patch
+'@backstage/plugin-search-backend-module-stack-overflow-collator': patch
+'@backstage/plugin-search-backend-module-techdocs': patch
+---
+
+Migrated tests from MSW v1 to MSW v2.

--- a/plugins/search-backend-module-explore/package.json
+++ b/plugins/search-backend-module-explore/package.json
@@ -58,7 +58,7 @@
   "devDependencies": {
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
-    "msw": "^1.2.1"
+    "msw": "^2.0.0"
   },
   "configSchema": "config.d.ts"
 }

--- a/plugins/search-backend-module-explore/src/collators/ToolDocumentCollatorFactory.test.ts
+++ b/plugins/search-backend-module-explore/src/collators/ToolDocumentCollatorFactory.test.ts
@@ -19,7 +19,7 @@ import {
   mockServices,
   registerMswTestHooks,
 } from '@backstage/backend-test-utils';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { Readable } from 'node:stream';
 import { ToolDocumentCollatorFactory } from './ToolDocumentCollatorFactory';
@@ -81,8 +81,8 @@ describe('ToolDocumentCollatorFactory', () => {
       collator = await factory.getCollator();
 
       worker.use(
-        rest.get('http://test-backend/api/explore/tools', (_, res, ctx) =>
-          res(ctx.status(200), ctx.json(mockTools)),
+        http.get('http://test-backend/api/explore/tools', () =>
+          HttpResponse.json(mockTools),
         ),
       );
     });

--- a/plugins/search-backend-module-stack-overflow-collator/package.json
+++ b/plugins/search-backend-module-stack-overflow-collator/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
-    "msw": "^1.2.1"
+    "msw": "^2.0.0"
   },
   "configSchema": "config.d.ts"
 }

--- a/plugins/search-backend-module-stack-overflow-collator/src/collators/StackOverflowQuestionsCollatorFactory.test.ts
+++ b/plugins/search-backend-module-stack-overflow-collator/src/collators/StackOverflowQuestionsCollatorFactory.test.ts
@@ -25,7 +25,7 @@ import { TestPipeline } from '@backstage/plugin-search-backend-node';
 import { ConfigReader } from '@backstage/config';
 import { Readable } from 'node:stream';
 import { setupServer } from 'msw/node';
-import { rest, RestRequest } from 'msw';
+import { http, HttpResponse } from 'msw';
 
 const logger = mockServices.logger.mock();
 
@@ -71,7 +71,7 @@ const mockOverrideQuestion = {
 };
 
 const testSearchQuery = (
-  request: RestRequest | undefined,
+  request: Request | undefined,
   expectedSearch: unknown,
 ) => {
   if (!request) {
@@ -80,7 +80,7 @@ const testSearchQuery = (
   }
 
   const executedSearch: { [key: string]: string } = {};
-  request.url.searchParams.forEach((value: string, key: string) => {
+  new URL(request.url).searchParams.forEach((value: string, key: string) => {
     executedSearch[key] = value;
   });
   expect(executedSearch).toEqual(expectedSearch);
@@ -119,11 +119,14 @@ describe('StackOverflowQuestionsCollatorFactory using custom request params', ()
     it('uses site query parameter when provided and baseUrl is not default', async () => {
       let request;
       worker.use(
-        rest.get('http://stack.overflow.local/questions', (req, res, ctx) => {
-          request = req;
+        http.get(
+          'http://stack.overflow.local/questions',
+          ({ request: req }) => {
+            request = req;
 
-          return res(ctx.status(200), ctx.json(mockQuestion));
-        }),
+            return HttpResponse.json(mockQuestion);
+          },
+        ),
       );
       const factory = StackOverflowQuestionsCollatorFactory.fromConfig(config, {
         logger,
@@ -149,10 +152,10 @@ describe('StackOverflowQuestionsCollatorFactory using custom request params', ()
     it('uses site query parameter when provided and baseUrl is default', async () => {
       let request;
       worker.use(
-        rest.get(`${BASE_URL}/questions`, (req, res, ctx) => {
+        http.get(`${BASE_URL}/questions`, ({ request: req }) => {
           request = req;
 
-          return res(ctx.status(200), ctx.json(mockQuestion));
+          return HttpResponse.json(mockQuestion);
         }),
       );
       const factory = StackOverflowQuestionsCollatorFactory.fromConfig(config, {
@@ -179,10 +182,10 @@ describe('StackOverflowQuestionsCollatorFactory using custom request params', ()
     it('uses default when site is not provided and baseUrl is default', async () => {
       let request;
       worker.use(
-        rest.get(`${BASE_URL}/questions`, (req, res, ctx) => {
+        http.get(`${BASE_URL}/questions`, ({ request: req }) => {
           request = req;
 
-          return res(ctx.status(200), ctx.json(mockQuestion));
+          return HttpResponse.json(mockQuestion);
         }),
       );
       const factory = StackOverflowQuestionsCollatorFactory.fromConfig(config, {
@@ -220,11 +223,14 @@ describe('StackOverflowQuestionsCollatorFactory using custom request params', ()
     it('fetches from the configured endpoint', async () => {
       let request;
       worker.use(
-        rest.get('http://stack.overflow.local/questions', (req, res, ctx) => {
-          request = req;
+        http.get(
+          'http://stack.overflow.local/questions',
+          ({ request: req }) => {
+            request = req;
 
-          return res(ctx.status(200), ctx.json(mockQuestion));
-        }),
+            return HttpResponse.json(mockQuestion);
+          },
+        ),
       );
       const factory = StackOverflowQuestionsCollatorFactory.fromConfig(
         config,
@@ -248,11 +254,11 @@ describe('StackOverflowQuestionsCollatorFactory using custom request params', ()
     it('fetches from the overridden endpoint', async () => {
       let request;
       worker.use(
-        rest.get(
+        http.get(
           'http://stack.overflow.override/questions',
-          (req, res, ctx) => {
+          ({ request: req }) => {
             request = req;
-            return res(ctx.status(200), ctx.json(mockOverrideQuestion));
+            return HttpResponse.json(mockOverrideQuestion);
           },
         ),
       );
@@ -280,13 +286,13 @@ describe('StackOverflowQuestionsCollatorFactory using custom request params', ()
     it('uses API key when provided', async () => {
       let request;
       worker.use(
-        rest.get(
+        http.get(
           'http://stack.overflow.override/questions',
-          (req, res, ctx) => {
+          ({ request: req }) => {
             request = req;
-            return req.url.searchParams.get('key') === 'abcdefg'
-              ? res(ctx.status(200), ctx.json(mockOverrideQuestion))
-              : res(ctx.status(401), ctx.json({}));
+            return new URL(req.url).searchParams.get('key') === 'abcdefg'
+              ? HttpResponse.json(mockOverrideQuestion)
+              : HttpResponse.json({}, { status: 401 });
           },
         ),
       );
@@ -316,13 +322,13 @@ describe('StackOverflowQuestionsCollatorFactory using custom request params', ()
     it('uses teamName when provided', async () => {
       let request;
       worker.use(
-        rest.get(
+        http.get(
           'http://stack.overflow.override/questions',
-          (req, res, ctx) => {
+          ({ request: req }) => {
             request = req;
-            return req.url.searchParams.get('team') === 'abcdefg'
-              ? res(ctx.status(200), ctx.json(mockOverrideQuestion))
-              : res(ctx.status(401), ctx.json({}));
+            return new URL(req.url).searchParams.get('team') === 'abcdefg'
+              ? HttpResponse.json(mockOverrideQuestion)
+              : HttpResponse.json({}, { status: 401 });
           },
         ),
       );
@@ -387,10 +393,10 @@ describe('StackOverflowQuestionsCollatorFactory using default request params', (
     it('fetches from the configured endpoint', async () => {
       let request;
       worker.use(
-        rest.get(`${BASE_URL}/questions`, (req, res, ctx) => {
+        http.get(`${BASE_URL}/questions`, ({ request: req }) => {
           request = req;
 
-          return res(ctx.status(200), ctx.json(mockQuestion));
+          return HttpResponse.json(mockQuestion);
         }),
       );
       const factory = StackOverflowQuestionsCollatorFactory.fromConfig(
@@ -414,9 +420,9 @@ describe('StackOverflowQuestionsCollatorFactory using default request params', (
     it('fetches from the overridden endpoint', async () => {
       let request;
       worker.use(
-        rest.get(`${BASE_URL}/questions`, (req, res, ctx) => {
+        http.get(`${BASE_URL}/questions`, ({ request: req }) => {
           request = req;
-          return res(ctx.status(200), ctx.json(mockOverrideQuestion));
+          return HttpResponse.json(mockOverrideQuestion);
         }),
       );
       const factory = StackOverflowQuestionsCollatorFactory.fromConfig(config, {
@@ -442,11 +448,11 @@ describe('StackOverflowQuestionsCollatorFactory using default request params', (
     it('uses API key when provided', async () => {
       let request;
       worker.use(
-        rest.get(`${BASE_URL}/questions`, (req, res, ctx) => {
+        http.get(`${BASE_URL}/questions`, ({ request: req }) => {
           request = req;
-          return req.url.searchParams.get('key') === 'abcdefg'
-            ? res(ctx.status(200), ctx.json(mockOverrideQuestion))
-            : res(ctx.status(401), ctx.json({}));
+          return new URL(req.url).searchParams.get('key') === 'abcdefg'
+            ? HttpResponse.json(mockOverrideQuestion)
+            : HttpResponse.json({}, { status: 401 });
         }),
       );
       const factory = StackOverflowQuestionsCollatorFactory.fromConfig(config, {
@@ -474,11 +480,11 @@ describe('StackOverflowQuestionsCollatorFactory using default request params', (
     it('uses teamName when provided', async () => {
       let request;
       worker.use(
-        rest.get(`${BASE_URL}/questions`, (req, res, ctx) => {
+        http.get(`${BASE_URL}/questions`, ({ request: req }) => {
           request = req;
-          return req.url.searchParams.get('team') === 'abcdefg'
-            ? res(ctx.status(200), ctx.json(mockOverrideQuestion))
-            : res(ctx.status(401), ctx.json({}));
+          return new URL(req.url).searchParams.get('team') === 'abcdefg'
+            ? HttpResponse.json(mockOverrideQuestion)
+            : HttpResponse.json({}, { status: 401 });
         }),
       );
       const factory = StackOverflowQuestionsCollatorFactory.fromConfig(config, {

--- a/plugins/search-backend-module-techdocs/package.json
+++ b/plugins/search-backend-module-techdocs/package.json
@@ -64,7 +64,7 @@
   "devDependencies": {
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
-    "msw": "^1.0.0"
+    "msw": "^2.0.0"
   },
   "configSchema": "config.d.ts"
 }

--- a/plugins/search-backend-module-techdocs/src/collators/DefaultTechDocsCollatorFactory.test.ts
+++ b/plugins/search-backend-module-techdocs/src/collators/DefaultTechDocsCollatorFactory.test.ts
@@ -22,7 +22,7 @@ import {
   registerMswTestHooks,
 } from '@backstage/backend-test-utils';
 import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { Readable } from 'node:stream';
 import { DefaultTechDocsCollatorFactory } from './DefaultTechDocsCollatorFactory';
@@ -111,9 +111,9 @@ describe('DefaultTechDocsCollatorFactory', () => {
       collator = await factory.getCollator();
 
       worker.use(
-        rest.get(
+        http.get(
           'http://test-backend/static/docs/default/Component/test-entity-with-docs/search/search_index.json',
-          (_, res, ctx) => res(ctx.status(200), ctx.json(mockSearchDocIndex)),
+          () => HttpResponse.json(mockSearchDocIndex),
         ),
       );
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6856,7 +6856,7 @@ __metadata:
     "@backstage/config": "workspace:^"
     "@backstage/plugin-search-backend-node": "workspace:^"
     "@backstage/plugin-search-common": "workspace:^"
-    msw: "npm:^1.2.1"
+    msw: "npm:^2.0.0"
   languageName: unknown
   linkType: soft
 
@@ -6885,7 +6885,7 @@ __metadata:
     "@backstage/config": "workspace:^"
     "@backstage/plugin-search-backend-node": "workspace:^"
     "@backstage/plugin-search-common": "workspace:^"
-    msw: "npm:^1.2.1"
+    msw: "npm:^2.0.0"
     qs: "npm:^6.15.2"
   languageName: unknown
   linkType: soft
@@ -6907,7 +6907,7 @@ __metadata:
     "@backstage/plugin-search-common": "workspace:^"
     "@backstage/plugin-techdocs-node": "workspace:^"
     lodash: "npm:^4.17.21"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     p-limit: "npm:^3.1.0"
   languageName: unknown
   linkType: soft
@@ -36268,7 +36268,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"msw@npm:^1.0.0, msw@npm:^1.2.1, msw@npm:^1.3.1":
+"msw@npm:^1.0.0, msw@npm:^1.3.1":
   version: 1.3.5
   resolution: "msw@npm:1.3.5"
   dependencies:


### PR DESCRIPTION
## Hey 👋

This PR migrates the following packages owned by `@backstage/search-maintainers` from MSW v1 to MSW v2:

- `@backstage/plugin-search-backend-module-explore`
- `@backstage/plugin-search-backend-module-stack-overflow-collator`
- `@backstage/plugin-search-backend-module-techdocs`

### Changes
- Updated MSW imports and handler syntax to v2 API
- Replaced `rest.*` handlers with `http.*` handlers
- Updated response helpers to use `HttpResponse`
- Updated `package.json` dependencies

---

### Checklist

- [x] I have read the [contribution guidelines](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md)
- [x] Added or updated tests
- [ ] Added or updated documentation
- [x] Verified that the change works locally