### PR TITLE
backend-app-api: validate installed backend features

### DIFF
--- a/.changeset/fair-tools-check.md
+++ b/.changeset/fair-tools-check.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-app-api': patch
+---
+
+Hardened backend startup against malformed installed backend features, with contextual input errors and configured boot-failure handling when invalid registrations can be attributed to a plugin or module.

--- a/packages/backend-app-api/src/wiring/BackendInitializer.test.ts
+++ b/packages/backend-app-api/src/wiring/BackendInitializer.test.ts
@@ -29,6 +29,7 @@ import { BackendInitializer } from './BackendInitializer';
 import { mockServices } from '@backstage/backend-test-utils';
 import { BackendStartupError } from './BackendStartupError';
 import { createExtensionPointFactoryMiddleware } from './types';
+import { InputError } from '@backstage/errors';
 
 const baseFactories = [
   mockServices.rootLifecycle.factory(),
@@ -407,6 +408,199 @@ describe('BackendInitializer', () => {
     await expect(init.start()).rejects.toThrow(
       /^Feature loaders can only depend on root scoped services, but 'service1' is scoped to 'plugin'. Offending loader is created at '.*'$/,
     );
+  });
+
+  it('should report the first malformed installed feature field', async () => {
+    const init = new BackendInitializer(baseFactories);
+    init.add({
+      $$type: '@backstage/BackendFeature',
+      version: 'v1',
+      featureType: 'service',
+      service: {
+        $$type: '@backstage/ServiceRef',
+        id: 'test',
+        scope: 'plugin',
+      },
+      deps: { broken: undefined },
+      factory: async () => ({}),
+    } as any);
+    init.add(null as any);
+
+    const error = await init.start().catch(e => e);
+    expect(error).toBeInstanceOf(InputError);
+    expect(error.message).toBe(
+      'Invalid backend feature at service factory for "test".deps.broken, expected a service reference object, received undefined',
+    );
+  });
+
+  it('should identify malformed feature loader output', async () => {
+    const init = new BackendInitializer(baseFactories);
+    init.add(
+      createBackendFeatureLoader({
+        loader() {
+          return [
+            {
+              $$type: '@backstage/BackendFeature',
+              version: 'v1',
+              featureType: 'service',
+              service: {
+                $$type: '@backstage/ServiceRef',
+                id: 'loaded',
+                scope: 'plugin',
+              },
+              deps: { broken: undefined },
+              factory: async () => ({}),
+            },
+          ] as any;
+        },
+      }),
+    );
+
+    const error = await init.start().catch(e => e);
+    expect(error).toBeInstanceOf(InputError);
+    expect(error.message).toMatch(
+      /^Invalid backend feature at service factory for "loaded" \(returned by feature loader created at '.*', output\[0\]\)\.deps\.broken, expected a service reference object, received undefined$/,
+    );
+  });
+
+  it('should attribute malformed registration fields to the plugin', async () => {
+    const init = new BackendInitializer(baseFactories);
+    init.add({
+      $$type: '@backstage/BackendFeature',
+      version: 'v1',
+      featureType: 'registrations',
+      getRegistrations: () => [
+        {
+          type: 'plugin-v1.1',
+          pluginId: 'test',
+          extensionPoints: undefined,
+          connections: [],
+          init: { deps: {}, func: async () => {} },
+        },
+      ],
+    } as any);
+
+    const error = await init.start().catch(e => e);
+    expect(error).toBeInstanceOf(BackendStartupError);
+    const failure = error.result.plugins.find(
+      (plugin: { pluginId: string }) => plugin.pluginId === 'test',
+    )?.failure;
+    expect(failure?.error).toBeInstanceOf(InputError);
+    expect(failure?.error.message).toBe(
+      'Invalid backend feature at plugin "test".extensionPoints, expected an array, received undefined',
+    );
+    expect(failure?.allowed).toBe(false);
+  });
+
+  it('should permit attributable malformed registration fields', async () => {
+    const testInit = jest.fn(async () => {});
+    const init = new BackendInitializer([
+      ...baseFactories,
+      mockServices.rootConfig.factory({
+        data: {
+          backend: {
+            startup: {
+              plugins: {
+                catalog: { onPluginBootFailure: 'continue' },
+                test: {
+                  modules: {
+                    bad: { onPluginModuleBootFailure: 'continue' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      }),
+    ]);
+    init.add(
+      createBackendPlugin({
+        pluginId: 'catalog',
+        register(reg) {
+          reg.registerInit({
+            deps: { broken: undefined as any },
+            async init() {},
+          });
+        },
+      }),
+    );
+    init.add(
+      createBackendModule({
+        pluginId: 'test',
+        moduleId: 'bad',
+        register(reg) {
+          reg.registerInit({
+            deps: { broken: undefined as any },
+            async init() {},
+          });
+        },
+      }),
+    );
+    init.add(
+      createBackendPlugin({
+        pluginId: 'test',
+        register(reg) {
+          reg.registerInit({
+            deps: {},
+            init: testInit,
+          });
+        },
+      }),
+    );
+
+    const { result } = await init.start();
+
+    expect(testInit).toHaveBeenCalled();
+    expect(result.outcome).toBe('success');
+    const catalog = result.plugins.find(p => p.pluginId === 'catalog');
+    expect(catalog?.failure?.error).toBeInstanceOf(InputError);
+    expect(catalog?.failure).toMatchObject({
+      allowed: true,
+      error: {
+        message:
+          'Invalid backend feature at plugin "catalog".init.deps.broken, expected a service reference object, received undefined',
+      },
+    });
+    const test = result.plugins.find(p => p.pluginId === 'test');
+    expect(test?.failure).toBeUndefined();
+    expect(test?.modules).toEqual([
+      expect.objectContaining({
+        moduleId: 'bad',
+        failure: {
+          allowed: true,
+          error: expect.objectContaining({
+            message:
+              'Invalid backend feature at module "bad" for plugin "test".init.deps.broken, expected a service reference object, received undefined',
+          }),
+        },
+      }),
+    ]);
+  });
+
+  it('should accept legacy duck-typed features', async () => {
+    const ref = createServiceRef<{}>({ id: 'legacy' });
+    const service = createServiceFactory({
+      service: ref,
+      deps: {},
+      factory: async () => ({}),
+    }) as any;
+    delete service.featureType;
+
+    const pluginInit = jest.fn(async () => {});
+    const plugin = createBackendPlugin({
+      pluginId: 'legacy',
+      register(reg) {
+        reg.registerInit({ deps: { ref }, init: pluginInit });
+      },
+    }) as any;
+    delete plugin.featureType;
+
+    const init = new BackendInitializer(baseFactories);
+    init.add(service);
+    init.add(plugin);
+    await init.start();
+
+    expect(pluginInit).toHaveBeenCalled();
   });
 
   it('should initialize plugin scoped services with eager initialization', async () => {

--- a/packages/backend-app-api/src/wiring/BackendInitializer.ts
+++ b/packages/backend-app-api/src/wiring/BackendInitializer.ts
@@ -37,12 +37,9 @@ import {
 // Direct internal import to avoid duplication
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import type {
-  InternalBackendFeature,
   InternalBackendFeatureLoader,
   InternalBackendRegistrations,
 } from '../../../backend-plugin-api/src/wiring/types';
-// eslint-disable-next-line @backstage/no-relative-monorepo-imports
-import type { InternalServiceFactory } from '../../../backend-plugin-api/src/services/system/types';
 import { ConflictError, ForwardedError, toError } from '@backstage/errors';
 import { DependencyGraph } from '../lib/DependencyGraph';
 import { ServiceRegistry } from './ServiceRegistry';
@@ -55,6 +52,16 @@ import { createAllowBootFailurePredicate } from './createAllowBootFailurePredica
 import type { ConnectionsService } from '@backstage/connections';
 import { connectionsServiceRef } from '@backstage/connections-node';
 import { withDeclaredConnections } from './withDeclaredConnections';
+import {
+  assertObject,
+  describeBackendFeature,
+  throwInvalidBackendFeature,
+  validateBackendFeature,
+  validateBackendRegistration,
+  validateBackendRegistrations,
+  validateServiceRef,
+  type ValidatedBackendFeature,
+} from './validateBackendFeature';
 
 export interface BackendRegisterInit {
   consumes: Set<ServiceOrExtensionPoint>;
@@ -64,6 +71,11 @@ export interface BackendRegisterInit {
     func: (deps: { [name: string]: unknown }) => Promise<void>;
   };
 }
+
+type InstalledFeatureLoader = {
+  feature: InternalBackendFeatureLoader;
+  source: string;
+};
 
 /**
  * A registry of backend instances, used to manage process shutdown hooks across all instances.
@@ -152,13 +164,10 @@ function collectCallerConnectionRegistrations(
 }
 
 function createRootInstanceMetadataServiceFactory(
-  rawRegistrations: InternalBackendRegistrations[],
+  registrations: ReturnType<InternalBackendRegistrations['getRegistrations']>,
 ) {
   const installedPlugins: Map<string, RootInstanceMetadataServicePluginInfo> =
     new Map();
-  const registrations = rawRegistrations
-    .filter(registration => registration.featureType === 'registrations')
-    .flatMap(registration => registration.getRegistrations());
   const plugins = registrations.filter(
     registration =>
       registration.type === 'plugin' || registration.type === 'plugin-v1.1',
@@ -205,7 +214,13 @@ function createRootInstanceMetadataServiceFactory(
 export class BackendInitializer {
   #startPromise?: Promise<{ result: BackendStartupResult }>;
   #stopPromise?: Promise<void>;
-  #registrations = new Array<InternalBackendRegistrations>();
+  #registrations = new Array<{
+    feature: InternalBackendRegistrations;
+    source: string;
+  }>();
+  #allRegistrations = new Array<
+    ReturnType<InternalBackendRegistrations['getRegistrations']>[number]
+  >();
   #extensionPoints = new Map<
     string,
     {
@@ -214,8 +229,11 @@ export class BackendInitializer {
     }
   >();
   #serviceRegistry: ServiceRegistry;
-  #registeredFeatures = new Array<Promise<BackendFeature>>();
-  #registeredFeatureLoaders = new Array<InternalBackendFeatureLoader>();
+  #registeredFeatures = new Array<{
+    feature: Promise<BackendFeature>;
+    source: string;
+  }>();
+  #registeredFeatureLoaders = new Array<InstalledFeatureLoader>();
   #extensionPointFactoryMiddleware: ExtensionPointFactoryMiddleware[];
   #callerConnectionRegistrations = new Map<string, ConnectionRegistration[]>();
 
@@ -330,20 +348,25 @@ export class BackendInitializer {
     if (this.#startPromise) {
       throw new Error('feature can not be added after the backend has started');
     }
-    this.#registeredFeatures.push(Promise.resolve(feature));
+    this.#registeredFeatures.push({
+      feature: Promise.resolve(feature),
+      source: `features[${this.#registeredFeatures.length}]`,
+    });
   }
 
-  #addFeature(feature: BackendFeature) {
-    if (isServiceFactory(feature)) {
-      this.#serviceRegistry.add(feature);
-    } else if (isBackendFeatureLoader(feature)) {
-      this.#registeredFeatureLoaders.push(feature);
-    } else if (isBackendRegistrations(feature)) {
-      this.#registrations.push(feature);
+  #addFeature(feature: ValidatedBackendFeature, source: string) {
+    if (feature.type === 'service') {
+      this.#serviceRegistry.add(feature.feature, source);
+    } else if (feature.type === 'loader') {
+      this.#registeredFeatureLoaders.push({
+        feature: feature.feature,
+        source,
+      });
     } else {
-      throw new Error(
-        `Failed to add feature, invalid feature ${JSON.stringify(feature)}`,
-      );
+      this.#registrations.push({
+        feature: feature.feature,
+        source,
+      });
     }
   }
 
@@ -364,14 +387,21 @@ export class BackendInitializer {
   async #doStart(): Promise<{ result: BackendStartupResult }> {
     this.#serviceRegistry.checkForCircularDeps();
 
-    for (const feature of this.#registeredFeatures) {
-      this.#addFeature(await feature);
+    for (const { feature, source: fallbackSource } of this
+      .#registeredFeatures) {
+      const resolvedFeature = await feature;
+      const source = describeBackendFeature(resolvedFeature) ?? fallbackSource;
+      this.#addFeature(validateBackendFeature(resolvedFeature, source), source);
     }
 
     await this.#applyBackendFeatureLoaders(this.#registeredFeatureLoaders);
 
+    this.#allRegistrations = this.#registrations.flatMap(
+      ({ feature, source }) => validateBackendRegistrations(feature, source),
+    );
+
     this.#serviceRegistry.add(
-      createRootInstanceMetadataServiceFactory(this.#registrations),
+      createRootInstanceMetadataServiceFactory(this.#allRegistrations),
     );
 
     // This makes sure that any uncaught errors or unhandled rejections are
@@ -412,9 +442,7 @@ export class BackendInitializer {
       'root',
     );
 
-    const allRegistrations = this.#registrations.flatMap(f =>
-      f.getRegistrations(),
-    );
+    const allRegistrations = this.#allRegistrations;
 
     this.#callerConnectionRegistrations =
       collectCallerConnectionRegistrations(allRegistrations);
@@ -542,8 +570,18 @@ export class BackendInitializer {
     const moduleInits = new Map<string, Map<string, BackendRegisterInit>>();
 
     for (const r of allRegistrations) {
+      const pluginId =
+        'pluginId' in r && typeof r.pluginId === 'string'
+          ? r.pluginId
+          : undefined;
+      const moduleId =
+        'moduleId' in r && typeof r.moduleId === 'string'
+          ? r.moduleId
+          : undefined;
       const addedExtensionPointIds: string[] = [];
       try {
+        validateBackendRegistration(r);
+
         const provides = new Set<ExtensionPoint<unknown>>();
 
         if (r.type === 'plugin' || r.type === 'module') {
@@ -612,12 +650,12 @@ export class BackendInitializer {
         for (const id of addedExtensionPointIds) {
           this.#extensionPoints.delete(id);
         }
-        if ('pluginId' in r && 'moduleId' in r) {
-          resultCollector.onPluginModuleResult(r.pluginId, r.moduleId, err);
-        } else if ('pluginId' in r) {
-          pluginInits.delete(r.pluginId);
-          moduleInits.delete(r.pluginId);
-          resultCollector.onPluginResult(r.pluginId, err);
+        if (pluginId !== undefined && moduleId !== undefined) {
+          resultCollector.onPluginModuleResult(pluginId, moduleId, err);
+        } else if (pluginId !== undefined) {
+          pluginInits.delete(pluginId);
+          moduleInits.delete(pluginId);
+          resultCollector.onPluginResult(pluginId, err);
         } else {
           throw err;
         }
@@ -655,11 +693,12 @@ export class BackendInitializer {
 
     // Get all plugins.
     const allPlugins = new Set<string>();
-    for (const feature of this.#registrations) {
-      for (const r of feature.getRegistrations()) {
-        if (r.type === 'plugin' || r.type === 'plugin-v1.1') {
-          allPlugins.add(r.pluginId);
-        }
+    for (const registration of this.#allRegistrations) {
+      if (
+        registration.type === 'plugin' ||
+        registration.type === 'plugin-v1.1'
+      ) {
+        allPlugins.add(registration.pluginId);
       }
     }
 
@@ -732,17 +771,24 @@ export class BackendInitializer {
     throw new Error('Unexpected plugin lifecycle service implementation');
   }
 
-  async #applyBackendFeatureLoaders(loaders: InternalBackendFeatureLoader[]) {
-    const servicesAddedByLoaders = new Map<
-      string,
-      InternalBackendFeatureLoader
-    >();
+  async #applyBackendFeatureLoaders(loaders: InstalledFeatureLoader[]) {
+    const servicesAddedByLoaders = new Map<string, InstalledFeatureLoader>();
 
-    for (const loader of loaders) {
+    for (const installedLoader of loaders) {
+      const { feature: loader, source: loaderSource } = installedLoader;
+      if (loader.deps !== undefined) {
+        assertObject(
+          loader.deps,
+          `${loaderSource}.deps`,
+          'a dependency object',
+        );
+      }
+
       const deps = new Map<string, unknown>();
       const missingRefs = new Set<ServiceOrExtensionPoint>();
 
       for (const [name, ref] of Object.entries(loader.deps ?? {})) {
+        validateServiceRef(ref, `${loaderSource}.deps.${name}`);
         if (ref.scope !== 'root') {
           throw new Error(
             `Feature loaders can only depend on root scoped services, but '${name}' is scoped to '${ref.scope}'. Offending loader is ${loader.description}`,
@@ -766,23 +812,48 @@ export class BackendInitializer {
         );
       }
 
-      const result = await loader
-        .loader(Object.fromEntries(deps))
-        .then(features => features.map(unwrapFeature))
-        .catch(error => {
-          throw new ForwardedError(
-            `Feature loader ${loader.description} failed`,
-            error,
-          );
-        });
+      let result: unknown;
+      try {
+        result = await loader.loader(Object.fromEntries(deps));
+      } catch (error) {
+        throw new ForwardedError(
+          `Feature loader ${loader.description} failed`,
+          error,
+        );
+      }
+      if (!Array.isArray(result)) {
+        throwInvalidBackendFeature(
+          `${loaderSource} -> loader output`,
+          'an array of backend features',
+          result,
+        );
+      }
+
+      const loadedFeatures = result.map((feature, index) => {
+        const fallbackSource = `${loaderSource} -> loader output[${index}]`;
+        const unwrappedFeature = unwrapFeature(
+          feature as BackendFeature | { default: BackendFeature },
+        );
+        const description = describeBackendFeature(unwrappedFeature);
+        const source = description
+          ? `${description} (returned by ${loaderSource}, output[${index}])`
+          : fallbackSource;
+        return {
+          feature: validateBackendFeature(unwrappedFeature, source),
+          source,
+        };
+      });
 
       let didAddServiceFactory = false;
-      const newLoaders = new Array<InternalBackendFeatureLoader>();
+      const newLoaders = new Array<InstalledFeatureLoader>();
 
-      for await (const feature of result) {
-        if (isBackendFeatureLoader(feature)) {
-          newLoaders.push(feature);
-        } else {
+      for (const loadedFeature of loadedFeatures) {
+        const { feature, source } = loadedFeature;
+        if (feature.type === 'loader') {
+          newLoaders.push({ feature: feature.feature, source });
+        } else if (feature.type === 'service') {
+          validateServiceRef(feature.feature.service, `${source}.service`);
+
           // This block makes sure that feature loaders do not provide duplicate
           // implementations for the same service, but at the same time allows
           // service factories provided by feature loaders to be overridden by
@@ -790,25 +861,30 @@ export class BackendInitializer {
           //
           // If a factory has already been explicitly installed, the service
           // factory provided by the loader will simply be ignored.
-          if (isServiceFactory(feature) && !feature.service.multiton) {
+          if (!feature.feature.service.multiton) {
             const conflictingLoader = servicesAddedByLoaders.get(
-              feature.service.id,
+              feature.feature.service.id,
             );
             if (conflictingLoader) {
               throw new Error(
-                `Duplicate service implementations provided for ${feature.service.id} by both feature loader ${loader.description} and feature loader ${conflictingLoader.description}`,
+                `Duplicate service implementations provided for ${feature.feature.service.id} by both feature loader ${loader.description} and feature loader ${conflictingLoader.feature.description}`,
               );
             }
 
             // Check that this service wasn't already explicitly added by backend.add(serviceFactory)
-            if (!this.#serviceRegistry.hasBeenAdded(feature.service)) {
+            if (!this.#serviceRegistry.hasBeenAdded(feature.feature.service)) {
               didAddServiceFactory = true;
-              servicesAddedByLoaders.set(feature.service.id, loader);
-              this.#addFeature(feature);
+              servicesAddedByLoaders.set(
+                feature.feature.service.id,
+                installedLoader,
+              );
+              this.#addFeature(feature, source);
             }
           } else {
-            this.#addFeature(feature);
+            this.#addFeature(feature, source);
           }
+        } else {
+          this.#addFeature(feature, source);
         }
       }
 
@@ -823,47 +899,4 @@ export class BackendInitializer {
       }
     }
   }
-}
-
-function toInternalBackendFeature(
-  feature: BackendFeature,
-): InternalBackendFeature {
-  if (feature.$$type !== '@backstage/BackendFeature') {
-    throw new Error(`Invalid BackendFeature, bad type '${feature.$$type}'`);
-  }
-  const internal = feature as InternalBackendFeature;
-  if (internal.version !== 'v1') {
-    throw new Error(
-      `Invalid BackendFeature, bad version '${internal.version}'`,
-    );
-  }
-  return internal;
-}
-
-function isServiceFactory(
-  feature: BackendFeature,
-): feature is InternalServiceFactory {
-  const internal = toInternalBackendFeature(feature);
-  if (internal.featureType === 'service') {
-    return true;
-  }
-  // Backwards compatibility for v1 registrations that use duck typing
-  return 'service' in internal;
-}
-
-function isBackendRegistrations(
-  feature: BackendFeature,
-): feature is InternalBackendRegistrations {
-  const internal = toInternalBackendFeature(feature);
-  if (internal.featureType === 'registrations') {
-    return true;
-  }
-  // Backwards compatibility for v1 registrations that use duck typing
-  return 'getRegistrations' in internal;
-}
-
-function isBackendFeatureLoader(
-  feature: BackendFeature,
-): feature is InternalBackendFeatureLoader {
-  return toInternalBackendFeature(feature).featureType === 'loader';
 }

--- a/packages/backend-app-api/src/wiring/BackstageBackend.ts
+++ b/packages/backend-app-api/src/wiring/BackstageBackend.ts
@@ -38,7 +38,7 @@ export class BackstageBackend implements Backend {
 
   add(feature: BackendFeature | Promise<{ default: BackendFeature }>): void {
     if (isPromise(feature)) {
-      this.#initializer.add(feature.then(f => unwrapFeature(f.default)));
+      this.#initializer.add(feature.then(unwrapFeature));
     } else {
       this.#initializer.add(unwrapFeature(feature));
     }

--- a/packages/backend-app-api/src/wiring/ServiceRegistry.ts
+++ b/packages/backend-app-api/src/wiring/ServiceRegistry.ts
@@ -25,6 +25,14 @@ import { ConflictError, stringifyError } from '@backstage/errors';
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import { InternalServiceFactory } from '../../../backend-plugin-api/src/services/system/types';
 import { DependencyGraph } from '../lib/DependencyGraph';
+import {
+  assertObject,
+  assertObjectLike,
+  describeBackendFeature,
+  throwInvalidBackendFeature,
+  validateServiceRef,
+} from './validateBackendFeature';
+
 /**
  * Keep in sync with `@backstage/backend-plugin-api/src/services/system/types.ts`
  * @internal
@@ -37,14 +45,27 @@ export type InternalServiceRef = ServiceRef<unknown> & {
 
 function toInternalServiceFactory<TService, TScope extends 'plugin' | 'root'>(
   factory: ServiceFactory<TService, TScope>,
+  path: string,
 ): InternalServiceFactory<TService, TScope> {
-  const f = factory as InternalServiceFactory<TService, TScope>;
+  assertObjectLike(factory, path);
+  const f = factory as unknown as InternalServiceFactory<TService, TScope>;
   if (f.$$type !== '@backstage/BackendFeature') {
-    throw new Error(`Invalid service factory, bad type '${f.$$type}'`);
+    throwInvalidBackendFeature(
+      `${path}.$$type`,
+      '"@backstage/BackendFeature"',
+      f.$$type,
+    );
   }
   if (f.version !== 'v1') {
-    throw new Error(`Invalid service factory, bad version '${f.version}'`);
+    throwInvalidBackendFeature(`${path}.version`, '"v1"', f.version);
   }
+
+  validateServiceRef(f.service, `${path}.service`);
+  assertObject(f.deps, `${path}.deps`, 'a dependency object');
+  for (const [name, ref] of Object.entries(f.deps)) {
+    validateServiceRef(ref, `${path}.deps.${name}`);
+  }
+
   return f;
 }
 
@@ -61,15 +82,16 @@ function createPluginMetadataServiceFactory(pluginId: string) {
 export class ServiceRegistry {
   static create(factories: Array<ServiceFactory>): ServiceRegistry {
     const factoryMap = new Map<string, InternalServiceFactory[]>();
-    for (const factory of factories) {
+    for (let index = 0; index < factories.length; index++) {
+      const source =
+        describeBackendFeature(factories[index]) ??
+        `default service factories[${index}]`;
+      const factory = toInternalServiceFactory(factories[index], source);
       if (factory.service.multiton) {
         const existing = factoryMap.get(factory.service.id) ?? [];
-        factoryMap.set(
-          factory.service.id,
-          existing.concat(toInternalServiceFactory(factory)),
-        );
+        factoryMap.set(factory.service.id, existing.concat(factory));
       } else {
-        factoryMap.set(factory.service.id, [toInternalServiceFactory(factory)]);
+        factoryMap.set(factory.service.id, [factory]);
       }
     }
     const registry = new ServiceRegistry(factoryMap);
@@ -109,7 +131,10 @@ export class ServiceRegistry {
     // Special case handling of the plugin metadata service, generating a custom factory for it each time
     if (ref.id === coreServices.pluginMetadata.id) {
       return Promise.resolve([
-        toInternalServiceFactory(createPluginMetadataServiceFactory(pluginId)),
+        toInternalServiceFactory(
+          createPluginMetadataServiceFactory(pluginId),
+          'plugin metadata service factory',
+        ),
       ]);
     }
 
@@ -128,7 +153,10 @@ export class ServiceRegistry {
         loadedFactory = Promise.resolve()
           .then(() => defaultFactory!(ref))
           .then(f =>
-            toInternalServiceFactory(typeof f === 'function' ? f() : f),
+            toInternalServiceFactory(
+              typeof f === 'function' ? f() : f,
+              `default factory for service ${JSON.stringify(ref.id)}`,
+            ),
           );
         this.#loadedDefaultFactories.set(defaultFactory!, loadedFactory);
       }
@@ -200,8 +228,11 @@ export class ServiceRegistry {
     return this.#addedFactoryIds.has(ref.id);
   }
 
-  add(factory: ServiceFactory) {
-    const factoryId = factory.service.id;
+  add(factory: ServiceFactory, source?: string) {
+    const factorySource =
+      source ?? describeBackendFeature(factory) ?? 'service factory';
+    const internalFactory = toInternalServiceFactory(factory, factorySource);
+    const factoryId = internalFactory.service.id;
     if (factoryId === coreServices.pluginMetadata.id) {
       throw new Error(
         `The ${coreServices.pluginMetadata.id} service cannot be overridden`,
@@ -214,10 +245,10 @@ export class ServiceRegistry {
       );
     }
 
-    if (factory.service.multiton) {
+    if (internalFactory.service.multiton) {
       const newFactories = (
         this.#providedFactories.get(factoryId) ?? []
-      ).concat(toInternalServiceFactory(factory));
+      ).concat(internalFactory);
       this.#providedFactories.set(factoryId, newFactories);
     } else {
       if (this.#addedFactoryIds.has(factoryId)) {
@@ -227,9 +258,7 @@ export class ServiceRegistry {
       }
 
       this.#addedFactoryIds.add(factoryId);
-      this.#providedFactories.set(factoryId, [
-        toInternalServiceFactory(factory),
-      ]);
+      this.#providedFactories.set(factoryId, [internalFactory]);
     }
   }
 

--- a/packages/backend-app-api/src/wiring/createSpecializedBackend.test.ts
+++ b/packages/backend-app-api/src/wiring/createSpecializedBackend.test.ts
@@ -18,6 +18,7 @@ import {
   coreServices,
   createServiceFactory,
 } from '@backstage/backend-plugin-api';
+import { InputError } from '@backstage/errors';
 import { createSpecializedBackend } from './createSpecializedBackend';
 
 describe('createSpecializedBackend', () => {
@@ -25,6 +26,19 @@ describe('createSpecializedBackend', () => {
     expect(() =>
       createSpecializedBackend({ defaultServiceFactories: [] }),
     ).not.toThrow();
+  });
+
+  it('should report malformed dynamic imports during startup', async () => {
+    const backend = createSpecializedBackend({
+      defaultServiceFactories: [],
+    });
+    backend.add(Promise.resolve(null as any));
+
+    await expect(backend.start()).rejects.toThrow(
+      new InputError(
+        'Invalid backend feature at features[0], expected an object or function, received null',
+      ),
+    );
   });
 
   it('should throw on duplicate service implementations', () => {

--- a/packages/backend-app-api/src/wiring/validateBackendFeature.ts
+++ b/packages/backend-app-api/src/wiring/validateBackendFeature.ts
@@ -1,0 +1,333 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { InputError } from '@backstage/errors';
+// Direct internal import to avoid duplication
+// eslint-disable-next-line @backstage/no-relative-monorepo-imports
+import type {
+  InternalBackendFeatureLoader,
+  InternalBackendRegistrations,
+} from '../../../backend-plugin-api/src/wiring/types';
+// eslint-disable-next-line @backstage/no-relative-monorepo-imports
+import type { InternalServiceFactory } from '../../../backend-plugin-api/src/services/system/types';
+
+export type ValidatedBackendFeature =
+  | { type: 'service'; feature: InternalServiceFactory }
+  | { type: 'loader'; feature: InternalBackendFeatureLoader }
+  | { type: 'registrations'; feature: InternalBackendRegistrations };
+
+function describeValue(value: unknown): string {
+  if (value === undefined) {
+    return 'undefined';
+  }
+  if (value === null) {
+    return 'null';
+  }
+  if (typeof value === 'string') {
+    return JSON.stringify(value);
+  }
+  if (
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    typeof value === 'bigint'
+  ) {
+    return String(value);
+  }
+  if (typeof value === 'function') {
+    return 'a function';
+  }
+  if (Array.isArray(value)) {
+    return 'an array';
+  }
+  return 'an object';
+}
+
+export function throwInvalidBackendFeature(
+  path: string,
+  expected: string,
+  value: unknown,
+): never {
+  throw new InputError(
+    `Invalid backend feature at ${path}, expected ${expected}, received ${describeValue(
+      value,
+    )}`,
+  );
+}
+
+export function assertObject(
+  value: unknown,
+  path: string,
+  expected = 'an object',
+): asserts value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throwInvalidBackendFeature(path, expected, value);
+  }
+}
+
+export function assertObjectLike(
+  value: unknown,
+  path: string,
+): asserts value is Record<string, unknown> {
+  if (
+    (typeof value !== 'object' || value === null) &&
+    typeof value !== 'function'
+  ) {
+    throwInvalidBackendFeature(path, 'an object or function', value);
+  }
+}
+
+export function assertString(
+  value: unknown,
+  path: string,
+): asserts value is string {
+  if (typeof value !== 'string') {
+    throwInvalidBackendFeature(path, 'a string', value);
+  }
+}
+
+export function assertFunction(
+  value: unknown,
+  path: string,
+): asserts value is (...args: any[]) => unknown {
+  if (typeof value !== 'function') {
+    throwInvalidBackendFeature(path, 'a function', value);
+  }
+}
+
+export function assertArray(
+  value: unknown,
+  path: string,
+): asserts value is unknown[] {
+  if (!Array.isArray(value)) {
+    throwInvalidBackendFeature(path, 'an array', value);
+  }
+}
+
+export function validateServiceRef(value: unknown, path: string): void {
+  assertObject(value, path, 'a service reference object');
+  assertString(value.id, `${path}.id`);
+  if (value.scope !== 'root' && value.scope !== 'plugin') {
+    throwInvalidBackendFeature(
+      `${path}.scope`,
+      '"root" or "plugin"',
+      value.scope,
+    );
+  }
+}
+
+export function validateExtensionPoint(value: unknown, path: string): void {
+  assertObject(value, path, 'an extension point reference object');
+  assertString(value.id, `${path}.id`);
+}
+
+/**
+ * Reads the registrations from a backend feature and validates the outer
+ * registration objects and their identifying fields.
+ *
+ * Nested registration data is validated later by
+ * {@link validateBackendRegistration}, when each registration is enumerated.
+ */
+export function validateBackendRegistrations(
+  feature: InternalBackendRegistrations,
+  source: string,
+): ReturnType<InternalBackendRegistrations['getRegistrations']> {
+  assertFunction(feature.getRegistrations, `${source}.getRegistrations`);
+  const registrations: unknown = feature.getRegistrations();
+  assertArray(registrations, `${source}.getRegistrations()`);
+
+  for (let index = 0; index < registrations.length; index++) {
+    const path = `${source}.getRegistrations()[${index}]`;
+    const registration = registrations[index];
+    assertObject(registration, path, 'a registration object');
+
+    if (
+      registration.type === 'plugin' ||
+      registration.type === 'module' ||
+      registration.type === 'plugin-v1.1' ||
+      registration.type === 'module-v1.1'
+    ) {
+      assertString(registration.pluginId, `${path}.pluginId`);
+    }
+    if (registration.type === 'module' || registration.type === 'module-v1.1') {
+      const modulePath =
+        typeof registration.pluginId === 'string'
+          ? `module registration for plugin ${JSON.stringify(
+              registration.pluginId,
+            )}`
+          : path;
+      assertString(registration.moduleId, `${modulePath}.moduleId`);
+    }
+  }
+
+  return registrations as ReturnType<
+    InternalBackendRegistrations['getRegistrations']
+  >;
+}
+
+/**
+ * Validates the nested extension point and dependency data consumed while a
+ * single plugin or module registration is enumerated.
+ *
+ * The registration object and its identifying fields have already been
+ * validated by {@link validateBackendRegistrations}. Duplicate and conflicting
+ * registrations are handled separately by the backend initializer.
+ */
+export function validateBackendRegistration(
+  registration: ReturnType<
+    InternalBackendRegistrations['getRegistrations']
+  >[number],
+): void {
+  let registrationPath = 'registration';
+  if ('moduleId' in registration) {
+    registrationPath = `module ${JSON.stringify(
+      registration.moduleId,
+    )} for plugin ${JSON.stringify(registration.pluginId)}`;
+  } else if ('pluginId' in registration) {
+    registrationPath = `plugin ${JSON.stringify(registration.pluginId)}`;
+  }
+
+  if (registration.type === 'plugin' || registration.type === 'module') {
+    assertArray(
+      registration.extensionPoints,
+      `${registrationPath}.extensionPoints`,
+    );
+    for (let index = 0; index < registration.extensionPoints.length; index++) {
+      const itemPath = `${registrationPath}.extensionPoints[${index}]`;
+      const item: unknown = registration.extensionPoints[index];
+      assertArray(item, itemPath);
+      validateExtensionPoint(item[0], `${itemPath}[0]`);
+    }
+  } else if (
+    registration.type === 'plugin-v1.1' ||
+    registration.type === 'module-v1.1'
+  ) {
+    assertArray(
+      registration.extensionPoints,
+      `${registrationPath}.extensionPoints`,
+    );
+    for (let index = 0; index < registration.extensionPoints.length; index++) {
+      const itemPath = `${registrationPath}.extensionPoints[${index}]`;
+      const item: unknown = registration.extensionPoints[index];
+      assertObject(item, itemPath, 'an extension point registration object');
+      validateExtensionPoint(item.extensionPoint, `${itemPath}.extensionPoint`);
+    }
+  }
+
+  if (
+    registration.type === 'plugin' ||
+    registration.type === 'module' ||
+    registration.type === 'plugin-v1.1' ||
+    registration.type === 'module-v1.1'
+  ) {
+    assertObject(
+      registration.init,
+      `${registrationPath}.init`,
+      'an init registration object',
+    );
+    assertObject(
+      registration.init.deps,
+      `${registrationPath}.init.deps`,
+      'a dependency object',
+    );
+    for (const [name, ref] of Object.entries(registration.init.deps)) {
+      const path = `${registrationPath}.init.deps.${name}`;
+      if (
+        (registration.type === 'module' ||
+          registration.type === 'module-v1.1') &&
+        typeof ref === 'object' &&
+        ref !== null &&
+        (ref as { $$type?: unknown }).$$type === '@backstage/ExtensionPoint'
+      ) {
+        validateExtensionPoint(ref, path);
+      } else {
+        validateServiceRef(ref, path);
+      }
+    }
+  }
+}
+
+export function describeBackendFeature(value: unknown): string | undefined {
+  if (
+    (typeof value !== 'object' || value === null) &&
+    typeof value !== 'function'
+  ) {
+    return undefined;
+  }
+
+  const feature = value as Record<string, unknown>;
+  const service = feature.service;
+  if (typeof service === 'object' && service !== null && 'id' in service) {
+    const serviceId = service.id;
+    if (typeof serviceId === 'string') {
+      return `service factory for ${JSON.stringify(serviceId)}`;
+    }
+  }
+
+  if (
+    feature.featureType === 'loader' &&
+    typeof feature.description === 'string'
+  ) {
+    return `feature loader ${feature.description}`;
+  }
+
+  if (typeof feature.description === 'string') {
+    return `backend feature ${feature.description}`;
+  }
+
+  return undefined;
+}
+
+export function validateBackendFeature(
+  value: unknown,
+  path: string,
+): ValidatedBackendFeature {
+  assertObjectLike(value, path);
+  if (value.$$type !== '@backstage/BackendFeature') {
+    throwInvalidBackendFeature(
+      `${path}.$$type`,
+      '"@backstage/BackendFeature"',
+      value.$$type,
+    );
+  }
+  if (value.version !== 'v1') {
+    throwInvalidBackendFeature(`${path}.version`, '"v1"', value.version);
+  }
+
+  if (value.featureType === 'service' || 'service' in value) {
+    return {
+      type: 'service',
+      feature: value as unknown as InternalServiceFactory,
+    };
+  }
+  if (value.featureType === 'loader') {
+    return {
+      type: 'loader',
+      feature: value as unknown as InternalBackendFeatureLoader,
+    };
+  }
+  if (value.featureType === 'registrations' || 'getRegistrations' in value) {
+    return {
+      type: 'registrations',
+      feature: value as unknown as InternalBackendRegistrations,
+    };
+  }
+
+  return throwInvalidBackendFeature(
+    `${path}.featureType`,
+    '"service", "registrations", or "loader"',
+    value.featureType,
+  );
+}

--- a/packages/backend-internal/src/wiring/helpers.ts
+++ b/packages/backend-internal/src/wiring/helpers.ts
@@ -38,13 +38,22 @@ export function isPromise<T>(value: unknown | Promise<T>): value is Promise<T> {
 export function unwrapFeature(
   feature: BackendFeature | { default: BackendFeature },
 ): BackendFeature {
-  if ('$$type' in feature) {
-    return feature;
+  let current: unknown = feature;
+  for (let i = 0; i < 2; i++) {
+    if (
+      current !== null &&
+      (typeof current === 'object' || typeof current === 'function')
+    ) {
+      if ('$$type' in current) {
+        return current as BackendFeature;
+      }
+      if ('default' in current) {
+        current = current.default;
+        continue;
+      }
+    }
+    break;
   }
 
-  if ('default' in feature) {
-    return feature.default;
-  }
-
-  return feature;
+  return current as BackendFeature;
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds validation of installed backend features before their data is consumed, surfacing contextual input errors instead of unrelated runtime failures.

Validation errors are attributed to plugins and modules when possible, allowing the existing boot failure configuration to determine whether backend startup should continue.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
