### PR TITLE
fix(mcp-actions): advertise scopes_supported in protected resource metadata

### DIFF
--- a/.changeset/mcp-protected-resource-scopes.md
+++ b/.changeset/mcp-protected-resource-scopes.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-mcp-actions-backend': patch
+---
+
+Added `scopes_supported` to the OAuth 2.0 Protected Resource Metadata (RFC 9728) response. Without this field, RFC-compliant MCP clients did not know which scope to request and never received a refresh token, causing sessions to expire with the short-lived access token. The field now includes `openid`, and also `offline_access` when `auth.experimentalRefreshToken` is enabled.

--- a/plugins/mcp-actions-backend/src/plugin.test.ts
+++ b/plugins/mcp-actions-backend/src/plugin.test.ts
@@ -333,6 +333,49 @@ describe('Mcp Backend', () => {
       expect(response.body.authorization_servers[0]).toContain(
         `${mockExternalBaseUrl}/`,
       );
+      expect(response.body.scopes_supported).toEqual(['openid']);
+    });
+
+    it('should include offline_access in scopes_supported when refresh tokens are enabled', async () => {
+      const mockExternalBaseUrl = 'http://external.local:0/api';
+      const mockDiscovery = mockServices.discovery.mock({
+        getExternalBaseUrl: async pluginId =>
+          `${mockExternalBaseUrl}/${pluginId}`,
+      });
+
+      const { server } = await startTestBackend({
+        features: [
+          mcpPlugin,
+          mockPluginWithActions,
+          mockDiscovery.factory,
+          mockServices.rootConfig.factory({
+            data: {
+              backend: {
+                actions: {
+                  pluginSources: ['local'],
+                },
+              },
+              auth: {
+                experimentalDynamicClientRegistration: {
+                  enabled: true,
+                },
+                experimentalRefreshToken: {
+                  enabled: true,
+                },
+              },
+            },
+          }),
+        ],
+      });
+
+      const response = await request(server).get(
+        '/.well-known/oauth-protected-resource/api/mcp-actions/v1',
+      );
+      expect(response.status).toBe(200);
+      expect(response.body.scopes_supported).toEqual([
+        'openid',
+        'offline_access',
+      ]);
     });
 
     const pathTestCases = [
@@ -391,6 +434,7 @@ describe('Mcp Backend', () => {
         expect(response.body.authorization_servers[0]).toContain(
           `${mockExternalBaseUrl}/`,
         );
+        expect(response.body.scopes_supported).toEqual(['openid']);
       },
     );
 
@@ -423,6 +467,7 @@ describe('Mcp Backend', () => {
       expect(response.body.resource).toMatch(/\/api\/mcp-actions\/v1$/);
       expect(response.body.authorization_servers).toHaveLength(1);
       expect(response.body.authorization_servers[0]).toMatch(/\/api\/auth$/);
+      expect(response.body.scopes_supported).toEqual(['openid']);
     });
 
     it('should support the deprecated experimental CIMD configuration', async () => {

--- a/plugins/mcp-actions-backend/src/plugin.ts
+++ b/plugins/mcp-actions-backend/src/plugin.ts
@@ -149,6 +149,10 @@ export const mcpPlugin = createBackendPlugin({
           // Protected Resource Metadata (RFC 9728)
           // https://datatracker.ietf.org/doc/html/rfc9728
           // This allows MCP clients to discover the authorization server for this resource
+          const refreshTokenEnabled = config.getOptionalBoolean(
+            'auth.experimentalRefreshToken.enabled',
+          );
+
           const serverSuffixes = serverConfigs?.size
             ? [...serverConfigs.keys()].map(key => `/v1/${key}`)
             : ['/v1'];
@@ -167,6 +171,14 @@ export const mcpPlugin = createBackendPlugin({
                 res.json({
                   resource: `${mcpBaseUrl}${suffix}`,
                   authorization_servers: [authBaseUrl],
+                  // RFC 9728 §2: clients discover which scope to request from
+                  // this field. Without it, RFC-compliant MCP clients request
+                  // no scope and never receive a refresh token (OIDC Core §11
+                  // requires offline_access to signal refresh token issuance).
+                  scopes_supported: [
+                    'openid',
+                    ...(refreshTokenEnabled ? ['offline_access'] : []),
+                  ],
                 });
               },
             );


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Summary

The OAuth 2.0 Protected Resource Metadata endpoint (`/.well-known/oauth-protected-resource`) did not include `scopes_supported` ([RFC 9728 §2](https://www.rfc-editor.org/rfc/rfc9728#section-2)). This field is how RFC-compliant MCP clients discover which scope to include in the authorization request.

Without it, clients request no scope and never receive a refresh token ([OIDC Core §11](https://openid.net/specs/openid-connect-core-1_0.html#OfflineAccess) requires `offline_access` to signal refresh token issuance), causing MCP sessions to expire with the ~1 hour access token.

### Changes

- Added `scopes_supported` to the protected resource metadata response. Always includes `openid`; includes `offline_access` when `auth.experimentalRefreshToken.enabled` is set — matching what the auth service already advertises in its own OIDC discovery document (`OidcService.ts`).
- Added test coverage for the new field, including a dedicated test for the refresh token config gate.

### Reproduction

1. Start Backstage with MCP and OAuth enabled (`auth.experimentalDynamicClientRegistration.enabled` or CIMD)
2. `curl /.well-known/oauth-protected-resource/api/mcp-actions/v1`
3. Observe no `scopes_supported` in the response
4. Connect an RFC-compliant MCP client (Claude Code, Cursor, MCP Inspector) — the authorization URL has no `scope` parameter
5. Token response has no `refresh_token` — session dies after ~1h access token expires

With the fix, the client discovers `offline_access` from the metadata and includes it in the authorization request, receiving a refresh token.

### Checklist

- [x] Changeset included
- [x] Tests pass (`yarn workspace @backstage/plugin-mcp-actions-backend test --no-watch` — 46 passing)
- [x] Changes follow the coding guidelines