### PR TITLE
chore(permission): Migrate permission packages to MSW 2

### DIFF
--- a/.changeset/migrate-msw2-permission.md
+++ b/.changeset/migrate-msw2-permission.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-permission-backend': patch
+'@backstage/plugin-permission-common': patch
+'@backstage/plugin-permission-node': patch
+---
+
+Migrated tests from MSW v1 to MSW v2.

--- a/plugins/permission-backend/package.json
+++ b/plugins/permission-backend/package.json
@@ -70,7 +70,7 @@
     "@types/express": "^4.17.6",
     "@types/lodash": "^4.14.151",
     "@types/supertest": "^2.0.8",
-    "msw": "^1.0.0",
+    "msw": "^2.0.0",
     "supertest": "^7.0.0"
   }
 }

--- a/plugins/permission-backend/src/service/PermissionIntegrationClient.test.ts
+++ b/plugins/permission-backend/src/service/PermissionIntegrationClient.test.ts
@@ -17,7 +17,7 @@
 import { AddressInfo } from 'node:net';
 import { Server } from 'node:http';
 import express, { Router, RequestHandler } from 'express';
-import { RestContext, rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer, SetupServer } from 'msw/node';
 import { mockCredentials, mockServices } from '@backstage/backend-test-utils';
 import {
@@ -51,13 +51,21 @@ describe('PermissionIntegrationClient', () => {
       },
     };
 
-    const mockApplyConditionsHandler = jest.fn(
-      (_req, res, { json }: RestContext) => {
-        return res(
-          json({ items: [{ id: '123', result: AuthorizeResult.ALLOW }] }),
-        );
-      },
-    );
+    let mockApplyConditionsRequestBody: {
+      items: {
+        id: string;
+        resourceRef: string;
+        resourceType: string;
+        conditions: PermissionCriteria<PermissionCondition>;
+      }[];
+    };
+    const mockApplyConditionsHandler = jest.fn(async ({ request }) => {
+      mockApplyConditionsRequestBody =
+        (await request.json()) as typeof mockApplyConditionsRequestBody;
+      return HttpResponse.json({
+        items: [{ id: '123', result: AuthorizeResult.ALLOW }],
+      });
+    });
 
     const mockBaseUrl = 'http://backstage:9191';
     const discovery: DiscoveryService = {
@@ -80,7 +88,7 @@ describe('PermissionIntegrationClient', () => {
       server = setupServer();
       server.listen({ onUnhandledRequest: 'error' });
       server.use(
-        rest.post(
+        http.post(
           `${mockBaseUrl}/plugin-1/.well-known/backstage/permissions/apply-conditions`,
           mockApplyConditionsHandler,
         ),
@@ -116,22 +124,16 @@ describe('PermissionIntegrationClient', () => {
         },
       ]);
 
-      expect(mockApplyConditionsHandler).toHaveBeenCalledWith(
-        expect.objectContaining({
-          body: {
-            items: [
-              {
-                id: '123',
-                resourceRef: 'testResource1',
-                resourceType: 'test-resource',
-                conditions: mockConditions,
-              },
-            ],
+      expect(mockApplyConditionsRequestBody).toEqual({
+        items: [
+          {
+            id: '123',
+            resourceRef: 'testResource1',
+            resourceType: 'test-resource',
+            conditions: mockConditions,
           },
-        }),
-        expect.anything(),
-        expect.anything(),
-      );
+        ],
+      });
     });
 
     it('should return the response from the fetch request', async () => {
@@ -161,8 +163,11 @@ describe('PermissionIntegrationClient', () => {
         },
       ]);
 
-      const request = mockApplyConditionsHandler.mock.calls[0][0];
-      expect(request.headers.has('authorization')).toEqual(false);
+      expect(
+        mockApplyConditionsHandler.mock.calls[0][0].request.headers.has(
+          'authorization',
+        ),
+      ).toEqual(false);
     });
 
     it('should include correctly-constructed authorization header if token is supplied', async () => {
@@ -175,8 +180,11 @@ describe('PermissionIntegrationClient', () => {
         },
       ]);
 
-      const request = mockApplyConditionsHandler.mock.calls[0][0];
-      expect(request.headers.get('authorization')).toEqual(
+      expect(
+        mockApplyConditionsHandler.mock.calls[0][0].request.headers.get(
+          'authorization',
+        ),
+      ).toEqual(
         mockCredentials.service.header({
           onBehalfOf: mockCredentials.user(),
           targetPluginId: 'plugin-1',
@@ -186,9 +194,7 @@ describe('PermissionIntegrationClient', () => {
 
     it('should forward response errors', async () => {
       mockApplyConditionsHandler.mockImplementationOnce(
-        (_req, res, { status }: RestContext) => {
-          return res(status(401));
-        },
+        async () => new HttpResponse(null, { status: 401 }),
       );
 
       await expect(
@@ -204,12 +210,10 @@ describe('PermissionIntegrationClient', () => {
     });
 
     it('should reject invalid responses', async () => {
-      mockApplyConditionsHandler.mockImplementationOnce(
-        (_req, res, { json }: RestContext) => {
-          return res(
-            json({ items: [{ id: '123', outcome: AuthorizeResult.ALLOW }] }),
-          );
-        },
+      mockApplyConditionsHandler.mockImplementationOnce(async () =>
+        HttpResponse.json({
+          items: [{ id: '123', outcome: AuthorizeResult.ALLOW }],
+        }),
       );
 
       await expect(
@@ -225,18 +229,14 @@ describe('PermissionIntegrationClient', () => {
     });
 
     it('should batch requests to plugin backends', async () => {
-      mockApplyConditionsHandler.mockImplementationOnce(
-        (_req, res, { json }: RestContext) => {
-          return res(
-            json({
-              items: [
-                { id: '123', result: AuthorizeResult.ALLOW },
-                { id: '456', result: AuthorizeResult.DENY },
-                { id: '789', result: AuthorizeResult.ALLOW },
-              ],
-            }),
-          );
-        },
+      mockApplyConditionsHandler.mockImplementationOnce(async () =>
+        HttpResponse.json({
+          items: [
+            { id: '123', result: AuthorizeResult.ALLOW },
+            { id: '456', result: AuthorizeResult.DENY },
+            { id: '789', result: AuthorizeResult.ALLOW },
+          ],
+        }),
       );
 
       await expect(

--- a/plugins/permission-common/package.json
+++ b/plugins/permission-common/package.json
@@ -57,7 +57,7 @@
   },
   "devDependencies": {
     "@backstage/cli": "workspace:^",
-    "msw": "^1.0.0"
+    "msw": "^2.0.0"
   },
   "configSchema": "config.d.ts"
 }

--- a/plugins/permission-common/src/PermissionClient.test.ts
+++ b/plugins/permission-common/src/PermissionClient.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { RestContext, rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { ConfigReader } from '@backstage/config';
 import {
@@ -65,19 +65,26 @@ describe('PermissionClient', () => {
       resourceRef: 'foo:bar',
     };
 
-    const mockAuthorizeHandler = jest.fn((req, res, { json }: RestContext) => {
-      const responses = req.body.items.map(
+    let mockAuthorizeRequestBody: {
+      items: IdentifiedPermissionMessage<EvaluatePermissionRequest>[];
+    };
+    const mockAuthorizeHandler = jest.fn(async ({ request }) => {
+      const body = (await request.json()) as {
+        items: IdentifiedPermissionMessage<EvaluatePermissionRequest>[];
+      };
+      mockAuthorizeRequestBody = body;
+      const responses = body.items.map(
         (a: IdentifiedPermissionMessage<EvaluatePermissionRequest>) => ({
           id: a.id,
           result: AuthorizeResult.ALLOW,
         }),
       );
 
-      return res(json({ items: responses }));
+      return HttpResponse.json({ items: responses });
     });
 
     beforeEach(() => {
-      server.use(rest.post(`${mockBaseUrl}/authorize`, mockAuthorizeHandler));
+      server.use(http.post(`${mockBaseUrl}/authorize`, mockAuthorizeHandler));
     });
 
     afterEach(() => {
@@ -92,9 +99,7 @@ describe('PermissionClient', () => {
     it('should include a request body', async () => {
       await client.authorize([mockAuthorizeConditional]);
 
-      const request = mockAuthorizeHandler.mock.calls[0][0];
-
-      expect(request.body).toEqual({
+      expect(mockAuthorizeRequestBody).toEqual({
         items: [
           expect.objectContaining({
             permission: mockPermission,
@@ -114,22 +119,26 @@ describe('PermissionClient', () => {
     it('should not include authorization headers if no token is supplied', async () => {
       await client.authorize([mockAuthorizeConditional]);
 
-      const request = mockAuthorizeHandler.mock.calls[0][0];
-      expect(request.headers.has('authorization')).toEqual(false);
+      expect(
+        mockAuthorizeHandler.mock.calls[0][0].request.headers.has(
+          'authorization',
+        ),
+      ).toEqual(false);
     });
 
     it('should include correctly-constructed authorization header if token is supplied', async () => {
       await client.authorize([mockAuthorizeConditional], { token });
 
-      const request = mockAuthorizeHandler.mock.calls[0][0];
-      expect(request.headers.get('authorization')).toEqual('Bearer fake-token');
+      expect(
+        mockAuthorizeHandler.mock.calls[0][0].request.headers.get(
+          'authorization',
+        ),
+      ).toEqual('Bearer fake-token');
     });
 
     it('should forward response errors', async () => {
       mockAuthorizeHandler.mockImplementationOnce(
-        (_req, res, { status }: RestContext) => {
-          return res(status(401));
-        },
+        async () => new HttpResponse(null, { status: 401 }),
       );
       await expect(
         client.authorize([mockAuthorizeConditional], { token }),
@@ -137,14 +146,10 @@ describe('PermissionClient', () => {
     });
 
     it('should reject responses with missing ids', async () => {
-      mockAuthorizeHandler.mockImplementationOnce(
-        (_req, res, { json }: RestContext) => {
-          return res(
-            json({
-              items: [{ id: 'wrong-id', result: AuthorizeResult.ALLOW }],
-            }),
-          );
-        },
+      mockAuthorizeHandler.mockImplementationOnce(async () =>
+        HttpResponse.json({
+          items: [{ id: 'wrong-id', result: AuthorizeResult.ALLOW }],
+        }),
       );
       await expect(
         client.authorize([mockAuthorizeConditional], { token }),
@@ -152,36 +157,25 @@ describe('PermissionClient', () => {
     });
 
     it('should reject invalid responses', async () => {
-      mockAuthorizeHandler.mockImplementationOnce(
-        (req, res, { json }: RestContext) => {
-          const responses = req.body.items.map(
-            (a: IdentifiedPermissionMessage<EvaluatePermissionRequest>) => ({
-              id: a.id,
-              outcome: AuthorizeResult.ALLOW,
-            }),
-          );
+      mockAuthorizeHandler.mockImplementationOnce(async ({ request }) => {
+        const body = (await request.json()) as {
+          items: IdentifiedPermissionMessage<EvaluatePermissionRequest>[];
+        };
+        const responses = body.items.map(
+          (a: IdentifiedPermissionMessage<EvaluatePermissionRequest>) => ({
+            id: a.id,
+            outcome: AuthorizeResult.ALLOW,
+          }),
+        );
 
-          return res(json({ items: responses }));
-        },
-      );
+        return HttpResponse.json({ items: responses });
+      });
       await expect(
         client.authorize([mockAuthorizeConditional], { token }),
       ).rejects.toThrow(/invalid input/i);
     });
 
     it('should allow all when permission.enabled is false', async () => {
-      mockAuthorizeHandler.mockImplementationOnce(
-        (req, res, { json }: RestContext) => {
-          const responses = req.body.map(
-            (a: IdentifiedPermissionMessage<EvaluatePermissionRequest>) => ({
-              id: a.id,
-              result: AuthorizeResult.DENY,
-            }),
-          );
-
-          return res(json({ items: responses }));
-        },
-      );
       const disabled = new PermissionClient({
         discovery,
         config: new ConfigReader({ permission: { enabled: false } }),
@@ -194,18 +188,6 @@ describe('PermissionClient', () => {
     });
 
     it('should allow all when permission.enabled is not configured', async () => {
-      mockAuthorizeHandler.mockImplementationOnce(
-        (req, res, { json }: RestContext) => {
-          const responses = req.body.map(
-            (a: IdentifiedPermissionMessage<EvaluatePermissionRequest>) => ({
-              id: a.id,
-              outcome: AuthorizeResult.DENY,
-            }),
-          );
-
-          return res(json(responses));
-        },
-      );
       const disabled = new PermissionClient({
         discovery,
         config: new ConfigReader({}),
@@ -237,23 +219,28 @@ describe('PermissionClient', () => {
     };
 
     const mockAuthorizeHandler = jest.fn();
+    let mockAuthorizeRequestBody: {
+      items: BatchedAuthorizePermissionRequest[];
+    };
 
     beforeEach(() => {
       mockAuthorizeHandler.mockReset();
-      server.use(rest.post(`${mockBaseUrl}/authorize`, mockAuthorizeHandler));
+      server.use(http.post(`${mockBaseUrl}/authorize`, mockAuthorizeHandler));
 
-      mockAuthorizeHandler.mockImplementation(
-        (req, res, { json }: RestContext) => {
-          const responses = req.body.items.map(
-            (a: BatchedAuthorizePermissionRequest) => ({
-              id: a.id,
-              result: [AuthorizeResult.ALLOW],
-            }),
-          );
+      mockAuthorizeHandler.mockImplementation(async ({ request }) => {
+        const body = (await request.json()) as {
+          items: BatchedAuthorizePermissionRequest[];
+        };
+        mockAuthorizeRequestBody = body;
+        const responses = body.items.map(
+          (a: BatchedAuthorizePermissionRequest) => ({
+            id: a.id,
+            result: [AuthorizeResult.ALLOW],
+          }),
+        );
 
-          return res(json({ items: responses }));
-        },
-      );
+        return HttpResponse.json({ items: responses });
+      });
     });
 
     afterEach(() => {
@@ -278,9 +265,7 @@ describe('PermissionClient', () => {
         { permission: basicPermission },
       ]);
 
-      const request = mockAuthorizeHandler.mock.calls[0][0];
-
-      expect(request.body).toEqual({
+      expect(mockAuthorizeRequestBody).toEqual({
         items: [
           {
             id: expect.any(String),
@@ -305,22 +290,26 @@ describe('PermissionClient', () => {
     it('should not include authorization headers if no token is supplied', async () => {
       await client.authorize([mockAuthorizeConditional]);
 
-      const request = mockAuthorizeHandler.mock.calls[0][0];
-      expect(request.headers.has('authorization')).toEqual(false);
+      expect(
+        mockAuthorizeHandler.mock.calls[0][0].request.headers.has(
+          'authorization',
+        ),
+      ).toEqual(false);
     });
 
     it('should include correctly-constructed authorization header if token is supplied', async () => {
       await client.authorize([mockAuthorizeConditional], { token });
 
-      const request = mockAuthorizeHandler.mock.calls[0][0];
-      expect(request.headers.get('authorization')).toEqual('Bearer fake-token');
+      expect(
+        mockAuthorizeHandler.mock.calls[0][0].request.headers.get(
+          'authorization',
+        ),
+      ).toEqual('Bearer fake-token');
     });
 
     it('should forward response errors', async () => {
       mockAuthorizeHandler.mockImplementationOnce(
-        (_req, res, { status }: RestContext) => {
-          return res(status(401));
-        },
+        () => new HttpResponse(null, { status: 401 }),
       );
       await expect(
         client.authorize([mockAuthorizeConditional], { token }),
@@ -328,14 +317,10 @@ describe('PermissionClient', () => {
     });
 
     it('should reject responses with missing ids', async () => {
-      mockAuthorizeHandler.mockImplementationOnce(
-        (_req, res, { json }: RestContext) => {
-          return res(
-            json({
-              items: [{ id: 'wrong-id', result: [AuthorizeResult.ALLOW] }],
-            }),
-          );
-        },
+      mockAuthorizeHandler.mockImplementationOnce(() =>
+        HttpResponse.json({
+          items: [{ id: 'wrong-id', result: [AuthorizeResult.ALLOW] }],
+        }),
       );
       await expect(
         client.authorize([mockAuthorizeConditional], { token }),
@@ -343,18 +328,19 @@ describe('PermissionClient', () => {
     });
 
     it('should reject invalid responses', async () => {
-      mockAuthorizeHandler.mockImplementationOnce(
-        (req, res, { json }: RestContext) => {
-          const responses = req.body.items.map(
-            (a: IdentifiedPermissionMessage<EvaluatePermissionRequest>) => ({
-              id: a.id,
-              outcome: AuthorizeResult.ALLOW,
-            }),
-          );
+      mockAuthorizeHandler.mockImplementationOnce(async ({ request }) => {
+        const body = (await request.json()) as {
+          items: IdentifiedPermissionMessage<EvaluatePermissionRequest>[];
+        };
+        const responses = body.items.map(
+          (a: IdentifiedPermissionMessage<EvaluatePermissionRequest>) => ({
+            id: a.id,
+            outcome: AuthorizeResult.ALLOW,
+          }),
+        );
 
-          return res(json({ items: responses }));
-        },
-      );
+        return HttpResponse.json({ items: responses });
+      });
       await expect(
         client.authorize([mockAuthorizeConditional], { token }),
       ).rejects.toThrow(/invalid_type/i);
@@ -396,28 +382,28 @@ describe('PermissionClient', () => {
         attributes: {},
       });
 
-      mockAuthorizeHandler.mockImplementationOnce(
-        (req, res, { json }: RestContext) => {
-          return res(
-            json({
-              items: [
-                {
-                  id: req.body.items[0].id,
-                  result: [AuthorizeResult.ALLOW, AuthorizeResult.DENY],
-                },
-                {
-                  id: req.body.items[1].id,
-                  result: AuthorizeResult.DENY,
-                },
-                {
-                  id: req.body.items[2].id,
-                  result: [AuthorizeResult.DENY, AuthorizeResult.ALLOW],
-                },
-              ],
-            }),
-          );
-        },
-      );
+      mockAuthorizeHandler.mockImplementationOnce(async ({ request }) => {
+        const body = (await request.json()) as {
+          items: BatchedAuthorizePermissionRequest[];
+        };
+        mockAuthorizeRequestBody = body;
+        return HttpResponse.json({
+          items: [
+            {
+              id: body.items[0].id,
+              result: [AuthorizeResult.ALLOW, AuthorizeResult.DENY],
+            },
+            {
+              id: body.items[1].id,
+              result: AuthorizeResult.DENY,
+            },
+            {
+              id: body.items[2].id,
+              result: [AuthorizeResult.DENY, AuthorizeResult.ALLOW],
+            },
+          ],
+        });
+      });
 
       const response = await client.authorize([
         {
@@ -444,7 +430,7 @@ describe('PermissionClient', () => {
         },
       ]);
 
-      expect(mockAuthorizeHandler.mock.calls[0][0].body).toEqual({
+      expect(mockAuthorizeRequestBody).toEqual({
         items: [
           {
             permission: {
@@ -500,29 +486,34 @@ describe('PermissionClient', () => {
       permission: mockPermission,
     };
 
-    const mockPolicyDecisionHandler = jest.fn(
-      (req, res, { json }: RestContext) => {
-        const responses = req.body.items.map(
-          (a: IdentifiedPermissionMessage<ConditionalPolicyDecision>) => ({
-            id: a.id,
-            pluginId: 'test-plugin',
+    let mockPolicyDecisionRequestBody: {
+      items: IdentifiedPermissionMessage<ConditionalPolicyDecision>[];
+    };
+    const mockPolicyDecisionHandler = jest.fn(async ({ request }) => {
+      const body = (await request.json()) as {
+        items: IdentifiedPermissionMessage<ConditionalPolicyDecision>[];
+      };
+      mockPolicyDecisionRequestBody = body;
+      const responses = body.items.map(
+        (a: IdentifiedPermissionMessage<ConditionalPolicyDecision>) => ({
+          id: a.id,
+          pluginId: 'test-plugin',
+          resourceType: 'test-resource',
+          result: AuthorizeResult.CONDITIONAL,
+          conditions: {
             resourceType: 'test-resource',
-            result: AuthorizeResult.CONDITIONAL,
-            conditions: {
-              resourceType: 'test-resource',
-              rule: 'FOO',
-              params: { foo: 'bar' },
-            },
-          }),
-        );
+            rule: 'FOO',
+            params: { foo: 'bar' },
+          },
+        }),
+      );
 
-        return res(json({ items: responses }));
-      },
-    );
+      return HttpResponse.json({ items: responses });
+    });
 
     beforeEach(() => {
       server.use(
-        rest.post(`${mockBaseUrl}/authorize`, mockPolicyDecisionHandler),
+        http.post(`${mockBaseUrl}/authorize`, mockPolicyDecisionHandler),
       );
     });
 
@@ -538,9 +529,7 @@ describe('PermissionClient', () => {
     it('should include a request body', async () => {
       await client.authorizeConditional([mockResourceAuthorizeConditional]);
 
-      const request = mockPolicyDecisionHandler.mock.calls[0][0];
-
-      expect(request.body).toEqual({
+      expect(mockPolicyDecisionRequestBody).toEqual({
         items: [
           expect.objectContaining({
             permission: mockPermission,
@@ -568,8 +557,11 @@ describe('PermissionClient', () => {
     it('should not include authorization headers if no token is supplied', async () => {
       await client.authorizeConditional([mockResourceAuthorizeConditional]);
 
-      const request = mockPolicyDecisionHandler.mock.calls[0][0];
-      expect(request.headers.has('authorization')).toEqual(false);
+      expect(
+        mockPolicyDecisionHandler.mock.calls[0][0].request.headers.has(
+          'authorization',
+        ),
+      ).toEqual(false);
     });
 
     it('should include correctly-constructed authorization header if token is supplied', async () => {
@@ -577,15 +569,16 @@ describe('PermissionClient', () => {
         token,
       });
 
-      const request = mockPolicyDecisionHandler.mock.calls[0][0];
-      expect(request.headers.get('authorization')).toEqual('Bearer fake-token');
+      expect(
+        mockPolicyDecisionHandler.mock.calls[0][0].request.headers.get(
+          'authorization',
+        ),
+      ).toEqual('Bearer fake-token');
     });
 
     it('should forward response errors', async () => {
       mockPolicyDecisionHandler.mockImplementationOnce(
-        (_req, res, { status }: RestContext) => {
-          return res(status(401));
-        },
+        async () => new HttpResponse(null, { status: 401 }),
       );
       await expect(
         client.authorizeConditional([mockResourceAuthorizeConditional], {
@@ -595,24 +588,25 @@ describe('PermissionClient', () => {
     });
 
     it('should handle responses with rules with no params', async () => {
-      mockPolicyDecisionHandler.mockImplementationOnce(
-        (req, res, { json }: RestContext) => {
-          const responses = req.body.items.map(
-            (a: IdentifiedPermissionMessage<ConditionalPolicyDecision>) => ({
-              id: a.id,
-              pluginId: 'test-plugin',
+      mockPolicyDecisionHandler.mockImplementationOnce(async ({ request }) => {
+        const body = (await request.json()) as {
+          items: IdentifiedPermissionMessage<ConditionalPolicyDecision>[];
+        };
+        const responses = body.items.map(
+          (a: IdentifiedPermissionMessage<ConditionalPolicyDecision>) => ({
+            id: a.id,
+            pluginId: 'test-plugin',
+            resourceType: 'test-resource',
+            result: AuthorizeResult.CONDITIONAL,
+            conditions: {
               resourceType: 'test-resource',
-              result: AuthorizeResult.CONDITIONAL,
-              conditions: {
-                resourceType: 'test-resource',
-                rule: 'FOO',
-              },
-            }),
-          );
+              rule: 'FOO',
+            },
+          }),
+        );
 
-          return res(json({ items: responses }));
-        },
-      );
+        return HttpResponse.json({ items: responses });
+      });
 
       const response = await client.authorizeConditional([
         mockResourceAuthorizeConditional,
@@ -629,14 +623,10 @@ describe('PermissionClient', () => {
     });
 
     it('should reject responses with missing ids', async () => {
-      mockPolicyDecisionHandler.mockImplementationOnce(
-        (_req, res, { json }: RestContext) => {
-          return res(
-            json({
-              items: [{ id: 'wrong-id', result: AuthorizeResult.ALLOW }],
-            }),
-          );
-        },
+      mockPolicyDecisionHandler.mockImplementationOnce(async () =>
+        HttpResponse.json({
+          items: [{ id: 'wrong-id', result: AuthorizeResult.ALLOW }],
+        }),
       );
       await expect(
         client.authorizeConditional([mockResourceAuthorizeConditional], {
@@ -646,18 +636,19 @@ describe('PermissionClient', () => {
     });
 
     it('should reject invalid responses', async () => {
-      mockPolicyDecisionHandler.mockImplementationOnce(
-        (req, res, { json }: RestContext) => {
-          const responses = req.body.items.map(
-            (a: IdentifiedPermissionMessage<ConditionalPolicyDecision>) => ({
-              id: a.id,
-              outcome: AuthorizeResult.ALLOW,
-            }),
-          );
+      mockPolicyDecisionHandler.mockImplementationOnce(async ({ request }) => {
+        const body = (await request.json()) as {
+          items: IdentifiedPermissionMessage<ConditionalPolicyDecision>[];
+        };
+        const responses = body.items.map(
+          (a: IdentifiedPermissionMessage<ConditionalPolicyDecision>) => ({
+            id: a.id,
+            outcome: AuthorizeResult.ALLOW,
+          }),
+        );
 
-          return res(json({ items: responses }));
-        },
-      );
+        return HttpResponse.json({ items: responses });
+      });
       await expect(
         client.authorizeConditional([mockResourceAuthorizeConditional], {
           token,
@@ -666,18 +657,6 @@ describe('PermissionClient', () => {
     });
 
     it('should allow all when permission.enabled is false', async () => {
-      mockPolicyDecisionHandler.mockImplementationOnce(
-        (req, res, { json }: RestContext) => {
-          const responses = req.body.map(
-            (a: IdentifiedPermissionMessage<ConditionalPolicyDecision>) => ({
-              id: a.id,
-              result: AuthorizeResult.DENY,
-            }),
-          );
-
-          return res(json({ items: responses }));
-        },
-      );
       const disabled = new PermissionClient({
         discovery,
         config: new ConfigReader({ permission: { enabled: false } }),
@@ -695,18 +674,6 @@ describe('PermissionClient', () => {
     });
 
     it('should allow all when permission.enabled is not configured', async () => {
-      mockPolicyDecisionHandler.mockImplementationOnce(
-        (req, res, { json }: RestContext) => {
-          const responses = req.body.map(
-            (a: IdentifiedPermissionMessage<ConditionalPolicyDecision>) => ({
-              id: a.id,
-              outcome: AuthorizeResult.DENY,
-            }),
-          );
-
-          return res(json({ items: responses }));
-        },
-      );
       const disabled = new PermissionClient({
         discovery,
         config: new ConfigReader({}),

--- a/plugins/permission-node/package.json
+++ b/plugins/permission-node/package.json
@@ -71,7 +71,7 @@
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@types/supertest": "^2.0.8",
-    "msw": "^1.0.0",
+    "msw": "^2.0.0",
     "supertest": "^7.0.0"
   }
 }

--- a/plugins/permission-node/src/ServerPermissionClient.test.ts
+++ b/plugins/permission-node/src/ServerPermissionClient.test.ts
@@ -29,7 +29,7 @@ import {
 } from '@backstage/backend-test-utils';
 import { ConfigReader } from '@backstage/config';
 import { setupServer } from 'msw/node';
-import { RestContext, rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 
 const server = setupServer();
 
@@ -65,18 +65,21 @@ describe('ServerPermissionClient', () => {
     let mockAuthorizeHandler: jest.Mock;
 
     beforeEach(() => {
-      mockAuthorizeHandler = jest.fn((req, res, { json }: RestContext) => {
-        const responses = req.body.items.map(
+      mockAuthorizeHandler = jest.fn(async ({ request }) => {
+        const body = (await request.json()) as {
+          items: IdentifiedPermissionMessage<DefinitivePolicyDecision>[];
+        };
+        const responses = body.items.map(
           (r: IdentifiedPermissionMessage<DefinitivePolicyDecision>) => ({
             id: r.id,
             result: AuthorizeResult.ALLOW,
           }),
         );
 
-        return res(json({ items: responses }));
+        return HttpResponse.json({ items: responses });
       });
 
-      server.use(rest.post(`${mockBaseUrl}/authorize`, mockAuthorizeHandler));
+      server.use(http.post(`${mockBaseUrl}/authorize`, mockAuthorizeHandler));
     });
 
     it('should bypass the permission backend if permissions are disabled', async () => {
@@ -122,7 +125,9 @@ describe('ServerPermissionClient', () => {
 
       expect(mockAuthorizeHandler).toHaveBeenCalled();
       expect(
-        mockAuthorizeHandler.mock.calls[0][0].headers.get('authorization'),
+        mockAuthorizeHandler.mock.calls[0][0].request.headers.get(
+          'authorization',
+        ),
       ).toBe(
         mockCredentials.service.header({
           onBehalfOf: mockCredentials.user(),
@@ -136,18 +141,21 @@ describe('ServerPermissionClient', () => {
     let mockAuthorizeHandler: jest.Mock;
 
     beforeEach(() => {
-      mockAuthorizeHandler = jest.fn((req, res, { json }: RestContext) => {
-        const responses = req.body.items.map(
+      mockAuthorizeHandler = jest.fn(async ({ request }) => {
+        const body = (await request.json()) as {
+          items: IdentifiedPermissionMessage<ConditionalPolicyDecision>[];
+        };
+        const responses = body.items.map(
           (r: IdentifiedPermissionMessage<ConditionalPolicyDecision>) => ({
             id: r.id,
             result: AuthorizeResult.ALLOW,
           }),
         );
 
-        return res(json({ items: responses }));
+        return HttpResponse.json({ items: responses });
       });
 
-      server.use(rest.post(`${mockBaseUrl}/authorize`, mockAuthorizeHandler));
+      server.use(http.post(`${mockBaseUrl}/authorize`, mockAuthorizeHandler));
     });
 
     it('should bypass the permission backend if permissions are disabled', async () => {
@@ -197,7 +205,9 @@ describe('ServerPermissionClient', () => {
 
       expect(mockAuthorizeHandler).toHaveBeenCalled();
       expect(
-        mockAuthorizeHandler.mock.calls[0][0].headers.get('authorization'),
+        mockAuthorizeHandler.mock.calls[0][0].request.headers.get(
+          'authorization',
+        ),
       ).toBe(
         mockCredentials.service.header({
           onBehalfOf: mockCredentials.user(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -6144,7 +6144,7 @@ __metadata:
     express: "npm:^4.22.0"
     express-promise-router: "npm:^4.1.0"
     lodash: "npm:^4.17.21"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     supertest: "npm:^7.0.0"
     zod: "npm:^3.25.76 || ^4.0.0"
   languageName: unknown
@@ -6159,7 +6159,7 @@ __metadata:
     "@backstage/errors": "workspace:^"
     "@backstage/types": "workspace:^"
     cross-fetch: "npm:^4.0.0"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     zod: "npm:^3.25.76 || ^4.0.0"
     zod-to-json-schema: "npm:^3.25.1"
   languageName: unknown
@@ -6180,7 +6180,7 @@ __metadata:
     "@types/supertest": "npm:^2.0.8"
     express: "npm:^4.22.0"
     express-promise-router: "npm:^4.1.0"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     supertest: "npm:^7.0.0"
     zod: "npm:^3.25.76 || ^4.0.0"
     zod-to-json-schema: "npm:^3.25.1"


### PR DESCRIPTION
## Hey 👋

This PR migrates the following packages owned by `@backstage/permission-maintainers` from MSW v1 to MSW v2:

- `@backstage/plugin-permission-backend`
- `@backstage/plugin-permission-common`
- `@backstage/plugin-permission-node`

### Changes
- Updated MSW imports and handler syntax to v2 API
- Replaced `rest.*` handlers with `http.*` handlers
- Updated response helpers to use `HttpResponse`
- Updated `package.json` dependencies

---

### Checklist

- [x] I have read the [contribution guidelines](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md)
- [x] Added or updated tests
- [ ] Added or updated documentation
- [x] Verified that the change works locally