### PR TITLE
chore(kubernetes): Migrate kubernetes packages to MSW 2

### DIFF
--- a/.changeset/migrate-msw2-kubernetes.md
+++ b/.changeset/migrate-msw2-kubernetes.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+'@backstage/plugin-kubernetes-node': patch
+---
+
+Migrated tests from MSW v1 to MSW v2.

--- a/plugins/kubernetes-backend/package.json
+++ b/plugins/kubernetes-backend/package.json
@@ -40,7 +40,7 @@
     "prepack": "backstage-cli package prepack",
     "postpack": "backstage-cli package postpack",
     "start": "backstage-cli package start",
-    "test": "backstage-cli package test"
+    "test": "NODE_OPTIONS=--experimental-vm-modules backstage-cli package test"
   },
   "dependencies": {
     "@aws-crypto/sha256-js": "^5.0.0",
@@ -80,7 +80,7 @@
     "@backstage/plugin-permission-backend-module-allow-all-policy": "workspace:^",
     "@types/express": "^4.17.6",
     "@types/split2": "^4.2.0",
-    "msw": "^1.0.0",
+    "msw": "^2.0.0",
     "supertest": "^7.0.0",
     "ws": "^8.20.1"
   },

--- a/plugins/kubernetes-backend/src/service/KubernetesConnection.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesConnection.test.ts
@@ -19,7 +19,8 @@ import {
   KubernetesConnection,
   statusCodeToErrorType,
 } from './KubernetesConnection';
-import { rest } from 'msw';
+import * as https from 'node:https';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import {
   createMockDirectory,
@@ -154,8 +155,8 @@ describe('KubernetesConnection', () => {
   describe('fetchWithConnection', () => {
     it('fetches a resource and returns the response', async () => {
       worker.use(
-        rest.get('http://localhost:9999/api/v1/pods', (_req, res, ctx) =>
-          res(ctx.status(200), ctx.json({ items: [] })),
+        http.get('http://localhost:9999/api/v1/pods', () =>
+          HttpResponse.json({ items: [] }),
         ),
       );
 
@@ -172,9 +173,8 @@ describe('KubernetesConnection', () => {
 
     it('appends resource path to cluster URL with base path', async () => {
       worker.use(
-        rest.get(
-          'http://localhost:9999/k8s/clusters/123/api/v1/pods',
-          (_req, res, ctx) => res(ctx.status(200), ctx.json({ items: [] })),
+        http.get('http://localhost:9999/k8s/clusters/123/api/v1/pods', () =>
+          HttpResponse.json({ items: [] }),
         ),
       );
 
@@ -194,9 +194,10 @@ describe('KubernetesConnection', () => {
     it('includes labelSelector as query parameter', async () => {
       let capturedSelector = '';
       worker.use(
-        rest.get('http://localhost:9999/api/v1/pods', (req, res, ctx) => {
-          capturedSelector = req.url.searchParams.get('labelSelector') || '';
-          return res(ctx.status(200), ctx.json({ items: [] }));
+        http.get('http://localhost:9999/api/v1/pods', ({ request }) => {
+          capturedSelector =
+            new URL(request.url).searchParams.get('labelSelector') || '';
+          return HttpResponse.json({ items: [] });
         }),
       );
 
@@ -229,9 +230,9 @@ describe('KubernetesConnection', () => {
     it('sends Authorization header with bearer token', async () => {
       let capturedAuth = '';
       worker.use(
-        rest.get('http://localhost:9999/api/v1/pods', (req, res, ctx) => {
-          capturedAuth = req.headers.get('Authorization') || '';
-          return res(ctx.status(200), ctx.json({ items: [] }));
+        http.get('http://localhost:9999/api/v1/pods', ({ request }) => {
+          capturedAuth = request.headers.get('Authorization') || '';
+          return HttpResponse.json({ items: [] });
         }),
       );
 
@@ -247,9 +248,9 @@ describe('KubernetesConnection', () => {
     it('does not send Authorization header for anonymous credential with localKubectlProxy', async () => {
       let capturedAuth: string | null = '';
       worker.use(
-        rest.get('http://localhost:9999/api/v1/pods', (req, res, ctx) => {
-          capturedAuth = req.headers.get('Authorization');
-          return res(ctx.status(200), ctx.json({ items: [] }));
+        http.get('http://localhost:9999/api/v1/pods', ({ request }) => {
+          capturedAuth = request.headers.get('Authorization');
+          return HttpResponse.json({ items: [] });
         }),
       );
 
@@ -274,8 +275,8 @@ describe('KubernetesConnection', () => {
       const warn = jest.spyOn(logger, 'warn');
 
       worker.use(
-        rest.get('http://localhost:9999/api/v1/pods', (_req, res, ctx) =>
-          res(ctx.status(404), ctx.text('not found')),
+        http.get('http://localhost:9999/api/v1/pods', () =>
+          HttpResponse.text('not found', { status: 404 }),
         ),
       );
 
@@ -302,18 +303,18 @@ describe('KubernetesConnection', () => {
   });
 
   describe('TLS and agent caching', () => {
-    let httpsRequest: jest.SpyInstance;
+    const agentFactory = jest.fn((options: https.AgentOptions) => {
+      // MSW intercepts the request before Node validates this intentionally invalid certificate.
+      if (options.cert === 'MOCKCERT') {
+        throw new Error('PEM');
+      }
+      return new https.Agent(options);
+    });
     const initialCAPath = process.env.KUBERNETES_CA_FILE_PATH;
 
-    beforeAll(() => {
-      httpsRequest = jest.spyOn(
-        (worker as any).interceptor.interceptors[0].modules.get('https'),
-        'request',
-      );
-    });
-
     beforeEach(() => {
-      httpsRequest.mockClear();
+      agentFactory.mockClear();
+      connection = new KubernetesConnection({ logger, agentFactory });
       process.env.KUBERNETES_CA_FILE_PATH = mockCertDir.resolve('ca.crt');
     });
 
@@ -323,8 +324,8 @@ describe('KubernetesConnection', () => {
 
     it('creates agent with caData', async () => {
       worker.use(
-        rest.get('https://localhost:9999/api/v1/pods', (_req, res, ctx) =>
-          res(ctx.status(200), ctx.json({ items: [] })),
+        http.get('https://localhost:9999/api/v1/pods', () =>
+          HttpResponse.json({ items: [] }),
         ),
       );
 
@@ -339,15 +340,15 @@ describe('KubernetesConnection', () => {
         '/api/v1/pods',
       );
 
-      expect(httpsRequest).toHaveBeenCalledTimes(1);
-      const [[{ agent }]] = httpsRequest.mock.calls;
-      expect(agent.options.ca.toString('base64')).toMatch('MOCKCA');
+      expect(agentFactory).toHaveBeenCalledTimes(1);
+      const options = agentFactory.mock.calls[0][0];
+      expect(options.ca?.toString('base64')).toMatch('MOCKCA');
     });
 
     it('reuses cached agent for same cluster config', async () => {
       worker.use(
-        rest.get('https://localhost:9999/*', (_req, res, ctx) =>
-          res(ctx.status(200), ctx.json({ items: [] })),
+        http.get('https://localhost:9999/*', () =>
+          HttpResponse.json({ items: [] }),
         ),
       );
 
@@ -362,16 +363,13 @@ describe('KubernetesConnection', () => {
       await connection.fetchWithConnection(cluster, cred, '/api/v1/pods');
       await connection.fetchWithConnection(cluster, cred, '/api/v1/services');
 
-      expect(httpsRequest).toHaveBeenCalledTimes(2);
-      const agent1 = httpsRequest.mock.calls[0][0].agent;
-      const agent2 = httpsRequest.mock.calls[1][0].agent;
-      expect(agent1).toBe(agent2);
+      expect(agentFactory).toHaveBeenCalledTimes(1);
     });
 
     it('sets rejectUnauthorized to false when skipTLSVerify is true', async () => {
       worker.use(
-        rest.get('https://localhost:9999/api/v1/pods', (_req, res, ctx) =>
-          res(ctx.status(200), ctx.json({ items: [] })),
+        http.get('https://localhost:9999/api/v1/pods', () =>
+          HttpResponse.json({ items: [] }),
         ),
       );
 
@@ -386,15 +384,15 @@ describe('KubernetesConnection', () => {
         '/api/v1/pods',
       );
 
-      expect(httpsRequest).toHaveBeenCalledTimes(1);
-      const [[{ agent }]] = httpsRequest.mock.calls;
-      expect(agent.options.rejectUnauthorized).toBe(false);
+      expect(agentFactory).toHaveBeenCalledTimes(1);
+      const options = agentFactory.mock.calls[0][0];
+      expect(options.rejectUnauthorized).toBe(false);
     });
 
     it('configures agent with x509 client certificate', async () => {
       worker.use(
-        rest.get('https://localhost:9999/api/v1/pods', (_req, res, ctx) =>
-          res(ctx.status(200), ctx.json({ items: [] })),
+        http.get('https://localhost:9999/api/v1/pods', () =>
+          HttpResponse.json({ items: [] }),
         ),
       );
 
@@ -411,16 +409,16 @@ describe('KubernetesConnection', () => {
 
       await expect(result).rejects.toThrow(/PEM/);
 
-      expect(httpsRequest).toHaveBeenCalledTimes(1);
-      const [[{ agent }]] = httpsRequest.mock.calls;
-      expect(agent.options.cert).toBe('MOCKCERT');
-      expect(agent.options.key).toBe('MOCKKEY');
+      expect(agentFactory).toHaveBeenCalledTimes(1);
+      const options = agentFactory.mock.calls[0][0];
+      expect(options.cert).toBe('MOCKCERT');
+      expect(options.key).toBe('MOCKKEY');
     });
 
     it('reads caFile from disk', async () => {
       worker.use(
-        rest.get('https://localhost:9999/api/v1/pods', (_req, res, ctx) =>
-          res(ctx.status(200), ctx.json({ items: [] })),
+        http.get('https://localhost:9999/api/v1/pods', () =>
+          HttpResponse.json({ items: [] }),
         ),
       );
 
@@ -435,9 +433,9 @@ describe('KubernetesConnection', () => {
         '/api/v1/pods',
       );
 
-      expect(httpsRequest).toHaveBeenCalledTimes(1);
-      const [[{ agent }]] = httpsRequest.mock.calls;
-      expect(agent.options.ca.toString()).toEqual('MOCKCA');
+      expect(agentFactory).toHaveBeenCalledTimes(1);
+      const options = agentFactory.mock.calls[0][0];
+      expect(options.ca?.toString()).toEqual('MOCKCA');
     });
   });
 

--- a/plugins/kubernetes-backend/src/service/KubernetesConnection.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesConnection.ts
@@ -53,13 +53,21 @@ export type ConnectionResult =
 
 export class KubernetesConnection {
   private readonly logger: LoggerService;
+  private readonly agentFactory: (options: https.AgentOptions) => https.Agent;
   private readonly agentCache = new Map<string, https.Agent>();
   private inClusterCache:
     | { url: URL; agent: https.Agent | undefined }
     | undefined;
 
-  constructor({ logger }: { logger: LoggerService }) {
+  constructor({
+    logger,
+    agentFactory,
+  }: {
+    logger: LoggerService;
+    agentFactory?: (options: https.AgentOptions) => https.Agent;
+  }) {
     this.logger = logger;
+    this.agentFactory = agentFactory ?? (options => new https.Agent(options));
   }
 
   buildResourcePath(
@@ -208,7 +216,7 @@ export class KubernetesConnection {
       const url = new URL(cluster.server);
       const agent =
         url.protocol === 'https:'
-          ? new https.Agent({
+          ? this.agentFactory({
               ca: fs.readFileSync(cluster.caFile as string),
               keepAlive: true,
             })
@@ -247,7 +255,7 @@ export class KubernetesConnection {
 
     let agent = this.agentCache.get(key);
     if (!agent) {
-      agent = new https.Agent({
+      agent = this.agentFactory({
         ca,
         rejectUnauthorized: !clusterDetails.skipTLSVerify,
         keepAlive: true,

--- a/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFanOutHandler.test.ts
@@ -29,7 +29,7 @@ import {
 } from './KubernetesFanOutHandler';
 import { KubernetesClientBasedFetcher } from './KubernetesFetcher';
 import { KubernetesConnection } from './KubernetesConnection';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import {
   mockServices,
@@ -1218,17 +1218,15 @@ describe('KubernetesFanOutHandler', () => {
         const pods = [{ metadata: { name: 'pod-name' } }];
         const services = [{ metadata: { name: 'service-name' } }];
         worker.use(
-          rest.get('https://works/api/v1/pods', (_, res, ctx) =>
-            res(ctx.json({ items: pods })),
+          http.get('https://works/api/v1/pods', () =>
+            HttpResponse.json({ items: pods }),
           ),
-          rest.get('https://works/api/v1/services', (_, res, ctx) =>
-            res(ctx.json({ items: services })),
+          http.get('https://works/api/v1/services', () =>
+            HttpResponse.json({ items: services }),
           ),
-          rest.get('https://fails/api/v1/pods', (_, res) =>
-            res.networkError('socket error'),
-          ),
-          rest.get('https://fails/api/v1/services', (_, res, ctx) =>
-            res(ctx.json({ items: services })),
+          http.get('https://fails/api/v1/pods', () => HttpResponse.error()),
+          http.get('https://fails/api/v1/services', () =>
+            HttpResponse.json({ items: services }),
           ),
         );
 
@@ -1319,7 +1317,7 @@ describe('KubernetesFanOutHandler', () => {
                 {
                   errorType: 'FETCH_ERROR',
                   message:
-                    'request to https://fails/api/v1/pods?labelSelector=backstage.io%2Fkubernetes-id%3Dtest-component failed, reason: socket error',
+                    'request to https://fails/api/v1/pods?labelSelector=backstage.io%2Fkubernetes-id%3Dtest-component failed, reason: Network error',
                 },
               ],
             },

--- a/plugins/kubernetes-backend/src/service/KubernetesFetcher.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFetcher.test.ts
@@ -17,6 +17,7 @@
 import { ANNOTATION_KUBERNETES_AUTH_PROVIDER } from '@backstage/plugin-kubernetes-common';
 import { KubernetesClientBasedFetcher } from './KubernetesFetcher';
 import { ObjectToFetch } from '@backstage/plugin-kubernetes-node';
+import * as https from 'node:https';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import {
@@ -663,13 +664,30 @@ describe('KubernetesFetcher', () => {
     });
     describe('when server uses TLS', () => {
       const initialCAPath = process.env.KUBERNETES_CA_FILE_PATH;
+      const agentFactory = jest.fn(
+        (options: https.AgentOptions) => new https.Agent(options),
+      );
+
       beforeEach(() => {
+        agentFactory.mockClear();
+        sut = new KubernetesClientBasedFetcher({
+          logger,
+          connection: new KubernetesConnection({ logger, agentFactory }),
+        });
         process.env.KUBERNETES_CA_FILE_PATH = mockCertDir.resolve('ca.crt');
       });
 
       afterEach(() => {
         process.env.KUBERNETES_CA_FILE_PATH = initialCAPath;
       });
+
+      const getAgentOptions = (): https.AgentOptions => {
+        const options = agentFactory.mock.calls[0]?.[0];
+        if (!options) {
+          throw new Error('Expected an HTTPS agent options argument');
+        }
+        return options;
+      };
 
       it('should trust specified caData', async () => {
         worker.use(
@@ -704,8 +722,8 @@ describe('KubernetesFetcher', () => {
           customResources: [],
         });
 
-        const options = [...(sut as any).agentCache.values()][0].options;
-        expect(options.ca.toString('base64')).toMatch('MOCKCA');
+        const options = getAgentOptions();
+        expect(options.ca!.toString('base64')).toMatch('MOCKCA');
       });
       it('should use default chain of trust when caData is unspecified', async () => {
         worker.use(
@@ -739,7 +757,7 @@ describe('KubernetesFetcher', () => {
           customResources: [],
         });
 
-        const options = [...(sut as any).agentCache.values()][0].options;
+        const options = getAgentOptions();
         expect(options.ca).toBeUndefined();
       });
       describe('with a CA file on disk', () => {
@@ -776,8 +794,8 @@ describe('KubernetesFetcher', () => {
             customResources: [],
           });
 
-          const options = [...(sut as any).agentCache.values()][0].options;
-          expect(options.ca.toString()).toEqual('MOCKCA');
+          const options = getAgentOptions();
+          expect(options.ca!.toString()).toEqual('MOCKCA');
         });
       });
       it('should accept unauthorized certs when skipTLSVerify is set', async () => {
@@ -813,7 +831,7 @@ describe('KubernetesFetcher', () => {
           customResources: [],
         });
 
-        const options = [...(sut as any).agentCache.values()][0].options;
+        const options = getAgentOptions();
         expect(options.rejectUnauthorized).toBe(false);
       });
 
@@ -859,8 +877,8 @@ describe('KubernetesFetcher', () => {
 
         await expect(result).resolves.toBeDefined();
 
-        const options = [...(sut as any).agentCache.values()][0].options;
-        expect(options.ca.toString('base64')).toMatch('MOCKCA');
+        const options = getAgentOptions();
+        expect(options.ca!.toString('base64')).toMatch('MOCKCA');
         expect(options.cert).toEqual(myCert);
         expect(options.key).toEqual(myKey);
       });
@@ -932,8 +950,8 @@ describe('KubernetesFetcher', () => {
 
         await expect(result).resolves.toBeDefined();
 
-        const options = [...(sut as any).agentCache.values()][0].options;
-        expect(options.ca.toString('base64')).toMatch('MOCKCA');
+        const options = getAgentOptions();
+        expect(options.ca!.toString('base64')).toMatch('MOCKCA');
         expect(options.cert).toEqual(myCert);
         expect(options.key).toEqual(myKey);
       });

--- a/plugins/kubernetes-backend/src/service/KubernetesFetcher.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesFetcher.test.ts
@@ -17,13 +17,7 @@
 import { ANNOTATION_KUBERNETES_AUTH_PROVIDER } from '@backstage/plugin-kubernetes-common';
 import { KubernetesClientBasedFetcher } from './KubernetesFetcher';
 import { ObjectToFetch } from '@backstage/plugin-kubernetes-node';
-import {
-  MockedRequest,
-  RestContext,
-  ResponseTransformer,
-  compose,
-  rest,
-} from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import {
   createMockDirectory,
@@ -73,45 +67,64 @@ describe('KubernetesFetcher', () => {
   const worker = setupServer();
   registerMswTestHooks(worker);
 
-  const labels = (req: MockedRequest): object => {
-    const selectorParam = req.url.searchParams.get('labelSelector');
+  const labels = (request: Request): object => {
+    const selectorParam = new URL(request.url).searchParams.get(
+      'labelSelector',
+    );
     if (selectorParam) {
       const [key, value] = selectorParam.split('=');
       return { [key]: value };
     }
     return {};
   };
-  const checkToken = (
-    req: MockedRequest,
-    ctx: RestContext,
-    token: string,
-  ): ResponseTransformer => {
-    switch (req.headers.get('Authorization')) {
+  const checkToken = (request: Request, token: string) => {
+    switch (request.headers.get('Authorization')) {
       case `Bearer ${token}`:
-        return ctx.status(200);
+        return undefined;
       default:
-        return compose(
-          ctx.status(401),
-          ctx.json({
+        return HttpResponse.json(
+          {
             kind: 'Status',
             apiVersion: 'v1',
             code: 401,
-          }),
+          },
+          { status: 401 },
         );
     }
   };
   const withLabels = <T extends { items: { metadata: object }[] }>(
-    req: MockedRequest,
-    ctx: RestContext,
+    request: Request,
     body: T,
-  ): ResponseTransformer =>
-    ctx.json({
+  ) =>
+    HttpResponse.json({
       ...body,
       items: body.items.map(item => ({
         ...item,
-        metadata: { ...item.metadata, labels: labels(req) },
+        metadata: { ...item.metadata, labels: labels(request) },
       })),
     });
+  const status = (statusCode: number) => ({ statusCode });
+  const json = (body: object) => HttpResponse.json(body);
+  const response = (
+    ...responses: (HttpResponse<any> | { statusCode: number } | undefined)[]
+  ) => {
+    const body = responses.find(
+      (value): value is HttpResponse<any> => value instanceof HttpResponse,
+    );
+    if (!body) {
+      throw new Error('response() requires at least one HttpResponse argument');
+    }
+    const statusCode = responses.find(
+      (value): value is { statusCode: number } =>
+        value !== undefined && 'statusCode' in value,
+    )?.statusCode;
+    return statusCode === undefined
+      ? body
+      : new HttpResponse(body.body, {
+          headers: body.headers,
+          status: statusCode,
+        });
+  };
 
   describe('fetchObjectsForService', () => {
     let sut: KubernetesClientBasedFetcher;
@@ -122,25 +135,25 @@ describe('KubernetesFetcher', () => {
       expectedResult: any,
     ) => {
       worker.use(
-        rest.get('http://localhost:9999/api/v1/pods', (req, res, ctx) =>
-          res(
-            checkToken(req, ctx, 'token'),
-            withLabels(req, ctx, {
+        http.get('http://localhost:9999/api/v1/pods', ({ request: req }) =>
+          response(
+            checkToken(req, 'token'),
+            withLabels(req, {
               items: [{ metadata: { name: 'pod-name' } }],
             }),
           ),
         ),
-        rest.get('http://localhost:9999/api/v1/services', (_, res, ctx) => {
-          return res(
-            ctx.status(errorResponse.response.statusCode),
-            ctx.json({
+        http.get('http://localhost:9999/api/v1/services', () =>
+          HttpResponse.json(
+            {
               kind: 'Status',
               apiVersion: 'v1',
               status: 'Failure',
               code: errorResponse.response.statusCode,
-            }),
-          );
-        }),
+            },
+            { status: errorResponse.response.statusCode },
+          ),
+        ),
       );
 
       const result = await sut.fetchObjectsForService({
@@ -183,22 +196,22 @@ describe('KubernetesFetcher', () => {
 
     it('should support clusters with a base path', async () => {
       worker.use(
-        rest.get(
+        http.get(
           'http://localhost:9999/k8s/clusters/1234/api/v1/pods',
-          (req, res, ctx) =>
-            res(
-              checkToken(req, ctx, 'token'),
-              withLabels(req, ctx, {
+          ({ request: req }) =>
+            response(
+              checkToken(req, 'token'),
+              withLabels(req, {
                 items: [{ metadata: { name: 'pod-name' } }],
               }),
             ),
         ),
-        rest.get(
+        http.get(
           'http://localhost:9999/k8s/clusters/1234/api/v1/services',
-          (req, res, ctx) =>
-            res(
-              checkToken(req, ctx, 'token'),
-              withLabels(req, ctx, {
+          ({ request: req }) =>
+            response(
+              checkToken(req, 'token'),
+              withLabels(req, {
                 items: [{ metadata: { name: 'service-name' } }],
               }),
             ),
@@ -248,11 +261,11 @@ describe('KubernetesFetcher', () => {
     });
     it('localKubectlProxy authProvider fetches resources correctly', async () => {
       worker.use(
-        rest.get(
+        http.get(
           'http://localhost:9999/k8s/clusters/1234/api/v1/services',
-          (req, res, ctx) =>
-            res(
-              withLabels(req, ctx, {
+          ({ request: req }) =>
+            response(
+              withLabels(req, {
                 items: [{ metadata: { name: 'service-name' } }],
               }),
             ),
@@ -300,18 +313,18 @@ describe('KubernetesFetcher', () => {
     });
     it('should return pods, services', async () => {
       worker.use(
-        rest.get('http://localhost:9999/api/v1/pods', (req, res, ctx) =>
-          res(
-            checkToken(req, ctx, 'token'),
-            withLabels(req, ctx, {
+        http.get('http://localhost:9999/api/v1/pods', ({ request: req }) =>
+          response(
+            checkToken(req, 'token'),
+            withLabels(req, {
               items: [{ metadata: { name: 'pod-name' } }],
             }),
           ),
         ),
-        rest.get('http://localhost:9999/api/v1/services', (req, res, ctx) =>
-          res(
-            checkToken(req, ctx, 'token'),
-            withLabels(req, ctx, {
+        http.get('http://localhost:9999/api/v1/services', ({ request: req }) =>
+          response(
+            checkToken(req, 'token'),
+            withLabels(req, {
               items: [{ metadata: { name: 'service-name' } }],
             }),
           ),
@@ -361,30 +374,30 @@ describe('KubernetesFetcher', () => {
     });
     it('should return pods, services and customobjects', async () => {
       worker.use(
-        rest.get('http://localhost:9999/api/v1/pods', (req, res, ctx) =>
-          res(
-            checkToken(req, ctx, 'token'),
-            withLabels(req, ctx, {
+        http.get('http://localhost:9999/api/v1/pods', ({ request: req }) =>
+          response(
+            checkToken(req, 'token'),
+            withLabels(req, {
               kind: 'PodList',
               items: [{ metadata: { name: 'pod-name' } }],
             }),
           ),
         ),
-        rest.get('http://localhost:9999/api/v1/services', (req, res, ctx) =>
-          res(
-            checkToken(req, ctx, 'token'),
-            withLabels(req, ctx, {
+        http.get('http://localhost:9999/api/v1/services', ({ request: req }) =>
+          response(
+            checkToken(req, 'token'),
+            withLabels(req, {
               kind: 'ServiceList',
               items: [{ metadata: { name: 'service-name' } }],
             }),
           ),
         ),
-        rest.get(
+        http.get(
           'http://localhost:9999/apis/some-group/v2/things',
-          (req, res, ctx) =>
-            res(
-              checkToken(req, ctx, 'token'),
-              withLabels(req, ctx, {
+          ({ request: req }) =>
+            response(
+              checkToken(req, 'token'),
+              withLabels(req, {
                 kind: 'ThingList',
                 items: [{ metadata: { name: 'something-else' } }],
               }),
@@ -471,16 +484,16 @@ describe('KubernetesFetcher', () => {
     it('should return pods and unauthorized error, logging a warning', async () => {
       const warn = jest.spyOn(logger, 'warn');
       worker.use(
-        rest.get('http://localhost:9999/api/v1/pods', (req, res, ctx) =>
-          res(
-            checkToken(req, ctx, 'token'),
-            withLabels(req, ctx, {
+        http.get('http://localhost:9999/api/v1/pods', ({ request: req }) =>
+          response(
+            checkToken(req, 'token'),
+            withLabels(req, {
               items: [{ metadata: { name: 'pod-name' } }],
             }),
           ),
         ),
-        rest.get('http://localhost:9999/api/v1/services', (req, res, ctx) =>
-          res(checkToken(req, ctx, 'other-token')),
+        http.get('http://localhost:9999/api/v1/services', ({ request: req }) =>
+          response(checkToken(req, 'other-token')),
         ),
       );
 
@@ -557,15 +570,15 @@ describe('KubernetesFetcher', () => {
     });
     it('fails on a network error', async () => {
       worker.use(
-        rest.get('http://badurl.does.not.exist/api/v1/pods', (_, res) =>
-          res.networkError('getaddrinfo ENOTFOUND badurl.does.not.exist'),
+        http.get('http://badurl.does.not.exist/api/v1/pods', () =>
+          HttpResponse.error(),
         ),
-        rest.get(
+        http.get(
           'http://badurl.does.not.exist/api/v1/services',
-          (req, res, ctx) =>
-            res(
-              checkToken(req, ctx, 'token'),
-              withLabels(req, ctx, {
+          ({ request: req }) =>
+            response(
+              checkToken(req, 'token'),
+              withLabels(req, {
                 items: [{ metadata: { name: 'service-name' } }],
               }),
             ),
@@ -585,24 +598,22 @@ describe('KubernetesFetcher', () => {
         customResources: [],
       });
 
-      await expect(result).rejects.toThrow(
-        'getaddrinfo ENOTFOUND badurl.does.not.exist',
-      );
+      await expect(result).rejects.toThrow('Network error');
     });
     it('should respect labelSelector', async () => {
       worker.use(
-        rest.get('http://localhost:9999/api/v1/pods', (req, res, ctx) =>
-          res(
-            checkToken(req, ctx, 'token'),
-            withLabels(req, ctx, {
+        http.get('http://localhost:9999/api/v1/pods', ({ request: req }) =>
+          response(
+            checkToken(req, 'token'),
+            withLabels(req, {
               items: [{ metadata: { name: 'pod-name' } }],
             }),
           ),
         ),
-        rest.get('http://localhost:9999/api/v1/services', (req, res, ctx) =>
-          res(
-            checkToken(req, ctx, 'token'),
-            withLabels(req, ctx, {
+        http.get('http://localhost:9999/api/v1/services', ({ request: req }) =>
+          response(
+            checkToken(req, 'token'),
+            withLabels(req, {
               items: [{ metadata: { name: 'service-name' } }],
             }),
           ),
@@ -651,19 +662,8 @@ describe('KubernetesFetcher', () => {
       });
     });
     describe('when server uses TLS', () => {
-      let httpsRequest: jest.SpyInstance;
       const initialCAPath = process.env.KUBERNETES_CA_FILE_PATH;
-      beforeAll(() => {
-        httpsRequest = jest.spyOn(
-          // this is pretty egregious reverse engineering of msw.
-          // If the SetupServerApi constructor was exported, we wouldn't need
-          // to be quite so hacky here
-          (worker as any).interceptor.interceptors[0].modules.get('https'),
-          'request',
-        );
-      });
       beforeEach(() => {
-        httpsRequest.mockClear();
         process.env.KUBERNETES_CA_FILE_PATH = mockCertDir.resolve('ca.crt');
       });
 
@@ -673,10 +673,10 @@ describe('KubernetesFetcher', () => {
 
       it('should trust specified caData', async () => {
         worker.use(
-          rest.get('https://localhost:9999/api/v1/pods', (req, res, ctx) =>
-            res(
-              checkToken(req, ctx, 'token'),
-              withLabels(req, ctx, {
+          http.get('https://localhost:9999/api/v1/pods', ({ request: req }) =>
+            response(
+              checkToken(req, 'token'),
+              withLabels(req, {
                 items: [{ metadata: { name: 'pod-name' } }],
               }),
             ),
@@ -704,16 +704,15 @@ describe('KubernetesFetcher', () => {
           customResources: [],
         });
 
-        expect(httpsRequest).toHaveBeenCalledTimes(1);
-        const [[{ agent }]] = httpsRequest.mock.calls;
-        expect(agent.options.ca.toString('base64')).toMatch('MOCKCA');
+        const options = [...(sut as any).agentCache.values()][0].options;
+        expect(options.ca.toString('base64')).toMatch('MOCKCA');
       });
       it('should use default chain of trust when caData is unspecified', async () => {
         worker.use(
-          rest.get('https://localhost:9999/api/v1/pods', (req, res, ctx) =>
-            res(
-              checkToken(req, ctx, 'token'),
-              withLabels(req, ctx, {
+          http.get('https://localhost:9999/api/v1/pods', ({ request: req }) =>
+            response(
+              checkToken(req, 'token'),
+              withLabels(req, {
                 items: [{ metadata: { name: 'pod-name' } }],
               }),
             ),
@@ -740,17 +739,16 @@ describe('KubernetesFetcher', () => {
           customResources: [],
         });
 
-        expect(httpsRequest).toHaveBeenCalledTimes(1);
-        const [[{ agent }]] = httpsRequest.mock.calls;
-        expect(agent.options.ca).toBeUndefined();
+        const options = [...(sut as any).agentCache.values()][0].options;
+        expect(options.ca).toBeUndefined();
       });
       describe('with a CA file on disk', () => {
         it('should trust contents of specified caFile', async () => {
           worker.use(
-            rest.get('https://localhost:9999/api/v1/pods', (req, res, ctx) =>
-              res(
-                checkToken(req, ctx, 'token'),
-                withLabels(req, ctx, {
+            http.get('https://localhost:9999/api/v1/pods', ({ request: req }) =>
+              response(
+                checkToken(req, 'token'),
+                withLabels(req, {
                   items: [{ metadata: { name: 'pod-name' } }],
                 }),
               ),
@@ -778,17 +776,16 @@ describe('KubernetesFetcher', () => {
             customResources: [],
           });
 
-          expect(httpsRequest).toHaveBeenCalledTimes(1);
-          const [[{ agent }]] = httpsRequest.mock.calls;
-          expect(agent.options.ca.toString()).toEqual('MOCKCA');
+          const options = [...(sut as any).agentCache.values()][0].options;
+          expect(options.ca.toString()).toEqual('MOCKCA');
         });
       });
       it('should accept unauthorized certs when skipTLSVerify is set', async () => {
         worker.use(
-          rest.get('https://localhost:9999/api/v1/pods', (req, res, ctx) =>
-            res(
-              checkToken(req, ctx, 'token'),
-              withLabels(req, ctx, {
+          http.get('https://localhost:9999/api/v1/pods', ({ request: req }) =>
+            response(
+              checkToken(req, 'token'),
+              withLabels(req, {
                 items: [{ metadata: { name: 'pod-name' } }],
               }),
             ),
@@ -816,17 +813,16 @@ describe('KubernetesFetcher', () => {
           customResources: [],
         });
 
-        expect(httpsRequest).toHaveBeenCalledTimes(1);
-        const [[{ agent }]] = httpsRequest.mock.calls;
-        expect(agent.options.rejectUnauthorized).toBe(false);
+        const options = [...(sut as any).agentCache.values()][0].options;
+        expect(options.rejectUnauthorized).toBe(false);
       });
 
       it('fetchObjectsForService authenticates with k8s using x509 client cert from authentication strategy', async () => {
         worker.use(
-          rest.get('https://localhost:9999/api/v1/pods', (req, res, ctx) =>
-            res(
-              checkToken(req, ctx, 'token'),
-              withLabels(req, ctx, {
+          http.get('https://localhost:9999/api/v1/pods', ({ request: req }) =>
+            response(
+              checkToken(req, 'token'),
+              withLabels(req, {
                 items: [{ metadata: { name: 'pod-name' } }],
               }),
             ),
@@ -861,22 +857,21 @@ describe('KubernetesFetcher', () => {
           customResources: [],
         });
 
-        await expect(result).rejects.toThrow(/PEM/);
+        await expect(result).resolves.toBeDefined();
 
-        expect(httpsRequest).toHaveBeenCalledTimes(1);
-        const [[{ agent }]] = httpsRequest.mock.calls;
-        expect(agent.options.ca.toString('base64')).toMatch('MOCKCA');
-        expect(agent.options.cert).toEqual(myCert);
-        expect(agent.options.key).toEqual(myKey);
+        const options = [...(sut as any).agentCache.values()][0].options;
+        expect(options.ca.toString('base64')).toMatch('MOCKCA');
+        expect(options.cert).toEqual(myCert);
+        expect(options.key).toEqual(myKey);
       });
 
       it('fetchPodMetricsByNamespaces authenticates with k8s using x509 client cert from authentication strategy', async () => {
         worker.use(
-          rest.get(
+          http.get(
             'https://localhost:9999/api/v1/namespaces/:namespace/pods',
-            (req, res, ctx) =>
-              res(
-                withLabels(req, ctx, {
+            ({ request: req }) =>
+              response(
+                withLabels(req, {
                   items: [
                     {
                       metadata: { name: 'pod-name' },
@@ -896,11 +891,11 @@ describe('KubernetesFetcher', () => {
                 }),
               ),
           ),
-          rest.get(
+          http.get(
             'https://localhost:9999/apis/metrics.k8s.io/v1beta1/namespaces/:namespace/pods',
-            (req, res, ctx) =>
-              res(
-                withLabels(req, ctx, {
+            ({ request: req }) =>
+              response(
+                withLabels(req, {
                   items: [
                     {
                       metadata: { name: 'pod-name' },
@@ -935,34 +930,33 @@ describe('KubernetesFetcher', () => {
           new Set(['ns-a']),
         );
 
-        await expect(result).rejects.toThrow(/PEM/);
+        await expect(result).resolves.toBeDefined();
 
-        expect(httpsRequest).toHaveBeenCalledTimes(2);
-        const [[{ agent }]] = httpsRequest.mock.calls;
-        expect(agent.options.ca.toString('base64')).toMatch('MOCKCA');
-        expect(agent.options.cert).toEqual(myCert);
-        expect(agent.options.key).toEqual(myKey);
+        const options = [...(sut as any).agentCache.values()][0].options;
+        expect(options.ca.toString('base64')).toMatch('MOCKCA');
+        expect(options.cert).toEqual(myCert);
+        expect(options.key).toEqual(myKey);
       });
     });
 
     it('should use namespace if provided', async () => {
       worker.use(
-        rest.get(
+        http.get(
           'http://localhost:9999/api/v1/namespaces/some-namespace/pods',
-          (req, res, ctx) =>
-            res(
-              checkToken(req, ctx, 'token'),
-              withLabels(req, ctx, {
+          ({ request: req }) =>
+            response(
+              checkToken(req, 'token'),
+              withLabels(req, {
                 items: [{ metadata: { name: 'pod-name' } }],
               }),
             ),
         ),
-        rest.get(
+        http.get(
           'http://localhost:9999/api/v1/namespaces/some-namespace/services',
-          (req, res, ctx) =>
-            res(
-              checkToken(req, ctx, 'token'),
-              withLabels(req, ctx, {
+          ({ request: req }) =>
+            response(
+              checkToken(req, 'token'),
+              withLabels(req, {
                 items: [{ metadata: { name: 'service-name' } }],
               }),
             ),
@@ -1049,10 +1043,10 @@ describe('KubernetesFetcher', () => {
         process.env.KUBERNETES_SERVICE_HOST = '10.10.10.10';
         process.env.KUBERNETES_SERVICE_PORT = '443';
         worker.use(
-          rest.get('https://10.10.10.10/api/v1/pods', (req, res, ctx) =>
-            res(
-              checkToken(req, ctx, 'allowed-token'),
-              withLabels(req, ctx, {
+          http.get('https://10.10.10.10/api/v1/pods', ({ request: req }) =>
+            response(
+              checkToken(req, 'allowed-token'),
+              withLabels(req, {
                 items: [{ metadata: { name: 'pod-name' } }],
               }),
             ),
@@ -1114,12 +1108,12 @@ describe('KubernetesFetcher', () => {
 
     it('should return pod metrics', async () => {
       worker.use(
-        rest.get(
+        http.get(
           'http://localhost:9999/api/v1/namespaces/:namespace/pods',
-          (req, res, ctx) =>
-            res(
-              checkToken(req, ctx, 'token'),
-              withLabels(req, ctx, {
+          ({ request: req }) =>
+            response(
+              checkToken(req, 'token'),
+              withLabels(req, {
                 items: [
                   {
                     metadata: { name: 'pod-name' },
@@ -1139,12 +1133,12 @@ describe('KubernetesFetcher', () => {
               }),
             ),
         ),
-        rest.get(
+        http.get(
           'http://localhost:9999/apis/metrics.k8s.io/v1beta1/namespaces/:namespace/pods',
-          (req, res, ctx) =>
-            res(
-              checkToken(req, ctx, 'token'),
-              withLabels(req, ctx, {
+          ({ request: req }) =>
+            response(
+              checkToken(req, 'token'),
+              withLabels(req, {
                 items: [
                   {
                     metadata: { name: 'pod-name' },
@@ -1177,12 +1171,12 @@ describe('KubernetesFetcher', () => {
     });
     it('should return pod metrics and error', async () => {
       worker.use(
-        rest.get(
+        http.get(
           'http://localhost:9999/api/v1/namespaces/ns-a/pods',
-          (req, res, ctx) =>
-            res(
-              checkToken(req, ctx, 'token'),
-              withLabels(req, ctx, {
+          ({ request: req }) =>
+            response(
+              checkToken(req, 'token'),
+              withLabels(req, {
                 items: [
                   {
                     metadata: { name: 'pod-name' },
@@ -1202,12 +1196,12 @@ describe('KubernetesFetcher', () => {
               }),
             ),
         ),
-        rest.get(
+        http.get(
           'http://localhost:9999/apis/metrics.k8s.io/v1beta1/namespaces/ns-a/pods',
-          (req, res, ctx) =>
-            res(
-              checkToken(req, ctx, 'token'),
-              withLabels(req, ctx, {
+          ({ request: req }) =>
+            response(
+              checkToken(req, 'token'),
+              withLabels(req, {
                 items: [
                   {
                     metadata: { name: 'pod-name' },
@@ -1222,24 +1216,22 @@ describe('KubernetesFetcher', () => {
               }),
             ),
         ),
-        rest.get(
-          'http://localhost:9999/api/v1/namespaces/ns-b/pods',
-          (_, res, ctx) =>
-            res(
-              ctx.status(404),
-              ctx.json({
-                kind: 'Status',
-                apiVersion: 'v1',
-                code: 404,
-              }),
-            ),
+        http.get('http://localhost:9999/api/v1/namespaces/ns-b/pods', () =>
+          response(
+            status(404),
+            json({
+              kind: 'Status',
+              apiVersion: 'v1',
+              code: 404,
+            }),
+          ),
         ),
-        rest.get(
+        http.get(
           'http://localhost:9999/apis/metrics.k8s.io/v1beta1/namespaces/ns-b/pods',
-          (_, res, ctx) =>
-            res(
-              ctx.status(404),
-              ctx.json({
+          () =>
+            response(
+              status(404),
+              json({
                 kind: 'Status',
                 apiVersion: 'v1',
                 code: 404,
@@ -1269,10 +1261,10 @@ describe('KubernetesFetcher', () => {
     });
     it('should mask secret data values with ***', async () => {
       worker.use(
-        rest.get('http://localhost:9999/api/v1/secrets', (req, res, ctx) =>
-          res(
-            checkToken(req, ctx, 'token'),
-            withLabels(req, ctx, {
+        http.get('http://localhost:9999/api/v1/secrets', ({ request: req }) =>
+          response(
+            checkToken(req, 'token'),
+            withLabels(req, {
               items: [
                 {
                   metadata: { name: 'secret-name' },
@@ -1333,10 +1325,10 @@ describe('KubernetesFetcher', () => {
 
     it('should handle secrets without data field', async () => {
       worker.use(
-        rest.get('http://localhost:9999/api/v1/secrets', (req, res, ctx) =>
-          res(
-            checkToken(req, ctx, 'token'),
-            withLabels(req, ctx, {
+        http.get('http://localhost:9999/api/v1/secrets', ({ request: req }) =>
+          response(
+            checkToken(req, 'token'),
+            withLabels(req, {
               items: [
                 {
                   metadata: { name: 'secret-without-data' },

--- a/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
@@ -34,7 +34,8 @@ import express from 'express';
 import * as httpProxyMiddleware from 'http-proxy-middleware';
 import Router from 'express-promise-router';
 import { Server } from 'node:http';
-import { rest } from 'msw';
+import https from 'node:https';
+import { http, HttpResponse, passthrough } from 'msw';
 import { setupServer } from 'msw/node';
 import request from 'supertest';
 import { AddressInfo, WebSocket, WebSocketServer } from 'ws';
@@ -150,7 +151,12 @@ describe('KubernetesProxy', () => {
     }
 
     // Let this request through so it reaches the express router above
-    worker.use(rest.all(requestPromise.url, (req: any) => req.passthrough()));
+    const requestUrl = new URL(requestPromise.url);
+    worker.use(
+      http.all(`${requestUrl.origin}${requestUrl.pathname}`, () =>
+        passthrough(),
+      ),
+    );
 
     return requestPromise;
   };
@@ -194,8 +200,8 @@ describe('KubernetesProxy', () => {
       ]);
 
       worker.use(
-        rest.get('https://localhost:9999/api', (_: any, res: any, ctx: any) =>
-          res(ctx.status(200), ctx.json({ ok: true })),
+        http.get('https://localhost:9999/api', () =>
+          HttpResponse.json({ ok: true }),
         ),
       );
 
@@ -267,8 +273,8 @@ describe('KubernetesProxy', () => {
       ]);
 
       worker.use(
-        rest.get('https://localhost:9999/api', (_: any, res: any, ctx: any) =>
-          res(ctx.status(200), ctx.json({ ok: true })),
+        http.get('https://localhost:9999/api', () =>
+          HttpResponse.json({ ok: true }),
         ),
       );
 
@@ -294,8 +300,8 @@ describe('KubernetesProxy', () => {
       ]);
 
       worker.use(
-        rest.get('https://localhost:9999/api', (_: any, res: any, ctx: any) =>
-          res(ctx.status(401), ctx.json({ message: 'Unauthorized' })),
+        http.get('https://localhost:9999/api', () =>
+          HttpResponse.json({ message: 'Unauthorized' }, { status: 401 }),
         ),
       );
 
@@ -326,8 +332,8 @@ describe('KubernetesProxy', () => {
       ]);
 
       worker.use(
-        rest.get('https://localhost:9999/api', (_: any, res: any, ctx: any) =>
-          res(ctx.status(403), ctx.json({ message: 'Forbidden' })),
+        http.get('https://localhost:9999/api', () =>
+          HttpResponse.json({ message: 'Forbidden' }, { status: 403 }),
         ),
       );
 
@@ -369,7 +375,7 @@ describe('KubernetesProxy', () => {
         },
       ]);
 
-      worker.use(rest.all('*', (req: any) => req.passthrough()));
+      worker.use(http.all('*', () => passthrough()));
 
       const app = express().use(
         Router()
@@ -438,8 +444,8 @@ describe('KubernetesProxy', () => {
       ]);
 
       worker.use(
-        rest.get('https://localhost:9999/api', (_: any, res: any, ctx: any) =>
-          res(ctx.status(200), ctx.json({ ok: true })),
+        http.get('https://localhost:9999/api', () =>
+          HttpResponse.json({ ok: true }),
         ),
       );
 
@@ -497,8 +503,8 @@ describe('KubernetesProxy', () => {
       ]);
 
       worker.use(
-        rest.get('https://localhost:9999/api', (_: any, res: any, ctx: any) =>
-          res(ctx.status(200), ctx.json({ ok: true })),
+        http.get('https://localhost:9999/api', () =>
+          HttpResponse.json({ ok: true }),
         ),
       );
 
@@ -511,7 +517,12 @@ describe('KubernetesProxy', () => {
       const proxyRequest = request(app)
         .get(`/mountpath/api?command=${sentinel}`)
         .set(HEADER_KUBERNETES_CLUSTER, 'cluster1');
-      worker.use(rest.all(proxyRequest.url, (r: any) => r.passthrough()));
+      const proxyRequestUrl = new URL(proxyRequest.url);
+      worker.use(
+        http.all(`${proxyRequestUrl.origin}${proxyRequestUrl.pathname}`, () =>
+          passthrough(),
+        ),
+      );
 
       await proxyRequest;
 
@@ -545,7 +556,7 @@ describe('KubernetesProxy', () => {
     });
 
     it('recognizes websocket upgrade with comma-separated Connection header', async () => {
-      worker.use(rest.all('*', (req: any) => req.passthrough()));
+      worker.use(http.all('*', () => passthrough()));
 
       const wsServer = new WebSocketServer({ port: 0, path: '/ws' });
       const wsServerPort = (wsServer.address() as AddressInfo).port;
@@ -606,8 +617,8 @@ describe('KubernetesProxy', () => {
       ]);
 
       worker.use(
-        rest.get('https://localhost:9999/api', (_: any, res: any, ctx: any) =>
-          res(ctx.status(200), ctx.json({ ok: true })),
+        http.get('https://localhost:9999/api', () =>
+          HttpResponse.json({ ok: true }),
         ),
       );
 
@@ -633,7 +644,7 @@ describe('KubernetesProxy', () => {
         new Error('auditor transport unavailable'),
       );
 
-      worker.use(rest.all('*', (req: any) => req.passthrough()));
+      worker.use(http.all('*', () => passthrough()));
 
       const app = express().use(
         Router()
@@ -645,8 +656,8 @@ describe('KubernetesProxy', () => {
       });
       const port = (server.address() as AddressInfo).port;
 
-      const http = await import('node:http');
-      const agent = new http.Agent({ keepAlive: true, maxSockets: 1 });
+      const nodeHttp = await import('node:http');
+      const agent = new nodeHttp.Agent({ keepAlive: true, maxSockets: 1 });
 
       let serverSocket: import('net').Socket | undefined;
       server.on('connection', (s: import('net').Socket) => {
@@ -655,7 +666,7 @@ describe('KubernetesProxy', () => {
 
       const doRequest = () =>
         new Promise<number>(resolve => {
-          const r = http.get(
+          const r = nodeHttp.get(
             `http://127.0.0.1:${port}/mountpath/api`,
             { agent, headers: { [HEADER_KUBERNETES_CLUSTER]: 'cluster1' } },
             res => {
@@ -710,8 +721,8 @@ describe('KubernetesProxy', () => {
       ]);
 
       worker.use(
-        rest.get('https://localhost:9999/api', (_: any, res: any, ctx: any) =>
-          res(ctx.status(200), ctx.json({ ok: true })),
+        http.get('https://localhost:9999/api', () =>
+          HttpResponse.json({ ok: true }),
         ),
       );
 
@@ -802,8 +813,8 @@ describe('KubernetesProxy', () => {
     ]);
 
     worker.use(
-      rest.get('https://localhost:9999/api', (_: any, res: any, ctx: any) =>
-        res(ctx.status(299), ctx.json(apiResponse)),
+      http.get('https://localhost:9999/api', () =>
+        HttpResponse.json(apiResponse, { status: 299 }),
       ),
     );
 
@@ -831,10 +842,8 @@ describe('KubernetesProxy', () => {
     ]);
 
     worker.use(
-      rest.get(
-        'https://localhost:9999/api/v1/pods',
-        (_: any, res: any, ctx: any) =>
-          res(ctx.status(200), ctx.json(apiResponse)),
+      http.get('https://localhost:9999/api/v1/pods', () =>
+        HttpResponse.json(apiResponse),
       ),
     );
 
@@ -871,8 +880,8 @@ describe('KubernetesProxy', () => {
     ]);
 
     worker.use(
-      rest.get('https://localhost:9999/api', (_: any, res: any, ctx: any) =>
-        res(ctx.status(299), ctx.json(apiResponse)),
+      http.get('https://localhost:9999/api', () =>
+        HttpResponse.json(apiResponse, { status: 299 }),
       ),
     );
 
@@ -889,13 +898,13 @@ describe('KubernetesProxy', () => {
 
   it('sets host header to support clusters behind name-based virtual hosts', async () => {
     worker.use(
-      rest.get(
+      http.get(
         'http://localhost:9999/api/v1/namespaces',
-        (req: any, res: any, ctx: any) => {
-          const host = req.headers.get('Host');
+        ({ request: mswRequest }) => {
+          const host = mswRequest.headers.get('Host');
           return host === 'localhost:9999'
-            ? res(ctx.status(200))
-            : res.networkError(`Host '${host}' is not in the cert's altnames`);
+            ? new HttpResponse(null, { status: 200 })
+            : HttpResponse.error();
         },
       ),
     );
@@ -922,28 +931,25 @@ describe('KubernetesProxy', () => {
 
   it('should default to using a strategy-provided bearer token as authorization headers to kubeapi when backstage-kubernetes-auth field is not provided', async () => {
     worker.use(
-      rest.get(
+      http.get(
         'https://localhost:9999/api/v1/namespaces',
-        (req: any, res: any, ctx: any) => {
-          if (!req.headers.get('Authorization')) {
-            return res(ctx.status(401));
+        ({ request: mswRequest }) => {
+          if (!mswRequest.headers.get('Authorization')) {
+            return new HttpResponse(null, { status: 401 });
           }
 
           if (
-            req.headers.get('Authorization') !==
+            mswRequest.headers.get('Authorization') !==
             'Bearer strategy-provided-token'
           ) {
-            return res(ctx.status(403));
+            return new HttpResponse(null, { status: 403 });
           }
 
-          return res(
-            ctx.status(200),
-            ctx.json({
-              kind: 'NamespaceList',
-              apiVersion: 'v1',
-              items: [],
-            }),
-          );
+          return HttpResponse.json({
+            kind: 'NamespaceList',
+            apiVersion: 'v1',
+            items: [],
+          });
         },
       ),
     );
@@ -975,24 +981,24 @@ describe('KubernetesProxy', () => {
 
   it('should add an authStrategy-provided serviceAccountToken as authorization headers to kubeapi if one isnt provided in request and one isnt set up in cluster details', async () => {
     worker.use(
-      rest.get('https://localhost:9999/api/v1/namespaces', (req, res, ctx) => {
-        if (!req.headers.get('Authorization')) {
-          return res(ctx.status(401));
-        }
+      http.get(
+        'https://localhost:9999/api/v1/namespaces',
+        ({ request: mswRequest }) => {
+          if (!mswRequest.headers.get('Authorization')) {
+            return new HttpResponse(null, { status: 401 });
+          }
 
-        if (req.headers.get('Authorization') !== 'Bearer my-token') {
-          return res(ctx.status(403));
-        }
+          if (mswRequest.headers.get('Authorization') !== 'Bearer my-token') {
+            return new HttpResponse(null, { status: 403 });
+          }
 
-        return res(
-          ctx.status(200),
-          ctx.json({
+          return HttpResponse.json({
             kind: 'NamespaceList',
             apiVersion: 'v1',
             items: [],
-          }),
-        );
-      }),
+          });
+        },
+      ),
     );
 
     clusterSupplier.getClusters.mockResolvedValue([
@@ -1027,24 +1033,24 @@ describe('KubernetesProxy', () => {
 
   it('should append the Backstage-Kubernetes-Auth field to the requests authorization header if one is provided', async () => {
     worker.use(
-      rest.get('https://localhost:9999/api/v1/namespaces', (req, res, ctx) => {
-        if (!req.headers.get('Authorization')) {
-          return res(ctx.status(401));
-        }
+      http.get(
+        'https://localhost:9999/api/v1/namespaces',
+        ({ request: mswRequest }) => {
+          if (!mswRequest.headers.get('Authorization')) {
+            return new HttpResponse(null, { status: 401 });
+          }
 
-        if (req.headers.get('Authorization') !== 'tokenB') {
-          return res(ctx.status(403));
-        }
+          if (mswRequest.headers.get('Authorization') !== 'tokenB') {
+            return new HttpResponse(null, { status: 403 });
+          }
 
-        return res(
-          ctx.status(200),
-          ctx.json({
+          return HttpResponse.json({
             kind: 'NamespaceList',
             apiVersion: 'v1',
             items: [],
-          }),
-        );
-      }),
+          });
+        },
+      ),
     );
 
     clusterSupplier.getClusters.mockResolvedValue([
@@ -1082,24 +1088,24 @@ describe('KubernetesProxy', () => {
 
   it('should not invoke authStrategy if Backstage-Kubernetes-Authorization field is provided', async () => {
     worker.use(
-      rest.get('https://localhost:9999/api/v1/namespaces', (req, res, ctx) => {
-        if (!req.headers.get('Authorization')) {
-          return res(ctx.status(401));
-        }
+      http.get(
+        'https://localhost:9999/api/v1/namespaces',
+        ({ request: mswRequest }) => {
+          if (!mswRequest.headers.get('Authorization')) {
+            return new HttpResponse(null, { status: 401 });
+          }
 
-        if (req.headers.get('Authorization') !== 'tokenB') {
-          return res(ctx.status(403));
-        }
+          if (mswRequest.headers.get('Authorization') !== 'tokenB') {
+            return new HttpResponse(null, { status: 403 });
+          }
 
-        return res(
-          ctx.status(200),
-          ctx.json({
+          return HttpResponse.json({
             kind: 'NamespaceList',
             apiVersion: 'v1',
             items: [],
-          }),
-        );
-      }),
+          });
+        },
+      ),
     );
 
     clusterSupplier.getClusters.mockResolvedValue([
@@ -1150,24 +1156,24 @@ describe('KubernetesProxy', () => {
     });
 
     worker.use(
-      rest.get('https://localhost:9999/api/v1/namespaces', (req, res, ctx) => {
-        if (!req.headers.get('Authorization')) {
-          return res(ctx.status(401));
-        }
+      http.get(
+        'https://localhost:9999/api/v1/namespaces',
+        ({ request: mswRequest }) => {
+          if (!mswRequest.headers.get('Authorization')) {
+            return new HttpResponse(null, { status: 401 });
+          }
 
-        if (req.headers.get('Authorization') !== 'Bearer MY_TOKEN3') {
-          return res(ctx.status(403));
-        }
+          if (mswRequest.headers.get('Authorization') !== 'Bearer MY_TOKEN3') {
+            return new HttpResponse(null, { status: 403 });
+          }
 
-        return res(
-          ctx.status(200),
-          ctx.json({
+          return HttpResponse.json({
             kind: 'NamespaceList',
             apiVersion: 'v1',
             items: [],
-          }),
-        );
-      }),
+          });
+        },
+      ),
     );
 
     clusterSupplier.getClusters.mockResolvedValue([
@@ -1217,15 +1223,12 @@ describe('KubernetesProxy', () => {
 
   it('should invoke the Auth strategy with an empty auth object when no Backstage-Kubernetes-Authorization-X-X are provided', async () => {
     worker.use(
-      rest.get('https://localhost:9999/api/v1/namespaces', (_, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.json({
-            kind: 'NamespaceList',
-            apiVersion: 'v1',
-            items: [],
-          }),
-        );
+      http.get('https://localhost:9999/api/v1/namespaces', () => {
+        return HttpResponse.json({
+          kind: 'NamespaceList',
+          apiVersion: 'v1',
+          items: [],
+        });
       }),
     );
 
@@ -1274,18 +1277,18 @@ describe('KubernetesProxy', () => {
     });
 
     worker.use(
-      rest.get('http://127.0.0.1:8001/api/v1/namespaces', (req, res, ctx) => {
-        return req.headers.get('Authorization')
-          ? res(ctx.status(401))
-          : res(
-              ctx.status(200),
-              ctx.json({
+      http.get(
+        'http://127.0.0.1:8001/api/v1/namespaces',
+        ({ request: mswRequest }) => {
+          return mswRequest.headers.get('Authorization')
+            ? new HttpResponse(null, { status: 401 })
+            : HttpResponse.json({
                 kind: 'NamespaceList',
                 apiVersion: 'v1',
                 items: [],
-              }),
-            );
-      }),
+              });
+        },
+      ),
     );
 
     const requestPromise = setupProxyPromise({
@@ -1309,24 +1312,24 @@ describe('KubernetesProxy', () => {
 
   it('returns a 500 error if authStrategy errors out and Backstage-Kubernetes-Authorization field is not provided', async () => {
     worker.use(
-      rest.get('https://localhost:9999/api/v1/namespaces', (req, res, ctx) => {
-        if (!req.headers.get('Authorization')) {
-          return res(ctx.status(401));
-        }
+      http.get(
+        'https://localhost:9999/api/v1/namespaces',
+        ({ request: mswRequest }) => {
+          if (!mswRequest.headers.get('Authorization')) {
+            return new HttpResponse(null, { status: 401 });
+          }
 
-        if (req.headers.get('Authorization') !== 'tokenB') {
-          return res(ctx.status(403));
-        }
+          if (mswRequest.headers.get('Authorization') !== 'tokenB') {
+            return new HttpResponse(null, { status: 403 });
+          }
 
-        return res(
-          ctx.status(200),
-          ctx.json({
+          return HttpResponse.json({
             kind: 'NamespaceList',
             apiVersion: 'v1',
             items: [],
-          }),
-        );
-      }),
+          });
+        },
+      ),
     );
 
     clusterSupplier.getClusters.mockResolvedValue([
@@ -1355,19 +1358,13 @@ describe('KubernetesProxy', () => {
 
   it('should get res through proxy with cluster url has sub path', async () => {
     worker.use(
-      rest.get(
-        'http://localhost:9999/subpath/api/v1/namespaces',
-        (_req, res, ctx) => {
-          return res(
-            ctx.status(200),
-            ctx.json({
-              kind: 'NamespaceList',
-              apiVersion: 'v1',
-              items: [],
-            }),
-          );
-        },
-      ),
+      http.get('http://localhost:9999/subpath/api/v1/namespaces', () => {
+        return HttpResponse.json({
+          kind: 'NamespaceList',
+          apiVersion: 'v1',
+          items: [],
+        });
+      }),
     );
 
     clusterSupplier.getClusters.mockResolvedValue([
@@ -1394,18 +1391,15 @@ describe('KubernetesProxy', () => {
 
   describe('when server uses TLS', () => {
     let httpsRequest: jest.SpyInstance;
+
     beforeAll(() => {
-      httpsRequest = jest.spyOn(
-        // this is pretty egregious reverse engineering of msw.
-        // If the SetupServerApi constructor was exported, we wouldn't need
-        // to be quite so hacky here
-        (worker as any).interceptor.interceptors[0].modules.get('https'),
-        'request',
-      );
+      httpsRequest = jest.spyOn(https, 'request');
     });
+
     beforeEach(() => {
       httpsRequest.mockClear();
     });
+
     describe('should pass the exact response from Kubernetes using the CA file', () => {
       it('should trust contents of specified caFile', async () => {
         const apiResponse = {
@@ -1429,8 +1423,8 @@ describe('KubernetesProxy', () => {
         ] as ClusterDetails[]);
 
         worker.use(
-          rest.get('https://localhost:9999/api', (_: any, res: any, ctx: any) =>
-            res(ctx.status(299), ctx.json(apiResponse)),
+          http.get('https://localhost:9999/api', () =>
+            HttpResponse.json(apiResponse, { status: 299 }),
           ),
         );
 
@@ -1445,29 +1439,28 @@ describe('KubernetesProxy', () => {
         expect(response.status).toEqual(299);
         expect(response.body).toStrictEqual(apiResponse);
 
-        expect(httpsRequest).toHaveBeenCalledTimes(1);
-        const [[{ ca }]] = httpsRequest.mock.calls;
-        expect(ca).toMatch('MOCKCA');
+        expect(httpsRequest).toHaveBeenCalledWith(
+          expect.objectContaining({
+            ca: 'MOCKCA\n',
+          }),
+        );
       });
     });
 
     it('should use a x509 client cert authentication strategy to consume kubeapi when backstage-kubernetes-auth field is not provided and the authStrategy enables x509 client cert authentication', async () => {
       worker.use(
-        rest.get(
+        http.get(
           'https://localhost:9999/api/v1/namespaces',
-          (req: any, res: any, ctx: any) => {
-            if (req.headers.get('Authorization')) {
-              return res(ctx.status(403));
+          ({ request: mswRequest }) => {
+            if (mswRequest.headers.get('Authorization')) {
+              return new HttpResponse(null, { status: 403 });
             }
 
-            return res(
-              ctx.status(200),
-              ctx.json({
-                kind: 'NamespaceList',
-                apiVersion: 'v1',
-                items: [],
-              }),
-            );
+            return HttpResponse.json({
+              kind: 'NamespaceList',
+              apiVersion: 'v1',
+              items: [],
+            });
           },
         ),
       );
@@ -1504,12 +1497,14 @@ describe('KubernetesProxy', () => {
         {},
       );
 
-      const [[{ key, cert }]] = httpsRequest.mock.calls;
-      expect(cert).toEqual(myCert);
-      expect(key).toEqual(myKey);
+      expect(httpsRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cert: myCert,
+          key: myKey,
+        }),
+      );
 
-      // 500 Since the key and cert are fake
-      expect(response.status).toEqual(500);
+      expect(response.status).toEqual(200);
     });
   });
 
@@ -1528,6 +1523,8 @@ describe('KubernetesProxy', () => {
     ) => new Promise(resolve => ws.once(event, x => resolve(x?.toString())));
 
     beforeEach(async () => {
+      worker.close();
+
       await new Promise(resolve => {
         expressServer = express()
           .use(
@@ -1558,9 +1555,16 @@ describe('KubernetesProxy', () => {
       wsEchoServer.on('error', console.error);
     });
 
-    afterEach(() => {
-      wsEchoServer.close();
-      expressServer.close();
+    afterEach(async () => {
+      wsEchoServer.clients.forEach(client => client.terminate());
+      expressServer.closeAllConnections?.();
+
+      await Promise.all([
+        new Promise<void>(resolve => wsEchoServer.close(() => resolve())),
+        new Promise<void>(resolve => expressServer.close(() => resolve())),
+      ]);
+
+      worker.listen({ onUnhandledRequest: 'error' });
     });
 
     it('should proxy websocket connections', async () => {
@@ -1573,17 +1577,6 @@ describe('KubernetesProxy', () => {
       ]);
 
       const wsProxyAddress = `ws://127.0.0.1:${proxyPort}${proxyPath}${wsPath}`;
-      const wsAddress = `ws://localhost:${wsPort}${wsPath}`;
-
-      // Let this request through so it reaches the express router above
-      worker.use(
-        rest.all(wsAddress.replace('ws', 'http'), (req: any) =>
-          req.passthrough(),
-        ),
-        rest.all(wsProxyAddress.replace('ws', 'http'), (req: any) =>
-          req.passthrough(),
-        ),
-      );
 
       const webSocket = new WebSocket(wsProxyAddress);
 
@@ -1622,8 +1615,6 @@ describe('KubernetesProxy', () => {
     });
 
     it('emits failed audit event when websocket upgrade fails', async () => {
-      worker.use(rest.all('*', req => req.passthrough()));
-
       clusterSupplier.getClusters.mockResolvedValue([
         {
           name: 'unreachable',
@@ -1644,8 +1635,6 @@ describe('KubernetesProxy', () => {
     });
 
     it('emits exactly one failed audit event when client closes during delayed upstream handshake', async () => {
-      worker.use(rest.all('*', (req: any) => req.passthrough()));
-
       // TCP server that accepts connections but never completes the
       // WebSocket handshake, simulating a slow upstream.
       const net = require('node:net');
@@ -1729,20 +1718,17 @@ describe('KubernetesProxy', () => {
       });
 
       worker.use(
-        rest.get(
+        http.get(
           'https://10.10.10.10/api/v1/namespaces',
-          (req: any, res: any, ctx: any) => {
-            if (req.headers.get('Authorization') === 'Bearer SA_token') {
-              return res(
-                ctx.status(200),
-                ctx.json({
-                  kind: 'NamespaceList',
-                  apiVersion: 'v1',
-                  items: [],
-                }),
-              );
+          ({ request: mswRequest }) => {
+            if (mswRequest.headers.get('Authorization') === 'Bearer SA_token') {
+              return HttpResponse.json({
+                kind: 'NamespaceList',
+                apiVersion: 'v1',
+                items: [],
+              });
             }
-            return res(ctx.status(403));
+            return new HttpResponse(null, { status: 403 });
           },
         ),
       );

--- a/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesProxy.test.ts
@@ -1396,6 +1396,10 @@ describe('KubernetesProxy', () => {
       httpsRequest = jest.spyOn(https, 'request');
     });
 
+    afterAll(() => {
+      httpsRequest.mockRestore();
+    });
+
     beforeEach(() => {
       httpsRequest.mockClear();
     });

--- a/plugins/kubernetes-backend/src/service/KubernetesRouter.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesRouter.test.ts
@@ -41,7 +41,7 @@ import {
   registerMswTestHooks,
   startTestBackend,
 } from '@backstage/backend-test-utils';
-import { rest } from 'msw';
+import { http, HttpResponse, passthrough } from 'msw';
 import { AuthorizeResult } from '@backstage/plugin-permission-common';
 import { createBackendModule } from '@backstage/backend-plugin-api';
 import {
@@ -664,20 +664,18 @@ describe('API integration tests', () => {
 
     beforeEach(() => {
       worker.use(
-        rest.post(
+        http.post(
           'https://localhost:1234/api/v1/namespaces',
-          (req, res, ctx) => {
-            if (!req.headers.get('Authorization')) {
-              return res(ctx.status(401));
+          async ({ request: mswRequest }) => {
+            if (!mswRequest.headers.get('Authorization')) {
+              return new HttpResponse(null, { status: 401 });
             }
-            return req
-              .arrayBuffer()
-              .then(body =>
-                res(
-                  ctx.set('content-type', `${req.headers.get('content-type')}`),
-                  ctx.body(body),
-                ),
-              );
+            const body = await mswRequest.arrayBuffer();
+            return new HttpResponse(body, {
+              headers: {
+                'content-type': mswRequest.headers.get('content-type') ?? '',
+              },
+            });
           },
         ),
       );
@@ -695,7 +693,7 @@ describe('API integration tests', () => {
         .set(HEADER_KUBERNETES_CLUSTER, 'some-cluster')
         .set(HEADER_KUBERNETES_AUTH, 'randomtoken')
         .send(namespaceManifest);
-      worker.use(rest.all(proxyEndpointRequest.url, req => req.passthrough()));
+      worker.use(http.all(proxyEndpointRequest.url, () => passthrough()));
       const response = await proxyEndpointRequest;
 
       expect(response.body).toStrictEqual(namespaceManifest);
@@ -729,7 +727,7 @@ metadata:
         .set('content-type', 'application/yaml')
         .send(yamlManifest);
 
-      worker.use(rest.all(proxyEndpointRequest.url, req => req.passthrough()));
+      worker.use(http.all(proxyEndpointRequest.url, () => passthrough()));
 
       const response = await proxyEndpointRequest;
       expect(response.text).toEqual(yamlManifest);
@@ -748,7 +746,7 @@ metadata:
           metadata: { name: 'new-ns' },
         });
 
-      worker.use(rest.all(proxyEndpointRequest.url, req => req.passthrough()));
+      worker.use(http.all(proxyEndpointRequest.url, () => passthrough()));
 
       const response = await proxyEndpointRequest;
 
@@ -770,12 +768,15 @@ metadata:
 
     it('permits custom client-side auth strategy', async () => {
       worker.use(
-        rest.get('http://my.cluster.url/api/v1/namespaces', (req, res, ctx) => {
-          if (req.headers.get('Authorization') !== 'custom-token') {
-            return res(ctx.status(401));
-          }
-          return res(ctx.json({ items: [] }));
-        }),
+        http.get(
+          'http://my.cluster.url/api/v1/namespaces',
+          ({ request: mswRequest }) => {
+            if (mswRequest.headers.get('Authorization') !== 'custom-token') {
+              return new HttpResponse(null, { status: 401 });
+            }
+            return HttpResponse.json({ items: [] });
+          },
+        ),
       );
 
       const { server } = await startTestBackend({
@@ -817,7 +818,7 @@ metadata:
         .get('/api/kubernetes/proxy/api/v1/namespaces')
         .set(HEADER_KUBERNETES_CLUSTER, 'custom-cluster')
         .set(HEADER_KUBERNETES_AUTH, 'custom-token');
-      worker.use(rest.all(proxyEndpointRequest.url, req => req.passthrough()));
+      worker.use(http.all(proxyEndpointRequest.url, () => passthrough()));
       const response = await proxyEndpointRequest;
 
       expect(response.body).toStrictEqual({ items: [] });
@@ -830,9 +831,7 @@ metadata:
         presentAuthMetadata: jest.fn().mockReturnValue({}),
       };
       worker.use(
-        rest.get('http://my.cluster/api', (_req, res, ctx) =>
-          res(ctx.json({})),
-        ),
+        http.get('http://my.cluster/api', () => HttpResponse.json({})),
       );
       const { server } = await startTestBackend({
         features: [
@@ -876,7 +875,7 @@ metadata:
       const proxyEndpointRequest = request(app).get(
         '/api/kubernetes/proxy/api',
       );
-      worker.use(rest.all(proxyEndpointRequest.url, req => req.passthrough()));
+      worker.use(http.all(proxyEndpointRequest.url, () => passthrough()));
       const response = await proxyEndpointRequest;
 
       expect(response.body).toStrictEqual({});

--- a/plugins/kubernetes-backend/src/service/KubernetesWatcher.test.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesWatcher.test.ts
@@ -21,13 +21,7 @@ import {
 import { KubernetesClientBasedWatcher } from './KubernetesWatcher';
 import { KubernetesConnection } from './KubernetesConnection';
 import { KubernetesCredential } from '@backstage/plugin-kubernetes-node';
-import {
-  MockedRequest,
-  RestContext,
-  ResponseTransformer,
-  compose,
-  rest,
-} from 'msw';
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import {
   mockServices,
@@ -38,22 +32,18 @@ describe('KubernetesWatcher', () => {
   const worker = setupServer();
   registerMswTestHooks(worker);
 
-  const checkToken = (
-    req: MockedRequest,
-    ctx: RestContext,
-    token: string,
-  ): ResponseTransformer => {
-    switch (req.headers.get('Authorization')) {
+  const checkToken = (request: Request, token: string) => {
+    switch (request.headers.get('Authorization')) {
       case `Bearer ${token}`:
-        return ctx.status(200);
+        return undefined;
       default:
-        return compose(
-          ctx.status(401),
-          ctx.json({
+        return HttpResponse.json(
+          {
             kind: 'Status',
             apiVersion: 'v1',
             code: 401,
-          }),
+          },
+          { status: 401 },
         );
     }
   };
@@ -99,13 +89,15 @@ describe('KubernetesWatcher', () => {
       });
 
       worker.use(
-        rest.get(
+        http.get(
           'http://localhost:9999/api/v1/namespaces/default/pods',
-          (req, res, ctx) => {
-            if (req.url.searchParams.get('watch') === 'true') {
-              return res(checkToken(req, ctx, 'token'), ctx.text(watchData));
+          ({ request }) => {
+            if (new URL(request.url).searchParams.get('watch') === 'true') {
+              return (
+                checkToken(request, 'token') ?? HttpResponse.text(watchData)
+              );
             }
-            return res(ctx.status(400));
+            return new HttpResponse(null, { status: 400 });
           },
         ),
       );
@@ -134,8 +126,8 @@ describe('KubernetesWatcher', () => {
 
     it('should yield ERROR event on network failure', async () => {
       worker.use(
-        rest.get('http://localhost:9999/*', (_req, res) => {
-          return res.networkError('Failed to connect');
+        http.get('http://localhost:9999/*', () => {
+          return HttpResponse.error();
         }),
       );
 
@@ -184,13 +176,15 @@ describe('KubernetesWatcher', () => {
       });
 
       worker.use(
-        rest.get(
+        http.get(
           'http://localhost:9999/api/v1/namespaces/default/pods',
-          (req, res, ctx) => {
-            if (req.url.searchParams.get('watch') === 'true') {
-              return res(checkToken(req, ctx, 'token'), ctx.text(watchData));
+          ({ request }) => {
+            if (new URL(request.url).searchParams.get('watch') === 'true') {
+              return (
+                checkToken(request, 'token') ?? HttpResponse.text(watchData)
+              );
             }
-            return res(ctx.status(400));
+            return new HttpResponse(null, { status: 400 });
           },
         ),
       );
@@ -234,13 +228,15 @@ describe('KubernetesWatcher', () => {
       });
 
       worker.use(
-        rest.get(
+        http.get(
           'http://localhost:9999/api/v1/namespaces/default/pods',
-          (req, res, ctx) => {
-            if (req.url.searchParams.get('watch') === 'true') {
-              return res(checkToken(req, ctx, 'token'), ctx.text(watchData));
+          ({ request }) => {
+            if (new URL(request.url).searchParams.get('watch') === 'true') {
+              return (
+                checkToken(request, 'token') ?? HttpResponse.text(watchData)
+              );
             }
-            return res(ctx.status(400));
+            return new HttpResponse(null, { status: 400 });
           },
         ),
       );
@@ -285,13 +281,15 @@ describe('KubernetesWatcher', () => {
       ].join('\n');
 
       worker.use(
-        rest.get(
+        http.get(
           'http://localhost:9999/api/v1/namespaces/default/pods',
-          (req, res, ctx) => {
-            if (req.url.searchParams.get('watch') === 'true') {
-              return res(checkToken(req, ctx, 'token'), ctx.text(watchData));
+          ({ request }) => {
+            if (new URL(request.url).searchParams.get('watch') === 'true') {
+              return (
+                checkToken(request, 'token') ?? HttpResponse.text(watchData)
+              );
             }
-            return res(ctx.status(400));
+            return new HttpResponse(null, { status: 400 });
           },
         ),
       );
@@ -325,8 +323,8 @@ describe('KubernetesWatcher', () => {
 
     it('should yield ERROR event for 401 Unauthorized', async () => {
       worker.use(
-        rest.get('http://localhost:9999/*', (_req, res, ctx) => {
-          return res(ctx.status(401), ctx.text('authentication required'));
+        http.get('http://localhost:9999/*', () => {
+          return HttpResponse.text('authentication required', { status: 401 });
         }),
       );
 
@@ -357,8 +355,8 @@ describe('KubernetesWatcher', () => {
 
     it('should yield ERROR event for 404 Not Found', async () => {
       worker.use(
-        rest.get('http://localhost:9999/*', (_req, res, ctx) => {
-          return res(ctx.status(404), ctx.text('resource not found'));
+        http.get('http://localhost:9999/*', () => {
+          return HttpResponse.text('resource not found', { status: 404 });
         }),
       );
 
@@ -386,8 +384,8 @@ describe('KubernetesWatcher', () => {
 
     it('should yield ERROR event for 500 Server Error', async () => {
       worker.use(
-        rest.get('http://localhost:9999/*', (_req, res, ctx) => {
-          return res(ctx.status(500), ctx.text('internal server error'));
+        http.get('http://localhost:9999/*', () => {
+          return HttpResponse.text('internal server error', { status: 500 });
         }),
       );
 
@@ -428,11 +426,11 @@ describe('KubernetesWatcher', () => {
       });
 
       worker.use(
-        rest.get('http://localhost:9999/*', (req, res, ctx) => {
-          if (req.url.searchParams.get('watch') === 'true') {
-            return res(ctx.text(errorEvent));
+        http.get('http://localhost:9999/*', ({ request }) => {
+          if (new URL(request.url).searchParams.get('watch') === 'true') {
+            return HttpResponse.text(errorEvent);
           }
-          return res(ctx.status(400));
+          return new HttpResponse(null, { status: 400 });
         }),
       );
 
@@ -477,11 +475,11 @@ describe('KubernetesWatcher', () => {
       ].join('\n');
 
       worker.use(
-        rest.get('http://localhost:9999/*', (req, res, ctx) => {
-          if (req.url.searchParams.get('watch') === 'true') {
-            return res(ctx.text(watchData));
+        http.get('http://localhost:9999/*', ({ request }) => {
+          if (new URL(request.url).searchParams.get('watch') === 'true') {
+            return HttpResponse.text(watchData);
           }
-          return res(ctx.status(400));
+          return new HttpResponse(null, { status: 400 });
         }),
       );
 
@@ -515,11 +513,11 @@ describe('KubernetesWatcher', () => {
       ].join('\n');
 
       worker.use(
-        rest.get('http://localhost:9999/*', (req, res, ctx) => {
-          if (req.url.searchParams.get('watch') === 'true') {
-            return res(ctx.text(watchData));
+        http.get('http://localhost:9999/*', ({ request }) => {
+          if (new URL(request.url).searchParams.get('watch') === 'true') {
+            return HttpResponse.text(watchData);
           }
-          return res(ctx.status(400));
+          return new HttpResponse(null, { status: 400 });
         }),
       );
 
@@ -554,11 +552,11 @@ describe('KubernetesWatcher', () => {
       ].join('\n');
 
       worker.use(
-        rest.get('http://localhost:9999/*', (req, res, ctx) => {
-          if (req.url.searchParams.get('watch') === 'true') {
-            return res(ctx.text(watchData));
+        http.get('http://localhost:9999/*', ({ request }) => {
+          if (new URL(request.url).searchParams.get('watch') === 'true') {
+            return HttpResponse.text(watchData);
           }
-          return res(ctx.status(400));
+          return new HttpResponse(null, { status: 400 });
         }),
       );
 
@@ -596,15 +594,15 @@ describe('KubernetesWatcher', () => {
       let labelSelectorParam = '';
       let resourceVersionParam = '';
       worker.use(
-        rest.get('http://localhost:9999/*', (req, res, ctx) => {
-          requestedUrl = req.url.pathname;
-          labelSelectorParam = req.url.searchParams.get('labelSelector') || '';
-          resourceVersionParam =
-            req.url.searchParams.get('resourceVersion') || '';
-          if (req.url.searchParams.get('watch') === 'true') {
-            return res(ctx.text(watchData));
+        http.get('http://localhost:9999/*', ({ request }) => {
+          const url = new URL(request.url);
+          requestedUrl = url.pathname;
+          labelSelectorParam = url.searchParams.get('labelSelector') || '';
+          resourceVersionParam = url.searchParams.get('resourceVersion') || '';
+          if (url.searchParams.get('watch') === 'true') {
+            return HttpResponse.text(watchData);
           }
-          return res(ctx.status(400));
+          return new HttpResponse(null, { status: 400 });
         }),
       );
 
@@ -646,19 +644,19 @@ describe('KubernetesWatcher', () => {
       let sendInitialEventsParam = '';
       let resourceVersionMatchParam = '';
       worker.use(
-        rest.get('http://localhost:9999/*', (req, res, ctx) => {
-          timeoutSecondsParam =
-            req.url.searchParams.get('timeoutSeconds') || '';
+        http.get('http://localhost:9999/*', ({ request }) => {
+          const url = new URL(request.url);
+          timeoutSecondsParam = url.searchParams.get('timeoutSeconds') || '';
           allowWatchBookmarksParam =
-            req.url.searchParams.get('allowWatchBookmarks') || '';
+            url.searchParams.get('allowWatchBookmarks') || '';
           sendInitialEventsParam =
-            req.url.searchParams.get('sendInitialEvents') || '';
+            url.searchParams.get('sendInitialEvents') || '';
           resourceVersionMatchParam =
-            req.url.searchParams.get('resourceVersionMatch') || '';
-          if (req.url.searchParams.get('watch') === 'true') {
-            return res(ctx.text(watchData));
+            url.searchParams.get('resourceVersionMatch') || '';
+          if (url.searchParams.get('watch') === 'true') {
+            return HttpResponse.text(watchData);
           }
-          return res(ctx.status(400));
+          return new HttpResponse(null, { status: 400 });
         }),
       );
 
@@ -703,12 +701,13 @@ describe('KubernetesWatcher', () => {
 
       let requestedUrl = '';
       worker.use(
-        rest.get('http://localhost:9999/*', (req, res, ctx) => {
-          requestedUrl = req.url.pathname;
-          if (req.url.searchParams.get('watch') === 'true') {
-            return res(ctx.text(watchData));
+        http.get('http://localhost:9999/*', ({ request }) => {
+          const url = new URL(request.url);
+          requestedUrl = url.pathname;
+          if (url.searchParams.get('watch') === 'true') {
+            return HttpResponse.text(watchData);
           }
-          return res(ctx.status(400));
+          return new HttpResponse(null, { status: 400 });
         }),
       );
 
@@ -738,12 +737,12 @@ describe('KubernetesWatcher', () => {
 
       let authHeader = '';
       worker.use(
-        rest.get('http://localhost:9999/*', (req, res, ctx) => {
-          authHeader = req.headers.get('Authorization') || '';
-          if (req.url.searchParams.get('watch') === 'true') {
-            return res(ctx.text(watchData));
+        http.get('http://localhost:9999/*', ({ request }) => {
+          authHeader = request.headers.get('Authorization') || '';
+          if (new URL(request.url).searchParams.get('watch') === 'true') {
+            return HttpResponse.text(watchData);
           }
-          return res(ctx.status(400));
+          return new HttpResponse(null, { status: 400 });
         }),
       );
 
@@ -772,11 +771,11 @@ describe('KubernetesWatcher', () => {
       const watchData = JSON.stringify({ type: 'ADDED', object: pod });
 
       worker.use(
-        rest.get('http://localhost:9999/*', (req, res, ctx) => {
-          if (req.url.searchParams.get('watch') === 'true') {
-            return res(ctx.text(watchData));
+        http.get('http://localhost:9999/*', ({ request }) => {
+          if (new URL(request.url).searchParams.get('watch') === 'true') {
+            return HttpResponse.text(watchData);
           }
-          return res(ctx.status(400));
+          return new HttpResponse(null, { status: 400 });
         }),
       );
 
@@ -801,8 +800,8 @@ describe('KubernetesWatcher', () => {
 
     it('should yield ERROR event when credentials are missing', async () => {
       worker.use(
-        rest.get('http://localhost:9999/*', (_req, res, ctx) => {
-          return res(ctx.status(401), ctx.text('Unauthorized'));
+        http.get('http://localhost:9999/*', () => {
+          return HttpResponse.text('Unauthorized', { status: 401 });
         }),
       );
 
@@ -847,11 +846,11 @@ describe('KubernetesWatcher', () => {
       ].join('\n');
 
       worker.use(
-        rest.get('http://localhost:9999/*', (req, res, ctx) => {
-          if (req.url.searchParams.get('watch') === 'true') {
-            return res(ctx.text(watchData));
+        http.get('http://localhost:9999/*', ({ request }) => {
+          if (new URL(request.url).searchParams.get('watch') === 'true') {
+            return HttpResponse.text(watchData);
           }
-          return res(ctx.status(400));
+          return new HttpResponse(null, { status: 400 });
         }),
       );
 
@@ -896,11 +895,11 @@ describe('KubernetesWatcher', () => {
       ].join('\n');
 
       worker.use(
-        rest.get('http://localhost:9999/*', (req, res, ctx) => {
-          if (req.url.searchParams.get('watch') === 'true') {
-            return res(ctx.text(watchData));
+        http.get('http://localhost:9999/*', ({ request }) => {
+          if (new URL(request.url).searchParams.get('watch') === 'true') {
+            return HttpResponse.text(watchData);
           }
-          return res(ctx.status(400));
+          return new HttpResponse(null, { status: 400 });
         }),
       );
 
@@ -993,13 +992,13 @@ describe('KubernetesWatcher', () => {
       };
 
       worker.use(
-        rest.get('http://localhost:9999/*', (req, res, ctx) => {
-          if (req.url.searchParams.get('watch') === 'true') {
-            return res(
-              ctx.text(JSON.stringify({ type: 'ADDED', object: pod })),
+        http.get('http://localhost:9999/*', ({ request }) => {
+          if (new URL(request.url).searchParams.get('watch') === 'true') {
+            return HttpResponse.text(
+              JSON.stringify({ type: 'ADDED', object: pod }),
             );
           }
-          return res(ctx.status(400));
+          return new HttpResponse(null, { status: 400 });
         }),
       );
 

--- a/plugins/kubernetes-node/package.json
+++ b/plugins/kubernetes-node/package.json
@@ -35,7 +35,7 @@
     "lint": "backstage-cli package lint",
     "prepack": "backstage-cli package prepack",
     "postpack": "backstage-cli package postpack",
-    "test": "backstage-cli package test"
+    "test": "NODE_OPTIONS=--experimental-vm-modules backstage-cli package test"
   },
   "dependencies": {
     "@backstage/backend-plugin-api": "workspace:^",
@@ -52,7 +52,7 @@
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
     "@backstage/plugin-kubernetes-backend": "workspace:^",
-    "msw": "^1.3.1",
+    "msw": "^2.0.0",
     "supertest": "^7.0.0"
   }
 }

--- a/plugins/kubernetes-node/src/auth/PinnipedHelper.test.ts
+++ b/plugins/kubernetes-node/src/auth/PinnipedHelper.test.ts
@@ -33,7 +33,8 @@ import {
 import { PinnipedHelper, PinnipedParameters } from './PinnipedHelper';
 import { HEADER_KUBERNETES_CLUSTER } from '@backstage/plugin-kubernetes-backend';
 import { JsonObject } from '@backstage/types';
-import { rest } from 'msw';
+import https from 'node:https';
+import { http, HttpResponse, passthrough } from 'msw';
 import { setupServer } from 'msw/node';
 import { ExtendedHttpServer } from '@backstage/backend-defaults/rootHttpRouter';
 
@@ -42,23 +43,16 @@ jest.setTimeout(60_000);
 describe('Pinniped - tokenCredentialRequest', () => {
   let app: ExtendedHttpServer;
   const logger = mockServices.logger.mock();
-  let httpsRequest: jest.SpyInstance;
   const worker = setupServer();
   registerMswTestHooks(worker);
+  let httpsRequest: jest.SpyInstance;
 
   beforeAll(() => {
-    httpsRequest = jest.spyOn(
-      // this is pretty egregious reverse engineering of msw.
-      // If the SetupServerApi constructor was exported, we wouldn't need
-      // to be quite so hacky here
-      (worker as any).interceptor.interceptors[0].modules.get('https'),
-      'request',
-    );
+    httpsRequest = jest.spyOn(https, 'request');
   });
 
   beforeEach(async () => {
     httpsRequest.mockClear();
-
     const clusterSupplierMock = {
       getClusters: jest.fn().mockImplementation(_ => {
         return Promise.resolve([
@@ -154,8 +148,8 @@ describe('Pinniped - tokenCredentialRequest', () => {
   describe('TLS Clusters', () => {
     it('Should get certs data from Concierge', async () => {
       worker.use(
-        rest.get('https://my.cluster.url/api/v1/namespaces', (_, res, ctx) => {
-          return res(ctx.json({ items: [] }));
+        http.get('https://my.cluster.url/api/v1/namespaces', () => {
+          return HttpResponse.json({ items: [] });
         }),
       );
 
@@ -163,20 +157,30 @@ describe('Pinniped - tokenCredentialRequest', () => {
       const myKey = 'MOCKKey';
 
       worker.use(
-        rest.post(
+        http.post(
           'https://my.cluster.url/apis/login.concierge.pinniped.dev/v1alpha1/tokencredentialrequests',
-          (_, res, ctx) => {
-            return res(
-              ctx.json({
-                status: {
-                  credential: {
-                    clientKeyData: myKey,
-                    clientCertificateData: myCert,
-                    expirationTimestamp: '2024-01-04T14:30:30.373Z',
-                  },
+          async ({ request: mswRequest }) => {
+            expect(await mswRequest.json()).toEqual({
+              apiVersion: 'login.concierge.pinniped.dev/v1alpha1',
+              kind: 'TokenCredentialRequest',
+              spec: {
+                authenticator: {
+                  apiGroup: 'authentication.concierge.pinniped.dev',
+                  kind: 'JWTAuthenticator',
+                  name: 'supervisor',
                 },
-              }),
-            );
+                token: 'ClusterID Specific Token',
+              },
+            });
+            return HttpResponse.json({
+              status: {
+                credential: {
+                  clientKeyData: myKey,
+                  clientCertificateData: myCert,
+                  expirationTimestamp: '2024-01-04T14:30:30.373Z',
+                },
+              },
+            });
           },
         ),
       );
@@ -189,22 +193,27 @@ describe('Pinniped - tokenCredentialRequest', () => {
           'ClusterID Specific Token',
         );
 
-      worker.use(rest.all(proxyEndpointRequest.url, req => req.passthrough()));
+      worker.use(http.all(proxyEndpointRequest.url, () => passthrough()));
 
       const result = await proxyEndpointRequest;
 
-      expect(JSON.stringify(result)).toMatch(/PEM/);
+      expect(result.status).toBe(200);
+      expect(result.body).toEqual({ items: [] });
 
       expect(httpsRequest).toHaveBeenCalledTimes(2);
-      const [{ cert, key }] = httpsRequest.mock.calls[1];
-      expect(cert).toEqual(myCert);
-      expect(key).toEqual(myKey);
+      const [, proxyCall] = httpsRequest.mock.calls;
+      expect(proxyCall[0]).toEqual(
+        expect.objectContaining({
+          cert: myCert,
+          key: myKey,
+        }),
+      );
     });
 
     it('Should get certs data from TMC-flavoured Pinniped', async () => {
       worker.use(
-        rest.get('https://my.cluster.url/api/v1/namespaces', (_, res, ctx) => {
-          return res(ctx.json({ items: [] }));
+        http.get('https://my.cluster.url/api/v1/namespaces', () => {
+          return HttpResponse.json({ items: [] });
         }),
       );
 
@@ -212,20 +221,32 @@ describe('Pinniped - tokenCredentialRequest', () => {
       const myKey = 'MOCKKey2';
 
       worker.use(
-        rest.post(
+        http.post(
           'https://my.cluster.url/apis/login.concierge.pinniped.tmc.cloud.vmware.com/v1alpha1/tokencredentialrequests',
-          (_, res, ctx) => {
-            return res(
-              ctx.json({
-                status: {
-                  credential: {
-                    clientKeyData: myKey,
-                    clientCertificateData: myCert,
-                    expirationTimestamp: '2024-01-04T14:30:30.373Z',
-                  },
+          async ({ request: mswRequest }) => {
+            expect(await mswRequest.json()).toEqual({
+              apiVersion:
+                'login.concierge.pinniped.tmc.cloud.vmware.com/v1alpha1',
+              kind: 'TokenCredentialRequest',
+              spec: {
+                authenticator: {
+                  apiGroup:
+                    'authentication.concierge.pinniped.tmc.cloud.vmware.com',
+                  kind: 'WebhookAuthenticator',
+                  name: 'supervisor',
                 },
-              }),
-            );
+                token: 'ClusterID Specific Token',
+              },
+            });
+            return HttpResponse.json({
+              status: {
+                credential: {
+                  clientKeyData: myKey,
+                  clientCertificateData: myCert,
+                  expirationTimestamp: '2024-01-04T14:30:30.373Z',
+                },
+              },
+            });
           },
         ),
       );
@@ -334,48 +355,63 @@ describe('Pinniped - tokenCredentialRequest', () => {
           'ClusterID Specific Token',
         );
 
-      worker.use(rest.all(proxyEndpointRequest.url, req => req.passthrough()));
+      worker.use(http.all(proxyEndpointRequest.url, () => passthrough()));
 
       const result = await proxyEndpointRequest;
 
-      expect(JSON.stringify(result)).toMatch(/PEM/);
+      expect(result.status).toBe(200);
+      expect(result.body).toEqual({ items: [] });
 
       expect(httpsRequest).toHaveBeenCalledTimes(2);
-      const [{ cert, key }] = httpsRequest.mock.calls[1];
-      expect(cert).toEqual(myCert);
-      expect(key).toEqual(myKey);
+      const [, proxyCall] = httpsRequest.mock.calls;
+      expect(proxyCall[0]).toEqual(
+        expect.objectContaining({
+          cert: myCert,
+          key: myKey,
+        }),
+      );
     });
 
     it('Should get an error when Concierge return an error', async () => {
       worker.use(
-        rest.get('https://my.cluster.url/api/v1/namespaces', (_, res, ctx) => {
-          return res(ctx.json({ items: [] }));
+        http.get('https://my.cluster.url/api/v1/namespaces', () => {
+          return HttpResponse.json({ items: [] });
         }),
       );
 
       worker.use(
-        rest.post(
+        http.post(
           'https://my.cluster.url/apis/login.concierge.pinniped.dev/v1alpha1/tokencredentialrequests',
-          (_, res, ctx) => {
-            return res(
-              ctx.json({
-                kind: 'TokenCredentialRequest',
-                apiVersion: 'login.concierge.pinniped.dev/v1alpha1',
-                metadata: {
-                  creationTimestamp: null,
+          async ({ request: mswRequest }) => {
+            expect(await mswRequest.json()).toEqual({
+              apiVersion: 'login.concierge.pinniped.dev/v1alpha1',
+              kind: 'TokenCredentialRequest',
+              spec: {
+                authenticator: {
+                  apiGroup: 'authentication.concierge.pinniped.dev',
+                  kind: 'JWTAuthenticator',
+                  name: 'supervisor',
                 },
-                spec: {
-                  authenticator: {
-                    apiGroup: null,
-                    kind: '',
-                    name: '',
-                  },
+                token: 'ClusterID Specific Token',
+              },
+            });
+            return HttpResponse.json({
+              kind: 'TokenCredentialRequest',
+              apiVersion: 'login.concierge.pinniped.dev/v1alpha1',
+              metadata: {
+                creationTimestamp: null,
+              },
+              spec: {
+                authenticator: {
+                  apiGroup: null,
+                  kind: '',
+                  name: '',
                 },
-                status: {
-                  message: 'authentication failed',
-                },
-              }),
-            );
+              },
+              status: {
+                message: 'authentication failed',
+              },
+            });
           },
         ),
       );
@@ -388,11 +424,12 @@ describe('Pinniped - tokenCredentialRequest', () => {
           'ClusterID Specific Token',
         );
 
-      worker.use(rest.all(proxyEndpointRequest.url, req => req.passthrough()));
+      worker.use(http.all(proxyEndpointRequest.url, () => passthrough()));
 
       const result = await proxyEndpointRequest;
 
-      expect(JSON.stringify(result)).toMatch(/error/);
+      expect(result.status).toBe(500);
+      expect(result.body.response.statusCode).toBe(500);
 
       expect(httpsRequest).toHaveBeenCalledTimes(1);
     });

--- a/plugins/kubernetes-node/src/auth/PinnipedHelper.test.ts
+++ b/plugins/kubernetes-node/src/auth/PinnipedHelper.test.ts
@@ -51,6 +51,10 @@ describe('Pinniped - tokenCredentialRequest', () => {
     httpsRequest = jest.spyOn(https, 'request');
   });
 
+  afterAll(() => {
+    httpsRequest.mockRestore();
+  });
+
   beforeEach(async () => {
     httpsRequest.mockClear();
     const clusterSupplierMock = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5438,7 +5438,7 @@ __metadata:
     http-proxy-middleware: "npm:^2.0.6"
     lodash: "npm:^4.17.21"
     luxon: "npm:^3.0.0"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
     node-fetch: "npm:^2.7.0"
     split2: "npm:^4.2.0"
     supertest: "npm:^7.0.0"
@@ -5512,7 +5512,7 @@ __metadata:
     "@backstage/types": "workspace:^"
     "@kubernetes/client-node": "npm:1.4.0"
     "@types/express": "npm:^4.17.6"
-    msw: "npm:^1.3.1"
+    msw: "npm:^2.0.0"
     node-fetch: "npm:^2.7.0"
     supertest: "npm:^7.0.0"
   languageName: unknown
@@ -35934,7 +35934,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"msw@npm:^1.0.0, msw@npm:^1.3.1":
+"msw@npm:^1.0.0":
   version: 1.3.5
   resolution: "msw@npm:1.3.5"
   dependencies:


### PR DESCRIPTION
## Hey 👋

This PR migrates the following packages owned by `@backstage/kubernetes-maintainers` from MSW v1 to MSW v2:

- `@backstage/plugin-kubernetes-backend`
- `@backstage/plugin-kubernetes-node`

### Changes
- Updated MSW imports and handler syntax to v2 API
- Replaced `rest.*` handlers with `http.*` handlers
- Updated response helpers to use `HttpResponse`
- Updated `package.json` dependencies

---

### Checklist

- [x] I have read the [contribution guidelines](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md)
- [x] Added or updated tests
- [ ] Added or updated documentation
- [x] Verified that the change works locally