### PR TITLE
chore(release-manifests): Migrate release-manifests to MSW 2

### DIFF
--- a/.changeset/migrate-msw2-release-manifests.md
+++ b/.changeset/migrate-msw2-release-manifests.md
@@ -1,0 +1,5 @@
+---
+'@backstage/release-manifests': patch
+---
+
+Migrated tests from MSW v1 to MSW v2.

--- a/packages/release-manifests/package.json
+++ b/packages/release-manifests/package.json
@@ -38,6 +38,6 @@
   "devDependencies": {
     "@backstage/cli": "workspace:^",
     "@backstage/test-utils": "workspace:^",
-    "msw": "^1.0.0"
+    "msw": "^2.0.0"
   }
 }

--- a/packages/release-manifests/src/manifest.test.ts
+++ b/packages/release-manifests/src/manifest.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { setupServer } from 'msw/node';
-import { rest } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { registerMswTestHooks } from '@backstage/test-utils';
 import {
   getManifestByReleaseLine,
@@ -30,16 +30,16 @@ describe('Release Manifests', () => {
   describe('getManifestByVersion', () => {
     it('should return a list of packages in a release', async () => {
       worker.use(
-        rest.get('*/v1/releases/0.0.0/manifest.json', (_, res, ctx) =>
-          res(
-            ctx.status(200),
-            ctx.json({
+        http.get(
+          'https://versions.backstage.io/v1/releases/0.0.0/manifest.json',
+          () =>
+            HttpResponse.json({
               packages: [{ name: '@backstage/core', version: '1.2.3' }],
             }),
-          ),
         ),
-        rest.get('*/v1/releases/999.0.1/manifest.json', (_, res, ctx) =>
-          res(ctx.status(404), ctx.json({})),
+        http.get(
+          'https://versions.backstage.io/v1/releases/999.0.1/manifest.json',
+          () => HttpResponse.json({}, { status: 404 }),
         ),
       );
 
@@ -156,19 +156,16 @@ describe('Release Manifests', () => {
   describe('getManifestByReleaseLine', () => {
     it('should return a list of packages in a release', async () => {
       worker.use(
-        rest.get(
+        http.get(
           'https://versions.backstage.io/v1/tags/main/manifest.json',
-          (_, res, ctx) =>
-            res(
-              ctx.status(200),
-              ctx.json({
-                packages: [{ name: '@backstage/core', version: '1.2.3' }],
-              }),
-            ),
+          () =>
+            HttpResponse.json({
+              packages: [{ name: '@backstage/core', version: '1.2.3' }],
+            }),
         ),
-        rest.get(
+        http.get(
           'https://versions.backstage.io/v1/tags/foo/manifest.json',
-          (_, res, ctx) => res(ctx.status(404), ctx.json({})),
+          () => HttpResponse.json({}, { status: 404 }),
         ),
       );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7486,7 +7486,7 @@ __metadata:
   dependencies:
     "@backstage/cli": "workspace:^"
     "@backstage/test-utils": "workspace:^"
-    msw: "npm:^1.0.0"
+    msw: "npm:^2.0.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Hey 👋

This PR migrates `@backstage/release-manifests` (owned by `@backstage/operations-maintainers`) from MSW v1 to MSW v2.

### Changes
- Updated MSW imports and handler syntax to v2 API
- Replaced `rest.*` handlers with `http.*` handlers
- Updated response helpers to use `HttpResponse`
- Updated `package.json` dependencies

---

### Checklist

- [x] I have read the [contribution guidelines](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md)
- [x] Added or updated tests
- [ ] Added or updated documentation
- [x] Verified that the change works locally