### PR TITLE
fix(catalog-incremental): reduce round trips for `ingestion_mark_entities` writes

### DIFF
--- a/.changeset/incremental-ingestion-mark-entities-upsert.md
+++ b/.changeset/incremental-ingestion-mark-entities-upsert.md
@@ -1,0 +1,9 @@
+---
+'@backstage/plugin-catalog-backend-module-incremental-ingestion': minor
+---
+
+Added a `source_key` column and a `UNIQUE(source_key, entity_ref)` constraint to the `ingestion_mark_entities` table, enabling a single native upsert instead of a select-then-update-or-insert sequence per ingestion mark.
+This significantly reduces the number of database round trips during ingestion.
+
+As part of this change, the table's `ref` column is renamed to `entity_ref` to standardize its naming with the rest of the table's columns.
+This rename means the migration cannot be applied as part of a rolling, zero-downtime upgrade, which is fine since incremental ingestion providers are designed to run sequentially on a single Backstage backend instance.

--- a/plugins/catalog-backend-module-incremental-ingestion/migrations/20260811133818_ingestion_mark_entities_source_key.js
+++ b/plugins/catalog-backend-module-incremental-ingestion/migrations/20260811133818_ingestion_mark_entities_source_key.js
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @ts-check
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.up = async function up(knex) {
+  await knex.schema.alterTable('ingestion_mark_entities', table => {
+    table
+      .string('source_key')
+      .nullable()
+      .comment('The provider name of the ingestion that produced this mark');
+  });
+
+  await knex('ingestion_mark_entities').update({
+    source_key: knex('ingestions')
+      .select('ingestions.provider_name')
+      .innerJoin(
+        'ingestion_marks',
+        'ingestion_marks.ingestion_id',
+        'ingestions.id',
+      )
+      .where(
+        'ingestion_marks.id',
+        knex.ref('ingestion_mark_entities.ingestion_mark_id'),
+      ),
+  });
+
+  await knex.schema.alterTable('ingestion_mark_entities', table => {
+    table.renameColumn('ref', 'entity_ref');
+  });
+
+  // Prior to this migration, `(source_key, entity_ref)` was never enforced
+  // to be unique, so pre-existing installations may have duplicate rows.
+  // Keep only the row tied to the most recently created mark, breaking ties
+  // by the highest `id`.
+  await knex.raw(`
+    DELETE FROM ingestion_mark_entities WHERE id IN (
+      SELECT id FROM (
+        SELECT
+          ime.id AS id,
+          ROW_NUMBER() OVER (
+            PARTITION BY ime.source_key, ime.entity_ref
+            ORDER BY im.created_at DESC, ime.id DESC
+          ) AS rn
+        FROM ingestion_mark_entities ime
+        JOIN ingestion_marks im ON im.id = ime.ingestion_mark_id
+      ) ranked WHERE ranked.rn > 1
+    )
+  `);
+
+  await knex.schema.alterTable('ingestion_mark_entities', table => {
+    table.string('source_key').notNullable().alter();
+    table.unique(['source_key', 'entity_ref'], {
+      indexName: 'ingestion_mark_entities_source_key_entity_ref_uniq',
+    });
+  });
+};
+
+/**
+ * @param {import('knex').Knex} knex
+ */
+exports.down = async function down(knex) {
+  await knex.schema.alterTable('ingestion_mark_entities', table => {
+    table.dropUnique(
+      ['source_key', 'entity_ref'],
+      'ingestion_mark_entities_source_key_entity_ref_uniq',
+    );
+  });
+
+  await knex.schema.alterTable('ingestion_mark_entities', table => {
+    table.renameColumn('entity_ref', 'ref');
+  });
+
+  await knex.schema.alterTable('ingestion_mark_entities', table => {
+    table.dropColumn('source_key');
+  });
+};

--- a/plugins/catalog-backend-module-incremental-ingestion/report.sql.md
+++ b/plugins/catalog-backend-module-incremental-ingestion/report.sql.md
@@ -6,13 +6,15 @@
 
 | Column              | Type                | Nullable | Max Length | Default |
 | ------------------- | ------------------- | -------- | ---------- | ------- |
+| `entity_ref`        | `character varying` | false    | 255        | -       |
 | `id`                | `uuid`              | false    | -          | -       |
 | `ingestion_mark_id` | `uuid`              | false    | -          | -       |
-| `ref`               | `character varying` | false    | 255        | -       |
+| `source_key`        | `character varying` | false    | 255        | -       |
 
 ### Indices
 
 - `ingestion_mark_entities_pkey` (`id`) unique primary
+- `ingestion_mark_entities_source_key_entity_ref_uniq` (`source_key`, `entity_ref`) unique
 - `ingestion_mark_entity_ingestion_mark_id_idx` (`ingestion_mark_id`)
 
 ## Table `ingestion_marks`

--- a/plugins/catalog-backend-module-incremental-ingestion/src/database/IncrementalIngestionDatabaseManager.test.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/database/IncrementalIngestionDatabaseManager.test.ts
@@ -14,12 +14,29 @@
  * limitations under the License.
  */
 
+import { Knex } from 'knex';
 import { TestDatabases } from '@backstage/backend-test-utils';
 import { DeferredEntity } from '@backstage/plugin-catalog-node';
 import { randomUUID as uuid } from 'node:crypto';
+import fs from 'node:fs';
 import { IncrementalIngestionDatabaseManager } from './IncrementalIngestionDatabaseManager';
 
 const migrationsDir = `${__dirname}/../../migrations`;
+const migrationsFiles = fs.readdirSync(migrationsDir).sort();
+
+async function migrateUpOnce(knex: Knex): Promise<void> {
+  await knex.migrate.up({ directory: migrationsDir });
+}
+
+async function migrateUntilBefore(knex: Knex, target: string): Promise<void> {
+  const index = migrationsFiles.indexOf(target);
+  if (index === -1) {
+    throw new Error(`Migration ${target} not found`);
+  }
+  for (let i = 0; i < index; i++) {
+    await migrateUpOnce(knex);
+  }
+}
 
 jest.setTimeout(60_000);
 
@@ -109,11 +126,11 @@ describe.each(databases.eachSupportedId())(
       });
 
       // Create multiple mark entities
-      await manager.createMarkEntities(markId, [
-        makeEntity('comp1'),
-        makeEntity('comp2'),
-        makeEntity('comp3'),
-      ]);
+      await manager.createMarkEntities(
+        'testProvider',
+        [makeEntity('comp1'), makeEntity('comp2'), makeEntity('comp3')],
+        markId,
+      );
 
       const result = await manager.computeRemoved('testProvider', ingestionId);
 
@@ -150,13 +167,13 @@ describe.each(databases.eachSupportedId())(
       });
 
       // First batch: create 3 entities
-      await manager.createMarkEntities(markId1, [
-        makeEntity('a'),
-        makeEntity('b'),
-        makeEntity('c'),
-      ]);
+      await manager.createMarkEntities(
+        'testProvider',
+        [makeEntity('a'), makeEntity('b'), makeEntity('c')],
+        markId1,
+      );
 
-      const rows1 = await knex('ingestion_mark_entities').select('ref');
+      const rows1 = await knex('ingestion_mark_entities').select('entity_ref');
       expect(rows1).toHaveLength(3);
 
       // Second batch with overlap: b and c already exist, d is new.
@@ -171,33 +188,37 @@ describe.each(databases.eachSupportedId())(
         },
       });
 
-      await manager.createMarkEntities(markId2, [
-        makeEntity('b'),
-        makeEntity('c'),
-        makeEntity('d'),
-      ]);
+      await manager.createMarkEntities(
+        'testProvider',
+        [makeEntity('b'), makeEntity('c'), makeEntity('d')],
+        markId2,
+      );
 
       const rows2 = await knex('ingestion_mark_entities')
-        .select('ref', 'ingestion_mark_id')
-        .orderBy('ref');
+        .select('entity_ref', 'ingestion_mark_id')
+        .orderBy('entity_ref');
       expect(rows2).toHaveLength(4);
 
       // a stays on markId1, b and c moved to markId2, d is new on markId2
       expect(
-        rows2.find(r => r.ref === 'component:default/a')?.ingestion_mark_id,
+        rows2.find(r => r.entity_ref === 'component:default/a')
+          ?.ingestion_mark_id,
       ).toBe(markId1);
       expect(
-        rows2.find(r => r.ref === 'component:default/b')?.ingestion_mark_id,
+        rows2.find(r => r.entity_ref === 'component:default/b')
+          ?.ingestion_mark_id,
       ).toBe(markId2);
       expect(
-        rows2.find(r => r.ref === 'component:default/c')?.ingestion_mark_id,
+        rows2.find(r => r.entity_ref === 'component:default/c')
+          ?.ingestion_mark_id,
       ).toBe(markId2);
       expect(
-        rows2.find(r => r.ref === 'component:default/d')?.ingestion_mark_id,
+        rows2.find(r => r.entity_ref === 'component:default/d')
+          ?.ingestion_mark_id,
       ).toBe(markId2);
     });
 
-    it('deleteEntityRecordsByRef removes matching refs', async () => {
+    it('deleteEntityRecordsByRef removes matching refs scoped to the given provider', async () => {
       const knex = await databases.init(databaseId);
       await knex.migrate.latest({ directory: migrationsDir });
 
@@ -205,12 +226,23 @@ describe.each(databases.eachSupportedId())(
       const { ingestionId } = (await manager.createProviderIngestionRecord(
         'testProvider',
       ))!;
+      const { ingestionId: otherIngestionId } =
+        (await manager.createProviderIngestionRecord('otherProvider'))!;
 
       const markId = uuid();
       await manager.createMark({
         record: {
           id: markId,
           ingestion_id: ingestionId,
+          sequence: 1,
+          cursor: { data: 1 },
+        },
+      });
+      const otherMarkId = uuid();
+      await manager.createMark({
+        record: {
+          id: otherMarkId,
+          ingestion_id: otherIngestionId,
           sequence: 1,
           cursor: { data: 1 },
         },
@@ -224,21 +256,109 @@ describe.each(databases.eachSupportedId())(
         },
       });
 
-      await manager.createMarkEntities(markId, [
-        makeEntity('x'),
-        makeEntity('y'),
-        makeEntity('z'),
-      ]);
+      await manager.createMarkEntities(
+        'testProvider',
+        [makeEntity('x'), makeEntity('y'), makeEntity('z')],
+        markId,
+      );
+      // otherProvider owns the same entity ref as one of testProvider's.
+      await manager.createMarkEntities(
+        'otherProvider',
+        [makeEntity('x')],
+        otherMarkId,
+      );
 
-      // Delete two of the three
-      await manager.deleteEntityRecordsByRef([
+      // Delete two of testProvider's three; otherProvider's matching ref
+      // must survive.
+      await manager.deleteEntityRecordsByRef('testProvider', [
         { entityRef: 'component:default/x' },
         { entityRef: 'component:default/z' },
       ]);
 
-      const remaining = await knex('ingestion_mark_entities').select('ref');
-      expect(remaining).toHaveLength(1);
-      expect(remaining[0].ref).toBe('component:default/y');
+      const remaining = await knex('ingestion_mark_entities')
+        .select('source_key', 'entity_ref')
+        .orderBy('source_key');
+      expect(remaining).toEqual([
+        { source_key: 'otherProvider', entity_ref: 'component:default/x' },
+        { source_key: 'testProvider', entity_ref: 'component:default/y' },
+      ]);
+    });
+
+    it('migration backfills source_key, dedupes, and renames ref to entity_ref', async () => {
+      const knex = await databases.init(databaseId);
+
+      // Migrate up to (but not including) the `source_key` migration under
+      // test, so we can seed dirty data under the old schema shape.
+      await migrateUntilBefore(
+        knex,
+        '20260811133818_ingestion_mark_entities_source_key.js',
+      );
+
+      const ingestionId = uuid();
+      await knex('ingestions').insert({
+        id: ingestionId,
+        provider_name: 'dupProvider',
+        status: 'bursting',
+        next_action: 'ingest',
+        completion_ticket: 'open',
+      });
+
+      const olderMarkId = uuid();
+      const newerMarkId = uuid();
+      await knex('ingestion_marks').insert([
+        {
+          id: olderMarkId,
+          ingestion_id: ingestionId,
+          sequence: 1,
+          created_at: new Date('2026-01-01T00:00:00.000Z'),
+        },
+        {
+          id: newerMarkId,
+          ingestion_id: ingestionId,
+          sequence: 2,
+          created_at: new Date('2026-01-02T00:00:00.000Z'),
+        },
+      ]);
+
+      // A duplicate pair (same eventual source_key + ref) tied to two
+      // different marks, plus one unique row.
+      await knex('ingestion_mark_entities').insert([
+        {
+          id: uuid(),
+          ingestion_mark_id: olderMarkId,
+          ref: 'component:default/dup',
+        },
+        {
+          id: uuid(),
+          ingestion_mark_id: newerMarkId,
+          ref: 'component:default/dup',
+        },
+        {
+          id: uuid(),
+          ingestion_mark_id: newerMarkId,
+          ref: 'component:default/unique',
+        },
+      ]);
+
+      // Apply the migration under test.
+      await migrateUpOnce(knex);
+
+      const rows = await knex('ingestion_mark_entities')
+        .select('source_key', 'entity_ref', 'ingestion_mark_id')
+        .orderBy('entity_ref');
+
+      expect(rows).toEqual([
+        {
+          source_key: 'dupProvider',
+          entity_ref: 'component:default/dup',
+          ingestion_mark_id: newerMarkId,
+        },
+        {
+          source_key: 'dupProvider',
+          entity_ref: 'component:default/unique',
+          ingestion_mark_id: newerMarkId,
+        },
+      ]);
     });
 
     it('updateIngestionRecordById with long last_error value', async () => {

--- a/plugins/catalog-backend-module-incremental-ingestion/src/database/IncrementalIngestionDatabaseManager.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/database/IncrementalIngestionDatabaseManager.ts
@@ -187,33 +187,6 @@ export class IncrementalIngestionDatabaseManager {
   }
 
   /**
-   * Automatically cleans up duplicate ingestion records if they were accidentally created.
-   * Any ingestion record where the `rest_completed_at` is null (meaning it is active) AND
-   * the ingestionId is incorrect is a duplicate ingestion record.
-   * @param ingestionId - string
-   * @param provider - string
-   */
-  async clearDuplicateIngestions(ingestionId: string, provider: string) {
-    await this.client.transaction(async tx => {
-      const invalid = await tx<IngestionRecord>('ingestions')
-        .where('provider_name', provider)
-        .andWhere('rest_completed_at', null)
-        .andWhereNot('id', ingestionId);
-
-      if (invalid.length > 0) {
-        await tx('ingestions').delete().whereIn('id', invalid);
-        await tx('ingestion_mark_entities')
-          .delete()
-          .whereIn(
-            'ingestion_mark_id',
-            tx('ingestion_marks').select('id').whereIn('ingestion_id', invalid),
-          );
-        await tx('ingestion_marks').delete().whereIn('ingestion_id', invalid);
-      }
-    });
-  }
-
-  /**
    * This method fully purges and resets all ingestion records for the named provider, and
    * leaves it in a paused state.
    * @param provider - string
@@ -283,14 +256,22 @@ export class IncrementalIngestionDatabaseManager {
 
   /**
    * This method is used to remove entity records from the ingestion_mark_entities
-   * table by their entity reference.
+   * table by their entity reference, scoped to a single source_key.
    */
-  async deleteEntityRecordsByRef(entities: { entityRef: string }[]) {
+  async deleteEntityRecordsByRef(
+    sourceKey: string,
+    entities: { entityRef: string }[],
+  ) {
+    if (entities.length === 0) {
+      return;
+    }
+
     const refs = entities.map(e => e.entityRef);
     await this.client.transaction(async tx => {
       await tx('ingestion_mark_entities')
         .delete()
-        .modify(this.whereInArray('ref', refs));
+        .where('source_key', sourceKey)
+        .modify(this.whereInArray('entity_ref', refs));
     });
   }
 
@@ -327,7 +308,7 @@ export class IncrementalIngestionDatabaseManager {
     const previousIngestion = await this.getPreviousIngestionRecord(provider);
     return await this.client.transaction(async tx => {
       const count = await tx('ingestion_mark_entities')
-        .count({ total: 'ingestion_mark_entities.ref' })
+        .count({ total: 'ingestion_mark_entities.entity_ref' })
         .join(
           'ingestion_marks',
           'ingestion_marks.id',
@@ -340,8 +321,10 @@ export class IncrementalIngestionDatabaseManager {
 
       const removed: { entityRef: string }[] = [];
       if (previousIngestion) {
-        const stale: { ref: string }[] = await tx('ingestion_mark_entities')
-          .select('ingestion_mark_entities.ref')
+        const stale: { entity_ref: string }[] = await tx(
+          'ingestion_mark_entities',
+        )
+          .select('ingestion_mark_entities.entity_ref')
           .join(
             'ingestion_marks',
             'ingestion_marks.id',
@@ -350,8 +333,8 @@ export class IncrementalIngestionDatabaseManager {
           .join('ingestions', 'ingestions.id', 'ingestion_marks.ingestion_id')
           .where('ingestions.id', previousIngestion.id);
 
-        for (const entityRef of stale) {
-          removed.push({ entityRef: entityRef.ref });
+        for (const row of stale) {
+          removed.push({ entityRef: row.entity_ref });
         }
       }
 
@@ -607,38 +590,33 @@ export class IncrementalIngestionDatabaseManager {
 
   /**
    * Performs an upsert to the `ingestion_mark_entities` table for all deferred entities.
-   * @param markId - string
+   * @param sourceKey - string
    * @param entities - DeferredEntity[]
+   * @param markId - string
    */
-  async createMarkEntities(markId: string, entities: DeferredEntity[]) {
+  async createMarkEntities(
+    sourceKey: string,
+    entities: DeferredEntity[],
+    markId: string,
+  ) {
+    if (entities.length === 0) {
+      return;
+    }
+
     const refs = entities.map(e => stringifyEntityRef(e.entity));
 
     await this.client.transaction(async tx => {
-      const existingRefsArray = (
-        await tx<{ ref: string }>('ingestion_mark_entities')
-          .select('ref')
-          .modify(this.whereInArray('ref', refs))
-      ).map((e: { ref: string }) => e.ref);
-
-      const existingRefsSet = new Set(existingRefsArray);
-
-      const newRefs = refs.filter(e => !existingRefsSet.has(e));
-
-      if (existingRefsArray.length > 0) {
-        await tx('ingestion_mark_entities')
-          .update('ingestion_mark_id', markId)
-          .modify(this.whereInArray('ref', existingRefsArray));
-      }
-
-      if (newRefs.length > 0) {
-        await tx('ingestion_mark_entities').insert(
-          newRefs.map(ref => ({
+      await tx('ingestion_mark_entities')
+        .insert(
+          refs.map(entityRef => ({
             id: v4(),
             ingestion_mark_id: markId,
-            ref,
+            source_key: sourceKey,
+            entity_ref: entityRef,
           })),
-        );
-      }
+        )
+        .onConflict(['source_key', 'entity_ref'])
+        .merge(['ingestion_mark_id']);
     });
   }
 

--- a/plugins/catalog-backend-module-incremental-ingestion/src/engine/IncrementalIngestionEngine.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/engine/IncrementalIngestionEngine.ts
@@ -264,17 +264,22 @@ export class IncrementalIngestionEngine implements IterationEngine {
     return done;
   }
 
-  async mark(options: {
+  async mark({
+    id,
+    sequence,
+    entities = [],
+    done,
+    cursor,
+  }: {
     id: string;
     sequence: number;
     entities?: DeferredEntity[];
     done: boolean;
     cursor?: unknown;
   }) {
-    const { id, sequence, entities, done, cursor } = options;
     this.options.logger.debug(
       `incremental-engine: Ingestion '${id}': MARK ${
-        entities ? entities.length : 0
+        entities.length
       } entities, cursor: ${
         cursor ? JSON.stringify(cursor) : 'none'
       }, done: ${done}`,
@@ -290,23 +295,24 @@ export class IncrementalIngestionEngine implements IterationEngine {
       },
     });
 
-    if (entities && entities.length > 0) {
-      await this.manager.createMarkEntities(markId, entities);
-    }
+    await this.manager.createMarkEntities(
+      this.options.provider.getProviderName(),
+      entities,
+      markId,
+    );
 
-    const added =
-      entities?.map(deferred => ({
-        ...deferred,
-        entity: {
-          ...deferred.entity,
-          metadata: {
-            ...deferred.entity.metadata,
-            annotations: {
-              ...deferred.entity.metadata.annotations,
-            },
+    const added = entities.map(deferred => ({
+      ...deferred,
+      entity: {
+        ...deferred.entity,
+        metadata: {
+          ...deferred.entity.metadata,
+          annotations: {
+            ...deferred.entity.metadata.annotations,
           },
         },
-      })) ?? [];
+      },
+    }));
 
     const removed: { entityRef: string }[] = [];
 
@@ -384,44 +390,47 @@ export class IncrementalIngestionEngine implements IterationEngine {
 
     const result = await provider.eventHandler.onEvent(params);
 
-    if (result.type === 'delta') {
-      if (result.added.length > 0) {
-        const ingestionRecord = await this.manager.getCurrentIngestionRecord(
-          providerName,
-        );
-
-        if (!ingestionRecord) {
-          logger.debug(
-            `incremental-engine: ${providerName} skipping delta addition because incremental ingestion is restarting.`,
-          );
-        } else {
-          const mark =
-            ingestionRecord.status === 'resting'
-              ? await this.manager.getLastMark(ingestionRecord.id)
-              : await this.manager.getFirstMark(ingestionRecord.id);
-
-          if (!mark) {
-            throw new Error(
-              `Cannot apply delta, page records are missing! Please re-run incremental ingestion for ${providerName}.`,
-            );
-          }
-          await this.manager.createMarkEntities(mark.id, result.added);
-        }
-      }
-
-      if (result.removed.length > 0) {
-        await this.manager.deleteEntityRecordsByRef(result.removed);
-      }
-
-      await connection.applyMutation(result);
-      logger.debug(
-        `incremental-engine: ${providerName} processed delta from '${topic}' event`,
-      );
-    } else {
+    if (result.type === 'ignored') {
       logger.debug(
         `incremental-engine: ${providerName} ignored event from topic '${topic}'`,
       );
+      return;
     }
+
+    if (result.added.length > 0) {
+      const ingestionRecord = await this.manager.getCurrentIngestionRecord(
+        providerName,
+      );
+
+      if (!ingestionRecord) {
+        logger.debug(
+          `incremental-engine: ${providerName} skipping delta addition because incremental ingestion is restarting.`,
+        );
+      } else {
+        const mark =
+          ingestionRecord.status === 'resting'
+            ? await this.manager.getLastMark(ingestionRecord.id)
+            : await this.manager.getFirstMark(ingestionRecord.id);
+
+        if (!mark) {
+          throw new Error(
+            `Cannot apply delta, page records are missing! Please re-run incremental ingestion for ${providerName}.`,
+          );
+        }
+        await this.manager.createMarkEntities(
+          providerName,
+          result.added,
+          mark.id,
+        );
+      }
+    }
+
+    await this.manager.deleteEntityRecordsByRef(providerName, result.removed);
+
+    await connection.applyMutation(result);
+    logger.debug(
+      `incremental-engine: ${providerName} processed delta from '${topic}' event`,
+    );
   }
 
   supportsEventTopics(): string[] {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

## Context

`createMarkEntities` in `IncrementalIngestionDatabaseManager` performed a select, then an update, then an insert for every ingestion mark, because `ingestion_mark_entities.ref` had no unique constraint to upsert against. A native Knex upsert would cut this to a single round trip, but needs a real unique constraint to conflict on.

`source_key` is named to match the [catalog redesign proposal](https://gist.github.com/freben/873776c4848b23d8a100213039a17b58), which buckets candidates per source using a `(source_type, source_key, entity_ref)` key, so this change moves `ingestion_mark_entities` a step in that direction. `source_type` is not added here since it would always be `'provider'` for this table, and can be patched in easily later if the redesign needs it.

An expand/contract approach (keeping `ref` alongside the new columns, with runtime fallback for old code and old schema) was considered to make this change safe for a rolling deploy of multiple Backstage instances against a shared database, but was decided against: it would drag the deprecation of `ref` out over multiple release lines, for a scenario that isn't common enough to justify the added complexity. This lands as a plain rename instead.

## Changes

- Add a `source_key` column to `ingestion_mark_entities`, backfilled from the owning ingestion's provider name, and rename its `ref` column to `entity_ref`, with a `UNIQUE(source_key, entity_ref)` constraint.
- `createMarkEntities` now performs a single upsert against these columns, cutting per-mark round trips from three to one.
- The migration deduplicates any pre-existing `(source_key, entity_ref)` collisions, keeping the most recently marked row, since this pairing was never enforced unique before.
- Remove `clearDuplicateIngestions`, which has no callers anywhere in the codebase and a pre-existing bug: it passes an array of full row objects to `.whereIn('id', invalid)` instead of an array of ids, so the delete silently never matches anything.
- Scope entity-removal deletes to the calling provider, now that `source_key` exists to filter on: a removal from one provider could otherwise delete a same-ref row belonging to a different provider.
- Refactor `IncrementalIngestionEngine` around these signature changes: flatten `onEvent`'s delta/ignored branching into an early return on `'ignored'`, and drop redundant emptiness checks around `createMarkEntities`/`deleteEntityRecordsByRef` now that both early-return on an empty list themselves.

Contributes to #35158

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
