### PR TITLE
techdocs-cli: add --dangerouslyAllowAdditionalKeys option to generate

### DIFF
--- a/.changeset/techdocs-cli-dangerously-allow-additional-keys.md
+++ b/.changeset/techdocs-cli-dangerously-allow-additional-keys.md
@@ -1,0 +1,5 @@
+---
+'@techdocs/cli': minor
+---
+
+Added a `--dangerouslyAllowAdditionalKeys` option to `techdocs-cli generate`, matching the existing `techdocs.generator.mkdocs.dangerouslyAllowAdditionalKeys` backend config option. Previously, running `techdocs-cli generate` directly had no way to allow additional `mkdocs.yml` top-level keys, even if the equivalent setting was configured in `app-config.yaml`, since the CLI builds its own in-memory config from flags rather than reading a config file.

--- a/.changeset/techdocs-cli-dangerously-allow-additional-keys.md
+++ b/.changeset/techdocs-cli-dangerously-allow-additional-keys.md
@@ -2,4 +2,4 @@
 '@techdocs/cli': minor
 ---
 
-Added a `--dangerouslyAllowAdditionalKeys` option to `techdocs-cli generate`, matching the existing `techdocs.generator.mkdocs.dangerouslyAllowAdditionalKeys` backend config option. Previously, running `techdocs-cli generate` directly had no way to allow additional `mkdocs.yml` top-level keys, even if the equivalent setting was configured in `app-config.yaml`, since the CLI builds its own in-memory config from flags rather than reading a config file.
+Added a `--dangerouslyAllowAdditionalKeys` option to `techdocs-cli generate`

--- a/docs/features/techdocs/cli.md
+++ b/docs/features/techdocs/cli.md
@@ -147,6 +147,11 @@ Options:
   --defaultPlugin <PLUGIN_NAME>   Plugins which should be added automatically to the mkdocs.yaml file. (default: [])
   --omitTechdocsCoreMkdocsPlugin  An option to disable automatic addition of techdocs-core plugin to the mkdocs.yaml files.
                                   Defaults to false, which means that the techdocs-core plugin is always added to the mkdocs file.
+  --dangerouslyAllowAdditionalKeys [additionalKeys...]
+                                  Top-level mkdocs.yml keys to allow beyond the built-in supported set, without failing
+                                  or stripping them. Same as the techdocs.generator.mkdocs.dangerouslyAllowAdditionalKeys
+                                  backend config option, which techdocs-cli generate does not currently read from a
+                                  config file. (default: [])
   --legacyCopyReadmeMdToIndexMd   Attempt to ensure an index.md exists falling back to using <docs-dir>/README.md or README.md
                                   in case a default <docs-dir>/index.md is not provided. (default: false)
   --disableExternalFonts          Disable external font downloads for all TechDocs sites. Useful for air-gapped environments

--- a/docs/features/techdocs/configuration.md
+++ b/docs/features/techdocs/configuration.md
@@ -141,6 +141,23 @@ techdocs:
       defaultPlugins: ['techdocs-core']
 ```
 
+#### Dangerously Allow Additional Keys
+
+`techdocs.generator.mkdocs.dangerouslyAllowAdditionalKeys`
+
+(Optional) By default, TechDocs validates `mkdocs.yml` against a built-in allow list of supported top-level keys. This option explicitly allows the listed additional keys, such as the `hooks` key which some MkDocs plugins require, without failing or stripping them. Use with caution: allowed keys are passed through without validation.
+
+**Example:**
+
+```yaml
+techdocs:
+  generator:
+    mkdocs:
+      dangerouslyAllowAdditionalKeys: ['hooks']
+```
+
+When running `techdocs-cli generate` directly, the same behavior is available via the `--dangerouslyAllowAdditionalKeys` CLI flag, since the CLI does not currently read this option from a config file.
+
 ## Builder Configuration
 
 `techdocs.builder`

--- a/packages/techdocs-cli/cli-report.md
+++ b/packages/techdocs-cli/cli-report.md
@@ -26,6 +26,7 @@ Commands:
 Usage: techdocs-cli generate|build [options]
 
 Options:
+  --dangerouslyAllowAdditionalKeys [additionalKeys...]
   --defaultPlugin [defaultPlugins...]
   --disableExternalFonts
   --docker-image <DOCKER_IMAGE>

--- a/packages/techdocs-cli/src/commands/generate/generate.ts
+++ b/packages/techdocs-cli/src/commands/generate/generate.ts
@@ -44,6 +44,7 @@ export default async function generate(opts: OptionValues) {
   const legacyCopyReadmeMdToIndexMd = opts.legacyCopyReadmeMdToIndexMd;
   const disableExternalFonts = opts.disableExternalFonts;
   const defaultPlugins = opts.defaultPlugin;
+  const dangerouslyAllowAdditionalKeys = opts.dangerouslyAllowAdditionalKeys;
 
   logger.info(`Using source dir ${sourceDir}`);
   logger.info(`Will output generated files in ${outputDir}`);
@@ -67,6 +68,7 @@ export default async function generate(opts: OptionValues) {
           omitTechdocsCorePlugin,
           disableExternalFonts,
           defaultPlugins,
+          dangerouslyAllowAdditionalKeys,
         },
       },
     },

--- a/packages/techdocs-cli/src/commands/index.ts
+++ b/packages/techdocs-cli/src/commands/index.ts
@@ -81,6 +81,11 @@ export function registerCommands(program: Command) {
       [],
     )
     .option(
+      '--dangerouslyAllowAdditionalKeys [additionalKeys...]',
+      'Top-level mkdocs.yml keys to allow beyond the built-in supported set, without failing or stripping them. Same as the techdocs.generator.mkdocs.dangerouslyAllowAdditionalKeys backend config option, which techdocs-cli generate does not currently read from a config file.',
+      [],
+    )
+    .option(
       '--runAsDefaultUser',
       'Bypass setting the container user as the same user and group id as host for Linux and MacOS',
       false,


### PR DESCRIPTION
Per discussion on #32859: `techdocs-cli generate` currently has no way to allow additional `mkdocs.yml` top-level keys, even though the backend plugin's equivalent setting (`techdocs.generator.mkdocs.dangerouslyAllowAdditionalKeys`) already exists in `app-config.yaml`. This is because `generate.ts` builds its own in-memory `ConfigReader` from CLI flags rather than reading any config file, so the setting was simply unreachable when running the CLI directly.

Adds `--dangerouslyAllowAdditionalKeys [additionalKeys...]`, mirroring the existing `--defaultPlugin` option's array-flag pattern exactly, and threads it through to the `ConfigReader`'s `mkdocs` object at the same config path `readGeneratorConfig` already reads (`techdocs.generator.mkdocs.dangerouslyAllowAdditionalKeys`).

**Verified:** `yarn tsc` (0 errors), `yarn lint` (clean on `techdocs-cli` and `techdocs-node`).

**Gap I'm flagging rather than hiding:** there's no existing test coverage for `dangerouslyAllowAdditionalKeys` at either the CLI flag level or in `readGeneratorConfig`'s own test suite, and `generate.ts` currently has no test file at all. Happy to add coverage if that's expected before merge.

This is one half of the plan discussed on #32859 (config gap per @dyson's comment); the fail-loudly validation approach (per @freben/@mtvx) is a separate, larger change I'm working on next.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))