### PR TITLE
UI Update: Entity page tab history

### DIFF
--- a/.changeset/header-nav-replace-navigation.md
+++ b/.changeset/header-nav-replace-navigation.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/ui': patch
+'@backstage/ui': minor
 ---
 
-Tab navigation in the header now replaces the current browser history entry instead of pushing a new one. This prevents the back button from cycling through previously selected tabs, so it returns to the actual previous page instead.
+Added an opt-in `replaceTabNavigation` prop to the `Header` component. When enabled, tab navigation replaces the current browser history entry instead of pushing a new one, preventing the back button from cycling through previously selected tabs.

--- a/.changeset/header-nav-replace-navigation.md
+++ b/.changeset/header-nav-replace-navigation.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Tab navigation in the header now replaces the current browser history entry instead of pushing a new one. This prevents the back button from cycling through previously selected tabs, so it returns to the actual previous page instead.

--- a/packages/ui/src/components/Header/Header.tsx
+++ b/packages/ui/src/components/Header/Header.tsx
@@ -88,6 +88,7 @@ export const Header = (props: HeaderProps) => {
     title,
     tabs,
     activeTabId,
+    replaceTabNavigation,
     customActions,
     breadcrumbs,
     description,
@@ -282,7 +283,11 @@ export const Header = (props: HeaderProps) => {
         )}
         {tabs && (
           <div className={classes.tabsWrapper}>
-            <HeaderNav tabs={tabs} activeTabId={activeTabId} />
+            <HeaderNav
+              tabs={tabs}
+              activeTabId={activeTabId}
+              replaceNavigation={replaceTabNavigation}
+            />
           </div>
         )}
       </Container>

--- a/packages/ui/src/components/Header/HeaderNav.test.tsx
+++ b/packages/ui/src/components/Header/HeaderNav.test.tsx
@@ -15,10 +15,16 @@
  */
 
 import { fireEvent, render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, useNavigationType } from 'react-router-dom';
 import { BUIProvider } from '../../provider';
 import { HeaderNav } from './HeaderNav';
 import type { ComponentProps } from 'react';
+
+let lastNavigationType: string | undefined;
+function NavigationTypeSpy() {
+  lastNavigationType = useNavigationType();
+  return null;
+}
 
 function renderHeaderNav(
   props: ComponentProps<typeof HeaderNav>,
@@ -78,6 +84,29 @@ describe('HeaderNav', () => {
     expect(screen.getByRole('link', { name: 'Settings' })).not.toHaveAttribute(
       'aria-current',
     );
+  });
+
+  it('uses replace navigation when clicking a tab', () => {
+    render(
+      <MemoryRouter basename="/app" initialEntries={['/app/catalog']}>
+        <BUIProvider>
+          <NavigationTypeSpy />
+          <HeaderNav
+            tabs={[
+              { id: 'overview', label: 'Overview', href: '/catalog/overview' },
+              { id: 'settings', label: 'Settings', href: '/catalog/settings' },
+            ]}
+            activeTabId={null}
+          />
+        </BUIProvider>
+      </MemoryRouter>,
+    );
+
+    expect(lastNavigationType).toBe('POP');
+
+    fireEvent.click(screen.getByRole('link', { name: 'Settings' }));
+
+    expect(lastNavigationType).toBe('REPLACE');
   });
 
   it('includes the router basename in grouped tab hrefs', async () => {

--- a/packages/ui/src/components/Header/HeaderNav.test.tsx
+++ b/packages/ui/src/components/Header/HeaderNav.test.tsx
@@ -86,7 +86,31 @@ describe('HeaderNav', () => {
     );
   });
 
-  it('uses replace navigation when clicking a tab', () => {
+  it('uses replace navigation when replaceNavigation is enabled', () => {
+    render(
+      <MemoryRouter basename="/app" initialEntries={['/app/catalog']}>
+        <BUIProvider>
+          <NavigationTypeSpy />
+          <HeaderNav
+            tabs={[
+              { id: 'overview', label: 'Overview', href: '/catalog/overview' },
+              { id: 'settings', label: 'Settings', href: '/catalog/settings' },
+            ]}
+            activeTabId={null}
+            replaceNavigation
+          />
+        </BUIProvider>
+      </MemoryRouter>,
+    );
+
+    expect(lastNavigationType).toBe('POP');
+
+    fireEvent.click(screen.getByRole('link', { name: 'Settings' }));
+
+    expect(lastNavigationType).toBe('REPLACE');
+  });
+
+  it('uses push navigation by default', () => {
     render(
       <MemoryRouter basename="/app" initialEntries={['/app/catalog']}>
         <BUIProvider>
@@ -106,7 +130,7 @@ describe('HeaderNav', () => {
 
     fireEvent.click(screen.getByRole('link', { name: 'Settings' }));
 
-    expect(lastNavigationType).toBe('REPLACE');
+    expect(lastNavigationType).toBe('PUSH');
   });
 
   it('includes the router basename in grouped tab hrefs', async () => {

--- a/packages/ui/src/components/Header/HeaderNav.tsx
+++ b/packages/ui/src/components/Header/HeaderNav.tsx
@@ -21,10 +21,9 @@ import {
   resolvePath,
   useInRouterContext,
   useLocation,
-  useNavigate,
   useResolvedPath,
 } from 'react-router-dom';
-import { Button as RAButton, RouterProvider } from 'react-aria-components';
+import { Button as RAButton } from 'react-aria-components';
 import { RiArrowDownSLine } from '@remixicon/react';
 import { useDefinition } from '../../hooks/useDefinition';
 import {
@@ -34,7 +33,6 @@ import {
 } from './HeaderNavDefinition';
 import { HeaderNavIndicators } from './HeaderNavIndicators';
 import { MenuTrigger, Menu, MenuItem } from '../Menu';
-import { useResolvedHref } from '../../hooks/useResolvedHref';
 import type {
   HeaderNavLinkProps,
   HeaderNavTabGroup,
@@ -50,7 +48,10 @@ function HeaderNavLink(props: HeaderNavLinkProps) {
   const { id, label, href, active, registerRef, onHighlight } = ownProps;
 
   const linkRef = useRef<HTMLAnchorElement>(null);
-  const { linkProps } = useLink({ href }, linkRef);
+  const { linkProps } = useLink(
+    { href, routerOptions: { replace: true } },
+    linkRef,
+  );
   const { hoverProps } = useHover({
     onHoverStart: () => onHighlight(id),
     onHoverEnd: () => onHighlight(null),
@@ -123,7 +124,12 @@ function HeaderNavGroupItem(props: HeaderNavGroupItemProps) {
           selectedKeys={new Set(activeChildId ? [activeChildId] : [])}
         >
           {group.items.map(item => (
-            <MenuItem key={item.id} id={item.id} href={item.href}>
+            <MenuItem
+              key={item.id}
+              id={item.id}
+              href={item.href}
+              routerOptions={{ replace: true }}
+            >
               {item.label}
             </MenuItem>
           ))}
@@ -238,36 +244,12 @@ function HeaderNavInner(props: HeaderNavProps) {
   );
 }
 
-function ReplaceNavigateWrapper(props: { children: React.ReactNode }) {
-  const navigate = useNavigate();
-  const replaceNavigate = useCallback(
-    (to: string) => navigate(to, { replace: true }),
-    [navigate],
-  );
-  return (
-    <RouterProvider navigate={replaceNavigate} useHref={useResolvedHref}>
-      {props.children}
-    </RouterProvider>
-  );
-}
-
 /** @internal */
 export function HeaderNav(props: HeaderNavProps) {
   const inRouter = useInRouterContext();
 
-  if (inRouter) {
-    if (props.activeTabId === undefined) {
-      return (
-        <ReplaceNavigateWrapper>
-          <HeaderNavAutoDetect tabs={props.tabs} />
-        </ReplaceNavigateWrapper>
-      );
-    }
-    return (
-      <ReplaceNavigateWrapper>
-        <HeaderNavInner tabs={props.tabs} activeTabId={props.activeTabId} />
-      </ReplaceNavigateWrapper>
-    );
+  if (props.activeTabId === undefined && inRouter) {
+    return <HeaderNavAutoDetect tabs={props.tabs} />;
   }
 
   return <HeaderNavInner tabs={props.tabs} activeTabId={props.activeTabId} />;

--- a/packages/ui/src/components/Header/HeaderNav.tsx
+++ b/packages/ui/src/components/Header/HeaderNav.tsx
@@ -21,9 +21,10 @@ import {
   resolvePath,
   useInRouterContext,
   useLocation,
+  useNavigate,
   useResolvedPath,
 } from 'react-router-dom';
-import { Button as RAButton } from 'react-aria-components';
+import { Button as RAButton, RouterProvider } from 'react-aria-components';
 import { RiArrowDownSLine } from '@remixicon/react';
 import { useDefinition } from '../../hooks/useDefinition';
 import {
@@ -33,6 +34,7 @@ import {
 } from './HeaderNavDefinition';
 import { HeaderNavIndicators } from './HeaderNavIndicators';
 import { MenuTrigger, Menu, MenuItem } from '../Menu';
+import { useResolvedHref } from '../../hooks/useResolvedHref';
 import type {
   HeaderNavLinkProps,
   HeaderNavTabGroup,
@@ -48,10 +50,7 @@ function HeaderNavLink(props: HeaderNavLinkProps) {
   const { id, label, href, active, registerRef, onHighlight } = ownProps;
 
   const linkRef = useRef<HTMLAnchorElement>(null);
-  const { linkProps } = useLink(
-    { href, routerOptions: { replace: true } },
-    linkRef,
-  );
+  const { linkProps } = useLink({ href }, linkRef);
   const { hoverProps } = useHover({
     onHoverStart: () => onHighlight(id),
     onHoverEnd: () => onHighlight(null),
@@ -124,12 +123,7 @@ function HeaderNavGroupItem(props: HeaderNavGroupItemProps) {
           selectedKeys={new Set(activeChildId ? [activeChildId] : [])}
         >
           {group.items.map(item => (
-            <MenuItem
-              key={item.id}
-              id={item.id}
-              href={item.href}
-              routerOptions={{ replace: true }}
-            >
+            <MenuItem key={item.id} id={item.id} href={item.href}>
               {item.label}
             </MenuItem>
           ))}
@@ -142,6 +136,7 @@ function HeaderNavGroupItem(props: HeaderNavGroupItemProps) {
 interface HeaderNavProps {
   tabs: HeaderNavTabItem[];
   activeTabId?: string | null;
+  replaceNavigation?: boolean;
 }
 
 function useAutoActiveTabId(tabs: HeaderNavTabItem[]): string | undefined {
@@ -244,13 +239,37 @@ function HeaderNavInner(props: HeaderNavProps) {
   );
 }
 
+function ReplaceNavigateWrapper(props: { children: React.ReactNode }) {
+  const navigate = useNavigate();
+  const replaceNavigate = useCallback(
+    (to: string) => navigate(to, { replace: true }),
+    [navigate],
+  );
+  return (
+    <RouterProvider navigate={replaceNavigate} useHref={useResolvedHref}>
+      {props.children}
+    </RouterProvider>
+  );
+}
+
 /** @internal */
 export function HeaderNav(props: HeaderNavProps) {
   const inRouter = useInRouterContext();
 
-  if (props.activeTabId === undefined && inRouter) {
-    return <HeaderNavAutoDetect tabs={props.tabs} />;
+  if (!inRouter) {
+    return <HeaderNavInner tabs={props.tabs} activeTabId={props.activeTabId} />;
   }
 
-  return <HeaderNavInner tabs={props.tabs} activeTabId={props.activeTabId} />;
+  const inner =
+    props.activeTabId === undefined ? (
+      <HeaderNavAutoDetect tabs={props.tabs} />
+    ) : (
+      <HeaderNavInner tabs={props.tabs} activeTabId={props.activeTabId} />
+    );
+
+  if (props.replaceNavigation) {
+    return <ReplaceNavigateWrapper>{inner}</ReplaceNavigateWrapper>;
+  }
+
+  return inner;
 }

--- a/packages/ui/src/components/Header/HeaderNav.tsx
+++ b/packages/ui/src/components/Header/HeaderNav.tsx
@@ -21,9 +21,10 @@ import {
   resolvePath,
   useInRouterContext,
   useLocation,
+  useNavigate,
   useResolvedPath,
 } from 'react-router-dom';
-import { Button as RAButton } from 'react-aria-components';
+import { Button as RAButton, RouterProvider } from 'react-aria-components';
 import { RiArrowDownSLine } from '@remixicon/react';
 import { useDefinition } from '../../hooks/useDefinition';
 import {
@@ -33,6 +34,7 @@ import {
 } from './HeaderNavDefinition';
 import { HeaderNavIndicators } from './HeaderNavIndicators';
 import { MenuTrigger, Menu, MenuItem } from '../Menu';
+import { useResolvedHref } from '../../hooks/useResolvedHref';
 import type {
   HeaderNavLinkProps,
   HeaderNavTabGroup,
@@ -236,12 +238,36 @@ function HeaderNavInner(props: HeaderNavProps) {
   );
 }
 
+function ReplaceNavigateWrapper(props: { children: React.ReactNode }) {
+  const navigate = useNavigate();
+  const replaceNavigate = useCallback(
+    (to: string) => navigate(to, { replace: true }),
+    [navigate],
+  );
+  return (
+    <RouterProvider navigate={replaceNavigate} useHref={useResolvedHref}>
+      {props.children}
+    </RouterProvider>
+  );
+}
+
 /** @internal */
 export function HeaderNav(props: HeaderNavProps) {
   const inRouter = useInRouterContext();
 
-  if (props.activeTabId === undefined && inRouter) {
-    return <HeaderNavAutoDetect tabs={props.tabs} />;
+  if (inRouter) {
+    if (props.activeTabId === undefined) {
+      return (
+        <ReplaceNavigateWrapper>
+          <HeaderNavAutoDetect tabs={props.tabs} />
+        </ReplaceNavigateWrapper>
+      );
+    }
+    return (
+      <ReplaceNavigateWrapper>
+        <HeaderNavInner tabs={props.tabs} activeTabId={props.activeTabId} />
+      </ReplaceNavigateWrapper>
+    );
   }
 
   return <HeaderNavInner tabs={props.tabs} activeTabId={props.activeTabId} />;

--- a/packages/ui/src/components/Header/definition.ts
+++ b/packages/ui/src/components/Header/definition.ts
@@ -51,6 +51,7 @@ export const HeaderDefinition = defineComponent<HeaderOwnProps>()({
     customActions: {},
     tabs: {},
     activeTabId: {},
+    replaceTabNavigation: {},
     breadcrumbs: {},
     description: {},
     tags: {},

--- a/packages/ui/src/components/Header/types.ts
+++ b/packages/ui/src/components/Header/types.ts
@@ -105,6 +105,12 @@ export interface HeaderOwnProps {
   tabs?: HeaderNavTabItem[];
   activeTabId?: string | null;
   /**
+   * When true, tab navigation replaces the current browser history entry
+   * instead of pushing a new one. This prevents the back button from
+   * cycling through previously selected tabs.
+   */
+  replaceTabNavigation?: boolean;
+  /**
    * @deprecated The breadcrumbs prop will be removed in a future release.
    */
   breadcrumbs?: HeaderBreadcrumb[];


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- Tab navigation in the header now replaces the current browser history entry instead of pushing a new one. This prevents the back button from cycling through previously selected tabs, so it returns to the actual previous page instead.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
