### PR TITLE
docs: improve vale error reporting and add 'accessor' to vocabulary

### DIFF
--- a/.github/vale/config/vocabularies/Backstage/accept.txt
+++ b/.github/vale/config/vocabularies/Backstage/accept.txt
@@ -1,4 +1,5 @@
 abc
+accessor
 accessors
 ACLs
 addon

--- a/scripts/check-docs-quality.js
+++ b/scripts/check-docs-quality.js
@@ -133,25 +133,49 @@ async function ciCheck(prFilesPath) {
     process.exit(1);
   }
 
-  let issueCount = 0;
+  let errorCount = 0;
+  let warningCount = 0;
 
   if (result.stdout && result.stdout.trim()) {
     try {
       const data = JSON.parse(result.stdout);
+      const severityLevels = {
+        error: 'error',
+        warning: 'warning',
+        suggestion: 'notice',
+      };
+
       for (const [file, alerts] of Object.entries(data)) {
+        if (alerts.length === 0) continue;
+
+        // Emit GitHub Actions annotations
         for (const alert of alerts) {
-          const severityLevels = {
-            error: 'error',
-            warning: 'warning',
-            suggestion: 'notice',
-          };
           const level = severityLevels[alert.Severity] ?? 'notice';
           const col = alert.Span ? alert.Span[0] : 1;
           const endCol = alert.Span ? `,endColumn=${alert.Span[1] + 1}` : '';
           console.log(
             `::${level} file=${file},line=${alert.Line},col=${col}${endCol},title=${alert.Check}::${alert.Message}`,
           );
-          issueCount++;
+        }
+
+        // Print eslint-style file group, e.g.:
+        //   .changeset/my-change.md
+        //     9:74      error      Did you really mean 'accessor'?  Vale.Terms
+        console.log(`\n${file}`);
+        for (const alert of alerts) {
+          const level = alert.Severity === 'error' ? 'error' : 'warning';
+          const col = alert.Span ? alert.Span[0] : 1;
+          const loc = `${alert.Line}:${col}`;
+          console.log(
+            `  ${loc.padEnd(8)}  ${level.padEnd(9)}  ${alert.Message}  ${
+              alert.Check
+            }`,
+          );
+          if (alert.Severity === 'error') {
+            errorCount++;
+          } else {
+            warningCount++;
+          }
         }
       }
     } catch {
@@ -165,9 +189,19 @@ async function ciCheck(prFilesPath) {
     console.error(result.stderr);
   }
 
+  const issueCount = errorCount + warningCount;
   if (issueCount > 0) {
+    const parts = [];
+    if (errorCount > 0) {
+      parts.push(`${errorCount} error${errorCount !== 1 ? 's' : ''}`);
+    }
+    if (warningCount > 0) {
+      parts.push(`${warningCount} warning${warningCount !== 1 ? 's' : ''}`);
+    }
     console.log(
-      `\nFound ${issueCount} documentation quality issue(s). Please review the annotations above.`,
+      `\n✖ ${issueCount} problem${issueCount !== 1 ? 's' : ''} (${parts.join(
+        ', ',
+      )})`,
     );
   }
 


### PR DESCRIPTION
## Summary
- Add the singular "accessor" to the Vale vocabulary (the plural "accessors" was already listed)
- Improve CI error output in `check-docs-quality.js` to use an eslint-style format — issues grouped by filename with line:col, severity, and rule name, plus a problem count summary

Before:
```
Error: Did you really mean 'accessor'?
Error: Did you really mean 'accessor'?

Found 2 documentation quality issue(s). Please review the annotations above.
```

After:
```
.changeset/test-vale-accessor.md
  4:43      error      Did you really mean 'accessor'?  Vale.Spelling
  4:136     error      Did you really mean 'accessor'?  Vale.Spelling

✖ 2 problems (2 errors)
```

## Test plan
- [x] Verified locally with a test changeset containing "accessor" — clean with vocab fix, eslint-style output without it
- [ ] CI docs-quality check passes

### Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have verified that any new or changed files have appropriate copyright headers