### PR TITLE
fix(ui): include margin-bottom in --bui-header-height calculation

### DIFF
--- a/.changeset/fix-fullpage-scrollable.md
+++ b/.changeset/fix-fullpage-scrollable.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed an issue where using `PluginHeader` with `FullPage` caused the page to be unexpectedly scrollable. The `--bui-header-height` CSS variable now correctly accounts for the header's `margin-bottom`, preventing the layout from overflowing the viewport.

--- a/packages/ui/src/components/PluginHeader/PluginHeader.test.tsx
+++ b/packages/ui/src/components/PluginHeader/PluginHeader.test.tsx
@@ -188,4 +188,27 @@ describe('PluginHeader', () => {
       screen.queryByRole('button', { name: 'Show more breadcrumbs' }),
     ).not.toBeInTheDocument();
   });
+
+  it('sets header height including margin and removes it on unmount', () => {
+    jest
+      .spyOn(HTMLElement.prototype, 'offsetHeight', 'get')
+      .mockReturnValue(50);
+    jest.spyOn(window, 'getComputedStyle').mockReturnValue({
+      marginBottom: '10px',
+    } as CSSStyleDeclaration);
+
+    const { unmount } = renderPluginHeader({ title: 'Test' });
+
+    expect(
+      document.documentElement.style.getPropertyValue('--bui-header-height'),
+    ).toBe('60px');
+
+    unmount();
+
+    expect(
+      document.documentElement.style.getPropertyValue('--bui-header-height'),
+    ).toBe('');
+
+    jest.restoreAllMocks();
+  });
 });

--- a/packages/ui/src/components/PluginHeader/PluginHeader.tsx
+++ b/packages/ui/src/components/PluginHeader/PluginHeader.tsx
@@ -91,16 +91,22 @@ export const PluginHeader = (props: PluginHeaderProps) => {
       );
     };
 
+    const getHeight = () => {
+      const marginBottom =
+        parseFloat(window.getComputedStyle(el).marginBottom) || 0;
+      return el.offsetHeight + marginBottom;
+    };
+
     const scheduleHeightUpdate = () => {
       cancelScheduledUpdate();
       animationFrameRef.current = requestAnimationFrame(() => {
         animationFrameRef.current = undefined;
-        applyHeight(el.offsetHeight);
+        applyHeight(getHeight());
       });
     };
 
     // Set height once immediately so the initial layout is correct.
-    applyHeight(el.offsetHeight);
+    applyHeight(getHeight());
 
     // Observe for resize changes if ResizeObserver is available
     // (not present in Jest/jsdom by default)


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #35153

`PluginHeader` was setting `--bui-header-height` using only `offsetHeight`, which excludes CSS margins. The header has a `margin-bottom` of 24px, so `FullPage` which uses `height: calc(100dvh - var(--bui-header-height))` was 24px taller than the remaining viewport, making the page scrollable.

The fix reads `window.getComputedStyle(el).marginBottom` and adds it to `offsetHeight` before applying the CSS variable.

screenshot showing that the scrollbar is no longer visible:
<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/b4f0260c-3d7d-40e2-ac08-3e1689b61bee" />

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))