### PR TITLE
permission-node: support Standard Schema rule params

### DIFF
--- a/.changeset/tidy-schema-permissions.md
+++ b/.changeset/tidy-schema-permissions.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-permission-node': patch
+---
+
+Added support for Standard Schema-compatible permission rule parameter schemas through `params.schema`. Schemas must support JSON Schema conversion. The Zod v3-specific `paramsSchema` option is now deprecated and remains available for compatibility.

--- a/.changeset/tidy-schema-permissions.md
+++ b/.changeset/tidy-schema-permissions.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-permission-node': patch
 ---
 
-Added support for Standard Schema-compatible permission rule parameter schemas through `params.schema`. Schemas must support JSON Schema conversion. The Zod v3-specific `paramsSchema` option is now deprecated and remains available for compatibility.
+Permission rule parameter schemas now accept JSON Schema-compatible Standard Schema implementations, such as Zod v4. Zod v3 schemas remain supported but are deprecated.

--- a/docs/golden-path/plugins/integrations/003-permissions.md
+++ b/docs/golden-path/plugins/integrations/003-permissions.md
@@ -65,7 +65,7 @@ import {
   createPermissionRule,
 } from '@backstage/plugin-permission-node';
 import { TODO_RESOURCE_TYPE } from '@internal/plugin-todo-common';
-import { z } from 'zod/v3';
+import { z } from 'zod';
 import type { TodoItem } from './services/TodoListService';
 
 export const todoResourceRef = createPermissionResourceRef<
@@ -80,9 +80,11 @@ export const isCreator = createPermissionRule({
   name: 'IS_CREATOR',
   description: 'Allow if the todo was created by the current user',
   resourceRef: todoResourceRef,
-  paramsSchema: z.object({
-    userRef: z.string().describe('The entity ref of the user'),
-  }),
+  params: {
+    schema: z.object({
+      userRef: z.string().describe('The entity ref of the user'),
+    }),
+  },
   apply(todo, { userRef }) {
     return todo.createdBy === userRef;
   },

--- a/docs/golden-path/plugins/integrations/003-permissions.md
+++ b/docs/golden-path/plugins/integrations/003-permissions.md
@@ -65,7 +65,7 @@ import {
   createPermissionRule,
 } from '@backstage/plugin-permission-node';
 import { TODO_RESOURCE_TYPE } from '@internal/plugin-todo-common';
-import { z } from 'zod';
+import * as z from 'zod';
 import type { TodoItem } from './services/TodoListService';
 
 export const todoResourceRef = createPermissionResourceRef<

--- a/docs/golden-path/plugins/integrations/003-permissions.md
+++ b/docs/golden-path/plugins/integrations/003-permissions.md
@@ -80,11 +80,9 @@ export const isCreator = createPermissionRule({
   name: 'IS_CREATOR',
   description: 'Allow if the todo was created by the current user',
   resourceRef: todoResourceRef,
-  params: {
-    schema: z.object({
-      userRef: z.string().describe('The entity ref of the user'),
-    }),
-  },
+  paramsSchema: z.object({
+    userRef: z.string().describe('The entity ref of the user'),
+  }),
   apply(todo, { userRef }) {
     return todo.createdBy === userRef;
   },

--- a/docs/permissions/custom-rules.md
+++ b/docs/permissions/custom-rules.md
@@ -32,13 +32,11 @@ export const isInSystemRule = createPermissionRule({
   name: 'IS_IN_SYSTEM',
   description: 'Checks if an entity is part of the system provided',
   resourceRef: catalogEntityPermissionResourceRef,
-  params: {
-    schema: z.object({
-      systemRef: z
-        .string()
-        .describe('SystemRef to check the resource is part of'),
-    }),
-  },
+  paramsSchema: z.object({
+    systemRef: z
+      .string()
+      .describe('SystemRef to check the resource is part of'),
+  }),
   apply: (resource: Entity, { systemRef }) => {
     if (!resource.relations) {
       return false;

--- a/docs/permissions/custom-rules.md
+++ b/docs/permissions/custom-rules.md
@@ -25,7 +25,7 @@ import {
   createConditionFactory,
   createPermissionRule,
 } from '@backstage/plugin-permission-node';
-import { z } from 'zod';
+import * as z from 'zod';
 
 export const isInSystemRule = createPermissionRule({
   name: 'IS_IN_SYSTEM',

--- a/docs/permissions/custom-rules.md
+++ b/docs/permissions/custom-rules.md
@@ -10,10 +10,12 @@ For some use cases, you may want to define custom [rules](../references/glossary
 
 Plugins should export a rule factory that provides type-safety that ensures compatibility with the plugin's backend. The catalog plugin exports `createCatalogPermissionRule` from `@backstage/plugin-catalog-backend/alpha` for this purpose. Note: the `/alpha` path segment is temporary until this API is marked as stable. For this example, we'll define the rule and create a condition in a new file called `permissionRules.ts`. Create this file in the `src/` directory of your permission policy module (the package scaffolded by `yarn new` in the [Getting Started](./getting-started.md) section).
 
-We use `zod` and `@backstage/catalog-model` in our example below. To install them run:
+Permission rule parameter schemas accept libraries that implement Standard
+Schema and support JSON Schema conversion. We use Zod v4 and
+`@backstage/catalog-model` in the example below. To install them, run:
 
 ```bash title="from your Backstage root directory"
-yarn --cwd plugins/permission-backend-module-custom add zod@3 @backstage/catalog-model
+yarn --cwd plugins/permission-backend-module-custom add zod@4 @backstage/catalog-model
 ```
 
 ```ts title="plugins/permission-backend-module-custom/src/permissionRules.ts"
@@ -23,17 +25,19 @@ import {
   createConditionFactory,
   createPermissionRule,
 } from '@backstage/plugin-permission-node';
-import { z } from 'zod/v3';
+import { z } from 'zod';
 
 export const isInSystemRule = createPermissionRule({
   name: 'IS_IN_SYSTEM',
   description: 'Checks if an entity is part of the system provided',
   resourceRef: catalogEntityPermissionResourceRef,
-  paramsSchema: z.object({
-    systemRef: z
-      .string()
-      .describe('SystemRef to check the resource is part of'),
-  }),
+  params: {
+    schema: z.object({
+      systemRef: z
+        .string()
+        .describe('SystemRef to check the resource is part of'),
+    }),
+  },
   apply: (resource: Entity, { systemRef }) => {
     if (!resource.relations) {
       return false;

--- a/docs/permissions/custom-rules.md
+++ b/docs/permissions/custom-rules.md
@@ -11,7 +11,8 @@ For some use cases, you may want to define custom [rules](../references/glossary
 Plugins should export a rule factory that provides type-safety that ensures compatibility with the plugin's backend. The catalog plugin exports `createCatalogPermissionRule` from `@backstage/plugin-catalog-backend/alpha` for this purpose. Note: the `/alpha` path segment is temporary until this API is marked as stable. For this example, we'll define the rule and create a condition in a new file called `permissionRules.ts`. Create this file in the `src/` directory of your permission policy module (the package scaffolded by `yarn new` in the [Getting Started](./getting-started.md) section).
 
 Permission rule parameter schemas accept libraries that implement Standard
-Schema and support JSON Schema conversion. We use Zod v4 and
+Schema, validate synchronously, and support JSON Schema conversion. Async
+refinements and transforms are not supported. We use Zod v4 and
 `@backstage/catalog-model` in the example below. To install them, run:
 
 ```bash title="from your Backstage root directory"

--- a/docs/permissions/plugin-authors/03-adding-a-resource-permission-check.md
+++ b/docs/permissions/plugin-authors/03-adding-a-resource-permission-check.md
@@ -126,7 +126,7 @@ import {
   createPermissionRule,
 } from '@backstage/plugin-permission-node';
 import { TODO_LIST_RESOURCE_TYPE } from '@internal/plugin-todo-list-common';
-import { z } from 'zod/v3';
+import { z } from 'zod';
 import { Todo, TodoFilter } from './todos';
 
 export const todoListPermissionResourceRef = createPermissionResourceRef<
@@ -141,9 +141,11 @@ export const isOwner = createPermissionRule({
   name: 'IS_OWNER',
   description: 'Should allow only if the todo belongs to the user',
   resourceRef: todoListPermissionResourceRef,
-  paramsSchema: z.object({
-    userId: z.string().describe('User ID to match on the resource'),
-  }),
+  params: {
+    schema: z.object({
+      userId: z.string().describe('User ID to match on the resource'),
+    }),
+  },
   apply: (resource: Todo, { userId }) => {
     return resource.author === userId;
   },

--- a/docs/permissions/plugin-authors/03-adding-a-resource-permission-check.md
+++ b/docs/permissions/plugin-authors/03-adding-a-resource-permission-check.md
@@ -141,11 +141,9 @@ export const isOwner = createPermissionRule({
   name: 'IS_OWNER',
   description: 'Should allow only if the todo belongs to the user',
   resourceRef: todoListPermissionResourceRef,
-  params: {
-    schema: z.object({
-      userId: z.string().describe('User ID to match on the resource'),
-    }),
-  },
+  paramsSchema: z.object({
+    userId: z.string().describe('User ID to match on the resource'),
+  }),
   apply: (resource: Todo, { userId }) => {
     return resource.author === userId;
   },

--- a/docs/permissions/plugin-authors/03-adding-a-resource-permission-check.md
+++ b/docs/permissions/plugin-authors/03-adding-a-resource-permission-check.md
@@ -126,7 +126,7 @@ import {
   createPermissionRule,
 } from '@backstage/plugin-permission-node';
 import { TODO_LIST_RESOURCE_TYPE } from '@internal/plugin-todo-list-common';
-import { z } from 'zod';
+import * as z from 'zod';
 import { Todo, TodoFilter } from './todos';
 
 export const todoListPermissionResourceRef = createPermissionResourceRef<

--- a/docs/permissions/plugin-authors/03-adding-a-resource-permission-check.md
+++ b/docs/permissions/plugin-authors/03-adding-a-resource-permission-check.md
@@ -115,7 +115,7 @@ This enables decisions based on characteristics of the resource, but it's import
 Install the missing module:
 
 ```bash
-$ yarn workspace @internal/plugin-todo-list-backend add zod
+$ yarn workspace @internal/plugin-todo-list-backend add zod@4
 ```
 
 Create a new `plugins/todo-list-backend/src/service/rules.ts` file and append the following code:

--- a/plugins/permission-node/package.json
+++ b/plugins/permission-node/package.json
@@ -60,6 +60,7 @@
     "@backstage/config": "workspace:^",
     "@backstage/errors": "workspace:^",
     "@backstage/plugin-permission-common": "workspace:^",
+    "@standard-schema/spec": "^1.1.0",
     "@types/express": "^4.17.6",
     "express": "^4.22.0",
     "express-promise-router": "^4.1.0",

--- a/plugins/permission-node/report.api.md
+++ b/plugins/permission-node/report.api.md
@@ -254,10 +254,9 @@ export type CreatePermissionRuleOptions<
       name: string;
       description: string;
       resourceRef: TRef;
+      paramsSchema?: StandardSchemaV1<TParams> & StandardJSONSchemaV1<TParams>;
       apply(resource: IResource, params: NoInfer_2<TParams>): boolean;
       toQuery(params: NoInfer_2<TParams>): PermissionCriteria<IQuery>;
-    } & {
-      paramsSchema?: StandardSchemaV1<TParams> & StandardJSONSchemaV1<TParams>;
     }
   : never;
 

--- a/plugins/permission-node/report.api.md
+++ b/plugins/permission-node/report.api.md
@@ -29,6 +29,7 @@ import { PermissionsServiceRequestOptions } from '@backstage/backend-plugin-api'
 import { PolicyDecision } from '@backstage/plugin-permission-common';
 import { QueryPermissionRequest } from '@backstage/plugin-permission-common';
 import { ResourcePermission } from '@backstage/plugin-permission-common';
+import type { StandardJSONSchemaV1 } from '@standard-schema/spec';
 import type { StandardSchemaV1 } from '@standard-schema/spec';
 import { z } from 'zod/v3';
 
@@ -216,6 +217,24 @@ export function createPermissionRule<
   TParams
 >;
 
+// @public @deprecated (undocumented)
+export function createPermissionRule<
+  TRef extends PermissionResourceRef,
+  TParams extends PermissionRuleParams = undefined,
+>(rule: {
+  name: string;
+  description: string;
+  resourceRef: TRef;
+  paramsSchema: z.ZodSchema<TParams>;
+  apply(resource: TRef['TResource'], params: NoInfer_2<TParams>): boolean;
+  toQuery(params: NoInfer_2<TParams>): PermissionCriteria<TRef['TQuery']>;
+}): PermissionRule<
+  TRef['TResource'],
+  TRef['TQuery'],
+  TRef['resourceType'],
+  TParams
+>;
+
 // @public @deprecated
 export function createPermissionRule<
   TResource,
@@ -237,18 +256,9 @@ export type CreatePermissionRuleOptions<
       resourceRef: TRef;
       apply(resource: IResource, params: NoInfer_2<TParams>): boolean;
       toQuery(params: NoInfer_2<TParams>): PermissionCriteria<IQuery>;
-    } & (
-      | {
-          params?: {
-            schema: StandardSchemaV1<TParams>;
-          };
-          paramsSchema?: never;
-        }
-      | {
-          params?: never;
-          paramsSchema?: z.ZodSchema<TParams>;
-        }
-    )
+    } & {
+      paramsSchema?: StandardSchemaV1<TParams> & StandardJSONSchemaV1<TParams>;
+    }
   : never;
 
 // @public
@@ -358,14 +368,10 @@ export type PermissionRule<
   toQuery(params: NoInfer_2<TParams>): PermissionCriteria<TQuery>;
 } & (
   | {
-      params?: {
-        schema: StandardSchemaV1<TParams>;
-      };
-      paramsSchema?: never;
+      paramsSchema?: StandardSchemaV1<TParams> & StandardJSONSchemaV1<TParams>;
     }
   | {
-      params?: never;
-      paramsSchema?: z.ZodSchema<TParams>;
+      paramsSchema: z.ZodSchema<TParams>;
     }
 );
 

--- a/plugins/permission-node/report.api.md
+++ b/plugins/permission-node/report.api.md
@@ -29,6 +29,7 @@ import { PermissionsServiceRequestOptions } from '@backstage/backend-plugin-api'
 import { PolicyDecision } from '@backstage/plugin-permission-common';
 import { QueryPermissionRequest } from '@backstage/plugin-permission-common';
 import { ResourcePermission } from '@backstage/plugin-permission-common';
+import type { StandardSchemaV1 } from '@standard-schema/spec';
 import { z } from 'zod/v3';
 
 // @public
@@ -234,10 +235,20 @@ export type CreatePermissionRuleOptions<
       name: string;
       description: string;
       resourceRef: TRef;
-      paramsSchema?: z.ZodSchema<TParams>;
       apply(resource: IResource, params: NoInfer_2<TParams>): boolean;
       toQuery(params: NoInfer_2<TParams>): PermissionCriteria<IQuery>;
-    }
+    } & (
+      | {
+          params?: {
+            schema: StandardSchemaV1<TParams>;
+          };
+          paramsSchema?: never;
+        }
+      | {
+          params?: never;
+          paramsSchema?: z.ZodSchema<TParams>;
+        }
+    )
   : never;
 
 // @public
@@ -343,10 +354,20 @@ export type PermissionRule<
   name: string;
   description: string;
   resourceType: TResourceType;
-  paramsSchema?: z.ZodSchema<TParams>;
   apply(resource: TResource, params: NoInfer_2<TParams>): boolean;
   toQuery(params: NoInfer_2<TParams>): PermissionCriteria<TQuery>;
-};
+} & (
+  | {
+      params?: {
+        schema: StandardSchemaV1<TParams>;
+      };
+      paramsSchema?: never;
+    }
+  | {
+      params?: never;
+      paramsSchema?: z.ZodSchema<TParams>;
+    }
+);
 
 // @public
 export type PermissionRuleset<

--- a/plugins/permission-node/src/integration/createConditionTransformer.test.ts
+++ b/plugins/permission-node/src/integration/createConditionTransformer.test.ts
@@ -18,7 +18,10 @@ import {
   PermissionCondition,
   PermissionCriteria,
 } from '@backstage/plugin-permission-common';
-import type { StandardSchemaV1 } from '@standard-schema/spec';
+import type {
+  StandardJSONSchemaV1,
+  StandardSchemaV1,
+} from '@standard-schema/spec';
 import { z as zodV3 } from 'zod/v3';
 import { z as zodV4 } from 'zod/v4';
 import { createConditionTransformer } from './createConditionTransformer';
@@ -279,9 +282,7 @@ describe('createConditionTransformer', () => {
         name: 'standard-rule',
         description: 'Standard Schema rule',
         resourceType: 'test-resource',
-        params: {
-          schema: zodV4.object({ foo: zodV4.string() }),
-        },
+        paramsSchema: zodV4.object({ foo: zodV4.string() }),
         apply: () => true,
         toQuery: ({ foo }) => `standard-rule:${foo}`,
       }),
@@ -304,18 +305,18 @@ describe('createConditionTransformer', () => {
   });
 
   it('rejects asynchronous Standard Schema validation', () => {
-    type AsyncSchema = StandardSchemaV1<{ foo: string }> & {
-      '~standard': {
-        jsonSchema: { input: () => object };
-      };
-    };
+    type AsyncSchema = StandardSchemaV1<{ foo: string }> &
+      StandardJSONSchemaV1<{ foo: string }>;
     const schemas: AsyncSchema[] = [
       {
         '~standard': {
           version: 1,
           vendor: 'test',
           validate: async value => ({ value: value as { foo: string } }),
-          jsonSchema: { input: () => ({ type: 'object' }) },
+          jsonSchema: {
+            input: () => ({ type: 'object' }),
+            output: () => ({ type: 'object' }),
+          },
         },
       },
       {
@@ -326,7 +327,10 @@ describe('createConditionTransformer', () => {
             ({
               then: () => undefined,
             } as unknown as Promise<StandardSchemaV1.Result<{ foo: string }>>),
-          jsonSchema: { input: () => ({ type: 'object' }) },
+          jsonSchema: {
+            input: () => ({ type: 'object' }),
+            output: () => ({ type: 'object' }),
+          },
         },
       },
     ];
@@ -338,7 +342,7 @@ describe('createConditionTransformer', () => {
           name,
           description: 'Async rule',
           resourceType: 'test-resource',
-          params: { schema },
+          paramsSchema: schema,
           apply: () => true,
           toQuery: ({ foo }) => foo,
         }),

--- a/plugins/permission-node/src/integration/createConditionTransformer.test.ts
+++ b/plugins/permission-node/src/integration/createConditionTransformer.test.ts
@@ -18,7 +18,9 @@ import {
   PermissionCondition,
   PermissionCriteria,
 } from '@backstage/plugin-permission-common';
-import { z } from 'zod/v3';
+import { StandardSchemaV1 } from '@standard-schema/spec';
+import { z as zodV3 } from 'zod/v3';
+import { z as zodV4 } from 'zod/v4';
 import { createConditionTransformer } from './createConditionTransformer';
 import { createPermissionRule } from './createPermissionRule';
 
@@ -27,9 +29,9 @@ const transformConditions = createConditionTransformer([
     name: 'test-rule-1',
     description: 'Test rule 1',
     resourceType: 'test-resource',
-    paramsSchema: z.object({
-      foo: z.string(),
-      bar: z.number(),
+    paramsSchema: zodV3.object({
+      foo: zodV3.string(),
+      bar: zodV3.number(),
     }),
     apply: jest.fn(),
     toQuery: jest.fn(({ foo, bar }) => `test-rule-1:${foo}/${bar}`),
@@ -38,8 +40,8 @@ const transformConditions = createConditionTransformer([
     name: 'test-rule-2',
     description: 'Test rule 2',
     resourceType: 'test-resource',
-    paramsSchema: z.object({
-      foo: z.string(),
+    paramsSchema: zodV3.object({
+      foo: zodV3.string(),
     }),
     apply: jest.fn(),
     toQuery: jest.fn(({ foo }) => `test-rule-2:${foo}`),
@@ -260,4 +262,79 @@ describe('createConditionTransformer', () => {
       expect(transformConditions(conditions)).toEqual(expectedResult);
     },
   );
+
+  it('continues to validate legacy Zod parameter schemas', () => {
+    expect(() =>
+      transformConditions({
+        rule: 'test-rule-1',
+        resourceType: 'test-resource',
+        params: { foo: 'invalid', bar: 'invalid' },
+      }),
+    ).toThrow('Parameters to rule are invalid');
+  });
+
+  it('validates parameters using Standard Schema', () => {
+    const transformer = createConditionTransformer([
+      createPermissionRule({
+        name: 'standard-rule',
+        description: 'Standard Schema rule',
+        resourceType: 'test-resource',
+        params: {
+          schema: zodV4.object({ foo: zodV4.string() }),
+        },
+        apply: () => true,
+        toQuery: ({ foo }) => `standard-rule:${foo}`,
+      }),
+    ]);
+
+    expect(
+      transformer({
+        rule: 'standard-rule',
+        resourceType: 'test-resource',
+        params: { foo: 'valid' },
+      }),
+    ).toBe('standard-rule:valid');
+    expect(() =>
+      transformer({
+        rule: 'standard-rule',
+        resourceType: 'test-resource',
+        params: { foo: 1 },
+      }),
+    ).toThrow('Parameters to rule are invalid');
+  });
+
+  it('rejects asynchronous Standard Schema validation', () => {
+    const schema: StandardSchemaV1<{ foo: string }> & {
+      '~standard': {
+        jsonSchema: { input: () => object };
+      };
+    } = {
+      '~standard': {
+        version: 1,
+        vendor: 'test',
+        validate: async value => ({ value: value as { foo: string } }),
+        jsonSchema: { input: () => ({ type: 'object' }) },
+      },
+    };
+    const transformer = createConditionTransformer([
+      createPermissionRule({
+        name: 'async-rule',
+        description: 'Async rule',
+        resourceType: 'test-resource',
+        params: { schema },
+        apply: () => true,
+        toQuery: ({ foo }) => foo,
+      }),
+    ]);
+
+    expect(() =>
+      transformer({
+        rule: 'async-rule',
+        resourceType: 'test-resource',
+        params: { foo: 'value' },
+      }),
+    ).toThrow(
+      "Permission rule 'async-rule' parameter schema returned a Promise; async schemas are not supported",
+    );
+  });
 });

--- a/plugins/permission-node/src/integration/createConditionTransformer.test.ts
+++ b/plugins/permission-node/src/integration/createConditionTransformer.test.ts
@@ -18,7 +18,7 @@ import {
   PermissionCondition,
   PermissionCriteria,
 } from '@backstage/plugin-permission-common';
-import { StandardSchemaV1 } from '@standard-schema/spec';
+import type { StandardSchemaV1 } from '@standard-schema/spec';
 import { z as zodV3 } from 'zod/v3';
 import { z as zodV4 } from 'zod/v4';
 import { createConditionTransformer } from './createConditionTransformer';
@@ -304,37 +304,55 @@ describe('createConditionTransformer', () => {
   });
 
   it('rejects asynchronous Standard Schema validation', () => {
-    const schema: StandardSchemaV1<{ foo: string }> & {
+    type AsyncSchema = StandardSchemaV1<{ foo: string }> & {
       '~standard': {
         jsonSchema: { input: () => object };
       };
-    } = {
-      '~standard': {
-        version: 1,
-        vendor: 'test',
-        validate: async value => ({ value: value as { foo: string } }),
-        jsonSchema: { input: () => ({ type: 'object' }) },
-      },
     };
-    const transformer = createConditionTransformer([
-      createPermissionRule({
-        name: 'async-rule',
-        description: 'Async rule',
-        resourceType: 'test-resource',
-        params: { schema },
-        apply: () => true,
-        toQuery: ({ foo }) => foo,
-      }),
-    ]);
+    const schemas: AsyncSchema[] = [
+      {
+        '~standard': {
+          version: 1,
+          vendor: 'test',
+          validate: async value => ({ value: value as { foo: string } }),
+          jsonSchema: { input: () => ({ type: 'object' }) },
+        },
+      },
+      {
+        '~standard': {
+          version: 1,
+          vendor: 'test',
+          validate: () =>
+            ({
+              then: () => undefined,
+            } as unknown as Promise<StandardSchemaV1.Result<{ foo: string }>>),
+          jsonSchema: { input: () => ({ type: 'object' }) },
+        },
+      },
+    ];
 
-    expect(() =>
-      transformer({
-        rule: 'async-rule',
-        resourceType: 'test-resource',
-        params: { foo: 'value' },
-      }),
-    ).toThrow(
-      "Permission rule 'async-rule' parameter schema returned a Promise; async schemas are not supported",
-    );
+    for (const [index, schema] of schemas.entries()) {
+      const name = `async-rule-${index}`;
+      const transformer = createConditionTransformer([
+        createPermissionRule({
+          name,
+          description: 'Async rule',
+          resourceType: 'test-resource',
+          params: { schema },
+          apply: () => true,
+          toQuery: ({ foo }) => foo,
+        }),
+      ]);
+
+      expect(() =>
+        transformer({
+          rule: name,
+          resourceType: 'test-resource',
+          params: { foo: 'value' },
+        }),
+      ).toThrow(
+        `Permission rule '${name}' parameter schema returned a Promise; async schemas are not supported`,
+      );
+    }
   });
 });

--- a/plugins/permission-node/src/integration/createConditionTransformer.ts
+++ b/plugins/permission-node/src/integration/createConditionTransformer.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { InputError } from '@backstage/errors';
 import {
   AllOfCriteria,
   AnyOfCriteria,
@@ -27,6 +26,7 @@ import {
   isNotCriteria,
   isOrCriteria,
 } from './util';
+import { validatePermissionRuleParams } from './permissionRuleParams';
 
 const mapConditions = <TQuery>(
   criteria: PermissionCriteria<PermissionCondition>,
@@ -47,11 +47,7 @@ const mapConditions = <TQuery>(
   }
 
   const rule = getRule(criteria.rule);
-  const result = rule.paramsSchema?.safeParse(criteria.params);
-
-  if (result && !result.success) {
-    throw new InputError(`Parameters to rule are invalid`, result.error);
-  }
+  validatePermissionRuleParams(rule, criteria.params);
 
   return rule.toQuery(criteria.params ?? {});
 };

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
@@ -16,12 +16,16 @@
 
 import {
   AuthorizeResult,
+  ConditionalPolicyDecision,
   createPermission,
   Permission,
 } from '@backstage/plugin-permission-common';
+import { StandardSchemaV1 } from '@standard-schema/spec';
 import express from 'express';
 import request, { Response } from 'supertest';
-import { z } from 'zod/v3';
+import { z as zodV3 } from 'zod/v3';
+import { z as zodV4 } from 'zod/v4';
+import { PermissionRule } from '../types';
 import {
   createPermissionIntegrationRouter,
   CreatePermissionIntegrationRouterResourceOptions,
@@ -49,9 +53,9 @@ const testRule1 = createPermissionRule({
   name: 'test-rule-1',
   description: 'Test rule 1',
   resourceType: 'test-resource',
-  paramsSchema: z.object({
-    foo: z.string(),
-    bar: z.number().describe('bar'),
+  paramsSchema: zodV3.object({
+    foo: zodV3.string(),
+    bar: zodV3.number().describe('bar'),
   }),
   apply: mockTestRule1Apply,
   toQuery: _params => ({}),
@@ -899,6 +903,77 @@ describe('createPermissionIntegrationRouter', () => {
   });
 
   describe('GET /.well-known/backstage/permissions/metadata', () => {
+    it('serializes Standard Schema rule parameters', async () => {
+      const rule = createPermissionRule({
+        name: 'standard-rule',
+        description: 'Standard Schema rule',
+        resourceType: 'test-resource',
+        params: {
+          schema: zodV4.object({
+            foo: zodV4.string(),
+            bar: zodV4.number().describe('bar'),
+          }),
+        },
+        apply: () => true,
+        toQuery: () => ({}),
+      });
+      const router = createPermissionIntegrationRouter({
+        permissions: [],
+        resourceType: 'test-resource',
+        rules: [rule],
+      });
+
+      const response = await request(express().use(router)).get(
+        '/.well-known/backstage/permissions/metadata',
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.body.rules).toEqual([
+        {
+          name: 'standard-rule',
+          description: 'Standard Schema rule',
+          resourceType: 'test-resource',
+          paramsSchema: {
+            $schema: 'http://json-schema.org/draft-07/schema#',
+            type: 'object',
+            properties: {
+              foo: { type: 'string' },
+              bar: { type: 'number', description: 'bar' },
+            },
+            required: ['foo', 'bar'],
+          },
+        },
+      ]);
+    });
+
+    it('rejects registered Standard Schemas without JSON Schema conversion', () => {
+      const schema: StandardSchemaV1<Record<string, never>> = {
+        '~standard': {
+          version: 1,
+          vendor: 'test',
+          validate: value => ({ value: value as Record<string, never> }),
+        },
+      };
+      const rule: PermissionRule<
+        unknown,
+        unknown,
+        'test-resource',
+        Record<string, never>
+      > = {
+        name: 'unsupported',
+        description: 'Unsupported schema',
+        resourceType: 'test-resource',
+        params: { schema },
+        apply: () => true,
+        toQuery: () => ({}),
+      };
+      const router = createPermissionIntegrationRouter();
+
+      expect(() => router.addPermissionRules([rule])).toThrow(
+        "Permission rule 'unsupported' parameter schema does not support JSON Schema conversion",
+      );
+    });
+
     it('returns a list of permissions and rules of a single resource type', async () => {
       const response = await request(createApp()).get(
         '/.well-known/backstage/permissions/metadata',
@@ -1237,5 +1312,38 @@ describe('createConditionAuthorizer', () => {
 
     expect(mockTestRule1Apply).toHaveBeenCalledTimes(1);
     expect(mockTestRule2Apply).toHaveBeenCalledTimes(1);
+  });
+
+  it('validates Standard Schema parameters before applying conditions', () => {
+    const rule = createPermissionRule({
+      name: 'standard-rule',
+      description: 'Standard Schema rule',
+      resourceType: 'test-resource',
+      params: {
+        schema: zodV4.object({ owner: zodV4.string() }),
+      },
+      apply: (_resource, { owner }) => owner === 'user:default/test',
+      toQuery: () => ({}),
+    });
+    const isAuthorized = createConditionAuthorizer([rule]);
+    const decision = (params: {
+      owner: string | number;
+    }): ConditionalPolicyDecision => ({
+      pluginId: 'plugin',
+      resourceType: 'test-resource',
+      result: AuthorizeResult.CONDITIONAL,
+      conditions: {
+        rule: 'standard-rule',
+        resourceType: 'test-resource',
+        params,
+      },
+    });
+
+    expect(isAuthorized(decision({ owner: 'user:default/test' }), {})).toBe(
+      true,
+    );
+    expect(() => isAuthorized(decision({ owner: 1 }), {})).toThrow(
+      'Parameters to rule are invalid',
+    );
   });
 });

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
@@ -908,12 +908,10 @@ describe('createPermissionIntegrationRouter', () => {
         name: 'standard-rule',
         description: 'Standard Schema rule',
         resourceType: 'test-resource',
-        params: {
-          schema: zodV4.object({
-            foo: zodV4.string(),
-            bar: zodV4.number().describe('bar'),
-          }),
-        },
+        paramsSchema: zodV4.object({
+          foo: zodV4.string(),
+          bar: zodV4.number().describe('bar'),
+        }),
         apply: () => true,
         toQuery: () => ({}),
       });
@@ -963,7 +961,7 @@ describe('createPermissionIntegrationRouter', () => {
         name: 'unsupported',
         description: 'Unsupported schema',
         resourceType: 'test-resource',
-        params: { schema },
+        paramsSchema: schema as any,
         apply: () => true,
         toQuery: () => ({}),
       };
@@ -1319,9 +1317,7 @@ describe('createConditionAuthorizer', () => {
       name: 'standard-rule',
       description: 'Standard Schema rule',
       resourceType: 'test-resource',
-      params: {
-        schema: zodV4.object({ owner: zodV4.string() }),
-      },
+      paramsSchema: zodV4.object({ owner: zodV4.string() }),
       apply: (_resource, { owner }) => owner === 'user:default/test',
       toQuery: () => ({}),
     });

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.test.ts
@@ -20,12 +20,12 @@ import {
   createPermission,
   Permission,
 } from '@backstage/plugin-permission-common';
-import { StandardSchemaV1 } from '@standard-schema/spec';
+import type { StandardSchemaV1 } from '@standard-schema/spec';
 import express from 'express';
 import request, { Response } from 'supertest';
 import { z as zodV3 } from 'zod/v3';
 import { z as zodV4 } from 'zod/v4';
-import { PermissionRule } from '../types';
+import type { PermissionRule } from '../types';
 import {
   createPermissionIntegrationRouter,
   CreatePermissionIntegrationRouterResourceOptions,

--- a/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
+++ b/plugins/permission-node/src/integration/createPermissionIntegrationRouter.ts
@@ -17,7 +17,6 @@
 import express, { Response } from 'express';
 import Router from 'express-promise-router';
 import { z } from 'zod/v3';
-import zodToJsonSchema from 'zod-to-json-schema';
 import { InputError } from '@backstage/errors';
 import {
   AuthorizeResult,
@@ -39,6 +38,11 @@ import {
 } from './util';
 import { NotImplementedError } from '@backstage/errors';
 import { PermissionResourceRef } from './createPermissionResourceRef';
+import {
+  assertPermissionRuleParamsSchema,
+  permissionRuleParamsToJsonSchema,
+  validatePermissionRuleParams,
+} from './permissionRuleParams';
 
 const permissionCriteriaSchema: z.ZodSchema<
   PermissionCriteria<PermissionCondition>
@@ -152,11 +156,7 @@ const applyConditions = <TResourceType extends string, TResource>(
   }
 
   const rule = getRule(criteria.rule);
-  const result = rule.paramsSchema?.safeParse(criteria.params);
-
-  if (result && !result.success) {
-    throw new InputError(`Parameters to rule are invalid`, result.error);
-  }
+  validatePermissionRuleParams(rule, criteria.params);
 
   return rule.apply(resource, criteria.params ?? {});
 };
@@ -343,6 +343,7 @@ class PermissionIntegrationMetadataStore {
 
   addPermissionRules(rules: PermissionRule<unknown, unknown, string>[]) {
     for (const rule of rules) {
+      assertPermissionRuleParamsSchema(rule);
       const rulesByName =
         this.#rulesByTypeByName.get(rule.resourceType) ?? new Map();
       this.#rulesByTypeByName.set(rule.resourceType, rulesByName);
@@ -358,7 +359,7 @@ class PermissionIntegrationMetadataStore {
         name: rule.name,
         description: rule.description,
         resourceType: rule.resourceType,
-        paramsSchema: zodToJsonSchema(rule.paramsSchema ?? z.object({})),
+        paramsSchema: permissionRuleParamsToJsonSchema(rule),
       });
     }
   }

--- a/plugins/permission-node/src/integration/createPermissionRule.test.ts
+++ b/plugins/permission-node/src/integration/createPermissionRule.test.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import type { StandardSchemaV1 } from '@standard-schema/spec';
+import type {
+  StandardJSONSchemaV1,
+  StandardSchemaV1,
+} from '@standard-schema/spec';
 import { z as zodV3 } from 'zod/v3';
 import { z as zodV4 } from 'zod/v4';
 import type { PermissionRule } from '../types';
@@ -23,6 +26,7 @@ import {
   type CreatePermissionRuleOptions,
 } from './createPermissionRule';
 import { createPermissionResourceRef } from './createPermissionResourceRef';
+import { permissionRuleParamsToJsonSchema } from './permissionRuleParams';
 
 const resourceRef = createPermissionResourceRef<
   unknown,
@@ -38,18 +42,39 @@ describe('createPermissionRule', () => {
       name: 'test',
       description: 'test',
       resourceRef,
-      params: {
-        schema: zodV4.object({ owner: zodV4.string() }),
-      },
+      paramsSchema: zodV4.object({ owner: zodV4.string() }),
       apply: (_resource, params) => params.owner.length > 0,
       toQuery: params => ({ owner: params.owner }),
     });
 
-    expect(rule.params?.schema).toBeDefined();
+    expect(rule.paramsSchema).toBeDefined();
   });
 
-  it('keeps the legacy schema form but rejects combining both forms', () => {
-    createPermissionRule({
+  it('accepts resource ref rules without a parameter schema', () => {
+    const rule = createPermissionRule({
+      name: 'parameterless',
+      description: 'parameterless',
+      resourceRef,
+      apply: (_resource, params) => {
+        const noParams: undefined = params;
+        return noParams === undefined;
+      },
+      toQuery: params => {
+        const noParams: undefined = params;
+        return { owner: String(noParams) };
+      },
+    });
+
+    expect(permissionRuleParamsToJsonSchema(rule)).toEqual({
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      additionalProperties: false,
+      properties: {},
+      type: 'object',
+    });
+  });
+
+  it('keeps the legacy Zod schema overload and supports both rule types', () => {
+    const legacyRule = createPermissionRule({
       name: 'legacy',
       description: 'legacy',
       resourceRef,
@@ -58,42 +83,56 @@ describe('createPermissionRule', () => {
       toQuery: params => ({ owner: params.owner }),
     });
 
-    // @ts-expect-error params.schema and paramsSchema are mutually exclusive
-    const invalidRule: CreatePermissionRuleOptions<
+    const standardOptions: CreatePermissionRuleOptions<
       typeof resourceRef,
       { owner: string }
     > = {
-      name: 'invalid',
-      description: 'invalid',
+      name: 'standard',
+      description: 'standard',
       resourceRef,
-      params: {
-        schema: zodV4.object({ owner: zodV4.string() }),
-      },
-      paramsSchema: zodV3.object({ owner: zodV3.string() }),
+      paramsSchema: zodV4.object({ owner: zodV4.string() }),
       apply: () => true,
       toQuery: params => ({ owner: params.owner }),
     };
 
-    // @ts-expect-error params.schema and paramsSchema are mutually exclusive
-    const invalidPermissionRule: PermissionRule<
+    const standardPermissionRule: PermissionRule<
       unknown,
       { owner: string },
       'test-resource',
       { owner: string }
     > = {
-      name: 'invalid',
-      description: 'invalid',
+      name: 'standard',
+      description: 'standard',
       resourceType: 'test-resource',
-      params: {
-        schema: zodV4.object({ owner: zodV4.string() }),
-      },
+      paramsSchema: zodV4.object({ owner: zodV4.string() }),
+      apply: () => true,
+      toQuery: params => ({ owner: params.owner }),
+    };
+
+    const legacyPermissionRule: PermissionRule<
+      unknown,
+      { owner: string },
+      'test-resource',
+      { owner: string }
+    > = legacyRule;
+
+    const legacyOptions: CreatePermissionRuleOptions<
+      typeof resourceRef,
+      { owner: string }
+    > = {
+      name: 'legacy',
+      description: 'legacy',
+      resourceRef,
+      // @ts-expect-error Zod v3 is only accepted by the deprecated function overload
       paramsSchema: zodV3.object({ owner: zodV3.string() }),
       apply: () => true,
       toQuery: params => ({ owner: params.owner }),
     };
 
-    expect(invalidRule).toBeDefined();
-    expect(invalidPermissionRule).toBeDefined();
+    expect(standardOptions.paramsSchema).toBeDefined();
+    expect(standardPermissionRule.paramsSchema).toBeDefined();
+    expect(legacyPermissionRule.paramsSchema).toBeDefined();
+    expect(legacyOptions.paramsSchema).toBeDefined();
   });
 
   it('rejects Standard Schemas without JSON Schema conversion', () => {
@@ -110,7 +149,8 @@ describe('createPermissionRule', () => {
         name: 'unsupported',
         description: 'unsupported',
         resourceRef,
-        params: { schema },
+        paramsSchema: schema as StandardSchemaV1<Record<string, never>> &
+          StandardJSONSchemaV1<Record<string, never>>,
         apply: () => true,
         toQuery: () => ({ owner: 'test' }),
       }),
@@ -123,14 +163,29 @@ describe('createPermissionRule', () => {
         name: 'malformed',
         description: 'malformed',
         resourceRef,
-        params: {
-          schema: {} as StandardSchemaV1<Record<string, never>>,
-        },
+        paramsSchema: {} as StandardSchemaV1<Record<string, never>> &
+          StandardJSONSchemaV1<Record<string, never>>,
         apply: () => true,
         toQuery: () => ({ owner: 'test' }),
       }),
     ).toThrow(
       "Permission rule 'malformed' parameter schema does not support JSON Schema conversion",
+    );
+
+    expect(() =>
+      createPermissionRule({
+        name: 'not-zod',
+        description: 'not-zod',
+        resourceRef,
+        paramsSchema: {
+          safeParse: () => ({ success: true }),
+        } as unknown as StandardSchemaV1<Record<string, never>> &
+          StandardJSONSchemaV1<Record<string, never>>,
+        apply: () => true,
+        toQuery: () => ({ owner: 'test' }),
+      }),
+    ).toThrow(
+      "Permission rule 'not-zod' parameter schema does not support JSON Schema conversion",
     );
   });
 });

--- a/plugins/permission-node/src/integration/createPermissionRule.test.ts
+++ b/plugins/permission-node/src/integration/createPermissionRule.test.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { StandardSchemaV1 } from '@standard-schema/spec';
+import { z as zodV3 } from 'zod/v3';
+import { z as zodV4 } from 'zod/v4';
+import { PermissionRule } from '../types';
+import {
+  createPermissionRule,
+  CreatePermissionRuleOptions,
+} from './createPermissionRule';
+import { createPermissionResourceRef } from './createPermissionResourceRef';
+
+const resourceRef = createPermissionResourceRef<
+  unknown,
+  { owner: string }
+>().with({
+  pluginId: 'test',
+  resourceType: 'test-resource',
+});
+
+describe('createPermissionRule', () => {
+  it('accepts Standard Schema parameter schemas', () => {
+    const rule = createPermissionRule({
+      name: 'test',
+      description: 'test',
+      resourceRef,
+      params: {
+        schema: zodV4.object({ owner: zodV4.string() }),
+      },
+      apply: (_resource, params) => params.owner.length > 0,
+      toQuery: params => ({ owner: params.owner }),
+    });
+
+    expect(rule.params?.schema).toBeDefined();
+  });
+
+  it('keeps the legacy schema form but rejects combining both forms', () => {
+    createPermissionRule({
+      name: 'legacy',
+      description: 'legacy',
+      resourceRef,
+      paramsSchema: zodV3.object({ owner: zodV3.string() }),
+      apply: () => true,
+      toQuery: params => ({ owner: params.owner }),
+    });
+
+    // @ts-expect-error params.schema and paramsSchema are mutually exclusive
+    const invalidRule: CreatePermissionRuleOptions<
+      typeof resourceRef,
+      { owner: string }
+    > = {
+      name: 'invalid',
+      description: 'invalid',
+      resourceRef,
+      params: {
+        schema: zodV4.object({ owner: zodV4.string() }),
+      },
+      paramsSchema: zodV3.object({ owner: zodV3.string() }),
+      apply: () => true,
+      toQuery: params => ({ owner: params.owner }),
+    };
+
+    // @ts-expect-error params.schema and paramsSchema are mutually exclusive
+    const invalidPermissionRule: PermissionRule<
+      unknown,
+      { owner: string },
+      'test-resource',
+      { owner: string }
+    > = {
+      name: 'invalid',
+      description: 'invalid',
+      resourceType: 'test-resource',
+      params: {
+        schema: zodV4.object({ owner: zodV4.string() }),
+      },
+      paramsSchema: zodV3.object({ owner: zodV3.string() }),
+      apply: () => true,
+      toQuery: params => ({ owner: params.owner }),
+    };
+
+    expect(invalidRule).toBeDefined();
+    expect(invalidPermissionRule).toBeDefined();
+  });
+
+  it('rejects Standard Schemas without JSON Schema conversion', () => {
+    const schema: StandardSchemaV1<Record<string, never>> = {
+      '~standard': {
+        version: 1,
+        vendor: 'test',
+        validate: value => ({ value: value as Record<string, never> }),
+      },
+    };
+
+    expect(() =>
+      createPermissionRule({
+        name: 'unsupported',
+        description: 'unsupported',
+        resourceRef,
+        params: { schema },
+        apply: () => true,
+        toQuery: () => ({ owner: 'test' }),
+      }),
+    ).toThrow(
+      "Permission rule 'unsupported' parameter schema does not support JSON Schema conversion",
+    );
+  });
+});

--- a/plugins/permission-node/src/integration/createPermissionRule.test.ts
+++ b/plugins/permission-node/src/integration/createPermissionRule.test.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import { StandardSchemaV1 } from '@standard-schema/spec';
+import type { StandardSchemaV1 } from '@standard-schema/spec';
 import { z as zodV3 } from 'zod/v3';
 import { z as zodV4 } from 'zod/v4';
-import { PermissionRule } from '../types';
+import type { PermissionRule } from '../types';
 import {
   createPermissionRule,
-  CreatePermissionRuleOptions,
+  type CreatePermissionRuleOptions,
 } from './createPermissionRule';
 import { createPermissionResourceRef } from './createPermissionResourceRef';
 
@@ -116,6 +116,21 @@ describe('createPermissionRule', () => {
       }),
     ).toThrow(
       "Permission rule 'unsupported' parameter schema does not support JSON Schema conversion",
+    );
+
+    expect(() =>
+      createPermissionRule({
+        name: 'malformed',
+        description: 'malformed',
+        resourceRef,
+        params: {
+          schema: {} as StandardSchemaV1<Record<string, never>>,
+        },
+        apply: () => true,
+        toQuery: () => ({ owner: 'test' }),
+      }),
+    ).toThrow(
+      "Permission rule 'malformed' parameter schema does not support JSON Schema conversion",
     );
   });
 });

--- a/plugins/permission-node/src/integration/createPermissionRule.ts
+++ b/plugins/permission-node/src/integration/createPermissionRule.ts
@@ -18,7 +18,10 @@ import {
   PermissionCriteria,
   PermissionRuleParams,
 } from '@backstage/plugin-permission-common';
-import type { StandardSchemaV1 } from '@standard-schema/spec';
+import type {
+  StandardJSONSchemaV1,
+  StandardSchemaV1,
+} from '@standard-schema/spec';
 import { NoInfer, PermissionRule } from '../types';
 import { z } from 'zod/v3';
 import { PermissionResourceRef } from './createPermissionResourceRef';
@@ -50,26 +53,13 @@ export type CreatePermissionRuleOptions<
        * applied.
        */
       toQuery(params: NoInfer<TParams>): PermissionCriteria<IQuery>;
-    } & (
-      | {
-          /**
-           * A Standard Schema that reflects the structure of the parameters that are passed to the rule.
-           * The schema must validate synchronously and support JSON Schema conversion.
-           */
-          params?: { schema: StandardSchemaV1<TParams> };
-          paramsSchema?: never;
-        }
-      | {
-          params?: never;
-
-          /**
-           * A ZodSchema that reflects the structure of the parameters that are passed to the rule.
-           *
-           * @deprecated Use `params.schema` instead.
-           */
-          paramsSchema?: z.ZodSchema<TParams>;
-        }
-    )
+    } & {
+      /**
+       * A Standard Schema that reflects the structure of the parameters that are passed to the rule.
+       * The schema must validate synchronously and support JSON Schema conversion.
+       */
+      paramsSchema?: StandardSchemaV1<TParams> & StandardJSONSchemaV1<TParams>;
+    }
   : never;
 
 /**
@@ -83,6 +73,26 @@ export function createPermissionRule<
 >(
   rule: CreatePermissionRuleOptions<TRef, TParams>,
 ): PermissionRule<
+  TRef['TResource'],
+  TRef['TQuery'],
+  TRef['resourceType'],
+  TParams
+>;
+/**
+ * @public
+ * @deprecated Zod v3 parameter schemas are deprecated, switch to a JSON Schema-compatible Standard Schema instead, such as Zod v4.
+ */
+export function createPermissionRule<
+  TRef extends PermissionResourceRef,
+  TParams extends PermissionRuleParams = undefined,
+>(rule: {
+  name: string;
+  description: string;
+  resourceRef: TRef;
+  paramsSchema: z.ZodSchema<TParams>;
+  apply(resource: TRef['TResource'], params: NoInfer<TParams>): boolean;
+  toQuery(params: NoInfer<TParams>): PermissionCriteria<TRef['TQuery']>;
+}): PermissionRule<
   TRef['TResource'],
   TRef['TQuery'],
   TRef['resourceType'],
@@ -111,7 +121,15 @@ export function createPermissionRule<
 >(
   rule:
     | PermissionRule<TResource, TQuery, TResourceType, TParams>
-    | CreatePermissionRuleOptions<TRef, TParams>,
+    | CreatePermissionRuleOptions<TRef, TParams>
+    | {
+        name: string;
+        description: string;
+        resourceRef: TRef;
+        paramsSchema: z.ZodSchema<TParams>;
+        apply(resource: TRef['TResource'], params: NoInfer<TParams>): boolean;
+        toQuery(params: NoInfer<TParams>): PermissionCriteria<TRef['TQuery']>;
+      },
 ): PermissionRule<TResource, TQuery, TResourceType, TParams> {
   assertPermissionRuleParamsSchema(rule);
   if ('resourceRef' in rule) {

--- a/plugins/permission-node/src/integration/createPermissionRule.ts
+++ b/plugins/permission-node/src/integration/createPermissionRule.ts
@@ -18,9 +18,11 @@ import {
   PermissionCriteria,
   PermissionRuleParams,
 } from '@backstage/plugin-permission-common';
+import type { StandardSchemaV1 } from '@standard-schema/spec';
 import { NoInfer, PermissionRule } from '../types';
 import { z } from 'zod/v3';
 import { PermissionResourceRef } from './createPermissionResourceRef';
+import { assertPermissionRuleParamsSchema } from './permissionRuleParams';
 
 /**
  * @public
@@ -36,11 +38,6 @@ export type CreatePermissionRuleOptions<
       resourceRef: TRef;
 
       /**
-       * A ZodSchema that reflects the structure of the parameters that are passed to
-       */
-      paramsSchema?: z.ZodSchema<TParams>;
-
-      /**
        * Apply this rule to a resource already loaded from a backing data source. The params are
        * arguments supplied for the rule; for example, a rule could be `isOwner` with entityRefs as the
        * params.
@@ -53,7 +50,26 @@ export type CreatePermissionRuleOptions<
        * applied.
        */
       toQuery(params: NoInfer<TParams>): PermissionCriteria<IQuery>;
-    }
+    } & (
+      | {
+          /**
+           * A Standard Schema that reflects the structure of the parameters that are passed to the rule.
+           * The schema must support JSON Schema conversion.
+           */
+          params?: { schema: StandardSchemaV1<TParams> };
+          paramsSchema?: never;
+        }
+      | {
+          params?: never;
+
+          /**
+           * A ZodSchema that reflects the structure of the parameters that are passed to the rule.
+           *
+           * @deprecated Use `params.schema` instead.
+           */
+          paramsSchema?: z.ZodSchema<TParams>;
+        }
+    )
   : never;
 
 /**
@@ -97,6 +113,7 @@ export function createPermissionRule<
     | PermissionRule<TResource, TQuery, TResourceType, TParams>
     | CreatePermissionRuleOptions<TRef, TParams>,
 ): PermissionRule<TResource, TQuery, TResourceType, TParams> {
+  assertPermissionRuleParamsSchema(rule);
   if ('resourceRef' in rule) {
     return {
       ...rule,

--- a/plugins/permission-node/src/integration/createPermissionRule.ts
+++ b/plugins/permission-node/src/integration/createPermissionRule.ts
@@ -54,7 +54,7 @@ export type CreatePermissionRuleOptions<
       | {
           /**
            * A Standard Schema that reflects the structure of the parameters that are passed to the rule.
-           * The schema must support JSON Schema conversion.
+           * The schema must validate synchronously and support JSON Schema conversion.
            */
           params?: { schema: StandardSchemaV1<TParams> };
           paramsSchema?: never;

--- a/plugins/permission-node/src/integration/createPermissionRule.ts
+++ b/plugins/permission-node/src/integration/createPermissionRule.ts
@@ -41,6 +41,12 @@ export type CreatePermissionRuleOptions<
       resourceRef: TRef;
 
       /**
+       * A Standard Schema that reflects the structure of the parameters that are passed to the rule.
+       * The schema must validate synchronously and support JSON Schema conversion.
+       */
+      paramsSchema?: StandardSchemaV1<TParams> & StandardJSONSchemaV1<TParams>;
+
+      /**
        * Apply this rule to a resource already loaded from a backing data source. The params are
        * arguments supplied for the rule; for example, a rule could be `isOwner` with entityRefs as the
        * params.
@@ -53,12 +59,6 @@ export type CreatePermissionRuleOptions<
        * applied.
        */
       toQuery(params: NoInfer<TParams>): PermissionCriteria<IQuery>;
-    } & {
-      /**
-       * A Standard Schema that reflects the structure of the parameters that are passed to the rule.
-       * The schema must validate synchronously and support JSON Schema conversion.
-       */
-      paramsSchema?: StandardSchemaV1<TParams> & StandardJSONSchemaV1<TParams>;
     }
   : never;
 

--- a/plugins/permission-node/src/integration/permissionRuleParams.ts
+++ b/plugins/permission-node/src/integration/permissionRuleParams.ts
@@ -22,8 +22,7 @@ import zodToJsonSchema from 'zod-to-json-schema';
 
 type RuleWithParamsSchema = {
   name: string;
-  params?: { schema: StandardSchemaV1 };
-  paramsSchema?: z.ZodSchema<any>;
+  paramsSchema?: unknown;
 };
 
 type StandardSchemaWithJsonSchemaInput = StandardSchemaV1 & {
@@ -35,23 +34,41 @@ type StandardSchemaWithJsonSchemaInput = StandardSchemaV1 & {
 };
 
 function supportsJsonSchema(
-  schema: StandardSchemaV1,
+  schema: unknown,
 ): schema is StandardSchemaWithJsonSchemaInput {
-  const standard = schema['~standard'] as unknown as
+  const standard = (schema as StandardSchemaV1 | undefined)?.[
+    '~standard'
+  ] as unknown as
     | {
+        validate?: unknown;
         jsonSchema?: { input?: unknown };
       }
     | undefined;
-  return typeof standard?.jsonSchema?.input === 'function';
+  return (
+    typeof standard?.validate === 'function' &&
+    typeof standard.jsonSchema?.input === 'function'
+  );
+}
+
+function isZodSchema(schema: unknown): schema is z.ZodSchema<any> {
+  return (
+    typeof schema === 'object' &&
+    schema !== null &&
+    '_def' in schema &&
+    typeof (schema as { _parse?: unknown })._parse === 'function' &&
+    typeof (schema as { safeParse?: unknown }).safeParse === 'function'
+  );
 }
 
 /** Ensures that a rule parameter schema can be serialized as permission metadata. */
 export function assertPermissionRuleParamsSchema(
   rule: RuleWithParamsSchema,
-): asserts rule is RuleWithParamsSchema & {
-  params?: { schema: StandardSchemaWithJsonSchemaInput };
-} {
-  if (rule.params?.schema && !supportsJsonSchema(rule.params.schema)) {
+): void {
+  if (
+    rule.paramsSchema &&
+    !supportsJsonSchema(rule.paramsSchema) &&
+    !isZodSchema(rule.paramsSchema)
+  ) {
     throw new Error(
       `Permission rule '${rule.name}' parameter schema does not support JSON Schema conversion`,
     );
@@ -66,8 +83,8 @@ export function validatePermissionRuleParams(
   rule: RuleWithParamsSchema,
   params: unknown,
 ): void {
-  if (rule.params?.schema) {
-    const result = rule.params.schema['~standard'].validate(params);
+  if (supportsJsonSchema(rule.paramsSchema)) {
+    const result = rule.paramsSchema['~standard'].validate(params);
     if (isPromise(result)) {
       throw new Error(
         `Permission rule '${rule.name}' parameter schema returned a Promise; async schemas are not supported`,
@@ -82,9 +99,13 @@ export function validatePermissionRuleParams(
     return;
   }
 
-  const result = rule.paramsSchema?.safeParse(params);
-  if (result && !result.success) {
-    throw new InputError('Parameters to rule are invalid', result.error);
+  if (isZodSchema(rule.paramsSchema)) {
+    const result = rule.paramsSchema.safeParse(params);
+    if (!result.success) {
+      throw new InputError('Parameters to rule are invalid', result.error);
+    }
+  } else if (rule.paramsSchema) {
+    assertPermissionRuleParamsSchema(rule);
   }
 }
 
@@ -92,12 +113,16 @@ export function validatePermissionRuleParams(
 export function permissionRuleParamsToJsonSchema(
   rule: RuleWithParamsSchema,
 ): ReturnType<typeof zodToJsonSchema> {
-  if (rule.params?.schema) {
-    assertPermissionRuleParamsSchema(rule);
-    return rule.params.schema['~standard'].jsonSchema.input({
+  if (supportsJsonSchema(rule.paramsSchema)) {
+    return rule.paramsSchema['~standard'].jsonSchema.input({
       target: 'draft-07',
     }) as ReturnType<typeof zodToJsonSchema>;
   }
 
-  return zodToJsonSchema(rule.paramsSchema ?? z.object({}));
+  if (isZodSchema(rule.paramsSchema)) {
+    return zodToJsonSchema(rule.paramsSchema);
+  }
+
+  assertPermissionRuleParamsSchema(rule);
+  return zodToJsonSchema(z.object({}));
 }

--- a/plugins/permission-node/src/integration/permissionRuleParams.ts
+++ b/plugins/permission-node/src/integration/permissionRuleParams.ts
@@ -42,6 +42,7 @@ function supportsJsonSchema(
   return typeof standard.jsonSchema?.input === 'function';
 }
 
+/** Ensures that a rule parameter schema can be serialized as permission metadata. */
 export function assertPermissionRuleParamsSchema(
   rule: RuleWithParamsSchema,
 ): asserts rule is RuleWithParamsSchema & {
@@ -54,6 +55,10 @@ export function assertPermissionRuleParamsSchema(
   }
 }
 
+/**
+ * Validates rule parameters using either the Standard Schema or legacy Zod schema.
+ * Standard Schema validation must be synchronous because rule evaluation is synchronous.
+ */
 export function validatePermissionRuleParams(
   rule: RuleWithParamsSchema,
   params: unknown,
@@ -80,6 +85,7 @@ export function validatePermissionRuleParams(
   }
 }
 
+/** Converts a rule parameter schema to JSON Schema for permission metadata. */
 export function permissionRuleParamsToJsonSchema(
   rule: RuleWithParamsSchema,
 ): ReturnType<typeof zodToJsonSchema> {

--- a/plugins/permission-node/src/integration/permissionRuleParams.ts
+++ b/plugins/permission-node/src/integration/permissionRuleParams.ts
@@ -15,6 +15,7 @@
  */
 
 import { InputError } from '@backstage/errors';
+import { isPromise } from '@internal/backend';
 import type { StandardSchemaV1 } from '@standard-schema/spec';
 import { z } from 'zod/v3';
 import zodToJsonSchema from 'zod-to-json-schema';
@@ -44,15 +45,6 @@ function supportsJsonSchema(
   return typeof standard?.jsonSchema?.input === 'function';
 }
 
-function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
-  return (
-    value !== null &&
-    (typeof value === 'object' || typeof value === 'function') &&
-    'then' in value &&
-    typeof value.then === 'function'
-  );
-}
-
 /** Ensures that a rule parameter schema can be serialized as permission metadata. */
 export function assertPermissionRuleParamsSchema(
   rule: RuleWithParamsSchema,
@@ -76,7 +68,7 @@ export function validatePermissionRuleParams(
 ): void {
   if (rule.params?.schema) {
     const result = rule.params.schema['~standard'].validate(params);
-    if (isPromiseLike(result)) {
+    if (isPromise(result)) {
       throw new Error(
         `Permission rule '${rule.name}' parameter schema returned a Promise; async schemas are not supported`,
       );

--- a/plugins/permission-node/src/integration/permissionRuleParams.ts
+++ b/plugins/permission-node/src/integration/permissionRuleParams.ts
@@ -36,10 +36,21 @@ type StandardSchemaWithJsonSchemaInput = StandardSchemaV1 & {
 function supportsJsonSchema(
   schema: StandardSchemaV1,
 ): schema is StandardSchemaWithJsonSchemaInput {
-  const standard = schema['~standard'] as unknown as {
-    jsonSchema?: { input?: unknown };
-  };
-  return typeof standard.jsonSchema?.input === 'function';
+  const standard = schema['~standard'] as unknown as
+    | {
+        jsonSchema?: { input?: unknown };
+      }
+    | undefined;
+  return typeof standard?.jsonSchema?.input === 'function';
+}
+
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return (
+    value !== null &&
+    (typeof value === 'object' || typeof value === 'function') &&
+    'then' in value &&
+    typeof value.then === 'function'
+  );
 }
 
 /** Ensures that a rule parameter schema can be serialized as permission metadata. */
@@ -65,7 +76,7 @@ export function validatePermissionRuleParams(
 ): void {
   if (rule.params?.schema) {
     const result = rule.params.schema['~standard'].validate(params);
-    if (result instanceof Promise) {
+    if (isPromiseLike(result)) {
       throw new Error(
         `Permission rule '${rule.name}' parameter schema returned a Promise; async schemas are not supported`,
       );

--- a/plugins/permission-node/src/integration/permissionRuleParams.ts
+++ b/plugins/permission-node/src/integration/permissionRuleParams.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { InputError } from '@backstage/errors';
+import type { StandardSchemaV1 } from '@standard-schema/spec';
+import { z } from 'zod/v3';
+import zodToJsonSchema from 'zod-to-json-schema';
+
+type RuleWithParamsSchema = {
+  name: string;
+  params?: { schema: StandardSchemaV1 };
+  paramsSchema?: z.ZodSchema<any>;
+};
+
+type StandardSchemaWithJsonSchemaInput = StandardSchemaV1 & {
+  '~standard': {
+    jsonSchema: {
+      input(options: { target: 'draft-07' }): Record<string, unknown>;
+    };
+  };
+};
+
+function supportsJsonSchema(
+  schema: StandardSchemaV1,
+): schema is StandardSchemaWithJsonSchemaInput {
+  const standard = schema['~standard'] as unknown as {
+    jsonSchema?: { input?: unknown };
+  };
+  return typeof standard.jsonSchema?.input === 'function';
+}
+
+export function assertPermissionRuleParamsSchema(
+  rule: RuleWithParamsSchema,
+): asserts rule is RuleWithParamsSchema & {
+  params?: { schema: StandardSchemaWithJsonSchemaInput };
+} {
+  if (rule.params?.schema && !supportsJsonSchema(rule.params.schema)) {
+    throw new Error(
+      `Permission rule '${rule.name}' parameter schema does not support JSON Schema conversion`,
+    );
+  }
+}
+
+export function validatePermissionRuleParams(
+  rule: RuleWithParamsSchema,
+  params: unknown,
+): void {
+  if (rule.params?.schema) {
+    const result = rule.params.schema['~standard'].validate(params);
+    if (result instanceof Promise) {
+      throw new Error(
+        `Permission rule '${rule.name}' parameter schema returned a Promise; async schemas are not supported`,
+      );
+    }
+    if (result.issues) {
+      throw new InputError(
+        'Parameters to rule are invalid',
+        new Error(result.issues.map(issue => issue.message).join('; ')),
+      );
+    }
+    return;
+  }
+
+  const result = rule.paramsSchema?.safeParse(params);
+  if (result && !result.success) {
+    throw new InputError('Parameters to rule are invalid', result.error);
+  }
+}
+
+export function permissionRuleParamsToJsonSchema(
+  rule: RuleWithParamsSchema,
+): ReturnType<typeof zodToJsonSchema> {
+  if (rule.params?.schema) {
+    assertPermissionRuleParamsSchema(rule);
+    return rule.params.schema['~standard'].jsonSchema.input({
+      target: 'draft-07',
+    }) as ReturnType<typeof zodToJsonSchema>;
+  }
+
+  return zodToJsonSchema(rule.paramsSchema ?? z.object({}));
+}

--- a/plugins/permission-node/src/types.ts
+++ b/plugins/permission-node/src/types.ts
@@ -18,7 +18,10 @@ import type {
   PermissionCriteria,
   PermissionRuleParams,
 } from '@backstage/plugin-permission-common';
-import type { StandardSchemaV1 } from '@standard-schema/spec';
+import type {
+  StandardJSONSchemaV1,
+  StandardSchemaV1,
+} from '@standard-schema/spec';
 import { z } from 'zod/v3';
 
 /**
@@ -75,18 +78,15 @@ export type PermissionRule<
        * A Standard Schema that reflects the structure of the parameters that are passed to the rule.
        * The schema must validate synchronously and support JSON Schema conversion.
        */
-      params?: { schema: StandardSchemaV1<TParams> };
-      paramsSchema?: never;
+      paramsSchema?: StandardSchemaV1<TParams> & StandardJSONSchemaV1<TParams>;
     }
   | {
-      params?: never;
-
       /**
        * A ZodSchema that reflects the structure of the parameters that are passed to the rule.
        *
-       * @deprecated Use `params.schema` instead.
+       * @deprecated Zod v3 is deprecated, switch to a JSON Schema-compatible Standard Schema instead, such as Zod v4.
        */
-      paramsSchema?: z.ZodSchema<TParams>;
+      paramsSchema: z.ZodSchema<TParams>;
     }
 );
 

--- a/plugins/permission-node/src/types.ts
+++ b/plugins/permission-node/src/types.ts
@@ -18,6 +18,7 @@ import type {
   PermissionCriteria,
   PermissionRuleParams,
 } from '@backstage/plugin-permission-common';
+import type { StandardSchemaV1 } from '@standard-schema/spec';
 import { z } from 'zod/v3';
 
 /**
@@ -56,11 +57,6 @@ export type PermissionRule<
   resourceType: TResourceType;
 
   /**
-   * A ZodSchema that reflects the structure of the parameters that are passed to
-   */
-  paramsSchema?: z.ZodSchema<TParams>;
-
-  /**
    * Apply this rule to a resource already loaded from a backing data source. The params are
    * arguments supplied for the rule; for example, a rule could be `isOwner` with entityRefs as the
    * params.
@@ -73,7 +69,26 @@ export type PermissionRule<
    * applied.
    */
   toQuery(params: NoInfer<TParams>): PermissionCriteria<TQuery>;
-};
+} & (
+  | {
+      /**
+       * A Standard Schema that reflects the structure of the parameters that are passed to the rule.
+       * The schema must support JSON Schema conversion.
+       */
+      params?: { schema: StandardSchemaV1<TParams> };
+      paramsSchema?: never;
+    }
+  | {
+      params?: never;
+
+      /**
+       * A ZodSchema that reflects the structure of the parameters that are passed to the rule.
+       *
+       * @deprecated Use `params.schema` instead.
+       */
+      paramsSchema?: z.ZodSchema<TParams>;
+    }
+);
 
 /**
  * A set of registered rules for a particular resource type.

--- a/plugins/permission-node/src/types.ts
+++ b/plugins/permission-node/src/types.ts
@@ -73,7 +73,7 @@ export type PermissionRule<
   | {
       /**
        * A Standard Schema that reflects the structure of the parameters that are passed to the rule.
-       * The schema must support JSON Schema conversion.
+       * The schema must validate synchronously and support JSON Schema conversion.
        */
       params?: { schema: StandardSchemaV1<TParams> };
       paramsSchema?: never;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6176,6 +6176,7 @@ __metadata:
     "@backstage/config": "workspace:^"
     "@backstage/errors": "workspace:^"
     "@backstage/plugin-permission-common": "workspace:^"
+    "@standard-schema/spec": "npm:^1.1.0"
     "@types/express": "npm:^4.17.6"
     "@types/supertest": "npm:^2.0.8"
     express: "npm:^4.22.0"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds Standard Schema-compatible permission rule parameter schemas through params.schema, while retaining the deprecated Zod v3 paramsSchema option for compatibility. Standard Schema inputs are validated synchronously and must support draft-07 JSON Schema conversion for permission metadata.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a Signed-off-by line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))