### PR TITLE
fix: update remaining HomePageTopVisited references to HomePageMostVisited

### DIFF
--- a/packages/app-legacy/src/components/home/CustomizableHomePage.tsx
+++ b/packages/app-legacy/src/components/home/CustomizableHomePage.tsx
@@ -47,7 +47,7 @@ const defaultConfig = [
     height: 4,
   },
   {
-    component: 'HomePageTopVisited',
+    component: 'HomePageMostVisited',
     x: 5,
     y: 1,
     width: 5,

--- a/packages/app-legacy/src/components/home/CustomizableHomePage.tsx
+++ b/packages/app-legacy/src/components/home/CustomizableHomePage.tsx
@@ -47,7 +47,7 @@ const defaultConfig = [
     height: 4,
   },
   {
-    component: 'HomePageMostVisited',
+    component: 'HomePageTopVisited',
     x: 5,
     y: 1,
     width: 5,

--- a/packages/create-app/templates/default-app/app-config.yaml.hbs
+++ b/packages/create-app/templates/default-app/app-config.yaml.hbs
@@ -85,7 +85,7 @@ app:
               row: 6
               width: 4
               height: 3
-            - component: HomePageTopVisited
+            - component: HomePageMostVisited
               column: 4
               row: 9
               width: 4


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Follow-up to #35132 — spotted an additional `HomePageTopVisited` string reference that was missed when updating the demo site. Updates it to `HomePageMostVisited` in the `create-app` default template.

No changeset needed as this is a follow-up to unreleased changes.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))