### PR TITLE
Devtools external deps bui migration

### DIFF
--- a/.changeset/smart-owls-migrate.md
+++ b/.changeset/smart-owls-migrate.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-devtools': patch
+---
+
+Migrated the external dependencies table on the DevTools page to use the Backstage UI `Table` component instead of the legacy Material UI table.

--- a/plugins/devtools/src/components/Content/ExternalDependenciesContent/ExternalDependenciesContent.tsx
+++ b/plugins/devtools/src/components/Content/ExternalDependenciesContent/ExternalDependenciesContent.tsx
@@ -23,7 +23,6 @@ import {
 import { ExternalDependency } from '@backstage/plugin-devtools-common';
 import {
   Alert,
-  Box,
   Cell,
   CellText,
   ColumnConfig,
@@ -86,49 +85,44 @@ export const ExternalDependenciesContent = () => {
     },
   });
 
-  const columns: ColumnConfig<ExternalDependencyRow>[] = [
-    {
-      id: 'name',
-      label: 'Name',
-      isRowHeader: true,
-      cell: item => <CellText title={item.name} />,
-    },
-    {
-      id: 'target',
-      label: 'Target',
-      cell: item => <CellText title={item.target} />,
-    },
-    {
-      id: 'type',
-      label: 'Type',
-      cell: item => <CellText title={item.type} />,
-    },
-    {
-      id: 'status',
-      label: 'Status',
-      cell: item => (
-        <Cell>
-          <Flex direction="column" gap="0.5">
-            <Text as="span">{getExternalDependencyStatus(item)}</Text>
-            {item.error && <Text as="span">{item.error}</Text>}
-          </Flex>
-        </Cell>
-      ),
-    },
-  ];
+  const columns = useMemo<ColumnConfig<ExternalDependencyRow>[]>(
+    () => [
+      {
+        id: 'name',
+        label: 'Name',
+        isRowHeader: true,
+        cell: item => <CellText title={item.name} />,
+      },
+      {
+        id: 'target',
+        label: 'Target',
+        cell: item => <CellText title={item.target} />,
+      },
+      {
+        id: 'type',
+        label: 'Type',
+        cell: item => <CellText title={item.type} />,
+      },
+      {
+        id: 'status',
+        label: 'Status',
+        cell: item => (
+          <Cell>
+            <Flex direction="column" gap="0.5">
+              {getExternalDependencyStatus(item)}
+              {item.error && <Text as="span">{item.error}</Text>}
+            </Flex>
+          </Cell>
+        ),
+      },
+    ],
+    [],
+  );
 
   if (loading) {
     return <Progress />;
   } else if (error) {
     return <Alert status="danger" description={error.message} />;
-  }
-
-  if (!externalDependencies || externalDependencies.length === 0) {
-    return (
-      <Box p="4">
-        <Text as="p">No external dependencies found</Text>
-      </Box>
-    );
   }
 
   return (

--- a/plugins/devtools/src/components/Content/ExternalDependenciesContent/ExternalDependenciesContent.tsx
+++ b/plugins/devtools/src/components/Content/ExternalDependenciesContent/ExternalDependenciesContent.tsx
@@ -71,7 +71,7 @@ export const ExternalDependenciesContent = () => {
     () =>
       (externalDependencies ?? []).map(dependency => ({
         ...dependency,
-        id: dependency.name,
+        id: `${dependency.name}:${dependency.type}:${dependency.target}`,
       })),
     [externalDependencies],
   );

--- a/plugins/devtools/src/components/Content/ExternalDependenciesContent/ExternalDependenciesContent.tsx
+++ b/plugins/devtools/src/components/Content/ExternalDependenciesContent/ExternalDependenciesContent.tsx
@@ -19,25 +19,21 @@ import {
   StatusError,
   StatusOK,
   StatusWarning,
-  Table,
-  TableColumn,
 } from '@backstage/core-components';
 import { ExternalDependency } from '@backstage/plugin-devtools-common';
-import Box from '@material-ui/core/Box';
-import Grid from '@material-ui/core/Grid';
-import Paper from '@material-ui/core/Paper';
-import Typography from '@material-ui/core/Typography';
-import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
-import Alert from '@material-ui/lab/Alert';
+import {
+  Alert,
+  Box,
+  Cell,
+  CellText,
+  ColumnConfig,
+  Flex,
+  Table,
+  Text,
+  useTable,
+} from '@backstage/ui';
+import { useMemo } from 'react';
 import { useExternalDependencies } from '../../../hooks';
-
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    paperStyle: {
-      padding: theme.spacing(2),
-    },
-  }),
-);
 
 export const getExternalDependencyStatus = (
   result: Partial<ExternalDependency> | undefined,
@@ -45,91 +41,101 @@ export const getExternalDependencyStatus = (
   switch (result?.status) {
     case 'Healthy':
       return (
-        <Typography component="span">
+        <Text as="span">
           <StatusOK /> {result.status}
-        </Typography>
+        </Text>
       );
     case 'Unhealthy':
       return (
-        <Typography component="span">
+        <Text as="span">
           <StatusError /> {`${result.status}`}
-        </Typography>
+        </Text>
       );
     case undefined:
     default:
       return (
-        <Typography component="span">
+        <Text as="span">
           <StatusWarning /> Unknown
-        </Typography>
+        </Text>
       );
   }
 };
 
-const columns: TableColumn[] = [
-  {
-    title: 'Name',
-    width: 'auto',
-    field: 'name',
-  },
-  {
-    title: 'Target',
-    width: 'auto',
-    field: 'target',
-  },
-  {
-    title: 'Type',
-    width: 'auto',
-    field: 'type',
-  },
-  {
-    title: 'Status',
-    width: 'auto',
-    render: (row: Partial<ExternalDependency>) => (
-      <Grid container direction="column">
-        <Grid item>
-          <Typography variant="button">
-            {getExternalDependencyStatus(row)}
-          </Typography>
-        </Grid>
-        <Grid item>{row.error && <Typography>{row.error}</Typography>}</Grid>
-      </Grid>
-    ),
-  },
-];
+type ExternalDependencyRow = ExternalDependency & { id: string };
 
 /** @public */
 export const ExternalDependenciesContent = () => {
-  const classes = useStyles();
   const { externalDependencies, loading, error } = useExternalDependencies();
+
+  const rows = useMemo<ExternalDependencyRow[]>(
+    () =>
+      (externalDependencies ?? []).map(dependency => ({
+        ...dependency,
+        id: dependency.name,
+      })),
+    [externalDependencies],
+  );
+
+  const { tableProps } = useTable({
+    mode: 'complete',
+    data: rows,
+    paginationOptions: {
+      type: 'page',
+      pageSize: 20,
+      pageSizeOptions: [20, 50, 100],
+    },
+  });
+
+  const columns: ColumnConfig<ExternalDependencyRow>[] = [
+    {
+      id: 'name',
+      label: 'Name',
+      isRowHeader: true,
+      cell: item => <CellText title={item.name} />,
+    },
+    {
+      id: 'target',
+      label: 'Target',
+      cell: item => <CellText title={item.target} />,
+    },
+    {
+      id: 'type',
+      label: 'Type',
+      cell: item => <CellText title={item.type} />,
+    },
+    {
+      id: 'status',
+      label: 'Status',
+      cell: item => (
+        <Cell>
+          <Flex direction="column" gap="0.5">
+            <Text as="span">{getExternalDependencyStatus(item)}</Text>
+            {item.error && <Text as="span">{item.error}</Text>}
+          </Flex>
+        </Cell>
+      ),
+    },
+  ];
 
   if (loading) {
     return <Progress />;
   } else if (error) {
-    return <Alert severity="error">{error.message}</Alert>;
+    return <Alert status="danger" description={error.message} />;
   }
 
   if (!externalDependencies || externalDependencies.length === 0) {
     return (
-      <Box>
-        <Paper className={classes.paperStyle}>
-          <Typography>No external dependencies found</Typography>
-        </Paper>
+      <Box p="4">
+        <Text as="p">No external dependencies found</Text>
       </Box>
     );
   }
 
   return (
     <Table
-      title="Status"
-      options={{
-        paging: true,
-        pageSize: 20,
-        pageSizeOptions: [20, 50, 100],
-        loadingType: 'linear',
-        showEmptyDataSourceMessage: !loading,
-      }}
-      columns={columns}
-      data={externalDependencies || []}
+      columnConfig={columns}
+      {...tableProps}
+      emptyState={<Text as="p">No external dependencies found</Text>}
     />
   );
 };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Participating in TD OSPO Hackathon :)

Issue: https://github.com/backstage/backstage/issues/32746

Migrated ExternalDependenciesContent in the DevTools plugin from Material UI to Backstage UI (per the migration ticket issue). 

Swapped out MUI's Table, Alert, Box, Grid, Typography, and makeStyles for BUI's Table/useTable, Alert, Box, Flex, Text, CellText, and Cell. Loading, error, empty, and populated states all work the same as before, just rebuilt with BUI primitives and ColumnConfig.


Screenshots of UI after changes made:
<img width="2006" height="1297" alt="image" src="https://github.com/user-attachments/assets/ff93538a-8171-4330-b8b2-21416122191b" />
<img width="2009" height="1308" alt="image" src="https://github.com/user-attachments/assets/13ec97db-2aba-41a1-bf56-36e2eba6b3f7" />

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [X] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
