### PR TITLE
fix(ci): auto-accept Chromatic baselines on master

### DIFF
--- a/.github/workflows/verify_chromatic.yml
+++ b/.github/workflows/verify_chromatic.yml
@@ -57,6 +57,7 @@ jobs:
           # https://www.chromatic.com/docs/custom-ci-provider#run-chromatic-on-external-forks-of-open-source-projects
           projectToken: chpt_dab72dc0f97d55b
           storybookBuildDir: dist-storybook
+          autoAcceptChanges: master
           onlyChanged: true
           externals: |
             packages/ui/**/*.css


### PR DESCRIPTION
## Summary

- Add `autoAcceptChanges: master` to the Chromatic GitHub Action config

Without this flag, Chromatic runs on master after merge but does not accept snapshots as baselines. This has caused every PR since #34976 (which added 556 new stories) to report them as "556 new stories" instead of showing visual diffs against the accepted baseline.

## Test plan

- [ ] Merge this PR and verify the Chromatic build on master auto-accepts all snapshots
- [ ] Open a subsequent PR that touches a story and confirm it shows a visual diff (not "new")