### PR TITLE
Add `package schema openapi validate` command

### DIFF
--- a/.changeset/openapi-validate-command.md
+++ b/.changeset/openapi-validate-command.md
@@ -1,0 +1,5 @@
+---
+'@backstage/repo-tools': patch
+---
+
+Added a new `package schema openapi validate` command to validate that an OpenAPI spec is a valid OpenAPI 3.x document.

--- a/.changeset/openapi-validate-command.md
+++ b/.changeset/openapi-validate-command.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/repo-tools': patch
+'@backstage/repo-tools': minor
 ---
 
-Added a new `package schema openapi validate` command to validate that an OpenAPI spec is a valid OpenAPI 3.x document.
+**BREAKING**: Renamed the `repo schema openapi verify` command to `repo schema openapi validate`. Added a new `package schema openapi validate` command to validate that an OpenAPI spec is a valid OpenAPI 3.x document.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,8 +129,8 @@ jobs:
       - name: lint openapi yaml files
         run: yarn backstage-repo-tools repo schema openapi lint
 
-      - name: verify openapi yaml file matches generated ts file
-        run: yarn backstage-repo-tools repo schema openapi verify
+      - name: validate openapi yaml file matches generated ts file
+        run: yarn backstage-repo-tools repo schema openapi validate
 
       - name: verify doc links
         run: node scripts/verify-links.js

--- a/docs/.well-known/skills/onboard-to-openapi-server/SKILL.md
+++ b/docs/.well-known/skills/onboard-to-openapi-server/SKILL.md
@@ -91,10 +91,16 @@ Conventions to follow:
 Validate the spec is well-formed:
 
 ```
+yarn --cwd <plugin-dir> backstage-repo-tools package schema openapi validate
+```
+
+Then lint for style and best-practice issues:
+
+```
 yarn backstage-repo-tools repo schema openapi lint <plugin-dir>/src/schema/openapi.yaml
 ```
 
-Iterate on lint output until clean.
+Iterate on validation and lint output until clean.
 
 ### Step 4 — Wire up dependencies and the `generate` script
 

--- a/docs/.well-known/skills/onboard-to-openapi-server/SKILL.md
+++ b/docs/.well-known/skills/onboard-to-openapi-server/SKILL.md
@@ -97,7 +97,7 @@ yarn --cwd <plugin-dir> backstage-repo-tools package schema openapi validate
 Then lint for style and best-practice issues:
 
 ```
-yarn backstage-repo-tools repo schema openapi lint <plugin-dir>/src/schema/openapi.yaml
+yarn backstage-repo-tools repo schema openapi lint <plugin-dir>
 ```
 
 Iterate on validation and lint output until clean.

--- a/docs/openapi/01-getting-started.md
+++ b/docs/openapi/01-getting-started.md
@@ -50,6 +50,22 @@ You should create a new folder, `src/schema` in your backend plugin to store you
 
 > Currently, only the `.yaml` extension is supported, not `.yml`.
 
+## Validating your spec
+
+After writing your `openapi.yaml`, you can validate that it is a structurally valid OpenAPI 3.x document by running the following command from your plugin directory:
+
+```bash
+yarn backstage-repo-tools package schema openapi validate
+```
+
+This checks that the spec parses correctly and conforms to the OpenAPI specification. It is a good idea to run this before generating any code from the spec.
+
+For style and best-practice linting, you can additionally run:
+
+```bash
+yarn backstage-repo-tools repo schema openapi lint
+```
+
 ## Generating a typed express router from a spec
 
 Run `yarn backstage-repo-tools package schema openapi generate --server` from the directory with your plugin. This will create a `router.ts` file in the `src/schema/openapi/generated` directory that contains the OpenAPI schema as well as a factory function for a generated express router with types that match your schema.

--- a/packages/repo-tools/cli-report.md
+++ b/packages/repo-tools/cli-report.md
@@ -226,7 +226,7 @@ Commands:
   fuzz [options]
   help [command]
   lint [options] [paths...]
-  verify [paths...]
+  validate [paths...]
 ```
 
 ### `backstage-repo-tools repo schema openapi diff`
@@ -259,10 +259,10 @@ Options:
   -h, --help
 ```
 
-### `backstage-repo-tools repo schema openapi verify`
+### `backstage-repo-tools repo schema openapi validate`
 
 ```
-Usage: backstage-repo-tools repo schema openapi verify [options] [paths...]
+Usage: backstage-repo-tools repo schema openapi validate [options] [paths...]
 
 Options:
   -h, --help

--- a/packages/repo-tools/cli-report.md
+++ b/packages/repo-tools/cli-report.md
@@ -138,6 +138,7 @@ Commands:
   fuzz [options]
   generate [options]
   help [command]
+  validate
 ```
 
 ### `backstage-repo-tools package schema openapi fuzz`
@@ -164,6 +165,15 @@ Options:
   --server
   --server-additional-properties [properties]
   --watch
+  -h, --help
+```
+
+### `backstage-repo-tools package schema openapi validate`
+
+```
+Usage: backstage-repo-tools package schema openapi validate [options]
+
+Options:
   -h, --help
 ```
 

--- a/packages/repo-tools/src/commands/index.ts
+++ b/packages/repo-tools/src/commands/index.ts
@@ -113,6 +113,17 @@ function registerRepoCommand(program: Command) {
     );
 
   openApiCommand
+    .command('verify', { hidden: true })
+    .description('Deprecated: use validate instead.')
+    .action(async () => {
+      exitWithError(
+        new Error(
+          `This command has been removed, use 'repo schema openapi validate' instead`,
+        ),
+      );
+    });
+
+  openApiCommand
     .command('lint [paths...]')
     .description('Lint OpenAPI schemas.')
     .option(

--- a/packages/repo-tools/src/commands/index.ts
+++ b/packages/repo-tools/src/commands/index.ts
@@ -104,11 +104,13 @@ function registerRepoCommand(program: Command) {
     .description('Tooling for OpenApi schema');
 
   openApiCommand
-    .command('verify [paths...]')
+    .command('validate [paths...]')
     .description(
-      'Verify that all OpenAPI schemas are valid and set up correctly.',
+      'Validate that all OpenAPI schemas are valid and set up correctly.',
     )
-    .action(lazy(() => import('./repo/schema/openapi/verify'), 'bulkCommand'));
+    .action(
+      lazy(() => import('./repo/schema/openapi/validate'), 'bulkCommand'),
+    );
 
   openApiCommand
     .command('lint [paths...]')

--- a/packages/repo-tools/src/commands/index.ts
+++ b/packages/repo-tools/src/commands/index.ts
@@ -59,6 +59,13 @@ function registerPackageCommand(program: Command) {
     .action(lazy(() => import('./package/schema/openapi/generate'), 'command'));
 
   openApiCommand
+    .command('validate')
+    .description(
+      'Validate that the OpenAPI spec is a valid OpenAPI 3.x document.',
+    )
+    .action(lazy(() => import('./package/schema/openapi/validate'), 'command'));
+
+  openApiCommand
     .command('fuzz')
     .description(
       'Fuzz an OpenAPI schema by generating random data and sending it to the server.',

--- a/packages/repo-tools/src/commands/package/schema/openapi/validate.ts
+++ b/packages/repo-tools/src/commands/package/schema/openapi/validate.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import chalk from 'chalk';
+import {
+  getPathToCurrentOpenApiSpec,
+  loadAndValidateOpenApiYaml,
+} from '../../../../lib/openapi/helpers';
+
+export async function command() {
+  const resolvedOpenapiPath = await getPathToCurrentOpenApiSpec();
+
+  try {
+    await loadAndValidateOpenApiYaml(resolvedOpenapiPath);
+    console.log(chalk.green('OpenAPI spec is valid.'));
+  } catch (err) {
+    console.log(chalk.red('OpenAPI spec validation failed:'));
+    console.error(err);
+    process.exit(1);
+  }
+}

--- a/packages/repo-tools/src/commands/package/schema/openapi/validate.ts
+++ b/packages/repo-tools/src/commands/package/schema/openapi/validate.ts
@@ -21,9 +21,8 @@ import {
 } from '../../../../lib/openapi/helpers';
 
 export async function command() {
-  const resolvedOpenapiPath = await getPathToCurrentOpenApiSpec();
-
   try {
+    const resolvedOpenapiPath = await getPathToCurrentOpenApiSpec();
     await loadAndValidateOpenApiYaml(resolvedOpenapiPath);
     console.log(chalk.green('OpenAPI spec is valid.'));
   } catch (err) {

--- a/packages/repo-tools/src/commands/repo/schema/openapi/validate.ts
+++ b/packages/repo-tools/src/commands/repo/schema/openapi/validate.ts
@@ -31,7 +31,7 @@ import {
   loadAndValidateOpenApiYaml,
 } from '../../../../lib/openapi/helpers';
 
-async function verify(directoryPath: string) {
+async function validate(directoryPath: string) {
   let openapiPath = '';
   try {
     openapiPath = await getPathToOpenApiSpec(directoryPath);
@@ -68,7 +68,7 @@ async function verify(directoryPath: string) {
 }
 
 export async function bulkCommand(paths: string[] = []): Promise<void> {
-  const resultsList = await runner(paths, dir => verify(dir));
+  const resultsList = await runner(paths, dir => validate(dir));
 
   let failed = false;
   for (const { relativeDir, resultText } of resultsList) {
@@ -84,6 +84,6 @@ export async function bulkCommand(paths: string[] = []): Promise<void> {
   if (failed) {
     process.exit(1);
   } else {
-    console.log(chalk.green('Verified all files.'));
+    console.log(chalk.green('Validated all files.'));
   }
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

**BREAKING**: Renames the `repo schema openapi verify` command to `repo schema openapi validate`. Also adds a new `package schema openapi validate` command for per-package structural validation of OpenAPI 3.x specs.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))