### PR TITLE
feat(microsite): add GCP catalog provider to plugin directory

### DIFF
--- a/microsite/data/plugins/gcp-catalog-provider.yaml
+++ b/microsite/data/plugins/gcp-catalog-provider.yaml
@@ -1,0 +1,11 @@
+---
+title: GCP Catalog Provider
+author: Simon Bordeyne
+authorUrl: https://github.com/sbordeyne
+category: Catalog
+description: Import your GCP resources into Backstage as Resource entities, including relations and links.
+documentation: https://sbordeyne.github.io/backstage-plugins/dev/plugins/gcp-catalog-provider/
+iconUrl: https://avatars1.githubusercontent.com/u/2810941?s=280&v=4
+npmPackageName: '@sbordeyne/plugin-catalog-backend-module-gcp-provider'
+addedDate: '2026-08-13'
+status: active

--- a/microsite/data/plugins/gcp-catalog-provider.yaml
+++ b/microsite/data/plugins/gcp-catalog-provider.yaml
@@ -4,8 +4,7 @@ author: Simon Bordeyne
 authorUrl: https://github.com/sbordeyne
 category: Catalog
 description: Import your GCP resources into Backstage as Resource entities, including relations and links.
-documentation: https://sbordeyne.github.io/backstage-plugins/dev/plugins/gcp-catalog-provider/
-iconUrl: https://avatars1.githubusercontent.com/u/2810941?s=280&v=4
+documentation: https://github.com/sbordeyne/backstage-plugins/blob/master/plugins/catalog-backend-module-gcp-provider/README.md
 npmPackageName: '@sbordeyne/plugin-catalog-backend-module-gcp-provider'
 addedDate: '2026-08-13'
 status: active


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This adds the GCP Catalog Provider plugin to the backstage plugin directory.

The plugin differs from BackToStage's by supporting more resource types, linking entities to one another, giving the ability to the user to set namespaces, systems, owners on the generated entities and adding custom relations between entities representing IAM roles.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
