### PR TITLE
feat(catalog): add opt-in back button to entity page header

### DIFF
--- a/.changeset/entity-header-back-button.md
+++ b/.changeset/entity-header-back-button.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-catalog': minor
+'@backstage/ui': minor
+---
+
+Added an opt-in back button to the entity page header that navigates to the page the user came from. Enable it by passing `showBackButton` to `EntityHeaderBui` or `EntityLayoutBui`. The button uses the Navigation API to detect the entry point and remains stable across tab switches within the entity page.
+
+Added a `leadingAction` prop to the `Header` component that renders content inline before the tags row.

--- a/packages/ui/src/components/Header/Header.module.css
+++ b/packages/ui/src/components/Header/Header.module.css
@@ -23,6 +23,13 @@
     margin-bottom: 0;
   }
 
+  .bui-HeaderTop[data-has-leading] {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: var(--bui-space-2);
+  }
+
   .bui-HeaderBottom {
     display: flex;
     flex-direction: column;

--- a/packages/ui/src/components/Header/Header.tsx
+++ b/packages/ui/src/components/Header/Header.tsx
@@ -89,6 +89,7 @@ export const Header = (props: HeaderProps) => {
     tabs,
     activeTabId,
     customActions,
+    leadingAction,
     breadcrumbs,
     description,
     tags,
@@ -156,7 +157,9 @@ export const Header = (props: HeaderProps) => {
       <Container
         className={classes.headerTop}
         data-sticky={sticky || undefined}
+        data-has-leading={leadingAction ? '' : undefined}
       >
+        {leadingAction}
         {tags && tags.length > 0 && (
           <ul className={classes.tags}>
             {tags.map((tag, i) => (

--- a/packages/ui/src/components/Header/definition.ts
+++ b/packages/ui/src/components/Header/definition.ts
@@ -49,6 +49,7 @@ export const HeaderDefinition = defineComponent<HeaderOwnProps>()({
   propDefs: {
     title: {},
     customActions: {},
+    leadingAction: {},
     tabs: {},
     activeTabId: {},
     breadcrumbs: {},

--- a/packages/ui/src/components/Header/types.ts
+++ b/packages/ui/src/components/Header/types.ts
@@ -102,6 +102,10 @@ export interface HeaderMetadataStatusProps {
 export interface HeaderOwnProps {
   title?: string;
   customActions?: React.ReactNode;
+  /**
+   * Content rendered before the tags row, inline with the tags.
+   */
+  leadingAction?: React.ReactNode;
   tabs?: HeaderNavTabItem[];
   activeTabId?: string | null;
   /**

--- a/plugins/catalog/src/alpha/components/EntityHeader/EntityHeaderBui.test.tsx
+++ b/plugins/catalog/src/alpha/components/EntityHeader/EntityHeaderBui.test.tsx
@@ -67,10 +67,15 @@ async function renderHeader(options: {
   entity?: Entity;
   catalogEntities?: Entity[];
   catalogApi?: ReturnType<typeof catalogApiMock>;
+  showBackButton?: boolean;
 }) {
   return renderInTestApp(
     <EntityProvider entity={options.entity}>
-      <EntityHeaderBui tabs={[]} contextMenuItems={[]} />
+      <EntityHeaderBui
+        tabs={[]}
+        contextMenuItems={[]}
+        showBackButton={options.showBackButton}
+      />
     </EntityProvider>,
     {
       apis: [
@@ -87,7 +92,21 @@ async function renderHeader(options: {
   );
 }
 
+function mockNavigation(entries: { url: string }[], currentIndex: number) {
+  Object.defineProperty(window, 'navigation', {
+    value: {
+      currentEntry: { url: entries[currentIndex]?.url, index: currentIndex },
+      entries: () => entries.map((e, i) => ({ url: e.url, index: i })),
+    },
+    writable: true,
+    configurable: true,
+  });
+}
+
 describe('EntityHeaderBui', () => {
+  afterEach(() => {
+    delete (window as any).navigation;
+  });
   it('renders rich entity data from canonical relations', async () => {
     await renderHeader({
       entity: componentEntity,
@@ -136,5 +155,37 @@ describe('EntityHeaderBui', () => {
     expect(
       screen.getByRole('heading', { name: 'artist-lookup' }),
     ).toBeInTheDocument();
+  });
+
+  it('renders a back button inline with tags when showBackButton is enabled', async () => {
+    mockNavigation(
+      [
+        { url: 'http://localhost/ai-explorer?q=test' },
+        { url: 'http://localhost/catalog/default/component/artist-lookup' },
+      ],
+      1,
+    );
+
+    await renderHeader({
+      entity: componentEntity,
+      catalogEntities: [componentEntity, ownerEntity],
+      showBackButton: true,
+    });
+
+    expect(
+      await screen.findByRole('button', { name: 'Back to previous page' }),
+    ).toBeInTheDocument();
+  });
+
+  it('does not render a back button when no referrer exists', async () => {
+    await renderHeader({
+      entity: componentEntity,
+      catalogEntities: [componentEntity, ownerEntity],
+    });
+
+    await screen.findByRole('heading', { name: 'Artist Lookup' });
+    expect(
+      screen.queryByRole('button', { name: 'Back to previous page' }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/plugins/catalog/src/alpha/components/EntityHeader/EntityHeaderBui.tsx
+++ b/plugins/catalog/src/alpha/components/EntityHeader/EntityHeaderBui.tsx
@@ -15,6 +15,7 @@
  */
 
 import { useMemo } from 'react';
+import { useNavigate, useResolvedPath } from 'react-router-dom';
 import {
   Box,
   ButtonIcon,
@@ -44,13 +45,14 @@ import {
   useEntityRefLink,
   useStarredEntity,
 } from '@backstage/plugin-catalog-react';
-import { RiStarFill, RiStarLine } from '@remixicon/react';
+import { RiArrowLeftLine, RiStarFill, RiStarLine } from '@remixicon/react';
 import useAsync from 'react-use/esm/useAsync';
 import { catalogTranslationRef } from '../../translation';
 import {
   EntityContextMenu,
   type EntityContextMenuItemDataWithNode,
 } from '../EntityContextMenu';
+import { useEntryReferrer } from '../../hooks/useEntryReferrer';
 
 function useOwnerUsers(entity: Entity | undefined): HeaderMetadataUser[] {
   const catalogApi = useApi(catalogApiRef);
@@ -186,16 +188,32 @@ export function EntityHeaderBui(props: {
   tabs: HeaderNavTabItem[];
   activeTabId?: string;
   contextMenuItems?: EntityContextMenuItemDataWithNode[];
+  showBackButton?: boolean;
 }) {
   const { entity } = useAsyncEntity();
   const routeParams = useRouteRefParams(entityRouteRef);
   const presentation = useEntityPresentation(entity ?? routeParams);
   const metadata = useMetadata(entity);
   const type = entity?.spec?.type?.toString();
+  const navigate = useNavigate();
+  const entityBasePath = useResolvedPath('.').pathname;
+  const detectedReferrer = useEntryReferrer(entityBasePath);
+  const referrer = props.showBackButton ? detectedReferrer : undefined;
 
   return (
     <Header
       title={presentation.primaryTitle}
+      leadingAction={
+        referrer ? (
+          <ButtonIcon
+            size="small"
+            variant="tertiary"
+            aria-label="Back to previous page"
+            icon={<RiArrowLeftLine />}
+            onPress={() => navigate(referrer)}
+          />
+        ) : undefined
+      }
       tags={[
         { label: entity?.kind ?? routeParams.kind },
         ...(type ? [{ label: type }] : []),

--- a/plugins/catalog/src/alpha/components/EntityLayout/EntityLayoutBui.tsx
+++ b/plugins/catalog/src/alpha/components/EntityLayout/EntityLayoutBui.tsx
@@ -152,6 +152,7 @@ export function EntityLayoutBui(props: {
   defaultContentOrder: 'title' | 'natural';
   contextMenuItems?: ComponentProps<typeof EntityHeaderBui>['contextMenuItems'];
   HeaderComponent?: ComponentType<EntityHeaderLayoutProps>;
+  showBackButton?: boolean;
 }) {
   const {
     routes,
@@ -160,6 +161,7 @@ export function EntityLayoutBui(props: {
     defaultContentOrder,
     contextMenuItems,
     HeaderComponent,
+    showBackButton,
   } = props;
   const { entity } = useAsyncEntity();
   const visibleRoutes = filterEntityLayoutRoutes(routes, entity);
@@ -179,6 +181,7 @@ export function EntityLayoutBui(props: {
           tabs={tabs.tabs}
           activeTabId={tabs.activeTabId}
           contextMenuItems={contextMenuItems}
+          showBackButton={showBackButton}
         />
       )}
       <EntityLayoutContent

--- a/plugins/catalog/src/alpha/hooks/useEntryReferrer.test.tsx
+++ b/plugins/catalog/src/alpha/hooks/useEntryReferrer.test.tsx
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { useEntryReferrer } from './useEntryReferrer';
+
+function mockNavigation(entries: { url: string }[], currentIndex: number) {
+  Object.defineProperty(window, 'navigation', {
+    value: {
+      currentEntry: { url: entries[currentIndex]?.url, index: currentIndex },
+      entries: () => entries.map((e, i) => ({ url: e.url, index: i })),
+    },
+    writable: true,
+    configurable: true,
+  });
+}
+
+function clearNavigation() {
+  delete (window as any).navigation;
+}
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <MemoryRouter>{children}</MemoryRouter>;
+}
+
+describe('useEntryReferrer', () => {
+  afterEach(clearNavigation);
+
+  it('returns the first entry outside the entity base path', () => {
+    mockNavigation(
+      [
+        { url: 'http://localhost/ai-explorer?q=test' },
+        { url: 'http://localhost/catalog/default/component/my-service' },
+        { url: 'http://localhost/catalog/default/component/my-service/ci-cd' },
+      ],
+      2,
+    );
+
+    const { result } = renderHook(
+      () => useEntryReferrer('/catalog/default/component/my-service'),
+      { wrapper },
+    );
+
+    expect(result.current).toBe('/ai-explorer?q=test');
+  });
+
+  it('returns undefined when all previous entries are within the entity', () => {
+    mockNavigation(
+      [
+        { url: 'http://localhost/catalog/default/component/my-service' },
+        { url: 'http://localhost/catalog/default/component/my-service/docs' },
+      ],
+      1,
+    );
+
+    const { result } = renderHook(
+      () => useEntryReferrer('/catalog/default/component/my-service'),
+      { wrapper },
+    );
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns undefined when the Navigation API is unavailable', () => {
+    clearNavigation();
+
+    const { result } = renderHook(
+      () => useEntryReferrer('/catalog/default/component/my-service'),
+      { wrapper },
+    );
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('skips entity tab entries to find the real referrer', () => {
+    mockNavigation(
+      [
+        { url: 'http://localhost/search?q=my+service' },
+        { url: 'http://localhost/catalog/default/component/my-service' },
+        { url: 'http://localhost/catalog/default/component/my-service/api' },
+        { url: 'http://localhost/catalog/default/component/my-service/docs' },
+        { url: 'http://localhost/catalog/default/component/my-service/ci-cd' },
+      ],
+      4,
+    );
+
+    const { result } = renderHook(
+      () => useEntryReferrer('/catalog/default/component/my-service'),
+      { wrapper },
+    );
+
+    expect(result.current).toBe('/search?q=my+service');
+  });
+
+  it('returns undefined when the entity page was opened directly', () => {
+    mockNavigation(
+      [{ url: 'http://localhost/catalog/default/component/my-service' }],
+      0,
+    );
+
+    const { result } = renderHook(
+      () => useEntryReferrer('/catalog/default/component/my-service'),
+      { wrapper },
+    );
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('recalculates when the entity base path changes', () => {
+    mockNavigation(
+      [
+        { url: 'http://localhost/ai-explorer' },
+        { url: 'http://localhost/catalog/default/component/service-a' },
+        { url: 'http://localhost/catalog/default/component/service-b' },
+      ],
+      2,
+    );
+
+    const { result, rerender } = renderHook(
+      ({ basePath }) => useEntryReferrer(basePath),
+      {
+        wrapper,
+        initialProps: {
+          basePath: '/catalog/default/component/service-b',
+        },
+      },
+    );
+
+    expect(result.current).toBe('/catalog/default/component/service-a');
+
+    rerender({ basePath: '/catalog/default/component/service-a' });
+
+    expect(result.current).toBe('/ai-explorer');
+  });
+});

--- a/plugins/catalog/src/alpha/hooks/useEntryReferrer.ts
+++ b/plugins/catalog/src/alpha/hooks/useEntryReferrer.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useRef } from 'react';
+
+interface NavigationEntry {
+  url: string | null;
+  index: number;
+}
+
+interface NavigationAPI {
+  currentEntry: NavigationEntry;
+  entries(): NavigationEntry[];
+}
+
+function getEntryReferrer(entityBasePath: string): string | undefined {
+  const nav = (window as any).navigation as NavigationAPI | undefined;
+  if (!nav) {
+    return undefined;
+  }
+
+  const entries = nav.entries();
+  const currentIndex = nav.currentEntry.index;
+
+  for (let i = currentIndex - 1; i >= 0; i--) {
+    const entry = entries[i];
+    if (!entry.url) {
+      continue;
+    }
+    try {
+      const parsed = new URL(entry.url);
+      if (!parsed.pathname.startsWith(entityBasePath)) {
+        return parsed.pathname + parsed.search + parsed.hash;
+      }
+    } catch {
+      // skip malformed URLs
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Returns the URL the user navigated from before arriving at the current
+ * entity page. Uses the Navigation API to walk backward through the
+ * session history and find the first entry whose path is outside the
+ * current entity page's base path.
+ *
+ * The value is captured once on mount and remains stable across tab
+ * switches within the entity page.
+ *
+ * Returns `undefined` when the Navigation API is unavailable or when
+ * there is no qualifying previous entry (e.g. the user opened the
+ * entity page directly).
+ */
+export function useEntryReferrer(entityBasePath: string): string | undefined {
+  const referrerRef = useRef<string | undefined | null>(null);
+
+  if (referrerRef.current === null) {
+    referrerRef.current = getEntryReferrer(entityBasePath);
+  }
+
+  // Reset when navigating to a different entity page
+  const basePathRef = useRef(entityBasePath);
+  if (basePathRef.current !== entityBasePath) {
+    basePathRef.current = entityBasePath;
+    referrerRef.current = getEntryReferrer(entityBasePath);
+  }
+
+  return referrerRef.current;
+}


### PR DESCRIPTION
- Adds a leadingAction prop to the Header component in @backstage/ui and an opt-in back button to entity pages that navigates to the page the user came from. Uses the Navigation API to capture the entry point, remaining stable across tab switches.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
