### PR TITLE
Fetch github repositories by splitting job into chunks

### DIFF
--- a/.changeset/github-org-repositories-in-chunks.md
+++ b/.changeset/github-org-repositories-in-chunks.md
@@ -1,0 +1,22 @@
+---
+'@backstage/plugin-catalog-backend-module-github': minor
+---
+
+Adds a new `queryLimits.repositoryChunkSize` configuration option for the GitHub repository provider, which allows fetching GitHub repositories in chunks (GraphQL client sessions). This helps fetch repositories in large organizations when the job fails with 502 errors (session timing out).
+
+The `allowArchived` filter is now applied directly in the GraphQL query, which speeds up the job.
+
+```yaml title="app-config.yaml"
+catalog:
+  providers:
+    customProviderId:
+      organization: 'new-org' # string
+      catalogPath: '/custom/path/catalog-info.yaml' # string
+      filters: # optional filters
+        branch: 'develop' # optional string
+        repository: '.*' # optional Regex
+      pageSizes:
+        repositories: 25
++     queryLimits:
++       repositoryChunkSize: 5000
+```

--- a/docs/integrations/github/discovery.md
+++ b/docs/integrations/github/discovery.md
@@ -254,6 +254,8 @@ catalog:
           repository: '.*' # optional Regex
         pageSizes:
           repositories: 25
+        queryLimits:
+          repositoryChunkSize: 5000
       wildcardProviderId:
         organization: 'new-org' # string
         catalogPath: '/groups/**/*.yaml' # this will search all folders for files that end in .yaml
@@ -356,6 +358,9 @@ If you do so, `default` will be used as provider ID.
   Configure page sizes for GitHub GraphQL API queries. This can help prevent `RESOURCE_LIMITS_EXCEEDED` errors.
   - **`repositories`** _(optional)_:
     Number of repositories to fetch per page. Defaults to `25`. Reduce this value if hitting API resource limits.
+- **`queryLimits`** _(optional)_: Configure limits for GitHub GraphQL API queries to make sure catalog jobs do not time out. This can happen if you have large organization and too many GraphQL request are executed in one session. Request headers timeout is 60 minutes, check if your jobs are reaching this limit.
+  - **`repositoryChunkSize`**: Number of repositories to fetch per chunk in a GraphQL client session. Set this if you are getting 502 errors. It probably means you have more repositories than you are able to fetch in one session.
+    (default: undefined - no chunking, fetch all repositories in one session)
 
 ## GitHub API Rate Limits
 

--- a/plugins/catalog-backend-module-github/config.d.ts
+++ b/plugins/catalog-backend-module-github/config.d.ts
@@ -143,6 +143,16 @@ export interface Config {
                */
               repositories?: number;
             };
+
+            queryLimits?: {
+              /**
+               * Number of repositories to fetch per chunk in a GraphQL client session.
+               * Set this if you are getting 502 errors.
+               * It probably means you have more repositories than you are able to fetch in one session.
+               * Default: `undefined` - no chunking, fetch all repositories in one session.
+               */
+              repositoryChunkSize?: number;
+            };
           }
         | {
             [name: string]: {

--- a/plugins/catalog-backend-module-github/src/lib/github.test.ts
+++ b/plugins/catalog-backend-module-github/src/lib/github.test.ts
@@ -972,6 +972,7 @@ describe('github', () => {
             visibility: 'private',
           },
         ],
+        nextCursor: undefined,
       };
 
       server.use(
@@ -1021,6 +1022,58 @@ describe('github', () => {
         undefined,
         'develop',
       );
+    });
+
+    it('passes startCursor and returns nextCursor when chunkSize is reached', async () => {
+      server.use(
+        graphqlMsw.query('repositories', ({ variables }) => {
+          if (variables.cursor === 'start-cursor') {
+            return HttpResponse.json({
+              data: {
+                repositoryOwner: {
+                  repositories: {
+                    pageInfo: { hasNextPage: true, endCursor: 'end-cursor' },
+                    nodes: [
+                      {
+                        name: 'repo1',
+                        url: 'https://github.com/my-org/repo1',
+                        isArchived: false,
+                        isFork: false,
+                        visibility: 'public',
+                        defaultBranchRef: { name: 'main' },
+                        catalogInfoFile: null,
+                        repositoryTopics: { nodes: [] },
+                      },
+                    ],
+                  },
+                },
+              },
+            });
+          }
+          return HttpResponse.json({
+            data: {
+              repositoryOwner: {
+                repositories: {
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                  nodes: [],
+                },
+              },
+            },
+          });
+        }),
+      );
+
+      const { repositories, nextCursor } = await getOrganizationRepositories(
+        graphql as any,
+        'my-org',
+        '/catalog-info.yaml',
+        undefined,
+        undefined,
+        { startCursor: 'start-cursor', chunkSize: 1 },
+      );
+
+      expect(repositories).toHaveLength(1);
+      expect(nextCursor).toBe('end-cursor');
     });
   });
 
@@ -1783,17 +1836,28 @@ describe('github', () => {
         }),
       );
 
-      await getOrganizationRepositories(
-        graphql as any,
-        org,
-        '/catalog-info.yaml',
-        {
+      await expect(
+        getOrganizationRepositories(graphql as any, org, '/catalog-info.yaml', {
           teams: 10,
           teamMembers: 20,
           organizationMembers: 30,
           repositories: 15,
-        },
-      );
+        }),
+      ).resolves.toEqual({
+        repositories: [
+          {
+            name: 'repo1',
+            url: 'https://github.com/my-org/repo1',
+            isArchived: false,
+            isFork: false,
+            visibility: 'public',
+            defaultBranchRef: { name: 'main' },
+            catalogInfoFile: null,
+            repositoryTopics: { nodes: [] },
+          },
+        ],
+        nextCursor: undefined,
+      });
     });
 
     it('uses default page sizes when not specified', async () => {

--- a/plugins/catalog-backend-module-github/src/lib/github.ts
+++ b/plugins/catalog-backend-module-github/src/lib/github.ts
@@ -67,6 +67,20 @@ export type GithubPageSizes = {
 };
 
 /**
+ * Configuration for GitHub GraphQL API
+ *
+ * @public
+ */
+export type GithubQueryLimits = {
+  /**
+   * Number of repositories to fetch per chunk in a GraphQL client session.
+   * Helps avoiding token expiration and 502 errors during long-running fetches.
+   * Default: undefined (no chunking, fetch all repositories in one session)
+   */
+  repositoryChunkSize?: number;
+};
+
+/**
  * Default page sizes for GitHub GraphQL API queries.
  * These values are reduced to prevent RESOURCE_LIMITS_EXCEEDED errors with large organizations.
  *
@@ -79,12 +93,21 @@ export const DEFAULT_PAGE_SIZES: GithubPageSizes = {
   repositories: 25,
 };
 
+export const DEFAULT_QUERY_LIMITS: GithubQueryLimits = {
+  repositoryChunkSize: undefined,
+};
+
 // Graphql types
 
 export type QueryResponse = {
   organization?: OrganizationResponse;
   repositoryOwner?: RepositoryOwnerResponse;
   user?: UserResponse;
+  rateLimit?: {
+    cost?: number;
+    remaining?: number;
+    resetAt?: string;
+  };
 };
 
 type RepositoryOwnerResponse = {
@@ -239,7 +262,7 @@ export async function getOrganizationUsers(
   // There is no user -> teams edge, so we leave the memberships empty for
   // now and let the team iteration handle it instead
 
-  const users = await queryWithPaging({
+  const { result: users } = await queryWithPaging({
     client,
     query,
     org,
@@ -339,7 +362,7 @@ export async function getOrganizationTeams(
     return await teamTransformer(team, ctx);
   };
 
-  const teams = await queryWithPaging({
+  const { result: teams } = await queryWithPaging({
     client,
     query,
     org,
@@ -434,7 +457,7 @@ export async function getOrganizationTeamsFromUsers(
     return await teamTransformer(team, ctx);
   };
 
-  const teams = await queryWithPaging({
+  const { result: teams } = await queryWithPaging({
     client,
     query,
     org,
@@ -493,7 +516,7 @@ export async function getOrganizationTeamsForUser(
     return await teamTransformer(team, ctx);
   };
 
-  const teams = await queryWithPaging({
+  const { result: teams } = await queryWithPaging({
     client,
     query,
     org,
@@ -521,7 +544,7 @@ export async function getOrganizationsFromUser(
     }
   }`;
 
-  const orgs = await queryWithPaging({
+  const { result: orgs } = await queryWithPaging({
     client,
     query,
     org: '',
@@ -620,7 +643,12 @@ export async function getOrganizationRepositories(
   catalogPath: string,
   pageSizes: GithubPageSizes = DEFAULT_PAGE_SIZES,
   branch?: string,
-): Promise<{ repositories: RepositoryResponse[] }> {
+  options?: {
+    allowArchived?: boolean;
+    startCursor?: string;
+    chunkSize?: number;
+  },
+): Promise<{ repositories: RepositoryResponse[]; nextCursor?: string }> {
   let relativeCatalogPathRef: string;
   // We must strip the leading slash or the query for objects does not work
   if (catalogPath.startsWith('/')) {
@@ -630,11 +658,19 @@ export async function getOrganizationRepositories(
   }
   const branchRef = branch ?? 'HEAD';
   const catalogPathRef = `${branchRef}:${relativeCatalogPathRef}`;
+  const allowArchived = options?.allowArchived ?? true;
+  const archivedFilter = allowArchived ? '' : ', isArchived: false';
+  const chunkSize = options?.chunkSize;
   const query = `
     query repositories($org: String!, $catalogPathRef: String!, $cursor: String, $repositoriesPageSize: Int!) {
+      rateLimit {
+        cost
+        remaining
+        resetAt
+      }
       repositoryOwner(login: $org) {
         login
-        repositories(first: $repositoriesPageSize, after: $cursor) {
+        repositories(first: $repositoriesPageSize, after: $cursor${archivedFilter}) {
           nodes {
             name
             catalogInfoFile: object(expression: $catalogPathRef) {
@@ -669,20 +705,24 @@ export async function getOrganizationRepositories(
       }
     }`;
 
-  const repositories = await queryWithPaging({
+  const { result: repositories, nextCursor } = await queryWithPaging({
     client,
     query,
     org,
-    connection: r => r.repositoryOwner?.repositories,
+    connection: r => r?.repositoryOwner?.repositories,
     transformer: async x => x,
     variables: {
       org,
       catalogPathRef,
-      repositoriesPageSize: pageSizes.repositories,
+      repositoriesPageSize: chunkSize
+        ? Math.min(pageSizes.repositories, chunkSize)
+        : pageSizes.repositories,
     },
+    startCursor: options?.startCursor,
+    chunkSize,
   });
 
-  return { repositories };
+  return { repositories, nextCursor };
 }
 
 export async function getOrganizationRepository(
@@ -770,7 +810,7 @@ export async function getTeamMembers(
       }
     }`;
 
-  const members = await queryWithPaging({
+  const { result: members } = await queryWithPaging({
     client,
     query,
     org,
@@ -818,13 +858,24 @@ export async function queryWithPaging<
   ) => Promise<OutputType | undefined>;
   variables: Variables;
   filter?: (item: GraphqlType) => Promise<boolean> | boolean;
-}): Promise<OutputType[]> {
-  const { client, query, org, connection, transformer, variables, filter } =
-    params;
+  startCursor?: string;
+  chunkSize?: number;
+}): Promise<{ result: OutputType[]; nextCursor?: string }> {
+  const {
+    client,
+    query,
+    org,
+    connection,
+    transformer,
+    variables,
+    startCursor,
+    chunkSize,
+    filter,
+  } = params;
   const result: OutputType[] = [];
   const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));
 
-  let cursor: string | undefined = undefined;
+  let cursor: string | undefined = startCursor;
   for (let j = 0; j < 1000 /* just for sanity */; ++j) {
     const response: Response = await client(query, {
       ...variables,
@@ -852,13 +903,19 @@ export async function queryWithPaging<
 
     if (!conn.pageInfo.hasNextPage) {
       break;
-    } else {
-      await sleep(1000);
-      cursor = conn.pageInfo.endCursor;
     }
+
+    // check if we reached the chunk size limit,
+    // then we return next cursor to know where to start in next chunk
+    if (chunkSize && result.length >= chunkSize) {
+      return { result, nextCursor: conn.pageInfo.endCursor };
+    }
+
+    await sleep(1000);
+    cursor = conn.pageInfo.endCursor;
   }
 
-  return result;
+  return { result, nextCursor: undefined };
 }
 
 export type DeferredEntitiesBuilder = (

--- a/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.test.ts
@@ -487,6 +487,11 @@ describe('GithubEntityProvider', () => {
       'catalog-custom.yaml',
       expect.any(Object),
       'backstage',
+      expect.objectContaining({
+        allowArchived: false,
+        startCursor: undefined,
+        chunkSize: undefined,
+      }),
     );
 
     const url = `https://github.com/test-org/another-repo/blob/backstage/catalog-custom.yaml`;
@@ -625,6 +630,120 @@ describe('GithubEntityProvider', () => {
     expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith({
       type: 'full',
       entities: expectedEntities,
+    });
+  });
+
+  it('chunks repository fetching when queryLimits.repositoryChunkSize is set', async () => {
+    const config = createSingleProviderConfig({
+      providerConfig: {
+        catalogPath: 'custom/path/catalog-custom.yaml',
+        filters: {
+          branch: 'main',
+        },
+        queryLimits: {
+          repositoryChunkSize: 1,
+        },
+      },
+    });
+    const schedule = new PersistingTaskRunner();
+    const entityProviderConnection: EntityProviderConnection = {
+      applyMutation: jest.fn(),
+      refresh: jest.fn(),
+    };
+
+    const provider = GithubEntityProvider.fromConfig(config, {
+      logger,
+      schedule,
+    })[0];
+
+    const mockGetOrganizationRepositories = jest.spyOn(
+      helpers,
+      'getOrganizationRepositories',
+    );
+
+    mockGetOrganizationRepositories
+      .mockResolvedValueOnce({
+        repositories: [
+          {
+            name: 'test-repo',
+            url: 'https://github.com/test-org/test-repo',
+            repositoryTopics: { nodes: [] },
+            isArchived: false,
+            isFork: false,
+            defaultBranchRef: { name: 'main' },
+            catalogInfoFile: {
+              __typename: 'Blob',
+              id: 'abc123',
+              text: 'some yaml',
+            },
+            visibility: 'public',
+          },
+        ],
+        nextCursor: 'cursor-1',
+      })
+      .mockResolvedValueOnce({
+        repositories: [
+          {
+            name: 'test-repo-2',
+            url: 'https://github.com/test-org/test-repo-2',
+            repositoryTopics: { nodes: [] },
+            isArchived: false,
+            isFork: false,
+            defaultBranchRef: { name: 'main' },
+            catalogInfoFile: {
+              __typename: 'Blob',
+              id: 'def456',
+              text: 'some yaml',
+            },
+            visibility: 'public',
+          },
+        ],
+        nextCursor: undefined,
+      });
+
+    await provider.connect(entityProviderConnection);
+
+    const taskDef = schedule.getTasks()[0];
+    await (taskDef.fn as () => Promise<void>)();
+
+    expect(mockGetOrganizationRepositories).toHaveBeenCalledTimes(2);
+    expect(mockGetOrganizationRepositories).toHaveBeenNthCalledWith(
+      1,
+      expect.anything(),
+      'test-org',
+      'custom/path/catalog-custom.yaml',
+      expect.any(Object),
+      'main',
+      expect.objectContaining({
+        allowArchived: false,
+        startCursor: undefined,
+        chunkSize: 1,
+      }),
+    );
+    expect(mockGetOrganizationRepositories).toHaveBeenNthCalledWith(
+      2,
+      expect.anything(),
+      'test-org',
+      'custom/path/catalog-custom.yaml',
+      expect.any(Object),
+      'main',
+      expect.objectContaining({
+        allowArchived: false,
+        startCursor: 'cursor-1',
+        chunkSize: 1,
+      }),
+    );
+    expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith({
+      type: 'full',
+      entities: expect.arrayContaining([
+        expect.objectContaining({
+          entity: expect.objectContaining({
+            spec: expect.objectContaining({
+              target: expect.stringContaining('test-repo'),
+            }),
+          }),
+        }),
+      ]),
     });
   });
 

--- a/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubEntityProvider.ts
@@ -260,29 +260,41 @@ export class GithubEntityProvider implements EntityProvider, EventSubscriber {
   private async findCatalogFiles(): Promise<Repository[]> {
     const organizations = await this.getOrganizations();
     const catalogPath = this.config.catalogPath;
+    const chunkSize = this.config.queryLimits?.repositoryChunkSize;
 
     let repositories: Repository[] = [];
     for (const organization of organizations) {
-      const client = await this.createGraphqlClient(organization);
-
       const pageSizes: GithubPageSizes = {
         ...DEFAULT_PAGE_SIZES,
         ...this.config.pageSizes,
       };
 
-      const { repositories: repositoriesFromGithub } =
-        await getOrganizationRepositories(
-          client,
-          organization,
-          catalogPath,
-          pageSizes,
-          this.config.filters.branch,
+      let startCursor: string | undefined = undefined;
+
+      do {
+        const client = await this.createGraphqlClient(organization);
+
+        const { repositories: repositoriesFromGithub, nextCursor } =
+          await getOrganizationRepositories(
+            client,
+            organization,
+            catalogPath,
+            pageSizes,
+            this.config.filters.branch,
+            {
+              allowArchived: this.config.filters.allowArchived,
+              startCursor,
+              chunkSize,
+            },
+          );
+        repositories = repositories.concat(
+          repositoriesFromGithub.map(r =>
+            this.createRepoFromGithubResponse(r, organization),
+          ),
         );
-      repositories = repositories.concat(
-        repositoriesFromGithub.map(r =>
-          this.createRepoFromGithubResponse(r, organization),
-        ),
-      );
+
+        startCursor = nextCursor;
+      } while (startCursor);
     }
 
     if (this.config.validateLocationsExist) {

--- a/plugins/catalog-backend-module-github/src/providers/GithubEntityProviderConfig.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubEntityProviderConfig.test.ts
@@ -111,6 +111,12 @@ describe('readProviderConfigs', () => {
                 },
               },
             },
+            providerWithQueryLimits: {
+              organization: 'test-org1',
+              queryLimits: {
+                repositoryChunkSize: 100,
+              },
+            },
             providerAppOnly: {
               app: '1234',
             },
@@ -124,7 +130,7 @@ describe('readProviderConfigs', () => {
     });
     const providerConfigs = readProviderConfigs(config);
 
-    expect(providerConfigs).toHaveLength(12);
+    expect(providerConfigs).toHaveLength(13);
     expect(providerConfigs[0]).toEqual({
       id: 'providerOrganizationOnly',
       organization: 'test-org1',
@@ -143,6 +149,7 @@ describe('readProviderConfigs', () => {
       },
       schedule: DEFAULT_GITHUB_ENTITY_PROVIDER_CONFIG_SCHEDULE,
       validateLocationsExist: false,
+      queryLimits: undefined,
     });
     expect(providerConfigs[1]).toEqual({
       id: 'providerCustomCatalogPath',
@@ -162,6 +169,7 @@ describe('readProviderConfigs', () => {
       },
       schedule: DEFAULT_GITHUB_ENTITY_PROVIDER_CONFIG_SCHEDULE,
       validateLocationsExist: false,
+      queryLimits: undefined,
     });
     expect(providerConfigs[2]).toEqual({
       id: 'providerWithRepositoryFilter',
@@ -181,6 +189,7 @@ describe('readProviderConfigs', () => {
       },
       schedule: DEFAULT_GITHUB_ENTITY_PROVIDER_CONFIG_SCHEDULE,
       validateLocationsExist: false,
+      queryLimits: undefined,
     });
     expect(providerConfigs[3]).toEqual({
       id: 'providerWithBranchFilter',
@@ -200,6 +209,7 @@ describe('readProviderConfigs', () => {
       },
       schedule: DEFAULT_GITHUB_ENTITY_PROVIDER_CONFIG_SCHEDULE,
       validateLocationsExist: false,
+      queryLimits: undefined,
     });
     expect(providerConfigs[4]).toEqual({
       id: 'providerWithTopicFilter',
@@ -219,6 +229,7 @@ describe('readProviderConfigs', () => {
       },
       schedule: DEFAULT_GITHUB_ENTITY_PROVIDER_CONFIG_SCHEDULE,
       validateLocationsExist: false,
+      queryLimits: undefined,
     });
     expect(providerConfigs[5]).toEqual({
       id: 'providerWithForkFilter',
@@ -238,6 +249,7 @@ describe('readProviderConfigs', () => {
       },
       schedule: DEFAULT_GITHUB_ENTITY_PROVIDER_CONFIG_SCHEDULE,
       validateLocationsExist: false,
+      queryLimits: undefined,
     });
     expect(providerConfigs[6]).toEqual({
       id: 'providerWithVisibilityFilter',
@@ -257,6 +269,7 @@ describe('readProviderConfigs', () => {
       },
       schedule: DEFAULT_GITHUB_ENTITY_PROVIDER_CONFIG_SCHEDULE,
       validateLocationsExist: false,
+      queryLimits: undefined,
     });
     expect(providerConfigs[7]).toEqual({
       id: 'providerWithArchiveFilter',
@@ -295,6 +308,7 @@ describe('readProviderConfigs', () => {
       },
       validateLocationsExist: false,
       schedule: DEFAULT_GITHUB_ENTITY_PROVIDER_CONFIG_SCHEDULE,
+      queryLimits: undefined,
     });
     expect(providerConfigs[9]).toEqual({
       id: 'providerWithSchedule',
@@ -319,8 +333,31 @@ describe('readProviderConfigs', () => {
         },
       },
       validateLocationsExist: false,
+      queryLimits: undefined,
     });
     expect(providerConfigs[10]).toEqual({
+      id: 'providerWithQueryLimits',
+      organization: 'test-org1',
+      catalogPath: '/catalog-info.yaml',
+      host: 'github.com',
+      filters: {
+        repository: undefined,
+        branch: undefined,
+        allowForks: true,
+        topic: {
+          include: undefined,
+          exclude: undefined,
+        },
+        visibility: undefined,
+        allowArchived: false,
+      },
+      schedule: DEFAULT_GITHUB_ENTITY_PROVIDER_CONFIG_SCHEDULE,
+      validateLocationsExist: false,
+      queryLimits: {
+        repositoryChunkSize: 100,
+      },
+    });
+    expect(providerConfigs[11]).toEqual({
       id: 'providerAppOnly',
       app: 1234,
       catalogPath: '/catalog-info.yaml',
@@ -338,8 +375,9 @@ describe('readProviderConfigs', () => {
       },
       schedule: DEFAULT_GITHUB_ENTITY_PROVIDER_CONFIG_SCHEDULE,
       validateLocationsExist: false,
+      queryLimits: undefined,
     });
-    expect(providerConfigs[11]).toEqual({
+    expect(providerConfigs[12]).toEqual({
       id: 'providerAppAndOrganization',
       app: 1234,
       organization: 'test-org1',
@@ -488,5 +526,42 @@ describe('readProviderConfigs', () => {
       repositories: 15,
     });
     expect(providerConfigs[1].pageSizes).toBeUndefined();
+  });
+
+  it('reads query limits configuration', () => {
+    const config = new ConfigReader({
+      catalog: {
+        providers: {
+          github: {
+            organization: 'test-org',
+            queryLimits: {
+              repositoryChunkSize: 50,
+            },
+          },
+        },
+      },
+    });
+    const providerConfigs = readProviderConfigs(config);
+
+    expect(providerConfigs).toHaveLength(1);
+    expect(providerConfigs[0].queryLimits).toEqual({
+      repositoryChunkSize: 50,
+    });
+  });
+
+  it('handles missing query limits configuration', () => {
+    const config = new ConfigReader({
+      catalog: {
+        providers: {
+          github: {
+            organization: 'test-org',
+          },
+        },
+      },
+    });
+    const providerConfigs = readProviderConfigs(config);
+
+    expect(providerConfigs).toHaveLength(1);
+    expect(providerConfigs[0].queryLimits).toBeUndefined();
   });
 });

--- a/plugins/catalog-backend-module-github/src/providers/GithubEntityProviderConfig.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubEntityProviderConfig.ts
@@ -51,6 +51,9 @@ export type GithubEntityProviderConfig = {
   pageSizes?: {
     repositories?: number;
   };
+  queryLimits?: {
+    repositoryChunkSize?: number;
+  };
 };
 
 export type GithubTopicFilters = {
@@ -137,6 +140,14 @@ function readProviderConfig(
       }
     : undefined;
 
+  const queryLimits = config.has('queryLimits')
+    ? {
+        repositoryChunkSize: config.getOptionalNumber(
+          'queryLimits.repositoryChunkSize',
+        ),
+      }
+    : undefined;
+
   return {
     id,
     catalogPath,
@@ -159,6 +170,7 @@ function readProviderConfig(
     schedule,
     validateLocationsExist,
     pageSizes,
+    queryLimits,
   };
 }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds a new `queryLimits.repositoryChunkSize` configuration option for the GitHub Org provider, which allows to fetch GitHub repositories in chunks (GraphQL client sessions). This allows to fetch repositories in large organizations when the job is failing with 502 error (session times out).

Also `allowArchived` filter whether to include archived repositories is now applied directly in the GraphQL query which speeds up the job.

This PR is related to [35156](https://github.com/backstage/backstage/pull/35156) as it also solves issue for large organizations.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x]  Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
