### PR TITLE
fix(app-defaults): prevent app remount on theme switch

### DIFF
--- a/.changeset/fix-theme-switch-remount.md
+++ b/.changeset/fix-theme-switch-remount.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-app-api': patch
+---
+
+Fixed theme switching causing a full application remount by calling the theme Provider as a render function instead of a JSX component, so that React reconciles the returned element tree in place rather than unmounting and remounting the entire subtree.

--- a/packages/core-app-api/src/app/AppThemeProvider.tsx
+++ b/packages/core-app-api/src/app/AppThemeProvider.tsx
@@ -88,5 +88,6 @@ export function AppThemeProvider({ children }: PropsWithChildren<{}>) {
     throw new Error('App has no themes');
   }
 
-  return <appTheme.Provider children={children} />;
+  const provider = appTheme.Provider;
+  return provider({ children });
 }


### PR DESCRIPTION


  ## Hey, I just made a Pull Request!

  Fixes #14479


Switching themes causes the entire application tree to remount. This happens because `AppThemeProvider` renders `<appTheme.Provider>` as a JSX component, and each theme defines its own Provider function. React treats the changing function reference as a component type change and tears down the entire subtree.

The fix calls the Provider as a render function instead of rendering it as a JSX component. This way React never creates a fiber for the Provider itself, it reconciles the *returned* element tree directly. Since all standard theme Providers return `<UnifiedThemeProvider>` as their top-level element, React sees the same component type on every theme switch and updates the theme prop in place.


## Screenshots

### Before fix

https://github.com/user-attachments/assets/86a4dbf5-4a58-44ed-8ece-85a37f8a842e


---

### After fix


https://github.com/user-attachments/assets/de08ec69-24c3-49bf-9bcd-a38ad8854bdf



#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
