### PR TITLE
Fix catalog model relation kind pair handling

### DIFF
--- a/.changeset/exact-relations-connect.md
+++ b/.changeset/exact-relations-connect.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': patch
+---
+
+Corrected catalog relation generation to honor declared kind combinations, and completed reverse relations for existing `AiResource` fields.

--- a/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.test.ts
+++ b/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.test.ts
@@ -15,10 +15,13 @@
  */
 
 import type { Entity } from '../entity/Entity';
+import { compileCatalogModel } from '../model/compileCatalogModel';
+import { defaultCatalogEntityModel } from '../model/defaultCatalogEntityModel';
 import {
   type AiResourceEntityV1alpha1Default,
   type SkillAiResourceEntityV1alpha1,
   type RuleAiResourceEntityV1alpha1,
+  aiResourceEntityModel,
   aiResourceEntityV1alpha1Validator as defaultValidator,
   skillAiResourceEntityV1alpha1Validator as skillValidator,
   ruleAiResourceEntityV1alpha1Validator as ruleValidator,
@@ -355,5 +358,60 @@ describe('isRuleAiResourceEntity', () => {
       spec: { type: 'skill' },
     };
     expect(isRuleAiResourceEntity(entity)).toBe(false);
+  });
+});
+
+describe('aiResourceEntityModel', () => {
+  it('declares and restricts all existing relation fields', () => {
+    const model = compileCatalogModel([
+      defaultCatalogEntityModel,
+      aiResourceEntityModel,
+    ]);
+    const skill = model.getKind({
+      kind: 'AiResource',
+      apiVersion: 'backstage.io/v1alpha1',
+      spec: { type: 'skill' },
+    });
+
+    expect(skill?.relationFields).toEqual([
+      expect.objectContaining({
+        path: 'spec.owner',
+        relation: 'ownedBy',
+        allowedKinds: ['Group', 'User'],
+      }),
+      expect.objectContaining({
+        path: 'spec.system',
+        relation: 'partOf',
+        allowedKinds: ['System'],
+      }),
+      expect.objectContaining({
+        path: 'spec.dependsOn',
+        relation: 'dependsOn',
+        allowedKinds: ['AiResource'],
+      }),
+    ]);
+
+    const relations = model.getRelations({ kind: 'AiResource' });
+    expect(relations?.find(r => r.forward.type === 'ownedBy')?.toKind).toEqual([
+      'Group',
+      'User',
+    ]);
+    expect(relations?.find(r => r.forward.type === 'partOf')?.toKind).toEqual([
+      'System',
+    ]);
+    expect(
+      relations?.find(r => r.forward.type === 'dependsOn')?.toKind,
+    ).toEqual(['AiResource']);
+
+    expect(
+      model
+        .getRelations({ kind: 'System' })
+        ?.find(r => r.forward.type === 'hasPart')?.toKind,
+    ).toContain('AiResource');
+    expect(
+      model
+        .getRelations({ kind: 'AiResource' })
+        ?.find(r => r.forward.type === 'dependencyOf')?.toKind,
+    ).toEqual(['AiResource']);
   });
 });

--- a/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.ts
@@ -178,6 +178,7 @@ const baseRelationFields = [
     relation: 'partOf',
     defaultKind: 'System',
     defaultNamespace: 'inherit' as const,
+    allowedKinds: ['System'],
   },
 ];
 
@@ -216,6 +217,7 @@ export const aiResourceEntityModel = createCatalogModelLayer({
               relation: 'dependsOn',
               defaultKind: 'AiResource',
               defaultNamespace: 'inherit' as const,
+              allowedKinds: ['AiResource'],
             },
           ],
           schema: {
@@ -231,6 +233,24 @@ export const aiResourceEntityModel = createCatalogModelLayer({
           },
         },
       ],
+    });
+    model.updateRelationPair({
+      fromKind: 'AiResource',
+      toKind: ['Group', 'User'],
+      forward: { type: 'ownedBy' },
+      reverse: { type: 'ownerOf' },
+    });
+    model.updateRelationPair({
+      fromKind: 'AiResource',
+      toKind: 'System',
+      forward: { type: 'partOf' },
+      reverse: { type: 'hasPart' },
+    });
+    model.updateRelationPair({
+      fromKind: 'AiResource',
+      toKind: 'AiResource',
+      forward: { type: 'dependsOn' },
+      reverse: { type: 'dependencyOf' },
     });
   },
 });

--- a/packages/catalog-model/src/model/compileCatalogModel.test.ts
+++ b/packages/catalog-model/src/model/compileCatalogModel.test.ts
@@ -801,4 +801,47 @@ describe('compileCatalogModel relation pairs', () => {
       }),
     );
   });
+
+  it('preserves relation summary kind order when extending a relation', () => {
+    const base = createCatalogModelLayer({
+      layerId: 'example.com/base-related-to',
+      builder: model => {
+        model.addRelationPair({
+          fromKind: 'A',
+          toKind: 'X',
+          description: 'A relation used to verify summary ordering.',
+          forward: { type: 'relatedTo', title: 'related to' },
+          reverse: { type: 'relatedFrom', title: 'related from' },
+        });
+      },
+    });
+    const extension = createCatalogModelLayer({
+      layerId: 'example.com/extended-related-to',
+      builder: model => {
+        model.updateRelationPair({
+          fromKind: 'B',
+          toKind: 'Y',
+          forward: { type: 'relatedTo' },
+          reverse: { type: 'relatedFrom' },
+        });
+        model.updateRelationPair({
+          fromKind: 'A',
+          toKind: 'Z',
+          forward: { type: 'relatedTo' },
+          reverse: { type: 'relatedFrom' },
+        });
+      },
+    });
+
+    expect(
+      compileCatalogModel([base, extension])
+        .listRelations()
+        .find(r => r.forward.type === 'relatedTo'),
+    ).toEqual(
+      expect.objectContaining({
+        fromKind: ['A', 'B'],
+        toKind: ['X', 'Y', 'Z'],
+      }),
+    );
+  });
 });

--- a/packages/catalog-model/src/model/compileCatalogModel.test.ts
+++ b/packages/catalog-model/src/model/compileCatalogModel.test.ts
@@ -17,6 +17,7 @@
 import Ajv from 'ajv';
 import { createCatalogModelLayer } from './createCatalogModelLayer';
 import { compileCatalogModel } from './compileCatalogModel';
+import { defaultCatalogEntityModel } from './defaultCatalogEntityModel';
 
 const layer = createCatalogModelLayer({
   layerId: 'Test',
@@ -756,5 +757,48 @@ describe('compileCatalogModel integration', () => {
       }),
     ).toBeUndefined();
     expect(model4.getRelations({ kind: 'Widget' })).toBeUndefined();
+  });
+});
+
+describe('compileCatalogModel relation pairs', () => {
+  it('preserves exact kind pairs when extending a relation', () => {
+    const extension = createCatalogModelLayer({
+      layerId: 'example.com/extended-part-of',
+      builder: model => {
+        model.updateRelationPair({
+          fromKind: 'User',
+          toKind: 'Location',
+          forward: { type: 'partOf' },
+          reverse: { type: 'hasPart' },
+        });
+      },
+    });
+
+    const model = compileCatalogModel([defaultCatalogEntityModel, extension]);
+
+    expect(
+      model
+        .getRelations({ kind: 'Component' })
+        ?.find(r => r.forward.type === 'partOf')?.toKind,
+    ).toEqual(['Component', 'System']);
+    expect(
+      model
+        .getRelations({ kind: 'User' })
+        ?.find(r => r.forward.type === 'partOf')?.toKind,
+    ).toEqual(['Location']);
+    expect(
+      model
+        .getRelations({ kind: 'Location' })
+        ?.find(r => r.forward.type === 'hasPart')?.toKind,
+    ).toEqual(['User']);
+
+    expect(
+      model.listRelations().find(r => r.forward.type === 'partOf'),
+    ).toEqual(
+      expect.objectContaining({
+        fromKind: ['Component', 'API', 'Resource', 'System', 'Domain', 'User'],
+        toKind: ['Component', 'System', 'Domain', 'Location'],
+      }),
+    );
   });
 });

--- a/packages/catalog-model/src/model/compileCatalogModel.ts
+++ b/packages/catalog-model/src/model/compileCatalogModel.ts
@@ -72,6 +72,7 @@ interface SpecTypeState {
 
 interface RelationState {
   kindPairs: Map<string, Set<string>>;
+  toKinds: Set<string>;
   description: string;
   forward: { type: string; title: string };
   reverse: { type: string; title: string };
@@ -174,6 +175,7 @@ function addRelationKindPair(
     relation.kindPairs.set(fromKind, toKinds);
   }
   toKinds.add(toKind);
+  relation.toKinds.add(toKind);
 }
 
 function applyDeclareRelation(
@@ -186,6 +188,7 @@ function applyDeclareRelation(
   } else {
     const relation: RelationState = {
       kindPairs: new Map(),
+      toKinds: new Set(),
       description: op.properties.description,
       forward: {
         type: op.type,
@@ -725,12 +728,9 @@ export function compileCatalogModel(
     ...relations.values(),
   ].map(r => {
     const reverseEntry = relations.get(r.reverse.type);
-    const toKinds = new Set(
-      [...r.kindPairs.values()].flatMap(targetKinds => [...targetKinds]),
-    );
     return {
       fromKind: [...r.kindPairs.keys()],
-      toKind: [...toKinds],
+      toKind: [...r.toKinds],
       description: r.description,
       forward: r.forward,
       reverse: {

--- a/packages/catalog-model/src/model/compileCatalogModel.ts
+++ b/packages/catalog-model/src/model/compileCatalogModel.ts
@@ -726,7 +726,7 @@ export function compileCatalogModel(
   ].map(r => {
     const reverseEntry = relations.get(r.reverse.type);
     const toKinds = new Set(
-      [...r.kindPairs.values()].flatMap(kinds => [...kinds]),
+      [...r.kindPairs.values()].flatMap(targetKinds => [...targetKinds]),
     );
     return {
       fromKind: [...r.kindPairs.keys()],

--- a/packages/catalog-model/src/model/compileCatalogModel.ts
+++ b/packages/catalog-model/src/model/compileCatalogModel.ts
@@ -71,8 +71,7 @@ interface SpecTypeState {
 }
 
 interface RelationState {
-  fromKinds: Set<string>;
-  toKinds: Set<string>;
+  kindPairs: Map<string, Set<string>>;
   description: string;
   forward: { type: string; title: string };
   reverse: { type: string; title: string };
@@ -164,18 +163,29 @@ function applyDeclareKindVersion(
   });
 }
 
+function addRelationKindPair(
+  relation: RelationState,
+  fromKind: string,
+  toKind: string,
+): void {
+  let toKinds = relation.kindPairs.get(fromKind);
+  if (!toKinds) {
+    toKinds = new Set();
+    relation.kindPairs.set(fromKind, toKinds);
+  }
+  toKinds.add(toKind);
+}
+
 function applyDeclareRelation(
   relations: Map<string, RelationState>,
   op: OpDeclareRelationV1,
 ): void {
   const existing = relations.get(op.type);
   if (existing) {
-    existing.fromKinds.add(op.fromKind);
-    existing.toKinds.add(op.toKind);
+    addRelationKindPair(existing, op.fromKind, op.toKind);
   } else {
-    relations.set(op.type, {
-      fromKinds: new Set([op.fromKind]),
-      toKinds: new Set([op.toKind]),
+    const relation: RelationState = {
+      kindPairs: new Map(),
       description: op.properties.description,
       forward: {
         type: op.type,
@@ -185,7 +195,9 @@ function applyDeclareRelation(
         type: op.properties.reverseType,
         title: op.properties.title,
       },
-    });
+    };
+    addRelationKindPair(relation, op.fromKind, op.toKind);
+    relations.set(op.type, relation);
   }
 }
 
@@ -258,8 +270,7 @@ function applyUpdateRelation(
   if (!relation) {
     throw new InputError(`Cannot update undeclared relation "${op.type}"`);
   }
-  relation.fromKinds.add(op.fromKind);
-  relation.toKinds.add(op.toKind);
+  addRelationKindPair(relation, op.fromKind, op.toKind);
   if (op.properties.reverseType !== undefined) {
     relation.reverse.type = op.properties.reverseType;
   }
@@ -641,22 +652,26 @@ export function compileCatalogModel(
   for (const kindName of kinds.keys()) {
     compiledRelations.set(
       kindName,
-      [...relations.values()]
-        .filter(r => r.fromKinds.has(kindName))
-        .map(r => {
-          // Look up the reverse relation entry to get its actual title
-          const reverseEntry = relations.get(r.reverse.type);
-          return {
-            fromKind: [...r.fromKinds],
-            toKind: [...r.toKinds],
+      [...relations.values()].flatMap(r => {
+        const toKinds = r.kindPairs.get(kindName);
+        if (!toKinds) {
+          return [];
+        }
+        // Look up the reverse relation entry to get its actual title
+        const reverseEntry = relations.get(r.reverse.type);
+        return [
+          {
+            fromKind: [kindName],
+            toKind: [...toKinds],
             description: r.description,
             forward: r.forward,
             reverse: {
               type: r.reverse.type,
               title: reverseEntry?.forward.title ?? r.reverse.title,
             },
-          };
-        }),
+          },
+        ];
+      }),
     );
   }
 
@@ -710,9 +725,12 @@ export function compileCatalogModel(
     ...relations.values(),
   ].map(r => {
     const reverseEntry = relations.get(r.reverse.type);
+    const toKinds = new Set(
+      [...r.kindPairs.values()].flatMap(kinds => [...kinds]),
+    );
     return {
-      fromKind: [...r.fromKinds],
-      toKind: [...r.toKinds],
+      fromKind: [...r.kindPairs.keys()],
+      toKind: [...toKinds],
       description: r.description,
       forward: r.forward,
       reverse: {

--- a/plugins/catalog-backend/src/processors/ModelProcessor.test.ts
+++ b/plugins/catalog-backend/src/processors/ModelProcessor.test.ts
@@ -19,6 +19,8 @@ import {
   CatalogModel,
   CatalogModelKind,
   CatalogModelRelation,
+  compileCatalogModel,
+  defaultCatalogEntityModel,
 } from '@backstage/catalog-model/alpha';
 import { ModelProcessor } from './ModelProcessor';
 import { ModelHolder } from '../model/ModelHolder';
@@ -342,6 +344,47 @@ describe('ModelProcessor', () => {
               name: 'service-b',
             },
           },
+        }),
+      );
+    });
+
+    it('does not emit an inverse for an undeclared kind pair', async () => {
+      const model = compileCatalogModel([defaultCatalogEntityModel]);
+      const processor = new ModelProcessor(
+        ModelHolder.modelPassthroughForTest(model),
+      );
+      const emit = jest.fn();
+      const entity = createEntity({
+        type: 'service',
+        lifecycle: 'production',
+        owner: 'group:default/my-team',
+        system: 'domain:default/not-a-system',
+      });
+
+      await processor.postProcessEntity(entity, location, emit);
+
+      expect(emit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          relation: expect.objectContaining({
+            type: 'partOf',
+            target: {
+              kind: 'domain',
+              namespace: 'default',
+              name: 'not-a-system',
+            },
+          }),
+        }),
+      );
+      expect(emit).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          relation: expect.objectContaining({
+            type: 'hasPart',
+            source: {
+              kind: 'domain',
+              namespace: 'default',
+              name: 'not-a-system',
+            },
+          }),
         }),
       );
     });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes catalog model relation compilation so that exact source and target kind pairs are preserved when determining inverse relations, while keeping the existing union-style relation summaries and public API shapes unchanged.

Also makes the existing `AiResource` model self-contained by registering its ownership, system, and dependency relation pairs and restricting those fields to their intended target kinds.

Related to #34891 and #34892.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))