### PR TITLE
docs: link the frontend system demo

### DIFF
--- a/docs/frontend-system/building-apps/08-migrating.md
+++ b/docs/frontend-system/building-apps/08-migrating.md
@@ -962,5 +962,7 @@ If you have a use case where these are required, please reach out to us either t
 
 ## Next Steps
 
+- Explore the [Backstage demo repository](https://github.com/backstage/demo),
+  which uses the new frontend system, for a complete app reference.
 - See [architecture docs](../architecture/00-index.md) for more on the new system.
 - If you encounter issues, check [GitHub issues](https://github.com/backstage/backstage/issues) or ask in [Discord](https://discord.gg/backstage-687207715902193673).


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds the Backstage demo repository as a complete application reference in the new frontend-system migration guide. The demo now uses the new frontend system and gives app maintainers a concrete reference during migration. This addresses the demo-reference gap in #34134.

AI-assisted drafting; verified against the demo repository documentation.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages.
- [x] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots attached (for UI changes).
- [x] All commits have a `Signed-off-by` line in the message.