### PR TITLE
ui: harden Table, TablePagination and useTable for post-mount state changes

### DIFF
--- a/.changeset/ui-table-release-readiness.md
+++ b/.changeset/ui-table-release-readiness.md
@@ -1,0 +1,11 @@
+---
+'@backstage/ui': patch
+---
+
+Hardened the `Table`, `TablePagination`, and `useTable` stack against state changes after mount:
+
+- `useTable` in `complete` mode now honors `paginationOptions.initialOffset`, and moves to the last available page instead of showing an empty page when the data shrinks below the current offset.
+- `useTable` in `offset` and `cursor` mode now follows changes to `paginationOptions.pageSize` after mount, and no longer loses the debounced reload when the user navigates right after changing the search, filter, or sort. Navigating during that window now applies the new query from the first page.
+- `Table` now correctly matches `selection.selected` keys against numeric item ids and reports selection changes using the original id type, so `selected` sets built from `item.id` work as expected.
+- `Table` now exposes `aria-busy` on the grid while loading, announces empty and count-only pages in its live region, and renders the error state with `role="alert"`.
+- `TablePagination` now keeps the page size selector in sync with the `pageSize` prop, keeps keyboard focus within the controls when a navigation button becomes disabled, and no longer flickers the navigation buttons to disabled while the next page is loading.

--- a/packages/ui/src/components/Table/Table.test.tsx
+++ b/packages/ui/src/components/Table/Table.test.tsx
@@ -1,0 +1,657 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import { StrictMode, Suspense, useState, type ReactElement } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { BUIProvider } from '../../provider';
+import {
+  Cell,
+  CellText,
+  Row,
+  Table,
+  useTable,
+  type ColumnConfig,
+  type SortDescriptor,
+  type TableProps,
+} from '.';
+import type { CursorParams, OffsetParams } from './hooks/types';
+
+type Item = { id: number; name: string; owner: string };
+
+const makeItems = (count: number): Item[] =>
+  Array.from({ length: count }, (_, i) => ({
+    id: i + 1,
+    name: `Item ${i + 1}`,
+    owner: i % 2 === 0 ? 'team-a' : 'team-b',
+  }));
+
+const columns: ColumnConfig<Item>[] = [
+  {
+    id: 'name',
+    label: 'Name',
+    isRowHeader: true,
+    isSortable: true,
+    cell: item => <CellText title={item.name} />,
+  },
+  {
+    id: 'owner',
+    label: 'Owner',
+    cell: item => <CellText title={item.owner} />,
+  },
+];
+
+function renderTable(ui: ReactElement) {
+  return render(
+    <MemoryRouter>
+      <BUIProvider>{ui}</BUIProvider>
+    </MemoryRouter>,
+  );
+}
+
+const grid = () => screen.getByRole('grid', { name: 'Data table' });
+const bodyRows = () => within(grid()).getAllByRole('row').slice(1);
+const rowNames = () =>
+  bodyRows().map(row => within(row).getAllByRole('rowheader')[0].textContent);
+const liveRegion = () =>
+  document.getElementById(grid().getAttribute('aria-describedby')!);
+const nextButton = () =>
+  screen.getByRole('button', { name: 'Next table page' });
+const previousButton = () =>
+  screen.getByRole('button', { name: 'Previous table page' });
+
+describe('Table', () => {
+  it('renders columns and rows from columnConfig, hides hidden columns and shows the empty state', () => {
+    const { rerender } = renderTable(
+      <Table
+        columnConfig={[
+          ...columns,
+          {
+            id: 'hidden',
+            label: 'Hidden',
+            isHidden: true,
+            cell: () => <Cell />,
+          },
+        ]}
+        data={makeItems(2)}
+        pagination={{ type: 'none' }}
+        emptyState="Nothing here"
+      />,
+    );
+
+    expect(
+      within(grid())
+        .getAllByRole('columnheader')
+        .map(c => c.textContent),
+    ).toEqual(['Name', 'Owner']);
+    expect(rowNames()).toEqual(['Item 1', 'Item 2']);
+    expect(
+      screen.queryByRole('button', { name: 'Next table page' }),
+    ).toBeNull();
+    expect(liveRegion()).toHaveTextContent('');
+
+    rerender(
+      <MemoryRouter>
+        <BUIProvider>
+          <Table
+            columnConfig={columns}
+            data={[]}
+            pagination={{ type: 'none' }}
+            emptyState="Nothing here"
+          />
+        </BUIProvider>
+      </MemoryRouter>,
+    );
+    expect(screen.getByText('Nothing here')).toBeInTheDocument();
+  });
+
+  it('exposes loading, stale and error states to assistive technology', () => {
+    const pagination = {
+      type: 'page' as const,
+      pageSize: 5,
+      offset: 0,
+      totalCount: 12,
+      hasNextPage: true,
+      hasPreviousPage: false,
+      onNextPage: () => {},
+      onPreviousPage: () => {},
+    };
+    const { rerender } = renderTable(
+      <Table
+        columnConfig={columns}
+        data={undefined}
+        isPending
+        pagination={pagination}
+      />,
+    );
+
+    // Initial load: skeleton rows, busy grid, live announcement.
+    expect(grid()).toHaveAttribute('aria-busy', 'true');
+    expect(grid()).toHaveAttribute('aria-describedby', liveRegion()?.id);
+    expect(liveRegion()).toHaveTextContent('Loading table data.');
+    expect(bodyRows().length).toBeGreaterThan(0);
+    expect(
+      within(grid()).queryByRole('rowheader', { name: /Item/ }),
+    ).toBeNull();
+
+    const withData = (extra: Partial<TableProps<Item>>) => (
+      <MemoryRouter>
+        <BUIProvider>
+          <Table
+            columnConfig={columns}
+            data={makeItems(5)}
+            pagination={pagination}
+            {...extra}
+          />
+        </BUIProvider>
+      </MemoryRouter>
+    );
+
+    rerender(withData({}));
+    expect(grid()).not.toHaveAttribute('aria-busy');
+    expect(rowNames()).toEqual([
+      'Item 1',
+      'Item 2',
+      'Item 3',
+      'Item 4',
+      'Item 5',
+    ]);
+    expect(liveRegion()).toHaveTextContent(
+      'Table page loaded. Showing 1 to 5 of 12',
+    );
+
+    // Stale: rows stay visible while the next page loads.
+    rerender(withData({ isPending: true, isStale: true }));
+    expect(grid()).toHaveAttribute('aria-busy', 'true');
+    expect(grid()).toHaveAttribute('data-stale', 'true');
+    expect(rowNames()).toHaveLength(5);
+    expect(liveRegion()).toHaveTextContent('Loading table data.');
+
+    // Deprecated `loading` alias still marks the table busy.
+    rerender(withData({ loading: true, isStale: true }));
+    expect(grid()).toHaveAttribute('aria-busy', 'true');
+
+    rerender(withData({ pagination: { ...pagination, offset: undefined } }));
+    expect(liveRegion()).toHaveTextContent('Table page loaded. 12 items');
+
+    rerender(
+      withData({
+        data: [],
+        pagination: { ...pagination, totalCount: 0, hasNextPage: false },
+      }),
+    );
+    expect(liveRegion()).toHaveTextContent(
+      'Table page loaded. No items to show.',
+    );
+
+    rerender(withData({ error: new Error('Something broke') }));
+    expect(screen.queryByRole('grid')).toBeNull();
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Error: Something broke',
+    );
+
+    // Recovering from the error re-renders the table.
+    rerender(withData({}));
+    expect(rowNames()).toHaveLength(5);
+  });
+
+  it('reports sort changes from column headers and reflects the controlled descriptor', () => {
+    function Harness() {
+      const [descriptor, setDescriptor] = useState<SortDescriptor | null>(null);
+      return (
+        <Table
+          columnConfig={columns}
+          data={makeItems(2)}
+          pagination={{ type: 'none' }}
+          sort={{ descriptor, onSortChange: setDescriptor }}
+        />
+      );
+    }
+    renderTable(<Harness />);
+    const nameHeader = () => screen.getByRole('columnheader', { name: /Name/ });
+
+    expect(nameHeader()).toHaveAttribute('aria-sort', 'none');
+    fireEvent.click(nameHeader());
+    expect(nameHeader()).toHaveAttribute('aria-sort', 'ascending');
+    fireEvent.click(nameHeader());
+    expect(nameHeader()).toHaveAttribute('aria-sort', 'descending');
+    // Non-sortable columns do not react.
+    expect(
+      screen.getByRole('columnheader', { name: 'Owner' }),
+    ).not.toHaveAttribute('aria-sort');
+  });
+
+  it('keeps multiple selection consistent with item ids across numeric keys, disabled rows and page changes', () => {
+    const onSelectionChange = jest.fn();
+    function Harness() {
+      const [selected, setSelected] = useState<Set<string | number> | 'all'>(
+        new Set([1]),
+      );
+      const [page, setPage] = useState(0);
+      const data = makeItems(6).slice(page * 3, page * 3 + 3);
+      return (
+        <>
+          <button onClick={() => setPage(1)}>page 2</button>
+          <Table
+            columnConfig={columns}
+            data={data}
+            pagination={{ type: 'none' }}
+            rowConfig={{ getIsDisabled: item => item.id === 3 }}
+            selection={{
+              mode: 'multiple',
+              selected,
+              onSelectionChange: keys => {
+                onSelectionChange(keys);
+                setSelected(keys);
+              },
+            }}
+          />
+        </>
+      );
+    }
+    renderTable(<Harness />);
+
+    // Numeric ids in `selected` match the rows.
+    expect(bodyRows().map(r => r.getAttribute('aria-selected'))).toEqual([
+      'true',
+      'false',
+      'false',
+    ]);
+    expect(
+      within(grid()).getByRole('checkbox', { name: 'Select all' }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      within(bodyRows()[1]).getByRole('checkbox', { name: /Select row/ }),
+    );
+    // Reported keys keep the original id type.
+    expect([...(onSelectionChange.mock.calls[0][0] as Set<unknown>)]).toEqual([
+      1, 2,
+    ]);
+    expect(bodyRows()[1]).toHaveAttribute('aria-selected', 'true');
+
+    // Disabled rows cannot be selected.
+    expect(
+      within(bodyRows()[2]).getByRole('checkbox', { name: /Select row/ }),
+    ).toBeDisabled();
+    fireEvent.click(
+      within(bodyRows()[2]).getByRole('checkbox', { name: /Select row/ }),
+    );
+    expect(bodyRows()[2]).toHaveAttribute('aria-selected', 'false');
+
+    // Selection is preserved when the visible rows change.
+    fireEvent.click(screen.getByText('page 2'));
+    expect(rowNames()).toEqual(['Item 4', 'Item 5', 'Item 6']);
+    expect(bodyRows().map(r => r.getAttribute('aria-selected'))).toEqual([
+      'false',
+      'false',
+      'false',
+    ]);
+    fireEvent.click(
+      within(bodyRows()[0]).getByRole('checkbox', { name: /Select row/ }),
+    );
+    expect([
+      ...(onSelectionChange.mock.calls.at(-1)[0] as Set<unknown>),
+    ]).toEqual([1, 2, 4]);
+  });
+
+  it('supports single selection with row clicks and string ids passed by the adopter', () => {
+    const onSelectionChange = jest.fn();
+    renderTable(
+      <Table
+        columnConfig={columns}
+        data={makeItems(3)}
+        pagination={{ type: 'none' }}
+        selection={{
+          mode: 'single',
+          selected: new Set(['2']),
+          onSelectionChange,
+        }}
+      />,
+    );
+    expect(bodyRows().map(r => r.getAttribute('aria-selected'))).toEqual([
+      'false',
+      'true',
+      'false',
+    ]);
+    expect(within(grid()).queryByRole('checkbox')).toBeNull();
+
+    fireEvent.click(within(bodyRows()[0]).getByRole('rowheader'));
+    // Adopters using string keys keep receiving string keys.
+    expect([...(onSelectionChange.mock.calls[0][0] as Set<unknown>)]).toEqual([
+      '1',
+    ]);
+  });
+
+  it('runs row actions and renders row links from rowConfig', () => {
+    const onClick = jest.fn();
+    renderTable(
+      <Table
+        columnConfig={columns}
+        data={makeItems(2)}
+        pagination={{ type: 'none' }}
+        rowConfig={{
+          onClick,
+          getHref: item => (item.id === 1 ? '/items/1' : undefined),
+        }}
+      />,
+    );
+    expect(bodyRows()[0]).toHaveAttribute('data-href', '/items/1');
+    fireEvent.click(within(bodyRows()[1]).getByRole('rowheader'));
+    expect(onClick).toHaveBeenCalledWith(expect.objectContaining({ id: 2 }));
+  });
+
+  it('renders custom rows via a row render function and leaves their selection keys untouched', () => {
+    const onSelectionChange = jest.fn();
+    renderTable(
+      <Table
+        columnConfig={columns}
+        data={makeItems(2)}
+        pagination={{ type: 'none' }}
+        selection={{
+          mode: 'multiple',
+          selected: new Set([2]),
+          onSelectionChange,
+        }}
+        rowConfig={({ item, index }) => (
+          <Row id={item.id} columns={columns}>
+            {column => (
+              <CellText
+                title={`${index}:${item[column.id as 'name' | 'owner']}`}
+              />
+            )}
+          </Row>
+        )}
+      />,
+    );
+    expect(rowNames()).toEqual(['0:Item 1', '1:Item 2']);
+    expect(bodyRows().map(r => r.getAttribute('aria-selected'))).toEqual([
+      'false',
+      'true',
+    ]);
+    fireEvent.click(
+      within(bodyRows()[0]).getByRole('checkbox', { name: /Select row/ }),
+    );
+    expect([...(onSelectionChange.mock.calls[0][0] as Set<unknown>)]).toEqual([
+      2, 1,
+    ]);
+  });
+
+  it('paginates and reloads end to end with useTable in complete mode', () => {
+    function Harness() {
+      const [count, setCount] = useState(12);
+      const { tableProps, reload, search } = useTable<Item>({
+        mode: 'complete',
+        data: makeItems(count),
+        paginationOptions: { pageSize: 5 },
+        searchFn: (data, s) => data.filter(i => i.name.includes(s)),
+      });
+      return (
+        <>
+          <input
+            aria-label="Search"
+            value={search.value}
+            onChange={e => search.onChange(e.target.value)}
+          />
+          <button onClick={() => setCount(7)}>shrink</button>
+          <button onClick={() => reload()}>reload</button>
+          <Table columnConfig={columns} {...tableProps} />
+        </>
+      );
+    }
+    renderTable(<Harness />);
+
+    expect(rowNames()).toEqual([
+      'Item 1',
+      'Item 2',
+      'Item 3',
+      'Item 4',
+      'Item 5',
+    ]);
+    expect(screen.getByText('1 - 5 of 12')).toBeInTheDocument();
+    expect(previousButton()).toBeDisabled();
+
+    fireEvent.click(nextButton());
+    fireEvent.click(nextButton());
+    expect(rowNames()).toEqual(['Item 11', 'Item 12']);
+    expect(screen.getByText('11 - 12 of 12')).toBeInTheDocument();
+    expect(nextButton()).toBeDisabled();
+    expect(liveRegion()).toHaveTextContent(
+      'Table page loaded. Showing 11 to 12 of 12',
+    );
+
+    // Data shrinking under the current page falls back to the last page.
+    fireEvent.click(screen.getByText('shrink'));
+    expect(rowNames()).toEqual(['Item 6', 'Item 7']);
+    expect(screen.getByText('6 - 7 of 7')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Search'), {
+      target: { value: '1' },
+    });
+    expect(rowNames()).toEqual(['Item 1']);
+    expect(screen.getByText('1 - 1 of 1')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Search'), {
+      target: { value: '' },
+    });
+    fireEvent.click(nextButton());
+    fireEvent.click(screen.getByText('reload'));
+    expect(rowNames()).toEqual([
+      'Item 1',
+      'Item 2',
+      'Item 3',
+      'Item 4',
+      'Item 5',
+    ]);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /Select table page size/ }),
+    );
+    fireEvent.click(screen.getByRole('option', { name: 'Show 10 results' }));
+    expect(rowNames()).toHaveLength(7);
+    expect(
+      screen.getByRole('button', { name: /Select table page size/ }),
+    ).toHaveTextContent('Show 10 results');
+  });
+
+  it('shows skeleton, stale rows and busy state while server pages load with useTable in offset mode', async () => {
+    const all = makeItems(7);
+    const pending: Array<() => void> = [];
+    const getData = jest.fn(
+      ({ offset, pageSize }: OffsetParams<unknown>) =>
+        new Promise<{ data: Item[]; totalCount: number }>(resolve => {
+          pending.push(() =>
+            resolve({
+              data: all.slice(offset, offset + pageSize),
+              totalCount: all.length,
+            }),
+          );
+        }),
+    );
+    function Harness() {
+      const { tableProps } = useTable<Item>({
+        mode: 'offset',
+        getData,
+        paginationOptions: { pageSize: 5 },
+      });
+      return <Table columnConfig={columns} {...tableProps} />;
+    }
+    renderTable(<Harness />);
+
+    expect(grid()).toHaveAttribute('aria-busy', 'true');
+    expect(liveRegion()).toHaveTextContent('Loading table data.');
+    expect(
+      within(grid()).queryByRole('rowheader', { name: /Item/ }),
+    ).toBeNull();
+
+    await act(async () => pending.shift()!());
+    expect(grid()).not.toHaveAttribute('aria-busy');
+    expect(rowNames()).toHaveLength(5);
+    expect(liveRegion()).toHaveTextContent(
+      'Table page loaded. Showing 1 to 5 of 7',
+    );
+
+    act(() => nextButton().focus());
+    fireEvent.click(nextButton());
+    // Old rows stay visible and the navigation buttons keep their state
+    // (and focus) while the next page is loading.
+    expect(grid()).toHaveAttribute('aria-busy', 'true');
+    expect(grid()).toHaveAttribute('data-stale', 'true');
+    expect(rowNames()).toEqual([
+      'Item 1',
+      'Item 2',
+      'Item 3',
+      'Item 4',
+      'Item 5',
+    ]);
+    expect(nextButton()).toBeEnabled();
+    expect(nextButton()).toHaveFocus();
+    expect(liveRegion()).toHaveTextContent('Loading table data.');
+
+    await act(async () => pending.shift()!());
+    expect(rowNames()).toEqual(['Item 6', 'Item 7']);
+    expect(nextButton()).toBeDisabled();
+    expect(previousButton()).toHaveFocus();
+    expect(liveRegion()).toHaveTextContent(
+      'Table page loaded. Showing 6 to 7 of 7',
+    );
+    expect(screen.getByText('6 - 7 of 7')).toBeInTheDocument();
+  });
+
+  it('does not fetch during an abandoned first render and settles correctly after Suspense and StrictMode remounts', async () => {
+    let suspend = true;
+    let releaseSuspense!: () => void;
+    const suspensePromise = new Promise<void>(resolve => {
+      releaseSuspense = resolve;
+    });
+    function Suspender() {
+      if (suspend) {
+        throw suspensePromise;
+      }
+      return null;
+    }
+
+    const all = makeItems(12);
+    const offsetSignals: AbortSignal[] = [];
+    const offsetGetData = jest.fn(
+      async ({ offset, pageSize, signal }: OffsetParams<unknown>) => {
+        offsetSignals.push(signal);
+        return { data: all.slice(offset, offset + pageSize), totalCount: 12 };
+      },
+    );
+    const cursorGetData = jest.fn(
+      async ({ cursor, pageSize }: CursorParams<unknown>) => {
+        const start = cursor ? Number(cursor) : 0;
+        return {
+          data: all.slice(start, start + pageSize),
+          nextCursor:
+            start + pageSize < 12 ? String(start + pageSize) : undefined,
+        };
+      },
+    );
+    const completeGetData = jest.fn(async () => all.slice(0, 3));
+
+    function OffsetHarness() {
+      const { tableProps } = useTable<Item>({
+        mode: 'offset',
+        getData: offsetGetData,
+        paginationOptions: { pageSize: 5, initialOffset: 5 },
+      });
+      return (
+        <>
+          <Suspender />
+          <Table columnConfig={columns} {...tableProps} />
+        </>
+      );
+    }
+    function CursorHarness() {
+      const { tableProps } = useTable<Item>({
+        mode: 'cursor',
+        getData: cursorGetData,
+        paginationOptions: { pageSize: 5 },
+      });
+      return <Table columnConfig={columns} {...tableProps} />;
+    }
+    function CompleteHarness() {
+      const { tableProps } = useTable<Item>({
+        mode: 'complete',
+        getData: completeGetData,
+      });
+      return <Table columnConfig={columns} {...tableProps} />;
+    }
+
+    render(
+      <StrictMode>
+        <MemoryRouter>
+          <BUIProvider>
+            <Suspense fallback={<div>fallback</div>}>
+              <OffsetHarness />
+            </Suspense>
+            <CursorHarness />
+            <CompleteHarness />
+          </BUIProvider>
+        </MemoryRouter>
+      </StrictMode>,
+    );
+
+    // The suspended (uncommitted) render must not issue a request.
+    expect(screen.getByText('fallback')).toBeInTheDocument();
+    expect(offsetGetData).not.toHaveBeenCalled();
+
+    suspend = false;
+    await act(async () => releaseSuspense());
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // StrictMode mounts effects twice: the abandoned mount's request is
+    // aborted and the retained mount's request produces the visible page.
+    expect(offsetGetData).toHaveBeenCalledTimes(2);
+    expect(offsetSignals.map(s => s.aborted)).toEqual([true, false]);
+    expect(cursorGetData).toHaveBeenCalledTimes(2);
+    expect(completeGetData).toHaveBeenCalledTimes(2);
+
+    const grids = screen.getAllByRole('grid', { name: 'Data table' });
+    expect(grids).toHaveLength(3);
+    const namesIn = (g: HTMLElement) =>
+      within(g)
+        .getAllByRole('row')
+        .slice(1)
+        .map(row => within(row).getAllByRole('rowheader')[0].textContent);
+    expect(namesIn(grids[0])).toEqual([
+      'Item 6',
+      'Item 7',
+      'Item 8',
+      'Item 9',
+      'Item 10',
+    ]);
+    expect(namesIn(grids[1])).toEqual([
+      'Item 1',
+      'Item 2',
+      'Item 3',
+      'Item 4',
+      'Item 5',
+    ]);
+    expect(namesIn(grids[2])).toEqual(['Item 1', 'Item 2', 'Item 3']);
+    for (const g of grids) {
+      expect(g).not.toHaveAttribute('aria-busy');
+    }
+    expect(
+      screen.getAllByRole('button', { name: 'Next table page' })[1],
+    ).toBeEnabled();
+  });
+});

--- a/packages/ui/src/components/Table/components/Table.tsx
+++ b/packages/ui/src/components/Table/components/Table.tsx
@@ -17,6 +17,7 @@
 import { useId } from 'react-aria';
 import {
   type Key,
+  type Selection,
   ResizableTableContainer,
   Virtualizer,
 } from 'react-aria-components';
@@ -35,8 +36,9 @@ import type {
   RowConfig,
   RowRenderFn,
   TablePaginationType,
+  TableSelection,
 } from '../types';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { VisuallyHidden } from '../../VisuallyHidden';
 import { Flex } from '../../Flex';
 import { TableBodySkeleton } from './TableBodySkeleton';
@@ -66,7 +68,71 @@ function useDisabledRows<T extends TableItem>({
   }, [data, rowConfig]);
 }
 
-function useLiveRegionLabel(
+/**
+ * Rows rendered from `columnConfig` are keyed by `String(item.id)`. Adopters
+ * with numeric ids naturally pass numeric keys in `selection.selected`, so
+ * incoming keys are normalized to strings. When the adopter's selection uses
+ * numeric keys, reported keys are mapped back to the matching item's `id` so
+ * the round trip stays consistent; otherwise keys are reported unchanged.
+ */
+function useNormalizedSelection<T extends TableItem>({
+  data,
+  selectedKeys,
+  onSelectionChange,
+  enabled,
+}: {
+  data: T[] | undefined;
+  selectedKeys: TableSelection['selected'];
+  onSelectionChange: TableSelection['onSelectionChange'];
+  enabled: boolean;
+}) {
+  const normalizedSelectedKeys = useMemo(() => {
+    if (!enabled || !selectedKeys || selectedKeys === 'all') {
+      return selectedKeys;
+    }
+    return new Set<Key>(Array.from(selectedKeys, key => String(key)));
+  }, [enabled, selectedKeys]);
+
+  const handleSelectionChange = useCallback(
+    (keys: Selection) => {
+      if (!onSelectionChange) {
+        return;
+      }
+      if (!enabled || keys === 'all') {
+        onSelectionChange(keys);
+        return;
+      }
+      const originalKeys = new Map<string, Key>();
+      let usesNumericKeys = false;
+      if (selectedKeys && selectedKeys !== 'all') {
+        for (const key of selectedKeys) {
+          originalKeys.set(String(key), key);
+          usesNumericKeys ||= typeof key === 'number';
+        }
+      }
+      if (usesNumericKeys) {
+        for (const item of data ?? []) {
+          if (!originalKeys.has(String(item.id))) {
+            originalKeys.set(String(item.id), item.id);
+          }
+        }
+      }
+      onSelectionChange(
+        new Set<Key>(
+          Array.from(keys, key => originalKeys.get(String(key)) ?? key),
+        ),
+      );
+    },
+    [enabled, onSelectionChange, selectedKeys, data],
+  );
+
+  return {
+    selectedKeys: normalizedSelectedKeys,
+    onSelectionChange: onSelectionChange ? handleSelectionChange : undefined,
+  };
+}
+
+function getLiveRegionLabel(
   pagination: TablePaginationType,
   isStale: boolean,
   isLoading: boolean,
@@ -86,16 +152,21 @@ function useLiveRegionLabel(
     return 'Loading table data.';
   }
 
-  let liveRegionLabel = 'Table page loaded. ';
-
   if (getLabel) {
-    liveRegionLabel += getLabel({ pageSize, offset, totalCount });
-  } else if (offset !== undefined) {
+    return `Table page loaded. ${getLabel({ pageSize, offset, totalCount })}`;
+  }
+  if (totalCount === 0) {
+    return 'Table page loaded. No items to show.';
+  }
+  if (offset !== undefined) {
     const fromCount = offset + 1;
     const toCount = Math.min(offset + pageSize, totalCount ?? 0);
-    liveRegionLabel += `Showing ${fromCount} to ${toCount} of ${totalCount}`;
+    return `Table page loaded. Showing ${fromCount} to ${toCount} of ${totalCount}`;
   }
-  return liveRegionLabel;
+  if (totalCount !== undefined) {
+    return `Table page loaded. ${totalCount} items`;
+  }
+  return 'Table page loaded.';
 }
 
 /**
@@ -141,15 +212,22 @@ export function Table<T extends TableItem>({
 
   const isInitialLoading = pending && !data;
 
+  const normalizedSelection = useNormalizedSelection({
+    data,
+    selectedKeys,
+    onSelectionChange,
+    enabled: !isRowRenderFn(rowConfig),
+  });
+
   if (error) {
     return (
-      <div className={classes.root} style={style}>
+      <div className={classes.root} style={style} role="alert">
         Error: {error.message}
       </div>
     );
   }
 
-  const liveRegionLabel = useLiveRegionLabel(
+  const liveRegionLabel = getLiveRegionLabel(
     pagination,
     isStale,
     isInitialLoading,
@@ -202,8 +280,8 @@ export function Table<T extends TableItem>({
                 : {
                     selectionMode,
                     selectionBehavior,
-                    selectedKeys,
-                    onSelectionChange,
+                    selectedKeys: normalizedSelection.selectedKeys,
+                    onSelectionChange: normalizedSelection.onSelectionChange,
                   })}
               sortDescriptor={sort?.descriptor ?? undefined}
               onSortChange={sort?.onSortChange}

--- a/packages/ui/src/components/Table/components/TableRoot.tsx
+++ b/packages/ui/src/components/Table/components/TableRoot.tsx
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
+import { useRef } from 'react';
 import { useDefinition } from '../../../hooks/useDefinition';
+import { useIsomorphicLayoutEffect } from '../../../hooks/useIsomorphicLayoutEffect';
 import { TableDefinition } from '../definition';
 import { Table as ReactAriaTable } from 'react-aria-components';
 import { TableRootProps } from '../types';
@@ -39,11 +41,29 @@ export const TableRoot = (props: TableRootProps) => {
     },
   );
 
+  const isBusy = Boolean(ownProps.stale || ownProps.isPending);
+  const ref = useRef<HTMLTableElement | HTMLDivElement>(null);
+
+  // React Aria only forwards a fixed set of ARIA attributes to the underlying
+  // grid element, and `aria-busy` is not one of them, so apply it directly to
+  // the DOM node to expose the loading state to assistive technology.
+  useIsomorphicLayoutEffect(() => {
+    const element = ref.current;
+    if (!element) {
+      return;
+    }
+    if (isBusy) {
+      element.setAttribute('aria-busy', 'true');
+    } else {
+      element.removeAttribute('aria-busy');
+    }
+  }, [isBusy]);
+
   return (
     <ReactAriaTable
+      ref={ref}
       className={ownProps.classes.root}
       aria-label="Data table"
-      aria-busy={ownProps.stale || ownProps.isPending}
       {...dataAttributes}
       {...restProps}
     />

--- a/packages/ui/src/components/Table/hooks/useCompletePagination.ts
+++ b/packages/ui/src/components/Table/hooks/useCompletePagination.ts
@@ -58,10 +58,15 @@ export function useCompletePagination<T extends TableItem, TFilter>(
   const [offset, setOffset] = useState(initialOffset);
   const [pageSize, setPageSize] = useState(defaultPageSize);
 
-  // Sync pageSize when the caller changes paginationOptions.pageSize
+  // Sync pageSize when the caller changes paginationOptions.pageSize after
+  // mount. Skipped on the initial render so that `initialOffset` is honored.
+  const prevDefaultPageSizeRef = useRef(defaultPageSize);
   useEffect(() => {
-    setPageSize(defaultPageSize);
-    setOffset(0);
+    if (prevDefaultPageSizeRef.current !== defaultPageSize) {
+      prevDefaultPageSizeRef.current = defaultPageSize;
+      setPageSize(defaultPageSize);
+      setOffset(0);
+    }
   }, [defaultPageSize]);
 
   // Load data on mount and when loadCount changes (reload trigger)
@@ -150,29 +155,41 @@ export function useCompletePagination<T extends TableItem, TFilter>(
 
   const totalCount = processedData?.length ?? 0;
 
+  // Keep the offset within the result set. When the data shrinks (for example
+  // after a reload or a `data` prop change) the current page may no longer
+  // exist, so fall back to the last available page instead of an empty one.
+  const effectiveOffset = useMemo(() => {
+    if (noPagination || processedData === undefined || offset < totalCount) {
+      return offset;
+    }
+    return totalCount === 0
+      ? 0
+      : Math.floor((totalCount - 1) / pageSize) * pageSize;
+  }, [noPagination, processedData, offset, totalCount, pageSize]);
+
   // Paginate the processed data
   const paginatedData = useMemo(
     () =>
       noPagination
         ? processedData
-        : processedData?.slice(offset, offset + pageSize),
-    [processedData, offset, pageSize, noPagination],
+        : processedData?.slice(effectiveOffset, effectiveOffset + pageSize),
+    [processedData, effectiveOffset, pageSize, noPagination],
   );
 
-  const hasNextPage = !noPagination && offset + pageSize < totalCount;
-  const hasPreviousPage = !noPagination && offset > 0;
+  const hasNextPage = !noPagination && effectiveOffset + pageSize < totalCount;
+  const hasPreviousPage = !noPagination && effectiveOffset > 0;
 
   const onNextPage = useCallback(() => {
-    if (offset + pageSize < totalCount) {
-      setOffset(offset + pageSize);
+    if (effectiveOffset + pageSize < totalCount) {
+      setOffset(effectiveOffset + pageSize);
     }
-  }, [offset, pageSize, totalCount]);
+  }, [effectiveOffset, pageSize, totalCount]);
 
   const onPreviousPage = useCallback(() => {
-    if (offset > 0) {
-      setOffset(Math.max(0, offset - pageSize));
+    if (effectiveOffset > 0) {
+      setOffset(Math.max(0, effectiveOffset - pageSize));
     }
-  }, [offset, pageSize]);
+  }, [effectiveOffset, pageSize]);
 
   const onPageSizeChange = useCallback((newSize: number) => {
     setPageSize(newSize);
@@ -189,7 +206,7 @@ export function useCompletePagination<T extends TableItem, TFilter>(
     isPending: isPending,
     error,
     totalCount,
-    offset,
+    offset: effectiveOffset,
     pageSize,
     hasNextPage,
     hasPreviousPage,

--- a/packages/ui/src/components/Table/hooks/useCursorPagination.ts
+++ b/packages/ui/src/components/Table/hooks/useCursorPagination.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import type { TableItem } from '../types';
 import type {
   UseTableCursorOptions,
@@ -37,6 +37,16 @@ export function useCursorPagination<T extends TableItem, TFilter>(
   const { sort, filter, search } = query;
 
   const [pageSize, setPageSize] = useState(defaultPageSize);
+
+  // Follow the caller's `paginationOptions.pageSize` when it changes after
+  // mount, matching the behavior of complete mode.
+  const prevDefaultPageSizeRef = useRef(defaultPageSize);
+  useEffect(() => {
+    if (prevDefaultPageSizeRef.current !== defaultPageSize) {
+      prevDefaultPageSizeRef.current = defaultPageSize;
+      setPageSize(defaultPageSize);
+    }
+  }, [defaultPageSize]);
 
   const wrappedGetData = useCallback(
     async ({
@@ -69,7 +79,25 @@ export function useCursorPagination<T extends TableItem, TFilter>(
 
   const cache = usePageCache<T, string>({ getData: wrappedGetData });
 
-  useDebouncedReload(query, pageSize, cache.reload);
+  const debouncedReload = useDebouncedReload(query, pageSize, cache.reload);
+
+  // When the query or page size changed but the debounced reload has not run
+  // yet, navigating would fetch a page for the new query at the old position.
+  // Flush the pending reload instead so the table lands on the first page of
+  // the new result set.
+  const { flush } = debouncedReload;
+  const { onNextPage: cacheNextPage, onPreviousPage: cachePreviousPage } =
+    cache;
+  const onNextPage = useCallback(() => {
+    if (!flush()) {
+      cacheNextPage();
+    }
+  }, [flush, cacheNextPage]);
+  const onPreviousPage = useCallback(() => {
+    if (!flush()) {
+      cachePreviousPage();
+    }
+  }, [flush, cachePreviousPage]);
 
   const onPageSizeChange = useCallback(
     (newSize: number) => setPageSize(newSize),
@@ -85,8 +113,8 @@ export function useCursorPagination<T extends TableItem, TFilter>(
     pageSize,
     hasNextPage: cache.hasNextPage,
     hasPreviousPage: cache.hasPreviousPage,
-    onNextPage: cache.onNextPage,
-    onPreviousPage: cache.onPreviousPage,
+    onNextPage,
+    onPreviousPage,
     onPageSizeChange,
     reload: cache.reload,
   };

--- a/packages/ui/src/components/Table/hooks/useDebouncedReload.ts
+++ b/packages/ui/src/components/Table/hooks/useDebouncedReload.ts
@@ -14,12 +14,25 @@
  * limitations under the License.
  */
 
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { QueryState } from './types';
+import { useStableCallback } from './useStableCallback';
+
+/** @internal */
+export interface DebouncedReloadResult {
+  /**
+   * If a debounced reload is currently scheduled, cancels the timer and runs
+   * the reload immediately. Returns `true` when a reload was flushed.
+   */
+  flush: () => boolean;
+}
 
 /**
  * Triggers a debounced reload when query or pageSize changes.
  * Debouncing reduces backend load during rapid changes (e.g., typing in search).
+ *
+ * The scheduled reload survives unrelated re-renders (for example a page
+ * navigation resolving) and can be flushed early via the returned `flush`.
  */
 /** @internal */
 export function useDebouncedReload<TFilter>(
@@ -27,16 +40,43 @@ export function useDebouncedReload<TFilter>(
   pageSize: number,
   reload: () => void,
   delay: number = 200,
-): void {
+): DebouncedReloadResult {
+  const stableReload = useStableCallback(reload);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const prevDepsRef = useRef({ query, pageSize });
+
+  const clear = useCallback(() => {
+    if (timerRef.current !== undefined) {
+      clearTimeout(timerRef.current);
+      timerRef.current = undefined;
+    }
+  }, []);
 
   useEffect(() => {
     const prev = prevDepsRef.current;
-    if (prev.query !== query || prev.pageSize !== pageSize) {
-      prevDepsRef.current = { query, pageSize };
-      const timer = setTimeout(reload, delay);
-      return () => clearTimeout(timer);
+    if (prev.query === query && prev.pageSize === pageSize) {
+      return undefined;
     }
+    prevDepsRef.current = { query, pageSize };
+    clear();
+    timerRef.current = setTimeout(() => {
+      timerRef.current = undefined;
+      stableReload();
+    }, delay);
     return undefined;
-  }, [query, pageSize, reload, delay]);
+  }, [query, pageSize, delay, stableReload, clear]);
+
+  // Cancel any scheduled reload on unmount.
+  useEffect(() => clear, [clear]);
+
+  const flush = useCallback(() => {
+    if (timerRef.current === undefined) {
+      return false;
+    }
+    clear();
+    stableReload();
+    return true;
+  }, [clear, stableReload]);
+
+  return useMemo(() => ({ flush }), [flush]);
 }

--- a/packages/ui/src/components/Table/hooks/useOffsetPagination.ts
+++ b/packages/ui/src/components/Table/hooks/useOffsetPagination.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import type { TableItem } from '../types';
 import type {
   UseTableOffsetOptions,
@@ -38,6 +38,16 @@ export function useOffsetPagination<T extends TableItem, TFilter>(
   const { sort, filter, search } = query;
 
   const [pageSize, setPageSize] = useState(defaultPageSize);
+
+  // Follow the caller's `paginationOptions.pageSize` when it changes after
+  // mount, matching the behavior of complete mode.
+  const prevDefaultPageSizeRef = useRef(defaultPageSize);
+  useEffect(() => {
+    if (prevDefaultPageSizeRef.current !== defaultPageSize) {
+      prevDefaultPageSizeRef.current = defaultPageSize;
+      setPageSize(defaultPageSize);
+    }
+  }, [defaultPageSize]);
 
   const wrappedGetData = useCallback(
     async ({
@@ -82,7 +92,25 @@ export function useOffsetPagination<T extends TableItem, TFilter>(
     initialCurrentCursor: initialOffset > 0 ? initialOffset : undefined,
   });
 
-  useDebouncedReload(query, pageSize, cache.reload);
+  const debouncedReload = useDebouncedReload(query, pageSize, cache.reload);
+
+  // When the query or page size changed but the debounced reload has not run
+  // yet, navigating would fetch a page for the new query at the old position.
+  // Flush the pending reload instead so the table lands on the first page of
+  // the new result set.
+  const { flush } = debouncedReload;
+  const { onNextPage: cacheNextPage, onPreviousPage: cachePreviousPage } =
+    cache;
+  const onNextPage = useCallback(() => {
+    if (!flush()) {
+      cacheNextPage();
+    }
+  }, [flush, cacheNextPage]);
+  const onPreviousPage = useCallback(() => {
+    if (!flush()) {
+      cachePreviousPage();
+    }
+  }, [flush, cachePreviousPage]);
 
   const onPageSizeChange = useCallback(
     (newSize: number) => setPageSize(newSize),
@@ -98,8 +126,8 @@ export function useOffsetPagination<T extends TableItem, TFilter>(
     pageSize,
     hasNextPage: cache.hasNextPage,
     hasPreviousPage: cache.hasPreviousPage,
-    onNextPage: cache.onNextPage,
-    onPreviousPage: cache.onPreviousPage,
+    onNextPage,
+    onPreviousPage,
     onPageSizeChange,
     reload: cache.reload,
   };

--- a/packages/ui/src/components/Table/hooks/useTable.test.tsx
+++ b/packages/ui/src/components/Table/hooks/useTable.test.tsx
@@ -1,0 +1,838 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import type { SortDescriptor } from '../types';
+import type { CursorParams, OffsetParams } from './types';
+import { useTable } from './useTable';
+
+type Item = { id: number; name: string };
+
+const makeItems = (count: number): Item[] =>
+  Array.from({ length: count }, (_, i) => ({
+    id: i + 1,
+    name: `Item ${i + 1}`,
+  }));
+
+const ids = (data: Item[] | undefined) => data?.map(item => item.id);
+
+const flushPromises = () =>
+  act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+/** Creates a deferred getData for asserting on in-flight state. */
+function createDeferredSource<TResponse>() {
+  const pending: Array<{
+    resolve: (value: TResponse) => void;
+    reject: (error: Error) => void;
+    signal: AbortSignal;
+  }> = [];
+  const getData = jest.fn(
+    (params: { signal: AbortSignal }) =>
+      new Promise<TResponse>((resolve, reject) => {
+        pending.push({ resolve, reject, signal: params.signal });
+      }),
+  );
+  return { getData, pending };
+}
+
+describe('useTable', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('complete mode', () => {
+    it('paginates client-side data, honors initialOffset and clamps at both boundaries', () => {
+      const { result } = renderHook(() =>
+        useTable<Item>({
+          mode: 'complete',
+          data: makeItems(12),
+          paginationOptions: { pageSize: 5, initialOffset: 10 },
+        }),
+      );
+
+      const pagination = () => result.current.tableProps.pagination;
+      expect(ids(result.current.tableProps.data)).toEqual([11, 12]);
+      expect(pagination()).toMatchObject({
+        type: 'page',
+        offset: 10,
+        pageSize: 5,
+        totalCount: 12,
+        hasNextPage: false,
+        hasPreviousPage: true,
+      });
+      expect(result.current.tableProps.isPending).toBe(false);
+
+      // Next at the last page is a no-op.
+      act(() => (pagination() as any).onNextPage());
+      expect(pagination()).toMatchObject({ offset: 10 });
+
+      act(() => (pagination() as any).onPreviousPage());
+      act(() => (pagination() as any).onPreviousPage());
+      expect(ids(result.current.tableProps.data)).toEqual([1, 2, 3, 4, 5]);
+      expect(pagination()).toMatchObject({
+        offset: 0,
+        hasNextPage: true,
+        hasPreviousPage: false,
+      });
+
+      // Previous at the first page is a no-op.
+      act(() => (pagination() as any).onPreviousPage());
+      expect(pagination()).toMatchObject({ offset: 0 });
+    });
+
+    it('moves to the last available page when the data shrinks below the current offset', () => {
+      const { result, rerender } = renderHook(
+        ({ data }: { data: Item[] }) =>
+          useTable<Item>({
+            mode: 'complete',
+            data,
+            paginationOptions: { pageSize: 5 },
+          }),
+        { initialProps: { data: makeItems(12) } },
+      );
+      const pagination = () => result.current.tableProps.pagination as any;
+
+      act(() => pagination().onNextPage());
+      act(() => pagination().onNextPage());
+      expect(ids(result.current.tableProps.data)).toEqual([11, 12]);
+
+      rerender({ data: makeItems(7) });
+      expect(ids(result.current.tableProps.data)).toEqual([6, 7]);
+      expect(pagination()).toMatchObject({
+        offset: 5,
+        totalCount: 7,
+        hasNextPage: false,
+        hasPreviousPage: true,
+      });
+
+      rerender({ data: [] });
+      expect(result.current.tableProps.data).toEqual([]);
+      expect(pagination()).toMatchObject({
+        offset: 0,
+        totalCount: 0,
+        hasNextPage: false,
+        hasPreviousPage: false,
+      });
+    });
+
+    it('applies filter, search and sort, resetting to the first page when they change', () => {
+      const onSearchChange = jest.fn();
+      const { result } = renderHook(() =>
+        useTable<Item, { minId: number }>({
+          mode: 'complete',
+          data: makeItems(30),
+          paginationOptions: { pageSize: 5 },
+          filterFn: (data, filter) => data.filter(i => i.id >= filter.minId),
+          searchFn: (data, search) => data.filter(i => i.name.includes(search)),
+          sortFn: (data, sort) =>
+            [...data].sort((a, b) =>
+              sort.direction === 'ascending' ? a.id - b.id : b.id - a.id,
+            ),
+          onSearchChange,
+        }),
+      );
+      const pagination = () => result.current.tableProps.pagination as any;
+
+      act(() => pagination().onNextPage());
+      expect(pagination().offset).toBe(5);
+
+      act(() => result.current.filter.onChange({ minId: 20 }));
+      expect(pagination()).toMatchObject({ offset: 0, totalCount: 11 });
+      expect(ids(result.current.tableProps.data)).toEqual([20, 21, 22, 23, 24]);
+      expect(result.current.filter.value).toEqual({ minId: 20 });
+
+      act(() => result.current.search.onChange('2'));
+      expect(onSearchChange).toHaveBeenCalledWith('2');
+      expect(result.current.search.value).toBe('2');
+      // 20-29 all contain "2"; 30 does not
+      expect(pagination().totalCount).toBe(10);
+
+      act(() => pagination().onNextPage());
+      expect(pagination().offset).toBe(5);
+
+      act(() =>
+        result.current.tableProps.sort?.onSortChange({
+          column: 'name',
+          direction: 'descending',
+        }),
+      );
+      expect(result.current.tableProps.sort?.descriptor).toEqual({
+        column: 'name',
+        direction: 'descending',
+      });
+      expect(pagination().offset).toBe(0);
+      expect(ids(result.current.tableProps.data)).toEqual([29, 28, 27, 26, 25]);
+    });
+
+    it('supports controlled sort, filter and search without keeping internal copies', () => {
+      const onSortChange = jest.fn();
+      const onFilterChange = jest.fn();
+      const initialSort: SortDescriptor = {
+        column: 'name',
+        direction: 'ascending',
+      };
+      const { result, rerender } = renderHook(
+        (props: { sort: SortDescriptor | null; search: string }) =>
+          useTable<Item, string>({
+            mode: 'complete',
+            data: makeItems(3),
+            sort: props.sort,
+            onSortChange,
+            filter: 'x',
+            onFilterChange,
+            search: props.search,
+            searchFn: (data, search) =>
+              data.filter(i => i.name.includes(search)),
+          }),
+        {
+          initialProps: {
+            sort: initialSort as SortDescriptor | null,
+            search: '',
+          },
+        },
+      );
+
+      expect(result.current.tableProps.sort?.descriptor).toEqual(initialSort);
+      act(() =>
+        result.current.tableProps.sort?.onSortChange({
+          column: 'name',
+          direction: 'descending',
+        }),
+      );
+      expect(onSortChange).toHaveBeenCalledWith({
+        column: 'name',
+        direction: 'descending',
+      });
+      // Controlled: value does not change until the parent re-renders.
+      expect(result.current.tableProps.sort?.descriptor).toEqual(initialSort);
+
+      rerender({ sort: null, search: '3' });
+      expect(result.current.tableProps.sort?.descriptor).toBeNull();
+      expect(result.current.search.value).toBe('3');
+      expect(ids(result.current.tableProps.data)).toEqual([3]);
+
+      act(() => result.current.filter.onChange('y'));
+      expect(onFilterChange).toHaveBeenCalledWith('y');
+      expect(result.current.filter.value).toBe('x');
+    });
+
+    it('debounces search before it reaches searchFn while keeping the input value live', () => {
+      jest.useFakeTimers();
+      const searchFn = jest.fn((data: Item[], search: string) =>
+        data.filter(i => i.name.includes(search)),
+      );
+      const { result } = renderHook(() =>
+        useTable<Item>({
+          mode: 'complete',
+          data: makeItems(12),
+          paginationOptions: { pageSize: 5 },
+          searchFn,
+          searchDebounceMs: 300,
+        }),
+      );
+      const pagination = () => result.current.tableProps.pagination as any;
+      act(() => pagination().onNextPage());
+
+      act(() => result.current.search.onChange('1'));
+      expect(result.current.search.value).toBe('1');
+      expect(searchFn).not.toHaveBeenCalled();
+      expect(pagination().offset).toBe(5);
+
+      act(() => result.current.search.onChange('12'));
+      act(() => jest.advanceTimersByTime(299));
+      expect(searchFn).not.toHaveBeenCalled();
+      act(() => jest.advanceTimersByTime(1));
+      // Only the settled value reaches searchFn — never the intermediate "1".
+      expect(searchFn.mock.calls.map(([, search]) => search)).toEqual(
+        expect.arrayContaining(['12']),
+      );
+      expect(searchFn.mock.calls.map(([, search]) => search)).not.toContain(
+        '1',
+      );
+      expect(ids(result.current.tableProps.data)).toEqual([12]);
+      expect(pagination().offset).toBe(0);
+    });
+
+    it('follows pageSize option changes after mount and validates against pageSizeOptions', () => {
+      const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const { result, rerender } = renderHook(
+        ({ pageSize }: { pageSize: number }) =>
+          useTable<Item>({
+            mode: 'complete',
+            data: makeItems(12),
+            paginationOptions: { pageSize, pageSizeOptions: [5, 10] },
+          }),
+        { initialProps: { pageSize: 5 } },
+      );
+      const pagination = () => result.current.tableProps.pagination as any;
+      act(() => pagination().onNextPage());
+      expect(pagination().offset).toBe(5);
+
+      rerender({ pageSize: 10 });
+      expect(pagination()).toMatchObject({ pageSize: 10, offset: 0 });
+      expect(result.current.tableProps.data).toHaveLength(10);
+
+      act(() => pagination().onPageSizeChange(5));
+      expect(pagination()).toMatchObject({ pageSize: 5, offset: 0 });
+
+      // A pageSize outside the options falls back to the first option.
+      rerender({ pageSize: 7 });
+      expect(pagination().pageSize).toBe(5);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('pageSize 7 is not in pageSizeOptions'),
+      );
+      warn.mockRestore();
+    });
+
+    it('loads async getData, exposes errors, and keeps rows visible as stale during reload', async () => {
+      const source = createDeferredSource<Item[]>();
+      const { result } = renderHook(() =>
+        useTable<Item>({
+          mode: 'complete',
+          getData: () =>
+            source.getData({ signal: new AbortController().signal }),
+          paginationOptions: { pageSize: 5 },
+        }),
+      );
+
+      expect(result.current.tableProps).toMatchObject({
+        isPending: true,
+        loading: true,
+        isStale: false,
+        data: undefined,
+      });
+
+      await act(async () => source.pending[0].resolve(makeItems(12)));
+      expect(result.current.tableProps.isPending).toBe(false);
+      expect(ids(result.current.tableProps.data)).toEqual([1, 2, 3, 4, 5]);
+      act(() => (result.current.tableProps.pagination as any).onNextPage());
+
+      act(() => result.current.reload());
+      expect(source.getData).toHaveBeenCalledTimes(2);
+      // Previous rows stay visible, flagged stale, and pagination resets.
+      expect(result.current.tableProps).toMatchObject({
+        isPending: true,
+        isStale: true,
+      });
+      expect(ids(result.current.tableProps.data)).toEqual([1, 2, 3, 4, 5]);
+
+      await act(async () => source.pending[1].reject(new Error('boom')));
+      expect(result.current.tableProps.error?.message).toBe('boom');
+      expect(result.current.tableProps.isPending).toBe(false);
+
+      act(() => result.current.reload());
+      expect(result.current.tableProps.error).toBeUndefined();
+      await act(async () => source.pending[2].resolve(makeItems(3)));
+      expect(ids(result.current.tableProps.data)).toEqual([1, 2, 3]);
+      expect(result.current.tableProps.pagination).toMatchObject({
+        totalCount: 3,
+        hasNextPage: false,
+      });
+    });
+
+    it('does not refetch when getData identity changes between renders', async () => {
+      const getData = jest.fn(() => makeItems(3));
+      const { result, rerender } = renderHook(() =>
+        useTable<Item>({ mode: 'complete', getData: () => getData() }),
+      );
+      await flushPromises();
+      rerender();
+      rerender();
+      expect(getData).toHaveBeenCalledTimes(1);
+      expect(ids(result.current.tableProps.data)).toEqual([1, 2, 3]);
+    });
+
+    it("returns everything on one page with pagination type 'none'", () => {
+      const { result } = renderHook(() =>
+        useTable<Item>({
+          mode: 'complete',
+          data: makeItems(40),
+          paginationOptions: { type: 'none' },
+        }),
+      );
+      expect(result.current.tableProps.pagination).toEqual({ type: 'none' });
+      expect(result.current.tableProps.data).toHaveLength(40);
+    });
+
+    it('throws if the mode changes after mount', () => {
+      const error = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const { rerender } = renderHook(
+        ({ mode }: { mode: 'complete' | 'offset' }) =>
+          mode === 'complete'
+            ? useTable<Item>({ mode, data: [] })
+            : useTable<Item>({
+                mode,
+                getData: async () => ({ data: [], totalCount: 0 }),
+              }),
+        { initialProps: { mode: 'complete' } },
+      );
+      expect(() => rerender({ mode: 'offset' })).toThrow(
+        /mode cannot change from 'complete' to 'offset'/,
+      );
+      error.mockRestore();
+    });
+  });
+
+  describe('offset mode', () => {
+    const allItems = makeItems(12);
+    const offsetSource = () =>
+      jest.fn(async ({ offset, pageSize, search }: OffsetParams<unknown>) => {
+        const matching = allItems.filter(i => i.name.includes(search));
+        return {
+          data: matching.slice(offset, offset + pageSize),
+          totalCount: matching.length,
+        };
+      });
+
+    it('fetches pages on demand, exposes stale rows while loading, and serves cached pages synchronously', async () => {
+      const source = createDeferredSource<{
+        data: Item[];
+        totalCount: number;
+      }>();
+      const getData = jest.fn((params: OffsetParams<unknown>) =>
+        source.getData(params).then(res => res),
+      );
+      const { result } = renderHook(() =>
+        useTable<Item>({
+          mode: 'offset',
+          getData,
+          paginationOptions: { pageSize: 5 },
+        }),
+      );
+      const pagination = () => result.current.tableProps.pagination as any;
+
+      expect(result.current.tableProps).toMatchObject({
+        isPending: true,
+        isStale: false,
+        data: undefined,
+      });
+      expect(getData).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          offset: 0,
+          pageSize: 5,
+          sort: null,
+          search: '',
+          signal: expect.any(AbortSignal),
+        }),
+      );
+
+      await act(async () =>
+        source.pending[0].resolve({
+          data: allItems.slice(0, 5),
+          totalCount: 12,
+        }),
+      );
+      expect(result.current.tableProps.isPending).toBe(false);
+      expect(pagination()).toMatchObject({
+        offset: 0,
+        totalCount: 12,
+        hasNextPage: true,
+        hasPreviousPage: false,
+      });
+
+      act(() => pagination().onNextPage());
+      expect(getData).toHaveBeenLastCalledWith(
+        expect.objectContaining({ offset: 5 }),
+      );
+      // Rows and navigation state from the visible page are kept while loading.
+      expect(result.current.tableProps).toMatchObject({
+        isPending: true,
+        isStale: true,
+      });
+      expect(ids(result.current.tableProps.data)).toEqual([1, 2, 3, 4, 5]);
+      expect(pagination()).toMatchObject({
+        offset: 5,
+        hasNextPage: true,
+        hasPreviousPage: false,
+      });
+
+      // Repeated clicks during loading do not trigger extra requests.
+      act(() => pagination().onNextPage());
+      expect(getData).toHaveBeenCalledTimes(2);
+
+      await act(async () =>
+        source.pending[1].resolve({
+          data: allItems.slice(5, 10),
+          totalCount: 12,
+        }),
+      );
+      expect(ids(result.current.tableProps.data)).toEqual([6, 7, 8, 9, 10]);
+      expect(pagination()).toMatchObject({
+        offset: 5,
+        hasNextPage: true,
+        hasPreviousPage: true,
+      });
+
+      act(() => pagination().onNextPage());
+      await act(async () =>
+        source.pending[2].resolve({ data: allItems.slice(10), totalCount: 12 }),
+      );
+      expect(ids(result.current.tableProps.data)).toEqual([11, 12]);
+      expect(pagination()).toMatchObject({
+        offset: 10,
+        hasNextPage: false,
+        hasPreviousPage: true,
+      });
+
+      // Going back is served from cache without a request.
+      act(() => pagination().onPreviousPage());
+      expect(getData).toHaveBeenCalledTimes(3);
+      expect(result.current.tableProps.isPending).toBe(false);
+      expect(ids(result.current.tableProps.data)).toEqual([6, 7, 8, 9, 10]);
+    });
+
+    it('starts at initialOffset and reload returns to the first page with a fresh request', async () => {
+      const getData = offsetSource();
+      const { result } = renderHook(() =>
+        useTable<Item>({
+          mode: 'offset',
+          getData,
+          paginationOptions: { pageSize: 5, initialOffset: 5 },
+        }),
+      );
+      await flushPromises();
+      expect(ids(result.current.tableProps.data)).toEqual([6, 7, 8, 9, 10]);
+      expect(result.current.tableProps.pagination).toMatchObject({
+        offset: 5,
+        hasPreviousPage: true,
+        hasNextPage: true,
+      });
+
+      act(() => result.current.reload());
+      await flushPromises();
+      expect(getData).toHaveBeenCalledTimes(2);
+      expect(getData).toHaveBeenLastCalledWith(
+        expect.objectContaining({ offset: 0 }),
+      );
+      expect(ids(result.current.tableProps.data)).toEqual([1, 2, 3, 4, 5]);
+      expect(result.current.tableProps.pagination).toMatchObject({
+        offset: 0,
+        hasPreviousPage: false,
+      });
+    });
+
+    it('debounces query changes into a single first-page request and aborts superseded requests', async () => {
+      jest.useFakeTimers();
+      const source = createDeferredSource<{
+        data: Item[];
+        totalCount: number;
+      }>();
+      const getData = jest.fn((params: OffsetParams<unknown>) =>
+        source.getData(params),
+      );
+      const { result } = renderHook(() =>
+        useTable<Item>({
+          mode: 'offset',
+          getData,
+          paginationOptions: { pageSize: 5 },
+        }),
+      );
+      await act(async () =>
+        source.pending[0].resolve({
+          data: allItems.slice(0, 5),
+          totalCount: 12,
+        }),
+      );
+      act(() => (result.current.tableProps.pagination as any).onNextPage());
+      await act(async () =>
+        source.pending[1].resolve({
+          data: allItems.slice(5, 10),
+          totalCount: 12,
+        }),
+      );
+      expect(result.current.tableProps.pagination).toMatchObject({ offset: 5 });
+
+      act(() => result.current.search.onChange('1'));
+      act(() => result.current.search.onChange('12'));
+      act(() => jest.advanceTimersByTime(150));
+      expect(getData).toHaveBeenCalledTimes(2);
+      act(() => jest.advanceTimersByTime(100));
+      expect(getData).toHaveBeenCalledTimes(3);
+      expect(getData).toHaveBeenLastCalledWith(
+        expect.objectContaining({ offset: 0, search: '12' }),
+      );
+      expect(result.current.tableProps.isStale).toBe(true);
+
+      // A further change while the request is in flight aborts it.
+      act(() => result.current.search.onChange('11'));
+      act(() => jest.advanceTimersByTime(200));
+      expect(source.pending[2].signal.aborted).toBe(true);
+      expect(getData).toHaveBeenCalledTimes(4);
+
+      // A late response from the aborted request is ignored.
+      await act(async () =>
+        source.pending[2].resolve({ data: [allItems[11]], totalCount: 1 }),
+      );
+      expect(ids(result.current.tableProps.data)).toEqual([6, 7, 8, 9, 10]);
+      await act(async () =>
+        source.pending[3].resolve({ data: [allItems[10]], totalCount: 1 }),
+      );
+      expect(ids(result.current.tableProps.data)).toEqual([11]);
+      expect(result.current.tableProps.pagination).toMatchObject({
+        offset: 0,
+        totalCount: 1,
+        hasNextPage: false,
+      });
+    });
+
+    it('navigating right after a query change applies the new query from the first page', async () => {
+      jest.useFakeTimers();
+      const getData = offsetSource();
+      const { result } = renderHook(() =>
+        useTable<Item>({
+          mode: 'offset',
+          getData,
+          paginationOptions: { pageSize: 5 },
+        }),
+      );
+      await flushPromises();
+
+      act(() => result.current.search.onChange('1'));
+      act(() => jest.advanceTimersByTime(50));
+      act(() => (result.current.tableProps.pagination as any).onNextPage());
+      await flushPromises();
+      act(() => jest.advanceTimersByTime(500));
+      await flushPromises();
+
+      expect(
+        getData.mock.calls.map(([params]) => [params.offset, params.search]),
+      ).toEqual([
+        [0, ''],
+        [0, '1'],
+      ]);
+      expect(ids(result.current.tableProps.data)).toEqual([1, 10, 11, 12]);
+      expect(result.current.tableProps.pagination).toMatchObject({
+        offset: 0,
+        totalCount: 4,
+      });
+    });
+
+    it('page size changes from the user or from options refetch from the first page', async () => {
+      jest.useFakeTimers();
+      const getData = offsetSource();
+      const { result, rerender } = renderHook(
+        ({ pageSize }: { pageSize: number }) =>
+          useTable<Item>({
+            mode: 'offset',
+            getData,
+            paginationOptions: { pageSize },
+          }),
+        { initialProps: { pageSize: 5 } },
+      );
+      const pagination = () => result.current.tableProps.pagination as any;
+      await flushPromises();
+      act(() => pagination().onNextPage());
+      await flushPromises();
+      expect(pagination().offset).toBe(5);
+
+      act(() => pagination().onPageSizeChange(10));
+      expect(pagination().pageSize).toBe(10);
+      act(() => jest.advanceTimersByTime(200));
+      await flushPromises();
+      expect(getData).toHaveBeenLastCalledWith(
+        expect.objectContaining({ offset: 0, pageSize: 10 }),
+      );
+      expect(result.current.tableProps.data).toHaveLength(10);
+      expect(pagination()).toMatchObject({ offset: 0, hasNextPage: true });
+
+      rerender({ pageSize: 20 });
+      expect(pagination().pageSize).toBe(20);
+      act(() => jest.advanceTimersByTime(200));
+      await flushPromises();
+      expect(getData).toHaveBeenLastCalledWith(
+        expect.objectContaining({ offset: 0, pageSize: 20 }),
+      );
+      expect(result.current.tableProps.data).toHaveLength(12);
+      expect(pagination().hasNextPage).toBe(false);
+    });
+
+    it('surfaces request errors and recovers on reload', async () => {
+      let shouldFail = true;
+      const getData = jest.fn(
+        async ({ offset, pageSize }: OffsetParams<unknown>) => {
+          if (shouldFail) {
+            throw new Error('server down');
+          }
+          return {
+            data: allItems.slice(offset, offset + pageSize),
+            totalCount: 12,
+          };
+        },
+      );
+      const { result } = renderHook(() =>
+        useTable<Item>({
+          mode: 'offset',
+          getData,
+          paginationOptions: { pageSize: 5 },
+        }),
+      );
+      await flushPromises();
+      expect(result.current.tableProps.error?.message).toBe('server down');
+      expect(result.current.tableProps.isPending).toBe(false);
+
+      shouldFail = false;
+      act(() => result.current.reload());
+      expect(result.current.tableProps.error).toBeUndefined();
+      await flushPromises();
+      expect(ids(result.current.tableProps.data)).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it('aborts the in-flight request on unmount', () => {
+      const source = createDeferredSource<{
+        data: Item[];
+        totalCount: number;
+      }>();
+      const { unmount } = renderHook(() =>
+        useTable<Item>({ mode: 'offset', getData: source.getData }),
+      );
+      expect(source.pending[0].signal.aborted).toBe(false);
+      unmount();
+      expect(source.pending[0].signal.aborted).toBe(true);
+    });
+  });
+
+  describe('cursor mode', () => {
+    const allItems = makeItems(12);
+    const cursorSource = (withTotal = true) =>
+      jest.fn(async ({ cursor, pageSize, search }: CursorParams<unknown>) => {
+        const matching = allItems.filter(i => i.name.includes(search));
+        const start = cursor ? Number(cursor) : 0;
+        const end = start + pageSize;
+        return {
+          data: matching.slice(start, end),
+          nextCursor: end < matching.length ? String(end) : undefined,
+          prevCursor:
+            start > 0 ? String(Math.max(0, start - pageSize)) : undefined,
+          ...(withTotal ? { totalCount: matching.length } : {}),
+        };
+      });
+
+    it('navigates with cursors from the response, caches visited pages and reports no offset', async () => {
+      const getData = cursorSource();
+      const { result } = renderHook(() =>
+        useTable<Item>({
+          mode: 'cursor',
+          getData,
+          paginationOptions: { pageSize: 5 },
+        }),
+      );
+      const pagination = () => result.current.tableProps.pagination as any;
+      await flushPromises();
+      expect(getData).toHaveBeenLastCalledWith(
+        expect.objectContaining({ cursor: undefined, pageSize: 5 }),
+      );
+      expect(pagination()).toMatchObject({
+        offset: undefined,
+        totalCount: 12,
+        hasNextPage: true,
+        hasPreviousPage: false,
+      });
+
+      act(() => pagination().onNextPage());
+      expect(getData).toHaveBeenLastCalledWith(
+        expect.objectContaining({ cursor: '5' }),
+      );
+      await flushPromises();
+      act(() => pagination().onNextPage());
+      await flushPromises();
+      expect(ids(result.current.tableProps.data)).toEqual([11, 12]);
+      expect(pagination()).toMatchObject({
+        hasNextPage: false,
+        hasPreviousPage: true,
+      });
+
+      act(() => pagination().onPreviousPage());
+      expect(getData).toHaveBeenCalledTimes(3);
+      expect(ids(result.current.tableProps.data)).toEqual([6, 7, 8, 9, 10]);
+      act(() => pagination().onPreviousPage());
+      expect(ids(result.current.tableProps.data)).toEqual([1, 2, 3, 4, 5]);
+      expect(pagination().hasPreviousPage).toBe(false);
+    });
+
+    it('works without totalCount and resets to the first page on query and page size changes', async () => {
+      jest.useFakeTimers();
+      const getData = cursorSource(false);
+      const { result } = renderHook(() =>
+        useTable<Item>({
+          mode: 'cursor',
+          getData,
+          paginationOptions: { pageSize: 5 },
+        }),
+      );
+      const pagination = () => result.current.tableProps.pagination as any;
+      await flushPromises();
+      expect(pagination().totalCount).toBeUndefined();
+
+      act(() => pagination().onNextPage());
+      await flushPromises();
+      expect(ids(result.current.tableProps.data)).toEqual([6, 7, 8, 9, 10]);
+
+      act(() => result.current.search.onChange('1'));
+      act(() => jest.advanceTimersByTime(200));
+      await flushPromises();
+      expect(getData).toHaveBeenLastCalledWith(
+        expect.objectContaining({ cursor: undefined, search: '1' }),
+      );
+      expect(ids(result.current.tableProps.data)).toEqual([1, 10, 11, 12]);
+      expect(pagination()).toMatchObject({
+        hasNextPage: false,
+        hasPreviousPage: false,
+      });
+
+      act(() => result.current.search.onChange(''));
+      act(() => jest.advanceTimersByTime(200));
+      await flushPromises();
+      act(() => pagination().onNextPage());
+      await flushPromises();
+      act(() => pagination().onPageSizeChange(10));
+      act(() => jest.advanceTimersByTime(200));
+      await flushPromises();
+      expect(getData).toHaveBeenLastCalledWith(
+        expect.objectContaining({ cursor: undefined, pageSize: 10 }),
+      );
+      expect(result.current.tableProps.data).toHaveLength(10);
+      expect(pagination().hasPreviousPage).toBe(false);
+    });
+
+    it('reload refetches the first page and drops cached pages', async () => {
+      const getData = cursorSource();
+      const { result } = renderHook(() =>
+        useTable<Item>({
+          mode: 'cursor',
+          getData,
+          paginationOptions: { pageSize: 5 },
+        }),
+      );
+      const pagination = () => result.current.tableProps.pagination as any;
+      await flushPromises();
+      act(() => pagination().onNextPage());
+      await flushPromises();
+      expect(getData).toHaveBeenCalledTimes(2);
+
+      act(() => result.current.reload());
+      expect(result.current.tableProps.isStale).toBe(true);
+      await flushPromises();
+      expect(getData).toHaveBeenCalledTimes(3);
+      expect(ids(result.current.tableProps.data)).toEqual([1, 2, 3, 4, 5]);
+
+      act(() => pagination().onNextPage());
+      expect(getData).toHaveBeenCalledTimes(4);
+    });
+  });
+});

--- a/packages/ui/src/components/Table/hooks/useTable.ts
+++ b/packages/ui/src/components/Table/hooks/useTable.ts
@@ -54,6 +54,23 @@ function useTableProps<T extends TableItem>(
   const displayData = paginationResult.data ?? previousDataRef.current;
   const isStale = paginationResult.isPending && displayData !== undefined;
 
+  // While a new page is loading, keep showing the navigation state of the
+  // page that is still visible. Otherwise the buttons flicker to disabled
+  // during the fetch, which drops keyboard focus in the browser.
+  const previousNavRef = useRef({
+    hasNextPage: paginationResult.hasNextPage,
+    hasPreviousPage: paginationResult.hasPreviousPage,
+  });
+  if (!isStale) {
+    previousNavRef.current = {
+      hasNextPage: paginationResult.hasNextPage,
+      hasPreviousPage: paginationResult.hasPreviousPage,
+    };
+  }
+  const { hasNextPage, hasPreviousPage } = isStale
+    ? previousNavRef.current
+    : paginationResult;
+
   const pagination = useMemo(() => {
     if (paginationOptions.type === 'none') {
       return { type: 'none' as const };
@@ -64,8 +81,8 @@ function useTableProps<T extends TableItem>(
       pageSizeOptions,
       offset: paginationResult.offset,
       totalCount: paginationResult.totalCount,
-      hasNextPage: paginationResult.hasNextPage,
-      hasPreviousPage: paginationResult.hasPreviousPage,
+      hasNextPage,
+      hasPreviousPage,
       onNextPage: () => {
         paginationResult.onNextPage();
         onNextPageCallback?.();
@@ -88,8 +105,8 @@ function useTableProps<T extends TableItem>(
     pageSizeOptions,
     paginationResult.offset,
     paginationResult.totalCount,
-    paginationResult.hasNextPage,
-    paginationResult.hasPreviousPage,
+    hasNextPage,
+    hasPreviousPage,
     paginationResult.onNextPage,
     paginationResult.onPreviousPage,
     paginationResult.onPageSizeChange,

--- a/packages/ui/src/components/TablePagination/TablePagination.module.css
+++ b/packages/ui/src/components/TablePagination/TablePagination.module.css
@@ -22,6 +22,11 @@
     align-items: center;
     justify-content: space-between;
     padding-top: var(--bui-space-5);
+
+    /* Programmatic focus sink only (see focus handling in TablePagination). */
+    &:focus {
+      outline: none;
+    }
   }
 
   .bui-TablePaginationLeft {

--- a/packages/ui/src/components/TablePagination/TablePagination.test.tsx
+++ b/packages/ui/src/components/TablePagination/TablePagination.test.tsx
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { BUIProvider } from '../../provider';
+import { TablePagination } from './TablePagination';
+import type { TablePaginationProps } from './types';
+
+const baseProps: TablePaginationProps = {
+  pageSize: 10,
+  offset: 0,
+  totalCount: 25,
+  hasNextPage: true,
+  hasPreviousPage: false,
+  onNextPage: () => {},
+  onPreviousPage: () => {},
+};
+
+function renderPagination(props: Partial<TablePaginationProps> = {}) {
+  return render(
+    <BUIProvider>
+      <TablePagination {...baseProps} {...props} />
+    </BUIProvider>,
+  );
+}
+
+const nextButton = () =>
+  screen.getByRole('button', { name: 'Next table page' });
+const previousButton = () =>
+  screen.getByRole('button', { name: 'Previous table page' });
+const pageSizeSelect = () =>
+  screen.getByRole('button', { name: /Select table page size/ });
+
+describe('TablePagination', () => {
+  it('renders the range label, wires navigation callbacks and disables unavailable directions', () => {
+    const onNextPage = jest.fn();
+    const onPreviousPage = jest.fn();
+    const { rerender } = renderPagination({ onNextPage, onPreviousPage });
+
+    expect(screen.getByText('1 - 10 of 25')).toBeInTheDocument();
+    expect(previousButton()).toBeDisabled();
+    expect(nextButton()).toBeEnabled();
+    expect(nextButton()).toHaveAccessibleDescription('1 - 10 of 25');
+
+    fireEvent.click(nextButton());
+    expect(onNextPage).toHaveBeenCalledTimes(1);
+    fireEvent.click(previousButton());
+    expect(onPreviousPage).not.toHaveBeenCalled();
+
+    rerender(
+      <BUIProvider>
+        <TablePagination
+          {...baseProps}
+          onNextPage={onNextPage}
+          onPreviousPage={onPreviousPage}
+          offset={20}
+          hasNextPage={false}
+          hasPreviousPage
+        />
+      </BUIProvider>,
+    );
+    expect(screen.getByText('21 - 25 of 25')).toBeInTheDocument();
+    expect(nextButton()).toBeDisabled();
+    fireEvent.click(previousButton());
+    expect(onPreviousPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a count-only label without offset, hides the label for empty or unknown totals, and supports getLabel', () => {
+    const { rerender } = renderPagination({ offset: undefined });
+    expect(screen.getByText('25 items')).toBeInTheDocument();
+
+    rerender(
+      <BUIProvider>
+        <TablePagination {...baseProps} totalCount={0} />
+      </BUIProvider>,
+    );
+    expect(screen.queryByText(/of 0|items/)).not.toBeInTheDocument();
+    expect(nextButton()).not.toHaveAttribute('aria-describedby');
+
+    rerender(
+      <BUIProvider>
+        <TablePagination {...baseProps} totalCount={undefined} />
+      </BUIProvider>,
+    );
+    expect(screen.queryByText(/of|items/)).not.toBeInTheDocument();
+
+    const getLabel = jest.fn(() => 'Page 1');
+    rerender(
+      <BUIProvider>
+        <TablePagination {...baseProps} getLabel={getLabel} />
+      </BUIProvider>,
+    );
+    expect(getLabel).toHaveBeenCalledWith({
+      pageSize: 10,
+      offset: 0,
+      totalCount: 25,
+    });
+    expect(screen.getByText('Page 1')).toBeInTheDocument();
+
+    rerender(
+      <BUIProvider>
+        <TablePagination {...baseProps} showPaginationLabel={false} />
+      </BUIProvider>,
+    );
+    expect(screen.queryByText('1 - 10 of 25')).not.toBeInTheDocument();
+  });
+
+  it('keeps the page size select in sync with the pageSize prop and reports user changes', () => {
+    const onPageSizeChange = jest.fn();
+    function Harness() {
+      const [pageSize, setPageSize] = useState(10);
+      return (
+        <BUIProvider>
+          <button onClick={() => setPageSize(20)}>set 20</button>
+          <TablePagination
+            {...baseProps}
+            pageSize={pageSize}
+            onPageSizeChange={size => {
+              onPageSizeChange(size);
+              setPageSize(size);
+            }}
+          />
+        </BUIProvider>
+      );
+    }
+    render(<Harness />);
+    expect(pageSizeSelect()).toHaveTextContent('Show 10 results');
+
+    fireEvent.click(pageSizeSelect());
+    fireEvent.click(screen.getByRole('option', { name: 'Show 5 results' }));
+    expect(onPageSizeChange).toHaveBeenCalledWith(5);
+    expect(pageSizeSelect()).toHaveTextContent('Show 5 results');
+    expect(screen.getByText('1 - 5 of 25')).toBeInTheDocument();
+
+    // A prop-driven change (e.g. reload or reset) is reflected too.
+    fireEvent.click(screen.getByText('set 20'));
+    expect(pageSizeSelect()).toHaveTextContent('Show 20 results');
+    expect(screen.getByText('1 - 20 of 25')).toBeInTheDocument();
+  });
+
+  it('accepts numeric and labelled page size options, hides the select on request, and falls back for invalid sizes', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const { rerender } = renderPagination({
+      pageSizeOptions: [
+        { label: 'Ten', value: 10 },
+        { label: 'Fifty', value: 50 },
+      ],
+    });
+    expect(pageSizeSelect()).toHaveTextContent('Ten');
+
+    rerender(
+      <BUIProvider>
+        <TablePagination
+          {...baseProps}
+          pageSize={7}
+          pageSizeOptions={[10, 50]}
+        />
+      </BUIProvider>,
+    );
+    expect(pageSizeSelect()).toHaveTextContent('Show 10 results');
+    expect(screen.getByText('1 - 10 of 25')).toBeInTheDocument();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('pageSize 7 is not in pageSizeOptions'),
+    );
+
+    rerender(
+      <BUIProvider>
+        <TablePagination {...baseProps} showPageSizeOptions={false} />
+      </BUIProvider>,
+    );
+    expect(
+      screen.queryByRole('button', { name: /Select table page size/ }),
+    ).not.toBeInTheDocument();
+    warn.mockRestore();
+  });
+
+  it('keeps keyboard focus within the controls when the focused button becomes disabled', () => {
+    function Harness() {
+      const [offset, setOffset] = useState(0);
+      const hasNextPage = offset < 20;
+      return (
+        <BUIProvider>
+          <TablePagination
+            {...baseProps}
+            offset={offset}
+            hasNextPage={hasNextPage}
+            hasPreviousPage={offset > 0}
+            onNextPage={() => setOffset(o => o + 10)}
+            onPreviousPage={() => setOffset(o => o - 10)}
+          />
+        </BUIProvider>
+      );
+    }
+    render(<Harness />);
+
+    act(() => nextButton().focus());
+    fireEvent.click(nextButton());
+    expect(nextButton()).toHaveFocus();
+    fireEvent.click(nextButton());
+    // Reached the last page: "Next" is disabled, focus moves to "Previous".
+    expect(nextButton()).toBeDisabled();
+    expect(previousButton()).toHaveFocus();
+
+    fireEvent.click(previousButton());
+    fireEvent.click(previousButton());
+    expect(previousButton()).toBeDisabled();
+    expect(nextButton()).toHaveFocus();
+  });
+});

--- a/packages/ui/src/components/TablePagination/TablePagination.test.tsx
+++ b/packages/ui/src/components/TablePagination/TablePagination.test.tsx
@@ -205,6 +205,24 @@ describe('TablePagination', () => {
         </BUIProvider>
       );
     }
+    // Browsers synchronously blur a focused element the moment it becomes
+    // disabled (relatedTarget: null); jsdom does not, so emulate it at the
+    // point React sets the attribute, before layout effects run.
+    const originalSetAttribute = Element.prototype.setAttribute;
+    jest
+      .spyOn(Element.prototype, 'setAttribute')
+      .mockImplementation(function setAttribute(this: Element, name, value) {
+        originalSetAttribute.call(this, name, value);
+        if (name === 'disabled' && document.activeElement === this) {
+          (this as HTMLElement).blur();
+          this.dispatchEvent(
+            new FocusEvent('blur', { relatedTarget: null, bubbles: false }),
+          );
+          this.dispatchEvent(
+            new FocusEvent('focusout', { relatedTarget: null, bubbles: true }),
+          );
+        }
+      });
     render(<Harness />);
 
     act(() => nextButton().focus());
@@ -219,5 +237,6 @@ describe('TablePagination', () => {
     fireEvent.click(previousButton());
     expect(previousButton()).toBeDisabled();
     expect(nextButton()).toHaveFocus();
+    jest.restoreAllMocks();
   });
 });

--- a/packages/ui/src/components/TablePagination/TablePagination.tsx
+++ b/packages/ui/src/components/TablePagination/TablePagination.tsx
@@ -22,7 +22,8 @@ import type { TablePaginationProps, PageSizeOption } from './types';
 import { useDefinition } from '../../hooks/useDefinition';
 import { TablePaginationDefinition } from './definition';
 import { RiArrowLeftSLine, RiArrowRightSLine } from '@remixicon/react';
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
+import { useIsomorphicLayoutEffect } from '../../hooks/useIsomorphicLayoutEffect';
 
 function getOptionValue(option: number | PageSizeOption): number {
   return typeof option === 'number' ? option : option.value;
@@ -70,6 +71,35 @@ export function TablePagination(props: TablePaginationProps) {
   } = ownProps;
 
   const labelId = useId();
+  const rootRef = useRef<HTMLDivElement>(null);
+  const previousButtonRef = useRef<HTMLButtonElement>(null);
+  const nextButtonRef = useRef<HTMLButtonElement>(null);
+
+  // When the focused navigation button becomes disabled (for example after
+  // reaching the last page, or while a page is loading), browsers drop focus
+  // to the document body. Keep keyboard users in place by moving focus to
+  // the other navigation button, or to the pagination container as a
+  // fallback. A layout effect is used so focus is moved before the browser's
+  // focus fixup runs for the newly disabled element.
+  useIsomorphicLayoutEffect(() => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+    const active = document.activeElement;
+    const focusedDisabled =
+      (!hasNextPage && active === nextButtonRef.current) ||
+      (!hasPreviousPage && active === previousButtonRef.current);
+    if (!focusedDisabled) {
+      return;
+    }
+    if (hasNextPage && nextButtonRef.current) {
+      nextButtonRef.current.focus();
+    } else if (hasPreviousPage && previousButtonRef.current) {
+      previousButtonRef.current.focus();
+    } else {
+      rootRef.current?.focus();
+    }
+  }, [hasNextPage, hasPreviousPage]);
   const normalizedOptions = useMemo(
     () => normalizePageSizeOptions(pageSizeOptions),
     [pageSizeOptions],
@@ -103,7 +133,7 @@ export function TablePagination(props: TablePaginationProps) {
   }
 
   return (
-    <div className={classes.root}>
+    <div className={classes.root} ref={rootRef} tabIndex={-1}>
       <div className={classes.left}>
         {showPageSizeOptions && (
           <Select
@@ -114,7 +144,7 @@ export function TablePagination(props: TablePaginationProps) {
               label: opt.label,
               value: String(opt.value),
             }))}
-            defaultValue={effectivePageSize.toString()}
+            value={effectivePageSize.toString()}
             onChange={value => {
               const newPageSize = Number(value);
               onPageSizeChange?.(newPageSize);
@@ -130,6 +160,7 @@ export function TablePagination(props: TablePaginationProps) {
           </Text>
         )}
         <ButtonIcon
+          ref={previousButtonRef}
           variant="secondary"
           size="small"
           onClick={onPreviousPage}
@@ -139,6 +170,7 @@ export function TablePagination(props: TablePaginationProps) {
           aria-describedby={showLabel ? labelId : undefined}
         />
         <ButtonIcon
+          ref={nextButtonRef}
           variant="secondary"
           size="small"
           onClick={onNextPage}

--- a/packages/ui/src/components/TablePagination/TablePagination.tsx
+++ b/packages/ui/src/components/TablePagination/TablePagination.tsx
@@ -74,24 +74,37 @@ export function TablePagination(props: TablePaginationProps) {
   const rootRef = useRef<HTMLDivElement>(null);
   const previousButtonRef = useRef<HTMLButtonElement>(null);
   const nextButtonRef = useRef<HTMLButtonElement>(null);
+  const focusedButtonRef = useRef<'previous' | 'next' | null>(null);
 
   // When the focused navigation button becomes disabled (for example after
   // reaching the last page, or while a page is loading), browsers drop focus
   // to the document body. Keep keyboard users in place by moving focus to
   // the other navigation button, or to the pagination container as a
-  // fallback. A layout effect is used so focus is moved before the browser's
-  // focus fixup runs for the newly disabled element.
+  // fallback. Browsers blur a button synchronously when it becomes disabled,
+  // so track which button was focused via focus/blur events instead of
+  // reading `document.activeElement` after the fact.
+  const trackFocus = (button: 'previous' | 'next') => ({
+    onFocus: () => {
+      focusedButtonRef.current = button;
+    },
+    onBlur: (event: React.FocusEvent) => {
+      // A blur without a relatedTarget means focus was lost (e.g. the button
+      // became disabled) rather than moved elsewhere by the user.
+      if (event.relatedTarget !== null) {
+        focusedButtonRef.current = null;
+      }
+    },
+  });
+
   useIsomorphicLayoutEffect(() => {
-    if (typeof document === 'undefined') {
-      return;
-    }
-    const active = document.activeElement;
+    const focused = focusedButtonRef.current;
     const focusedDisabled =
-      (!hasNextPage && active === nextButtonRef.current) ||
-      (!hasPreviousPage && active === previousButtonRef.current);
+      (focused === 'next' && !hasNextPage) ||
+      (focused === 'previous' && !hasPreviousPage);
     if (!focusedDisabled) {
       return;
     }
+    focusedButtonRef.current = null;
     if (hasNextPage && nextButtonRef.current) {
       nextButtonRef.current.focus();
     } else if (hasPreviousPage && previousButtonRef.current) {
@@ -100,6 +113,7 @@ export function TablePagination(props: TablePaginationProps) {
       rootRef.current?.focus();
     }
   }, [hasNextPage, hasPreviousPage]);
+
   const normalizedOptions = useMemo(
     () => normalizePageSizeOptions(pageSizeOptions),
     [pageSizeOptions],
@@ -161,6 +175,7 @@ export function TablePagination(props: TablePaginationProps) {
         )}
         <ButtonIcon
           ref={previousButtonRef}
+          {...trackFocus('previous')}
           variant="secondary"
           size="small"
           onClick={onPreviousPage}
@@ -171,6 +186,7 @@ export function TablePagination(props: TablePaginationProps) {
         />
         <ButtonIcon
           ref={nextButtonRef}
+          {...trackFocus('next')}
           variant="secondary"
           size="small"
           onClick={onNextPage}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Release-readiness pass over the `@backstage/ui` `Table` / `TablePagination` / `useTable` stack ahead of calling it stable. The stack had no unit tests (confidence came from Storybook), so this adds black-box regression tests through the public APIs — focused on state changing *after mount* across complete, offset and cursor data — and fixes the blockers those tests exposed. No public types change (`report.api.md` is unchanged); the pending infinite-scroll work is untouched.

### Fixes

| Area | Problem | Fix |
|---|---|---|
| Row identity / selection | Rows are keyed `String(item.id)`, so `selection.selected = new Set([1])` for numeric ids never highlighted a row and `onSelectionChange` reported mixed `{1, '2'}` sets. | `Table` normalizes incoming keys and, when the adopter's set uses numeric keys, reports keys as the matching `item.id`. String-key adopters and custom `RowRenderFn` rows are unchanged. |
| Screen readers / loading | `aria-busy` never reached the DOM (React Aria's `Table` filters it). | `TableRoot` sets/removes `aria-busy` on the grid element directly. |
| Offset/cursor navigation | Changing search/filter/sort and clicking Next within the 200 ms debounce window fetched the *old* offset with the *new* query and lost the debounced reload → empty page labelled “6 - 4 of 4”. | `useDebouncedReload` no longer drops its timer on unrelated re-renders and exposes `flush()`; navigating during the window flushes the reload (page 1 of the new query). |
| Complete mode boundaries | `initialOffset` was ignored; when data shrank below the current offset the table showed an empty page. | Skip the page-size reset on mount; clamp to the last available page. |
| Controlled inputs | `paginationOptions.pageSize` changes after mount were honored in complete mode only; `TablePagination`'s Select was uncontrolled and desynced from `pageSize`. | Sync page size in all modes; Select is controlled. |
| Keyboard | Next/Previous flipped to disabled during every server fetch and at the last page, dropping focus to `<body>`. | `useTable` keeps navigation state while stale; `TablePagination` moves focus to the other button (or its root) when the focused button becomes disabled. |

Also: live region announces “No items to show.” / “N items” instead of “Showing 1 to 0 of 0” or a bare “Table page loaded. ”, and the error state has `role="alert"`.

### Tests added
- `Table/hooks/useTable.test.tsx` (20): all three modes — boundaries, `initialOffset`, shrink/clamp, filter/search/sort reset, controlled vs uncontrolled, search debounce, page-size changes (user + prop), async load/stale/error/reload, aborting superseded requests and on unmount, cache hits, cursor without `totalCount`, mode-change guard.
- `Table/Table.test.tsx` (10): rendering, empty state, loading/stale/error a11y, sort headers, multi/single selection with numeric + string ids and disabled rows across page changes, row links/actions, custom row render fn, end-to-end complete + offset flows with focus retention, and an abandoned-first-render case (Suspense + StrictMode: no fetch from the uncommitted render, abandoned mount's request aborted, correct settled state).
- `TablePagination/TablePagination.test.tsx` (5): labels/`getLabel`, callbacks & disabled state, controlled page size, option normalization/invalid fallback, focus retention.

Verified: `yarn tsc`, `backstage-cli package lint`, `backstage-cli package build`, `yarn build:api-reports:only packages/ui` (report unchanged), `CI=1 yarn test packages/ui` (288 tests pass).

### Screenshots — keyboard focus retention

Captured in Chromium against the `Backstage UI/Table/dev → ServerSidePaginationOffset` story (offset mode, 500 ms simulated latency, 100 items). Every navigation below is done with <kbd>Enter</kbd> on the focused button; the banner text is read from `document.activeElement` at capture time.

| Step | Before | After |
|---|---|---|
| Keyboard focus on **Next**, press <kbd>Enter</kbd> | focus on Next | Next stays **enabled and focused** while the next page loads (rows shown stale) — previously the button flipped to `disabled` mid-load and focus dropped to `<body>` |
| Reach the last page | Next disabled → focus lost | focus moves to **Previous** |
| <kbd>Enter</kbd> on Previous back to page 1 | Previous disabled → focus lost | focus moves to **Next** |

**1. Focus on Next**
![Step 1: keyboard focus on Next](https://raw.githubusercontent.com/XenKloud/backstage/assets/pr-35216-focus-retention/1-focus-next.png)

**2. Enter pressed — next page loading, focus held on Next**
![Step 2: loading, focus held](https://raw.githubusercontent.com/XenKloud/backstage/assets/pr-35216-focus-retention/2-loading-focus-held.png)

**3. Last page reached — Next disabled, focus moved to Previous**
![Step 3: last page, focus moved to Previous](https://raw.githubusercontent.com/XenKloud/backstage/assets/pr-35216-focus-retention/3-last-page-focus-moved.png)

**4. Back on the first page — Previous disabled, focus moved to Next**
![Step 4: first page, focus moved to Next](https://raw.githubusercontent.com/XenKloud/backstage/assets/pr-35216-focus-retention/4-first-page-focus-moved.png)

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

🤖 Generated with [Claude Code](https://claude.com/claude-code)

