### PR TITLE
@backstage/ui: fix pagination, selection, and a11y bugs in the Table stack

### DIFF
--- a/.changeset/great-pandas-repeat.md
+++ b/.changeset/great-pandas-repeat.md
@@ -7,8 +7,8 @@ Fixed a number of issues in `Table`, `TablePagination`, and `useTable`:
 - `useTable` in `offset` mode no longer gets stuck when navigating back to the first page after mounting with an `initialOffset`.
 - `useTable` in `complete` mode now honors `paginationOptions.initialOffset` instead of always starting at the first page.
 - `useTable` in `complete` mode now clamps to the last page when the provided data shrinks below the current page offset, instead of showing an empty page.
-- `useTable` in `complete` mode now reports a pending state again when caller-provided `data` changes back to `undefined`, for example while the caller refetches.
-- `useTable` in `offset` and `cursor` modes no longer resets to the first page and refetches when callback options such as `onSortChange` are re-created on every render.
+- `useTable` in `complete` mode now reports a pending state again when caller-provided `data` changes back to `undefined`, for example while the caller loads new data.
+- `useTable` in `offset` and `cursor` modes no longer resets to the first page and reloads when callback options such as `onSortChange` are re-created on every render.
 - `useTable` in `offset` and `cursor` modes now clears a previous page load error when navigating to an already loaded page, and no longer misses updates from data sources that resolve immediately.
 - The page size selector in `TablePagination` now stays in sync when the `pageSize` prop changes after mount, and an empty `pageSizeOptions` array no longer crashes the component.
 - `Table` now applies controlled row selection correctly when items have numeric ids.

--- a/.changeset/great-pandas-repeat.md
+++ b/.changeset/great-pandas-repeat.md
@@ -1,0 +1,15 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed a number of issues in `Table`, `TablePagination`, and `useTable`:
+
+- `useTable` in `offset` mode no longer gets stuck when navigating back to the first page after mounting with an `initialOffset`.
+- `useTable` in `complete` mode now honors `paginationOptions.initialOffset` instead of always starting at the first page.
+- `useTable` in `complete` mode now clamps to the last page when the provided data shrinks below the current page offset, instead of showing an empty page.
+- `useTable` in `complete` mode now reports a pending state again when caller-provided `data` changes back to `undefined`, for example while the caller refetches.
+- `useTable` in `offset` and `cursor` modes no longer resets to the first page and refetches when callback options such as `onSortChange` are re-created on every render.
+- `useTable` in `offset` and `cursor` modes now clears a previous page load error when navigating to an already loaded page, and no longer misses updates from data sources that resolve immediately.
+- The page size selector in `TablePagination` now stays in sync when the `pageSize` prop changes after mount, and an empty `pageSizeOptions` array no longer crashes the component.
+- `Table` now applies controlled row selection correctly when items have numeric ids.
+- The table element now exposes `aria-busy` to assistive technologies while data is loading or refreshing.

--- a/packages/ui/src/components/Table/Table.test.tsx
+++ b/packages/ui/src/components/Table/Table.test.tsx
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { CellText, Table } from '.';
+import type { ColumnConfig, TableProps } from '.';
+
+interface Item {
+  id: number;
+  name: string;
+  owner: string;
+}
+
+const items: Item[] = [
+  { id: 1, name: 'Component Library', owner: 'Design System' },
+  { id: 2, name: 'API Gateway', owner: 'Platform' },
+  { id: 3, name: 'Documentation Site', owner: 'DevEx' },
+];
+
+const columns: ColumnConfig<Item>[] = [
+  {
+    id: 'name',
+    label: 'Name',
+    isRowHeader: true,
+    cell: item => <CellText title={item.name} />,
+  },
+  {
+    id: 'owner',
+    label: 'Owner',
+    cell: item => <CellText title={item.owner} />,
+  },
+];
+
+function renderTable(props: Partial<TableProps<Item>> = {}) {
+  const defaultProps: TableProps<Item> = {
+    columnConfig: columns,
+    data: items,
+    pagination: { type: 'none' },
+  };
+  return render(<Table {...defaultProps} {...props} />);
+}
+
+describe('Table', () => {
+  it('renders headers, rows and cells from the column config', () => {
+    renderTable({
+      columnConfig: [
+        ...columns,
+        {
+          id: 'secret',
+          label: 'Secret',
+          isHidden: true,
+          cell: item => <CellText title={String(item.id)} />,
+        },
+      ],
+    });
+
+    const grid = screen.getByRole('grid');
+    expect(
+      within(grid).getByRole('columnheader', { name: 'Name' }),
+    ).toBeInTheDocument();
+    expect(
+      within(grid).getByRole('columnheader', { name: 'Owner' }),
+    ).toBeInTheDocument();
+    expect(
+      within(grid).queryByRole('columnheader', { name: 'Secret' }),
+    ).toBeNull();
+
+    expect(
+      within(grid).getByRole('row', { name: /Component Library/ }),
+    ).toBeInTheDocument();
+    expect(within(grid).getByText('Platform')).toBeInTheDocument();
+    expect(within(grid).getByText('DevEx')).toBeInTheDocument();
+  });
+
+  it('renders the empty state when there is no data', () => {
+    renderTable({ data: [], emptyState: 'No results found' });
+    expect(screen.getByText('No results found')).toBeInTheDocument();
+  });
+
+  it('renders the error state', () => {
+    renderTable({ error: new Error('something broke') });
+    expect(screen.getByText('Error: something broke')).toBeInTheDocument();
+    expect(screen.queryByRole('grid')).toBeNull();
+  });
+
+  it('shows a skeleton during initial load and keeps data visible while stale', () => {
+    const { rerender } = renderTable({ data: undefined, isPending: true });
+
+    const grid = screen.getByRole('grid');
+    expect(grid).toHaveAttribute('aria-busy', 'true');
+    expect(screen.queryByText('Component Library')).toBeNull();
+    expect(screen.getByText('Loading table data.')).toBeInTheDocument();
+
+    rerender(
+      <Table
+        columnConfig={columns}
+        data={items}
+        pagination={{ type: 'none' }}
+      />,
+    );
+    expect(screen.getByText('Component Library')).toBeInTheDocument();
+    expect(screen.getByRole('grid')).not.toHaveAttribute('aria-busy', 'true');
+
+    // A stale reload keeps the previous rows on screen.
+    rerender(
+      <Table
+        columnConfig={columns}
+        data={items}
+        isPending
+        isStale
+        pagination={{ type: 'none' }}
+      />,
+    );
+    expect(screen.getByText('Component Library')).toBeInTheDocument();
+    expect(screen.getByRole('grid')).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('announces page changes to assistive technology', () => {
+    const pagination = {
+      type: 'page' as const,
+      pageSize: 10,
+      offset: 10,
+      totalCount: 25,
+      hasNextPage: true,
+      hasPreviousPage: true,
+      onNextPage: jest.fn(),
+      onPreviousPage: jest.fn(),
+    };
+    const { rerender } = renderTable({ pagination });
+
+    const liveRegion = screen.getByText(
+      'Table page loaded. Showing 11 to 20 of 25',
+    );
+    expect(liveRegion).toHaveAttribute('aria-live', 'polite');
+    expect(screen.getByRole('grid')).toHaveAttribute(
+      'aria-describedby',
+      liveRegion.id,
+    );
+
+    rerender(
+      <Table
+        columnConfig={columns}
+        data={items}
+        isPending
+        isStale
+        pagination={pagination}
+      />,
+    );
+    expect(screen.getByText('Loading table data.')).toBeInTheDocument();
+  });
+
+  it('wires up the pagination controls', () => {
+    const onNextPage = jest.fn();
+    const onPreviousPage = jest.fn();
+    renderTable({
+      pagination: {
+        type: 'page',
+        pageSize: 10,
+        offset: 10,
+        totalCount: 25,
+        hasNextPage: true,
+        hasPreviousPage: true,
+        onNextPage,
+        onPreviousPage,
+      },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next table page' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Previous table page' }),
+    );
+    expect(onNextPage).toHaveBeenCalledTimes(1);
+    expect(onPreviousPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onSortChange when a sortable column header is clicked', () => {
+    const onSortChange = jest.fn();
+    renderTable({
+      columnConfig: [{ ...columns[0], isSortable: true }, columns[1]],
+      sort: { descriptor: null, onSortChange },
+    });
+
+    fireEvent.click(screen.getByRole('columnheader', { name: /Name/ }));
+    expect(onSortChange).toHaveBeenCalledWith({
+      column: 'name',
+      direction: 'ascending',
+    });
+  });
+
+  it('supports controlled selection with numeric item ids', () => {
+    const onSelectionChange = jest.fn();
+    renderTable({
+      selection: {
+        mode: 'multiple',
+        behavior: 'toggle',
+        selected: new Set([2]),
+        onSelectionChange,
+      },
+    });
+
+    const rows = screen.getAllByRole('row');
+    const gatewayRow = screen.getByRole('row', { name: /API Gateway/ });
+    expect(gatewayRow).toHaveAttribute('aria-selected', 'true');
+    expect(
+      rows.filter(row => row.getAttribute('aria-selected') === 'true'),
+    ).toHaveLength(1);
+
+    const libraryRow = screen.getByRole('row', { name: /Component Library/ });
+    fireEvent.click(within(libraryRow).getByRole('checkbox'));
+    expect(onSelectionChange).toHaveBeenCalledTimes(1);
+    const selected = onSelectionChange.mock.calls[0][0];
+    expect(Array.from(selected)).toContain('1');
+  });
+
+  it('disables rows through rowConfig.getIsDisabled and triggers row actions', () => {
+    const onClick = jest.fn();
+    renderTable({
+      selection: { mode: 'multiple', behavior: 'toggle' },
+      rowConfig: {
+        onClick,
+        getIsDisabled: item => item.id === 3,
+      },
+    });
+
+    expect(
+      screen.getByRole('row', { name: /Documentation Site/ }),
+    ).toHaveAttribute('aria-disabled', 'true');
+
+    fireEvent.click(screen.getByRole('row', { name: /API Gateway/ }));
+    expect(onClick).toHaveBeenCalledWith(items[1]);
+  });
+});

--- a/packages/ui/src/components/Table/components/Table.tsx
+++ b/packages/ui/src/components/Table/components/Table.tsx
@@ -134,12 +134,28 @@ export function Table<T extends TableItem>({
 
   const {
     mode: selectionMode,
-    selected: selectedKeys,
+    selected,
     behavior: selectionBehavior,
     onSelectionChange,
   } = selection || {};
 
+  // Rows are keyed by `String(item.id)`, so normalize selected keys to
+  // strings to also match items with numeric ids.
+  const selectedKeys = useMemo(() => {
+    if (selected === undefined || selected === 'all') {
+      return selected;
+    }
+    return new Set<Key>(Array.from(selected, key => String(key)));
+  }, [selected]);
+
   const isInitialLoading = pending && !data;
+
+  const liveRegionLabel = useLiveRegionLabel(
+    pagination,
+    isStale,
+    isInitialLoading,
+    data !== undefined,
+  );
 
   if (error) {
     return (
@@ -148,13 +164,6 @@ export function Table<T extends TableItem>({
       </div>
     );
   }
-
-  const liveRegionLabel = useLiveRegionLabel(
-    pagination,
-    isStale,
-    isInitialLoading,
-    data !== undefined,
-  );
 
   const manualColumnSizing = columnConfig.some(
     col =>

--- a/packages/ui/src/components/Table/components/TableRoot.tsx
+++ b/packages/ui/src/components/Table/components/TableRoot.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { useEffect, useRef } from 'react';
 import { useDefinition } from '../../../hooks/useDefinition';
 import { TableDefinition } from '../definition';
 import { Table as ReactAriaTable } from 'react-aria-components';
@@ -39,11 +40,19 @@ export const TableRoot = (props: TableRootProps) => {
     },
   );
 
+  // react-aria-components filters unknown ARIA props off the table element,
+  // so `aria-busy` has to be applied to the rendered element directly.
+  const tableRef = useRef<HTMLTableElement>(null);
+  const isBusy = Boolean(ownProps.stale || ownProps.isPending);
+  useEffect(() => {
+    tableRef.current?.setAttribute('aria-busy', String(isBusy));
+  }, [isBusy]);
+
   return (
     <ReactAriaTable
+      ref={tableRef}
       className={ownProps.classes.root}
       aria-label="Data table"
-      aria-busy={ownProps.stale || ownProps.isPending}
       {...dataAttributes}
       {...restProps}
     />

--- a/packages/ui/src/components/Table/hooks/getEffectivePageSize.ts
+++ b/packages/ui/src/components/Table/hooks/getEffectivePageSize.ts
@@ -29,7 +29,7 @@ export function getEffectivePageSize(
 ): number {
   const { pageSize, pageSizeOptions } = paginationOptions;
 
-  if (!pageSizeOptions) {
+  if (!pageSizeOptions || pageSizeOptions.length === 0) {
     return pageSize ?? DEFAULT_PAGE_SIZE;
   }
 

--- a/packages/ui/src/components/Table/hooks/useCompletePagination.ts
+++ b/packages/ui/src/components/Table/hooks/useCompletePagination.ts
@@ -58,10 +58,15 @@ export function useCompletePagination<T extends TableItem, TFilter>(
   const [offset, setOffset] = useState(initialOffset);
   const [pageSize, setPageSize] = useState(defaultPageSize);
 
-  // Sync pageSize when the caller changes paginationOptions.pageSize
+  // Sync pageSize when the caller changes paginationOptions.pageSize after
+  // mount. Guarded by a ref so the mount run doesn't wipe initialOffset.
+  const prevDefaultPageSizeRef = useRef(defaultPageSize);
   useEffect(() => {
-    setPageSize(defaultPageSize);
-    setOffset(0);
+    if (prevDefaultPageSizeRef.current !== defaultPageSize) {
+      prevDefaultPageSizeRef.current = defaultPageSize;
+      setPageSize(defaultPageSize);
+      setOffset(0);
+    }
   }, [defaultPageSize]);
 
   // Load data on mount and when loadCount changes (reload trigger)
@@ -72,6 +77,8 @@ export function useCompletePagination<T extends TableItem, TFilter>(
     }
 
     if (!hasGetData) {
+      // With caller-managed data, `undefined` means a load is in progress.
+      setIsPending(true);
       return;
     }
 
@@ -150,29 +157,41 @@ export function useCompletePagination<T extends TableItem, TFilter>(
 
   const totalCount = processedData?.length ?? 0;
 
+  // Clamp to the last page when the data shrinks below the current offset,
+  // e.g. when caller-managed data is replaced by a shorter array.
+  const effectiveOffset = useMemo(() => {
+    if (noPagination || totalCount === 0) {
+      return 0;
+    }
+    if (offset >= totalCount) {
+      return Math.floor((totalCount - 1) / pageSize) * pageSize;
+    }
+    return offset;
+  }, [noPagination, offset, totalCount, pageSize]);
+
   // Paginate the processed data
   const paginatedData = useMemo(
     () =>
       noPagination
         ? processedData
-        : processedData?.slice(offset, offset + pageSize),
-    [processedData, offset, pageSize, noPagination],
+        : processedData?.slice(effectiveOffset, effectiveOffset + pageSize),
+    [processedData, effectiveOffset, pageSize, noPagination],
   );
 
-  const hasNextPage = !noPagination && offset + pageSize < totalCount;
-  const hasPreviousPage = !noPagination && offset > 0;
+  const hasNextPage = !noPagination && effectiveOffset + pageSize < totalCount;
+  const hasPreviousPage = !noPagination && effectiveOffset > 0;
 
   const onNextPage = useCallback(() => {
-    if (offset + pageSize < totalCount) {
-      setOffset(offset + pageSize);
+    if (effectiveOffset + pageSize < totalCount) {
+      setOffset(effectiveOffset + pageSize);
     }
-  }, [offset, pageSize, totalCount]);
+  }, [effectiveOffset, pageSize, totalCount]);
 
   const onPreviousPage = useCallback(() => {
-    if (offset > 0) {
-      setOffset(Math.max(0, offset - pageSize));
+    if (effectiveOffset > 0) {
+      setOffset(Math.max(0, effectiveOffset - pageSize));
     }
-  }, [offset, pageSize]);
+  }, [effectiveOffset, pageSize]);
 
   const onPageSizeChange = useCallback((newSize: number) => {
     setPageSize(newSize);
@@ -189,7 +208,7 @@ export function useCompletePagination<T extends TableItem, TFilter>(
     isPending: isPending,
     error,
     totalCount,
-    offset,
+    offset: effectiveOffset,
     pageSize,
     hasNextPage,
     hasPreviousPage,

--- a/packages/ui/src/components/Table/hooks/useDebouncedReload.ts
+++ b/packages/ui/src/components/Table/hooks/useDebouncedReload.ts
@@ -28,15 +28,24 @@ export function useDebouncedReload<TFilter>(
   reload: () => void,
   delay: number = 200,
 ): void {
-  const prevDepsRef = useRef({ query, pageSize });
+  // Compare the query values rather than object identities, so that inline
+  // callback props with fresh identities on every render don't trigger
+  // spurious reloads.
+  const { sort, filter, search } = query;
+  const prevDepsRef = useRef({ sort, filter, search, pageSize });
 
   useEffect(() => {
     const prev = prevDepsRef.current;
-    if (prev.query !== query || prev.pageSize !== pageSize) {
-      prevDepsRef.current = { query, pageSize };
+    if (
+      prev.sort !== sort ||
+      prev.filter !== filter ||
+      prev.search !== search ||
+      prev.pageSize !== pageSize
+    ) {
+      prevDepsRef.current = { sort, filter, search, pageSize };
       const timer = setTimeout(reload, delay);
       return () => clearTimeout(timer);
     }
     return undefined;
-  }, [query, pageSize, reload, delay]);
+  }, [sort, filter, search, pageSize, reload, delay]);
 }

--- a/packages/ui/src/components/Table/hooks/usePageCache.ts
+++ b/packages/ui/src/components/Table/hooks/usePageCache.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useState, useCallback, useRef, useEffect } from 'react';
+import { useState, useCallback, useRef, useEffect, useReducer } from 'react';
 
 const FIRST_PAGE_CURSOR = Symbol('firstPage');
 
@@ -152,6 +152,11 @@ export function usePageCache<T, TCursor extends CursorType = string>(
   const [isPending, setIsPending] = useState(true);
   const [error, setError] = useState<Error | undefined>(undefined);
   const [totalCount, setTotalCount] = useState<number | undefined>(undefined);
+  // Page data lives in the mutable cache store, which React cannot observe.
+  // Bumping this after each cache write guarantees a re-render even when the
+  // surrounding state updates cancel each other out (e.g. a getData that
+  // resolves within the same batch that started it).
+  const [, bumpCacheVersion] = useReducer((version: number) => version + 1, 0);
 
   const abortControllerRef = useRef<AbortController | null>(null);
 
@@ -168,13 +173,15 @@ export function usePageCache<T, TCursor extends CursorType = string>(
         initialCurrentCursor,
       );
 
-      if (!targetCursor) {
+      // Cursors are only absent when undefined — 0 and '' are valid cursors.
+      if (targetCursor === undefined) {
         return;
       }
 
       const existingEntry = cacheStore.get(targetCursor);
       if (existingEntry?.data !== undefined) {
         setCurrentCursor(targetCursor);
+        setError(undefined);
         return;
       }
 
@@ -215,6 +222,7 @@ export function usePageCache<T, TCursor extends CursorType = string>(
           setTotalCount(result.totalCount);
         }
 
+        bumpCacheVersion();
         setIsPending(false);
       } catch (err) {
         if (abortController.signal.aborted) {
@@ -241,14 +249,14 @@ export function usePageCache<T, TCursor extends CursorType = string>(
   const onNextPage = useCallback(() => {
     if (isPending) return;
     const page = cacheStore.get(currentCursor);
-    if (!page?.nextCursor) return;
+    if (page?.nextCursor === undefined) return;
     goToPage('next');
   }, [isPending, currentCursor, goToPage, cacheStore]);
 
   const onPreviousPage = useCallback(() => {
     if (isPending) return;
     const page = cacheStore.get(currentCursor);
-    if (!page?.prevCursor) return;
+    if (page?.prevCursor === undefined) return;
     goToPage('prev');
   }, [isPending, currentCursor, goToPage, cacheStore]);
 

--- a/packages/ui/src/components/Table/hooks/useTable.test.tsx
+++ b/packages/ui/src/components/Table/hooks/useTable.test.tsx
@@ -1,0 +1,849 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  act,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { StrictMode, Suspense } from 'react';
+import { CellText, Table, useTable } from '..';
+import type { ColumnConfig } from '..';
+import type {
+  CursorParams,
+  OffsetParams,
+  PagePagination,
+  SortDescriptor,
+  UseTableCompleteOptions,
+  UseTableResult,
+} from '..';
+
+interface Item {
+  id: number;
+  name: string;
+}
+
+function makeItems(count: number, start = 0): Item[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: start + i,
+    name: `Item ${start + i}`,
+  }));
+}
+
+function getPagination<TFilter>(
+  result: UseTableResult<Item, TFilter>,
+): PagePagination {
+  const { pagination } = result.tableProps;
+  if (pagination.type !== 'page') {
+    throw new Error(`Expected page pagination, got '${pagination.type}'`);
+  }
+  return pagination;
+}
+
+function ids<TFilter>(result: UseTableResult<Item, TFilter>): number[] {
+  return result.tableProps.data?.map(item => item.id) ?? [];
+}
+
+function createOffsetGetData(items: Item[]) {
+  return jest.fn(async (params: OffsetParams<unknown>) => {
+    let filtered = items;
+    if (params.search) {
+      filtered = filtered.filter(item => item.name.includes(params.search));
+    }
+    return {
+      data: filtered.slice(params.offset, params.offset + params.pageSize),
+      totalCount: filtered.length,
+    };
+  });
+}
+
+function createCursorGetData(items: Item[]) {
+  return jest.fn(async (params: CursorParams<unknown>) => {
+    const pageIndex = params.cursor ? Number(params.cursor) : 0;
+    const start = pageIndex * params.pageSize;
+    return {
+      data: items.slice(start, start + params.pageSize),
+      nextCursor:
+        start + params.pageSize < items.length
+          ? String(pageIndex + 1)
+          : undefined,
+      prevCursor: pageIndex > 0 ? String(pageIndex - 1) : undefined,
+      totalCount: items.length,
+    };
+  });
+}
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('useTable', () => {
+  describe('complete mode', () => {
+    it('paginates static data and navigates across page boundaries', () => {
+      const { result } = renderHook(() =>
+        useTable<Item>({
+          mode: 'complete',
+          data: makeItems(25),
+          paginationOptions: { pageSize: 10 },
+        }),
+      );
+
+      expect(result.current.tableProps.isPending).toBe(false);
+      expect(ids(result.current)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+      expect(getPagination(result.current)).toMatchObject({
+        offset: 0,
+        totalCount: 25,
+        hasPreviousPage: false,
+        hasNextPage: true,
+      });
+
+      act(() => getPagination(result.current).onNextPage());
+      act(() => getPagination(result.current).onNextPage());
+
+      expect(ids(result.current)).toEqual([20, 21, 22, 23, 24]);
+      expect(getPagination(result.current)).toMatchObject({
+        offset: 20,
+        hasPreviousPage: true,
+        hasNextPage: false,
+      });
+
+      // Navigating past the last page is a no-op.
+      act(() => getPagination(result.current).onNextPage());
+      expect(getPagination(result.current).offset).toBe(20);
+
+      act(() => getPagination(result.current).onPreviousPage());
+      expect(ids(result.current)).toEqual([
+        10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+      ]);
+
+      // Changing the page size resets to the first page.
+      act(() => getPagination(result.current).onPageSizeChange?.(5));
+      expect(getPagination(result.current)).toMatchObject({
+        offset: 0,
+        pageSize: 5,
+      });
+      expect(ids(result.current)).toEqual([0, 1, 2, 3, 4]);
+    });
+
+    it('starts at initialOffset', () => {
+      const { result } = renderHook(() =>
+        useTable<Item>({
+          mode: 'complete',
+          data: makeItems(25),
+          paginationOptions: { pageSize: 10, initialOffset: 10 },
+        }),
+      );
+
+      expect(getPagination(result.current).offset).toBe(10);
+      expect(ids(result.current)).toEqual([
+        10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+      ]);
+      expect(getPagination(result.current).hasPreviousPage).toBe(true);
+
+      act(() => getPagination(result.current).onPreviousPage());
+      expect(ids(result.current)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    });
+
+    it('clamps to the last page when the data shrinks below the current offset', () => {
+      const { result, rerender } = renderHook(
+        ({ data }: { data: Item[] }) =>
+          useTable<Item>({
+            mode: 'complete',
+            data,
+            paginationOptions: { pageSize: 10 },
+          }),
+        { initialProps: { data: makeItems(25) } },
+      );
+
+      act(() => getPagination(result.current).onNextPage());
+      act(() => getPagination(result.current).onNextPage());
+      expect(getPagination(result.current).offset).toBe(20);
+
+      rerender({ data: makeItems(15) });
+
+      expect(getPagination(result.current)).toMatchObject({
+        offset: 10,
+        totalCount: 15,
+        hasNextPage: false,
+        hasPreviousPage: true,
+      });
+      expect(ids(result.current)).toEqual([10, 11, 12, 13, 14]);
+
+      rerender({ data: [] });
+      expect(getPagination(result.current)).toMatchObject({
+        offset: 0,
+        totalCount: 0,
+        hasNextPage: false,
+        hasPreviousPage: false,
+      });
+    });
+
+    it('loads async data with getData, exposes errors, and reloads', async () => {
+      let shouldFail = false;
+      let items = makeItems(3);
+      const getData = jest.fn(async () => {
+        if (shouldFail) {
+          throw new Error('load failed');
+        }
+        return items;
+      });
+
+      const { result } = renderHook(() =>
+        useTable<Item>({ mode: 'complete', getData }),
+      );
+
+      expect(result.current.tableProps.isPending).toBe(true);
+      expect(result.current.tableProps.data).toBeUndefined();
+
+      await waitFor(() =>
+        expect(result.current.tableProps.isPending).toBe(false),
+      );
+      expect(ids(result.current)).toEqual([0, 1, 2]);
+
+      items = makeItems(4);
+      act(() => result.current.reload());
+      await waitFor(() => expect(ids(result.current)).toEqual([0, 1, 2, 3]));
+      expect(getData).toHaveBeenCalledTimes(2);
+
+      shouldFail = true;
+      act(() => result.current.reload());
+      await waitFor(() =>
+        expect(result.current.tableProps.error?.message).toBe('load failed'),
+      );
+      expect(result.current.tableProps.isPending).toBe(false);
+    });
+
+    it('marks retained data as pending and stale when controlled data becomes undefined', () => {
+      const { result, rerender } = renderHook(
+        ({ data }: { data: Item[] | undefined }) =>
+          useTable<Item>({
+            mode: 'complete',
+            data,
+            paginationOptions: { pageSize: 10 },
+          }),
+        { initialProps: { data: makeItems(5) as Item[] | undefined } },
+      );
+
+      expect(result.current.tableProps.isPending).toBe(false);
+
+      rerender({ data: undefined });
+
+      // The previous page is retained for display, but the table reports
+      // that a load is in progress again.
+      expect(ids(result.current)).toEqual([0, 1, 2, 3, 4]);
+      expect(result.current.tableProps.isPending).toBe(true);
+      expect(result.current.tableProps.isStale).toBe(true);
+
+      rerender({ data: makeItems(2) });
+      expect(result.current.tableProps.isPending).toBe(false);
+      expect(ids(result.current)).toEqual([0, 1]);
+    });
+
+    it('applies searchFn, filterFn and sortFn and resets the page on query changes', () => {
+      const searchFn = (data: Item[], search: string) =>
+        data.filter(item => item.name.includes(search));
+      const filterFn = (data: Item[], filter: { even: boolean }) =>
+        filter.even ? data.filter(item => item.id % 2 === 0) : data;
+      const sortFn = (data: Item[], sort: SortDescriptor) =>
+        [...data].sort(
+          (a, b) => (a.id - b.id) * (sort.direction === 'descending' ? -1 : 1),
+        );
+
+      const { result } = renderHook(() =>
+        useTable<Item, { even: boolean }>({
+          mode: 'complete',
+          data: makeItems(25),
+          paginationOptions: { pageSize: 10 },
+          searchFn,
+          filterFn,
+          sortFn,
+        }),
+      );
+
+      act(() => getPagination(result.current).onNextPage());
+      expect(getPagination(result.current).offset).toBe(10);
+
+      // Searching resets to the first page of matching items.
+      act(() => result.current.search.onChange('Item 2'));
+      expect(result.current.search.value).toBe('Item 2');
+      expect(getPagination(result.current).offset).toBe(0);
+      // 'Item 2' matches 2 and 20-24
+      expect(ids(result.current)).toEqual([2, 20, 21, 22, 23, 24]);
+
+      act(() => result.current.search.onChange(''));
+      act(() => result.current.filter.onChange({ even: true }));
+      expect(getPagination(result.current).totalCount).toBe(13);
+      expect(ids(result.current)).toEqual([0, 2, 4, 6, 8, 10, 12, 14, 16, 18]);
+
+      act(() =>
+        result.current.tableProps.sort?.onSortChange({
+          column: 'name',
+          direction: 'descending',
+        }),
+      );
+      expect(result.current.tableProps.sort?.descriptor).toEqual({
+        column: 'name',
+        direction: 'descending',
+      });
+      expect(ids(result.current)).toEqual([
+        24, 22, 20, 18, 16, 14, 12, 10, 8, 6,
+      ]);
+    });
+
+    it('supports controlled search without mutating internal state', () => {
+      const onSearchChange = jest.fn();
+      const searchFn = (data: Item[], search: string) =>
+        data.filter(item => item.name.includes(search));
+
+      const { result, rerender } = renderHook(
+        ({ search }: { search: string }) =>
+          useTable<Item>({
+            mode: 'complete',
+            data: makeItems(25),
+            paginationOptions: { pageSize: 10 },
+            search,
+            onSearchChange,
+            searchFn,
+          }),
+        { initialProps: { search: 'Item 1' } },
+      );
+
+      expect(result.current.search.value).toBe('Item 1');
+      expect(ids(result.current)).toEqual([
+        1, 10, 11, 12, 13, 14, 15, 16, 17, 18,
+      ]);
+
+      // Changing through the handler notifies the owner but does not change
+      // the controlled value by itself.
+      act(() => result.current.search.onChange('Item 2'));
+      expect(onSearchChange).toHaveBeenCalledWith('Item 2');
+      expect(result.current.search.value).toBe('Item 1');
+
+      rerender({ search: 'Item 2' });
+      expect(result.current.search.value).toBe('Item 2');
+      expect(ids(result.current)).toEqual([2, 20, 21, 22, 23, 24]);
+    });
+
+    it('throws when the mode changes after mount', () => {
+      const consoleError = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      try {
+        const items = makeItems(3);
+        // Intentionally violates the typed contract that the mode is fixed,
+        // to exercise the runtime guard.
+        const { rerender } = renderHook(
+          ({ mode }: { mode: 'complete' | 'offset' }) =>
+            useTable<Item>(
+              (mode === 'complete'
+                ? { mode, data: items }
+                : {
+                    mode,
+                    getData: async () => ({ data: items, totalCount: 3 }),
+                  }) as UseTableCompleteOptions<Item>,
+            ),
+          {
+            initialProps: { mode: 'complete' } as {
+              mode: 'complete' | 'offset';
+            },
+          },
+        );
+
+        expect(() => rerender({ mode: 'offset' })).toThrow(
+          /mode cannot change/,
+        );
+      } finally {
+        consoleError.mockRestore();
+      }
+    });
+  });
+
+  describe('offset mode', () => {
+    it('fetches pages on demand, caches visited pages, and navigates back to the first page', async () => {
+      const getData = createOffsetGetData(makeItems(25));
+      const { result } = renderHook(() =>
+        useTable<Item>({
+          mode: 'offset',
+          getData,
+          paginationOptions: { pageSize: 10 },
+        }),
+      );
+
+      expect(result.current.tableProps.isPending).toBe(true);
+      await waitFor(() =>
+        expect(result.current.tableProps.isPending).toBe(false),
+      );
+
+      expect(getData).toHaveBeenCalledTimes(1);
+      expect(getData.mock.calls[0][0]).toMatchObject({
+        offset: 0,
+        pageSize: 10,
+        sort: null,
+        search: '',
+      });
+      expect(getData.mock.calls[0][0].signal).toBeInstanceOf(AbortSignal);
+      expect(ids(result.current)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+      expect(getPagination(result.current)).toMatchObject({
+        offset: 0,
+        totalCount: 25,
+        hasPreviousPage: false,
+        hasNextPage: true,
+      });
+
+      act(() => getPagination(result.current).onNextPage());
+      await waitFor(() =>
+        expect(result.current.tableProps.isPending).toBe(false),
+      );
+      expect(getData).toHaveBeenCalledTimes(2);
+      expect(getData.mock.calls[1][0]).toMatchObject({ offset: 10 });
+      expect(ids(result.current)).toEqual([
+        10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+      ]);
+
+      // Going back serves the first page from the cache without refetching.
+      act(() => getPagination(result.current).onPreviousPage());
+      expect(ids(result.current)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+      expect(getData).toHaveBeenCalledTimes(2);
+      expect(getPagination(result.current).hasPreviousPage).toBe(false);
+    });
+
+    it('can navigate back to the first page when mounted at an initialOffset', async () => {
+      const getData = createOffsetGetData(makeItems(25));
+      const { result } = renderHook(() =>
+        useTable<Item>({
+          mode: 'offset',
+          getData,
+          paginationOptions: { pageSize: 10, initialOffset: 10 },
+        }),
+      );
+
+      await waitFor(() =>
+        expect(result.current.tableProps.isPending).toBe(false),
+      );
+      expect(getData.mock.calls[0][0]).toMatchObject({ offset: 10 });
+      expect(ids(result.current)).toEqual([
+        10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+      ]);
+      expect(getPagination(result.current)).toMatchObject({
+        offset: 10,
+        hasPreviousPage: true,
+      });
+
+      act(() => getPagination(result.current).onPreviousPage());
+      await waitFor(() => expect(getPagination(result.current).offset).toBe(0));
+      await waitFor(() =>
+        expect(result.current.tableProps.isPending).toBe(false),
+      );
+      expect(ids(result.current)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+      expect(getPagination(result.current).hasPreviousPage).toBe(false);
+    });
+
+    it('keeps showing the previous page as stale while the next page loads', async () => {
+      const items = makeItems(25);
+      const resolvers: Array<() => void> = [];
+      const getData = jest.fn(async (params: OffsetParams<unknown>) => {
+        await new Promise<void>(resolve => resolvers.push(resolve));
+        return {
+          data: items.slice(params.offset, params.offset + params.pageSize),
+          totalCount: items.length,
+        };
+      });
+
+      const { result } = renderHook(() =>
+        useTable<Item>({
+          mode: 'offset',
+          getData,
+          paginationOptions: { pageSize: 10 },
+        }),
+      );
+
+      await act(async () => resolvers.shift()?.());
+      expect(result.current.tableProps.isPending).toBe(false);
+      expect(result.current.tableProps.isStale).toBe(false);
+
+      act(() => getPagination(result.current).onNextPage());
+
+      expect(result.current.tableProps.isPending).toBe(true);
+      expect(result.current.tableProps.isStale).toBe(true);
+      expect(ids(result.current)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+      await act(async () => resolvers.shift()?.());
+      expect(result.current.tableProps.isStale).toBe(false);
+      expect(ids(result.current)).toEqual([
+        10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+      ]);
+    });
+
+    it('resets to the first page and refetches when the search changes, debounced', async () => {
+      jest.useFakeTimers();
+      const getData = createOffsetGetData(makeItems(25));
+      const { result } = renderHook(() =>
+        useTable<Item>({
+          mode: 'offset',
+          getData,
+          paginationOptions: { pageSize: 10 },
+        }),
+      );
+
+      await waitFor(() =>
+        expect(result.current.tableProps.isPending).toBe(false),
+      );
+      act(() => getPagination(result.current).onNextPage());
+      await waitFor(() =>
+        expect(result.current.tableProps.isPending).toBe(false),
+      );
+      expect(getData).toHaveBeenCalledTimes(2);
+
+      act(() => result.current.search.onChange('Item 2'));
+      expect(result.current.search.value).toBe('Item 2');
+
+      // Rapid changes within the debounce window collapse into one reload.
+      act(() => result.current.search.onChange('Item 22'));
+      act(() => jest.advanceTimersByTime(150));
+      expect(getData).toHaveBeenCalledTimes(2);
+
+      act(() => jest.advanceTimersByTime(100));
+      await waitFor(() =>
+        expect(result.current.tableProps.isPending).toBe(false),
+      );
+      expect(getData).toHaveBeenCalledTimes(3);
+      expect(getData.mock.calls[2][0]).toMatchObject({
+        offset: 0,
+        search: 'Item 22',
+      });
+      expect(ids(result.current)).toEqual([22]);
+    });
+
+    it('does not reload when callback options change identity without a value change', async () => {
+      jest.useFakeTimers();
+      const getData = createOffsetGetData(makeItems(25));
+      const { result, rerender } = renderHook(
+        ({ onSortChange }: { onSortChange: (sort: SortDescriptor) => void }) =>
+          useTable<Item>({
+            mode: 'offset',
+            getData,
+            paginationOptions: { pageSize: 10 },
+            onSortChange,
+          }),
+        { initialProps: { onSortChange: () => {} } },
+      );
+
+      await waitFor(() =>
+        expect(result.current.tableProps.isPending).toBe(false),
+      );
+      expect(getData).toHaveBeenCalledTimes(1);
+
+      // A parent re-render typically passes new inline callback identities.
+      rerender({ onSortChange: () => {} });
+      rerender({ onSortChange: () => {} });
+
+      await act(async () => {
+        jest.advanceTimersByTime(1000);
+      });
+      expect(getData).toHaveBeenCalledTimes(1);
+    });
+
+    it('recovers after a failed page load', async () => {
+      const items = makeItems(25);
+      let failOffset: number | undefined = 10;
+      const getData = jest.fn(async (params: OffsetParams<unknown>) => {
+        if (params.offset === failOffset) {
+          throw new Error('page failed');
+        }
+        return {
+          data: items.slice(params.offset, params.offset + params.pageSize),
+          totalCount: items.length,
+        };
+      });
+
+      const { result } = renderHook(() =>
+        useTable<Item>({
+          mode: 'offset',
+          getData,
+          paginationOptions: { pageSize: 10 },
+        }),
+      );
+
+      await waitFor(() =>
+        expect(result.current.tableProps.isPending).toBe(false),
+      );
+
+      act(() => getPagination(result.current).onNextPage());
+      await waitFor(() =>
+        expect(result.current.tableProps.error?.message).toBe('page failed'),
+      );
+
+      // Navigating back to the cached first page clears the error.
+      act(() => getPagination(result.current).onPreviousPage());
+      expect(result.current.tableProps.error).toBeUndefined();
+      expect(ids(result.current)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+      // Retrying the failed page fetches it again.
+      failOffset = undefined;
+      act(() => getPagination(result.current).onNextPage());
+      await waitFor(() =>
+        expect(ids(result.current)).toEqual([
+          10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+        ]),
+      );
+      expect(result.current.tableProps.error).toBeUndefined();
+    });
+
+    it('reload refetches from the first page with a cleared cache', async () => {
+      const getData = createOffsetGetData(makeItems(25));
+      const { result } = renderHook(() =>
+        useTable<Item>({
+          mode: 'offset',
+          getData,
+          paginationOptions: { pageSize: 10 },
+        }),
+      );
+
+      await waitFor(() =>
+        expect(result.current.tableProps.isPending).toBe(false),
+      );
+      act(() => getPagination(result.current).onNextPage());
+      await waitFor(() =>
+        expect(result.current.tableProps.isPending).toBe(false),
+      );
+
+      act(() => result.current.reload());
+      await waitFor(() =>
+        expect(result.current.tableProps.isPending).toBe(false),
+      );
+      expect(getData).toHaveBeenCalledTimes(3);
+      expect(getData.mock.calls[2][0]).toMatchObject({ offset: 0 });
+      expect(getPagination(result.current).offset).toBe(0);
+
+      // The cache was cleared, so the next page is fetched again.
+      act(() => getPagination(result.current).onNextPage());
+      await waitFor(() =>
+        expect(result.current.tableProps.isPending).toBe(false),
+      );
+      expect(getData).toHaveBeenCalledTimes(4);
+    });
+  });
+
+  describe('cursor mode', () => {
+    it('navigates using cursors from the response', async () => {
+      const getData = createCursorGetData(makeItems(25));
+      const { result } = renderHook(() =>
+        useTable<Item>({
+          mode: 'cursor',
+          getData,
+          paginationOptions: { pageSize: 10 },
+        }),
+      );
+
+      await waitFor(() =>
+        expect(result.current.tableProps.isPending).toBe(false),
+      );
+      expect(getData.mock.calls[0][0]).toMatchObject({
+        cursor: undefined,
+        pageSize: 10,
+      });
+      expect(ids(result.current)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+      expect(getPagination(result.current)).toMatchObject({
+        offset: undefined,
+        totalCount: 25,
+        hasPreviousPage: false,
+        hasNextPage: true,
+      });
+
+      act(() => getPagination(result.current).onNextPage());
+      await waitFor(() =>
+        expect(result.current.tableProps.isPending).toBe(false),
+      );
+      expect(getData.mock.calls[1][0]).toMatchObject({ cursor: '1' });
+
+      act(() => getPagination(result.current).onNextPage());
+      await waitFor(() =>
+        expect(result.current.tableProps.isPending).toBe(false),
+      );
+      expect(getData.mock.calls[2][0]).toMatchObject({ cursor: '2' });
+      expect(ids(result.current)).toEqual([20, 21, 22, 23, 24]);
+      expect(getPagination(result.current).hasNextPage).toBe(false);
+
+      // Both previous pages come from the cache.
+      act(() => getPagination(result.current).onPreviousPage());
+      act(() => getPagination(result.current).onPreviousPage());
+      expect(ids(result.current)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+      expect(getPagination(result.current).hasPreviousPage).toBe(false);
+      expect(getData).toHaveBeenCalledTimes(3);
+    });
+
+    it('reload resets to the first page and pageSize changes trigger a debounced reload', async () => {
+      jest.useFakeTimers();
+      const getData = createCursorGetData(makeItems(25));
+      const { result } = renderHook(() =>
+        useTable<Item>({
+          mode: 'cursor',
+          getData,
+          paginationOptions: { pageSize: 10 },
+        }),
+      );
+
+      await waitFor(() =>
+        expect(result.current.tableProps.isPending).toBe(false),
+      );
+      act(() => getPagination(result.current).onNextPage());
+      await waitFor(() =>
+        expect(result.current.tableProps.isPending).toBe(false),
+      );
+
+      act(() => result.current.reload());
+      await waitFor(() =>
+        expect(result.current.tableProps.isPending).toBe(false),
+      );
+      expect(getData).toHaveBeenCalledTimes(3);
+      expect(getData.mock.calls[2][0]).toMatchObject({ cursor: undefined });
+      expect(ids(result.current)).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+      act(() => getPagination(result.current).onPageSizeChange?.(5));
+      await act(async () => {
+        jest.advanceTimersByTime(250);
+      });
+      await waitFor(() =>
+        expect(result.current.tableProps.isPending).toBe(false),
+      );
+      expect(getData.mock.calls[3][0]).toMatchObject({
+        cursor: undefined,
+        pageSize: 5,
+      });
+      expect(ids(result.current)).toEqual([0, 1, 2, 3, 4]);
+      expect(getPagination(result.current).pageSize).toBe(5);
+    });
+  });
+
+  describe('render lifecycle', () => {
+    const columns: ColumnConfig<Item>[] = [
+      {
+        id: 'name',
+        label: 'Name',
+        isRowHeader: true,
+        cell: item => <CellText title={item.name} />,
+      },
+    ];
+
+    function OffsetHarness({
+      getData,
+    }: {
+      getData: (
+        params: OffsetParams<unknown>,
+      ) => Promise<{ data: Item[]; totalCount: number }>;
+    }) {
+      const { tableProps } = useTable<Item>({
+        mode: 'offset',
+        getData,
+        paginationOptions: { pageSize: 10 },
+      });
+      return <Table {...tableProps} columnConfig={columns} />;
+    }
+
+    it('recovers from the StrictMode double mount and keeps the page cache intact', async () => {
+      const getData = createOffsetGetData(makeItems(25));
+
+      render(
+        <StrictMode>
+          <OffsetHarness getData={getData} />
+        </StrictMode>,
+      );
+
+      // The simulated unmount aborts the first mount fetch; the remount
+      // fetches again. Every mount call targets the first page.
+      expect(await screen.findByText('Item 0')).toBeInTheDocument();
+      for (const [params] of getData.mock.calls) {
+        expect(params.offset).toBe(0);
+      }
+
+      act(() => {
+        screen.getByRole('button', { name: 'Next table page' }).click();
+      });
+      expect(await screen.findByText('Item 10')).toBeInTheDocument();
+      const callsAfterNext = getData.mock.calls.length;
+      expect(getData.mock.calls[callsAfterNext - 1][0].offset).toBe(10);
+
+      // Going back must be served from the cache despite the double mount.
+      act(() => {
+        screen.getByRole('button', { name: 'Previous table page' }).click();
+      });
+      expect(await screen.findByText('Item 0')).toBeInTheDocument();
+      expect(getData.mock.calls.length).toBe(callsAfterNext);
+    });
+
+    it('starts no fetch from a render that is abandoned by a suspended sibling', async () => {
+      let resolveGate: () => void = () => {};
+      const gate = new Promise<void>(resolve => {
+        resolveGate = resolve;
+      });
+      let gateOpen = false;
+
+      function Suspender() {
+        if (!gateOpen) {
+          throw gate.then(() => {
+            gateOpen = true;
+          });
+        }
+        return null;
+      }
+
+      const getData = createOffsetGetData(makeItems(25));
+
+      render(
+        <Suspense fallback={<div>suspense-fallback</div>}>
+          <OffsetHarness getData={getData} />
+          <Suspender />
+        </Suspense>,
+      );
+
+      // The first render never commits, so no request may be started.
+      expect(screen.getByText('suspense-fallback')).toBeInTheDocument();
+      expect(getData).not.toHaveBeenCalled();
+
+      await act(async () => {
+        resolveGate();
+        await gate;
+      });
+
+      expect(await screen.findByText('Item 0')).toBeInTheDocument();
+      expect(getData).toHaveBeenCalledTimes(1);
+    });
+
+    it('honors initialOffset in complete mode under StrictMode', async () => {
+      const getData = jest.fn(async () => makeItems(25));
+
+      function CompleteHarness() {
+        const { tableProps } = useTable<Item>({
+          mode: 'complete',
+          getData,
+          paginationOptions: { pageSize: 10, initialOffset: 10 },
+        });
+        return <Table {...tableProps} columnConfig={columns} />;
+      }
+
+      render(
+        <StrictMode>
+          <CompleteHarness />
+        </StrictMode>,
+      );
+
+      expect(await screen.findByText('Item 10')).toBeInTheDocument();
+      expect(screen.getByText('11 - 20 of 25')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ui/src/components/TablePagination/TablePagination.test.tsx
+++ b/packages/ui/src/components/TablePagination/TablePagination.test.tsx
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { TablePagination } from '.';
+import type { TablePaginationProps } from '.';
+
+function renderPagination(props: Partial<TablePaginationProps> = {}) {
+  const defaultProps: TablePaginationProps = {
+    pageSize: 10,
+    offset: 0,
+    totalCount: 25,
+    hasNextPage: true,
+    hasPreviousPage: false,
+    onNextPage: jest.fn(),
+    onPreviousPage: jest.fn(),
+    onPageSizeChange: jest.fn(),
+  };
+  const merged = { ...defaultProps, ...props };
+  return { ...render(<TablePagination {...merged} />), props: merged };
+}
+
+describe('TablePagination', () => {
+  it('renders the range label and wires up the navigation buttons', () => {
+    const { props } = renderPagination();
+
+    expect(screen.getByText('1 - 10 of 25')).toBeInTheDocument();
+
+    const previousButton = screen.getByRole('button', {
+      name: 'Previous table page',
+    });
+    const nextButton = screen.getByRole('button', { name: 'Next table page' });
+
+    expect(previousButton).toBeDisabled();
+    expect(nextButton).toBeEnabled();
+    expect(previousButton).toHaveAccessibleDescription('1 - 10 of 25');
+    expect(nextButton).toHaveAccessibleDescription('1 - 10 of 25');
+
+    fireEvent.click(nextButton);
+    expect(props.onNextPage).toHaveBeenCalledTimes(1);
+    expect(props.onPreviousPage).not.toHaveBeenCalled();
+  });
+
+  it('handles label boundary values', () => {
+    // Last, partial page.
+    const { unmount } = renderPagination({
+      offset: 20,
+      hasNextPage: false,
+      hasPreviousPage: true,
+    });
+    expect(screen.getByText('21 - 25 of 25')).toBeInTheDocument();
+    unmount();
+
+    // No offset (cursor pagination) falls back to a total count label.
+    const second = renderPagination({ offset: undefined, totalCount: 42 });
+    expect(screen.getByText('42 items')).toBeInTheDocument();
+    second.unmount();
+
+    // No label for an empty or unknown total.
+    const third = renderPagination({ totalCount: 0 });
+    expect(screen.queryByText(/of 0/)).toBeNull();
+    third.unmount();
+
+    renderPagination({ totalCount: undefined });
+    expect(screen.queryByText(/items|of/)).toBeNull();
+  });
+
+  it('supports a custom getLabel', () => {
+    renderPagination({
+      getLabel: ({ offset, pageSize, totalCount }) =>
+        `page starting at ${offset} showing ${pageSize} of ${totalCount}`,
+    });
+    expect(
+      screen.getByText('page starting at 0 showing 10 of 25'),
+    ).toBeInTheDocument();
+  });
+
+  it('keeps the page size select in sync when the pageSize prop changes after mount', () => {
+    const onPageSizeChange = jest.fn();
+    const { rerender } = render(
+      <TablePagination
+        pageSize={10}
+        offset={0}
+        totalCount={25}
+        hasNextPage
+        hasPreviousPage={false}
+        onNextPage={jest.fn()}
+        onPreviousPage={jest.fn()}
+        onPageSizeChange={onPageSizeChange}
+      />,
+    );
+
+    const select = screen.getByRole('button', {
+      name: /Select table page size/,
+    });
+    expect(select).toHaveTextContent('Show 10 results');
+
+    rerender(
+      <TablePagination
+        pageSize={20}
+        offset={0}
+        totalCount={25}
+        hasNextPage
+        hasPreviousPage={false}
+        onNextPage={jest.fn()}
+        onPreviousPage={jest.fn()}
+        onPageSizeChange={onPageSizeChange}
+      />,
+    );
+    expect(select).toHaveTextContent('Show 20 results');
+
+    // Selecting an option reports the numeric page size.
+    fireEvent.click(select);
+    fireEvent.click(screen.getByRole('option', { name: 'Show 5 results' }));
+    expect(onPageSizeChange).toHaveBeenCalledWith(5);
+  });
+
+  it('falls back to the first option when pageSize is not in pageSizeOptions', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      renderPagination({ pageSize: 7, pageSizeOptions: [10, 25, 50] });
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('pageSize 7 is not in pageSizeOptions'),
+      );
+      expect(
+        screen.getByRole('button', { name: /Select table page size/ }),
+      ).toHaveTextContent('Show 10 results');
+      expect(screen.getByText('1 - 10 of 25')).toBeInTheDocument();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('renders navigation without crashing when pageSizeOptions is empty', () => {
+    renderPagination({ pageSizeOptions: [] });
+
+    expect(
+      screen.getByRole('button', { name: 'Next table page' }),
+    ).toBeEnabled();
+    expect(screen.getByText('1 - 10 of 25')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /Select table page size/ }),
+    ).toBeNull();
+  });
+
+  it('can hide the page size select and the label', () => {
+    renderPagination({
+      showPageSizeOptions: false,
+      showPaginationLabel: false,
+    });
+
+    expect(
+      screen.queryByRole('button', { name: /Select table page size/ }),
+    ).toBeNull();
+    expect(screen.queryByText('1 - 10 of 25')).toBeNull();
+    expect(
+      screen.getByRole('button', { name: 'Next table page' }),
+    ).not.toHaveAccessibleDescription();
+  });
+});

--- a/packages/ui/src/components/TablePagination/TablePagination.tsx
+++ b/packages/ui/src/components/TablePagination/TablePagination.tsx
@@ -76,6 +76,9 @@ export function TablePagination(props: TablePaginationProps) {
   );
 
   const effectivePageSize = useMemo(() => {
+    if (pageSizeOptions.length === 0) {
+      return pageSize;
+    }
     const isValid = pageSizeOptions.some(
       opt => getOptionValue(opt) === pageSize,
     );
@@ -105,7 +108,7 @@ export function TablePagination(props: TablePaginationProps) {
   return (
     <div className={classes.root}>
       <div className={classes.left}>
-        {showPageSizeOptions && (
+        {showPageSizeOptions && normalizedOptions.length > 0 && (
           <Select
             name="pageSize"
             size="small"
@@ -114,7 +117,7 @@ export function TablePagination(props: TablePaginationProps) {
               label: opt.label,
               value: String(opt.value),
             }))}
-            defaultValue={effectivePageSize.toString()}
+            value={effectivePageSize.toString()}
             onChange={value => {
               const newPageSize = Number(value);
               onPageSizeChange?.(newPageSize);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Release-readiness fixes for `Table`, `TablePagination`, and `useTable` in `@backstage/ui`, together with black-box regression tests through their public APIs. The bugs all involve state changing after mount and were invisible to the existing Storybook coverage:

- **`useTable` (offset mode) could never navigate back to the first page after mounting with an `initialOffset`** — offset `0` was treated as "no page" because cursors were checked for truthiness. Valid cursors are now only absent when `undefined`.
- **`useTable` (complete mode) ignored `paginationOptions.initialOffset`** — a pageSize-sync effect reset the offset to 0 right after mount. The reset is now guarded so it only runs when the configured page size actually changes.
- **Inline callback options caused spurious page resets and refetches** — the debounced reload compared the query object by identity, which changed whenever `onSortChange`/`onFilterChange`/`onSearchChange` were passed as inline functions. It now compares the sort/filter/search values.
- **Immediately-resolving data sources could render stale pages** — page data lives in a mutable cache that React cannot observe, and when a fetch resolved in the same batch that started it, the pending-state updates cancelled out and no re-render happened. Cache writes now bump a version state.
- **A failed page load left the whole table stuck in the error state** even after navigating back to an already-loaded page. Errors now clear on cached navigation, and retrying the failed page works.
- **Complete mode showed an empty page with a nonsensical range label when the data shrank below the current offset** — the offset now clamps to the last page. It also reports a pending/stale state again when caller-managed `data` returns to `undefined`.
- **The `TablePagination` page size select was uncontrolled**, so a `pageSize` prop change after mount left the visible selection out of sync with the actual page size. An empty `pageSizeOptions` array also crashed the component; both are fixed.
- **Controlled row selection silently failed for numeric item ids** — rows are keyed by `String(item.id)`, so `selected: new Set([2])` never matched. Selected keys are now normalized to strings.
- **`aria-busy` never reached the DOM** — react-aria-components filters non-labelable ARIA props, so screen-reader users got no busy indication. It is now applied to the rendered table element directly.

New test suites cover complete, offset, and cursor modes end to end: boundary navigation, controlled sort/filter/search, async loading and error recovery, reload and debounced query changes, stale-data display, page caching, row selection and disabled rows, live region announcements, and StrictMode/Suspense render lifecycle behavior. Each fix was written test-first against the previous behavior.

No exported type signatures changed; the pending infinite-scroll work is untouched.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

🤖 Generated with [Claude Code](https://claude.com/claude-code)