### PR TITLE
ui: added destructive prop to ButtonIcon

### DIFF
--- a/.changeset/twelve-trams-study.md
+++ b/.changeset/twelve-trams-study.md
@@ -1,0 +1,7 @@
+---
+'@backstage/ui': patch
+---
+
+Added a `destructive` prop to `ButtonIcon` to support the same destructive-action styling already available on `Button`.
+
+**Affected components:** ButtonIcon

--- a/docs-ui/src/app/components/button-icon/props-definition.tsx
+++ b/docs-ui/src/app/components/button-icon/props-definition.tsx
@@ -19,6 +19,12 @@ export const buttonIconPropDefs: Record<string, PropDef> = {
       </>
     ),
   },
+  destructive: {
+    type: 'boolean',
+    default: 'false',
+    description:
+      'Applies destructive styling for dangerous actions like delete or remove.',
+  },
   size: {
     type: 'enum',
     values: ['small', 'medium'],

--- a/packages/ui/report.api.md
+++ b/packages/ui/report.api.md
@@ -574,6 +574,9 @@ export const ButtonIconDefinition: {
       readonly dataAttribute: true;
       readonly default: 'primary';
     };
+    readonly destructive: {
+      readonly dataAttribute: true;
+    };
     readonly isPending: {
       readonly dataAttribute: true;
     };
@@ -589,6 +592,7 @@ export const ButtonIconDefinition: {
 export type ButtonIconOwnProps = {
   size?: Responsive<'small' | 'medium'>;
   variant?: Responsive<'primary' | 'secondary' | 'tertiary'>;
+  destructive?: boolean;
   icon?: ReactElement;
   isPending?: boolean;
   loading?: boolean;

--- a/packages/ui/src/components/ButtonIcon/ButtonIcon.module.css
+++ b/packages/ui/src/components/ButtonIcon/ButtonIcon.module.css
@@ -78,8 +78,8 @@
       outline-offset: 2px;
     }
   }
-  
-.bui-ButtonIcon[data-variant='primary'][data-destructive='true'] {
+
+  .bui-ButtonIcon[data-variant='primary'][data-destructive='true'] {
     --bg-solid-danger: #dc2626;
     --bg-solid-danger-hover: #b91c1c;
     --bg-solid-danger-pressed: #991b1b;
@@ -149,7 +149,7 @@
     }
   }
 
-.bui-ButtonIcon[data-variant='secondary'][data-destructive='true'] {
+  .bui-ButtonIcon[data-variant='secondary'][data-destructive='true'] {
     --bg-danger-hover: #fecaca;
     --bg-danger-pressed: #fca5a5;
 
@@ -209,7 +209,7 @@
     }
   }
 
-.bui-ButtonIcon[data-variant='tertiary'][data-destructive='true'] {
+  .bui-ButtonIcon[data-variant='tertiary'][data-destructive='true'] {
     --bg-danger-hover: #fecaca;
     --bg-danger-pressed: #fca5a5;
 

--- a/packages/ui/src/components/ButtonIcon/ButtonIcon.module.css
+++ b/packages/ui/src/components/ButtonIcon/ButtonIcon.module.css
@@ -78,6 +78,38 @@
       outline-offset: 2px;
     }
   }
+  
+.bui-ButtonIcon[data-variant='primary'][data-destructive='true'] {
+    --bg-solid-danger: #dc2626;
+    --bg-solid-danger-hover: #b91c1c;
+    --bg-solid-danger-pressed: #991b1b;
+    --bg-solid-danger-disabled: #fca5a5;
+    --fg-solid-danger: var(--bui-white);
+
+    [data-theme-mode='dark'] & {
+      --bg-solid-danger: #ef4444;
+      --bg-solid-danger-hover: #dc2626;
+      --bg-solid-danger-pressed: #b91c1c;
+      --bg-solid-danger-disabled: #7f1d1d;
+    }
+
+    --bg: var(--bg-solid-danger);
+    --bg-hover: var(--bg-solid-danger-hover);
+    --bg-active: var(--bg-solid-danger-pressed);
+    --fg: var(--fg-solid-danger);
+
+    &[data-disabled='true'],
+    &[data-ispending='true'] {
+      --bg: var(--bg-solid-danger-disabled);
+      --bg-hover: var(--bg-solid-danger-disabled);
+      --bg-active: var(--bg-solid-danger-disabled);
+    }
+
+    &[data-focus-visible] {
+      outline: 2px solid var(--bui-border-danger);
+      outline-offset: 2px;
+    }
+  }
 
   .bui-ButtonIcon[data-variant='secondary'] {
     --bg: var(--bui-bg-neutral-1);
@@ -117,6 +149,32 @@
     }
   }
 
+.bui-ButtonIcon[data-variant='secondary'][data-destructive='true'] {
+    --bg-danger-hover: #fecaca;
+    --bg-danger-pressed: #fca5a5;
+
+    [data-theme-mode='dark'] & {
+      --bg-danger-hover: #450a0a;
+      --bg-danger-pressed: #7f1d1d;
+    }
+
+    --bg: var(--bui-bg-danger);
+    --bg-hover: var(--bg-danger-hover);
+    --bg-active: var(--bg-danger-pressed);
+    --fg: var(--bui-fg-danger);
+
+    &[data-disabled='true'],
+    &[data-ispending='true'] {
+      --bg-hover: var(--bg);
+      --bg-active: var(--bg);
+      --fg: var(--bui-fg-disabled);
+    }
+
+    &[data-focus-visible] {
+      box-shadow: inset 0 0 0 2px var(--bui-border-danger);
+    }
+  }
+
   .bui-ButtonIcon[data-variant='tertiary'] {
     --bg-hover: var(--bui-bg-neutral-1-hover);
     --bg-active: var(--bui-bg-neutral-1-pressed);
@@ -148,6 +206,31 @@
       outline: none;
       transition: none;
       box-shadow: inset 0 0 0 2px var(--bui-ring);
+    }
+  }
+
+.bui-ButtonIcon[data-variant='tertiary'][data-destructive='true'] {
+    --bg-danger-hover: #fecaca;
+    --bg-danger-pressed: #fca5a5;
+
+    [data-theme-mode='dark'] & {
+      --bg-danger-hover: #450a0a;
+      --bg-danger-pressed: #7f1d1d;
+    }
+
+    --bg-hover: var(--bui-bg-danger);
+    --bg-active: var(--bg-danger-pressed);
+    --fg: var(--bui-fg-danger);
+
+    &[data-disabled='true'],
+    &[data-ispending='true'] {
+      --bg-hover: var(--bg);
+      --bg-active: var(--bg);
+      --fg: var(--bui-fg-disabled);
+    }
+
+    &[data-focus-visible] {
+      box-shadow: inset 0 0 0 2px var(--bui-border-danger);
     }
   }
 

--- a/packages/ui/src/components/ButtonIcon/ButtonIcon.stories.tsx
+++ b/packages/ui/src/components/ButtonIcon/ButtonIcon.stories.tsx
@@ -49,6 +49,69 @@ export const Variants = meta.story({
   ),
 });
 
+export const Destructive = meta.story({
+  render: () => (
+    <Flex direction="column" gap="4">
+      <Flex direction="column" gap="4">
+        <Text>Primary Destructive</Text>
+        <Flex align="center" gap="4">
+          <ButtonIcon variant="primary" destructive icon={<RiCloudLine />} />
+          <ButtonIcon
+            variant="primary"
+            destructive
+            isDisabled
+            icon={<RiCloudLine />}
+          />
+          <ButtonIcon
+            variant="primary"
+            destructive
+            isPending
+            icon={<RiCloudLine />}
+          />
+        </Flex>
+      </Flex>
+
+      <Flex direction="column" gap="4">
+        <Text>Secondary Destructive</Text>
+        <Flex align="center" gap="4">
+          <ButtonIcon variant="secondary" destructive icon={<RiCloudLine />} />
+          <ButtonIcon
+            variant="secondary"
+            destructive
+            isDisabled
+            icon={<RiCloudLine />}
+          />
+          <ButtonIcon
+            variant="secondary"
+            destructive
+            isPending
+            icon={<RiCloudLine />}
+          />
+        </Flex>
+      </Flex>
+
+      <Flex direction="column" gap="4">
+        <Text>Tertiary Destructive</Text>
+        <Flex align="center" gap="4">
+          <ButtonIcon variant="tertiary" destructive icon={<RiCloudLine />} />
+          <ButtonIcon
+            variant="tertiary"
+            destructive
+            isDisabled
+            icon={<RiCloudLine />}
+          />
+          <ButtonIcon
+            variant="tertiary"
+            destructive
+            isPending
+            icon={<RiCloudLine />}
+          />
+        </Flex>
+      </Flex>
+    </Flex>
+  ),
+});
+
 export const Sizes = meta.story({
   render: () => (
     <Flex align="center" gap="2">

--- a/packages/ui/src/components/ButtonIcon/definition.ts
+++ b/packages/ui/src/components/ButtonIcon/definition.ts
@@ -33,6 +33,7 @@ export const ButtonIconDefinition = defineComponent<ButtonIconOwnProps>()({
   propDefs: {
     size: { dataAttribute: true, default: 'small' },
     variant: { dataAttribute: true, default: 'primary' },
+    destructive: { dataAttribute: true },
     isPending: { dataAttribute: true },
     loading: { dataAttribute: true },
     icon: {},

--- a/packages/ui/src/components/ButtonIcon/types.ts
+++ b/packages/ui/src/components/ButtonIcon/types.ts
@@ -22,6 +22,7 @@ import type { Responsive } from '../../types';
 export type ButtonIconOwnProps = {
   size?: Responsive<'small' | 'medium'>;
   variant?: Responsive<'primary' | 'secondary' | 'tertiary'>;
+  destructive?: boolean;
   icon?: ReactElement;
   isPending?: boolean;
   /** @deprecated Use `isPending` instead. */


### PR DESCRIPTION
## What

Adds a `destructive` prop to `ButtonIcon`, mirroring the existing `destructive`
prop already supported on `Button`.

## Why

`Button` supports a `destructive` variant for dangerous actions (delete, remove,
etc.), styled with the danger color tokens. `ButtonIcon` had no equivalent, so
icon-only destructive actions (e.g. a delete icon button) had no way to signal
danger through the design system, teams would have had to hand-roll custom
styling or use an inconsistent-looking default button.

This adds the same `destructive: boolean` prop, wired through `definition.ts`
as a data attribute, with matching CSS for all three variants (primary,
secondary, tertiary), copied from `Button`'s existing implementation to keep
the design system consistent.

## Screenshot

<img width="1470" height="805" alt="Screenshot 2026-08-16 at 4 46 13 PM" src="https://github.com/user-attachments/assets/bd669105-84ca-46e3-9d37-11a32e9a192a" />

## Docs

Added the `destructive` prop to the ButtonIcon props table in docs-ui,
matching the existing entry on Button.

## Testing

- Verified visually in Storybook (`ButtonIcon → Destructive` story) across all
  three variants, plus disabled and pending states
- Verified the props table renders correctly in docs-ui
- Existing `@backstage/ui` test suite passes (253/253)
- Added a changeset

Fixes #35023

#### :heavy_check_mark: Checklist
- [x] A changeset describing the change and affected packages.
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.