### PR TITLE
fix(catalog-backend-module-github): log a warning and skip org when no GitHub App installation is found

### DIFF
--- a/.changeset/github-multiorg-app-not-installed-warning.md
+++ b/.changeset/github-multiorg-app-not-installed-warning.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+`GithubMultiOrgEntityProvider` now logs a warning and skips an org instead of failing the entire ingestion when no GitHub App installation can be found for that org. Previously, a single org without an installed GitHub App (for example because the app was installed by a user without organization owner permissions) would cause the whole read to throw, silently blocking ingestion for every other org as well.

--- a/docs/integrations/github/github-apps.md
+++ b/docs/integrations/github/github-apps.md
@@ -180,3 +180,15 @@ is the result of not installing the app in your organization. Even if created vi
 as a member and app manager of your organization, the app will not automatically install. You
 must possess the `Owner` role in the organization to see the `Install` menu under your
 app settings, then manually press `Install` to authorize the application.
+
+If you're using `GithubMultiOrgEntityProvider` to ingest from multiple orgs, a missing
+installation for one org no longer aborts ingestion for the rest. Instead, that org is skipped
+and a warning is logged:
+
+```text
+Skipping org 'my-org' as no GitHub App installation was found for it. This usually means the
+GitHub App has not been installed for this organization, or was installed by a user without
+owner permissions. See https://backstage.io/docs/integrations/github/github-apps for more details.
+```
+
+If you see this warning, follow the steps above to install the app for that organization.

--- a/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.test.ts
@@ -958,6 +958,94 @@ describe('GithubMultiOrgEntityProvider', () => {
       });
     });
 
+    it('should skip an org and log a warning when no GitHub App installation is found for it', async () => {
+      entityProvider = new GithubMultiOrgEntityProvider({
+        id: 'my-id',
+        gitHubConfig,
+        githubCredentialsProvider: {
+          getCredentials: mockGetCredentials,
+        },
+        githubUrl: 'https://github.com',
+        logger,
+        orgs: ['orgA', 'orgB'],
+      });
+
+      await entityProvider.connect(entityProviderConnection);
+
+      const notFoundError = new Error(
+        'No app installation found for orgA in 12345',
+      );
+      notFoundError.name = 'NotFoundError';
+
+      mockGetCredentials
+        .mockRejectedValueOnce(notFoundError)
+        .mockResolvedValueOnce({
+          headers: { token: 'blah' },
+          type: 'app',
+        });
+
+      mockClient
+        .mockResolvedValueOnce({
+          organization: {
+            membersWithRole: {
+              pageInfo: { hasNextPage: false },
+              nodes: [],
+            },
+          },
+        })
+        .mockResolvedValueOnce({
+          organization: {
+            teams: {
+              pageInfo: { hasNextPage: false },
+              nodes: [],
+            },
+          },
+        });
+
+      (graphql.defaults as jest.Mock).mockReturnValue(mockClient);
+
+      await entityProvider.read();
+
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('orgA'));
+
+      expect(mockGetCredentials).toHaveBeenCalledWith({
+        url: 'https://github.com/orgA',
+      });
+      expect(mockGetCredentials).toHaveBeenCalledWith({
+        url: 'https://github.com/orgB',
+      });
+
+      // Only orgB should have actually been queried via the GraphQL client
+      expect(mockClient).toHaveBeenCalledTimes(2);
+
+      expect(entityProviderConnection.applyMutation).toHaveBeenCalledWith({
+        entities: [],
+        type: 'full',
+      });
+    });
+
+    it('should rethrow non-NotFoundError errors from getCredentials', async () => {
+      entityProvider = new GithubMultiOrgEntityProvider({
+        id: 'my-id',
+        gitHubConfig,
+        githubCredentialsProvider: {
+          getCredentials: mockGetCredentials,
+        },
+        githubUrl: 'https://github.com',
+        logger,
+        orgs: ['orgA'],
+      });
+
+      await entityProvider.connect(entityProviderConnection);
+
+      mockGetCredentials.mockRejectedValueOnce(new Error('Some other error'));
+
+      await expect(entityProvider.read()).rejects.toThrow('Some other error');
+
+      expect(logger.warn).not.toHaveBeenCalled();
+      expect(entityProviderConnection.applyMutation).not.toHaveBeenCalled();
+    });
+
     it('should not call applyMutation if an error is thrown', async () => {
       entityProvider = new GithubMultiOrgEntityProvider({
         id: 'my-id',

--- a/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
@@ -28,6 +28,7 @@ import { Config } from '@backstage/config';
 import {
   DefaultGithubCredentialsProvider,
   GithubAppCredentialsMux,
+  GithubCredentials,
   GithubCredentialsProvider,
   GithubIntegrationConfig,
   ScmIntegrations,
@@ -97,6 +98,12 @@ const EVENT_TOPICS = [
   'github.organization',
   'github.team',
 ];
+
+// The credentials provider throws an `Error` named `NotFoundError` when a
+// GitHub App is not installed for the requested org/owner.
+function isNotFoundError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'NotFoundError';
+}
 
 /**
  * Options for {@link GithubMultiOrgEntityProvider}.
@@ -361,10 +368,22 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       : await this.getAllOrgs(this.options.gitHubConfig);
 
     for (const org of orgsToProcess) {
-      const { headers, type: tokenType } =
-        await this.options.githubCredentialsProvider.getCredentials({
-          url: `${this.options.githubUrl}/${org}`,
-        });
+      let headers: GithubCredentials['headers'];
+      let tokenType: GithubCredentials['type'];
+      try {
+        ({ headers, type: tokenType } =
+          await this.options.githubCredentialsProvider.getCredentials({
+            url: `${this.options.githubUrl}/${org}`,
+          }));
+      } catch (error) {
+        if (isNotFoundError(error)) {
+          logger.warn(
+            `Skipping org '${org}' as no GitHub App installation was found for it. This usually means the GitHub App has not been installed for this organization, or was installed by a user without owner permissions. See https://backstage.io/docs/integrations/github/github-apps for more details.`,
+          );
+          continue;
+        }
+        throw error;
+      }
       const client = graphql.defaults({
         baseUrl: this.options.gitHubConfig.apiBaseUrl,
         headers,


### PR DESCRIPTION
## What
Catches the `NotFoundError` thrown when fetching credentials for a GitHub org
that doesn't have the GitHub App installed, logs a warning naming the org and
pointing to the GitHub Apps docs, and skips just that org so ingestion
continues for the rest.

## Why
`GithubMultiOrgEntityProvider.read()` previously let that `NotFoundError`
propagate unhandled. A single org without the App installed (for example,
because it was installed by a user without organization owner permissions)
would throw and abort ingestion for every org in the batch, with no
indication of which org was the problem or why. New users had no way to
self-diagnose this beyond a raw `NotFoundError: No app installation found
for...` in the logs.

## Docs
Added a note to the GitHub Apps troubleshooting doc
(`docs/integrations/github/github-apps.md`) explaining the new skip-and-warn
behavior for `GithubMultiOrgEntityProvider`, matching the warning text
emitted in code.

## Testing
- Added a test: skips an org and logs a warning when no GitHub App
  installation is found for it, while still processing the other orgs.
- Added a test: rethrows non-`NotFoundError` errors from `getCredentials` so
  other failure modes still surface as before.
- Existing `@backstage/plugin-catalog-backend-module-github` test suite
  passes (22/22).
- Added a changeset.

Fixes #32972

#### :heavy_check_mark: Checklist
- [x] A changeset describing the change and affected packages.
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached
- [x] All your commits have a `Signed-off-by` line in the message.