### PR TITLE
docs: link README screenshots with absolute URLs

### DIFF
--- a/.changeset/silver-pugs-argue.md
+++ b/.changeset/silver-pugs-argue.md
@@ -1,0 +1,9 @@
+---
+'@backstage/plugin-api-docs': patch
+'@backstage/plugin-catalog-import': patch
+'@backstage/plugin-catalog-unprocessed-entities': patch
+'@backstage/plugin-devtools': patch
+'@backstage/plugin-org': patch
+---
+
+Screenshots in the README now load when it is rendered outside the repository, such as on the API reference site and on the npm package page. They were linked with repository-relative paths, which only resolve when browsing the repository on GitHub.

--- a/plugins/api-docs/README.md
+++ b/plugins/api-docs/README.md
@@ -6,9 +6,9 @@ They are defined in machine readable formats and provide a human readable docume
 
 The plugin provides a standalone list of APIs, as well as an integration into the API tab of a catalog entity.
 
-![Standalone API list](./docs/api_list.png)
-![OpenAPI Definition](./docs/openapi_definition.png)
-![Integration into components](./docs/entity_tab_api.png)
+![Standalone API list](https://raw.githubusercontent.com/backstage/backstage/master/plugins/api-docs/docs/api_list.png)
+![OpenAPI Definition](https://raw.githubusercontent.com/backstage/backstage/master/plugins/api-docs/docs/openapi_definition.png)
+![Integration into components](https://raw.githubusercontent.com/backstage/backstage/master/plugins/api-docs/docs/entity_tab_api.png)
 
 Right now, the following API formats are supported:
 

--- a/plugins/catalog-import/README.md
+++ b/plugins/catalog-import/README.md
@@ -3,7 +3,7 @@
 The Catalog Import Plugin provides a wizard to onboard projects with existing `catalog-info.yaml` files.
 It also assists by creating pull requests in repositories where no `catalog-info.yaml` exists.
 
-![Catalog Import Plugin](./docs/catalog-import-screenshot.png)
+![Catalog Import Plugin](https://raw.githubusercontent.com/backstage/backstage/master/plugins/catalog-import/docs/catalog-import-screenshot.png)
 
 Current features:
 

--- a/plugins/catalog-unprocessed-entities/README.md
+++ b/plugins/catalog-unprocessed-entities/README.md
@@ -8,19 +8,19 @@ Frontend plugin to view unprocessed entities.
 
 You can see entities that are in a failed state:
 
-![Example of failed entities tab](./docs/catalog-unprocessed-entities-failed.png)
+![Example of failed entities tab](https://raw.githubusercontent.com/backstage/backstage/master/plugins/catalog-unprocessed-entities/docs/catalog-unprocessed-entities-failed.png)
 
 ### Pending Entities
 
 You can see entities that are in a pending state:
 
-![Example of pending entities tab](./docs/catalog-unprocessed-entities-pending.png)
+![Example of pending entities tab](https://raw.githubusercontent.com/backstage/backstage/master/plugins/catalog-unprocessed-entities/docs/catalog-unprocessed-entities-pending.png)
 
 ### Raw View
 
 In either of the failed or pending tabs you have the option to see the raw entity as JSON:
 
-![Example of raw entity](./docs/catalog-unprocessed-entities-raw.png)
+![Example of raw entity](https://raw.githubusercontent.com/backstage/backstage/master/plugins/catalog-unprocessed-entities/docs/catalog-unprocessed-entities-raw.png)
 
 ## Requirements
 

--- a/plugins/devtools/README.md
+++ b/plugins/devtools/README.md
@@ -10,7 +10,7 @@ The DevTools plugin comes with two tabs out of the box.
 
 Lists helpful information about your current running Backstage instance such as: OS, NodeJS version, Backstage version, and package versions.
 
-![Example of Info tab](./docs/devtools-info-tab.png)
+![Example of Info tab](https://raw.githubusercontent.com/backstage/backstage/master/plugins/devtools/docs/devtools-info-tab.png)
 
 #### Backstage Version Reporting
 
@@ -32,13 +32,13 @@ Lists the configuration being used by your current running Backstage instance.
 
 **Note:** The Config tab uses the configuration schema [defined by each plugin](https://backstage.io/docs/conf/defining) to be able to mask secrets. It does this by checking that the [visibility](https://backstage.io/docs/conf/defining#visibility) has been marked as `secret`. If this is not set then the secret will appear in clear text. To mitigate this it is highly recommended that you enable the [permission framework](https://backstage.io/docs/permissions/overview) and [apply the proper permissions](#permissions)). If you do see secrets in clear text please contact the plugin's author to get the visibility set to secret for the applicable property.
 
-![Example of Config tab](./docs/devtools-config-tab.png)
+![Example of Config tab](https://raw.githubusercontent.com/backstage/backstage/master/plugins/devtools/docs/devtools-config-tab.png)
 
 ### Scheduled Tasks
 
 Scheduled tasks can be viewed and triggered under the `Scheduled Tasks` tab. [See below to configure](#scheduled-tasks-configuration).
 
-![Example of Scheduled Tasks tab](./docs/devtools-scheduled-tasks-tab.png)
+![Example of Scheduled Tasks tab](https://raw.githubusercontent.com/backstage/backstage/master/plugins/devtools/docs/devtools-scheduled-tasks-tab.png)
 
 ## Optional Features
 
@@ -48,13 +48,13 @@ The DevTools plugin can be setup with other tabs with additional helpful feature
 
 Lists the status of configured External Dependencies based on your current running Backstage instance's ability to reach them.
 
-![Example of external dependencies tab](./docs/devtools-external-dependencies.png)
+![Example of external dependencies tab](https://raw.githubusercontent.com/backstage/backstage/master/plugins/devtools/docs/devtools-external-dependencies.png)
 
 ### Catalog Unprocessed Entities
 
 The [Catalog Unprocessed Entities plugin](https://github.com/backstage/backstage/tree/master/plugins/catalog-unprocessed-entities) has an optional tab that you can also be added that will show unprocessed entities:
 
-![Example of unprocessed entities tab](./docs/catalog-unprocessed-entities-tab.png)
+![Example of unprocessed entities tab](https://raw.githubusercontent.com/backstage/backstage/master/plugins/devtools/docs/catalog-unprocessed-entities-tab.png)
 
 ## Setup
 

--- a/plugins/org/README.md
+++ b/plugins/org/README.md
@@ -10,13 +10,13 @@
 
 Here's an example of what the Group Page looks like:
 
-![Group Page example](./docs/group-page-example.png)
+![Group Page example](https://raw.githubusercontent.com/backstage/backstage/master/plugins/org/docs/group-page-example.png)
 
 ### User Profile
 
 Here's an example of what the User Profile looks like:
 
-![Group Page example](./docs/user-profile-example.png)
+![Group Page example](https://raw.githubusercontent.com/backstage/backstage/master/plugins/org/docs/user-profile-example.png)
 
 ## Installation
 
@@ -78,8 +78,8 @@ Once added MyGroupsSidebarItem will work in three ways:
 1. The user is not logged in or the logged in user is not a member of any group: the MyGroupsSidebarItem will not display anything in the sidebar
 2. The user is logged in and a member of only one group: the MyGroupsSidebarItem will display a single item in the sidebar like this:
 
-   ![MyGroupsSidebarItem single example](./docs/mygroupssidebaritem-single.png)
+   ![MyGroupsSidebarItem single example](https://raw.githubusercontent.com/backstage/backstage/master/plugins/org/docs/mygroupssidebaritem-single.png)
 
 3. The user is logged in and a member of more than one group: the MyGroupsSidebarItem will display a single items with a sub-menu with all the related groups like this:
 
-   ![MyGroupsSidebarItem multiple example](./docs/mygroupssidebaritem-multiple.png)
+   ![MyGroupsSidebarItem multiple example](https://raw.githubusercontent.com/backstage/backstage/master/plugins/org/docs/mygroupssidebaritem-multiple.png)


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #35195.

These READMEs are rendered in three places: the repository on GitHub, the API reference on backstage.io, and the npm package page. The API reference passes repository-relative image paths through verbatim, so they resolve against `backstage.io/api/stable/modules/` and 404 — that is the breakage reported in #35195.

**Correction (2026-08-17):** this description originally claimed the npm package page was broken too. That was wrong — npm rewrites relative image paths correctly (it honours `repository.directory`, producing `https://raw.githubusercontent.com/backstage/backstage/HEAD/plugins/<name>/docs/<image>.png`), so npm already serves these screenshots from raw.githubusercontent.com and is unaffected by this change. Details in the review thread. The API reference on backstage.io remains the renderer this PR fixes.

I went through every plugin README rather than only the one reported, since the same paths break the same way wherever the file is rendered outside the repository. Five READMEs were affected. I checked each of the 16 resulting URLs resolves (all 200).

Happy to switch to a different form if you would rather not point at `raw.githubusercontent.com` — for example resolving the assets at doc build time instead — but that would need changes in the docs pipeline (`packages/repo-tools` package-docs generation) rather than in the READMEs.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
