### PR TITLE
fix(scaffolder): await checkpoint persistence

### DIFF
--- a/.changeset/steady-checkpoints-wait.md
+++ b/.changeset/steady-checkpoints-wait.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-backend': patch
 ---
 
-Scaffolder tasks now wait for recovery checkpoint state to be persisted before continuing, preventing later execution from racing ahead of stored recovery state.
+Scaffolder tasks now wait for recovery checkpoint state to be persisted before continuing, preventing later execution from racing ahead of stored recovery state. Restored checkpoints also preserve falsy values without re-running their callbacks.

--- a/.changeset/steady-checkpoints-wait.md
+++ b/.changeset/steady-checkpoints-wait.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Scaffolder tasks now wait for recovery checkpoint state to be persisted before continuing, preventing later execution from racing ahead of stored recovery state.

--- a/.github/vale/config/vocabularies/Backstage/accept.txt
+++ b/.github/vale/config/vocabularies/Backstage/accept.txt
@@ -157,6 +157,7 @@ etag
 Expedia
 facto
 failover
+falsy
 faq
 Fargate
 faqs

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.test.ts
@@ -650,6 +650,42 @@ describe('NunjucksWorkflowRunner', () => {
   });
 
   describe('templating', () => {
+    const createDeferred = () => {
+      let resolve!: () => void;
+      const promise = new Promise<void>(promiseResolve => {
+        resolve = promiseResolve;
+      });
+      return { promise, resolve };
+    };
+
+    const registerCheckpointAction = (
+      id: string,
+      fn: () => Promise<string>,
+      afterCheckpoint?: () => void,
+    ) => {
+      actionRegistry.register(
+        createTemplateAction({
+          id,
+          handler: async ctx => {
+            await ctx.checkpoint({ key: 'key', fn });
+            afterCheckpoint?.();
+          },
+        }),
+      );
+    };
+
+    const createCheckpointTask = (
+      action: string,
+      updateCheckpoint: jest.Mock,
+      serializeWorkspace?: jest.Mock,
+    ) => ({
+      ...createMockTaskWithSpec({
+        steps: [{ id: 'test', name: 'name', action }],
+      }),
+      updateCheckpoint,
+      ...(serializeWorkspace && { serializeWorkspace }),
+    });
+
     it('should template the input to an action', async () => {
       const task = createMockTaskWithSpec({
         steps: [
@@ -908,6 +944,93 @@ describe('NunjucksWorkflowRunner', () => {
       expect(result.output.key3).toEqual('updated');
       expect(result.output.key4).toEqual(undefined);
       expect(result.output.key5).toEqual(undefined);
+    });
+
+    it('waits for successful checkpoint state to be persisted', async () => {
+      let actionContinued = false;
+      registerCheckpointAction(
+        'checkpoint-persistence-action',
+        async () => 'value',
+        () => {
+          actionContinued = true;
+        },
+      );
+
+      const updateStarted = createDeferred();
+      const pendingUpdate = createDeferred();
+      const task = createCheckpointTask(
+        'checkpoint-persistence-action',
+        jest.fn(() => {
+          updateStarted.resolve();
+          return pendingUpdate.promise;
+        }),
+      );
+
+      const execution = runner.execute(task);
+      await updateStarted.promise;
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(actionContinued).toBe(false);
+
+      pendingUpdate.resolve();
+      await execution;
+      expect(actionContinued).toBe(true);
+    });
+
+    it('does not record callback failure when successful persistence fails', async () => {
+      registerCheckpointAction(
+        'checkpoint-persistence-rejection-action',
+        async () => 'value',
+      );
+
+      const persistenceError = new Error('checkpoint persistence failed');
+      const updateCheckpoint = jest.fn().mockRejectedValue(persistenceError);
+      const task = createCheckpointTask(
+        'checkpoint-persistence-rejection-action',
+        updateCheckpoint,
+      );
+
+      await expect(runner.execute(task)).rejects.toBe(persistenceError);
+      expect(updateCheckpoint).toHaveBeenCalledTimes(1);
+      expect(updateCheckpoint).toHaveBeenCalledWith({
+        key: 'v1.task.checkpoint.test.key',
+        status: 'success',
+        value: 'value',
+      });
+    });
+
+    it('waits for failed checkpoint state to be persisted', async () => {
+      const checkpointError = new Error('checkpoint failed');
+      registerCheckpointAction(
+        'failed-checkpoint-persistence-action',
+        async () => {
+          throw checkpointError;
+        },
+      );
+
+      const updateStarted = createDeferred();
+      const pendingUpdate = createDeferred();
+      const serializeWorkspace = jest.fn();
+      const task = createCheckpointTask(
+        'failed-checkpoint-persistence-action',
+        jest.fn(() => {
+          updateStarted.resolve();
+          return pendingUpdate.promise;
+        }),
+        serializeWorkspace,
+      );
+
+      const execution = runner.execute(task).then(
+        () => ({ error: undefined }),
+        error => ({ error }),
+      );
+
+      await updateStarted.promise;
+      expect(serializeWorkspace).not.toHaveBeenCalled();
+
+      pendingUpdate.resolve();
+      await expect(execution).resolves.toEqual({ error: checkpointError });
+      expect(serializeWorkspace).toHaveBeenCalled();
     });
 
     it('should template the output from simple actions', async () => {

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.test.ts
@@ -999,6 +999,57 @@ describe('NunjucksWorkflowRunner', () => {
       });
     });
 
+    it('restores successful checkpoints with falsy values', async () => {
+      const checkpointCallback = jest.fn(async () => 'rerun');
+      const restoredValues: unknown[] = [];
+      actionRegistry.register(
+        createTemplateAction({
+          id: 'falsy-checkpoint-action',
+          handler: async ctx => {
+            for (const key of ['false', 'zero', 'empty']) {
+              restoredValues.push(
+                await ctx.checkpoint({ key, fn: checkpointCallback }),
+              );
+            }
+          },
+        }),
+      );
+
+      const updateCheckpoint = jest.fn();
+      const task = {
+        ...createMockTaskWithSpec({
+          steps: [
+            { id: 'test', name: 'name', action: 'falsy-checkpoint-action' },
+          ],
+        }),
+        getTaskState: async () => ({
+          state: {
+            checkpoints: {
+              'v1.task.checkpoint.test.false': {
+                status: 'success',
+                value: false,
+              },
+              'v1.task.checkpoint.test.zero': {
+                status: 'success',
+                value: 0,
+              },
+              'v1.task.checkpoint.test.empty': {
+                status: 'success',
+                value: '',
+              },
+            },
+          },
+        }),
+        updateCheckpoint,
+      };
+
+      await runner.execute(task);
+
+      expect(restoredValues).toEqual([false, 0, '']);
+      expect(checkpointCallback).not.toHaveBeenCalled();
+      expect(updateCheckpoint).not.toHaveBeenCalled();
+    });
+
     it('waits for failed checkpoint state to be persisted', async () => {
       const checkpointError = new Error('checkpoint failed');
       registerCheckpointAction(
@@ -1031,6 +1082,28 @@ describe('NunjucksWorkflowRunner', () => {
       pendingUpdate.resolve();
       await expect(execution).resolves.toEqual({ error: checkpointError });
       expect(serializeWorkspace).toHaveBeenCalled();
+    });
+
+    it('preserves callback and persistence errors for failed checkpoints', async () => {
+      const checkpointError = new Error('checkpoint failed');
+      registerCheckpointAction(
+        'failed-checkpoint-persistence-rejection-action',
+        async () => {
+          throw checkpointError;
+        },
+      );
+
+      const persistenceError = new Error('checkpoint persistence failed');
+      const task = createCheckpointTask(
+        'failed-checkpoint-persistence-rejection-action',
+        jest.fn().mockRejectedValue(persistenceError),
+      );
+
+      const execution = runner.execute(task);
+      await expect(execution).rejects.toBeInstanceOf(AggregateError);
+      await expect(execution).rejects.toMatchObject({
+        errors: [checkpointError, persistenceError],
+      });
     });
 
     it('should template the output from simple actions', async () => {

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
@@ -513,34 +513,37 @@ export class NunjucksWorkflowRunner implements WorkflowRunner {
 
             try {
               let prevValue: T | undefined;
+              let value: T;
 
-              if (prevTaskState) {
-                const prevState = (
-                  prevTaskState.state?.checkpoints as CheckpointState
-                )?.[key];
+              try {
+                if (prevTaskState) {
+                  const prevState = (
+                    prevTaskState.state?.checkpoints as CheckpointState
+                  )?.[key];
 
-                if (prevState && prevState.status === 'success') {
-                  prevValue = prevState.value as T;
+                  if (prevState && prevState.status === 'success') {
+                    prevValue = prevState.value as T;
+                  }
                 }
+
+                value = prevValue ? prevValue : await fn();
+              } catch (err) {
+                await task.updateCheckpoint?.({
+                  key,
+                  status: 'failed',
+                  reason: stringifyError(err),
+                });
+                throw err;
               }
 
-              const value = prevValue ? prevValue : await fn();
-
               if (!prevValue) {
-                task.updateCheckpoint?.({
+                await task.updateCheckpoint?.({
                   key,
                   status: 'success',
                   value: value ?? {},
                 });
               }
               return value;
-            } catch (err) {
-              task.updateCheckpoint?.({
-                key,
-                status: 'failed',
-                reason: stringifyError(err),
-              });
-              throw err;
             } finally {
               await task.serializeWorkspace?.({ path: workspacePath });
             }

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
@@ -526,17 +526,24 @@ export class NunjucksWorkflowRunner implements WorkflowRunner {
                   }
                 }
 
-                value = prevValue ? prevValue : await fn();
+                value = prevValue !== undefined ? prevValue : await fn();
               } catch (err) {
-                await task.updateCheckpoint?.({
-                  key,
-                  status: 'failed',
-                  reason: stringifyError(err),
-                });
+                try {
+                  await task.updateCheckpoint?.({
+                    key,
+                    status: 'failed',
+                    reason: stringifyError(err),
+                  });
+                } catch (persistenceError) {
+                  throw new AggregateError(
+                    [err, persistenceError],
+                    `Checkpoint '${checkpointKey}' failed and its failure state could not be persisted`,
+                  );
+                }
                 throw err;
               }
 
-              if (!prevValue) {
+              if (prevValue === undefined) {
                 await task.updateCheckpoint?.({
                   key,
                   status: 'success',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Checkpoint persistence was started without being awaited, allowing action execution to continue before state storage completed and leaving persistence failures as unhandled rejections.

This waits for both successful and failed checkpoint state to be stored. Successful persistence failures are kept separate from callback failures so they do not trigger a second, misleading failed-state write.

It also preserves successful checkpoint values such as `false`, `0`, and an empty string without re-running their callbacks.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
