### PR TITLE
feat(techdocs-cli): add --skip-if-unchanged flag to publish command

### DIFF
--- a/.changeset/techdocs-cli-skip-if-unchanged.md
+++ b/.changeset/techdocs-cli-skip-if-unchanged.md
@@ -1,0 +1,7 @@
+---
+'@techdocs/cli': minor
+---
+
+Added `--etag sha256` support to `techdocs-cli generate` that auto-computes a content hash of the source directory, removing the need for callers to compute and pass an etag value.
+
+Added `--skip-if-unchanged` flag to `techdocs-cli publish` that compares local and remote etags before uploading. When the etag in the local `techdocs_metadata.json` matches the remote, the publish step is skipped entirely. This avoids redundant uploads in CI pipelines when docs haven't changed between builds.

--- a/packages/techdocs-cli/src/commands/generate/generate.ts
+++ b/packages/techdocs-cli/src/commands/generate/generate.ts
@@ -28,6 +28,7 @@ import {
   createLogger,
   getLogStream,
 } from '../../lib/utility';
+import { computeDirectoryEtag } from '../../lib/etag';
 
 export default async function generate(opts: OptionValues) {
   // Use techdocs-node package to generate docs. Keep consistency between Backstage and CI generating docs.
@@ -83,6 +84,13 @@ export default async function generate(opts: OptionValues) {
     }
   }
 
+  // Resolve etag: if "sha256" is passed, compute a content hash of the source directory.
+  let etag = opts.etag;
+  if (etag === 'sha256') {
+    etag = await computeDirectoryEtag(sourceDir);
+    logger.info(`Computed source directory content hash: ${etag}`);
+  }
+
   // Generate docs using @backstage/plugin-techdocs-node
   const techdocsGenerator = await TechdocsGenerator.fromConfig(config, {
     logger,
@@ -99,7 +107,7 @@ export default async function generate(opts: OptionValues) {
         }
       : {}),
     logger,
-    etag: opts.etag,
+    etag,
     logStream: getLogStream(logger),
     siteOptions: { name: opts.siteName },
     runAsDefaultUser: opts.runAsDefaultUser,

--- a/packages/techdocs-cli/src/commands/index.ts
+++ b/packages/techdocs-cli/src/commands/index.ts
@@ -52,7 +52,8 @@ export function registerCommands(program: Command) {
     )
     .option(
       '--etag <ETAG>',
-      'A unique identifier for the prepared tree e.g. commit SHA. If provided it will be stored in techdocs_metadata.json.',
+      'A unique identifier for the prepared tree e.g. commit SHA. If provided it will be stored in techdocs_metadata.json.' +
+        ' Use "sha256" to auto-compute a content hash of the source directory.',
     )
     .option(
       '--site-name',
@@ -229,6 +230,12 @@ export function registerCommands(program: Command) {
       '--directory <PATH>',
       'Path of the directory containing generated files to publish',
       './site/',
+    )
+    .option(
+      '--skip-if-unchanged',
+      'Skip publishing if the local etag in techdocs_metadata.json matches the remote etag.' +
+        ' Requires --etag (e.g. --etag sha256) to have been passed to the generate step.',
+      false,
     )
     .action(lazy(() => import('./publish/publish'), 'default'));
 

--- a/packages/techdocs-cli/src/commands/publish/publish.test.ts
+++ b/packages/techdocs-cli/src/commands/publish/publish.test.ts
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { OptionValues } from 'commander';
+import fs from 'fs-extra';
+
+const mockPublish = jest.fn().mockResolvedValue({ objects: [] });
+const mockGetReadiness = jest
+  .fn()
+  .mockResolvedValue({ isAvailable: true });
+const mockFetchTechDocsMetadata = jest.fn();
+
+jest.mock('@backstage/plugin-techdocs-node', () => ({
+  Publisher: {
+    fromConfig: jest.fn().mockResolvedValue({
+      publish: mockPublish,
+      getReadiness: mockGetReadiness,
+      fetchTechDocsMetadata: mockFetchTechDocsMetadata,
+    }),
+  },
+}));
+
+jest.mock('@backstage/backend-defaults/discovery', () => ({
+  HostDiscovery: {
+    fromConfig: jest.fn().mockReturnValue({}),
+  },
+}));
+
+jest.mock('../../lib/PublisherConfig', () => ({
+  PublisherConfig: {
+    getValidConfig: jest.fn().mockReturnValue({}),
+  },
+}));
+
+jest.mock('../../lib/utility', () => ({
+  createLogger: jest.fn().mockReturnValue({
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  }),
+}));
+
+import publish from './publish';
+
+const baseOpts: OptionValues = {
+  publisherType: 'googleGcs',
+  storageName: 'my-bucket',
+  entity: 'default/Component/my-entity',
+  directory: '/tmp/site',
+  verbose: false,
+};
+
+describe('publish', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetReadiness.mockResolvedValue({ isAvailable: true });
+  });
+
+  it('should publish without --skip-if-unchanged', async () => {
+    await publish(baseOpts);
+    expect(mockPublish).toHaveBeenCalledTimes(1);
+    expect(mockFetchTechDocsMetadata).not.toHaveBeenCalled();
+  });
+
+  describe('--skip-if-unchanged', () => {
+    const skipOpts: OptionValues = {
+      ...baseOpts,
+      skipIfUnchanged: true,
+    };
+
+    it('should skip publish when local and remote etags match', async () => {
+      jest.spyOn(fs, 'pathExists').mockResolvedValue(true as never);
+      jest.spyOn(fs, 'readJson').mockResolvedValue({
+        site_name: 'Test',
+        site_description: 'Test site',
+        etag: 'abc123',
+        build_timestamp: 1234567890,
+      });
+      mockFetchTechDocsMetadata.mockResolvedValue({
+        site_name: 'Test',
+        site_description: 'Test site',
+        etag: 'abc123',
+        build_timestamp: 1234567890,
+      });
+
+      const result = await publish(skipOpts);
+
+      expect(result).toBe(true);
+      expect(mockFetchTechDocsMetadata).toHaveBeenCalledWith({
+        namespace: 'default',
+        kind: 'Component',
+        name: 'my-entity',
+      });
+      expect(mockPublish).not.toHaveBeenCalled();
+    });
+
+    it('should proceed with publish when etags differ', async () => {
+      jest.spyOn(fs, 'pathExists').mockResolvedValue(true as never);
+      jest.spyOn(fs, 'readJson').mockResolvedValue({
+        site_name: 'Test',
+        site_description: 'Test site',
+        etag: 'new-sha',
+        build_timestamp: 1234567890,
+      });
+      mockFetchTechDocsMetadata.mockResolvedValue({
+        site_name: 'Test',
+        site_description: 'Test site',
+        etag: 'old-sha',
+        build_timestamp: 1234567890,
+      });
+
+      await publish(skipOpts);
+
+      expect(mockPublish).toHaveBeenCalledTimes(1);
+    });
+
+    it('should proceed when remote metadata is not found (first publish)', async () => {
+      jest.spyOn(fs, 'pathExists').mockResolvedValue(true as never);
+      jest.spyOn(fs, 'readJson').mockResolvedValue({
+        site_name: 'Test',
+        site_description: 'Test site',
+        etag: 'abc123',
+        build_timestamp: 1234567890,
+      });
+      mockFetchTechDocsMetadata.mockRejectedValue(
+        new Error('Metadata Not Found'),
+      );
+
+      await publish(skipOpts);
+
+      expect(mockPublish).toHaveBeenCalledTimes(1);
+    });
+
+    it('should proceed when local techdocs_metadata.json does not exist', async () => {
+      jest.spyOn(fs, 'pathExists').mockResolvedValue(false as never);
+
+      await publish(skipOpts);
+
+      expect(mockPublish).toHaveBeenCalledTimes(1);
+      expect(mockFetchTechDocsMetadata).not.toHaveBeenCalled();
+    });
+
+    it('should proceed when local etag is empty', async () => {
+      jest.spyOn(fs, 'pathExists').mockResolvedValue(true as never);
+      jest.spyOn(fs, 'readJson').mockResolvedValue({
+        site_name: 'Test',
+        site_description: 'Test site',
+        etag: '',
+        build_timestamp: 1234567890,
+      });
+
+      await publish(skipOpts);
+
+      expect(mockPublish).toHaveBeenCalledTimes(1);
+      expect(mockFetchTechDocsMetadata).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/techdocs-cli/src/commands/publish/publish.ts
+++ b/packages/techdocs-cli/src/commands/publish/publish.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { resolve } from 'node:path';
+import { resolve, join } from 'node:path';
+import fs from 'fs-extra';
 import { OptionValues } from 'commander';
 import { createLogger } from '../../lib/utility';
 import { HostDiscovery } from '@backstage/backend-defaults/discovery';
@@ -46,6 +47,52 @@ export default async function publish(opts: OptionValues): Promise<any> {
   } as Entity;
 
   const directory = resolve(opts.directory);
+
+  if (opts.skipIfUnchanged) {
+    const metadataPath = join(directory, 'techdocs_metadata.json');
+
+    if (!(await fs.pathExists(metadataPath))) {
+      logger.info(
+        '--skip-if-unchanged: techdocs_metadata.json not found locally, proceeding with publish',
+      );
+    } else {
+      const localMetadata = await fs.readJson(metadataPath);
+      const localEtag = localMetadata?.etag;
+
+      if (!localEtag) {
+        logger.info(
+          '--skip-if-unchanged: no etag in local techdocs_metadata.json (was --etag passed to generate?), proceeding with publish',
+        );
+      } else {
+        try {
+          const remoteMetadata = await publisher.fetchTechDocsMetadata({
+            namespace,
+            kind,
+            name,
+          });
+          const remoteEtag = remoteMetadata?.etag;
+
+          if (localEtag === remoteEtag) {
+            logger.info(
+              `--skip-if-unchanged: local etag "${localEtag}" matches remote, skipping publish`,
+            );
+            return true;
+          }
+
+          logger.info(
+            `--skip-if-unchanged: etag changed from "${remoteEtag}" to "${localEtag}", proceeding with publish`,
+          );
+        } catch (error) {
+          // fetchTechDocsMetadata rejects when metadata is not found (first publish),
+          // but may also fail for other reasons (network, auth), so log the cause.
+          logger.info(
+            `--skip-if-unchanged: could not fetch remote metadata (first publish?), proceeding with publish: ${error}`,
+          );
+        }
+      }
+    }
+  }
+
   await publisher.publish({ entity, directory });
 
   return true;

--- a/packages/techdocs-cli/src/lib/etag.test.ts
+++ b/packages/techdocs-cli/src/lib/etag.test.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { join } from 'node:path';
+import fs from 'fs-extra';
+import os from 'os';
+import { computeDirectoryEtag } from './etag';
+
+describe('computeDirectoryEtag', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(join(os.tmpdir(), 'etag-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.remove(tmpDir);
+  });
+
+  it('should produce a deterministic sha256 hash', async () => {
+    await fs.writeFile(join(tmpDir, 'a.md'), 'hello');
+    await fs.writeFile(join(tmpDir, 'b.md'), 'world');
+
+    const etag1 = await computeDirectoryEtag(tmpDir);
+    const etag2 = await computeDirectoryEtag(tmpDir);
+
+    expect(etag1).toBe(etag2);
+    expect(etag1).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('should change when file content changes', async () => {
+    await fs.writeFile(join(tmpDir, 'a.md'), 'hello');
+
+    const etag1 = await computeDirectoryEtag(tmpDir);
+
+    await fs.writeFile(join(tmpDir, 'a.md'), 'changed');
+
+    const etag2 = await computeDirectoryEtag(tmpDir);
+
+    expect(etag1).not.toBe(etag2);
+  });
+
+  it('should change when a file is renamed', async () => {
+    await fs.writeFile(join(tmpDir, 'a.md'), 'hello');
+
+    const etag1 = await computeDirectoryEtag(tmpDir);
+
+    await fs.rename(join(tmpDir, 'a.md'), join(tmpDir, 'b.md'));
+
+    const etag2 = await computeDirectoryEtag(tmpDir);
+
+    expect(etag1).not.toBe(etag2);
+  });
+
+  it('should include files in subdirectories', async () => {
+    await fs.ensureDir(join(tmpDir, 'sub'));
+    await fs.writeFile(join(tmpDir, 'sub', 'nested.md'), 'nested');
+
+    const etag1 = await computeDirectoryEtag(tmpDir);
+
+    await fs.writeFile(join(tmpDir, 'sub', 'nested.md'), 'changed');
+
+    const etag2 = await computeDirectoryEtag(tmpDir);
+
+    expect(etag1).not.toBe(etag2);
+  });
+
+  it('should return a consistent hash for an empty directory', async () => {
+    const etag = await computeDirectoryEtag(tmpDir);
+
+    expect(etag).toMatch(/^[a-f0-9]{64}$/);
+  });
+});

--- a/packages/techdocs-cli/src/lib/etag.ts
+++ b/packages/techdocs-cli/src/lib/etag.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createHash } from 'node:crypto';
+import { readFile, readdir } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+
+/**
+ * Recursively list all files under a directory, returning paths relative to it.
+ */
+async function listFiles(dir: string, base: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await listFiles(fullPath, base)));
+    } else if (entry.isFile()) {
+      files.push(relative(base, fullPath));
+    }
+  }
+
+  return files;
+}
+
+/**
+ * Compute a deterministic sha256 etag for a directory by hashing all file
+ * contents. Files are sorted by their relative path so the result is stable
+ * regardless of filesystem enumeration order.
+ *
+ * This mirrors the approach used in CI pipelines:
+ *   find . -type f | sort | xargs sha256sum | sha256sum
+ */
+export async function computeDirectoryEtag(directory: string): Promise<string> {
+  const files = await listFiles(directory, directory);
+  files.sort();
+
+  const combinedHash = createHash('sha256');
+
+  for (const file of files) {
+    const content = await readFile(join(directory, file));
+    const fileHash = createHash('sha256').update(content).digest('hex');
+    combinedHash.update(`${fileHash}  ${file}\n`);
+  }
+
+  return combinedHash.digest('hex');
+}


### PR DESCRIPTION
## What

Adds two features to `techdocs-cli` that together enable skipping redundant doc publishes in CI:

1. **`generate --etag sha256`** — auto-computes a deterministic sha256 content hash of the source directory and stores it in `techdocs_metadata.json`, removing the need for callers to compute and pass an etag externally.

2. **`publish --skip-if-unchanged`** — compares the local etag against the remote etag (via `fetchTechDocsMetadata()`) and skips the upload when they match.

## Why

`techdocs-cli generate --etag <value>` already supports storing an etag, and `fetchTechDocsMetadata()` can retrieve it from remote storage. But:
- Callers had to compute the etag themselves (e.g. `git rev-parse HEAD` or a shell hash pipeline)
- `publish` always re-uploaded everything regardless

In CI pipelines this causes redundant uploads on every build even when docs haven't changed.

## Usage

```bash
techdocs-cli generate --etag sha256
techdocs-cli publish --publisher-type googleGcs --storage-name my-bucket \
  --entity default/Component/my-service --skip-if-unchanged
```

## How

### `--etag sha256` (generate)
When `sha256` is passed as the etag value, the CLI computes a content hash: list all files recursively, sort by relative path, sha256 each file, then sha256 the combined hashes. This produces a stable digest that changes only when file content or names change.

### `--skip-if-unchanged` (publish)
Before calling `publisher.publish()`:
1. Read `techdocs_metadata.json` from the local output directory
2. Call `publisher.fetchTechDocsMetadata()` to get the remote etag
3. If they match, skip publish and exit successfully

Edge cases (all fall through to normal publish):
- **First publish**: `fetchTechDocsMetadata()` rejects → caught, proceeds (error logged)
- **Missing local metadata**: no `techdocs_metadata.json` → proceeds
- **Empty/missing etag**: `--etag` wasn't used with `generate` → proceeds

## Changes

- `packages/techdocs-cli/src/commands/index.ts` — CLI option definitions
- `packages/techdocs-cli/src/commands/generate/generate.ts` — resolve `sha256` etag
- `packages/techdocs-cli/src/commands/publish/publish.ts` — etag comparison logic
- `packages/techdocs-cli/src/lib/etag.ts` — `computeDirectoryEtag()` helper
- `packages/techdocs-cli/src/lib/etag.test.ts` — etag hash tests (5 cases)
- `packages/techdocs-cli/src/commands/publish/publish.test.ts` — publish skip tests (5 cases)
- `.changeset/techdocs-cli-skip-if-unchanged.md` — minor version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)