### PR TITLE
fix(auth): throw when payload.uip is missing in createLimitedUserToken

### DIFF
--- a/.changeset/throw-on-missing-uip.md
+++ b/.changeset/throw-on-missing-uip.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Throw an error when `payload.uip` is missing in `createLimitedUserToken` instead of constructing an invalid limited token with an undefined signature.

--- a/packages/backend-defaults/src/entrypoints/auth/user/UserTokenHandler.test.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/user/UserTokenHandler.test.ts
@@ -345,7 +345,11 @@ describe('UserTokenHandler', () => {
 
       expect(() =>
         userTokenHandler.createLimitedUserToken(backstageToken),
-      ).toThrow(/payload\.uip/i);
+      ).toThrow(
+        new AuthenticationError(
+          'Failed to create limited user token, missing user identity proof',
+        ),
+      );
     });
 
     it('should create a limited user token from a user token', async () => {

--- a/packages/backend-defaults/src/entrypoints/auth/user/UserTokenHandler.test.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/user/UserTokenHandler.test.ts
@@ -331,6 +331,23 @@ describe('UserTokenHandler', () => {
       );
     });
 
+    it('should throw if payload.uip is missing', async () => {
+      const backstageToken = await createToken({
+        header: { typ: 'vnd.backstage.user', alg: 'ES256' },
+        payload: {
+          aud: 'backstage',
+          sub: 'mock',
+          ent: ['mock'],
+          iat: 1,
+          exp: 2,
+        },
+      });
+
+      expect(() =>
+        userTokenHandler.createLimitedUserToken(backstageToken),
+      ).toThrow(/payload\.uip/i);
+    });
+
     it('should create a limited user token from a user token', async () => {
       const backstageToken = await createToken({
         header: { typ: 'vnd.backstage.user', alg: 'ES256' },

--- a/packages/backend-defaults/src/entrypoints/auth/user/UserTokenHandler.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/user/UserTokenHandler.ts
@@ -134,6 +134,12 @@ export class UserTokenHandler {
       );
     }
 
+    if (!payload.uip) {
+      throw new Error(
+        'Cannot create limited user token: payload.uip is missing',
+      );
+    }
+
     // NOTE: The order and properties in both the header and payload must match
     //       the usage in plugins/auth-backend/src/identity/TokenFactory.ts
     const limitedUserToken = [

--- a/packages/backend-defaults/src/entrypoints/auth/user/UserTokenHandler.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/user/UserTokenHandler.ts
@@ -135,8 +135,8 @@ export class UserTokenHandler {
     }
 
     if (!payload.uip) {
-      throw new Error(
-        'Cannot create limited user token: payload.uip is missing',
+      throw new AuthenticationError(
+        'Failed to create limited user token, missing user identity proof',
       );
     }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`createLimitedUserToken` now throws an error when `payload.uip` is missing instead of constructing an invalid limited token with an undefined signature. This prevents silent creation of tokens that will fail verification downstream.

Based on #31856.

Fixes #31513

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))