### PR TITLE
feat(auth-backend): allow ChatGPT Codex CIMD clients

### DIFF
--- a/.changeset/fuzzy-apples-smile.md
+++ b/.changeset/fuzzy-apples-smile.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Allow ChatGPT Codex clients to use Client ID Metadata Documents by default.

--- a/docs/ai/mcp-actions.md
+++ b/docs/ai/mcp-actions.md
@@ -214,13 +214,14 @@ auth:
   clientIdMetadataDocuments:
     enabled: true
     # Optional: override which client_id URLs are allowed.
-    # Defaults to Claude, VS Code, and the built-in Backstage CLI.
-    # Note: setting this replaces the Claude and VS Code defaults entirely.
-    # The built-in CLI client is always allowed, since this backend serves
-    # its metadata document itself.
+    # Defaults to Claude, VS Code, ChatGPT Codex, and the built-in Backstage CLI.
+    # Note: setting this replaces the Claude, VS Code, and ChatGPT Codex
+    # defaults entirely. The built-in CLI client is always allowed, since
+    # this backend serves its metadata document itself.
     # allowedClientIdPatterns:
     #   - 'https://claude.ai/*'
     #   - 'https://vscode.dev/*'
+    #   - 'https://chatgpt.com/oauth/codex/*/client.json'
     #   - 'https://my-custom-client.example.com/*'
     # Optional: override which redirect URIs are allowed.
     # Defaults to loopback addresses (localhost, 127.0.0.1, [::1]).

--- a/plugins/auth-backend/config.d.ts
+++ b/plugins/auth-backend/config.d.ts
@@ -194,12 +194,12 @@ export interface Config {
       /**
        * A list of allowed URI patterns for client_id URLs.
        * Uses glob-style pattern matching where `*` matches any characters.
-       * Defaults to `['https://claude.ai/*', 'https://vscode.dev/*', '{baseUrl}/.well-known/oauth-client/cli.json']`
+       * Defaults to `['https://claude.ai/*', 'https://vscode.dev/*', 'https://chatgpt.com/oauth/codex/*\/client.json', '{baseUrl}/.well-known/oauth-client/cli.json']`
        * where `{baseUrl}` is the auth backend's base URL.
        *
-       * Setting this replaces the Claude and VS Code defaults. The built-in
-       * CLI client is always allowed, since this backend serves its metadata
-       * document itself.
+       * Setting this replaces the Claude, VS Code, and ChatGPT Codex defaults.
+       * The built-in CLI client is always allowed, since this backend serves
+       * its metadata document itself.
        *
        * @example ['https://example.com/*', 'https://*.trusted-domain.com/*']
        */
@@ -233,12 +233,12 @@ export interface Config {
        * path only matches within that component, and a `:*` port matches
        * any port. Patterns must include an explicit protocol.
        *
-       * Defaults to `['https://claude.ai/*', 'https://vscode.dev/*', '{baseUrl}/.well-known/oauth-client/cli.json']`
+       * Defaults to `['https://claude.ai/*', 'https://vscode.dev/*', 'https://chatgpt.com/oauth/codex/*\/client.json', '{baseUrl}/.well-known/oauth-client/cli.json']`
        * where `{baseUrl}` is the auth backend's base URL.
        *
-       * Setting this replaces the Claude and VS Code defaults. The built-in
-       * CLI client is always allowed, since this backend serves its metadata
-       * document itself.
+       * Setting this replaces the Claude, VS Code, and ChatGPT Codex defaults.
+       * The built-in CLI client is always allowed, since this backend serves
+       * its metadata document itself.
        *
        * @example ['https://example.com/*', 'https://*.trusted-domain.com/*']
        */

--- a/plugins/auth-backend/src/service/OidcService.test.ts
+++ b/plugins/auth-backend/src/service/OidcService.test.ts
@@ -1223,6 +1223,35 @@ describe('OidcService', () => {
       });
 
       describe('createAuthorizationSession with CIMD', () => {
+        it('should accept ChatGPT Codex client IDs with default CIMD patterns', async () => {
+          const codexClientId =
+            'https://chatgpt.com/oauth/codex/backstage/client.json';
+          mockFetchCimdMetadata.mockResolvedValueOnce({
+            ...cimdMetadata,
+            clientId: codexClientId,
+          });
+          const { service } = await createOidcService({
+            databaseId,
+            config: {
+              auth: {
+                clientIdMetadataDocuments: { enabled: true },
+              },
+            },
+          });
+
+          await expect(
+            service.createAuthorizationSession({
+              clientId: codexClientId,
+              redirectUri: 'http://localhost:8080/callback',
+              responseType: 'code',
+              scope: 'openid',
+              ...pkceParams,
+            }),
+          ).resolves.toEqual(
+            expect.objectContaining({ clientName: 'CIMD Test Client' }),
+          );
+        });
+
         it('should accept loopback redirect URIs with default CIMD patterns', async () => {
           const { service } = await createOidcService({
             databaseId,

--- a/plugins/auth-backend/src/service/OidcService.ts
+++ b/plugins/auth-backend/src/service/OidcService.ts
@@ -391,7 +391,12 @@ export class OidcService {
       enabled,
       allowedClientIdPatterns: configuredClientIdPatterns
         ? [...new Set([...configuredClientIdPatterns, cliClientId])]
-        : ['https://claude.ai/*', 'https://vscode.dev/*', cliClientId],
+        : [
+            'https://claude.ai/*',
+            'https://vscode.dev/*',
+            'https://chatgpt.com/oauth/codex/*/client.json',
+            cliClientId,
+          ],
       allowedRedirectUriPatterns:
         this.config.getOptionalStringArray(
           `${configPath}.allowedRedirectUriPatterns`,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

## What

Adds ChatGPT Codex's client ID metadata document pattern to the default CIMD allowlist. Explicit `allowedClientIdPatterns` configuration replaces the third-party defaults, while the built-in Backstage CLI remains allowed.

## Why

Currently, Backstage adopters need instance-specific configuration before ChatGPT Codex can use CIMD authentication. Adding the client-hosted metadata pattern upstream makes it work by default when CIMD is enabled, while keeping the default allowlist constrained to known clients.

To test, run `CI=1 yarn test plugins/auth-backend/src/service/OidcService.test.ts --no-watch`.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
