### PR TITLE
fix(cli-module-new): add missing packages to template version map

### DIFF
--- a/.changeset/fix-template-version-queries.md
+++ b/.changeset/fix-template-version-queries.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli-module-new': patch
+---
+
+Fixed `yarn new` failing with "No version available" for several templates by adding missing packages to the version map.

--- a/packages/cli-module-new/src/lib/version.test.ts
+++ b/packages/cli-module-new/src/lib/version.test.ts
@@ -33,7 +33,7 @@ describe('packageVersions', () => {
           walk(fullPath);
         } else if (entry.name.endsWith('.hbs')) {
           const content = fs.readFileSync(fullPath, 'utf8');
-          const re = /\{\{versionQuery '([^']+)'\s*\}\}/g;
+          const re = /\{\{\s*versionQuery\s+'([^']+)'\s*\}\}/g;
           for (const m of content.matchAll(re)) {
             const pkg = m[1];
             if (pkg.startsWith('@backstage/') && !packageVersions[pkg]) {

--- a/packages/cli-module-new/src/lib/version.test.ts
+++ b/packages/cli-module-new/src/lib/version.test.ts
@@ -18,6 +18,37 @@ import { packageVersions, createPackageVersionProvider } from './version';
 import { Lockfile } from '@backstage/cli-node';
 import corePluginApiPkg from '@backstage/core-plugin-api/package.json';
 import { createMockDirectory } from '@backstage/backend-test-utils';
+import fs from 'node:fs';
+import { resolve as resolvePath, join as joinPath } from 'node:path';
+
+describe('packageVersions', () => {
+  it('should include all @backstage packages used by templates without a version hint', () => {
+    const templatesDir = resolvePath(__dirname, '../../templates');
+    const missing: string[] = [];
+
+    function walk(dir: string) {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const fullPath = joinPath(dir, entry.name);
+        if (entry.isDirectory()) {
+          walk(fullPath);
+        } else if (entry.name.endsWith('.hbs')) {
+          const content = fs.readFileSync(fullPath, 'utf8');
+          const re = /\{\{versionQuery '([^']+)'\s*\}\}/g;
+          for (const m of content.matchAll(re)) {
+            const pkg = m[1];
+            if (pkg.startsWith('@backstage/') && !packageVersions[pkg]) {
+              missing.push(pkg);
+            }
+          }
+        }
+      }
+    }
+
+    walk(templatesDir);
+
+    expect(missing).toEqual([]);
+  });
+});
 
 describe('createPackageVersionProvider', () => {
   const mockDir = createMockDirectory();

--- a/packages/cli-module-new/src/lib/version.ts
+++ b/packages/cli-module-new/src/lib/version.ts
@@ -37,6 +37,8 @@ import { version as backendTestUtils } from '../../../backend-test-utils/package
 import { version as catalogClient } from '../../../catalog-client/package.json';
 import { version as catalogModel } from '../../../catalog-model/package.json';
 import { version as cli } from '../../../cli/package.json';
+import { version as cliCommon } from '../../../cli-common/package.json';
+import { version as cliNode } from '../../../cli-node/package.json';
 import { version as config } from '../../../config/package.json';
 import { version as coreAppApi } from '../../../core-app-api/package.json';
 import { version as coreComponents } from '../../../core-components/package.json';
@@ -60,11 +62,16 @@ import { version as eventsBackend } from '../../../../plugins/events-backend/pac
 import { version as kubernetesBackend } from '../../../../plugins/kubernetes-backend/package.json';
 import { version as notificationsBackend } from '../../../../plugins/notifications-backend/package.json';
 import { version as permissionBackend } from '../../../../plugins/permission-backend/package.json';
+import { version as permissionCommon } from '../../../../plugins/permission-common/package.json';
+import { version as permissionNode } from '../../../../plugins/permission-node/package.json';
 import { version as proxyBackend } from '../../../../plugins/proxy-backend/package.json';
 import { version as scaffolderBackend } from '../../../../plugins/scaffolder-backend/package.json';
 import { version as scaffolderNode } from '../../../../plugins/scaffolder-node/package.json';
 import { version as scaffolderNodeTestUtils } from '../../../../plugins/scaffolder-node-test-utils/package.json';
+import { version as scaffolderReact } from '../../../../plugins/scaffolder-react/package.json';
 import { version as searchBackend } from '../../../../plugins/search-backend/package.json';
+import { version as searchBackendNode } from '../../../../plugins/search-backend-node/package.json';
+import { version as searchCommon } from '../../../../plugins/search-common/package.json';
 import { version as techdocsBackend } from '../../../../plugins/techdocs-backend/package.json';
 
 export const packageVersions: Record<string, string> = {
@@ -74,6 +81,8 @@ export const packageVersions: Record<string, string> = {
   '@backstage/catalog-client': catalogClient,
   '@backstage/catalog-model': catalogModel,
   '@backstage/cli': cli,
+  '@backstage/cli-common': cliCommon,
+  '@backstage/cli-node': cliNode,
   '@backstage/config': config,
   '@backstage/core-app-api': coreAppApi,
   '@backstage/core-components': coreComponents,
@@ -90,6 +99,7 @@ export const packageVersions: Record<string, string> = {
   '@backstage/ui': ui,
   '@backstage/plugin-scaffolder-node': scaffolderNode,
   '@backstage/plugin-scaffolder-node-test-utils': scaffolderNodeTestUtils,
+  '@backstage/plugin-scaffolder-react': scaffolderReact,
   '@backstage/plugin-app-backend': appBackend,
   '@backstage/plugin-auth-backend': authBackend,
   '@backstage/plugin-auth-backend-module-guest-provider':
@@ -100,9 +110,13 @@ export const packageVersions: Record<string, string> = {
   '@backstage/plugin-kubernetes-backend': kubernetesBackend,
   '@backstage/plugin-notifications-backend': notificationsBackend,
   '@backstage/plugin-permission-backend': permissionBackend,
+  '@backstage/plugin-permission-common': permissionCommon,
+  '@backstage/plugin-permission-node': permissionNode,
   '@backstage/plugin-proxy-backend': proxyBackend,
   '@backstage/plugin-scaffolder-backend': scaffolderBackend,
   '@backstage/plugin-search-backend': searchBackend,
+  '@backstage/plugin-search-backend-node': searchBackendNode,
+  '@backstage/plugin-search-common': searchCommon,
   '@backstage/plugin-techdocs-backend': techdocsBackend,
 };
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #35221

Several `yarn new` templates reference `@backstage/` packages via `versionQuery` that were missing from the `packageVersions` map in `version.ts`. This caused `"No version available for package ..."` errors when scaffolding without the Backstage Yarn plugin.

When using the Yarn Backstage plugin, all `@backstage/` packages resolve to `backstage:^` via the protocol handler, so the `packageVersions` map is bypassed entirely — which is why this bug went unnoticed. Without the plugin, the version provider falls back to the map, and missing entries cause the error.

Added the 7 missing packages: `plugin-scaffolder-react`, `cli-common`, `cli-node`, `plugin-permission-common`, `plugin-permission-node`, `plugin-search-backend-node`, `plugin-search-common`.

Also added a test that verifies all `@backstage/` packages referenced by templates have a corresponding entry in the version map.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

🤖 Generated with [Claude Code](https://claude.com/claude-code)