### PR TITLE
fix(backend-defaults): rate limit JWKS reloads

### DIFF
--- a/.changeset/tidy-spoons-refresh.md
+++ b/.changeset/tidy-spoons-refresh.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Improve authentication reliability during signing key rotation by refreshing JWKS endpoints for newly published keys even while remote key set refreshes are normally paused.

--- a/.changeset/tidy-spoons-refresh.md
+++ b/.changeset/tidy-spoons-refresh.md
@@ -2,4 +2,4 @@
 '@backstage/backend-defaults': patch
 ---
 
-Improve authentication reliability during signing key rotation by refreshing JWKS endpoints for newly published keys even while remote key set refreshes are normally paused.
+Improve authentication reliability during signing key rotation by performing budgeted JWKS reloads when a newly published key is requested during the remote key set cooldown.

--- a/packages/backend-defaults/src/entrypoints/auth/JwksClient.test.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/JwksClient.test.ts
@@ -155,6 +155,45 @@ describe('JwksClient', () => {
     expect(requestCount).toBe(2);
   });
 
+  it('evicts the least recently used resolver after 100 endpoints', async () => {
+    let endpoint = 0;
+    const requestCounts = new Map<string, number>();
+    const client = new JwksClient(
+      async () => new URL(`http://localhost:7007/${endpoint}/jwks.json`),
+    );
+    server.use(
+      http.get('http://localhost:7007/:endpoint/jwks.json', ({ params }) => {
+        const endpointName = String(params.endpoint);
+        requestCounts.set(
+          endpointName,
+          (requestCounts.get(endpointName) ?? 0) + 1,
+        );
+        return HttpResponse.json({ keys: [firstKey.publicKey] });
+      }),
+    );
+    const token = await createToken(firstKey);
+
+    for (endpoint = 0; endpoint < 100; endpoint += 1) {
+      await jwtVerify(token, client.getKey);
+    }
+
+    endpoint = 0;
+    await jwtVerify(token, client.getKey);
+    expect(requestCounts.get('0')).toBe(1);
+
+    endpoint = 100;
+    await jwtVerify(token, client.getKey);
+    expect(requestCounts.get('100')).toBe(1);
+
+    endpoint = 1;
+    await jwtVerify(token, client.getKey);
+    expect(requestCounts.get('1')).toBe(2);
+
+    endpoint = 0;
+    await jwtVerify(token, client.getKey);
+    expect(requestCounts.get('0')).toBe(1);
+  });
+
   it('bounds failed forced reloads in a sliding window', async () => {
     let now = Date.now();
     jest.spyOn(Date, 'now').mockImplementation(() => now);

--- a/packages/backend-defaults/src/entrypoints/auth/JwksClient.test.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/JwksClient.test.ts
@@ -65,7 +65,7 @@ describe('JwksClient', () => {
     jest.restoreAllMocks();
   });
 
-  it('reloads newly published keys during cooldown and follows endpoint changes', async () => {
+  it('reloads newly published keys and reuses resolvers across endpoint changes', async () => {
     let endpoint = firstEndpoint;
     let keys = [firstKey.publicKey];
     let firstEndpointRequests = 0;
@@ -84,7 +84,6 @@ describe('JwksClient', () => {
       }),
     );
 
-    await client.refreshKeyStore();
     await expect(
       jwtVerify(await createToken(firstKey), client.getKey),
     ).resolves.toBeDefined();
@@ -103,7 +102,14 @@ describe('JwksClient', () => {
     ).resolves.toBeDefined();
     expect(firstEndpointRequests).toBe(2);
     expect(secondEndpointRequests).toBe(1);
-    expect(getEndpoint).toHaveBeenCalledTimes(3);
+
+    endpoint = firstEndpoint;
+    await expect(
+      jwtVerify(await createToken(secondKey), client.getKey),
+    ).resolves.toBeDefined();
+    expect(firstEndpointRequests).toBe(2);
+    expect(secondEndpointRequests).toBe(1);
+    expect(getEndpoint).toHaveBeenCalledTimes(4);
   });
 
   it('coalesces concurrent forced reloads', async () => {
@@ -130,7 +136,6 @@ describe('JwksClient', () => {
       }),
     );
 
-    await client.refreshKeyStore();
     await jwtVerify(await createToken(firstKey), client.getKey);
 
     keys = [firstKey.publicKey, secondKey.publicKey];
@@ -164,7 +169,6 @@ describe('JwksClient', () => {
       }),
     );
 
-    await client.refreshKeyStore();
     await jwtVerify(await createToken(firstKey), client.getKey);
     failRequests = true;
 
@@ -199,7 +203,7 @@ describe('JwksClient', () => {
     expect(requestCount).toBe(13);
   });
 
-  it('preserves normal resolver and initialization errors', async () => {
+  it('preserves normal resolver errors', async () => {
     let requestCount = 0;
     const client = new JwksClient(async () => firstEndpoint);
     server.use(
@@ -209,11 +213,6 @@ describe('JwksClient', () => {
       }),
     );
 
-    expect(() => client.getKey).toThrow(
-      'refreshKeyStore must be called before jwksClient.getKey',
-    );
-
-    await client.refreshKeyStore();
     await expect(
       jwtVerify(await createToken(firstKey, 'unknown'), client.getKey),
     ).rejects.toBeInstanceOf(errors.JWKSNoMatchingKey);

--- a/packages/backend-defaults/src/entrypoints/auth/JwksClient.test.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/JwksClient.test.ts
@@ -107,9 +107,12 @@ describe('JwksClient', () => {
     await expect(
       jwtVerify(await createToken(secondKey), client.getKey),
     ).resolves.toBeDefined();
+    await expect(
+      jwtVerify(await createToken(firstKey), client.getKey),
+    ).resolves.toBeDefined();
     expect(firstEndpointRequests).toBe(2);
     expect(secondEndpointRequests).toBe(1);
-    expect(getEndpoint).toHaveBeenCalledTimes(4);
+    expect(getEndpoint).toHaveBeenCalledTimes(5);
   });
 
   it('coalesces concurrent forced reloads', async () => {

--- a/packages/backend-defaults/src/entrypoints/auth/JwksClient.test.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/JwksClient.test.ts
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { registerMswTestHooks } from '@backstage/backend-test-utils';
+import { errors, exportJWK, generateKeyPair, jwtVerify, SignJWT } from 'jose';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { JwksClient } from './JwksClient';
+
+const server = setupServer();
+const firstEndpoint = new URL('http://localhost:7007/jwks.json');
+const secondEndpoint = new URL('http://localhost:7008/jwks.json');
+
+async function createSigningKey(kid: string) {
+  const keyPair = await generateKeyPair('ES256');
+  return {
+    privateKey: keyPair.privateKey,
+    publicKey: {
+      ...(await exportJWK(keyPair.publicKey)),
+      alg: 'ES256',
+      kid,
+      use: 'sig',
+    },
+  };
+}
+
+async function createToken(
+  key: Awaited<ReturnType<typeof createSigningKey>>,
+  kid = key.publicKey.kid,
+) {
+  return new SignJWT({ sub: 'user:default/test' })
+    .setProtectedHeader({ alg: 'ES256', kid })
+    .sign(key.privateKey);
+}
+
+describe('JwksClient', () => {
+  registerMswTestHooks(server);
+
+  let firstKey: Awaited<ReturnType<typeof createSigningKey>>;
+  let secondKey: Awaited<ReturnType<typeof createSigningKey>>;
+  let thirdKey: Awaited<ReturnType<typeof createSigningKey>>;
+
+  beforeAll(async () => {
+    [firstKey, secondKey, thirdKey] = await Promise.all([
+      createSigningKey('first'),
+      createSigningKey('second'),
+      createSigningKey('third'),
+    ]);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('reloads newly published keys during cooldown and follows endpoint changes', async () => {
+    let endpoint = firstEndpoint;
+    let keys = [firstKey.publicKey];
+    let firstEndpointRequests = 0;
+    let secondEndpointRequests = 0;
+    const getEndpoint = jest.fn(async () => endpoint);
+    const client = new JwksClient(getEndpoint);
+
+    server.use(
+      http.get(firstEndpoint.href, () => {
+        firstEndpointRequests += 1;
+        return HttpResponse.json({ keys });
+      }),
+      http.get(secondEndpoint.href, () => {
+        secondEndpointRequests += 1;
+        return HttpResponse.json({ keys });
+      }),
+    );
+
+    await client.refreshKeyStore();
+    await expect(
+      jwtVerify(await createToken(firstKey), client.getKey),
+    ).resolves.toBeDefined();
+    expect(firstEndpointRequests).toBe(1);
+
+    keys = [firstKey.publicKey, secondKey.publicKey];
+    await expect(
+      jwtVerify(await createToken(secondKey), client.getKey),
+    ).resolves.toBeDefined();
+    expect(firstEndpointRequests).toBe(2);
+
+    endpoint = secondEndpoint;
+    keys = [thirdKey.publicKey];
+    await expect(
+      jwtVerify(await createToken(thirdKey), client.getKey),
+    ).resolves.toBeDefined();
+    expect(firstEndpointRequests).toBe(2);
+    expect(secondEndpointRequests).toBe(1);
+    expect(getEndpoint).toHaveBeenCalledTimes(3);
+  });
+
+  it('coalesces concurrent forced reloads', async () => {
+    let keys = [firstKey.publicKey];
+    let requestCount = 0;
+    let releaseReload: () => void;
+    let markReloadStarted: () => void;
+    const reloadStarted = new Promise<void>(resolve => {
+      markReloadStarted = resolve;
+    });
+    const reloadReleased = new Promise<void>(resolve => {
+      releaseReload = resolve;
+    });
+    const client = new JwksClient(async () => firstEndpoint);
+
+    server.use(
+      http.get(firstEndpoint.href, async () => {
+        requestCount += 1;
+        if (requestCount === 2) {
+          markReloadStarted();
+          await reloadReleased;
+        }
+        return HttpResponse.json({ keys });
+      }),
+    );
+
+    await client.refreshKeyStore();
+    await jwtVerify(await createToken(firstKey), client.getKey);
+
+    keys = [firstKey.publicKey, secondKey.publicKey];
+    const token = await createToken(secondKey);
+    const verifications = Promise.all([
+      jwtVerify(token, client.getKey),
+      jwtVerify(token, client.getKey),
+    ]);
+    await reloadStarted;
+    expect(requestCount).toBe(2);
+
+    releaseReload!();
+    await expect(verifications).resolves.toHaveLength(2);
+    expect(requestCount).toBe(2);
+  });
+
+  it('bounds failed forced reloads in a sliding window', async () => {
+    let now = Date.now();
+    jest.spyOn(Date, 'now').mockImplementation(() => now);
+    let failRequests = false;
+    let requestCount = 0;
+    const client = new JwksClient(async () => firstEndpoint);
+
+    server.use(
+      http.get(firstEndpoint.href, () => {
+        requestCount += 1;
+        if (failRequests) {
+          return new HttpResponse(null, { status: 500 });
+        }
+        return HttpResponse.json({ keys: [firstKey.publicKey] });
+      }),
+    );
+
+    await client.refreshKeyStore();
+    await jwtVerify(await createToken(firstKey), client.getKey);
+    failRequests = true;
+
+    for (let index = 0; index < 10; index += 1) {
+      await expect(
+        jwtVerify(
+          await createToken(firstKey, `unknown-${index}`),
+          client.getKey,
+        ),
+      ).rejects.toThrow(
+        'Expected 200 OK from the JSON Web Key Set HTTP response',
+      );
+    }
+    await expect(
+      jwtVerify(await createToken(firstKey, 'unknown-limited'), client.getKey),
+    ).rejects.toBeInstanceOf(errors.JWKSNoMatchingKey);
+    expect(requestCount).toBe(11);
+
+    failRequests = false;
+    now += 60_001;
+    await expect(
+      jwtVerify(await createToken(firstKey, 'unknown-normal'), client.getKey),
+    ).rejects.toBeInstanceOf(errors.JWKSNoMatchingKey);
+    await expect(
+      jwtVerify(await createToken(firstKey, 'unknown-reset'), client.getKey),
+    ).rejects.toBeInstanceOf(errors.JWKSNoMatchingKey);
+    expect(requestCount).toBe(13);
+
+    await expect(
+      jwtVerify(await createToken(firstKey), client.getKey),
+    ).resolves.toBeDefined();
+    expect(requestCount).toBe(13);
+  });
+
+  it('preserves normal resolver and initialization errors', async () => {
+    let requestCount = 0;
+    const client = new JwksClient(async () => firstEndpoint);
+    server.use(
+      http.get(firstEndpoint.href, () => {
+        requestCount += 1;
+        return HttpResponse.json({ keys: [firstKey.publicKey] });
+      }),
+    );
+
+    expect(() => client.getKey).toThrow(
+      'refreshKeyStore must be called before jwksClient.getKey',
+    );
+
+    await client.refreshKeyStore();
+    await expect(
+      jwtVerify(await createToken(firstKey, 'unknown'), client.getKey),
+    ).rejects.toBeInstanceOf(errors.JWKSNoMatchingKey);
+    expect(requestCount).toBe(1);
+  });
+});

--- a/packages/backend-defaults/src/entrypoints/auth/JwksClient.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/JwksClient.ts
@@ -29,29 +29,17 @@ type RemoteJWKSet = ReturnType<typeof createRemoteJWKSet>;
 
 class JwksKeyStore {
   readonly #resolver: RemoteJWKSet;
-  readonly #getLatestKeyStore: () => Promise<JwksKeyStore>;
   readonly #tryUseForcedReload: () => boolean;
 
-  constructor(
-    endpoint: URL,
-    getLatestKeyStore: () => Promise<JwksKeyStore>,
-    tryUseForcedReload: () => boolean,
-  ) {
+  constructor(endpoint: URL, tryUseForcedReload: () => boolean) {
     this.#resolver = createRemoteJWKSet(endpoint);
-    this.#getLatestKeyStore = getLatestKeyStore;
     this.#tryUseForcedReload = tryUseForcedReload;
   }
 
-  getKey: GetKeyFunction<JWSHeaderParameters, FlattenedJWSInput> = (
+  getKey: GetKeyFunction<JWSHeaderParameters, FlattenedJWSInput> = async (
     protectedHeader,
     token,
-  ) => this.#getKey(protectedHeader, token, true);
-
-  async #getKey(
-    protectedHeader: JWSHeaderParameters,
-    token: FlattenedJWSInput,
-    resolveLatestEndpoint: boolean,
-  ): ReturnType<RemoteJWKSet> {
+  ) => {
     const coolingDown = this.#resolver.coolingDown;
 
     try {
@@ -61,19 +49,12 @@ class JwksKeyStore {
         throw error;
       }
 
-      if (resolveLatestEndpoint) {
-        const latestKeyStore = await this.#getLatestKeyStore();
-        if (latestKeyStore !== this) {
-          return latestKeyStore.#getKey(protectedHeader, token, false);
-        }
-      }
-
       if (!coolingDown || !(await this.#reload())) {
         throw error;
       }
       return this.#resolver(protectedHeader, token);
     }
-  }
+  };
 
   async #reload(): Promise<boolean> {
     if (!this.#resolver.reloading && !this.#tryUseForcedReload()) {
@@ -86,7 +67,6 @@ class JwksKeyStore {
 
 export class JwksClient {
   #keyStores = new Map<string, JwksKeyStore>();
-  #currentKeyStore?: JwksKeyStore;
   #forcedReloads: number[] = [];
 
   private readonly getEndpoint: () => Promise<URL>;
@@ -103,22 +83,17 @@ export class JwksClient {
     protectedHeader,
     token,
   ) => {
-    const keyStore = this.#currentKeyStore ?? (await this.#getLatestKeyStore());
+    const keyStore = await this.#getKeyStore();
     return keyStore.getKey(protectedHeader, token);
   };
 
-  async #getLatestKeyStore(): Promise<JwksKeyStore> {
+  async #getKeyStore(): Promise<JwksKeyStore> {
     const endpoint = await this.getEndpoint();
     let keyStore = this.#keyStores.get(endpoint.href);
     if (!keyStore) {
-      keyStore = new JwksKeyStore(
-        endpoint,
-        () => this.#getLatestKeyStore(),
-        () => this.#tryUseForcedReload(),
-      );
+      keyStore = new JwksKeyStore(endpoint, () => this.#tryUseForcedReload());
       this.#keyStores.set(endpoint.href, keyStore);
     }
-    this.#currentKeyStore = keyStore;
     return keyStore;
   }
 

--- a/packages/backend-defaults/src/entrypoints/auth/JwksClient.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/JwksClient.ts
@@ -24,6 +24,7 @@ import {
 
 const FORCED_RELOAD_LIMIT = 10;
 const FORCED_RELOAD_WINDOW_MS = 60_000;
+const KEY_STORE_CACHE_LIMIT = 100;
 
 type RemoteJWKSet = ReturnType<typeof createRemoteJWKSet>;
 
@@ -90,9 +91,15 @@ export class JwksClient {
   async #getKeyStore(): Promise<JwksKeyStore> {
     const endpoint = await this.getEndpoint();
     let keyStore = this.#keyStores.get(endpoint.href);
-    if (!keyStore) {
+    if (keyStore) {
+      // Reinsert entries to keep the least recently used endpoint first.
+      this.#keyStores.delete(endpoint.href);
+    } else {
       keyStore = new JwksKeyStore(endpoint, () => this.#tryUseForcedReload());
-      this.#keyStores.set(endpoint.href, keyStore);
+    }
+    this.#keyStores.set(endpoint.href, keyStore);
+    if (this.#keyStores.size > KEY_STORE_CACHE_LIMIT) {
+      this.#keyStores.delete(this.#keyStores.keys().next().value!);
     }
     return keyStore;
   }

--- a/packages/backend-defaults/src/entrypoints/auth/JwksClient.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/JwksClient.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { AuthenticationError } from '@backstage/errors';
 import {
   createRemoteJWKSet,
   errors,
@@ -28,11 +27,67 @@ const FORCED_RELOAD_WINDOW_MS = 60_000;
 
 type RemoteJWKSet = ReturnType<typeof createRemoteJWKSet>;
 
+class JwksKeyStore {
+  readonly #resolver: RemoteJWKSet;
+  readonly #getLatestKeyStore: () => Promise<JwksKeyStore>;
+  readonly #tryUseForcedReload: () => boolean;
+
+  constructor(
+    endpoint: URL,
+    getLatestKeyStore: () => Promise<JwksKeyStore>,
+    tryUseForcedReload: () => boolean,
+  ) {
+    this.#resolver = createRemoteJWKSet(endpoint);
+    this.#getLatestKeyStore = getLatestKeyStore;
+    this.#tryUseForcedReload = tryUseForcedReload;
+  }
+
+  getKey: GetKeyFunction<JWSHeaderParameters, FlattenedJWSInput> = (
+    protectedHeader,
+    token,
+  ) => this.#getKey(protectedHeader, token, true);
+
+  async #getKey(
+    protectedHeader: JWSHeaderParameters,
+    token: FlattenedJWSInput,
+    resolveLatestEndpoint: boolean,
+  ): ReturnType<RemoteJWKSet> {
+    const coolingDown = this.#resolver.coolingDown;
+
+    try {
+      return await this.#resolver(protectedHeader, token);
+    } catch (error) {
+      if (!(error instanceof errors.JWKSNoMatchingKey)) {
+        throw error;
+      }
+
+      if (resolveLatestEndpoint) {
+        const latestKeyStore = await this.#getLatestKeyStore();
+        if (latestKeyStore !== this) {
+          return latestKeyStore.#getKey(protectedHeader, token, false);
+        }
+      }
+
+      if (!coolingDown || !(await this.#reload())) {
+        throw error;
+      }
+      return this.#resolver(protectedHeader, token);
+    }
+  }
+
+  async #reload(): Promise<boolean> {
+    if (!this.#resolver.reloading && !this.#tryUseForcedReload()) {
+      return false;
+    }
+    await this.#resolver.reload();
+    return true;
+  }
+}
+
 export class JwksClient {
-  #keyStore?: RemoteJWKSet;
-  #keyStoreUrl?: string;
+  #keyStores = new Map<string, JwksKeyStore>();
+  #currentKeyStore?: JwksKeyStore;
   #forcedReloads: number[] = [];
-  #forcedReload?: Promise<void>;
 
   private readonly getEndpoint: () => Promise<URL>;
 
@@ -41,68 +96,33 @@ export class JwksClient {
   }
 
   get getKey() {
-    if (!this.#keyStore) {
-      throw new AuthenticationError(
-        'refreshKeyStore must be called before jwksClient.getKey',
-      );
-    }
     return this.#getKey;
-  }
-
-  /**
-   * Initializes the remote key store using the latest endpoint.
-   */
-  async refreshKeyStore(): Promise<void> {
-    if (!this.#keyStore) {
-      const endpoint = await this.getEndpoint();
-      if (!this.#keyStore) {
-        this.#keyStore = createRemoteJWKSet(endpoint);
-        this.#keyStoreUrl = endpoint.href;
-      }
-    }
   }
 
   #getKey: GetKeyFunction<JWSHeaderParameters, FlattenedJWSInput> = async (
     protectedHeader,
     token,
   ) => {
-    const keyStore = this.#keyStore!;
-    const coolingDown = keyStore.coolingDown;
-
-    try {
-      return await keyStore(protectedHeader, token);
-    } catch (error) {
-      if (!(error instanceof errors.JWKSNoMatchingKey)) {
-        throw error;
-      }
-      if (this.#keyStore !== keyStore) {
-        return this.#keyStore!(protectedHeader, token);
-      }
-
-      let endpoint: URL | undefined;
-      if (!coolingDown) {
-        endpoint = await this.getEndpoint();
-        if (this.#keyStore !== keyStore) {
-          return this.#keyStore!(protectedHeader, token);
-        }
-        if (endpoint.href === this.#keyStoreUrl) {
-          throw error;
-        }
-      }
-      if (!(await this.#forceReload(endpoint))) {
-        throw error;
-      }
-
-      return this.#keyStore!(protectedHeader, token);
-    }
+    const keyStore = this.#currentKeyStore ?? (await this.#getLatestKeyStore());
+    return keyStore.getKey(protectedHeader, token);
   };
 
-  async #forceReload(endpoint?: URL): Promise<boolean> {
-    if (this.#forcedReload) {
-      await this.#forcedReload;
-      return true;
+  async #getLatestKeyStore(): Promise<JwksKeyStore> {
+    const endpoint = await this.getEndpoint();
+    let keyStore = this.#keyStores.get(endpoint.href);
+    if (!keyStore) {
+      keyStore = new JwksKeyStore(
+        endpoint,
+        () => this.#getLatestKeyStore(),
+        () => this.#tryUseForcedReload(),
+      );
+      this.#keyStores.set(endpoint.href, keyStore);
     }
+    this.#currentKeyStore = keyStore;
+    return keyStore;
+  }
 
+  #tryUseForcedReload(): boolean {
     const windowStart = Date.now() - FORCED_RELOAD_WINDOW_MS;
     this.#forcedReloads = this.#forcedReloads.filter(
       timestamp => timestamp > windowStart,
@@ -110,27 +130,7 @@ export class JwksClient {
     if (this.#forcedReloads.length >= FORCED_RELOAD_LIMIT) {
       return false;
     }
-
-    const forcedReload = (async () => {
-      const latestEndpoint = endpoint ?? (await this.getEndpoint());
-      if (latestEndpoint.href !== this.#keyStoreUrl) {
-        this.#keyStore = createRemoteJWKSet(latestEndpoint);
-        this.#keyStoreUrl = latestEndpoint.href;
-      }
-
-      const keyStore = this.#keyStore!;
-      if (!keyStore.reloading) {
-        this.#forcedReloads.push(Date.now());
-      }
-      await keyStore.reload();
-    })();
-    this.#forcedReload = forcedReload;
-
-    try {
-      await forcedReload;
-      return true;
-    } finally {
-      this.#forcedReload = undefined;
-    }
+    this.#forcedReloads.push(Date.now());
+    return true;
   }
 }

--- a/packages/backend-defaults/src/entrypoints/auth/JwksClient.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/JwksClient.ts
@@ -17,18 +17,22 @@
 import { AuthenticationError } from '@backstage/errors';
 import {
   createRemoteJWKSet,
-  decodeJwt,
-  decodeProtectedHeader,
+  errors,
   FlattenedJWSInput,
+  GetKeyFunction,
   JWSHeaderParameters,
 } from 'jose';
-import { GetKeyFunction } from 'jose';
 
-const CLOCK_MARGIN_S = 10;
+const FORCED_RELOAD_LIMIT = 10;
+const FORCED_RELOAD_WINDOW_MS = 60_000;
+
+type RemoteJWKSet = ReturnType<typeof createRemoteJWKSet>;
 
 export class JwksClient {
-  #keyStore?: GetKeyFunction<JWSHeaderParameters, FlattenedJWSInput>;
-  #keyStoreUpdated: number = 0;
+  #keyStore?: RemoteJWKSet;
+  #keyStoreUrl?: string;
+  #forcedReloads: number[] = [];
+  #forcedReload?: Promise<void>;
 
   private readonly getEndpoint: () => Promise<URL>;
 
@@ -42,38 +46,91 @@ export class JwksClient {
         'refreshKeyStore must be called before jwksClient.getKey',
       );
     }
-    return this.#keyStore;
+    return this.#getKey;
   }
 
   /**
-   * If the last keystore refresh is stale, update the keystore URL to the latest
+   * Initializes the remote key store using the latest endpoint.
    */
-  async refreshKeyStore(rawJwtToken: string): Promise<void> {
-    const payload = await decodeJwt(rawJwtToken);
-    const header = await decodeProtectedHeader(rawJwtToken);
-
-    // Refresh public keys if needed
-    let keyStoreHasKey;
-    try {
-      if (this.#keyStore) {
-        // Check if the key is present in the keystore
-        const [_, rawPayload, rawSignature] = rawJwtToken.split('.');
-        keyStoreHasKey = await this.#keyStore(header, {
-          payload: rawPayload,
-          signature: rawSignature,
-        });
-      }
-    } catch (error) {
-      keyStoreHasKey = false;
-    }
-    // Refresh public key URL if needed
-    // Add a small margin in case clocks are out of sync
-    const issuedAfterLastRefresh =
-      payload?.iat && payload.iat > this.#keyStoreUpdated - CLOCK_MARGIN_S;
-    if (!this.#keyStore || (!keyStoreHasKey && issuedAfterLastRefresh)) {
+  async refreshKeyStore(): Promise<void> {
+    if (!this.#keyStore) {
       const endpoint = await this.getEndpoint();
-      this.#keyStore = createRemoteJWKSet(endpoint);
-      this.#keyStoreUpdated = Date.now() / 1000;
+      if (!this.#keyStore) {
+        this.#keyStore = createRemoteJWKSet(endpoint);
+        this.#keyStoreUrl = endpoint.href;
+      }
+    }
+  }
+
+  #getKey: GetKeyFunction<JWSHeaderParameters, FlattenedJWSInput> = async (
+    protectedHeader,
+    token,
+  ) => {
+    const keyStore = this.#keyStore!;
+    const coolingDown = keyStore.coolingDown;
+
+    try {
+      return await keyStore(protectedHeader, token);
+    } catch (error) {
+      if (!(error instanceof errors.JWKSNoMatchingKey)) {
+        throw error;
+      }
+      if (this.#keyStore !== keyStore) {
+        return this.#keyStore!(protectedHeader, token);
+      }
+
+      let endpoint: URL | undefined;
+      if (!coolingDown) {
+        endpoint = await this.getEndpoint();
+        if (this.#keyStore !== keyStore) {
+          return this.#keyStore!(protectedHeader, token);
+        }
+        if (endpoint.href === this.#keyStoreUrl) {
+          throw error;
+        }
+      }
+      if (!(await this.#forceReload(endpoint))) {
+        throw error;
+      }
+
+      return this.#keyStore!(protectedHeader, token);
+    }
+  };
+
+  async #forceReload(endpoint?: URL): Promise<boolean> {
+    if (this.#forcedReload) {
+      await this.#forcedReload;
+      return true;
+    }
+
+    const windowStart = Date.now() - FORCED_RELOAD_WINDOW_MS;
+    this.#forcedReloads = this.#forcedReloads.filter(
+      timestamp => timestamp > windowStart,
+    );
+    if (this.#forcedReloads.length >= FORCED_RELOAD_LIMIT) {
+      return false;
+    }
+
+    const forcedReload = (async () => {
+      const latestEndpoint = endpoint ?? (await this.getEndpoint());
+      if (latestEndpoint.href !== this.#keyStoreUrl) {
+        this.#keyStore = createRemoteJWKSet(latestEndpoint);
+        this.#keyStoreUrl = latestEndpoint.href;
+      }
+
+      const keyStore = this.#keyStore!;
+      if (!keyStore.reloading) {
+        this.#forcedReloads.push(Date.now());
+      }
+      await keyStore.reload();
+    })();
+    this.#forcedReload = forcedReload;
+
+    try {
+      await forcedReload;
+      return true;
+    } finally {
+      this.#forcedReload = undefined;
     }
   }
 }

--- a/packages/backend-defaults/src/entrypoints/auth/plugin/PluginTokenHandler.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/plugin/PluginTokenHandler.ts
@@ -123,7 +123,7 @@ export class DefaultPluginTokenHandler implements PluginTokenHandler {
     }
 
     const jwksClient = await this.getJwksClient(pluginId);
-    await jwksClient.refreshKeyStore(token); // TODO(Rugvip): Refactor so that this isn't needed
+    await jwksClient.refreshKeyStore(); // TODO(Rugvip): Refactor so that this isn't needed
 
     const { payload } = await jwtVerify<{ sub: string; obo?: string }>(
       token,

--- a/packages/backend-defaults/src/entrypoints/auth/plugin/PluginTokenHandler.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/plugin/PluginTokenHandler.ts
@@ -123,7 +123,6 @@ export class DefaultPluginTokenHandler implements PluginTokenHandler {
     }
 
     const jwksClient = await this.getJwksClient(pluginId);
-    await jwksClient.refreshKeyStore(); // TODO(Rugvip): Refactor so that this isn't needed
 
     const { payload } = await jwtVerify<{ sub: string; obo?: string }>(
       token,

--- a/packages/backend-defaults/src/entrypoints/auth/user/UserTokenHandler.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/user/UserTokenHandler.ts
@@ -58,7 +58,7 @@ export class UserTokenHandler {
       return undefined;
     }
 
-    await this.jwksClient.refreshKeyStore(token);
+    await this.jwksClient.refreshKeyStore();
 
     // Verify a limited token, ensuring the necessarily claims are present and token type is correct
     const { payload } = await jwtVerify(

--- a/packages/backend-defaults/src/entrypoints/auth/user/UserTokenHandler.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/user/UserTokenHandler.ts
@@ -58,8 +58,6 @@ export class UserTokenHandler {
       return undefined;
     }
 
-    await this.jwksClient.refreshKeyStore();
-
     // Verify a limited token, ensuring the necessarily claims are present and token type is correct
     const { payload } = await jwtVerify(
       token,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Improves JWKS verification reliability during signing key rotation by retaining the shared jose resolver and allowing a budgeted reload when a newly published key is requested during its cooldown.

Cooldown-bypassing fetches are limited to 10 attempts per minute for each client and concurrent misses share one attempt. Discovery is re-resolved before these fetches, with the resolver replaced only when the endpoint has changed.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

<!-- mana-workspace:XMMyJEcmCQv -->