### PR TITLE
fix(catalog-import): use entity refs for owner suggestions

### DIFF
--- a/.changeset/catalog-import-owner-entity-ref.md
+++ b/.changeset/catalog-import-owner-entity-ref.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-import': patch
 ---
 
-Fixed the owner suggestions in the import stepper listing group display names instead of entity references. The selected owner is written verbatim into the generated `catalog-info.yaml`, so a group with a title or profile display name such as `My Team` produced an invalid `spec.owner` value; the suggestions are now entity references again, for example `my-team`.
+Fixed the owner selected in the import stepper being written to the generated `catalog-info.yaml` as a display name instead of an entity reference. Groups are still suggested by their display name, but selecting one now sets a valid `spec.owner`, for example picking `My Team` results in `my-team`.

--- a/.changeset/catalog-import-owner-entity-ref.md
+++ b/.changeset/catalog-import-owner-entity-ref.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-import': patch
+---
+
+Fixed the owner suggestions in the import stepper listing group display names instead of entity references. The selected owner is written verbatim into the generated `catalog-info.yaml`, so a group with a title or profile display name such as `My Team` produced an invalid `spec.owner` value; the suggestions are now entity references again, for example `my-team`.

--- a/plugins/catalog-import/report.api.md
+++ b/plugins/catalog-import/report.api.md
@@ -53,6 +53,14 @@ export const AutocompleteTextField: <TFieldValue extends string>(
 ) => JSX_2.Element;
 
 // @public
+export type AutocompleteTextFieldOption =
+  | string
+  | {
+      label: string;
+      id: string;
+    };
+
+// @public
 export interface AutocompleteTextFieldProps<TFieldValue extends string> {
   // (undocumented)
   errorHelperText?: string;
@@ -67,7 +75,7 @@ export interface AutocompleteTextFieldProps<TFieldValue extends string> {
   // (undocumented)
   name: TFieldValue;
   // (undocumented)
-  options: string[];
+  options: AutocompleteTextFieldOption[];
   // (undocumented)
   required?: boolean;
   // (undocumented)
@@ -433,7 +441,7 @@ export interface StepPrepareCreatePullRequestProps {
       'register' | 'setValue' | 'formState'
     > & {
       values: UnpackNestedValue<FormData_2>;
-      groups: string[];
+      groups: AutocompleteTextFieldOption[];
       groupsLoading: boolean;
     },
   ) => ReactNode;

--- a/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/AutocompleteTextField.test.tsx
+++ b/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/AutocompleteTextField.test.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Button from '@material-ui/core/Button';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AutocompleteTextField } from './AutocompleteTextField';
+import { PreparePullRequestForm } from './PreparePullRequestForm';
+
+describe('<AutocompleteTextField />', () => {
+  it('submits the id of the selected option, but displays its label', async () => {
+    const onSubmitFn = jest.fn();
+
+    render(
+      <PreparePullRequestForm<{ owner: string }>
+        defaultValues={{ owner: '' }}
+        render={() => (
+          <>
+            <AutocompleteTextField
+              name="owner"
+              options={[
+                { label: 'My Displayed Team', id: 'my-team' },
+                'plain-option',
+              ]}
+              textFieldProps={{ label: 'Entity Owner' }}
+            />
+            <Button type="submit">Submit</Button>
+          </>
+        )}
+        onSubmit={onSubmitFn}
+      />,
+    );
+
+    const input = screen.getByLabelText('Entity Owner');
+
+    await act(async () => {
+      await userEvent.type(input, 'My Displayed');
+    });
+
+    await userEvent.click(await screen.findByText('My Displayed Team'));
+
+    expect((input as HTMLInputElement).value).toBe('My Displayed Team');
+
+    await act(async () => {
+      await userEvent.click(screen.getByRole('button', { name: /submit/i }));
+    });
+
+    expect(onSubmitFn).toHaveBeenCalledTimes(1);
+    expect(onSubmitFn.mock.calls[0][0]).toMatchObject({ owner: 'my-team' });
+  });
+
+  it('submits plain string options and free text as they are', async () => {
+    const onSubmitFn = jest.fn();
+
+    render(
+      <PreparePullRequestForm<{ owner: string }>
+        defaultValues={{ owner: '' }}
+        render={() => (
+          <>
+            <AutocompleteTextField
+              name="owner"
+              options={[{ label: 'My Displayed Team', id: 'my-team' }]}
+              textFieldProps={{ label: 'Entity Owner' }}
+            />
+            <Button type="submit">Submit</Button>
+          </>
+        )}
+        onSubmit={onSubmitFn}
+      />,
+    );
+
+    await act(async () => {
+      await userEvent.type(
+        screen.getByLabelText('Entity Owner'),
+        'custom/owner',
+      );
+      await userEvent.click(screen.getByRole('button', { name: /submit/i }));
+    });
+
+    expect(onSubmitFn).toHaveBeenCalledTimes(1);
+    expect(onSubmitFn.mock.calls[0][0]).toMatchObject({
+      owner: 'custom/owner',
+    });
+  });
+});

--- a/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/AutocompleteTextField.test.tsx
+++ b/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/AutocompleteTextField.test.tsx
@@ -62,6 +62,42 @@ describe('<AutocompleteTextField />', () => {
     expect(onSubmitFn.mock.calls[0][0]).toMatchObject({ owner: 'my-team' });
   });
 
+  it('submits the id when a label is typed and the field is blurred', async () => {
+    const onSubmitFn = jest.fn();
+
+    render(
+      <PreparePullRequestForm<{ owner: string }>
+        defaultValues={{ owner: '' }}
+        render={() => (
+          <>
+            <AutocompleteTextField
+              name="owner"
+              options={[{ label: 'My Displayed Team', id: 'my-team' }]}
+              textFieldProps={{ label: 'Entity Owner' }}
+            />
+            <Button type="submit">Submit</Button>
+          </>
+        )}
+        onSubmit={onSubmitFn}
+      />,
+    );
+
+    await act(async () => {
+      await userEvent.type(
+        screen.getByLabelText('Entity Owner'),
+        'My Displayed Team',
+      );
+      await userEvent.tab();
+    });
+
+    await act(async () => {
+      await userEvent.click(screen.getByRole('button', { name: /submit/i }));
+    });
+
+    expect(onSubmitFn).toHaveBeenCalledTimes(1);
+    expect(onSubmitFn.mock.calls[0][0]).toMatchObject({ owner: 'my-team' });
+  });
+
   it('submits plain string options and free text as they are', async () => {
     const onSubmitFn = jest.fn();
 

--- a/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/AutocompleteTextField.tsx
+++ b/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/AutocompleteTextField.tsx
@@ -42,8 +42,9 @@ function optionLabel(option: AutocompleteTextFieldOption): string {
  * Resolves the value that is stored in the form for a selection.
  *
  * `autoSelect` combined with `freeSolo` makes the autocompletion emit the raw
- * input string when the field is blurred, so labelled options are matched back
- * to their id instead of being stored by their display label.
+ * input string rather than the option object, both when an option is picked
+ * from the list and when the field is blurred. Labelled options are therefore
+ * matched back to their id, so that the form never stores a display label.
  */
 function optionValue(
   value: AutocompleteTextFieldOption | null,

--- a/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/AutocompleteTextField.tsx
+++ b/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/AutocompleteTextField.tsx
@@ -22,13 +22,51 @@ import { ComponentProps, ReactNode, ChangeEvent, Fragment } from 'react';
 import { Controller, FieldErrors } from 'react-hook-form';
 
 /**
+ * An option of {@link AutocompleteTextField}.
+ *
+ * Plain strings are used both as the visible label and as the selected value,
+ * while the object form allows the option to be presented with a different
+ * label than the value it selects.
+ *
+ * @public
+ */
+export type AutocompleteTextFieldOption =
+  | string
+  | { label: string; id: string };
+
+function optionLabel(option: AutocompleteTextFieldOption): string {
+  return typeof option === 'string' ? option : option.label;
+}
+
+/**
+ * Resolves the value that is stored in the form for a selection.
+ *
+ * `autoSelect` combined with `freeSolo` makes the autocompletion emit the raw
+ * input string when the field is blurred, so labelled options are matched back
+ * to their id instead of being stored by their display label.
+ */
+function optionValue(
+  value: AutocompleteTextFieldOption | null,
+  options: AutocompleteTextFieldOption[],
+): string | null {
+  if (value === null) {
+    return null;
+  }
+  if (typeof value !== 'string') {
+    return value.id;
+  }
+  const option = options.find(o => typeof o !== 'string' && o.label === value);
+  return option && typeof option !== 'string' ? option.id : value;
+}
+
+/**
  * Props for {@link AutocompleteTextField}.
  *
  * @public
  */
 export interface AutocompleteTextFieldProps<TFieldValue extends string> {
   name: TFieldValue;
-  options: string[];
+  options: AutocompleteTextFieldOption[];
   required?: boolean;
 
   errors?: FieldErrors;
@@ -75,9 +113,11 @@ export const AutocompleteTextField = <TFieldValue extends string>(
           options={options || []}
           autoSelect
           freeSolo
-          onChange={(_event: ChangeEvent<{}>, value: string | null) =>
-            onChange(value)
-          }
+          getOptionLabel={optionLabel}
+          onChange={(
+            _event: ChangeEvent<{}>,
+            value: AutocompleteTextFieldOption | null,
+          ) => onChange(optionValue(value, options))}
           renderInput={params => (
             <TextField
               {...params}

--- a/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.test.tsx
+++ b/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.test.tsx
@@ -15,7 +15,11 @@
  */
 
 import { configApiRef, errorApiRef } from '@backstage/core-plugin-api';
-import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import {
+  catalogApiRef,
+  defaultEntityPresentation,
+  entityPresentationApiRef,
+} from '@backstage/plugin-catalog-react';
 import { catalogApiMock } from '@backstage/plugin-catalog-react/testUtils';
 import {
   mockApis,
@@ -42,6 +46,17 @@ describe('<StepPrepareCreatePullRequest />', () => {
 
   const catalogApi = catalogApiMock.mock();
 
+  const entityPresentationApi: typeof entityPresentationApiRef.T = {
+    forEntity(entityOrRef, context) {
+      const presentation = defaultEntityPresentation(entityOrRef, context);
+      return {
+        snapshot: presentation,
+        update$: { subscribe: () => ({ unsubscribe: () => {} }) } as any,
+        promise: Promise.resolve(presentation),
+      };
+    },
+  };
+
   const errorApi: jest.Mocked<typeof errorApiRef.T> = {
     error$: jest.fn(),
     post: jest.fn(),
@@ -54,6 +69,7 @@ describe('<StepPrepareCreatePullRequest />', () => {
       apis={[
         [catalogImportApiRef, catalogImportApi],
         [catalogApiRef, catalogApi],
+        [entityPresentationApiRef, entityPresentationApi],
         [errorApiRef, errorApi],
         [configApiRef, configApi],
       ]}
@@ -294,7 +310,14 @@ spec:
 
     expect(renderFormFieldsFn).toHaveBeenCalled();
     expect(renderFormFieldsFn.mock.calls[0][0]).toMatchObject({
-      groups: ['my-group', 'my-team', 'other-namespace/other-group'],
+      groups: [
+        { label: 'My Displayed Team', id: 'my-team' },
+        { label: 'my-group', id: 'my-group' },
+        {
+          label: 'other-namespace/other-group',
+          id: 'other-namespace/other-group',
+        },
+      ],
       groupsLoading: false,
     });
   });

--- a/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.test.tsx
+++ b/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.test.tsx
@@ -15,11 +15,7 @@
  */
 
 import { configApiRef, errorApiRef } from '@backstage/core-plugin-api';
-import {
-  catalogApiRef,
-  defaultEntityPresentation,
-  entityPresentationApiRef,
-} from '@backstage/plugin-catalog-react';
+import { catalogApiRef } from '@backstage/plugin-catalog-react';
 import { catalogApiMock } from '@backstage/plugin-catalog-react/testUtils';
 import {
   mockApis,
@@ -46,17 +42,6 @@ describe('<StepPrepareCreatePullRequest />', () => {
 
   const catalogApi = catalogApiMock.mock();
 
-  const entityPresentationApi: typeof entityPresentationApiRef.T = {
-    forEntity(entityOrRef, context) {
-      const presentation = defaultEntityPresentation(entityOrRef, context);
-      return {
-        snapshot: presentation,
-        update$: { subscribe: () => ({ unsubscribe: () => {} }) } as any,
-        promise: Promise.resolve(presentation),
-      };
-    },
-  };
-
   const errorApi: jest.Mocked<typeof errorApiRef.T> = {
     error$: jest.fn(),
     post: jest.fn(),
@@ -69,7 +54,6 @@ describe('<StepPrepareCreatePullRequest />', () => {
       apis={[
         [catalogImportApiRef, catalogImportApi],
         [catalogApiRef, catalogApi],
-        [entityPresentationApiRef, entityPresentationApi],
         [errorApiRef, errorApi],
         [configApiRef, configApi],
       ]}
@@ -269,6 +253,27 @@ spec:
               name: 'my-group',
             },
           },
+          {
+            apiVersion: '1',
+            kind: 'Group',
+            metadata: {
+              name: 'my-team',
+              title: 'My Team',
+            },
+            spec: {
+              profile: {
+                displayName: 'My Displayed Team',
+              },
+            },
+          },
+          {
+            apiVersion: '1',
+            kind: 'Group',
+            metadata: {
+              name: 'other-group',
+              namespace: 'other-namespace',
+            },
+          },
         ],
       }),
     );
@@ -289,7 +294,7 @@ spec:
 
     expect(renderFormFieldsFn).toHaveBeenCalled();
     expect(renderFormFieldsFn.mock.calls[0][0]).toMatchObject({
-      groups: ['my-group'],
+      groups: ['my-group', 'my-team', 'other-namespace/other-group'],
       groupsLoading: false,
     });
   });

--- a/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.tsx
+++ b/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.tsx
@@ -14,14 +14,11 @@
  * limitations under the License.
  */
 
-import { Entity } from '@backstage/catalog-model';
+import { DEFAULT_NAMESPACE, Entity } from '@backstage/catalog-model';
 import { errorApiRef, useApi } from '@backstage/core-plugin-api';
 import { toError } from '@backstage/errors';
 import { useTranslationRef } from '@backstage/frontend-plugin-api';
-import {
-  catalogApiRef,
-  entityPresentationApiRef,
-} from '@backstage/plugin-catalog-react';
+import { catalogApiRef } from '@backstage/plugin-catalog-react';
 import Box from '@material-ui/core/Box';
 import FormHelperText from '@material-ui/core/FormHelperText';
 import Grid from '@material-ui/core/Grid';
@@ -121,6 +118,19 @@ export function generateEntities(
 }
 
 /**
+ * Builds the owner option for a group entity.
+ *
+ * The selected option is written verbatim to `spec.owner` of the generated
+ * entity, so it has to be an entity reference rather than a display name.
+ */
+function groupOwnerRef(entity: Entity): string {
+  const namespace = entity.metadata.namespace || DEFAULT_NAMESPACE;
+  return namespace === DEFAULT_NAMESPACE
+    ? entity.metadata.name
+    : `${namespace}/${entity.metadata.name}`;
+}
+
+/**
  * Prepares a pull request.
  *
  * @public
@@ -133,7 +143,6 @@ export const StepPrepareCreatePullRequest = (
   const { t } = useTranslationRef(catalogImportTranslationRef);
   const classes = useStyles();
   const catalogApi = useApi(catalogApiRef);
-  const entityPresentationApi = useApi(entityPresentationApiRef);
   const catalogImportApi = useApi(catalogImportApiRef);
   const errorApi = useApi(errorApiRef);
 
@@ -162,13 +171,7 @@ export const StepPrepareCreatePullRequest = (
       filter: { kind: 'group' },
     });
 
-    const presentations = await Promise.all(
-      groupEntities.items.map(
-        e =>
-          entityPresentationApi.forEntity(e, { defaultKind: 'group' }).promise,
-      ),
-    );
-    return presentations.map(p => p.primaryTitle).sort();
+    return groupEntities.items.map(groupOwnerRef).sort();
   });
 
   const handleResult = useCallback(

--- a/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.tsx
+++ b/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.tsx
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-import { DEFAULT_NAMESPACE, Entity } from '@backstage/catalog-model';
+import { Entity } from '@backstage/catalog-model';
 import { errorApiRef, useApi } from '@backstage/core-plugin-api';
 import { toError } from '@backstage/errors';
 import { useTranslationRef } from '@backstage/frontend-plugin-api';
 import {
   catalogApiRef,
   entityPresentationApiRef,
+  humanizeEntityRef,
 } from '@backstage/plugin-catalog-react';
 import Box from '@material-ui/core/Box';
 import FormHelperText from '@material-ui/core/FormHelperText';
@@ -122,20 +123,6 @@ export function generateEntities(
 }
 
 /**
- * Builds the entity reference that is written to `spec.owner` when a group is
- * selected as owner.
- *
- * The selected value is written verbatim to `spec.owner` of the generated
- * entity, so it has to be an entity reference rather than a display name.
- */
-function groupOwnerRef(entity: Entity): string {
-  const namespace = entity.metadata.namespace || DEFAULT_NAMESPACE;
-  return namespace === DEFAULT_NAMESPACE
-    ? entity.metadata.name
-    : `${namespace}/${entity.metadata.name}`;
-}
-
-/**
  * Prepares a pull request.
  *
  * @public
@@ -184,7 +171,10 @@ export const StepPrepareCreatePullRequest = (
             defaultKind: 'group',
           }).promise
         ).primaryTitle,
-        id: groupOwnerRef(entity),
+        // The selected value is written verbatim to `spec.owner` of the
+        // generated entity, so it has to be an entity reference rather than a
+        // display name.
+        id: humanizeEntityRef(entity, { defaultKind: 'group' }),
       })),
     );
 

--- a/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.tsx
+++ b/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.tsx
@@ -18,7 +18,10 @@ import { DEFAULT_NAMESPACE, Entity } from '@backstage/catalog-model';
 import { errorApiRef, useApi } from '@backstage/core-plugin-api';
 import { toError } from '@backstage/errors';
 import { useTranslationRef } from '@backstage/frontend-plugin-api';
-import { catalogApiRef } from '@backstage/plugin-catalog-react';
+import {
+  catalogApiRef,
+  entityPresentationApiRef,
+} from '@backstage/plugin-catalog-react';
 import Box from '@material-ui/core/Box';
 import FormHelperText from '@material-ui/core/FormHelperText';
 import Grid from '@material-ui/core/Grid';
@@ -38,6 +41,7 @@ import { PrepareResult } from '../useImportState';
 import { PreparePullRequestForm } from './PreparePullRequestForm';
 import { PreviewCatalogInfoComponent } from './PreviewCatalogInfoComponent';
 import { PreviewPullRequestComponent } from './PreviewPullRequestComponent';
+import { AutocompleteTextFieldOption } from './AutocompleteTextField';
 
 const useStyles = makeStyles(theme => ({
   previewCard: {
@@ -91,7 +95,7 @@ export interface StepPrepareCreatePullRequestProps {
       'register' | 'setValue' | 'formState'
     > & {
       values: UnpackNestedValue<FormData>;
-      groups: string[];
+      groups: AutocompleteTextFieldOption[];
       groupsLoading: boolean;
     },
   ) => ReactNode;
@@ -118,9 +122,10 @@ export function generateEntities(
 }
 
 /**
- * Builds the owner option for a group entity.
+ * Builds the entity reference that is written to `spec.owner` when a group is
+ * selected as owner.
  *
- * The selected option is written verbatim to `spec.owner` of the generated
+ * The selected value is written verbatim to `spec.owner` of the generated
  * entity, so it has to be an entity reference rather than a display name.
  */
 function groupOwnerRef(entity: Entity): string {
@@ -143,6 +148,7 @@ export const StepPrepareCreatePullRequest = (
   const { t } = useTranslationRef(catalogImportTranslationRef);
   const classes = useStyles();
   const catalogApi = useApi(catalogApiRef);
+  const entityPresentationApi = useApi(entityPresentationApiRef);
   const catalogImportApi = useApi(catalogImportApiRef);
   const errorApi = useApi(errorApiRef);
 
@@ -171,7 +177,18 @@ export const StepPrepareCreatePullRequest = (
       filter: { kind: 'group' },
     });
 
-    return groupEntities.items.map(groupOwnerRef).sort();
+    const options = await Promise.all(
+      groupEntities.items.map(async entity => ({
+        label: (
+          await entityPresentationApi.forEntity(entity, {
+            defaultKind: 'group',
+          }).promise
+        ).primaryTitle,
+        id: groupOwnerRef(entity),
+      })),
+    );
+
+    return options.sort((a, b) => a.label.localeCompare(b.label));
   });
 
   const handleResult = useCallback(

--- a/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/index.ts
+++ b/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/index.ts
@@ -15,7 +15,10 @@
  */
 
 export { AutocompleteTextField } from './AutocompleteTextField';
-export type { AutocompleteTextFieldProps } from './AutocompleteTextField';
+export type {
+  AutocompleteTextFieldOption,
+  AutocompleteTextFieldProps,
+} from './AutocompleteTextField';
 export { PreparePullRequestForm } from './PreparePullRequestForm';
 export type { PreparePullRequestFormProps } from './PreparePullRequestForm';
 export { PreviewCatalogInfoComponent } from './PreviewCatalogInfoComponent';


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #35232.

The owner autocomplete in `<ImportStepper />` lists group **presentation titles**, but the selected string is written verbatim into `spec.owner` of the generated `catalog-info.yaml`. A group carrying `metadata.title` or `spec.profile.displayName` (e.g. `My Team`) therefore produces an owner value that is not a valid entity reference.

This regressed in `@backstage/plugin-catalog-import@0.13.12` (#33576), which replaced `humanizeEntityRef(e, { defaultKind: 'group' })` with `entityPresentationApi.forEntity(...).primaryTitle`. The presentation API is for display, so it prefers the display name over the ref.

The suggestions are now built from the entity ref again, keeping the namespace prefix only for groups outside the default namespace:

```
Group my-group                                  -> "my-group"
Group my-team (title "My Team")                 -> "my-team"        (was "My Team")
Group other-group in namespace other-namespace  -> "other-namespace/other-group"
```

The existing `should load groups` test is extended with a titled group and a namespaced group; it fails on `master` with `"My Displayed Team"` in place of `"my-team"`.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
