### PR TITLE
Normalize techdocs analytics events

### DIFF
--- a/.changeset/quiet-dolphins-listen.md
+++ b/.changeset/quiet-dolphins-listen.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-app-api': patch
+---
+
+Normalize the `kind` analytics attribute for TechDocs reader navigation events.

--- a/packages/frontend-app-api/src/routing/RouteTracker.test.tsx
+++ b/packages/frontend-app-api/src/routing/RouteTracker.test.tsx
@@ -108,6 +108,47 @@ describe('RouteTracker', () => {
     });
   });
 
+  it('should normalize the TechDocs entity kind', async () => {
+    const techDocsRouteObjects: BackstageRouteObject[] = [
+      {
+        path: '/docs/:namespace/:kind/:name',
+        element: <div>docs</div>,
+        routeRefs: new Set([createRouteRef()]),
+        caseSensitive: false,
+        children: [MATCH_ALL_ROUTE],
+        appNode: {
+          spec: {
+            extension: { id: 'page:techdocs/reader' },
+            plugin: { id: 'techdocs' },
+          },
+        } as AppNode,
+      },
+    ];
+
+    render(
+      <MemoryRouter initialEntries={['/docs/default/Component/My-Service']}>
+        <TestApiProvider apis={[[analyticsApiRef, mockedAnalytics]]}>
+          <RouteTracker routeObjects={techDocsRouteObjects} />
+        </TestApiProvider>
+      </MemoryRouter>,
+    );
+
+    expect(mockedAnalytics.captureEvent).toHaveBeenCalledWith({
+      action: 'navigate',
+      attributes: {
+        namespace: 'default',
+        kind: 'component',
+        name: 'My-Service',
+      },
+      context: {
+        extensionId: 'page:techdocs/reader',
+        pluginId: 'techdocs',
+      },
+      subject: '/docs/default/Component/My-Service',
+      value: undefined,
+    });
+  });
+
   it('should capture the navigate event on route change', async () => {
     const { getByText } = render(
       <MemoryRouter initialEntries={['/path/foo/bar']}>

--- a/packages/frontend-app-api/src/routing/RouteTracker.tsx
+++ b/packages/frontend-app-api/src/routing/RouteTracker.tsx
@@ -54,17 +54,19 @@ const getExtensionContext = (
       return undefined;
     }
 
+    const plugin = routeObject.appNode?.spec.plugin;
+    const extension = routeObject.appNode?.spec.extension;
     const params = Object.entries(
       routeMatch?.params || {},
     ).reduce<AnalyticsEventAttributes>((acc, [key, value]) => {
       if (value !== undefined && key !== '*') {
-        acc[key] = value;
+        acc[key] =
+          extension?.id === 'page:techdocs/reader' && key === 'kind'
+            ? value.toLocaleLowerCase('en-US')
+            : value;
       }
       return acc;
     }, {});
-
-    const plugin = routeObject.appNode?.spec.plugin;
-    const extension = routeObject.appNode?.spec.extension;
 
     return {
       params,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<img width="1281" height="255" alt="image" src="https://github.com/user-attachments/assets/4bffd400-4a5c-4bb0-b4e6-8fbcfe6e8161" />

On navigation to techdocs pages, if the `/<kind>` path fragment is uppercase, the corresponding analytics event `context.kind` will be the uppercased too.

Remediated by normalizing through lowercasing.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
