### PR TITLE
docs: add patch branch step to main line release process

### DIFF
--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -57,6 +57,16 @@ Additional steps for the main line release
 
 Once the release has been published edit the newly created release in the [GitHub repository](https://github.com/backstage/backstage/releases) and replace the text content with the release notes.
 
+- Create Patch Branch
+  - The [deploy microsite workflow](https://github.com/backstage/backstage/blob/master/.github/workflows/deploy_microsite.yml) uses the latest `patch/v*` branch to build the stable docs at `backstage.io/docs/`. Without this branch, the stable docs will continue to reflect the previous release.
+  - Create and push the branch from the release tag:
+    ```bash
+    git checkout v1.x.0
+    git checkout -b patch/v1.x.0
+    git push --set-upstream origin patch/v1.x.0
+    ```
+  - The next deploy microsite run will automatically pick up the new branch and update the stable docs.
+
 ## Switching Release Modes
 
 - To enter pre-release mode: `yarn changeset pre enter next` & create PR + merge changes


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The deploy microsite workflow depends on a `patch/v*` branch to build stable docs at `backstage.io/docs/`, but creating this branch was not documented as part of the main line release process. This adds it as a step.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))