### PR TITLE
fix(cli-module-new): normalize template file paths to forward slashes on Windows

### DIFF
--- a/.changeset/fix-cli-windows-template-paths.md
+++ b/.changeset/fix-cli-windows-template-paths.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli-module-new': patch
+---
+
+Fixed an issue where scaffolding templates on Windows could generate corrupted file names for files in subdirectories.

--- a/packages/cli-module-new/src/lib/execution/writeTemplateContents.test.ts
+++ b/packages/cli-module-new/src/lib/execution/writeTemplateContents.test.ts
@@ -70,7 +70,9 @@ describe('writeTemplateContents', () => {
       },
     );
 
-    expect(relativePath(mockDir.path, targetDir)).toBe('plugins/plugin-test');
+    expect(relativePath(mockDir.path, targetDir).replace(/\\/g, '/')).toBe(
+      'plugins/plugin-test',
+    );
     expect(mockDir.content()).toEqual({
       'package.json': JSON.stringify({
         workspaces: { packages: ['packages/*', 'plugins/*'] },
@@ -96,14 +98,26 @@ describe('writeTemplateContents', () => {
             content: '{"x":1}',
             path: 'test.json',
           },
+          {
+            content: 'component={{ extensionName }}',
+            path: 'src/extensions/{{ extensionName }}.tsx',
+            syntax: 'handlebars',
+          },
         ],
-        role: 'frontend-plugin',
-        values: {},
+        role: 'frontend-plugin-module',
+        values: {
+          extensionName: 'MyFieldExtension',
+        },
       },
       {
         ...baseConfig,
-        roleParams: { role: 'frontend-plugin', pluginId: 'test' },
-        packageName: '@internal/plugin-test',
+        roleParams: {
+          role: 'frontend-plugin-module',
+          pluginId: 'test',
+          moduleId: 'my-field',
+          pluginPackage: '@backstage/plugin-test',
+        },
+        packageName: '@internal/plugin-test-module-my-field',
         packagePath: 'out',
       },
     );
@@ -116,6 +130,11 @@ describe('writeTemplateContents', () => {
         'test.txt': 'test',
         'plugin.txt': 'id=test',
         'test.json': '{"x":1}',
+        src: {
+          extensions: {
+            'MyFieldExtension.tsx': 'component=MyFieldExtension',
+          },
+        },
       },
     });
   });

--- a/packages/cli-module-new/src/lib/preparation/loadPortableTemplate.test.ts
+++ b/packages/cli-module-new/src/lib/preparation/loadPortableTemplate.test.ts
@@ -36,6 +36,8 @@ describe('loadTemplate', () => {
         `,
       },
       'path/to/hello.txt': 'hello world',
+      'path/to/nested/file.txt': 'nested content',
+      'path/to/nested/template.txt.hbs': 'id={{ pluginId }}',
     });
 
     await expect(
@@ -46,7 +48,15 @@ describe('loadTemplate', () => {
     ).resolves.toEqual({
       name: 'template1',
       role: 'frontend-plugin',
-      files: [{ path: 'hello.txt', content: 'hello world' }],
+      files: expect.arrayContaining([
+        { path: 'hello.txt', content: 'hello world' },
+        { path: 'nested/file.txt', content: 'nested content' },
+        {
+          path: 'nested/template.txt',
+          content: 'id={{ pluginId }}',
+          syntax: 'handlebars',
+        },
+      ]),
       values: { foo: 'bar' },
     });
   });

--- a/packages/cli-module-new/src/lib/preparation/loadPortableTemplate.ts
+++ b/packages/cli-module-new/src/lib/preparation/loadPortableTemplate.ts
@@ -77,7 +77,7 @@ export async function loadPortableTemplate(
   const loadedFiles = new Array<PortableTemplateFile>();
 
   for (const filePath of filePaths) {
-    const path = relativePath(templatePath, filePath);
+    const path = relativePath(templatePath, filePath).split('\\').join('/');
     if (filePath === pointer.target) {
       continue;
     }

--- a/packages/cli-module-new/src/lib/preparation/resolvePackageParams.ts
+++ b/packages/cli-module-new/src/lib/preparation/resolvePackageParams.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { join as joinPath } from 'node:path';
+import { join as joinPath } from 'node:path/posix';
 import { PortableTemplateInputRoleParams } from '../types';
 
 export type ResolvePackageParamsOptions = {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #35231 

This PR fixes an issue where running `backstage-cli new` on Windows generates corrupted filenames (such as `src/extensions{{extensionName}}.tsx`) for
template files in nested subdirectories.

### Problem
On Windows, `path.relative()` returns backslashes (`src\extensions\{{extensionName}}.tsx`). When passed into Handlebars, the backslash right before the braces acts as an escape character (`\{{`), causing Handlebars to treat `{{extensionName}}` as literal text without interpolating it and stripping the path separator.

### Solution
- Normalized relative template file paths to forward slashes with `.split('\\').join('/')` in `loadPortableTemplate`.
- Used `posix.join` in `resolvePackageParams` for consistent package path resolution.
- Added tests verifying nested template files and Handlebars variable resolution in subdirectory paths.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.
md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.
md#developer-certificate-of-origin))