### PR TITLE
fix(catalog-import): resolve owner group display title back to entity ref

### DIFF
--- a/.changeset/fix-catalog-import-owner-entity-ref.md
+++ b/.changeset/fix-catalog-import-owner-entity-ref.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-import': patch
+---
+
+Fixed the import stepper's owner autocomplete writing the group's display title (e.g. "My Team") into the generated `catalog-info.yaml` instead of a valid entity ref (e.g. "group:default/my-team"). Group options are now resolved back to their entity ref before the value is used to generate the pull request content and preview, while still showing the friendly title in the dropdown.

--- a/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.test.tsx
+++ b/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.test.tsx
@@ -294,6 +294,84 @@ spec:
     });
   });
 
+  it('should resolve a selected group display title back to its entity ref when submitting', async () => {
+    catalogApi.getEntities.mockReturnValue(
+      Promise.resolve({
+        items: [
+          {
+            apiVersion: '1',
+            kind: 'Group',
+            metadata: {
+              name: 'my-team',
+              namespace: 'default',
+              title: 'My Team',
+            },
+          },
+        ],
+      }),
+    );
+    catalogImportApi.submitPullRequest.mockReturnValue(
+      Promise.resolve({
+        location: 'https://my/location.yaml',
+        link: 'https://my/pull',
+      }),
+    );
+
+    await renderInTestApp(
+      <Wrapper>
+        <StepPrepareCreatePullRequest
+          analyzeResult={analyzeResult}
+          onPrepare={onPrepareFn}
+          renderFormFields={({ register, groups, groupsLoading }) => {
+            return (
+              <>
+                <TextField {...asInputRef(register('title'))} />
+                <TextField {...asInputRef(register('body'))} />
+                <TextField
+                  {...asInputRef(register('componentName'))}
+                  id="name"
+                  label="name"
+                />
+                <TextField
+                  {...asInputRef(register('owner'))}
+                  id="owner"
+                  label="owner"
+                  data-testid="owner-loading"
+                  data-loading={groupsLoading}
+                  data-groups={JSON.stringify(groups)}
+                />
+              </>
+            );
+          }}
+        />
+      </Wrapper>,
+    );
+
+    // Wait for the group presentation title to be resolved.
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('owner-loading').getAttribute('data-groups'),
+      ).toBe(JSON.stringify(['My Team']));
+    });
+
+    // Simulate the user selecting the group by its displayed title, exactly
+    // as the AutocompleteTextField would populate the owner field.
+    const ownerField = await screen.findByLabelText('owner');
+    await userEvent.clear(ownerField);
+    await userEvent.type(ownerField, 'My Team');
+    await userEvent.click(screen.getByRole('button', { name: /Create PR/i }));
+
+    expect(catalogImportApi.submitPullRequest).toHaveBeenCalledTimes(1);
+    expect(catalogImportApi.submitPullRequest.mock.calls[0]).toMatchObject([
+      {
+        fileContent: expect.stringContaining('owner: group:default/my-team'),
+      },
+    ]);
+    expect(
+      catalogImportApi.submitPullRequest.mock.calls[0][0].fileContent,
+    ).not.toContain('owner: My Team');
+  });
+
   describe('generateEntities', () => {
     it.each([[undefined], [null]])(
       'should not include blank namespace for %s',

--- a/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.tsx
+++ b/plugins/catalog-import/src/components/StepPrepareCreatePullRequest/StepPrepareCreatePullRequest.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Entity } from '@backstage/catalog-model';
+import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
 import { errorApiRef, useApi } from '@backstage/core-plugin-api';
 import { toError } from '@backstage/errors';
 import { useTranslationRef } from '@backstage/frontend-plugin-api';
@@ -100,6 +100,22 @@ export interface StepPrepareCreatePullRequestProps {
   ) => ReactNode;
 }
 
+/**
+ * Resolves the owner value entered/selected in the form back to an entity
+ * ref, when it matches one of the known groups. Falls back to the raw
+ * value for free-form entries that don't match a known group (the
+ * autocomplete field allows arbitrary text).
+ */
+function resolveOwnerEntityRef(
+  owner: string | undefined,
+  groupRefsByTitle: Map<string, string>,
+): string | undefined {
+  if (!owner) {
+    return owner;
+  }
+  return groupRefsByTitle.get(owner) ?? owner;
+}
+
 export function generateEntities(
   entities: PartialEntity[],
   componentName: string,
@@ -157,23 +173,43 @@ export const StepPrepareCreatePullRequest = (
     }
   }, [prDefaultsError, errorApi]);
 
+  // Maps the human-readable group title shown in the owner autocomplete
+  // back to the entity ref that must actually be written to the
+  // catalog-info.yaml `spec.owner` field. Titles (e.g. "My Team") are not
+  // valid entity refs (e.g. "group:default/my-team"), so this mapping is
+  // required whenever the presentation title differs from the ref.
+  const [groupRefsByTitle, setGroupRefsByTitle] = useState<Map<string, string>>(
+    new Map(),
+  );
+
   const { loading: groupsLoading, value: groups } = useAsync(async () => {
     const groupEntities = await catalogApi.getEntities({
       filter: { kind: 'group' },
     });
 
     const presentations = await Promise.all(
-      groupEntities.items.map(
-        e =>
-          entityPresentationApi.forEntity(e, { defaultKind: 'group' }).promise,
+      groupEntities.items.map(async e => ({
+        entityRef: stringifyEntityRef(e),
+        presentation: await entityPresentationApi.forEntity(e, {
+          defaultKind: 'group',
+        }).promise,
+      })),
+    );
+
+    setGroupRefsByTitle(
+      new Map(
+        presentations.map(p => [p.presentation.primaryTitle, p.entityRef]),
       ),
     );
-    return presentations.map(p => p.primaryTitle).sort();
+
+    return presentations.map(p => p.presentation.primaryTitle).sort();
   });
 
   const handleResult = useCallback(
     async (data: FormData) => {
       setSubmitted(true);
+
+      const owner = resolveOwnerEntityRef(data.owner, groupRefsByTitle);
 
       try {
         const pr = await catalogImportApi.submitPullRequest({
@@ -183,7 +219,7 @@ export const StepPrepareCreatePullRequest = (
           fileContent: generateEntities(
             analyzeResult.generatedEntities,
             data.componentName,
-            data.owner,
+            owner,
           )
             .map(e => YAML.stringify(e))
             .join('---\n'),
@@ -203,7 +239,7 @@ export const StepPrepareCreatePullRequest = (
                 entities: generateEntities(
                   analyzeResult.generatedEntities,
                   data.componentName,
-                  data.owner,
+                  owner,
                 ).map(e => ({
                   kind: e.kind,
                   namespace: e.metadata.namespace!,
@@ -225,6 +261,7 @@ export const StepPrepareCreatePullRequest = (
       analyzeResult.url,
       catalogImportApi,
       onPrepare,
+      groupRefsByTitle,
     ],
   );
 
@@ -285,7 +322,7 @@ export const StepPrepareCreatePullRequest = (
                 entities={generateEntities(
                   analyzeResult.generatedEntities,
                   values.componentName,
-                  values.owner,
+                  resolveOwnerEntityRef(values.owner, groupRefsByTitle),
                 )}
                 repositoryUrl={analyzeResult.url}
                 classes={{


### PR DESCRIPTION
# fix(catalog-import): resolve owner group display title back to entity ref

## Hey, I just made a Pull Request!

Fixes #35232.

When importing a repository via the `<ImportStepper />` component's owner
autocomplete, selecting a group whose display title differs from its short
ref (e.g. a group with `metadata.title: "My Team"` or
`spec.profile.displayName` set, backing entity name `my-team`) caused the
**display title** ("My Team") to be written verbatim into the generated
`catalog-info.yaml`'s `spec.owner` field, instead of a valid entity ref
(`group:default/my-team`). This produces catalog entities with an
unresolvable owner.

This regressed in `@backstage/plugin-catalog-import@0.13.12` when the group
list generation in `StepPrepareCreatePullRequest` was switched from
`humanizeEntityRef(e, { defaultKind: 'Group' })` (which always returned a
valid ref) to the Catalog Presentation API's `primaryTitle` (which is a
human-readable label, not a machine-readable identifier), with no mapping
back from title to ref.

### What changed

- `StepPrepareCreatePullRequest` now keeps a `title -> entityRef` map
  alongside the existing list of group titles used to populate the owner
  autocomplete (the autocomplete UI and its public `AutocompleteTextField`
  API are unchanged, so this is not a breaking change).
- Before generating the PR content (`generateEntities(...)` call used both
  for the actual submission and for the live catalog-info preview shown in
  the stepper), the selected owner value is resolved through that map. If
  it matches a known group's title, the corresponding entity ref is used;
  otherwise the raw typed value is kept as-is (the field is `freeSolo`, so
  users can still type an arbitrary owner value, matching prior behavior).
- Added a changeset for `@backstage/plugin-catalog-import`.
- Added a regression test that selects a group with
  `metadata.title: 'My Team'` / `metadata.name: 'my-team'` and asserts the
  submitted `catalog-info.yaml` contains `owner: group:default/my-team`,
  not `owner: My Team`.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

This is a data-layer fix in `StepPrepareCreatePullRequest.tsx` (the value
resolution happens before YAML generation), so there is no visual change to
the stepper UI itself — the owner field still displays the same group
titles in the same autocomplete as before. I did not include a screenshot
for that reason; happy to add one of the (unchanged) UI if maintainers
would still like it.

### How I verified this

Cloned `backstage/backstage`, installed with the repo's pinned Yarn (`yarn@4.8.1`
via `.yarn/releases/yarn-4.8.1.cjs`), and ran the same checks CI runs for
changed packages:

- `yarn workspace @backstage/plugin-catalog-import test --watchAll=false`
  → `Test Suites: 14 passed, 14 total`, `Tests: 80 passed, 80 total`
  (includes the new regression test).
- `yarn workspace @backstage/plugin-catalog-import lint` → exits 0, no
  findings.
- `yarn prettier:check --cache=false <changed files>` → `All matched files
  use Prettier code style!` (after running `yarn prettier --write` on the
  two changed source files).
- `yarn tsc` (repo-root incremental typecheck) → exits 0, no errors.

I did not run the full `yarn tsc:full` / `yarn build:api-reports` /
`yarn backstage-cli repo build --all` verify-job steps locally, since they
touch/build the entire monorepo; the change doesn't add or remove any
exported symbols (only internal state and an internal helper function), so
no API report changes are expected.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes) — no visual change, see note above
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
