### PR TITLE
Fix global line-height leak in BUI

### DIFF
--- a/.changeset/calm-otters-listen.md
+++ b/.changeset/calm-otters-listen.md
@@ -1,0 +1,5 @@
+---
+'@backstage/ui': patch
+---
+
+Prevent BUI styles from overriding document and native control line heights while preserving BUI component typography.

--- a/.changeset/tidy-toasts-smile.md
+++ b/.changeset/tidy-toasts-smile.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-app': patch
+---
+
+Fixed toast text layout when the application does not define a global line height.

--- a/packages/ui/src/components/Badge/Badge.module.css
+++ b/packages/ui/src/components/Badge/Badge.module.css
@@ -25,6 +25,7 @@
     align-items: center;
     justify-content: center;
     font-weight: var(--bui-font-weight-regular);
+    line-height: 1.15;
     gap: var(--bui-space-1);
 
     &[data-on-bg='neutral-1'] {

--- a/packages/ui/src/components/Button/Button.module.css
+++ b/packages/ui/src/components/Button/Button.module.css
@@ -30,6 +30,7 @@
     user-select: none;
     font-family: var(--bui-font-regular);
     font-weight: var(--bui-font-weight-bold);
+    line-height: 1.15;
     padding: 0;
     cursor: pointer;
     border-radius: var(--bui-radius-2);

--- a/packages/ui/src/components/ButtonLink/ButtonLink.module.css
+++ b/packages/ui/src/components/ButtonLink/ButtonLink.module.css
@@ -29,6 +29,7 @@
     user-select: none;
     font-family: var(--bui-font-regular);
     font-weight: var(--bui-font-weight-bold);
+    line-height: 1.15;
     padding: 0;
     cursor: pointer;
     border-radius: var(--bui-radius-2);

--- a/packages/ui/src/components/Card/Card.module.css
+++ b/packages/ui/src/components/Card/Card.module.css
@@ -22,6 +22,7 @@
     flex-direction: column;
     border-radius: var(--bui-radius-3);
     color: var(--bui-fg-primary);
+    line-height: 1.15;
     overflow: auto;
     min-height: 0;
     width: 100%;

--- a/packages/ui/src/components/Checkbox/Checkbox.module.css
+++ b/packages/ui/src/components/Checkbox/Checkbox.module.css
@@ -25,6 +25,7 @@
     font-size: var(--bui-font-size-3);
     font-family: var(--bui-font-regular);
     font-weight: var(--bui-font-weight-regular);
+    line-height: 1.15;
     color: var(--bui-fg-primary);
     user-select: none;
     cursor: pointer;

--- a/packages/ui/src/components/Combobox/Combobox.module.css
+++ b/packages/ui/src/components/Combobox/Combobox.module.css
@@ -198,6 +198,7 @@
     cursor: pointer;
     user-select: none;
     font-size: var(--bui-font-size-3);
+    line-height: 1.15;
     outline: none;
     border-radius: var(--bui-radius-2);
 
@@ -300,6 +301,7 @@
     padding-left: var(--bui-space-3);
     color: var(--bui-fg-primary);
     font-size: var(--bui-font-size-1);
+    line-height: 1.15;
     font-weight: bold;
     letter-spacing: 0.05rem;
     text-transform: uppercase;
@@ -312,6 +314,7 @@
     font-size: var(--bui-font-size-3);
     font-family: var(--bui-font-regular);
     font-weight: var(--bui-font-weight-regular);
+    line-height: 1.15;
   }
 
   .bui-ComboboxLoading {

--- a/packages/ui/src/components/DatePicker/DatePicker.module.css
+++ b/packages/ui/src/components/DatePicker/DatePicker.module.css
@@ -122,6 +122,7 @@
     font-size: var(--bui-font-size-3);
     font-family: var(--bui-font-regular);
     font-weight: var(--bui-font-weight-regular);
+    line-height: 1.15;
     color: var(--bui-fg-primary);
     caret-color: transparent;
     outline: none;
@@ -205,6 +206,7 @@
     font-size: var(--bui-font-size-3);
     font-weight: var(--bui-font-weight-bold);
     font-family: var(--bui-font-regular);
+    line-height: 1.15;
     color: var(--bui-fg-primary);
     flex: 1;
     text-align: center;
@@ -252,6 +254,7 @@
   .bui-DatePickerCalendarHeaderCell {
     font-size: var(--bui-font-size-2);
     font-weight: var(--bui-font-weight-regular);
+    line-height: 1.15;
     color: var(--bui-fg-secondary);
     text-align: center;
     padding-bottom: var(--bui-space-2);
@@ -274,6 +277,7 @@
     cursor: default;
     font-size: var(--bui-font-size-3);
     font-family: var(--bui-font-regular);
+    line-height: 1.15;
     color: var(--bui-fg-primary);
     border-radius: var(--bui-radius-full);
 

--- a/packages/ui/src/components/DateRangePicker/DateRangePicker.module.css
+++ b/packages/ui/src/components/DateRangePicker/DateRangePicker.module.css
@@ -136,6 +136,7 @@
     font-size: var(--bui-font-size-3);
     font-family: var(--bui-font-regular);
     font-weight: var(--bui-font-weight-regular);
+    line-height: 1.15;
     color: var(--bui-fg-primary);
     caret-color: transparent;
     outline: none;
@@ -172,6 +173,7 @@
   .bui-DateRangePickerSeparator {
     color: var(--bui-fg-secondary);
     font-size: var(--bui-font-size-3);
+    line-height: 1.15;
     flex-shrink: 0;
     user-select: none;
     padding: 0 var(--bui-space-1);
@@ -231,6 +233,7 @@
     font-size: var(--bui-font-size-3);
     font-weight: var(--bui-font-weight-bold);
     font-family: var(--bui-font-regular);
+    line-height: 1.15;
     color: var(--bui-fg-primary);
     flex: 1;
     text-align: center;
@@ -278,6 +281,7 @@
   .bui-DateRangePickerCalendarHeaderCell {
     font-size: var(--bui-font-size-2);
     font-weight: var(--bui-font-weight-regular);
+    line-height: 1.15;
     color: var(--bui-fg-secondary);
     text-align: center;
     padding-bottom: var(--bui-space-2);
@@ -306,6 +310,7 @@
     cursor: default;
     font-size: var(--bui-font-size-3);
     font-family: var(--bui-font-regular);
+    line-height: 1.15;
     color: var(--bui-fg-primary);
 
     &[data-outside-month] {

--- a/packages/ui/src/components/Dialog/Dialog.module.css
+++ b/packages/ui/src/components/Dialog/Dialog.module.css
@@ -96,6 +96,7 @@
 
   .bui-DialogHeaderTitle {
     font-size: var(--bui-font-size-3);
+    line-height: 1.15;
     font-weight: var(--bui-font-weight-bold);
     margin: 0;
   }

--- a/packages/ui/src/components/FieldError/FieldError.module.css
+++ b/packages/ui/src/components/FieldError/FieldError.module.css
@@ -22,6 +22,7 @@
     color: var(--bui-fg-danger);
     font-size: var(--bui-font-size-2);
     font-weight: var(--bui-font-weight-regular);
+    line-height: 1.15;
     margin-top: var(--bui-space-2);
   }
 }

--- a/packages/ui/src/components/FieldLabel/FieldLabel.module.css
+++ b/packages/ui/src/components/FieldLabel/FieldLabel.module.css
@@ -22,6 +22,7 @@
     flex-direction: column;
     margin-bottom: var(--bui-space-3);
     gap: var(--bui-space-1);
+    line-height: 1.15;
   }
 
   .bui-FieldLabel {

--- a/packages/ui/src/components/Header/HeaderNav.module.css
+++ b/packages/ui/src/components/Header/HeaderNav.module.css
@@ -52,6 +52,7 @@
   .bui-HeaderNavGroup {
     font-family: var(--bui-font-regular);
     font-size: var(--bui-font-size-3);
+    line-height: 1.15;
     font-weight: var(--bui-font-weight-regular);
     color: var(--bui-fg-secondary);
     height: 36px;

--- a/packages/ui/src/components/List/List.module.css
+++ b/packages/ui/src/components/List/List.module.css
@@ -42,6 +42,7 @@
     border-radius: var(--bui-radius-2);
     font-size: var(--bui-font-size-3);
     font-family: var(--bui-font-regular);
+    line-height: 1.15;
     color: var(--bui-fg-primary);
     outline: none;
 

--- a/packages/ui/src/components/Menu/Menu.module.css
+++ b/packages/ui/src/components/Menu/Menu.module.css
@@ -83,6 +83,7 @@
     outline: none;
     color: var(--bui-fg-primary);
     font-size: var(--bui-font-size-3);
+    line-height: 1.15;
     gap: var(--bui-space-6);
     cursor: pointer;
     margin-inline: var(--bui-space-1);
@@ -127,6 +128,7 @@
     outline: none;
     color: var(--bui-fg-primary);
     font-size: var(--bui-font-size-3);
+    line-height: 1.15;
     cursor: pointer;
 
     &[data-focus-visible] {
@@ -198,6 +200,7 @@
     padding-left: var(--bui-space-3);
     color: var(--bui-fg-primary);
     font-size: var(--bui-font-size-1);
+    line-height: 1.15;
     font-weight: bold;
     letter-spacing: 0.05rem;
     text-transform: uppercase;
@@ -237,6 +240,7 @@
     font-size: var(--bui-font-size-3);
     font-family: var(--bui-font-regular);
     font-weight: var(--bui-font-weight-regular);
+    line-height: 1.15;
     color: var(--bui-fg-primary);
     width: 100%;
     height: 100%;
@@ -288,5 +292,6 @@
     font-size: var(--bui-font-size-3);
     font-family: var(--bui-font-regular);
     font-weight: var(--bui-font-weight-regular);
+    line-height: 1.15;
   }
 }

--- a/packages/ui/src/components/NumberField/NumberField.module.css
+++ b/packages/ui/src/components/NumberField/NumberField.module.css
@@ -99,6 +99,7 @@
     font-size: var(--bui-font-size-3);
     font-family: var(--bui-font-regular);
     font-weight: var(--bui-font-weight-regular);
+    line-height: 1.15;
     color: var(--bui-fg-primary);
     transition: box-shadow 0.2s ease-in-out;
     width: 100%;

--- a/packages/ui/src/components/PasswordField/PasswordField.module.css
+++ b/packages/ui/src/components/PasswordField/PasswordField.module.css
@@ -96,6 +96,7 @@
     font-size: var(--bui-font-size-3);
     font-family: var(--bui-font-regular);
     font-weight: var(--bui-font-weight-regular);
+    line-height: 1.15;
     color: var(--bui-fg-primary);
     transition: box-shadow 0.2s ease-in-out;
     width: 100%;

--- a/packages/ui/src/components/RadioGroup/RadioGroup.module.css
+++ b/packages/ui/src/components/RadioGroup/RadioGroup.module.css
@@ -41,6 +41,7 @@
     align-items: center;
     gap: var(--bui-space-2);
     font-size: var(--bui-font-size-2);
+    line-height: 1.15;
     color: var(--bui-fg-primary);
     forced-color-adjust: none;
     cursor: pointer;

--- a/packages/ui/src/components/SearchAutocomplete/SearchAutocomplete.module.css
+++ b/packages/ui/src/components/SearchAutocomplete/SearchAutocomplete.module.css
@@ -91,6 +91,7 @@
     font-size: var(--bui-font-size-3);
     font-family: var(--bui-font-regular);
     font-weight: var(--bui-font-weight-regular);
+    line-height: 1.15;
     color: var(--bui-fg-primary);
     width: 100%;
     height: 100%;
@@ -212,6 +213,7 @@
     cursor: default;
     color: var(--bui-fg-primary);
     font-size: var(--bui-font-size-3);
+    line-height: 1.15;
   }
 
   .bui-SearchAutocompleteLoadingState,
@@ -222,5 +224,6 @@
     font-size: var(--bui-font-size-3);
     font-family: var(--bui-font-regular);
     font-weight: var(--bui-font-weight-regular);
+    line-height: 1.15;
   }
 }

--- a/packages/ui/src/components/SearchField/SearchField.module.css
+++ b/packages/ui/src/components/SearchField/SearchField.module.css
@@ -163,6 +163,7 @@
     font-size: var(--bui-font-size-3);
     font-family: var(--bui-font-regular);
     font-weight: var(--bui-font-weight-regular);
+    line-height: 1.15;
     color: var(--bui-fg-primary);
     transition: padding 0.3s ease-in-out;
     width: 100%;

--- a/packages/ui/src/components/Select/Select.module.css
+++ b/packages/ui/src/components/Select/Select.module.css
@@ -131,6 +131,7 @@
     font-size: var(--bui-font-size-3);
     font-family: var(--bui-font-regular);
     font-weight: var(--bui-font-weight-regular);
+    line-height: 1.15;
     color: var(--bui-fg-primary);
     text-align: left;
 
@@ -173,6 +174,7 @@
     cursor: pointer;
     user-select: none;
     font-size: var(--bui-font-size-3);
+    line-height: 1.15;
     outline: none;
     border-radius: var(--bui-radius-2);
 
@@ -342,6 +344,7 @@
     padding-left: var(--bui-space-3);
     color: var(--bui-fg-primary);
     font-size: var(--bui-font-size-1);
+    line-height: 1.15;
     font-weight: bold;
     letter-spacing: 0.05rem;
     text-transform: uppercase;
@@ -354,6 +357,7 @@
     font-size: var(--bui-font-size-3);
     font-family: var(--bui-font-regular);
     font-weight: var(--bui-font-weight-regular);
+    line-height: 1.15;
   }
 
   .bui-SelectLoading {

--- a/packages/ui/src/components/Slider/Slider.module.css
+++ b/packages/ui/src/components/Slider/Slider.module.css
@@ -39,6 +39,7 @@
 
   .bui-SliderOutput {
     font-size: var(--bui-font-size-2);
+    line-height: 1.15;
     font-weight: var(--bui-font-weight-medium);
     color: var(--bui-fg-secondary);
     white-space: nowrap;

--- a/packages/ui/src/components/Switch/Switch.module.css
+++ b/packages/ui/src/components/Switch/Switch.module.css
@@ -30,6 +30,7 @@
     align-items: center;
     gap: var(--bui-space-3);
     font-size: var(--bui-font-size-3);
+    line-height: 1.15;
     color: var(--bui-fg-primary);
     cursor: pointer;
 

--- a/packages/ui/src/components/Table/Table.module.css
+++ b/packages/ui/src/components/Table/Table.module.css
@@ -60,6 +60,7 @@
     text-align: left;
     padding: var(--bui-space-3);
     font-size: var(--bui-font-size-3);
+    line-height: 1.15;
     color: var(--bui-fg-primary);
   }
 
@@ -197,6 +198,7 @@
     font-size: var(--bui-font-size-3);
     font-family: var(--bui-font-regular);
     font-weight: var(--bui-font-weight-regular);
+    line-height: 1.15;
     min-width: 0;
     overflow: hidden;
   }

--- a/packages/ui/src/components/Table/components/Table.tsx
+++ b/packages/ui/src/components/Table/components/Table.tsx
@@ -40,6 +40,7 @@ import { useMemo } from 'react';
 import { VisuallyHidden } from '../../VisuallyHidden';
 import { Flex } from '../../Flex';
 import { TableBodySkeleton } from './TableBodySkeleton';
+import { Text } from '../../Text';
 
 function isRowRenderFn<T extends TableItem>(
   rowConfig: RowConfig<T> | RowRenderFn<T> | undefined,
@@ -144,7 +145,7 @@ export function Table<T extends TableItem>({
   if (error) {
     return (
       <div className={classes.root} style={style}>
-        Error: {error.message}
+        <Text variant="body-medium">Error: {error.message}</Text>
       </div>
     );
   }

--- a/packages/ui/src/components/Tabs/Tabs.module.css
+++ b/packages/ui/src/components/Tabs/Tabs.module.css
@@ -50,6 +50,7 @@
   .bui-Tab {
     font-size: var(--bui-font-size-3);
     font-family: var(--bui-font-regular);
+    line-height: 1.15;
     font-weight: var(--bui-font-weight-regular);
     color: var(--bui-fg-secondary);
     height: 36px;

--- a/packages/ui/src/components/TagGroup/TagGroup.module.css
+++ b/packages/ui/src/components/TagGroup/TagGroup.module.css
@@ -31,6 +31,7 @@
     align-items: center;
     justify-content: center;
     font-weight: var(--bui-font-weight-regular);
+    line-height: 1.15;
     gap: var(--bui-space-1);
     transition-property: background-color, box-shadow, color;
     transition-duration: 0.2s;

--- a/packages/ui/src/components/TextField/TextField.module.css
+++ b/packages/ui/src/components/TextField/TextField.module.css
@@ -92,6 +92,7 @@
     font-size: var(--bui-font-size-3);
     font-family: var(--bui-font-regular);
     font-weight: var(--bui-font-weight-regular);
+    line-height: 1.15;
     color: var(--bui-fg-primary);
     transition: box-shadow 0.2s ease-in-out;
     width: 100%;

--- a/packages/ui/src/components/ToggleButton/ToggleButton.module.css
+++ b/packages/ui/src/components/ToggleButton/ToggleButton.module.css
@@ -29,6 +29,7 @@
     color: var(--bui-fg-primary);
     font-family: var(--bui-font-regular);
     font-weight: var(--bui-font-weight-bold);
+    line-height: 1.15;
     padding: 0 var(--bui-space-2);
     cursor: pointer;
     transition: background-color 150ms ease, box-shadow 150ms ease,

--- a/packages/ui/src/components/Tooltip/Tooltip.module.css
+++ b/packages/ui/src/components/Tooltip/Tooltip.module.css
@@ -31,6 +31,7 @@
     transition: transform 200ms, opacity 200ms;
     font-size: var(--bui-font-size-3);
     font-family: var(--bui-font-regular);
+    line-height: 1.15;
     color: var(--bui-fg-primary);
 
     &[data-entering],

--- a/packages/ui/src/css/normalize.css
+++ b/packages/ui/src/css/normalize.css
@@ -18,17 +18,15 @@ Use a better box model (opinionated).
 
   /**
 1. Improve consistency of default fonts in all browsers. (https://github.com/sindresorhus/modern-normalize/issues/3)
-2. Correct the line height in all browsers.
-3. Prevent adjustments of font size after orientation changes in iOS.
-4. Use a more readable tab size (opinionated).
+2. Prevent adjustments of font size after orientation changes in iOS.
+3. Use a more readable tab size (opinionated).
 */
 
   html {
     font-family: system-ui, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif,
       'Apple Color Emoji', 'Segoe UI Emoji'; /* 1 */
-    line-height: 1.15; /* 2 */
-    -webkit-text-size-adjust: 100%; /* 3 */
-    tab-size: 4; /* 4 */
+    -webkit-text-size-adjust: 100%; /* 2 */
+    tab-size: 4; /* 3 */
   }
 
   /*
@@ -130,7 +128,6 @@ Forms
   textarea {
     font-family: inherit; /* 1 */
     font-size: 100%; /* 1 */
-    line-height: 1.15; /* 1 */
     margin: 0; /* 2 */
   }
 

--- a/plugins/app/src/components/Toast/Toast.module.css
+++ b/plugins/app/src/components/Toast/Toast.module.css
@@ -66,6 +66,7 @@
   gap: var(--bui-space-3);
   border-radius: var(--bui-radius-3);
   font-size: var(--bui-font-size-3);
+  line-height: 1.15;
   background-color: var(--bui-bg-app);
   border: 1px solid var(--bui-border-1);
   color: var(--bui-fg-primary);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

The modified normalize stylesheet in BUI globally set `line-height: 1.15` on the document and native form controls. This affected unrelated UI systems whenever BUI styles were loaded.

This removes those global line-height declarations and explicitly preserves the existing line height on affected BUI components. Other normalize behavior remains unchanged.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))