### PR TITLE
feat(scaffolder): add inline template dry run permission

### DIFF
--- a/.changeset/calm-inline-templates.md
+++ b/.changeset/calm-inline-templates.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-common': minor
+---
+
+Added `templateDryRunPermission`, which allows permission policies to control who can submit inline Software Template dry runs.

--- a/.changeset/quiet-dry-runs.md
+++ b/.changeset/quiet-dry-runs.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': minor
+---
+
+Applied `templateDryRunPermission` to inline Software Template dry runs and the corresponding backend action. Permission policies that deny unknown permissions must explicitly allow `scaffolder.template.dry-run` to retain existing dry-run access.

--- a/docs/features/software-templates/authorizing-scaffolder-template-details.md
+++ b/docs/features/software-templates/authorizing-scaffolder-template-details.md
@@ -12,6 +12,53 @@ To better understand the following examples make sure to review the [Writing a p
 
 :::
 
+## Authorizing inline template dry runs
+
+The `templateDryRunPermission` permission controls who can submit inline
+Software Template dry runs. It applies to both the `/v2/dry-run` endpoint and
+the `scaffolder:dry-run-template` backend action.
+
+Use this permission when only selected users or services should be able to
+submit inline templates. Direct dry-run requests also require
+`taskCreatePermission`, and the backend action calls the same endpoint with the
+caller's credentials. The `actionExecutePermission` permission still
+authorizes each action that a dry run executes.
+
+For example, the following policy allows only the user `alice` to submit
+inline template dry runs:
+
+```ts title="packages/backend/src/plugins/permission.ts"
+import { templateDryRunPermission } from '@backstage/plugin-scaffolder-common/alpha';
+import {
+  AuthorizeResult,
+  isPermission,
+  PolicyDecision,
+} from '@backstage/plugin-permission-common';
+import {
+  PermissionPolicy,
+  PolicyQuery,
+  PolicyQueryUser,
+} from '@backstage/plugin-permission-node';
+
+class ExamplePermissionPolicy implements PermissionPolicy {
+  async handle(
+    request: PolicyQuery,
+    user?: PolicyQueryUser,
+  ): Promise<PolicyDecision> {
+    if (isPermission(request.permission, templateDryRunPermission)) {
+      return {
+        result:
+          user?.info.userEntityRef === 'user:default/alice'
+            ? AuthorizeResult.ALLOW
+            : AuthorizeResult.DENY,
+      };
+    }
+
+    return { result: AuthorizeResult.ALLOW };
+  }
+}
+```
+
 ## Authorizing parameters and steps
 
 To mark specific parameters or steps as requiring permission, add the `backstage:permissions` property to the parameter or step with one or more tags. For example:

--- a/plugins/scaffolder-backend/src/actions/createDryRunTemplateAction.test.ts
+++ b/plugins/scaffolder-backend/src/actions/createDryRunTemplateAction.test.ts
@@ -61,6 +61,20 @@ describe('createDryRunTemplateAction', () => {
     jest.resetAllMocks();
   });
 
+  it('requires dry-run permission for action visibility', () => {
+    const mockActionsRegistry = actionsRegistryServiceMock();
+
+    createDryRunTemplateAction({
+      actionsRegistry: mockActionsRegistry,
+      scaffolderService: mockScaffolderService,
+    });
+
+    expect(
+      mockActionsRegistry.actions.get('test:dry-run-template')
+        ?.visibilityPermission?.name,
+    ).toBe('scaffolder.template.dry-run');
+  });
+
   it('should return success with logs when dry-run succeeds', async () => {
     const mockActionsRegistry = actionsRegistryServiceMock();
     const dryRunResult = {

--- a/plugins/scaffolder-backend/src/actions/createDryRunTemplateAction.ts
+++ b/plugins/scaffolder-backend/src/actions/createDryRunTemplateAction.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { ActionsRegistryService } from '@backstage/backend-plugin-api/alpha';
+import { templateDryRunPermission } from '@backstage/plugin-scaffolder-common/alpha';
 import { ScaffolderService } from '@backstage/plugin-scaffolder-node';
 import { JsonObject } from '@backstage/types';
 import yaml from 'yaml';
@@ -44,6 +45,7 @@ export const createDryRunTemplateAction = ({
     },
     description:
       'Dry-runs a scaffolder template to validate it without making changes. Returns success with execution logs, or errors for validation failures.',
+    visibilityPermission: templateDryRunPermission,
     schema: {
       input: z =>
         z.object({

--- a/plugins/scaffolder-backend/src/service/router.test.ts
+++ b/plugins/scaffolder-backend/src/service/router.test.ts
@@ -1648,6 +1648,34 @@ data: {"id":1,"taskId":"a-random-id","type":"completion","createdAt":"","body":{
   });
 
   describe('POST /v2/dry-run', () => {
+    it('rejects dry runs without dry-run permission', async () => {
+      const { unwrappedRouter, permissions } = await createTestRouter();
+      const mockToken = mockCredentials.user.token();
+
+      jest.spyOn(permissions, 'authorize').mockImplementation(async requests =>
+        requests.map(permissionRequest => ({
+          result:
+            permissionRequest.permission.name === 'scaffolder.template.dry-run'
+              ? AuthorizeResult.DENY
+              : AuthorizeResult.ALLOW,
+        })),
+      );
+
+      const response = await request(unwrappedRouter)
+        .post('/v2/dry-run')
+        .set('Authorization', `Bearer ${mockToken}`)
+        .send({
+          template: generateMockTemplate(),
+          values: {
+            requiredParameter1: 'required-value-1',
+            requiredParameter2: 'required-value-2',
+          },
+          directoryContents: [],
+        });
+
+      expect(response.status).toEqual(403);
+    });
+
     it('should get user entity', async () => {
       const { router, catalog } = await createTestRouter();
       const mockToken = mockCredentials.user.token();

--- a/plugins/scaffolder-backend/src/service/router.ts
+++ b/plugins/scaffolder-backend/src/service/router.ts
@@ -59,6 +59,7 @@ import {
   taskCancelPermission,
   taskCreatePermission,
   taskReadPermission,
+  templateDryRunPermission,
   templateManagementPermission,
   templateParameterReadPermission,
   templateStepReadPermission,
@@ -439,6 +440,7 @@ export async function createRouter(
 
   permissionsRegistry.addPermissions([
     taskCreatePermission,
+    templateDryRunPermission,
     templateManagementPermission,
   ]);
 
@@ -1009,7 +1011,7 @@ export async function createRouter(
         const credentials = await httpAuth.credentials(req);
         await checkPermission({
           credentials,
-          permissions: [taskCreatePermission],
+          permissions: [taskCreatePermission, templateDryRunPermission],
           permissionService: permissions,
         });
 

--- a/plugins/scaffolder-common/report-alpha.api.md
+++ b/plugins/scaffolder-common/report-alpha.api.md
@@ -52,6 +52,9 @@ export const taskCreatePermission: BasicPermission;
 export const taskReadPermission: ResourcePermission<'scaffolder-task'>;
 
 // @alpha
+export const templateDryRunPermission: BasicPermission;
+
+// @alpha
 export const templateManagementPermission: BasicPermission;
 
 // @alpha

--- a/plugins/scaffolder-common/src/permissions.ts
+++ b/plugins/scaffolder-common/src/permissions.ts
@@ -86,6 +86,17 @@ export const templateStepReadPermission = createPermission({
 });
 
 /**
+ * This permission is used to authorize dry runs of inline scaffolder
+ * templates.
+ *
+ * @alpha
+ */
+export const templateDryRunPermission = createPermission({
+  name: 'scaffolder.template.dry-run',
+  attributes: {},
+});
+
+/**
  * This permission is used to authorize actions that involve reading one or more tasks in the scaffolder,
  * and reading logs of tasks
  *
@@ -165,5 +176,6 @@ export const scaffolderPermissions = [
   ...scaffolderTemplatePermissions,
   ...scaffolderActionPermissions,
   ...scaffolderTaskPermissions,
+  templateDryRunPermission,
   templateManagementPermission,
 ];


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds a dedicated permission for inline Software Template dry runs and applies it consistently to the direct Scaffolder API and the corresponding backend action.

Permission policies can use `scaffolder.template.dry-run` to restrict dry-run access. The permission is checked before parsing caller-supplied inline template content. Direct dry-run requests continue to require `scaffolder.task.create`, and each executed step continues to use its existing action permission.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes) — not applicable; no UI changes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
