### PR TITLE
Improve Harness URL reader redirect handling

### DIFF
--- a/.changeset/calm-harness-redirects.md
+++ b/.changeset/calm-harness-redirects.md
@@ -1,0 +1,6 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Updated Harness URL reading to validate cross-origin redirect destinations
+against `backend.reading.allow`.

--- a/docs/integrations/harness/locations.md
+++ b/docs/integrations/harness/locations.md
@@ -31,3 +31,7 @@ check out <https://developer.harness.io/docs/platform/automation/api/add-and-man
 - `host`: The host of the Harness Code instance that you want to match on.
 - `token` (optional): The password or api token to authenticate with.
 - `apiKey` (optional): The API key to authenticate with.
+
+Harness requests follow redirects that remain on the configured Harness origin.
+Cross-origin redirects are followed only when the destination is allowed by
+`backend.reading.allow`.

--- a/packages/backend-defaults/report-urlReader.api.md
+++ b/packages/backend-defaults/report-urlReader.api.md
@@ -354,6 +354,7 @@ export class HarnessUrlReader implements UrlReaderService {
     integration: HarnessIntegration,
     deps: {
       treeResponseFactory: ReadTreeResponseFactory;
+      allowedRedirectPredicate?: (url: URL) => boolean;
     },
   );
   // (undocumented)

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/FetchUrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/FetchUrlReader.ts
@@ -66,7 +66,7 @@ const parsePortPredicate = (port: string | undefined) => {
   return (url: URL) => !url.port;
 };
 
-function predicateFromConfig(config: Config): (url: URL) => boolean {
+export function predicateFromConfig(config: Config): (url: URL) => boolean {
   const allow = config
     .getOptionalConfigArray('backend.reading.allow')
     ?.map(allowConfig => {

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/HarnessUrlReader.test.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/HarnessUrlReader.test.ts
@@ -287,6 +287,124 @@ describe('HarnessUrlReader', () => {
       },
     );
 
+    it('allows direct consumers to provide a cross-origin redirect predicate', async () => {
+      let receivedApiKey: string | null = null;
+      worker.use(
+        http.get(
+          'https://app.harness.io/gateway/code/api/v1/repos/accountId/orgName/projName/repoName/:path+/raw/direct-redirect.yaml',
+          () =>
+            new HttpResponse(null, {
+              status: 302,
+              headers: {
+                location: 'https://downloads.example.com/direct-target.yaml',
+              },
+            }),
+        ),
+        http.get(
+          'https://downloads.example.com/direct-target.yaml',
+          ({ request }) => {
+            receivedApiKey = request.headers.get('x-api-key');
+            return new HttpResponse('redirected content', { status: 200 });
+          },
+        ),
+      );
+
+      const reader = new HarnessUrlReader(
+        new HarnessIntegration(
+          readHarnessConfig(
+            new ConfigReader({
+              host: 'app.harness.io',
+              apiKey: 'harness-api-key',
+            }),
+          ),
+        ),
+        {
+          treeResponseFactory,
+          allowedRedirectPredicate: url =>
+            url.hostname === 'downloads.example.com',
+        },
+      );
+
+      const response = await reader.readUrl(
+        'https://app.harness.io/ng/account/accountId/module/code/orgs/orgName/projects/projName/repos/repoName/files/refMain/~/direct-redirect.yaml',
+      );
+
+      expect((await response.buffer()).toString()).toBe('redirected content');
+      expect(receivedApiKey).toBeNull();
+    });
+
+    it.each([
+      {
+        authType: 'API key',
+        integrationAuth: { apiKey: 'harness-api-key' },
+        sourceHeader: 'x-api-key',
+        sourceValue: 'harness-api-key',
+      },
+      {
+        authType: 'token',
+        integrationAuth: { token: 'harness-token' },
+        sourceHeader: 'authorization',
+        sourceValue: 'Bearer harness-token',
+      },
+    ])(
+      'does not restore $authType after a redirect chain leaves the Harness origin',
+      async ({ integrationAuth, sourceHeader, sourceValue }) => {
+        let receivedSourceHeader: string | null = null;
+        let receivedExternalHeader: string | null = null;
+        let receivedReturnedHeader: string | null = null;
+        worker.use(
+          http.get(
+            'https://app.harness.io/gateway/code/api/v1/repos/accountId/orgName/projName/repoName/:path+/raw/out-and-back.yaml',
+            ({ request }) => {
+              receivedSourceHeader = request.headers.get(sourceHeader);
+              return new HttpResponse(null, {
+                status: 302,
+                headers: {
+                  location: 'https://downloads.example.com/redirect-hop',
+                },
+              });
+            },
+          ),
+          http.get(
+            'https://downloads.example.com/redirect-hop',
+            ({ request }) => {
+              receivedExternalHeader = request.headers.get(sourceHeader);
+              return new HttpResponse(null, {
+                status: 302,
+                headers: {
+                  location: 'https://app.harness.io/redirect-target',
+                },
+              });
+            },
+          ),
+          http.get('https://app.harness.io/redirect-target', ({ request }) => {
+            receivedReturnedHeader = request.headers.get(sourceHeader);
+            return new HttpResponse('redirected content', { status: 200 });
+          }),
+        );
+
+        const [{ reader }] = createReader({
+          integrations: {
+            harness: [{ host: 'app.harness.io', ...integrationAuth }],
+          },
+          backend: {
+            reading: {
+              allow: [{ host: 'downloads.example.com' }],
+            },
+          },
+        });
+
+        const response = await reader.readUrl(
+          'https://app.harness.io/ng/account/accountId/module/code/orgs/orgName/projects/projName/repos/repoName/files/refMain/~/out-and-back.yaml',
+        );
+
+        expect((await response.buffer()).toString()).toBe('redirected content');
+        expect(receivedSourceHeader).toBe(sourceValue);
+        expect(receivedExternalHeader).toBeNull();
+        expect(receivedReturnedHeader).toBeNull();
+      },
+    );
+
     it('follows at most five same-origin redirects', async () => {
       worker.use(
         http.get(

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/HarnessUrlReader.test.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/HarnessUrlReader.test.ts
@@ -47,6 +47,18 @@ const harnessProcessor = new HarnessUrlReader(
   { treeResponseFactory },
 );
 
+const apiKeyHarnessProcessor = new HarnessUrlReader(
+  new HarnessIntegration(
+    readHarnessConfig(
+      new ConfigReader({
+        host: 'app.harness.io',
+        apiKey: 'harness-api-key',
+      }),
+    ),
+  ),
+  { treeResponseFactory },
+);
+
 const createReader = (config: JsonObject): UrlReaderPredicateTuple[] => {
   return HarnessUrlReader.factory({
     config: new ConfigReader(config),
@@ -151,6 +163,181 @@ describe('HarnessUrlReader', () => {
   });
 
   describe('readUrl part 1', () => {
+    it('rejects non-allowlisted cross-origin redirects at any hop', async () => {
+      let receivedApiKey: string | null = null;
+      worker.use(
+        http.get(
+          'https://app.harness.io/gateway/code/api/v1/repos/accountId/orgName/projName/repoName/:path+/raw/redirect.yaml',
+          () =>
+            new HttpResponse(null, {
+              status: 302,
+              headers: { location: '/redirect-hop' },
+            }),
+        ),
+        http.get(
+          'https://app.harness.io/redirect-hop',
+          () =>
+            new HttpResponse(null, {
+              status: 302,
+              headers: { location: 'https://redirect.example/target' },
+            }),
+        ),
+        http.get('https://redirect.example/target', ({ request }) => {
+          receivedApiKey = request.headers.get('x-api-key');
+          return new HttpResponse('redirected content', { status: 200 });
+        }),
+      );
+
+      await expect(
+        apiKeyHarnessProcessor.readUrl(
+          'https://app.harness.io/ng/account/accountId/module/code/orgs/orgName/projects/projName/repos/repoName/files/refMain/~/redirect.yaml',
+        ),
+      ).rejects.toThrow('Refusing to follow cross-origin Harness redirect');
+      expect(receivedApiKey).toBeNull();
+    });
+
+    it('follows same-origin redirects with the API key', async () => {
+      let receivedApiKey: string | null = null;
+      worker.use(
+        http.get(
+          'https://app.harness.io/gateway/code/api/v1/repos/accountId/orgName/projName/repoName/:path+/raw/same-origin-redirect.yaml',
+          () =>
+            new HttpResponse(null, {
+              status: 302,
+              headers: { location: '/redirect-target' },
+            }),
+        ),
+        http.get('https://app.harness.io/redirect-target', ({ request }) => {
+          receivedApiKey = request.headers.get('x-api-key');
+          return new HttpResponse('redirected content', { status: 200 });
+        }),
+      );
+
+      const response = await apiKeyHarnessProcessor.readUrl(
+        'https://app.harness.io/ng/account/accountId/module/code/orgs/orgName/projects/projName/repos/repoName/files/refMain/~/same-origin-redirect.yaml',
+      );
+
+      expect((await response.buffer()).toString()).toBe('redirected content');
+      expect(receivedApiKey).toBe('harness-api-key');
+    });
+
+    it.each([
+      {
+        authType: 'API key',
+        integrationAuth: { apiKey: 'harness-api-key' },
+        sourceHeader: 'x-api-key',
+        sourceValue: 'harness-api-key',
+      },
+      {
+        authType: 'token',
+        integrationAuth: { token: 'harness-token' },
+        sourceHeader: 'authorization',
+        sourceValue: 'Bearer harness-token',
+      },
+    ])(
+      'follows allowlisted cross-origin redirects with origin-scoped $authType request options',
+      async ({ integrationAuth, sourceHeader, sourceValue }) => {
+        let receivedSourceHeader: string | null = null;
+        let receivedTargetApiKey: string | null = null;
+        let receivedTargetAuthorization: string | null = null;
+        worker.use(
+          http.get(
+            'https://app.harness.io/gateway/code/api/v1/repos/accountId/orgName/projName/repoName/:path+/raw/allowlisted-redirect.yaml',
+            ({ request }) => {
+              receivedSourceHeader = request.headers.get(sourceHeader);
+              return new HttpResponse(null, {
+                status: 302,
+                headers: {
+                  location:
+                    'https://downloads.example.com/allowlisted-target.yaml',
+                },
+              });
+            },
+          ),
+          http.get(
+            'https://downloads.example.com/allowlisted-target.yaml',
+            ({ request }) => {
+              receivedTargetApiKey = request.headers.get('x-api-key');
+              receivedTargetAuthorization =
+                request.headers.get('authorization');
+              return new HttpResponse('redirected content', { status: 200 });
+            },
+          ),
+        );
+
+        const [{ reader }] = createReader({
+          integrations: {
+            harness: [{ host: 'app.harness.io', ...integrationAuth }],
+          },
+          backend: {
+            reading: {
+              allow: [{ host: 'downloads.example.com' }],
+            },
+          },
+        });
+
+        const response = await reader.readUrl(
+          'https://app.harness.io/ng/account/accountId/module/code/orgs/orgName/projects/projName/repos/repoName/files/refMain/~/allowlisted-redirect.yaml',
+        );
+
+        expect((await response.buffer()).toString()).toBe('redirected content');
+        expect(receivedSourceHeader).toBe(sourceValue);
+        expect(receivedTargetApiKey).toBeNull();
+        expect(receivedTargetAuthorization).toBeNull();
+      },
+    );
+
+    it('follows at most five same-origin redirects', async () => {
+      worker.use(
+        http.get(
+          'https://app.harness.io/gateway/code/api/v1/repos/accountId/orgName/projName/repoName/:path+/raw/five-redirects.yaml',
+          () =>
+            new HttpResponse(null, {
+              status: 302,
+              headers: { location: '/five-redirects/1' },
+            }),
+        ),
+        http.get('https://app.harness.io/five-redirects/:hop', ({ params }) => {
+          const hop = Number(params.hop);
+          return hop === 5
+            ? new HttpResponse('redirected content', { status: 200 })
+            : new HttpResponse(null, {
+                status: 302,
+                headers: { location: `/five-redirects/${hop + 1}` },
+              });
+        }),
+        http.get(
+          'https://app.harness.io/gateway/code/api/v1/repos/accountId/orgName/projName/repoName/:path+/raw/too-many-redirects.yaml',
+          () =>
+            new HttpResponse(null, {
+              status: 302,
+              headers: { location: '/too-many-redirects/1' },
+            }),
+        ),
+        http.get(
+          'https://app.harness.io/too-many-redirects/:hop',
+          ({ params }) => {
+            const hop = Number(params.hop);
+            return new HttpResponse(null, {
+              status: 302,
+              headers: { location: `/too-many-redirects/${hop + 1}` },
+            });
+          },
+        ),
+      );
+
+      const response = await apiKeyHarnessProcessor.readUrl(
+        'https://app.harness.io/ng/account/accountId/module/code/orgs/orgName/projects/projName/repos/repoName/files/refMain/~/five-redirects.yaml',
+      );
+      expect((await response.buffer()).toString()).toBe('redirected content');
+
+      await expect(
+        apiKeyHarnessProcessor.readUrl(
+          'https://app.harness.io/ng/account/accountId/module/code/orgs/orgName/projects/projName/repos/repoName/files/refMain/~/too-many-redirects.yaml',
+        ),
+      ).rejects.toThrow('Too many redirects (max 5)');
+    });
+
     it('should be able to read file contents as buffer', async () => {
       const result = await harnessProcessor.readUrl(
         'https://app.harness.io/ng/account/accountId/module/code/orgs/orgName/projects/projName/repos/repoName/files/refMain/~/buffer.TXT',
@@ -192,6 +379,71 @@ describe('HarnessUrlReader', () => {
     const repoBuffer = fs.readFileSync(
       path.resolve(__dirname, '__fixtures__/mock-main.zip'),
     );
+
+    it('rejects cross-origin redirects while reading the latest commit', async () => {
+      let receivedApiKey: string | null = null;
+      worker.use(
+        http.get(
+          'https://app.harness.io/gateway/code/api/v1/repos/accountId/orgName4/projectName/repoName/:path+/content',
+          () =>
+            new HttpResponse(null, {
+              status: 302,
+              headers: { location: 'https://redirect.example/commit' },
+            }),
+        ),
+        http.get('https://redirect.example/commit', ({ request }) => {
+          receivedApiKey = request.headers.get('x-api-key');
+          return HttpResponse.json({ latest_commit: { sha: commitHash } });
+        }),
+        http.get(
+          'https://app.harness.io/gateway/code/api/v1/repos/accountId/orgName4/projectName/repoName/:path+/archive/branchName.zip',
+          () =>
+            new HttpResponse(new Uint8Array(repoBuffer), {
+              status: 200,
+              headers: { 'Content-Type': 'application/gzip' },
+            }),
+        ),
+      );
+
+      await expect(
+        apiKeyHarnessProcessor.readTree(
+          'https://app.harness.io/ng/account/accountId/module/code/orgs/orgName4/projects/projectName/repos/repoName/files/branchName',
+        ),
+      ).rejects.toThrow('Refusing to follow cross-origin Harness redirect');
+      expect(receivedApiKey).toBeNull();
+    });
+
+    it('rejects cross-origin redirects while reading the archive', async () => {
+      let receivedApiKey: string | null = null;
+      worker.use(
+        http.get(
+          'https://app.harness.io/gateway/code/api/v1/repos/accountId/orgName5/projectName/repoName/:path+/content',
+          () => HttpResponse.json({ latest_commit: { sha: commitHash } }),
+        ),
+        http.get(
+          'https://app.harness.io/gateway/code/api/v1/repos/accountId/orgName5/projectName/repoName/:path+/archive/branchName.zip',
+          () =>
+            new HttpResponse(null, {
+              status: 302,
+              headers: { location: 'https://redirect.example/archive' },
+            }),
+        ),
+        http.get('https://redirect.example/archive', ({ request }) => {
+          receivedApiKey = request.headers.get('x-api-key');
+          return new HttpResponse(new Uint8Array(repoBuffer), {
+            status: 200,
+            headers: { 'Content-Type': 'application/gzip' },
+          });
+        }),
+      );
+
+      await expect(
+        apiKeyHarnessProcessor.readTree(
+          'https://app.harness.io/ng/account/accountId/module/code/orgs/orgName5/projects/projectName/repos/repoName/files/branchName',
+        ),
+      ).rejects.toThrow('Refusing to follow cross-origin Harness redirect');
+      expect(receivedApiKey).toBeNull();
+    });
 
     it('should be able to get archive', async () => {
       worker.use(

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/HarnessUrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/HarnessUrlReader.ts
@@ -42,6 +42,10 @@ import {
   NotModifiedError,
 } from '@backstage/errors';
 import { Readable } from 'node:stream';
+import { predicateFromConfig } from './FetchUrlReader';
+
+const REDIRECT_STATUS_CODES = [301, 302, 303, 307, 308];
+const MAX_REDIRECTS = 5;
 
 /**
  * Implements a {@link @backstage/backend-plugin-api#UrlReaderService} for the Harness code v1 api.
@@ -51,12 +55,14 @@ import { Readable } from 'node:stream';
  */
 export class HarnessUrlReader implements UrlReaderService {
   static factory: ReaderFactory = ({ config, treeResponseFactory }) => {
+    const allowedRedirectPredicate = predicateFromConfig(config);
     return ScmIntegrations.fromConfig(config)
       .harness.list()
       .map(integration => {
         const reader = new HarnessUrlReader(integration, {
           treeResponseFactory,
         });
+        reader.allowedRedirectPredicate = allowedRedirectPredicate;
         const predicate = (url: URL) => {
           return url.host === integration.config.host;
         };
@@ -68,6 +74,7 @@ export class HarnessUrlReader implements UrlReaderService {
   private readonly deps: {
     treeResponseFactory: ReadTreeResponseFactory;
   };
+  private allowedRedirectPredicate: (url: URL) => boolean = () => false;
 
   constructor(
     integration: HarnessIntegration,
@@ -87,18 +94,8 @@ export class HarnessUrlReader implements UrlReaderService {
     url: string,
     options?: UrlReaderServiceReadUrlOptions,
   ): Promise<UrlReaderServiceReadUrlResponse> {
-    let response: Response;
     const blobUrl = getHarnessFileContentsUrl(this.integration.config, url);
-
-    try {
-      response = await fetch(blobUrl, {
-        method: 'GET',
-        ...getHarnessRequestOptions(this.integration.config),
-        signal: options?.signal as any,
-      });
-    } catch (e) {
-      throw new Error(`Unable to read ${blobUrl}, ${e}`);
-    }
+    const response = await this.fetchUrl(blobUrl, options?.signal);
 
     if (response.ok) {
       // Harness Code returns the raw content object
@@ -143,16 +140,7 @@ export class HarnessUrlReader implements UrlReaderService {
 
     const archiveUri = getHarnessArchiveUrl(this.integration.config, url);
 
-    let response: Response;
-    try {
-      response = await fetch(archiveUri, {
-        method: 'GET',
-        ...getHarnessRequestOptions(this.integration.config),
-        signal: options?.signal as any,
-      });
-    } catch (e) {
-      throw new Error(`Unable to read ${archiveUri}, ${e}`);
-    }
+    const response = await this.fetchUrl(archiveUri, options?.signal);
 
     const parsedUri = parseHarnessUrl(this.integration.config, url);
 
@@ -205,13 +193,69 @@ export class HarnessUrlReader implements UrlReaderService {
       this.integration.config.token || this.integration.config.apiKey,
     )}}`;
   }
+
+  private async fetchUrl(url: string, signal?: AbortSignal): Promise<Response> {
+    const configuredOrigin = new URL(`https://${this.integration.config.host}`)
+      .origin;
+    let currentUrl = url;
+
+    for (let redirectCount = 0; ; redirectCount += 1) {
+      const currentUrlObject = new URL(currentUrl);
+      const requestOptions =
+        currentUrlObject.origin === configuredOrigin
+          ? getHarnessRequestOptions(this.integration.config)
+          : {};
+      let response: Response;
+      try {
+        response = await fetch(currentUrl, {
+          method: 'GET',
+          ...requestOptions,
+          redirect: 'manual',
+          signal: signal as any,
+        });
+      } catch (e) {
+        throw new Error(`Unable to read ${currentUrl}, ${e}`);
+      }
+
+      const location = response.headers.get('location');
+      if (!REDIRECT_STATUS_CODES.includes(response.status) || !location) {
+        return response;
+      }
+
+      response.body.resume();
+
+      let redirectUrl: URL;
+      try {
+        redirectUrl = new URL(location, currentUrl);
+      } catch (e) {
+        throw new Error(
+          `Unable to read ${currentUrl}, invalid redirect URL ${location}, ${e}`,
+        );
+      }
+
+      if (
+        redirectUrl.origin !== configuredOrigin &&
+        !this.allowedRedirectPredicate(redirectUrl)
+      ) {
+        throw new Error(
+          `Refusing to follow cross-origin Harness redirect to ${redirectUrl.origin}`,
+        );
+      }
+
+      if (redirectCount === MAX_REDIRECTS) {
+        throw new Error(
+          `Too many redirects (max ${MAX_REDIRECTS}) when reading ${url}`,
+        );
+      }
+
+      currentUrl = redirectUrl.toString();
+    }
+  }
+
   private async getLastCommitHash(url: string): Promise<string> {
     const commitUri = getHarnessLatestCommitUrl(this.integration.config, url);
 
-    const response = await fetch(
-      commitUri,
-      getHarnessRequestOptions(this.integration.config),
-    );
+    const response = await this.fetchUrl(commitUri);
     if (!response.ok) {
       const message = `Failed to retrieve latest commit information from ${commitUri}, ${response.status} ${response.statusText}`;
       if (response.status === 404) {

--- a/packages/backend-defaults/src/entrypoints/urlReader/lib/HarnessUrlReader.ts
+++ b/packages/backend-defaults/src/entrypoints/urlReader/lib/HarnessUrlReader.ts
@@ -61,8 +61,8 @@ export class HarnessUrlReader implements UrlReaderService {
       .map(integration => {
         const reader = new HarnessUrlReader(integration, {
           treeResponseFactory,
+          allowedRedirectPredicate,
         });
-        reader.allowedRedirectPredicate = allowedRedirectPredicate;
         const predicate = (url: URL) => {
           return url.host === integration.config.host;
         };
@@ -73,17 +73,21 @@ export class HarnessUrlReader implements UrlReaderService {
   private readonly integration: HarnessIntegration;
   private readonly deps: {
     treeResponseFactory: ReadTreeResponseFactory;
+    allowedRedirectPredicate?: (url: URL) => boolean;
   };
-  private allowedRedirectPredicate: (url: URL) => boolean = () => false;
+  private readonly allowedRedirectPredicate: (url: URL) => boolean;
 
   constructor(
     integration: HarnessIntegration,
     deps: {
       treeResponseFactory: ReadTreeResponseFactory;
+      allowedRedirectPredicate?: (url: URL) => boolean;
     },
   ) {
     this.integration = integration;
     this.deps = deps;
+    this.allowedRedirectPredicate =
+      deps.allowedRedirectPredicate ?? (() => false);
   }
   async read(url: string): Promise<Buffer> {
     const response = await this.readUrl(url);
@@ -198,11 +202,12 @@ export class HarnessUrlReader implements UrlReaderService {
     const configuredOrigin = new URL(`https://${this.integration.config.host}`)
       .origin;
     let currentUrl = url;
+    let includeCredentials = true;
 
     for (let redirectCount = 0; ; redirectCount += 1) {
       const currentUrlObject = new URL(currentUrl);
       const requestOptions =
-        currentUrlObject.origin === configuredOrigin
+        includeCredentials && currentUrlObject.origin === configuredOrigin
           ? getHarnessRequestOptions(this.integration.config)
           : {};
       let response: Response;
@@ -240,6 +245,10 @@ export class HarnessUrlReader implements UrlReaderService {
         throw new Error(
           `Refusing to follow cross-origin Harness redirect to ${redirectUrl.origin}`,
         );
+      }
+
+      if (redirectUrl.origin !== configuredOrigin) {
+        includeCredentials = false;
       }
 
       if (redirectCount === MAX_REDIRECTS) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This updates the Harness URL reader to handle redirects explicitly. Redirects
that stay on the configured Harness origin continue normally, while
cross-origin destinations must match `backend.reading.allow`.

Redirect processing is shared by file, archive, and latest-commit requests and
includes a fixed redirect limit.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
