### PR TITLE
feat(connections): support find without authMethods

### DIFF
--- a/.changeset/connections-optional-auth-methods.md
+++ b/.changeset/connections-optional-auth-methods.md
@@ -1,0 +1,5 @@
+---
+'@backstage/connections': patch
+---
+
+Added support for calling `find` without `authMethods`, which returns connection info (type, title, and config fields) without any auth data. This is useful for consumers that only need connection metadata like API base URLs and don't handle authentication themselves.

--- a/packages/backend-app-api/src/wiring/withDeclaredConnections.ts
+++ b/packages/backend-app-api/src/wiring/withDeclaredConnections.ts
@@ -32,9 +32,9 @@ export function withDeclaredConnections(
     }
   };
   return {
-    async find(options) {
+    async find(options: Parameters<ConnectionsService['find']>[0]) {
       assertDeclared(options.type);
       return service.find(options);
     },
-  };
+  } as ConnectionsService;
 }

--- a/packages/connections-node/src/DefaultConnectionsService.test.ts
+++ b/packages/connections-node/src/DefaultConnectionsService.test.ts
@@ -1158,6 +1158,121 @@ describe('DefaultConnectionsService', () => {
     });
   });
 
+  describe('find without authMethods', () => {
+    it('returns connection info without auth when authMethods is omitted', async () => {
+      const service = DefaultConnectionsService.create({
+        logger: mockServices.logger.mock(),
+        config: mockConnectionsConfig([
+          {
+            type: 'github',
+            host: 'github.com',
+            auth: [{ method: 'token', token: 'secret-token' }],
+          },
+        ]),
+      });
+
+      const info = await service.forPlugin('catalog').find({
+        type: 'github',
+        query: { url: 'https://github.com/my-org/my-repo' },
+      });
+
+      expect(info.type).toBe('github');
+      expect(info.host).toBe('github.com');
+      expect(info.title).toBe('GitHub');
+      expect('auth' in info).toBe(false);
+    });
+
+    it('succeeds even when the plugin has no visible auth methods', async () => {
+      const service = DefaultConnectionsService.create({
+        logger: mockServices.logger.mock(),
+        config: mockConnectionsConfig([
+          {
+            type: 'github',
+            host: 'github.com',
+            auth: [
+              {
+                method: 'token',
+                token: 'scaffolder-only',
+                match: { plugins: ['scaffolder'] },
+              },
+            ],
+          },
+        ]),
+      });
+
+      const info = await service.forPlugin('catalog').find({
+        type: 'github',
+        query: { url: 'https://github.com/foo' },
+      });
+
+      expect(info.host).toBe('github.com');
+      expect('auth' in info).toBe(false);
+    });
+
+    it('throws NotFoundError when no connection matches', async () => {
+      const service = DefaultConnectionsService.create({
+        logger: mockServices.logger.mock(),
+        config: mockConnectionsConfig([
+          {
+            type: 'github',
+            host: 'github.com',
+            auth: [{ method: 'token', token: 'abc' }],
+          },
+        ]),
+      });
+
+      await expect(
+        service.forPlugin('catalog').find({
+          type: 'github',
+          query: { url: 'https://missing.example.com/foo' },
+        }),
+      ).rejects.toThrow(/Connection not found/);
+    });
+
+    it('still respects connection-level plugin matching', async () => {
+      const service = DefaultConnectionsService.create({
+        logger: mockServices.logger.mock(),
+        config: mockConnectionsConfig([
+          {
+            type: 'github',
+            host: 'enterprise.example.com',
+            match: { plugins: ['scaffolder'] },
+            auth: [{ method: 'token', token: 'enterprise-token' }],
+          },
+        ]),
+      });
+
+      await expect(
+        service.forPlugin('catalog').find({
+          type: 'github',
+          query: { url: 'https://enterprise.example.com/foo' },
+        }),
+      ).rejects.toThrow(/Connection not found/);
+    });
+
+    it('returns config fields for aws connections without auth', async () => {
+      const service = DefaultConnectionsService.create({
+        logger: mockServices.logger.mock(),
+        config: mockConnectionsConfig([
+          {
+            type: 'aws',
+            roleName: 'wildcard-role',
+            auth: [{ method: 'account', mainAccount: true }],
+          },
+        ]),
+      });
+
+      const info = await service.forPlugin('catalog').find({
+        type: 'aws',
+        query: {},
+      });
+
+      expect(info.type).toBe('aws');
+      expect(info.roleName).toBe('wildcard-role');
+      expect('auth' in info).toBe(false);
+    });
+  });
+
   describe('cardinality', () => {
     it('allows multiple multiton connections with different identities', () => {
       const service = DefaultConnectionsService.create({

--- a/packages/connections-node/src/DefaultConnectionsService.ts
+++ b/packages/connections-node/src/DefaultConnectionsService.ts
@@ -71,8 +71,10 @@ class PluginConnectionsService implements ConnectionsService {
   >(options: {
     type: TType;
     query: ConnectionQuery<TType>;
-    authMethods: readonly [TAuthMethod, ...TAuthMethod[]];
-  }): Promise<Connection<TType, TAuthMethod>> {
+    authMethods?: readonly [TAuthMethod, ...TAuthMethod[]];
+  }): Promise<
+    Connection<TType, TAuthMethod> | Omit<Connection<TType>, 'auth'>
+  > {
     const result = await this.findOptional(options);
     if (!result) {
       throw new NotFoundError(
@@ -82,7 +84,7 @@ class PluginConnectionsService implements ConnectionsService {
     return result;
   }
 
-  async findOptional<
+  private async findOptional<
     TType extends ConnectionTypeKey,
     TAuthMethod extends ConnectionAuthMethodKey<TType>,
   >({
@@ -92,8 +94,10 @@ class PluginConnectionsService implements ConnectionsService {
   }: {
     type: TType;
     query: ConnectionQuery<TType>;
-    authMethods: readonly [TAuthMethod, ...TAuthMethod[]];
-  }): Promise<Connection<TType, TAuthMethod> | undefined> {
+    authMethods?: readonly [TAuthMethod, ...TAuthMethod[]];
+  }): Promise<
+    Connection<TType, TAuthMethod> | Omit<Connection<TType>, 'auth'> | undefined
+  > {
     const connectionType = getConnectionType(type);
     const strategy = getLookupStrategy(connectionType.lookupStrategy);
     const identity = strategy.identityFromQuery(query);
@@ -117,6 +121,11 @@ class PluginConnectionsService implements ConnectionsService {
 
     if (!connection) {
       return undefined;
+    }
+
+    if (!authMethods) {
+      const { auth: _, ...info } = connection;
+      return info as Omit<Connection<TType>, 'auth'>;
     }
 
     if (connection.auth.length === 0) {

--- a/packages/connections/report.api.md
+++ b/packages/connections/report.api.md
@@ -101,6 +101,13 @@ export interface ConnectionsService {
       : never;
     authMethods: readonly [TAuthMethod, ...TAuthMethod[]];
   }): Promise<Connection<TType, TAuthMethod>>;
+  // (undocumented)
+  find<TType extends ConnectionTypeKey>(options: {
+    type: TType;
+    query: LookupConnectionType<TType> extends ConnectionType<infer IDefinition>
+      ? IDefinition['query']
+      : never;
+  }): Promise<Omit<Connection<TType>, 'auth'>>;
 }
 
 // @public

--- a/packages/connections/src/api/ConnectionsService.ts
+++ b/packages/connections/src/api/ConnectionsService.ts
@@ -29,4 +29,11 @@ export interface ConnectionsService {
       : never;
     authMethods: readonly [TAuthMethod, ...TAuthMethod[]];
   }): Promise<Connection<TType, TAuthMethod>>;
+
+  find<TType extends ConnectionTypeKey>(options: {
+    type: TType;
+    query: LookupConnectionType<TType> extends ConnectionType<infer IDefinition>
+      ? IDefinition['query']
+      : never;
+  }): Promise<Omit<Connection<TType>, 'auth'>>;
 }


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Allow calling `find` without specifying `authMethods`. When omitted, the call returns connection info (type, title, config fields like `host` and `apiBaseUrl`) without any auth data. This makes consumers that only need connection metadata resilient to auth configuration changes.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))