### PR TITLE
fix(gitlab): Add missing branch check

### DIFF
--- a/.changeset/fix-gitlab-push-branch-filter.md
+++ b/.changeset/fix-gitlab-push-branch-filter.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-gitlab': patch
+---
+
+Fixed `GitlabDiscoveryEntityProvider` to only process push events targeting the configured branch.

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.test.ts
@@ -598,6 +598,42 @@ describe('GitlabDiscoveryEntityProvider - events', () => {
     expect(entityProviderConnection.applyMutation).toHaveBeenCalledTimes(0);
   });
 
+  it('should ignore push events from non-configured branches', async () => {
+    const config = new ConfigReader(mock.config_single_integration);
+    const schedule = new PersistingTaskRunner();
+    const events = DefaultEventsService.create({ logger });
+    const entityProviderConnection: EntityProviderConnection = {
+      applyMutation: jest.fn(),
+      refresh: jest.fn(),
+    };
+    const provider = GitlabDiscoveryEntityProvider.fromConfig(config, {
+      logger,
+      schedule,
+      events,
+    })[0];
+
+    await provider.connect(entityProviderConnection);
+
+    const basePayload = mock.push_remove_event.eventPayload as Record<
+      string,
+      unknown
+    >;
+    const featureBranchEvent = {
+      topic: 'gitlab.push',
+      metadata: { 'x-gitlab-event': 'Push Hook' },
+      eventPayload: {
+        ...basePayload,
+        ref: 'refs/heads/feature-branch',
+        ref_protected: false,
+      },
+    };
+
+    await events.publish(featureBranchEvent);
+
+    expect(entityProviderConnection.applyMutation).toHaveBeenCalledTimes(0);
+    expect(entityProviderConnection.refresh).toHaveBeenCalledTimes(0);
+  });
+
   it('should ignore projects when none of the groups regex patterns match', async () => {
     const config = new ConfigReader(mock.config_groupPatterns_only_noMatch);
 

--- a/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts
+++ b/plugins/catalog-backend-module-gitlab/src/providers/GitlabDiscoveryEntityProvider.ts
@@ -458,6 +458,18 @@ export class GitlabDiscoveryEntityProvider implements EntityProvider {
       return;
     }
 
+    const targetBranch =
+      this.config.branch ??
+      event.project.default_branch ??
+      this.config.fallbackBranch;
+
+    if (targetBranch && event.ref !== `refs/heads/${targetBranch}`) {
+      this.logger.debug(
+        `Skipping push event for ${event.project.path_with_namespace} targeting ${event.ref}`,
+      );
+      return;
+    }
+
     // Get array of added, removed or modified files from the push event
     const added = this.getFilesMatchingConfig(
       event,


### PR DESCRIPTION
## What / Why

There's a bug in the event side of the GitLab entity provider where it doesn't filter down to the configured branch. Quick fix for that here.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
