### PR TITLE
Bump nunjitsu to 0.6.0

### DIFF
--- a/.changeset/tidy-pandas-juggle.md
+++ b/.changeset/tidy-pandas-juggle.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Updated Nunjitsu to v0.6.0, allowing software templates to use intrinsic string, number, array, `Map`, and `Set` methods.

--- a/.changeset/tidy-pandas-juggle.md
+++ b/.changeset/tidy-pandas-juggle.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-scaffolder-backend': patch
 ---
 
-Updated Nunjitsu to v0.6.0, allowing software templates to use intrinsic string, number, array, `Map`, and `Set` methods.
+Restored support for intrinsic string, number, array, `Map`, and `Set` methods in software templates.

--- a/.patches/pr-35258.txt
+++ b/.patches/pr-35258.txt
@@ -1,0 +1,1 @@
+Enable intrinsic string, number, array, `Map`, and `Set` methods in software templates.

--- a/.patches/pr-35258.txt
+++ b/.patches/pr-35258.txt
@@ -1,1 +1,1 @@
-Enable intrinsic string, number, array, `Map`, and `Set` methods in software templates.
+Fixed the unintended removal of support for intrinsic string, number, array, `Map`, and `Set` methods in software templates.

--- a/plugins/scaffolder-backend/package.json
+++ b/plugins/scaffolder-backend/package.json
@@ -86,7 +86,7 @@
     "lodash": "^4.17.21",
     "logform": "^2.3.2",
     "luxon": "^3.0.0",
-    "nunjitsu": "^0.5.0",
+    "nunjitsu": "^0.6.0",
     "p-queue": "^6.6.2",
     "prom-client": "^15.0.0",
     "triple-beam": "^1.4.1",

--- a/plugins/scaffolder-backend/src/lib/templating/Nunjitsu.test.ts
+++ b/plugins/scaffolder-backend/src/lib/templating/Nunjitsu.test.ts
@@ -34,6 +34,23 @@ describe('Nunjitsu', () => {
     );
   });
 
+  it('supports intrinsic methods', () => {
+    const { render } = createTemplateRenderer();
+    const context = {
+      text: 'backstage',
+      number: 12.345,
+      array: ['catalog', 'scaffolder'],
+      map: new Map([['plugin', 'scaffolder']]),
+      set: new Set(['catalog', 'scaffolder']),
+    };
+
+    expect(render('${{ text.toUpperCase() }}', context)).toBe('BACKSTAGE');
+    expect(render('${{ number.toFixed(2) }}', context)).toBe('12.35');
+    expect(render('${{ array.includes("scaffolder") }}', context)).toBe('true');
+    expect(render('${{ map.get("plugin") }}', context)).toBe('scaffolder');
+    expect(render('${{ set.has("catalog") }}', context)).toBe('true');
+  });
+
   it('preserves native values for sole interpolations', () => {
     const renderer = createTemplateRenderer();
     const context = renderer.prepareContext({

--- a/plugins/scaffolder-backend/src/lib/templating/Nunjitsu.test.ts
+++ b/plugins/scaffolder-backend/src/lib/templating/Nunjitsu.test.ts
@@ -35,20 +35,26 @@ describe('Nunjitsu', () => {
   });
 
   it('supports intrinsic methods', () => {
-    const { render } = createTemplateRenderer();
-    const context = {
+    const renderer = createTemplateRenderer();
+    const context = renderer.prepareContext({
       text: 'backstage',
       number: 12.345,
       array: ['catalog', 'scaffolder'],
       map: new Map([['plugin', 'scaffolder']]),
       set: new Set(['catalog', 'scaffolder']),
-    };
+    });
 
-    expect(render('${{ text.toUpperCase() }}', context)).toBe('BACKSTAGE');
-    expect(render('${{ number.toFixed(2) }}', context)).toBe('12.35');
-    expect(render('${{ array.includes("scaffolder") }}', context)).toBe('true');
-    expect(render('${{ map.get("plugin") }}', context)).toBe('scaffolder');
-    expect(render('${{ set.has("catalog") }}', context)).toBe('true');
+    expect(renderer.render('${{ text.toUpperCase() }}', context)).toBe(
+      'BACKSTAGE',
+    );
+    expect(renderer.render('${{ number.toFixed(2) }}', context)).toBe('12.35');
+    expect(
+      renderer.render('${{ array.includes("scaffolder") }}', context),
+    ).toBe('true');
+    expect(renderer.render('${{ map.get("plugin") }}', context)).toBe(
+      'scaffolder',
+    );
+    expect(renderer.render('${{ set.has("catalog") }}', context)).toBe('true');
   });
 
   it('preserves native values for sole interpolations', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6320,7 +6320,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     logform: "npm:^2.3.2"
     luxon: "npm:^3.0.0"
-    nunjitsu: "npm:^0.5.0"
+    nunjitsu: "npm:^0.6.0"
     p-queue: "npm:^6.6.2"
     prom-client: "npm:^15.0.0"
     strip-ansi: "npm:^7.1.0"
@@ -36802,10 +36802,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nunjitsu@npm:^0.5.0":
-  version: 0.5.0
-  resolution: "nunjitsu@npm:0.5.0"
-  checksum: 10/7482355dbb7c8921ce84e1d634bf627dd4704b9f69315660dd98ff0328f91f3e9d295adad04e629c2254de00348720059d7ec306d0edea2af71614473041f9b6
+"nunjitsu@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "nunjitsu@npm:0.6.0"
+  checksum: 10/287347334beac63b4228d07757c392c24d396f5a7a0ad38ef7c771692384976b9a2aa2e64d1fde2d5d0150df4247689467a3b29578746f185bc96ddd5709c8f8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Bumps Nunjitsu to v0.6.0 in the scaffolder backend, enabling software templates to use intrinsic string, number, array, `Map`, and `Set` methods such as `.reverse()`, `.slice()`, etc.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

<!-- mana-workspace:6rAn2H74cj3 -->