### PR TITLE
feat(kubernetes-react): make pod table rows clickable to open drawer

### DIFF
--- a/.changeset/icy-islands-bet.md
+++ b/.changeset/icy-islands-bet.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-react': patch
+---
+
+Clicking any cell in a pod row now opens the pod drawer, not just the pod name button.

--- a/plugins/kubernetes-react/report.api.md
+++ b/plugins/kubernetes-react/report.api.md
@@ -818,7 +818,7 @@ export interface PodScope {
 // @public (undocumented)
 export const PodsTable: (input: PodsTablesProps) => JSX_2.Element;
 
-// @public (undocumented)
+// @public
 export type PodsTablesProps = {
   pods: Pod_2 | V1Pod[];
   extraColumns?: PodColumns[];

--- a/plugins/kubernetes-react/src/components/Pods/PodsTable.test.tsx
+++ b/plugins/kubernetes-react/src/components/Pods/PodsTable.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { screen, fireEvent, act } from '@testing-library/react';
+import { screen, fireEvent } from '@testing-library/react';
 import * as pod from './__fixtures__/pod.json';
 import * as crashingPod from './__fixtures__/crashing-pod.json';
 import { renderInTestApp } from '@backstage/test-utils';
@@ -185,18 +185,13 @@ describe('PodsTable', () => {
     expect(row).toHaveStyle({ cursor: 'pointer' });
   });
 
-  it('should trigger the row button when clicking a non-button cell', async () => {
+  it('should open the pod drawer when clicking a non-button cell', async () => {
     await renderInTestApp(<PodsTable pods={[pod as any]} />);
 
-    const row = screen.getByText('dice-roller-6c8646bfd-2m5hv').closest('tr')!;
-    const button = row.querySelector('button');
-    const clickSpy = jest.spyOn(button!, 'click');
+    expect(screen.queryByText('Pod (172.17.0.11)')).not.toBeInTheDocument();
 
-    jest.useFakeTimers();
     fireEvent.click(screen.getByText('Running'));
-    act(() => jest.runAllTimers());
-    jest.useRealTimers();
 
-    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText('Pod (172.17.0.11)')).toBeInTheDocument();
   });
 });

--- a/plugins/kubernetes-react/src/components/Pods/PodsTable.test.tsx
+++ b/plugins/kubernetes-react/src/components/Pods/PodsTable.test.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { screen } from '@testing-library/react';
+import { screen, fireEvent, act } from '@testing-library/react';
 import * as pod from './__fixtures__/pod.json';
 import * as crashingPod from './__fixtures__/crashing-pod.json';
 import { renderInTestApp } from '@backstage/test-utils';
@@ -176,5 +176,27 @@ describe('PodsTable', () => {
     expect(screen.getByText('Container: side-car')).toBeInTheDocument();
     expect(screen.getByText('Container: other-side-car')).toBeInTheDocument();
     expect(screen.getAllByText('CrashLoopBackOff')).toHaveLength(2);
+  });
+
+  it('should have pointer cursor style on rows', async () => {
+    await renderInTestApp(<PodsTable pods={[pod as any]} />);
+
+    const row = screen.getByText('dice-roller-6c8646bfd-2m5hv').closest('tr');
+    expect(row).toHaveStyle({ cursor: 'pointer' });
+  });
+
+  it('should trigger the row button when clicking a non-button cell', async () => {
+    await renderInTestApp(<PodsTable pods={[pod as any]} />);
+
+    const row = screen.getByText('dice-roller-6c8646bfd-2m5hv').closest('tr')!;
+    const button = row.querySelector('button');
+    const clickSpy = jest.spyOn(button!, 'click');
+
+    jest.useFakeTimers();
+    fireEvent.click(screen.getByText('Running'));
+    act(() => jest.runAllTimers());
+    jest.useRealTimers();
+
+    expect(clickSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/plugins/kubernetes-react/src/components/Pods/PodsTable.tsx
+++ b/plugins/kubernetes-react/src/components/Pods/PodsTable.tsx
@@ -185,7 +185,19 @@ export const PodsTable = ({ pods, extraColumns = [] }: PodsTablesProps) => {
   return (
     <div style={tableStyle}>
       <Table
-        options={{ paging: true, search: false, emptyRowsWhenPaging: false }}
+        options={{
+          paging: true,
+          search: false,
+          emptyRowsWhenPaging: false,
+          rowStyle: { cursor: 'pointer' },
+        }}
+        onRowClick={(event?: React.MouseEvent) => {
+          if ((event?.target as HTMLElement)?.closest('button')) return;
+          (event?.target as HTMLElement)
+            ?.closest('tr')
+            ?.querySelector('button')
+            ?.click();
+        }}
         // It was observed that in some instances the pod drawer closes when new data (like CPU usage) is available and the table reloads.
         // Mapping the metadata UID to the tables ID fixes this problem.
         data={

--- a/plugins/kubernetes-react/src/components/Pods/PodsTable.tsx
+++ b/plugins/kubernetes-react/src/components/Pods/PodsTable.tsx
@@ -55,7 +55,9 @@ export const RESOURCE_COLUMNS: PodColumns = 'RESOURCE';
 export type PodColumns = 'READY' | 'RESOURCE';
 
 /**
+ * Props for the PodsTable component.
  *
+ * Clicking any non-button cell in a row opens the pod drawer for that pod.
  *
  * @public
  */


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR makes the pod row clickable.

Example with this PR (With Clickable Row):
<img width="800" height="439" alt="backstageclickpod" src="https://github.com/user-attachments/assets/17ea200d-20df-440c-95f4-e93a6ef8251a" />

Current Master Branch (Must click pod name):
<img width="800" height="439" alt="backstagemasterbranch" src="https://github.com/user-attachments/assets/cbb98348-784d-4909-8ebd-4f33e9b74354" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
