### PR TITLE
fix(search): optimize catalog pagination in search collators

### DIFF
--- a/.changeset/quick-collators-page.md
+++ b/.changeset/quick-collators-page.md
@@ -1,0 +1,6 @@
+---
+'@backstage/plugin-search-backend-module-catalog': patch
+'@backstage/plugin-search-backend-module-techdocs': patch
+---
+
+Improved catalog indexing performance by using cursor pagination for TechDocs and avoiding unused total item counts in search collators.

--- a/plugins/search-backend-module-catalog/src/collators/DefaultCatalogCollatorFactory.test.ts
+++ b/plugins/search-backend-module-catalog/src/collators/DefaultCatalogCollatorFactory.test.ts
@@ -216,7 +216,11 @@ describe('DefaultCatalogCollatorFactory', () => {
       expect(documents).toHaveLength(0);
     });
 
-    it('paginates through catalog entities using batchSize', async () => {
+    it('paginates without requesting total item counts', async () => {
+      const paginationCatalog = catalogServiceMock({
+        entities: expectedEntities,
+      });
+      const queryEntitiesSpy = jest.spyOn(paginationCatalog, 'queryEntities');
       factory = DefaultCatalogCollatorFactory.fromConfig(
         mockServices.rootConfig({
           data: {
@@ -227,7 +231,7 @@ describe('DefaultCatalogCollatorFactory', () => {
         }),
         {
           auth,
-          catalog,
+          catalog: paginationCatalog,
         },
       );
       collator = await factory.getCollator();
@@ -242,6 +246,17 @@ describe('DefaultCatalogCollatorFactory', () => {
       expect(documents[1].location).toBe(
         '/catalog/default/component/test-entity-2',
       );
+      expect(queryEntitiesSpy).toHaveBeenNthCalledWith(
+        1,
+        { filter: undefined, limit: 1, totalItems: 'exclude' },
+        { credentials: expect.anything() },
+      );
+      expect(queryEntitiesSpy).toHaveBeenNthCalledWith(
+        2,
+        { cursor: expect.any(String), limit: 1 },
+        { credentials: expect.anything() },
+      );
+      expect(queryEntitiesSpy).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/plugins/search-backend-module-catalog/src/collators/DefaultCatalogCollatorFactory.ts
+++ b/plugins/search-backend-module-catalog/src/collators/DefaultCatalogCollatorFactory.ts
@@ -98,20 +98,19 @@ export class DefaultCatalogCollatorFactory implements DocumentCollatorFactory {
   }
 
   private async *execute(): AsyncGenerator<CatalogEntityDocument> {
-    let entitiesRetrieved = 0;
     let cursor: string | undefined = undefined;
+    const initialRequest: QueryEntitiesInitialRequest = {
+      filter: this.filter,
+      limit: this.batchSize,
+      totalItems: 'exclude',
+    };
 
     do {
       const response = await this.catalog.queryEntities(
-        {
-          filter: this.filter,
-          limit: this.batchSize,
-          ...(cursor ? { cursor } : {}),
-        },
+        cursor ? { cursor, limit: this.batchSize } : initialRequest,
         { credentials: await this.auth.getOwnServiceCredentials() },
       );
       cursor = response.pageInfo.nextCursor;
-      entitiesRetrieved += response.items.length;
 
       for (const entity of response.items) {
         yield {

--- a/plugins/search-backend-module-techdocs/src/collators/DefaultTechDocsCollatorFactory.test.ts
+++ b/plugins/search-backend-module-techdocs/src/collators/DefaultTechDocsCollatorFactory.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { Entity } from '@backstage/catalog-model';
+import { CATALOG_FILTER_EXISTS } from '@backstage/catalog-client';
 import { ConfigReader } from '@backstage/config';
 import { TestPipeline } from '@backstage/plugin-search-backend-node';
 import {
@@ -185,10 +186,15 @@ describe('DefaultTechDocsCollatorFactory', () => {
       expect(documents).toHaveLength(0);
     });
 
-    it('paginates through catalog entities using batchSize', async () => {
+    it('paginates through catalog entities using cursors', async () => {
       // parallelismLimit of 1 → batchSize of 50 per request.
-      // First page returns exactly 50 (no techdocs annotation) triggering a
-      // second request; second page returns the real entity with annotation.
+      const paginatedEntities = Array.from({ length: 51 }, (_, index) => ({
+        ...expectedEntities[0],
+        metadata: {
+          ...expectedEntities[0].metadata,
+          name: `test-entity-with-docs-${index}`,
+        },
+      }));
       const _config = new ConfigReader({
         ...config.get(),
         search: {
@@ -199,24 +205,48 @@ describe('DefaultTechDocsCollatorFactory', () => {
           },
         },
       });
-      const paginationCatalog = catalogServiceMock({ entities: [] });
-      jest
-        .spyOn(paginationCatalog, 'getEntities')
-        .mockResolvedValueOnce({ items: Array(50).fill({}) })
-        .mockResolvedValueOnce({ items: expectedEntities });
+      const paginationCatalog = catalogServiceMock({
+        entities: paginatedEntities,
+      });
+      const queryEntitiesSpy = jest.spyOn(paginationCatalog, 'queryEntities');
       factory = DefaultTechDocsCollatorFactory.fromConfig(_config, {
         ...options,
         catalog: paginationCatalog,
+        customCatalogApiFilters: { kind: 'Component' },
       });
       collator = await factory.getCollator();
+      worker.use(
+        http.get(
+          'http://test-backend/static/docs/default/Component/:name/search/search_index.json',
+          () => HttpResponse.json(mockSearchDocIndex),
+        ),
+      );
 
       const pipeline = TestPipeline.fromCollator(collator);
       const { documents } = await pipeline.execute();
 
-      expect(paginationCatalog.getEntities).toHaveBeenCalledTimes(2);
-      // First page: 50 entities with no techdocs annotation → 0 docs
-      // Second page: 1 entity × 3 search index docs → 3 docs
-      expect(documents).toHaveLength(3);
+      expect(queryEntitiesSpy).toHaveBeenNthCalledWith(
+        1,
+        {
+          filter: {
+            kind: 'Component',
+            'metadata.annotations.backstage.io/techdocs-ref':
+              CATALOG_FILTER_EXISTS,
+          },
+          limit: 50,
+          totalItems: 'exclude',
+        },
+        { credentials: expect.anything() },
+      );
+      expect(queryEntitiesSpy).toHaveBeenNthCalledWith(
+        2,
+        { cursor: expect.any(String), limit: 50 },
+        { credentials: expect.anything() },
+      );
+      expect(queryEntitiesSpy).toHaveBeenCalledTimes(2);
+      expect(documents).toHaveLength(
+        paginatedEntities.length * mockSearchDocIndex.docs.length,
+      );
     });
 
     describe('with legacyPathCasing configuration', () => {

--- a/plugins/search-backend-module-techdocs/src/collators/DefaultTechDocsCollatorFactory.ts
+++ b/plugins/search-backend-module-techdocs/src/collators/DefaultTechDocsCollatorFactory.ts
@@ -17,6 +17,7 @@
 import {
   CATALOG_FILTER_EXISTS,
   EntityFilterQuery,
+  QueryEntitiesInitialRequest,
 } from '@backstage/catalog-client';
 import {
   Entity,
@@ -135,34 +136,27 @@ export class DefaultTechDocsCollatorFactory implements DocumentCollatorFactory {
     const limit = pLimit(this.parallelismLimit);
     const techDocsBaseUrl = await this.discovery.getBaseUrl('techdocs');
 
-    let entitiesRetrieved = 0;
-    let moreEntitiesToGet = true;
+    let cursor: string | undefined;
 
-    // Offset/limit pagination is used on the Catalog Client in order to
-    // limit (and allow some control over) memory used by the search backend
-    // at index-time. The batchSize is calculated as a factor of the given
-    // parallelism limit to simplify configuration.
+    // The batchSize is calculated as a factor of the given parallelism limit
+    // to simplify configuration while bounding index-time memory use.
     const batchSize = this.parallelismLimit * 50;
-    while (moreEntitiesToGet) {
-      const credentials = await this.auth.getOwnServiceCredentials();
-      const entities = (
-        await this.catalog.getEntities(
-          {
-            filter: {
-              'metadata.annotations.backstage.io/techdocs-ref':
-                CATALOG_FILTER_EXISTS,
-              ...this.customCatalogApiFilters,
-            },
-            limit: batchSize,
-            offset: entitiesRetrieved,
-          },
-          { credentials },
-        )
-      ).items;
+    const initialRequest: QueryEntitiesInitialRequest = {
+      filter: {
+        'metadata.annotations.backstage.io/techdocs-ref': CATALOG_FILTER_EXISTS,
+        ...this.customCatalogApiFilters,
+      },
+      limit: batchSize,
+      totalItems: 'exclude',
+    };
 
-      // Control looping through entity batches.
-      moreEntitiesToGet = entities.length === batchSize;
-      entitiesRetrieved += entities.length;
+    do {
+      const response = await this.catalog.queryEntities(
+        cursor ? { cursor, limit: batchSize } : initialRequest,
+        { credentials: await this.auth.getOwnServiceCredentials() },
+      );
+      cursor = response.pageInfo.nextCursor;
+      const entities = response.items;
 
       const filteredEntities = this.entityFilterFunction
         ? this.entityFilterFunction(entities)
@@ -230,7 +224,7 @@ export class DefaultTechDocsCollatorFactory implements DocumentCollatorFactory {
         }),
       );
       yield* (await Promise.all(docPromises)).flat();
-    }
+    } while (cursor);
   }
 
   private applyArgsToFormat(


### PR DESCRIPTION
## What changed

- replace offset pagination in the TechDocs search collator with cursor pagination
- avoid calculating unused total item counts in both the TechDocs and catalog search collators
- preserve custom TechDocs catalog filters and request fresh service credentials for each page

This avoids increasingly expensive late-page catalog queries during full search indexing runs.

## Verification

- TechDocs search backend module: 12 tests passed
- Catalog search backend module: 19 tests passed
- both affected packages build successfully
- lint, formatting, and diff checks pass

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
