### PR TITLE
fix(frontend-app-api): coerce boolean-ish strings for app.extensions shorthand and disabled field

### DIFF
--- a/.changeset/solid-brooms-sink.md
+++ b/.changeset/solid-brooms-sink.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-app-api': patch
+---
+
+Fixed `app.extensions` shorthand and `disabled` field to accept boolean-ish strings (`'true'`/`'false'`), so environment variable substitution can be used to toggle extensions, e.g. `${CATALOG_OVERVIEW_ENABLED}`.

--- a/docs/frontend-system/building-apps/02-configuring-extensions.md
+++ b/docs/frontend-system/building-apps/02-configuring-extensions.md
@@ -26,6 +26,8 @@ app:
 
 All of the top-level fields are optional: `attachTo`, `disabled`, and `config`. Every extension implementation must provide defaults for all of these fields that will be used if they are not provided in the configuration.
 
+The `disabled` field also accepts the strings 'true' and 'false', since environment variable substitution in configuration always produces a string rather than a real boolean.
+
 Note that `app.extensions` is always an array rather than an object. For example, the following is invalid:
 
 ```yaml title="INVALID"
@@ -52,3 +54,5 @@ app:
   extensions:
     - <id>: <true/false>
 ```
+
+This also accepts the strings 'true' and 'false', so the value can come from an environment variable, e.g. `- <id>: ${SOME_EXTENSION_ENABLED}`.

--- a/packages/frontend-app-api/src/tree/readAppExtensionsConfig.test.ts
+++ b/packages/frontend-app-api/src/tree/readAppExtensionsConfig.test.ts
@@ -189,6 +189,17 @@ describe('expandShorthandExtensionParameters', () => {
     });
   });
 
+  it('supports boolean-ish string value from env var substitution', () => {
+    expect(run({ 'app/root': 'true' })).toEqual({
+      id: 'app/root',
+      disabled: false,
+    });
+    expect(run({ 'app/root': 'false' })).toEqual({
+      id: 'app/root',
+      disabled: true,
+    });
+  });
+
   it('should not support string values', () => {
     expect(() =>
       run({ 'app/root': 'example-package#MyRouter' }),
@@ -236,6 +247,22 @@ describe('expandShorthandExtensionParameters', () => {
     });
     expect(() =>
       run({ 'app/root': { disabled: 0 } }),
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Invalid extension configuration at app.extensions[1][app/root].disabled, must be a boolean"`,
+    );
+  });
+
+  it('supports boolean-ish string for object disabled from env var substitution', () => {
+    expect(run({ 'app/root': { disabled: 'true' } })).toEqual({
+      id: 'app/root',
+      disabled: true,
+    });
+    expect(run({ 'app/root': { disabled: 'false' } })).toEqual({
+      id: 'app/root',
+      disabled: false,
+    });
+    expect(() =>
+      run({ 'app/root': { disabled: 'yes' } }),
     ).toThrowErrorMatchingInlineSnapshot(
       `"Invalid extension configuration at app.extensions[1][app/root].disabled, must be a boolean"`,
     );

--- a/packages/frontend-app-api/src/tree/readAppExtensionsConfig.test.ts
+++ b/packages/frontend-app-api/src/tree/readAppExtensionsConfig.test.ts
@@ -94,7 +94,7 @@ describe('readAppExtensionsConfig', () => {
         }),
       ),
     ).toThrow(
-      'Invalid extension configuration at app.extensions[0][app/root], value must be a boolean or object',
+      "Invalid extension configuration at app.extensions[0][app/root], value must be a boolean, 'true', 'false', or object",
     );
   });
 
@@ -148,10 +148,10 @@ describe('expandShorthandExtensionParameters', () => {
 
   it('rejects unknown values', () => {
     expect(() => run({ a: 1 })).toThrowErrorMatchingInlineSnapshot(
-      `"Invalid extension configuration at app.extensions[1][a], value must be a boolean or object"`,
+      `"Invalid extension configuration at app.extensions[1][a], value must be a boolean, 'true', 'false', or object"`,
     );
     expect(() => run({ a: [] })).toThrowErrorMatchingInlineSnapshot(
-      `"Invalid extension configuration at app.extensions[1][a], value must be a boolean or object"`,
+      `"Invalid extension configuration at app.extensions[1][a], value must be a boolean, 'true', 'false', or object"`,
     );
   });
 
@@ -204,7 +204,7 @@ describe('expandShorthandExtensionParameters', () => {
     expect(() =>
       run({ 'app/root': 'example-package#MyRouter' }),
     ).toThrowErrorMatchingInlineSnapshot(
-      `"Invalid extension configuration at app.extensions[1][app/root], value must be a boolean or object"`,
+      `"Invalid extension configuration at app.extensions[1][app/root], value must be a boolean, 'true', 'false', or object"`,
     );
   });
 
@@ -248,7 +248,7 @@ describe('expandShorthandExtensionParameters', () => {
     expect(() =>
       run({ 'app/root': { disabled: 0 } }),
     ).toThrowErrorMatchingInlineSnapshot(
-      `"Invalid extension configuration at app.extensions[1][app/root].disabled, must be a boolean"`,
+      `"Invalid extension configuration at app.extensions[1][app/root].disabled, must be a boolean, 'true', or 'false'"`,
     );
   });
 
@@ -264,7 +264,7 @@ describe('expandShorthandExtensionParameters', () => {
     expect(() =>
       run({ 'app/root': { disabled: 'yes' } }),
     ).toThrowErrorMatchingInlineSnapshot(
-      `"Invalid extension configuration at app.extensions[1][app/root].disabled, must be a boolean"`,
+      `"Invalid extension configuration at app.extensions[1][app/root].disabled, must be a boolean, 'true', or 'false'"`,
     );
   });
 

--- a/packages/frontend-app-api/src/tree/readAppExtensionsConfig.ts
+++ b/packages/frontend-app-api/src/tree/readAppExtensionsConfig.ts
@@ -119,6 +119,16 @@ export function expandShorthandExtensionParameters(
     };
   }
 
+  // Environment variable substitution always produces a string, so boolean-ish
+  // strings need to be coerced too. Example YAML:
+  // - catalog.page.cicd: ${CATALOG_PAGE_CICD_ENABLED}
+  if (value === 'true' || value === 'false') {
+    return {
+      id,
+      disabled: value === 'false',
+    };
+  }
+
   // The remaining case is the generic object. Example YAML:
   //  - tech-radar.page:
   //      at: core.router/routes
@@ -134,7 +144,7 @@ export function expandShorthandExtensionParameters(
   }
 
   const attachTo = value.attachTo as { id: string; input: string } | undefined;
-  const disabled = value.disabled;
+  let disabled = value.disabled;
   const config = value.config;
 
   if (attachTo !== undefined) {
@@ -157,7 +167,13 @@ export function expandShorthandExtensionParameters(
     }
   }
   if (disabled !== undefined && typeof disabled !== 'boolean') {
-    throw new Error(errorMsg('must be a boolean', id, 'disabled'));
+    // Environment variable substitution always produces a string, e.g.
+    // disabled: ${CATALOG_OVERVIEW_DISABLED}
+    if (disabled === 'true' || disabled === 'false') {
+      disabled = disabled === 'true';
+    } else {
+      throw new Error(errorMsg('must be a boolean', id, 'disabled'));
+    }
   }
   if (
     config !== undefined &&

--- a/packages/frontend-app-api/src/tree/readAppExtensionsConfig.ts
+++ b/packages/frontend-app-api/src/tree/readAppExtensionsConfig.ts
@@ -140,7 +140,9 @@ export function expandShorthandExtensionParameters(
   if (typeof value !== 'object' || Array.isArray(value)) {
     // We don't mention null here - we don't want people to explicitly enter
     // - entity.card.about: null
-    throw new Error(errorMsg('value must be a boolean or object', id));
+    throw new Error(
+      errorMsg("value must be a boolean, 'true', 'false', or object", id),
+    );
   }
 
   const attachTo = value.attachTo as { id: string; input: string } | undefined;
@@ -172,7 +174,9 @@ export function expandShorthandExtensionParameters(
     if (disabled === 'true' || disabled === 'false') {
       disabled = disabled === 'true';
     } else {
-      throw new Error(errorMsg('must be a boolean', id, 'disabled'));
+      throw new Error(
+        errorMsg("must be a boolean, 'true', or 'false'", id, 'disabled'),
+      );
     }
   }
   if (


### PR DESCRIPTION
**What**

Adds string-to-boolean coercion for the app.extensions shorthand value and the object-form disabled field in readAppExtensionsConfig.ts.

**Why**

Environment variable substitution in Backstage config always produces a string, but the app.extensions shorthand and disabled field only accepted real booleans. This meant an app couldn't toggle an extension via an env var without the app failing to start, even though config:check reported the config as valid. This mirrors the same class of fix already applied for schema-validated config in #16844.


**Docs**

Updated docs/frontend-system/building-apps/02-configuring-extensions.md to note that the shorthand value and disabled field also accept 'true'/'false' strings, alongside the existing boolean examples.

**Testing**

- Added test cases for boolean-ish string values on both the shorthand and object-form disabled field, including a rejection case for a non-boolean-ish string
- Existing @backstage/frontend-app-api test suite passes (18/18)
- yarn tsc clean
- yarn backstage-cli repo lint --since origin/master clean
- yarn build:api-reports clean (no public API surface change - functions are @internal)
- Added a changeset

Fixes #35252

**✔️ Checklist**

- [x] A changeset describing the change and affected packages.
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a Signed-off-by line in the messages