### PR TITLE
Fix comment.md cache misses in the API breaking changes comment workflow

### DIFF
--- a/.github/workflows/api-breaking-changes-comment.yml
+++ b/.github/workflows/api-breaking-changes-comment.yml
@@ -77,7 +77,7 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: comment.md
-          key: ${{ steps.hash.outputs.COMMENT_FILE_HASH }}
+          key: ${{ steps.hash.outputs.COMMENT_FILE_HASH }}-${{ github.event.workflow_run.id }}
 
       - name: DEBUG - Print Job Outputs
         if: ${{ runner.debug }}
@@ -92,7 +92,7 @@ jobs:
     name: Write comment about issues
     needs:
       - setup
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && needs.setup.outputs.action != 'closed' }}
     permissions:
       contents: read
       pull-requests: write
@@ -106,7 +106,7 @@ jobs:
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: comment.md
-          key: ${{ needs.setup.outputs.comment-cache-key }}
+          key: ${{ needs.setup.outputs.comment-cache-key }}-${{ github.event.workflow_run.id }}
 
       # Identify comment to be updated
       - name: Find comment for API Changes


### PR DESCRIPTION
Hey, I just made a Pull Request!

The "API Breaking Changes (comment)" workflow fails regularly with:

```
##[error]File 'comment.md' does not exist.
```

12 of its last 20 runs failed this way. Run 31726966081 shows the mechanism end to end:

```
Cache not found for input keys: 647f21304bc9103a18304973bc15fcbd        (setup restore, expected on a fresh key)
Failed to save: Unable to reserve cache with key 647f21304bc9103a18304973bc15fcbd, another job may be creating this cache.
Cache not found for input keys: 647f21304bc9103a18304973bc15fcbd        (add-comment, 9 minutes later)
```

The cache key is the md5 of `comment.md` alone. Two runs whose comment content is identical, which is the normal case since most PRs produce the same "no breaking changes" body, collide on the same key. Whichever run reserves the key first wins; the other run's save is rejected, and its `add-comment` job then restores nothing and `create-or-update-comment` fails on the missing `body-path`.

There is a second, smaller hole: when the PR action is `closed`, `setup` deliberately skips the "Cache Comment" step, but `add-comment` still ran and tried to read the file.

Two changes, both in the one workflow file:

1. Append `${{ github.event.workflow_run.id }}` to the cache key on both sides. Each run's save and restore become a private pair: no cross-run collision is possible, and the restore always hits because the save completes when `setup` ends and `add-comment` only starts after it. The md5 stays in the key so it remains recognizable in the cache list.
2. Gate `add-comment` on `needs.setup.outputs.action != 'closed'`, matching the condition `setup` already applies to the save.

I could not execute this workflow myself since it only triggers via `workflow_run` on the upstream trigger workflow, so the evidence above is from the run logs on master. Happy to adjust if you would rather solve it by re-downloading the artifact in `add-comment` instead of the cache round-trip, but this seemed like the smallest change that stops the failures.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets)) - not applicable, CI workflow only, no package touched
- [x] Added or updated documentation - not applicable
- [x] Tests for new functionality and regression tests for bug fixes - not applicable to workflow YAML; verification is from the run logs above
- [x] Screenshots attached (for UI changes) - not applicable
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
