### PR TITLE
Add specific relations for AiResource hierarchies

### DIFF
--- a/.changeset/airesource-specific-relations.md
+++ b/.changeset/airesource-specific-relations.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': minor
+---
+
+Updated the alpha `AiResource` model to use distinct `hasSkill`/`skillOf` and `hasPlugin`/`pluginOf` relations for plugin and marketplace membership. The standard `partOf`/`hasPart` relations are now reserved for `spec.system`, allowing relation consumers to determine the meaning of an edge without fetching related entities.

--- a/docs/ai/ai-in-the-catalog.md
+++ b/docs/ai/ai-in-the-catalog.md
@@ -86,14 +86,62 @@ Rule-specific fields:
 - `rationale` (required): An explanation of why the rule exists.
 - `disciplines` (optional): A list of disciplines the rule applies to.
 
+### Plugin
+
+Plugins package skills for distribution as a unit.
+
+```yaml
+apiVersion: backstage.io/v1alpha1
+kind: AiResource
+metadata:
+  name: code-review-plugin
+spec:
+  type: plugin
+  lifecycle: production
+  owner: ai-platform-team
+  skills:
+    - airesource:default/code-review
+  version: 1.0.0
+```
+
+Plugin-specific fields:
+
+- `skills` (required): References to the skills contained in the plugin. Each entry generates a `hasSkill` relation from the plugin and a `skillOf` relation from the skill.
+- `version` (optional): The plugin version.
+
+### Marketplace
+
+Marketplaces are registries of plugins for discovery and distribution.
+
+```yaml
+apiVersion: backstage.io/v1alpha1
+kind: AiResource
+metadata:
+  name: company-ai-tools
+spec:
+  type: marketplace
+  lifecycle: production
+  owner: ai-platform-team
+  plugins:
+    - airesource:default/code-review-plugin
+  version: 1.0.0
+```
+
+Marketplace-specific fields:
+
+- `plugins` (required): References to the plugins contained in the marketplace. Each entry generates a `hasPlugin` relation from the marketplace and a `pluginOf` relation from the plugin.
+- `version` (optional): The marketplace version.
+
 ### Base Fields
 
 All `AiResource` entities share these spec fields regardless of type:
 
-- `type` (required): The type of AI resource. Supported values are `skill` and `rule`, but any string is accepted.
+- `type` (required): The type of AI resource. Structured schemas are available for `skill`, `rule`, `plugin`, and `marketplace`, but any string is accepted.
 - `lifecycle` (required): The lifecycle stage of the resource, such as `experimental` or `production`.
 - `owner` (required): A reference to the owning entity, typically a group or user.
 - `system` (optional): A reference to the system this resource belongs to.
+
+The `system` field generates the standard `partOf` and `hasPart` relations. Plugin-to-skill and marketplace-to-plugin relationships use the more specific relations described above, allowing consumers to identify their meaning without fetching the related entity bodies.
 
 ### Accessing Skill and Rule Content
 

--- a/packages/catalog-model/report-alpha.api.md
+++ b/packages/catalog-model/report-alpha.api.md
@@ -601,6 +601,18 @@ export interface PluginAiResourceEntityV1alpha1
 export const pluginAiResourceEntityV1alpha1Validator: KindValidator;
 
 // @alpha
+export const RELATION_HAS_PLUGIN = 'hasPlugin';
+
+// @alpha
+export const RELATION_HAS_SKILL = 'hasSkill';
+
+// @alpha
+export const RELATION_PLUGIN_OF = 'pluginOf';
+
+// @alpha
+export const RELATION_SKILL_OF = 'skillOf';
+
+// @alpha
 export interface RuleAiResourceEntityV1alpha1
   extends AiResourceEntityV1alpha1Default {
   // (undocumented)

--- a/packages/catalog-model/src/alpha.ts
+++ b/packages/catalog-model/src/alpha.ts
@@ -46,6 +46,10 @@ export {
   isRuleAiResourceEntity,
   isPluginAiResourceEntity,
   isMarketplaceAiResourceEntity,
+  RELATION_HAS_SKILL,
+  RELATION_SKILL_OF,
+  RELATION_HAS_PLUGIN,
+  RELATION_PLUGIN_OF,
   aiResourceEntityModel,
 } from './kinds/AiResourceEntityV1alpha1';
 export type {

--- a/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.test.ts
+++ b/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.test.ts
@@ -34,6 +34,10 @@ import {
   isRuleAiResourceEntity,
   isPluginAiResourceEntity,
   isMarketplaceAiResourceEntity,
+  RELATION_HAS_SKILL,
+  RELATION_SKILL_OF,
+  RELATION_HAS_PLUGIN,
+  RELATION_PLUGIN_OF,
 } from './AiResourceEntityV1alpha1';
 
 describe('AiResourceV1alpha1 default validator', () => {
@@ -469,7 +473,6 @@ describe('aiResourceEntityModel', () => {
     ]);
     expect(relations?.find(r => r.forward.type === 'partOf')?.toKind).toEqual([
       'System',
-      'AiResource',
     ]);
     expect(
       relations?.find(r => r.forward.type === 'dependsOn')?.toKind,
@@ -484,6 +487,45 @@ describe('aiResourceEntityModel', () => {
       model
         .getRelations({ kind: 'AiResource' })
         ?.find(r => r.forward.type === 'dependencyOf')?.toKind,
+    ).toEqual(['AiResource']);
+
+    const plugin = model.getKind({
+      kind: 'AiResource',
+      apiVersion: 'backstage.io/v1alpha1',
+      spec: { type: 'plugin' },
+    });
+    expect(plugin?.relationFields).toContainEqual(
+      expect.objectContaining({
+        path: 'spec.skills',
+        relation: RELATION_HAS_SKILL,
+        allowedKinds: ['AiResource'],
+      }),
+    );
+
+    const marketplace = model.getKind({
+      kind: 'AiResource',
+      apiVersion: 'backstage.io/v1alpha1',
+      spec: { type: 'marketplace' },
+    });
+    expect(marketplace?.relationFields).toContainEqual(
+      expect.objectContaining({
+        path: 'spec.plugins',
+        relation: RELATION_HAS_PLUGIN,
+        allowedKinds: ['AiResource'],
+      }),
+    );
+
+    expect(
+      relations?.find(r => r.forward.type === RELATION_HAS_SKILL)?.toKind,
+    ).toEqual(['AiResource']);
+    expect(
+      relations?.find(r => r.forward.type === RELATION_SKILL_OF)?.toKind,
+    ).toEqual(['AiResource']);
+    expect(
+      relations?.find(r => r.forward.type === RELATION_HAS_PLUGIN)?.toKind,
+    ).toEqual(['AiResource']);
+    expect(
+      relations?.find(r => r.forward.type === RELATION_PLUGIN_OF)?.toKind,
     ).toEqual(['AiResource']);
   });
 });

--- a/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.ts
+++ b/packages/catalog-model/src/kinds/AiResourceEntityV1alpha1.ts
@@ -254,6 +254,38 @@ export const marketplaceAiResourceEntityV1alpha1Validator: KindValidator = {
   },
 };
 
+/**
+ * A relation from an AI plugin to one of the skills that it contains.
+ * Reversed direction of {@link RELATION_SKILL_OF}.
+ *
+ * @alpha
+ */
+export const RELATION_HAS_SKILL = 'hasSkill';
+
+/**
+ * A relation from an AI skill to a plugin that contains it. Reversed
+ * direction of {@link RELATION_HAS_SKILL}.
+ *
+ * @alpha
+ */
+export const RELATION_SKILL_OF = 'skillOf';
+
+/**
+ * A relation from an AI marketplace to one of the plugins that it contains.
+ * Reversed direction of {@link RELATION_PLUGIN_OF}.
+ *
+ * @alpha
+ */
+export const RELATION_HAS_PLUGIN = 'hasPlugin';
+
+/**
+ * A relation from an AI plugin to a marketplace that contains it. Reversed
+ * direction of {@link RELATION_HAS_PLUGIN}.
+ *
+ * @alpha
+ */
+export const RELATION_PLUGIN_OF = 'pluginOf';
+
 const baseRelationFields = [
   {
     selector: { path: 'spec.owner' },
@@ -328,7 +360,7 @@ export const aiResourceEntityModel = createCatalogModelLayer({
             ...baseRelationFields,
             {
               selector: { path: 'spec.skills' },
-              relation: 'hasPart',
+              relation: RELATION_HAS_SKILL,
               defaultKind: 'AiResource',
               defaultNamespace: 'inherit' as const,
               allowedKinds: ['AiResource'],
@@ -345,7 +377,7 @@ export const aiResourceEntityModel = createCatalogModelLayer({
             ...baseRelationFields,
             {
               selector: { path: 'spec.plugins' },
-              relation: 'hasPart',
+              relation: RELATION_HAS_PLUGIN,
               defaultKind: 'AiResource',
               defaultNamespace: 'inherit' as const,
               allowedKinds: ['AiResource'],
@@ -375,11 +407,19 @@ export const aiResourceEntityModel = createCatalogModelLayer({
       forward: { type: 'dependsOn' },
       reverse: { type: 'dependencyOf' },
     });
-    model.updateRelationPair({
+    model.addRelationPair({
       fromKind: 'AiResource',
       toKind: 'AiResource',
-      forward: { type: 'hasPart' },
-      reverse: { type: 'partOf' },
+      description: 'An AI plugin contains an AI skill.',
+      forward: { type: RELATION_HAS_SKILL, title: 'has skill' },
+      reverse: { type: RELATION_SKILL_OF, title: 'skill of' },
+    });
+    model.addRelationPair({
+      fromKind: 'AiResource',
+      toKind: 'AiResource',
+      description: 'An AI marketplace contains an AI plugin.',
+      forward: { type: RELATION_HAS_PLUGIN, title: 'has plugin' },
+      reverse: { type: RELATION_PLUGIN_OF, title: 'plugin of' },
     });
   },
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`AiResource` now has multiple same-kind hierarchies: marketplaces contain plugins, and plugins contain skills. Reusing `hasPart` / `partOf` for both makes the meaning of an edge impossible to determine from the relation graph alone, especially since `spec.system` already uses the same pair.

This updates the alpha model to emit `hasPlugin` / `pluginOf` and `hasSkill` / `skillOf` for those hierarchies. `partOf` / `hasPart` remains the relation pair for `spec.system`. This lets consumers traverse the graph without fetching each target entity to inspect `spec.type`.

The new relation constants are exported from `@backstage/catalog-model/alpha`. Since the affected model is alpha and the plugin and marketplace types were introduced recently, this PR changes the emitted relations directly instead of carrying both ambiguous and specific edges.

> [!NOTE]
> This draft was prepared with Codex as a coding assistant and is pending author review before being marked ready.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (not applicable; no UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
