### PR TITLE
chore: clean up released patch files

### DIFF
--- a/.patches/pr-35258.txt
+++ b/.patches/pr-35258.txt
@@ -1,1 +1,0 @@
-Fixed the unintended removal of support for intrinsic string, number, array, `Map`, and `Set` methods in software templates.


### PR DESCRIPTION
Removes patch files that have already been included in a release.

- pr-35258.txt