### PR TITLE
fix(scaffolder): reject un-iterable `.each` iteration values

### DIFF
--- a/.changeset/fuzzy-lions-repeat.md
+++ b/.changeset/fuzzy-lions-repeat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Reject Scaffolder steps where `each` resolves to a primitive value instead of an array or object.

--- a/docs/features/software-templates/writing-templates.md
+++ b/docs/features/software-templates/writing-templates.md
@@ -725,7 +725,8 @@ By default we ship some [built in actions](./builtin-actions.md) that you can
 take a look at, or you can
 [create your own custom actions](./writing-custom-actions.md).
 
-When `each` is provided, the current iteration value is available in the `${{ each }}` input.
+The `each` value must resolve to an array or object. The current iteration value
+is available in the `${{ each }}` input.
 
 Examples:
 

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.test.ts
@@ -1979,7 +1979,8 @@ describe('NunjucksWorkflowRunner', () => {
             {
               id: 'test',
               name: 'name',
-              each,
+              // Deliberately bypass the static constraint to test malformed input at runtime
+              each: each as unknown as string,
               action: 'jest-mock-action',
             },
           ],

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.test.ts
@@ -1972,6 +1972,27 @@ describe('NunjucksWorkflowRunner', () => {
       expect(fakeActionHandler).not.toHaveBeenCalled();
     });
 
+    it('should reject literal falsy each values', async () => {
+      for (const each of [0, false]) {
+        const task = createMockTaskWithSpec({
+          steps: [
+            {
+              id: 'test',
+              name: 'name',
+              each,
+              action: 'jest-mock-action',
+            },
+          ],
+        });
+
+        await expect(runner.execute(task)).rejects.toThrow(
+          'must resolve to an array or object',
+        );
+      }
+
+      expect(fakeActionHandler).not.toHaveBeenCalled();
+    });
+
     it('should validate each parameter renders to a valid value', async () => {
       const task = createMockTaskWithSpec({
         steps: [

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.test.ts
@@ -1950,6 +1950,28 @@ describe('NunjucksWorkflowRunner', () => {
       expect(fakeActionHandler).not.toHaveBeenCalled();
     });
 
+    it('should reject non-collection each values', async () => {
+      for (const value of ['single', '', 1, 0, true, false, null]) {
+        const task = createMockTaskWithSpec({
+          steps: [
+            {
+              id: 'test',
+              name: 'name',
+              each: '${{ parameters.data }}',
+              action: 'jest-mock-action',
+            },
+          ],
+          parameters: { data: value },
+        });
+
+        await expect(runner.execute(task)).rejects.toThrow(
+          'must resolve to an array or object',
+        );
+      }
+
+      expect(fakeActionHandler).not.toHaveBeenCalled();
+    });
+
     it('should validate each parameter renders to a valid value', async () => {
       const task = createMockTaskWithSpec({
         steps: [

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
@@ -378,13 +378,23 @@ export class NunjucksWorkflowRunner implements WorkflowRunner {
           preIterationContext.secrets as NunjitsuTemplateValue,
         );
 
-      const resolvedEach =
-        step.each &&
-        this.render(step.each, preparedPreIterationContext, templateRenderer);
+      const hasEach = step.each !== undefined;
+      const resolvedEach = hasEach
+        ? this.render(step.each, preparedPreIterationContext, templateRenderer)
+        : undefined;
 
-      if (step.each && !resolvedEach) {
+      if (hasEach && resolvedEach === undefined) {
         throw new InputError(
           `Invalid value on action ${action.id}.each parameter, "${step.each}" cannot be resolved to a value`,
+        );
+      }
+
+      if (
+        hasEach &&
+        (resolvedEach === null || typeof resolvedEach !== 'object')
+      ) {
+        throw new InputError(
+          `Invalid value on action ${action.id}.each parameter, must resolve to an array or object`,
         );
       }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This updates Scaffolder step iteration to reject `each` values that resolve to
primitives. Arrays and objects continue to be supported, while invalid values
now fail with a clear input error.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
