### PR TITLE
fix(catalog-react): normalize owner query params before first render

### DIFF
--- a/.changeset/fix-entity-owner-picker-humanized-refs.md
+++ b/.changeset/fix-entity-owner-picker-humanized-refs.md
@@ -1,0 +1,9 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Fixed `EntityOwnerPicker` crashing with `Entity reference "<name>" had missing or empty kind` when the `owners` query parameter contains humanized entity refs, as produced by the `OwnershipCard` links in `@backstage/plugin-org`.
+
+Query parameters were stored as-is in the initial state and only converted to full entity refs by an effect, which runs after the first render. That first render passed the raw value to the entity presentation API, whose `parseEntityRef` call rejects a ref without a kind. The same raw value was also sent to `catalogApi.getEntitiesByRefs` on mount, and made the option checkboxes render unselected until the effect ran.
+
+The query parameters are now normalized through `EntityOwnerFilter` when the state is initialized, matching what the existing effect already did and what the `filters` code path already produced.

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.test.tsx
@@ -207,7 +207,7 @@ describe('<EntityOwnerPicker mode="all" />', () => {
     );
 
     expect(mockCatalogApi.getEntitiesByRefs).toHaveBeenCalledWith({
-      entityRefs: ['another-owner'],
+      entityRefs: ['group:default/another-owner'],
     });
     expect(updateFilters).toHaveBeenLastCalledWith({
       owners: new EntityOwnerFilter(['group:default/another-owner']),
@@ -253,7 +253,7 @@ describe('<EntityOwnerPicker mode="all" />', () => {
     );
 
     expect(mockCatalogApi.getEntitiesByRefs).toHaveBeenCalledWith({
-      entityRefs: ['another-owner'],
+      entityRefs: ['group:default/another-owner'],
     });
 
     fireEvent.click(screen.getByTestId('owner-picker-expand'));
@@ -345,7 +345,7 @@ describe('<EntityOwnerPicker mode="all" />', () => {
       </ApiProvider>,
     );
     expect(mockCatalogApi.getEntitiesByRefs).toHaveBeenCalledWith({
-      entityRefs: ['team-a'],
+      entityRefs: ['group:default/team-a'],
     });
     expect(updateFilters).toHaveBeenLastCalledWith({
       owners: new EntityOwnerFilter(['group:default/team-a']),

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
@@ -154,8 +154,12 @@ export const EntityOwnerPicker = (props?: EntityOwnerPickerProps) => {
     [ownersParameter],
   );
 
+  // Query parameters may contain humanized refs (e.g. `guests` rather than
+  // `group:default/guests`), so they are normalized before being stored.
   const [selectedOwners, setSelectedOwners] = useState<string[]>(
-    queryParamOwners.length ? queryParamOwners : filters.owners?.values ?? [],
+    queryParamOwners.length
+      ? new EntityOwnerFilter(queryParamOwners).values
+      : filters.owners?.values ?? [],
   );
 
   const [{ value, loading }, handleFetch, cache] = useFetchEntities({


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Open a user page like `/catalog/default/user/guest` and click one of the ownership cards. The catalog page breaks:

```
Entity reference "guests" had missing or empty kind (e.g. did not start with "component:" or similar)
    at parseEntityRef
    at DefaultEntityPresentationApi.forEntity
    at getOptionLabel (EntityOwnerPicker)
```

The card links to `?filters[owners]=guests`. The owner picker needs a full ref there, like `group:default/guests`, and throws on the short one. You get this on a fresh `create-app`.

The picker does fix up that value, but only after the page has rendered once, so the first render is the one that throws. I moved the fix up to where the state is first set.

The short ref was also being sent to the catalog API, which rejects it for the same reason, and the checkboxes showed up unchecked for a moment.

No new tests. Three of the existing ones expected the short ref to reach the catalog, which is the bug, so I changed those. They fail without the fix.

Fixes #35272 

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.
