### PR TITLE
fix(catalog-react): normalize kindless owner filter query param on init

### DIFF
--- a/.changeset/owner-picker-kindless-query-param.md
+++ b/.changeset/owner-picker-kindless-query-param.md
@@ -1,0 +1,8 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Fixed `EntityOwnerPicker` throwing when the owner filter query parameter value
+lacks a kind (e.g. `?filters[owners]=team-a`). The initial selected-owner state
+is now normalized to a full entity ref, so the presentation API never receives a
+kindless ref and the filter is applied correctly.

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.test.tsx
@@ -207,7 +207,7 @@ describe('<EntityOwnerPicker mode="all" />', () => {
     );
 
     expect(mockCatalogApi.getEntitiesByRefs).toHaveBeenCalledWith({
-      entityRefs: ['another-owner'],
+      entityRefs: ['group:default/another-owner'],
     });
     expect(updateFilters).toHaveBeenLastCalledWith({
       owners: new EntityOwnerFilter(['group:default/another-owner']),
@@ -253,7 +253,7 @@ describe('<EntityOwnerPicker mode="all" />', () => {
     );
 
     expect(mockCatalogApi.getEntitiesByRefs).toHaveBeenCalledWith({
-      entityRefs: ['another-owner'],
+      entityRefs: ['group:default/another-owner'],
     });
 
     fireEvent.click(screen.getByTestId('owner-picker-expand'));
@@ -345,7 +345,7 @@ describe('<EntityOwnerPicker mode="all" />', () => {
       </ApiProvider>,
     );
     expect(mockCatalogApi.getEntitiesByRefs).toHaveBeenCalledWith({
-      entityRefs: ['team-a'],
+      entityRefs: ['group:default/team-a'],
     });
     expect(updateFilters).toHaveBeenLastCalledWith({
       owners: new EntityOwnerFilter(['group:default/team-a']),
@@ -521,6 +521,33 @@ describe('<EntityOwnerPicker mode="owners-only" />', () => {
 
     expect(updateFilters).toHaveBeenLastCalledWith({
       owners: new EntityOwnerFilter(['group:default/another-owner']),
+    });
+  });
+
+  it('normalizes a kindless query parameter value before initial render', async () => {
+    // Regression test for https://github.com/backstage/backstage/issues/35272
+    // A URL like ?filters[owners]=team-a must be normalized to a full entity
+    // ref during state initialization, so neither the catalog request nor the
+    // presentation API ever sees a ref without a kind.
+    const updateFilters = jest.fn();
+    const queryParameters = { owners: ['team-a'] };
+    await renderInTestApp(
+      <ApiProvider apis={mockApis}>
+        <MockEntityListContextProvider
+          value={{
+            updateFilters,
+            queryParameters,
+          }}
+        >
+          <EntityOwnerPicker mode="owners-only" />
+        </MockEntityListContextProvider>
+      </ApiProvider>,
+    );
+
+    // In owners-only mode the initial fetch is disabled, so we assert on the
+    // normalized filter value rather than the (skipped) catalog request.
+    expect(updateFilters).toHaveBeenLastCalledWith({
+      owners: new EntityOwnerFilter(['group:default/team-a']),
     });
   });
 

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
@@ -154,9 +154,15 @@ export const EntityOwnerPicker = (props?: EntityOwnerPickerProps) => {
     [ownersParameter],
   );
 
-  const [selectedOwners, setSelectedOwners] = useState<string[]>(
-    queryParamOwners.length ? queryParamOwners : filters.owners?.values ?? [],
-  );
+  const [selectedOwners, setSelectedOwners] = useState<string[]>(() => {
+    // Normalize raw query-parameter values (which may lack a kind, e.g.
+    // ?filters[owners]=team-a) through the filter so they become full
+    // entity refs before anything renders or parses them.
+    if (queryParamOwners.length) {
+      return new EntityOwnerFilter(queryParamOwners).values;
+    }
+    return filters.owners?.values ?? [];
+  });
 
   const [{ value, loading }, handleFetch, cache] = useFetchEntities({
     mode,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #35272

### Problem
A kindless owner filter value in the URL (e.g. `?filters[owners]=team-a`) was used un-normalized for the initial selected-owners state. Any registered `EntityPresentationApi` that parses entity refs strictly then threw `had missing or empty kind`, and the filter never resolved to a full ref so it was not applied.

### Fix
Normalize the initial selected owners through `EntityOwnerFilter` so the value becomes a full entity ref (`group:default/team-a`) before anything renders or parses it — matching what the query-parameter effect already does on updates.

### Changeset
Added `.changeset/owner-picker-kindless-query-param.md` (patch for `@backstage/plugin-catalog-react`).

### Verification
`EntityOwnerPicker.test.tsx`: 14/14 passing, including a new regression test asserting the kindless query param is normalized before initial render.

#### Checklist
- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.

Note: this change was developed with the assistance of an AI coding agent, reviewed and verified locally by a human maintainer-contributor (test suite green).