### PR TITLE
fix(catalog-react): EntityOwnerPicker crashes on bare owner refs from query params

### DIFF
--- a/.changeset/fix-entity-owner-picker-bare-owner-ref.md
+++ b/.changeset/fix-entity-owner-picker-bare-owner-ref.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Fixed a crash in `EntityOwnerPicker` (the default `mode="owners-only"`) when the `owners` query parameter contains a humanized or otherwise non-namespaced entity ref, for example `?filters[owners]=my-team` instead of `?filters[owners]=group:default/my-team`. This is a legitimate value for the `owners` filter -- `EntityOwnerFilter` itself defaults such refs to kind `Group` -- but on the initial render, before that normalization has run, the picker computed the selected-owner chip's label without supplying a default kind/namespace to the presentation API, which threw `Entity reference "..." had missing or empty kind` and crashed the whole page.

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.test.tsx
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
+import {
+  Entity,
+  parseEntityRef,
+  stringifyEntityRef,
+} from '@backstage/catalog-model';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import {
   MockEntityListContextProvider,
@@ -675,5 +679,53 @@ describe('<EntityOwnerPicker mode="owners-only" />', () => {
 
     expect(mockCatalogApi.getEntityFacets).toHaveBeenCalledTimes(1);
     expect(mockCatalogApi.getEntitiesByRefs).not.toHaveBeenCalled();
+  });
+
+  it('does not crash when the owners query parameter is a bare, non-namespaced ref', async () => {
+    // Regression test for a crash reported against a real Backstage instance:
+    // callers are explicitly allowed to put humanized/partial refs (e.g. "my-team"
+    // instead of "group:default/my-team") into the `owners` query parameter --
+    // EntityOwnerFilter itself defaults their kind to "Group" for exactly this
+    // reason. On the very first render, before the effect that normalizes
+    // `queryParamOwners` through `EntityOwnerFilter` has run, `getOptionLabel`
+    // (used to render the selected-owner chip) receives this raw, still
+    // un-namespaced string. It must resolve a title for it via the presentation
+    // API rather than throwing "Entity reference ... had missing or empty kind".
+    const forEntity = jest.fn((entityOrRef: Entity | string, context?: any) => {
+      const ref =
+        typeof entityOrRef === 'string'
+          ? entityOrRef
+          : stringifyEntityRef(entityOrRef);
+      // Mirrors the real DefaultEntityPresentationApi, which parses the ref
+      // using whatever default kind/namespace it is given.
+      const parsed = parseEntityRef(ref, context);
+      const snapshot = {
+        entityRef: stringifyEntityRef(parsed),
+        primaryTitle: parsed.name,
+      };
+      return { snapshot, promise: Promise.resolve(snapshot) };
+    });
+
+    const testApis = TestApiRegistry.from(
+      [catalogApiRef, mockCatalogApi],
+      [errorApiRef, mockErrorApi],
+      [entityPresentationApiRef, { forEntity }],
+    );
+
+    await renderInTestApp(
+      <ApiProvider apis={testApis}>
+        <MockEntityListContextProvider
+          value={{ queryParameters: { owners: ['another-owner'] } }}
+        >
+          <EntityOwnerPicker mode="owners-only" />
+        </MockEntityListContextProvider>
+      </ApiProvider>,
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: 'another-owner' }),
+      ).toBeInTheDocument(),
+    );
   });
 });

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
@@ -213,10 +213,15 @@ export const EntityOwnerPicker = (props?: EntityOwnerPickerProps) => {
         getOptionLabel={o => {
           if (mode === 'owners-only') {
             // Stubs have no title; use string ref so entityPresentationSnapshot hits the API cache.
+            // `o` may still be the raw, un-normalized value from the `owners` query parameter (e.g.
+            // on the very first render, before the effect above resolves it through
+            // `EntityOwnerFilter`), which is allowed to be a humanized/partial ref such as
+            // `my-team` rather than `group:default/my-team`. A default kind/namespace must be
+            // supplied so that presentation lookup does not throw on such refs.
             const ref = typeof o === 'string' ? o : stringifyEntityRef(o);
             return entityPresentationSnapshot(
               ref,
-              undefined,
+              { defaultKind: 'group', defaultNamespace: 'default' },
               entityPresentationApi,
             ).primaryTitle;
           }


### PR DESCRIPTION
Fixes #35276

## Hey, I just made a Pull Request!

The `owners` filter query parameter is designed to accept humanized/partial entity refs, not just fully-qualified ones -- `EntityOwnerFilter`'s constructor already defaults such values to kind `Group`:

```ts
constructor(values: string[]) {
  this.values = values.reduce((fullRefs, ref) => {
    try {
      fullRefs.push(stringifyEntityRef(parseEntityRef(ref, { defaultKind: 'Group' })));
      return fullRefs;
    } catch (err) {
      return fullRefs;
    }
  }, [] as string[]);
}
```

However, `EntityOwnerPicker` initializes `selectedOwners` directly from the raw `owners` query parameter and only runs it through `EntityOwnerFilter` in a `useEffect` that fires *after* the first render. On that first render, the still-raw value is passed as the Autocomplete's controlled `value`, and its default `renderTags` calls `getOptionLabel` to build each selected-owner chip. In the default `mode="owners-only"`, that callback calls `entityPresentationSnapshot` with no default-kind context:

```tsx
if (mode === 'owners-only') {
  const ref = typeof o === 'string' ? o : stringifyEntityRef(o);
  return entityPresentationSnapshot(ref, undefined, entityPresentationApi).primaryTitle;
}
```

`entityPresentationSnapshot` forwards that `undefined` context to `entityPresentationApi.forEntity(ref, context)`, which parses `ref` and throws `Entity reference "..." had missing or empty kind` because the ref has no `:` and no default kind was supplied. The sibling `mode="all"` branch a few lines below already guards against exactly this by parsing with `{ defaultKind: 'group', defaultNamespace: 'default' }` first -- the `owners-only` branch (the default mode, used by the plain Catalog page) was missing the equivalent handling.

This is easy to trigger in practice: `@backstage/plugin-org`'s `OwnershipCard` intentionally builds catalog links with humanized owner refs in the `owners` query parameter (see its own test `should produce query params with humanized entity refs as owners` in `useGetEntities.test.ts`), so simply clicking one of its entity-count tiles navigates to a URL that crashes the Catalog page.

This PR passes the same default kind/namespace context to `entityPresentationSnapshot` in the `owners-only` branch, so a bare owner ref resolves to a best-effort label instead of throwing.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.
