### PR TITLE
Bump nunjitsu to 0.6.1

### DIFF
--- a/.changeset/calm-taxis-listen.md
+++ b/.changeset/calm-taxis-listen.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Software template inline conditionals without an `else` branch now render an empty string when their condition is false, matching Nunjucks behavior.

--- a/.patches/pr-35279.txt
+++ b/.patches/pr-35279.txt
@@ -1,0 +1,1 @@
+Fixed software template inline conditionals without an `else` branch to render an empty string when their condition is false.

--- a/plugins/scaffolder-backend/package.json
+++ b/plugins/scaffolder-backend/package.json
@@ -86,7 +86,7 @@
     "lodash": "^4.17.21",
     "logform": "^2.3.2",
     "luxon": "^3.0.0",
-    "nunjitsu": "^0.6.0",
+    "nunjitsu": "^0.6.1",
     "p-queue": "^6.6.2",
     "prom-client": "^15.0.0",
     "triple-beam": "^1.4.1",

--- a/plugins/scaffolder-backend/src/lib/templating/Nunjitsu.test.ts
+++ b/plugins/scaffolder-backend/src/lib/templating/Nunjitsu.test.ts
@@ -29,6 +29,8 @@ describe('Nunjitsu', () => {
       renderer.render('${{ test | replace("my-", "our-") }}', context),
     ).toBe('our-value');
 
+    expect(renderer.render('${{ "value" if false }}', context)).toBe('');
+
     expect(() => renderer.render('${{ invalid...syntax }}', context)).toThrow(
       /Expected name/,
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -6336,7 +6336,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     logform: "npm:^2.3.2"
     luxon: "npm:^3.0.0"
-    nunjitsu: "npm:^0.6.0"
+    nunjitsu: "npm:^0.6.1"
     p-queue: "npm:^6.6.2"
     prom-client: "npm:^15.0.0"
     strip-ansi: "npm:^7.1.0"
@@ -36818,10 +36818,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nunjitsu@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "nunjitsu@npm:0.6.0"
-  checksum: 10/287347334beac63b4228d07757c392c24d396f5a7a0ad38ef7c771692384976b9a2aa2e64d1fde2d5d0150df4247689467a3b29578746f185bc96ddd5709c8f8
+"nunjitsu@npm:^0.6.1":
+  version: 0.6.1
+  resolution: "nunjitsu@npm:0.6.1"
+  checksum: 10/29b1ed8b93c5f099493d3b7e9a706bcece6dc8c5d58cafe2642abd4fd1e93911e2a1f800f0490641f3057e885478db87405d42f7f3525abb5f577db62112fdeb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Bumps `nunjitsu` to 0.6.1 so software template inline conditionals without an `else` branch render an empty string when false, matching Nunjucks behavior. Adds a focused regression assertion and prepares `@backstage/plugin-scaffolder-backend` for a patch release.

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

<!-- mana-workspace:5pYpdMUNiR4 -->