### PR TITLE
Speed up build-workspace feature detection

### DIFF
--- a/.changeset/fast-build-workspaces.md
+++ b/.changeset/fast-build-workspaces.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli-module-build': patch
+---
+
+Significantly improve the performance of `build-workspace` when packaging many Backstage packages.

--- a/packages/cli-module-build/src/lib/packager/createDistWorkspace.ts
+++ b/packages/cli-module-build/src/lib/packager/createDistWorkspace.ts
@@ -331,7 +331,12 @@ async function moveToDistWorkspace(
   });
   const featureDetectionProject =
     fastPackPackages.length > 0 && enableFeatureDetection
-      ? await createTypeDistProject()
+      ? await createTypeDistProject(
+          fastPackPackages.map(pkg => ({
+            dir: pkg.dir,
+            role: pkg.packageJson.backstage?.role,
+          })),
+        )
       : undefined;
 
   // New an improved flow where we avoid calling `yarn pack`

--- a/packages/cli-module-build/src/lib/typeDistProject.test.ts
+++ b/packages/cli-module-build/src/lib/typeDistProject.test.ts
@@ -15,10 +15,47 @@
  */
 
 import { PackageRole, BackstagePackageFeatureType } from '@backstage/cli-node';
+import { createMockDirectory } from '@backstage/backend-test-utils';
 import createFeatureEnvironment from './__testUtils__/createFeatureEnvironment';
-import { getEntryPointDefaultFeatureType } from './typeDistProject';
+import {
+  createTypeDistProject,
+  getEntryPointDefaultFeatureType,
+} from './typeDistProject';
 
 describe('typeDistProject', () => {
+  const mockDir = createMockDirectory();
+
+  afterEach(() => {
+    mockDir.clear();
+  });
+
+  it('preloads declarations for feature-producing package roles', async () => {
+    mockDir.setContent({
+      allowed: {
+        dist: {
+          'index.d.ts': 'export declare const value: string;',
+        },
+      },
+      disallowed: {
+        dist: {
+          'index.d.ts': 'export declare const value: string;',
+        },
+      },
+    });
+
+    const project = await createTypeDistProject([
+      { dir: mockDir.resolve('allowed'), role: 'node-library' },
+      { dir: mockDir.resolve('disallowed'), role: 'cli' },
+    ]);
+
+    expect(
+      project.getSourceFile(mockDir.resolve('allowed/dist/index.d.ts')),
+    ).toBeDefined();
+    expect(
+      project.getSourceFile(mockDir.resolve('disallowed/dist/index.d.ts')),
+    ).toBeUndefined();
+  });
+
   describe('for package role', () => {
     // This Record makes sure we're checking all package roles
     const packageRoles: Record<PackageRole, boolean> = {

--- a/packages/cli-module-build/src/lib/typeDistProject.ts
+++ b/packages/cli-module-build/src/lib/typeDistProject.ts
@@ -22,11 +22,21 @@ import { resolve as resolvePath } from 'node:path';
 import { Project, SourceFile, SyntaxKind, ts, Type } from 'ts-morph';
 import { targetPaths } from '@backstage/cli-common';
 
-export const createTypeDistProject = async () => {
-  return new Project({
+export const createTypeDistProject = async (
+  packages: Array<{ dir: string; role?: PackageRole }> = [],
+) => {
+  const project = new Project({
     tsConfigFilePath: targetPaths.resolveRoot('tsconfig.json'),
     skipAddingFilesFromTsConfig: true,
   });
+  // Adding source files invalidates the TypeScript program, so load all entry
+  // point declarations before any package starts querying their types.
+  project.addSourceFilesAtPaths(
+    packages.flatMap(({ dir, role }) =>
+      isTargetPackageRole(role) ? resolvePath(dir, 'dist', '*.d.ts') : [],
+    ),
+  );
+  return project;
 };
 
 // A list of the package roles we want to extract features for
@@ -130,7 +140,7 @@ function getBackstagePackageFeature$$TypeFromType(
 }
 
 // Condition for a package role matches a target package role
-function isTargetPackageRole(role: PackageRole): boolean {
+function isTargetPackageRole(role?: PackageRole): boolean {
   return !!role && targetPackageRoles.includes(role);
 }
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Preload declaration files for feature-producing packages before inspecting their types. This allows the TypeScript project to reuse one program instead of invalidating and rebuilding it for each package.

In a local run of the CLI E2E workspace preparation flow, this reduced the `build-workspace` phase from 138.6 seconds to 8.0 seconds.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
