### PR TITLE
fix(org): use entity refs in ownership links

### DIFF
--- a/.changeset/owner-links-use-entity-refs.md
+++ b/.changeset/owner-links-use-entity-refs.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-org': patch
+---
+
+Fixed ownership card catalog links to filter by stable entity references instead of display titles.

--- a/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.test.tsx
+++ b/plugins/org/src/components/Cards/OwnershipCard/OwnershipCard.test.tsx
@@ -288,7 +288,7 @@ describe('OwnershipCard', () => {
     // This env does not support URLSearchParams
     const queryParams = decodeURIComponent(href);
 
-    expect(queryParams).toContain('filters[owners]=my-team');
+    expect(queryParams).toContain('filters[owners]=group:default/my-team');
   });
 
   it('links to the catalog with the user and groups filters from an user profile', async () => {
@@ -311,7 +311,7 @@ describe('OwnershipCard', () => {
     // This env does not support URLSearchParams
     const queryParams = decodeURIComponent(href);
     expect(queryParams).toMatch(
-      /filters\[owners\]=custom\/some\-team.*filters\[owners\]=user:the-user/,
+      /filters\[owners\]=group:custom\/some\-team.*filters\[owners\]=user:default\/the-user/,
     );
   });
 

--- a/plugins/org/src/components/Cards/OwnershipCard/useGetEntities.test.ts
+++ b/plugins/org/src/components/Cards/OwnershipCard/useGetEntities.test.ts
@@ -359,13 +359,18 @@ describe('useGetEntities', () => {
         filters: {
           kind: 'api',
           type: 'openapi',
-          owners: [
-            `group:default/${givenLeafGroup}`,
-            `group:default/${givenParentGroup}`,
-          ],
+          owners: expect.any(Array),
           user: 'all',
         },
       });
+      const owners = (params.filters as { owners: string[] }).owners;
+      expect(owners).toEqual(
+        expect.arrayContaining([
+          `group:default/${givenLeafGroup}`,
+          `group:default/${givenParentGroup}`,
+        ]),
+      );
+      expect(owners).toHaveLength(2);
     });
 
     it('should group entities by kind and type in query params', async () => {

--- a/plugins/org/src/components/Cards/OwnershipCard/useGetEntities.test.ts
+++ b/plugins/org/src/components/Cards/OwnershipCard/useGetEntities.test.ts
@@ -293,7 +293,7 @@ describe('useGetEntities', () => {
       catalogApi.getEntitiesByRefs.mockRestore();
     });
 
-    it('should produce query params with humanized entity refs as owners', async () => {
+    it('should produce query params with canonical entity refs as owners', async () => {
       getEntityRelationsMock.mockReturnValue([]);
       catalogApi.getEntities.mockResolvedValueOnce({
         items: [
@@ -320,7 +320,7 @@ describe('useGetEntities', () => {
         filters: {
           kind: 'component',
           type: 'service',
-          owners: givenLeafGroup,
+          owners: `group:default/${givenLeafGroup}`,
           user: 'all',
         },
       });
@@ -359,7 +359,10 @@ describe('useGetEntities', () => {
         filters: {
           kind: 'api',
           type: 'openapi',
-          owners: expect.arrayContaining([givenLeafGroup, givenParentGroup]),
+          owners: [
+            `group:default/${givenLeafGroup}`,
+            `group:default/${givenParentGroup}`,
+          ],
           user: 'all',
         },
       });

--- a/plugins/org/src/components/Cards/OwnershipCard/useGetEntities.ts
+++ b/plugins/org/src/components/Cards/OwnershipCard/useGetEntities.ts
@@ -23,7 +23,6 @@ import {
 import {
   CatalogApi,
   catalogApiRef,
-  entityPresentationSnapshot,
   getEntityRelations,
 } from '@backstage/plugin-catalog-react';
 import limiterFactory from 'p-limit';
@@ -46,14 +45,10 @@ const getQueryParams = (
   selectedEntity: EntityTypeProps,
 ): string => {
   const { kind, type } = selectedEntity;
-  const owners = ownersEntityRef.map(
-    ref =>
-      entityPresentationSnapshot(ref, { defaultKind: 'group' }).primaryTitle,
-  );
   const filters = {
     kind: kind.toLocaleLowerCase('en-US'),
     type,
-    owners,
+    owners: ownersEntityRef,
     user: 'all',
   };
   return qs.stringify({ filters }, { arrayFormat: 'repeat' });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Ownership card links currently serialize owner presentation titles into the catalog filter query. Presentation titles are mutable display text rather than entity identifiers, and bare values can also be rejected by the owner picker.

This keeps the canonical owner entity references when constructing catalog links. It complements #35270, which normalizes legacy bare owner query parameters in the picker.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
