### PR TITLE
Update docs UI changelog for 0.17.0 and 0.17.1

### DIFF
--- a/docs-ui/src/utils/changelog.ts
+++ b/docs-ui/src/utils/changelog.ts
@@ -1,4 +1,6 @@
 export * from './types';
+import { changelog_0_17_1 } from './changelogs/v0.17.1';
+import { changelog_0_17_0 } from './changelogs/v0.17.0';
 import { changelog_0_16_0 } from './changelogs/v0.16.0';
 import { changelog_0_15_0 } from './changelogs/v0.15.0';
 import { changelog_0_14_0 } from './changelogs/v0.14.0';
@@ -23,6 +25,8 @@ import { changelog_0_2_0 } from './changelogs/v0.2.0';
 import { changelog_0_1_0 } from './changelogs/v0.1.0';
 
 export const changelog = [
+  ...changelog_0_17_1,
+  ...changelog_0_17_0,
   ...changelog_0_16_0,
   ...changelog_0_15_0,
   ...changelog_0_14_0,

--- a/docs-ui/src/utils/changelogs/v0.17.0.ts
+++ b/docs-ui/src/utils/changelogs/v0.17.0.ts
@@ -1,0 +1,41 @@
+import type { ChangelogProps } from '../types';
+
+export const changelog_0_17_0: ChangelogProps[] = [
+  {
+    components: [],
+    version: '0.17.0',
+    prs: [],
+    description: `Added re-exports from \`react-aria-components\`. The types \`Selection\`, \`SortDirection\`, and \`Key\` are available as type-only exports (use \`import type\`), while \`Focusable\` is a runtime export. Consumers can now import these directly from \`@backstage/ui\` instead of depending on \`react-aria-components\`, avoiding version mismatches.`,
+    breaking: true,
+    commitSha: '503ba32',
+  },
+  {
+    components: ['plugin-header'],
+    version: '0.17.0',
+    prs: [],
+    description: `Make PluginHeader > Breadcrumbs separator align with rest of text`,
+
+    commitSha: '2341682',
+  },
+  {
+    components: ['plugin-header'],
+    version: '0.17.0',
+    prs: [],
+    description: `Add \`breadcrumbs\` prop & breadcrumbs to \`PluginHeader\`. When passed \`breadcrumbs\`, \`PluginHeader\` renders a \`nav\` with breadcrumbs & visually hides the plugin title.
+
+  These breadcrumbs:
+
+  - Collapses middle segments if 5 or more segments
+  - Shows tooltip if text is truncated`,
+
+    commitSha: '791703e',
+  },
+  {
+    components: [],
+    version: '0.17.0',
+    prs: [],
+    description: `Added a new \`TextAreaField\` component for multi-line text input, following the same conventions as \`TextField\` with support for a label, secondary label, and description.`,
+
+    commitSha: '066c7ac',
+  },
+];

--- a/docs-ui/src/utils/changelogs/v0.17.0.ts
+++ b/docs-ui/src/utils/changelogs/v0.17.0.ts
@@ -4,7 +4,7 @@ export const changelog_0_17_0: ChangelogProps[] = [
   {
     components: [],
     version: '0.17.0',
-    prs: [],
+    prs: ['34540'],
     description: `Added re-exports from \`react-aria-components\`. The types \`Selection\`, \`SortDirection\`, and \`Key\` are available as type-only exports (use \`import type\`), while \`Focusable\` is a runtime export. Consumers can now import these directly from \`@backstage/ui\` instead of depending on \`react-aria-components\`, avoiding version mismatches.`,
     breaking: true,
     commitSha: '503ba32',
@@ -12,7 +12,7 @@ export const changelog_0_17_0: ChangelogProps[] = [
   {
     components: ['plugin-header'],
     version: '0.17.0',
-    prs: [],
+    prs: ['34682'],
     description: `Make PluginHeader > Breadcrumbs separator align with rest of text`,
 
     commitSha: '2341682',
@@ -20,7 +20,7 @@ export const changelog_0_17_0: ChangelogProps[] = [
   {
     components: ['plugin-header'],
     version: '0.17.0',
-    prs: [],
+    prs: ['34587'],
     description: `Add \`breadcrumbs\` prop & breadcrumbs to \`PluginHeader\`. When passed \`breadcrumbs\`, \`PluginHeader\` renders a \`nav\` with breadcrumbs & visually hides the plugin title.
 
   These breadcrumbs:
@@ -33,7 +33,7 @@ export const changelog_0_17_0: ChangelogProps[] = [
   {
     components: [],
     version: '0.17.0',
-    prs: [],
+    prs: ['34611'],
     description: `Added a new \`TextAreaField\` component for multi-line text input, following the same conventions as \`TextField\` with support for a label, secondary label, and description.`,
 
     commitSha: '066c7ac',

--- a/docs-ui/src/utils/changelogs/v0.17.1.ts
+++ b/docs-ui/src/utils/changelogs/v0.17.1.ts
@@ -4,7 +4,7 @@ export const changelog_0_17_1: ChangelogProps[] = [
   {
     components: [],
     version: '0.17.1',
-    prs: [],
+    prs: ['34755'],
     description: `Fixed Table not filling container width in Firefox when using \`TableRoot\` directly inside \`ResizableTableContainer\`. Changed \`overflow: hidden\` to \`overflow: auto\` on the resizable container so it handles scrolling for direct \`TableRoot\` usages.`,
 
     commitSha: '52a58be',

--- a/docs-ui/src/utils/changelogs/v0.17.1.ts
+++ b/docs-ui/src/utils/changelogs/v0.17.1.ts
@@ -1,0 +1,12 @@
+import type { ChangelogProps } from '../types';
+
+export const changelog_0_17_1: ChangelogProps[] = [
+  {
+    components: [],
+    version: '0.17.1',
+    prs: [],
+    description: `Fixed Table not filling container width in Firefox when using \`TableRoot\` directly inside \`ResizableTableContainer\`. Changed \`overflow: hidden\` to \`overflow: auto\` on the resizable container so it handles scrolling for direct \`TableRoot\` usages.`,
+
+    commitSha: '52a58be',
+  },
+];


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

Syncs the Backstage UI documentation changelog with released `@backstage/ui` versions `0.17.0` and `0.17.1`, so component changelog pages include the latest release details and PR links.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
