### PR TITLE
catalog-react: normalize kindless entity ref in EntityOwnerPicker owners-only mode

### DIFF
--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.test.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.test.tsx
@@ -676,4 +676,46 @@ describe('<EntityOwnerPicker mode="owners-only" />', () => {
     expect(mockCatalogApi.getEntityFacets).toHaveBeenCalledTimes(1);
     expect(mockCatalogApi.getEntitiesByRefs).not.toHaveBeenCalled();
   });
+
+  it('handles bare/kind-less query parameter in owners-only mode without error', async () => {
+    const updateFilters = jest.fn();
+    const queryParameters = { owners: ['team-a'] };
+
+    const mockPresentationApi: jest.Mocked<EntityPresentationApi> = {
+      forEntity: jest.fn().mockImplementation((entityOrRef: Entity | string) => {
+        const ref = typeof entityOrRef === 'string' ? entityOrRef : stringifyEntityRef(entityOrRef);
+        const snapshot = { entityRef: ref, primaryTitle: ref };
+        return { snapshot, promise: Promise.resolve(snapshot) };
+      }),
+    };
+
+    mockCatalogApi.getEntityFacets.mockResolvedValue({
+      facets: {
+        'relations.ownedBy': [{ count: 1, value: 'group:default/team-a' }],
+      },
+    });
+
+    const testApis = TestApiRegistry.from(
+      [catalogApiRef, mockCatalogApi],
+      [errorApiRef, mockErrorApi],
+      [entityPresentationApiRef, mockPresentationApi],
+    );
+
+    await renderInTestApp(
+      <ApiProvider apis={testApis}>
+        <MockEntityListContextProvider
+          value={{
+            updateFilters,
+            queryParameters,
+          }}
+        >
+          <EntityOwnerPicker mode="owners-only" />
+        </MockEntityListContextProvider>
+      </ApiProvider>,
+    );
+
+    expect(updateFilters).toHaveBeenCalledWith({
+      owners: new EntityOwnerFilter(['group:default/team-a']),
+    });
+  });
 });

--- a/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
+++ b/plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx
@@ -213,7 +213,15 @@ export const EntityOwnerPicker = (props?: EntityOwnerPickerProps) => {
         getOptionLabel={o => {
           if (mode === 'owners-only') {
             // Stubs have no title; use string ref so entityPresentationSnapshot hits the API cache.
-            const ref = typeof o === 'string' ? o : stringifyEntityRef(o);
+            const ref =
+              typeof o === 'string'
+                ? stringifyEntityRef(
+                    parseEntityRef(o, {
+                      defaultKind: 'group',
+                      defaultNamespace: 'default',
+                    }),
+                  )
+                : stringifyEntityRef(o);
             return entityPresentationSnapshot(
               ref,
               undefined,


### PR DESCRIPTION
## Problem
When navigating to the catalog list page with a filter value that lacks an explicit kind (such as `filters[owners]=team-a`), `EntityOwnerPicker` in `owners-only` mode throws an unhandled error:
```
Entity reference "team-a" had missing or empty kind (e.g. did not start with "component:" or similar)
```

## Solution
In `plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.tsx`, parse string entity refs with `defaultKind: 'group'` and `defaultNamespace: 'default'` before stringifying when resolving snapshot presentation titles in `owners-only` mode.

Fixes #35272

## Testing
- Added unit test in `plugins/catalog-react/src/components/EntityOwnerPicker/EntityOwnerPicker.test.tsx` verifying that kind-less query parameters (e.g. `owners: ['team-a']`) are safely handled in `owners-only` mode without crashing.