### PR TITLE
perf(kubernetes): Keep kubernetes plugin and deps out of the initial bundle

### DIFF
--- a/.changeset/kubernetes-filter-leaf-module.md
+++ b/.changeset/kubernetes-filter-leaf-module.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes': patch
+---
+
+The Kubernetes entity content no longer loads its UI until the tab is opened, keeping it out of the initial bundle. Tab visibility is now an entity filter predicate that can be overridden through app config, and entities with an empty Kubernetes annotation now show the tab where previously it was hidden.

--- a/.changeset/kubernetes-react-lazy-xterm.md
+++ b/.changeset/kubernetes-react-lazy-xterm.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-react': patch
+---
+
+The pod exec terminal now loads `@xterm/xterm` and its stylesheet when a terminal is opened, instead of including them in the initial bundle.

--- a/plugins/kubernetes-react/src/components/PodExecTerminal/PodExecTerminal.tsx
+++ b/plugins/kubernetes-react/src/components/PodExecTerminal/PodExecTerminal.tsx
@@ -13,40 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import '@xterm/xterm/css/xterm.css';
 
-import { discoveryApiRef, useApi } from '@backstage/core-plugin-api';
-import { ClusterAttributes } from '@backstage/plugin-kubernetes-common';
-import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
-import { useRef, useEffect, useMemo, useState } from 'react';
-import { Terminal } from '@xterm/xterm';
-import { FitAddon } from '@xterm/addon-fit';
+import { Progress } from '@backstage/core-components';
+import { lazy, Suspense } from 'react';
+import type { PodExecTerminalProps } from './PodExecTerminalContent';
 
-import { PodExecTerminalAttachAddon } from './PodExecTerminalAttachAddon';
+export type { PodExecTerminalProps } from './PodExecTerminalContent';
 
-/**
- * Props drilled down to the PodExecTerminal component
- *
- * @public
- */
-export interface PodExecTerminalProps {
-  cluster: ClusterAttributes;
-  containerName: string;
-  podName: string;
-  podNamespace: string;
-}
-
-const hasSocketProtocol = (url: string | URL) =>
-  /wss?:\/\//.test(url.toString());
-
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    podExecTerminal: {
-      width: '100%',
-      height: '100%',
-      '& .xterm-screen': { padding: theme.spacing(1) },
-    },
-  }),
+// @xterm/xterm and related CSS are large; only load them when a terminal mounts.
+const LazyPodExecTerminalContent = lazy(() =>
+  import('./PodExecTerminalContent').then(m => ({
+    default: m.PodExecTerminalContent,
+  })),
 );
 
 /**
@@ -54,88 +32,8 @@ const useStyles = makeStyles((theme: Theme) =>
  *
  * @public
  */
-export const PodExecTerminal = (props: PodExecTerminalProps) => {
-  const classes = useStyles();
-  const { containerName, podNamespace, podName } = props;
-
-  const [baseUrl, setBaseUrl] = useState(window.location.host);
-
-  const terminalRef = useRef(null);
-  const discoveryApi = useApi(discoveryApiRef);
-  const namespace = podNamespace ?? 'default';
-
-  useEffect(() => {
-    discoveryApi
-      .getBaseUrl('kubernetes')
-      .then(url => url ?? window.location.host)
-      .then(url => url.replace(/^http(s?):\/\//, 'ws$1://'))
-      .then(url => setBaseUrl(url));
-  }, [discoveryApi]);
-
-  const urlParams = useMemo(() => {
-    const params = new URLSearchParams({
-      container: containerName,
-      stdin: 'true',
-      stdout: 'true',
-      stderr: 'true',
-      tty: 'true',
-      command: '/bin/sh',
-    });
-    return params;
-  }, [containerName]);
-
-  const socketUrl = useMemo(() => {
-    if (!hasSocketProtocol(baseUrl)) {
-      return '';
-    }
-
-    return new URL(
-      `${baseUrl}/proxy/api/v1/namespaces/${namespace}/pods/${podName}/exec?${urlParams}`,
-    );
-  }, [baseUrl, namespace, podName, urlParams]);
-
-  useEffect(() => {
-    if (!hasSocketProtocol(socketUrl)) {
-      return () => {};
-    }
-
-    const terminal = new Terminal();
-    const fitAddon = new FitAddon();
-    terminal.loadAddon(fitAddon);
-
-    if (terminalRef.current) {
-      terminal.open(terminalRef.current);
-      fitAddon.fit();
-    }
-
-    terminal.writeln('Starting terminal, please wait...');
-
-    const socket = new WebSocket(socketUrl, ['channel.k8s.io']);
-
-    socket.onopen = () => {
-      terminal.clear();
-      const attachAddon = new PodExecTerminalAttachAddon(socket, {
-        bidirectional: true,
-      });
-
-      terminal.loadAddon(attachAddon);
-    };
-
-    socket.onclose = () => {
-      terminal.writeln('Socket connection closed');
-    };
-
-    return () => {
-      terminal?.clear();
-      socket?.close();
-    };
-  }, [baseUrl, socketUrl]);
-
-  return (
-    <div
-      data-testid="terminal"
-      ref={terminalRef}
-      className={classes.podExecTerminal}
-    />
-  );
-};
+export const PodExecTerminal = (props: PodExecTerminalProps) => (
+  <Suspense fallback={<Progress />}>
+    <LazyPodExecTerminalContent {...props} />
+  </Suspense>
+);

--- a/plugins/kubernetes-react/src/components/PodExecTerminal/PodExecTerminalContent.tsx
+++ b/plugins/kubernetes-react/src/components/PodExecTerminal/PodExecTerminalContent.tsx
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2023 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import '@xterm/xterm/css/xterm.css';
+
+import { discoveryApiRef, useApi } from '@backstage/core-plugin-api';
+import { ClusterAttributes } from '@backstage/plugin-kubernetes-common';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+import { useRef, useEffect, useMemo, useState } from 'react';
+import { Terminal } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
+
+import { PodExecTerminalAttachAddon } from './PodExecTerminalAttachAddon';
+
+/**
+ * Props drilled down to the PodExecTerminal component
+ *
+ * @public
+ */
+export interface PodExecTerminalProps {
+  cluster: ClusterAttributes;
+  containerName: string;
+  podName: string;
+  podNamespace: string;
+}
+
+const hasSocketProtocol = (url: string | URL) =>
+  /wss?:\/\//.test(url.toString());
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    podExecTerminal: {
+      width: '100%',
+      height: '100%',
+      '& .xterm-screen': { padding: theme.spacing(1) },
+    },
+  }),
+);
+
+/**
+ * Executes a `/bin/sh` process in the given pod's container and opens a terminal connected to it
+ *
+ * @internal
+ */
+export const PodExecTerminalContent = (props: PodExecTerminalProps) => {
+  const classes = useStyles();
+  const { containerName, podNamespace, podName } = props;
+
+  const [baseUrl, setBaseUrl] = useState(window.location.host);
+
+  const terminalRef = useRef(null);
+  const discoveryApi = useApi(discoveryApiRef);
+  const namespace = podNamespace ?? 'default';
+
+  useEffect(() => {
+    discoveryApi
+      .getBaseUrl('kubernetes')
+      .then(url => url ?? window.location.host)
+      .then(url => url.replace(/^http(s?):\/\//, 'ws$1://'))
+      .then(url => setBaseUrl(url));
+  }, [discoveryApi]);
+
+  const urlParams = useMemo(() => {
+    const params = new URLSearchParams({
+      container: containerName,
+      stdin: 'true',
+      stdout: 'true',
+      stderr: 'true',
+      tty: 'true',
+      command: '/bin/sh',
+    });
+    return params;
+  }, [containerName]);
+
+  const socketUrl = useMemo(() => {
+    if (!hasSocketProtocol(baseUrl)) {
+      return '';
+    }
+
+    return new URL(
+      `${baseUrl}/proxy/api/v1/namespaces/${namespace}/pods/${podName}/exec?${urlParams}`,
+    );
+  }, [baseUrl, namespace, podName, urlParams]);
+
+  useEffect(() => {
+    if (!hasSocketProtocol(socketUrl)) {
+      return () => {};
+    }
+
+    const terminal = new Terminal();
+    const fitAddon = new FitAddon();
+    terminal.loadAddon(fitAddon);
+
+    if (terminalRef.current) {
+      terminal.open(terminalRef.current);
+      fitAddon.fit();
+    }
+
+    terminal.writeln('Starting terminal, please wait...');
+
+    const socket = new WebSocket(socketUrl, ['channel.k8s.io']);
+
+    socket.onopen = () => {
+      terminal.clear();
+      const attachAddon = new PodExecTerminalAttachAddon(socket, {
+        bidirectional: true,
+      });
+
+      terminal.loadAddon(attachAddon);
+    };
+
+    socket.onclose = () => {
+      terminal.writeln('Socket connection closed');
+    };
+
+    return () => {
+      terminal?.clear();
+      socket?.close();
+    };
+  }, [baseUrl, socketUrl]);
+
+  return (
+    <div
+      data-testid="terminal"
+      ref={terminalRef}
+      className={classes.podExecTerminal}
+    />
+  );
+};

--- a/plugins/kubernetes/src/alpha/entityContents.tsx
+++ b/plugins/kubernetes/src/alpha/entityContents.tsx
@@ -15,7 +15,10 @@
  */
 
 import { EntityContentBlueprint } from '@backstage/plugin-catalog-react/alpha';
-import { isKubernetesAvailable } from '../Router';
+import {
+  KUBERNETES_ANNOTATION,
+  KUBERNETES_LABEL_SELECTOR_QUERY_ANNOTATION,
+} from '@backstage/plugin-kubernetes-common';
 
 export const entityKubernetesContent = EntityContentBlueprint.make({
   name: 'kubernetes',
@@ -23,7 +26,17 @@ export const entityKubernetesContent = EntityContentBlueprint.make({
     path: '/kubernetes',
     title: 'Kubernetes',
     group: 'deployment',
-    filter: isKubernetesAvailable,
+    filter: {
+      $any: [
+        {
+          [`metadata.annotations.${KUBERNETES_ANNOTATION}`]: { $exists: true },
+        },
+        {
+          [`metadata.annotations.${KUBERNETES_LABEL_SELECTOR_QUERY_ANNOTATION}`]:
+            { $exists: true },
+        },
+      ],
+    },
     loader: () =>
       import('./KubernetesContentPage').then(m => <m.KubernetesContentPage />),
   },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Installing the Kubernetes plugin puts ~1 MB of UI in the entry bundle, 241 KB gzipped. It loads whether or not anyone opens the Kubernetes tab. 

Two causes:

- xterm can't be deferred by bundler config:
  - A static import stays on the synchronous module graph, so `splitChunks` can't defer it. Only a dynamic `import()` can.
  - [@szubster raised this exact import in #23417](https://github.com/backstage/backstage/pull/23417) and saw no way to tree-shake it.
- The entity content loaded eagerly despite an async loader:
  - `EntityContentBlueprint` registers a `filter` next to the lazy `loader`, and the filter was exported from the same module as the UI.
  - Importing it pulled the pod table, drawers and manifest viewer into startup.

### Measurements

Production builds of `packages/app`. Entry set = assets referenced by `dist/index.html`.

The fixes are not additive:

- The filter fix owns the entry-bundle saving.
- The xterm fix shrinks the Kubernetes tab instead.

| | Entry bundle | Kubernetes tab |
| --- | --- | --- |
| Baseline | 4.2 MB / 1.2 MB gzip | N/A |
| Filter fix | 3.2 MB / 957 KB gzip ; **−973 KB / −241 KB gzip** | ships 282 KB of xterm |
| Both | unchanged, within 50 B | **−282 KB / −66 KB gzip** |

- Tab chunk group: 311 KB → 29 KB raw, 75 KB → 9 KB gzip.
- Alone, the xterm fix removes `module-xterm.js` from the entry set, −283 KB.
  - The filter fix includes that saving

<details>
<summary>Which modules the filter fix removes from the entry set</summary>

Five modules leave, three shrink:

| Asset | Raw | Gzip |
| --- | --- | --- |
| `module-material-table.js` | −150 KB | −31 KB |
| `module-react-beautiful-dnd.js` | −85 KB | −25 KB |
| `module-luxon.js` | −68 KB | −21 KB |
| `module-date-fns.js` | −62 KB | −12 KB |
| `module-js-yaml.js` | −41 KB | −14 KB |
| `module-material-ui.js` (shrank) | −129 KB | −35 KB |
| `main.js` (shrank) | −94 KB | −22 KB |
| `vendor.js` (shrank) | −59 KB | −16 KB |

Reproduce with `yarn --cwd packages/app build`. Compare what `dist/index.html` references against the rest of `dist/static/`.

</details>

### Testing

- Deployed internally (-6% gz entry bundle)
- `CI=1 yarn test plugins/kubernetes-react/src/components/PodExecTerminal plugins/kubernetes/src` passes.
  - The existing terminal tests render through the new `Suspense` boundary.
- Exercised in the `plugins/kubernetes` dev app.
  - Nothing xterm-related loads until the terminal opens; two chunks are then fetched and it renders correctly.
  - Styling verified, since the stylesheet now loads from a lazy chunk; the regression [#22093](https://github.com/backstage/backstage/pull/22093) fixed.

<img width="1386" height="806" alt="pr-screenshot-pod-exec-terminal" src="https://github.com/user-attachments/assets/d78a8401-01e7-40af-8cd2-9ca831a6fd82" />

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
