### PR TITLE
feat(backend-defaults): add backend.logger.redactAllowlist config option

### DIFF
--- a/.changeset/tough-buckets-bet.md
+++ b/.changeset/tough-buckets-bet.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Added support for `backend.logger.redactAllowlist` configuration option, which allows specific secret values to pass through log redaction when they are known to be safe to log.

--- a/docs/backend-system/core-services/root-logger.md
+++ b/docs/backend-system/core-services/root-logger.md
@@ -25,6 +25,8 @@ The following parameters are available:
 
 - `overrides` (array, optional): Allows to specify logger overrides for specific plugins or messages. Each override can match on plugin names, message patterns, or any field contained in the log, and set a custom log level for those matches.
 
+- `redactAllowlist` (array of strings, optional): A list of values that should not be redacted from log output. By default, all sensitive configuration values are automatically redacted. Use this option to allow specific values through when they are known to be safe to log.
+
 Log level overrides are useful for controlling the volume of logs generated in Backstage.
 They allow you to apply a global log level, `info` for example, while setting a stricter level, such as `warn`, for specific verbose plugins.
 
@@ -56,6 +58,10 @@ backend:
       - matchers:
           message: ['/^Registered scheduled task/']
         level: warn
+
+    # Allow specific secret values to appear in logs without being redacted
+    redactAllowlist:
+      - 'backstage'
 ```
 
 ### Modifying the log level

--- a/packages/backend-defaults/config.d.ts
+++ b/packages/backend-defaults/config.d.ts
@@ -1306,6 +1306,15 @@ export interface Config {
          */
         level: 'debug' | 'info' | 'warn' | 'error';
       }>;
+
+      /**
+       * List of values to allow through redaction.
+       *
+       * This allows to avoid redacting certain values that are known to be safe to log.
+       *
+       * @visibility backend
+       */
+      redactAllowlist?: string[];
     };
 
     /**

--- a/packages/backend-defaults/src/entrypoints/rootLogger/config.test.ts
+++ b/packages/backend-defaults/src/entrypoints/rootLogger/config.test.ts
@@ -33,6 +33,7 @@ describe('getRootLoggerConfig', () => {
               level: 'warn',
             },
           ],
+          redactAllowlist: ['backstage'],
         },
       },
     };

--- a/packages/backend-defaults/src/entrypoints/rootLogger/config.ts
+++ b/packages/backend-defaults/src/entrypoints/rootLogger/config.ts
@@ -50,9 +50,14 @@ export const getRootLoggerConfig = (
     };
   });
 
+  const redactAllowlist = config.getOptionalStringArray(
+    'backend.logger.redactAllowlist',
+  );
+
   return {
     meta,
     level,
     overrides,
+    redactAllowlist,
   };
 };

--- a/packages/backend-defaults/src/entrypoints/rootLogger/rootLoggerServiceFactory.ts
+++ b/packages/backend-defaults/src/entrypoints/rootLogger/rootLoggerServiceFactory.ts
@@ -54,8 +54,16 @@ export const rootLoggerServiceFactory = createServiceFactory({
     });
 
     const secretEnumerator = await createConfigSecretEnumerator({ logger });
-    logger.addRedactions(secretEnumerator(config));
-    config.subscribe?.(() => logger.addRedactions(secretEnumerator(config)));
+    const allowlist = new Set(rootLoggerConfig.redactAllowlist);
+    logger.addRedactions(
+      [...secretEnumerator(config)].filter(s => !allowlist.has(s)),
+    );
+    config.subscribe?.(() => {
+      const newAllowlist = new Set(getRootLoggerConfig(config).redactAllowlist);
+      logger.addRedactions(
+        [...secretEnumerator(config)].filter(s => !newAllowlist.has(s)),
+      );
+    });
 
     logger.setLevelOverrides(rootLoggerConfig.overrides ?? []);
     config.subscribe?.(() =>

--- a/packages/backend-defaults/src/entrypoints/rootLogger/types.ts
+++ b/packages/backend-defaults/src/entrypoints/rootLogger/types.ts
@@ -35,6 +35,7 @@ export type RootLoggerConfig = {
   level?: string;
   meta?: JsonObject;
   overrides?: WinstonLoggerLevelOverride[];
+  redactAllowlist?: string[];
 };
 
 export const winstonLevels = winstonConfig.npm.levels;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Add `backend.logger.redactAllowlist` configuration option, which allows specific secret values to pass through log redaction when they are known to be safe to log.

```yaml
logger:
    # Allow specific secret values to appear in logs without being redacted
    redactAllowlist:
      - 'backstage'
```

### Context

We have `backstage` as a value for a secret configuration option (database username or something like this), and the logger redacts every `backstage` occurence, including in `service`:

```
{"level":"debug","message":"Running 2 plugin startup tasks...","plugin":"search","service":"***"}
```

This makes searching for logs more complicated (logs are wrongly attributed to the `***` service).
Since by default the service field defaults to `backstage`, it's not really sensitive anyway.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [X] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [X] ~Screenshots attached (for UI changes)~
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
