### PR TITLE
chore: clean up released patch files

### DIFF
--- a/.patches/pr-35235.txt
+++ b/.patches/pr-35235.txt
@@ -1,1 +1,0 @@
-Fixed the catalog import owner autocomplete to write canonical group entity references instead of display names to generated `catalog-info.yaml` files.

--- a/.patches/pr-35270.txt
+++ b/.patches/pr-35270.txt
@@ -1,1 +1,0 @@
-Fixed catalog pages opened from ownership cards to normalize legacy bare owner filters before rendering, preventing entity reference errors.

--- a/.patches/pr-35279.txt
+++ b/.patches/pr-35279.txt
@@ -1,1 +1,0 @@
-Fixed software template inline conditionals without an `else` branch to render an empty string when their condition is false.

--- a/.patches/pr-35284.txt
+++ b/.patches/pr-35284.txt
@@ -1,1 +1,0 @@
-Fixed ownership card links to filter the catalog by canonical owner entity references instead of mutable presentation titles.


### PR DESCRIPTION
Removes patch files that have already been included in a release.

- pr-35235.txt
- pr-35270.txt
- pr-35279.txt
- pr-35284.txt