### PR TITLE
fix(catalog-model): guarantee unique schema $id per kind/apiVersion/specType

### DIFF
--- a/.changeset/witty-otters-invent.md
+++ b/.changeset/witty-otters-invent.md
@@ -1,0 +1,5 @@
+---
+'@backstage/catalog-model': patch
+---
+
+Fixed compiled catalog model schemas so that each kind, `apiVersion`, and spec type combination always gets a unique JSON Schema `$id`, even when the underlying schema document is reused across versions. Previously, two different schemas could end up sharing the same `$id`, which could cause validators that cache compiled schemas by `$id` (such as a shared Ajv instance) to fail when compiling the second schema.

--- a/packages/catalog-model/src/model/compileCatalogModel.test.ts
+++ b/packages/catalog-model/src/model/compileCatalogModel.test.ts
@@ -144,6 +144,7 @@ describe('compileCatalogModel jsonSchema $id', () => {
   // a model source might if it hasn't changed the spec shape between
   // apiVersions.
   const sharedKindSchema = {
+    $id: 'SharedGadgetSchema',
     type: 'object',
     required: ['spec'],
     properties: {
@@ -195,6 +196,22 @@ describe('compileCatalogModel jsonSchema $id', () => {
     const v1beta1 = model.getKind({
       kind: 'Gadget',
       apiVersion: 'example.com/v1beta1',
+    });
+
+    const ajv = new Ajv({ allowUnionTypes: true, allErrors: true });
+    expect(() => ajv.compile(v1alpha1!.jsonSchema)).not.toThrow();
+    expect(() => ajv.compile(v1beta1!.jsonSchema)).not.toThrow();
+  });
+
+  it('lets a single shared Ajv instance compile multiple versions of a built-in kind', () => {
+    const model = compileCatalogModel([defaultCatalogEntityModel]);
+    const v1alpha1 = model.getKind({
+      kind: 'Component',
+      apiVersion: 'backstage.io/v1alpha1',
+    });
+    const v1beta1 = model.getKind({
+      kind: 'Component',
+      apiVersion: 'backstage.io/v1beta1',
     });
 
     const ajv = new Ajv({ allowUnionTypes: true, allErrors: true });

--- a/packages/catalog-model/src/model/compileCatalogModel.test.ts
+++ b/packages/catalog-model/src/model/compileCatalogModel.test.ts
@@ -139,6 +139,115 @@ describe('compileCatalogModel', () => {
   });
 });
 
+describe('compileCatalogModel jsonSchema $id', () => {
+  // Both versions intentionally reuse the exact same schema object, the way
+  // a model source might if it hasn't changed the spec shape between
+  // apiVersions.
+  const sharedKindSchema = {
+    type: 'object',
+    required: ['spec'],
+    properties: {
+      spec: {
+        type: 'object',
+        required: ['owner'],
+        properties: { owner: { type: 'string' } },
+      },
+    },
+  };
+
+  const multiVersionLayer = createCatalogModelLayer({
+    layerId: 'MultiVersion',
+    builder: model => {
+      model.addKind({
+        group: 'example.com',
+        names: { kind: 'Gadget', singular: 'gadget', plural: 'gadgets' },
+        description: 'A test gadget kind with multiple apiVersions',
+        versions: [
+          { name: 'v1alpha1', schema: { jsonSchema: sharedKindSchema } },
+          { name: 'v1beta1', schema: { jsonSchema: sharedKindSchema } },
+        ],
+      });
+    },
+  });
+
+  it('gives distinct $ids to different apiVersions of the same kind, even when they share a schema object', () => {
+    const model = compileCatalogModel([multiVersionLayer]);
+    const v1alpha1 = model.getKind({
+      kind: 'Gadget',
+      apiVersion: 'example.com/v1alpha1',
+    });
+    const v1beta1 = model.getKind({
+      kind: 'Gadget',
+      apiVersion: 'example.com/v1beta1',
+    });
+
+    expect(v1alpha1?.jsonSchema.$id).toBeDefined();
+    expect(v1beta1?.jsonSchema.$id).toBeDefined();
+    expect(v1alpha1?.jsonSchema.$id).not.toEqual(v1beta1?.jsonSchema.$id);
+  });
+
+  it('lets a single shared Ajv instance compile both apiVersion schemas without an $id collision', () => {
+    const model = compileCatalogModel([multiVersionLayer]);
+    const v1alpha1 = model.getKind({
+      kind: 'Gadget',
+      apiVersion: 'example.com/v1alpha1',
+    });
+    const v1beta1 = model.getKind({
+      kind: 'Gadget',
+      apiVersion: 'example.com/v1beta1',
+    });
+
+    const ajv = new Ajv({ allowUnionTypes: true, allErrors: true });
+    expect(() => ajv.compile(v1alpha1!.jsonSchema)).not.toThrow();
+    expect(() => ajv.compile(v1beta1!.jsonSchema)).not.toThrow();
+  });
+
+  it('gives distinct $ids to different specTypes of the same kind/apiVersion', () => {
+    const specTypeLayer = createCatalogModelLayer({
+      layerId: 'SpecTypes',
+      builder: model => {
+        model.addKind({
+          group: 'example.com',
+          names: {
+            kind: 'Sprocket',
+            singular: 'sprocket',
+            plural: 'sprockets',
+          },
+          description: 'A test sprocket kind with discriminated spec types',
+          versions: [
+            {
+              name: 'v1alpha1',
+              specType: 'database',
+              schema: { jsonSchema: { type: 'object', properties: {} } },
+            },
+            {
+              name: 'v1alpha1',
+              specType: 'bucket',
+              schema: { jsonSchema: { type: 'object', properties: {} } },
+            },
+          ],
+        });
+      },
+    });
+
+    const model = compileCatalogModel([specTypeLayer]);
+    const database = model.getKind({
+      kind: 'Sprocket',
+      apiVersion: 'example.com/v1alpha1',
+      spec: { type: 'database' },
+    });
+    const bucket = model.getKind({
+      kind: 'Sprocket',
+      apiVersion: 'example.com/v1alpha1',
+      spec: { type: 'bucket' },
+    });
+
+    expect(database?.jsonSchema.$id).toBeDefined();
+    expect(bucket?.jsonSchema.$id).toBeDefined();
+    expect(database?.jsonSchema.$id).not.toEqual(bucket?.jsonSchema.$id);
+  });
+});
+
 describe('compileCatalogModel specType', () => {
   const specTypeLayer = createCatalogModelLayer({
     layerId: 'SpecType',
@@ -330,6 +439,7 @@ describe('compileCatalogModel integration', () => {
         },
       ],
       jsonSchema: {
+        $id: 'Widget/example.com%2Fv1alpha1',
         type: 'object',
         required: ['spec', 'apiVersion', 'kind', 'metadata'],
         additionalProperties: false,
@@ -505,6 +615,7 @@ describe('compileCatalogModel integration', () => {
         },
       ],
       jsonSchema: {
+        $id: 'Widget/example.com%2Fv1alpha1',
         type: 'object',
         required: ['spec', 'apiVersion', 'kind', 'metadata'],
         additionalProperties: false,
@@ -646,6 +757,7 @@ describe('compileCatalogModel integration', () => {
         },
       ],
       jsonSchema: {
+        $id: 'Widget/example.com%2Fv1alpha1',
         type: 'object',
         required: ['spec', 'apiVersion', 'kind', 'metadata'],
         additionalProperties: false,

--- a/packages/catalog-model/src/model/compileCatalogModel.ts
+++ b/packages/catalog-model/src/model/compileCatalogModel.ts
@@ -415,9 +415,24 @@ function applyRemoveTag(tags: Map<string, TagState>, op: OpRemoveTagV1): void {
   tags.delete(op.name);
 }
 
+// Builds a schema $id that's guaranteed to be unique per kind, apiVersion,
+// and specType combination, regardless of whatever $id (if any) the input
+// kind schema declares. Each component is percent-encoded so that the '/'
+// separators added here can't be produced by the components themselves,
+// keeping the combination unambiguous.
+function buildSchemaId(
+  kind: string,
+  apiVersion: string,
+  specType: string | undefined,
+): string {
+  const parts = [kind, apiVersion, ...(specType ? [specType] : [])];
+  return parts.map(encodeURIComponent).join('/');
+}
+
 function buildFullSchema(options: {
   kind: string;
   apiVersion: string;
+  specType?: string;
   kindSchema: JsonObject;
   annotations: Map<string, AnnotationState>;
   labels: Map<string, LabelState>;
@@ -514,6 +529,11 @@ function buildFullSchema(options: {
     : [];
 
   const generatedSchema: JsonObject = {
+    // Always override any $id declared on the kind schema itself, so that
+    // distinct kind/apiVersion/specType combinations never end up sharing an
+    // $id even if their underlying kind schemas do (e.g. because a model
+    // source reuses the same schema document across apiVersions).
+    $id: buildSchemaId(options.kind, options.apiVersion, options.specType),
     type: 'object',
     required: [...new Set([...kindRequired, 'apiVersion', 'kind', 'metadata'])],
     additionalProperties: false,
@@ -640,6 +660,7 @@ export function compileCatalogModel(
           jsonSchema: buildFullSchema({
             kind: kindName,
             apiVersion: version.apiVersion,
+            specType,
             kindSchema: specificKind.jsonSchema,
             annotations,
             labels,

--- a/plugins/catalog-backend/src/processors/ModelProcessor.test.ts
+++ b/plugins/catalog-backend/src/processors/ModelProcessor.test.ts
@@ -195,6 +195,32 @@ describe('ModelProcessor', () => {
         /Validation of Component entity failed/,
       );
     });
+
+    it('validates API entities with different apiVersions', async () => {
+      const model = compileCatalogModel([defaultCatalogEntityModel]);
+      const processor = new ModelProcessor(
+        ModelHolder.modelPassthroughForTest(model),
+      );
+      const entity = {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'API',
+        metadata: { name: 'my-api' },
+        spec: {
+          type: 'openapi',
+          lifecycle: 'production',
+          owner: 'group:default/my-team',
+          definition: 'openapi: 3.0.0',
+        },
+      };
+
+      await expect(processor.validateEntityKind(entity)).resolves.toBe(true);
+      await expect(
+        processor.validateEntityKind({
+          ...entity,
+          apiVersion: 'backstage.io/v1beta1',
+        }),
+      ).resolves.toBe(true);
+    });
   });
 
   describe('postProcessEntity', () => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes a schema `$id` collision in the compiled catalog model: `buildFullSchema` previously carried through whatever `$id` (if any) the underlying kind schema declared, unchanged across `apiVersion`/spec type. If a model source reused the same schema document across multiple `apiVersion`s of a kind (e.g. `v1alpha1` and `v1beta1`), the compiled schemas ended up as distinct objects sharing an identical `$id` — which breaks validators that cache compiled schemas by `$id` on a shared instance, such as Ajv (see #34551 / #34552, which patches around this on the Ajv side in `@backstage/plugin-catalog-backend`).

This PR fixes it at the source instead: `$id` is now derived deterministically from `kind` + `apiVersion` + spec type, guaranteeing uniqueness across every compiled schema regardless of what the input schema documents declare.

Opening as a draft to get eyes on the approach (and how it should relate to #34552) before finalizing.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
