### PR TITLE
fix(auth-backend): use consistent URL pattern matching

### DIFF
--- a/.changeset/v-mp-s-c.md
+++ b/.changeset/v-mp-s-c.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend': patch
+---
+
+Fixed inconsistent URL pattern matching in token revocation.

--- a/plugins/auth-backend/src/service/OidcService.test.ts
+++ b/plugins/auth-backend/src/service/OidcService.test.ts
@@ -1184,6 +1184,14 @@ describe('OidcService', () => {
             }),
           ).resolves.toBe(false);
 
+          // Client IDs that match the full URL string but not the hostname
+          // component are rejected
+          await expect(
+            service.verifyRevocationClient({
+              clientId: 'https://other.com/.example.com/client.json',
+            }),
+          ).resolves.toBe(false);
+
           // DCR clients must present a valid client secret
           const client = await service.registerClient({
             clientName: 'Test Client',

--- a/plugins/auth-backend/src/service/OidcService.ts
+++ b/plugins/auth-backend/src/service/OidcService.ts
@@ -748,7 +748,7 @@ export class OidcService {
       return (
         cimd.enabled &&
         cimd.allowedClientIdPatterns.some(pattern =>
-          matcher.isMatch(clientId, pattern),
+          createUrlPatternMatcher(pattern)(cimdUrl),
         )
       );
     }


### PR DESCRIPTION
## What / Why

Noticed that we were using inconsistent matching approaches in the OIDC service. Fixing that up now.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Tests for new functionality and regression tests for bug fixes
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
