### PR TITLE
fix(catalog-graph): stabilize alpha graph tests

### DIFF
--- a/plugins/catalog-graph/src/alpha.test.tsx
+++ b/plugins/catalog-graph/src/alpha.test.tsx
@@ -25,6 +25,8 @@ import catalogGraphPlugin from './alpha';
 import { catalogGraphRouteRef } from './routes';
 import { catalogGraphApiRef, DefaultCatalogGraphApi } from './api';
 
+jest.setTimeout(30_000);
+
 jest.mock('./components/CatalogGraphPage', () => {
   const { useCatalogGraphPage } = jest.requireActual<
     typeof import('./components/CatalogGraphPage/useCatalogGraphPage')
@@ -163,7 +165,11 @@ describe('catalog-graph alpha plugin', () => {
 
       expect(await screen.findByText('Relations')).toBeInTheDocument();
       expect(
-        await screen.findByText('component:default/my-service'),
+        await screen.findByText(
+          'component:default/my-service',
+          {},
+          { timeout: 5_000 },
+        ),
       ).toBeInTheDocument();
     });
 
@@ -200,7 +206,11 @@ describe('catalog-graph alpha plugin', () => {
 
       expect(await screen.findByText('Relations')).toBeInTheDocument();
       expect(
-        await screen.findByText('api:production/my-api'),
+        await screen.findByText(
+          'api:production/my-api',
+          {},
+          { timeout: 5_000 },
+        ),
       ).toBeInTheDocument();
     });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Stabilize the catalog graph alpha integration tests when running under a heavily loaded CI worker. Graph nodes pass through the lazy-loaded and debounced dependency graph renderer, so their appearance can exceed Testing Library's default one-second timeout.

This applies the same bounded node wait already used by the `CatalogGraphCard` tests, without changing production behavior or weakening the rendered-node assertions.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
