### PR TITLE
feat(ui): integrate BUI navigation with the application router

### DIFF
--- a/.changeset/tidy-routes-navigate.md
+++ b/.changeset/tidy-routes-navigate.md
@@ -1,0 +1,15 @@
+---
+'@backstage/ui': minor
+---
+
+Updated BUI links to use the hosting application's client-side router, including relative destinations and the application's configured router base path, while preserving native browser navigation where required.
+
+**BREAKING**: Anchor-based components no longer accept the React Aria `render` prop. BUI now owns the underlying anchor so routing behavior remains consistent across application and plugin package versions.
+
+ListRow, Tag, and table Row now retain client-side navigation when application and plugin packages load separate React Aria copies. Their existing modifier-key, target, download, and link-metadata behavior is unchanged.
+
+**Migration:**
+
+Remove `render` props from ButtonLink, ComboboxItem, Link, MenuItem, MenuListBoxItem, SearchAutocompleteItem, SelectItem, and Tab. BUI now selects and renders the appropriate anchor or router link automatically.
+
+**Affected components:** ButtonLink, Card, ComboboxItem, Header, Link, ListRow, MenuItem, MenuListBoxItem, Row, SearchAutocompleteItem, SelectItem, Tab, Tag

--- a/packages/ui/report.api.md
+++ b/packages/ui/report.api.md
@@ -616,6 +616,9 @@ export const ButtonLinkDefinition: {
   };
   readonly bg: 'consumer';
   readonly analytics: true;
+  readonly navigation: {
+    readonly type: 'anchor';
+  };
   readonly propDefs: {
     readonly noTrack: {};
     readonly size: {
@@ -646,7 +649,7 @@ export type ButtonLinkOwnProps = {
 
 // @public
 export interface ButtonLinkProps
-  extends Omit<LinkProps_2, keyof ButtonLinkOwnProps>,
+  extends Omit<LinkProps_2, keyof ButtonLinkOwnProps | 'render'>,
     ButtonLinkOwnProps {}
 
 // @public (undocumented)
@@ -1223,6 +1226,9 @@ export const ComboboxItemDefinition: {
     readonly indicator: 'bui-ComboboxItemIndicator';
     readonly content: 'bui-ComboboxItemContent';
   };
+  readonly navigation: {
+    readonly type: 'anchor';
+  };
   readonly propDefs: {
     readonly children: {};
     readonly textValue: {};
@@ -1280,7 +1286,8 @@ export type ComboboxItemProfileProps<T extends object = object> =
 
 // @public (undocumented)
 export type ComboboxItemProps<T extends object = object> =
-  ComboboxItemOwnProps & Omit<ListBoxItemProps<T>, keyof ComboboxItemOwnProps>;
+  ComboboxItemOwnProps &
+    Omit<ListBoxItemProps<T>, keyof ComboboxItemOwnProps | 'render'>;
 
 // @public (undocumented)
 export type ComboboxItemSelectionProps<
@@ -2339,6 +2346,9 @@ export const HeaderNavItemDefinition: {
     readonly root: 'bui-HeaderNavItem';
   };
   readonly analytics: true;
+  readonly navigation: {
+    readonly type: 'anchor';
+  };
   readonly propDefs: {
     readonly noTrack: {};
     readonly id: {};
@@ -2516,6 +2526,9 @@ export const LinkDefinition: {
     readonly root: 'bui-Link';
   };
   readonly analytics: true;
+  readonly navigation: {
+    readonly type: 'anchor';
+  };
   readonly propDefs: {
     readonly noTrack: {};
     readonly variant: {
@@ -2560,7 +2573,7 @@ export type LinkOwnProps = {
 
 // @public (undocumented)
 export interface LinkProps
-  extends Omit<LinkProps_2, 'children' | 'className'>,
+  extends Omit<LinkProps_2, 'children' | 'className' | 'render'>,
     LinkOwnProps {}
 
 // @public
@@ -2738,7 +2751,7 @@ export type MenuItemOwnProps = {
 // @public (undocumented)
 export interface MenuItemProps
   extends MenuItemOwnProps,
-    Omit<MenuItemProps_2, keyof MenuItemOwnProps> {}
+    Omit<MenuItemProps_2, keyof MenuItemOwnProps | 'render'> {}
 
 // @public (undocumented)
 export const MenuListBox: (props: MenuListBoxProps<object>) => JSX_2.Element;
@@ -2755,7 +2768,7 @@ export type MenuListBoxItemOwnProps = {
 // @public (undocumented)
 export interface MenuListBoxItemProps
   extends MenuListBoxItemOwnProps,
-    Omit<ListBoxItemProps, keyof MenuListBoxItemOwnProps> {}
+    Omit<ListBoxItemProps, keyof MenuListBoxItemOwnProps | 'render'> {}
 
 // @public (undocumented)
 export type MenuListBoxOwnProps = MenuPopoverOwnProps & {
@@ -3291,7 +3304,7 @@ export type SearchAutocompleteItemOwnProps = {
 // @public (undocumented)
 export interface SearchAutocompleteItemProps
   extends SearchAutocompleteItemOwnProps,
-    Omit<ListBoxItemProps, keyof SearchAutocompleteItemOwnProps> {}
+    Omit<ListBoxItemProps, keyof SearchAutocompleteItemOwnProps | 'render'> {}
 
 // @public (undocumented)
 export type SearchAutocompleteOwnProps = {
@@ -3543,6 +3556,9 @@ export const SelectItemDefinition: {
     readonly indicator: 'bui-SelectItemIndicator';
     readonly content: 'bui-SelectItemContent';
   };
+  readonly navigation: {
+    readonly type: 'anchor';
+  };
   readonly propDefs: {
     readonly children: {};
     readonly showSelectionIndicator: {};
@@ -3600,7 +3616,10 @@ export type SelectItemProfileProps<T extends object = object> =
 
 // @public (undocumented)
 export type SelectItemProps<T extends object = object> = SelectItemOwnProps &
-  Omit<ListBoxItemProps<T>, keyof SelectItemOwnProps | 'textValue'> & {
+  Omit<
+    ListBoxItemProps<T>,
+    keyof SelectItemOwnProps | 'render' | 'textValue'
+  > & {
     textValue: string;
   };
 
@@ -4251,7 +4270,7 @@ export interface TabPanelProps
 // @public
 export interface TabProps
   extends TabOwnProps,
-    Omit<TabProps_2, keyof TabOwnProps> {}
+    Omit<TabProps_2, keyof TabOwnProps | 'render'> {}
 
 // @public
 export const Tabs: (props: TabsProps) => JSX_2.Element | null;

--- a/packages/ui/src/analytics/useAnalytics.ts
+++ b/packages/ui/src/analytics/useAnalytics.ts
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 
-import { useRef } from 'react';
-import {
-  createVersionedContext,
-  useVersionedContext,
-} from '@backstage/version-bridge';
+import { useContext, useRef } from 'react';
 import type { AnalyticsTracker, UseAnalyticsFn } from './types';
+import { BUIContext } from '../provider/BUIContext';
 
 /** @internal */
 export const noopTracker: AnalyticsTracker = {
@@ -27,16 +24,6 @@ export const noopTracker: AnalyticsTracker = {
 };
 
 const noopUseAnalytics: UseAnalyticsFn = () => noopTracker;
-
-/** @internal */
-export type BUIContextValue = {
-  useAnalytics?: UseAnalyticsFn;
-};
-
-/** @internal */
-export const BUIContext = createVersionedContext<{
-  1: BUIContextValue;
-}>('bui');
 
 /**
  * Returns an AnalyticsTracker for capturing analytics events.
@@ -47,7 +34,8 @@ export const BUIContext = createVersionedContext<{
  * @public
  */
 export function useAnalytics(): AnalyticsTracker {
-  const ctx = useVersionedContext<{ 1: BUIContextValue }>('bui')?.atVersion(1);
+  const context = useContext(BUIContext);
+  const ctx = context?.atVersion(2) ?? context?.atVersion(1);
   const impl = ctx?.useAnalytics ?? noopUseAnalytics;
 
   if (process.env.NODE_ENV !== 'production') {

--- a/packages/ui/src/components/ButtonLink/ButtonLink.test.tsx
+++ b/packages/ui/src/components/ButtonLink/ButtonLink.test.tsx
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createVersionedValueMap } from '@backstage/version-bridge';
+import { fireEvent, render, screen } from '@testing-library/react';
+import {
+  forwardRef,
+  useMemo,
+  type ComponentProps,
+  type PropsWithChildren,
+} from 'react';
+import { RouterProvider } from 'react-aria-components';
+import {
+  Link as RouterLink,
+  MemoryRouter,
+  useHref,
+  useInRouterContext,
+  useLocation,
+  useNavigate,
+  useResolvedPath,
+} from 'react-router-dom';
+import { useResolvedHref } from '../../hooks/useResolvedHref';
+import { BUIContext } from '../../provider/BUIContext';
+import { BUIProvider } from '../../provider/BUIProvider';
+import type { BUIRoutingIntegration } from '../../navigation/types';
+import { ButtonLink } from './ButtonLink';
+
+function LocationStatus() {
+  return <span role="status">{useLocation().pathname}</span>;
+}
+
+describe('ButtonLink', () => {
+  it('renders a disabled destination as a non-link element', () => {
+    render(
+      <MemoryRouter
+        initialEntries={['/catalog']}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <BUIProvider>
+          <ButtonLink href="/catalog/overview" isDisabled>
+            Overview
+          </ButtonLink>
+        </BUIProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Overview').closest('a')).toBeNull();
+  });
+
+  it('renders the host href and navigates without a document reload', () => {
+    render(
+      <MemoryRouter
+        basename="/app"
+        initialEntries={['/app/catalog']}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <BUIProvider>
+          <ButtonLink href="/catalog/overview">Overview</ButtonLink>
+          <LocationStatus />
+        </BUIProvider>
+      </MemoryRouter>,
+    );
+
+    const link = screen.getByRole('link', { name: 'Overview' });
+    expect(link).toHaveAttribute('href', '/app/catalog/overview');
+    fireEvent.click(link);
+    expect(screen.getByRole('status')).toHaveTextContent('/catalog/overview');
+  });
+
+  it('passes the exact options registered by the component to React Aria', () => {
+    const navigate = jest.fn();
+    const register = jest.fn();
+    render(
+      <MemoryRouter
+        basename="/app"
+        initialEntries={['/app/catalog']}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <TrackingProvider navigate={navigate} register={register}>
+          <ButtonLink
+            href="/catalog/overview"
+            routerOptions={{ replace: true }}
+          >
+            Overview
+          </ButtonLink>
+        </TrackingProvider>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'Overview' }));
+    const registeredOptions = register.mock.calls[0]?.[0];
+    expect(registeredOptions).toBeDefined();
+    expect(navigate).toHaveBeenCalledWith(
+      '/catalog/overview',
+      registeredOptions,
+    );
+  });
+
+  it('renders the configured host Link with the raw destination', () => {
+    const hostLink = jest.fn();
+    const HostLink = forwardRef<
+      HTMLAnchorElement,
+      ComponentProps<typeof RouterLink>
+    >((props, ref) => {
+      hostLink(props);
+      return <RouterLink {...props} ref={ref} />;
+    });
+
+    render(
+      <MemoryRouter
+        basename="/app"
+        initialEntries={['/app/catalog']}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <TrackingProvider
+          navigate={jest.fn()}
+          register={jest.fn()}
+          link={HostLink}
+        >
+          <ButtonLink href="child">Overview</ButtonLink>
+        </TrackingProvider>
+      </MemoryRouter>,
+    );
+
+    const hostLinkProps = hostLink.mock.calls.find(
+      ([props]) => props.to === 'child',
+    )?.[0];
+    expect(hostLinkProps).toBeDefined();
+    expect(hostLinkProps).not.toHaveProperty('href');
+  });
+});
+
+function TrackingProvider({
+  children,
+  navigate,
+  register,
+  link: Link = RouterLink,
+}: PropsWithChildren<{
+  navigate: jest.Mock;
+  register: jest.Mock;
+  link?: BUIRoutingIntegration['Link'];
+}>) {
+  const routing = useMemo<BUIRoutingIntegration>(
+    () => ({
+      Link,
+      useHref,
+      useInRouterContext,
+      useLocation,
+      useNavigate,
+      useResolvedPath,
+      createRouterOptions(_action, options) {
+        const registered = { ...options };
+        register(registered);
+        return registered;
+      },
+    }),
+    [Link, register],
+  );
+  const value = useMemo(
+    () => createVersionedValueMap({ 1: {}, 2: { routing } }),
+    [routing],
+  );
+
+  return (
+    <RouterProvider navigate={navigate} useHref={useResolvedHref}>
+      <BUIContext.Provider value={value}>{children}</BUIContext.Provider>
+    </RouterProvider>
+  );
+}

--- a/packages/ui/src/components/ButtonLink/ButtonLink.tsx
+++ b/packages/ui/src/components/ButtonLink/ButtonLink.tsx
@@ -17,9 +17,65 @@
 import { forwardRef, Ref } from 'react';
 import { Link as RALink } from 'react-aria-components';
 import type { ButtonLinkProps } from './types';
-import { useDefinition } from '../../hooks/useDefinition';
+import {
+  useDefinition,
+  type UseDefinitionResult,
+} from '../../hooks/useDefinition';
 import { ButtonLinkDefinition } from './definition';
 import { getNodeText } from '../../analytics/getNodeText';
+import {
+  getReactAriaAnchorProps,
+  type AnchorNavigation,
+} from '../../navigation/useNavigation';
+
+type ButtonLinkViewProps = {
+  definitionResult: UseDefinitionResult<
+    typeof ButtonLinkDefinition,
+    ButtonLinkProps
+  >;
+  navigation: AnchorNavigation;
+  forwardedRef: Ref<HTMLAnchorElement>;
+};
+
+function ButtonLinkView({
+  definitionResult,
+  navigation,
+  forwardedRef,
+}: ButtonLinkViewProps) {
+  const { ownProps, restProps, dataAttributes, analytics } = definitionResult;
+  const { classes, iconStart, iconEnd, children } = ownProps;
+  const navigationProps = restProps.isDisabled
+    ? { href: undefined, routerOptions: undefined, render: undefined }
+    : getReactAriaAnchorProps(navigation, restProps);
+
+  const handlePress: typeof restProps.onPress = e => {
+    restProps.onPress?.(e);
+    const text =
+      restProps['aria-label'] ??
+      getNodeText(children) ??
+      String(restProps.href ?? '');
+    analytics.captureEvent('click', text, {
+      attributes: { to: String(restProps.href ?? '') },
+    });
+  };
+
+  return (
+    <RALink
+      className={classes.root}
+      ref={forwardedRef}
+      {...dataAttributes}
+      {...restProps}
+      {...navigationProps}
+      onPress={handlePress}
+    >
+      <span className={classes.content}>
+        {iconStart}
+        {children}
+        {iconEnd}
+      </span>
+    </RALink>
+  );
+}
 
 /**
  * A button-styled anchor element for navigation, supporting optional start and end icon slots and analytics event tracking.
@@ -28,37 +84,15 @@ import { getNodeText } from '../../analytics/getNodeText';
  */
 export const ButtonLink = forwardRef(
   (props: ButtonLinkProps, ref: Ref<HTMLAnchorElement>) => {
-    const { ownProps, restProps, dataAttributes, analytics } = useDefinition(
-      ButtonLinkDefinition,
-      props,
-    );
-    const { classes, iconStart, iconEnd, children } = ownProps;
-
-    const handlePress: typeof restProps.onPress = e => {
-      restProps.onPress?.(e);
-      const text =
-        restProps['aria-label'] ??
-        getNodeText(children) ??
-        String(restProps.href ?? '');
-      analytics.captureEvent('click', text, {
-        attributes: { to: String(restProps.href ?? '') },
-      });
-    };
+    const definitionResult = useDefinition(ButtonLinkDefinition, props);
+    const Navigation = definitionResult.navigation;
 
     return (
-      <RALink
-        className={classes.root}
-        ref={ref}
-        {...dataAttributes}
-        {...restProps}
-        onPress={handlePress}
-      >
-        <span className={classes.content}>
-          {iconStart}
-          {children}
-          {iconEnd}
-        </span>
-      </RALink>
+      <Navigation
+        props={definitionResult.restProps}
+        view={ButtonLinkView}
+        viewProps={{ definitionResult, forwardedRef: ref }}
+      />
     );
   },
 );

--- a/packages/ui/src/components/ButtonLink/definition.ts
+++ b/packages/ui/src/components/ButtonLink/definition.ts
@@ -30,6 +30,7 @@ export const ButtonLinkDefinition = defineComponent<ButtonLinkOwnProps>()({
   },
   bg: 'consumer',
   analytics: true,
+  navigation: { type: 'anchor' },
   propDefs: {
     noTrack: {},
     size: { dataAttribute: true, default: 'small' },

--- a/packages/ui/src/components/ButtonLink/types.ts
+++ b/packages/ui/src/components/ButtonLink/types.ts
@@ -35,5 +35,5 @@ export type ButtonLinkOwnProps = {
  * @public
  */
 export interface ButtonLinkProps
-  extends Omit<RALinkProps, keyof ButtonLinkOwnProps>,
+  extends Omit<RALinkProps, keyof ButtonLinkOwnProps | 'render'>,
     ButtonLinkOwnProps {}

--- a/packages/ui/src/components/Card/Card.test.tsx
+++ b/packages/ui/src/components/Card/Card.test.tsx
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { BUIProvider } from '../../provider';
+import { Card } from './Card';
+
+function LocationStatus() {
+  return <span role="status">{useLocation().pathname}</span>;
+}
+
+function renderCard() {
+  return render(
+    <MemoryRouter
+      basename="/app"
+      initialEntries={['/app/catalog/entity']}
+      future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+    >
+      <BUIProvider>
+        <Routes>
+          <Route
+            path="catalog/entity/*"
+            element={
+              <>
+                <Card href="overview" label="Entity overview">
+                  <div>Card content</div>
+                </Card>
+                <LocationStatus />
+              </>
+            }
+          />
+        </Routes>
+      </BUIProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('Card navigation', () => {
+  it('delegates an ordinary surface click to its relative real anchor', () => {
+    renderCard();
+
+    expect(
+      screen.getByRole('link', { name: 'Entity overview' }),
+    ).toHaveAttribute('href', '/app/catalog/entity/overview');
+    fireEvent.click(screen.getByText('Card content'));
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '/catalog/entity/overview',
+    );
+  });
+
+  it('preserves modifier keys when delegating surface clicks', () => {
+    renderCard();
+    const anchor = screen.getByRole('link', { name: 'Entity overview' });
+    const content = screen.getByText('Card content');
+    const received: MouseEvent[] = [];
+    anchor.addEventListener('click', event => received.push(event));
+
+    fireEvent.click(content, { metaKey: true });
+    expect(received.at(-1)?.metaKey).toBe(true);
+    expect(screen.getByRole('status')).toHaveTextContent('/catalog/entity');
+
+    fireEvent.click(content, { ctrlKey: true });
+    expect(received.at(-1)?.ctrlKey).toBe(true);
+    expect(screen.getByRole('status')).toHaveTextContent('/catalog/entity');
+
+    fireEvent.click(content, { shiftKey: true });
+    expect(received.at(-1)?.shiftKey).toBe(true);
+    expect(screen.getByRole('status')).toHaveTextContent('/catalog/entity');
+
+    fireEvent.click(content, { altKey: true });
+    expect(received.at(-1)?.altKey).toBe(true);
+    expect(screen.getByRole('status')).toHaveTextContent('/catalog/entity');
+  });
+});

--- a/packages/ui/src/components/Card/Card.tsx
+++ b/packages/ui/src/components/Card/Card.tsx
@@ -82,6 +82,7 @@ export const Card = forwardRef<HTMLDivElement, CardProps>((props, ref) => {
           ctrlKey: e.ctrlKey,
           metaKey: e.metaKey,
           shiftKey: e.shiftKey,
+          altKey: e.altKey,
         }),
       );
     },

--- a/packages/ui/src/components/Combobox/Combobox.test.tsx
+++ b/packages/ui/src/components/Combobox/Combobox.test.tsx
@@ -15,8 +15,22 @@
  */
 
 import { act, fireEvent, render, screen, within } from '@testing-library/react';
-import { useState } from 'react';
+import { useMemo, useState, type PropsWithChildren } from 'react';
+import { createVersionedValueMap } from '@backstage/version-bridge';
+import {
+  Link as RouterLink,
+  MemoryRouter,
+  Route,
+  Routes,
+  useHref,
+  useInRouterContext,
+  useLocation,
+  useNavigate,
+  useResolvedPath,
+} from 'react-router-dom';
 import { BUIProvider } from '../../provider';
+import { BUIContext } from '../../provider/BUIContext';
+import type { BUIRoutingIntegration } from '../../navigation/types';
 import type { AsyncListSource } from '../../types/selectableCollection';
 import { Combobox } from './Combobox';
 import {
@@ -263,6 +277,91 @@ describe('Combobox', () => {
     const option = screen.getByRole('option', { name: 'Custom' });
     expect(option.querySelector('.bui-ComboboxItemIndicator')).toBeVisible();
     expect(option.querySelector('.bui-ComboboxItemContent')).toBeVisible();
+  });
+
+  it('renders a linked item with the host basename and navigates client-side', () => {
+    render(
+      <MemoryRouter
+        basename="/app"
+        initialEntries={['/app/catalog']}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <BUIProvider>
+          <Combobox aria-label="Destination">
+            <ComboboxItem id="docs" textValue="TechDocs" href="/catalog/docs">
+              TechDocs
+            </ComboboxItem>
+          </Combobox>
+          <LocationStatus />
+        </BUIProvider>
+      </MemoryRouter>,
+    );
+
+    openCombobox();
+    const option = screen.getByRole('option', { name: 'TechDocs' });
+    expect(option).toHaveAttribute('href', '/app/catalog/docs');
+    fireEvent.click(option);
+    expect(screen.getByRole('status')).toHaveTextContent('/catalog/docs');
+  });
+
+  it('routes a relative text preset from the component route with one basename', () => {
+    render(
+      <MemoryRouter
+        basename="/app"
+        initialEntries={['/app/catalog/entity']}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <BUIProvider>
+          <Routes>
+            <Route
+              path="catalog/entity/*"
+              element={
+                <>
+                  <Combobox aria-label="Destination">
+                    <ComboboxItemText id="docs" title="TechDocs" href="docs" />
+                  </Combobox>
+                  <LocationStatus />
+                </>
+              }
+            />
+          </Routes>
+        </BUIProvider>
+      </MemoryRouter>,
+    );
+
+    openCombobox();
+    const option = screen.getByRole('option', { name: 'TechDocs' });
+    expect(option).toHaveAttribute('href', '/app/catalog/entity/docs');
+    fireEvent.click(option);
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '/catalog/entity/docs',
+    );
+  });
+
+  it('registers linked item navigation with the selected routing integration', () => {
+    const createRouterOptions = jest.fn(() => ({ replace: true }));
+    render(
+      <MemoryRouter
+        basename="/app"
+        initialEntries={['/app/catalog']}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <TrackingRoutingProvider createRouterOptions={createRouterOptions}>
+          <Combobox aria-label="Destination">
+            <ComboboxItem id="docs" textValue="TechDocs" href="/catalog/docs">
+              TechDocs
+            </ComboboxItem>
+          </Combobox>
+        </TrackingRoutingProvider>
+      </MemoryRouter>,
+    );
+
+    openCombobox();
+    expect(screen.getByRole('option', { name: 'TechDocs' })).toHaveAttribute(
+      'href',
+      '/app/catalog/docs',
+    );
+    expect(createRouterOptions).toHaveBeenCalledTimes(1);
   });
 
   it('renders dynamic profile items with injected identity and value', () => {
@@ -1233,3 +1332,32 @@ describe('Combobox', () => {
     expect(onInputChange).toHaveBeenCalledWith('next-query');
   });
 });
+
+function LocationStatus() {
+  return <span role="status">{useLocation().pathname}</span>;
+}
+
+function TrackingRoutingProvider({
+  children,
+  createRouterOptions,
+}: PropsWithChildren<{
+  createRouterOptions: BUIRoutingIntegration['createRouterOptions'];
+}>) {
+  const routing = useMemo<BUIRoutingIntegration>(
+    () => ({
+      Link: RouterLink,
+      useHref,
+      useInRouterContext,
+      useLocation,
+      useNavigate,
+      useResolvedPath,
+      createRouterOptions,
+    }),
+    [createRouterOptions],
+  );
+  const value = useMemo(
+    () => createVersionedValueMap({ 1: {}, 2: { routing } }),
+    [routing],
+  );
+  return <BUIContext.Provider value={value}>{children}</BUIContext.Provider>;
+}

--- a/packages/ui/src/components/Combobox/ComboboxItem.tsx
+++ b/packages/ui/src/components/Combobox/ComboboxItem.tsx
@@ -17,7 +17,10 @@
 import { ListBoxItem, Text } from 'react-aria-components';
 import { RiCheckLine } from '@remixicon/react';
 import { Avatar } from '../Avatar';
-import { useDefinition } from '../../hooks/useDefinition';
+import {
+  useDefinition,
+  type UseDefinitionResult,
+} from '../../hooks/useDefinition';
 import {
   ComboboxItemDefinition,
   ComboboxItemProfileDefinition,
@@ -28,20 +31,34 @@ import type {
   ComboboxItemProps,
   ComboboxItemTextProps,
 } from './types';
+import {
+  getReactAriaAnchorProps,
+  type AnchorNavigation,
+} from '../../navigation/useNavigation';
 
-/**
- * A combobox item wrapper for custom content.
- *
- * @public
- */
-export function ComboboxItem<T extends object = object>(
-  props: ComboboxItemProps<T>,
-) {
-  const { ownProps, restProps } = useDefinition(ComboboxItemDefinition, props);
+type ComboboxItemViewProps = {
+  definitionResult: UseDefinitionResult<
+    typeof ComboboxItemDefinition,
+    ComboboxItemProps
+  >;
+  navigation: AnchorNavigation;
+};
+
+function ComboboxItemView({
+  definitionResult,
+  navigation,
+}: ComboboxItemViewProps) {
+  const { ownProps, restProps } = definitionResult;
   const { classes, children, textValue, showSelectionIndicator } = ownProps;
+  const navigationProps = getReactAriaAnchorProps(navigation, restProps);
 
   return (
-    <ListBoxItem {...restProps} className={classes.root} textValue={textValue}>
+    <ListBoxItem
+      {...restProps}
+      className={classes.root}
+      textValue={textValue}
+      {...navigationProps}
+    >
       {values => {
         const content =
           typeof children === 'function' ? children(values) : children;
@@ -60,6 +77,26 @@ export function ComboboxItem<T extends object = object>(
         );
       }}
     </ListBoxItem>
+  );
+}
+
+/**
+ * A combobox item wrapper for custom content.
+ *
+ * @public
+ */
+export function ComboboxItem<T extends object = object>(
+  props: ComboboxItemProps<T>,
+) {
+  const definitionResult = useDefinition(ComboboxItemDefinition, props);
+  const Navigation = definitionResult.navigation;
+
+  return (
+    <Navigation
+      props={definitionResult.restProps}
+      view={ComboboxItemView}
+      viewProps={{ definitionResult }}
+    />
   );
 }
 

--- a/packages/ui/src/components/Combobox/definition.ts
+++ b/packages/ui/src/components/Combobox/definition.ts
@@ -113,6 +113,7 @@ export const ComboboxItemDefinition = defineComponent<ComboboxItemOwnProps>()({
     indicator: 'bui-ComboboxItemIndicator',
     content: 'bui-ComboboxItemContent',
   },
+  navigation: { type: 'anchor' },
   propDefs: {
     children: {},
     textValue: {},

--- a/packages/ui/src/components/Combobox/types.ts
+++ b/packages/ui/src/components/Combobox/types.ts
@@ -346,7 +346,7 @@ export type ComboboxItemOwnProps = {
 /** @public */
 export type ComboboxItemProps<T extends object = object> =
   ComboboxItemOwnProps &
-    Omit<AriaListBoxItemProps<T>, keyof ComboboxItemOwnProps>;
+    Omit<AriaListBoxItemProps<T>, keyof ComboboxItemOwnProps | 'render'>;
 
 /** @public */
 export type ComboboxItemTextOwnProps = {

--- a/packages/ui/src/components/Header/Header.test.tsx
+++ b/packages/ui/src/components/Header/Header.test.tsx
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { BUIProvider } from '../../provider';
+import { Header } from './Header';
+import { HeaderMetadataStatus } from './HeaderMetadataStatus';
+import { HeaderMetadataUsers } from './HeaderMetadataUsers';
+import type { HeaderProps } from './types';
+
+function LocationStatus() {
+  return <span role="status">{useLocation().pathname}</span>;
+}
+
+function renderHeader(
+  props: HeaderProps,
+  initialEntry = '/app/catalog/entity',
+) {
+  return render(
+    <MemoryRouter
+      basename="/app"
+      initialEntries={[initialEntry]}
+      future={{ v7_startTransition: true, v7_relativeSplatPath: false }}
+    >
+      <BUIProvider>
+        <Routes>
+          <Route
+            path="catalog/entity/*"
+            element={
+              <>
+                <Header title="Entity" {...props} />
+                <LocationStatus />
+              </>
+            }
+          />
+        </Routes>
+      </BUIProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('Header navigation', () => {
+  it.each([
+    {
+      name: 'inline description link',
+      props: { description: '[Description](description)' },
+      linkName: 'Description',
+      destination: 'description',
+    },
+    {
+      name: 'tag link',
+      props: { tags: [{ label: 'Tag', href: 'tag' }] },
+      linkName: 'Tag',
+      destination: 'tag',
+    },
+    {
+      name: 'breadcrumb link',
+      props: { breadcrumbs: [{ label: 'Parent', href: 'parent' }] },
+      linkName: 'Parent',
+      destination: 'parent',
+    },
+    {
+      name: 'metadata status link',
+      props: {
+        metadata: [
+          {
+            label: 'Status',
+            value: (
+              <HeaderMetadataStatus
+                label="Healthy"
+                color="success"
+                href="health"
+              />
+            ),
+          },
+        ],
+      },
+      linkName: 'Healthy',
+      destination: 'health',
+    },
+    {
+      name: 'metadata user link',
+      props: {
+        metadata: [
+          {
+            label: 'Owner',
+            value: (
+              <HeaderMetadataUsers
+                users={[{ name: 'Ada Lovelace', href: 'owner' }]}
+              />
+            ),
+          },
+        ],
+      },
+      linkName: 'Ada Lovelace',
+      destination: 'owner',
+    },
+  ] satisfies Array<{
+    name: string;
+    props: HeaderProps;
+    linkName: string;
+    destination: string;
+  }>)(
+    'routes the relative $name through the host router',
+    ({ props, linkName, destination }) => {
+      renderHeader(props);
+
+      const link = screen.getByRole('link', { name: linkName });
+      expect(link).toHaveAttribute(
+        'href',
+        `/app/catalog/entity/${destination}`,
+      );
+      fireEvent.click(link);
+      expect(screen.getByRole('status')).toHaveTextContent(
+        `/catalog/entity/${destination}`,
+      );
+    },
+  );
+
+  it('routes a relative flat tab through HeaderNav', () => {
+    renderHeader({
+      tabs: [{ id: 'overview', label: 'Overview', href: 'overview' }],
+      activeTabId: null,
+    });
+
+    const link = screen.getByRole('link', { name: 'Overview' });
+    expect(link).toHaveAttribute('href', '/app/catalog/entity/overview');
+    fireEvent.click(link);
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '/catalog/entity/overview',
+    );
+  });
+
+  it('routes an empty flat tab href to the parent wildcard route', () => {
+    renderHeader(
+      {
+        tabs: [{ id: 'overview', label: 'Overview', href: '' }],
+        activeTabId: null,
+      },
+      '/app/catalog/entity/techdocs',
+    );
+
+    const link = screen.getByRole('link', { name: 'Overview' });
+    expect(link).toHaveAttribute('href', '/app/catalog/entity');
+    fireEvent.click(link);
+    expect(screen.getByRole('status')).toHaveTextContent('/catalog/entity');
+  });
+
+  it('routes a relative grouped tab through its menu item', async () => {
+    renderHeader({
+      tabs: [
+        {
+          id: 'resources',
+          label: 'Resources',
+          items: [{ id: 'docs', label: 'TechDocs', href: 'docs' }],
+        },
+      ],
+      activeTabId: null,
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Resources' }));
+    const link = await screen.findByRole('menuitemradio', {
+      name: 'TechDocs',
+    });
+    expect(link).toHaveAttribute('href', '/app/catalog/entity/docs');
+    fireEvent.click(link);
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '/catalog/entity/docs',
+    );
+  });
+});

--- a/packages/ui/src/components/Header/HeaderNav.test.tsx
+++ b/packages/ui/src/components/Header/HeaderNav.test.tsx
@@ -15,22 +15,51 @@
  */
 
 import { fireEvent, render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { createVersionedValueMap } from '@backstage/version-bridge';
+import {
+  Link as RouterLink,
+  MemoryRouter,
+  Route,
+  Routes,
+  useHref,
+  useInRouterContext,
+  useLocation,
+  useNavigate,
+  useResolvedPath,
+} from 'react-router-dom';
 import { BUIProvider } from '../../provider';
+import { BUIContext } from '../../provider/BUIContext';
+import type { BUIRoutingIntegration } from '../../navigation/types';
 import { HeaderNav } from './HeaderNav';
-import type { ComponentProps } from 'react';
+import { useMemo, type ComponentProps, type PropsWithChildren } from 'react';
 
 function renderHeaderNav(
   props: ComponentProps<typeof HeaderNav>,
   initialEntry = '/app/catalog',
 ) {
   return render(
-    <MemoryRouter basename="/app" initialEntries={[initialEntry]}>
-      <BUIProvider>
-        <HeaderNav {...props} />
-      </BUIProvider>
+    <MemoryRouter
+      basename="/app"
+      initialEntries={[initialEntry]}
+      future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+    >
+      <Routes>
+        <Route
+          path="catalog/*"
+          element={
+            <BUIProvider>
+              <HeaderNav {...props} />
+              <LocationStatus />
+            </BUIProvider>
+          }
+        />
+      </Routes>
     </MemoryRouter>,
   );
+}
+
+function LocationStatus() {
+  return <span role="status">{useLocation().pathname}</span>;
 }
 
 describe('HeaderNav', () => {
@@ -80,6 +109,54 @@ describe('HeaderNav', () => {
     );
   });
 
+  it('ignores query and hash values when automatically detecting the active tab', () => {
+    renderHeaderNav(
+      {
+        tabs: [
+          {
+            id: 'overview',
+            label: 'Overview',
+            href: '/catalog/overview?tab=docs#api',
+          },
+          {
+            id: 'settings',
+            label: 'Settings',
+            href: '/catalog/settings',
+          },
+        ],
+      },
+      '/app/catalog/overview?view=grid#details',
+    );
+
+    expect(screen.getByRole('link', { name: 'Overview' })).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+    expect(screen.getByRole('link', { name: 'Settings' })).not.toHaveAttribute(
+      'aria-current',
+    );
+  });
+
+  it('automatically selects the most-specific tab for a nested path', () => {
+    renderHeaderNav(
+      {
+        tabs: [
+          { id: 'catalog', label: 'Catalog', href: '/catalog' },
+          { id: 'users', label: 'Users', href: '/catalog/users' },
+        ],
+      },
+      '/app/catalog/users/ada/details',
+    );
+
+    expect(screen.getByRole('link', { name: 'Users' })).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+    expect(screen.getByRole('link', { name: 'Catalog' })).not.toHaveAttribute(
+      'aria-current',
+    );
+  });
+
   it('includes the router basename in grouped tab hrefs', async () => {
     renderHeaderNav({
       tabs: [
@@ -104,4 +181,150 @@ describe('HeaderNav', () => {
       await screen.findByRole('menuitemradio', { name: 'TechDocs' }),
     ).toHaveAttribute('href', '/app/catalog/docs');
   });
+
+  it('resolves a nested relative flat tab and navigates client-side', () => {
+    renderHeaderNav({
+      tabs: [
+        {
+          id: 'overview',
+          label: 'Overview',
+          href: 'overview',
+        },
+      ],
+      activeTabId: null,
+    });
+
+    expect(screen.getByRole('link', { name: 'Overview' })).toHaveAttribute(
+      'href',
+      '/app/catalog/overview',
+    );
+    fireEvent.click(screen.getByRole('link', { name: 'Overview' }));
+    expect(screen.getByRole('status')).toHaveTextContent('/catalog/overview');
+  });
+
+  it('navigates grouped items client-side', async () => {
+    renderHeaderNav({
+      tabs: [
+        {
+          id: 'resources',
+          label: 'Resources',
+          items: [
+            {
+              id: 'docs',
+              label: 'TechDocs',
+              href: '/catalog/docs',
+            },
+          ],
+        },
+      ],
+      activeTabId: null,
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Resources' }));
+    fireEvent.click(
+      await screen.findByRole('menuitemradio', { name: 'TechDocs' }),
+    );
+    expect(screen.getByRole('status')).toHaveTextContent('/catalog/docs');
+  });
+
+  it('retains external grouped item target defaults', async () => {
+    renderHeaderNav({
+      tabs: [
+        {
+          id: 'resources',
+          label: 'Resources',
+          items: [
+            {
+              id: 'docs',
+              label: 'External docs',
+              href: 'https://example.test/docs',
+            },
+          ],
+        },
+      ],
+      activeTabId: null,
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Resources' }));
+    const item = await screen.findByRole('menuitemradio', {
+      name: 'External docs',
+    });
+    expect(item).toHaveAttribute('target', '_blank');
+    expect(item).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('preserves aria-current and the registered anchor ref', () => {
+    renderHeaderNav({
+      tabs: [
+        {
+          id: 'overview',
+          label: 'Overview',
+          href: '/catalog/overview',
+        },
+      ],
+      activeTabId: 'overview',
+    });
+
+    const link = screen.getByRole('link', { name: 'Overview' });
+    const navigation = screen.getByRole('navigation', {
+      name: 'Content navigation',
+    });
+    expect(link).toHaveAttribute('aria-current', 'page');
+    expect(navigation.style.getPropertyValue('--active-tab-opacity')).toBe('1');
+  });
+
+  it('registers flat navigation with the selected routing integration', () => {
+    const createRouterOptions = jest.fn(() => ({ replace: true }));
+    render(
+      <MemoryRouter
+        basename="/app"
+        initialEntries={['/app/catalog']}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <TrackingRoutingProvider createRouterOptions={createRouterOptions}>
+          <HeaderNav
+            tabs={[
+              {
+                id: 'overview',
+                label: 'Overview',
+                href: '/catalog/overview',
+              },
+            ]}
+            activeTabId={null}
+          />
+        </TrackingRoutingProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('link', { name: 'Overview' })).toHaveAttribute(
+      'href',
+      '/app/catalog/overview',
+    );
+    expect(createRouterOptions).toHaveBeenCalledTimes(1);
+  });
 });
+
+function TrackingRoutingProvider({
+  children,
+  createRouterOptions,
+}: PropsWithChildren<{
+  createRouterOptions: BUIRoutingIntegration['createRouterOptions'];
+}>) {
+  const routing = useMemo<BUIRoutingIntegration>(
+    () => ({
+      Link: RouterLink,
+      useHref,
+      useInRouterContext,
+      useLocation,
+      useNavigate,
+      useResolvedPath,
+      createRouterOptions,
+    }),
+    [createRouterOptions],
+  );
+  const value = useMemo(
+    () => createVersionedValueMap({ 1: {}, 2: { routing } }),
+    [routing],
+  );
+  return <BUIContext.Provider value={value}>{children}</BUIContext.Provider>;
+}

--- a/packages/ui/src/components/Header/HeaderNav.tsx
+++ b/packages/ui/src/components/Header/HeaderNav.tsx
@@ -15,17 +15,18 @@
  */
 
 import { useCallback, useMemo, useRef, useState } from 'react';
-import { useFocusVisible, useHover, useLink } from 'react-aria';
+import { mergeProps, useFocusVisible, useHover, useLink } from 'react-aria';
 import {
   matchRoutes,
   resolvePath,
-  useInRouterContext,
-  useLocation,
-  useResolvedPath,
+  type NavigateOptions,
 } from 'react-router-dom';
 import { Button as RAButton } from 'react-aria-components';
 import { RiArrowDownSLine } from '@remixicon/react';
-import { useDefinition } from '../../hooks/useDefinition';
+import {
+  useDefinition,
+  type UseDefinitionResult,
+} from '../../hooks/useDefinition';
 import {
   HeaderNavDefinition,
   HeaderNavItemDefinition,
@@ -38,17 +39,45 @@ import type {
   HeaderNavTabGroup,
   HeaderNavTabItem,
 } from './types';
+import { useRoutingIntegration } from '../../navigation/useRouting';
+import type { AnchorNavigation } from '../../navigation/useNavigation';
 
 function isTabGroup(tab: HeaderNavTabItem): tab is HeaderNavTabGroup {
   return 'items' in tab;
 }
 
-function HeaderNavLink(props: HeaderNavLinkProps) {
-  const { ownProps, analytics } = useDefinition(HeaderNavItemDefinition, props);
-  const { id, label, href, active, registerRef, onHighlight } = ownProps;
+type HeaderNavLinkViewProps = {
+  definitionResult: UseDefinitionResult<
+    typeof HeaderNavItemDefinition,
+    HeaderNavLinkProps
+  >;
+  navigation: AnchorNavigation;
+};
+
+function HeaderNavLinkView({
+  definitionResult,
+  navigation,
+}: HeaderNavLinkViewProps) {
+  const { ownProps, analytics } = definitionResult;
+  const { id, label, active, registerRef, onHighlight } = ownProps;
+  const { href } = ownProps;
 
   const linkRef = useRef<HTMLAnchorElement>(null);
-  const { linkProps } = useLink({ href }, linkRef);
+  let ariaHref = href;
+  let routerOptions: NavigateOptions | undefined;
+  if (navigation.type === 'router') {
+    ariaHref = navigation.ariaHref;
+    routerOptions = navigation.routerOptions;
+  } else if (navigation.type === 'native') {
+    ariaHref = navigation.ariaHref;
+  }
+  const { linkProps } = useLink(
+    {
+      href: ariaHref,
+      routerOptions,
+    },
+    linkRef,
+  );
   const { hoverProps } = useHover({
     onHoverStart: () => onHighlight(id),
     onHoverEnd: () => onHighlight(null),
@@ -60,27 +89,52 @@ function HeaderNavLink(props: HeaderNavLinkProps) {
       attributes: { to: href },
     });
   };
+  const { href: _href, ...anchorProps } = mergeProps(
+    linkProps,
+    hoverProps,
+  ) as React.AnchorHTMLAttributes<HTMLAnchorElement>;
+  const ref = (el: HTMLAnchorElement | null) => {
+    (linkRef as React.MutableRefObject<HTMLAnchorElement | null>).current = el;
+    registerRef(id, el);
+  };
+  const commonProps = {
+    ...anchorProps,
+    ref,
+    className: ownProps.classes.root,
+    'aria-current': active ? ('page' as const) : undefined,
+    onClick: handleClick,
+    onFocus: () => onHighlight(id),
+    onBlur: () => onHighlight(null),
+    children: label,
+  };
+  const browserHref =
+    navigation.type === 'native' ? navigation.browserHref : href;
 
   return (
     <li>
-      <a
-        {...linkProps}
-        {...hoverProps}
-        ref={el => {
-          (
-            linkRef as React.MutableRefObject<HTMLAnchorElement | null>
-          ).current = el;
-          registerRef(id, el);
-        }}
-        className={ownProps.classes.root}
-        aria-current={active ? 'page' : undefined}
-        onClick={handleClick}
-        onFocus={() => onHighlight(id)}
-        onBlur={() => onHighlight(null)}
-      >
-        {label}
-      </a>
+      {navigation.type === 'router' ? (
+        <navigation.Link
+          {...commonProps}
+          {...navigation.routerLinkOptions}
+          to={navigation.to}
+        />
+      ) : (
+        <a {...commonProps} href={browserHref} />
+      )}
     </li>
+  );
+}
+
+function HeaderNavLink(props: HeaderNavLinkProps) {
+  const definitionResult = useDefinition(HeaderNavItemDefinition, props);
+  const Navigation = definitionResult.navigation;
+
+  return (
+    <Navigation
+      props={{ href: definitionResult.ownProps.href }}
+      view={HeaderNavLinkView}
+      viewProps={{ definitionResult }}
+    />
   );
 }
 
@@ -137,8 +191,9 @@ interface HeaderNavProps {
 }
 
 function useAutoActiveTabId(tabs: HeaderNavTabItem[]): string | undefined {
-  const basePath = useResolvedPath('.').pathname;
-  const { pathname } = useLocation();
+  const routing = useRoutingIntegration({ fallback: true });
+  const basePath = routing.useResolvedPath('.').pathname;
+  const { pathname } = routing.useLocation();
 
   return useMemo(() => {
     const allTabs = tabs.flatMap(tab => (isTabGroup(tab) ? tab.items : [tab]));
@@ -238,7 +293,8 @@ function HeaderNavInner(props: HeaderNavProps) {
 
 /** @internal */
 export function HeaderNav(props: HeaderNavProps) {
-  const inRouter = useInRouterContext();
+  const routing = useRoutingIntegration({ fallback: true });
+  const inRouter = routing.useInRouterContext();
 
   if (props.activeTabId === undefined && inRouter) {
     return <HeaderNavAutoDetect tabs={props.tabs} />;

--- a/packages/ui/src/components/Header/HeaderNavDefinition.ts
+++ b/packages/ui/src/components/Header/HeaderNavDefinition.ts
@@ -47,6 +47,7 @@ export const HeaderNavItemDefinition = defineComponent<HeaderNavLinkProps>()({
     root: 'bui-HeaderNavItem',
   },
   analytics: true,
+  navigation: { type: 'anchor' },
   propDefs: {
     noTrack: {},
     id: {},

--- a/packages/ui/src/components/Link/Link.test.tsx
+++ b/packages/ui/src/components/Link/Link.test.tsx
@@ -1,0 +1,456 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  createVersionedValueMap,
+  type VersionedValue,
+} from '@backstage/version-bridge';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { createRef, useMemo, type PropsWithChildren } from 'react';
+import * as ProviderReactAria from 'react-aria';
+import { RouterProvider } from 'react-aria-components';
+import {
+  MemoryRouter,
+  Outlet,
+  Route,
+  Routes,
+  useLocation,
+  useNavigate,
+  useNavigationType,
+  type NavigateOptions,
+} from 'react-router-dom';
+import { BUIContext, type BUIContextVersions } from '../../provider/BUIContext';
+import { BUIProvider } from '../../provider/BUIProvider';
+import { useResolvedHref } from '../../hooks/useResolvedHref';
+import { Link } from './Link';
+
+const routerFuture = {
+  v7_startTransition: true,
+  v7_relativeSplatPath: true,
+} as const;
+
+function LocationStatus() {
+  const location = useLocation();
+  const navigationType = useNavigationType();
+  return (
+    <span role="status">
+      {location.pathname}
+      {location.search}
+      {location.hash}:{navigationType}:{location.state?.source}
+    </span>
+  );
+}
+
+function HistoryBackButton() {
+  const navigate = useNavigate();
+  return <button onClick={() => navigate(-1)}>Back</button>;
+}
+
+function OldBUIProvider({ children }: PropsWithChildren) {
+  const navigate = useNavigate();
+  const value = useMemo(
+    () =>
+      createVersionedValueMap({
+        1: { useAnalytics: undefined },
+      }) as VersionedValue<BUIContextVersions>,
+    [],
+  );
+
+  return (
+    <RouterProvider navigate={navigate} useHref={useResolvedHref}>
+      <BUIContext.Provider value={value}>{children}</BUIContext.Provider>
+    </RouterProvider>
+  );
+}
+
+function createRouterWrapper({
+  entry = '/app/catalog/entity/docs',
+  provider = 'new',
+}: {
+  entry?: string;
+  provider?: 'new' | 'old';
+} = {}) {
+  return function RouterWrapper({ children }: PropsWithChildren) {
+    const content = (
+      <>
+        <Routes>
+          <Route path="catalog" element={<Outlet />}>
+            <Route path="entity" element={<Outlet />}>
+              <Route path="docs/*" element={children} />
+            </Route>
+          </Route>
+          <Route path="*" element={null} />
+        </Routes>
+        <LocationStatus />
+      </>
+    );
+
+    return (
+      <MemoryRouter
+        basename="/app"
+        initialEntries={[entry]}
+        future={routerFuture}
+      >
+        {provider === 'new' ? (
+          <BUIProvider>{content}</BUIProvider>
+        ) : (
+          <OldBUIProvider>{content}</OldBUIProvider>
+        )}
+      </MemoryRouter>
+    );
+  };
+}
+
+describe('Link', () => {
+  it.each(['new', 'old'] as const)(
+    'navigates client-side under the %s provider and applies the basename once',
+    provider => {
+      render(<Link href="/catalog/overview">Overview</Link>, {
+        wrapper: createRouterWrapper({ provider }),
+      });
+
+      const link = screen.getByRole('link', { name: 'Overview' });
+      expect(link).toHaveAttribute('href', '/app/catalog/overview');
+      fireEvent.click(link);
+      expect(screen.getByRole('status')).toHaveTextContent('/catalog/overview');
+    },
+  );
+
+  it.each([
+    ['child', '/catalog/entity/docs/child'],
+    ['.', '/catalog/entity/docs'],
+    ['..', '/catalog/entity'],
+    ['?tab=docs', '/catalog/entity/docs?tab=docs'],
+    ['#api', '/catalog/entity/docs#api'],
+  ])('preserves relative destination %s', (href, expectedLocation) => {
+    render(<Link href={href}>Destination</Link>, {
+      wrapper: createRouterWrapper(),
+    });
+
+    fireEvent.click(screen.getByRole('link', { name: 'Destination' }));
+    expect(screen.getByRole('status')).toHaveTextContent(expectedLocation);
+  });
+
+  it('renders a native relative anchor outside React Router', () => {
+    render(<Link href="../entity?tab=docs#api">Destination</Link>);
+
+    expect(screen.getByRole('link', { name: 'Destination' })).toHaveAttribute(
+      'href',
+      '../entity?tab=docs#api',
+    );
+  });
+
+  it('preserves refs and accessibility properties', () => {
+    const ref = createRef<HTMLAnchorElement>();
+    render(
+      <Link
+        ref={ref}
+        href="/catalog/overview"
+        aria-label="Catalog overview"
+        aria-current="page"
+      >
+        Overview
+      </Link>,
+      { wrapper: createRouterWrapper() },
+    );
+
+    const link = screen.getByRole('link', { name: 'Catalog overview' });
+    expect(ref.current).toBe(link);
+    expect(link).toHaveAttribute('aria-current', 'page');
+    expect(link).toHaveAttribute('data-variant', 'body-medium');
+    expect(link).toHaveAttribute('data-weight', 'regular');
+    expect(link).toHaveAttribute('data-color', 'primary');
+  });
+
+  it('reports the caller raw href to analytics', () => {
+    const captureEvent = jest.fn();
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <MemoryRouter
+        basename="/app"
+        initialEntries={['/app/catalog/entity/docs']}
+        future={routerFuture}
+      >
+        <BUIProvider useAnalytics={() => ({ captureEvent })}>
+          <Routes>
+            <Route path="catalog/entity/docs/*" element={children} />
+          </Routes>
+        </BUIProvider>
+      </MemoryRouter>
+    );
+    render(<Link href="child">Child</Link>, { wrapper });
+
+    fireEvent.click(screen.getByRole('link', { name: 'Child' }));
+    expect(captureEvent).toHaveBeenCalledWith('click', 'Child', {
+      attributes: { to: 'child' },
+    });
+  });
+
+  it('does not consume modifier clicks', () => {
+    render(<Link href="child">Child</Link>, {
+      wrapper: createRouterWrapper(),
+    });
+    const link = screen.getByRole('link', { name: 'Child' });
+
+    fireEvent.click(link, { metaKey: true });
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '/catalog/entity/docs',
+    );
+    fireEvent.click(link, { ctrlKey: true });
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '/catalog/entity/docs',
+    );
+    fireEvent.click(link, { shiftKey: true });
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '/catalog/entity/docs',
+    );
+    fireEvent.click(link, { altKey: true });
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '/catalog/entity/docs',
+    );
+  });
+
+  it.each([
+    ['_blank', '_blank'],
+    ['preview', 'preview'],
+    ['_parent', '_parent'],
+    ['_top', '_top'],
+  ])('leaves target %s navigation to the browser', (_name, target) => {
+    render(
+      <Link href="/catalog/overview" target={target}>
+        Overview
+      </Link>,
+      { wrapper: createRouterWrapper() },
+    );
+
+    const link = screen.getByRole('link', { name: 'Overview' });
+    expect(link).toHaveAttribute('href', '/app/catalog/overview');
+    expect(link).toHaveAttribute('target', target);
+  });
+
+  it('keeps _self navigation client-side', () => {
+    render(
+      <Link href="/catalog/overview" target="_self">
+        Overview
+      </Link>,
+      { wrapper: createRouterWrapper() },
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'Overview' }));
+    expect(screen.getByRole('status')).toHaveTextContent('/catalog/overview');
+  });
+
+  it.each([
+    ['https://example.test/docs', undefined],
+    ['mailto:owner@example.test', undefined],
+    ['tel:+123456789', undefined],
+    ['sms:+123456789', undefined],
+    ['ftp://example.test/file', undefined],
+    ['vscode://file/workspace', undefined],
+    ['//cdn.example.test/file', undefined],
+    ['/catalog/export', true],
+    ['/catalog/export', 'catalog.yaml'],
+  ])('preserves browser-owned href %s and download %s', (href, download) => {
+    render(
+      <Link href={href} download={download}>
+        Destination
+      </Link>,
+      { wrapper: createRouterWrapper() },
+    );
+
+    const link = screen.getByRole('link', { name: 'Destination' });
+    expect(link).toHaveAttribute(
+      'href',
+      href.startsWith('/') && !href.startsWith('//') ? `/app${href}` : href,
+    );
+    if (download !== undefined) {
+      expect(link).toHaveAttribute(
+        'download',
+        download === true ? '' : download,
+      );
+    }
+  });
+
+  it.each(['new', 'old'] as const)(
+    'navigates with the actual Link from an isolated BUI graph under the %s provider',
+    provider => {
+      const sharedReact = jest.requireActual<typeof import('react')>('react');
+      const sharedReactDom =
+        jest.requireActual<typeof import('react-dom')>('react-dom');
+      const sharedReactDomClient =
+        jest.requireActual<typeof import('react-dom/client')>(
+          'react-dom/client',
+        );
+      const sharedReactRouter =
+        jest.requireActual<typeof import('react-router')>('react-router');
+      const sharedReactRouterDom =
+        jest.requireActual<typeof import('react-router-dom')>(
+          'react-router-dom',
+        );
+      let IsolatedLink!: typeof Link;
+      let IsolatedReactAria!: typeof ProviderReactAria;
+
+      jest.isolateModules(() => {
+        jest.doMock('react', () => sharedReact);
+        jest.doMock('react-dom', () => sharedReactDom);
+        jest.doMock('react-dom/client', () => sharedReactDomClient);
+        jest.doMock('react-router', () => sharedReactRouter);
+        jest.doMock('react-router-dom', () => sharedReactRouterDom);
+        IsolatedReactAria = jest.requireActual('react-aria');
+        ({ Link: IsolatedLink } = jest.requireActual('./Link'));
+      });
+
+      expect(IsolatedReactAria).not.toBe(ProviderReactAria);
+      render(
+        <IsolatedLink
+          href="child"
+          routerOptions={{
+            replace: true,
+            state: { source: `isolated-${provider}` },
+          }}
+        >
+          Isolated child
+        </IsolatedLink>,
+        { wrapper: createRouterWrapper({ provider }) },
+      );
+
+      fireEvent.click(screen.getByRole('link', { name: 'Isolated child' }));
+      expect(screen.getByRole('status')).toHaveTextContent(
+        `/catalog/entity/docs/child:REPLACE:isolated-${provider}`,
+      );
+    },
+  );
+
+  it('navigates once when React Aria delegates flushSync navigation', () => {
+    render(
+      <MemoryRouter initialEntries={['/source']} future={routerFuture}>
+        <BUIProvider>
+          <Routes>
+            <Route
+              path="source"
+              element={
+                <Link
+                  href="/destination"
+                  routerOptions={{
+                    flushSync: true,
+                    state: { source: 'shared-react-aria' },
+                  }}
+                >
+                  Destination
+                </Link>
+              }
+            />
+            <Route path="destination" element={<LocationStatus />} />
+          </Routes>
+          <HistoryBackButton />
+        </BUIProvider>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'Destination' }));
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '/destination:PUSH:shared-react-aria',
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+    expect(
+      screen.getByRole('link', { name: 'Destination' }),
+    ).toBeInTheDocument();
+  });
+
+  it('passes complete router options once from an isolated BUI graph under a V1 provider', () => {
+    const sharedReact = jest.requireActual<typeof import('react')>('react');
+    const sharedReactDom =
+      jest.requireActual<typeof import('react-dom')>('react-dom');
+    const sharedReactDomClient =
+      jest.requireActual<typeof import('react-dom/client')>('react-dom/client');
+    const sharedReactRouter =
+      jest.requireActual<typeof import('react-router')>('react-router');
+    const sharedReactRouterDom =
+      jest.requireActual<typeof import('react-router-dom')>('react-router-dom');
+    const navigationCalls: Array<[string, NavigateOptions | undefined]> = [];
+    let hostNavigate: ReturnType<typeof useNavigate> | undefined;
+    const trackedNavigate = ((to: string, options?: NavigateOptions) => {
+      navigationCalls.push([to, options]);
+      hostNavigate?.(to, options);
+    }) as ReturnType<typeof useNavigate>;
+    let IsolatedLink!: typeof Link;
+
+    jest.isolateModules(() => {
+      jest.doMock('react', () => sharedReact);
+      jest.doMock('react-dom', () => sharedReactDom);
+      jest.doMock('react-dom/client', () => sharedReactDomClient);
+      jest.doMock('react-router', () => sharedReactRouter);
+      jest.doMock('react-router-dom', () => ({
+        ...sharedReactRouterDom,
+        useNavigate: () => trackedNavigate,
+      }));
+      ({ Link: IsolatedLink } = jest.requireActual('./Link'));
+    });
+
+    const routerOptions = {
+      flushSync: true,
+      preventScrollReset: true,
+      relative: 'route' as const,
+      replace: false,
+      state: { source: 'isolated-v1' },
+      viewTransition: true,
+    };
+    const CaptureHostNavigate = ({ children }: PropsWithChildren) => {
+      hostNavigate = useNavigate();
+      return children;
+    };
+
+    render(
+      <MemoryRouter initialEntries={['/source']} future={routerFuture}>
+        <CaptureHostNavigate>
+          <OldBUIProvider>
+            <Routes>
+              <Route
+                path="source"
+                element={
+                  <IsolatedLink
+                    href="/destination"
+                    routerOptions={routerOptions}
+                  >
+                    Isolated destination
+                  </IsolatedLink>
+                }
+              />
+              <Route path="destination" element={<LocationStatus />} />
+            </Routes>
+            <HistoryBackButton />
+          </OldBUIProvider>
+        </CaptureHostNavigate>
+      </MemoryRouter>,
+    );
+
+    const link = screen.getByRole('link', { name: 'Isolated destination' });
+    fireEvent.click(link, { metaKey: true });
+    expect(navigationCalls).toHaveLength(0);
+    expect(link).toBeInTheDocument();
+
+    fireEvent.click(link);
+    expect(navigationCalls).toEqual([['/destination', routerOptions]]);
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '/destination:PUSH:isolated-v1',
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+    expect(
+      screen.getByRole('link', { name: 'Isolated destination' }),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/Link/Link.tsx
+++ b/packages/ui/src/components/Link/Link.tsx
@@ -17,24 +17,56 @@
 import { forwardRef, useRef } from 'react';
 import { mergeProps, useFocusRing, useLink } from 'react-aria';
 import type { LinkProps } from './types';
-import { useDefinition } from '../../hooks/useDefinition';
+import {
+  useDefinition,
+  type UseDefinitionResult,
+} from '../../hooks/useDefinition';
 import { useResolvedHref } from '../../hooks/useResolvedHref';
 import { LinkDefinition } from './definition';
 import { getNodeText } from '../../analytics/getNodeText';
+import {
+  handleRouterLinkClick,
+  type AnchorNavigation,
+} from '../../navigation/useNavigation';
 
-const LinkInternal = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
-  const { ownProps, restProps, dataAttributes, analytics } = useDefinition(
-    LinkDefinition,
-    props,
-  );
+type LinkViewProps = {
+  definitionResult: UseDefinitionResult<typeof LinkDefinition, LinkProps>;
+  navigation: AnchorNavigation;
+  forwardedRef: React.ForwardedRef<HTMLAnchorElement>;
+};
+
+function LinkView({
+  definitionResult,
+  navigation,
+  forwardedRef,
+}: LinkViewProps) {
+  const { ownProps, restProps, dataAttributes, analytics } = definitionResult;
   const { classes, title, children } = ownProps;
 
   const internalRef = useRef<HTMLAnchorElement>(null);
-  const linkRef = (ref || internalRef) as React.RefObject<HTMLAnchorElement>;
+  const linkRef = (forwardedRef ||
+    internalRef) as React.RefObject<HTMLAnchorElement>;
 
-  const { linkProps } = useLink(restProps, linkRef);
+  let resolvedLinkProps = restProps;
+  if (navigation.type === 'router') {
+    resolvedLinkProps = {
+      ...restProps,
+      href: navigation.ariaHref,
+      routerOptions: navigation.routerOptions,
+    };
+  } else if (navigation.type === 'native') {
+    resolvedLinkProps = {
+      ...restProps,
+      href: navigation.ariaHref,
+    };
+  }
+  // React Aria Components' Link filters out the native title attribute.
+  // Render the anchor explicitly so truncated links retain their browser tooltip.
+  const { linkProps } = useLink(resolvedLinkProps, linkRef);
   const { isFocusVisible, focusProps } = useFocusRing();
-  const resolvedHref = useResolvedHref(restProps.href);
+  const fallbackHref = useResolvedHref(restProps.href);
+  const resolvedHref =
+    navigation.type === 'native' ? navigation.browserHref : fallbackHref;
 
   const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     linkProps.onClick?.(e);
@@ -45,26 +77,42 @@ const LinkInternal = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
     analytics.captureEvent('click', text, {
       attributes: { to: String(restProps.href ?? '') },
     });
+    handleRouterLinkClick(e, navigation);
   };
 
-  return (
-    <a
-      {...mergeProps(linkProps, focusProps)}
-      {...dataAttributes}
-      {...(restProps as React.AnchorHTMLAttributes<HTMLAnchorElement>)}
-      href={resolvedHref}
-      ref={linkRef}
-      title={title}
-      className={classes.root}
-      data-focus-visible={isFocusVisible || undefined}
-      onClick={handleClick}
-    >
-      {children}
-    </a>
-  );
-});
+  const { href: _href, ...interactionProps } = mergeProps(
+    linkProps,
+    focusProps,
+  ) as React.AnchorHTMLAttributes<HTMLAnchorElement>;
+  const {
+    href: _restHref,
+    routerOptions: _routerOptions,
+    ...anchorProps
+  } = restProps;
+  const commonProps = {
+    ...interactionProps,
+    ...dataAttributes,
+    ...(anchorProps as React.AnchorHTMLAttributes<HTMLAnchorElement>),
+    ref: linkRef,
+    title,
+    className: classes.root,
+    'data-focus-visible': isFocusVisible || undefined,
+    onClick: handleClick,
+    children,
+  };
 
-LinkInternal.displayName = 'LinkInternal';
+  if (navigation.type === 'router') {
+    return (
+      <navigation.Link
+        {...commonProps}
+        {...navigation.routerLinkOptions}
+        to={navigation.to}
+      />
+    );
+  }
+
+  return <a {...commonProps} href={resolvedHref} />;
+}
 
 /**
  * A styled anchor element that supports analytics event tracking on click.
@@ -72,7 +120,16 @@ LinkInternal.displayName = 'LinkInternal';
  * @public
  */
 export const Link = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
-  return <LinkInternal {...props} ref={ref} />;
+  const definitionResult = useDefinition(LinkDefinition, props);
+  const Navigation = definitionResult.navigation;
+
+  return (
+    <Navigation
+      props={definitionResult.restProps}
+      view={LinkView}
+      viewProps={{ definitionResult, forwardedRef: ref }}
+    />
+  );
 });
 
 Link.displayName = 'Link';

--- a/packages/ui/src/components/Link/definition.ts
+++ b/packages/ui/src/components/Link/definition.ts
@@ -28,6 +28,7 @@ export const LinkDefinition = defineComponent<LinkOwnProps>()({
     root: 'bui-Link',
   },
   analytics: true,
+  navigation: { type: 'anchor' },
   propDefs: {
     noTrack: {},
     variant: { dataAttribute: true, default: 'body-medium' },

--- a/packages/ui/src/components/Link/types.ts
+++ b/packages/ui/src/components/Link/types.ts
@@ -42,5 +42,5 @@ export type LinkOwnProps = {
 
 /** @public */
 export interface LinkProps
-  extends Omit<AriaLinkProps, 'children' | 'className'>,
+  extends Omit<AriaLinkProps, 'children' | 'className' | 'render'>,
     LinkOwnProps {}

--- a/packages/ui/src/components/List/List.test.tsx
+++ b/packages/ui/src/components/List/List.test.tsx
@@ -1,0 +1,464 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  createVersionedValueMap,
+  type VersionedValue,
+} from '@backstage/version-bridge';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import {
+  useMemo,
+  type JSX,
+  type MutableRefObject,
+  type PropsWithChildren,
+} from 'react';
+import * as ProviderReactAria from 'react-aria';
+import * as ProviderReactAriaComponents from 'react-aria-components';
+import {
+  RouterProvider,
+  type GridListItemRenderProps,
+} from 'react-aria-components';
+import {
+  MemoryRouter,
+  Route,
+  Routes,
+  useLocation,
+  useNavigate,
+} from 'react-router-dom';
+import { useResolvedHref } from '../../hooks/useResolvedHref';
+import { BUIContext, type BUIContextVersions } from '../../provider/BUIContext';
+import { BUIProvider } from '../../provider/BUIProvider';
+import { List, ListRow } from './List';
+
+const routerFuture = {
+  v7_startTransition: true,
+  v7_relativeSplatPath: true,
+} as const;
+
+function LocationStatus() {
+  const location = useLocation();
+
+  return (
+    <span role="status" data-location-state={JSON.stringify(location.state)}>
+      {location.pathname}
+    </span>
+  );
+}
+
+function RouterFixture({ children }: PropsWithChildren) {
+  return (
+    <MemoryRouter
+      basename="/app"
+      initialEntries={['/app/catalog/entity/docs']}
+      future={routerFuture}
+    >
+      <BUIProvider>
+        <Routes>
+          <Route path="catalog/entity/docs/*" element={children} />
+        </Routes>
+        <LocationStatus />
+      </BUIProvider>
+    </MemoryRouter>
+  );
+}
+
+function OldBUIProvider({ children }: PropsWithChildren) {
+  const navigate = useNavigate();
+  const value = useMemo(
+    () =>
+      createVersionedValueMap({
+        1: { useAnalytics: undefined },
+      }) as VersionedValue<BUIContextVersions>,
+    [],
+  );
+
+  return (
+    <RouterProvider navigate={navigate} useHref={useResolvedHref}>
+      <BUIContext.Provider value={value}>{children}</BUIContext.Provider>
+    </RouterProvider>
+  );
+}
+
+function activate(element: HTMLElement, method: 'click' | 'keyboard') {
+  if (method === 'click') {
+    fireEvent.click(element);
+    return;
+  }
+  act(() => element.focus());
+  fireEvent.keyDown(element, { key: 'Enter', code: 'Enter' });
+  fireEvent.keyUp(element, { key: 'Enter', code: 'Enter' });
+}
+
+describe('ListRow navigation', () => {
+  it.each(['click', 'keyboard'] as const)(
+    'uses an ordinary internal href as a component-relative %s action',
+    method => {
+      const onAction = jest.fn();
+      render(
+        <List aria-label="Destinations">
+          <ListRow id="child" href="child" onAction={onAction}>
+            Child
+          </ListRow>
+        </List>,
+        { wrapper: RouterFixture },
+      );
+
+      const row = screen.getByRole('row', { name: 'Child' });
+      expect(row).toHaveAttribute(
+        'data-href',
+        '/app/catalog/entity/docs/child',
+      );
+      activate(row, method);
+      expect(screen.getByRole('status')).toHaveTextContent(
+        '/catalog/entity/docs/child',
+      );
+      expect(onAction).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('preserves modifier activation for an ordinary internal href', () => {
+    render(
+      <List aria-label="Destinations">
+        <ListRow id="child" href="child">
+          Child
+        </ListRow>
+      </List>,
+      { wrapper: RouterFixture },
+    );
+
+    const row = screen.getByRole('row', { name: 'Child' });
+    const activated: Array<{
+      href: string;
+      metaKey: boolean;
+      ctrlKey: boolean;
+    }> = [];
+    const capture = (event: MouseEvent) => {
+      if (event.target instanceof HTMLAnchorElement) {
+        event.preventDefault();
+        activated.push({
+          href: event.target.getAttribute('href') ?? '',
+          metaKey: event.metaKey,
+          ctrlKey: event.ctrlKey,
+        });
+      }
+    };
+    document.addEventListener('click', capture, true);
+    try {
+      fireEvent.click(row, { metaKey: true });
+    } finally {
+      document.removeEventListener('click', capture, true);
+    }
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '/catalog/entity/docs',
+    );
+    expect(activated).toEqual([
+      { href: '/app/catalog/entity/docs/child', metaKey: true, ctrlKey: false },
+    ]);
+  });
+
+  it('does not activate an ordinary internal href when disabled', () => {
+    const onAction = jest.fn();
+    render(
+      <List aria-label="Destinations">
+        <ListRow id="child" href="child" onAction={onAction} isDisabled>
+          Child
+        </ListRow>
+      </List>,
+      { wrapper: RouterFixture },
+    );
+
+    fireEvent.click(screen.getByRole('row', { name: 'Child' }));
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '/catalog/entity/docs',
+    );
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      href: 'https://example.test/docs',
+      expectedHref: 'https://example.test/docs',
+    },
+    {
+      href: 'mailto:owner@example.test',
+      expectedHref: 'mailto:owner@example.test',
+    },
+    { href: '/catalog', target: '_blank', expectedHref: '/app/catalog' },
+    { href: '/catalog', target: 'preview', expectedHref: '/app/catalog' },
+    { href: '/catalog', target: '_parent', expectedHref: '/app/catalog' },
+    { href: '/catalog', target: '_top', expectedHref: '/app/catalog' },
+    { href: '/catalog', download: true, expectedHref: '/app/catalog' },
+    {
+      href: '/catalog',
+      download: 'catalog.csv',
+      expectedHref: '/app/catalog',
+    },
+  ])(
+    'preserves native ListRow navigation for $href $target $download',
+    ({ href, target, download, expectedHref }) => {
+      render(
+        <List aria-label="Destinations">
+          <ListRow
+            id="destination"
+            href={href}
+            target={target}
+            rel="author"
+            ping="/navigation-ping"
+            download={download}
+            referrerPolicy="no-referrer"
+          >
+            Destination
+          </ListRow>
+        </List>,
+        { wrapper: RouterFixture },
+      );
+
+      const row = screen.getByRole('row', { name: 'Destination' });
+      expect(row).toHaveAttribute('data-href', expectedHref);
+      expect(row).toHaveAttribute('data-rel', 'author');
+      expect(row).toHaveAttribute('data-ping', '/navigation-ping');
+      expect(row).toHaveAttribute('data-referrer-policy', 'no-referrer');
+      if (target) {
+        expect(row).toHaveAttribute('data-target', target);
+      }
+      if (download !== undefined) {
+        expect(row).toHaveAttribute('data-download', String(download));
+      }
+    },
+  );
+
+  it('uses router options for an ordinary internal relative href', () => {
+    render(
+      <List aria-label="Destinations">
+        <ListRow
+          id="child"
+          href="child"
+          routerOptions={{ replace: true, state: { source: 'list-row' } }}
+        >
+          Child
+        </ListRow>
+      </List>,
+      { wrapper: RouterFixture },
+    );
+
+    const row = screen.getByRole('row', { name: 'Child' });
+    expect(row).toHaveAttribute('data-href', '/app/catalog/entity/docs/child');
+    fireEvent.click(row);
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '/catalog/entity/docs/child',
+    );
+    expect(screen.getByRole('status')).toHaveAttribute(
+      'data-location-state',
+      '{"source":"list-row"}',
+    );
+  });
+
+  it('keeps native keyboard action and selection behavior in React Aria', () => {
+    const onPress = jest.fn();
+    render(
+      <List
+        aria-label="Destinations"
+        selectionMode="multiple"
+        selectionBehavior="toggle"
+        defaultSelectedKeys={['destination']}
+      >
+        <ListRow
+          id="destination"
+          href="/catalog"
+          target="_blank"
+          onPress={onPress}
+        >
+          Destination
+        </ListRow>
+      </List>,
+      { wrapper: RouterFixture },
+    );
+
+    const row = screen.getByRole('row', { name: 'Destination' });
+    expect(row).toHaveAttribute('aria-selected', 'true');
+    act(() => row.focus());
+    fireEvent.keyDown(row, { key: 'Enter', code: 'Enter' });
+    fireEvent.keyUp(row, { key: 'Enter', code: 'Enter' });
+    expect(onPress).toHaveBeenCalledTimes(1);
+    expect(row).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('preserves consumer render state, DOM props, content, and refs', () => {
+    let renderedElement: HTMLDivElement | null = null;
+    const consumerRender = jest.fn(
+      (
+        domProps: JSX.IntrinsicElements['div'],
+        renderProps: GridListItemRenderProps,
+      ) => (
+        <div
+          {...domProps}
+          ref={element => {
+            const renderRef = domProps.ref;
+            if (typeof renderRef === 'function') {
+              renderRef(element);
+            } else if (renderRef) {
+              (renderRef as MutableRefObject<HTMLDivElement | null>).current =
+                element;
+            }
+            renderedElement = element;
+          }}
+          data-href="/consumer"
+          data-selected={String(renderProps.isSelected)}
+        />
+      ),
+    );
+    render(
+      <List aria-label="Destinations">
+        <ListRow
+          id="destination"
+          href="/catalog"
+          target="_blank"
+          aria-label="Catalog destination"
+          className="consumer-row"
+          render={consumerRender}
+        >
+          Catalog
+        </ListRow>
+      </List>,
+      { wrapper: RouterFixture },
+    );
+
+    const row = screen.getByRole('row', { name: 'Catalog destination' });
+    expect(row.tagName).toBe('DIV');
+    expect(row).toHaveClass('bui-ListRow', 'consumer-row');
+    expect(row).toHaveAttribute('data-href', '/consumer');
+    expect(row).toHaveAttribute('data-selected', 'false');
+    expect(row).toHaveTextContent('Catalog');
+    expect(renderedElement).toBe(row);
+    expect(consumerRender).toHaveBeenCalledWith(
+      expect.objectContaining({
+        'aria-label': 'Catalog destination',
+        'data-href': '/app/catalog',
+      }),
+      expect.objectContaining({ isSelected: false }),
+    );
+  });
+
+  it('keeps raw native hrefs outside React Router', () => {
+    render(
+      <List aria-label="Destinations">
+        <ListRow id="destination" href="https://example.test/docs">
+          Destination
+        </ListRow>
+      </List>,
+    );
+
+    expect(screen.getByRole('row', { name: 'Destination' })).toHaveAttribute(
+      'data-href',
+      'https://example.test/docs',
+    );
+  });
+
+  it.each([
+    ['V2', 'shared'],
+    ['V2', 'isolated'],
+    ['V1-only', 'shared'],
+    ['V1-only', 'isolated'],
+  ] as const)(
+    'applies the basename once under a %s host with %s React Aria',
+    (provider, reactAriaGraph) => {
+      const sharedReact = jest.requireActual<typeof import('react')>('react');
+      const sharedReactDom =
+        jest.requireActual<typeof import('react-dom')>('react-dom');
+      const sharedReactDomClient =
+        jest.requireActual<typeof import('react-dom/client')>(
+          'react-dom/client',
+        );
+      const sharedReactRouter =
+        jest.requireActual<typeof import('react-router')>('react-router');
+      const sharedReactRouterDom =
+        jest.requireActual<typeof import('react-router-dom')>(
+          'react-router-dom',
+        );
+      let IsolatedList!: typeof List;
+      let IsolatedListRow!: typeof ListRow;
+      let IsolatedReactAria!: typeof ProviderReactAria;
+      let IsolatedReactAriaComponents!: typeof ProviderReactAriaComponents;
+      let IsolatedRouterDom!: typeof sharedReactRouterDom;
+
+      jest.isolateModules(() => {
+        jest.doMock('react', () => sharedReact);
+        jest.doMock('react-dom', () => sharedReactDom);
+        jest.doMock('react-dom/client', () => sharedReactDomClient);
+        jest.doMock('react-router', () => sharedReactRouter);
+        jest.doMock('react-router-dom', () => sharedReactRouterDom);
+        if (reactAriaGraph === 'shared') {
+          jest.doMock('react-aria', () => ProviderReactAria);
+          jest.doMock(
+            'react-aria-components',
+            () => ProviderReactAriaComponents,
+          );
+        } else {
+          jest.dontMock('react-aria');
+          jest.dontMock('react-aria-components');
+        }
+        IsolatedReactAria =
+          reactAriaGraph === 'shared'
+            ? jest.requireMock('react-aria')
+            : jest.requireActual('react-aria');
+        IsolatedReactAriaComponents =
+          reactAriaGraph === 'shared'
+            ? jest.requireMock('react-aria-components')
+            : jest.requireActual('react-aria-components');
+        IsolatedRouterDom = jest.requireMock('react-router-dom');
+        ({ List: IsolatedList, ListRow: IsolatedListRow } =
+          jest.requireActual('./List'));
+      });
+
+      jest.dontMock('react-aria');
+      jest.dontMock('react-aria-components');
+      expect(IsolatedReactAria === ProviderReactAria).toBe(
+        reactAriaGraph === 'shared',
+      );
+      expect(IsolatedReactAriaComponents === ProviderReactAriaComponents).toBe(
+        reactAriaGraph === 'shared',
+      );
+      expect(IsolatedRouterDom).toBe(sharedReactRouterDom);
+
+      const content = (
+        <IsolatedList aria-label="Destinations">
+          <IsolatedListRow id="destination" href="child">
+            Destination
+          </IsolatedListRow>
+        </IsolatedList>
+      );
+      render(
+        <MemoryRouter
+          basename="/app"
+          initialEntries={['/app/catalog/entity/docs']}
+          future={routerFuture}
+        >
+          {provider === 'V2' ? (
+            <BUIProvider>{content}</BUIProvider>
+          ) : (
+            <OldBUIProvider>{content}</OldBUIProvider>
+          )}
+          <LocationStatus />
+        </MemoryRouter>,
+      );
+
+      const row = screen.getByRole('row', { name: 'Destination' });
+      expect(row).toHaveAttribute('data-href', '/app/child');
+      fireEvent.click(row);
+      expect(screen.getByRole('status')).toHaveTextContent('/child');
+    },
+  );
+});

--- a/packages/ui/src/components/List/List.tsx
+++ b/packages/ui/src/components/List/List.tsx
@@ -26,6 +26,7 @@ import type { ListProps, ListRowProps } from './types';
 import { Box } from '../Box/Box';
 import { ButtonIcon } from '../ButtonIcon';
 import { MenuTrigger, Menu } from '../Menu';
+import { BUIRoutingProvider } from '../../navigation/BUIRoutingProvider';
 
 /**
  * A list displays a list of interactive rows with support for keyboard
@@ -41,15 +42,17 @@ export const List = <T extends object>(props: ListProps<T>) => {
   const { classes, items, children, renderEmptyState } = ownProps;
 
   return (
-    <RAGridList
-      className={classes.root}
-      items={items}
-      renderEmptyState={renderEmptyState}
-      {...dataAttributes}
-      {...restProps}
-    >
-      {children}
-    </RAGridList>
+    <BUIRoutingProvider>
+      <RAGridList
+        className={classes.root}
+        items={items}
+        renderEmptyState={renderEmptyState}
+        {...dataAttributes}
+        {...restProps}
+      >
+        {children}
+      </RAGridList>
+    </BUIRoutingProvider>
   );
 };
 

--- a/packages/ui/src/components/Menu/Menu.test.tsx
+++ b/packages/ui/src/components/Menu/Menu.test.tsx
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  createVersionedValueMap,
+  type VersionedValue,
+} from '@backstage/version-bridge';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useMemo, type PropsWithChildren } from 'react';
+import { RouterProvider } from 'react-aria-components';
+import {
+  Link as RouterLink,
+  MemoryRouter,
+  Route,
+  Routes,
+  useHref,
+  useInRouterContext,
+  useLocation,
+  useNavigate,
+  useResolvedPath,
+} from 'react-router-dom';
+import type { BUIRoutingIntegration } from '../../navigation/types';
+import { useResolvedHref } from '../../hooks/useResolvedHref';
+import { BUIContext, type BUIContextVersions } from '../../provider/BUIContext';
+import { BUIProvider } from '../../provider/BUIProvider';
+import { Button } from '../Button';
+import {
+  Menu,
+  MenuItem,
+  MenuListBox,
+  MenuListBoxItem,
+  MenuTrigger,
+} from './Menu';
+
+function LocationStatus() {
+  return <span role="status">{useLocation().pathname}</span>;
+}
+
+describe('Menu links', () => {
+  it('renders MenuItem with the host basename and navigates client-side', async () => {
+    render(
+      <MemoryRouter
+        basename="/app"
+        initialEntries={['/app/catalog']}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <BUIProvider>
+          <MenuTrigger defaultOpen>
+            <Button>Open</Button>
+            <Menu>
+              <MenuItem href="/catalog/docs">TechDocs</MenuItem>
+            </Menu>
+          </MenuTrigger>
+          <LocationStatus />
+        </BUIProvider>
+      </MemoryRouter>,
+    );
+
+    const item = await screen.findByRole('menuitem', { name: 'TechDocs' });
+    expect(item).toHaveAttribute('href', '/app/catalog/docs');
+    fireEvent.click(item);
+    expect(screen.getByRole('status')).toHaveTextContent('/catalog/docs');
+  });
+
+  it('reports a relative raw href through V1 analytics', async () => {
+    const captureEvent = jest.fn();
+    render(
+      <MemoryRouter
+        basename="/app"
+        initialEntries={['/app/catalog/entity/docs']}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <V1AnalyticsProvider captureEvent={captureEvent}>
+          <Routes>
+            <Route
+              path="catalog/entity/docs/*"
+              element={
+                <MenuTrigger defaultOpen>
+                  <Button>Open</Button>
+                  <Menu>
+                    <MenuItem href="child">Child</MenuItem>
+                  </Menu>
+                </MenuTrigger>
+              }
+            />
+          </Routes>
+          <LocationStatus />
+        </V1AnalyticsProvider>
+      </MemoryRouter>,
+    );
+
+    const item = await screen.findByRole('menuitem', { name: 'Child' });
+    expect(item).toHaveAttribute('href', '/app/catalog/entity/docs/child');
+    fireEvent.click(item);
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '/catalog/entity/docs/child',
+    );
+    expect(captureEvent).toHaveBeenCalledWith('click', 'Child', {
+      attributes: { to: 'child' },
+    });
+  });
+
+  it('passes MenuItem the exact options registered by the component', async () => {
+    const navigate = jest.fn();
+    const register = jest.fn();
+    render(
+      <MemoryRouter
+        basename="/app"
+        initialEntries={['/app/catalog']}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <TrackingProvider navigate={navigate} register={register}>
+          <MenuTrigger defaultOpen>
+            <Button>Open</Button>
+            <Menu>
+              <MenuItem href="/catalog/docs" routerOptions={{ replace: true }}>
+                TechDocs
+              </MenuItem>
+            </Menu>
+          </MenuTrigger>
+        </TrackingProvider>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'TechDocs' }));
+    const registeredOptions = register.mock.calls[0]?.[0];
+    expect(registeredOptions).toBeDefined();
+    expect(navigate).toHaveBeenCalledWith('/catalog/docs', registeredOptions);
+  });
+
+  it('wires MenuListBoxItem href into host navigation', async () => {
+    const navigate = jest.fn();
+    const register = jest.fn();
+    render(
+      <MemoryRouter
+        basename="/app"
+        initialEntries={['/app/catalog']}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <TrackingProvider navigate={navigate} register={register}>
+          <MenuTrigger defaultOpen>
+            <Button>Open</Button>
+            <MenuListBox aria-label="Destinations">
+              <MenuListBoxItem
+                id="docs"
+                href="/catalog/docs"
+                routerOptions={{ replace: true }}
+              >
+                TechDocs
+              </MenuListBoxItem>
+            </MenuListBox>
+          </MenuTrigger>
+        </TrackingProvider>
+      </MemoryRouter>,
+    );
+
+    const item = await screen.findByRole('option', { name: 'TechDocs' });
+    expect(item).toHaveAttribute('href', '/app/catalog/docs');
+    fireEvent.click(item);
+    const registeredOptions = register.mock.calls[0]?.[0];
+    expect(registeredOptions).toBeDefined();
+    expect(navigate).toHaveBeenCalledWith('/catalog/docs', registeredOptions);
+  });
+
+  it('retains the external target and rel defaults', async () => {
+    render(
+      <MenuTrigger defaultOpen>
+        <Button>Open</Button>
+        <Menu>
+          <MenuItem href="https://example.test/docs">External docs</MenuItem>
+        </Menu>
+      </MenuTrigger>,
+    );
+
+    expect(
+      await screen.findByRole('menuitem', { name: 'External docs' }),
+    ).toHaveAttribute('target', '_blank');
+    expect(
+      screen.getByRole('menuitem', { name: 'External docs' }),
+    ).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+});
+
+function V1AnalyticsProvider({
+  children,
+  captureEvent,
+}: PropsWithChildren<{ captureEvent: jest.Mock }>) {
+  const navigate = useNavigate();
+  const value = useMemo(
+    () =>
+      createVersionedValueMap({
+        1: { useAnalytics: () => ({ captureEvent }) },
+      }) as unknown as VersionedValue<BUIContextVersions>,
+    [captureEvent],
+  );
+
+  return (
+    <RouterProvider navigate={navigate} useHref={useResolvedHref}>
+      <BUIContext.Provider value={value}>{children}</BUIContext.Provider>
+    </RouterProvider>
+  );
+}
+
+function TrackingProvider({
+  children,
+  navigate,
+  register,
+}: PropsWithChildren<{
+  navigate: jest.Mock;
+  register: jest.Mock;
+}>) {
+  const routing = useMemo<BUIRoutingIntegration>(
+    () => ({
+      Link: RouterLink,
+      useHref,
+      useInRouterContext,
+      useLocation,
+      useNavigate,
+      useResolvedPath,
+      createRouterOptions(_action, options) {
+        const registered = { ...options };
+        register(registered);
+        return registered;
+      },
+    }),
+    [register],
+  );
+  const value = useMemo(
+    () => createVersionedValueMap({ 1: {}, 2: { routing } }),
+    [routing],
+  );
+
+  return (
+    <RouterProvider navigate={navigate} useHref={useResolvedHref}>
+      <BUIContext.Provider value={value}>{children}</BUIContext.Provider>
+    </RouterProvider>
+  );
+}

--- a/packages/ui/src/components/Menu/Menu.tsx
+++ b/packages/ui/src/components/Menu/Menu.tsx
@@ -33,7 +33,10 @@ import {
   Virtualizer,
   ListLayout,
 } from 'react-aria-components';
-import { useDefinition } from '../../hooks/useDefinition';
+import {
+  useDefinition,
+  type UseDefinitionResult,
+} from '../../hooks/useDefinition';
 import {
   MenuDefinition,
   MenuListBoxDefinition,
@@ -66,6 +69,10 @@ import { isInternalLink } from '../../utils/linkUtils';
 import { getNodeText } from '../../analytics/getNodeText';
 import { Box } from '../Box';
 import { BgReset } from '../../hooks/useBg';
+import {
+  getReactAriaAnchorProps,
+  type AnchorNavigation,
+} from '../../navigation/useNavigation';
 
 // The height will be used for virtualized menus. It should match the size set in CSS for each menu item.
 const rowHeight = 32;
@@ -304,25 +311,36 @@ export const MenuAutocompleteListbox = (
   );
 };
 
-/** @public */
-export const MenuItem = (props: MenuItemProps) => {
-  const { ownProps, restProps, dataAttributes, analytics } = useDefinition(
-    MenuItemDefinition,
-    props,
-  );
-  const { classes, iconStart, children, href } = ownProps;
+type MenuItemViewProps = {
+  definitionResult: UseDefinitionResult<
+    typeof MenuItemDefinition,
+    MenuItemProps
+  >;
+  navigation: AnchorNavigation;
+};
+
+const MenuItemView = ({ definitionResult, navigation }: MenuItemViewProps) => {
+  const { ownProps, restProps, dataAttributes, analytics } = definitionResult;
+  const { classes, iconStart, children } = ownProps;
+  const { href } = ownProps;
 
   const isExternal = href && !isInternalLink(href);
+  const target = restProps.target ?? (isExternal ? '_blank' : undefined);
+  const rel = restProps.rel ?? (isExternal ? 'noopener noreferrer' : undefined);
+  const navigationProps = getReactAriaAnchorProps(navigation, {
+    href,
+    routerOptions: restProps.routerOptions,
+  });
 
   return (
     <RAMenuItem
       className={classes.root}
       {...dataAttributes}
-      href={href}
-      target={isExternal ? '_blank' : undefined}
-      rel={isExternal ? 'noopener noreferrer' : undefined}
       textValue={typeof children === 'string' ? children : undefined}
       {...restProps}
+      {...navigationProps}
+      target={target}
+      rel={rel}
       onAction={() => {
         restProps.onAction?.();
         if (href) {
@@ -346,18 +364,44 @@ export const MenuItem = (props: MenuItemProps) => {
 };
 
 /** @public */
-export const MenuListBoxItem = (props: MenuListBoxItemProps) => {
-  const { ownProps, restProps } = useDefinition(
-    MenuListBoxItemDefinition,
-    props,
+export const MenuItem = (props: MenuItemProps) => {
+  const definitionResult = useDefinition(MenuItemDefinition, props);
+  const Navigation = definitionResult.navigation;
+
+  return (
+    <Navigation
+      props={{
+        ...definitionResult.restProps,
+        href: definitionResult.ownProps.href,
+      }}
+      view={MenuItemView}
+      viewProps={{ definitionResult }}
+    />
   );
+};
+
+type MenuListBoxItemViewProps = {
+  definitionResult: UseDefinitionResult<
+    typeof MenuListBoxItemDefinition,
+    MenuListBoxItemProps
+  >;
+  navigation: AnchorNavigation;
+};
+
+const MenuListBoxItemView = ({
+  definitionResult,
+  navigation,
+}: MenuListBoxItemViewProps) => {
+  const { ownProps, restProps } = definitionResult;
   const { classes, children } = ownProps;
+  const navigationProps = getReactAriaAnchorProps(navigation, restProps);
 
   return (
     <RAListBoxItem
       textValue={typeof children === 'string' ? children : undefined}
       className={classes.root}
       {...restProps}
+      {...navigationProps}
     >
       <div className={classes.itemContent}>
         <div className={classes.check}>
@@ -366,6 +410,20 @@ export const MenuListBoxItem = (props: MenuListBoxItemProps) => {
         {children}
       </div>
     </RAListBoxItem>
+  );
+};
+
+/** @public */
+export const MenuListBoxItem = (props: MenuListBoxItemProps) => {
+  const definitionResult = useDefinition(MenuListBoxItemDefinition, props);
+  const Navigation = definitionResult.navigation;
+
+  return (
+    <Navigation
+      props={definitionResult.restProps}
+      view={MenuListBoxItemView}
+      viewProps={{ definitionResult }}
+    />
   );
 };
 

--- a/packages/ui/src/components/Menu/definition.ts
+++ b/packages/ui/src/components/Menu/definition.ts
@@ -104,6 +104,7 @@ export const MenuItemDefinition = defineComponent<MenuItemOwnProps>()({
     itemArrow: 'bui-MenuItemArrow',
   },
   analytics: true,
+  navigation: { type: 'anchor' },
   propDefs: {
     iconStart: {},
     children: {},
@@ -123,6 +124,7 @@ export const MenuListBoxItemDefinition =
       itemContent: 'bui-MenuItemContent',
       check: 'bui-MenuItemListBoxCheck',
     },
+    navigation: { type: 'anchor' },
     propDefs: {
       children: {},
       className: {},

--- a/packages/ui/src/components/Menu/types.ts
+++ b/packages/ui/src/components/Menu/types.ts
@@ -98,7 +98,7 @@ export type MenuItemOwnProps = {
 /** @public */
 export interface MenuItemProps
   extends MenuItemOwnProps,
-    Omit<RAMenuItemProps, keyof MenuItemOwnProps> {}
+    Omit<RAMenuItemProps, keyof MenuItemOwnProps | 'render'> {}
 
 /** @public */
 export type MenuListBoxItemOwnProps = {
@@ -109,7 +109,7 @@ export type MenuListBoxItemOwnProps = {
 /** @public */
 export interface MenuListBoxItemProps
   extends MenuListBoxItemOwnProps,
-    Omit<RAListBoxItemProps, keyof MenuListBoxItemOwnProps> {}
+    Omit<RAListBoxItemProps, keyof MenuListBoxItemOwnProps | 'render'> {}
 
 /** @public */
 export type MenuSectionOwnProps = {

--- a/packages/ui/src/components/PluginHeader/PluginHeader.test.tsx
+++ b/packages/ui/src/components/PluginHeader/PluginHeader.test.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { BUIProvider } from '../../provider';
 import { PluginHeader } from './PluginHeader';
 import type { PluginHeaderProps } from './types';
@@ -25,6 +25,34 @@ function renderPluginHeader(props: PluginHeaderProps = {}, initialEntry = '/') {
     <MemoryRouter initialEntries={[initialEntry]}>
       <BUIProvider>
         <PluginHeader {...props} />
+      </BUIProvider>
+    </MemoryRouter>,
+  );
+}
+
+function LocationStatus() {
+  return <span role="status">{useLocation().pathname}</span>;
+}
+
+function renderNestedPluginHeader(props: PluginHeaderProps) {
+  return render(
+    <MemoryRouter
+      basename="/app"
+      initialEntries={['/app/catalog/entity']}
+      future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+    >
+      <BUIProvider>
+        <Routes>
+          <Route
+            path="catalog/entity/*"
+            element={
+              <>
+                <PluginHeader {...props} />
+                <LocationStatus />
+              </>
+            }
+          />
+        </Routes>
       </BUIProvider>
     </MemoryRouter>,
   );
@@ -52,6 +80,17 @@ describe('PluginHeader', () => {
 
     const link = screen.getByRole('link', { name: 'Catalog' });
     expect(link).toHaveAttribute('href', '/catalog');
+  });
+
+  it('routes a relative title link through the host router', () => {
+    renderNestedPluginHeader({ title: 'Catalog', titleLink: 'overview' });
+
+    const link = screen.getByRole('link', { name: 'Catalog' });
+    expect(link).toHaveAttribute('href', '/app/catalog/entity/overview');
+    fireEvent.click(link);
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '/catalog/entity/overview',
+    );
   });
 
   it('renders a custom icon', () => {
@@ -88,6 +127,20 @@ describe('PluginHeader', () => {
 
     expect(screen.getByRole('tab', { name: 'Overview' })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Settings' })).toBeInTheDocument();
+  });
+
+  it('routes a relative tab through the host router', () => {
+    renderNestedPluginHeader({
+      title: 'Catalog',
+      tabs: [{ id: 'overview', label: 'Overview', href: 'overview' }],
+    });
+
+    const tab = screen.getByRole('tab', { name: 'Overview' });
+    expect(tab).toHaveAttribute('href', '/app/catalog/entity/overview');
+    fireEvent.click(tab);
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '/catalog/entity/overview',
+    );
   });
 
   it('renders a single breadcrumb (plugin root page) as a clickable link', () => {

--- a/packages/ui/src/components/PluginHeader/PluginHeaderBreadcrumbs.test.tsx
+++ b/packages/ui/src/components/PluginHeader/PluginHeaderBreadcrumbs.test.tsx
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { render, screen, act } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { render, screen, act, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { BUIProvider } from '../../provider';
 import { PluginHeaderBreadcrumbs } from './PluginHeaderBreadcrumbs';
 import type { PluginHeaderBreadcrumbEntry } from './types';
@@ -25,6 +25,34 @@ function renderBreadcrumbs(entries: PluginHeaderBreadcrumbEntry[]) {
     <MemoryRouter>
       <BUIProvider>
         <PluginHeaderBreadcrumbs entries={entries} />
+      </BUIProvider>
+    </MemoryRouter>,
+  );
+}
+
+function LocationStatus() {
+  return <span role="status">{useLocation().pathname}</span>;
+}
+
+function renderNestedBreadcrumbs(entries: PluginHeaderBreadcrumbEntry[]) {
+  return render(
+    <MemoryRouter
+      basename="/app"
+      initialEntries={['/app/catalog/entity']}
+      future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+    >
+      <BUIProvider>
+        <Routes>
+          <Route
+            path="catalog/entity/*"
+            element={
+              <>
+                <PluginHeaderBreadcrumbs entries={entries} />
+                <LocationStatus />
+              </>
+            }
+          />
+        </Routes>
       </BUIProvider>
     </MemoryRouter>,
   );
@@ -77,6 +105,40 @@ describe('PluginHeaderBreadcrumbs', () => {
     expect(
       screen.queryByRole('link', { name: 'my-service' }),
     ).not.toBeInTheDocument();
+  });
+
+  it('routes a visible relative ancestor through the host router', () => {
+    renderNestedBreadcrumbs([
+      { label: 'Parent', href: 'parent' },
+      { label: 'Current', href: 'current' },
+    ]);
+
+    const link = screen.getByRole('link', { name: 'Parent' });
+    expect(link).toHaveAttribute('href', '/app/catalog/entity/parent');
+    fireEvent.click(link);
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '/catalog/entity/parent',
+    );
+  });
+
+  it('routes a collapsed relative ancestor through the host router', async () => {
+    renderNestedBreadcrumbs([
+      { label: 'Root', href: '/catalog' },
+      { label: 'Docs', href: 'docs' },
+      { label: 'Guides', href: 'guides' },
+      { label: 'Setup', href: 'setup' },
+      { label: 'Current', href: 'current' },
+    ]);
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Show more breadcrumbs' }),
+    );
+    const link = await screen.findByRole('menuitem', { name: 'Docs' });
+    expect(link).toHaveAttribute('href', '/app/catalog/entity/docs');
+    fireEvent.click(link);
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '/catalog/entity/docs',
+    );
   });
 
   it('renders separators between ancestor segments', () => {

--- a/packages/ui/src/components/SearchAutocomplete/SearchAutocomplete.test.tsx
+++ b/packages/ui/src/components/SearchAutocomplete/SearchAutocomplete.test.tsx
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createVersionedValueMap } from '@backstage/version-bridge';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useMemo, type PropsWithChildren } from 'react';
+import { RouterProvider } from 'react-aria-components';
+import {
+  Link as RouterLink,
+  MemoryRouter,
+  useHref,
+  useInRouterContext,
+  useLocation,
+  useNavigate,
+  useResolvedPath,
+} from 'react-router-dom';
+import type { BUIRoutingIntegration } from '../../navigation/types';
+import { useResolvedHref } from '../../hooks/useResolvedHref';
+import { BUIContext } from '../../provider/BUIContext';
+import {
+  SearchAutocomplete,
+  SearchAutocompleteItem,
+} from './SearchAutocomplete';
+
+describe('SearchAutocompleteItem links', () => {
+  it('renders the host basename and delegates client-side navigation', async () => {
+    const navigate = jest.fn();
+    const register = jest.fn();
+    render(
+      <MemoryRouter
+        basename="/app"
+        initialEntries={['/app/catalog']}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <TrackingProvider navigate={navigate} register={register}>
+          <SearchAutocomplete aria-label="Search" defaultOpen inputValue="doc">
+            <SearchAutocompleteItem
+              id="docs"
+              textValue="TechDocs"
+              href="/catalog/docs"
+              routerOptions={{ replace: true }}
+            >
+              TechDocs
+            </SearchAutocompleteItem>
+          </SearchAutocomplete>
+        </TrackingProvider>
+      </MemoryRouter>,
+    );
+
+    const item = await screen.findByRole('option', { name: 'TechDocs' });
+    expect(item).toHaveAttribute('href', '/app/catalog/docs');
+    fireEvent.click(item);
+    const registeredOptions = register.mock.calls[0]?.[0];
+    expect(registeredOptions).toBeDefined();
+    expect(navigate).toHaveBeenCalledWith('/catalog/docs', registeredOptions);
+  });
+
+  it('renders native links with their browser-owned href', async () => {
+    render(
+      <SearchAutocomplete aria-label="Search" defaultOpen inputValue="doc">
+        <SearchAutocompleteItem
+          id="external"
+          textValue="External docs"
+          href="https://example.test/docs"
+        >
+          External docs
+        </SearchAutocompleteItem>
+      </SearchAutocomplete>,
+    );
+
+    expect(
+      await screen.findByRole('option', { name: 'External docs' }),
+    ).toHaveAttribute('href', 'https://example.test/docs');
+  });
+});
+
+function TrackingProvider({
+  children,
+  navigate,
+  register,
+}: PropsWithChildren<{
+  navigate: jest.Mock;
+  register: jest.Mock;
+}>) {
+  const routing = useMemo<BUIRoutingIntegration>(
+    () => ({
+      Link: RouterLink,
+      useHref,
+      useInRouterContext,
+      useLocation,
+      useNavigate,
+      useResolvedPath,
+      createRouterOptions(_action, options) {
+        const registered = { ...options };
+        register(registered);
+        return registered;
+      },
+    }),
+    [register],
+  );
+  const value = useMemo(
+    () => createVersionedValueMap({ 1: {}, 2: { routing } }),
+    [routing],
+  );
+
+  return (
+    <RouterProvider navigate={navigate} useHref={useResolvedHref}>
+      <BUIContext.Provider value={value}>{children}</BUIContext.Provider>
+    </RouterProvider>
+  );
+}

--- a/packages/ui/src/components/SearchAutocomplete/SearchAutocomplete.tsx
+++ b/packages/ui/src/components/SearchAutocomplete/SearchAutocomplete.tsx
@@ -28,7 +28,10 @@ import {
 } from 'react-aria-components';
 import { useOverlayTriggerState } from 'react-stately';
 import { RiSearch2Line, RiCloseCircleLine } from '@remixicon/react';
-import { useDefinition } from '../../hooks/useDefinition';
+import {
+  useDefinition,
+  type UseDefinitionResult,
+} from '../../hooks/useDefinition';
 import {
   SearchAutocompleteDefinition,
   SearchAutocompleteItemDefinition,
@@ -36,6 +39,10 @@ import {
 import { Box } from '../Box';
 import { BgReset } from '../../hooks/useBg';
 import { VisuallyHidden } from '../VisuallyHidden';
+import {
+  getReactAriaAnchorProps,
+  type AnchorNavigation,
+} from '../../navigation/useNavigation';
 
 import type {
   SearchAutocompleteProps,
@@ -188,25 +195,51 @@ export function SearchAutocomplete(props: SearchAutocompleteProps) {
   );
 }
 
-/**
- * An individual option item within a SearchAutocomplete dropdown.
- *
- * @public
- */
-export function SearchAutocompleteItem(props: SearchAutocompleteItemProps) {
-  const { ownProps, restProps } = useDefinition(
-    SearchAutocompleteItemDefinition,
-    props,
-  );
+type SearchAutocompleteItemViewProps = {
+  definitionResult: UseDefinitionResult<
+    typeof SearchAutocompleteItemDefinition,
+    SearchAutocompleteItemProps
+  >;
+  navigation: AnchorNavigation;
+};
+
+function SearchAutocompleteItemView({
+  definitionResult,
+  navigation,
+}: SearchAutocompleteItemViewProps) {
+  const { ownProps, restProps } = definitionResult;
   const { classes, children } = ownProps;
+  const navigationProps = getReactAriaAnchorProps(navigation, restProps);
 
   return (
     <ListBoxItem
       textValue={typeof children === 'string' ? children : undefined}
       className={classes.root}
       {...restProps}
+      {...navigationProps}
     >
       <div className={classes.itemContent}>{children}</div>
     </ListBoxItem>
+  );
+}
+
+/**
+ * An individual option item within a SearchAutocomplete dropdown.
+ *
+ * @public
+ */
+export function SearchAutocompleteItem(props: SearchAutocompleteItemProps) {
+  const definitionResult = useDefinition(
+    SearchAutocompleteItemDefinition,
+    props,
+  );
+  const Navigation = definitionResult.navigation;
+
+  return (
+    <Navigation
+      props={definitionResult.restProps}
+      view={SearchAutocompleteItemView}
+      viewProps={{ definitionResult }}
+    />
   );
 }

--- a/packages/ui/src/components/SearchAutocomplete/definition.ts
+++ b/packages/ui/src/components/SearchAutocomplete/definition.ts
@@ -65,6 +65,7 @@ export const SearchAutocompleteItemDefinition =
       root: 'bui-SearchAutocompleteItem',
       itemContent: 'bui-SearchAutocompleteItemContent',
     },
+    navigation: { type: 'anchor' },
     propDefs: {
       children: {},
       className: {},

--- a/packages/ui/src/components/SearchAutocomplete/types.ts
+++ b/packages/ui/src/components/SearchAutocomplete/types.ts
@@ -98,4 +98,7 @@ export type SearchAutocompleteItemOwnProps = {
 /** @public */
 export interface SearchAutocompleteItemProps
   extends SearchAutocompleteItemOwnProps,
-    Omit<AriaListBoxItemProps, keyof SearchAutocompleteItemOwnProps> {}
+    Omit<
+      AriaListBoxItemProps,
+      keyof SearchAutocompleteItemOwnProps | 'render'
+    > {}

--- a/packages/ui/src/components/Select/Select.test.tsx
+++ b/packages/ui/src/components/Select/Select.test.tsx
@@ -22,12 +22,27 @@ import {
   waitFor,
   within,
 } from '@testing-library/react';
-import { useState } from 'react';
+import { useMemo, useState, type PropsWithChildren } from 'react';
+import { createVersionedValueMap } from '@backstage/version-bridge';
+import {
+  Link as RouterLink,
+  MemoryRouter,
+  Route,
+  Routes,
+  useHref,
+  useInRouterContext,
+  useLocation,
+  useNavigate,
+  useResolvedPath,
+} from 'react-router-dom';
 import type {
   AsyncListSource,
   IdentifiedOption,
 } from '../../types/selectableCollection';
 import { useAsyncList } from '../../hooks/useAsyncList';
+import { BUIProvider } from '../../provider';
+import { BUIContext } from '../../provider/BUIContext';
+import type { BUIRoutingIntegration } from '../../navigation/types';
 import { Select, SelectItem, SelectItemProfile, SelectItemText } from '.';
 
 function openSelect() {
@@ -203,6 +218,91 @@ describe('Select', () => {
     const option = screen.getByRole('option', { name: 'Custom' });
     expect(option.querySelector('.bui-SelectItemIndicator')).toBeVisible();
     expect(option.querySelector('.bui-SelectItemContent')).toBeVisible();
+  });
+
+  it('renders a linked item with the host basename and navigates client-side', () => {
+    render(
+      <MemoryRouter
+        basename="/app"
+        initialEntries={['/app/catalog']}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <BUIProvider>
+          <Select aria-label="Destination">
+            <SelectItem id="docs" textValue="TechDocs" href="/catalog/docs">
+              TechDocs
+            </SelectItem>
+          </Select>
+          <LocationStatus />
+        </BUIProvider>
+      </MemoryRouter>,
+    );
+
+    openSelect();
+    const option = screen.getByRole('option', { name: 'TechDocs' });
+    expect(option).toHaveAttribute('href', '/app/catalog/docs');
+    fireEvent.click(option);
+    expect(screen.getByRole('status')).toHaveTextContent('/catalog/docs');
+  });
+
+  it('routes a relative text preset from the component route with one basename', () => {
+    render(
+      <MemoryRouter
+        basename="/app"
+        initialEntries={['/app/catalog/entity']}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <BUIProvider>
+          <Routes>
+            <Route
+              path="catalog/entity/*"
+              element={
+                <>
+                  <Select aria-label="Destination">
+                    <SelectItemText id="docs" title="TechDocs" href="docs" />
+                  </Select>
+                  <LocationStatus />
+                </>
+              }
+            />
+          </Routes>
+        </BUIProvider>
+      </MemoryRouter>,
+    );
+
+    openSelect();
+    const option = screen.getByRole('option', { name: 'TechDocs' });
+    expect(option).toHaveAttribute('href', '/app/catalog/entity/docs');
+    fireEvent.click(option);
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '/catalog/entity/docs',
+    );
+  });
+
+  it('registers linked item navigation with the selected routing integration', () => {
+    const createRouterOptions = jest.fn(() => ({ replace: true }));
+    render(
+      <MemoryRouter
+        basename="/app"
+        initialEntries={['/app/catalog']}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <TrackingRoutingProvider createRouterOptions={createRouterOptions}>
+          <Select aria-label="Destination">
+            <SelectItem id="docs" textValue="TechDocs" href="/catalog/docs">
+              TechDocs
+            </SelectItem>
+          </Select>
+        </TrackingRoutingProvider>
+      </MemoryRouter>,
+    );
+
+    openSelect();
+    expect(screen.getByRole('option', { name: 'TechDocs' })).toHaveAttribute(
+      'href',
+      '/app/catalog/docs',
+    );
+    expect(createRouterOptions).toHaveBeenCalledTimes(1);
   });
 
   it('renders normalized convenience options through the text preset', () => {
@@ -822,3 +922,32 @@ describe('Select', () => {
     }
   });
 });
+
+function LocationStatus() {
+  return <span role="status">{useLocation().pathname}</span>;
+}
+
+function TrackingRoutingProvider({
+  children,
+  createRouterOptions,
+}: PropsWithChildren<{
+  createRouterOptions: BUIRoutingIntegration['createRouterOptions'];
+}>) {
+  const routing = useMemo<BUIRoutingIntegration>(
+    () => ({
+      Link: RouterLink,
+      useHref,
+      useInRouterContext,
+      useLocation,
+      useNavigate,
+      useResolvedPath,
+      createRouterOptions,
+    }),
+    [createRouterOptions],
+  );
+  const value = useMemo(
+    () => createVersionedValueMap({ 1: {}, 2: { routing } }),
+    [routing],
+  );
+  return <BUIContext.Provider value={value}>{children}</BUIContext.Provider>;
+}

--- a/packages/ui/src/components/Select/SelectItem.tsx
+++ b/packages/ui/src/components/Select/SelectItem.tsx
@@ -17,7 +17,10 @@
 import { RiCheckLine } from '@remixicon/react';
 import { ListBoxItem, Text } from 'react-aria-components';
 import { Avatar } from '../Avatar';
-import { useDefinition } from '../../hooks/useDefinition';
+import {
+  useDefinition,
+  type UseDefinitionResult,
+} from '../../hooks/useDefinition';
 import {
   SelectItemDefinition,
   SelectItemProfileDefinition,
@@ -28,20 +31,26 @@ import type {
   SelectItemProps,
   SelectItemTextProps,
 } from './types';
+import {
+  getReactAriaAnchorProps,
+  type AnchorNavigation,
+} from '../../navigation/useNavigation';
 
-/**
- * A low-level Select item wrapper for custom item content.
- *
- * @public
- */
-export function SelectItem<T extends object = object>(
-  props: SelectItemProps<T>,
-) {
-  const { ownProps, restProps } = useDefinition(SelectItemDefinition, props);
+type SelectItemViewProps = {
+  definitionResult: UseDefinitionResult<
+    typeof SelectItemDefinition,
+    SelectItemProps
+  >;
+  navigation: AnchorNavigation;
+};
+
+function SelectItemView({ definitionResult, navigation }: SelectItemViewProps) {
+  const { ownProps, restProps } = definitionResult;
   const { classes, children, showSelectionIndicator } = ownProps;
+  const navigationProps = getReactAriaAnchorProps(navigation, restProps);
 
   return (
-    <ListBoxItem className={classes.root} {...restProps}>
+    <ListBoxItem className={classes.root} {...restProps} {...navigationProps}>
       {values => {
         const content =
           typeof children === 'function' ? children(values) : children;
@@ -60,6 +69,26 @@ export function SelectItem<T extends object = object>(
         );
       }}
     </ListBoxItem>
+  );
+}
+
+/**
+ * A low-level Select item wrapper for custom item content.
+ *
+ * @public
+ */
+export function SelectItem<T extends object = object>(
+  props: SelectItemProps<T>,
+) {
+  const definitionResult = useDefinition(SelectItemDefinition, props);
+  const Navigation = definitionResult.navigation;
+
+  return (
+    <Navigation
+      props={definitionResult.restProps}
+      view={SelectItemView}
+      viewProps={{ definitionResult }}
+    />
   );
 }
 

--- a/packages/ui/src/components/Select/definition.ts
+++ b/packages/ui/src/components/Select/definition.ts
@@ -135,6 +135,7 @@ export const SelectItemDefinition = defineComponent<SelectItemOwnProps>()({
     indicator: 'bui-SelectItemIndicator',
     content: 'bui-SelectItemContent',
   },
+  navigation: { type: 'anchor' },
   propDefs: {
     children: {},
     showSelectionIndicator: {},

--- a/packages/ui/src/components/Select/types.ts
+++ b/packages/ui/src/components/Select/types.ts
@@ -302,7 +302,10 @@ export type SelectItemOwnProps = {
 
 /** @public */
 export type SelectItemProps<T extends object = object> = SelectItemOwnProps &
-  Omit<ListBoxItemProps<T>, keyof SelectItemOwnProps | 'textValue'> & {
+  Omit<
+    ListBoxItemProps<T>,
+    keyof SelectItemOwnProps | 'render' | 'textValue'
+  > & {
     textValue: string;
   };
 

--- a/packages/ui/src/components/Table/components/CellNavigation.test.tsx
+++ b/packages/ui/src/components/Table/components/CellNavigation.test.tsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { BUIProvider } from '../../../provider';
+import { CellProfile } from './CellProfile';
+import { CellText } from './CellText';
+import { Column } from './Column';
+import { Row } from './Row';
+import { TableBody } from './TableBody';
+import { TableHeader } from './TableHeader';
+import { TableRoot } from './TableRoot';
+
+function LocationStatus() {
+  return <span role="status">{useLocation().pathname}</span>;
+}
+
+function renderCell(cell: React.ReactElement) {
+  return render(
+    <MemoryRouter
+      basename="/app"
+      initialEntries={['/app/catalog/entity']}
+      future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+    >
+      <BUIProvider>
+        <Routes>
+          <Route
+            path="catalog/entity/*"
+            element={
+              <>
+                <TableRoot aria-label="Entities">
+                  <TableHeader>
+                    <Column isRowHeader>Name</Column>
+                  </TableHeader>
+                  <TableBody>
+                    <Row id="entity">{cell}</Row>
+                  </TableBody>
+                </TableRoot>
+                <LocationStatus />
+              </>
+            }
+          />
+        </Routes>
+      </BUIProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe('table cell navigation', () => {
+  it('preserves the native title of a linked CellText', () => {
+    renderCell(<CellText title="TechDocs" href="docs" />);
+
+    expect(screen.getByRole('link', { name: 'TechDocs' })).toHaveAttribute(
+      'title',
+      'TechDocs',
+    );
+  });
+
+  it.each([
+    ['CellText', <CellText title="TechDocs" href="docs" />, 'TechDocs', 'docs'],
+    [
+      'CellProfile',
+      <CellProfile name="Ada Lovelace" href="owner" />,
+      'Ada Lovelace',
+      'owner',
+    ],
+  ] as const)(
+    'routes a relative %s link through the host router',
+    (_name, cell, linkName, destination) => {
+      renderCell(cell);
+
+      const link = screen.getByRole('link', { name: linkName });
+      expect(link).toHaveAttribute(
+        'href',
+        `/app/catalog/entity/${destination}`,
+      );
+      fireEvent.click(link);
+      expect(screen.getByRole('status')).toHaveTextContent(
+        `/catalog/entity/${destination}`,
+      );
+    },
+  );
+});

--- a/packages/ui/src/components/Table/components/Row.test.tsx
+++ b/packages/ui/src/components/Table/components/Row.test.tsx
@@ -1,0 +1,495 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import type { JSX, MutableRefObject, PropsWithChildren } from 'react';
+import * as ProviderReactAria from 'react-aria';
+import * as ProviderReactAriaComponents from 'react-aria-components';
+import type { Key, RowRenderProps } from 'react-aria-components';
+import {
+  MemoryRouter,
+  Route,
+  Routes,
+  useLocation,
+  useNavigate,
+} from 'react-router-dom';
+import { BUIProvider } from '../../../provider/BUIProvider';
+import { Cell } from './Cell';
+import { Column } from './Column';
+import { Row } from './Row';
+import { TableBody } from './TableBody';
+import { TableHeader } from './TableHeader';
+import { TableRoot } from './TableRoot';
+import type { RowProps as BuiRowProps } from '../types';
+
+const routerFuture = {
+  v7_startTransition: true,
+  v7_relativeSplatPath: true,
+} as const;
+
+function LocationStatus() {
+  const location = useLocation();
+
+  return (
+    <span role="status" data-location-state={JSON.stringify(location.state)}>
+      {location.pathname}
+    </span>
+  );
+}
+
+function HistoryBackButton() {
+  const navigate = useNavigate();
+
+  return <button onClick={() => navigate(-1)}>Back</button>;
+}
+
+function TableFixture({
+  children,
+  selectionMode,
+  selectionBehavior,
+  defaultSelectedKeys,
+}: PropsWithChildren<{
+  selectionMode?: 'none' | 'single' | 'multiple';
+  selectionBehavior?: 'toggle' | 'replace';
+  defaultSelectedKeys?: Iterable<Key>;
+}>) {
+  return (
+    <TableRoot
+      aria-label="Destinations"
+      selectionMode={selectionMode}
+      selectionBehavior={selectionBehavior}
+      defaultSelectedKeys={defaultSelectedKeys}
+    >
+      <TableHeader>
+        <Column isRowHeader>Name</Column>
+      </TableHeader>
+      <TableBody>{children}</TableBody>
+    </TableRoot>
+  );
+}
+
+function RouterFixture({
+  children,
+  captureEvent,
+  showBackButton,
+}: PropsWithChildren<{ captureEvent?: jest.Mock; showBackButton?: boolean }>) {
+  return (
+    <MemoryRouter
+      basename="/app"
+      initialEntries={['/app/catalog/entity/docs']}
+      future={routerFuture}
+    >
+      <BUIProvider
+        useAnalytics={captureEvent ? () => ({ captureEvent }) : undefined}
+      >
+        <Routes>
+          <Route path="catalog/entity/docs/*" element={children} />
+        </Routes>
+        <LocationStatus />
+        {showBackButton && <HistoryBackButton />}
+      </BUIProvider>
+    </MemoryRouter>
+  );
+}
+
+function activate(element: HTMLElement, method: 'click' | 'keyboard') {
+  if (method === 'click') {
+    fireEvent.click(element);
+    return;
+  }
+  act(() => element.focus());
+  fireEvent.keyDown(element, { key: 'Enter', code: 'Enter' });
+  fireEvent.keyUp(element, { key: 'Enter', code: 'Enter' });
+}
+
+describe('Row navigation', () => {
+  it.each(['click', 'keyboard'] as const)(
+    'uses an ordinary internal href as a component-relative %s action',
+    method => {
+      const onAction = jest.fn();
+      const captureEvent = jest.fn();
+      render(
+        <RouterFixture captureEvent={captureEvent}>
+          <TableFixture>
+            <Row id="child" href="child" onAction={onAction}>
+              <Cell>Child</Cell>
+            </Row>
+          </TableFixture>
+        </RouterFixture>,
+      );
+
+      const row = screen.getByRole('row', { name: 'Child' });
+      expect(row).toHaveAttribute(
+        'data-href',
+        '/app/catalog/entity/docs/child',
+      );
+      expect(row).toHaveAttribute('data-react-aria-pressable', 'true');
+      activate(row, method);
+      expect(screen.getByRole('status')).toHaveTextContent(
+        '/catalog/entity/docs/child',
+      );
+      expect(onAction).toHaveBeenCalledTimes(1);
+      expect(captureEvent).toHaveBeenCalledWith('click', 'child', {
+        attributes: { to: 'child' },
+      });
+    },
+  );
+
+  it.each([
+    ['Cmd', { metaKey: true }, { metaKey: true, ctrlKey: false }],
+    ['Ctrl', { ctrlKey: true }, { metaKey: false, ctrlKey: true }],
+  ] as const)(
+    'preserves %s activation for an ordinary internal href',
+    (_modifier, modifier, expectedModifier) => {
+      const onAction = jest.fn();
+      const captureEvent = jest.fn();
+      render(
+        <RouterFixture captureEvent={captureEvent}>
+          <TableFixture>
+            <Row id="child" href="child" onAction={onAction}>
+              <Cell>Child</Cell>
+            </Row>
+          </TableFixture>
+        </RouterFixture>,
+      );
+
+      const row = screen.getByRole('row', { name: 'Child' });
+      const activated: Array<{
+        href: string;
+        metaKey: boolean;
+        ctrlKey: boolean;
+      }> = [];
+      const capture = (event: MouseEvent) => {
+        if (event.target instanceof HTMLAnchorElement) {
+          event.preventDefault();
+          activated.push({
+            href: event.target.getAttribute('href') ?? '',
+            metaKey: event.metaKey,
+            ctrlKey: event.ctrlKey,
+          });
+        }
+      };
+      document.addEventListener('click', capture, true);
+      try {
+        fireEvent.click(row, modifier);
+      } finally {
+        document.removeEventListener('click', capture, true);
+      }
+
+      expect(screen.getByRole('status')).toHaveTextContent(
+        '/catalog/entity/docs',
+      );
+      expect(activated).toEqual([
+        {
+          href: '/app/catalog/entity/docs/child',
+          ...expectedModifier,
+        },
+      ]);
+      expect(onAction).toHaveBeenCalledTimes(1);
+      expect(captureEvent).toHaveBeenCalledTimes(1);
+      expect(captureEvent).toHaveBeenCalledWith('click', 'child', {
+        attributes: { to: 'child' },
+      });
+    },
+  );
+
+  it('does not activate an ordinary internal href when disabled', () => {
+    const onAction = jest.fn();
+    render(
+      <TableFixture>
+        <Row id="child" href="child" onAction={onAction} isDisabled>
+          <Cell>Child</Cell>
+        </Row>
+      </TableFixture>,
+      { wrapper: RouterFixture },
+    );
+
+    fireEvent.click(screen.getByRole('row', { name: 'Child' }));
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '/catalog/entity/docs',
+    );
+    expect(onAction).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      href: 'https://example.test/docs',
+      expectedHref: 'https://example.test/docs',
+      target: '_blank',
+    },
+    {
+      href: 'mailto:owner@example.test',
+      expectedHref: 'mailto:owner@example.test',
+      target: '_blank',
+    },
+    { href: '/catalog', expectedHref: '/app/catalog', target: '_blank' },
+    { href: '/catalog', expectedHref: '/app/catalog', target: 'preview' },
+    { href: '/catalog', expectedHref: '/app/catalog', target: '_parent' },
+    { href: '/catalog', expectedHref: '/app/catalog', target: '_top' },
+    { href: '/catalog', expectedHref: '/app/catalog', download: true },
+    {
+      href: '/catalog',
+      expectedHref: '/app/catalog',
+      download: 'catalog.csv',
+    },
+  ])(
+    'preserves native Row navigation for $href $target $download',
+    ({ href, expectedHref, target, download }) => {
+      render(
+        <TableFixture>
+          <Row
+            id="destination"
+            href={href}
+            target={target}
+            rel="author"
+            ping="/navigation-ping"
+            download={download}
+            referrerPolicy="no-referrer"
+          >
+            <Cell>Destination</Cell>
+          </Row>
+        </TableFixture>,
+        { wrapper: RouterFixture },
+      );
+
+      const row = screen.getByRole('row', { name: 'Destination' });
+      expect(row).toHaveAttribute('data-href', expectedHref);
+      expect(row).toHaveAttribute('data-ping', '/navigation-ping');
+      expect(row).toHaveAttribute('data-referrer-policy', 'no-referrer');
+      if (target) {
+        expect(row).toHaveAttribute('data-target', target);
+      }
+      if (target === '_blank') {
+        expect(row).toHaveAttribute('data-rel', 'noopener noreferrer author');
+      } else {
+        expect(row).toHaveAttribute('data-rel', 'author');
+      }
+      if (download !== undefined) {
+        expect(row).toHaveAttribute('data-download', String(download));
+      }
+    },
+  );
+
+  it('uses router options for an ordinary internal relative href', () => {
+    render(
+      <RouterFixture showBackButton>
+        <TableFixture>
+          <Row
+            id="child"
+            href="child"
+            routerOptions={{ replace: true, state: { source: 'table-row' } }}
+          >
+            <Cell>Child</Cell>
+          </Row>
+        </TableFixture>
+      </RouterFixture>,
+    );
+
+    const row = screen.getByRole('row', { name: 'Child' });
+    expect(row).toHaveAttribute('data-href', '/app/catalog/entity/docs/child');
+    fireEvent.click(row);
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '/catalog/entity/docs/child',
+    );
+    expect(screen.getByRole('status')).toHaveAttribute(
+      'data-location-state',
+      '{"source":"table-row"}',
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '/catalog/entity/docs/child',
+    );
+  });
+
+  it('keeps native keyboard action and table selection cells in React Aria', () => {
+    const onPress = jest.fn();
+    render(
+      <TableFixture
+        selectionMode="multiple"
+        selectionBehavior="toggle"
+        defaultSelectedKeys={['destination']}
+      >
+        <Row id="destination" href="/catalog" target="_blank" onPress={onPress}>
+          <Cell>Destination</Cell>
+        </Row>
+      </TableFixture>,
+      { wrapper: RouterFixture },
+    );
+
+    expect(screen.getByRole('checkbox', { name: /Select row/ })).toBeChecked();
+    const row = screen.getByRole('row', { name: /Destination/ });
+    expect(row).toHaveAttribute('aria-selected', 'true');
+    act(() => row.focus());
+    fireEvent.keyDown(row, { key: 'Enter', code: 'Enter' });
+    fireEvent.keyUp(row, { key: 'Enter', code: 'Enter' });
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves consumer render state, DOM props, content, and refs', () => {
+    let renderedElement: HTMLTableRowElement | null = null;
+    const consumerRender = jest.fn<
+      ReturnType<NonNullable<BuiRowProps<object>['render']>>,
+      Parameters<NonNullable<BuiRowProps<object>['render']>>
+    >((domProps, renderProps: RowRenderProps) => {
+      const rowProps = domProps as JSX.IntrinsicElements['tr'];
+      return (
+        <tr
+          {...rowProps}
+          ref={element => {
+            const renderRef = rowProps.ref;
+            if (typeof renderRef === 'function') {
+              renderRef(element);
+            } else if (renderRef) {
+              (
+                renderRef as MutableRefObject<HTMLTableRowElement | null>
+              ).current = element;
+            }
+            renderedElement = element;
+          }}
+          data-href="/consumer"
+          data-selected={String(renderProps.isSelected)}
+        />
+      );
+    });
+    render(
+      <TableFixture selectionMode="multiple" selectionBehavior="toggle">
+        <Row
+          id="destination"
+          href="/catalog"
+          target="_blank"
+          aria-label="Catalog destination"
+          className="consumer-row"
+          render={consumerRender}
+        >
+          <Cell>Catalog</Cell>
+        </Row>
+      </TableFixture>,
+      { wrapper: RouterFixture },
+    );
+
+    const row = screen.getByRole('row', { name: /Catalog/ });
+    expect(row.tagName).toBe('TR');
+    expect(row).toHaveClass('bui-TableRow', 'consumer-row');
+    expect(row).toHaveAttribute('data-href', '/consumer');
+    expect(row).toHaveAttribute('data-selected', 'false');
+    expect(row).toHaveAttribute('aria-labelledby');
+    expect(row).toHaveTextContent('Catalog');
+    expect(screen.getByRole('checkbox', { name: /Select row/ })).toBeVisible();
+    expect(renderedElement).toBe(row);
+    expect(consumerRender).toHaveBeenCalledWith(
+      expect.objectContaining({
+        'aria-labelledby': expect.any(String),
+        'data-href': '/app/catalog',
+      }),
+      expect.objectContaining({ isSelected: false }),
+    );
+  });
+
+  it('keeps raw native hrefs outside React Router', () => {
+    render(
+      <TableFixture>
+        <Row id="destination" href="https://example.test/docs">
+          <Cell>Destination</Cell>
+        </Row>
+      </TableFixture>,
+    );
+
+    const row = screen.getByRole('row', { name: 'Destination' });
+    expect(row).toHaveAttribute('data-href', 'https://example.test/docs');
+    expect(row).toHaveAttribute('data-target', '_blank');
+    expect(row).toHaveAttribute('data-rel', 'noopener noreferrer');
+  });
+
+  it('routes an ordinary internal href with an isolated React Aria V2 graph', () => {
+    const sharedReact = jest.requireActual<typeof import('react')>('react');
+    const sharedReactDom =
+      jest.requireActual<typeof import('react-dom')>('react-dom');
+    const sharedReactDomClient =
+      jest.requireActual<typeof import('react-dom/client')>('react-dom/client');
+    const sharedReactRouter =
+      jest.requireActual<typeof import('react-router')>('react-router');
+    const sharedReactRouterDom =
+      jest.requireActual<typeof import('react-router-dom')>('react-router-dom');
+    let IsolatedCell!: typeof Cell;
+    let IsolatedColumn!: typeof Column;
+    let IsolatedRow!: typeof Row;
+    let IsolatedTableBody!: typeof TableBody;
+    let IsolatedTableHeader!: typeof TableHeader;
+    let IsolatedTableRoot!: typeof TableRoot;
+    let IsolatedReactAria!: typeof ProviderReactAria;
+    let IsolatedReactAriaComponents!: typeof ProviderReactAriaComponents;
+
+    jest.isolateModules(() => {
+      jest.doMock('react', () => sharedReact);
+      jest.doMock('react-dom', () => sharedReactDom);
+      jest.doMock('react-dom/client', () => sharedReactDomClient);
+      jest.doMock('react-router', () => sharedReactRouter);
+      jest.doMock('react-router-dom', () => sharedReactRouterDom);
+      jest.dontMock('react-aria');
+      jest.dontMock('react-aria-components');
+      IsolatedReactAria = jest.requireActual('react-aria');
+      IsolatedReactAriaComponents = jest.requireActual('react-aria-components');
+      ({ Cell: IsolatedCell } = jest.requireActual('./Cell'));
+      ({ Column: IsolatedColumn } = jest.requireActual('./Column'));
+      ({ Row: IsolatedRow } = jest.requireActual('./Row'));
+      ({ TableBody: IsolatedTableBody } = jest.requireActual('./TableBody'));
+      ({ TableHeader: IsolatedTableHeader } =
+        jest.requireActual('./TableHeader'));
+      ({ TableRoot: IsolatedTableRoot } = jest.requireActual('./TableRoot'));
+    });
+
+    jest.dontMock('react-aria');
+    jest.dontMock('react-aria-components');
+    expect(IsolatedReactAria).not.toBe(ProviderReactAria);
+    expect(IsolatedReactAriaComponents).not.toBe(ProviderReactAriaComponents);
+
+    render(
+      <MemoryRouter
+        basename="/app"
+        initialEntries={['/app/catalog/entity/docs']}
+        future={routerFuture}
+      >
+        <BUIProvider>
+          <Routes>
+            <Route
+              path="catalog/entity/docs/*"
+              element={
+                <IsolatedTableRoot aria-label="Destinations">
+                  <IsolatedTableHeader>
+                    <IsolatedColumn isRowHeader>Name</IsolatedColumn>
+                  </IsolatedTableHeader>
+                  <IsolatedTableBody>
+                    <IsolatedRow id="destination" href="child">
+                      <IsolatedCell>Destination</IsolatedCell>
+                    </IsolatedRow>
+                  </IsolatedTableBody>
+                </IsolatedTableRoot>
+              }
+            />
+          </Routes>
+        </BUIProvider>
+        <LocationStatus />
+      </MemoryRouter>,
+    );
+
+    const row = screen.getByRole('row', { name: 'Destination' });
+    expect(row).toHaveAttribute('data-href', '/app/catalog/entity/docs/child');
+    fireEvent.click(row);
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '/catalog/entity/docs/child',
+    );
+  });
+});

--- a/packages/ui/src/components/Table/components/Row.tsx
+++ b/packages/ui/src/components/Table/components/Row.tsx
@@ -38,11 +38,12 @@ export function Row<T extends object>(props: RowProps<T>) {
     RowDefinition,
     props,
   );
-  const { classes, columns, children, href } = ownProps;
-  const isExternal = isExternalLink(href);
-  const hasInternalHref = !!href && !isExternal;
-  const hasExternalHref = !!href && isExternal;
-  const hasInteraction = !!restProps.onAction || !!href;
+  const { classes, columns, children } = ownProps;
+  const rawHref = restProps.href;
+  const isExternal = isExternalLink(rawHref);
+  const hasInternalHref = !!rawHref && !isExternal;
+  const hasExternalHref = !!rawHref && isExternal;
+  const hasInteraction = !!restProps.onAction || !!rawHref;
 
   // Derive the effective target, defaulting to _blank for external links.
   const effectiveTarget = hasExternalHref ? '_blank' : restProps.target;
@@ -62,9 +63,9 @@ export function Row<T extends object>(props: RowProps<T>) {
   const handlePress = hasInteraction
     ? () => {
         restProps.onAction?.();
-        if (href) {
-          analytics.captureEvent('click', href, {
-            attributes: { to: String(href) },
+        if (rawHref) {
+          analytics.captureEvent('click', rawHref, {
+            attributes: { to: String(rawHref) },
           });
         }
       }
@@ -87,7 +88,6 @@ export function Row<T extends object>(props: RowProps<T>) {
 
   return (
     <ReactAriaRow
-      href={href}
       {...restProps}
       {...dataAttributes}
       target={effectiveTarget}

--- a/packages/ui/src/components/Table/components/Table.test.tsx
+++ b/packages/ui/src/components/Table/components/Table.test.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { PropsWithChildren } from 'react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { BUIProvider } from '../../../provider/BUIProvider';
+import { Cell } from './Cell';
+import { Table } from './Table';
+
+const routerFuture = {
+  v7_startTransition: true,
+  v7_relativeSplatPath: true,
+} as const;
+
+function LocationStatus() {
+  return <span role="status">{useLocation().pathname}</span>;
+}
+
+function RouterFixture({ children }: PropsWithChildren) {
+  return (
+    <MemoryRouter
+      basename="/app"
+      initialEntries={['/app/catalog/entity/docs']}
+      future={routerFuture}
+    >
+      <BUIProvider>
+        <Routes>
+          <Route path="catalog/entity/docs/*" element={children} />
+        </Routes>
+        <LocationStatus />
+      </BUIProvider>
+    </MemoryRouter>
+  );
+}
+
+describe('Table rowConfig navigation', () => {
+  it('passes a relative getHref result to Row as an ordinary internal action', () => {
+    const onClick = jest.fn();
+    render(
+      <RouterFixture>
+        <Table
+          columnConfig={[
+            {
+              id: 'name',
+              label: 'Name',
+              isRowHeader: true,
+              cell: item => <Cell>{item.name}</Cell>,
+            },
+          ]}
+          data={[{ id: 'child', name: 'Child' }]}
+          pagination={{ type: 'none' }}
+          rowConfig={{
+            getHref: item => item.id,
+            onClick,
+          }}
+        />
+      </RouterFixture>,
+    );
+
+    const row = screen.getByRole('row', { name: 'Child' });
+    expect(row).toHaveAttribute('data-href', '/app/catalog/entity/docs/child');
+    fireEvent.click(row);
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '/catalog/entity/docs/child',
+    );
+    expect(onClick).toHaveBeenCalledWith({ id: 'child', name: 'Child' });
+  });
+});

--- a/packages/ui/src/components/Table/components/TableRoot.tsx
+++ b/packages/ui/src/components/Table/components/TableRoot.tsx
@@ -18,6 +18,7 @@ import { useDefinition } from '../../../hooks/useDefinition';
 import { TableDefinition } from '../definition';
 import { Table as ReactAriaTable } from 'react-aria-components';
 import { TableRootProps } from '../types';
+import { BUIRoutingProvider } from '../../../navigation/BUIRoutingProvider';
 
 /**
  * The low-level table root element for building custom table layouts from atomic components.
@@ -40,12 +41,14 @@ export const TableRoot = (props: TableRootProps) => {
   );
 
   return (
-    <ReactAriaTable
-      className={ownProps.classes.root}
-      aria-label="Data table"
-      aria-busy={ownProps.stale || ownProps.isPending}
-      {...dataAttributes}
-      {...restProps}
-    />
+    <BUIRoutingProvider>
+      <ReactAriaTable
+        className={ownProps.classes.root}
+        aria-label="Data table"
+        aria-busy={ownProps.stale || ownProps.isPending}
+        {...dataAttributes}
+        {...restProps}
+      />
+    </BUIRoutingProvider>
   );
 };

--- a/packages/ui/src/components/Table/definition.ts
+++ b/packages/ui/src/components/Table/definition.ts
@@ -102,7 +102,6 @@ export const RowDefinition = defineComponent<RowOwnProps>()({
   propDefs: {
     columns: {},
     children: {},
-    href: {},
     noTrack: {},
   },
 });

--- a/packages/ui/src/components/Tabs/Tabs.test.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.test.tsx
@@ -1,0 +1,396 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import {
+  createVersionedValueMap,
+  type VersionedValue,
+} from '@backstage/version-bridge';
+import { useMemo, type PropsWithChildren } from 'react';
+import { RouterProvider } from 'react-aria-components';
+import {
+  Link as RouterLink,
+  MemoryRouter,
+  Route,
+  Routes,
+  useHref,
+  useInRouterContext,
+  useLocation,
+  useNavigate,
+  useResolvedPath,
+} from 'react-router-dom';
+import { useResolvedHref } from '../../hooks/useResolvedHref';
+import type { BUIRoutingIntegration } from '../../navigation/types';
+import { BUIContext, type BUIContextVersions } from '../../provider/BUIContext';
+import { BUIProvider } from '../../provider/BUIProvider';
+import { Tab, TabList, Tabs } from './Tabs';
+
+function LocationStatus() {
+  return <span role="status">{useLocation().pathname}</span>;
+}
+
+describe('Tab links', () => {
+  it('renders an internal href as a native anchor outside React Router', () => {
+    render(
+      <Tabs>
+        <TabList>
+          <Tab id="overview" href="/catalog/overview">
+            Overview
+          </Tab>
+        </TabList>
+      </Tabs>,
+    );
+
+    expect(screen.getByRole('tab', { name: 'Overview' })).toHaveAttribute(
+      'href',
+      '/catalog/overview',
+    );
+  });
+
+  it('renders the host basename and navigates without a document reload', () => {
+    render(
+      <MemoryRouter
+        basename="/app"
+        initialEntries={['/app/catalog']}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <BUIProvider>
+          <Tabs>
+            <TabList>
+              <Tab id="overview" href="/catalog/overview">
+                Overview
+              </Tab>
+            </TabList>
+          </Tabs>
+          <LocationStatus />
+        </BUIProvider>
+      </MemoryRouter>,
+    );
+
+    const tab = screen.getByRole('tab', { name: 'Overview' });
+    expect(tab).toHaveAttribute('href', '/app/catalog/overview');
+    fireEvent.click(tab);
+    expect(screen.getByRole('status')).toHaveTextContent('/catalog/overview');
+  });
+
+  it('reports a relative raw href through V1 analytics', () => {
+    const captureEvent = jest.fn();
+    render(
+      <MemoryRouter
+        basename="/app"
+        initialEntries={['/app/catalog/entity/docs']}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <V1AnalyticsProvider captureEvent={captureEvent}>
+          <Routes>
+            <Route
+              path="catalog/entity/docs/*"
+              element={
+                <Tabs>
+                  <TabList>
+                    <Tab id="child" href="child">
+                      Child
+                    </Tab>
+                  </TabList>
+                </Tabs>
+              }
+            />
+          </Routes>
+          <LocationStatus />
+        </V1AnalyticsProvider>
+      </MemoryRouter>,
+    );
+
+    const tab = screen.getByRole('tab', { name: 'Child' });
+    expect(tab).toHaveAttribute('href', '/app/catalog/entity/docs/child');
+    fireEvent.click(tab);
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '/catalog/entity/docs/child',
+    );
+    expect(captureEvent).toHaveBeenCalledWith('click', 'Child', {
+      attributes: { to: 'child' },
+    });
+  });
+
+  it('preserves active-route selection and render state', () => {
+    render(
+      <MemoryRouter
+        basename="/app"
+        initialEntries={['/app/catalog/overview']}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <BUIProvider>
+          <Tabs>
+            <TabList>
+              <Tab
+                id="overview"
+                href="/catalog/overview"
+                className="consumer-tab"
+                style={({ isSelected }) => ({
+                  opacity: isSelected ? 1 : 0.5,
+                })}
+              >
+                {({ isSelected }) =>
+                  isSelected ? 'Selected overview' : 'Overview'
+                }
+              </Tab>
+            </TabList>
+          </Tabs>
+        </BUIProvider>
+      </MemoryRouter>,
+    );
+
+    const tab = screen.getByRole('tab', { name: 'Selected overview' });
+    expect(tab).toHaveAttribute('aria-selected', 'true');
+    expect(tab).toHaveClass('consumer-tab');
+    expect(tab).toHaveStyle({ opacity: '1' });
+  });
+
+  it('matches relative internal tabs whose activation remains browser-owned', () => {
+    render(
+      <MemoryRouter
+        basename="/app"
+        initialEntries={['/app/catalog/entity/docs/child']}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <BUIProvider>
+          <Routes>
+            <Route
+              path="catalog/entity/docs/*"
+              element={
+                <>
+                  <Tabs>
+                    <TabList>
+                      <Tab id="target-other" href="other">
+                        Target other
+                      </Tab>
+                      <Tab id="target-child" href="." target="_blank">
+                        Target child
+                      </Tab>
+                    </TabList>
+                  </Tabs>
+                  <Tabs>
+                    <TabList>
+                      <Tab id="download-other" href="other">
+                        Download other
+                      </Tab>
+                      <Tab id="download-child" href="." download>
+                        Download child
+                      </Tab>
+                    </TabList>
+                  </Tabs>
+                </>
+              }
+            />
+          </Routes>
+        </BUIProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('tab', { name: 'Target child' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    expect(screen.getByRole('tab', { name: 'Download child' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+  });
+
+  it('matches an exact tab by pathname when href and location have query and hash', () => {
+    render(
+      <MemoryRouter
+        basename="/app"
+        initialEntries={['/app/catalog/entity/docs?view=grid#details']}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <BUIProvider>
+          <Tabs>
+            <TabList>
+              <Tab
+                id="docs"
+                href="/catalog/entity/docs?tab=all#api"
+                matchStrategy="exact"
+              >
+                Docs
+              </Tab>
+            </TabList>
+          </Tabs>
+        </BUIProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('tab', { name: 'Docs' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+  });
+
+  it('does not exact-match a nested splat path', () => {
+    render(
+      <MemoryRouter
+        basename="/app"
+        initialEntries={['/app/catalog/entity/docs/page']}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <BUIProvider>
+          <Routes>
+            <Route
+              path="catalog/entity/docs/*"
+              element={
+                <Tabs>
+                  <TabList>
+                    <Tab
+                      id="docs"
+                      href="/catalog/entity/docs"
+                      matchStrategy="exact"
+                    >
+                      Docs
+                    </Tab>
+                  </TabList>
+                </Tabs>
+              }
+            />
+          </Routes>
+        </BUIProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('tab', { name: 'Docs' })).toHaveAttribute(
+      'aria-selected',
+      'false',
+    );
+  });
+
+  it('prefix-matches a nested splat path and selects the most-specific tab', () => {
+    render(
+      <MemoryRouter
+        basename="/app"
+        initialEntries={['/app/catalog/entity/docs/page']}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <BUIProvider>
+          <Routes>
+            <Route
+              path="catalog/entity/*"
+              element={
+                <Tabs>
+                  <TabList>
+                    <Tab
+                      id="entity"
+                      href="/catalog/entity"
+                      matchStrategy="prefix"
+                    >
+                      Entity
+                    </Tab>
+                    <Tab
+                      id="docs"
+                      href="/catalog/entity/docs"
+                      matchStrategy="prefix"
+                    >
+                      Docs
+                    </Tab>
+                  </TabList>
+                </Tabs>
+              }
+            />
+          </Routes>
+        </BUIProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('tab', { name: 'Docs' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    expect(screen.getByRole('tab', { name: 'Entity' })).toHaveAttribute(
+      'aria-selected',
+      'false',
+    );
+  });
+
+  it('registers tab navigation with the selected routing integration', () => {
+    const createRouterOptions = jest.fn(() => ({ replace: true }));
+    render(
+      <MemoryRouter
+        basename="/app"
+        initialEntries={['/app/catalog']}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <TrackingRoutingProvider createRouterOptions={createRouterOptions}>
+          <Tabs>
+            <TabList>
+              <Tab id="overview" href="/catalog/overview">
+                Overview
+              </Tab>
+            </TabList>
+          </Tabs>
+        </TrackingRoutingProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('tab', { name: 'Overview' })).toHaveAttribute(
+      'href',
+      '/app/catalog/overview',
+    );
+    expect(createRouterOptions).toHaveBeenCalledTimes(1);
+  });
+});
+
+function V1AnalyticsProvider({
+  children,
+  captureEvent,
+}: PropsWithChildren<{ captureEvent: jest.Mock }>) {
+  const navigate = useNavigate();
+  const value = useMemo(
+    () =>
+      createVersionedValueMap({
+        1: { useAnalytics: () => ({ captureEvent }) },
+      }) as unknown as VersionedValue<BUIContextVersions>,
+    [captureEvent],
+  );
+
+  return (
+    <RouterProvider navigate={navigate} useHref={useResolvedHref}>
+      <BUIContext.Provider value={value}>{children}</BUIContext.Provider>
+    </RouterProvider>
+  );
+}
+
+function TrackingRoutingProvider({
+  children,
+  createRouterOptions,
+}: PropsWithChildren<{
+  createRouterOptions: BUIRoutingIntegration['createRouterOptions'];
+}>) {
+  const routing = useMemo<BUIRoutingIntegration>(
+    () => ({
+      Link: RouterLink,
+      useHref,
+      useInRouterContext,
+      useLocation,
+      useNavigate,
+      useResolvedPath,
+      createRouterOptions,
+    }),
+    [createRouterOptions],
+  );
+  const value = useMemo(
+    () => createVersionedValueMap({ 1: {}, 2: { routing } }),
+    [routing],
+  );
+  return <BUIContext.Provider value={value}>{children}</BUIContext.Provider>;
+}

--- a/packages/ui/src/components/Tabs/Tabs.tsx
+++ b/packages/ui/src/components/Tabs/Tabs.tsx
@@ -34,7 +34,6 @@ import type {
   TabsContextValue,
   TabProps,
 } from './types';
-import { useLocation } from 'react-router-dom';
 import { TabsIndicators } from './TabsIndicators';
 import {
   Tabs as AriaTabs,
@@ -43,15 +42,22 @@ import {
   TabPanel as AriaTabPanel,
   TabProps as AriaTabProps,
 } from 'react-aria-components';
-import { useDefinition } from '../../hooks/useDefinition';
+import {
+  useDefinition,
+  type UseDefinitionResult,
+} from '../../hooks/useDefinition';
 import {
   TabsDefinition,
   TabListDefinition,
   TabDefinition,
   TabPanelDefinition,
 } from './definition';
-import { isInternalLink } from '../../utils/linkUtils';
 import { getNodeText } from '../../analytics/getNodeText';
+import { useRoutingIntegration } from '../../navigation/useRouting';
+import {
+  getReactAriaAnchorProps,
+  type AnchorNavigation,
+} from '../../navigation/useNavigation';
 
 const TabsContext = createContext<TabsContextValue | undefined>(undefined);
 
@@ -289,7 +295,9 @@ function RoutedTabEffects({
   matchStrategy?: 'exact' | 'prefix';
 }) {
   const selectionCtx = useContext(TabSelectionContext);
-  const location = useLocation();
+  const routing = useRoutingIntegration({ fallback: true });
+  const location = routing.useLocation();
+  const resolvedPath = routing.useResolvedPath(href);
 
   // Register as a routed tab (for controlled vs uncontrolled mode)
   useEffect(() => {
@@ -301,8 +309,12 @@ function RoutedTabEffects({
   }, [id, selectionCtx]);
 
   // Register as active tab when URL matches (for tab selection)
-  const isActive = isTabActive(href, location.pathname, matchStrategy);
-  const segmentCount = hrefPathname(href).split('/').filter(Boolean).length;
+  const isActive = isTabActive(
+    resolvedPath.pathname,
+    location.pathname,
+    matchStrategy,
+  );
+  const segmentCount = resolvedPath.pathname.split('/').filter(Boolean).length;
 
   useEffect(() => {
     if (isActive && selectionCtx) {
@@ -315,18 +327,20 @@ function RoutedTabEffects({
   return null;
 }
 
-/**
- * A component that renders a tab.
- *
- * @public
- */
-export const Tab = (props: TabProps) => {
-  const { ownProps, restProps, analytics } = useDefinition(
-    TabDefinition,
-    props,
-  );
-  const { classes, matchStrategy, href, id } = ownProps;
+type TabViewProps = {
+  definitionResult: UseDefinitionResult<typeof TabDefinition, TabProps>;
+  navigation: AnchorNavigation;
+};
+
+const TabView = ({ definitionResult, navigation }: TabViewProps) => {
+  const { ownProps, restProps, analytics } = definitionResult;
+  const { classes, matchStrategy, id } = ownProps;
+  const { href } = ownProps;
   const { setTabRef } = useTabsContext();
+  const navigationProps = getReactAriaAnchorProps(navigation, {
+    href,
+    routerOptions: restProps.routerOptions,
+  });
 
   const handlePress = () => {
     if (href) {
@@ -342,7 +356,7 @@ export const Tab = (props: TabProps) => {
 
   return (
     <>
-      {isInternalLink(href) && (
+      {navigation.canMatchRoute && href && (
         <RoutedTabEffects
           id={id as string}
           href={href}
@@ -353,14 +367,35 @@ export const Tab = (props: TabProps) => {
         id={id}
         className={classes.root}
         ref={el => setTabRef(id as string, el as HTMLDivElement)}
-        href={href}
         {...restProps}
+        {...navigationProps}
         onPress={e => {
           restProps.onPress?.(e);
           handlePress();
         }}
       />
     </>
+  );
+};
+
+/**
+ * A component that renders a tab.
+ *
+ * @public
+ */
+export const Tab = (props: TabProps) => {
+  const definitionResult = useDefinition(TabDefinition, props);
+  const Navigation = definitionResult.navigation;
+
+  return (
+    <Navigation
+      props={{
+        ...definitionResult.restProps,
+        href: definitionResult.ownProps.href,
+      }}
+      view={TabView}
+      viewProps={{ definitionResult }}
+    />
   );
 };
 

--- a/packages/ui/src/components/Tabs/definition.ts
+++ b/packages/ui/src/components/Tabs/definition.ts
@@ -59,6 +59,7 @@ export const TabDefinition = defineComponent<TabOwnProps>()({
     root: 'bui-Tab',
   },
   analytics: true,
+  navigation: { type: 'anchor' },
   propDefs: {
     className: {},
     matchStrategy: {},

--- a/packages/ui/src/components/Tabs/types.ts
+++ b/packages/ui/src/components/Tabs/types.ts
@@ -92,7 +92,7 @@ export type TabOwnProps = {
  */
 export interface TabProps
   extends TabOwnProps,
-    Omit<AriaTabProps, keyof TabOwnProps> {}
+    Omit<AriaTabProps, keyof TabOwnProps | 'render'> {}
 
 /** Context for sharing refs between Tabs and TabList
  *

--- a/packages/ui/src/components/TagGroup/TagGroup.test.tsx
+++ b/packages/ui/src/components/TagGroup/TagGroup.test.tsx
@@ -1,0 +1,411 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { createRef, type JSX, type PropsWithChildren } from 'react';
+import * as ProviderReactAria from 'react-aria';
+import * as ProviderReactAriaComponents from 'react-aria-components';
+import type { TagRenderProps } from 'react-aria-components';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { BUIProvider } from '../../provider/BUIProvider';
+import { Tag, TagGroup } from './TagGroup';
+
+const routerFuture = {
+  v7_startTransition: true,
+  v7_relativeSplatPath: true,
+} as const;
+
+function LocationStatus() {
+  return <span role="status">{useLocation().pathname}</span>;
+}
+
+function RouterFixture({
+  children,
+  captureEvent,
+}: PropsWithChildren<{ captureEvent?: jest.Mock }>) {
+  return (
+    <MemoryRouter
+      basename="/app"
+      initialEntries={['/app/catalog/entity/docs']}
+      future={routerFuture}
+    >
+      <BUIProvider
+        useAnalytics={captureEvent ? () => ({ captureEvent }) : undefined}
+      >
+        <Routes>
+          <Route path="catalog/entity/docs/*" element={children} />
+        </Routes>
+        <LocationStatus />
+      </BUIProvider>
+    </MemoryRouter>
+  );
+}
+
+function activate(element: HTMLElement, method: 'click' | 'keyboard') {
+  if (method === 'click') {
+    fireEvent.click(element);
+    return;
+  }
+  act(() => element.focus());
+  fireEvent.keyDown(element, { key: 'Enter', code: 'Enter' });
+  fireEvent.keyUp(element, { key: 'Enter', code: 'Enter' });
+}
+
+describe('Tag navigation', () => {
+  it.each(['click', 'keyboard'] as const)(
+    'uses an ordinary internal href as a component-relative %s action',
+    method => {
+      const onPress = jest.fn();
+      const onAction = jest.fn();
+      const captureEvent = jest.fn();
+      render(
+        <RouterFixture captureEvent={captureEvent}>
+          <TagGroup aria-label="Destinations">
+            <Tag id="child" href="child" onAction={onAction} onPress={onPress}>
+              Child
+            </Tag>
+          </TagGroup>
+        </RouterFixture>,
+      );
+
+      const tag = screen.getByRole('row', { name: 'Child' });
+      expect(tag).toHaveAttribute(
+        'data-href',
+        '/app/catalog/entity/docs/child',
+      );
+      activate(tag, method);
+      expect(screen.getByRole('status')).toHaveTextContent(
+        '/catalog/entity/docs/child',
+      );
+      expect(onAction).toHaveBeenCalledTimes(1);
+      expect(onPress).toHaveBeenCalledTimes(1);
+      expect(captureEvent).toHaveBeenCalledWith('click', 'Child', {
+        attributes: { to: 'child' },
+      });
+    },
+  );
+
+  it.each([
+    ['Cmd', { metaKey: true }, { metaKey: true, ctrlKey: false }],
+    ['Ctrl', { ctrlKey: true }, { metaKey: false, ctrlKey: true }],
+  ] as const)(
+    'preserves %s activation for an ordinary internal href',
+    (_modifier, modifier, expectedModifier) => {
+      const onPress = jest.fn();
+      const onAction = jest.fn();
+      const captureEvent = jest.fn();
+      render(
+        <RouterFixture captureEvent={captureEvent}>
+          <TagGroup aria-label="Destinations">
+            <Tag id="child" href="child" onAction={onAction} onPress={onPress}>
+              Child
+            </Tag>
+          </TagGroup>
+        </RouterFixture>,
+      );
+
+      const tag = screen.getByRole('row', { name: 'Child' });
+      const activated: Array<{
+        href: string;
+        metaKey: boolean;
+        ctrlKey: boolean;
+      }> = [];
+      const capture = (event: MouseEvent) => {
+        if (event.target instanceof HTMLAnchorElement) {
+          event.preventDefault();
+          activated.push({
+            href: event.target.getAttribute('href') ?? '',
+            metaKey: event.metaKey,
+            ctrlKey: event.ctrlKey,
+          });
+        }
+      };
+      document.addEventListener('click', capture, true);
+      try {
+        fireEvent.click(tag, modifier);
+      } finally {
+        document.removeEventListener('click', capture, true);
+      }
+
+      expect(screen.getByRole('status')).toHaveTextContent(
+        '/catalog/entity/docs',
+      );
+      expect(activated).toEqual([
+        {
+          href: '/app/catalog/entity/docs/child',
+          ...expectedModifier,
+        },
+      ]);
+      expect(onPress).toHaveBeenCalledTimes(1);
+      expect(onAction).toHaveBeenCalledTimes(1);
+      expect(captureEvent).toHaveBeenCalledTimes(1);
+      expect(captureEvent).toHaveBeenCalledWith('click', 'Child', {
+        attributes: { to: 'child' },
+      });
+    },
+  );
+
+  it('does not activate an ordinary internal href when disabled', () => {
+    const onPress = jest.fn();
+    render(
+      <RouterFixture>
+        <TagGroup aria-label="Destinations">
+          <Tag id="child" href="child" onPress={onPress} isDisabled>
+            Child
+          </Tag>
+        </TagGroup>
+      </RouterFixture>,
+    );
+
+    fireEvent.click(screen.getByRole('row', { name: 'Child' }));
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '/catalog/entity/docs',
+    );
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      href: 'https://example.test/docs',
+      expectedHref: 'https://example.test/docs',
+    },
+    {
+      href: 'mailto:owner@example.test',
+      expectedHref: 'mailto:owner@example.test',
+    },
+    { href: '/catalog', target: '_blank', expectedHref: '/app/catalog' },
+    { href: '/catalog', target: 'preview', expectedHref: '/app/catalog' },
+    { href: '/catalog', target: '_parent', expectedHref: '/app/catalog' },
+    { href: '/catalog', target: '_top', expectedHref: '/app/catalog' },
+    { href: '/catalog', download: true, expectedHref: '/app/catalog' },
+    {
+      href: '/catalog',
+      download: 'catalog.csv',
+      expectedHref: '/app/catalog',
+    },
+  ])(
+    'preserves native Tag navigation for $href $target $download',
+    ({ href, expectedHref, target, download }) => {
+      render(
+        <RouterFixture>
+          <TagGroup aria-label="Destinations">
+            <Tag
+              id="destination"
+              href={href}
+              target={target}
+              rel="author"
+              ping="/navigation-ping"
+              download={download}
+              referrerPolicy="no-referrer"
+            >
+              Destination
+            </Tag>
+          </TagGroup>
+        </RouterFixture>,
+      );
+
+      const tag = screen.getByRole('row', { name: 'Destination' });
+      expect(tag).toHaveAttribute('data-href', expectedHref);
+      expect(tag).toHaveAttribute('data-rel', 'author');
+      expect(tag).toHaveAttribute('data-ping', '/navigation-ping');
+      expect(tag).toHaveAttribute('data-referrer-policy', 'no-referrer');
+      if (target) {
+        expect(tag).toHaveAttribute('data-target', target);
+      }
+      if (download !== undefined) {
+        expect(tag).toHaveAttribute('data-download', String(download));
+      }
+    },
+  );
+
+  it('keeps native keyboard action and tag selection in React Aria', () => {
+    const onPress = jest.fn();
+    render(
+      <RouterFixture>
+        <TagGroup
+          aria-label="Destinations"
+          selectionMode="multiple"
+          selectionBehavior="toggle"
+          defaultSelectedKeys={['destination']}
+        >
+          <Tag
+            id="destination"
+            href="/catalog"
+            target="_blank"
+            onPress={onPress}
+          >
+            Destination
+          </Tag>
+        </TagGroup>
+      </RouterFixture>,
+    );
+
+    const tag = screen.getByRole('row', { name: 'Destination' });
+    expect(tag).toHaveAttribute('aria-selected', 'true');
+    act(() => tag.focus());
+    fireEvent.keyDown(tag, { key: 'Enter', code: 'Enter' });
+    fireEvent.keyUp(tag, { key: 'Enter', code: 'Enter' });
+    expect(onPress).toHaveBeenCalledTimes(1);
+    expect(tag).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('does not select a linked tag in a multiple-selection group', () => {
+    render(
+      <RouterFixture>
+        <TagGroup aria-label="Destinations" selectionMode="multiple">
+          <Tag id="destination" href="/catalog" target="_blank">
+            Destination
+          </Tag>
+        </TagGroup>
+      </RouterFixture>,
+    );
+
+    const tag = screen.getByRole('row', { name: 'Destination' });
+    expect(tag).toHaveAttribute('aria-selected', 'false');
+    fireEvent.click(tag);
+    expect(tag).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('preserves consumer render state, DOM props, content, removal, and refs', () => {
+    const ref = createRef<HTMLDivElement>();
+    const onRemove = jest.fn();
+    const consumerRender = jest.fn(
+      (domProps: JSX.IntrinsicElements['div'], renderProps: TagRenderProps) => (
+        <div
+          {...domProps}
+          data-href="/consumer"
+          data-removable={String(renderProps.allowsRemoving)}
+        />
+      ),
+    );
+    render(
+      <RouterFixture>
+        <TagGroup aria-label="Destinations" onRemove={onRemove}>
+          <Tag
+            ref={ref}
+            id="destination"
+            href="/catalog"
+            target="_blank"
+            aria-label="Catalog destination"
+            className="consumer-tag"
+            render={consumerRender}
+          >
+            Catalog
+          </Tag>
+        </TagGroup>
+      </RouterFixture>,
+    );
+
+    const tag = screen.getByRole('row', { name: 'Catalog destination' });
+    expect(tag.tagName).toBe('DIV');
+    expect(tag).toHaveClass('bui-Tag', 'consumer-tag');
+    expect(tag).toHaveAttribute('data-href', '/consumer');
+    expect(tag).toHaveAttribute('data-removable', 'true');
+    expect(tag).toHaveTextContent('Catalog');
+    expect(ref.current).toBe(tag);
+    expect(consumerRender).toHaveBeenCalledWith(
+      expect.objectContaining({
+        'aria-label': 'Catalog destination',
+        'data-href': '/app/catalog',
+      }),
+      expect.objectContaining({ allowsRemoving: true }),
+    );
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(onRemove).toHaveBeenCalledWith(new Set(['destination']));
+  });
+
+  it('keeps raw native hrefs outside React Router', () => {
+    render(
+      <TagGroup aria-label="Destinations">
+        <Tag id="destination" href="https://example.test/docs">
+          Destination
+        </Tag>
+      </TagGroup>,
+    );
+
+    expect(screen.getByRole('row', { name: 'Destination' })).toHaveAttribute(
+      'data-href',
+      'https://example.test/docs',
+    );
+  });
+
+  it('routes an ordinary internal href with an isolated React Aria V2 graph', () => {
+    const sharedReact = jest.requireActual<typeof import('react')>('react');
+    const sharedReactDom =
+      jest.requireActual<typeof import('react-dom')>('react-dom');
+    const sharedReactDomClient =
+      jest.requireActual<typeof import('react-dom/client')>('react-dom/client');
+    const sharedReactRouter =
+      jest.requireActual<typeof import('react-router')>('react-router');
+    const sharedReactRouterDom =
+      jest.requireActual<typeof import('react-router-dom')>('react-router-dom');
+    let IsolatedTagGroup!: typeof TagGroup;
+    let IsolatedTag!: typeof Tag;
+    let IsolatedReactAria!: typeof ProviderReactAria;
+    let IsolatedReactAriaComponents!: typeof ProviderReactAriaComponents;
+
+    jest.isolateModules(() => {
+      jest.doMock('react', () => sharedReact);
+      jest.doMock('react-dom', () => sharedReactDom);
+      jest.doMock('react-dom/client', () => sharedReactDomClient);
+      jest.doMock('react-router', () => sharedReactRouter);
+      jest.doMock('react-router-dom', () => sharedReactRouterDom);
+      jest.dontMock('react-aria');
+      jest.dontMock('react-aria-components');
+      IsolatedReactAria = jest.requireActual('react-aria');
+      IsolatedReactAriaComponents = jest.requireActual('react-aria-components');
+      ({ TagGroup: IsolatedTagGroup, Tag: IsolatedTag } =
+        jest.requireActual('./TagGroup'));
+    });
+
+    jest.dontMock('react-aria');
+    jest.dontMock('react-aria-components');
+    expect(IsolatedReactAria).not.toBe(ProviderReactAria);
+    expect(IsolatedReactAriaComponents).not.toBe(ProviderReactAriaComponents);
+
+    render(
+      <MemoryRouter
+        basename="/app"
+        initialEntries={['/app/catalog/entity/docs']}
+        future={routerFuture}
+      >
+        <BUIProvider>
+          <Routes>
+            <Route
+              path="catalog/entity/docs/*"
+              element={
+                <IsolatedTagGroup aria-label="Destinations">
+                  <IsolatedTag id="destination" href="child">
+                    Destination
+                  </IsolatedTag>
+                </IsolatedTagGroup>
+              }
+            />
+          </Routes>
+        </BUIProvider>
+        <LocationStatus />
+      </MemoryRouter>,
+    );
+
+    const tag = screen.getByRole('row', { name: 'Destination' });
+    expect(tag).toHaveAttribute('data-href', '/app/catalog/entity/docs/child');
+    fireEvent.click(tag);
+    expect(screen.getByRole('status')).toHaveTextContent(
+      '/catalog/entity/docs/child',
+    );
+  });
+});

--- a/packages/ui/src/components/TagGroup/TagGroup.tsx
+++ b/packages/ui/src/components/TagGroup/TagGroup.tsx
@@ -26,6 +26,7 @@ import { RiCloseCircleLine } from '@remixicon/react';
 import { useDefinition } from '../../hooks/useDefinition';
 import { TagGroupDefinition, TagDefinition } from './definition';
 import { getNodeText } from '../../analytics/getNodeText';
+import { BUIRoutingProvider } from '../../navigation/BUIRoutingProvider';
 
 /**
  * A component that renders a list of tags.
@@ -37,15 +38,17 @@ export const TagGroup = <T extends object>(props: TagGroupProps<T>) => {
   const { classes, items, children, renderEmptyState } = ownProps;
 
   return (
-    <ReactAriaTagGroup className={classes.root} {...restProps}>
-      <ReactAriaTagList
-        className={classes.list}
-        items={items}
-        renderEmptyState={renderEmptyState}
-      >
-        {children}
-      </ReactAriaTagList>
-    </ReactAriaTagGroup>
+    <BUIRoutingProvider>
+      <ReactAriaTagGroup className={classes.root} {...restProps}>
+        <ReactAriaTagList
+          className={classes.list}
+          items={items}
+          renderEmptyState={renderEmptyState}
+        >
+          {children}
+        </ReactAriaTagList>
+      </ReactAriaTagGroup>
+    </BUIRoutingProvider>
   );
 };
 
@@ -59,18 +62,20 @@ export const Tag = forwardRef<HTMLDivElement, TagProps>((props, ref) => {
     TagDefinition,
     props,
   );
-  const { classes, children, icon, href } = ownProps;
+  const { classes, children, icon } = ownProps;
+  const rawHref = restProps.href;
   const textValue = typeof children === 'string' ? children : undefined;
 
-  const handlePress = () => {
-    if (href) {
+  const handlePress: typeof restProps.onPress = e => {
+    restProps.onPress?.(e);
+    if (rawHref) {
       const text =
-        (props as React.AriaAttributes)['aria-label'] ??
+        (restProps as React.AriaAttributes)['aria-label'] ??
         textValue ??
         getNodeText(children) ??
-        String(href);
+        String(rawHref);
       analytics.captureEvent('click', text, {
-        attributes: { to: String(href) },
+        attributes: { to: String(rawHref) },
       });
     }
   };
@@ -80,13 +85,9 @@ export const Tag = forwardRef<HTMLDivElement, TagProps>((props, ref) => {
       ref={ref}
       textValue={textValue}
       className={classes.root}
-      href={href}
       {...dataAttributes}
       {...restProps}
-      onPress={e => {
-        restProps.onPress?.(e);
-        handlePress();
-      }}
+      onPress={handlePress}
     >
       {({ allowsRemoving }) => (
         <>
@@ -102,3 +103,5 @@ export const Tag = forwardRef<HTMLDivElement, TagProps>((props, ref) => {
     </ReactAriaTag>
   );
 });
+
+Tag.displayName = 'Tag';

--- a/packages/ui/src/components/TagGroup/definition.ts
+++ b/packages/ui/src/components/TagGroup/definition.ts
@@ -49,7 +49,6 @@ export const TagDefinition = defineComponent<TagOwnProps>()({
     noTrack: {},
     icon: {},
     size: { dataAttribute: true, default: 'small' },
-    href: {},
     children: {},
     className: {},
   },

--- a/packages/ui/src/hooks/useDefinition/types.ts
+++ b/packages/ui/src/hooks/useDefinition/types.ts
@@ -14,9 +14,13 @@
  * limitations under the License.
  */
 
-import type { ReactNode } from 'react';
+import type { ComponentType, ReactElement, ReactNode } from 'react';
 import type { Responsive } from '../../types';
 import type { AnalyticsTracker } from '../../analytics/types';
+import type {
+  AnchorNavigation,
+  NavigationProps,
+} from '../../navigation/useNavigation';
 import type { utilityClassMap } from '../../utils/utilityClassMap';
 
 export type UnwrapResponsive<T> = T extends Responsive<infer U> ? U : T;
@@ -27,6 +31,16 @@ export interface PropDefConfig<T> {
 }
 
 export type UtilityPropKey = keyof typeof utilityClassMap;
+
+export type DefinitionNavigationConfig = { type: 'anchor' };
+
+export type DefinitionNavigationResult = AnchorNavigation;
+
+export type DefinitionNavigationComponent = <P extends object>(props: {
+  props: NavigationProps;
+  view: ComponentType<P & { navigation: DefinitionNavigationResult }>;
+  viewProps: P;
+}) => ReactElement;
 
 export interface ComponentConfig<
   P extends Record<string, any>,
@@ -51,6 +65,7 @@ export interface ComponentConfig<
    * `noTrack?: boolean`.
    */
   analytics?: boolean;
+  navigation?: DefinitionNavigationConfig;
 }
 
 /**
@@ -169,4 +184,9 @@ export type UseDefinitionResult<
   dataAttributes: DataAttributes<D['propDefs']>;
 
   utilityStyle: ResolvedUtilityStyle<D>;
-} & (D['analytics'] extends true ? { analytics: AnalyticsTracker } : {});
+} & (D['analytics'] extends true ? { analytics: AnalyticsTracker } : {}) &
+  (D['navigation'] extends DefinitionNavigationConfig
+    ? {
+        navigation: DefinitionNavigationComponent;
+      }
+    : {});

--- a/packages/ui/src/hooks/useDefinition/useDefinition.test.tsx
+++ b/packages/ui/src/hooks/useDefinition/useDefinition.test.tsx
@@ -13,14 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { type PropsWithChildren, type ReactNode } from 'react';
-import { renderHook, render } from '@testing-library/react';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { useState, type PropsWithChildren } from 'react';
+import { renderHook, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { useDefinition } from './useDefinition';
 import type { ComponentConfig } from './types';
 import { BgProvider, useBgConsumer } from '../useBg';
 import { noopTracker } from '../../analytics/useAnalytics';
 import { BUIProvider } from '../../provider';
+import type { AnchorNavigation } from '../../navigation/useNavigation';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -109,50 +110,50 @@ const hrefDef = {
   },
 } as const satisfies ComponentConfig<any, any>;
 
+const anchorDefinition = {
+  styles: { root: 'css-root' },
+  classNames: { root: 'root' },
+  propDefs: {
+    variant: { default: 'primary' } as const,
+    className: {},
+  },
+  navigation: { type: 'anchor' },
+} as const satisfies ComponentConfig<any, any>;
+
+function AnchorNavigationView({
+  navigation,
+  label,
+}: {
+  navigation: AnchorNavigation;
+  label: string;
+}) {
+  const [renderedLabel] = useState(label);
+  return (
+    <span data-testid="navigation" data-type={navigation.type}>
+      {renderedLabel}
+      {navigation.type === 'router' || navigation.type === 'native'
+        ? navigation.ariaHref
+        : ''}
+    </span>
+  );
+}
+
+function AnchorProbe(props: { href?: string; variant?: string }) {
+  const result = useDefinition(anchorDefinition, props);
+  const Navigation = result.navigation;
+
+  return (
+    <Navigation
+      props={result.restProps}
+      view={AnchorNavigationView}
+      viewProps={{ label: 'anchor:' }}
+    />
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
-
-function createRouterWrapper({
-  basename,
-  currentRoute,
-}: {
-  basename?: string;
-  currentRoute: string;
-}) {
-  return function RouterWrapper({ children }: PropsWithChildren) {
-    const entry = basename ? `${basename}${currentRoute}` : currentRoute;
-    // Build nested Routes one level per path segment. The leaf route uses a
-    // non-splat path so that `..` resolution works correctly.
-    const segments =
-      currentRoute === '/'
-        ? []
-        : currentRoute.replace(/^\//, '').split('/').filter(Boolean);
-
-    const buildRoutes = (segs: string[], el: ReactNode): ReactNode => {
-      if (segs.length === 0) return <Route index element={el} />;
-      const [head, ...tail] = segs;
-      if (tail.length === 0) {
-        return <Route path={head} element={el} />;
-      }
-      return <Route path={`${head}/*`}>{buildRoutes(tail, el)}</Route>;
-    };
-
-    return (
-      <MemoryRouter basename={basename} initialEntries={[entry]}>
-        <BUIProvider>
-          <Routes>
-            {segments.length === 0 ? (
-              <Route path="*" element={children} />
-            ) : (
-              buildRoutes(segments, children)
-            )}
-          </Routes>
-        </BUIProvider>
-      </MemoryRouter>
-    );
-  };
-}
 
 describe('useDefinition', () => {
   describe('prop resolution', () => {
@@ -609,89 +610,103 @@ describe('useDefinition', () => {
     });
   });
 
-  describe('href resolution', () => {
-    describe('inside router context', () => {
-      describe.each([
-        ['no basename', undefined],
-        ['with basename /app', '/app'],
-      ] as const)('%s', (_label, basename) => {
-        it.each`
-          description                       | href                  | currentRoute        | expected
-          ${'absolute path'}                | ${'/foo'}             | ${'/catalog'}       | ${'/foo'}
-          ${'root /'}                       | ${'/'}                | ${'/catalog'}       | ${'/'}
-          ${'relative path "foo"'}          | ${'foo'}              | ${'/catalog'}       | ${'/catalog/foo'}
-          ${'relative path "./foo"'}        | ${'./foo'}            | ${'/catalog'}       | ${'/catalog/foo'}
-          ${'relative path "../foo"'}       | ${'../foo'}           | ${'/catalog/items'} | ${'/catalog/foo'}
-          ${'empty string'}                 | ${''}                 | ${'/catalog'}       | ${'/catalog'}
-          ${'absolute with query params'}   | ${'/foo?q=1'}         | ${'/catalog'}       | ${'/foo?q=1'}
-          ${'absolute with hash'}           | ${'/foo#section'}     | ${'/catalog'}       | ${'/foo#section'}
-          ${'absolute with query and hash'} | ${'/foo?q=1#section'} | ${'/catalog'}       | ${'/foo?q=1#section'}
-          ${'relative with query params'}   | ${'foo?q=1'}          | ${'/catalog'}       | ${'/catalog/foo?q=1'}
-        `(
-          'resolves $description — returns $expected',
-          ({
-            href,
-            currentRoute,
-            expected,
-          }: {
-            href: string;
-            currentRoute: string;
-            expected: string;
-          }) => {
-            const { result } = renderHook(
-              () => useDefinition(hrefDef, { href }),
-              {
-                wrapper: createRouterWrapper({ basename, currentRoute }),
-              },
-            );
-
-            expect(result.current.ownProps.href).toBe(expected);
-          },
-        );
-
-        it.each`
-          description                | href
-          ${'https:// URL'}          | ${'https://example.com'}
-          ${'http:// URL'}           | ${'http://example.com'}
-          ${'mailto: link'}          | ${'mailto:a@b.com'}
-          ${'tel: link'}             | ${'tel:123'}
-          ${'protocol-relative URL'} | ${'//example.com'}
-        `('leaves $description unchanged', ({ href }: { href: string }) => {
-          const { result } = renderHook(
-            () => useDefinition(hrefDef, { href }),
-            {
-              wrapper: createRouterWrapper({
-                basename,
-                currentRoute: '/catalog',
-              }),
-            },
-          );
-
-          expect(result.current.ownProps.href).toBe(href);
-        });
-
-        it('does not modify props when href is undefined', () => {
-          const { result } = renderHook(() => useDefinition(hrefDef, {}), {
-            wrapper: createRouterWrapper({
-              basename,
-              currentRoute: '/catalog',
-            }),
-          });
-
-          expect(result.current.ownProps).not.toHaveProperty('href');
-        });
+  describe('href props', () => {
+    it.each([
+      '/absolute',
+      'child',
+      '../sibling?tab=docs#api',
+      'mailto:',
+      '//host/path',
+    ])('preserves the caller href %s inside and outside React Router', href => {
+      const outsideRouter = renderHook(() => useDefinition(hrefDef, { href }), {
+        wrapper: Wrapper,
       });
+      expect(
+        outsideRouter.result.current.ownProps.href ??
+          outsideRouter.result.current.restProps.href,
+      ).toBe(href);
+
+      const insideRouter = renderHook(() => useDefinition(hrefDef, { href }), {
+        wrapper: ({ children }: PropsWithChildren) => (
+          <MemoryRouter
+            initialEntries={['/catalog/entity']}
+            future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+          >
+            <BUIProvider>{children}</BUIProvider>
+          </MemoryRouter>
+        ),
+      });
+      expect(
+        insideRouter.result.current.ownProps.href ??
+          insideRouter.result.current.restProps.href,
+      ).toBe(href);
+    });
+  });
+
+  describe('navigation', () => {
+    it('selects native anchor navigation outside React Router', () => {
+      render(<AnchorProbe href="../sibling?tab=docs#api" />);
+
+      expect(screen.getByTestId('navigation')).toHaveAttribute(
+        'data-type',
+        'native',
+      );
+      expect(screen.getByTestId('navigation')).toHaveTextContent(
+        'anchor:../sibling?tab=docs#api',
+      );
     });
 
-    describe('outside router context', () => {
-      it('passes all href values through unchanged', () => {
-        const { result } = renderHook(
-          () => useDefinition(hrefDef, { href: '/foo' }),
-          { wrapper: Wrapper },
-        );
+    it('selects routed anchor navigation inside React Router', () => {
+      render(
+        <MemoryRouter
+          initialEntries={['/catalog/entity']}
+          future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+        >
+          <BUIProvider>
+            <AnchorProbe href="child" />
+          </BUIProvider>
+        </MemoryRouter>,
+      );
 
-        expect(result.current.ownProps.href).toBe('/foo');
-      });
+      expect(screen.getByTestId('navigation')).toHaveAttribute(
+        'data-type',
+        'router',
+      );
+      expect(screen.getByTestId('navigation')).toHaveTextContent(
+        'anchor:child',
+      );
+    });
+
+    it('returns none for an absent href with anchor navigation', () => {
+      render(<AnchorProbe />);
+
+      expect(screen.getByTestId('navigation')).toHaveAttribute(
+        'data-type',
+        'none',
+      );
+    });
+
+    it('does not add navigation to definitions without the opt-in', () => {
+      const { result } = renderHook(
+        () => useDefinition(basicDef, { variant: 'primary' }),
+        { wrapper: Wrapper },
+      );
+
+      expect(result.current).not.toHaveProperty('navigation');
+    });
+
+    it('keeps raw rest hrefs while resolving definition defaults', () => {
+      const { result } = renderHook(
+        () =>
+          useDefinition<
+            typeof anchorDefinition,
+            { href?: string; variant?: string }
+          >(anchorDefinition, { href: '../sibling?tab=docs#api' }),
+        { wrapper: Wrapper },
+      );
+
+      expect(result.current.ownProps.variant).toBe('primary');
+      expect(result.current.restProps.href).toBe('../sibling?tab=docs#api');
     });
   });
 

--- a/packages/ui/src/hooks/useDefinition/useDefinition.tsx
+++ b/packages/ui/src/hooks/useDefinition/useDefinition.tsx
@@ -21,12 +21,7 @@ import { useBgProvider, useBgConsumer, BgProvider } from '../useBg';
 import { resolveDefinitionProps, processUtilityProps } from './helpers';
 import { useAnalytics } from '../../analytics/useAnalytics';
 import { noopTracker } from '../../analytics/useAnalytics';
-import {
-  useResolvedPath,
-  useInRouterContext,
-  createPath,
-} from 'react-router-dom';
-import { isExternalLink } from '../../utils/linkUtils';
+import { useDefinitionNavigation } from './useDefinitionNavigation';
 import type {
   ComponentConfig,
   UseDefinitionOptions,
@@ -44,22 +39,19 @@ export function useDefinition<
 ): UseDefinitionResult<D, P> {
   const { breakpoint } = useBreakpoint();
 
-  let hrefResolvedProps = props;
-  const hasRouter = useInRouterContext();
-  if (hasRouter) {
-    const rawHref = (props as any).href;
-    const resolved = useResolvedPath(rawHref ?? '');
-    if (rawHref !== undefined && !isExternalLink(rawHref)) {
-      hrefResolvedProps = { ...props, href: createPath(resolved) } as P;
-    }
-  }
-
   // Resolve all props centrally — applies responsive values and defaults
   const { ownPropsResolved, restProps } = resolveDefinitionProps(
     definition,
-    hrefResolvedProps,
+    props,
     breakpoint,
   );
+
+  let navigation;
+  if (definition.navigation) {
+    // Component definitions are module constants, so this hook condition is
+    // stable for the lifetime of the component.
+    navigation = useDefinitionNavigation(definition.navigation);
+  }
 
   const dataAttributes: Record<string, string | undefined> = {};
 
@@ -148,5 +140,6 @@ export function useDefinition<
     dataAttributes,
     utilityStyle,
     ...(definition.analytics ? { analytics } : {}),
+    ...(definition.navigation ? { navigation } : {}),
   } as unknown as UseDefinitionResult<D, P>;
 }

--- a/packages/ui/src/hooks/useDefinition/useDefinitionNavigation.tsx
+++ b/packages/ui/src/hooks/useDefinition/useDefinitionNavigation.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ComponentType, ReactElement } from 'react';
+import {
+  useAnchorNavigation,
+  type AnchorNavigation,
+  type NavigationProps,
+} from '../../navigation/useNavigation';
+import { useRoutingIntegration } from '../../navigation/useRouting';
+import type {
+  DefinitionNavigationComponent,
+  DefinitionNavigationConfig,
+} from './types';
+
+type NavigationResolverProps<N, P extends object> = {
+  props: NavigationProps;
+  view: ComponentType<P & { navigation: N }>;
+  viewProps: P;
+};
+
+type AnchorNavigationProps<P extends object> = NavigationResolverProps<
+  AnchorNavigation,
+  P
+>;
+
+function NavigationView<N, P extends object>({
+  navigation,
+  view: View,
+  viewProps,
+}: Omit<NavigationResolverProps<N, P>, 'props'> & {
+  navigation: N;
+}): ReactElement {
+  const props = { ...viewProps, navigation } as P & { navigation: N };
+  return <View {...props} />;
+}
+
+function RoutedAnchorNavigation<P extends object>({
+  props,
+  view,
+  viewProps,
+}: AnchorNavigationProps<P>): ReactElement {
+  const navigation = useAnchorNavigation(props);
+  return (
+    <NavigationView navigation={navigation} view={view} viewProps={viewProps} />
+  );
+}
+
+function NativeAnchorNavigation<P extends object>({
+  props,
+  view,
+  viewProps,
+}: AnchorNavigationProps<P>): ReactElement {
+  let navigation: AnchorNavigation = {
+    type: 'none',
+    canMatchRoute: false,
+  };
+  if (props.href) {
+    navigation = {
+      type: 'native',
+      canMatchRoute: false,
+      ariaHref: props.href,
+      browserHref: props.href,
+    };
+  }
+
+  return (
+    <NavigationView navigation={navigation} view={view} viewProps={viewProps} />
+  );
+}
+
+/**
+ * Selects a resolver component so router-specific hooks only mount when a
+ * React Router context is available. The resolver injects the normalized
+ * navigation into the component view as an ordinary React prop.
+ */
+export function useDefinitionNavigation(
+  _config: DefinitionNavigationConfig,
+): DefinitionNavigationComponent {
+  const routing = useRoutingIntegration({ fallback: true });
+  const inRouterContext = routing.useInRouterContext();
+
+  if (inRouterContext) {
+    return RoutedAnchorNavigation;
+  }
+  return NativeAnchorNavigation;
+}

--- a/packages/ui/src/navigation/BUIRoutingProvider.tsx
+++ b/packages/ui/src/navigation/BUIRoutingProvider.tsx
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useCallback, type ReactNode } from 'react';
+import { RouterProvider } from 'react-aria-components';
+import {
+  Link,
+  useHref,
+  useInRouterContext,
+  useLocation,
+  useNavigate,
+  useResolvedPath,
+} from 'react-router-dom';
+import { useResolvedHref } from '../hooks/useResolvedHref';
+import type { BUIRoutingIntegration } from './types';
+
+// BUIProvider mounts this provider centrally so older BUI components from the
+// same React Aria module instance keep delegated client-side navigation.
+// Collection roots also mount it locally so their synthetic link items and the
+// provider always use the same React Aria module instance. Preserving each
+// item's href and original activation event lets React Aria choose between
+// client navigation and temporary-anchor activation for native link behavior.
+//
+// The exact options object identifies a component-scoped action. Unregistered
+// objects, including those from older BUI components or direct React Aria
+// usage, use the provider's router context instead. A separate React Aria
+// module instance cannot reach this provider and is handled by the rendered
+// host Link in useNavigation.
+const delegatedNavigations = new WeakMap<object, () => void>();
+
+/** @internal */
+export const buiRoutingIntegration: BUIRoutingIntegration = {
+  Link,
+  useHref,
+  useInRouterContext,
+  useLocation,
+  useNavigate,
+  useResolvedPath,
+  createRouterOptions(action, options) {
+    const routerOptions = { ...options };
+    delegatedNavigations.set(routerOptions, action);
+    return routerOptions;
+  },
+};
+
+/** @internal */
+export function BUIRoutingProvider({ children }: { children: ReactNode }) {
+  if (!useInRouterContext()) {
+    return children;
+  }
+  return <ReactAriaRoutingProvider>{children}</ReactAriaRoutingProvider>;
+}
+
+function ReactAriaRoutingProvider({ children }: { children: ReactNode }) {
+  const providerNavigate = useNavigate();
+  const navigate = useCallback(
+    (href: string, options: object | undefined) => {
+      const delegatedNavigation = options
+        ? delegatedNavigations.get(options)
+        : undefined;
+      if (delegatedNavigation) {
+        delegatedNavigation();
+        return;
+      }
+      providerNavigate(href, options);
+    },
+    [providerNavigate],
+  );
+
+  return (
+    <RouterProvider navigate={navigate} useHref={useResolvedHref}>
+      {children}
+    </RouterProvider>
+  );
+}

--- a/packages/ui/src/navigation/types.ts
+++ b/packages/ui/src/navigation/types.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Link as RouterLink,
+  type NavigateOptions,
+  useHref,
+  useInRouterContext,
+  useLocation,
+  useNavigate,
+  useResolvedPath,
+} from 'react-router-dom';
+
+/** @internal */
+export type BUIRoutingIntegration = {
+  Link: typeof RouterLink;
+  useHref: typeof useHref;
+  useInRouterContext: typeof useInRouterContext;
+  useLocation: typeof useLocation;
+  useNavigate: typeof useNavigate;
+  useResolvedPath: typeof useResolvedPath;
+  createRouterOptions(
+    action: () => void,
+    options?: NavigateOptions,
+  ): NavigateOptions;
+};

--- a/packages/ui/src/navigation/useNavigation.test.tsx
+++ b/packages/ui/src/navigation/useNavigation.test.tsx
@@ -1,0 +1,631 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  createVersionedValueMap,
+  type VersionedValue,
+} from '@backstage/version-bridge';
+import { fireEvent, render, renderHook, screen } from '@testing-library/react';
+import {
+  useCallback,
+  useMemo,
+  type ComponentType,
+  type PropsWithChildren,
+} from 'react';
+import * as ProviderReactAria from 'react-aria';
+import {
+  Link as ProviderAriaLink,
+  RouterProvider,
+  type ListBoxItemProps,
+} from 'react-aria-components';
+import {
+  Link as RouterLink,
+  MemoryRouter,
+  Outlet,
+  Route,
+  Routes,
+  useHref,
+  useInRouterContext,
+  useLocation,
+  useNavigate,
+  useNavigationType,
+  useResolvedPath,
+  type NavigateOptions,
+} from 'react-router-dom';
+import { BUIProvider } from '../provider/BUIProvider';
+import { BUIContext, type BUIContextVersions } from '../provider/BUIContext';
+import { useResolvedHref } from '../hooks/useResolvedHref';
+import { isExternalLink } from '../utils/linkUtils';
+import {
+  getReactAriaAnchorProps,
+  isBrowserOwnedHref,
+  isNativeNavigation,
+  useAnchorNavigation,
+} from './useNavigation';
+import {
+  fallbackRoutingIntegration,
+  useRoutingIntegration,
+} from './useRouting';
+import type { BUIRoutingIntegration } from './types';
+
+const routerFuture = {
+  v7_startTransition: true,
+  v7_relativeSplatPath: true,
+} as const;
+
+describe('navigation classification', () => {
+  it.each([
+    ['child', false],
+    ['./child', false],
+    ['../entity?tab=docs#api', false],
+    ['/catalog', false],
+    ['?tab=docs', false],
+    ['#api', false],
+    ['http://example.test', true],
+    ['https://example.test', true],
+    ['mailto:owner@example.test', true],
+    ['tel:+123456789', true],
+    ['sms:+123456789', true],
+    ['ftp://example.test/file', true],
+    ['HtTpS://example.test', true],
+    ['vscode://file/workspace', true],
+    ['APP+EXT.1:value', true],
+    ['//cdn.example.test/file', true],
+  ])('classifies %s as browser-owned: %s', (href, expected) => {
+    expect(isBrowserOwnedHref(href)).toBe(expected);
+    expect(isExternalLink(href)).toBe(expected);
+  });
+
+  it.each([
+    [{ href: '/entity' }, false],
+    [{ href: '/entity', target: '_self' }, false],
+    [{ href: '/entity', target: '_blank' }, true],
+    [{ href: '/entity', target: 'preview' }, true],
+    [{ href: '/entity', target: '_parent' }, true],
+    [{ href: '/entity', target: '_top' }, true],
+    [{ href: '/entity', download: true }, true],
+    [{ href: '/entity', download: 'entity.yaml' }, true],
+    [{ href: 'mailto:owner@example.test' }, true],
+  ])('classifies native navigation %# as %s', (props, expected) => {
+    expect(isNativeNavigation(props)).toBe(expected);
+  });
+});
+
+describe('useAnchorNavigation', () => {
+  it.each([
+    ['child', '/app/catalog/entity/docs'],
+    ['', '/app/catalog/entity/docs'],
+    ['.', '/app/catalog/entity/docs'],
+    ['..', '/app/catalog/entity/docs'],
+    ['?tab=docs', '/app/catalog/entity/docs'],
+    ['#api', '/app/catalog/entity/docs'],
+    ['child', '/app/catalog/entity/docs/reference/api'],
+  ])('keeps the raw V2 destination %s from %s', (href, entry) => {
+    const { result } = renderHook(() => useAnchorNavigation({ href }), {
+      wrapper: createRouterWrapper({ entry, provider: 'new' }),
+    });
+
+    expect(result.current).toMatchObject({
+      type: 'router',
+      canMatchRoute: true,
+      ariaHref: href,
+      to: href,
+      Link: RouterLink,
+    });
+    expect(result.current).toHaveProperty('routerOptions');
+  });
+
+  it.each([
+    ['child', '/app/catalog/entity/docs', '/catalog/entity/docs/child'],
+    ['', '/app/catalog/entity/docs', '/catalog/entity/docs'],
+    ['.', '/app/catalog/entity/docs', '/catalog/entity/docs'],
+    ['..', '/app/catalog/entity/docs', '/catalog/entity'],
+    ['?tab=docs', '/app/catalog/entity/docs', '/catalog/entity/docs?tab=docs'],
+    ['#api', '/app/catalog/entity/docs', '/catalog/entity/docs#api'],
+    [
+      'child',
+      '/app/catalog/entity/docs/reference/api',
+      '/catalog/entity/docs/reference/api/child',
+    ],
+  ])(
+    'resolves only the old-provider aria href for %s from %s',
+    (href, entry, expectedAriaHref) => {
+      const { result } = renderHook(() => useAnchorNavigation({ href }), {
+        wrapper: createRouterWrapper({ entry, provider: 'old' }),
+      });
+
+      expect(result.current).toEqual({
+        type: 'router',
+        canMatchRoute: true,
+        ariaHref: expectedAriaHref,
+        to: href,
+        Link: RouterLink,
+        routerOptions: undefined,
+        routerLinkOptions: undefined,
+        navigateWithFullOptions: undefined,
+      });
+    },
+  );
+
+  it('uses path-relative resolution for the old-provider aria href', () => {
+    const { result } = renderHook(
+      () =>
+        useAnchorNavigation({
+          href: '..',
+          routerOptions: { relative: 'path' },
+        }),
+      {
+        wrapper: createRouterWrapper({
+          entry: '/app/catalog/entity/docs/reference/api',
+          provider: 'old',
+        }),
+      },
+    );
+
+    expect(result.current).toMatchObject({
+      type: 'router',
+      ariaHref: '/catalog/entity/docs/reference',
+      to: '..',
+      routerOptions: { relative: 'path' },
+    });
+  });
+
+  it.each(['new', 'old'] as const)(
+    'uses path-relative hrefs for internal native destinations under the %s provider',
+    provider => {
+      const nativeOptions = [{ target: '_blank' as const }, { download: true }];
+
+      for (const nativeOption of nativeOptions) {
+        const { result, unmount } = renderHook(
+          () =>
+            useAnchorNavigation({
+              href: '..',
+              routerOptions: { relative: 'path' },
+              ...nativeOption,
+            }),
+          {
+            wrapper: createRouterWrapper({
+              entry: '/app/catalog/entity/docs/reference/api',
+              provider,
+            }),
+          },
+        );
+
+        expect(result.current).toMatchObject({
+          type: 'native',
+          ariaHref: '..',
+          browserHref: '/app/catalog/entity/docs/reference',
+        });
+        unmount();
+      }
+    },
+  );
+
+  it.each(['new', 'old'] as const)(
+    'applies the basename once to internal native destinations under the %s provider',
+    provider => {
+      const { result } = renderHook(
+        () => useAnchorNavigation({ href: '/entity', target: '_blank' }),
+        {
+          wrapper: createRouterWrapper({
+            entry: '/app/catalog/entity/docs',
+            provider,
+          }),
+        },
+      );
+
+      expect(result.current).toEqual({
+        type: 'native',
+        canMatchRoute: true,
+        ariaHref: '/entity',
+        browserHref: '/app/entity',
+      });
+      expect(result.current).not.toHaveProperty(
+        'browserHref',
+        '/app/app/entity',
+      );
+    },
+  );
+
+  it.each(['new', 'old'] as const)(
+    'keeps browser-owned destinations raw under the %s provider',
+    provider => {
+      const href = 'APP+EXT.1:value';
+      const { result } = renderHook(
+        () => useAnchorNavigation({ href, download: 'resource' }),
+        {
+          wrapper: createRouterWrapper({
+            entry: '/app/catalog/entity/docs',
+            provider,
+          }),
+        },
+      );
+
+      expect(result.current).toEqual({
+        type: 'native',
+        canMatchRoute: false,
+        ariaHref: href,
+        browserHref: href,
+      });
+    },
+  );
+
+  it('memoizes delegated options by its routing inputs', () => {
+    const routerOptions = { replace: true };
+    const { result, rerender } = renderHook(
+      ({ href, options }: { href: string; options: NavigateOptions }) =>
+        useAnchorNavigation({ href, routerOptions: options }),
+      {
+        initialProps: { href: 'child', options: routerOptions },
+        wrapper: createRouterWrapper({
+          entry: '/app/catalog/entity/docs',
+          provider: 'new',
+        }),
+      },
+    );
+    const firstOptions =
+      result.current.type === 'router'
+        ? result.current.routerOptions
+        : undefined;
+
+    rerender({ href: 'child', options: routerOptions });
+    const unchangedOptions =
+      result.current.type === 'router'
+        ? result.current.routerOptions
+        : undefined;
+    expect(unchangedOptions).toBe(firstOptions);
+
+    const replacementRouterOptions = { replace: true };
+    rerender({ href: 'child', options: replacementRouterOptions });
+    const replacedOptions =
+      result.current.type === 'router'
+        ? result.current.routerOptions
+        : undefined;
+    expect(replacedOptions).not.toBe(firstOptions);
+
+    rerender({ href: 'other', options: replacementRouterOptions });
+    expect(
+      result.current.type === 'router'
+        ? result.current.routerOptions
+        : undefined,
+    ).not.toBe(replacedOptions);
+  });
+
+  it('selects native href behavior outside React Router', () => {
+    const { result } = renderHook(() => useRoutingIntegration());
+    expect(result.current).toBeUndefined();
+
+    render(<OutsideRouterAnchor href="../entity?tab=docs#api" />);
+    expect(screen.getByRole('link', { name: 'Destination' })).toHaveAttribute(
+      'href',
+      '../entity?tab=docs#api',
+    );
+  });
+
+  it('opts into the fallback routing integration', () => {
+    const { result } = renderHook(() =>
+      useRoutingIntegration({ fallback: true }),
+    );
+
+    expect(result.current).toBe(fallbackRoutingIntegration);
+  });
+});
+
+describe('getReactAriaAnchorProps', () => {
+  it('does not pass a caller render when navigation is absent', () => {
+    const routerOptions = { replace: true };
+    const render: NonNullable<ListBoxItemProps<object>['render']> = () => (
+      <div />
+    );
+    const props = { href: '/caller', routerOptions, render };
+
+    const result = getReactAriaAnchorProps(
+      { type: 'none', canMatchRoute: false },
+      props,
+    );
+
+    expect(result).toEqual({
+      href: '/caller',
+      routerOptions,
+      render: undefined,
+    });
+  });
+
+  it('uses React Router with its supported options and no generated DOM href', () => {
+    const routerOptions = {
+      replace: true,
+      state: { source: 'navigation-test' },
+      preventScrollReset: true,
+      relative: 'path' as const,
+      flushSync: true,
+      viewTransition: true,
+    };
+    const navigation = {
+      type: 'router' as const,
+      canMatchRoute: true,
+      ariaHref: '/aria-destination',
+      to: 'raw-destination',
+      Link: RouterLink,
+      routerOptions,
+      routerLinkOptions: {
+        replace: true,
+        state: { source: 'navigation-test' },
+        preventScrollReset: true,
+        relative: 'path' as const,
+        viewTransition: true,
+      },
+    };
+
+    const result = getReactAriaAnchorProps(navigation, {
+      href: '/caller',
+      routerOptions: { preventScrollReset: true },
+    });
+    const rendered = result.render?.(
+      { href: '/generated-destination', className: 'anchor' },
+      {},
+    );
+
+    expect(result.href).toBe('/aria-destination');
+    expect(result.routerOptions).toBe(routerOptions);
+    expect(rendered).toEqual(
+      <RouterLink
+        className="anchor"
+        preventScrollReset
+        relative="path"
+        replace
+        state={{ source: 'navigation-test' }}
+        to="raw-destination"
+        viewTransition
+      />,
+    );
+  });
+
+  it('uses a BUI-owned anchor for native browser hrefs', () => {
+    const consumerRender = jest.fn(() => <a href="/consumer" />);
+    const props = {
+      href: '/caller',
+      render: consumerRender,
+    } as Parameters<typeof getReactAriaAnchorProps>[1] & {
+      render: typeof consumerRender;
+    };
+    const result = getReactAriaAnchorProps(
+      {
+        type: 'native',
+        canMatchRoute: true,
+        ariaHref: '/aria-destination',
+        browserHref: '/browser-destination',
+      },
+      props,
+    );
+
+    const rendered = result.render?.(
+      { href: '/generated-destination', className: 'anchor' },
+      {},
+    );
+
+    expect(result.href).toBe('/aria-destination');
+    expect(consumerRender).not.toHaveBeenCalled();
+    expect(rendered).toEqual(
+      <a className="anchor" href="/browser-destination" />,
+    );
+  });
+});
+
+describe('isolated React Aria compatibility', () => {
+  it('uses full router options once across an isolated React Aria graph', () => {
+    const sharedReact = jest.requireActual<typeof import('react')>('react');
+    const sharedReactDom =
+      jest.requireActual<typeof import('react-dom')>('react-dom');
+    const sharedReactDomClient =
+      jest.requireActual<typeof import('react-dom/client')>('react-dom/client');
+    const sharedReactRouter =
+      jest.requireActual<typeof import('react-router')>('react-router');
+    const sharedReactRouterDom =
+      jest.requireActual<typeof import('react-router-dom')>('react-router-dom');
+    let IsolatedProbeAnchor!: ComponentType<{ href: string }>;
+    let IsolatedAriaLink!: typeof ProviderAriaLink;
+    let IsolatedReactAria!: typeof ProviderReactAria;
+    let IsolatedRouterDom!: typeof sharedReactRouterDom;
+    const navigationCalls: Array<[string, NavigateOptions | undefined]> = [];
+    const routerOptions = {
+      flushSync: true,
+      preventScrollReset: true,
+      relative: 'route' as const,
+      replace: false,
+      state: { source: 'isolated-react-aria' },
+      viewTransition: true,
+    };
+
+    jest.isolateModules(() => {
+      jest.doMock('react', () => sharedReact);
+      jest.doMock('react-dom', () => sharedReactDom);
+      jest.doMock('react-dom/client', () => sharedReactDomClient);
+      jest.doMock('react-router', () => sharedReactRouter);
+      jest.doMock('react-router-dom', () => sharedReactRouterDom);
+      IsolatedRouterDom = jest.requireMock('react-router-dom');
+      IsolatedReactAria = jest.requireActual('react-aria');
+      ({ Link: IsolatedAriaLink } = jest.requireActual(
+        'react-aria-components',
+      ));
+      const {
+        getReactAriaAnchorProps: getIsolatedReactAriaAnchorProps,
+        useAnchorNavigation: useIsolatedAnchorNavigation,
+      } =
+        jest.requireActual<typeof import('./useNavigation')>('./useNavigation');
+      IsolatedProbeAnchor = ({ href }) => {
+        const navigation = useIsolatedAnchorNavigation({
+          href,
+          routerOptions,
+        });
+        if (navigation.type !== 'router') {
+          throw new Error('Expected router link');
+        }
+        const navigationProps = getIsolatedReactAriaAnchorProps(navigation, {
+          href,
+        });
+        return (
+          <IsolatedAriaLink {...navigationProps}>Destination</IsolatedAriaLink>
+        );
+      };
+    });
+
+    expect(IsolatedReactAria).not.toBe(ProviderReactAria);
+    expect(IsolatedAriaLink).not.toBe(ProviderAriaLink);
+    expect(IsolatedRouterDom).toBe(sharedReactRouterDom);
+
+    render(
+      <MemoryRouter initialEntries={['/source']} future={routerFuture}>
+        <TrackingV2BUIProvider navigationCalls={navigationCalls}>
+          <Routes>
+            <Route
+              path="source"
+              element={<IsolatedProbeAnchor href="/destination" />}
+            />
+            <Route path="destination" element={<DestinationPage />} />
+          </Routes>
+          <HistoryBackButton />
+        </TrackingV2BUIProvider>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'Destination' }));
+    expect(navigationCalls).toEqual([['/destination', routerOptions]]);
+    expect(
+      screen.getByRole('heading', { name: 'Destination page' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'PUSH:isolated-react-aria',
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+    expect(
+      screen.getByRole('link', { name: 'Destination' }),
+    ).toBeInTheDocument();
+  });
+});
+
+function HistoryBackButton() {
+  const navigate = useNavigate();
+  return <button onClick={() => navigate(-1)}>Back</button>;
+}
+
+function TrackingV2BUIProvider({
+  children,
+  navigationCalls,
+}: PropsWithChildren<{
+  navigationCalls: Array<[string, NavigateOptions | undefined]>;
+}>) {
+  const hostNavigate = useNavigate();
+  const trackedNavigate = useCallback(
+    ((to: string, options?: NavigateOptions) => {
+      navigationCalls.push([to, options]);
+      hostNavigate(to, options);
+    }) as ReturnType<typeof useNavigate>,
+    [hostNavigate, navigationCalls],
+  );
+  const routing = useMemo<BUIRoutingIntegration>(
+    () => ({
+      Link: RouterLink,
+      useHref,
+      useInRouterContext,
+      useLocation,
+      useNavigate: () => trackedNavigate,
+      useResolvedPath,
+      createRouterOptions(_action, options) {
+        return { ...options };
+      },
+    }),
+    [trackedNavigate],
+  );
+  const value = useMemo(
+    () => createVersionedValueMap({ 1: {}, 2: { routing } }),
+    [routing],
+  );
+
+  return <BUIContext.Provider value={value}>{children}</BUIContext.Provider>;
+}
+
+function DestinationPage() {
+  const location = useLocation();
+  const navigationType = useNavigationType();
+  return (
+    <>
+      <h1>Destination page</h1>
+      <span role="status">
+        {navigationType}:{location.state?.source}
+      </span>
+    </>
+  );
+}
+
+function createRouterWrapper({
+  entry,
+  provider,
+}: {
+  entry: string;
+  provider: 'new' | 'old';
+}) {
+  return function RouterWrapper({ children }: PropsWithChildren) {
+    const content = (
+      <Routes>
+        <Route path="catalog" element={<Outlet />}>
+          <Route path="entity" element={<Outlet />}>
+            <Route path="docs/*" element={children} />
+          </Route>
+        </Route>
+      </Routes>
+    );
+
+    return (
+      <MemoryRouter
+        basename="/app"
+        initialEntries={[entry]}
+        future={routerFuture}
+      >
+        {provider === 'new' ? (
+          <BUIProvider>{content}</BUIProvider>
+        ) : (
+          <OldBUIProvider>{content}</OldBUIProvider>
+        )}
+      </MemoryRouter>
+    );
+  };
+}
+
+function OldBUIProvider({ children }: PropsWithChildren) {
+  const navigate = useNavigate();
+  const value = useMemo(
+    () =>
+      createVersionedValueMap({
+        1: { useAnalytics: undefined },
+      }) as VersionedValue<BUIContextVersions>,
+    [],
+  );
+
+  return (
+    <RouterProvider navigate={navigate} useHref={useResolvedHref}>
+      <BUIContext.Provider value={value}>{children}</BUIContext.Provider>
+    </RouterProvider>
+  );
+}
+
+function OutsideRouterAnchor({ href }: { href: string }) {
+  const routing = useRoutingIntegration({ fallback: true });
+  if (!routing.useInRouterContext()) {
+    return <a href={href}>Destination</a>;
+  }
+  throw new Error('Expected to be outside React Router');
+}

--- a/packages/ui/src/navigation/useNavigation.tsx
+++ b/packages/ui/src/navigation/useNavigation.tsx
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  useCallback,
+  useMemo,
+  type HTMLAttributeAnchorTarget,
+  type JSX,
+  type MouseEvent,
+  type ReactElement,
+} from 'react';
+import { createPath, type NavigateOptions } from 'react-router-dom';
+import { isBrowserOwnedHref } from '../utils/linkUtils';
+import type { BUIRoutingIntegration } from './types';
+import {
+  fallbackRoutingIntegration,
+  useRoutingIntegration,
+} from './useRouting';
+
+/** @internal */
+export type NavigationProps = {
+  href?: string;
+  target?: HTMLAttributeAnchorTarget;
+  download?: boolean | string;
+  routerOptions?: NavigateOptions;
+};
+
+/** @internal */
+export type AnchorNavigation = { canMatchRoute: boolean } & (
+  | { type: 'none' }
+  | { type: 'native'; ariaHref: string; browserHref: string }
+  | {
+      type: 'router';
+      ariaHref: string;
+      to: string;
+      Link: BUIRoutingIntegration['Link'];
+      routerOptions?: NavigateOptions;
+      routerLinkOptions: Omit<NavigateOptions, 'flushSync'> | undefined;
+      navigateWithFullOptions?: () => void;
+    }
+);
+
+type PolymorphicRenderFunction = (...args: any[]) => ReactElement;
+
+export { isBrowserOwnedHref } from '../utils/linkUtils';
+
+/** @internal */
+export function isNativeNavigation(props: NavigationProps): boolean {
+  const { href, target, download } = props;
+  return Boolean(
+    (href !== undefined && isBrowserOwnedHref(href)) ||
+      (target && target !== '_self') ||
+      (download !== undefined && download !== false),
+  );
+}
+
+/**
+ * A BUI component may come from a plugin that was built and released
+ * independently from the application. We therefore cannot assume that the
+ * component and the application's BUIProvider use the same BUI version or the
+ * same installed copy of React Aria.
+ *
+ * These are two separate compatibility concerns:
+ *
+ * 1. BUIProvider version. A provider with routing support supplies the
+ *    application's React Router hooks and Link component. An older provider
+ *    does not, so the component falls back to directly imported React Router
+ *    APIs. This fallback can be removed when providers without routing support
+ *    are no longer supported.
+ *
+ * 2. React Aria package instance. React context is only visible to components
+ *    using the same React Aria copy. A plugin using another copy cannot see the
+ *    application's React Aria RouterProvider.
+ *
+ * Internal links render a React Router Link, either directly or through React
+ * Aria's render prop. In both cases, React Aria's generated props, including its
+ * click handler, are passed to that Link. React Router runs this supplied click
+ * handler before its own navigation handler.
+ *
+ * - If the component can see the application's React Aria RouterProvider,
+ *   React Aria prevents the click's default behavior and delegates navigation
+ *   through that provider. React Router sees the prevented event and does not
+ *   navigate a second time.
+ * - If the component uses a separate React Aria copy, it cannot see that
+ *   provider. React Aria leaves the event unhandled, so the rendered React
+ *   Router Link performs the navigation.
+ *
+ * Navigation options are provided to both paths so they behave consistently.
+ * React Router Link does not support `flushSync`, so when that option is
+ * enabled, BUI calls `navigate` directly if React Aria did not already handle
+ * an ordinary click. Modified clicks and other browser-owned activation still
+ * reach the rendered anchor unchanged.
+ *
+ * This dual click handling exists for compatibility with older BUI components
+ * and older BUIProvider implementations. Once supported applications and
+ * plugins are required to use both a routing-capable BUIProvider and BUI
+ * components that render React Router links, the React Aria RouterProvider and
+ * its delegated-navigation path can be removed. The rendered React Router Link
+ * can then become the only client-side navigation path for anchors.
+ *
+ * After selecting the routing integration, this hook determines who should
+ * handle the destination. React Router handles ordinary internal links. The
+ * browser handles external URLs, custom URL schemes, downloads, and links with
+ * a non-self target. Route matching is tracked separately: an internal tab can
+ * still match the current route even when its activation is browser-owned. A
+ * missing href does not navigate.
+ *
+ * @internal
+ */
+export function useAnchorNavigation(props: NavigationProps): AnchorNavigation {
+  const { href, routerOptions: navigateOptions } = props;
+  const routingIntegration = useRoutingIntegration();
+  const routing = routingIntegration ?? fallbackRoutingIntegration;
+  const navigate = routing.useNavigate();
+  // React hooks must be called in the same order on every render. Missing hrefs,
+  // external URLs, and custom URL schemes do not need route resolution, so "."
+  // is used as a harmless placeholder when calling the router hooks.
+  const routerHref =
+    href !== undefined && !isBrowserOwnedHref(href) ? href : '.';
+  const relativeOptions = { relative: navigateOptions?.relative };
+  const resolvedPath = routing.useResolvedPath(routerHref, relativeOptions);
+  const resolvedHref = routing.useHref(routerHref, relativeOptions);
+  const navigateWithOptions = useCallback(() => {
+    if (href !== undefined) {
+      navigate(href, navigateOptions);
+    }
+  }, [navigate, href, navigateOptions]);
+  const delegatedRouterOptions = useMemo(() => {
+    if (!routingIntegration || href === undefined) {
+      return undefined;
+    }
+    return routingIntegration.createRouterOptions(
+      navigateWithOptions,
+      navigateOptions,
+    );
+  }, [routingIntegration, navigateWithOptions, href, navigateOptions]);
+  let routerLinkOptions: Omit<NavigateOptions, 'flushSync'> | undefined;
+  if (navigateOptions) {
+    // React Aria accepts all NavigateOptions when it delegates through its
+    // RouterProvider. React Router Link accepts the same options except
+    // flushSync, so omit that option from the props passed to the rendered Link.
+    const { flushSync: _flushSync, ...supportedOptions } = navigateOptions;
+    routerLinkOptions = supportedOptions;
+  }
+  const navigateWithFullOptions =
+    navigateOptions?.flushSync === true ? navigateWithOptions : undefined;
+
+  if (href === undefined) {
+    return { type: 'none', canMatchRoute: false };
+  }
+  const canMatchRoute = !isBrowserOwnedHref(href);
+  if (isNativeNavigation(props)) {
+    return {
+      type: 'native',
+      canMatchRoute,
+      ariaHref: href,
+      browserHref: isBrowserOwnedHref(href) ? href : resolvedHref,
+    };
+  }
+  if (routingIntegration) {
+    return {
+      type: 'router',
+      canMatchRoute,
+      ariaHref: href,
+      to: href,
+      Link: routingIntegration.Link,
+      routerOptions: delegatedRouterOptions,
+      routerLinkOptions,
+      navigateWithFullOptions,
+    };
+  }
+  return {
+    type: 'router',
+    canMatchRoute,
+    ariaHref: createPath(resolvedPath),
+    to: href,
+    Link: fallbackRoutingIntegration.Link,
+    routerOptions: navigateOptions,
+    routerLinkOptions,
+    navigateWithFullOptions,
+  };
+}
+
+/**
+ * Completes an eligible click with the one navigation option that React Router
+ * Link cannot represent. Callers invoke this after React Aria's click handler.
+ *
+ * @internal
+ */
+export function handleRouterLinkClick(
+  event: MouseEvent<HTMLAnchorElement>,
+  navigation: AnchorNavigation,
+) {
+  const navigateWithFullOptions =
+    navigation.type === 'router'
+      ? navigation.navigateWithFullOptions
+      : undefined;
+  if (
+    !navigateWithFullOptions ||
+    event.defaultPrevented ||
+    event.button !== 0 ||
+    (event.currentTarget.target && event.currentTarget.target !== '_self') ||
+    event.metaKey ||
+    event.altKey ||
+    event.ctrlKey ||
+    event.shiftKey
+  ) {
+    return;
+  }
+
+  event.preventDefault();
+  navigateWithFullOptions();
+}
+
+/**
+ * Converts the selected navigation behavior into props understood by React
+ * Aria.
+ *
+ * Internal destinations are rendered as the selected React Router Link.
+ * `routerOptions` are used when React Aria delegates the click through its
+ * RouterProvider. The equivalent Link props are also applied to the rendered
+ * React Router Link for components that cannot see that provider.
+ *
+ * Destinations handled by the browser are rendered as plain anchors. Their
+ * final href includes any React Router basename exactly once.
+ *
+ * @internal
+ */
+export function getReactAriaAnchorProps(
+  navigation: AnchorNavigation,
+  props: {
+    href?: string;
+    routerOptions?: NavigateOptions;
+  },
+): {
+  href?: string;
+  routerOptions?: NavigateOptions;
+  render?: PolymorphicRenderFunction;
+} {
+  switch (navigation.type) {
+    case 'none':
+      return {
+        href: props.href,
+        routerOptions: props.routerOptions,
+        render: undefined,
+      };
+    case 'router':
+      return {
+        href: navigation.ariaHref,
+        routerOptions: navigation.routerOptions,
+        render: (domProps: JSX.IntrinsicElements['a']) => {
+          const {
+            href: _href,
+            onClick: reactAriaOnClick,
+            ...routerLinkProps
+          } = domProps;
+          const onClick = navigation.navigateWithFullOptions
+            ? (event: MouseEvent<HTMLAnchorElement>) => {
+                reactAriaOnClick?.(event);
+                handleRouterLinkClick(event, navigation);
+              }
+            : reactAriaOnClick;
+          return (
+            <navigation.Link
+              {...routerLinkProps}
+              {...navigation.routerLinkOptions}
+              {...(onClick ? { onClick } : {})}
+              to={navigation.to}
+            />
+          );
+        },
+      };
+    case 'native':
+      return {
+        href: navigation.ariaHref,
+        routerOptions: props.routerOptions,
+        // React Aria classifies the raw href, while the final DOM anchor needs
+        // the router-resolved href so a basename is applied exactly once.
+        render: (domProps: JSX.IntrinsicElements['a']) => (
+          <a {...domProps} href={navigation.browserHref} />
+        ),
+      };
+  }
+}

--- a/packages/ui/src/navigation/useNavigation.types.test.tsx
+++ b/packages/ui/src/navigation/useNavigation.types.test.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ButtonLink } from '../components/ButtonLink';
+import { ComboboxItem } from '../components/Combobox';
+import { Link } from '../components/Link';
+import { MenuItem, MenuListBoxItem } from '../components/Menu';
+import { SearchAutocompleteItem } from '../components/SearchAutocomplete';
+import { SelectItem } from '../components/Select';
+import { Tab } from '../components/Tabs';
+
+describe('anchor navigation types', () => {
+  it('does not allow callers to replace anchor rendering', () => {
+    const render = () => <a href="/custom">Custom</a>;
+    const invalid = (
+      <>
+        {/* @ts-expect-error BUI owns the anchor element used for navigation */}
+        <Link href="/link" render={render}>
+          Link
+        </Link>
+        {/* @ts-expect-error BUI owns the anchor element used for navigation */}
+        <ButtonLink href="/button" render={render}>
+          Button
+        </ButtonLink>
+        {/* @ts-expect-error BUI owns the anchor element used for navigation */}
+        <MenuItem href="/menu" render={render}>
+          Menu
+        </MenuItem>
+        {/* @ts-expect-error BUI owns the anchor element used for navigation */}
+        <MenuListBoxItem href="/listbox" render={render}>
+          List box
+        </MenuListBoxItem>
+        {/* @ts-expect-error BUI owns the anchor element used for navigation */}
+        <ComboboxItem href="/combobox" textValue="Combobox" render={render}>
+          Combobox
+        </ComboboxItem>
+        {/* @ts-expect-error BUI owns the anchor element used for navigation */}
+        <SelectItem href="/select" textValue="Select" render={render}>
+          Select
+        </SelectItem>
+        {/* @ts-expect-error BUI owns the anchor element used for navigation */}
+        <SearchAutocompleteItem href="/search" render={render}>
+          Search
+        </SearchAutocompleteItem>
+        {/* @ts-expect-error BUI owns the anchor element used for navigation */}
+        <Tab href="/tab" render={render}>
+          Tab
+        </Tab>
+      </>
+    );
+
+    expect(invalid).toBeDefined();
+  });
+});

--- a/packages/ui/src/navigation/useRouting.ts
+++ b/packages/ui/src/navigation/useRouting.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useVersionedContext } from '@backstage/version-bridge';
+import {
+  Link,
+  useHref,
+  useInRouterContext,
+  useLocation,
+  useNavigate,
+  useResolvedPath,
+} from 'react-router-dom';
+import type { BUIContextVersions } from '../provider/BUIContext';
+import type { BUIRoutingIntegration } from './types';
+
+/** @internal */
+export function useRoutingIntegration(): BUIRoutingIntegration | undefined;
+/** @internal */
+export function useRoutingIntegration(options: {
+  fallback: true;
+}): BUIRoutingIntegration;
+/** @internal */
+export function useRoutingIntegration(options?: {
+  fallback?: true;
+}): BUIRoutingIntegration | undefined {
+  const routing =
+    useVersionedContext<BUIContextVersions>('bui')?.atVersion(2)?.routing;
+  if (routing) {
+    return routing;
+  }
+  if (options?.fallback) {
+    return fallbackRoutingIntegration;
+  }
+  return undefined;
+}
+
+/** @internal */
+export const fallbackRoutingIntegration: BUIRoutingIntegration = {
+  Link,
+  useHref,
+  useInRouterContext,
+  useLocation,
+  useNavigate,
+  useResolvedPath,
+  createRouterOptions(_action, options) {
+    return { ...options };
+  },
+};

--- a/packages/ui/src/provider/BUIContext.ts
+++ b/packages/ui/src/provider/BUIContext.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createVersionedContext } from '@backstage/version-bridge';
+import type { UseAnalyticsFn } from '../analytics/types';
+import type { BUIRoutingIntegration } from '../navigation/types';
+
+/** @internal */
+export type BUIContextValueV1 = {
+  useAnalytics?: UseAnalyticsFn;
+};
+
+/** @internal */
+export type BUIContextValueV2 = {
+  useAnalytics?: UseAnalyticsFn;
+  routing: BUIRoutingIntegration;
+};
+
+/** @internal */
+export type BUIContextVersions = {
+  1: BUIContextValueV1;
+  2: BUIContextValueV2;
+};
+
+/** @internal */
+export const BUIContext = createVersionedContext<BUIContextVersions>('bui');

--- a/packages/ui/src/provider/BUIProvider.test.tsx
+++ b/packages/ui/src/provider/BUIProvider.test.tsx
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, renderHook, screen } from '@testing-library/react';
+import {
+  createVersionedContext,
+  createVersionedValueMap,
+  useVersionedContext,
+} from '@backstage/version-bridge';
+import { Link as ReactAriaLink } from 'react-aria-components';
+import { MemoryRouter } from 'react-router-dom';
+import { useMemo, type ComponentProps, type PropsWithChildren } from 'react';
+import { useAnalytics } from '../analytics/useAnalytics';
+import { fallbackRoutingIntegration } from '../navigation/useRouting';
+import {
+  BUIContext,
+  type BUIContextVersions,
+  type BUIContextValueV1,
+} from './BUIContext';
+import { BUIProvider } from './BUIProvider';
+
+const mockFallbackNavigate = jest.fn();
+const BUIContextV1 = createVersionedContext<{ 1: BUIContextValueV1 }>('bui');
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockFallbackNavigate,
+}));
+
+describe('BUIProvider', () => {
+  beforeEach(() => {
+    mockFallbackNavigate.mockReset();
+  });
+
+  it('provides stable, self-contained context versions', () => {
+    const captureEvent = jest.fn();
+    const useProvidedAnalytics = () => ({ captureEvent });
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <BUIProvider useAnalytics={useProvidedAnalytics}>{children}</BUIProvider>
+    );
+    const { result, rerender } = renderHook(
+      () => ({
+        context: useVersionedContext<BUIContextVersions>('bui'),
+        analytics: useAnalytics(),
+      }),
+      { wrapper },
+    );
+
+    const firstRouting = result.current.context?.atVersion(2)?.routing;
+    const firstCreateRouterOptions = firstRouting?.createRouterOptions;
+
+    expect(result.current.context?.atVersion(1)).toEqual({
+      useAnalytics: useProvidedAnalytics,
+    });
+    expect(result.current.context?.atVersion(2)).toEqual({
+      useAnalytics: useProvidedAnalytics,
+      routing: firstRouting,
+    });
+    result.current.analytics.captureEvent('click', 'Destination');
+    expect(captureEvent).toHaveBeenCalledWith('click', 'Destination');
+
+    const routerOptions = firstRouting?.createRouterOptions(jest.fn(), {
+      replace: true,
+    });
+    const anotherRouterOptions = firstRouting?.createRouterOptions(jest.fn(), {
+      replace: true,
+    });
+
+    expect(Object.keys(routerOptions ?? {})).toEqual(['replace']);
+    expect(routerOptions).toEqual({ replace: true });
+    expect(anotherRouterOptions).not.toBe(routerOptions);
+
+    rerender();
+
+    expect(result.current.context?.atVersion(2)?.routing).toBe(firstRouting);
+    expect(
+      result.current.context?.atVersion(2)?.routing.createRouterOptions,
+    ).toBe(firstCreateRouterOptions);
+  });
+
+  it('prefers V2 analytics when both context versions are available', () => {
+    const captureV1Event = jest.fn();
+    const captureV2Event = jest.fn();
+    const value = createVersionedValueMap({
+      1: { useAnalytics: () => ({ captureEvent: captureV1Event }) },
+      2: {
+        useAnalytics: () => ({ captureEvent: captureV2Event }),
+        routing: fallbackRoutingIntegration,
+      },
+    });
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <BUIContext.Provider value={value}>{children}</BUIContext.Provider>
+    );
+    const { result } = renderHook(() => useAnalytics(), { wrapper });
+
+    result.current.captureEvent('click', 'Destination');
+
+    expect(captureV2Event).toHaveBeenCalledWith('click', 'Destination');
+    expect(captureV1Event).not.toHaveBeenCalled();
+  });
+
+  it('accepts analytics from a V1-only provider', () => {
+    const captureV1Event = jest.fn();
+    const value = createVersionedValueMap({
+      1: { useAnalytics: () => ({ captureEvent: captureV1Event }) },
+    });
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <BUIContextV1.Provider value={value}>{children}</BUIContextV1.Provider>
+    );
+    const { result } = renderHook(() => useAnalytics(), { wrapper });
+
+    result.current.captureEvent('click', 'Legacy destination');
+    expect(captureV1Event).toHaveBeenCalledWith('click', 'Legacy destination');
+  });
+
+  it('delegates React Aria navigation created by the component', () => {
+    const componentNavigate = jest.fn();
+
+    render(
+      <MemoryRouter
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <BUIProvider>
+          <DelegatedLink onNavigate={componentNavigate} />
+        </BUIProvider>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'Destination' }));
+
+    expect(componentNavigate).toHaveBeenCalledTimes(1);
+    expect(mockFallbackNavigate).not.toHaveBeenCalled();
+  });
+
+  it('uses fallback navigation for unrecognized React Aria router options', () => {
+    const linkProps: ComponentProps<typeof ReactAriaLink> = {
+      href: '/destination',
+      routerOptions: { replace: true },
+    };
+
+    render(
+      <MemoryRouter
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <BUIProvider>
+          <ReactAriaLink {...linkProps}>Destination</ReactAriaLink>
+        </BUIProvider>
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByRole('link', { name: 'Destination' }));
+
+    expect(mockFallbackNavigate).toHaveBeenCalledWith('/destination', {
+      replace: true,
+    });
+  });
+});
+
+function DelegatedLink(props: { onNavigate: () => void }) {
+  const routing =
+    useVersionedContext<BUIContextVersions>('bui')?.atVersion(2)?.routing;
+  const routerOptions = useMemo(() => {
+    if (!routing) {
+      throw new Error('Expected BUI routing integration');
+    }
+    return routing.createRouterOptions(props.onNavigate, { replace: true });
+  }, [props.onNavigate, routing]);
+
+  return (
+    <ReactAriaLink href="/destination" routerOptions={routerOptions}>
+      Destination
+    </ReactAriaLink>
+  );
+}

--- a/packages/ui/src/provider/BUIProvider.tsx
+++ b/packages/ui/src/provider/BUIProvider.tsx
@@ -15,12 +15,13 @@
  */
 
 import { useMemo, type ReactNode } from 'react';
-import { RouterProvider } from 'react-aria-components';
-import { useInRouterContext, useNavigate } from 'react-router-dom';
 import { createVersionedValueMap } from '@backstage/version-bridge';
-import { BUIContext } from '../analytics/useAnalytics';
-import { useResolvedHref } from '../hooks/useResolvedHref';
+import { BUIContext } from './BUIContext';
 import type { UseAnalyticsFn } from '../analytics/types';
+import {
+  BUIRoutingProvider,
+  buiRoutingIntegration,
+} from '../navigation/BUIRoutingProvider';
 
 /** @public */
 export type BUIProviderProps = {
@@ -30,6 +31,15 @@ export type BUIProviderProps = {
 
 /**
  * Provides integration capabilities to all descendant BUI components.
+ *
+ * When rendered inside the Backstage app router, BUI components use
+ * client-side navigation for internal links. Relative destinations resolve
+ * from the route of the component that renders the link, and the router
+ * basename applies once.
+ *
+ * External and scheme links, downloads, and links with non-self targets use the
+ * browser's native navigation. BUI components rendered outside React Router use
+ * native links without throwing.
  *
  * @example
  * ```tsx
@@ -53,6 +63,7 @@ export function BUIProvider(props: BUIProviderProps) {
     () =>
       createVersionedValueMap({
         1: { useAnalytics },
+        2: { useAnalytics, routing: buiRoutingIntegration },
       }),
     [useAnalytics],
   );
@@ -60,19 +71,5 @@ export function BUIProvider(props: BUIProviderProps) {
   const content = (
     <BUIContext.Provider value={value}>{children}</BUIContext.Provider>
   );
-
-  if (useInRouterContext()) {
-    return <RoutedContent>{content}</RoutedContent>;
-  }
-
-  return content;
-}
-
-function RoutedContent({ children }: { children: ReactNode }) {
-  const navigate = useNavigate();
-  return (
-    <RouterProvider navigate={navigate} useHref={useResolvedHref}>
-      {children}
-    </RouterProvider>
-  );
+  return <BUIRoutingProvider>{content}</BUIRoutingProvider>;
 }

--- a/packages/ui/src/utils/linkUtils.ts
+++ b/packages/ui/src/utils/linkUtils.ts
@@ -14,6 +14,13 @@
  * limitations under the License.
  */
 
+const ABSOLUTE_DESTINATION = /^(?:[a-z][a-z0-9+.-]*:|\/\/)/i;
+
+/** @internal */
+export function isBrowserOwnedHref(href: string): boolean {
+  return ABSOLUTE_DESTINATION.test(href);
+}
+
 /**
  * Determines if a link is external.
  * @param href - The href of the link.
@@ -21,24 +28,7 @@
  * @internal
  */
 export function isExternalLink(href?: string): boolean {
-  if (!href) return false;
-
-  // Check if it's an absolute URL with protocol
-  if (href.startsWith('http://') || href.startsWith('https://')) {
-    return true;
-  }
-
-  // Check if it's a protocol-relative URL
-  if (href.startsWith('//')) {
-    return true;
-  }
-
-  // Check if it's a mailto: or tel: link
-  if (href.startsWith('mailto:') || href.startsWith('tel:')) {
-    return true;
-  }
-
-  return false;
+  return href ? isBrowserOwnedHref(href) : false;
 }
 
 /**


### PR DESCRIPTION
## Hey, I just made a Pull Request!

### Context

Backstage applications can load BUI components from plugins that were built independently from the application. React Router is shared with the host, but BUI and React Aria may be separate module instances.

Previously, navigation depended primarily on the React Aria `RouterProvider` mounted by `BUIProvider`. A component using another React Aria instance cannot see that context, so an internal link may fall back to browser navigation and cause a full-page reload. BUI also pre-resolved every `href` in `useDefinition`, which mixed routing behavior into the general component-definition system and made relative-path and basename ownership difficult to reason about.

### Implementation

- `BUIProvider` now publishes the host application's React Router integration through the versioned BUI context. New BUI components use the host's router hooks and `Link`, while retaining a fallback for applications using an older `BUIProvider`.
- Anchor-capable component definitions explicitly opt into shared navigation handling. Ordinary internal links render the host's React Router `Link` using the original destination, allowing React Router to resolve relative paths and apply its basename.
- External URLs, custom schemes, downloads, and links with non-self targets remain browser-owned.
- `List`, `TagGroup`, and `TableRoot` provide routing through their own React Aria module instance. This lets React Aria retain the original activation event and preserve modifier-key activation, targets, downloads, and synthetic-link metadata.
- `useDefinition` no longer rewrites `href` values. Components receive the caller's original props, with navigation behavior added only when enabled by their compile-time component definition.
- Existing React Aria provider integration remains available for older BUI components. Already-published components using an isolated React Aria instance cannot be retrofitted and retain their existing behavior.

### Public API change

**BREAKING:** BUI now owns the rendered anchor or router link. The React Aria `render` prop has therefore been removed from `ButtonLink`, `ComboboxItem`, `Link`, `MenuItem`, `MenuListBoxItem`, `SearchAutocompleteItem`, `SelectItem`, and `Tab`.

Consumers should remove custom `render` props from these components.

### Review guide

The implementation can be reviewed in four layers:

1. `BUIProvider`, the versioned BUI context, and the routing integration establish the application-owned router contract.
2. The navigation and definition helpers classify destinations and inject routing only for definitions that opt in.
3. `Link` and the other anchor-capable components adopt the shared anchor path, while collection roots provide React Aria routing locally.
4. Component tests cover adoption and regressions across relative destinations, basenames, browser-owned links, navigation options, disabled states, selection, analytics, and independently loaded React Aria instances.

The test suite includes compatibility coverage for new and old `BUIProvider` implementations, shared and separate React Aria instances, and rendering outside React Router. The example application and representative Storybook link, tab, menu, tag, and table-row stories were also checked manually.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (not applicable; this does not introduce visual changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
