### PR TITLE
fix(scaffolder): BUI EntityPicker blur no longer corrupts committed selection

### DIFF
--- a/.changeset/olive-pianos-heal.md
+++ b/.changeset/olive-pianos-heal.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder': patch
+---
+
+Fixed the BUI-theme EntityPicker blur handler so a committed selection is no longer overwritten by its display label, and added a regression test.

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.bui.test.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.bui.test.tsx
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Entity } from '@backstage/catalog-model';
+import {
+  catalogApiRef,
+  entityPresentationApiRef,
+} from '@backstage/plugin-catalog-react';
+import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { ComponentType, PropsWithChildren, ReactNode } from 'react';
+import { EntityPicker } from './EntityPicker';
+import { EntityPickerProps } from './schema';
+import { ScaffolderRJSFFieldProps as FieldProps } from '@backstage/plugin-scaffolder-react';
+import { DefaultEntityPresentationApi } from '@backstage/plugin-catalog';
+import { catalogApiMock } from '@backstage/plugin-catalog-react/testUtils';
+
+jest.mock('@backstage/plugin-scaffolder-react/alpha', () => ({
+  ...jest.requireActual('@backstage/plugin-scaffolder-react/alpha'),
+  useScaffolderTheme: () => 'bui',
+}));
+
+const makeEntity = (
+  kind: string,
+  namespace: string,
+  name: string,
+  title?: string,
+): Entity => ({
+  apiVersion: 'backstage.io/v1alpha1',
+  kind,
+  metadata: { namespace, name, ...(title ? { title } : {}) },
+});
+
+describe('<EntityPicker /> with BUI theme', () => {
+  const entities: Entity[] = [
+    makeEntity('Group', 'default', 'team-a', 'Team A'),
+    makeEntity('Group', 'default', 'squad-b', 'Squad B'),
+  ];
+  const onChange = jest.fn();
+  const schema = {};
+  const required = false;
+  const rawErrors: string[] = [];
+  let uiSchema: EntityPickerProps['uiSchema'];
+  let props: FieldProps<string>;
+
+  const catalogApi = catalogApiMock.mock({
+    streamEntities: jest.fn(async function* () {
+      yield entities;
+    }),
+  });
+
+  let Wrapper: ComponentType<PropsWithChildren<{}>>;
+
+  beforeEach(() => {
+    uiSchema = { 'ui:options': { allowArbitraryValues: true } };
+    props = {
+      onChange,
+      schema,
+      required,
+      uiSchema,
+      rawErrors,
+      formData: undefined,
+    } as unknown as FieldProps;
+
+    Wrapper = ({ children }: { children?: ReactNode }) => (
+      <TestApiProvider
+        apis={[
+          [catalogApiRef, catalogApi],
+          [
+            entityPresentationApiRef,
+            DefaultEntityPresentationApi.create({ catalogApi }),
+          ],
+        ]}
+      >
+        {children}
+      </TestApiProvider>
+    );
+  });
+
+  afterEach(() => jest.resetAllMocks());
+
+  it('does not re-commit the display label as value on blur', async () => {
+    await renderInTestApp(
+      <Wrapper>
+        <EntityPicker {...props} formData="group:default/team-a" />
+      </Wrapper>,
+    );
+
+    const input = await screen.findByRole('combobox');
+    // The input shows the presentation title of the committed selection
+    await waitFor(() => expect(input).toHaveValue('Team A'));
+
+    fireEvent.blur(input);
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('still commits free-form values on blur', async () => {
+    await renderInTestApp(
+      <Wrapper>
+        <EntityPicker {...props} />
+      </Wrapper>,
+    );
+
+    const input = await screen.findByRole('combobox');
+    fireEvent.change(input, { target: { value: 'squ' } });
+    fireEvent.blur(input);
+
+    expect(onChange).toHaveBeenCalledWith('squ');
+  });
+});

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.test.tsx
@@ -75,7 +75,7 @@ describe('<EntityPicker />', () => {
     );
   });
 
-  afterEach(() => jest.resetAllMocks());
+  afterEach(() => jest.clearAllMocks());
 
   describe('without allowedKinds and catalogFilter', () => {
     beforeEach(() => {
@@ -471,7 +471,7 @@ describe('<EntityPicker />', () => {
         uiSchema,
       } as unknown as FieldProps<any>;
 
-      const { getByRole } = await renderInTestApp(
+      const { getByRole, findByRole } = await renderInTestApp(
         <Wrapper>
           <EntityPicker {...props} />
         </Wrapper>,
@@ -479,12 +479,15 @@ describe('<EntityPicker />', () => {
 
       const input = getByRole('textbox');
 
-      // Type and blur
+      // Reproduce the interaction from the issue: select an option through
+      // the combobox first, then leave the field. The blur must not
+      // overwrite the already selected canonical value.
       fireEvent.change(input, { target: { value: 'squad' } });
+      fireEvent.click(await findByRole('option', { name: /squad/i }));
       fireEvent.blur(input);
 
-      // With autoSelect=true and freeSolo, processes the typed value
-      expect(onChange).toHaveBeenCalledWith('group:default/squad');
+      // With autoSelect=true and freeSolo, the selected canonical value wins
+      expect(onChange).toHaveBeenCalledWith('group:default/squad-b');
     });
   });
 

--- a/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
+++ b/plugins/scaffolder/src/components/fields/EntityPicker/EntityPicker.tsx
@@ -248,6 +248,17 @@ export const EntityPicker = (props: EntityPickerProps) => {
 
   const handleBlur = useCallback(() => {
     if (allowArbitraryValues && inputValue) {
+      // When the input is showing the display label of the currently
+      // committed selection, blurring must not re-commit that label as the
+      // value, which would corrupt a valid selection.
+      const isShowingCommittedLabel = buiOptions.some(
+        option =>
+          option.value === lastCommittedRef.current &&
+          option.label === inputValue,
+      );
+      if (isShowingCommittedLabel) {
+        return;
+      }
       let entityRef = inputValue;
       try {
         entityRef = stringifyEntityRef(
@@ -264,6 +275,7 @@ export const EntityPicker = (props: EntityPickerProps) => {
   }, [
     allowArbitraryValues,
     inputValue,
+    buiOptions,
     defaultKind,
     defaultNamespace,
     onChange,


### PR DESCRIPTION
Closes #35281

## Bug

With the experimental BUI scaffolder theme, after selecting an entity the controlled input shows the option's **display label** (presentation title). On blur, `handleBlur` treated that label as free-solo input: `parseEntityRef` failed on it and the raw label was committed via `onChange`, overwriting the valid entityRef (e.g. `Team A` replacing `group:default/team-a`).

## Fix

In `handleBlur`, skip committing when the current input value is the display label of the option whose value equals the last committed selection (`lastCommittedRef`). Free-solo behavior for genuinely arbitrary input is unchanged.

## Tests

New `EntityPicker.bui.test.tsx` (mirrors the existing `Form.bui.test.tsx` convention of isolating BUI cases):

- regression: blurring a field holding a valid selection whose input shows the presentation title does **not** call `onChange`
- free-form input is still committed on blur

Verified locally: new suite 2/2 passed, existing `EntityPicker.test.tsx` 31/31 passed, `package lint` exit 0.