### PR TITLE
plugin(kubernetes): Replace deprecated createPermissionIntegrationRouter API call with permissionsRegistry

### DIFF
--- a/.changeset/fair-phones-change.md
+++ b/.changeset/fair-phones-change.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-kubernetes-backend': patch
+---
+
+Replace deprecated `createPermissionIntegrationRouter` API call with `permissionsRegistry`

--- a/plugins/kubernetes-backend/package.json
+++ b/plugins/kubernetes-backend/package.json
@@ -56,7 +56,6 @@
     "@backstage/plugin-kubernetes-common": "workspace:^",
     "@backstage/plugin-kubernetes-node": "workspace:^",
     "@backstage/plugin-permission-common": "workspace:^",
-    "@backstage/plugin-permission-node": "workspace:^",
     "@backstage/types": "workspace:^",
     "@google-cloud/container": "^5.0.0",
     "@jest-mock/express": "^2.0.1",

--- a/plugins/kubernetes-backend/src/plugin.ts
+++ b/plugins/kubernetes-backend/src/plugin.ts
@@ -44,6 +44,7 @@ import {
   type KubernetesServiceLocatorExtensionPoint,
   KubernetesServiceLocatorFactory,
 } from '@backstage/plugin-kubernetes-node';
+import { kubernetesPermissions } from '@backstage/plugin-kubernetes-common';
 import { KubernetesRouter } from './service/KubernetesRouter';
 import { KubernetesInitializer } from './service/KubernetesInitializer';
 
@@ -222,6 +223,7 @@ export const kubernetesPlugin = createBackendPlugin({
         discovery: coreServices.discovery,
         catalog: catalogServiceRef,
         permissions: coreServices.permissions,
+        permissionsRegistry: coreServices.permissionsRegistry,
         auth: coreServices.auth,
         httpAuth: coreServices.httpAuth,
         auditor: coreServices.auditor,
@@ -233,10 +235,13 @@ export const kubernetesPlugin = createBackendPlugin({
         discovery,
         catalog,
         permissions,
+        permissionsRegistry,
         auth,
         httpAuth,
         auditor,
       }) {
+        permissionsRegistry.addPermissions(kubernetesPermissions);
+
         // TODO: this could do with a cleanup and push some of this initialization somewhere else
         if (config.has('kubernetes')) {
           const initializer = KubernetesInitializer.create({

--- a/plugins/kubernetes-backend/src/service/KubernetesRouter.ts
+++ b/plugins/kubernetes-backend/src/service/KubernetesRouter.ts
@@ -18,11 +18,9 @@ import {
   ANNOTATION_KUBERNETES_AUTH_PROVIDER,
   ANNOTATION_KUBERNETES_OIDC_TOKEN_PROVIDER,
   kubernetesClustersReadPermission,
-  kubernetesPermissions,
   kubernetesResourcesReadPermission,
 } from '@backstage/plugin-kubernetes-common';
 import { PermissionEvaluator } from '@backstage/plugin-permission-common';
-import { createPermissionIntegrationRouter } from '@backstage/plugin-permission-node';
 import express from 'express';
 import Router from 'express-promise-router';
 
@@ -177,11 +175,6 @@ export class KubernetesRouter {
     const router = Router();
     router.use('/proxy', proxy.createRequestHandler({ permissionApi }));
     router.use(express.json());
-    router.use(
-      createPermissionIntegrationRouter({
-        permissions: kubernetesPermissions,
-      }),
-    );
 
     // @deprecated
     router.post('/services/:serviceId', async (req, res) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5652,7 +5652,6 @@ __metadata:
     "@backstage/plugin-permission-backend": "workspace:^"
     "@backstage/plugin-permission-backend-module-allow-all-policy": "workspace:^"
     "@backstage/plugin-permission-common": "workspace:^"
-    "@backstage/plugin-permission-node": "workspace:^"
     "@backstage/types": "workspace:^"
     "@google-cloud/container": "npm:^5.0.0"
     "@jest-mock/express": "npm:^2.0.1"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR replaces the deprecated createPermissionIntegrationRouter with permissionsRegistry by following https://backstage.io/docs/backend-system/core-services/permissions-registry/#migrating-from-createpermissionintegrationrouter

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))