### PR TITLE
techdocs: fix styles due to orphaned css declarations

### DIFF
--- a/.changeset/techdocs-reader-stray-css-declarations.md
+++ b/.changeset/techdocs-reader-stray-css-declarations.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs': patch
+---
+
+Fixed the TechDocs reader so that documentation text uses the font from the Backstage theme, and keyboard key highlights pick up their accent color again.

--- a/.changeset/techdocs-reader-stray-css-declarations.md
+++ b/.changeset/techdocs-reader-stray-css-declarations.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-techdocs': patch
 ---
 
-Fixed the TechDocs reader so that documentation text uses the font from the Backstage theme, and keyboard key highlights pick up their accent color again.
+Fixed the TechDocs reader so that documentation text uses the theme font, keyboard key highlights get their accent color, and reader surfaces match the app background.

--- a/plugins/techdocs/package.json
+++ b/plugins/techdocs/package.json
@@ -102,6 +102,7 @@
     "@testing-library/user-event": "^14.0.0",
     "@types/dompurify": "^3.0.0",
     "@types/react": "^18.0.0",
+    "postcss": "^8.1.0",
     "react": "^18.0.2",
     "react-dom": "^18.0.2",
     "react-router-dom": "^6.30.2"

--- a/plugins/techdocs/src/reader/transformers/styles/rules/variables.ts
+++ b/plugins/techdocs/src/reader/transformers/styles/rules/variables.ts
@@ -161,7 +161,7 @@ export default ({ theme }: RuleOptions) => `
       : alpha(theme.palette.warning.light, 0.5)
   };
   --md-typeset-kbd-color: var(--md-code-bg-color);
-  --md-typeset-kbd-accent-color var(--md-code-bg-color);
+  --md-typeset-kbd-accent-color: var(--md-code-bg-color);
   --md-typeset-kbd-border-color: var(--md-default-fg-color--light);
 }
 
@@ -178,7 +178,4 @@ export default ({ theme }: RuleOptions) => `
     --md-typeset-font-size: .7rem;
   }
 }
-
-  --md-footer-bg-color: var(--md-default-bg-color);
-  --md-footer-bg-color--dark: var(--md-default-bg-color);
 `;

--- a/plugins/techdocs/src/reader/transformers/styles/rules/variables.ts
+++ b/plugins/techdocs/src/reader/transformers/styles/rules/variables.ts
@@ -32,7 +32,7 @@ export default ({ theme }: RuleOptions) => `
   --md-default-fg-color--lightest: ${alpha(theme.palette.text.secondary, 0.15)};
 
   /* BACKGROUND */
-  --md-default-bg-color:${theme.palette.background.default};
+  --md-default-bg-color: var(--bui-bg-app, ${theme.palette.background.default});
   --md-default-bg-color--light: ${theme.palette.background.paper};
   --md-default-bg-color--lighter: ${lighten(
     theme.palette.background.paper,

--- a/plugins/techdocs/src/reader/transformers/styles/transformer.test.tsx
+++ b/plugins/techdocs/src/reader/transformers/styles/transformer.test.tsx
@@ -18,6 +18,7 @@ import { renderHook } from '@testing-library/react';
 import { useStylesTransformer } from './transformer';
 import { createTheme, ThemeProvider } from '@material-ui/core/styles';
 import { ReactNode } from 'react';
+import postcss from 'postcss';
 
 describe('Transformers > Styles', () => {
   it('should return a function that injects all styles into a given dom element', () => {
@@ -50,6 +51,24 @@ describe('Transformers > Styles', () => {
     expect(style).toHaveTextContent(
       '/*================== Palette ==================*/',
     );
+  });
+
+  it('should not emit CSS a parser would silently drop', () => {
+    const { result } = renderHook(() => useStylesTransformer());
+    const dom = document.createElement('html');
+    dom.innerHTML = '<head></head>';
+    result.current(dom);
+
+    const style = dom.querySelector('head > style');
+    const stray = postcss
+      .parse(style!.textContent!)
+      .nodes.filter(node => node.type === 'decl')
+      .map(
+        node =>
+          `${node.prop} at line ${node.source?.start?.line} of the generated stylesheet`,
+      );
+
+    expect(stray).toEqual([]);
   });
 
   it('should use headers relative font-size value as the factor for the md-typeset variable', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7224,6 +7224,7 @@ __metadata:
     dompurify: "npm:^3.4.12"
     git-url-parse: "npm:^15.0.0"
     lodash: "npm:^4.17.21"
+    postcss: "npm:^8.1.0"
     react: "npm:^18.0.2"
     react-dom: "npm:^18.0.2"
     react-helmet: "npm:6.1.0"


### PR DESCRIPTION
## Hey, I just made a Pull Request!

While there's ongoing conversation about the future of TechDocs, a few fixes for the present of TechDocs.

- Theme font was ignored, due to 2 orphaned footer variables (outside of a rule, invalid CSS) introduced in #24809. Reported in #31450
  - Rules that followed the orphaned variables were ignored
  - Added a regression test to avoid future orphaned variables
- Keyboard key highlight was missing a colon, and was also invalid CSS
- Fixed background color slightly off in light theme (similar to #15420, although probably not the same cause)


Before (open full-res to notice the slightly different background colors):
<img width="3200" height="1800" alt="before-legacy-standalone-light" src="https://github.com/user-attachments/assets/08a9de9d-25e1-42f3-acb5-b332306d18ae" />
<img width="3200" height="1800" alt="before-nfs-entity-light" src="https://github.com/user-attachments/assets/feb8f866-bffc-48ac-8797-414739a722ff" />


After:
<img width="3200" height="1800" alt="after-legacy-standalone-light" src="https://github.com/user-attachments/assets/f22897c9-afc0-42ad-83ca-58709a53d04b" />
<img width="3200" height="1800" alt="after-nfs-entity-light" src="https://github.com/user-attachments/assets/1dec2f0d-f94f-41fa-970a-8b2be4f764e3" />


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] Verified across browsers, in light & dark themes, NFS & legacy, techdocs entity tab & standalone reader
- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
