### PR TITLE
plugin(catalog-backend-module-ldap): improve org ingest performance

### DIFF
--- a/.changeset/public-experts-go.md
+++ b/.changeset/public-experts-go.md
@@ -1,0 +1,7 @@
+---
+'@backstage/plugin-catalog-backend-module-ldap': minor
+---
+
+The LDAP org provider now parallelizes user and group reads, requests a minimal default LDAP attribute set instead of `['*', '+']` (including common identity and membership fields for OpenLDAP-compatible directories, Active Directory, and FreeIPA), and reduces memory and CPU overhead during relation resolution, hierarchy building, and entity commit. LDAP connections are closed after each refresh.
+
+If your custom transformers rely on LDAP attributes outside the default set, override the default attributes by setting `options.attributes` (or use `['*', '+']` to request everything).

--- a/docs/integrations/ldap/org.md
+++ b/docs/integrations/ldap/org.md
@@ -156,7 +156,20 @@ options:
   # to filter out disabled users.
   filter: (uid=*)
   # The attribute selectors for each item, as passed to the LDAP server.
-  attributes: ['*', '+']
+  # By default only attributes needed for entity mapping are requested. Custom
+  # `map.*` overrides are included automatically. Set `attributes: ['*', '+']`
+  # to load all attributes if your transformers need additional LDAP fields.
+  attributes:
+    - dn
+    - entryDN
+    - distinguishedName
+    - entryUUID
+    - objectGUID
+    - ipaUniqueID
+    - uid
+    - cn
+    - mail
+    - memberOf
   # This field is either 'false' to disable paging when reading from the
   # server, or an object on the form '{ pageSize: 100, pagePause: true }' that
   # specifies the details of how the paging shall work.
@@ -238,7 +251,21 @@ options:
   # to filter out disabled groups.
   filter: (&(objectClass=some-group-class)(!(groupType=email)))
   # The attribute selectors for each item, as passed to the LDAP server.
-  attributes: ['*', '+']
+  # By default only attributes needed for entity mapping are requested. Custom
+  # `map.*` overrides are included automatically. Set `attributes: ['*', '+']`
+  # to load all attributes if your transformers need additional LDAP fields.
+  attributes:
+    - dn
+    - entryDN
+    - distinguishedName
+    - entryUUID
+    - objectGUID
+    - ipaUniqueID
+    - cn
+    - description
+    - groupType
+    - memberOf
+    - member
   # This field is either 'false' to disable paging when reading from the
   # server, or an object on the form '{ pageSize: 100, pagePause: true }' that
   # specifies the details of how the paging shall work.

--- a/plugins/catalog-backend-module-ldap/report.api.md
+++ b/plugins/catalog-backend-module-ldap/report.api.md
@@ -96,6 +96,7 @@ export class LdapClient {
   getRootDSE(): Promise<Entry | undefined>;
   getVendor(): Promise<LdapVendor>;
   search(dn: string, options: SearchOptions): Promise<SearchResult>;
+  unbind(): Promise<void>;
 }
 
 // @public
@@ -220,6 +221,7 @@ export function readLdapOrg(
   groupConfig: GroupConfig[],
   vendorConfig: VendorConfig | undefined,
   options: {
+    groupClient?: LdapClient;
     groupTransformer?: GroupTransformer;
     userTransformer?: UserTransformer;
     logger: LoggerService;

--- a/plugins/catalog-backend-module-ldap/src/ldap/client.ts
+++ b/plugins/catalog-backend-module-ldap/src/ldap/client.ts
@@ -221,4 +221,11 @@ export class LdapClient {
     }
     return undefined;
   }
+
+  /**
+   * Closes the underlying LDAP connection.
+   */
+  async unbind(): Promise<void> {
+    await this.client.unbind();
+  }
 }

--- a/plugins/catalog-backend-module-ldap/src/ldap/config.test.ts
+++ b/plugins/catalog-backend-module-ldap/src/ldap/config.test.ts
@@ -47,7 +47,18 @@ describe('readLdapConfig', () => {
             dn: 'udn',
             options: {
               scope: 'one',
-              attributes: ['*', '+'],
+              attributes: [
+                'dn',
+                'entryDN',
+                'distinguishedName',
+                'entryUUID',
+                'objectGUID',
+                'ipaUniqueID',
+                'uid',
+                'cn',
+                'mail',
+                'memberOf',
+              ],
             },
             set: undefined,
             map: {
@@ -64,7 +75,19 @@ describe('readLdapConfig', () => {
             dn: 'gdn',
             options: {
               scope: 'one',
-              attributes: ['*', '+'],
+              attributes: [
+                'dn',
+                'entryDN',
+                'distinguishedName',
+                'entryUUID',
+                'objectGUID',
+                'ipaUniqueID',
+                'cn',
+                'description',
+                'groupType',
+                'memberOf',
+                'member',
+              ],
             },
             set: undefined,
             map: {
@@ -120,7 +143,18 @@ describe('readLdapConfig', () => {
             dn: 'udn',
             options: {
               scope: 'one',
-              attributes: ['*', '+'],
+              attributes: [
+                'dn',
+                'entryDN',
+                'distinguishedName',
+                'entryUUID',
+                'objectGUID',
+                'ipaUniqueID',
+                'uid',
+                'cn',
+                'mail',
+                'memberOf',
+              ],
             },
             set: undefined,
             map: {
@@ -137,7 +171,19 @@ describe('readLdapConfig', () => {
             dn: 'gdn',
             options: {
               scope: 'one',
-              attributes: ['*', '+'],
+              attributes: [
+                'dn',
+                'entryDN',
+                'distinguishedName',
+                'entryUUID',
+                'objectGUID',
+                'ipaUniqueID',
+                'cn',
+                'description',
+                'groupType',
+                'memberOf',
+                'member',
+              ],
             },
             set: undefined,
             map: {
@@ -241,7 +287,7 @@ describe('readLdapConfig', () => {
             dn: 'udn',
             options: {
               scope: 'base',
-              attributes: ['*'],
+              attributes: ['*', 'u', 'v', 'c', 'm', 'd', 'p'],
               filter: 'f',
               paged: true,
               timeLimit: 42,
@@ -266,7 +312,7 @@ describe('readLdapConfig', () => {
             dn: 'gdn',
             options: {
               scope: 'base',
-              attributes: ['*'],
+              attributes: ['*', 'u', 'v', 'd', 'c', 't', 'm', 'n', 'p'],
               filter: 'f',
               paged: {
                 pageSize: 7,
@@ -475,5 +521,88 @@ describe('readLdapConfig', () => {
 
     expect(actual[0].users).toHaveLength(0);
     expect(actual[0].groups).toHaveLength(0);
+  });
+
+  it('merges vendor and map attributes into effective search attributes', () => {
+    const config = {
+      catalog: {
+        providers: {
+          ldapOrg: {
+            default: {
+              target: 'target',
+              vendor: {
+                dnAttributeName: 'customDN',
+                uuidAttributeName: 'entryuuid',
+              },
+              users: {
+                dn: 'udn',
+                map: {
+                  picture: 'thumbnailPhoto',
+                },
+              },
+              groups: {
+                dn: 'gdn',
+                map: {
+                  type: 'tt',
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const actual = readProviderConfigs(new ConfigReader(config));
+
+    expect(actual[0].users[0].options.attributes).toEqual(
+      expect.arrayContaining(['customDN', 'entryuuid', 'thumbnailPhoto']),
+    );
+    expect(actual[0].groups[0].options.attributes).toEqual(
+      expect.arrayContaining(['customDN', 'entryuuid', 'tt', 'member']),
+    );
+  });
+
+  it('does not re-add member when an explicit attributes list omits it', () => {
+    const config = {
+      catalog: {
+        providers: {
+          ldapOrg: {
+            default: {
+              target: 'target',
+              users: {
+                dn: 'udn',
+                options: {
+                  attributes: [
+                    'uid',
+                    'cn',
+                    'mail',
+                    'memberOf',
+                    'entryDN',
+                    'entryUUID',
+                  ],
+                },
+              },
+              groups: {
+                dn: 'gdn',
+                options: {
+                  attributes: [
+                    'cn',
+                    'description',
+                    'groupType',
+                    'entryDN',
+                    'entryUUID',
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const actual = readProviderConfigs(new ConfigReader(config));
+
+    expect(actual[0].groups[0].options.attributes).not.toEqual(
+      expect.arrayContaining(['member']),
+    );
+    expect(actual[0].groups[0].map.members).toBe('member');
   });
 });

--- a/plugins/catalog-backend-module-ldap/src/ldap/config.ts
+++ b/plugins/catalog-backend-module-ldap/src/ldap/config.ts
@@ -22,6 +22,7 @@ import { Config } from '@backstage/config';
 import { JsonValue } from '@backstage/types';
 import { SearchOptions } from 'ldapts';
 import mergeWith from 'lodash/mergeWith';
+import cloneDeep from 'lodash/cloneDeep';
 import { trimEnd } from 'lodash';
 import { RecursivePartial } from './util';
 
@@ -88,7 +89,7 @@ export type UserConfig = {
   dn: string;
   // The search options to use.
   // Only the scope, filter, attributes, and paged fields are supported. The
-  // default is scope "one" and attributes "*" and "+".
+  // default is scope "one" and a minimal attribute set for mapped fields.
   options: SearchOptions;
 
   // JSON paths (on a.b.c form) and hard coded values to set on those paths
@@ -185,10 +186,37 @@ export type VendorConfig = {
   uuidAttributeName?: string;
 };
 
-const defaultUserConfig = {
+const DEFAULT_USER_SEARCH_ATTRIBUTES = [
+  'dn',
+  'entryDN',
+  'distinguishedName',
+  'entryUUID',
+  'objectGUID',
+  'ipaUniqueID',
+  'uid',
+  'cn',
+  'mail',
+  'memberOf',
+];
+
+const DEFAULT_GROUP_SEARCH_ATTRIBUTES = [
+  'dn',
+  'entryDN',
+  'distinguishedName',
+  'entryUUID',
+  'objectGUID',
+  'ipaUniqueID',
+  'cn',
+  'description',
+  'groupType',
+  'memberOf',
+];
+// `member` is added via map.members when that mapping is enabled (default).
+
+const defaultUserConfig: RecursivePartial<UserConfig> = {
   options: {
     scope: 'one',
-    attributes: ['*', '+'],
+    attributes: DEFAULT_USER_SEARCH_ATTRIBUTES,
   },
   map: {
     rdn: 'uid',
@@ -199,10 +227,10 @@ const defaultUserConfig = {
   },
 };
 
-const defaultGroupConfig = {
+const defaultGroupConfig: RecursivePartial<GroupConfig> = {
   options: {
     scope: 'one',
-    attributes: ['*', '+'],
+    attributes: DEFAULT_GROUP_SEARCH_ATTRIBUTES,
   },
   map: {
     rdn: 'cn',
@@ -214,6 +242,129 @@ const defaultGroupConfig = {
     members: 'member',
   },
 };
+
+function replaceArraysIfPresent(_into: any, from: any) {
+  // Replace arrays instead of merging, otherwise default behavior
+  return Array.isArray(from) ? from : undefined;
+}
+
+function membershipAttributeNames(
+  map: UserConfig['map'] | GroupConfig['map'],
+): Set<string> {
+  const names = new Set<string>();
+  if (typeof map.memberOf === 'string' && map.memberOf.length > 0) {
+    names.add(map.memberOf);
+  }
+  if (
+    'members' in map &&
+    typeof map.members === 'string' &&
+    map.members.length > 0
+  ) {
+    names.add(map.members);
+  }
+  return names;
+}
+
+/**
+ * Builds the LDAP attribute list for a search.
+ *
+ * Mapped fields and vendor DN/UUID names are merged in automatically so custom
+ * `map.*` overrides keep working. When the caller supplies an explicit
+ * attributes list (without `*`/`+`), membership attributes that were left out
+ * of that list are not re-added.
+ */
+function withEffectiveSearchAttributes<T extends UserConfig | GroupConfig>(
+  config: T,
+  vendor: VendorConfig | undefined,
+  baseAttributes: string[],
+  explicitAttributes?: string[],
+): T {
+  const startingAttributes = explicitAttributes ?? baseAttributes;
+  const hasWildcard =
+    startingAttributes.includes('*') || startingAttributes.includes('+');
+  const membershipAttrs = membershipAttributeNames(config.map);
+
+  const mappedAttributes = Object.values(config.map).filter(
+    (value): value is string => {
+      if (typeof value !== 'string' || value.length === 0) {
+        return false;
+      }
+      // Do not re-add membership attrs the caller left out of an explicit list.
+      if (
+        explicitAttributes &&
+        !hasWildcard &&
+        membershipAttrs.has(value) &&
+        !explicitAttributes.includes(value)
+      ) {
+        return false;
+      }
+      return true;
+    },
+  );
+
+  const attributes = [
+    ...new Set(
+      [
+        ...(config.options.attributes ?? baseAttributes),
+        ...mappedAttributes,
+        vendor?.dnAttributeName,
+        vendor?.uuidAttributeName,
+      ].filter((value): value is string => Boolean(value)),
+    ),
+  ];
+
+  return {
+    ...config,
+    options: {
+      ...config.options,
+      attributes,
+    },
+  };
+}
+
+function mergeWithEffectiveUserSearchAttributes(
+  defaults: RecursivePartial<UserConfig>,
+  config: RecursivePartial<UserConfig> | undefined,
+  vendor: VendorConfig | undefined,
+): UserConfig {
+  const explicitAttributes = Array.isArray(config?.options?.attributes)
+    ? config.options.attributes
+    : undefined;
+  const merged = mergeWith(
+    {},
+    defaults,
+    config,
+    replaceArraysIfPresent,
+  ) as UserConfig;
+  return withEffectiveSearchAttributes(
+    merged,
+    vendor,
+    DEFAULT_USER_SEARCH_ATTRIBUTES,
+    explicitAttributes,
+  );
+}
+
+function mergeWithEffectiveGroupSearchAttributes(
+  defaults: RecursivePartial<GroupConfig>,
+  config: RecursivePartial<GroupConfig> | undefined,
+  vendor: VendorConfig | undefined,
+): GroupConfig {
+  const explicitAttributes = Array.isArray(config?.options?.attributes)
+    ? config.options.attributes
+    : undefined;
+  const merged = mergeWith(
+    {},
+    defaults,
+    config,
+    replaceArraysIfPresent,
+  ) as GroupConfig;
+  return withEffectiveSearchAttributes(
+    merged,
+    vendor,
+    DEFAULT_GROUP_SEARCH_ATTRIBUTES,
+    explicitAttributes,
+  );
+}
 
 function freeze<T>(data: T): T {
   return JSON.parse(JSON.stringify(data), (_key, value) => {
@@ -306,7 +457,7 @@ function readSetConfig(
   if (!c) {
     return undefined;
   }
-  return c.get();
+  return cloneDeep(c.get());
 }
 
 function readUserMapConfig(c: Config | undefined): Partial<UserConfig['map']> {
@@ -403,17 +554,18 @@ function formatFilter(filter?: string): string | undefined {
 export function readLdapLegacyConfig(config: Config): LdapProviderConfig[] {
   const providerConfigs = config.getOptionalConfigArray('providers') ?? [];
   return providerConfigs.map(c => {
+    const vendor = readVendorConfig(c.getOptionalConfig('vendor'));
     const newConfig = {
       target: trimEnd(c.getString('target'), '/'),
       tls: readTlsConfig(c.getOptionalConfig('tls')),
       bind: readBindConfig(c.getOptionalConfig('bind')),
-      users: readUserConfig(c.getConfig('users')).map(it => {
-        return mergeWith({}, defaultUserConfig, it, replaceArraysIfPresent);
-      }),
-      groups: readGroupConfig(c.getConfig('groups')).map(it => {
-        return mergeWith({}, defaultGroupConfig, it, replaceArraysIfPresent);
-      }),
-      vendor: readVendorConfig(c.getOptionalConfig('vendor')),
+      users: readUserConfig(c.getConfig('users')).map(it =>
+        mergeWithEffectiveUserSearchAttributes(defaultUserConfig, it, vendor),
+      ),
+      groups: readGroupConfig(c.getConfig('groups')).map(it =>
+        mergeWithEffectiveGroupSearchAttributes(defaultGroupConfig, it, vendor),
+      ),
+      vendor,
     };
 
     return freeze(newConfig) as LdapProviderConfig;
@@ -444,6 +596,7 @@ export function readProviderConfigs(config: Config): LdapProviderConfig[] {
     const isUserList = Array.isArray(c.getOptional('users'));
     const isGroupList = Array.isArray(c.getOptional('groups'));
 
+    const vendor = readVendorConfig(c.getOptionalConfig('vendor'));
     const newConfig = {
       id,
       target: trimEnd(c.getString('target'), '/'),
@@ -453,25 +606,20 @@ export function readProviderConfigs(config: Config): LdapProviderConfig[] {
         isUserList
           ? c.getOptionalConfigArray('users')
           : c.getOptionalConfig('users'),
-      ).map(it => {
-        return mergeWith({}, defaultUserConfig, it, replaceArraysIfPresent);
-      }),
+      ).map(it =>
+        mergeWithEffectiveUserSearchAttributes(defaultUserConfig, it, vendor),
+      ),
       groups: readGroupConfig(
         isGroupList
           ? c.getOptionalConfigArray('groups')
           : c.getOptionalConfig('groups'),
-      ).map(it => {
-        return mergeWith({}, defaultGroupConfig, it, replaceArraysIfPresent);
-      }),
+      ).map(it =>
+        mergeWithEffectiveGroupSearchAttributes(defaultGroupConfig, it, vendor),
+      ),
       schedule,
-      vendor: readVendorConfig(c.getOptionalConfig('vendor')),
+      vendor,
     };
 
     return freeze(newConfig) as LdapProviderConfig;
   });
-}
-
-function replaceArraysIfPresent(_into: any, from: any) {
-  // Replace arrays instead of merging, otherwise default behavior
-  return Array.isArray(from) ? from : undefined;
 }

--- a/plugins/catalog-backend-module-ldap/src/ldap/org.ts
+++ b/plugins/catalog-backend-module-ldap/src/ldap/org.ts
@@ -25,6 +25,7 @@ import {
 
 export function buildOrgHierarchy(groups: GroupEntity[]) {
   const groupsByRef = new Map(groups.map(g => [stringifyEntityRef(g), g]));
+  const childrenByParentRef = new Map<string, Set<string>>();
 
   //
   // Make sure that g.parent.children contain g
@@ -35,8 +36,16 @@ export function buildOrgHierarchy(groups: GroupEntity[]) {
     const parentRef = group.spec.parent;
     if (parentRef) {
       const parent = groupsByRef.get(parentRef);
-      if (parent && !parent.spec.children.includes(selfRef)) {
-        parent.spec.children.push(selfRef);
+      if (parent) {
+        let childrenSet = childrenByParentRef.get(parentRef);
+        if (!childrenSet) {
+          childrenSet = new Set(parent.spec.children);
+          childrenByParentRef.set(parentRef, childrenSet);
+        }
+        if (!childrenSet.has(selfRef)) {
+          childrenSet.add(selfRef);
+          parent.spec.children.push(selfRef);
+        }
       }
     }
   }

--- a/plugins/catalog-backend-module-ldap/src/ldap/read.test.ts
+++ b/plugins/catalog-backend-module-ldap/src/ldap/read.test.ts
@@ -15,7 +15,8 @@
  */
 
 import { GroupEntity, UserEntity } from '@backstage/catalog-model';
-import { Entry } from 'ldapts';
+import { createDeferred } from '@backstage/types';
+import { Entry, SearchResult } from 'ldapts';
 import merge from 'lodash/merge';
 import { LdapClient } from './client';
 import { GroupConfig, UserConfig, VendorConfig } from './config';
@@ -28,6 +29,7 @@ import {
   defaultGroupTransformer,
   defaultUserTransformer,
   readLdapGroups,
+  readLdapOrg,
   readLdapUsers,
   resolveRelations,
 } from './read';
@@ -1542,5 +1544,172 @@ describe('defaultGroupTransformerWithCaseSensitiveDNs', () => {
         profile: { displayName: 'cn-value', email: 'mail-value' },
       },
     });
+  });
+});
+
+describe('readLdapOrg', () => {
+  type EntryOverrides = Record<string, string | string[] | Buffer | Buffer[]>;
+  const userClient: jest.Mocked<LdapClient> = {
+    search: jest.fn(),
+    getVendor: jest.fn(),
+  } as any;
+  const groupClient: jest.Mocked<LdapClient> = {
+    search: jest.fn(),
+    getVendor: jest.fn(),
+  } as any;
+  const logger = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    child: jest.fn(),
+  } as any;
+
+  const searchResult = (entries: Entry[]): SearchResult => ({
+    searchEntries: entries,
+    searchReferences: [],
+  });
+
+  const userEntry = (overrides: EntryOverrides = {}): Entry => ({
+    dn: 'user-dn',
+    uid: 'user',
+    cn: 'User',
+    mail: 'user@example.com',
+    entryDN: 'user-dn',
+    entryUUID: 'user-uuid',
+    ...overrides,
+  });
+
+  const groupEntry = (overrides: EntryOverrides = {}): Entry => ({
+    dn: 'group-dn',
+    cn: 'group',
+    description: 'Group',
+    groupType: 'team',
+    entryDN: 'group-dn',
+    entryUUID: 'group-uuid',
+    ...overrides,
+  });
+
+  const userConfig = (
+    overrides: {
+      dn?: string;
+      options?: UserConfig['options'];
+      map?: Partial<UserConfig['map']>;
+    } = {},
+  ): UserConfig => ({
+    dn: overrides.dn ?? 'ou=users',
+    options: overrides.options ?? {
+      attributes: ['uid', 'cn', 'mail', 'entryDN', 'entryUUID'],
+    },
+    map: {
+      rdn: 'uid',
+      name: 'uid',
+      displayName: 'cn',
+      email: 'mail',
+      memberOf: null,
+      ...overrides.map,
+    },
+  });
+
+  const groupConfig = (
+    overrides: {
+      dn?: string;
+      options?: GroupConfig['options'];
+      map?: Partial<GroupConfig['map']>;
+    } = {},
+  ): GroupConfig => ({
+    dn: overrides.dn ?? 'ou=groups',
+    options: overrides.options ?? {
+      attributes: ['cn', 'description', 'groupType', 'entryDN', 'entryUUID'],
+    },
+    map: {
+      rdn: 'cn',
+      name: 'cn',
+      description: 'description',
+      displayName: 'cn',
+      type: 'groupType',
+      memberOf: null,
+      members: null,
+      ...overrides.map,
+    },
+  });
+
+  afterEach(() => jest.resetAllMocks());
+
+  beforeEach(() => {
+    userClient.getVendor.mockResolvedValue(DefaultLdapVendor);
+    groupClient.getVendor.mockResolvedValue(DefaultLdapVendor);
+  });
+
+  it('reads users and groups in parallel using separate clients', async () => {
+    const userSearch = createDeferred<SearchResult>();
+    userClient.search.mockReturnValue(userSearch);
+    groupClient.search.mockResolvedValue(searchResult([groupEntry()]));
+
+    const readPromise = readLdapOrg(
+      userClient,
+      [userConfig()],
+      [groupConfig()],
+      undefined,
+      {
+        groupClient,
+        logger,
+      },
+    );
+
+    await Promise.resolve();
+
+    expect(groupClient.search).toHaveBeenCalledWith(
+      'ou=groups',
+      expect.any(Object),
+    );
+
+    userSearch.resolve(searchResult([userEntry()]));
+    await readPromise;
+
+    expect(userClient.search).toHaveBeenCalledWith(
+      'ou=users',
+      expect.any(Object),
+    );
+  });
+
+  it('reads users and groups sequentially when sharing one client', async () => {
+    const sharedClient: jest.Mocked<LdapClient> = {
+      search: jest.fn(),
+      getVendor: jest.fn(),
+    } as any;
+    const userSearch = createDeferred<SearchResult>();
+    sharedClient.getVendor.mockResolvedValue(DefaultLdapVendor);
+    sharedClient.search
+      .mockReturnValueOnce(userSearch)
+      .mockResolvedValueOnce(searchResult([groupEntry()]));
+
+    const readPromise = readLdapOrg(
+      sharedClient,
+      [userConfig()],
+      [groupConfig()],
+      undefined,
+      {
+        logger,
+      },
+    );
+
+    await Promise.resolve();
+
+    expect(sharedClient.search).toHaveBeenCalledTimes(1);
+    expect(sharedClient.search).toHaveBeenCalledWith(
+      'ou=users',
+      expect.any(Object),
+    );
+
+    userSearch.resolve(searchResult([userEntry()]));
+    await readPromise;
+
+    expect(sharedClient.search).toHaveBeenCalledTimes(2);
+    expect(sharedClient.search).toHaveBeenNthCalledWith(
+      2,
+      'ou=groups',
+      expect.any(Object),
+    );
   });
 });

--- a/plugins/catalog-backend-module-ldap/src/ldap/read.ts
+++ b/plugins/catalog-backend-module-ldap/src/ldap/read.ts
@@ -30,11 +30,25 @@ import {
   LDAP_RDN_ANNOTATION,
   LDAP_UUID_ANNOTATION,
 } from './constants';
+import { JsonValue } from '@backstage/types';
 import { LdapVendor } from './vendors';
 import { GroupTransformer, UserTransformer } from './types';
 import { mapStringAttr } from './util';
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { InputError } from '@backstage/errors';
+
+function applyConfigSet(
+  entity: object,
+  set: { [path: string]: JsonValue } | undefined,
+) {
+  if (!set) {
+    return;
+  }
+  const snapshot = cloneDeep(set);
+  for (const [path, value] of Object.entries(snapshot)) {
+    lodashSet(entity, path, value);
+  }
+}
 
 /**
  * The default implementation of the transformation from an LDAP entry to a
@@ -62,11 +76,7 @@ export async function defaultUserTransformer(
     },
   };
 
-  if (set) {
-    for (const [path, value] of Object.entries(set)) {
-      lodashSet(entity, path, cloneDeep(value));
-    }
-  }
+  applyConfigSet(entity, set);
 
   mapStringAttr(entry, vendor, map.name, v => {
     entity.metadata.name = v;
@@ -181,11 +191,7 @@ export async function defaultGroupTransformer(
     },
   };
 
-  if (set) {
-    for (const [path, value] of Object.entries(set)) {
-      lodashSet(entity, path, cloneDeep(value));
-    }
-  }
+  applyConfigSet(entity, set);
 
   mapStringAttr(entry, vendor, map.name, v => {
     entity.metadata.name = v;
@@ -307,6 +313,7 @@ export async function readLdapOrg(
   groupConfig: GroupConfig[],
   vendorConfig: VendorConfig | undefined,
   options: {
+    groupClient?: LdapClient;
     groupTransformer?: GroupTransformer;
     userTransformer?: UserTransformer;
     logger: LoggerService;
@@ -318,20 +325,28 @@ export async function readLdapOrg(
   // Invokes the above "raw" read functions and stitches together the results
   // with all relations etc filled in.
 
-  const { users, userMemberOf } = await readLdapUsers(
-    client,
-    userConfig,
-    vendorConfig,
-    {
-      transformer: options?.userTransformer,
-    },
-  );
-  const { groups, groupMemberOf, groupMember } = await readLdapGroups(
-    client,
-    groupConfig,
-    vendorConfig,
-    { transformer: options?.groupTransformer },
-  );
+  const groupClient = options.groupClient ?? client;
+  const [usersResult, groupsResult] =
+    groupClient === client
+      ? [
+          await readLdapUsers(client, userConfig, vendorConfig, {
+            transformer: options?.userTransformer,
+          }),
+          await readLdapGroups(groupClient, groupConfig, vendorConfig, {
+            transformer: options?.groupTransformer,
+          }),
+        ]
+      : await Promise.all([
+          readLdapUsers(client, userConfig, vendorConfig, {
+            transformer: options?.userTransformer,
+          }),
+          readLdapGroups(groupClient, groupConfig, vendorConfig, {
+            transformer: options?.groupTransformer,
+          }),
+        ]);
+
+  const { users, userMemberOf } = usersResult;
+  const { groups, groupMemberOf, groupMember } = groupsResult;
 
   resolveRelations(groups, users, userMemberOf, groupMemberOf, groupMember);
   users.sort((a, b) => a.metadata.name.localeCompare(b.metadata.name));
@@ -380,18 +395,36 @@ function ensureItems(
   }
 }
 
-/**
- * Helper function which dual searches the user/group maps first for original value, then for lowercased value.
- * @param map - The map of DN's user or group as the key usually multicased.
- * @param searchValue - The DN/memberOf search criteria which could potentially not match the map DN by case.
- * @returns The value/result of the search criteria dual searching.
- */
-function getValueFromMapWithInsensitiveKey(
-  map: Map<string, any>,
-  searchValue: string,
+function normalizeMapKey(key: string | undefined): string | undefined {
+  return key ? key.toLocaleLowerCase('en-US') : undefined;
+}
+
+function indexEntityInMap<T>(
+  map: Map<string, T>,
+  entity: T,
+  keys: {
+    entityRef: string;
+    dn?: string;
+    rdn?: string;
+    uuid?: string;
+  },
 ) {
-  const result = map.get(searchValue);
-  return result ? result : map.get(searchValue.toLocaleLowerCase('en-US'));
+  map.set(keys.entityRef, entity);
+  const dnKey = normalizeMapKey(keys.dn);
+  if (dnKey) {
+    map.set(dnKey, entity);
+  }
+  if (keys.rdn) {
+    map.set(keys.rdn, entity);
+  }
+  if (keys.uuid) {
+    map.set(keys.uuid, entity);
+  }
+}
+
+function getValueFromMap<T>(map: Map<string, T>, searchValue: string) {
+  const normalized = normalizeMapKey(searchValue);
+  return (normalized ? map.get(normalized) : undefined) ?? map.get(searchValue);
 }
 
 /**
@@ -421,36 +454,31 @@ export function resolveRelations(
   // the supported forms.
   const userMap: Map<string, UserEntity> = new Map(); // by entityRef, dn, uuid
   const groupMap: Map<string, GroupEntity> = new Map(); // by entityRef, dn, uuid
+  // Cache entity refs once — stringifyEntityRef lowercases three fields per call
+  // and is otherwise repeated on every membership edge.
+  const userRefs = new Map<UserEntity, string>();
+  const groupRefs = new Map<GroupEntity, string>();
+
   for (const user of users) {
-    userMap.set(stringifyEntityRef(user), user);
-    userMap.set(user.metadata.annotations![LDAP_DN_ANNOTATION], user);
-    userMap.set(
-      user.metadata.annotations![LDAP_DN_ANNOTATION]?.toLocaleLowerCase(
-        'en-US',
-      ),
-      user,
-    );
-    userMap.set(user.metadata.annotations![LDAP_RDN_ANNOTATION], user);
-    userMap.set(user.metadata.annotations![LDAP_UUID_ANNOTATION], user);
+    const entityRef = stringifyEntityRef(user);
+    userRefs.set(user, entityRef);
+    indexEntityInMap(userMap, user, {
+      entityRef,
+      dn: user.metadata.annotations![LDAP_DN_ANNOTATION],
+      rdn: user.metadata.annotations![LDAP_RDN_ANNOTATION],
+      uuid: user.metadata.annotations![LDAP_UUID_ANNOTATION],
+    });
   }
   for (const group of groups) {
-    groupMap.set(stringifyEntityRef(group), group);
-    groupMap.set(group.metadata.annotations![LDAP_DN_ANNOTATION], group);
-    groupMap.set(
-      group.metadata.annotations![LDAP_DN_ANNOTATION]?.toLocaleLowerCase(
-        'en-US',
-      ),
-      group,
-    );
-    groupMap.set(group.metadata.annotations![LDAP_RDN_ANNOTATION], group);
-    groupMap.set(group.metadata.annotations![LDAP_UUID_ANNOTATION], group);
+    const entityRef = stringifyEntityRef(group);
+    groupRefs.set(group, entityRef);
+    indexEntityInMap(groupMap, group, {
+      entityRef,
+      dn: group.metadata.annotations![LDAP_DN_ANNOTATION],
+      rdn: group.metadata.annotations![LDAP_RDN_ANNOTATION],
+      uuid: group.metadata.annotations![LDAP_UUID_ANNOTATION],
+    });
   }
-
-  // This can happen e.g. if entryUUID wasn't returned by the server
-  userMap.delete('');
-  groupMap.delete('');
-  userMap.delete(undefined!);
-  groupMap.delete(undefined!);
 
   // Fill in all of the immediate relations, now keyed on the entity reference. We
   // keep all parents at this point, whether the target model can support more
@@ -466,60 +494,47 @@ export function resolveRelations(
   // express relations in different directions. Some may have a user memberOf
   // overlay, some don't, for example.
   for (const [userN, groupsN] of userMemberOf.entries()) {
-    const user = getValueFromMapWithInsensitiveKey(userMap, userN);
+    const user = getValueFromMap(userMap, userN);
     if (user) {
+      const userRef = userRefs.get(user)!;
       for (const groupN of groupsN) {
-        const group = getValueFromMapWithInsensitiveKey(groupMap, groupN);
+        const group = getValueFromMap(groupMap, groupN);
         if (group) {
-          ensureItems(newUserMemberOf, stringifyEntityRef(user), [
-            stringifyEntityRef(group),
-          ]);
+          ensureItems(newUserMemberOf, userRef, [groupRefs.get(group)!]);
         }
       }
     }
   }
   for (const [groupN, parentsN] of groupMemberOf.entries()) {
-    const group = getValueFromMapWithInsensitiveKey(groupMap, groupN);
+    const group = getValueFromMap(groupMap, groupN);
     if (group) {
+      const groupRef = groupRefs.get(group)!;
       for (const parentN of parentsN) {
-        const parentGroup = getValueFromMapWithInsensitiveKey(
-          groupMap,
-          parentN,
-        );
+        const parentGroup = getValueFromMap(groupMap, parentN);
         if (parentGroup) {
-          ensureItems(newGroupParents, stringifyEntityRef(group), [
-            stringifyEntityRef(parentGroup),
-          ]);
-          ensureItems(newGroupChildren, stringifyEntityRef(parentGroup), [
-            stringifyEntityRef(group),
-          ]);
+          const parentRef = groupRefs.get(parentGroup)!;
+          ensureItems(newGroupParents, groupRef, [parentRef]);
+          ensureItems(newGroupChildren, parentRef, [groupRef]);
         }
       }
     }
   }
   for (const [groupN, membersN] of groupMember.entries()) {
-    const group = getValueFromMapWithInsensitiveKey(groupMap, groupN);
+    const group = getValueFromMap(groupMap, groupN);
     if (group) {
+      const groupRef = groupRefs.get(group)!;
       for (const memberN of membersN) {
         // Group members can be both users and groups in the input model, so
         // try both
-        const memberUser = getValueFromMapWithInsensitiveKey(userMap, memberN);
+        const memberUser = getValueFromMap(userMap, memberN);
         if (memberUser) {
-          ensureItems(newUserMemberOf, stringifyEntityRef(memberUser), [
-            stringifyEntityRef(group),
-          ]);
+          ensureItems(newUserMemberOf, userRefs.get(memberUser)!, [groupRef]);
         } else {
-          const memberGroup = getValueFromMapWithInsensitiveKey(
-            groupMap,
-            memberN,
-          );
+          const memberGroup = getValueFromMap(groupMap, memberN);
           if (memberGroup) {
-            ensureItems(newGroupChildren, stringifyEntityRef(group), [
-              stringifyEntityRef(memberGroup),
-            ]);
-            ensureItems(newGroupParents, stringifyEntityRef(memberGroup), [
-              stringifyEntityRef(group),
-            ]);
+            const memberRef = groupRefs.get(memberGroup)!;
+            ensureItems(newGroupChildren, groupRef, [memberRef]);
+            ensureItems(newGroupParents, memberRef, [groupRef]);
           }
         }
       }
@@ -528,21 +543,21 @@ export function resolveRelations(
 
   // Write down the relations again into the actual entities
   for (const [userN, groupsN] of newUserMemberOf.entries()) {
-    const user = getValueFromMapWithInsensitiveKey(userMap, userN);
+    const user = getValueFromMap(userMap, userN);
     if (user) {
       user.spec.memberOf = Array.from(groupsN).sort();
     }
   }
   for (const [groupN, parentsN] of newGroupParents.entries()) {
     if (parentsN.size === 1) {
-      const group = getValueFromMapWithInsensitiveKey(groupMap, groupN);
+      const group = getValueFromMap(groupMap, groupN);
       if (group) {
         group.spec.parent = parentsN.values().next().value;
       }
     }
   }
   for (const [groupN, childrenN] of newGroupChildren.entries()) {
-    const group = getValueFromMapWithInsensitiveKey(groupMap, groupN);
+    const group = getValueFromMap(groupMap, groupN);
     if (group) {
       group.spec.children = Array.from(childrenN).sort();
     }

--- a/plugins/catalog-backend-module-ldap/src/processors/LdapOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-ldap/src/processors/LdapOrgEntityProvider.ts
@@ -24,7 +24,6 @@ import {
   EntityProvider,
   EntityProviderConnection,
 } from '@backstage/plugin-catalog-node';
-import { merge } from 'lodash';
 import { randomUUID } from 'node:crypto';
 import {
   GroupTransformer,
@@ -282,37 +281,41 @@ export class LdapOrgEntityProvider implements EntityProvider {
 
     // Be lazy and create the client each time; even though it's pretty
     // inefficient, we usually only do this once per entire refresh loop and
-    // don't have to worry about timeouts and reconnects etc.
-    const client = await LdapClient.create(
+    // don't have to worry about timeouts and reconnects etc. Two clients so
+    // user and group searches can run in parallel (ldapts is not safe to share).
+    const [userClient, groupClient] = await createClientPair(
       this.options.logger,
-      this.options.provider.target,
-      this.options.provider.bind,
-      this.options.provider.tls,
+      this.options.provider,
     );
 
-    const { users, groups } = await readLdapOrg(
-      client,
-      this.options.provider.users,
-      this.options.provider.groups,
-      this.options.provider.vendor,
-      {
-        groupTransformer: this.options.groupTransformer,
-        userTransformer: this.options.userTransformer,
-        logger,
-      },
-    );
+    try {
+      const { users, groups } = await readLdapOrg(
+        userClient,
+        this.options.provider.users,
+        this.options.provider.groups,
+        this.options.provider.vendor,
+        {
+          groupClient,
+          groupTransformer: this.options.groupTransformer,
+          userTransformer: this.options.userTransformer,
+          logger,
+        },
+      );
 
-    const { markCommitComplete } = markReadComplete({ users, groups });
+      const { markCommitComplete } = markReadComplete({ users, groups });
 
-    await this.connection.applyMutation({
-      type: 'full',
-      entities: [...users, ...groups].map(entity => ({
-        locationKey: `ldap-org-provider:${this.options.id}`,
-        entity: withLocations(this.options.id, entity),
-      })),
-    });
+      await this.connection.applyMutation({
+        type: 'full',
+        entities: [...users, ...groups].map(entity => ({
+          locationKey: `ldap-org-provider:${this.options.id}`,
+          entity: withLocations(this.options.id, entity),
+        })),
+      });
 
-    markCommitComplete();
+      markCommitComplete();
+    } finally {
+      await Promise.allSettled([userClient.unbind(), groupClient.unbind()]);
+    }
   }
 
   private schedule(taskRunner: SchedulerServiceTaskRunner) {
@@ -339,6 +342,38 @@ export class LdapOrgEntityProvider implements EntityProvider {
       });
     };
   }
+}
+
+async function createClientPair(
+  logger: LoggerService,
+  provider: LdapProviderConfig,
+): Promise<[LdapClient, LdapClient]> {
+  const results = await Promise.allSettled([
+    LdapClient.create(logger, provider.target, provider.bind, provider.tls),
+    LdapClient.create(logger, provider.target, provider.bind, provider.tls),
+  ]);
+  const [userClient, groupClient] = results;
+
+  if (userClient.status === 'rejected' || groupClient.status === 'rejected') {
+    await Promise.allSettled(
+      results
+        .filter(
+          (result): result is PromiseFulfilledResult<LdapClient> =>
+            result.status === 'fulfilled',
+        )
+        .map(result => result.value.unbind()),
+    );
+
+    if (userClient.status === 'rejected') {
+      throw userClient.reason;
+    }
+    if (groupClient.status === 'rejected') {
+      throw groupClient.reason;
+    }
+    throw new Error('Failed to create LDAP client pair');
+  }
+
+  return [userClient.value, groupClient.value];
 }
 
 // Helps wrap the timing and logging behaviors
@@ -369,15 +404,15 @@ function withLocations(providerId: string, entity: Entity): Entity {
   const dn =
     entity.metadata.annotations?.[LDAP_DN_ANNOTATION] || entity.metadata.name;
   const location = `ldap://${providerId}/${encodeURIComponent(dn)}`;
-  return merge(
-    {
-      metadata: {
-        annotations: {
-          [ANNOTATION_LOCATION]: location,
-          [ANNOTATION_ORIGIN_LOCATION]: location,
-        },
+  return {
+    ...entity,
+    metadata: {
+      ...entity.metadata,
+      annotations: {
+        ...entity.metadata.annotations,
+        [ANNOTATION_LOCATION]: location,
+        [ANNOTATION_ORIGIN_LOCATION]: location,
       },
     },
-    entity,
-  ) as Entity;
+  };
 }

--- a/plugins/catalog-backend-module-ldap/src/processors/LdapOrgReaderProcessor.ts
+++ b/plugins/catalog-backend-module-ldap/src/processors/LdapOrgReaderProcessor.ts
@@ -105,29 +105,33 @@ export class LdapOrgReaderProcessor implements CatalogProcessor {
       provider.bind,
       provider.tls,
     );
-    const { users, groups } = await readLdapOrg(
-      client,
-      provider.users,
-      provider.groups,
-      provider.vendor,
-      {
-        groupTransformer: this.groupTransformer,
-        userTransformer: this.userTransformer,
-        logger: this.logger,
-      },
-    );
+    try {
+      const { users, groups } = await readLdapOrg(
+        client,
+        provider.users,
+        provider.groups,
+        provider.vendor,
+        {
+          groupTransformer: this.groupTransformer,
+          userTransformer: this.userTransformer,
+          logger: this.logger,
+        },
+      );
 
-    const duration = ((Date.now() - startTimestamp) / 1000).toFixed(1);
-    this.logger.debug(
-      `Read ${users.length} LDAP users and ${groups.length} LDAP groups in ${duration} seconds`,
-    );
+      const duration = ((Date.now() - startTimestamp) / 1000).toFixed(1);
+      this.logger.debug(
+        `Read ${users.length} LDAP users and ${groups.length} LDAP groups in ${duration} seconds`,
+      );
 
-    // Done!
-    for (const group of groups) {
-      emit(processingResult.entity(location, group));
-    }
-    for (const user of users) {
-      emit(processingResult.entity(location, user));
+      // Done!
+      for (const group of groups) {
+        emit(processingResult.entity(location, group));
+      }
+      for (const user of users) {
+        emit(processingResult.entity(location, user));
+      }
+    } finally {
+      await client.unbind();
     }
 
     return true;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Speeds up LDAP org provider ingestion for large directories while preserving group membership across OpenLDAP-compatible directories, Active Directory, and FreeIPA.

## Summary
- Read users and groups in parallel with separate LDAP clients, then close both connections after each refresh.
- Replace default `['*', '+']` searches with lean user and group attribute sets. Effective search attributes still merge vendor DN/UUID fields and custom `map.*` fields, and they respect explicit membership attribute omissions. Default attribute lists include the common identity and membership fields needed for the [supported vendors](https://backstage.io/docs/integrations/ldap/org/#supported-vendors) (OpenLDAP-compatible directories, Active Directory, and FreeIPA)
- Reduce CPU and memory overhead in relation resolution and org hierarchy building. Cache entity refs, index lookup keys once, and deduplicate children with a map-backed set.
- Make config and entity handling safer. Deep-clone configured `set` values, reuse that logic in both default transformers, and replace `lodash.merge` in location annotation handling with object spread.

One thing to note is that custom transformers that rely on LDAP attributes outside the new default sets would need to set `options.attributes` explicitly.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
