### PR TITLE
fix(auth): preserve Auth0 callback error descriptions

### DIFF
--- a/.changeset/calm-auth0-errors.md
+++ b/.changeset/calm-auth0-errors.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-auth-backend-module-auth0-provider': patch
+---
+
+Preserved Auth0 callback error descriptions so failed sign-ins report the provider-specific reason instead of an empty authentication rejection.

--- a/plugins/auth-backend-module-auth0-provider/src/strategy.test.ts
+++ b/plugins/auth-backend-module-auth0-provider/src/strategy.test.ts
@@ -16,17 +16,8 @@
 
 import { Auth0Strategy } from './strategy';
 import { InputError } from '@backstage/errors';
+import { PassportOAuthAuthenticatorHelper } from '@backstage/plugin-auth-node';
 import express from 'express';
-
-jest.mock('passport-auth0', () => {
-  class MockAuth0Strategy {
-    authenticate() {}
-    authorizationParams() {
-      return {};
-    }
-  }
-  return { __esModule: true, default: MockAuth0Strategy };
-});
 
 describe('Auth0Strategy', () => {
   const defaultOptions = {
@@ -47,17 +38,25 @@ describe('Auth0Strategy', () => {
 
   const noopVerify = () => {};
 
-  function createRequest(query: Record<string, string> = {}): express.Request {
+  function createRequest(
+    query: express.Request['query'] = {},
+  ): express.Request {
     return { query } as unknown as express.Request;
   }
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
 
   describe('authenticate', () => {
     it('forwards organization and invitation from req.query', () => {
       const strategy = new Auth0Strategy(defaultOptions, noopVerify);
-      const superAuth = jest.spyOn(
-        Object.getPrototypeOf(Object.getPrototypeOf(strategy)),
-        'authenticate',
-      );
+      const superAuth = jest
+        .spyOn(
+          Object.getPrototypeOf(Object.getPrototypeOf(strategy)),
+          'authenticate',
+        )
+        .mockImplementation(() => {});
 
       const req = createRequest({
         organization: 'org_abc',
@@ -75,10 +74,12 @@ describe('Auth0Strategy', () => {
 
     it('forwards screen_hint and login_hint from req.query', () => {
       const strategy = new Auth0Strategy(defaultOptions, noopVerify);
-      const superAuth = jest.spyOn(
-        Object.getPrototypeOf(Object.getPrototypeOf(strategy)),
-        'authenticate',
-      );
+      const superAuth = jest
+        .spyOn(
+          Object.getPrototypeOf(Object.getPrototypeOf(strategy)),
+          'authenticate',
+        )
+        .mockImplementation(() => {});
 
       const req = createRequest({
         screen_hint: 'signup',
@@ -96,10 +97,12 @@ describe('Auth0Strategy', () => {
 
     it('does not include absent query params', () => {
       const strategy = new Auth0Strategy(defaultOptions, noopVerify);
-      const superAuth = jest.spyOn(
-        Object.getPrototypeOf(Object.getPrototypeOf(strategy)),
-        'authenticate',
-      );
+      const superAuth = jest
+        .spyOn(
+          Object.getPrototypeOf(Object.getPrototypeOf(strategy)),
+          'authenticate',
+        )
+        .mockImplementation(() => {});
 
       const req = createRequest({});
 
@@ -124,16 +127,50 @@ describe('Auth0Strategy', () => {
         { ...defaultOptions, organization: 'org_abc' },
         noopVerify,
       );
-      const superAuth = jest.spyOn(
-        Object.getPrototypeOf(Object.getPrototypeOf(strategy)),
-        'authenticate',
-      );
+      const superAuth = jest
+        .spyOn(
+          Object.getPrototypeOf(Object.getPrototypeOf(strategy)),
+          'authenticate',
+        )
+        .mockImplementation(() => {});
 
       const req = createRequest({ organization: 'org_abc' });
 
       strategy.authenticate(req, {});
 
       expect(superAuth).toHaveBeenCalledWith(req, { organization: 'org_abc' });
+    });
+
+    it('preserves the provider error description when authentication is rejected', async () => {
+      const strategy = new Auth0Strategy(defaultOptions, noopVerify);
+      const helper = PassportOAuthAuthenticatorHelper.from(strategy);
+      const req = createRequest({
+        error: 'access_denied',
+        error_description: 'invitation not found or already used',
+      });
+
+      await expect(helper.authenticate({ req })).rejects.toThrow(
+        'Authentication rejected, invitation not found or already used',
+      );
+    });
+
+    it('falls back to the provider error code for absent or invalid descriptions', async () => {
+      const strategy = new Auth0Strategy(defaultOptions, noopVerify);
+      const helper = PassportOAuthAuthenticatorHelper.from(strategy);
+      const requestWithoutDescription = createRequest({
+        error: 'access_denied',
+      });
+      const requestWithInvalidDescription = createRequest({
+        error: 'access_denied',
+        error_description: ['untrusted', 'description'],
+      });
+
+      await expect(
+        helper.authenticate({ req: requestWithoutDescription }),
+      ).rejects.toThrow('Authentication rejected, access_denied');
+      await expect(
+        helper.authenticate({ req: requestWithInvalidDescription }),
+      ).rejects.toThrow('Authentication rejected, access_denied');
     });
   });
 

--- a/plugins/auth-backend-module-auth0-provider/src/strategy.ts
+++ b/plugins/auth-backend-module-auth0-provider/src/strategy.ts
@@ -50,7 +50,27 @@ export class Auth0Strategy extends Auth0InternalStrategy {
   }
 
   authenticate(req: express.Request, options: Record<string, any>): void {
-    const { organization, invitation, screen_hint, login_hint } = req.query;
+    const {
+      error,
+      error_description: errorDescription,
+      organization,
+      invitation,
+      screen_hint,
+      login_hint,
+    } = req.query;
+
+    // passport-auth0 discards error_description before reporting a failed
+    // callback, so preserve it while the original query is still available.
+    if (typeof error === 'string') {
+      this.fail({
+        type: 'error',
+        message:
+          typeof errorDescription === 'string' && errorDescription.length > 0
+            ? errorDescription
+            : error,
+      });
+      return;
+    }
 
     // Throw an error if the organization in the request does not match the organization configured in the strategy
     if (


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Auth0 callback failures currently lose the provider's `error_description` because `passport-auth0` reports only the error code to Passport. This leaves Backstage unable to surface specific reasons such as an expired or already-used invitation.

This change preserves string error descriptions in `Auth0Strategy` before delegating to `passport-auth0`, with the provider error code as a fallback. It also adds integration coverage through `PassportOAuthAuthenticatorHelper` for the described, absent, and invalid-description cases.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
