### PR TITLE
fix(msgraph): give each request its own dependent AbortSignal

### DIFF
--- a/.changeset/msgraph-per-request-abort-signal.md
+++ b/.changeset/msgraph-per-request-abort-signal.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog-backend-module-msgraph': patch
 ---
 
-Fixed `MicrosoftGraphClient` accumulating one abort listener per request on the caller's `AbortSignal`. undici registers a listener on whatever signal it is handed to `fetch` and only releases it once that request's internal controller is garbage collected, so reusing a single signal across a paged walk — as `requestCollection` does, once per group for `getGroupMembers` — retained one listener per request. On large directories that crossed undici's listener cap and produced a `MaxListenersExceededWarning` storm; below the cap it was still retained memory for the length of the walk. Each request now gets a dependent signal via `AbortSignal.any`, which aborts identically and forwards the same reason.
+Fixed accumulating abort listeners on `MicrosoftGraphClient`.

--- a/.changeset/msgraph-per-request-abort-signal.md
+++ b/.changeset/msgraph-per-request-abort-signal.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-msgraph': patch
+---
+
+Fixed `MicrosoftGraphClient` accumulating one abort listener per request on the caller's `AbortSignal`. undici registers a listener on whatever signal it is handed to `fetch` and only releases it once that request's internal controller is garbage collected, so reusing a single signal across a paged walk — as `requestCollection` does, once per group for `getGroupMembers` — retained one listener per request. On large directories that crossed undici's listener cap and produced a `MaxListenersExceededWarning` storm; below the cap it was still retained memory for the length of the walk. Each request now gets a dependent signal via `AbortSignal.any`, which aborts identically and forwards the same reason.

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/client.test.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/client.test.ts
@@ -18,6 +18,7 @@ import { TokenCredential } from '@azure/identity';
 import { registerMswTestHooks } from '@backstage/backend-test-utils';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
+import { getEventListeners } from 'node:events';
 import { MicrosoftGraphClient } from './client';
 
 describe('MicrosoftGraphClient', () => {
@@ -145,6 +146,56 @@ describe('MicrosoftGraphClient', () => {
     );
 
     expect(values).toEqual(['first', 'second']);
+  });
+
+  it('should not retain abort listeners on a signal reused across a collection walk', async () => {
+    // One page per request, so the number of requests in the walk is known.
+    const pages = 20;
+    worker.use(
+      http.get('https://example.com/users', ({ request }) => {
+        const page = Number(new URL(request.url).searchParams.get('page') ?? 0);
+        return HttpResponse.json({
+          value: [`entry-${page}`],
+          ...(page + 1 < pages
+            ? {
+                '@odata.nextLink': `https://example.com/users?page=${page + 1}`,
+              }
+            : {}),
+        });
+      }),
+    );
+
+    const controller = new AbortController();
+
+    const values = await collectAsyncIterable(
+      client.requestCollection<string>(
+        'users',
+        undefined,
+        'basic',
+        controller.signal,
+      ),
+    );
+
+    expect(values).toHaveLength(pages);
+    // Without a per-request dependent signal this is one listener per request,
+    // held until the requests are garbage collected.
+    expect(getEventListeners(controller.signal, 'abort')).toHaveLength(0);
+  });
+
+  it('should still abort a request, forwarding the original reason', async () => {
+    worker.use(
+      http.get('https://example.com/users', () =>
+        HttpResponse.json({ value: [] }),
+      ),
+    );
+
+    const controller = new AbortController();
+    const reason = new Error('task cancelled');
+    controller.abort(reason);
+
+    await expect(
+      client.requestApi('users', undefined, undefined, controller.signal),
+    ).rejects.toBe(reason);
   });
 
   it('should load user profile photo with max size of 120', async () => {

--- a/plugins/catalog-backend-module-msgraph/src/microsoftGraph/client.ts
+++ b/plugins/catalog-backend-module-msgraph/src/microsoftGraph/client.ts
@@ -245,7 +245,17 @@ export class MicrosoftGraphClient {
           ...headers,
           Authorization: `Bearer ${token.token}`,
         },
-        signal,
+        // Deliberately not `signal` itself. undici registers an abort listener
+        // on whatever signal it is handed and only releases it once that
+        // request's internal controller is garbage collected. Since
+        // `requestCollection` reuses one signal for an entire paged walk, and
+        // callers such as `getGroupMembers` run that walk per group, a single
+        // long-lived signal would accumulate one listener per request until GC
+        // — crossing undici's listener cap on large directories and retaining
+        // memory for the length of the walk. A per-request dependent signal
+        // aborts identically, forwarding the same reason, and leaves nothing
+        // behind on the caller's signal.
+        signal: signal ? AbortSignal.any([signal]) : undefined,
       });
     } catch (e: any) {
       if (e?.code === 'ETIMEDOUT' && retryCount > 0) {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

`MicrosoftGraphClient.requestRaw` passes the caller's `AbortSignal` straight to `fetch`. undici registers an abort listener on whatever signal it is handed and only releases it once that request's internal controller is garbage collected — so a signal reused across many requests accumulates one listener per request.

`requestCollection` reuses a single signal for an entire paged walk, and callers such as `getGroupMembers` run that walk once per group, so one long-lived scheduler signal (as propagated by `MicrosoftGraphOrgEntityProvider.schedule` since #33187) ends up holding thousands of listeners. On a large directory that crosses undici's own 1500-listener cap and produces a `MaxListenersExceededWarning` storm; below the cap it is still retained memory for the length of the walk.

We saw this on a ~10k-user tenant. The warning's stack — which Node hides behind `--trace-warnings` — pointed at `client.cjs.js:127`, the package's only `fetch` call:

```
MaxListenersExceededWarning: Possible EventTarget memory leak detected. 1501 abort listeners added to [AbortSignal]. MaxListeners is 1500.
    at Object.addAbortListener (node:internal/deps/undici/undici:1648:16)
    at new Request (node:internal/deps/undici/undici:10116:18)
    at fetch (node:internal/deps/undici/undici:10656:25)
    at MicrosoftGraphClient.requestRaw (.../microsoftGraph/client.cjs.js:127:20)
    at MicrosoftGraphClient.requestApi (.../microsoftGraph/client.cjs.js:105:12)
    at MicrosoftGraphClient.requestCollection (.../microsoftGraph/client.cjs.js:63:20)
    at MicrosoftGraphClient.getGroupMembers (.../microsoftGraph/client.cjs.js:214:5)
```

The characteristic shape is repeated episodes each climbing from 1501 and resetting, rather than one unbounded process-lifetime leak — the listeners are released when GC sweeps the requests.

### The change

`requestRaw` now passes `AbortSignal.any([signal])` instead of the signal itself, giving each request its own dependent signal. It aborts identically and forwards the same `reason` object, so existing `isAbortError` / `signal.aborted` handling is unaffected. `AbortSignal.any` is available from Node 20.3, well inside this repo's `engines` of `22 || 24`.

### Testing

Measured against real undici rather than inferred:

- Standalone on Node 22: 200 sequential fetches on a shared signal retain **200** abort listeners; routing each through `AbortSignal.any([signal])` retains **0**.
- The added regression test drives `requestCollection` through a 20-page walk and asserts nothing is retained. Reverting the one-line fix makes it fail with **20** retained listeners, so it is a genuine guard rather than a tautology.
- A second test asserts an already-aborted signal still rejects with the caller's original reason object.

`yarn workspace @backstage/plugin-catalog-backend-module-msgraph test` — 9 suites / 83 tests pass. `yarn tsc` clean. Package lint clean (0 errors; the 2 remaining `func-names` warnings in `read.test.ts` are pre-existing).

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
