### PR TITLE
feat(catalog-github): add debug logging for missing GitHub App installations

### DIFF
--- a/.changeset/github-app-not-installed-warning.md
+++ b/.changeset/github-app-not-installed-warning.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-github': patch
+---
+
+Added debug logging to help troubleshoot missing GitHub App installations. When a GitHub App is not installed for an organization, the GithubMultiOrgEntityProvider will now log a debug message with guidance on how to resolve the issue.

--- a/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
+++ b/plugins/catalog-backend-module-github/src/providers/GithubMultiOrgEntityProvider.ts
@@ -361,55 +361,72 @@ export class GithubMultiOrgEntityProvider implements EntityProvider {
       : await this.getAllOrgs(this.options.gitHubConfig);
 
     for (const org of orgsToProcess) {
-      const { headers, type: tokenType } =
-        await this.options.githubCredentialsProvider.getCredentials({
-          url: `${this.options.githubUrl}/${org}`,
+      try {
+        const { headers, type: tokenType } =
+          await this.options.githubCredentialsProvider.getCredentials({
+            url: `${this.options.githubUrl}/${org}`,
+          });
+        const client = graphql.defaults({
+          baseUrl: this.options.gitHubConfig.apiBaseUrl,
+          headers,
         });
-      const client = graphql.defaults({
-        baseUrl: this.options.gitHubConfig.apiBaseUrl,
-        headers,
-      });
 
-      logger.info(`Reading GitHub users and teams for org: ${org}`);
+        logger.info(`Reading GitHub users and teams for org: ${org}`);
 
-      const pageSizes = this.getPageSizes();
+        const pageSizes = this.getPageSizes();
 
-      const { users } = await getOrganizationUsers(
-        client,
-        org,
-        tokenType,
-        this.options.userTransformer,
-        pageSizes,
-        this.options.excludeSuspendedUsers,
-        this.useRestSuspendedCheck ? this.getRestClient(org) : undefined,
-      );
+        const { users } = await getOrganizationUsers(
+          client,
+          org,
+          tokenType,
+          this.options.userTransformer,
+          pageSizes,
+          this.options.excludeSuspendedUsers,
+          this.useRestSuspendedCheck ? this.getRestClient(org) : undefined,
+        );
 
-      const { teams } = await getOrganizationTeams(
-        client,
-        org,
-        this.defaultMultiOrgTeamTransformer.bind(this),
-        pageSizes,
-      );
+        const { teams } = await getOrganizationTeams(
+          client,
+          org,
+          this.defaultMultiOrgTeamTransformer.bind(this),
+          pageSizes,
+        );
 
-      // Grab current users from `allUsersMap` if they already exist in our
-      // pending users so we can append to their group membership relations
-      const pendingUsers = users.map(u => {
-        const userRef = stringifyEntityRef(u);
-        if (!allUsersMap.has(userRef)) {
-          allUsersMap.set(userRef, u);
+        // Grab current users from `allUsersMap` if they already exist in our
+        // pending users so we can append to their group membership relations
+        const pendingUsers = users.map(u => {
+          const userRef = stringifyEntityRef(u);
+          if (!allUsersMap.has(userRef)) {
+            allUsersMap.set(userRef, u);
+          }
+
+          return allUsersMap.get(userRef);
+        });
+
+        if (areGroupEntities(teams)) {
+          buildOrgHierarchy(teams);
+          if (areUserEntities(pendingUsers)) {
+            assignGroupsToUsers(pendingUsers, teams);
+          }
         }
 
-        return allUsersMap.get(userRef);
-      });
-
-      if (areGroupEntities(teams)) {
-        buildOrgHierarchy(teams);
-        if (areUserEntities(pendingUsers)) {
-          assignGroupsToUsers(pendingUsers, teams);
+        allTeams.push(...teams);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (
+          message.includes('No app installation found') ||
+          message.includes('NotFoundError')
+        ) {
+          logger.debug(
+            `GitHub app is not installed for organization '${org}'. ` +
+              `Ensure the GitHub App is installed for this organization ` +
+              `and that the GitHub credentials provider has appropriate permissions. ` +
+              `Error: ${message}`,
+          );
+        } else {
+          throw error;
         }
       }
-
-      allTeams.push(...teams);
     }
 
     const allUsers = Array.from(allUsersMap.values());


### PR DESCRIPTION
## Description

Adds debug logging to help users troubleshoot why the GitHub App integration is not working when the app is not installed for an organization.

## Changes

- Added try-catch block in GithubMultiOrgEntityProvider.read() to catch app installation errors
- Logs a debug message with helpful guidance when 'No app installation found' or similar errors occur
- Other errors are re-thrown to maintain existing error handling behavior

## Motivation

Users without GitHub Organization Owner role may not realize they don't have the GitHub App installed. The error message ('NotFoundError: No app installation found') doesn't bubble up to logs clearly, leaving users confused about what went wrong.

## Related Issue

Closes #32972