### PR TITLE
fix: allow releases without associated pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,10 @@ jobs:
 
       - name: verify plugin directory
         run: node scripts/verify-plugin-directory.js
+
+      - name: test release scripts
+        run: yarn node --test scripts/create-github-release.test.js
+
       - name: build all packages
         run: yarn backstage-cli repo build --all
 

--- a/scripts/create-github-release.js
+++ b/scripts/create-github-release.js
@@ -46,16 +46,11 @@ const semver = require('semver');
 // See Examples above to learn about these command line arguments.
 const [TAG_NAME, BOOL_CREATE_RELEASE] = process.argv.slice(2);
 
-if (!BOOL_CREATE_RELEASE) {
-  console.log(
-    '\nRunning script in Dry Run mode. It will output details, will create a draft release but will NOT publish it.',
-  );
-}
-
 const GH_OWNER = 'backstage';
 const GH_REPO = 'backstage';
 const EXPECTED_COMMIT_MESSAGE = /^Merge pull request #(?<prNumber>[0-9]+) from/;
 const CHANGESET_RELEASE_BRANCH = 'backstage/changeset-release/master';
+const FALLBACK_RELEASE_DESCRIPTION = 'The release notes will be updated soon.';
 
 // Initialize a GitHub client
 const octokit = new Octokit({
@@ -118,11 +113,11 @@ async function getCommitUsingTagName(tagName) {
 }
 
 // There is a PR number in our expected commit message. Get the description of that PR.
-async function getReleaseDescriptionFromCommit(commit) {
+async function getReleaseDescriptionFromCommit(commit, client = octokit) {
   let pullRequestBody = undefined;
 
   const { data: pullRequests } =
-    await octokit.repos.listPullRequestsAssociatedWithCommit({
+    await client.repos.listPullRequestsAssociatedWithCommit({
       owner: GH_OWNER,
       repo: GH_REPO,
       commit_sha: commit.sha,
@@ -134,27 +129,28 @@ async function getReleaseDescriptionFromCommit(commit) {
       `Found ${pullRequests.length} pull requests for commit ${commit.sha}, falling back to parsing commit message`,
     );
 
-    // It should exactly match the pattern of changeset commit message, or else will abort.
+    // It should exactly match the pattern of a changeset commit message.
     const expectedMessage = RegExp(EXPECTED_COMMIT_MESSAGE);
     if (!expectedMessage.test(commit.message)) {
-      throw new Error(
-        `Expected regex did not match commit message: ${commit.message}`,
+      console.warn(
+        `Expected regex did not match commit message, using placeholder release notes: ${commit.message}`,
       );
+      pullRequestBody = FALLBACK_RELEASE_DESCRIPTION;
+    } else {
+      // Get the PR description from the commit message
+      const prNumber = commit.message.match(expectedMessage).groups.prNumber;
+      console.log(
+        `Identified the changeset Pull request - https://github.com/backstage/backstage/pull/${prNumber}`,
+      );
+
+      const { data } = await client.pulls.get({
+        owner: GH_OWNER,
+        repo: GH_REPO,
+        pull_number: prNumber,
+      });
+
+      pullRequestBody = data.body;
     }
-
-    // Get the PR description from the commit message
-    const prNumber = commit.message.match(expectedMessage).groups.prNumber;
-    console.log(
-      `Identified the changeset Pull request - https://github.com/backstage/backstage/pull/${prNumber}`,
-    );
-
-    const { data } = await octokit.pulls.get({
-      owner: GH_OWNER,
-      repo: GH_REPO,
-      pull_number: prNumber,
-    });
-
-    pullRequestBody = data.body;
   }
 
   // Use the PR description to prepare for the release description
@@ -197,12 +193,22 @@ async function createRelease(releaseDescription) {
 }
 
 async function main() {
+  if (!BOOL_CREATE_RELEASE) {
+    console.log(
+      '\nRunning script in Dry Run mode. It will output details, will create a draft release but will NOT publish it.',
+    );
+  }
+
   const commit = await getCommitUsingTagName(TAG_NAME);
   const releaseDescription = await getReleaseDescriptionFromCommit(commit);
   await createRelease(releaseDescription);
 }
 
-main().catch(error => {
-  console.error(error.stack);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch(error => {
+    console.error(error.stack);
+    process.exit(1);
+  });
+}
+
+module.exports = { getReleaseDescriptionFromCommit };

--- a/scripts/create-github-release.test.js
+++ b/scripts/create-github-release.test.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const assert = require('node:assert/strict');
+const { test } = require('node:test');
+
+const { getReleaseDescriptionFromCommit } = require('./create-github-release');
+
+test('uses placeholder notes when the release commit has no pull request', async t => {
+  t.mock.method(console, 'warn', () => {});
+  const getPullRequest = t.mock.fn();
+  const client = {
+    repos: {
+      listPullRequestsAssociatedWithCommit: async () => ({ data: [] }),
+    },
+    pulls: {
+      get: getPullRequest,
+    },
+  };
+
+  const result = await getReleaseDescriptionFromCommit(
+    { sha: 'commit-sha', message: 'generate release' },
+    client,
+  );
+
+  assert.equal(result, 'The release notes will be updated soon.');
+  assert.equal(getPullRequest.mock.callCount(), 0);
+});


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Allow the GitHub release workflow to complete when the selected release commit has no associated pull request. Existing pull-request-derived release notes are preserved, while commits without a resolvable pull request use a short placeholder that can be updated after publication.

No changeset is needed because this only changes repository release tooling.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a Signed-off-by line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))