### PR TITLE
fix(catalog): avoid circular module imports

### DIFF
--- a/.changeset/calm-catalog-cycles.md
+++ b/.changeset/calm-catalog-cycles.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-catalog': patch
 ---
 
-Updated internal imports to avoid circular module dependencies in catalog pages and exports.
+Fixed circular dependency warnings when building the catalog plugin.

--- a/.changeset/calm-catalog-cycles.md
+++ b/.changeset/calm-catalog-cycles.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Updated internal imports to avoid circular module dependencies in catalog pages and exports.

--- a/plugins/catalog/src/components/CatalogExportButton/CatalogExportButton.tsx
+++ b/plugins/catalog/src/components/CatalogExportButton/CatalogExportButton.tsx
@@ -30,10 +30,13 @@ import {
   Select,
   Text,
 } from '@backstage/ui';
-import { useStreamingExport } from './file-download';
+import { useStreamingExport } from './file-download/useStreamingExport';
 import type { CatalogExportSettingsColumn } from './file-download/serializeEntities';
 import { getColumnTitle } from './file-download/serializeEntities';
 import type { CatalogExporter } from './file-download/useStreamingExport';
+import { CatalogExportType } from './CatalogExportType';
+
+export { CatalogExportType } from './CatalogExportType';
 
 /**
  * Custom exporter configuration for a catalog export format.
@@ -89,17 +92,6 @@ export interface CatalogExportSettings {
    * Receives an object containing the error for custom error handling.
    */
   onError?: (options: { error: Error }) => void;
-}
-
-/**
- * The available export formats for the catalog export.
- * Currently supports CSV and JSON.
- *
- * @public
- */
-export enum CatalogExportType {
-  CSV = 'csv',
-  JSON = 'json',
 }
 
 /**

--- a/plugins/catalog/src/components/CatalogExportButton/CatalogExportType.ts
+++ b/plugins/catalog/src/components/CatalogExportButton/CatalogExportType.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The available export formats for the catalog export.
+ * Currently supports CSV and JSON.
+ *
+ * @public
+ */
+export enum CatalogExportType {
+  CSV = 'csv',
+  JSON = 'json',
+}

--- a/plugins/catalog/src/components/CatalogExportButton/file-download/useStreamingExport.ts
+++ b/plugins/catalog/src/components/CatalogExportButton/file-download/useStreamingExport.ts
@@ -22,7 +22,7 @@ import {
   serializeEntityToJsonRow,
   CatalogExportSettingsColumn,
 } from './serializeEntities';
-import { CatalogExportType } from '../CatalogExportButton';
+import { CatalogExportType } from '../CatalogExportType';
 import type {
   CatalogApi,
   StreamEntitiesRequest,

--- a/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx
+++ b/plugins/catalog/src/components/CatalogPage/DefaultCatalogPage.tsx
@@ -36,10 +36,13 @@ import {
 } from '@backstage/plugin-catalog-react';
 import { ReactNode } from 'react';
 import { createComponentRouteRef } from '../../routes';
-import { CatalogTable, CatalogTableRow } from '../CatalogTable';
+import { CatalogTable } from '../CatalogTable/CatalogTable';
 import { catalogTranslationRef } from '../../alpha/translation';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
-import { CatalogTableColumnsFunc } from '../CatalogTable/types';
+import {
+  CatalogTableColumnsFunc,
+  CatalogTableRow,
+} from '../CatalogTable/types';
 import { catalogEntityCreatePermission } from '@backstage/plugin-catalog-common/alpha';
 import { usePermission } from '@backstage/plugin-permission-react';
 import { CatalogExportButton } from '../CatalogExportButton/CatalogExportButton';

--- a/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+++ b/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
@@ -51,7 +51,7 @@ import { CursorPaginatedCatalogTable } from './CursorPaginatedCatalogTable';
 import { defaultCatalogTableColumnsFunc } from './defaultCatalogTableColumnsFunc';
 import { useApiHolder } from '@backstage/core-plugin-api';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
-import { catalogTranslationRef } from '../../alpha';
+import { catalogTranslationRef } from '../../alpha/translation';
 import { FavoriteToggleIcon } from '@backstage/core-components';
 
 /**


### PR DESCRIPTION
Removes the catalog package's build-time circular dependency warnings by replacing barrel imports with direct imports and moving the existing export format enum into a small sibling module. The existing public API report is unchanged.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a Signed-off-by line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))