### PR TITLE
fix(notifications): avoid settings module cycle

### DIFF
--- a/.changeset/neat-notification-context.md
+++ b/.changeset/neat-notification-context.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-notifications': patch
 ---
 
-Updated internal imports to avoid circular module dependencies in notification settings.
+Fixed circular dependency warnings when building the notification settings UI.

--- a/.changeset/neat-notification-context.md
+++ b/.changeset/neat-notification-context.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-notifications': patch
+---
+
+Updated internal imports to avoid circular module dependencies in notification settings.

--- a/plugins/notifications/src/components/UserNotificationSettingsCard/NotificationFormatContext.tsx
+++ b/plugins/notifications/src/components/UserNotificationSettingsCard/NotificationFormatContext.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createContext, ReactNode, useContext } from 'react';
+import { capitalize } from 'lodash';
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import { notificationsTranslationRef } from '../../translation';
+
+type FormatContextType = {
+  formatOriginName: (id: string) => string;
+  formatTopicName: (id: string) => string;
+};
+
+const NotificationFormatContext = createContext<FormatContextType | undefined>(
+  undefined,
+);
+
+export const useNotificationFormat = () => {
+  const { t } = useTranslationRef(notificationsTranslationRef);
+  const context = useContext(NotificationFormatContext);
+  if (!context) throw new Error(t('settings.errors.useNotificationFormat'));
+  return context;
+};
+
+export const NotificationFormatProvider = ({
+  children,
+  originMap,
+  topicMap,
+}: {
+  children: ReactNode;
+  originMap: Record<string, string> | undefined;
+  topicMap: Record<string, string> | undefined;
+}) => {
+  const formatName = (
+    id: string,
+    nameMap: Record<string, string> | undefined,
+  ) => {
+    if (nameMap && id in nameMap) {
+      return nameMap[id];
+    }
+    return capitalize(id.replaceAll(/[-_:]/g, ' '));
+  };
+
+  const formatOriginName = (originId: string) => {
+    return formatName(originId, originMap);
+  };
+
+  const formatTopicName = (topicId: string) => {
+    return formatName(topicId, topicMap);
+  };
+
+  return (
+    <NotificationFormatContext.Provider
+      value={{ formatOriginName, formatTopicName }}
+    >
+      {children}
+    </NotificationFormatContext.Provider>
+  );
+};

--- a/plugins/notifications/src/components/UserNotificationSettingsCard/OriginRow.tsx
+++ b/plugins/notifications/src/components/UserNotificationSettingsCard/OriginRow.tsx
@@ -22,7 +22,7 @@ import {
 import { ButtonIcon, Switch, Tooltip, TooltipTrigger } from '@backstage/ui';
 import { RiArrowDownSLine, RiArrowUpSLine } from '@remixicon/react';
 import { NoBorderTableCell } from './NoBorderTableCell';
-import { useNotificationFormat } from './UserNotificationSettingsCard';
+import { useNotificationFormat } from './NotificationFormatContext';
 
 export const OriginRow = (props: {
   origin: OriginSetting;

--- a/plugins/notifications/src/components/UserNotificationSettingsCard/TopicRow.tsx
+++ b/plugins/notifications/src/components/UserNotificationSettingsCard/TopicRow.tsx
@@ -22,7 +22,7 @@ import {
 } from '@backstage/plugin-notifications-common';
 import { Switch, Tooltip, TooltipTrigger } from '@backstage/ui';
 import { NoBorderTableCell } from './NoBorderTableCell';
-import { useNotificationFormat } from './UserNotificationSettingsCard';
+import { useNotificationFormat } from './NotificationFormatContext';
 
 export const TopicRow = (props: {
   topic: TopicSetting;

--- a/plugins/notifications/src/components/UserNotificationSettingsCard/UserNotificationSettingsCard.tsx
+++ b/plugins/notifications/src/components/UserNotificationSettingsCard/UserNotificationSettingsCard.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { createContext, useState, useContext, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { ErrorPanel, InfoCard, Progress } from '@backstage/core-components';
 import { useNotificationsApi } from '../../hooks';
 import { NotificationSettings } from '@backstage/plugin-notifications-common';
@@ -23,60 +23,7 @@ import { useApi } from '@backstage/core-plugin-api';
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 import { notificationsTranslationRef } from '../../translation';
 import { UserNotificationSettingsPanel } from './UserNotificationSettingsPanel';
-import { capitalize } from 'lodash';
-
-type FormatContextType = {
-  formatOriginName: (id: string) => string;
-  formatTopicName: (id: string) => string;
-};
-
-const NotificationFormatContext = createContext<FormatContextType | undefined>(
-  undefined,
-);
-
-export const useNotificationFormat = () => {
-  const { t } = useTranslationRef(notificationsTranslationRef);
-  const context = useContext(NotificationFormatContext);
-  if (!context) throw new Error(t('settings.errors.useNotificationFormat'));
-  return context;
-};
-
-type Props = {
-  children: React.ReactNode;
-  originMap: Record<string, string> | undefined;
-  topicMap: Record<string, string> | undefined;
-};
-
-export const NotificationFormatProvider = ({
-  children,
-  originMap,
-  topicMap,
-}: Props) => {
-  const formatName = (
-    id: string,
-    nameMap: Record<string, string> | undefined,
-  ) => {
-    if (nameMap && id in nameMap) {
-      return nameMap[id];
-    }
-    return capitalize(id.replaceAll(/[-_:]/g, ' '));
-  };
-
-  const formatOriginName = (originId: string) => {
-    return formatName(originId, originMap);
-  };
-
-  const formatTopicName = (topicId: string) => {
-    return formatName(topicId, topicMap);
-  };
-  return (
-    <NotificationFormatContext.Provider
-      value={{ formatOriginName, formatTopicName }}
-    >
-      {children}
-    </NotificationFormatContext.Provider>
-  );
-};
+import { NotificationFormatProvider } from './NotificationFormatContext';
 
 /** @public */
 export const UserNotificationSettingsCard = (props: {

--- a/plugins/notifications/src/components/UserNotificationSettingsCard/UserNotificationSettingsPanel.test.tsx
+++ b/plugins/notifications/src/components/UserNotificationSettingsCard/UserNotificationSettingsPanel.test.tsx
@@ -16,7 +16,7 @@
 import { screen } from '@testing-library/react';
 import { renderInTestApp } from '@backstage/test-utils';
 import { UserNotificationSettingsPanel } from './UserNotificationSettingsPanel';
-import { NotificationFormatProvider } from './UserNotificationSettingsCard.tsx';
+import { NotificationFormatProvider } from './NotificationFormatContext';
 
 describe('UserNotificationSettingsPanel', () => {
   it('renders each origin only once even if present in multiple channels', async () => {


### PR DESCRIPTION
Moves the notification-name formatting context into a sibling module so the settings rows no longer import back through their parent card. The package API report is unchanged.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a Signed-off-by line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))