### PR TITLE
fix(integration): avoid Azure module cycle

### DIFF
--- a/.changeset/clean-azure-imports.md
+++ b/.changeset/clean-azure-imports.md
@@ -1,0 +1,5 @@
+---
+'@backstage/integration': patch
+---
+
+Updated internal Azure DevOps imports to avoid a circular module dependency.

--- a/packages/integration/src/azure/AzureUrl.ts
+++ b/packages/integration/src/azure/AzureUrl.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { isVisualStudioDomain } from './core';
+import { isVisualStudioDomain } from './isVisualStudioDomain';
 
 export class AzureUrl {
   /**

--- a/packages/integration/src/azure/DefaultAzureDevOpsCredentialsProvider.ts
+++ b/packages/integration/src/azure/DefaultAzureDevOpsCredentialsProvider.ts
@@ -20,7 +20,7 @@ import {
 import { CachedAzureDevOpsCredentialsProvider } from './CachedAzureDevOpsCredentialsProvider';
 import { ScmIntegrationRegistry } from '../registry';
 import { DefaultAzureCredential } from '@azure/identity';
-import { isVisualStudioDomain } from './core';
+import { isVisualStudioDomain } from './isVisualStudioDomain';
 
 /**
  * Default implementation of AzureDevOpsCredentialsProvider.

--- a/packages/integration/src/azure/core.ts
+++ b/packages/integration/src/azure/core.ts
@@ -16,6 +16,8 @@
 
 import { AzureUrl } from './AzureUrl';
 
+export { isVisualStudioDomain } from './isVisualStudioDomain';
+
 /**
  * Given a URL pointing to a file on a provider, returns a URL that is suitable
  * for fetching the contents of the data.
@@ -52,15 +54,4 @@ export function getAzureDownloadUrl(url: string): string {
  */
 export function getAzureCommitsUrl(url: string): string {
   return AzureUrl.fromRepoUrl(url).toCommitsUrl();
-}
-
-/**
- * Given a URL, return true if it contains `.visualstudio.com` and false if it does not
- * URLs can be in these two formats: `dev.azure.com/{org}` or the legacy `{org}.visualstudio.com`
- *
- * @param origin - A URL origin string pointing to an Azure DevOps instance
- * @public
- */
-export function isVisualStudioDomain(origin: string): boolean {
-  return origin.endsWith('.visualstudio.com');
 }

--- a/packages/integration/src/azure/isVisualStudioDomain.ts
+++ b/packages/integration/src/azure/isVisualStudioDomain.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Given a URL, return true if it contains `.visualstudio.com` and false if it does not
+ * URLs can be in these two formats: `dev.azure.com/{org}` or the legacy `{org}.visualstudio.com`
+ *
+ * @param origin - A URL origin string pointing to an Azure DevOps instance
+ * @public
+ */
+export function isVisualStudioDomain(origin: string): boolean {
+  return origin.endsWith('.visualstudio.com');
+}


### PR DESCRIPTION
Moves the Visual Studio domain predicate into a sibling helper so Azure URL parsing no longer imports through the module that depends on it. Existing exports and the package API report remain unchanged.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a Signed-off-by line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))