### PR TITLE
fix(frontend-plugin-api): avoid declaration cycles

### DIFF
--- a/.changeset/direct-frontend-types.md
+++ b/.changeset/direct-frontend-types.md
@@ -1,0 +1,5 @@
+---
+'@backstage/frontend-plugin-api': patch
+---
+
+Updated internal type imports to avoid circular declaration chunks in package builds.

--- a/packages/frontend-plugin-api/src/components/AppNodeProvider.tsx
+++ b/packages/frontend-plugin-api/src/components/AppNodeProvider.tsx
@@ -19,7 +19,7 @@ import {
   createVersionedValueMap,
   useVersionedContext,
 } from '@backstage/version-bridge';
-import { AppNode } from '../apis';
+import type { AppNode } from '../apis/definitions/AppTreeApi';
 import { ReactNode } from 'react';
 
 const CONTEXT_KEY = 'app-node-context';

--- a/packages/frontend-plugin-api/src/components/ExtensionBoundary.tsx
+++ b/packages/frontend-plugin-api/src/components/ExtensionBoundary.tsx
@@ -27,7 +27,8 @@ import { ErrorDisplayBoundary } from './ErrorDisplayBoundary';
 import { ErrorApiBoundary } from './ErrorApiBoundary';
 // eslint-disable-next-line @backstage/no-relative-monorepo-imports
 import { routableExtensionRenderedEvent } from '../../../core-plugin-api/src/analytics/Tracker';
-import { AppNode, ErrorApi, errorApiRef, useApi } from '../apis';
+import { ErrorApi, errorApiRef, useApi } from '../apis';
+import type { AppNode } from '../apis/definitions/AppTreeApi';
 import {
   PluginWrapperApi,
   pluginWrapperApiRef,

--- a/packages/frontend-plugin-api/src/types.ts
+++ b/packages/frontend-plugin-api/src/types.ts
@@ -15,7 +15,7 @@
  */
 
 import { ReactNode } from 'react';
-import { FrontendPlugin } from './wiring';
+import type { FrontendPlugin } from './wiring/createFrontendPlugin';
 
 /** @public */
 export type ProgressProps = {};


### PR DESCRIPTION
Uses direct type-only imports for declarations that were previously routed through mutually dependent barrels. This removes the package's circular declaration-chunk warnings without changing its API report.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a Signed-off-by line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))