### PR TITLE
fix(cli): externalize node declaration imports

### DIFF
--- a/.changeset/quiet-node-declarations.md
+++ b/.changeset/quiet-node-declarations.md
@@ -1,0 +1,5 @@
+---
+'@backstage/cli-module-build': patch
+---
+
+Fixed declaration bundling of imports that use the `node:` built-in module prefix.

--- a/packages/cli-module-build/src/lib/builder/config.test.ts
+++ b/packages/cli-module-build/src/lib/builder/config.test.ts
@@ -61,5 +61,8 @@ describe('makeRollupConfigs', () => {
     expect(external('c:\\foo', importerPath, true)).toBe(false);
     expect(external('@foo/bar', importerPath, true)).toBe(false);
     expect(external('../foo', importerPath, true)).toBe(false);
+
+    // Node.js built-ins remain external after resolution
+    expect(external('node:stream', importerPath, true)).toBe(true);
   });
 });

--- a/packages/cli-module-build/src/lib/builder/config.ts
+++ b/packages/cli-module-build/src/lib/builder/config.ts
@@ -148,13 +148,18 @@ export async function makeRollupConfigs(
     source: string,
     importer: string | undefined,
     isResolved: boolean,
-  ) =>
-    Boolean(
+  ) => {
+    if (source.startsWith('node:')) {
+      return true;
+    }
+
+    return Boolean(
       importer &&
         !isResolved &&
         !internalImportPattern.test(source) &&
         !isFileImport(source),
     );
+  };
 
   if (options.outputs.has(Output.cjs) || options.outputs.has(Output.esm)) {
     const output = new Array<OutputOptions>();


### PR DESCRIPTION
Keeps Node.js built-in imports that use the node: prefix external during declaration bundling, including after Rollup has resolved them. This removes the repeated unresolved built-in warnings from repo builds without changing ordinary module resolution.

The regression test fails on master for a resolved node:stream import and passes with this change. The full repo build succeeds without the previous node: declaration warnings, and the API-report build is unchanged.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a Signed-off-by line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))