### PR TITLE
fix(catalog-react): declare MUI runtime dependency

### DIFF
--- a/.changeset/solid-catalog-popovers.md
+++ b/.changeset/solid-catalog-popovers.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-react': patch
+---
+
+Added the missing Material UI dependency used by catalog popovers.

--- a/plugins/catalog-react/package.json
+++ b/plugins/catalog-react/package.json
@@ -78,6 +78,7 @@
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.61",
+    "@mui/material": "^5.12.2",
     "@react-hookz/web": "^24.0.0",
     "@remixicon/react": ">=4.6.0 <4.9.0",
     "classnames": "^2.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4787,6 +4787,7 @@ __metadata:
     "@material-ui/core": "npm:^4.12.2"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
+    "@mui/material": "npm:^5.12.2"
     "@react-hookz/web": "npm:^24.0.0"
     "@remixicon/react": "npm:>=4.6.0 <4.9.0"
     "@testing-library/dom": "npm:^10.0.0"


### PR DESCRIPTION
Declares the Material UI runtime dependency required by material-ui-popup-state's popover implementation. The range matches the repository's existing MUI v5 range, and yarn install changes only the catalog-react workspace row in yarn.lock without adding a resolution.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a Signed-off-by line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))