### PR TITLE
(connections): add Vault connection type

### DIFF
--- a/.changeset/connections-vault-connection-type.md
+++ b/.changeset/connections-vault-connection-type.md
@@ -1,0 +1,5 @@
+---
+'@backstage/connections': patch
+---
+
+Added the built-in `vault` connection type for HashiCorp Vault instances, with host-based lookup, an optional API base URL, and static token authentication.

--- a/packages/connections/report.api.md
+++ b/packages/connections/report.api.md
@@ -509,6 +509,22 @@ export const connectionTypes: {
       apiKey?: string | undefined;
     }[];
   }>;
+  readonly vault: ConnectionType<{
+    type: 'vault';
+    cardinality: 'multiton';
+    lookupStrategy: 'host';
+    query: {
+      url: string;
+    };
+    configSchema: {
+      host: string;
+      baseUrl?: string | undefined;
+    };
+    auth: readonly {
+      method: 'token';
+      token: string;
+    }[];
+  }>;
 };
 
 // @public (undocumented)

--- a/packages/connections/src/definitions/index.ts
+++ b/packages/connections/src/definitions/index.ts
@@ -26,4 +26,5 @@ export { GithubConnectionType } from '../schema/github';
 export { GitlabConnectionType } from '../schema/gitlab';
 export { GoogleGcsConnectionType } from '../schema/googleGcs';
 export { HarnessConnectionType } from '../schema/harness';
+export { VaultConnectionType } from '../schema/vault';
 export * from './types';

--- a/packages/connections/src/definitions/types.ts
+++ b/packages/connections/src/definitions/types.ts
@@ -26,6 +26,7 @@ import { GithubConnectionType } from '../schema/github';
 import { GitlabConnectionType } from '../schema/gitlab';
 import { GoogleGcsConnectionType } from '../schema/googleGcs';
 import { HarnessConnectionType } from '../schema/harness';
+import { VaultConnectionType } from '../schema/vault';
 import type { ConnectionType } from '../api/ConnectionType';
 
 function createConnectionTypes<
@@ -51,6 +52,7 @@ export const connectionTypes = createConnectionTypes({
   gitlab: GitlabConnectionType,
   'google-gcs': GoogleGcsConnectionType,
   harness: HarnessConnectionType,
+  vault: VaultConnectionType,
 });
 
 /** @public */

--- a/packages/connections/src/schema/vault.test.ts
+++ b/packages/connections/src/schema/vault.test.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ConfigReader } from '@backstage/config';
+import { buildConnectionsFromConfig } from '../config/buildConnectionsFromConfig';
+import { connectionTypes } from '../definitions/types';
+import { VaultConnectionType } from './vault';
+
+describe('VaultConnectionType', () => {
+  it('defines a host-based HashiCorp Vault connection with token authentication', () => {
+    expect(VaultConnectionType).toMatchObject({
+      type: 'vault',
+      title: 'HashiCorp Vault',
+      cardinality: 'multiton',
+      lookupStrategy: 'host',
+    });
+    expect(VaultConnectionType.authMethods.map(({ method }) => method)).toEqual(
+      ['token'],
+    );
+    expect(connectionTypes.vault).toBe(VaultConnectionType);
+  });
+
+  it('validates connection and token configuration', () => {
+    expect(
+      VaultConnectionType.configSchema.parse({
+        host: 'vault.example.com:8200',
+        baseUrl: 'https://vault.example.com:8200',
+      }),
+    ).toEqual({
+      host: 'vault.example.com:8200',
+      baseUrl: 'https://vault.example.com:8200',
+    });
+    expect(
+      VaultConnectionType.authMethods[0].configSchema.parse({
+        token: 'vault-token',
+      }),
+    ).toEqual({ token: 'vault-token' });
+
+    expect(() => VaultConnectionType.configSchema.parse({})).toThrow(
+      /Invalid configuration for connection type "vault"/,
+    );
+    expect(() =>
+      VaultConnectionType.authMethods[0].configSchema.parse({}),
+    ).toThrow(/Invalid configuration for auth method "token"/);
+  });
+
+  it('builds a fully typed Vault connection from configuration', () => {
+    const connections = buildConnectionsFromConfig({
+      config: new ConfigReader({
+        connections: [
+          {
+            type: 'vault',
+            host: 'vault.example.com',
+            baseUrl: 'https://vault.example.com',
+            auth: [{ method: 'token', token: 'vault-token' }],
+          },
+        ],
+      }),
+    });
+
+    expect(connections).toEqual([
+      {
+        type: 'vault',
+        title: 'HashiCorp Vault',
+        host: 'vault.example.com',
+        baseUrl: 'https://vault.example.com',
+        auth: [{ method: 'token', title: 'Token', token: 'vault-token' }],
+      },
+    ]);
+  });
+});

--- a/packages/connections/src/schema/vault.ts
+++ b/packages/connections/src/schema/vault.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { createConnectionType } from '../system/createConnectionType';
+import { z } from 'zod/v4';
+
+/**
+ * Access to HashiCorp Vault instances using static token authentication.
+ *
+ * The `host` identifies the Vault instance during URL-based lookups. Consumers
+ * can use `baseUrl` when the API endpoint cannot be derived from that host, for
+ * example when it uses a non-default scheme, port, or path.
+ *
+ * @public
+ */
+export const VaultConnectionType = createConnectionType({
+  type: 'vault',
+  title: 'HashiCorp Vault',
+  configSchema: z.object({
+    host: z.string(),
+    baseUrl: z.string().optional(),
+  }),
+  authMethods: [
+    {
+      method: 'token',
+      title: 'Token',
+      configSchema: z.object({
+        token: z.string(),
+      }),
+    },
+  ],
+});


### PR DESCRIPTION
## Hey, I just made a Pull Request!

HashiCorp Vault does not currently have a shared contract in the connections service, so plugins cannot declare or resolve Vault endpoints and credentials in the same way as the other built-in systems.

This establishes the initial host-based, static-token contract. 

Verification:

- `CI=1 yarn test packages/connections` (146 tests)
- `yarn tsc`
- `yarn lint --fix`
- `yarn build:api-reports`

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
