### PR TITLE
feat(catalog): add incremental ingestion permissions

### DIFF
--- a/.changeset/calm-catalog-permissions.md
+++ b/.changeset/calm-catalog-permissions.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-common': minor
+---
+
+Added permissions for reading and managing catalog ingestion providers.

--- a/.changeset/clean-providers-permissions.md
+++ b/.changeset/clean-providers-permissions.md
@@ -1,5 +1,5 @@
 ---
-'@backstage/plugin-catalog-backend-module-incremental-ingestion': patch
+'@backstage/plugin-catalog-backend-module-incremental-ingestion': minor
 ---
 
-Added permission checks for reading and managing catalog ingestion providers through the administrative routes.
+**BREAKING**: The incremental ingestion administrative routes now enforce separate read and manage permissions. Installations with custom permission policies must add decisions for the new permissions.

--- a/.changeset/clean-providers-permissions.md
+++ b/.changeset/clean-providers-permissions.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend-module-incremental-ingestion': patch
+---
+
+Added permission checks for reading and managing catalog ingestion providers through the administrative routes.

--- a/docs/features/software-catalog/external-integrations/incremental-entity-providers.md
+++ b/docs/features/software-catalog/external-integrations/incremental-entity-providers.md
@@ -327,20 +327,26 @@ backend.start();
 The incremental ingestion plugin exposes REST endpoints for managing
 providers at runtime:
 
-| Method | Path                                                   | Description                                                            |
-| :----- | :----------------------------------------------------- | :--------------------------------------------------------------------- |
-| GET    | `/api/catalog/incremental/health`                      | Check the health of all incremental providers.                         |
-| GET    | `/api/catalog/incremental/providers`                   | List all known incremental entity providers.                           |
-| GET    | `/api/catalog/incremental/providers/:provider`         | Check the status of a specific provider (resting, interstitial, etc.). |
-| POST   | `/api/catalog/incremental/providers/:provider/trigger` | Trigger the provider's next action immediately.                        |
-| POST   | `/api/catalog/incremental/providers/:provider/start`   | Stop the current ingestion cycle and start a new one immediately.      |
-| POST   | `/api/catalog/incremental/providers/:provider/cancel`  | Stop the current ingestion cycle and start a new one in 24 hours.      |
-| DELETE | `/api/catalog/incremental/providers/:provider`         | Remove all records for the provider and restart it in 24 hours.        |
-| GET    | `/api/catalog/incremental/providers/:provider/marks`   | Retrieve ingestion marks for the current cycle.                        |
-| DELETE | `/api/catalog/incremental/providers/:provider/marks`   | Remove all ingestion marks for the current cycle.                      |
-| POST   | `/api/catalog/incremental/cleanup`                     | Remove all records for all providers and restart them in 24 hours.     |
+| Method | Path                                                   | Permission                 | Description                                                            |
+| :----- | :----------------------------------------------------- | :------------------------- | :--------------------------------------------------------------------- |
+| GET    | `/api/catalog/incremental/health`                      | `catalog.ingestion.read`   | Check the health of all incremental providers.                         |
+| GET    | `/api/catalog/incremental/providers`                   | `catalog.ingestion.read`   | List all known incremental entity providers.                           |
+| GET    | `/api/catalog/incremental/providers/:provider`         | `catalog.ingestion.read`   | Check the status of a specific provider (resting, interstitial, etc.). |
+| POST   | `/api/catalog/incremental/providers/:provider/trigger` | `catalog.ingestion.manage` | Trigger the provider's next action immediately.                        |
+| POST   | `/api/catalog/incremental/providers/:provider/start`   | `catalog.ingestion.manage` | Stop the current ingestion cycle and start a new one immediately.      |
+| POST   | `/api/catalog/incremental/providers/:provider/cancel`  | `catalog.ingestion.manage` | Stop the current ingestion cycle and start a new one in 24 hours.      |
+| DELETE | `/api/catalog/incremental/providers/:provider`         | `catalog.ingestion.manage` | Remove all records for the provider and restart it in 24 hours.        |
+| GET    | `/api/catalog/incremental/providers/:provider/marks`   | `catalog.ingestion.read`   | Retrieve ingestion marks for the current cycle.                        |
+| DELETE | `/api/catalog/incremental/providers/:provider/marks`   | `catalog.ingestion.manage` | Remove all ingestion marks for the current cycle.                      |
+| POST   | `/api/catalog/incremental/cleanup`                     | `catalog.ingestion.manage` | Remove all records for all providers and restart them in 24 hours.     |
 
 In all cases, `:provider` is the name returned by `getProviderName`.
+
+The `@backstage/plugin-catalog-common/alpha` package exports
+`catalogIngestionReadPermission` and `catalogIngestionManagePermission` for use
+in a [permission policy](../../../permissions/overview.md). The catalog backend
+registers these permissions automatically. Backstage permits basic permissions
+by default, so you must configure a policy to restrict these operations.
 
 :::caution
 The cleanup endpoint removes records for all providers. Use it with care —

--- a/plugins/catalog-backend-module-incremental-ingestion/package.json
+++ b/plugins/catalog-backend-module-incremental-ingestion/package.json
@@ -53,8 +53,10 @@
     "@backstage/config": "workspace:^",
     "@backstage/errors": "workspace:^",
     "@backstage/plugin-catalog-backend": "workspace:^",
+    "@backstage/plugin-catalog-common": "workspace:^",
     "@backstage/plugin-catalog-node": "workspace:^",
     "@backstage/plugin-events-node": "workspace:^",
+    "@backstage/plugin-permission-common": "workspace:^",
     "@backstage/types": "workspace:^",
     "express": "^4.22.0",
     "express-promise-router": "^4.1.0",
@@ -64,6 +66,8 @@
   "devDependencies": {
     "@backstage/backend-test-utils": "workspace:^",
     "@backstage/cli": "workspace:^",
-    "@types/express": "^4.17.6"
+    "@types/express": "^4.17.6",
+    "@types/supertest": "^2.0.8",
+    "supertest": "^7.0.0"
   }
 }

--- a/plugins/catalog-backend-module-incremental-ingestion/src/module/WrapperProviders.test.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/module/WrapperProviders.test.ts
@@ -18,6 +18,7 @@ import { SchedulerService } from '@backstage/backend-plugin-api';
 import { TestDatabases, mockServices } from '@backstage/backend-test-utils';
 import { metricsServiceMock } from '@backstage/backend-test-utils/alpha';
 import { ConfigReader } from '@backstage/config';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
 import { IncrementalEntityProvider } from '../types';
 import { WrapperProviders } from './WrapperProviders';
 
@@ -72,6 +73,10 @@ describe.each(databases.eachSupportedId())(
         applyDatabaseMigrations,
         events: mockServices.events.mock(),
         metrics: metricsServiceMock.mock(),
+        permissions: mockServices.permissions.mock({
+          authorize: async () => [{ result: AuthorizeResult.ALLOW }],
+        }),
+        httpAuth: mockServices.httpAuth(),
       });
       const wrapped1 = providers.wrap(provider1, {
         burstInterval: { seconds: 1 },

--- a/plugins/catalog-backend-module-incremental-ingestion/src/module/WrapperProviders.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/module/WrapperProviders.ts
@@ -16,6 +16,8 @@
 
 import {
   LoggerService,
+  HttpAuthService,
+  PermissionsService,
   RootConfigService,
   SchedulerService,
 } from '@backstage/backend-plugin-api';
@@ -57,6 +59,8 @@ export class WrapperProviders {
       applyDatabaseMigrations?: typeof applyDatabaseMigrations;
       events: EventsService;
       metrics: MetricsService;
+      permissions: PermissionsService;
+      httpAuth: HttpAuthService;
     },
   ) {}
 
@@ -81,6 +85,8 @@ export class WrapperProviders {
     return new IncrementalProviderRouter(
       new IncrementalIngestionDatabaseManager({ client: this.options.client }),
       this.options.logger,
+      this.options.permissions,
+      this.options.httpAuth,
     ).createRouter();
   }
 

--- a/plugins/catalog-backend-module-incremental-ingestion/src/module/catalogModuleIncrementalIngestionEntityProvider.test.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/module/catalogModuleIncrementalIngestionEntityProvider.test.ts
@@ -17,6 +17,7 @@
 import { createBackendModule } from '@backstage/backend-plugin-api';
 import { mockServices, startTestBackend } from '@backstage/backend-test-utils';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
 import { IncrementalEntityProvider } from '../types';
 import {
   catalogModuleIncrementalIngestionEntityProvider,
@@ -38,13 +39,14 @@ describe('catalogModuleIncrementalIngestionEntityProvider', () => {
     const addEntityProvider = jest.fn();
 
     const httpRouterMock = mockServices.httpRouter.mock();
-
     await startTestBackend({
       extensionPoints: [
         [catalogProcessingExtensionPoint, { addEntityProvider }],
       ],
       features: [
         httpRouterMock.factory,
+        mockServices.httpAuth.factory(),
+        mockServices.permissions.factory({ result: AuthorizeResult.ALLOW }),
         catalogModuleIncrementalIngestionEntityProvider,
         createBackendModule({
           pluginId: 'catalog',

--- a/plugins/catalog-backend-module-incremental-ingestion/src/module/catalogModuleIncrementalIngestionEntityProvider.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/module/catalogModuleIncrementalIngestionEntityProvider.ts
@@ -110,6 +110,8 @@ export const catalogModuleIncrementalIngestionEntityProvider =
           scheduler: coreServices.scheduler,
           events: eventsServiceRef,
           metrics: metricsServiceRef,
+          permissions: coreServices.permissions,
+          httpAuth: coreServices.httpAuth,
         },
         async init({
           catalog,
@@ -120,6 +122,8 @@ export const catalogModuleIncrementalIngestionEntityProvider =
           scheduler,
           events,
           metrics,
+          permissions,
+          httpAuth,
         }) {
           const client = await database.getClient();
 
@@ -130,6 +134,8 @@ export const catalogModuleIncrementalIngestionEntityProvider =
             scheduler,
             events,
             metrics,
+            permissions,
+            httpAuth,
           });
 
           for (const entry of addedProviders) {

--- a/plugins/catalog-backend-module-incremental-ingestion/src/router/routes.test.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/router/routes.test.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import express from 'express';
+import request from 'supertest';
+import {
+  AuthorizeResult,
+  type PermissionEvaluator,
+} from '@backstage/plugin-permission-common';
+import { mockCredentials, mockServices } from '@backstage/backend-test-utils';
+import { IncrementalIngestionDatabaseManager } from '../database/IncrementalIngestionDatabaseManager';
+import { IncrementalProviderRouter } from './routes';
+
+describe('IncrementalProviderRouter', () => {
+  const credentials = mockCredentials.user();
+  const logger = mockServices.logger.mock();
+  let manager: jest.Mocked<IncrementalIngestionDatabaseManager>;
+  let permissions: jest.Mocked<PermissionEvaluator>;
+  let app: express.Express;
+
+  beforeEach(() => {
+    manager = {
+      healthcheck: jest.fn().mockResolvedValue([]),
+      cleanupProviders: jest.fn().mockResolvedValue({ success: true }),
+      getCurrentIngestionRecord: jest.fn().mockResolvedValue(undefined),
+      listProviders: jest.fn().mockResolvedValue([]),
+      purgeAndResetProvider: jest.fn().mockResolvedValue({ success: true }),
+      clearFinishedIngestions: jest.fn().mockResolvedValue(0),
+    } as unknown as jest.Mocked<IncrementalIngestionDatabaseManager>;
+    permissions = {
+      authorize: jest
+        .fn()
+        .mockResolvedValue([{ result: AuthorizeResult.ALLOW }]),
+      authorizeConditional: jest.fn(),
+    };
+
+    app = express().use(
+      new IncrementalProviderRouter(
+        manager,
+        logger,
+        permissions,
+        mockServices.httpAuth({ defaultCredentials: credentials }),
+      ).createRouter(),
+    );
+    app.use(
+      (
+        error: Error & { statusCode?: number },
+        _req: express.Request,
+        res: express.Response,
+        _next: express.NextFunction,
+      ) => {
+        const status =
+          error.statusCode ?? (error.name === 'NotAllowedError' ? 403 : 500);
+        res.status(status).json({ error: { name: error.name } });
+      },
+    );
+  });
+
+  it.each([
+    ['get', '/incremental/health', 'catalog.ingestion.read'],
+    ['head', '/incremental/health', 'catalog.ingestion.read'],
+    ['get', '/incremental/providers/example', 'catalog.ingestion.read'],
+    ['get', '/incremental/providers', 'catalog.ingestion.read'],
+    ['get', '/incremental/providers/example/marks', 'catalog.ingestion.read'],
+    ['post', '/incremental/cleanup', 'catalog.ingestion.manage'],
+    [
+      'post',
+      '/incremental/providers/example/trigger',
+      'catalog.ingestion.manage',
+    ],
+    [
+      'post',
+      '/incremental/providers/example/start',
+      'catalog.ingestion.manage',
+    ],
+    [
+      'post',
+      '/incremental/providers/example/cancel',
+      'catalog.ingestion.manage',
+    ],
+    ['delete', '/incremental/providers/example', 'catalog.ingestion.manage'],
+    [
+      'delete',
+      '/incremental/providers/example/marks',
+      'catalog.ingestion.manage',
+    ],
+  ] as const)(
+    '%s %s checks %s',
+    async (method, path, expectedPermissionName) => {
+      await request(app)[method](path);
+
+      expect(permissions.authorize).toHaveBeenCalledWith(
+        [
+          {
+            permission: expect.objectContaining({
+              name: expectedPermissionName,
+            }),
+          },
+        ],
+        { credentials },
+      );
+    },
+  );
+
+  it.each([
+    ['get', '/incremental/health'],
+    ['post', '/incremental/cleanup'],
+  ] as const)('returns 403 for denied %s %s requests', async (method, path) => {
+    permissions.authorize.mockResolvedValue([{ result: AuthorizeResult.DENY }]);
+
+    const response = await request(app)[method](path);
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/plugins/catalog-backend-module-incremental-ingestion/src/router/routes.ts
+++ b/plugins/catalog-backend-module-incremental-ingestion/src/router/routes.ts
@@ -14,10 +14,20 @@
  * limitations under the License.
  */
 
+import {
+  HttpAuthService,
+  LoggerService,
+  PermissionsService,
+} from '@backstage/backend-plugin-api';
+import { NotAllowedError } from '@backstage/errors';
+import {
+  catalogIngestionManagePermission,
+  catalogIngestionReadPermission,
+} from '@backstage/plugin-catalog-common/alpha';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
 import express from 'express';
 import Router from 'express-promise-router';
 import { IncrementalIngestionDatabaseManager } from '../database/IncrementalIngestionDatabaseManager';
-import { LoggerService } from '@backstage/backend-plugin-api';
 
 export class IncrementalProviderRouter {
   private manager: IncrementalIngestionDatabaseManager;
@@ -26,6 +36,8 @@ export class IncrementalProviderRouter {
   constructor(
     manager: IncrementalIngestionDatabaseManager,
     logger: LoggerService,
+    private readonly permissions: PermissionsService,
+    private readonly httpAuth: HttpAuthService,
   ) {
     this.manager = manager;
     this.logger = logger;
@@ -34,6 +46,19 @@ export class IncrementalProviderRouter {
   createRouter(): express.Router {
     const router = Router();
     router.use(express.json());
+    router.use('/incremental', async (req, _res, next) => {
+      const permission =
+        req.method === 'GET' || req.method === 'HEAD'
+          ? catalogIngestionReadPermission
+          : catalogIngestionManagePermission;
+      const [decision] = await this.permissions.authorize([{ permission }], {
+        credentials: await this.httpAuth.credentials(req),
+      });
+      if (decision.result === AuthorizeResult.DENY) {
+        throw new NotAllowedError('Unauthorized');
+      }
+      next();
+    });
 
     // Get the overall health of all incremental providers
     router.get('/incremental/health', async (_, res) => {

--- a/plugins/catalog-backend/src/service/CatalogPlugin.test.ts
+++ b/plugins/catalog-backend/src/service/CatalogPlugin.test.ts
@@ -23,7 +23,7 @@ import {
 import { createCatalogPermissionRule } from '../permissions';
 
 describe('catalogPlugin', () => {
-  it('should support custom permission rules', async () => {
+  it('should register permissions and support custom permission rules', async () => {
     const { server } = await startTestBackend({
       features: [
         catalogPlugin,
@@ -61,6 +61,12 @@ describe('catalogPlugin', () => {
     );
 
     expect(res.status).toBe(200);
+    expect(res.body.permissions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'catalog.ingestion.read' }),
+        expect.objectContaining({ name: 'catalog.ingestion.manage' }),
+      ]),
+    );
     expect(res.body.rules).toContainEqual({
       name: 'test',
       resourceType: 'catalog-entity',

--- a/plugins/catalog-common/report-alpha.api.md
+++ b/plugins/catalog-common/report-alpha.api.md
@@ -27,6 +27,15 @@ export const catalogEntityRefreshPermission: ResourcePermission<'catalog-entity'
 export const catalogEntityValidatePermission: BasicPermission;
 
 // @alpha
+export const catalogIngestionManagePermission: BasicPermission;
+
+// @alpha
+export const catalogIngestionPermissions: BasicPermission[];
+
+// @alpha
+export const catalogIngestionReadPermission: BasicPermission;
+
+// @alpha
 export const catalogLocationAnalyzePermission: BasicPermission;
 
 // @alpha

--- a/plugins/catalog-common/report-alpha.api.md
+++ b/plugins/catalog-common/report-alpha.api.md
@@ -30,9 +30,6 @@ export const catalogEntityValidatePermission: BasicPermission;
 export const catalogIngestionManagePermission: BasicPermission;
 
 // @alpha
-export const catalogIngestionPermissions: BasicPermission[];
-
-// @alpha
 export const catalogIngestionReadPermission: BasicPermission;
 
 // @alpha

--- a/plugins/catalog-common/src/alpha.ts
+++ b/plugins/catalog-common/src/alpha.ts
@@ -25,6 +25,9 @@ export {
   catalogLocationCreatePermission,
   catalogLocationDeletePermission,
   catalogLocationAnalyzePermission,
+  catalogIngestionReadPermission,
+  catalogIngestionManagePermission,
+  catalogIngestionPermissions,
   catalogPermissions,
 } from './permissions';
 export type { CatalogEntityPermission } from './permissions';

--- a/plugins/catalog-common/src/alpha.ts
+++ b/plugins/catalog-common/src/alpha.ts
@@ -27,7 +27,6 @@ export {
   catalogLocationAnalyzePermission,
   catalogIngestionReadPermission,
   catalogIngestionManagePermission,
-  catalogIngestionPermissions,
   catalogPermissions,
 } from './permissions';
 export type { CatalogEntityPermission } from './permissions';

--- a/plugins/catalog-common/src/permissions.ts
+++ b/plugins/catalog-common/src/permissions.ts
@@ -169,16 +169,6 @@ export const catalogIngestionManagePermission = createPermission({
 });
 
 /**
- * List of all catalog ingestion permissions.
- *
- * @alpha
- */
-export const catalogIngestionPermissions = [
-  catalogIngestionReadPermission,
-  catalogIngestionManagePermission,
-];
-
-/**
  * List of all catalog permissions.
  * @alpha
  */
@@ -192,5 +182,6 @@ export const catalogPermissions = [
   catalogLocationCreatePermission,
   catalogLocationDeletePermission,
   catalogLocationAnalyzePermission,
-  ...catalogIngestionPermissions,
+  catalogIngestionReadPermission,
+  catalogIngestionManagePermission,
 ];

--- a/plugins/catalog-common/src/permissions.ts
+++ b/plugins/catalog-common/src/permissions.ts
@@ -149,6 +149,36 @@ export const catalogLocationDeletePermission = createPermission({
 });
 
 /**
+ * Permission for reading catalog ingestion status and marks.
+ *
+ * @alpha
+ */
+export const catalogIngestionReadPermission = createPermission({
+  name: 'catalog.ingestion.read',
+  attributes: { action: 'read' },
+});
+
+/**
+ * Permission for managing catalog ingestion providers and marks.
+ *
+ * @alpha
+ */
+export const catalogIngestionManagePermission = createPermission({
+  name: 'catalog.ingestion.manage',
+  attributes: { action: 'update' },
+});
+
+/**
+ * List of all catalog ingestion permissions.
+ *
+ * @alpha
+ */
+export const catalogIngestionPermissions = [
+  catalogIngestionReadPermission,
+  catalogIngestionManagePermission,
+];
+
+/**
  * List of all catalog permissions.
  * @alpha
  */
@@ -162,4 +192,5 @@ export const catalogPermissions = [
   catalogLocationCreatePermission,
   catalogLocationDeletePermission,
   catalogLocationAnalyzePermission,
+  ...catalogIngestionPermissions,
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -4447,14 +4447,18 @@ __metadata:
     "@backstage/config": "workspace:^"
     "@backstage/errors": "workspace:^"
     "@backstage/plugin-catalog-backend": "workspace:^"
+    "@backstage/plugin-catalog-common": "workspace:^"
     "@backstage/plugin-catalog-node": "workspace:^"
     "@backstage/plugin-events-node": "workspace:^"
+    "@backstage/plugin-permission-common": "workspace:^"
     "@backstage/types": "workspace:^"
     "@types/express": "npm:^4.17.6"
+    "@types/supertest": "npm:^2.0.8"
     express: "npm:^4.22.0"
     express-promise-router: "npm:^4.1.0"
     knex: "npm:^3.0.0"
     luxon: "npm:^3.0.0"
+    supertest: "npm:^7.0.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Adds separate read and manage permissions for the incremental ingestion administrative routes. GET routes require the read permission, while POST and DELETE routes require the manage permission.

This provides the permission primitives anticipated by #30442 and preserves existing behavior for installations that use the default allow policy.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
