### PR TITLE
docs: how to avoid duplicated headers at migration to NFS

### DIFF
--- a/docs/frontend-system/building-apps/08-migrating.md
+++ b/docs/frontend-system/building-apps/08-migrating.md
@@ -51,7 +51,7 @@ If you encounter issues, check [GitHub issues](https://github.com/backstage/back
 
 ## Phase 1: Minimal Changes for Hybrid Configuration
 
-There are 5 steps to minimally change your app to start experimenting with the new frontend system in a hybrid mode.
+There are 6 steps to minimally change your app to start experimenting with the new frontend system in a hybrid mode.
 
 After completing these steps you should be able to start up the app and see that it still works.
 
@@ -265,6 +265,17 @@ describe('App', () => {
     });
   });
 });
+```
+
+### 6) Avoid double headers
+
+When running in hybrid mode, a duplicate header appears if the legacy header is still active alongside the new one. To avoid this, include the following code in packages/app/src/styles.css.
+
+```
+/* Hide the BUI header when the legacy backstage header is present in <main> */
+#root > .MuiBox-root:has(> main > header) > .bui-PluginHeader {
+  display: none;
+}
 ```
 
 ## Phase 2: Complete Transition to the New Frontend System

--- a/docs/frontend-system/building-apps/08-migrating.md
+++ b/docs/frontend-system/building-apps/08-migrating.md
@@ -269,7 +269,7 @@ describe('App', () => {
 
 ### 6) Avoid double headers
 
-When running in hybrid mode, a duplicate header appears if the legacy header is still active alongside the new one. To avoid this, include the following code in packages/app/src/styles.css.
+When running in hybrid mode, a duplicate header appears if the legacy header is still active alongside the new one. To avoid this, include the following code in `packages/app/src/styles.css`.
 
 ```
 /* Hide the BUI header when the legacy backstage header is present in <main> */


### PR DESCRIPTION
## Hey, I just made a Pull Request!

During a real-life migration to the new front-end system, duplicated headers was a problem.
The issue is migration guide gaps identified during real-world NFS migration
 #34134.
 Duplicated headers can be avoided with an addtion of code in styles.css

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
