### PR TITLE
fix(scaffolder): omit user from task metrics

### DIFF
--- a/.changeset/calm-metrics-rest.md
+++ b/.changeset/calm-metrics-rest.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Removed user entity references from scaffolder task count metrics to avoid exposing user identities and creating high-cardinality metric labels.

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.test.ts
@@ -46,6 +46,7 @@ import {
   actionsRegistryServiceMock,
   metricsServiceMock,
 } from '@backstage/backend-test-utils/alpha';
+import { register } from 'prom-client';
 import { collectTemplateCapabilities } from '../../util/templating';
 import { TaskWorker } from './TaskWorker';
 
@@ -55,6 +56,7 @@ describe('NunjucksWorkflowRunner', () => {
   let fakeActionHandler: jest.Mock;
   let fakeTaskLog: jest.Mock;
   let stripAnsi: typeof import('strip-ansi').default;
+  let metrics: ReturnType<typeof metricsServiceMock.mock>;
 
   const logger = mockServices.logger.mock();
   const mockDir = createMockDirectory();
@@ -250,6 +252,7 @@ describe('NunjucksWorkflowRunner', () => {
       },
     });
 
+    metrics = metricsServiceMock.mock();
     runner = new NunjucksWorkflowRunner({
       actionRegistry,
       integrations,
@@ -257,7 +260,7 @@ describe('NunjucksWorkflowRunner', () => {
       logger,
       permissions: mockedPermissionApi,
       config,
-      metrics: metricsServiceMock.mock(),
+      metrics,
       templateCapabilities: collectTemplateCapabilities({
         filters: {
           toSecretKeyedObject: input => ({
@@ -272,6 +275,30 @@ describe('NunjucksWorkflowRunner', () => {
     mockDir.clear();
 
     jest.resetAllMocks();
+  });
+
+  it('does not include the user identity in task count metrics', async () => {
+    const template = 'template:default/example';
+    const task = createMockTaskWithSpec({
+      steps: [],
+      templateInfo: { entityRef: template },
+      user: { ref: 'user:default/example' },
+    });
+
+    await runner.execute(task);
+
+    expect(register.getSingleMetric('scaffolder_task_count')).toMatchObject({
+      labelNames: ['template', 'result'],
+    });
+
+    const taskCountIndex = metrics.createCounter.mock.calls.findIndex(
+      ([name]) => name === 'scaffolder.task.count',
+    );
+    const taskCount = metrics.createCounter.mock.results[taskCountIndex].value;
+    expect(taskCount.add).toHaveBeenCalledWith(1, {
+      template,
+      result: 'ok',
+    });
   });
 
   it('should throw an error if the action does not exist', async () => {

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.ts
@@ -972,7 +972,7 @@ function scaffoldingTracker(metrics: MetricsService) {
   const promTaskCount = createCounterMetric({
     name: 'scaffolder_task_count',
     help: 'Count of task runs',
-    labelNames: ['template', 'user', 'result'],
+    labelNames: ['template', 'result'],
   });
   const promTaskDuration = createHistogramMetric({
     name: 'scaffolder_task_duration',
@@ -1011,7 +1011,6 @@ function scaffoldingTracker(metrics: MetricsService) {
   async function taskStart(task: TaskContext) {
     await task.emitLog(`Starting up task with ${task.spec.steps.length} steps`);
     const template = task.spec.templateInfo?.entityRef || '';
-    const user = task.spec.user?.ref || '';
 
     const startTime = process.hrtime();
     const taskTimer = promTaskDuration.startTimer({
@@ -1036,12 +1035,11 @@ function scaffoldingTracker(metrics: MetricsService) {
     async function markSuccessful() {
       promTaskCount.inc({
         template,
-        user,
         result: 'ok',
       });
       taskTimer({ result: 'ok' });
 
-      taskCount.add(1, { template, user, result: 'ok' });
+      taskCount.add(1, { template, result: 'ok' });
       taskDuration.record(endTime(), {
         template,
         result: 'ok',
@@ -1055,12 +1053,11 @@ function scaffoldingTracker(metrics: MetricsService) {
       });
       promTaskCount.inc({
         template,
-        user,
         result: 'failed',
       });
       taskTimer({ result: 'failed' });
 
-      taskCount.add(1, { template, user, result: 'failed' });
+      taskCount.add(1, { template, result: 'failed' });
       taskDuration.record(endTime(), {
         template,
         result: 'failed',
@@ -1074,12 +1071,11 @@ function scaffoldingTracker(metrics: MetricsService) {
       });
       promTaskCount.inc({
         template,
-        user,
         result: 'cancelled',
       });
       taskTimer({ result: 'cancelled' });
 
-      taskCount.add(1, { template, user, result: 'cancelled' });
+      taskCount.add(1, { template, result: 'cancelled' });
       taskDuration.record(endTime(), {
         template,
         result: 'cancelled',


### PR DESCRIPTION
## Description

Removes the Backstage user entity reference from scaffolder task count metrics. The user attribute exposed user identities as an unbounded, high-cardinality metric dimension in both the legacy Prometheus metric and the OpenTelemetry metric.

The task count continues to include the template and result dimensions. Task ownership, authorization, audit logging, and template/action user context are unchanged.

## Validation

- `CI=1 yarn test plugins/scaffolder-backend/src/scaffolder/tasks/NunjucksWorkflowRunner.test.ts`
- `yarn tsc`
- `yarn backstage-cli repo lint --fix --since 60975e4ec61`
- API reports generated without changes; the command exits after generation because Node 26 emits a `DEP0205` warning on stderr

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation (not needed; metric dimensions are not documented)
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (not applicable)
- [x] All commits have a `Signed-off-by` line in the message.
