### PR TITLE
perf(backend-defaults): reuse database existence checks

### DIFF
--- a/.changeset/quick-databases-share.md
+++ b/.changeset/quick-databases-share.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Reduced PostgreSQL startup connections when multiple plugins share a database by reusing the database existence check.

--- a/packages/backend-defaults/src/entrypoints/database/connectors/postgres.test.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/postgres.test.ts
@@ -21,14 +21,21 @@ import {
   createPgDatabaseClient,
   getPgConnectionConfig,
   parsePgConnectionString,
+  PgConnector,
 } from './postgres';
 import { type Knex } from 'knex';
+import { mockServices } from '@backstage/backend-test-utils';
 
 jest.mock('@google-cloud/cloud-sql-connector');
 jest.mock('@azure/identity');
 jest.mock('@aws-sdk/rds-signer');
 
 describe('postgres', () => {
+  const deps = {
+    logger: mockServices.logger.mock(),
+    lifecycle: mockServices.lifecycle.mock(),
+  };
+
   const createMockConnection = () => ({
     host: 'acme',
     user: 'foo',
@@ -836,6 +843,60 @@ describe('postgres', () => {
         },
         useNullAsDefault: true,
       });
+    });
+  });
+
+  describe('PgConnector', () => {
+    const createConnectorConfig = () =>
+      new ConfigReader({
+        client: 'pg',
+        connection: { host: 'localhost' },
+        plugin: {
+          plugin1: { connection: { database: 'shared' } },
+          plugin2: { connection: { database: 'shared' } },
+        },
+      });
+
+    it('shares database existence checks between plugins', async () => {
+      const ensureDatabaseExists = jest.fn().mockResolvedValue(undefined);
+      const connector = new PgConnector(
+        createConnectorConfig(),
+        'backstage_plugin_',
+        ensureDatabaseExists,
+      );
+
+      const clients = await Promise.all([
+        connector.getClient('plugin1', deps),
+        connector.getClient('plugin2', deps),
+      ]);
+
+      expect(ensureDatabaseExists).toHaveBeenCalledTimes(1);
+      expect(ensureDatabaseExists).toHaveBeenCalledWith(
+        expect.any(ConfigReader),
+        'shared',
+      );
+
+      await Promise.all(clients.map(client => client.destroy()));
+    });
+
+    it('retries a database existence check after failure', async () => {
+      const ensureDatabaseExists = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('temporary failure'))
+        .mockResolvedValueOnce(undefined);
+      const connector = new PgConnector(
+        createConnectorConfig(),
+        'backstage_plugin_',
+        ensureDatabaseExists,
+      );
+
+      await expect(connector.getClient('plugin1', deps)).rejects.toThrow(
+        "Failed to connect to the database to make sure that 'shared' exists, Error: temporary failure",
+      );
+
+      const client = await connector.getClient('plugin2', deps);
+      expect(ensureDatabaseExists).toHaveBeenCalledTimes(2);
+      await client.destroy();
     });
   });
 

--- a/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
@@ -668,10 +668,34 @@ export function computePgPluginConfig(
 export class PgConnector implements Connector {
   private readonly config: Config;
   private readonly prefix: string;
+  private readonly databaseEnsureCache = new Map<string, Promise<void>>();
+  private readonly ensureDatabaseExists: typeof ensurePgDatabaseExists;
 
-  constructor(config: Config, prefix: string) {
+  constructor(
+    config: Config,
+    prefix: string,
+    ensureDatabaseExists: typeof ensurePgDatabaseExists = ensurePgDatabaseExists,
+  ) {
     this.config = config;
     this.prefix = prefix;
+    this.ensureDatabaseExists = ensureDatabaseExists;
+  }
+
+  private async ensureDatabase(databaseName: string): Promise<void> {
+    let promise = this.databaseEnsureCache.get(databaseName);
+    if (!promise) {
+      promise = this.ensureDatabaseExists(this.config, databaseName);
+      this.databaseEnsureCache.set(databaseName, promise);
+    }
+
+    try {
+      await promise;
+    } catch (error) {
+      if (this.databaseEnsureCache.get(databaseName) === promise) {
+        this.databaseEnsureCache.delete(databaseName);
+      }
+      throw error;
+    }
   }
 
   async getClient(
@@ -689,7 +713,7 @@ export class PgConnector implements Connector {
 
     if (pluginDbConfig.databaseName && pluginDbConfig.ensureExists) {
       try {
-        await ensurePgDatabaseExists(this.config, pluginDbConfig.databaseName);
+        await this.ensureDatabase(pluginDbConfig.databaseName);
       } catch (error) {
         throw new Error(
           `Failed to connect to the database to make sure that '${pluginDbConfig.databaseName}' exists, ${error}`,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

When using PostgreSQL with `pluginDivisionMode: schema`, every plugin targets the same database but currently repeats the same database existence check during startup. Each check creates its own temporary administrative connection pool, queries `pg_database`, and then destroys the pool. This change shares in-flight and completed checks within the connector, avoiding those duplicate temporary pools and queries, while removing failed checks so later attempts can retry.

Schema creation itself remains scoped to each plugin and is unchanged by this PR.

#### Verification

- `CI=1 yarn test packages/backend-defaults/src/entrypoints/database/connectors/postgres.test.ts`
- `yarn tsc`
- `yarn build:api-reports`

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
