### PR TITLE
Speed up GitHub environment action tests with fake timers

### DIFF
--- a/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.examples.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.examples.test.ts
@@ -69,7 +69,14 @@ describe('github:environment:create examples', () => {
   const mockContext = createMockActionContext();
   const mockCatalogService = catalogServiceMock.mock();
 
+  async function runAction(context: Parameters<typeof action.handler>[0]) {
+    const result = action.handler(context);
+    await jest.advanceTimersByTimeAsync(2_000);
+    await result;
+  }
+
   beforeEach(() => {
+    jest.useFakeTimers();
     mockOctokit.rest.actions.getEnvironmentPublicKey.mockResolvedValue({
       data: {
         key: publicKey,
@@ -116,12 +123,15 @@ describe('github:environment:create examples', () => {
     });
   });
 
-  afterEach(jest.resetAllMocks);
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.resetAllMocks();
+  });
 
   it('Create a GitHub Environment (No Policies, No Variables, No Secrets)', async () => {
     const input = yaml.parse(examples[0].example).steps[0].input;
 
-    await action.handler({
+    await runAction({
       ...mockContext,
       input,
     });
@@ -154,7 +164,7 @@ describe('github:environment:create examples', () => {
   it('Create a GitHub Environment with Protected Branch Policy', async () => {
     const input = yaml.parse(examples[1].example).steps[0].input;
 
-    await action.handler({
+    await runAction({
       ...mockContext,
       input,
     });
@@ -191,7 +201,7 @@ describe('github:environment:create examples', () => {
   it('Create a GitHub Environment with Custom Branch Policies', async () => {
     const input = yaml.parse(examples[2].example).steps[0].input;
 
-    await action.handler({
+    await runAction({
       ...mockContext,
       input,
     });
@@ -243,7 +253,7 @@ describe('github:environment:create examples', () => {
   it('Create a GitHub Environment with Environment Variables and Secrets', async () => {
     const input = yaml.parse(examples[3].example).steps[0].input;
 
-    await action.handler({
+    await runAction({
       ...mockContext,
       input,
     });
@@ -318,7 +328,7 @@ describe('github:environment:create examples', () => {
   it(`should ${examples[4].description}`, async () => {
     const input = yaml.parse(examples[4].example).steps[0].input;
 
-    await action.handler({
+    await runAction({
       ...mockContext,
       input,
     });
@@ -369,7 +379,7 @@ describe('github:environment:create examples', () => {
   it(`should ${examples[5].description}`, async () => {
     const input = yaml.parse(examples[5].example).steps[0].input;
 
-    await action.handler({
+    await runAction({
       ...mockContext,
       input,
     });
@@ -423,7 +433,7 @@ describe('github:environment:create examples', () => {
   it(`should ${examples[6].description}`, async () => {
     const input = yaml.parse(examples[6].example).steps[0].input;
 
-    await action.handler({
+    await runAction({
       ...mockContext,
       input,
     });
@@ -520,7 +530,7 @@ describe('github:environment:create examples', () => {
   it(`should ${examples[7].description}`, async () => {
     const input = yaml.parse(examples[7].example).steps[0].input;
 
-    await action.handler({
+    await runAction({
       ...mockContext,
       input,
     });
@@ -553,7 +563,7 @@ describe('github:environment:create examples', () => {
   it(`should ${examples[8].description}`, async () => {
     const input = yaml.parse(examples[8].example).steps[0].input;
 
-    await action.handler({
+    await runAction({
       ...mockContext,
       input,
     });
@@ -586,7 +596,7 @@ describe('github:environment:create examples', () => {
   it(`should ${examples[9].description}`, async () => {
     const input = yaml.parse(examples[9].example).steps[0].input;
 
-    await action.handler({
+    await runAction({
       ...mockContext,
       input,
     });
@@ -649,7 +659,7 @@ describe('github:environment:create examples', () => {
   it(`should ${examples[10].description}`, async () => {
     const input = yaml.parse(examples[10].example).steps[0].input;
 
-    await action.handler({
+    await runAction({
       ...mockContext,
       input,
     });
@@ -702,7 +712,7 @@ describe('github:environment:create examples', () => {
   it(`should ${examples[11].description}`, async () => {
     const input = yaml.parse(examples[11].example).steps[0].input;
 
-    await action.handler({
+    await runAction({
       ...mockContext,
       input,
     });
@@ -756,7 +766,7 @@ describe('github:environment:create examples', () => {
   it(`should ${examples[12].description}`, async () => {
     const input = yaml.parse(examples[12].example).steps[0].input;
 
-    await action.handler({
+    await runAction({
       ...mockContext,
       input,
     });
@@ -791,7 +801,7 @@ describe('github:environment:create examples', () => {
   it(`should ${examples[13].description}`, async () => {
     const input = yaml.parse(examples[13].example).steps[0].input;
 
-    await action.handler({
+    await runAction({
       ...mockContext,
       input,
     });
@@ -866,7 +876,7 @@ describe('github:environment:create examples', () => {
   it(`should ${examples[14].description}`, async () => {
     const input = yaml.parse(examples[14].example).steps[0].input;
 
-    await action.handler({
+    await runAction({
       ...mockContext,
       input,
     });
@@ -899,7 +909,7 @@ describe('github:environment:create examples', () => {
   it(`should ${examples[15].description}`, async () => {
     const input = yaml.parse(examples[15].example).steps[0].input;
 
-    await action.handler({
+    await runAction({
       ...mockContext,
       input,
     });
@@ -932,7 +942,7 @@ describe('github:environment:create examples', () => {
   it(`should ${examples[16].description}`, async () => {
     const input = yaml.parse(examples[16].example).steps[0].input;
 
-    await action.handler({
+    await runAction({
       ...mockContext,
       input,
     });

--- a/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.test.ts
+++ b/plugins/scaffolder-backend-module-github/src/actions/githubEnvironment.test.ts
@@ -77,7 +77,14 @@ describe('github:environment:create', () => {
     },
   });
 
+  async function runAction(context: Parameters<typeof action.handler>[0]) {
+    const result = action.handler(context);
+    await jest.advanceTimersByTimeAsync(2_000);
+    await result;
+  }
+
   beforeEach(() => {
+    jest.useFakeTimers();
     octokitMock.mockImplementation(() => mockOctokit);
 
     mockOctokit.rest.actions.getEnvironmentPublicKey.mockResolvedValue({
@@ -127,10 +134,13 @@ describe('github:environment:create', () => {
     });
   });
 
-  afterEach(jest.resetAllMocks);
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.resetAllMocks();
+  });
 
   it('should pass context logger to Octokit client', async () => {
-    await action.handler(mockContext);
+    await runAction(mockContext);
 
     expect(octokitMock).toHaveBeenCalledWith(
       expect.objectContaining({ log: mockContext.logger }),
@@ -138,7 +148,7 @@ describe('github:environment:create', () => {
   });
 
   it('should work happy path', async () => {
-    await action.handler(mockContext);
+    await runAction(mockContext);
 
     expect(
       mockOctokit.rest.repos.createOrUpdateEnvironment,
@@ -154,7 +164,7 @@ describe('github:environment:create', () => {
   });
 
   it('should work specify deploymentBranchPolicy protected', async () => {
-    await action.handler({
+    await runAction({
       ...mockContext,
       input: {
         ...mockContext.input,
@@ -182,7 +192,7 @@ describe('github:environment:create', () => {
   });
 
   it('should work specify deploymentBranchPolicy custom', async () => {
-    await action.handler({
+    await runAction({
       ...mockContext,
       input: {
         ...mockContext.input,
@@ -230,7 +240,7 @@ describe('github:environment:create', () => {
   });
 
   it('should work specify deploymentTagPolicy custom', async () => {
-    await action.handler({
+    await runAction({
       ...mockContext,
       input: {
         ...mockContext.input,
@@ -278,7 +288,7 @@ describe('github:environment:create', () => {
   });
 
   it('should work specify environment variables', async () => {
-    await action.handler({
+    await runAction({
       ...mockContext,
       input: {
         ...mockContext.input,
@@ -327,7 +337,7 @@ describe('github:environment:create', () => {
   });
 
   it('should work specify secrets', async () => {
-    await action.handler({
+    await runAction({
       ...mockContext,
       input: {
         ...mockContext.input,
@@ -389,7 +399,7 @@ describe('github:environment:create', () => {
   });
 
   it('should work with wait_timer', async () => {
-    await action.handler({
+    await runAction({
       ...mockContext,
       input: {
         ...mockContext.input,
@@ -411,7 +421,7 @@ describe('github:environment:create', () => {
   });
 
   it('should work with wait_timer 0', async () => {
-    await action.handler({
+    await runAction({
       ...mockContext,
       input: {
         ...mockContext.input,
@@ -433,7 +443,7 @@ describe('github:environment:create', () => {
   });
 
   it('should work with preventSelfReview set to true', async () => {
-    await action.handler({
+    await runAction({
       ...mockContext,
       input: {
         ...mockContext.input,
@@ -455,7 +465,7 @@ describe('github:environment:create', () => {
   });
 
   it('should work with preventSelfReview set to false', async () => {
-    await action.handler({
+    await runAction({
       ...mockContext,
       input: {
         ...mockContext.input,
@@ -477,7 +487,7 @@ describe('github:environment:create', () => {
   });
 
   it('should work with reviewers', async () => {
-    await action.handler({
+    await runAction({
       ...mockContext,
       input: {
         ...mockContext.input,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Use fake timers for the intentional two-second delay in the GitHub environment action tests.

This preserves the delay in production and still runs each handler through the code after the delay, while reducing these two suites from roughly 36 seconds to under 2 seconds locally.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
