### PR TITLE
ci: gate Docker latest image promotion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
         run: node scripts/verify-plugin-directory.js
 
       - name: test release scripts
-        run: yarn node --test scripts/create-github-release.test.js
+        run: yarn node --test scripts/create-github-release.test.js scripts/find-latest-stable-release.test.js
 
       - name: build all packages
         run: yarn backstage-cli repo build --all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
         run: node scripts/verify-plugin-directory.js
 
       - name: test release scripts
-        run: yarn node --test scripts/create-github-release.test.js scripts/find-latest-stable-release.test.js
+        run: yarn node --test scripts/*.test.js
 
       - name: build all packages
         run: yarn backstage-cli repo build --all

--- a/.github/workflows/deploy_docker-image.yml
+++ b/.github/workflows/deploy_docker-image.yml
@@ -104,6 +104,7 @@ jobs:
         id: latest-release
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
+          retries: 3
           script: |
             const { findLatestStableRelease } = require(`${process.env.GITHUB_WORKSPACE}/backstage/scripts/find-latest-stable-release`);
             const tags = await github.paginate(github.rest.repos.listTags, {
@@ -134,4 +135,15 @@ jobs:
         env:
           IMAGE: ghcr.io/${{ github.repository_owner }}/backstage
           VERSION: ${{ github.event.client_payload.version }}
-        run: docker buildx imagetools create --tag "${IMAGE}:latest" "${IMAGE}:${VERSION}"
+        run: |
+          for attempt in 1 2 3; do
+            if docker buildx imagetools create --tag "${IMAGE}:latest" "${IMAGE}:${VERSION}"; then
+              exit 0
+            fi
+
+            if [ "${attempt}" -lt 3 ]; then
+              sleep $((attempt * 5))
+            fi
+          done
+
+          exit 1

--- a/.github/workflows/deploy_docker-image.yml
+++ b/.github/workflows/deploy_docker-image.yml
@@ -9,6 +9,10 @@ env:
   RELEASE_VERSION: v${{ github.event.client_payload.version }}
   TAG_VERSION: ghcr.io/${{ github.repository_owner }}/backstage:${{ github.event.client_payload.version }}
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -28,6 +32,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           path: backstage
+          persist-credentials: false
           ref: ${{ github.event.client_payload.version && env.RELEASE_VERSION || github.ref }}
 
       - name: use node.js ${{ matrix.node-version }}
@@ -92,6 +97,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           path: backstage
+          persist-credentials: false
           ref: ${{ github.sha }}
 
       - name: Check whether this is the latest stable release

--- a/.github/workflows/deploy_docker-image.yml
+++ b/.github/workflows/deploy_docker-image.yml
@@ -74,7 +74,6 @@ jobs:
           push: ${{ (github.event_name == 'repository_dispatch') && (github.event.action == 'release-published') }}
           platforms: linux/amd64,linux/arm64
           tags: |
-            ${{ github.event_name == 'workflow_dispatch' && format('ghcr.io/{0}/backstage:latest', github.repository_owner) || '' }}
             ${{ github.event.client_payload.version && env.TAG_VERSION || '' }}
           labels: |
             org.opencontainers.image.description=Docker image generated from the latest Backstage release; this contains what you would get out of the box by running npx @backstage/create-app and building a Docker image from the generated source. This is meant to ease the process of evaluating Backstage for the first time, but also has the severe limitation that there is no way to install additional plugins relevant to your infrastructure.

--- a/.github/workflows/deploy_docker-image.yml
+++ b/.github/workflows/deploy_docker-image.yml
@@ -69,7 +69,63 @@ jobs:
           push: ${{ (github.event_name == 'repository_dispatch') && (github.event.action == 'release-published') }}
           platforms: linux/amd64,linux/arm64
           tags: |
-            ghcr.io/${{ github.repository_owner }}/backstage:latest
+            ${{ github.event_name == 'workflow_dispatch' && format('ghcr.io/{0}/backstage:latest', github.repository_owner) || '' }}
             ${{ github.event.client_payload.version && env.TAG_VERSION || '' }}
           labels: |
             org.opencontainers.image.description=Docker image generated from the latest Backstage release; this contains what you would get out of the box by running npx @backstage/create-app and building a Docker image from the generated source. This is meant to ease the process of evaluating Backstage for the first time, but also has the severe limitation that there is no way to install additional plugins relevant to your infrastructure.
+
+  promote-latest:
+    if: ${{ (github.event_name == 'repository_dispatch') && (github.event.action == 'release-published') }}
+    needs: build
+    runs-on: ubuntu-latest
+    concurrency:
+      group: backstage-docker-latest-promotion
+      cancel-in-progress: false
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
+        with:
+          egress-policy: audit
+
+      - name: checkout workflow scripts
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          path: backstage
+          ref: ${{ github.sha }}
+
+      - name: Check whether this is the latest stable release
+        id: latest-release
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const { findLatestStableRelease } = require(`${process.env.GITHUB_WORKSPACE}/backstage/scripts/find-latest-stable-release`);
+            const tags = await github.paginate(github.rest.repos.listTags, {
+              ...context.repo,
+              per_page: 100,
+            });
+            const latestVersion = findLatestStableRelease(tags.map(tag => tag.name));
+            const releaseVersion = context.payload.client_payload.version;
+            const shouldPromote = releaseVersion === latestVersion;
+
+            core.info(`Latest stable release is v${latestVersion}`);
+            core.setOutput('should-promote', shouldPromote);
+
+      - name: Login to GitHub Container Registry
+        if: steps.latest-release.outputs.should-promote == 'true'
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        if: steps.latest-release.outputs.should-promote == 'true'
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Promote image to latest
+        if: steps.latest-release.outputs.should-promote == 'true'
+        env:
+          IMAGE: ghcr.io/${{ github.repository_owner }}/backstage
+          VERSION: ${{ github.event.client_payload.version }}
+        run: docker buildx imagetools create --tag "${IMAGE}:latest" "${IMAGE}:${VERSION}"

--- a/.github/workflows/deploy_docker-image.yml
+++ b/.github/workflows/deploy_docker-image.yml
@@ -84,6 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     concurrency:
       group: backstage-docker-latest-promotion
+      queue: max
       cancel-in-progress: false
 
     steps:

--- a/scripts/find-latest-stable-release.js
+++ b/scripts/find-latest-stable-release.js
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const stableReleasePattern = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+
+function isNewerVersion(version, otherVersion) {
+  for (let index = 0; index < version.length; index++) {
+    if (version[index] > otherVersion[index]) {
+      return true;
+    }
+    if (version[index] < otherVersion[index]) {
+      return false;
+    }
+  }
+  return false;
+}
+
+function findLatestStableRelease(tagNames) {
+  let latest;
+
+  for (const tagName of tagNames) {
+    const match = stableReleasePattern.exec(tagName);
+    if (!match) {
+      continue;
+    }
+
+    const version = match.slice(1).map(part => BigInt(part));
+    if (!latest || isNewerVersion(version, latest.version)) {
+      latest = { tagName, version };
+    }
+  }
+
+  if (!latest) {
+    throw new Error('No stable release tags found');
+  }
+
+  return latest.tagName.slice(1);
+}
+
+module.exports = { findLatestStableRelease };

--- a/scripts/find-latest-stable-release.test.js
+++ b/scripts/find-latest-stable-release.test.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const assert = require('node:assert/strict');
+const { test } = require('node:test');
+
+const { findLatestStableRelease } = require('./find-latest-stable-release');
+
+test('finds the highest stable release using numeric version ordering', () => {
+  assert.equal(
+    findLatestStableRelease(['v1.9.9', 'v1.10.0', 'v2.0.0', 'v1.54.6']),
+    '2.0.0',
+  );
+});
+
+test('ignores prerelease and malformed tags', () => {
+  assert.equal(
+    findLatestStableRelease([
+      'v1.54.6-next.1',
+      'v1.54.6',
+      '1.55.0',
+      'v1.55',
+      'v01.55.0',
+      'v2.0.0-beta.1',
+      'release-v3.0.0',
+    ]),
+    '1.54.6',
+  );
+});
+
+test('fails when no stable release tag is available', () => {
+  assert.throws(
+    () => findLatestStableRelease(['v1.55.0-next.1', 'not-a-release']),
+    /No stable release tags found/,
+  );
+});


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Every published release currently assigns both its immutable version tag and the latest Docker tag. This means that publishing a patch for an older release line can move latest backwards.

This keeps the existing build and version-specific image publication intact, but moves latest into a separate promotion job. At promotion time it:

- reads all exact stable vMAJOR.MINOR.PATCH tags and compares them numerically
- promotes only when the just-published version is the highest stable release
- retags the already-built multi-platform manifest without rebuilding it
- fails without changing latest if the tag lookup or promotion fails

The promotion job is serialized to avoid concurrent writes and retries transient API and registry failures. Prereleases and malformed tags are ignored. Manual workflow runs continue to build without pushing an image, and every release event still publishes its immutable version image.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. (Not applicable; workflow-only change.)
- [ ] Added or updated documentation (Not applicable.)
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (Not applicable.)
- [x] All commits have a Signed-off-by line in the message.
