### PR TITLE
ci: validate release manifest dispatch version

### DIFF
--- a/.github/workflows/sync_release-manifest.yml
+++ b/.github/workflows/sync_release-manifest.yml
@@ -3,6 +3,9 @@ on:
   repository_dispatch:
     types: [release-published]
 
+permissions:
+  contents: read
+
 jobs:
   create-new-version:
     runs-on: ubuntu-latest
@@ -12,11 +15,27 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Validate release version
+        id: release
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          RELEASE_VERSION: ${{ github.event.client_payload.version }}
+        with:
+          script: |
+            const version = process.env.RELEASE_VERSION;
+            const validVersion = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.test(version);
+            if (!validVersion) {
+              core.setFailed('Invalid release version');
+              return;
+            }
+            core.setOutput('version', version);
+
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
+          persist-credentials: false
           # 'v' prefix is added here for the tag, we keep it out of the manifest logic
-          ref: v${{ github.event.client_payload.version }}
+          ref: v${{ steps.release.outputs.version }}
 
       - name: Use Node.js 22.x
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -48,26 +67,32 @@ jobs:
 
       - name: Create release
         # This grabs the scripts from master in order to support backfills
+        env:
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
         run: |
           mkdir -p scripts
           wget -O scripts/assemble-manifest.js https://raw.githubusercontent.com/backstage/backstage/master/scripts/assemble-manifest.js
-          node scripts/assemble-manifest.js ${{ github.event.client_payload.version }}
+          node scripts/assemble-manifest.js "$RELEASE_VERSION"
 
       # Copies the build output of the yarn-plugin package to the appropriate
       # directory, allowing the plugin to be installed with a command like
       # `yarn plugin import https://versions.backstage.io/v1/tags/main/yarn-plugin`
       - name: Add yarn plugin to release
         working-directory: packages/yarn-plugin
+        env:
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
         run: >-
           cp
           bundles/@yarnpkg/plugin-backstage.js
-          ../../versions/v1/releases/${{ github.event.client_payload.version }}/yarn-plugin
+          "../../versions/v1/releases/${RELEASE_VERSION}/yarn-plugin"
 
       - name: Commit to versions repo
         working-directory: versions
+        env:
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
         run: |
           git add .
-          git commit -am "${{ github.event.client_payload.version }}"
+          git commit -am "$RELEASE_VERSION"
           git push
 
       - name: Dispatch update-helper update

--- a/.github/workflows/sync_release-manifest.yml
+++ b/.github/workflows/sync_release-manifest.yml
@@ -23,7 +23,8 @@ jobs:
         with:
           script: |
             const version = process.env.RELEASE_VERSION;
-            const validVersion = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.test(version);
+            // Numeric prerelease identifiers must not contain leading zeroes.
+            const validVersion = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-(?:(?:0|[1-9]\d*)|(?:\d*[A-Za-z-][0-9A-Za-z-]*))(?:\.(?:(?:0|[1-9]\d*)|(?:\d*[A-Za-z-][0-9A-Za-z-]*)))*)?$/.test(version);
             if (!validVersion) {
               core.setFailed('Invalid release version');
               return;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This hardens the release manifest workflow's repository dispatch input handling while preserving the existing single-job release flow.

The workflow now validates the dispatched release version before using it as a release tag, path segment, script argument, or commit message. Shell steps receive the validated version through an environment variable and quote it at use sites, rather than interpolating the raw dispatch payload directly into shell script text.

The release checkout also disables persisted default checkout credentials. Publishing to the `backstage/versions` repository still uses the existing service-account checkout and push flow.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. (Not applicable; workflow-only change.)
- [ ] Added or updated documentation (Not applicable.)
- [ ] Tests for new functionality and regression tests for bug fixes. (Not applicable; workflow-only change.)
- [ ] Screenshots attached (Not applicable.)
- [x] All commits have a Signed-off-by line in the message.
