### PR TITLE
Optimize lazy frontend plugin loading

### DIFF
--- a/.changeset/lazy-frontend-entrypoints.md
+++ b/.changeset/lazy-frontend-entrypoints.md
@@ -1,0 +1,13 @@
+---
+'@backstage/plugin-app': patch
+'@backstage/plugin-catalog': patch
+'@backstage/plugin-catalog-import': patch
+'@backstage/plugin-catalog-unprocessed-entities': patch
+'@backstage/plugin-devtools': patch
+'@backstage/plugin-home': patch
+'@backstage/plugin-search': patch
+'@backstage/plugin-techdocs': patch
+'@backstage/plugin-user-settings': patch
+---
+
+Reduced the initial app bundle size by loading page and optional UI implementations only when their extensions render.

--- a/plugins/app/src/extensions/DefaultSignInPage.lazy.test.tsx
+++ b/plugins/app/src/extensions/DefaultSignInPage.lazy.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The Backstage Authors
+ * Copyright 2026 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
-import { EntityIconLinkBlueprint } from '@backstage/plugin-catalog-react/alpha';
-import { useCatalogSourceIconLinkProps } from '../components/AboutCard/useCatalogSourceIconLinkProps';
+describe('DefaultSignInPage', () => {
+  it('does not load the default sign-in component until its loader runs', () => {
+    jest.doMock('@backstage/core-components', () => {
+      throw new Error('core-components was loaded eagerly');
+    });
 
-const catalogViewSourceEntityIconLink = EntityIconLinkBlueprint.make({
-  name: 'view-source',
-  params: {
-    useProps: useCatalogSourceIconLinkProps,
-  },
+    expect(() => require('./DefaultSignInPage')).not.toThrow();
+  });
 });
-
-export default [catalogViewSourceEntityIconLink];

--- a/plugins/app/src/extensions/DefaultSignInPage.tsx
+++ b/plugins/app/src/extensions/DefaultSignInPage.tsx
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 import { SignInPageBlueprint } from '@backstage/plugin-app-react';
-import { SignInPage } from '@backstage/core-components';
 
 export const DefaultSignInPage = SignInPageBlueprint.make({
   params: {
-    loader: async () => props =>
-      <SignInPage {...props} providers={['guest']} />,
+    loader: async () => {
+      const { SignInPage } = await import('@backstage/core-components');
+      return props => <SignInPage {...props} providers={['guest']} />;
+    },
   },
 });

--- a/plugins/catalog-import/src/alpha.lazy.test.tsx
+++ b/plugins/catalog-import/src/alpha.lazy.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The Backstage Authors
+ * Copyright 2026 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
-import { EntityIconLinkBlueprint } from '@backstage/plugin-catalog-react/alpha';
-import { useCatalogSourceIconLinkProps } from '../components/AboutCard/useCatalogSourceIconLinkProps';
+describe('catalog-import alpha entry point', () => {
+  it('does not load permission UI until the import page loader runs', () => {
+    jest.doMock('@backstage/plugin-permission-react', () => {
+      throw new Error('permission UI was loaded eagerly');
+    });
 
-const catalogViewSourceEntityIconLink = EntityIconLinkBlueprint.make({
-  name: 'view-source',
-  params: {
-    useProps: useCatalogSourceIconLinkProps,
-  },
+    expect(() => require('./alpha')).not.toThrow();
+  });
 });
-
-export default [catalogViewSourceEntityIconLink];

--- a/plugins/catalog-import/src/alpha.tsx
+++ b/plugins/catalog-import/src/alpha.tsx
@@ -33,7 +33,6 @@ import {
 import { CatalogImportClient, catalogImportApiRef } from './api';
 import { rootRouteRef } from './plugin';
 import { catalogApiRef } from '@backstage/plugin-catalog-react';
-import { RequirePermission } from '@backstage/plugin-permission-react';
 import { catalogEntityCreatePermission } from '@backstage/plugin-catalog-common/alpha';
 
 import { catalogImportTranslationRef as _catalogImportTranslationRef } from './translation';
@@ -50,12 +49,17 @@ const catalogImportPage = PageBlueprint.make({
   params: {
     path: '/catalog-import',
     routeRef: rootRouteRef,
-    loader: () =>
-      import('./components/ImportPage').then(m => (
+    loader: async () => {
+      const [m, { RequirePermission }] = await Promise.all([
+        import('./components/ImportPage'),
+        import('@backstage/plugin-permission-react'),
+      ]);
+      return (
         <RequirePermission permission={catalogEntityCreatePermission}>
           <m.ImportPage />
         </RequirePermission>
-      )),
+      );
+    },
   },
 });
 

--- a/plugins/catalog-import/src/api/CatalogImportClient.lazy.test.ts
+++ b/plugins/catalog-import/src/api/CatalogImportClient.lazy.test.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe('CatalogImportClient module', () => {
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  it('does not load yaml until a pull request is submitted', () => {
+    jest.doMock('yaml', () => {
+      throw new Error('yaml was loaded eagerly');
+    });
+
+    jest.isolateModules(() => {
+      expect(() => require('./CatalogImportClient')).not.toThrow();
+    });
+  });
+});

--- a/plugins/catalog-import/src/api/CatalogImportClient.ts
+++ b/plugins/catalog-import/src/api/CatalogImportClient.ts
@@ -22,7 +22,6 @@ import {
 } from '@backstage/integration';
 import { ScmAuthApi } from '@backstage/integration-react';
 import { AnalyzeResult, CatalogImportApi } from './CatalogImportApi';
-import YAML from 'yaml';
 import { GitHubOptions, submitGitHubPrToRepo } from './GitHub';
 import { getCatalogFilename } from '../components/helpers';
 import { AnalyzeLocationResponse } from '@backstage/plugin-catalog-common';
@@ -174,6 +173,7 @@ the component will become available.\n\nFor more information, read an \
     body: string;
   }): Promise<{ link: string; location: string }> {
     const { repositoryUrl, fileContent, title, body } = options;
+    const { default: YAML } = await import('yaml');
 
     const parseData = YAML.parseAllDocuments(fileContent);
 

--- a/plugins/catalog-unprocessed-entities/src/alpha/plugin.lazy.test.tsx
+++ b/plugins/catalog-unprocessed-entities/src/alpha/plugin.lazy.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The Backstage Authors
+ * Copyright 2026 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
-import { EntityIconLinkBlueprint } from '@backstage/plugin-catalog-react/alpha';
-import { useCatalogSourceIconLinkProps } from '../components/AboutCard/useCatalogSourceIconLinkProps';
+describe('catalog-unprocessed-entities alpha entry point', () => {
+  it('does not load page layout UI until the DevTools content loader runs', () => {
+    jest.doMock('@backstage/ui', () => {
+      throw new Error('Backstage UI was loaded eagerly');
+    });
 
-const catalogViewSourceEntityIconLink = EntityIconLinkBlueprint.make({
-  name: 'view-source',
-  params: {
-    useProps: useCatalogSourceIconLinkProps,
-  },
+    expect(() => require('./plugin')).not.toThrow();
+  });
 });
-
-export default [catalogViewSourceEntityIconLink];

--- a/plugins/catalog-unprocessed-entities/src/alpha/plugin.tsx
+++ b/plugins/catalog-unprocessed-entities/src/alpha/plugin.tsx
@@ -26,7 +26,6 @@ import {
 import { catalogUnprocessedEntitiesApiRef } from '../api';
 import { RiStackLine } from '@remixicon/react';
 import { rootRouteRef } from '../routes';
-import { Container } from '@backstage/ui';
 import { CatalogUnprocessedEntitiesClient } from '@backstage/plugin-catalog-unprocessed-entities-common';
 
 /** @alpha */
@@ -68,12 +67,17 @@ export const unprocessedEntitiesDevToolsContent = SubPageBlueprint.make({
   params: {
     path: 'unprocessed-entities',
     title: 'Unprocessed Entities',
-    loader: () =>
-      import('../components/UnprocessedEntities').then(m => (
+    loader: async () => {
+      const [m, { Container }] = await Promise.all([
+        import('../components/UnprocessedEntities'),
+        import('@backstage/ui'),
+      ]);
+      return (
         <Container>
           <m.UnprocessedEntitiesContent />
         </Container>
-      )),
+      );
+    },
   },
 });
 

--- a/plugins/catalog/src/alpha/components/CatalogEntityPage.tsx
+++ b/plugins/catalog/src/alpha/components/CatalogEntityPage.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentType, ReactElement } from 'react';
+import { Entity, stringifyEntityRef } from '@backstage/catalog-model';
+import { useRouteRefParams } from '@backstage/core-plugin-api';
+import {
+  AsyncEntityProvider,
+  entityRouteRef,
+} from '@backstage/plugin-catalog-react';
+import {
+  type EntityContentGroupDefinitions,
+  type EntityHeaderLayoutProps,
+} from '@backstage/plugin-catalog-react/alpha';
+import { useEntityFromUrl } from '../../components/CatalogEntityPage/useEntityFromUrl';
+import { EntityLayout } from './EntityLayout';
+import { EntityLayoutBui } from './EntityLayout/EntityLayoutBui';
+import type { EntityLayoutRoute } from './EntityLayout/entityLayoutRoutes';
+import type { EntityContextMenuItemDataWithNode } from './EntityContextMenu';
+
+export interface CatalogEntityPageProps {
+  menuItems: Array<
+    EntityContextMenuItemDataWithNode & { filter: (entity: Entity) => boolean }
+  >;
+  headerLayouts: Array<{
+    Component: ComponentType<EntityHeaderLayoutProps>;
+    filter: (entity: Entity) => boolean;
+  }>;
+  headers: Array<{
+    element?: ReactElement;
+    filter: (entity: Entity) => boolean;
+  }>;
+  routes: EntityLayoutRoute[];
+  groupDefinitions: EntityContentGroupDefinitions;
+  defaultContentOrder: 'title' | 'natural';
+  showNavItemIcons: boolean;
+}
+
+export function CatalogEntityPage(props: CatalogEntityPageProps) {
+  const routeParams = useRouteRefParams(entityRouteRef);
+  const entityFromUrl = useEntityFromUrl();
+  const matchesRoute =
+    !!entityFromUrl.entity &&
+    stringifyEntityRef(entityFromUrl.entity) ===
+      stringifyEntityRef(routeParams);
+  const entity = matchesRoute ? entityFromUrl.entity : undefined;
+  const entityProviderProps = {
+    ...entityFromUrl,
+    entity,
+    loading: entityFromUrl.loading || (!!entityFromUrl.entity && !matchesRoute),
+  };
+  const filteredMenuItems = entity
+    ? props.menuItems
+        .filter(item => item.filter(entity))
+        .map(({ data, node }) => ({ data, node }))
+    : [];
+
+  const HeaderComponent = entity
+    ? props.headerLayouts.find(layout => layout.filter(entity))?.Component
+    : undefined;
+  const legacyHeader = entity
+    ? props.headers.find(header => header.filter(entity))?.element
+    : undefined;
+
+  const layout =
+    HeaderComponent || !legacyHeader ? (
+      <EntityLayoutBui
+        routes={props.routes}
+        HeaderComponent={HeaderComponent}
+        contextMenuItems={filteredMenuItems}
+        groupDefinitions={props.groupDefinitions}
+        defaultContentOrder={props.defaultContentOrder}
+      />
+    ) : (
+      <EntityLayout
+        routes={props.routes}
+        header={legacyHeader}
+        contextMenuItems={filteredMenuItems}
+        groupDefinitions={props.groupDefinitions}
+        defaultContentOrder={props.defaultContentOrder}
+        showNavItemIcons={props.showNavItemIcons}
+      />
+    );
+
+  return (
+    <AsyncEntityProvider {...entityProviderProps}>{layout}</AsyncEntityProvider>
+  );
+}

--- a/plugins/catalog/src/alpha/components/CatalogOverviewPage.tsx
+++ b/plugins/catalog/src/alpha/components/CatalogOverviewPage.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ComponentType, lazy as reactLazy, ReactElement } from 'react';
+import { Entity } from '@backstage/catalog-model';
+import {
+  type AppNode,
+  ExtensionBoundary,
+} from '@backstage/frontend-plugin-api';
+import { useEntity } from '@backstage/plugin-catalog-react';
+import {
+  type EntityCardType,
+  type EntityContentLayoutProps,
+} from '@backstage/plugin-catalog-react/alpha';
+
+const LazyDefaultLayoutComponent = reactLazy(() =>
+  import('../DefaultEntityContentLayout').then(m => ({
+    default: m.DefaultEntityContentLayout,
+  })),
+);
+
+export interface CatalogOverviewPageProps {
+  node: AppNode;
+  layouts: Array<{
+    filter: (entity: Entity) => boolean;
+    Component: ComponentType<EntityContentLayoutProps>;
+  }>;
+  cards: Array<{
+    element: ReactElement;
+    type?: EntityCardType;
+    filter: (entity: Entity) => boolean;
+  }>;
+}
+
+export function CatalogOverviewPage(props: CatalogOverviewPageProps) {
+  const { entity } = useEntity();
+  const layout = props.layouts.find(item => item.filter(entity));
+  const cards = props.cards.filter(card => card.filter(entity));
+
+  if (layout) {
+    return <layout.Component cards={cards} />;
+  }
+
+  return (
+    <ExtensionBoundary node={props.node}>
+      <LazyDefaultLayoutComponent cards={cards} />
+    </ExtensionBoundary>
+  );
+}

--- a/plugins/catalog/src/alpha/entityContents.tsx
+++ b/plugins/catalog/src/alpha/entityContents.tsx
@@ -14,20 +14,16 @@
  * limitations under the License.
  */
 
-import { lazy as reactLazy } from 'react';
 import {
   coreExtensionData,
   createExtensionInput,
-  ExtensionBoundary,
 } from '@backstage/frontend-plugin-api';
 import {
   EntityCardBlueprint,
   EntityContentBlueprint,
   EntityContentLayoutBlueprint,
-  EntityContentLayoutProps,
 } from '@backstage/plugin-catalog-react/alpha';
 import { buildFilterFn } from './filter/FilterWrapper';
-import { useEntity } from '@backstage/plugin-catalog-react';
 
 export const catalogOverviewEntityContent =
   EntityContentBlueprint.makeWithOverrides({
@@ -51,39 +47,20 @@ export const catalogOverviewEntityContent =
         title: 'Overview',
         group: 'overview',
         loader: async () => {
-          const LazyDefaultLayoutComponent = reactLazy(() =>
-            import('./DefaultEntityContentLayout').then(m => ({
-              default: m.DefaultEntityContentLayout,
-            })),
+          const { CatalogOverviewPage } = await import(
+            './components/CatalogOverviewPage'
           );
-
-          const DefaultLayoutComponent = (props: EntityContentLayoutProps) => {
-            return (
-              <ExtensionBoundary node={node}>
-                <LazyDefaultLayoutComponent {...props} />
-              </ExtensionBoundary>
-            );
-          };
-
-          const layouts = [
-            ...inputs.layouts.map(layout => ({
-              filter: buildFilterFn(
-                layout.get(
-                  EntityContentLayoutBlueprint.dataRefs.filterFunction,
-                ),
-                layout.get(
-                  EntityContentLayoutBlueprint.dataRefs.filterExpression,
-                ),
+          const layouts = inputs.layouts.map(layout => ({
+            filter: buildFilterFn(
+              layout.get(EntityContentLayoutBlueprint.dataRefs.filterFunction),
+              layout.get(
+                EntityContentLayoutBlueprint.dataRefs.filterExpression,
               ),
-              Component: layout.get(
-                EntityContentLayoutBlueprint.dataRefs.component,
-              ),
-            })),
-            {
-              filter: buildFilterFn(),
-              Component: DefaultLayoutComponent,
-            },
-          ];
+            ),
+            Component: layout.get(
+              EntityContentLayoutBlueprint.dataRefs.component,
+            ),
+          }));
 
           const cards = inputs.cards.map(card => ({
             element: card.get(coreExtensionData.reactElement),
@@ -94,23 +71,9 @@ export const catalogOverviewEntityContent =
             ),
           }));
 
-          const Component = () => {
-            const { entity } = useEntity();
-
-            // Use the first layout that matches the entity filter
-            const layout = layouts.find(l => l.filter(entity));
-            if (!layout) {
-              throw new Error('No layout found for entity'); // Shouldn't be able to happen
-            }
-
-            return (
-              <layout.Component
-                cards={cards.filter(card => card.filter(entity))}
-              />
-            );
-          };
-
-          return <Component />;
+          return (
+            <CatalogOverviewPage node={node} layouts={layouts} cards={cards} />
+          );
         },
       });
     },

--- a/plugins/catalog/src/alpha/pages.tsx
+++ b/plugins/catalog/src/alpha/pages.tsx
@@ -15,8 +15,6 @@
  */
 
 import { convertLegacyRouteRef } from '@backstage/core-compat-api';
-import { stringifyEntityRef } from '@backstage/catalog-model';
-import { useRouteRefParams } from '@backstage/core-plugin-api';
 import {
   coreExtensionData,
   createExtensionInput,
@@ -25,10 +23,7 @@ import {
   PageBlueprint,
 } from '@backstage/frontend-plugin-api';
 import { z } from 'zod/v4';
-import {
-  AsyncEntityProvider,
-  entityRouteRef,
-} from '@backstage/plugin-catalog-react';
+import { entityRouteRef } from '@backstage/plugin-catalog-react';
 import {
   defaultEntityContentGroupDefinitions,
   EntityContentBlueprint,
@@ -39,7 +34,6 @@ import {
 } from '@backstage/plugin-catalog-react/alpha';
 import CategoryIcon from '@material-ui/icons/Category';
 import { rootRouteRef } from '../routes';
-import { useEntityFromUrl } from '../components/CatalogEntityPage/useEntityFromUrl';
 import { buildFilterFn } from './filter/FilterWrapper';
 import type { CatalogExportSettings } from '../components/CatalogExportButton';
 
@@ -209,10 +203,9 @@ export const catalogEntityPage = PageBlueprint.makeWithOverrides({
       // `core-compat-api` package.
       routeRef: convertLegacyRouteRef(entityRouteRef), // READ THE ABOVE
       loader: async () => {
-        const [{ EntityLayout }, { EntityLayoutBui }] = await Promise.all([
-          import('./components/EntityLayout'),
-          import('./components/EntityLayout/EntityLayoutBui'),
-        ]);
+        const { CatalogEntityPage } = await import(
+          './components/CatalogEntityPage'
+        );
 
         const menuItems = inputs.contextMenuItems.map(item => ({
           data: item.get(EntityContextMenuItemBlueprint.dataRefs.data),
@@ -271,62 +264,17 @@ export const catalogEntityPage = PageBlueprint.makeWithOverrides({
           children: output.get(coreExtensionData.reactElement),
         }));
 
-        const Component = () => {
-          const routeParams = useRouteRefParams(entityRouteRef);
-          const entityFromUrl = useEntityFromUrl();
-          const matchesRoute =
-            !!entityFromUrl.entity &&
-            stringifyEntityRef(entityFromUrl.entity) ===
-              stringifyEntityRef(routeParams);
-          const entity = matchesRoute ? entityFromUrl.entity : undefined;
-          const entityProviderProps = {
-            ...entityFromUrl,
-            entity,
-            loading:
-              entityFromUrl.loading ||
-              (!!entityFromUrl.entity && !matchesRoute),
-          };
-          const filteredMenuItems = entity
-            ? menuItems
-                .filter(i => i.filter(entity))
-                .map(({ data, node }) => ({ data, node }))
-            : [];
-
-          const HeaderComponent = entity
-            ? headerLayouts.find(layout => layout.filter(entity))?.Component
-            : undefined;
-          const legacyHeader = entity
-            ? headers.find(header => header.filter(entity))?.element
-            : undefined;
-
-          const layout =
-            HeaderComponent || !legacyHeader ? (
-              <EntityLayoutBui
-                routes={routes}
-                HeaderComponent={HeaderComponent}
-                contextMenuItems={filteredMenuItems}
-                groupDefinitions={groupDefinitions}
-                defaultContentOrder={config.defaultContentOrder}
-              />
-            ) : (
-              <EntityLayout
-                routes={routes}
-                header={legacyHeader}
-                contextMenuItems={filteredMenuItems}
-                groupDefinitions={groupDefinitions}
-                defaultContentOrder={config.defaultContentOrder}
-                showNavItemIcons={config.showNavItemIcons}
-              />
-            );
-
-          return (
-            <AsyncEntityProvider {...entityProviderProps}>
-              {layout}
-            </AsyncEntityProvider>
-          );
-        };
-
-        return <Component />;
+        return (
+          <CatalogEntityPage
+            menuItems={menuItems}
+            headerLayouts={headerLayouts}
+            headers={headers}
+            routes={routes}
+            groupDefinitions={groupDefinitions}
+            defaultContentOrder={config.defaultContentOrder}
+            showNavItemIcons={config.showNavItemIcons}
+          />
+        );
       },
     });
   },

--- a/plugins/catalog/src/alpha/plugin.lazy.test.tsx
+++ b/plugins/catalog/src/alpha/plugin.lazy.test.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+describe('catalog alpha entry point', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('does not load the entity page implementation until its loader runs', () => {
+    jest.doMock('../components/CatalogEntityPage/useEntityFromUrl', () => {
+      throw new Error('entity page implementation was loaded eagerly');
+    });
+
+    jest.isolateModules(() => {
+      expect(() => require('./plugin')).not.toThrow();
+    });
+  });
+
+  it('does not load the About card to provide the source icon link', () => {
+    jest.doMock('../components/AboutCard/AboutCard', () => {
+      throw new Error('AboutCard was loaded eagerly');
+    });
+
+    jest.isolateModules(() => {
+      expect(() => require('./plugin')).not.toThrow();
+    });
+  });
+});

--- a/plugins/catalog/src/alpha/plugin.lazy.test.tsx
+++ b/plugins/catalog/src/alpha/plugin.lazy.test.tsx
@@ -29,6 +29,16 @@ describe('catalog alpha entry point', () => {
     });
   });
 
+  it('does not load the catalog overview page until its loader runs', () => {
+    jest.doMock('./components/CatalogOverviewPage', () => {
+      throw new Error('catalog overview page was loaded eagerly');
+    });
+
+    jest.isolateModules(() => {
+      expect(() => require('./plugin')).not.toThrow();
+    });
+  });
+
   it('does not load the About card to provide the source icon link', () => {
     jest.doMock('../components/AboutCard/AboutCard', () => {
       throw new Error('AboutCard was loaded eagerly');

--- a/plugins/catalog/src/components/AboutCard/AboutCard.tsx
+++ b/plugins/catalog/src/components/AboutCard/AboutCard.tsx
@@ -39,21 +39,12 @@ import {
 import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
 
 import {
-  ScmIntegrationIcon,
-  scmIntegrationsApiRef,
-} from '@backstage/integration-react';
-
-import {
   DEFAULT_NAMESPACE,
   ANNOTATION_EDIT_URL,
   ANNOTATION_LOCATION,
   stringifyEntityRef,
 } from '@backstage/catalog-model';
-import {
-  catalogApiRef,
-  getEntitySourceLocation,
-  useEntity,
-} from '@backstage/plugin-catalog-react';
+import { catalogApiRef, useEntity } from '@backstage/plugin-catalog-react';
 import { useEntityPermission } from '@backstage/plugin-catalog-react/alpha';
 import { catalogEntityRefreshPermission } from '@backstage/plugin-catalog-common/alpha';
 
@@ -73,6 +64,7 @@ import { catalogTranslationRef } from '../../alpha/translation';
 import { useSourceTemplateCompoundEntityRef } from './hooks';
 import { AboutContent } from './AboutContent';
 import { makeStyles } from '@material-ui/core/styles';
+import { useCatalogSourceIconLinkProps } from './useCatalogSourceIconLinkProps';
 
 const useStyles = makeStyles({
   linkContainer: {
@@ -82,22 +74,6 @@ const useStyles = makeStyles({
     marginBottom: 'var(--bui-space-6)',
   },
 });
-
-export function useCatalogSourceIconLinkProps() {
-  const { entity } = useEntity();
-  const scmIntegrationsApi = useApi(scmIntegrationsApiRef);
-  const { t } = useTranslationRef(catalogTranslationRef);
-  const entitySourceLocation = getEntitySourceLocation(
-    entity,
-    scmIntegrationsApi,
-  );
-  return {
-    label: t('aboutCard.viewSource'),
-    disabled: !entitySourceLocation,
-    icon: <ScmIntegrationIcon type={entitySourceLocation?.integrationType} />,
-    href: entitySourceLocation?.locationTargetUrl,
-  };
-}
 
 // TODO: This hook is duplicated from the TechDocs plugin for backwards compatibility
 // Remove it when the the legacy frontend system support is dropped.

--- a/plugins/catalog/src/components/AboutCard/useCatalogSourceIconLinkProps.tsx
+++ b/plugins/catalog/src/components/AboutCard/useCatalogSourceIconLinkProps.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useApi } from '@backstage/core-plugin-api';
+import { useTranslationRef } from '@backstage/core-plugin-api/alpha';
+import {
+  ScmIntegrationIcon,
+  scmIntegrationsApiRef,
+} from '@backstage/integration-react';
+import {
+  getEntitySourceLocation,
+  useEntity,
+} from '@backstage/plugin-catalog-react';
+import { catalogTranslationRef } from '../../alpha/translation';
+
+export function useCatalogSourceIconLinkProps() {
+  const { entity } = useEntity();
+  const scmIntegrationsApi = useApi(scmIntegrationsApiRef);
+  const { t } = useTranslationRef(catalogTranslationRef);
+  const entitySourceLocation = getEntitySourceLocation(
+    entity,
+    scmIntegrationsApi,
+  );
+  return {
+    label: t('aboutCard.viewSource'),
+    disabled: !entitySourceLocation,
+    icon: <ScmIntegrationIcon type={entitySourceLocation?.integrationType} />,
+    href: entitySourceLocation?.locationTargetUrl,
+  };
+}

--- a/plugins/devtools/src/alpha/plugin.lazy.test.tsx
+++ b/plugins/devtools/src/alpha/plugin.lazy.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The Backstage Authors
+ * Copyright 2026 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
-import { EntityIconLinkBlueprint } from '@backstage/plugin-catalog-react/alpha';
-import { useCatalogSourceIconLinkProps } from '../components/AboutCard/useCatalogSourceIconLinkProps';
+describe('devtools alpha entry point', () => {
+  it('does not load page layout UI until a sub-page loader runs', () => {
+    jest.doMock('@backstage/core-components', () => {
+      throw new Error('core-components was loaded eagerly');
+    });
 
-const catalogViewSourceEntityIconLink = EntityIconLinkBlueprint.make({
-  name: 'view-source',
-  params: {
-    useProps: useCatalogSourceIconLinkProps,
-  },
+    expect(() => require('./plugin')).not.toThrow();
+  });
 });
-
-export default [catalogViewSourceEntityIconLink];

--- a/plugins/devtools/src/alpha/plugin.tsx
+++ b/plugins/devtools/src/alpha/plugin.tsx
@@ -26,14 +26,12 @@ import {
 
 import { devToolsApiRef, DevToolsClient } from '../api';
 import BuildIcon from '@material-ui/icons/Build';
-import { Content } from '@backstage/core-components';
 import { rootRouteRef } from '../routes';
 import {
   devToolsConfigReadPermission,
   devToolsInfoReadPermission,
 } from '@backstage/plugin-devtools-common';
 import { devToolsTaskSchedulerReadPermission } from '@backstage/plugin-devtools-common/alpha';
-import { RequirePermission } from '@backstage/plugin-permission-react';
 
 /** @alpha */
 export const devToolsApi = ApiBlueprint.make({
@@ -88,14 +86,20 @@ export const devToolsInfoPage = SubPageBlueprint.make({
   params: {
     path: 'info',
     title: 'Info',
-    loader: () =>
-      import('../components/Content').then(m => (
+    loader: async () => {
+      const [m, { Content }, { RequirePermission }] = await Promise.all([
+        import('../components/Content'),
+        import('@backstage/core-components'),
+        import('@backstage/plugin-permission-react'),
+      ]);
+      return (
         <Content>
           <RequirePermission permission={devToolsInfoReadPermission}>
             <m.InfoContent />
           </RequirePermission>
         </Content>
-      )),
+      );
+    },
   },
 });
 
@@ -105,14 +109,20 @@ export const devToolsConfigPage = SubPageBlueprint.make({
   params: {
     path: 'config',
     title: 'Config',
-    loader: () =>
-      import('../components/Content').then(m => (
+    loader: async () => {
+      const [m, { Content }, { RequirePermission }] = await Promise.all([
+        import('../components/Content'),
+        import('@backstage/core-components'),
+        import('@backstage/plugin-permission-react'),
+      ]);
+      return (
         <Content>
           <RequirePermission permission={devToolsConfigReadPermission}>
             <m.ConfigContent />
           </RequirePermission>
         </Content>
-      )),
+      );
+    },
   },
 });
 
@@ -122,14 +132,20 @@ export const devToolsScheduledTasksPage = SubPageBlueprint.make({
   params: {
     path: 'scheduled-tasks',
     title: 'Scheduled Tasks',
-    loader: () =>
-      import('../components/Content').then(m => (
+    loader: async () => {
+      const [m, { Content }, { RequirePermission }] = await Promise.all([
+        import('../components/Content'),
+        import('@backstage/core-components'),
+        import('@backstage/plugin-permission-react'),
+      ]);
+      return (
         <Content>
           <RequirePermission permission={devToolsTaskSchedulerReadPermission}>
             <m.ScheduledTasksContent />
           </RequirePermission>
         </Content>
-      )),
+      );
+    },
   },
 });
 

--- a/plugins/home/src/alpha.lazy.test.tsx
+++ b/plugins/home/src/alpha.lazy.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The Backstage Authors
+ * Copyright 2026 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,18 @@
  * limitations under the License.
  */
 
-import { EntityIconLinkBlueprint } from '@backstage/plugin-catalog-react/alpha';
-import { useCatalogSourceIconLinkProps } from '../components/AboutCard/useCatalogSourceIconLinkProps';
+describe('home alpha entry point', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
 
-const catalogViewSourceEntityIconLink = EntityIconLinkBlueprint.make({
-  name: 'view-source',
-  params: {
-    useProps: useCatalogSourceIconLinkProps,
-  },
+  it('does not load visit tracking UI unless it is enabled', () => {
+    jest.doMock('./components/', () => {
+      throw new Error('home components were loaded eagerly');
+    });
+
+    jest.isolateModules(() => {
+      expect(() => require('./alpha')).not.toThrow();
+    });
+  });
 });
-
-export default [catalogViewSourceEntityIconLink];

--- a/plugins/home/src/alpha.lazy.test.tsx
+++ b/plugins/home/src/alpha.lazy.test.tsx
@@ -20,8 +20,8 @@ describe('home alpha entry point', () => {
   });
 
   it('does not load visit tracking UI unless it is enabled', () => {
-    jest.doMock('./components/', () => {
-      throw new Error('home components were loaded eagerly');
+    jest.doMock('./components/VisitListener', () => {
+      throw new Error('visit listener was loaded eagerly');
     });
 
     jest.isolateModules(() => {

--- a/plugins/home/src/alpha.tsx
+++ b/plugins/home/src/alpha.tsx
@@ -40,7 +40,6 @@ import {
   iconsApiRef,
 } from '@backstage/frontend-plugin-api';
 import { useApi } from '@backstage/core-plugin-api';
-import { VisitListener } from './components/';
 import { visitsApiRef, VisitsStorageApi, VisitsWebStorageApi } from './api';
 import HomeIcon from '@material-ui/icons/Home';
 import LinkIcon from '@material-ui/icons/Link';
@@ -53,6 +52,12 @@ import {
 } from '@backstage/plugin-home-react/alpha';
 
 const rootRouteRef = createRouteRef();
+
+const VisitListener = reactLazy(() =>
+  import('./components/VisitListener').then(m => ({
+    default: m.VisitListener,
+  })),
+);
 
 const defaultConfigItemSchema = z.object({
   component: z.string(),

--- a/plugins/search/src/alpha.lazy.test.tsx
+++ b/plugins/search/src/alpha.lazy.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The Backstage Authors
+ * Copyright 2026 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
-import { EntityIconLinkBlueprint } from '@backstage/plugin-catalog-react/alpha';
-import { useCatalogSourceIconLinkProps } from '../components/AboutCard/useCatalogSourceIconLinkProps';
+describe('search alpha entry point', () => {
+  it('does not load the search page implementation until the page loader runs', () => {
+    jest.doMock('./components/SearchType', () => {
+      throw new Error('SearchType was loaded eagerly');
+    });
 
-const catalogViewSourceEntityIconLink = EntityIconLinkBlueprint.make({
-  name: 'view-source',
-  params: {
-    useProps: useCatalogSourceIconLinkProps,
-  },
+    expect(() => require('./alpha')).not.toThrow();
+  });
 });
-
-export default [catalogViewSourceEntityIconLink];

--- a/plugins/search/src/alpha.tsx
+++ b/plugins/search/src/alpha.tsx
@@ -14,47 +14,18 @@
  * limitations under the License.
  */
 
-import Grid from '@material-ui/core/Grid';
-import Paper from '@material-ui/core/Paper';
-import { makeStyles, Theme } from '@material-ui/core/styles';
 import SearchIcon from '@material-ui/icons/Search';
 import { z } from 'zod/v4';
 
-import {
-  CatalogIcon,
-  Content,
-  useSidebarPinState,
-} from '@backstage/core-components';
-import {
-  useApi,
-  discoveryApiRef,
-  fetchApiRef,
-} from '@backstage/core-plugin-api';
+import { discoveryApiRef, fetchApiRef } from '@backstage/core-plugin-api';
 
 import {
   createFrontendPlugin,
   ApiBlueprint,
   createExtensionInput,
   PageBlueprint,
-  configApiRef,
 } from '@backstage/frontend-plugin-api';
 
-import {
-  catalogApiRef,
-  CATALOG_FILTER_EXISTS,
-} from '@backstage/plugin-catalog-react';
-
-import {
-  DefaultResultListItem,
-  SearchBar,
-  SearchFilter,
-  SearchPagination,
-  SearchResult as SearchResults,
-  SearchResultPager,
-  useSearch,
-  SearchContextProvider,
-} from '@backstage/plugin-search-react';
-import { SearchResult } from '@backstage/plugin-search-common';
 import { searchApiRef } from '@backstage/plugin-search-react';
 import {
   SearchResultListItemBlueprint,
@@ -65,8 +36,6 @@ import { HomePageWidgetBlueprint } from '@backstage/plugin-home-react/alpha';
 
 import { rootRouteRef } from './plugin';
 import { SearchClient } from './apis';
-import { SearchType } from './components/SearchType';
-import { UrlUpdater } from './components/SearchPage/SearchPage';
 
 /** @alpha */
 export const searchApi = ApiBlueprint.make({
@@ -78,18 +47,6 @@ export const searchApi = ApiBlueprint.make({
         new SearchClient({ discoveryApi, fetchApi }),
     }),
 });
-
-const useSearchPageStyles = makeStyles((theme: Theme) => ({
-  filter: {
-    '& + &': {
-      marginTop: theme.spacing(2.5),
-    },
-  },
-  filters: {
-    padding: theme.spacing(2),
-    marginTop: theme.spacing(2),
-  },
-}));
 
 /** @alpha */
 export const searchPage = PageBlueprint.makeWithOverrides({
@@ -112,139 +69,24 @@ export const searchPage = PageBlueprint.makeWithOverrides({
       title: 'Search',
       icon: <SearchIcon fontSize="inherit" />,
       loader: async () => {
-        const getResultItemComponent = (result: SearchResult) => {
-          const value = inputs.items.find(item =>
-            item
-              ?.get(SearchResultListItemBlueprint.dataRefs.item)
-              .predicate?.(result),
-          );
-          return (
-            value?.get(SearchResultListItemBlueprint.dataRefs.item).component ??
-            DefaultResultListItem
-          );
-        };
-
+        const { SearchPage } = await import('./alpha/SearchPage');
+        const items = inputs.items.map(item =>
+          item.get(SearchResultListItemBlueprint.dataRefs.item),
+        );
         const resultTypes = inputs.resultTypes.map(item =>
           item.get(SearchFilterResultTypeBlueprint.dataRefs.resultType),
         );
-
-        const additionalSearchFilters = inputs.searchFilters.map(
+        const searchFilters = inputs.searchFilters.map(
           item =>
             item.get(SearchFilterBlueprint.dataRefs.searchFilters).component,
         );
-
-        const Component = () => {
-          const classes = useSearchPageStyles();
-          const { isMobile } = useSidebarPinState();
-          const { types } = useSearch();
-          const catalogApi = useApi(catalogApiRef);
-          const configApi = useApi(configApiRef);
-
-          return (
-            <Content>
-              <Grid container direction="row">
-                <Grid item xs={12}>
-                  <SearchBar debounceTime={100} />
-                </Grid>
-                {!isMobile && (
-                  <Grid item xs={3}>
-                    <SearchType.Accordion
-                      name="Result Type"
-                      defaultValue={configApi.getOptionalString(
-                        'search.defaultType',
-                      )}
-                      showCounts
-                      types={[
-                        {
-                          value: 'software-catalog',
-                          name: 'Software Catalog',
-                          icon: <CatalogIcon />,
-                        },
-                      ].concat(resultTypes)}
-                    />
-                    <Paper className={classes.filters}>
-                      {types.includes('techdocs') && (
-                        <SearchFilter.Select
-                          className={classes.filter}
-                          label="Entity"
-                          name="name"
-                          values={async () => {
-                            // Return a list of entities which are documented.
-                            const { items } = await catalogApi.getEntities({
-                              fields: ['metadata.name'],
-                              filter: {
-                                'metadata.annotations.backstage.io/techdocs-ref':
-                                  CATALOG_FILTER_EXISTS,
-                              },
-                            });
-
-                            const names = items.map(
-                              entity => entity.metadata.name,
-                            );
-                            names.sort();
-                            return names;
-                          }}
-                        />
-                      )}
-                      <SearchFilter.Select
-                        className={classes.filter}
-                        label="Kind"
-                        name="kind"
-                        values={async () => {
-                          const { facets } = await catalogApi.getEntityFacets({
-                            facets: ['kind'],
-                          });
-                          return (facets.kind ?? [])
-                            .map(facet => facet.value)
-                            .sort((a, b) => a.localeCompare(b));
-                        }}
-                      />
-                      <SearchFilter.Checkbox
-                        className={classes.filter}
-                        label="Lifecycle"
-                        name="lifecycle"
-                        values={['experimental', 'production']}
-                      />
-                      {additionalSearchFilters.map(SearchFilterComponent => (
-                        <SearchFilterComponent className={classes.filter} />
-                      ))}
-                    </Paper>
-                  </Grid>
-                )}
-                <Grid item xs>
-                  <SearchPagination />
-                  <SearchResults>
-                    {({ results }) => (
-                      <>
-                        {results.map((result, index) => {
-                          const { noTrack } = config;
-                          const { document, ...rest } = result;
-                          const SearchResultListItem =
-                            getResultItemComponent(result);
-                          return (
-                            <SearchResultListItem
-                              {...rest}
-                              key={index}
-                              result={document}
-                              noTrack={noTrack}
-                            />
-                          );
-                        })}
-                      </>
-                    )}
-                  </SearchResults>
-                  <SearchResultPager />
-                </Grid>
-              </Grid>
-            </Content>
-          );
-        };
-
         return (
-          <SearchContextProvider>
-            <UrlUpdater />
-            <Component />
-          </SearchContextProvider>
+          <SearchPage
+            noTrack={config.noTrack}
+            items={items}
+            resultTypes={resultTypes}
+            searchFilters={searchFilters}
+          />
         );
       },
     });

--- a/plugins/search/src/alpha/SearchPage.tsx
+++ b/plugins/search/src/alpha/SearchPage.tsx
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Grid from '@material-ui/core/Grid';
+import Paper from '@material-ui/core/Paper';
+import { makeStyles, Theme } from '@material-ui/core/styles';
+import {
+  CatalogIcon,
+  Content,
+  useSidebarPinState,
+} from '@backstage/core-components';
+import { useApi } from '@backstage/core-plugin-api';
+import { configApiRef } from '@backstage/frontend-plugin-api';
+import {
+  catalogApiRef,
+  CATALOG_FILTER_EXISTS,
+} from '@backstage/plugin-catalog-react';
+import { SearchResult } from '@backstage/plugin-search-common';
+import {
+  DefaultResultListItem,
+  SearchBar,
+  SearchContextProvider,
+  SearchFilter,
+  SearchPagination,
+  SearchResult as SearchResults,
+  SearchResultPager,
+  useSearch,
+} from '@backstage/plugin-search-react';
+import {
+  type SearchFilterExtensionComponent,
+  type SearchFilterResultTypeBlueprintParams,
+  type SearchResultItemExtensionComponent,
+  type SearchResultItemExtensionPredicate,
+} from '@backstage/plugin-search-react/alpha';
+import { SearchType } from '../components/SearchType';
+import { UrlUpdater } from '../components/SearchPage/SearchPage';
+
+const useSearchPageStyles = makeStyles((theme: Theme) => ({
+  filter: {
+    '& + &': {
+      marginTop: theme.spacing(2.5),
+    },
+  },
+  filters: {
+    padding: theme.spacing(2),
+    marginTop: theme.spacing(2),
+  },
+}));
+
+export interface SearchPageProps {
+  noTrack: boolean;
+  items: Array<{
+    predicate?: SearchResultItemExtensionPredicate;
+    component: SearchResultItemExtensionComponent;
+  }>;
+  resultTypes: SearchFilterResultTypeBlueprintParams[];
+  searchFilters: SearchFilterExtensionComponent[];
+}
+
+function SearchPageContent(props: SearchPageProps) {
+  const getResultItemComponent = (result: SearchResult) =>
+    props.items.find(item => item.predicate?.(result))?.component ??
+    DefaultResultListItem;
+
+  const classes = useSearchPageStyles();
+  const { isMobile } = useSidebarPinState();
+  const { types } = useSearch();
+  const catalogApi = useApi(catalogApiRef);
+  const configApi = useApi(configApiRef);
+
+  return (
+    <Content>
+      <Grid container direction="row">
+        <Grid item xs={12}>
+          <SearchBar debounceTime={100} />
+        </Grid>
+        {!isMobile && (
+          <Grid item xs={3}>
+            <SearchType.Accordion
+              name="Result Type"
+              defaultValue={configApi.getOptionalString('search.defaultType')}
+              showCounts
+              types={[
+                {
+                  value: 'software-catalog',
+                  name: 'Software Catalog',
+                  icon: <CatalogIcon />,
+                },
+              ].concat(props.resultTypes)}
+            />
+            <Paper className={classes.filters}>
+              {types.includes('techdocs') && (
+                <SearchFilter.Select
+                  className={classes.filter}
+                  label="Entity"
+                  name="name"
+                  values={async () => {
+                    const { items } = await catalogApi.getEntities({
+                      fields: ['metadata.name'],
+                      filter: {
+                        'metadata.annotations.backstage.io/techdocs-ref':
+                          CATALOG_FILTER_EXISTS,
+                      },
+                    });
+
+                    const names = items.map(entity => entity.metadata.name);
+                    names.sort();
+                    return names;
+                  }}
+                />
+              )}
+              <SearchFilter.Select
+                className={classes.filter}
+                label="Kind"
+                name="kind"
+                values={async () => {
+                  const { facets } = await catalogApi.getEntityFacets({
+                    facets: ['kind'],
+                  });
+                  return (facets.kind ?? [])
+                    .map(facet => facet.value)
+                    .sort((a, b) => a.localeCompare(b));
+                }}
+              />
+              <SearchFilter.Checkbox
+                className={classes.filter}
+                label="Lifecycle"
+                name="lifecycle"
+                values={['experimental', 'production']}
+              />
+              {props.searchFilters.map((SearchFilterComponent, index) => (
+                <SearchFilterComponent key={index} className={classes.filter} />
+              ))}
+            </Paper>
+          </Grid>
+        )}
+        <Grid item xs>
+          <SearchPagination />
+          <SearchResults>
+            {({ results }) => (
+              <>
+                {results.map((result, index) => {
+                  const { document, ...rest } = result;
+                  const SearchResultListItem = getResultItemComponent(result);
+                  return (
+                    <SearchResultListItem
+                      {...rest}
+                      key={index}
+                      result={document}
+                      noTrack={props.noTrack}
+                    />
+                  );
+                })}
+              </>
+            )}
+          </SearchResults>
+          <SearchResultPager />
+        </Grid>
+      </Grid>
+    </Content>
+  );
+}
+
+export function SearchPage(props: SearchPageProps) {
+  return (
+    <SearchContextProvider>
+      <UrlUpdater />
+      <SearchPageContent {...props} />
+    </SearchContextProvider>
+  );
+}

--- a/plugins/techdocs/src/alpha/components/TechDocsReaderPage.tsx
+++ b/plugins/techdocs/src/alpha/components/TechDocsReaderPage.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ReactElement, Suspense } from 'react';
+import {
+  TechDocsAddons,
+  type TechDocsAddonOptions,
+} from '@backstage/plugin-techdocs-react';
+import { attachTechDocsAddonComponentData } from '@backstage/plugin-techdocs-react/alpha';
+import { EmbeddedDocsRouter, TechDocsReaderRouter } from '../../Router';
+import { TechDocsReaderLayout } from './TechDocsReaderLayout';
+
+function Addons(props: { options: TechDocsAddonOptions[] }) {
+  return (
+    <TechDocsAddons>
+      {props.options.map(options => {
+        const Addon = options.component;
+        attachTechDocsAddonComponentData(Addon, options);
+        return (
+          <Suspense key={options.name} fallback={null}>
+            <Addon />
+          </Suspense>
+        );
+      })}
+    </TechDocsAddons>
+  );
+}
+
+export function TechDocsReaderPage(props: {
+  addonOptions: TechDocsAddonOptions[];
+  withSearch: boolean;
+  withHeader: boolean;
+}) {
+  return (
+    <TechDocsReaderRouter>
+      <TechDocsReaderLayout
+        withSearch={props.withSearch}
+        withHeader={props.withHeader}
+      />
+      <Addons options={props.addonOptions} />
+    </TechDocsReaderRouter>
+  );
+}
+
+export function TechDocsEntityContent(props: {
+  addonOptions: TechDocsAddonOptions[];
+  emptyState?: ReactElement;
+}) {
+  return (
+    <EmbeddedDocsRouter emptyState={props.emptyState}>
+      <Addons options={props.addonOptions} />
+    </EmbeddedDocsRouter>
+  );
+}

--- a/plugins/techdocs/src/alpha/index.lazy.test.tsx
+++ b/plugins/techdocs/src/alpha/index.lazy.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The Backstage Authors
+ * Copyright 2026 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
-import { EntityIconLinkBlueprint } from '@backstage/plugin-catalog-react/alpha';
-import { useCatalogSourceIconLinkProps } from '../components/AboutCard/useCatalogSourceIconLinkProps';
+describe('techdocs alpha entry point', () => {
+  it('does not load the reader layout until the reader page loader runs', () => {
+    jest.doMock('./components/TechDocsReaderLayout', () => {
+      throw new Error('TechDocsReaderLayout was loaded eagerly');
+    });
 
-const catalogViewSourceEntityIconLink = EntityIconLinkBlueprint.make({
-  name: 'view-source',
-  params: {
-    useProps: useCatalogSourceIconLinkProps,
-  },
+    expect(() => require('./index')).not.toThrow();
+  });
 });
-
-export default [catalogViewSourceEntityIconLink];

--- a/plugins/techdocs/src/alpha/index.tsx
+++ b/plugins/techdocs/src/alpha/index.tsx
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { Suspense } from 'react';
 import { z } from 'zod/v4';
 import { RiArticleLine } from '@remixicon/react';
 import {
@@ -39,10 +38,7 @@ import {
   SearchFilterResultTypeBlueprint,
   SearchResultListItemBlueprint,
 } from '@backstage/plugin-search-react/alpha';
-import {
-  AddonBlueprint,
-  attachTechDocsAddonComponentData,
-} from '@backstage/plugin-techdocs-react/alpha';
+import { AddonBlueprint } from '@backstage/plugin-techdocs-react/alpha';
 import { TechDocsAddonsApiExtension, techdocsAddonsApiRef } from './addonsApi';
 import { TechDocsClient, TechDocsStorageClient } from '../client';
 import {
@@ -50,15 +46,13 @@ import {
   rootDocsRouteRef,
   rootRouteRef,
 } from '../routes';
-import { TechDocsReaderLayout } from './components/TechDocsReaderLayout';
 import {
-  TechDocsAddons,
   techdocsApiRef,
   techdocsStorageApiRef,
 } from '@backstage/plugin-techdocs-react';
 
 import { useTechdocsReaderIconLinkProps } from './hooks/useTechdocsReaderIconLinkProps';
-import { DocsIcon, SupportButton } from '@backstage/core-components';
+import { DocsIcon } from '@backstage/core-components';
 
 /** @alpha */
 const techdocsEntityIconLink = EntityIconLinkBlueprint.make({
@@ -191,26 +185,16 @@ const techDocsReaderPage = PageBlueprint.makeWithOverrides({
           output.get(AddonBlueprint.dataRefs.addon),
         );
         const addonOptions = [...apiAddons, ...directAddons];
-
-        const addons = addonOptions.map(options => {
-          const Addon = options.component;
-          attachTechDocsAddonComponentData(Addon, options);
-          return (
-            <Suspense key={options.name} fallback={null}>
-              <Addon />
-            </Suspense>
-          );
-        });
-
-        return import('../Router').then(({ TechDocsReaderRouter }) => (
-          <TechDocsReaderRouter>
-            <TechDocsReaderLayout
-              withSearch={!config.withoutSearch}
-              withHeader={!config.withoutHeader}
-            />
-            <TechDocsAddons>{addons}</TechDocsAddons>
-          </TechDocsReaderRouter>
-        ));
+        const { TechDocsReaderPage } = await import(
+          './components/TechDocsReaderPage'
+        );
+        return (
+          <TechDocsReaderPage
+            addonOptions={addonOptions}
+            withSearch={!config.withoutSearch}
+            withHeader={!config.withoutHeader}
+          />
+        );
       },
     });
   },
@@ -248,25 +232,13 @@ const techDocsEntityContent = EntityContentBlueprint.makeWithOverrides({
             output.get(AddonBlueprint.dataRefs.addon),
           );
           const addonOptions = [...apiAddons, ...directAddons];
-
-          const addons = addonOptions.map(options => {
-            const Addon = options.component;
-            attachTechDocsAddonComponentData(Addon, options);
-            return (
-              <Suspense key={options.name} fallback={null}>
-                <Addon />
-              </Suspense>
-            );
-          });
-
-          return import('../Router').then(({ EmbeddedDocsRouter }) => (
-            <EmbeddedDocsRouter
+          return import('./components/TechDocsReaderPage').then(m => (
+            <m.TechDocsEntityContent
+              addonOptions={addonOptions}
               emptyState={context.inputs.emptyState?.get(
                 coreExtensionData.reactElement,
               )}
-            >
-              <TechDocsAddons>{addons}</TechDocsAddons>
-            </EmbeddedDocsRouter>
+            />
           ));
         },
       },
@@ -286,9 +258,12 @@ const techDocsEntityContentEmptyState = createExtension({
 const techDocsSupportAction = PluginHeaderActionBlueprint.make({
   params: defineParams =>
     defineParams({
-      loader: async () => (
-        <SupportButton>Discover documentation in your ecosystem.</SupportButton>
-      ),
+      loader: () =>
+        import('@backstage/core-components').then(({ SupportButton }) => (
+          <SupportButton>
+            Discover documentation in your ecosystem.
+          </SupportButton>
+        )),
     }),
 });
 

--- a/plugins/user-settings/src/alpha.lazy.test.tsx
+++ b/plugins/user-settings/src/alpha.lazy.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 The Backstage Authors
+ * Copyright 2026 The Backstage Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
-import { EntityIconLinkBlueprint } from '@backstage/plugin-catalog-react/alpha';
-import { useCatalogSourceIconLinkProps } from '../components/AboutCard/useCatalogSourceIconLinkProps';
+describe('user-settings alpha entry point', () => {
+  it('does not load page layout UI until a sub-page loader runs', () => {
+    jest.doMock('@backstage/core-components', () => {
+      throw new Error('core-components was loaded eagerly');
+    });
 
-const catalogViewSourceEntityIconLink = EntityIconLinkBlueprint.make({
-  name: 'view-source',
-  params: {
-    useProps: useCatalogSourceIconLinkProps,
-  },
+    expect(() => require('./alpha')).not.toThrow();
+  });
 });
-
-export default [catalogViewSourceEntityIconLink];

--- a/plugins/user-settings/src/alpha.tsx
+++ b/plugins/user-settings/src/alpha.tsx
@@ -20,7 +20,6 @@ import {
   PageBlueprint,
   SubPageBlueprint,
 } from '@backstage/frontend-plugin-api';
-import { Content } from '@backstage/core-components';
 import SettingsIcon from '@material-ui/icons/Settings';
 import { settingsRouteRef } from './plugin';
 
@@ -46,12 +45,17 @@ const generalSettingsPage = SubPageBlueprint.make({
   params: {
     path: 'general',
     title: 'General',
-    loader: () =>
-      import('./components/General').then(m => (
+    loader: async () => {
+      const [m, { Content }] = await Promise.all([
+        import('./components/General'),
+        import('@backstage/core-components'),
+      ]);
+      return (
         <Content>
           <m.UserSettingsGeneral />
         </Content>
-      )),
+      );
+    },
   },
 });
 
@@ -67,8 +71,12 @@ const authProvidersSettingsPage = SubPageBlueprint.makeWithOverrides({
     return originalFactory({
       path: 'auth-providers',
       title: 'Authentication Providers',
-      loader: () =>
-        import('./components/AuthProviders').then(m => (
+      loader: async () => {
+        const [m, { Content }] = await Promise.all([
+          import('./components/AuthProviders'),
+          import('@backstage/core-components'),
+        ]);
+        return (
           <Content>
             <m.UserSettingsAuthProviders
               providerSettings={inputs.providerSettings?.get(
@@ -76,7 +84,8 @@ const authProvidersSettingsPage = SubPageBlueprint.makeWithOverrides({
               )}
             />
           </Content>
-        )),
+        );
+      },
     });
   },
 });
@@ -86,12 +95,17 @@ const featureFlagsSettingsPage = SubPageBlueprint.make({
   params: {
     path: 'feature-flags',
     title: 'Feature Flags',
-    loader: () =>
-      import('./components/FeatureFlags').then(m => (
+    loader: async () => {
+      const [m, { Content }] = await Promise.all([
+        import('./components/FeatureFlags'),
+        import('@backstage/core-components'),
+      ]);
+      return (
         <Content>
           <m.UserSettingsFeatureFlags />
         </Content>
-      )),
+      );
+    },
   },
 });
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Moves page implementations and optional UI wrappers behind their existing frontend extension loaders. This keeps unrelated Search, TechDocs, Catalog, sign-in, Home, and sub-page UI out of the initial app bundle.

In the example app production build, the initial entrypoint decreases from 4,551,701 to 4,285,498 raw bytes (266,203 bytes, or 5.85%). Kubernetes is intentionally left to #35287.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
