### PR TITLE
fix: retry release tag reference creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
         run: node scripts/verify-plugin-directory.js
 
       - name: test release scripts
-        run: yarn node --test scripts/create-github-release.test.js
+        run: yarn node --test scripts/*.test.js
 
       - name: build all packages
         run: yarn backstage-cli repo build --all

--- a/scripts/create-release-tag.js
+++ b/scripts/create-release-tag.js
@@ -26,6 +26,12 @@ const baseOptions = {
   repo: 'backstage',
 };
 
+const createRefRetryDelays = [4_000, 8_000];
+
+function wait(delay) {
+  return new Promise(resolve => setTimeout(resolve, delay));
+}
+
 async function getCurrentReleaseTag() {
   const rootPath = path.resolve(__dirname, '../package.json');
   return fs.readJson(rootPath).then(_ => _.version);
@@ -40,21 +46,32 @@ async function createGitTag(octokit, commitSha, tagName) {
     type: 'commit',
   });
 
-  try {
-    await octokit.git.createRef({
-      ...baseOptions,
-      ref: `refs/tags/${tagName}`,
-      sha: annotatedTag.data.sha,
-    });
-  } catch (ex) {
-    if (
-      ex.status === 422 &&
-      ex.response.data.message === 'Reference already exists'
-    ) {
-      throw new Error(`Tag ${tagName} already exists in repository`);
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      await octokit.git.createRef({
+        ...baseOptions,
+        ref: `refs/tags/${tagName}`,
+        sha: annotatedTag.data.sha,
+      });
+      break;
+    } catch (ex) {
+      const retryDelay = createRefRetryDelays[attempt];
+      if (ex.status === 404 && retryDelay !== undefined) {
+        console.warn(
+          `Tag reference creation for ${tagName} returned 404, retrying in ${retryDelay}ms`,
+        );
+        await wait(retryDelay);
+        continue;
+      }
+      if (
+        ex.status === 422 &&
+        ex.response.data.message === 'Reference already exists'
+      ) {
+        throw new Error(`Tag ${tagName} already exists in repository`);
+      }
+      console.error(`Tag creation for ${tagName} failed`);
+      throw ex;
     }
-    console.error(`Tag creation for ${tagName} failed`);
-    throw ex;
   }
 }
 

--- a/scripts/create-release-tag.test.js
+++ b/scripts/create-release-tag.test.js
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { test } = require('node:test');
+const vm = require('node:vm');
+
+const scriptPath = path.resolve(__dirname, 'create-release-tag.js');
+const scriptSource = fs.readFileSync(scriptPath, 'utf8');
+
+async function runScript(createRef) {
+  const createTagCalls = [];
+  const createRefCalls = [];
+  const retryDelays = [];
+  let exitCode;
+
+  const octokit = {
+    git: {
+      createTag: async options => {
+        createTagCalls.push(options);
+        return { data: { sha: 'annotated-tag-sha' } };
+      },
+      createRef: async options => {
+        createRefCalls.push(options);
+        return createRef(options);
+      },
+    },
+  };
+
+  const context = {
+    __dirname,
+    console: { error() {}, log() {}, warn() {} },
+    process: {
+      env: {
+        GITHUB_OUTPUT: '/tmp/github-output',
+        GITHUB_TOKEN: 'token',
+        RELEASE_SHA: 'release-sha',
+      },
+      exit(code) {
+        exitCode = code;
+      },
+    },
+    require(id) {
+      if (id === '@octokit/rest') {
+        return {
+          Octokit: function Octokit() {
+            return octokit;
+          },
+        };
+      }
+      if (id === 'fs-extra') {
+        return {
+          appendFile: async () => {},
+          readJson: async () => ({ version: '1.2.3' }),
+        };
+      }
+      return require(id);
+    },
+    setTimeout(callback, delay) {
+      retryDelays.push(delay);
+      callback();
+    },
+  };
+
+  await vm.runInNewContext(scriptSource, context, { filename: scriptPath });
+
+  return { createRefCalls, createTagCalls, exitCode, retryDelays };
+}
+
+test('retries transient failures when creating the tag reference', async () => {
+  let attempt = 0;
+  const result = await runScript(async () => {
+    attempt += 1;
+    if (attempt < 3) {
+      throw Object.assign(new Error('Not Found'), { status: 404 });
+    }
+  });
+
+  assert.equal(result.exitCode, undefined);
+  assert.equal(result.createTagCalls.length, 1);
+  assert.equal(result.createRefCalls.length, 3);
+  assert.deepEqual(result.retryDelays, [4_000, 8_000]);
+});
+
+test('stops after three transient failures', async () => {
+  const result = await runScript(async () => {
+    throw Object.assign(new Error('Not Found'), { status: 404 });
+  });
+
+  assert.equal(result.exitCode, 1);
+  assert.equal(result.createTagCalls.length, 1);
+  assert.equal(result.createRefCalls.length, 3);
+  assert.deepEqual(result.retryDelays, [4_000, 8_000]);
+});
+
+test('does not retry other failures', async () => {
+  const result = await runScript(async () => {
+    throw Object.assign(new Error('Forbidden'), { status: 403 });
+  });
+
+  assert.equal(result.exitCode, 1);
+  assert.equal(result.createTagCalls.length, 1);
+  assert.equal(result.createRefCalls.length, 1);
+  assert.deepEqual(result.retryDelays, []);
+});


### PR DESCRIPTION
GitHub may briefly return a 404 when creating a tag reference immediately after creating its annotated tag object. This adds two bounded retries for reference creation, after 4 and 8 seconds, for three attempts total.

The annotated tag object is still created only once. Non-404 failures continue to fail immediately, and the existing friendly handling for an already-existing reference remains in place.

The release-script CI step now discovers all `scripts/*.test.js` tests, including regression coverage for recovery, exhaustion, and non-404 failures.

No changeset is required because this only changes repository release tooling.

#### :heavy_check_mark: Checklist

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
