### PR TITLE
fix(scaffolder): keep the task worker claiming after a failed claim

### DIFF
--- a/.changeset/tricky-otters-repeat.md
+++ b/.changeset/tricky-otters-repeat.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Fixed the scaffolder task worker silently giving up after a transient failure. A single error while picking up a task, such as a dropped database connection, would stop the backend from running any further software templates for the rest of its lifetime. New tasks stayed queued indefinitely with no error shown to the user and no failing health check, and the only way to recover was to restart the backend. Picking up tasks is now retried instead.

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/TaskWorker.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/TaskWorker.test.ts
@@ -642,6 +642,50 @@ describe('TaskWorker internals', () => {
     expect(claimedTaskCount).toBe(3);
     expect(inflightTasks.length).toBe(2);
   });
+
+  it('should keep claiming tasks after a claim fails', async () => {
+    const workflowRunner: WorkflowRunner = {
+      // Never resolves, so the worker parks at its concurrency limit once it
+      // has successfully claimed a task.
+      execute() {
+        return new Promise<never>(() => {});
+      },
+    };
+
+    let claimedTaskCount = 0;
+    const taskWorker = new TaskWorkerConstructor({
+      runners: { workflowRunner },
+      logger: mockServices.logger.mock(),
+      taskBroker: {
+        event$() {
+          return new ObservableImpl<{ events: SerializedTaskEvent[] }>(
+            () => {},
+          );
+        },
+        async claim() {
+          claimedTaskCount++;
+          if (claimedTaskCount === 1) {
+            throw new Error('Connection terminated unexpectedly');
+          }
+          return {
+            spec: {
+              apiVersion: 'scaffolder.backstage.io/v1beta3',
+            },
+            createdBy: 'test',
+            async complete(_result, _metadata) {},
+          } as TaskContext;
+        },
+      } as unknown as TaskBroker,
+      concurrentTasksLimit: 1,
+    });
+
+    taskWorker.start();
+
+    // The first claim rejects. The worker must retry rather than stop for good.
+    await waitForExpect(() => {
+      expect(claimedTaskCount).toBe(2);
+    });
+  });
 });
 
 describe('createParameterTruncator', () => {

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/TaskWorker.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/TaskWorker.ts
@@ -36,6 +36,9 @@ import { collectTemplateCapabilities } from '../../util/templating';
 
 const DEFAULT_TASK_PARAMETER_MAX_LENGTH = 256;
 
+/** How long to wait before trying to claim again after a failed claim. */
+const CLAIM_RETRY_DELAY_MS = 1000;
+
 /**
  * TaskWorkerOptions
  */
@@ -173,10 +176,22 @@ export class TaskWorker {
     })();
     (async () => {
       while (!this.stopWorkers) {
-        await this.onReadyToClaimTask();
-        if (!this.stopWorkers) {
-          const task = await this.options.taskBroker.claim();
-          void this.taskQueue.add(() => this.runOneTask(task));
+        try {
+          await this.onReadyToClaimTask();
+          if (!this.stopWorkers) {
+            const task = await this.options.taskBroker.claim();
+            void this.taskQueue.add(() => this.runOneTask(task));
+          }
+        } catch (err) {
+          // Without this the loop exits on the first rejection and the worker
+          // stops claiming tasks for the rest of the process lifetime, leaving
+          // every new task queued with no indication that anything is wrong.
+          this.logger?.error(
+            `Failed to claim task, retrying in ${CLAIM_RETRY_DELAY_MS}ms; caused by ${stringifyError(
+              err,
+            )}`,
+          );
+          await setTimeout(CLAIM_RETRY_DELAY_MS);
         }
       }
     })();


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Our scaffolder stopped running software templates for four days with no signal at all. Every new task sat in `status = 'open'` with zero `task_events` rows, the task page polled a row that never changed, and `/.backstage/health/v1/liveness` stayed green throughout, so nothing restarted the pod. A restart fixed it instantly and the backlog was claimed within seconds — then it recurred 25 minutes later.

The claim loop in `TaskWorker.start()` has no `try/catch`. One rejected `claimTask()` — for us a dropped Postgres connection — ends the loop, and the worker never claims another task for the life of the process. It surfaces only as a process-level unhandled rejection with no plugin attribution:

```
Unhandled rejection BEGIN; - Connection terminated unexpectedly
```

Nothing recovers from it: `recoverTasks()` only re-queues tasks already in `processing` with a stale heartbeat, so a task that was never claimed is invisible to it. That loop is already wrapped in `try/catch`; the claim loop beside it is not, which reads like an oversight rather than a deliberate difference. I used a 1s backoff rather than retrying immediately so a hard-down database can't spin the loop.

To reproduce without the added test: with the backend idle, run `SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE usename = '<backstage user>';` then trigger any template. Catalog, events and HTTP recover on their own; the scaffolder does not.

Possibly the same root cause as #27217 and #29849 — both describe this symptom and were closed as stale without a diagnosis.

**AI disclosure:** the patch and its test were drafted with AI assistance (Claude Code). I have read and understood the change, and verified it: the new test fails on unmodified `master` (`Expected: 2, Received: 1`) and passes with the fix, and the full `@backstage/plugin-scaffolder-backend` suite, lint and `build:api-reports` are clean.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages.
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message.
