### PR TITLE
refactor(scaffolder): harden task worker loops

### DIFF
--- a/.changeset/calm-workers-wait.md
+++ b/.changeset/calm-workers-wait.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Improved task worker resilience by backing off repeated database claim failures, containing unexpected task execution errors, and preventing new work from being claimed during graceful shutdown.

--- a/.changeset/quiet-claims-stop.md
+++ b/.changeset/quiet-claims-stop.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-node': patch
+---
+
+Added optional cancellation support when waiting to claim a scaffolder task.

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/StorageTaskBroker.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/StorageTaskBroker.test.ts
@@ -105,6 +105,24 @@ describe('StorageTaskBroker', () => {
     await expect(promise).resolves.toEqual(expect.any(TaskManager as any));
   });
 
+  it('should stop waiting for work when a claim is aborted', async () => {
+    const isolatedStorage = await createStore();
+    const broker = new StorageTaskBroker(isolatedStorage, logger);
+    const controller = new AbortController();
+    const claim = broker.claim({ signal: controller.signal });
+
+    await expect(Promise.race([claim, 'waiting'])).resolves.toBe('waiting');
+
+    controller.abort();
+
+    await expect(claim).rejects.toMatchObject({ name: 'AbortError' });
+
+    await broker.dispatch(emptyTaskSpec);
+    await expect(broker.claim()).resolves.toEqual(
+      expect.any(TaskManager as any),
+    );
+  });
+
   it('should dispatch multiple items and claim them in order', async () => {
     const broker = new StorageTaskBroker(storage, logger);
     await broker.dispatch({ spec: { steps: [{ id: 'a' }] } as TaskSpec });

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/StorageTaskBroker.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/StorageTaskBroker.ts
@@ -37,12 +37,7 @@ import {
   WorkspaceProvider,
   UpdateTaskCheckpointOptions,
 } from '@backstage/plugin-scaffolder-node/alpha';
-import {
-  HumanDuration,
-  JsonObject,
-  Observable,
-  createDeferred,
-} from '@backstage/types';
+import { HumanDuration, JsonObject, Observable } from '@backstage/types';
 import ObservableImpl from 'zen-observable';
 import {
   DefaultWorkspaceService,
@@ -345,7 +340,7 @@ export class StorageTaskBroker implements TaskBroker {
     return await this.storage.list(options ?? {});
   }
 
-  private deferredDispatch = createDeferred();
+  private readonly dispatchWaiters = new Set<() => void>();
 
   private async registerCancellable(
     taskId: string,
@@ -406,8 +401,9 @@ export class StorageTaskBroker implements TaskBroker {
   /**
    * {@inheritdoc TaskBroker.claim}
    */
-  async claim(): Promise<TaskContext> {
+  async claim(options?: { signal?: AbortSignal }): Promise<TaskContext> {
     for (;;) {
+      options?.signal?.throwIfAborted();
       const pendingTask = await this.storage.claimTask();
       if (pendingTask) {
         const abortController = new AbortController();
@@ -428,7 +424,7 @@ export class StorageTaskBroker implements TaskBroker {
         );
       }
 
-      await this.waitForDispatch();
+      await this.waitForDispatch(options?.signal);
     }
   }
 
@@ -526,13 +522,37 @@ export class StorageTaskBroker implements TaskBroker {
     );
   }
 
-  private waitForDispatch() {
-    return this.deferredDispatch;
+  private waitForDispatch(signal?: AbortSignal) {
+    return new Promise<void>((resolve, reject) => {
+      const onDispatch = () => {
+        cleanup();
+        resolve();
+      };
+      const onAbort = () => {
+        cleanup();
+        reject(signal?.reason);
+      };
+      const dispatchWaiters = this.dispatchWaiters;
+
+      function cleanup() {
+        dispatchWaiters.delete(onDispatch);
+        signal?.removeEventListener('abort', onAbort);
+      }
+
+      this.dispatchWaiters.add(onDispatch);
+      signal?.addEventListener('abort', onAbort, { once: true });
+      if (signal?.aborted) {
+        onAbort();
+      }
+    });
   }
 
   private signalDispatch() {
-    this.deferredDispatch.resolve();
-    this.deferredDispatch = createDeferred();
+    const waiters = [...this.dispatchWaiters];
+    this.dispatchWaiters.clear();
+    for (const waiter of waiters) {
+      waiter();
+    }
   }
 
   async cancel(taskId: string) {

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/TaskWorker.test.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/TaskWorker.test.ts
@@ -25,6 +25,7 @@ import {
   TaskWorkerOptions,
 } from './TaskWorker';
 import { ScmIntegrations } from '@backstage/integration';
+import { TaskSpec } from '@backstage/plugin-scaffolder-common';
 import {
   DefaultTemplateActionRegistry,
   TemplateActionRegistry,
@@ -36,7 +37,7 @@ import {
   TaskBroker,
   TaskContext,
 } from '@backstage/plugin-scaffolder-node';
-import { WorkflowRunner } from './types';
+import { WorkflowResponse, WorkflowRunner } from './types';
 import ObservableImpl from 'zen-observable';
 import waitForExpect from 'wait-for-expect';
 import { mockCredentials, mockServices } from '@backstage/backend-test-utils';
@@ -96,6 +97,28 @@ describe('TaskWorker', () => {
   });
 
   const logger = loggerToWinstonLogger(mockServices.logger.mock());
+
+  it('should use the configured logger for worker errors', async () => {
+    const workerLogger = mockServices.logger.mock();
+    const recoveryError = new Error('Failed to recover tasks');
+    const taskWorker = await TaskWorker.create({
+      logger: workerLogger,
+      workingDirectory,
+      integrations,
+      taskBroker: {
+        recoverTasks: jest.fn().mockRejectedValue(recoveryError),
+      } as unknown as TaskBroker,
+      actionRegistry,
+      metrics: metricsServiceMock.mock(),
+    });
+
+    await taskWorker.recoverTasks();
+
+    expect(workerLogger.error).toHaveBeenCalledWith(
+      'Failed to recover tasks',
+      recoveryError,
+    );
+  });
 
   it('should call the default workflow runner when the apiVersion is beta3', async () => {
     const broker = new StorageTaskBroker(storage, logger);
@@ -643,7 +666,12 @@ describe('TaskWorker internals', () => {
     expect(inflightTasks.length).toBe(2);
   });
 
-  it('should keep claiming tasks after a claim fails', async () => {
+  it('should back off and keep claiming tasks after claims fail', async () => {
+    jest.useFakeTimers();
+    const randomSpy = jest
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0)
+      .mockReturnValue(0.5);
     const workflowRunner: WorkflowRunner = {
       // Never resolves, so the worker parks at its concurrency limit once it
       // has successfully claimed a task.
@@ -652,10 +680,12 @@ describe('TaskWorker internals', () => {
       },
     };
 
+    const logger = mockServices.logger.mock();
+    const claimError = new Error('Connection terminated unexpectedly');
     let claimedTaskCount = 0;
     const taskWorker = new TaskWorkerConstructor({
       runners: { workflowRunner },
-      logger: mockServices.logger.mock(),
+      logger,
       taskBroker: {
         event$() {
           return new ObservableImpl<{ events: SerializedTaskEvent[] }>(
@@ -664,8 +694,8 @@ describe('TaskWorker internals', () => {
         },
         async claim() {
           claimedTaskCount++;
-          if (claimedTaskCount === 1) {
-            throw new Error('Connection terminated unexpectedly');
+          if (claimedTaskCount <= 8) {
+            throw claimError;
           }
           return {
             spec: {
@@ -679,11 +709,150 @@ describe('TaskWorker internals', () => {
       concurrentTasksLimit: 1,
     });
 
+    try {
+      taskWorker.start();
+      await jest.advanceTimersByTimeAsync(0);
+
+      const retryDelays = [
+        800, 2_000, 4_000, 8_000, 16_000, 32_000, 60_000, 60_000,
+      ];
+      for (const [index, retryDelay] of retryDelays.entries()) {
+        expect(claimedTaskCount).toBe(index + 1);
+        expect(logger.error).toHaveBeenNthCalledWith(
+          index + 1,
+          `Failed to claim task, retrying in ${retryDelay}ms`,
+          claimError,
+        );
+
+        await jest.advanceTimersByTimeAsync(retryDelay - 1);
+        expect(claimedTaskCount).toBe(index + 1);
+        await jest.advanceTimersByTimeAsync(1);
+      }
+
+      expect(claimedTaskCount).toBe(9);
+    } finally {
+      await taskWorker.stop();
+      randomSpy.mockRestore();
+      jest.useRealTimers();
+    }
+  });
+
+  it('should contain unexpected task execution errors', async () => {
+    const logger = mockServices.logger.mock();
+    const task = {
+      taskId: 'task-1',
+      spec: { apiVersion: 'scaffolder.backstage.io/v1beta3' },
+    } as TaskContext;
+    let claimedTaskCount = 0;
+    const taskWorker = new TaskWorkerConstructor({
+      runners: {
+        workflowRunner: { execute: jest.fn() },
+      },
+      logger,
+      taskBroker: {
+        async claim() {
+          claimedTaskCount++;
+          if (claimedTaskCount === 1) {
+            return task;
+          }
+          return new Promise<never>(() => {});
+        },
+      } as unknown as TaskBroker,
+      concurrentTasksLimit: 1,
+    });
+    const executionError = new Error('Unexpected task execution failure');
+    jest.spyOn(taskWorker, 'runOneTask').mockRejectedValueOnce(executionError);
+
     taskWorker.start();
 
-    // The first claim rejects. The worker must retry rather than stop for good.
     await waitForExpect(() => {
-      expect(claimedTaskCount).toBe(2);
+      expect(logger.error).toHaveBeenCalledWith(
+        'Unexpected error while executing task task-1',
+        executionError,
+      );
+    });
+    await taskWorker.stop();
+  });
+
+  it('should wait for running tasks during graceful shutdown', async () => {
+    let finishTask: (value: WorkflowResponse) => void = () => {};
+    const workflowRunner: WorkflowRunner = {
+      execute: jest.fn(
+        () =>
+          new Promise<WorkflowResponse>(resolve => {
+            finishTask = resolve;
+          }),
+      ),
+    };
+    const complete = jest.fn();
+    let claimedTaskCount = 0;
+    const taskWorker = new TaskWorkerConstructor({
+      runners: { workflowRunner },
+      taskBroker: {
+        async claim() {
+          claimedTaskCount++;
+          if (claimedTaskCount === 1) {
+            return {
+              taskId: 'task-1',
+              spec: { apiVersion: 'scaffolder.backstage.io/v1beta3' },
+              complete,
+            } as unknown as TaskContext;
+          }
+          return new Promise<never>(() => {});
+        },
+      } as unknown as TaskBroker,
+      concurrentTasksLimit: 1,
+      gracefulShutdown: true,
+    });
+
+    taskWorker.start();
+    await waitForExpect(() => {
+      expect(workflowRunner.execute).toHaveBeenCalledTimes(1);
+    });
+
+    let hasStopped = false;
+    const stopping = taskWorker.stop().then(() => {
+      hasStopped = true;
+    });
+    await Promise.resolve();
+    expect(hasStopped).toBe(false);
+
+    finishTask({ output: {} });
+    await stopping;
+    expect(complete).toHaveBeenCalledWith('completed', { output: {} });
+  });
+
+  it('should not claim tasks after graceful shutdown', async () => {
+    const isolatedStorage = await createStore();
+    const broker = new StorageTaskBroker(
+      isolatedStorage,
+      loggerToWinstonLogger(mockServices.logger.mock()),
+    );
+    const claimTaskSpy = jest.spyOn(isolatedStorage, 'claimTask');
+    const workflowRunner: WorkflowRunner = {
+      execute: jest.fn().mockResolvedValue({ output: {} }),
+    };
+    const taskWorker = new TaskWorkerConstructor({
+      runners: { workflowRunner },
+      taskBroker: broker,
+      concurrentTasksLimit: 1,
+      gracefulShutdown: true,
+    });
+
+    taskWorker.start();
+    await waitForExpect(() => {
+      expect(claimTaskSpy).toHaveBeenCalled();
+    });
+    await taskWorker.stop();
+
+    const { taskId } = await broker.dispatch({
+      spec: { steps: [] } as unknown as TaskSpec,
+    });
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    expect(workflowRunner.execute).not.toHaveBeenCalled();
+    await expect(isolatedStorage.getTask(taskId)).resolves.toMatchObject({
+      status: 'open',
     });
   });
 });

--- a/plugins/scaffolder-backend/src/scaffolder/tasks/TaskWorker.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/tasks/TaskWorker.ts
@@ -16,7 +16,7 @@
 
 import { AuditorService, LoggerService } from '@backstage/backend-plugin-api';
 import type { MetricsService } from '@backstage/backend-plugin-api/alpha';
-import { InputError, stringifyError, toError } from '@backstage/errors';
+import { InputError, toError } from '@backstage/errors';
 import { ScmIntegrations } from '@backstage/integration';
 import { PermissionEvaluator } from '@backstage/plugin-permission-common';
 import {
@@ -29,15 +29,15 @@ import PQueue from 'p-queue';
 import { TemplateActionRegistry } from '../actions/TemplateActionRegistry';
 import { NunjucksWorkflowRunner } from './NunjucksWorkflowRunner';
 import { WorkflowRunner } from './types';
-import { setTimeout } from 'node:timers/promises';
 import { JsonObject } from '@backstage/types';
 import { Config } from '@backstage/config';
 import { collectTemplateCapabilities } from '../../util/templating';
 
 const DEFAULT_TASK_PARAMETER_MAX_LENGTH = 256;
-
-/** How long to wait before trying to claim again after a failed claim. */
-const CLAIM_RETRY_DELAY_MS = 1000;
+const TASK_RECOVERY_INTERVAL_MS = 10_000;
+const CLAIM_RETRY_INITIAL_DELAY_MS = 1_000;
+const CLAIM_RETRY_MAX_DELAY_MS = 60_000;
+const CLAIM_RETRY_JITTER_FACTOR = 0.2;
 
 /**
  * TaskWorkerOptions
@@ -95,6 +95,8 @@ export class TaskWorker {
   private auditor: AuditorService | undefined;
   private parameterAuditTransform: ParameterAuditTransform;
   private stopWorkers: boolean;
+  private workerLoops: Promise<void> | undefined;
+  private readonly workerAbortController = new AbortController();
 
   private readonly options: TaskWorkerOptions & {
     parameterAuditTransform: ParameterAuditTransform;
@@ -151,6 +153,7 @@ export class TaskWorker {
       taskBroker: taskBroker,
       runners: { workflowRunner },
       concurrentTasksLimit,
+      logger,
       permissions,
       auditor,
       config,
@@ -162,48 +165,105 @@ export class TaskWorker {
   async recoverTasks() {
     try {
       await this.options.taskBroker.recoverTasks?.();
-    } catch (err) {
-      this.logger?.error(stringifyError(err));
+    } catch (error) {
+      this.logger?.error('Failed to recover tasks', toError(error));
     }
   }
 
   start() {
-    (async () => {
-      while (!this.stopWorkers) {
-        await setTimeout(10000);
-        await this.recoverTasks();
-      }
-    })();
-    (async () => {
-      while (!this.stopWorkers) {
-        try {
-          await this.onReadyToClaimTask();
-          if (!this.stopWorkers) {
-            const task = await this.options.taskBroker.claim();
-            void this.taskQueue.add(() => this.runOneTask(task));
-          }
-        } catch (err) {
-          // Without this the loop exits on the first rejection and the worker
-          // stops claiming tasks for the rest of the process lifetime, leaving
-          // every new task queued with no indication that anything is wrong.
-          this.logger?.error(
-            `Failed to claim task, retrying in ${CLAIM_RETRY_DELAY_MS}ms; caused by ${stringifyError(
-              err,
-            )}`,
-          );
-          await setTimeout(CLAIM_RETRY_DELAY_MS);
-        }
-      }
-    })();
+    if (this.workerLoops) {
+      return;
+    }
+
+    this.workerLoops = Promise.all([
+      this.runTaskRecoveryLoop(),
+      this.runTaskClaimLoop(),
+    ])
+      .then(() => undefined)
+      .catch(error => {
+        this.logger?.error(
+          'Unexpected task worker loop failure',
+          toError(error),
+        );
+      });
   }
 
   async stop() {
     this.stopWorkers = true;
+    this.workerAbortController.abort();
     if (this.options?.gracefulShutdown) {
-      while (this.taskQueue.size > 0) {
-        await setTimeout(1000);
+      await this.workerLoops;
+      await this.taskQueue.onIdle();
+    }
+  }
+
+  private async runTaskRecoveryLoop() {
+    while (!this.stopWorkers) {
+      await this.wait(TASK_RECOVERY_INTERVAL_MS);
+      if (!this.stopWorkers) {
+        await this.recoverTasks();
       }
     }
+  }
+
+  private async runTaskClaimLoop() {
+    let retryDelayMs = CLAIM_RETRY_INITIAL_DELAY_MS;
+
+    while (!this.stopWorkers) {
+      await this.onReadyToClaimTask();
+      if (this.stopWorkers) {
+        break;
+      }
+
+      try {
+        const task = await this.options.taskBroker.claim({
+          signal: this.workerAbortController.signal,
+        });
+        retryDelayMs = CLAIM_RETRY_INITIAL_DELAY_MS;
+        void this.taskQueue
+          .add(() => this.runOneTask(task))
+          .catch(error => {
+            this.logger?.error(
+              `Unexpected error while executing task ${task.taskId}`,
+              toError(error),
+            );
+          });
+      } catch (error) {
+        if (this.stopWorkers) {
+          break;
+        }
+        const jitter = retryDelayMs * CLAIM_RETRY_JITTER_FACTOR;
+        const actualDelayMs = Math.min(
+          CLAIM_RETRY_MAX_DELAY_MS,
+          Math.round(retryDelayMs - jitter + Math.random() * jitter * 2),
+        );
+        this.logger?.error(
+          `Failed to claim task, retrying in ${actualDelayMs}ms`,
+          toError(error),
+        );
+        await this.wait(actualDelayMs);
+        retryDelayMs = Math.min(retryDelayMs * 2, CLAIM_RETRY_MAX_DELAY_MS);
+      }
+    }
+  }
+
+  private wait(delayMs: number) {
+    return new Promise<void>(resolve => {
+      const signal = this.workerAbortController.signal;
+      const timeout = setTimeout(onDone, delayMs);
+
+      function onDone() {
+        clearTimeout(timeout);
+        signal.removeEventListener('abort', onDone);
+        resolve();
+      }
+
+      timeout.unref();
+      signal.addEventListener('abort', onDone, { once: true });
+      if (signal.aborted) {
+        onDone();
+      }
+    });
   }
 
   protected onReadyToClaimTask(): Promise<void> {

--- a/plugins/scaffolder-node/report.api.md
+++ b/plugins/scaffolder-node/report.api.md
@@ -499,7 +499,7 @@ export interface TaskBroker {
   // (undocumented)
   cancel(taskId: string): Promise<void>;
   // (undocumented)
-  claim(): Promise<TaskContext>;
+  claim(options?: { signal?: AbortSignal }): Promise<TaskContext>;
   // (undocumented)
   dispatch(
     options: TaskBrokerDispatchOptions,

--- a/plugins/scaffolder-node/src/tasks/types.ts
+++ b/plugins/scaffolder-node/src/tasks/types.ts
@@ -210,7 +210,10 @@ export interface TaskBroker {
 
   retry(options: { secrets?: TaskSecrets; taskId: string }): Promise<void>;
 
-  claim(): Promise<TaskContext>;
+  claim(options?: {
+    /** Stops waiting before a task has been claimed. */
+    signal?: AbortSignal;
+  }): Promise<TaskContext>;
 
   recoverTasks(): Promise<void>;
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Follow-up for #35359. 

This follow-up separates the task recovery and claim loops into named methods and adds explicit boundaries around each asynchronous layer. Claim failures now use bounded exponential backoff with jitter and structured error logging, while unexpected task execution failures are contained at the queue boundary. Graceful shutdown waits for both queued and running work using the queue's idle signal.

It also wires the configured logger into the worker itself; without that, the recovery added in #35359 would retry silently in the normal production construction path.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
