### PR TITLE
fix(techdocs): handle aliased local config paths

### DIFF
--- a/.changeset/calm-tools-walk.md
+++ b/.changeset/calm-tools-walk.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-node': patch
+---
+
+Fixed local TechDocs generation when temporary source paths resolve through filesystem aliases.

--- a/plugins/techdocs-node/src/stages/generate/techdocs.test.ts
+++ b/plugins/techdocs-node/src/stages/generate/techdocs.test.ts
@@ -15,6 +15,7 @@
  */
 
 import { ConfigReader } from '@backstage/config';
+import path from 'node:path';
 import { readGeneratorConfig, TechdocsGenerator } from './techdocs';
 import { getMkdocsYml, runCommand } from './helpers';
 
@@ -219,7 +220,10 @@ describe('TechdocsGenerator.run', () => {
     expect(jest.mocked(runCommand)).toHaveBeenCalledWith(
       expect.objectContaining({
         command: 'mkdocs',
-        args: expect.arrayContaining(['-f', 'config/mkdocs.yaml']),
+        args: expect.arrayContaining([
+          '-f',
+          path.join('config', 'mkdocs.yaml'),
+        ]),
         options: { cwd: inputDir },
       }),
     );

--- a/plugins/techdocs-node/src/stages/generate/techdocs.test.ts
+++ b/plugins/techdocs-node/src/stages/generate/techdocs.test.ts
@@ -187,23 +187,31 @@ describe('readGeneratorConfig', () => {
 });
 
 describe('TechdocsGenerator.run', () => {
+  const inputDir = '/var/folders/inputDir';
+
   beforeEach(() => {
     jest.resetAllMocks();
     jest.mocked(getMkdocsYml).mockResolvedValue({
-      path: '/tmp/inputDir/mkdocs.yaml',
+      path: `${inputDir}/mkdocs.yaml`,
       content: 'site_name: Test',
       configIsTemporary: false,
     });
   });
 
-  it('passes -f with the config path in local mode', async () => {
+  it('passes -f with the config path relative to the working directory in local mode', async () => {
+    jest.mocked(getMkdocsYml).mockResolvedValueOnce({
+      path: `${inputDir}/config/mkdocs.yaml`,
+      content: 'site_name: Test',
+      configIsTemporary: false,
+    });
+
     const generator = TechdocsGenerator.fromConfig(
       new ConfigReader({ techdocs: { generator: { runIn: 'local' } } }),
       { logger: mockLogger as any },
     );
 
     await generator.run({
-      inputDir: '/tmp/inputDir',
+      inputDir,
       outputDir: '/tmp/outputDir',
       logger: mockLogger as any,
     });
@@ -211,7 +219,8 @@ describe('TechdocsGenerator.run', () => {
     expect(jest.mocked(runCommand)).toHaveBeenCalledWith(
       expect.objectContaining({
         command: 'mkdocs',
-        args: expect.arrayContaining(['-f', '/tmp/inputDir/mkdocs.yaml']),
+        args: expect.arrayContaining(['-f', 'config/mkdocs.yaml']),
+        options: { cwd: inputDir },
       }),
     );
   });
@@ -228,7 +237,7 @@ describe('TechdocsGenerator.run', () => {
     });
 
     await generator.run({
-      inputDir: '/tmp/inputDir',
+      inputDir,
       outputDir: '/tmp/outputDir',
       logger: mockLogger as any,
     });

--- a/plugins/techdocs-node/src/stages/generate/techdocs.ts
+++ b/plugins/techdocs-node/src/stages/generate/techdocs.ts
@@ -180,7 +180,14 @@ export class TechdocsGenerator implements GeneratorBase {
         case 'local':
           await runCommand({
             command: 'mkdocs',
-            args: ['build', '-f', mkdocsYmlPath, '-d', outputDir, '-v'],
+            args: [
+              'build',
+              '-f',
+              path.relative(inputDir, mkdocsYmlPath),
+              '-d',
+              outputDir,
+              '-v',
+            ],
             options: {
               cwd: inputDir,
             },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #35355.

Local TechDocs generation now passes the selected MkDocs configuration path relative to the generator working directory. This avoids path alias mismatches on macOS while retaining the explicit `-f` argument, so MkDocs continues to process the exact configuration file selected by Backstage.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
