### PR TITLE
Add explicit permission checks to built-in actions

### DIFF
--- a/.changeset/calm-catalog-action-permission.md
+++ b/.changeset/calm-catalog-action-permission.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog-backend': patch
+---
+
+Catalog actions now perform explicit permission checks before operations begin, improving consistency and error reporting for callers using external access restrictions.

--- a/.changeset/calm-scaffolder-action-permission.md
+++ b/.changeset/calm-scaffolder-action-permission.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend': patch
+---
+
+Scaffolder actions now perform explicit permission checks before operations begin, improving consistency and error reporting for callers using external access restrictions.

--- a/docs/backend-system/core-services/actions-registry.md
+++ b/docs/backend-system/core-services/actions-registry.md
@@ -168,6 +168,12 @@ When accessed via the Actions Service or the `/.backstage/actions/v1/...` HTTP e
 
 Permissions declared on actions are automatically registered with the `PermissionsRegistryService` so they appear in the permission policy system.
 
+A `visibilityPermission` is a coarse access check consisting of a single
+`BasicPermission`. Action implementations are responsible for any additional
+input-dependent or resource-specific authorization required by the operation.
+Perform these checks using the caller credentials before starting side effects
+or making follow-up requests to other plugins.
+
 ### Adding a Permission to an Action
 
 ```typescript

--- a/plugins/catalog-backend/src/actions/createGetCatalogEntityAction.test.ts
+++ b/plugins/catalog-backend/src/actions/createGetCatalogEntityAction.test.ts
@@ -16,21 +16,17 @@
 import { createGetCatalogEntityAction } from './createGetCatalogEntityAction';
 import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
 import { actionsRegistryServiceMock } from '@backstage/backend-test-utils/alpha';
-import { PermissionsService } from '@backstage/backend-plugin-api';
+import { mockServices } from '@backstage/backend-test-utils';
 import { AuthorizeResult } from '@backstage/plugin-permission-common';
 import { NotFoundError } from '@backstage/errors';
 
-const permissions = {
-  authorizeConditional: jest
-    .fn()
-    .mockResolvedValue([{ result: AuthorizeResult.ALLOW }]),
-} as unknown as jest.Mocked<PermissionsService>;
-
 describe('createGetCatalogEntityAction', () => {
+  let permissions: ReturnType<typeof mockServices.permissions.mock>;
+
   beforeEach(() => {
-    permissions.authorizeConditional
-      .mockReset()
-      .mockResolvedValue([{ result: AuthorizeResult.ALLOW }]);
+    permissions = mockServices.permissions.mock({
+      authorizeConditional: async () => [{ result: AuthorizeResult.ALLOW }],
+    });
   });
 
   it('throws NotFoundError if the entity is not found', async () => {

--- a/plugins/catalog-backend/src/actions/createGetCatalogEntityAction.test.ts
+++ b/plugins/catalog-backend/src/actions/createGetCatalogEntityAction.test.ts
@@ -16,15 +16,31 @@
 import { createGetCatalogEntityAction } from './createGetCatalogEntityAction';
 import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
 import { actionsRegistryServiceMock } from '@backstage/backend-test-utils/alpha';
+import { PermissionsService } from '@backstage/backend-plugin-api';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
+import { NotFoundError } from '@backstage/errors';
+
+const permissions = {
+  authorizeConditional: jest
+    .fn()
+    .mockResolvedValue([{ result: AuthorizeResult.ALLOW }]),
+} as unknown as jest.Mocked<PermissionsService>;
 
 describe('createGetCatalogEntityAction', () => {
-  it('should throw an error if the entity is not found', async () => {
+  beforeEach(() => {
+    permissions.authorizeConditional
+      .mockReset()
+      .mockResolvedValue([{ result: AuthorizeResult.ALLOW }]);
+  });
+
+  it('throws NotFoundError if the entity is not found', async () => {
     const mockActionsRegistry = actionsRegistryServiceMock();
     const mockCatalog = catalogServiceMock();
 
     createGetCatalogEntityAction({
       catalog: mockCatalog,
       actionsRegistry: mockActionsRegistry,
+      permissions,
     });
 
     await expect(
@@ -32,7 +48,10 @@ describe('createGetCatalogEntityAction', () => {
         id: 'test:get-catalog-entity',
         input: { name: 'test' },
       }),
-    ).rejects.toThrow(`No entity found with name "test"`);
+    ).rejects.toMatchObject({
+      name: 'NotFoundError',
+      message: `No entity found with name "test"`,
+    } satisfies Partial<NotFoundError>);
   });
 
   it('should throw an error if theres multiple entities found', async () => {
@@ -64,6 +83,7 @@ describe('createGetCatalogEntityAction', () => {
     createGetCatalogEntityAction({
       catalog: mockCatalog,
       actionsRegistry: mockActionsRegistry,
+      permissions,
     });
 
     await expect(
@@ -74,5 +94,31 @@ describe('createGetCatalogEntityAction', () => {
     ).rejects.toThrow(
       `Multiple entities found with name "test", please provide more specific filters. Entities found: "component:default/test", "api:default/test"`,
     );
+  });
+
+  it('does not look up entities when read permission is denied', async () => {
+    const mockActionsRegistry = actionsRegistryServiceMock();
+    const mockCatalog = catalogServiceMock();
+    const querySpy = jest.spyOn(mockCatalog, 'queryEntities');
+    permissions.authorizeConditional.mockResolvedValue([
+      { result: AuthorizeResult.DENY },
+    ]);
+
+    createGetCatalogEntityAction({
+      catalog: mockCatalog,
+      actionsRegistry: mockActionsRegistry,
+      permissions,
+    });
+
+    await expect(
+      mockActionsRegistry.invoke({
+        id: 'test:get-catalog-entity',
+        input: { name: 'test' },
+      }),
+    ).rejects.toMatchObject({
+      name: 'NotFoundError',
+      message: `No entity found with name "test"`,
+    } satisfies Partial<NotFoundError>);
+    expect(querySpy).not.toHaveBeenCalled();
   });
 });

--- a/plugins/catalog-backend/src/actions/createGetCatalogEntityAction.ts
+++ b/plugins/catalog-backend/src/actions/createGetCatalogEntityAction.ts
@@ -64,8 +64,9 @@ Each entity is identified by a unique entity reference, which is a string of the
       output: z => z.object({}).passthrough(),
     },
     action: async ({ input, credentials }) => {
-      // Check before calling the catalog service so that external access
-      // restrictions are evaluated using the original caller credentials.
+      // TODO: Revisit this explicit check once service on-behalf-of
+      // authentication preserves caller identity and access restrictions
+      // across service boundaries. Until then, authorize before delegating.
       const [readDecision] = await permissions.authorizeConditional(
         [{ permission: catalogEntityReadPermission }],
         { credentials },

--- a/plugins/catalog-backend/src/actions/createGetCatalogEntityAction.ts
+++ b/plugins/catalog-backend/src/actions/createGetCatalogEntityAction.ts
@@ -13,17 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { PermissionsService } from '@backstage/backend-plugin-api';
 import { ActionsRegistryService } from '@backstage/backend-plugin-api/alpha';
 import { stringifyEntityRef } from '@backstage/catalog-model';
-import { ConflictError, InputError } from '@backstage/errors';
+import { ConflictError, NotFoundError } from '@backstage/errors';
 import { CatalogService } from '@backstage/plugin-catalog-node';
+import { catalogEntityReadPermission } from '@backstage/plugin-catalog-common/alpha';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
 
 export const createGetCatalogEntityAction = ({
   catalog,
   actionsRegistry,
+  permissions,
 }: {
   catalog: CatalogService;
   actionsRegistry: ActionsRegistryService;
+  permissions: PermissionsService;
 }) => {
   actionsRegistry.register({
     name: 'get-catalog-entity',
@@ -59,6 +64,16 @@ Each entity is identified by a unique entity reference, which is a string of the
       output: z => z.object({}).passthrough(),
     },
     action: async ({ input, credentials }) => {
+      // Check before calling the catalog service so that external access
+      // restrictions are evaluated using the original caller credentials.
+      const [readDecision] = await permissions.authorizeConditional(
+        [{ permission: catalogEntityReadPermission }],
+        { credentials },
+      );
+      if (readDecision.result === AuthorizeResult.DENY) {
+        throw new NotFoundError(`No entity found with name "${input.name}"`);
+      }
+
       const filter: Record<string, string> = { 'metadata.name': input.name };
 
       if (input.kind) {
@@ -77,7 +92,7 @@ Each entity is identified by a unique entity reference, which is a string of the
       );
 
       if (items.length === 0) {
-        throw new InputError(`No entity found with name "${input.name}"`);
+        throw new NotFoundError(`No entity found with name "${input.name}"`);
       }
 
       if (items.length > 1) {

--- a/plugins/catalog-backend/src/actions/createQueryCatalogEntitiesAction.test.ts
+++ b/plugins/catalog-backend/src/actions/createQueryCatalogEntitiesAction.test.ts
@@ -16,6 +16,8 @@
 import { createQueryCatalogEntitiesAction } from './createQueryCatalogEntitiesAction';
 import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
 import { actionsRegistryServiceMock } from '@backstage/backend-test-utils/alpha';
+import { PermissionsService } from '@backstage/backend-plugin-api';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
 
 const testEntities = [
   {
@@ -52,16 +54,28 @@ const testEntities = [
 
 function createCatalogQueryAction(options?: {
   entities?: typeof testEntities;
+  authorizeResult?: AuthorizeResult;
 }) {
   const mockActionsRegistry = actionsRegistryServiceMock();
   const mockCatalog = catalogServiceMock({
     entities: options?.entities ?? testEntities,
   });
+  const permissions = {
+    authorizeConditional: jest
+      .fn()
+      .mockResolvedValue([
+        { result: options?.authorizeResult ?? AuthorizeResult.ALLOW },
+      ]),
+  } as unknown as jest.Mocked<PermissionsService>;
   createQueryCatalogEntitiesAction({
     catalog: mockCatalog,
     actionsRegistry: mockActionsRegistry,
+    permissions,
   });
-  return { invoke: mockActionsRegistry.invoke.bind(mockActionsRegistry) };
+  return {
+    invoke: mockActionsRegistry.invoke.bind(mockActionsRegistry),
+    mockCatalog,
+  };
 }
 
 describe('createQueryCatalogEntitiesAction', () => {
@@ -93,6 +107,26 @@ describe('createQueryCatalogEntitiesAction', () => {
       hasMoreEntities: false,
       nextPageCursor: undefined,
     });
+  });
+
+  it('does not query entities when read permission is denied', async () => {
+    const { invoke, mockCatalog } = createCatalogQueryAction({
+      authorizeResult: AuthorizeResult.DENY,
+    });
+    const querySpy = jest.spyOn(mockCatalog, 'queryEntities');
+
+    const result = await invoke({
+      id: 'test:query-catalog-entities',
+      input: {},
+    });
+
+    expect(result.output).toEqual({
+      items: [],
+      totalItems: 0,
+      hasMoreEntities: false,
+      nextPageCursor: undefined,
+    });
+    expect(querySpy).not.toHaveBeenCalled();
   });
 
   it('should filter by kind', async () => {

--- a/plugins/catalog-backend/src/actions/createQueryCatalogEntitiesAction.test.ts
+++ b/plugins/catalog-backend/src/actions/createQueryCatalogEntitiesAction.test.ts
@@ -16,7 +16,7 @@
 import { createQueryCatalogEntitiesAction } from './createQueryCatalogEntitiesAction';
 import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
 import { actionsRegistryServiceMock } from '@backstage/backend-test-utils/alpha';
-import { PermissionsService } from '@backstage/backend-plugin-api';
+import { mockServices } from '@backstage/backend-test-utils';
 import { AuthorizeResult } from '@backstage/plugin-permission-common';
 
 const testEntities = [
@@ -54,19 +54,17 @@ const testEntities = [
 
 function createCatalogQueryAction(options?: {
   entities?: typeof testEntities;
-  authorizeResult?: AuthorizeResult;
+  authorizeResult?: AuthorizeResult.ALLOW | AuthorizeResult.DENY;
 }) {
   const mockActionsRegistry = actionsRegistryServiceMock();
   const mockCatalog = catalogServiceMock({
     entities: options?.entities ?? testEntities,
   });
-  const permissions = {
-    authorizeConditional: jest
-      .fn()
-      .mockResolvedValue([
-        { result: options?.authorizeResult ?? AuthorizeResult.ALLOW },
-      ]),
-  } as unknown as jest.Mocked<PermissionsService>;
+  const permissions = mockServices.permissions.mock({
+    authorizeConditional: async () => [
+      { result: options?.authorizeResult ?? AuthorizeResult.ALLOW },
+    ],
+  });
   createQueryCatalogEntitiesAction({
     catalog: mockCatalog,
     actionsRegistry: mockActionsRegistry,

--- a/plugins/catalog-backend/src/actions/createQueryCatalogEntitiesAction.ts
+++ b/plugins/catalog-backend/src/actions/createQueryCatalogEntitiesAction.ts
@@ -16,6 +16,9 @@
 import { ActionsRegistryService } from '@backstage/backend-plugin-api/alpha';
 import { CatalogService } from '@backstage/plugin-catalog-node';
 import { createZodV3FilterPredicateSchema } from '@backstage/filter-predicates';
+import { PermissionsService } from '@backstage/backend-plugin-api';
+import { catalogEntityReadPermission } from '@backstage/plugin-catalog-common/alpha';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
 
 const QUERY_SYNTAX = `
 ## Query Syntax
@@ -111,10 +114,12 @@ export const createQueryCatalogEntitiesAction = ({
   catalog,
   actionsRegistry,
   useExperimentalCatalogLayersDescriptions,
+  permissions,
 }: {
   catalog: CatalogService;
   actionsRegistry: ActionsRegistryService;
   useExperimentalCatalogLayersDescriptions?: boolean;
+  permissions: PermissionsService;
 }) => {
   actionsRegistry.register({
     name: 'query-catalog-entities',
@@ -213,6 +218,23 @@ export const createQueryCatalogEntitiesAction = ({
         }),
     },
     action: async ({ input, credentials }) => {
+      // Check before calling the catalog service so that external access
+      // restrictions are evaluated using the original caller credentials.
+      const [readDecision] = await permissions.authorizeConditional(
+        [{ permission: catalogEntityReadPermission }],
+        { credentials },
+      );
+      if (readDecision.result === AuthorizeResult.DENY) {
+        return {
+          output: {
+            items: [],
+            totalItems: 0,
+            hasMoreEntities: false,
+            nextPageCursor: undefined,
+          },
+        };
+      }
+
       const response = await catalog.queryEntities(
         {
           ...input,

--- a/plugins/catalog-backend/src/actions/createQueryCatalogEntitiesAction.ts
+++ b/plugins/catalog-backend/src/actions/createQueryCatalogEntitiesAction.ts
@@ -218,8 +218,9 @@ export const createQueryCatalogEntitiesAction = ({
         }),
     },
     action: async ({ input, credentials }) => {
-      // Check before calling the catalog service so that external access
-      // restrictions are evaluated using the original caller credentials.
+      // TODO: Revisit this explicit check once service on-behalf-of
+      // authentication preserves caller identity and access restrictions
+      // across service boundaries. Until then, authorize before delegating.
       const [readDecision] = await permissions.authorizeConditional(
         [{ permission: catalogEntityReadPermission }],
         { credentials },

--- a/plugins/catalog-backend/src/actions/createRefreshCatalogEntityAction.test.ts
+++ b/plugins/catalog-backend/src/actions/createRefreshCatalogEntityAction.test.ts
@@ -16,8 +16,30 @@
 import { createRefreshCatalogEntityAction } from './createRefreshCatalogEntityAction';
 import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
 import { actionsRegistryServiceMock } from '@backstage/backend-test-utils/alpha';
+import { PermissionsService } from '@backstage/backend-plugin-api';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
+import { NotAllowedError, NotFoundError } from '@backstage/errors';
 
 describe('createRefreshCatalogEntityAction', () => {
+  const permissions = {
+    authorize: jest.fn(),
+    authorizeConditional: jest
+      .fn()
+      .mockResolvedValue([
+        { result: AuthorizeResult.ALLOW },
+        { result: AuthorizeResult.ALLOW },
+      ]),
+  } as unknown as jest.Mocked<PermissionsService>;
+
+  beforeEach(() => {
+    permissions.authorize.mockReset();
+    permissions.authorizeConditional
+      .mockReset()
+      .mockResolvedValue([
+        { result: AuthorizeResult.ALLOW },
+        { result: AuthorizeResult.ALLOW },
+      ]);
+  });
   const componentEntity = {
     apiVersion: 'backstage.io/v1alpha1',
     kind: 'Component',
@@ -45,6 +67,7 @@ describe('createRefreshCatalogEntityAction', () => {
     createRefreshCatalogEntityAction({
       catalog: mockCatalog,
       actionsRegistry: mockActionsRegistry,
+      permissions,
     });
 
     const result = await mockActionsRegistry.invoke({
@@ -71,6 +94,7 @@ describe('createRefreshCatalogEntityAction', () => {
     createRefreshCatalogEntityAction({
       catalog: mockCatalog,
       actionsRegistry: mockActionsRegistry,
+      permissions,
     });
 
     const result = await mockActionsRegistry.invoke({
@@ -95,6 +119,7 @@ describe('createRefreshCatalogEntityAction', () => {
     createRefreshCatalogEntityAction({
       catalog: mockCatalog,
       actionsRegistry: mockActionsRegistry,
+      permissions,
     });
 
     const result = await mockActionsRegistry.invoke({
@@ -109,7 +134,7 @@ describe('createRefreshCatalogEntityAction', () => {
     );
   });
 
-  it('throws when no entity matches the name', async () => {
+  it('throws NotFoundError when no entity matches the name', async () => {
     const mockActionsRegistry = actionsRegistryServiceMock();
     const mockCatalog = catalogServiceMock({ entities: [] });
     const refreshSpy = jest.spyOn(mockCatalog, 'refreshEntity');
@@ -117,6 +142,7 @@ describe('createRefreshCatalogEntityAction', () => {
     createRefreshCatalogEntityAction({
       catalog: mockCatalog,
       actionsRegistry: mockActionsRegistry,
+      permissions,
     });
 
     await expect(
@@ -124,7 +150,10 @@ describe('createRefreshCatalogEntityAction', () => {
         id: 'test:refresh-catalog-entity',
         input: { name: 'missing-entity' },
       }),
-    ).rejects.toThrow(`No entity found with name "missing-entity"`);
+    ).rejects.toMatchObject({
+      name: 'NotFoundError',
+      message: `No entity found with name "missing-entity"`,
+    } satisfies Partial<NotFoundError>);
 
     expect(refreshSpy).not.toHaveBeenCalled();
   });
@@ -139,6 +168,7 @@ describe('createRefreshCatalogEntityAction', () => {
     createRefreshCatalogEntityAction({
       catalog: mockCatalog,
       actionsRegistry: mockActionsRegistry,
+      permissions,
     });
 
     await expect(
@@ -163,6 +193,7 @@ describe('createRefreshCatalogEntityAction', () => {
     createRefreshCatalogEntityAction({
       catalog: mockCatalog,
       actionsRegistry: mockActionsRegistry,
+      permissions,
     });
 
     await expect(
@@ -171,5 +202,121 @@ describe('createRefreshCatalogEntityAction', () => {
         input: { name: 'orders-api' },
       }),
     ).rejects.toThrow('processor unavailable');
+  });
+
+  it('rejects denied refresh permission before looking up the entity', async () => {
+    const mockActionsRegistry = actionsRegistryServiceMock();
+    const mockCatalog = catalogServiceMock({ entities: [componentEntity] });
+    const querySpy = jest.spyOn(mockCatalog, 'queryEntities');
+    const refreshSpy = jest.spyOn(mockCatalog, 'refreshEntity');
+    permissions.authorizeConditional.mockResolvedValue([
+      { result: AuthorizeResult.DENY },
+      { result: AuthorizeResult.ALLOW },
+    ]);
+
+    createRefreshCatalogEntityAction({
+      catalog: mockCatalog,
+      actionsRegistry: mockActionsRegistry,
+      permissions,
+    });
+
+    await expect(
+      mockActionsRegistry.invoke({
+        id: 'test:refresh-catalog-entity',
+        input: { name: 'orders-api' },
+      }),
+    ).rejects.toThrow(NotAllowedError);
+
+    expect(permissions.authorizeConditional).toHaveBeenCalledWith(
+      [
+        {
+          permission: expect.objectContaining({
+            name: 'catalog.entity.refresh',
+          }),
+        },
+        {
+          permission: expect.objectContaining({ name: 'catalog.entity.read' }),
+        },
+      ],
+      { credentials: expect.any(Object) },
+    );
+    expect(querySpy).not.toHaveBeenCalled();
+    expect(refreshSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects denied read permission before looking up the entity', async () => {
+    const mockActionsRegistry = actionsRegistryServiceMock();
+    const mockCatalog = catalogServiceMock({ entities: [componentEntity] });
+    const querySpy = jest.spyOn(mockCatalog, 'queryEntities');
+    const refreshSpy = jest.spyOn(mockCatalog, 'refreshEntity');
+    permissions.authorizeConditional.mockResolvedValue([
+      { result: AuthorizeResult.ALLOW },
+      { result: AuthorizeResult.DENY },
+    ]);
+
+    createRefreshCatalogEntityAction({
+      catalog: mockCatalog,
+      actionsRegistry: mockActionsRegistry,
+      permissions,
+    });
+
+    await expect(
+      mockActionsRegistry.invoke({
+        id: 'test:refresh-catalog-entity',
+        input: { name: 'orders-api' },
+      }),
+    ).rejects.toMatchObject({
+      name: 'NotFoundError',
+      message: 'No entity found with name "orders-api"',
+    } satisfies Partial<NotFoundError>);
+
+    expect(querySpy).not.toHaveBeenCalled();
+    expect(refreshSpy).not.toHaveBeenCalled();
+  });
+
+  it('checks conditional refresh permission for the resolved entity', async () => {
+    const mockActionsRegistry = actionsRegistryServiceMock();
+    const mockCatalog = catalogServiceMock({ entities: [componentEntity] });
+    const refreshSpy = jest.spyOn(mockCatalog, 'refreshEntity');
+    permissions.authorizeConditional.mockResolvedValue([
+      {
+        result: AuthorizeResult.CONDITIONAL,
+        pluginId: 'catalog',
+        resourceType: 'catalog-entity',
+        conditions: {
+          resourceType: 'catalog-entity',
+          rule: 'IS_ENTITY_OWNER',
+          params: { claims: ['group:default/team-a'] },
+        },
+      },
+      { result: AuthorizeResult.ALLOW },
+    ]);
+    permissions.authorize.mockResolvedValue([{ result: AuthorizeResult.DENY }]);
+
+    createRefreshCatalogEntityAction({
+      catalog: mockCatalog,
+      actionsRegistry: mockActionsRegistry,
+      permissions,
+    });
+
+    await expect(
+      mockActionsRegistry.invoke({
+        id: 'test:refresh-catalog-entity',
+        input: { name: 'orders-api' },
+      }),
+    ).rejects.toThrow(NotAllowedError);
+
+    expect(permissions.authorize).toHaveBeenCalledWith(
+      [
+        {
+          permission: expect.objectContaining({
+            name: 'catalog.entity.refresh',
+          }),
+          resourceRef: 'component:default/orders-api',
+        },
+      ],
+      { credentials: expect.any(Object) },
+    );
+    expect(refreshSpy).not.toHaveBeenCalled();
   });
 });

--- a/plugins/catalog-backend/src/actions/createRefreshCatalogEntityAction.test.ts
+++ b/plugins/catalog-backend/src/actions/createRefreshCatalogEntityAction.test.ts
@@ -16,29 +16,20 @@
 import { createRefreshCatalogEntityAction } from './createRefreshCatalogEntityAction';
 import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
 import { actionsRegistryServiceMock } from '@backstage/backend-test-utils/alpha';
-import { PermissionsService } from '@backstage/backend-plugin-api';
+import { mockServices } from '@backstage/backend-test-utils';
 import { AuthorizeResult } from '@backstage/plugin-permission-common';
 import { NotAllowedError, NotFoundError } from '@backstage/errors';
 
 describe('createRefreshCatalogEntityAction', () => {
-  const permissions = {
-    authorize: jest.fn(),
-    authorizeConditional: jest
-      .fn()
-      .mockResolvedValue([
-        { result: AuthorizeResult.ALLOW },
-        { result: AuthorizeResult.ALLOW },
-      ]),
-  } as unknown as jest.Mocked<PermissionsService>;
+  let permissions: ReturnType<typeof mockServices.permissions.mock>;
 
   beforeEach(() => {
-    permissions.authorize.mockReset();
-    permissions.authorizeConditional
-      .mockReset()
-      .mockResolvedValue([
+    permissions = mockServices.permissions.mock({
+      authorizeConditional: async () => [
         { result: AuthorizeResult.ALLOW },
         { result: AuthorizeResult.ALLOW },
-      ]);
+      ],
+    });
   });
   const componentEntity = {
     apiVersion: 'backstage.io/v1alpha1',

--- a/plugins/catalog-backend/src/actions/createRefreshCatalogEntityAction.ts
+++ b/plugins/catalog-backend/src/actions/createRefreshCatalogEntityAction.ts
@@ -81,8 +81,9 @@ Each entity in the software catalog has a unique name, kind, and namespace. If t
         }),
     },
     action: async ({ input, credentials }) => {
-      // Check before calling the catalog service so that external access
-      // restrictions are evaluated using the original caller credentials.
+      // TODO: Revisit this explicit check once service on-behalf-of
+      // authentication preserves caller identity and access restrictions
+      // across service boundaries. Until then, authorize before delegating.
       const [refreshDecision, readDecision] =
         await permissions.authorizeConditional(
           [

--- a/plugins/catalog-backend/src/actions/createRefreshCatalogEntityAction.ts
+++ b/plugins/catalog-backend/src/actions/createRefreshCatalogEntityAction.ts
@@ -13,17 +13,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type { PermissionsService } from '@backstage/backend-plugin-api';
 import type { ActionsRegistryService } from '@backstage/backend-plugin-api/alpha';
 import { stringifyEntityRef } from '@backstage/catalog-model';
-import { ConflictError, InputError } from '@backstage/errors';
+import {
+  ConflictError,
+  NotAllowedError,
+  NotFoundError,
+} from '@backstage/errors';
+import {
+  catalogEntityReadPermission,
+  catalogEntityRefreshPermission,
+} from '@backstage/plugin-catalog-common/alpha';
 import type { CatalogService } from '@backstage/plugin-catalog-node';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
 
 export const createRefreshCatalogEntityAction = ({
   catalog,
   actionsRegistry,
+  permissions,
 }: {
   catalog: CatalogService;
   actionsRegistry: ActionsRegistryService;
+  permissions: PermissionsService;
 }) => {
   actionsRegistry.register({
     name: 'refresh-catalog-entity',
@@ -69,6 +81,24 @@ Each entity in the software catalog has a unique name, kind, and namespace. If t
         }),
     },
     action: async ({ input, credentials }) => {
+      // Check before calling the catalog service so that external access
+      // restrictions are evaluated using the original caller credentials.
+      const [refreshDecision, readDecision] =
+        await permissions.authorizeConditional(
+          [
+            { permission: catalogEntityRefreshPermission },
+            { permission: catalogEntityReadPermission },
+          ],
+          { credentials },
+        );
+
+      if (refreshDecision.result === AuthorizeResult.DENY) {
+        throw new NotAllowedError();
+      }
+      if (readDecision.result === AuthorizeResult.DENY) {
+        throw new NotFoundError(`No entity found with name "${input.name}"`);
+      }
+
       const filter: Record<string, string> = { 'metadata.name': input.name };
 
       if (input.kind) {
@@ -85,7 +115,7 @@ Each entity in the software catalog has a unique name, kind, and namespace. If t
       );
 
       if (items.length === 0) {
-        throw new InputError(`No entity found with name "${input.name}"`);
+        throw new NotFoundError(`No entity found with name "${input.name}"`);
       }
 
       if (items.length > 1) {
@@ -99,6 +129,21 @@ Each entity in the software catalog has a unique name, kind, and namespace. If t
       }
 
       const entityRef = stringifyEntityRef(items[0]);
+
+      if (refreshDecision.result === AuthorizeResult.CONDITIONAL) {
+        const [entityDecision] = await permissions.authorize(
+          [
+            {
+              permission: catalogEntityRefreshPermission,
+              resourceRef: entityRef,
+            },
+          ],
+          { credentials },
+        );
+        if (entityDecision.result !== AuthorizeResult.ALLOW) {
+          throw new NotAllowedError();
+        }
+      }
 
       await catalog.refreshEntity(entityRef, { credentials });
 

--- a/plugins/catalog-backend/src/actions/createRegisterCatalogEntitiesAction.test.ts
+++ b/plugins/catalog-backend/src/actions/createRegisterCatalogEntitiesAction.test.ts
@@ -18,6 +18,20 @@ import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
 import { actionsRegistryServiceMock } from '@backstage/backend-test-utils/alpha';
 
 describe('createRegisterCatalogEntitiesAction', () => {
+  it('requires location creation permission for action visibility', () => {
+    const mockActionsRegistry = actionsRegistryServiceMock();
+
+    createRegisterCatalogEntitiesAction({
+      catalog: catalogServiceMock(),
+      actionsRegistry: mockActionsRegistry,
+    });
+
+    expect(
+      mockActionsRegistry.actions.get('test:register-entity')
+        ?.visibilityPermission?.name,
+    ).toBe('catalog.location.create');
+  });
+
   it('should successfully register a catalog location with a valid URL', async () => {
     const mockActionsRegistry = actionsRegistryServiceMock();
     const mockCatalog = catalogServiceMock();

--- a/plugins/catalog-backend/src/actions/createRegisterCatalogEntitiesAction.ts
+++ b/plugins/catalog-backend/src/actions/createRegisterCatalogEntitiesAction.ts
@@ -16,6 +16,7 @@
 import { ActionsRegistryService } from '@backstage/backend-plugin-api/alpha';
 import { InputError } from '@backstage/errors';
 import { CatalogService } from '@backstage/plugin-catalog-node';
+import { catalogLocationCreatePermission } from '@backstage/plugin-catalog-common/alpha';
 
 const isValidUrl = (url: string) => {
   try {
@@ -42,6 +43,7 @@ export const createRegisterCatalogEntitiesAction = ({
       readOnly: false,
       idempotent: false,
     },
+    visibilityPermission: catalogLocationCreatePermission,
     description: `Registers one or more entities in the Backstage catalog by creating a Location entity that points to a remote catalog-info.yaml file.
 
 This action is similar to the "Register existing component" flow in the Backstage UI, where you provide a URL to a catalog-info.yaml file describing catalog entities such as Components, Systems, Resources, APIs, Users, and Groups. The action will create a new Location entity that references the provided file; all entities defined within that file will be imported into the catalog.

--- a/plugins/catalog-backend/src/actions/createUnregisterCatalogEntitiesAction.test.ts
+++ b/plugins/catalog-backend/src/actions/createUnregisterCatalogEntitiesAction.test.ts
@@ -16,19 +16,17 @@
 import { createUnregisterCatalogEntitiesAction } from './createUnregisterCatalogEntitiesAction';
 import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
 import { actionsRegistryServiceMock } from '@backstage/backend-test-utils/alpha';
-import { PermissionsService } from '@backstage/backend-plugin-api';
+import { mockServices } from '@backstage/backend-test-utils';
 import { AuthorizeResult } from '@backstage/plugin-permission-common';
 import { NotFoundError } from '@backstage/errors';
 
 describe('createUnregisterCatalogEntitiesAction', () => {
-  const permissions = {
-    authorize: jest.fn().mockResolvedValue([{ result: AuthorizeResult.ALLOW }]),
-  } as unknown as jest.Mocked<PermissionsService>;
+  let permissions: ReturnType<typeof mockServices.permissions.mock>;
 
   beforeEach(() => {
-    permissions.authorize
-      .mockReset()
-      .mockResolvedValue([{ result: AuthorizeResult.ALLOW }]);
+    permissions = mockServices.permissions.mock({
+      authorize: async () => [{ result: AuthorizeResult.ALLOW }],
+    });
   });
 
   it('requires location deletion permission for action visibility', () => {

--- a/plugins/catalog-backend/src/actions/createUnregisterCatalogEntitiesAction.test.ts
+++ b/plugins/catalog-backend/src/actions/createUnregisterCatalogEntitiesAction.test.ts
@@ -16,8 +16,36 @@
 import { createUnregisterCatalogEntitiesAction } from './createUnregisterCatalogEntitiesAction';
 import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
 import { actionsRegistryServiceMock } from '@backstage/backend-test-utils/alpha';
+import { PermissionsService } from '@backstage/backend-plugin-api';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
+import { NotFoundError } from '@backstage/errors';
 
 describe('createUnregisterCatalogEntitiesAction', () => {
+  const permissions = {
+    authorize: jest.fn().mockResolvedValue([{ result: AuthorizeResult.ALLOW }]),
+  } as unknown as jest.Mocked<PermissionsService>;
+
+  beforeEach(() => {
+    permissions.authorize
+      .mockReset()
+      .mockResolvedValue([{ result: AuthorizeResult.ALLOW }]);
+  });
+
+  it('requires location deletion permission for action visibility', () => {
+    const mockActionsRegistry = actionsRegistryServiceMock();
+
+    createUnregisterCatalogEntitiesAction({
+      catalog: catalogServiceMock(),
+      actionsRegistry: mockActionsRegistry,
+      permissions,
+    });
+
+    expect(
+      mockActionsRegistry.actions.get('test:unregister-entity')
+        ?.visibilityPermission?.name,
+    ).toBe('catalog.location.delete');
+  });
+
   describe('with locationId', () => {
     it('should successfully unregister a catalog location with a valid locationId', async () => {
       const mockActionsRegistry = actionsRegistryServiceMock();
@@ -28,6 +56,7 @@ describe('createUnregisterCatalogEntitiesAction', () => {
       createUnregisterCatalogEntitiesAction({
         catalog: mockCatalog,
         actionsRegistry: mockActionsRegistry,
+        permissions,
       });
 
       const result = await mockActionsRegistry.invoke({
@@ -56,6 +85,7 @@ describe('createUnregisterCatalogEntitiesAction', () => {
       createUnregisterCatalogEntitiesAction({
         catalog: mockCatalog,
         actionsRegistry: mockActionsRegistry,
+        permissions,
       });
 
       await expect(
@@ -68,6 +98,52 @@ describe('createUnregisterCatalogEntitiesAction', () => {
   });
 
   describe('with locationUrl', () => {
+    it('rejects denied location read permission before listing locations', async () => {
+      const mockActionsRegistry = actionsRegistryServiceMock();
+      const mockCatalog = catalogServiceMock();
+      mockCatalog.getLocations = jest.fn().mockResolvedValue({ items: [] });
+      const getLocationsSpy = jest.spyOn(mockCatalog, 'getLocations');
+      const removeLocationSpy = jest.spyOn(mockCatalog, 'removeLocationById');
+      permissions.authorize.mockResolvedValue([
+        { result: AuthorizeResult.DENY },
+      ]);
+
+      const options = {
+        catalog: mockCatalog,
+        actionsRegistry: mockActionsRegistry,
+        permissions,
+      };
+      createUnregisterCatalogEntitiesAction(options);
+
+      await expect(
+        mockActionsRegistry.invoke({
+          id: 'test:unregister-entity',
+          input: {
+            type: {
+              locationUrl:
+                'https://github.com/backstage/demo/blob/master/catalog-info.yaml',
+            },
+          },
+        }),
+      ).rejects.toMatchObject({
+        name: 'NotFoundError',
+        message: 'No matching location found',
+      } satisfies Partial<NotFoundError>);
+
+      expect(permissions.authorize).toHaveBeenCalledWith(
+        [
+          {
+            permission: expect.objectContaining({
+              name: 'catalog.location.read',
+            }),
+          },
+        ],
+        { credentials: expect.any(Object) },
+      );
+      expect(getLocationsSpy).not.toHaveBeenCalled();
+      expect(removeLocationSpy).not.toHaveBeenCalled();
+    });
+
     it('should successfully unregister a catalog location with a valid locationUrl', async () => {
       const mockActionsRegistry = actionsRegistryServiceMock();
       const mockCatalog = catalogServiceMock();
@@ -86,6 +162,7 @@ describe('createUnregisterCatalogEntitiesAction', () => {
       createUnregisterCatalogEntitiesAction({
         catalog: mockCatalog,
         actionsRegistry: mockActionsRegistry,
+        permissions,
       });
 
       const result = await mockActionsRegistry.invoke({
@@ -127,6 +204,7 @@ describe('createUnregisterCatalogEntitiesAction', () => {
       createUnregisterCatalogEntitiesAction({
         catalog: mockCatalog,
         actionsRegistry: mockActionsRegistry,
+        permissions,
       });
 
       const result = await mockActionsRegistry.invoke({
@@ -167,6 +245,7 @@ describe('createUnregisterCatalogEntitiesAction', () => {
       createUnregisterCatalogEntitiesAction({
         catalog: mockCatalog,
         actionsRegistry: mockActionsRegistry,
+        permissions,
       });
 
       const result = await mockActionsRegistry.invoke({
@@ -208,6 +287,7 @@ describe('createUnregisterCatalogEntitiesAction', () => {
       createUnregisterCatalogEntitiesAction({
         catalog: mockCatalog,
         actionsRegistry: mockActionsRegistry,
+        permissions,
       });
 
       await expect(
@@ -232,6 +312,7 @@ describe('createUnregisterCatalogEntitiesAction', () => {
       createUnregisterCatalogEntitiesAction({
         catalog: mockCatalog,
         actionsRegistry: mockActionsRegistry,
+        permissions,
       });
 
       await expect(

--- a/plugins/catalog-backend/src/actions/createUnregisterCatalogEntitiesAction.ts
+++ b/plugins/catalog-backend/src/actions/createUnregisterCatalogEntitiesAction.ts
@@ -13,16 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { PermissionsService } from '@backstage/backend-plugin-api';
 import { ActionsRegistryService } from '@backstage/backend-plugin-api/alpha';
 import { NotFoundError } from '@backstage/errors';
+import {
+  catalogLocationDeletePermission,
+  catalogLocationReadPermission,
+} from '@backstage/plugin-catalog-common/alpha';
 import { CatalogService } from '@backstage/plugin-catalog-node';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
 
 export const createUnregisterCatalogEntitiesAction = ({
   catalog,
   actionsRegistry,
+  permissions,
 }: {
   catalog: CatalogService;
   actionsRegistry: ActionsRegistryService;
+  permissions: PermissionsService;
 }) => {
   actionsRegistry.register({
     name: 'unregister-entity',
@@ -32,6 +40,7 @@ export const createUnregisterCatalogEntitiesAction = ({
       readOnly: false,
       idempotent: true,
     },
+    visibilityPermission: catalogLocationDeletePermission,
     description: `Unregisters a Location entity and all entities it owns from the Backstage catalog.
 
 This action is similar to the "Unregister location" function in the Backstage UI, where you provide the unique identifier (locationId) of a Location entity. Alternatively, you can provide the URL used to register the location. The action will remove the specified Location from the catalog as well as all entities that were created when the Location was imported.
@@ -68,6 +77,16 @@ Once completed, all entities associated with the Location will be deleted from t
           credentials,
         });
       } else {
+        // Looking up a location by URL requires read permission in addition to
+        // the registry-enforced location deletion permission.
+        const [readDecision] = await permissions.authorize(
+          [{ permission: catalogLocationReadPermission }],
+          { credentials },
+        );
+        if (readDecision.result !== AuthorizeResult.ALLOW) {
+          throw new NotFoundError('No matching location found');
+        }
+
         const locations = await catalog
           .getLocations(
             {},

--- a/plugins/catalog-backend/src/actions/createValidateEntityAction.test.ts
+++ b/plugins/catalog-backend/src/actions/createValidateEntityAction.test.ts
@@ -55,6 +55,20 @@ spec:
     },
   };
 
+  it('requires entity validation permission for action visibility', () => {
+    const mockActionsRegistry = actionsRegistryServiceMock();
+
+    createValidateEntityAction({
+      catalog: catalogServiceMock(),
+      actionsRegistry: mockActionsRegistry,
+    });
+
+    expect(
+      mockActionsRegistry.actions.get('test:validate-entity')
+        ?.visibilityPermission?.name,
+    ).toBe('catalog.entity.validate');
+  });
+
   it('should validate a valid entity YAML and return success', async () => {
     const mockActionsRegistry = actionsRegistryServiceMock();
     const mockCatalog = catalogServiceMock.mock();

--- a/plugins/catalog-backend/src/actions/createValidateEntityAction.ts
+++ b/plugins/catalog-backend/src/actions/createValidateEntityAction.ts
@@ -16,6 +16,7 @@
 import { ActionsRegistryService } from '@backstage/backend-plugin-api/alpha';
 import yaml from 'yaml';
 import { CatalogService } from '@backstage/plugin-catalog-node';
+import { catalogEntityValidatePermission } from '@backstage/plugin-catalog-common/alpha';
 
 export const createValidateEntityAction = (options: {
   actionsRegistry: ActionsRegistryService;
@@ -34,6 +35,7 @@ export const createValidateEntityAction = (options: {
       idempotent: true,
       destructive: false,
     },
+    visibilityPermission: catalogEntityValidatePermission,
     schema: {
       input: z =>
         z.object({

--- a/plugins/catalog-backend/src/actions/index.ts
+++ b/plugins/catalog-backend/src/actions/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { PermissionsService } from '@backstage/backend-plugin-api';
 import { ActionsRegistryService } from '@backstage/backend-plugin-api/alpha';
 import { CatalogService } from '@backstage/plugin-catalog-node';
 import { ModelHolder } from '../model/ModelHolder';
@@ -29,6 +30,7 @@ export const createCatalogActions = (options: {
   actionsRegistry: ActionsRegistryService;
   catalog: CatalogService;
   modelHolder: ModelHolder | undefined;
+  permissions: PermissionsService;
   useExperimentalCatalogLayersDescriptions?: boolean;
 }) => {
   createGetCatalogModelDescriptionAction(options);

--- a/plugins/catalog-backend/src/service/CatalogPlugin.ts
+++ b/plugins/catalog-backend/src/service/CatalogPlugin.ts
@@ -287,6 +287,7 @@ export const catalogPlugin = createBackendPlugin({
         createCatalogActions({
           catalog,
           actionsRegistry,
+          permissions,
           modelHolder,
           useExperimentalCatalogLayersDescriptions:
             config.getOptionalBoolean(

--- a/plugins/notifications-backend/src/actions/createGetNotificationsAction.test.ts
+++ b/plugins/notifications-backend/src/actions/createGetNotificationsAction.test.ts
@@ -194,7 +194,7 @@ describe('createGetNotificationsAction', () => {
     );
   });
 
-  it('throws InputError when called without user credentials', async () => {
+  it('throws NotAllowedError when called without user credentials', async () => {
     const mockActionsRegistry = actionsRegistryServiceMock();
     const store = createMockStore();
 

--- a/plugins/scaffolder-backend/src/ScaffolderPlugin.ts
+++ b/plugins/scaffolder-backend/src/ScaffolderPlugin.ts
@@ -238,6 +238,7 @@ export const scaffolderPlugin = createBackendPlugin({
           actionsRegistry: actionsRegistryService,
           scaffolderService,
           auth,
+          permissions,
         });
 
         const router = await createRouter({

--- a/plugins/scaffolder-backend/src/actions/createDryRunTemplateAction.test.ts
+++ b/plugins/scaffolder-backend/src/actions/createDryRunTemplateAction.test.ts
@@ -16,6 +16,9 @@
 import { createDryRunTemplateAction } from './createDryRunTemplateAction';
 import { actionsRegistryServiceMock } from '@backstage/backend-test-utils/alpha';
 import { scaffolderServiceMock } from '@backstage/plugin-scaffolder-node/testUtils';
+import { PermissionsService } from '@backstage/backend-plugin-api';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
+import { NotAllowedError } from '@backstage/errors';
 
 type DryRunTemplateOutput = {
   valid: boolean;
@@ -56,9 +59,51 @@ spec:
 
 describe('createDryRunTemplateAction', () => {
   const mockScaffolderService = scaffolderServiceMock.mock();
+  const permissions = {
+    authorize: jest.fn().mockResolvedValue([{ result: AuthorizeResult.ALLOW }]),
+  } as unknown as jest.Mocked<PermissionsService>;
 
   beforeEach(() => {
     jest.resetAllMocks();
+    permissions.authorize.mockResolvedValue([
+      { result: AuthorizeResult.ALLOW },
+    ]);
+  });
+
+  it('rejects denied task creation permission before starting a dry run', async () => {
+    const mockActionsRegistry = actionsRegistryServiceMock();
+    mockScaffolderService.dryRun.mockResolvedValue({
+      log: [],
+      output: {},
+      steps: [],
+      directoryContents: [],
+    });
+    permissions.authorize.mockResolvedValue([{ result: AuthorizeResult.DENY }]);
+    const options = {
+      actionsRegistry: mockActionsRegistry,
+      scaffolderService: mockScaffolderService,
+      permissions,
+    };
+    createDryRunTemplateAction(options);
+
+    await expect(
+      mockActionsRegistry.invoke({
+        id: 'test:dry-run-template',
+        input: { templateYaml: validTemplateYaml },
+      }),
+    ).rejects.toThrow(NotAllowedError);
+
+    expect(permissions.authorize).toHaveBeenCalledWith(
+      [
+        {
+          permission: expect.objectContaining({
+            name: 'scaffolder.task.create',
+          }),
+        },
+      ],
+      { credentials: expect.any(Object) },
+    );
+    expect(mockScaffolderService.dryRun).not.toHaveBeenCalled();
   });
 
   it('requires dry-run permission for action visibility', () => {
@@ -67,6 +112,7 @@ describe('createDryRunTemplateAction', () => {
     createDryRunTemplateAction({
       actionsRegistry: mockActionsRegistry,
       scaffolderService: mockScaffolderService,
+      permissions,
     });
 
     expect(
@@ -97,6 +143,7 @@ describe('createDryRunTemplateAction', () => {
     createDryRunTemplateAction({
       actionsRegistry: mockActionsRegistry,
       scaffolderService: mockScaffolderService,
+      permissions,
     });
 
     const result = await mockActionsRegistry.invoke({
@@ -146,6 +193,7 @@ describe('createDryRunTemplateAction', () => {
     createDryRunTemplateAction({
       actionsRegistry: mockActionsRegistry,
       scaffolderService: mockScaffolderService,
+      permissions,
     });
 
     const values = { name: 'my-app' };
@@ -186,6 +234,7 @@ describe('createDryRunTemplateAction', () => {
     createDryRunTemplateAction({
       actionsRegistry: mockActionsRegistry,
       scaffolderService: mockScaffolderService,
+      permissions,
     });
 
     const result = await mockActionsRegistry.invoke({
@@ -214,6 +263,7 @@ describe('createDryRunTemplateAction', () => {
     createDryRunTemplateAction({
       actionsRegistry: mockActionsRegistry,
       scaffolderService: mockScaffolderService,
+      permissions,
     });
 
     await expect(
@@ -236,6 +286,7 @@ describe('createDryRunTemplateAction', () => {
     createDryRunTemplateAction({
       actionsRegistry: mockActionsRegistry,
       scaffolderService: mockScaffolderService,
+      permissions,
     });
 
     await mockActionsRegistry.invoke({
@@ -265,6 +316,7 @@ describe('createDryRunTemplateAction', () => {
     createDryRunTemplateAction({
       actionsRegistry: mockActionsRegistry,
       scaffolderService: mockScaffolderService,
+      permissions,
     });
 
     const result = await mockActionsRegistry.invoke({

--- a/plugins/scaffolder-backend/src/actions/createDryRunTemplateAction.test.ts
+++ b/plugins/scaffolder-backend/src/actions/createDryRunTemplateAction.test.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 import { createDryRunTemplateAction } from './createDryRunTemplateAction';
+import { mockServices } from '@backstage/backend-test-utils';
 import { actionsRegistryServiceMock } from '@backstage/backend-test-utils/alpha';
 import { scaffolderServiceMock } from '@backstage/plugin-scaffolder-node/testUtils';
-import { PermissionsService } from '@backstage/backend-plugin-api';
 import { AuthorizeResult } from '@backstage/plugin-permission-common';
 import { NotAllowedError } from '@backstage/errors';
 
@@ -59,15 +59,13 @@ spec:
 
 describe('createDryRunTemplateAction', () => {
   const mockScaffolderService = scaffolderServiceMock.mock();
-  const permissions = {
-    authorize: jest.fn().mockResolvedValue([{ result: AuthorizeResult.ALLOW }]),
-  } as unknown as jest.Mocked<PermissionsService>;
+  let permissions: ReturnType<typeof mockServices.permissions.mock>;
 
   beforeEach(() => {
     jest.resetAllMocks();
-    permissions.authorize.mockResolvedValue([
-      { result: AuthorizeResult.ALLOW },
-    ]);
+    permissions = mockServices.permissions.mock({
+      authorize: async () => [{ result: AuthorizeResult.ALLOW }],
+    });
   });
 
   it('rejects denied task creation permission before starting a dry run', async () => {

--- a/plugins/scaffolder-backend/src/actions/createDryRunTemplateAction.ts
+++ b/plugins/scaffolder-backend/src/actions/createDryRunTemplateAction.ts
@@ -13,9 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { PermissionsService } from '@backstage/backend-plugin-api';
 import { ActionsRegistryService } from '@backstage/backend-plugin-api/alpha';
-import { templateDryRunPermission } from '@backstage/plugin-scaffolder-common/alpha';
+import { NotAllowedError } from '@backstage/errors';
+import {
+  taskCreatePermission,
+  templateDryRunPermission,
+} from '@backstage/plugin-scaffolder-common/alpha';
 import { ScaffolderService } from '@backstage/plugin-scaffolder-node';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
 import { JsonObject } from '@backstage/types';
 import yaml from 'yaml';
 
@@ -31,9 +37,11 @@ function base64EncodeContent(content: string): string {
 export const createDryRunTemplateAction = ({
   actionsRegistry,
   scaffolderService,
+  permissions,
 }: {
   actionsRegistry: ActionsRegistryService;
   scaffolderService: ScaffolderService;
+  permissions: PermissionsService;
 }) => {
   actionsRegistry.register({
     name: 'dry-run-template',
@@ -107,6 +115,16 @@ export const createDryRunTemplateAction = ({
         }),
     },
     action: async ({ input, credentials }) => {
+      // The action registry enforces dry-run permission, while the operation
+      // also requires task creation permission.
+      const [createDecision] = await permissions.authorize(
+        [{ permission: taskCreatePermission }],
+        { credentials },
+      );
+      if (createDecision.result !== AuthorizeResult.ALLOW) {
+        throw new NotAllowedError();
+      }
+
       const { templateYaml, values = {}, files = [] } = input;
 
       let template;

--- a/plugins/scaffolder-backend/src/actions/createExecuteTemplateAction.test.ts
+++ b/plugins/scaffolder-backend/src/actions/createExecuteTemplateAction.test.ts
@@ -14,31 +14,25 @@
  * limitations under the License.
  */
 import { createExecuteTemplateAction } from './createExecuteTemplateAction';
+import { mockServices } from '@backstage/backend-test-utils';
 import { actionsRegistryServiceMock } from '@backstage/backend-test-utils/alpha';
 import { scaffolderServiceMock } from '@backstage/plugin-scaffolder-node/testUtils';
-import { PermissionsService } from '@backstage/backend-plugin-api';
 import { AuthorizeResult } from '@backstage/plugin-permission-common';
 import { NotAllowedError } from '@backstage/errors';
 
 describe('createExecuteTemplateAction', () => {
   const mockScaffolderService = scaffolderServiceMock.mock();
-  const permissions = {
-    authorizeConditional: jest
-      .fn()
-      .mockResolvedValue([
-        { result: AuthorizeResult.ALLOW },
-        { result: AuthorizeResult.ALLOW },
-        { result: AuthorizeResult.ALLOW },
-      ]),
-  } as unknown as jest.Mocked<PermissionsService>;
+  let permissions: ReturnType<typeof mockServices.permissions.mock>;
 
   beforeEach(() => {
     jest.resetAllMocks();
-    permissions.authorizeConditional.mockResolvedValue([
-      { result: AuthorizeResult.ALLOW },
-      { result: AuthorizeResult.ALLOW },
-      { result: AuthorizeResult.ALLOW },
-    ]);
+    permissions = mockServices.permissions.mock({
+      authorizeConditional: async () => [
+        { result: AuthorizeResult.ALLOW },
+        { result: AuthorizeResult.ALLOW },
+        { result: AuthorizeResult.ALLOW },
+      ],
+    });
   });
 
   it('rejects a denied Scaffolder permission before creating a task', async () => {

--- a/plugins/scaffolder-backend/src/actions/createExecuteTemplateAction.test.ts
+++ b/plugins/scaffolder-backend/src/actions/createExecuteTemplateAction.test.ts
@@ -27,21 +27,15 @@ describe('createExecuteTemplateAction', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     permissions = mockServices.permissions.mock({
-      authorizeConditional: async () => [
-        { result: AuthorizeResult.ALLOW },
-        { result: AuthorizeResult.ALLOW },
-        { result: AuthorizeResult.ALLOW },
-      ],
+      authorizeConditional: async () => [{ result: AuthorizeResult.ALLOW }],
     });
   });
 
-  it('rejects a denied Scaffolder permission before creating a task', async () => {
+  it('rejects denied action execution before creating a task', async () => {
     const mockActionsRegistry = actionsRegistryServiceMock();
     mockScaffolderService.scaffold.mockResolvedValue({ taskId: 'task-id' });
     permissions.authorizeConditional.mockResolvedValue([
-      { result: AuthorizeResult.ALLOW },
       { result: AuthorizeResult.DENY },
-      { result: AuthorizeResult.ALLOW },
     ]);
     const options = {
       actionsRegistry: mockActionsRegistry,
@@ -67,20 +61,39 @@ describe('createExecuteTemplateAction', () => {
             name: 'scaffolder.action.execute',
           }),
         },
-        {
-          permission: expect.objectContaining({
-            name: 'scaffolder.template.parameter.read',
-          }),
-        },
-        {
-          permission: expect.objectContaining({
-            name: 'scaffolder.template.step.read',
-          }),
-        },
       ],
       { credentials: expect.any(Object) },
     );
     expect(mockScaffolderService.scaffold).not.toHaveBeenCalled();
+  });
+
+  it('leaves template read permission filtering to the scaffolder service', async () => {
+    const mockActionsRegistry = actionsRegistryServiceMock();
+    mockScaffolderService.scaffold.mockResolvedValue({ taskId: 'task-id' });
+    permissions.authorizeConditional.mockImplementation(async requests =>
+      requests.map(request => ({
+        result:
+          request.permission.name === 'scaffolder.action.execute'
+            ? AuthorizeResult.ALLOW
+            : AuthorizeResult.DENY,
+      })),
+    );
+
+    createExecuteTemplateAction({
+      actionsRegistry: mockActionsRegistry,
+      scaffolderService: mockScaffolderService,
+      permissions,
+    });
+
+    await expect(
+      mockActionsRegistry.invoke({
+        id: 'test:execute-template',
+        input: {
+          templateRef: 'template:default/my-template',
+          values: { name: 'my-app' },
+        },
+      }),
+    ).resolves.toEqual({ output: { taskId: 'task-id' } });
   });
 
   it('requires task creation permission for action visibility', () => {

--- a/plugins/scaffolder-backend/src/actions/createExecuteTemplateAction.test.ts
+++ b/plugins/scaffolder-backend/src/actions/createExecuteTemplateAction.test.ts
@@ -16,12 +16,92 @@
 import { createExecuteTemplateAction } from './createExecuteTemplateAction';
 import { actionsRegistryServiceMock } from '@backstage/backend-test-utils/alpha';
 import { scaffolderServiceMock } from '@backstage/plugin-scaffolder-node/testUtils';
+import { PermissionsService } from '@backstage/backend-plugin-api';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
+import { NotAllowedError } from '@backstage/errors';
 
 describe('createExecuteTemplateAction', () => {
   const mockScaffolderService = scaffolderServiceMock.mock();
+  const permissions = {
+    authorizeConditional: jest
+      .fn()
+      .mockResolvedValue([
+        { result: AuthorizeResult.ALLOW },
+        { result: AuthorizeResult.ALLOW },
+        { result: AuthorizeResult.ALLOW },
+      ]),
+  } as unknown as jest.Mocked<PermissionsService>;
 
   beforeEach(() => {
     jest.resetAllMocks();
+    permissions.authorizeConditional.mockResolvedValue([
+      { result: AuthorizeResult.ALLOW },
+      { result: AuthorizeResult.ALLOW },
+      { result: AuthorizeResult.ALLOW },
+    ]);
+  });
+
+  it('rejects a denied Scaffolder permission before creating a task', async () => {
+    const mockActionsRegistry = actionsRegistryServiceMock();
+    mockScaffolderService.scaffold.mockResolvedValue({ taskId: 'task-id' });
+    permissions.authorizeConditional.mockResolvedValue([
+      { result: AuthorizeResult.ALLOW },
+      { result: AuthorizeResult.DENY },
+      { result: AuthorizeResult.ALLOW },
+    ]);
+    const options = {
+      actionsRegistry: mockActionsRegistry,
+      scaffolderService: mockScaffolderService,
+      permissions,
+    };
+    createExecuteTemplateAction(options);
+
+    await expect(
+      mockActionsRegistry.invoke({
+        id: 'test:execute-template',
+        input: {
+          templateRef: 'template:default/my-template',
+          values: { name: 'my-app' },
+        },
+      }),
+    ).rejects.toThrow(NotAllowedError);
+
+    expect(permissions.authorizeConditional).toHaveBeenCalledWith(
+      [
+        {
+          permission: expect.objectContaining({
+            name: 'scaffolder.action.execute',
+          }),
+        },
+        {
+          permission: expect.objectContaining({
+            name: 'scaffolder.template.parameter.read',
+          }),
+        },
+        {
+          permission: expect.objectContaining({
+            name: 'scaffolder.template.step.read',
+          }),
+        },
+      ],
+      { credentials: expect.any(Object) },
+    );
+    expect(mockScaffolderService.scaffold).not.toHaveBeenCalled();
+  });
+
+  it('requires task creation permission for action visibility', () => {
+    const mockActionsRegistry = actionsRegistryServiceMock();
+
+    createExecuteTemplateAction({
+      actionsRegistry: mockActionsRegistry,
+      scaffolderService: mockScaffolderService,
+      permissions,
+    });
+
+    expect(
+      mockActionsRegistry.actions.get('test:execute-template')
+        ?.visibilityPermission?.name,
+    ).toBe('scaffolder.task.create');
   });
 
   it('should scaffold a template and return the taskId', async () => {
@@ -33,6 +113,7 @@ describe('createExecuteTemplateAction', () => {
     createExecuteTemplateAction({
       actionsRegistry: mockActionsRegistry,
       scaffolderService: mockScaffolderService,
+      permissions,
     });
 
     const result = await mockActionsRegistry.invoke({
@@ -63,6 +144,7 @@ describe('createExecuteTemplateAction', () => {
     createExecuteTemplateAction({
       actionsRegistry: mockActionsRegistry,
       scaffolderService: mockScaffolderService,
+      permissions,
     });
 
     const result = await mockActionsRegistry.invoke({
@@ -94,6 +176,7 @@ describe('createExecuteTemplateAction', () => {
     createExecuteTemplateAction({
       actionsRegistry: mockActionsRegistry,
       scaffolderService: mockScaffolderService,
+      permissions,
     });
 
     await mockActionsRegistry.invoke({
@@ -117,6 +200,7 @@ describe('createExecuteTemplateAction', () => {
     createExecuteTemplateAction({
       actionsRegistry: mockActionsRegistry,
       scaffolderService: mockScaffolderService,
+      permissions,
     });
 
     await expect(

--- a/plugins/scaffolder-backend/src/actions/createExecuteTemplateAction.ts
+++ b/plugins/scaffolder-backend/src/actions/createExecuteTemplateAction.ts
@@ -13,16 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { PermissionsService } from '@backstage/backend-plugin-api';
 import { ActionsRegistryService } from '@backstage/backend-plugin-api/alpha';
+import { NotAllowedError } from '@backstage/errors';
+import {
+  actionExecutePermission,
+  taskCreatePermission,
+  templateParameterReadPermission,
+  templateStepReadPermission,
+} from '@backstage/plugin-scaffolder-common/alpha';
 import { ScaffolderService } from '@backstage/plugin-scaffolder-node';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
 import { JsonValue } from '@backstage/types';
 
 export const createExecuteTemplateAction = ({
   actionsRegistry,
   scaffolderService,
+  permissions,
 }: {
   actionsRegistry: ActionsRegistryService;
   scaffolderService: ScaffolderService;
+  permissions: PermissionsService;
 }) => {
   actionsRegistry.register({
     name: 'execute-template',
@@ -32,6 +43,7 @@ export const createExecuteTemplateAction = ({
       readOnly: false,
       idempotent: false,
     },
+    visibilityPermission: taskCreatePermission,
     description: `Executes a Scaffolder template with its template ref and input parameter values.
 The template is run using the credentials provided to this action, and respects any RBAC permissions associated with those credentials.
 Returns a taskId that can be used to track execution progress.
@@ -66,6 +78,22 @@ Use the catalog.get-catalog-entity action to fetch the Template entity and disco
         }),
     },
     action: async ({ input, credentials }) => {
+      // Check before calling the scaffolder service so that external access
+      // restrictions are evaluated using the original caller credentials.
+      const decisions = await permissions.authorizeConditional(
+        [
+          { permission: actionExecutePermission },
+          { permission: templateParameterReadPermission },
+          { permission: templateStepReadPermission },
+        ],
+        { credentials },
+      );
+      if (
+        decisions.some(decision => decision.result === AuthorizeResult.DENY)
+      ) {
+        throw new NotAllowedError();
+      }
+
       const { taskId } = await scaffolderService.scaffold(
         {
           templateRef: input.templateRef,

--- a/plugins/scaffolder-backend/src/actions/createExecuteTemplateAction.ts
+++ b/plugins/scaffolder-backend/src/actions/createExecuteTemplateAction.ts
@@ -76,8 +76,9 @@ Use the catalog.get-catalog-entity action to fetch the Template entity and disco
         }),
     },
     action: async ({ input, credentials }) => {
-      // Check before calling the scaffolder service so that external access
-      // restrictions are evaluated using the original caller credentials.
+      // TODO: Revisit this explicit check once service on-behalf-of
+      // authentication preserves caller identity and access restrictions
+      // across service boundaries. Until then, authorize before delegating.
       const [executeDecision] = await permissions.authorizeConditional(
         [{ permission: actionExecutePermission }],
         { credentials },

--- a/plugins/scaffolder-backend/src/actions/createExecuteTemplateAction.ts
+++ b/plugins/scaffolder-backend/src/actions/createExecuteTemplateAction.ts
@@ -19,8 +19,6 @@ import { NotAllowedError } from '@backstage/errors';
 import {
   actionExecutePermission,
   taskCreatePermission,
-  templateParameterReadPermission,
-  templateStepReadPermission,
 } from '@backstage/plugin-scaffolder-common/alpha';
 import { ScaffolderService } from '@backstage/plugin-scaffolder-node';
 import { AuthorizeResult } from '@backstage/plugin-permission-common';
@@ -80,17 +78,11 @@ Use the catalog.get-catalog-entity action to fetch the Template entity and disco
     action: async ({ input, credentials }) => {
       // Check before calling the scaffolder service so that external access
       // restrictions are evaluated using the original caller credentials.
-      const decisions = await permissions.authorizeConditional(
-        [
-          { permission: actionExecutePermission },
-          { permission: templateParameterReadPermission },
-          { permission: templateStepReadPermission },
-        ],
+      const [executeDecision] = await permissions.authorizeConditional(
+        [{ permission: actionExecutePermission }],
         { credentials },
       );
-      if (
-        decisions.some(decision => decision.result === AuthorizeResult.DENY)
-      ) {
+      if (executeDecision.result === AuthorizeResult.DENY) {
         throw new NotAllowedError();
       }
 

--- a/plugins/scaffolder-backend/src/actions/createGetScaffolderTaskLogsAction.test.ts
+++ b/plugins/scaffolder-backend/src/actions/createGetScaffolderTaskLogsAction.test.ts
@@ -17,8 +17,23 @@ import { actionsRegistryServiceMock } from '@backstage/backend-test-utils/alpha'
 import { scaffolderServiceMock } from '@backstage/plugin-scaffolder-node/testUtils';
 import { LogEvent } from '@backstage/plugin-scaffolder-common';
 import { createGetScaffolderTaskLogsAction } from './createGetScaffolderTaskLogsAction';
+import { PermissionsService } from '@backstage/backend-plugin-api';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
+import { NotAllowedError } from '@backstage/errors';
+
+const permissions = {
+  authorizeConditional: jest
+    .fn()
+    .mockResolvedValue([{ result: AuthorizeResult.ALLOW }]),
+} as unknown as jest.Mocked<PermissionsService>;
 
 describe('createGetScaffolderTaskLogsAction', () => {
+  beforeEach(() => {
+    permissions.authorizeConditional
+      .mockReset()
+      .mockResolvedValue([{ result: AuthorizeResult.ALLOW }]);
+  });
+
   it('should return log events for a task', async () => {
     const mockActionsRegistry = actionsRegistryServiceMock();
     const mockScaffolderService = scaffolderServiceMock.mock();
@@ -52,6 +67,7 @@ describe('createGetScaffolderTaskLogsAction', () => {
     createGetScaffolderTaskLogsAction({
       actionsRegistry: mockActionsRegistry,
       scaffolderService: mockScaffolderService,
+      permissions,
     });
 
     const result = await mockActionsRegistry.invoke({
@@ -111,6 +127,7 @@ describe('createGetScaffolderTaskLogsAction', () => {
     createGetScaffolderTaskLogsAction({
       actionsRegistry: mockActionsRegistry,
       scaffolderService: mockScaffolderService,
+      permissions,
     });
 
     const result = await mockActionsRegistry.invoke({
@@ -136,6 +153,7 @@ describe('createGetScaffolderTaskLogsAction', () => {
     createGetScaffolderTaskLogsAction({
       actionsRegistry: mockActionsRegistry,
       scaffolderService: mockScaffolderService,
+      permissions,
     });
 
     await expect(
@@ -144,5 +162,27 @@ describe('createGetScaffolderTaskLogsAction', () => {
         input: { taskId: 'task-3' },
       }),
     ).rejects.toThrow('Internal Server Error');
+  });
+
+  it('does not fetch logs when task read permission is denied', async () => {
+    const mockActionsRegistry = actionsRegistryServiceMock();
+    const mockScaffolderService = scaffolderServiceMock.mock();
+    permissions.authorizeConditional.mockResolvedValue([
+      { result: AuthorizeResult.DENY },
+    ]);
+
+    createGetScaffolderTaskLogsAction({
+      actionsRegistry: mockActionsRegistry,
+      scaffolderService: mockScaffolderService,
+      permissions,
+    });
+
+    await expect(
+      mockActionsRegistry.invoke({
+        id: 'test:get-scaffolder-task-logs',
+        input: { taskId: 'task-3' },
+      }),
+    ).rejects.toThrow(NotAllowedError);
+    expect(mockScaffolderService.getLogs).not.toHaveBeenCalled();
   });
 });

--- a/plugins/scaffolder-backend/src/actions/createGetScaffolderTaskLogsAction.test.ts
+++ b/plugins/scaffolder-backend/src/actions/createGetScaffolderTaskLogsAction.test.ts
@@ -14,24 +14,20 @@
  * limitations under the License.
  */
 import { actionsRegistryServiceMock } from '@backstage/backend-test-utils/alpha';
+import { mockServices } from '@backstage/backend-test-utils';
 import { scaffolderServiceMock } from '@backstage/plugin-scaffolder-node/testUtils';
 import { LogEvent } from '@backstage/plugin-scaffolder-common';
 import { createGetScaffolderTaskLogsAction } from './createGetScaffolderTaskLogsAction';
-import { PermissionsService } from '@backstage/backend-plugin-api';
 import { AuthorizeResult } from '@backstage/plugin-permission-common';
 import { NotAllowedError } from '@backstage/errors';
 
-const permissions = {
-  authorizeConditional: jest
-    .fn()
-    .mockResolvedValue([{ result: AuthorizeResult.ALLOW }]),
-} as unknown as jest.Mocked<PermissionsService>;
-
 describe('createGetScaffolderTaskLogsAction', () => {
+  let permissions: ReturnType<typeof mockServices.permissions.mock>;
+
   beforeEach(() => {
-    permissions.authorizeConditional
-      .mockReset()
-      .mockResolvedValue([{ result: AuthorizeResult.ALLOW }]);
+    permissions = mockServices.permissions.mock({
+      authorizeConditional: async () => [{ result: AuthorizeResult.ALLOW }],
+    });
   });
 
   it('should return log events for a task', async () => {

--- a/plugins/scaffolder-backend/src/actions/createGetScaffolderTaskLogsAction.ts
+++ b/plugins/scaffolder-backend/src/actions/createGetScaffolderTaskLogsAction.ts
@@ -93,8 +93,9 @@ Use the after parameter to fetch only events after a specific event ID for incre
           .describe('Object containing the events array'),
     },
     action: async ({ input, credentials }) => {
-      // Check before calling the scaffolder service so that external access
-      // restrictions are evaluated using the original caller credentials.
+      // TODO: Revisit this explicit check once service on-behalf-of
+      // authentication preserves caller identity and access restrictions
+      // across service boundaries. Until then, authorize before delegating.
       const [readDecision] = await permissions.authorizeConditional(
         [{ permission: taskReadPermission }],
         { credentials },

--- a/plugins/scaffolder-backend/src/actions/createGetScaffolderTaskLogsAction.ts
+++ b/plugins/scaffolder-backend/src/actions/createGetScaffolderTaskLogsAction.ts
@@ -13,15 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { PermissionsService } from '@backstage/backend-plugin-api';
 import { ActionsRegistryService } from '@backstage/backend-plugin-api/alpha';
+import { NotAllowedError } from '@backstage/errors';
+import { taskReadPermission } from '@backstage/plugin-scaffolder-common/alpha';
 import { ScaffolderService } from '@backstage/plugin-scaffolder-node';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
 
 export const createGetScaffolderTaskLogsAction = ({
   actionsRegistry,
   scaffolderService,
+  permissions,
 }: {
   actionsRegistry: ActionsRegistryService;
   scaffolderService: ScaffolderService;
+  permissions: PermissionsService;
 }) => {
   actionsRegistry.register({
     name: 'get-scaffolder-task-logs',
@@ -87,6 +93,16 @@ Use the after parameter to fetch only events after a specific event ID for incre
           .describe('Object containing the events array'),
     },
     action: async ({ input, credentials }) => {
+      // Check before calling the scaffolder service so that external access
+      // restrictions are evaluated using the original caller credentials.
+      const [readDecision] = await permissions.authorizeConditional(
+        [{ permission: taskReadPermission }],
+        { credentials },
+      );
+      if (readDecision.result === AuthorizeResult.DENY) {
+        throw new NotAllowedError();
+      }
+
       const events = await scaffolderService.getLogs(
         { taskId: input.taskId, after: input.after },
         { credentials },

--- a/plugins/scaffolder-backend/src/actions/index.ts
+++ b/plugins/scaffolder-backend/src/actions/index.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { ActionsRegistryService } from '@backstage/backend-plugin-api/alpha';
-import { AuthService } from '@backstage/backend-plugin-api';
+import { AuthService, PermissionsService } from '@backstage/backend-plugin-api';
 import { createListScaffolderTasksAction } from './listScaffolderTasksAction';
 import { ScaffolderService } from '@backstage/plugin-scaffolder-node';
 import { createDryRunTemplateAction } from './createDryRunTemplateAction';
@@ -26,11 +26,13 @@ export const createScaffolderActions = (options: {
   actionsRegistry: ActionsRegistryService;
   scaffolderService: ScaffolderService;
   auth: AuthService;
+  permissions: PermissionsService;
 }) => {
   createListScaffolderTasksAction({
     actionsRegistry: options.actionsRegistry,
     auth: options.auth,
     scaffolderService: options.scaffolderService,
+    permissions: options.permissions,
   });
   createDryRunTemplateAction(options);
   createListScaffolderActionsAction(options);

--- a/plugins/scaffolder-backend/src/actions/listScaffolderTasksAction.test.ts
+++ b/plugins/scaffolder-backend/src/actions/listScaffolderTasksAction.test.ts
@@ -20,20 +20,15 @@ import { ScaffolderTask } from '@backstage/plugin-scaffolder-common';
 import { scaffolderServiceMock } from '@backstage/plugin-scaffolder-node/testUtils';
 import { createListScaffolderTasksAction } from './listScaffolderTasksAction';
 import { ListTasksResponse } from '../schema/openapi/generated/models/ListTasksResponse.model';
-import { PermissionsService } from '@backstage/backend-plugin-api';
 import { AuthorizeResult } from '@backstage/plugin-permission-common';
 
-const permissions = {
-  authorizeConditional: jest
-    .fn()
-    .mockResolvedValue([{ result: AuthorizeResult.ALLOW }]),
-} as unknown as jest.Mocked<PermissionsService>;
-
 describe('createListScaffolderTasksAction', () => {
+  let permissions: ReturnType<typeof mockServices.permissions.mock>;
+
   beforeEach(() => {
-    permissions.authorizeConditional
-      .mockReset()
-      .mockResolvedValue([{ result: AuthorizeResult.ALLOW }]);
+    permissions = mockServices.permissions.mock({
+      authorizeConditional: async () => [{ result: AuthorizeResult.ALLOW }],
+    });
   });
 
   it('should list tasks successfully', async () => {

--- a/plugins/scaffolder-backend/src/actions/listScaffolderTasksAction.test.ts
+++ b/plugins/scaffolder-backend/src/actions/listScaffolderTasksAction.test.ts
@@ -20,8 +20,22 @@ import { ScaffolderTask } from '@backstage/plugin-scaffolder-common';
 import { scaffolderServiceMock } from '@backstage/plugin-scaffolder-node/testUtils';
 import { createListScaffolderTasksAction } from './listScaffolderTasksAction';
 import { ListTasksResponse } from '../schema/openapi/generated/models/ListTasksResponse.model';
+import { PermissionsService } from '@backstage/backend-plugin-api';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
+
+const permissions = {
+  authorizeConditional: jest
+    .fn()
+    .mockResolvedValue([{ result: AuthorizeResult.ALLOW }]),
+} as unknown as jest.Mocked<PermissionsService>;
 
 describe('createListScaffolderTasksAction', () => {
+  beforeEach(() => {
+    permissions.authorizeConditional
+      .mockReset()
+      .mockResolvedValue([{ result: AuthorizeResult.ALLOW }]);
+  });
+
   it('should list tasks successfully', async () => {
     const mockActionsRegistry = actionsRegistryServiceMock();
     const mockAuth = mockServices.auth.mock();
@@ -43,6 +57,7 @@ describe('createListScaffolderTasksAction', () => {
       actionsRegistry: mockActionsRegistry,
       auth: mockAuth,
       scaffolderService: mockScaffolderService,
+      permissions,
     });
 
     const result = await mockActionsRegistry.invoke({
@@ -103,6 +118,7 @@ describe('createListScaffolderTasksAction', () => {
       actionsRegistry: mockActionsRegistry,
       auth: mockAuth,
       scaffolderService: mockScaffolderService,
+      permissions,
     });
 
     const result = await mockActionsRegistry.invoke({
@@ -142,6 +158,7 @@ describe('createListScaffolderTasksAction', () => {
       actionsRegistry: mockActionsRegistry,
       auth: mockAuth,
       scaffolderService: mockScaffolderService,
+      permissions,
     });
 
     await expect(
@@ -180,6 +197,7 @@ describe('createListScaffolderTasksAction', () => {
       actionsRegistry: mockActionsRegistry,
       auth: mockAuth,
       scaffolderService: mockScaffolderService,
+      permissions,
     });
 
     await mockActionsRegistry.invoke({
@@ -216,6 +234,7 @@ describe('createListScaffolderTasksAction', () => {
       actionsRegistry: mockActionsRegistry,
       auth: mockAuth,
       scaffolderService: mockScaffolderService,
+      permissions,
     });
 
     const result = await mockActionsRegistry.invoke({
@@ -261,6 +280,7 @@ describe('createListScaffolderTasksAction', () => {
       actionsRegistry: mockActionsRegistry,
       auth: mockAuth,
       scaffolderService: mockScaffolderService,
+      permissions,
     });
 
     const result = await mockActionsRegistry.invoke({
@@ -300,6 +320,7 @@ describe('createListScaffolderTasksAction', () => {
       actionsRegistry: mockActionsRegistry,
       auth: mockAuth,
       scaffolderService: mockScaffolderService,
+      permissions,
     });
 
     await expect(
@@ -310,6 +331,30 @@ describe('createListScaffolderTasksAction', () => {
       }),
     ).rejects.toThrow(NotAllowedError);
 
+    expect(mockScaffolderService.listTasks).not.toHaveBeenCalled();
+  });
+
+  it('does not list tasks when task read permission is denied', async () => {
+    const mockActionsRegistry = actionsRegistryServiceMock();
+    const mockAuth = mockServices.auth.mock();
+    const mockScaffolderService = scaffolderServiceMock.mock();
+    permissions.authorizeConditional.mockResolvedValue([
+      { result: AuthorizeResult.DENY },
+    ]);
+
+    createListScaffolderTasksAction({
+      actionsRegistry: mockActionsRegistry,
+      auth: mockAuth,
+      scaffolderService: mockScaffolderService,
+      permissions,
+    });
+
+    const result = await mockActionsRegistry.invoke({
+      id: 'test:list-scaffolder-tasks',
+      input: {},
+    });
+
+    expect(result.output).toEqual({ tasks: [], totalTasks: 0 });
     expect(mockScaffolderService.listTasks).not.toHaveBeenCalled();
   });
 });

--- a/plugins/scaffolder-backend/src/actions/listScaffolderTasksAction.ts
+++ b/plugins/scaffolder-backend/src/actions/listScaffolderTasksAction.ts
@@ -14,18 +14,22 @@
  * limitations under the License.
  */
 import { ActionsRegistryService } from '@backstage/backend-plugin-api/alpha';
-import { AuthService } from '@backstage/backend-plugin-api';
+import { AuthService, PermissionsService } from '@backstage/backend-plugin-api';
 import { NotAllowedError } from '@backstage/errors';
 import { ScaffolderService } from '@backstage/plugin-scaffolder-node';
+import { taskReadPermission } from '@backstage/plugin-scaffolder-common/alpha';
+import { AuthorizeResult } from '@backstage/plugin-permission-common';
 
 export const createListScaffolderTasksAction = ({
   actionsRegistry,
   auth,
   scaffolderService,
+  permissions,
 }: {
   actionsRegistry: ActionsRegistryService;
   auth: AuthService;
   scaffolderService: ScaffolderService;
+  permissions: PermissionsService;
 }) => {
   actionsRegistry.register({
     name: 'list-scaffolder-tasks',
@@ -110,6 +114,16 @@ Filtering by one or multiple statuses is supported. Pagination is supported via 
           .describe('Object containing a tasks array and totalTasks count'),
     },
     action: async ({ input, credentials }) => {
+      // Check before calling the scaffolder service so that external access
+      // restrictions are evaluated using the original caller credentials.
+      const [readDecision] = await permissions.authorizeConditional(
+        [{ permission: taskReadPermission }],
+        { credentials },
+      );
+      if (readDecision.result === AuthorizeResult.DENY) {
+        return { output: { tasks: [], totalTasks: 0 } };
+      }
+
       if (input.owned && !auth.isPrincipal(credentials, 'user')) {
         throw new NotAllowedError(
           'Filtering by owned tasks requires a user identity.',

--- a/plugins/scaffolder-backend/src/actions/listScaffolderTasksAction.ts
+++ b/plugins/scaffolder-backend/src/actions/listScaffolderTasksAction.ts
@@ -114,8 +114,9 @@ Filtering by one or multiple statuses is supported. Pagination is supported via 
           .describe('Object containing a tasks array and totalTasks count'),
     },
     action: async ({ input, credentials }) => {
-      // Check before calling the scaffolder service so that external access
-      // restrictions are evaluated using the original caller credentials.
+      // TODO: Revisit this explicit check once service on-behalf-of
+      // authentication preserves caller identity and access restrictions
+      // across service boundaries. Until then, authorize before delegating.
       const [readDecision] = await permissions.authorizeConditional(
         [{ permission: taskReadPermission }],
         { credentials },


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Built-in Catalog and Scaffolder actions can perform several permission-aware operations on behalf of callers. This adds explicit early permission checks using the original caller credentials, so external access restrictions can reject unauthorized actions before follow-up work begins and authorization failures are reported consistently. It does not change existing service-to-service credential delegation behavior.

It also documents that `visibilityPermission` provides a coarse action-level check, while action implementations remain responsible for additional input-dependent or resource-specific authorization.

Companion PR #35363 restores trusted follow-up service requests after these targeted checks are in place.

This change was developed with AI assistance and has been manually reviewed and tested.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
