### PR TITLE
Restore trusted service request delegation

### DIFF
--- a/.changeset/soft-tools-follow.md
+++ b/.changeset/soft-tools-follow.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Service handlers can once again make follow-up plugin requests for callers authenticated with access-restricted external service tokens.

--- a/docs/auth/service-to-service-auth.md
+++ b/docs/auth/service-to-service-auth.md
@@ -252,6 +252,11 @@ access restrictions whenever possible, to reduce risk.
 
 :::
 
+Access restrictions apply when the external token is used to enter a plugin.
+They do not constrain follow-up requests that the receiving plugin makes to
+other plugins. Plugin request handlers are trusted to authorize the incoming
+request before performing further work on behalf of the caller.
+
 Each entry has one or more of the following fields:
 
 - **`plugin`**: Required. A plugin ID as a string, for example `'catalog'`. Permits

--- a/packages/backend-defaults/src/entrypoints/auth/DefaultAuthService.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/DefaultAuthService.ts
@@ -22,7 +22,7 @@ import {
   BackstageServicePrincipal,
   BackstageUserPrincipal,
 } from '@backstage/backend-plugin-api';
-import { AuthenticationError, NotAllowedError } from '@backstage/errors';
+import { AuthenticationError } from '@backstage/errors';
 import { JsonObject } from '@backstage/types';
 import { decodeJwt } from 'jose';
 import { ExternalAuthTokenHandler } from './external/ExternalAuthTokenHandler';
@@ -110,7 +110,6 @@ export class DefaultAuthService implements AuthService {
         externalResult.subject,
         undefined,
         externalResult.accessRestrictions,
-        externalResult.allAccessRestrictions,
       );
     }
 
@@ -169,31 +168,11 @@ export class DefaultAuthService implements AuthService {
     // by checking the public keys endpoint existence.
     switch (type) {
       // TODO: Check whether the principal is ourselves
-      case 'service': {
-        const servicePrincipal =
-          internalForward.principal as BackstageServicePrincipal;
-        if (servicePrincipal.accessRestrictions) {
-          const targetRestrictions =
-            internalForward.allAccessRestrictions?.get(targetPluginId);
-          if (!targetRestrictions) {
-            throw new NotAllowedError(
-              `Access to target plugin '${targetPluginId}' is not included in token's access restrictions`,
-            );
-          }
-          if (
-            targetRestrictions.permissionNames?.length ||
-            targetRestrictions.permissionAttributes
-          ) {
-            throw new NotAllowedError(
-              `Access to target plugin '${targetPluginId}' is restricted and cannot be delegated`,
-            );
-          }
-        }
+      case 'service':
         return this.pluginTokenHandler.issueToken({
           pluginId: this.pluginId,
           targetPluginId,
         });
-      }
       case 'user': {
         const { token } = internalForward;
         if (!token) {

--- a/packages/backend-defaults/src/entrypoints/auth/authServiceFactory.test.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/authServiceFactory.test.ts
@@ -440,25 +440,26 @@ describe('authServiceFactory', () => {
     });
   });
 
-  it('should enforce access restrictions when issuing plugin tokens on behalf of service principals', async () => {
+  it('should allow trusted services to issue plugin tokens on behalf of service principals', async () => {
     const tester = ServiceFactoryTester.from(authServiceFactory, {
       dependencies: mockDeps,
     });
 
     const catalogAuth = await tester.getSubject('catalog');
 
-    // Permission-level restrictions (e.g. permission name) cannot be forwarded
+    // Permission-level ingress restrictions do not constrain trusted service
+    // handlers from making follow-up requests.
     const restrictedCredentials = await catalogAuth.authenticate(
       'limited-static-token',
     );
     await expect(
       catalogAuth.getPluginRequestToken({
         onBehalfOf: restrictedCredentials,
-        targetPluginId: 'catalog',
+        targetPluginId: 'scaffolder',
       }),
-    ).rejects.toThrow('is restricted and cannot be delegated');
+    ).resolves.toEqual(expect.objectContaining({ token: expect.any(String) }));
 
-    // Permission attribute restrictions (e.g. action: read) cannot be forwarded
+    // Permission attribute restrictions likewise apply at ingress only.
     const actionRestrictedCredentials = await catalogAuth.authenticate(
       'action-restricted-static-token',
     );
@@ -467,9 +468,9 @@ describe('authServiceFactory', () => {
         onBehalfOf: actionRestrictedCredentials,
         targetPluginId: 'catalog',
       }),
-    ).rejects.toThrow('is restricted and cannot be delegated');
+    ).resolves.toEqual(expect.objectContaining({ token: expect.any(String) }));
 
-    // Plugin-only restrictions allow delegation to listed plugins
+    // Plugin-only ingress restrictions do not constrain follow-up requests.
     const pluginOnlyCredentials = await catalogAuth.authenticate(
       'plugin-only-static-token',
     );
@@ -480,13 +481,12 @@ describe('authServiceFactory', () => {
       }),
     ).resolves.toEqual(expect.objectContaining({ token: expect.any(String) }));
 
-    // Plugin-only restrictions reject delegation to unlisted plugins
     await expect(
       catalogAuth.getPluginRequestToken({
         onBehalfOf: pluginOnlyCredentials,
         targetPluginId: 'permission',
       }),
-    ).rejects.toThrow("is not included in token's access restrictions");
+    ).resolves.toEqual(expect.objectContaining({ token: expect.any(String) }));
 
     // Unrestricted credentials always allow delegation
     const unrestrictedCredentials = await catalogAuth.authenticate(

--- a/packages/backend-defaults/src/entrypoints/auth/external/ExternalAuthTokenHandler.test.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/external/ExternalAuthTokenHandler.test.ts
@@ -132,7 +132,7 @@ describe('ExternalTokenHandler', () => {
       },
     ]);
 
-    await expect(plugin1.verifyToken('token')).resolves.toMatchObject({
+    await expect(plugin1.verifyToken('token')).resolves.toEqual({
       subject: 'sub',
       accessRestrictions: { permissionNames: ['do.it'] },
     });
@@ -213,12 +213,12 @@ describe('ExternalTokenHandler', () => {
       .setProtectedHeader({ alg: 'HS256' })
       .sign(legacyKey);
 
-    await expect(handler.verifyToken(legacyToken)).resolves.toMatchObject({
+    await expect(handler.verifyToken(legacyToken)).resolves.toEqual({
       subject: 'legacy-subject',
       accessRestrictions: { permissionNames: ['catalog.entity.read'] },
     });
 
-    await expect(handler.verifyToken('defdefdef')).resolves.toMatchObject({
+    await expect(handler.verifyToken('defdefdef')).resolves.toEqual({
       subject: 'static-subject',
       accessRestrictions: { permissionNames: ['catalog.entity.read'] },
     });
@@ -226,7 +226,7 @@ describe('ExternalTokenHandler', () => {
     const jwksToken = await factory.issueToken({
       claims: { sub: 'jwks-subject' },
     });
-    await expect(handler.verifyToken(jwksToken)).resolves.toMatchObject({
+    await expect(handler.verifyToken(jwksToken)).resolves.toEqual({
       subject: 'external:custom-prefix:jwks-subject',
       accessRestrictions: { permissionNames: ['catalog.entity.read'] },
     });

--- a/packages/backend-defaults/src/entrypoints/auth/external/ExternalAuthTokenHandler.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/external/ExternalAuthTokenHandler.ts
@@ -163,7 +163,6 @@ export class ExternalAuthTokenHandler {
     | {
         subject: string;
         accessRestrictions?: BackstagePrincipalAccessRestrictions;
-        allAccessRestrictions?: AccessRestrictionsMap;
       }
     | undefined
   > {
@@ -186,7 +185,6 @@ export class ExternalAuthTokenHandler {
           return {
             ...result,
             accessRestrictions,
-            allAccessRestrictions,
           };
         }
 

--- a/packages/backend-defaults/src/entrypoints/auth/helpers.test.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/helpers.test.ts
@@ -129,27 +129,6 @@ describe('credentials', () => {
     });
   });
 
-  it('should retain allAccessRestrictions through internal conversion but omit from serialization', () => {
-    const restrictionsMap = new Map(
-      Object.entries({ catalog: { permissionNames: ['do.it'] } }),
-    );
-    const credentials = createCredentialsWithServicePrincipal(
-      'my-service',
-      undefined,
-      { permissionNames: ['do.it'] },
-      restrictionsMap,
-    );
-
-    const internal = toInternalBackstageCredentials(credentials);
-    expect(internal.allAccessRestrictions).toBe(restrictionsMap);
-    expect(internal.allAccessRestrictions?.get('catalog')).toEqual({
-      permissionNames: ['do.it'],
-    });
-
-    const serialized = JSON.stringify(credentials);
-    expect(serialized).not.toMatch(/allAccessRestrictions/);
-  });
-
   it('should have a serializable form both as strings and as JSON', () => {
     const simpleService = createCredentialsWithServicePrincipal('my-service');
     expect(String(simpleService)).toMatchInlineSnapshot(

--- a/packages/backend-defaults/src/entrypoints/auth/helpers.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/helpers.ts
@@ -22,14 +22,12 @@ import {
   BackstageUserPrincipal,
 } from '@backstage/backend-plugin-api';
 import { InternalBackstageCredentials } from './types';
-import { AccessRestrictionsMap } from './external/types';
 import { createHash } from 'node:crypto';
 
 export function createCredentialsWithServicePrincipal(
   sub: string,
   token?: string,
   accessRestrictions?: BackstagePrincipalAccessRestrictions,
-  allAccessRestrictions?: AccessRestrictionsMap,
 ): InternalBackstageCredentials<BackstageServicePrincipal> {
   const principal = createServicePrincipal(sub, accessRestrictions);
   const result = {
@@ -43,12 +41,6 @@ export function createCredentialsWithServicePrincipal(
       configurable: true,
       writable: true,
       value: token,
-    },
-    allAccessRestrictions: {
-      enumerable: false,
-      configurable: true,
-      writable: true,
-      value: allAccessRestrictions,
     },
     toString: {
       enumerable: false,

--- a/packages/backend-defaults/src/entrypoints/auth/types.ts
+++ b/packages/backend-defaults/src/entrypoints/auth/types.ts
@@ -15,12 +15,10 @@
  */
 
 import { BackstageCredentials } from '@backstage/backend-plugin-api';
-import { AccessRestrictionsMap } from './external/types';
 
 /** @internal */
 export type InternalBackstageCredentials<TPrincipal = unknown> =
   BackstageCredentials<TPrincipal> & {
     version: string;
     token?: string;
-    allAccessRestrictions?: AccessRestrictionsMap;
   };


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Restores follow-up plugin requests for trusted service handlers that receive access-restricted external service credentials. Access restrictions remain enforced at plugin ingress and explicit permission checks, while receiving handlers can once again issue plugin request tokens for follow-up work.

Together with #35362 adding targeted action permission checks close to the operation, this removes the broader delegation rejection and its now-unused internal credential data. The service-to-service auth documentation now clarifies the scope of external access restrictions.

Fixes #35347.

Depends on #35362 and must not be merged before it. The `backend-defaults` package change in this PR must not be released without the Catalog and Scaffolder package changes from #35362.

This change was developed with AI assistance and has been manually reviewed and tested.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
