### PR TITLE
fix(techdocs): allow the Python YAML tags mkdocs-material documents

### DIFF
--- a/.changeset/mkdocs-material-emoji-tags.md
+++ b/.changeset/mkdocs-material-emoji-tags.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-node': patch
+---
+
+Fixed TechDocs generation rejecting `mkdocs.yml` files that use the emoji indexes and generators or the `pymdownx.superfences` custom fences documented by mkdocs-material and pymdown-extensions.

--- a/.changeset/mkdocs-material-emoji-tags.md
+++ b/.changeset/mkdocs-material-emoji-tags.md
@@ -2,4 +2,4 @@
 '@backstage/plugin-techdocs-node': patch
 ---
 
-Fixed TechDocs generation rejecting `mkdocs.yml` files that use the emoji indexes and generators or the `pymdownx.superfences` custom fences documented by mkdocs-material and pymdown-extensions.
+Fixed TechDocs generation rejecting `mkdocs.yml` files that use the emoji indexes and generators or the `pymdownx.superfences` custom fence formats documented by mkdocs-material, pymdown-extensions and mkdocs-mermaid2.

--- a/.patches/pr-35364.txt
+++ b/.patches/pr-35364.txt
@@ -1,0 +1,1 @@
+Fixed TechDocs generation for documented MkDocs Markdown extension configurations.

--- a/plugins/techdocs-node/src/stages/generate/__fixtures__/mkdocs_with_extensions.yml
+++ b/plugins/techdocs-node/src/stages/generate/__fixtures__/mkdocs_with_extensions.yml
@@ -4,7 +4,7 @@ site_description: Test site description
 markdown_extensions:
   - pymdownx.emoji:
       emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/object.apply:materialx.emoji.to_svg
+      emoji_generator: !!python/name:materialx.emoji.to_svg
   - pymdownx.tabbed:
       alternate_style: true
       slugify: !!python/object/apply:pymdownx.slugs.slugify

--- a/plugins/techdocs-node/src/stages/generate/helpers.test.ts
+++ b/plugins/techdocs-node/src/stages/generate/helpers.test.ts
@@ -1034,6 +1034,55 @@ theme:
         'Unsupported Python YAML tag',
       );
     });
+
+    it.each(['pymdownx.emoji', 'materialx.emoji', 'material.extensions.emoji'])(
+      'should accept emoji tags from %s',
+      async module => {
+        const content = `markdown_extensions:
+  - pymdownx.emoji:
+      emoji_index: !!python/name:${module}.twemoji
+      emoji_generator: !!python/name:${module}.to_svg`;
+
+        await expect(
+          validateMkdocsYaml(inputDir, content),
+        ).resolves.toBeUndefined();
+      },
+    );
+
+    it('should accept superfences custom fence formats', async () => {
+      const content = `markdown_extensions:
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+        - name: math
+          class: arithmatex
+          format: !!python/name:pymdownx.superfences.fence_div_format`;
+
+      await expect(
+        validateMkdocsYaml(inputDir, content),
+      ).resolves.toBeUndefined();
+    });
+
+    it.each([
+      'pymdownx.emoji.to_svgX',
+      'material.extensions.emoji.evil',
+      'pymdownx.superfences.os',
+    ])('should reject the unlisted name %s', async name => {
+      await expect(
+        validateMkdocsYaml(inputDir, `site_name: !!python/name:${name}`),
+      ).rejects.toThrow('Unsupported Python YAML tag');
+    });
+
+    it('should reject an allowed name used under a different tag', async () => {
+      await expect(
+        validateMkdocsYaml(
+          inputDir,
+          'site_name: !!python/name:pymdownx.slugs.slugify',
+        ),
+      ).rejects.toThrow('Unsupported Python YAML tag');
+    });
   });
 
   describe('sanitizeMkdocsYml', () => {

--- a/plugins/techdocs-node/src/stages/generate/helpers.test.ts
+++ b/plugins/techdocs-node/src/stages/generate/helpers.test.ts
@@ -1049,16 +1049,35 @@ theme:
       },
     );
 
-    it('should accept superfences custom fence formats', async () => {
+    it.each([
+      'pymdownx.superfences.fence_code_format',
+      'pymdownx.superfences.fence_div_format',
+      'mermaid2.fence_mermaid',
+      'mermaid2.fence_mermaid_custom',
+    ])('should accept the custom fence format %s', async format => {
       const content = `markdown_extensions:
   - pymdownx.superfences:
       custom_fences:
         - name: mermaid
           class: mermaid
-          format: !!python/name:pymdownx.superfences.fence_code_format
-        - name: math
-          class: arithmatex
-          format: !!python/name:pymdownx.superfences.fence_div_format`;
+          format: !!python/name:${format}`;
+
+      await expect(
+        validateMkdocsYaml(inputDir, content),
+      ).resolves.toBeUndefined();
+    });
+
+    // https://github.com/backstage/backstage/issues/35388
+    it('should accept the mkdocs-material emoji and mkdocs-mermaid2 configuration', async () => {
+      const content = `markdown_extensions:
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:mermaid2.fence_mermaid_custom`;
 
       await expect(
         validateMkdocsYaml(inputDir, content),

--- a/plugins/techdocs-node/src/stages/generate/helpers.ts
+++ b/plugins/techdocs-node/src/stages/generate/helpers.ts
@@ -128,9 +128,29 @@ export const getRepoUrlFromLocationAnnotation = (
   return {};
 };
 
+// Listed exactly rather than by a `pymdownx.` prefix: resolving one of these
+// tags imports the module it names, and a prefix would accept any module-level
+// attribute of any importable submodule.
 const ALLOWED_PYTHON_YAML_TAGS = new Set([
+  // Emoji indexes; mkdocs-material moved its own from materialx to
+  // material.extensions in 9.4.
+  'tag:yaml.org,2002:python/name:pymdownx.emoji.emojione',
+  'tag:yaml.org,2002:python/name:pymdownx.emoji.gemoji',
+  'tag:yaml.org,2002:python/name:pymdownx.emoji.twemoji',
   'tag:yaml.org,2002:python/name:materialx.emoji.twemoji',
-  'tag:yaml.org,2002:python/object.apply:materialx.emoji.to_svg',
+  'tag:yaml.org,2002:python/name:material.extensions.emoji.twemoji',
+  // Emoji generators
+  'tag:yaml.org,2002:python/name:pymdownx.emoji.to_alt',
+  'tag:yaml.org,2002:python/name:pymdownx.emoji.to_png',
+  'tag:yaml.org,2002:python/name:pymdownx.emoji.to_png_sprite',
+  'tag:yaml.org,2002:python/name:pymdownx.emoji.to_svg',
+  'tag:yaml.org,2002:python/name:pymdownx.emoji.to_svg_sprite',
+  'tag:yaml.org,2002:python/name:materialx.emoji.to_svg',
+  'tag:yaml.org,2002:python/name:material.extensions.emoji.to_svg',
+  // Custom fence formats, used for Mermaid diagrams
+  'tag:yaml.org,2002:python/name:pymdownx.superfences.fence_code_format',
+  'tag:yaml.org,2002:python/name:pymdownx.superfences.fence_div_format',
+  // Slug factory for toc and pymdownx.tabbed
   'tag:yaml.org,2002:python/object/apply:pymdownx.slugs.slugify',
 ]);
 

--- a/plugins/techdocs-node/src/stages/generate/helpers.ts
+++ b/plugins/techdocs-node/src/stages/generate/helpers.ts
@@ -147,9 +147,12 @@ const ALLOWED_PYTHON_YAML_TAGS = new Set([
   'tag:yaml.org,2002:python/name:pymdownx.emoji.to_svg_sprite',
   'tag:yaml.org,2002:python/name:materialx.emoji.to_svg',
   'tag:yaml.org,2002:python/name:material.extensions.emoji.to_svg',
-  // Custom fence formats, used for Mermaid diagrams
+  // Custom fence formats, used for Mermaid diagrams. The mermaid2 ones come
+  // from mkdocs-mermaid2, which mkdocs-techdocs-core does not bundle.
   'tag:yaml.org,2002:python/name:pymdownx.superfences.fence_code_format',
   'tag:yaml.org,2002:python/name:pymdownx.superfences.fence_div_format',
+  'tag:yaml.org,2002:python/name:mermaid2.fence_mermaid',
+  'tag:yaml.org,2002:python/name:mermaid2.fence_mermaid_custom',
   // Slug factory for toc and pymdownx.tabbed
   'tag:yaml.org,2002:python/object/apply:pymdownx.slugs.slugify',
 ]);


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes [#35388](https://github.com/backstage/backstage/issues/35388)

TechDocs generation aborts with `Unsupported Python YAML tag` on two configurations mkdocs-material documents, [emoji](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#emoji) and [Mermaid diagrams](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#+pymdownx.superfences.custom_fences):

```yaml
markdown_extensions:
  - pymdownx.emoji:
      emoji_index: !!python/name:material.extensions.emoji.twemoji
      emoji_generator: !!python/name:material.extensions.emoji.to_svg
  - pymdownx.superfences:
      custom_fences:
        - name: mermaid
          class: mermaid
          format: !!python/name:pymdownx.superfences.fence_code_format
```

Regressed in v1.54.6 via [`45cbd0a3`](https://github.com/backstage/backstage/commit/45cbd0a3)/ https://github.com/backstage/backstage/commit/25125ee727a3de3418a8fa6a9e458cd5b73ecf26 (GHSA-qmw3-745m-w99g), published as `@backstage/plugin-techdocs-node` 1.15.4. The tag allowlist is too restrictive, and seems populated from the repo's test fixture but not all usages of the extensions `mkdocs-techdocs-core` bundles. 

This lists the callables mkdocs-material and pymdown-extensions document for these options, and corrects the fixture.

The list stays exact rather than matching a `pymdownx.` prefix: resolving one of these tags imports the module it names, and pymdownx calls the emoji and fence values with page content, so a prefix would be too broad.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [X] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
