### PR TITLE
fix(catalog): safely filter entity icon links

### DIFF
--- a/.changeset/calm-icons-filter.md
+++ b/.changeset/calm-icons-filter.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-catalog': patch
+---
+
+Fixed the About card to safely show and hide filtered icon links when navigating between entities, without initializing hidden links.

--- a/.changeset/soft-links-compose.md
+++ b/.changeset/soft-links-compose.md
@@ -1,0 +1,5 @@
+---
+'@backstage/core-components': patch
+---
+
+Added support for rendering custom link elements inside `HeaderIconLinkRow`.

--- a/packages/core-components/src/components/HeaderIconLinkRow/HeaderIconLinkRow.test.tsx
+++ b/packages/core-components/src/components/HeaderIconLinkRow/HeaderIconLinkRow.test.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { HeaderIconLinkRow } from './HeaderIconLinkRow';
+import { IconLinkVertical } from './IconLinkVertical';
+
+describe('HeaderIconLinkRow', () => {
+  it('renders links from props together with custom link elements', () => {
+    render(
+      <MemoryRouter>
+        <HeaderIconLinkRow links={[{ label: 'Prop link', href: '/prop' }]}>
+          <IconLinkVertical label="Child link" href="/child" />
+        </HeaderIconLinkRow>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('navigation')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Prop link' })).toHaveAttribute(
+      'href',
+      '/prop',
+    );
+    expect(screen.getByRole('link', { name: 'Child link' })).toHaveAttribute(
+      'href',
+      '/child',
+    );
+  });
+});

--- a/packages/core-components/src/components/HeaderIconLinkRow/HeaderIconLinkRow.tsx
+++ b/packages/core-components/src/components/HeaderIconLinkRow/HeaderIconLinkRow.tsx
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { makeStyles } from '@material-ui/core/styles';
+import { ReactNode } from 'react';
 import { IconLinkVertical, IconLinkVerticalProps } from './IconLinkVertical';
 
 /** @public */
@@ -35,22 +36,24 @@ const useStyles = makeStyles(
 
 type Props = {
   links: IconLinkVerticalProps[];
+  children?: ReactNode;
 };
 
 /**
- * HTML nav tag with links mapped inside
+ * HTML nav tag with links and optional custom link elements inside
  *
  * @public
  *
  */
 export function HeaderIconLinkRow(props: Props) {
-  const { links } = props;
+  const { links, children } = props;
   const classes = useStyles();
   return (
     <nav className={classes.links}>
       {links.map((link, index) => (
         <IconLinkVertical key={index + 1} {...link} />
       ))}
+      {children}
     </nav>
   );
 }

--- a/plugins/catalog/src/alpha/entityCards.test.tsx
+++ b/plugins/catalog/src/alpha/entityCards.test.tsx
@@ -14,13 +14,85 @@
  * limitations under the License.
  */
 
-import { screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { renderTestApp } from '@backstage/frontend-test-utils';
 import { Entity } from '@backstage/catalog-model';
+import { EntityProvider } from '@backstage/plugin-catalog-react';
+import { useEffect } from 'react';
+import { MemoryRouter } from 'react-router-dom';
 import { createTestEntityPage } from '@backstage/plugin-catalog-react/testUtils';
-import { catalogLinksEntityCard, catalogLabelsEntityCard } from './entityCards';
+import {
+  catalogLinksEntityCard,
+  catalogLabelsEntityCard,
+  EntityIconLinkRow,
+} from './entityCards';
 
 describe('catalog entity cards', () => {
+  describe('EntityIconLinkRow', () => {
+    it('mounts link hooks only while their entity filter matches', () => {
+      const mountEffect = jest.fn();
+      const unmountEffect = jest.fn();
+      const useProps = () => {
+        useEffect(() => {
+          mountEffect();
+          return unmountEffect;
+        }, []);
+        return { label: 'Filtered link', href: '/filtered' };
+      };
+      const links = [
+        {
+          id: 'entity-icon-link:test',
+          filter: (entity: Entity) => entity.metadata.name === 'visible',
+          useProps,
+        },
+      ];
+      const hiddenEntity: Entity = {
+        apiVersion: 'backstage.io/v1alpha1',
+        kind: 'Component',
+        metadata: { name: 'hidden' },
+      };
+      const visibleEntity: Entity = {
+        ...hiddenEntity,
+        metadata: { name: 'visible' },
+      };
+
+      const rendered = render(
+        <MemoryRouter>
+          <EntityProvider entity={hiddenEntity}>
+            <EntityIconLinkRow links={links} />
+          </EntityProvider>
+        </MemoryRouter>,
+      );
+
+      expect(screen.queryByText('Filtered link')).not.toBeInTheDocument();
+      expect(mountEffect).not.toHaveBeenCalled();
+
+      rendered.rerender(
+        <MemoryRouter>
+          <EntityProvider entity={visibleEntity}>
+            <EntityIconLinkRow links={links} />
+          </EntityProvider>
+        </MemoryRouter>,
+      );
+
+      expect(screen.getByText('Filtered link')).toBeInTheDocument();
+      expect(mountEffect).toHaveBeenCalledTimes(1);
+      expect(unmountEffect).not.toHaveBeenCalled();
+
+      rendered.rerender(
+        <MemoryRouter>
+          <EntityProvider entity={hiddenEntity}>
+            <EntityIconLinkRow links={links} />
+          </EntityProvider>
+        </MemoryRouter>,
+      );
+
+      expect(screen.queryByText('Filtered link')).not.toBeInTheDocument();
+      expect(mountEffect).toHaveBeenCalledTimes(1);
+      expect(unmountEffect).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('catalogLinksEntityCard', () => {
     it('should render for entities with links', async () => {
       const entity: Entity = {

--- a/plugins/catalog/src/alpha/entityCards.tsx
+++ b/plugins/catalog/src/alpha/entityCards.tsx
@@ -21,10 +21,37 @@ import {
 import { createExtensionInput } from '@backstage/frontend-plugin-api';
 import {
   HeaderIconLinkRow,
+  IconLinkVertical,
   IconLinkVerticalProps,
 } from '@backstage/core-components';
 import { useEntity } from '@backstage/plugin-catalog-react';
+import { Entity } from '@backstage/catalog-model';
 import { buildFilterFn } from './filter/FilterWrapper';
+
+type EntityIconLink = {
+  id: string;
+  filter: (entity: Entity) => boolean;
+  useProps: () => IconLinkVerticalProps;
+};
+
+function EntityIconLinkItem(props: Pick<EntityIconLink, 'useProps'>) {
+  const { useProps } = props;
+  const linkProps = useProps();
+  return <IconLinkVertical {...linkProps} />;
+}
+
+export function EntityIconLinkRow(props: { links: EntityIconLink[] }) {
+  const { entity } = useEntity();
+  const links = props.links.filter(link => link.filter(entity));
+
+  return links.length ? (
+    <HeaderIconLinkRow links={[]}>
+      {links.map(link => (
+        <EntityIconLinkItem key={link.id} useProps={link.useProps} />
+      ))}
+    </HeaderIconLinkRow>
+  ) : null;
+}
 
 export const catalogAboutEntityCard = EntityCardBlueprint.makeWithOverrides({
   name: 'about',
@@ -36,24 +63,17 @@ export const catalogAboutEntityCard = EntityCardBlueprint.makeWithOverrides({
     ]),
   },
   factory(originalFactory, { inputs }) {
+    const iconLinks = inputs.iconLinks.map(iconLink => ({
+      id: iconLink.node.spec.id,
+      filter: buildFilterFn(
+        iconLink.get(EntityIconLinkBlueprint.dataRefs.filterFunction),
+        iconLink.get(EntityIconLinkBlueprint.dataRefs.filterExpression),
+      ),
+      useProps: iconLink.get(EntityIconLinkBlueprint.dataRefs.useProps),
+    }));
+
     function Subheader() {
-      const { entity } = useEntity();
-      // The "useProps" functions may be calling other hooks, so we need to
-      // call them in a component function to avoid breaking the rules of hooks.
-      const links = inputs.iconLinks.reduce((rest, iconLink) => {
-        const filter = buildFilterFn(
-          iconLink.get(EntityIconLinkBlueprint.dataRefs.filterFunction),
-          iconLink.get(EntityIconLinkBlueprint.dataRefs.filterExpression),
-        );
-        if (filter(entity)) {
-          const props = iconLink.get(
-            EntityIconLinkBlueprint.dataRefs.useProps,
-          )();
-          return [...rest, props];
-        }
-        return rest;
-      }, new Array<IconLinkVerticalProps>());
-      return links.length ? <HeaderIconLinkRow links={links} /> : null;
+      return <EntityIconLinkRow links={iconLinks} />;
     }
     return originalFactory({
       type: 'info',


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #34763.

This is an alternative to #34764 that preserves the intended behavior of filtering icon links before their hooks run. Each matching link is rendered through a keyed child component, keeping hook ordering stable while avoiding initialization and side effects for filtered-out links.

`HeaderIconLinkRow` now supports custom child link elements so the links retain the existing layout.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
