### PR TITLE
fix(backend-defaults): allow idle database pools to close

### DIFF
--- a/.changeset/quiet-pools-rest.md
+++ b/.changeset/quiet-pools-rest.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Stopped issuing periodic per-plugin database keepalive queries, allowing configured connection pool idle timeouts to retire unused connections.

--- a/.changeset/quiet-pools-rest.md
+++ b/.changeset/quiet-pools-rest.md
@@ -2,4 +2,4 @@
 '@backstage/backend-defaults': patch
 ---
 
-Stopped issuing periodic per-plugin database keepalive queries, allowing configured connection pool idle timeouts to retire unused connections.
+Stopped issuing periodic per-plugin database keepalive queries and changed the default minimum PostgreSQL and MySQL connection pool size to zero. Idle connections can now be retired after the configured timeout, while explicitly configured pool minimums are preserved.

--- a/docs/backend-system/core-services/database.md
+++ b/docs/backend-system/core-services/database.md
@@ -50,9 +50,11 @@ createBackendPlugin({
 
 Each plugin that calls `getClient()` receives a Knex connection pool. You can
 configure the pool through `backend.database.knexConfig`. PostgreSQL and MySQL
-pools default the minimum pool size to zero, and the database service does not
-issue periodic queries to keep idle pools active. This allows Knex to close all
-idle connections after the configured idle timeout and reopen them on demand.
+pools default the minimum pool size to zero, as
+[recommended by Knex](https://knexjs.org/guide/#pool), and the database service
+does not issue periodic queries to keep idle pools active. This allows Knex to
+close all idle connections after the configured idle timeout and reopen them on
+demand.
 
 For example, you can limit each plugin pool to five connections and configure
 how long idle connections are retained:

--- a/docs/backend-system/core-services/database.md
+++ b/docs/backend-system/core-services/database.md
@@ -49,22 +49,26 @@ createBackendPlugin({
 ## Configuring connection pools
 
 Each plugin that calls `getClient()` receives a Knex connection pool. You can
-configure the pool through `backend.database.knexConfig`. The database service
-does not issue periodic queries to keep idle pools active, so Knex controls when
-idle connections are closed and reopened.
+configure the pool through `backend.database.knexConfig`. PostgreSQL and MySQL
+pools default the minimum pool size to zero, and the database service does not
+issue periodic queries to keep idle pools active. This allows Knex to close all
+idle connections after the configured idle timeout and reopen them on demand.
 
-For example, you can allow an inactive plugin pool to close all of its
-connections after the configured idle timeout:
+For example, you can limit each plugin pool to five connections and configure
+how long idle connections are retained:
 
 ```yaml
 backend:
   database:
     knexConfig:
       pool:
-        min: 0
         max: 5
         idleTimeoutMillis: 30000
 ```
+
+You can set `pool.min` explicitly if you need to retain a minimum number of
+connections. Connections retained by a nonzero minimum are not closed by the
+idle timeout.
 
 You can override these settings for individual plugins through
 `backend.database.plugin.<pluginId>.knexConfig`.

--- a/docs/backend-system/core-services/database.md
+++ b/docs/backend-system/core-services/database.md
@@ -45,3 +45,26 @@ createBackendPlugin({
   },
 });
 ```
+
+## Configuring connection pools
+
+Each plugin that calls `getClient()` receives a Knex connection pool. You can
+configure the pool through `backend.database.knexConfig`. The database service
+does not issue periodic queries to keep idle pools active, so Knex controls when
+idle connections are closed and reopened.
+
+For example, you can allow an inactive plugin pool to close all of its
+connections after the configured idle timeout:
+
+```yaml
+backend:
+  database:
+    knexConfig:
+      pool:
+        min: 0
+        max: 5
+        idleTimeoutMillis: 30000
+```
+
+You can override these settings for individual plugins through
+`backend.database.plugin.<pluginId>.knexConfig`.

--- a/packages/backend-defaults/src/entrypoints/database/DatabaseManager.test.ts
+++ b/packages/backend-defaults/src/entrypoints/database/DatabaseManager.test.ts
@@ -63,6 +63,29 @@ describe('DatabaseManagerImpl', () => {
     expect(connector2.getClient).toHaveBeenCalledTimes(0);
   });
 
+  it('does not query idle database clients', async () => {
+    jest.useFakeTimers();
+    const nodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    const raw = jest.fn();
+    const connector = {
+      getClient: jest.fn().mockResolvedValue({ raw }),
+    } satisfies Connector;
+    const impl = new DatabaseManagerImpl(new ConfigReader({ client: 'pg' }), {
+      pg: connector,
+    });
+
+    try {
+      await impl.forPlugin('plugin1', deps).getClient();
+      await jest.advanceTimersByTimeAsync(60_000);
+
+      expect(raw).not.toHaveBeenCalled();
+    } finally {
+      process.env.NODE_ENV = nodeEnv;
+      jest.useRealTimers();
+    }
+  });
+
   it('respects per-plugin overridden connectors', async () => {
     const connector1 = {
       getClient: jest.fn(),

--- a/packages/backend-defaults/src/entrypoints/database/DatabaseManager.test.ts
+++ b/packages/backend-defaults/src/entrypoints/database/DatabaseManager.test.ts
@@ -65,8 +65,9 @@ describe('DatabaseManagerImpl', () => {
 
   it('does not query idle database clients', async () => {
     jest.useFakeTimers();
-    const nodeEnv = process.env.NODE_ENV;
-    process.env.NODE_ENV = 'production';
+    const env = process.env as Record<string, string | undefined>;
+    const nodeEnv = env.NODE_ENV;
+    env.NODE_ENV = 'production';
     const raw = jest.fn();
     const connector = {
       getClient: jest.fn().mockResolvedValue({ raw }),
@@ -81,7 +82,7 @@ describe('DatabaseManagerImpl', () => {
 
       expect(raw).not.toHaveBeenCalled();
     } finally {
-      process.env.NODE_ENV = nodeEnv;
+      env.NODE_ENV = nodeEnv;
       jest.useRealTimers();
     }
   });

--- a/packages/backend-defaults/src/entrypoints/database/DatabaseManager.ts
+++ b/packages/backend-defaults/src/entrypoints/database/DatabaseManager.ts
@@ -56,20 +56,17 @@ export class DatabaseManagerImpl {
   private readonly connectors: Record<string, Connector>;
   private readonly options?: DatabaseManagerOptions;
   private readonly databaseCache: Map<string, Promise<Knex>>;
-  private readonly keepaliveIntervals: Map<string, NodeJS.Timeout>;
 
   constructor(
     config: Config,
     connectors: Record<string, Connector>,
     options?: DatabaseManagerOptions,
     databaseCache: Map<string, Promise<Knex>> = new Map(),
-    keepaliveIntervals: Map<string, NodeJS.Timeout> = new Map(),
   ) {
     this.config = config;
     this.connectors = connectors;
     this.options = options;
     this.databaseCache = databaseCache;
-    this.keepaliveIntervals = keepaliveIntervals;
     // If a rootLifecycle service was provided, register a shutdown hook to
     // clean up any database connections.
     if (options?.rootLifecycle !== undefined) {
@@ -118,9 +115,6 @@ export class DatabaseManagerImpl {
     const pluginIds = Array.from(this.databaseCache.keys());
     await Promise.allSettled(
       pluginIds.map(async pluginId => {
-        // We no longer need to keep connections alive.
-        clearInterval(this.keepaliveIntervals.get(pluginId));
-
         const connection = await this.databaseCache.get(pluginId);
         if (connection) {
           if (connection.client.config.includes('sqlite3')) {
@@ -187,44 +181,7 @@ export class DatabaseManagerImpl {
     const clientPromise = connector.getClient(pluginId, deps);
     this.databaseCache.set(pluginId, clientPromise);
 
-    if (process.env.NODE_ENV !== 'test') {
-      clientPromise.then(client =>
-        this.startKeepaliveLoop(pluginId, client, deps.logger),
-      );
-    }
-
     return clientPromise;
-  }
-
-  private startKeepaliveLoop(
-    pluginId: string,
-    client: Knex,
-    logger: LoggerService,
-  ): void {
-    let lastKeepaliveFailed = false;
-
-    this.keepaliveIntervals.set(
-      pluginId,
-      setInterval(() => {
-        // During testing it can happen that the environment is torn down and
-        // this client is `undefined`, but this interval is still run.
-        client?.raw('select 1').then(
-          () => {
-            lastKeepaliveFailed = false;
-          },
-          (error: unknown) => {
-            if (!lastKeepaliveFailed) {
-              lastKeepaliveFailed = true;
-              logger.warn(
-                `Database keepalive failed for plugin ${pluginId}, ${stringifyError(
-                  error,
-                )}`,
-              );
-            }
-          },
-        );
-      }, 60 * 1000),
-    );
   }
 }
 

--- a/packages/backend-defaults/src/entrypoints/database/connectors/mysql.test.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/mysql.test.ts
@@ -42,6 +42,7 @@ describe('mysql', () => {
       expect(buildMysqlDatabaseConfig(createConfig(mockConnection))).toEqual({
         client: 'mysql2',
         connection: mockConnection,
+        pool: { min: 0 },
         useNullAsDefault: true,
       });
     });
@@ -54,6 +55,7 @@ describe('mysql', () => {
       ).toEqual({
         client: 'mysql2',
         connection: mockConnectionString,
+        pool: { min: 0 },
         useNullAsDefault: true,
       });
     });
@@ -71,6 +73,7 @@ describe('mysql', () => {
           ...mockConnection,
           database: 'other_db',
         },
+        pool: { min: 0 },
         useNullAsDefault: true,
       });
     });
@@ -81,7 +84,7 @@ describe('mysql', () => {
       expect(
         buildMysqlDatabaseConfig(createConfig(mockConnection), {
           connection: { database: 'other_db' },
-          pool: { min: 0, max: 7 },
+          pool: { min: 2, max: 7 },
           debug: true,
         }),
       ).toEqual({
@@ -91,7 +94,7 @@ describe('mysql', () => {
           database: 'other_db',
         },
         useNullAsDefault: true,
-        pool: { min: 0, max: 7 },
+        pool: { min: 2, max: 7 },
         debug: true,
       });
     });
@@ -111,6 +114,7 @@ describe('mysql', () => {
           port: 3306,
           database: 'other_db',
         },
+        pool: { min: 0 },
         useNullAsDefault: true,
       });
     });

--- a/packages/backend-defaults/src/entrypoints/database/connectors/mysql.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/mysql.ts
@@ -55,6 +55,7 @@ export function buildMysqlDatabaseConfig(
   overrides?: Knex.Config,
 ) {
   return mergeDatabaseConfig(
+    { pool: { min: 0 } },
     dbConfig.get(),
     {
       connection: getMysqlConnectionConfig(dbConfig, !!overrides),

--- a/packages/backend-defaults/src/entrypoints/database/connectors/postgres.test.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/postgres.test.ts
@@ -57,6 +57,7 @@ describe('postgres', () => {
         {
           client: 'pg',
           connection: mockConnection,
+          pool: { min: 0 },
           useNullAsDefault: true,
         },
       );
@@ -70,6 +71,7 @@ describe('postgres', () => {
       ).toEqual({
         client: 'pg',
         connection: mockConnectionString,
+        pool: { min: 0 },
         useNullAsDefault: true,
       });
     });
@@ -87,6 +89,7 @@ describe('postgres', () => {
           ...mockConnection,
           database: 'other_db',
         },
+        pool: { min: 0 },
         useNullAsDefault: true,
       });
     });
@@ -104,6 +107,7 @@ describe('postgres', () => {
       ).toEqual({
         client: 'pg',
         connection: mockConnection,
+        pool: { min: 0 },
         searchPath: ['schemaName'],
         useNullAsDefault: true,
       });
@@ -115,7 +119,7 @@ describe('postgres', () => {
       expect(
         await buildPgDatabaseConfig(createConfig(mockConnection), {
           connection: { database: 'other_db' },
-          pool: { min: 0, max: 7 },
+          pool: { min: 2, max: 7 },
           debug: true,
         }),
       ).toEqual({
@@ -125,7 +129,7 @@ describe('postgres', () => {
           database: 'other_db',
         },
         useNullAsDefault: true,
-        pool: { min: 0, max: 7 },
+        pool: { min: 2, max: 7 },
         debug: true,
       });
     });
@@ -145,6 +149,7 @@ describe('postgres', () => {
           port: '5432',
           database: 'other_db',
         },
+        pool: { min: 0 },
         useNullAsDefault: true,
       });
     });
@@ -435,6 +440,7 @@ describe('postgres', () => {
           port: 5423,
           database: 'other_db',
         },
+        pool: { min: 0 },
         useNullAsDefault: true,
       });
     });
@@ -493,6 +499,7 @@ describe('postgres', () => {
           stream: mockStream,
           database: 'other_db',
         },
+        pool: { min: 0 },
         useNullAsDefault: true,
       });
     });
@@ -841,6 +848,7 @@ describe('postgres', () => {
           port: '5432',
           database: 'other_db',
         },
+        pool: { min: 0 },
         useNullAsDefault: true,
       });
     });

--- a/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
+++ b/packages/backend-defaults/src/entrypoints/database/connectors/postgres.ts
@@ -76,6 +76,7 @@ export async function buildPgDatabaseConfig(
   overrides?: Knex.Config,
 ) {
   const config = mergeDatabaseConfig(
+    { pool: { min: 0 } },
     dbConfig.get(),
     {
       connection: getPgConnectionConfig(dbConfig, !!overrides),


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Backstage currently runs a `SELECT 1` every minute for every plugin database client. It also inherits Knex's historical default minimum pool size of two, which prevents the idle timeout from retiring every unused connection.

This removes the framework-level keepalive and defaults PostgreSQL and MySQL pools to `min: 0`, as [recommended by Knex](https://knexjs.org/guide/#pool). Explicit pool minimums are preserved. Idle connections can be retired and reopened on demand, which is particularly useful when plugins share one PostgreSQL database using `pluginDivisionMode: schema`.

Related to #30412.

#### Verification

- `CI=1 yarn test packages/backend-defaults/src/entrypoints/database`
- `yarn tsc`
- `yarn workspace @backstage/backend-defaults lint --fix`
- `yarn build:api-reports packages/backend-defaults`

The full `yarn build:api-reports` completed package report generation but its final CLI-report check rejected a Node.js 26 `module.register()` deprecation warning written to stderr.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
