### PR TITLE
perf(filter-predicates): keep the zod v4 locales out of the bundle

### DIFF
--- a/.changeset/filter-predicates-zod-namespace.md
+++ b/.changeset/filter-predicates-zod-namespace.md
@@ -1,0 +1,5 @@
+---
+'@backstage/filter-predicates': patch
+---
+
+Reduced the frontend bundle size by letting bundlers tree-shake zod, which previously pulled every zod locale into the bundle. Takes effect on zod 4.5.0 and newer.

--- a/packages/filter-predicates/src/predicates/schema.ts
+++ b/packages/filter-predicates/src/predicates/schema.ts
@@ -79,12 +79,10 @@ export function createZodV4FilterPredicateSchema(): zodV4.ZodType<
   FilterPredicate,
   FilterPredicate
 > {
-  const z = zodV4;
-
-  const primitiveSchema = z.union([
-    z.string(),
-    z.number(),
-    z.boolean(),
+  const primitiveSchema = zodV4.union([
+    zodV4.string(),
+    zodV4.number(),
+    zodV4.boolean(),
   ]) as zodV4.ZodType<FilterPredicatePrimitive, FilterPredicatePrimitive>;
 
   // eslint-disable-next-line prefer-const
@@ -93,29 +91,29 @@ export function createZodV4FilterPredicateSchema(): zodV4.ZodType<
     FilterPredicateValue
   >;
 
-  const expressionSchema = z.lazy(() =>
-    z.union([
-      z.record(z.string().regex(/^(?!\$).*$/), valuePredicateSchema),
-      z.record(z.string().regex(/^\$/), z.never()),
+  const expressionSchema = zodV4.lazy(() =>
+    zodV4.union([
+      zodV4.record(zodV4.string().regex(/^(?!\$).*$/), valuePredicateSchema),
+      zodV4.record(zodV4.string().regex(/^\$/), zodV4.never()),
     ]),
   ) as zodV4.ZodType<FilterPredicateExpression, FilterPredicateExpression>;
 
-  const predicateSchema = z.lazy(() =>
-    z.union([
+  const predicateSchema = zodV4.lazy(() =>
+    zodV4.union([
       expressionSchema,
       primitiveSchema,
-      z.object({ $all: z.array(predicateSchema) }).strict(),
-      z.object({ $any: z.array(predicateSchema) }).strict(),
-      z.object({ $not: predicateSchema }).strict(),
+      zodV4.object({ $all: zodV4.array(predicateSchema) }).strict(),
+      zodV4.object({ $any: zodV4.array(predicateSchema) }).strict(),
+      zodV4.object({ $not: predicateSchema }).strict(),
     ]),
   ) as zodV4.ZodType<FilterPredicate, FilterPredicate>;
 
-  valuePredicateSchema = z.union([
+  valuePredicateSchema = zodV4.union([
     primitiveSchema,
-    z.object({ $exists: z.boolean() }),
-    z.object({ $in: z.array(primitiveSchema) }),
-    z.object({ $contains: predicateSchema }),
-    z.object({ $hasPrefix: z.string() }),
+    zodV4.object({ $exists: zodV4.boolean() }),
+    zodV4.object({ $in: zodV4.array(primitiveSchema) }),
+    zodV4.object({ $contains: predicateSchema }),
+    zodV4.object({ $hasPrefix: zodV4.string() }),
   ]) as zodV4.ZodType<FilterPredicateValue, FilterPredicateValue>;
 
   return predicateSchema;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

- The local `zodV4` assignment prevented rspack/webpack treeshaking
- On Zod 4.3.6, the change is a no-op (no bundle size decrease)
- On Zod 4.5.0+ (which includes some export changes e.g. https://github.com/colinhacks/zod/issues/6050), tree-shaking works properly, unused locales are ignored.
  - Zod not bumped in this PR, but newer versions are in range for consumers


| bundler         | zod   | before | after    | locales bundled |
| --------------- | ----- | ---------------------- | -------------------------- | --------------- |
| rspack 1.7.11   | 4.3.6 | 62.3 kB gz             | 62.3 kB gz | 49 either way   |
| rspack 1.7.11   | 4.5.0 | 86.9 kB gz             | 14.6 kB gz, −83%           | 63 → 1          |
| webpack 5.105.4 | 4.5.4 | 81.4 kB gz             | 23.1 kB gz, −72%           | 63 → 1          |

Same global objective as #35357, #35287

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [X] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
