### PR TITLE
fix(backend-defaults): dedupe metric instruments by name to avoid duplicate Prometheus HELP lines

### DIFF
--- a/.changeset/tame-poets-argue.md
+++ b/.changeset/tame-poets-argue.md
@@ -1,0 +1,5 @@
+---
+'@backstage/backend-defaults': patch
+---
+
+Fixed a bug where creating a metric with the same name from multiple plugins could cause the Prometheus exporter to emit duplicate `HELP`/`TYPE` lines for that metric, which some Prometheus scrapers reject as invalid. Instruments are now reused by name, so a metric name always maps to a single underlying instrument regardless of which plugin creates it first.

--- a/.changeset/tame-poets-argue.md
+++ b/.changeset/tame-poets-argue.md
@@ -2,4 +2,4 @@
 '@backstage/backend-defaults': patch
 ---
 
-Fixed a bug where creating a metric with the same name from multiple plugins could cause the Prometheus exporter to emit duplicate `HELP`/`TYPE` lines for that metric, which some Prometheus scrapers reject as invalid. Instruments are now reused by name, so a metric name always maps to a single underlying instrument regardless of which plugin creates it first.
+Fixed a bug where creating a metric with the same name from multiple plugins could cause the Prometheus exporter to emit duplicate `HELP`/`TYPE` lines for that metric, which some Prometheus scrapers reject as invalid. Instruments are now reused by name, so a metric name always maps to a single underlying instrument regardless of which plugin creates it first. If two plugins register the same metric name with a different description or unit, a warning is now logged so the collision is visible instead of silently discarding the second plugin's options.

--- a/packages/backend-defaults/src/alpha/entrypoints/metrics/DefaultMetricsService.test.ts
+++ b/packages/backend-defaults/src/alpha/entrypoints/metrics/DefaultMetricsService.test.ts
@@ -13,14 +13,46 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { metrics } from '@opentelemetry/api';
+import { Meter, metrics } from '@opentelemetry/api';
 import { DefaultMetricsService } from './DefaultMetricsService';
+
+// The real (noop) OpenTelemetry API meter provider used in tests collapses
+// every getMeter()/createXxx() call to shared singleton objects, which makes
+// it impossible to observe per-scope behavior. Each test instead gets a
+// fresh, independently-trackable fake Meter so instrument creation can be
+// asserted per meter/scope.
+function createFakeMeter(): jest.Mocked<Meter> {
+  return {
+    createCounter: jest.fn(name => ({ name, add: jest.fn() })),
+    createUpDownCounter: jest.fn(name => ({ name, add: jest.fn() })),
+    createHistogram: jest.fn(name => ({ name, record: jest.fn() })),
+    createGauge: jest.fn(name => ({ name, record: jest.fn() })),
+    createObservableCounter: jest.fn(name => ({
+      name,
+      addCallback: jest.fn(),
+      removeCallback: jest.fn(),
+    })),
+    createObservableUpDownCounter: jest.fn(name => ({
+      name,
+      addCallback: jest.fn(),
+      removeCallback: jest.fn(),
+    })),
+    createObservableGauge: jest.fn(name => ({
+      name,
+      addCallback: jest.fn(),
+      removeCallback: jest.fn(),
+    })),
+    addBatchObservableCallback: jest.fn(),
+    removeBatchObservableCallback: jest.fn(),
+  } as unknown as jest.Mocked<Meter>;
+}
 
 const mockGetMeter = jest.spyOn(metrics, 'getMeter');
 
 describe('DefaultMetricsService', () => {
   beforeEach(() => {
-    mockGetMeter.mockClear();
+    mockGetMeter.mockReset();
+    mockGetMeter.mockImplementation(() => createFakeMeter());
   });
 
   describe('create', () => {
@@ -54,7 +86,7 @@ describe('DefaultMetricsService', () => {
   describe('metric instruments', () => {
     it('should create a counter', () => {
       const service = DefaultMetricsService.create({ name: 'test' });
-      const counter = service.createCounter('my_counter', {
+      const counter = service.createCounter('metric_instruments_counter', {
         description: 'A test counter',
         unit: 'bytes',
       });
@@ -65,7 +97,9 @@ describe('DefaultMetricsService', () => {
 
     it('should create an up-down counter', () => {
       const service = DefaultMetricsService.create({ name: 'test' });
-      const upDownCounter = service.createUpDownCounter('my_updown');
+      const upDownCounter = service.createUpDownCounter(
+        'metric_instruments_updown',
+      );
 
       expect(upDownCounter).toBeDefined();
       expect(upDownCounter.add).toBeDefined();
@@ -73,7 +107,7 @@ describe('DefaultMetricsService', () => {
 
     it('should create a histogram', () => {
       const service = DefaultMetricsService.create({ name: 'test' });
-      const histogram = service.createHistogram('my_histogram');
+      const histogram = service.createHistogram('metric_instruments_histogram');
 
       expect(histogram).toBeDefined();
       expect(histogram.record).toBeDefined();
@@ -81,7 +115,7 @@ describe('DefaultMetricsService', () => {
 
     it('should create a gauge', () => {
       const service = DefaultMetricsService.create({ name: 'test' });
-      const gauge = service.createGauge('my_gauge');
+      const gauge = service.createGauge('metric_instruments_gauge');
 
       expect(gauge).toBeDefined();
       expect(gauge.record).toBeDefined();
@@ -89,7 +123,9 @@ describe('DefaultMetricsService', () => {
 
     it('should create an observable counter', () => {
       const service = DefaultMetricsService.create({ name: 'test' });
-      const counter = service.createObservableCounter('my_observable_counter');
+      const counter = service.createObservableCounter(
+        'metric_instruments_observable_counter',
+      );
 
       expect(counter).toBeDefined();
       expect(counter.addCallback).toBeDefined();
@@ -99,7 +135,7 @@ describe('DefaultMetricsService', () => {
     it('should create an observable up-down counter', () => {
       const service = DefaultMetricsService.create({ name: 'test' });
       const counter = service.createObservableUpDownCounter(
-        'my_observable_updown',
+        'metric_instruments_observable_updown',
       );
 
       expect(counter).toBeDefined();
@@ -108,10 +144,56 @@ describe('DefaultMetricsService', () => {
 
     it('should create an observable gauge', () => {
       const service = DefaultMetricsService.create({ name: 'test' });
-      const gauge = service.createObservableGauge('my_observable_gauge');
+      const gauge = service.createObservableGauge(
+        'metric_instruments_observable_gauge',
+      );
 
       expect(gauge).toBeDefined();
       expect(gauge.addCallback).toBeDefined();
+    });
+  });
+
+  describe('instrument deduplication', () => {
+    it('should reuse a single instrument for the same metric name across different meter scopes', () => {
+      const serviceA = DefaultMetricsService.create({ name: 'plugin-a' });
+      const meterA = mockGetMeter.mock.results[0].value as jest.Mocked<Meter>;
+
+      const instrumentA = serviceA.createCounter('shared_across_plugins');
+      expect(meterA.createCounter).toHaveBeenCalledTimes(1);
+
+      const serviceB = DefaultMetricsService.create({ name: 'plugin-b' });
+      const meterB = mockGetMeter.mock.results[1].value as jest.Mocked<Meter>;
+
+      const instrumentB = serviceB.createCounter('shared_across_plugins');
+
+      // The second meter's createCounter should never be called for a metric
+      // name that's already cached, otherwise the underlying OpenTelemetry
+      // Prometheus exporter would emit a duplicate HELP/TYPE block for the
+      // same metric name and break the Prometheus text format.
+      expect(meterB.createCounter).not.toHaveBeenCalled();
+      expect(instrumentB).toBe(instrumentA);
+    });
+
+    it('should create separate instruments for different metric names', () => {
+      const service = DefaultMetricsService.create({ name: 'plugin-c' });
+      const meter = mockGetMeter.mock.results[0].value as jest.Mocked<Meter>;
+
+      service.createCounter('distinct_metric_one');
+      service.createCounter('distinct_metric_two');
+
+      expect(meter.createCounter).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not share instruments across different instrument kinds with the same name', () => {
+      const service = DefaultMetricsService.create({ name: 'plugin-d' });
+      const meter = mockGetMeter.mock.results[0].value as jest.Mocked<Meter>;
+
+      const counter = service.createCounter('same_name');
+      const gauge = service.createGauge('same_name');
+
+      expect(meter.createCounter).toHaveBeenCalledTimes(1);
+      expect(meter.createGauge).toHaveBeenCalledTimes(1);
+      expect(counter).not.toBe(gauge);
     });
   });
 });

--- a/packages/backend-defaults/src/alpha/entrypoints/metrics/DefaultMetricsService.test.ts
+++ b/packages/backend-defaults/src/alpha/entrypoints/metrics/DefaultMetricsService.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { Meter, metrics } from '@opentelemetry/api';
+import { mockServices } from '@backstage/backend-test-utils';
 import { DefaultMetricsService } from './DefaultMetricsService';
 
 // The real (noop) OpenTelemetry API meter provider used in tests collapses
@@ -194,6 +195,51 @@ describe('DefaultMetricsService', () => {
       expect(meter.createCounter).toHaveBeenCalledTimes(1);
       expect(meter.createGauge).toHaveBeenCalledTimes(1);
       expect(counter).not.toBe(gauge);
+    });
+
+    it('should warn when a cached instrument is reused with different options', () => {
+      const logger = mockServices.logger.mock();
+
+      const serviceA = DefaultMetricsService.create({
+        name: 'plugin-e',
+        logger,
+      });
+      serviceA.createCounter('conflicting_metric', {
+        description: 'Counted by plugin e',
+      });
+
+      const serviceB = DefaultMetricsService.create({
+        name: 'plugin-f',
+        logger,
+      });
+      serviceB.createCounter('conflicting_metric', {
+        description: 'Counted by plugin f',
+      });
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('conflicting_metric'),
+      );
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('plugin-e'),
+      );
+    });
+
+    it('should not warn when a cached instrument is reused with matching options', () => {
+      const logger = mockServices.logger.mock();
+
+      const serviceA = DefaultMetricsService.create({
+        name: 'plugin-g',
+        logger,
+      });
+      serviceA.createCounter('matching_metric', { description: 'Same' });
+
+      const serviceB = DefaultMetricsService.create({
+        name: 'plugin-h',
+        logger,
+      });
+      serviceB.createCounter('matching_metric', { description: 'Same' });
+
+      expect(logger.warn).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/backend-defaults/src/alpha/entrypoints/metrics/DefaultMetricsService.ts
+++ b/packages/backend-defaults/src/alpha/entrypoints/metrics/DefaultMetricsService.ts
@@ -49,6 +49,16 @@ export interface DefaultMetricsServiceOptions {
 export class DefaultMetricsService implements MetricsService {
   private readonly meter: Meter;
 
+  // Instruments are cached process-wide, keyed by kind and metric name. When
+  // multiple plugins (each with their own Meter/Instrumentation Scope) create
+  // an instrument with the same name, the OpenTelemetry Prometheus exporter
+  // emits one `# HELP`/`# TYPE` block per scope, producing duplicate HELP
+  // lines for the same metric name. That violates the Prometheus text
+  // exposition format and causes scrapes to fail. Caching by name ensures a
+  // metric name maps to a single underlying instrument, regardless of which
+  // plugin creates it first.
+  private static readonly instrumentCache = new Map<string, unknown>();
+
   private constructor(opts: DefaultMetricsServiceOptions) {
     // The meter name sets the OpenTelemetry Instrumentation Scope which identifies the source of metrics in telemetry backends.
     this.meter = metrics.getMeter(opts.name, opts.version, {
@@ -66,32 +76,55 @@ export class DefaultMetricsService implements MetricsService {
     return new DefaultMetricsService(opts);
   }
 
+  private getOrCreateInstrument<T>(
+    kind: string,
+    name: string,
+    create: () => T,
+  ): T {
+    const key = `${kind}:${name}`;
+    const existing = DefaultMetricsService.instrumentCache.get(key);
+    if (existing) {
+      return existing as T;
+    }
+    const instrument = create();
+    DefaultMetricsService.instrumentCache.set(key, instrument);
+    return instrument;
+  }
+
   createCounter<TAttributes extends MetricAttributes = MetricAttributes>(
     name: string,
     opts?: MetricOptions,
   ): MetricsServiceCounter<TAttributes> {
-    return this.meter.createCounter(name, opts);
+    return this.getOrCreateInstrument('counter', name, () =>
+      this.meter.createCounter<TAttributes>(name, opts),
+    );
   }
 
   createUpDownCounter<TAttributes extends MetricAttributes = MetricAttributes>(
     name: string,
     opts?: MetricOptions,
   ): MetricsServiceUpDownCounter<TAttributes> {
-    return this.meter.createUpDownCounter(name, opts);
+    return this.getOrCreateInstrument('upDownCounter', name, () =>
+      this.meter.createUpDownCounter<TAttributes>(name, opts),
+    );
   }
 
   createHistogram<TAttributes extends MetricAttributes = MetricAttributes>(
     name: string,
     opts?: MetricOptions,
   ): MetricsServiceHistogram<TAttributes> {
-    return this.meter.createHistogram(name, opts);
+    return this.getOrCreateInstrument('histogram', name, () =>
+      this.meter.createHistogram<TAttributes>(name, opts),
+    );
   }
 
   createGauge<TAttributes extends MetricAttributes = MetricAttributes>(
     name: string,
     opts?: MetricOptions,
   ): MetricsServiceGauge<TAttributes> {
-    return this.meter.createGauge(name, opts);
+    return this.getOrCreateInstrument('gauge', name, () =>
+      this.meter.createGauge<TAttributes>(name, opts),
+    );
   }
 
   createObservableCounter<
@@ -100,7 +133,9 @@ export class DefaultMetricsService implements MetricsService {
     name: string,
     opts?: MetricOptions,
   ): MetricsServiceObservableCounter<TAttributes> {
-    return this.meter.createObservableCounter(name, opts);
+    return this.getOrCreateInstrument('observableCounter', name, () =>
+      this.meter.createObservableCounter<TAttributes>(name, opts),
+    );
   }
 
   createObservableUpDownCounter<
@@ -109,7 +144,9 @@ export class DefaultMetricsService implements MetricsService {
     name: string,
     opts?: MetricOptions,
   ): MetricsServiceObservableUpDownCounter<TAttributes> {
-    return this.meter.createObservableUpDownCounter(name, opts);
+    return this.getOrCreateInstrument('observableUpDownCounter', name, () =>
+      this.meter.createObservableUpDownCounter<TAttributes>(name, opts),
+    );
   }
 
   createObservableGauge<
@@ -118,6 +155,8 @@ export class DefaultMetricsService implements MetricsService {
     name: string,
     opts?: MetricOptions,
   ): MetricsServiceObservableGauge<TAttributes> {
-    return this.meter.createObservableGauge(name, opts);
+    return this.getOrCreateInstrument('observableGauge', name, () =>
+      this.meter.createObservableGauge<TAttributes>(name, opts),
+    );
   }
 }

--- a/packages/backend-defaults/src/alpha/entrypoints/metrics/DefaultMetricsService.ts
+++ b/packages/backend-defaults/src/alpha/entrypoints/metrics/DefaultMetricsService.ts
@@ -15,6 +15,7 @@
  */
 
 import { Meter, metrics } from '@opentelemetry/api';
+import { LoggerService } from '@backstage/backend-plugin-api';
 import {
   MetricsService,
   MetricAttributes,
@@ -37,6 +38,13 @@ export interface DefaultMetricsServiceOptions {
   name: string;
   version?: string;
   schemaUrl?: string;
+  logger?: LoggerService;
+}
+
+interface CachedInstrument {
+  instrument: unknown;
+  scopeName: string;
+  opts: MetricOptions | undefined;
 }
 
 /**
@@ -48,6 +56,8 @@ export interface DefaultMetricsServiceOptions {
  */
 export class DefaultMetricsService implements MetricsService {
   private readonly meter: Meter;
+  private readonly scopeName: string;
+  private readonly logger?: LoggerService;
 
   // Instruments are cached process-wide, keyed by kind and metric name. When
   // multiple plugins (each with their own Meter/Instrumentation Scope) create
@@ -57,9 +67,20 @@ export class DefaultMetricsService implements MetricsService {
   // exposition format and causes scrapes to fail. Caching by name ensures a
   // metric name maps to a single underlying instrument, regardless of which
   // plugin creates it first.
-  private static readonly instrumentCache = new Map<string, unknown>();
+  //
+  // Because this collapses instruments across otherwise-unrelated plugins,
+  // a second registration with a different description/unit for the same
+  // name is silently discarded rather than erroring or creating a separate
+  // series (Prometheus has no way to represent that). We log a warning so
+  // the collision is visible instead of silently producing a metric with
+  // the wrong documentation, and so an accidental name collision between
+  // two plugins that did not intend to share a metric can be noticed and
+  // renamed.
+  private static readonly instrumentCache = new Map<string, CachedInstrument>();
 
   private constructor(opts: DefaultMetricsServiceOptions) {
+    this.scopeName = opts.name;
+    this.logger = opts.logger;
     // The meter name sets the OpenTelemetry Instrumentation Scope which identifies the source of metrics in telemetry backends.
     this.meter = metrics.getMeter(opts.name, opts.version, {
       schemaUrl: opts.schemaUrl,
@@ -79,15 +100,34 @@ export class DefaultMetricsService implements MetricsService {
   private getOrCreateInstrument<T>(
     kind: string,
     name: string,
+    opts: MetricOptions | undefined,
     create: () => T,
   ): T {
     const key = `${kind}:${name}`;
     const existing = DefaultMetricsService.instrumentCache.get(key);
     if (existing) {
-      return existing as T;
+      if (
+        existing.opts?.description !== opts?.description ||
+        existing.opts?.unit !== opts?.unit
+      ) {
+        this.logger?.warn(
+          `Metric '${name}' (${kind}) was already registered by ` +
+            `'${existing.scopeName}' with different options; reusing that ` +
+            `instrument and ignoring the options requested by ` +
+            `'${this.scopeName}'. Prometheus does not support multiple ` +
+            `HELP/TYPE definitions for the same metric name, so if these ` +
+            `are unrelated metrics that happen to share a name, rename one ` +
+            `of them to avoid the collision.`,
+        );
+      }
+      return existing.instrument as T;
     }
     const instrument = create();
-    DefaultMetricsService.instrumentCache.set(key, instrument);
+    DefaultMetricsService.instrumentCache.set(key, {
+      instrument,
+      opts,
+      scopeName: this.scopeName,
+    });
     return instrument;
   }
 
@@ -95,7 +135,7 @@ export class DefaultMetricsService implements MetricsService {
     name: string,
     opts?: MetricOptions,
   ): MetricsServiceCounter<TAttributes> {
-    return this.getOrCreateInstrument('counter', name, () =>
+    return this.getOrCreateInstrument('counter', name, opts, () =>
       this.meter.createCounter<TAttributes>(name, opts),
     );
   }
@@ -104,7 +144,7 @@ export class DefaultMetricsService implements MetricsService {
     name: string,
     opts?: MetricOptions,
   ): MetricsServiceUpDownCounter<TAttributes> {
-    return this.getOrCreateInstrument('upDownCounter', name, () =>
+    return this.getOrCreateInstrument('upDownCounter', name, opts, () =>
       this.meter.createUpDownCounter<TAttributes>(name, opts),
     );
   }
@@ -113,7 +153,7 @@ export class DefaultMetricsService implements MetricsService {
     name: string,
     opts?: MetricOptions,
   ): MetricsServiceHistogram<TAttributes> {
-    return this.getOrCreateInstrument('histogram', name, () =>
+    return this.getOrCreateInstrument('histogram', name, opts, () =>
       this.meter.createHistogram<TAttributes>(name, opts),
     );
   }
@@ -122,7 +162,7 @@ export class DefaultMetricsService implements MetricsService {
     name: string,
     opts?: MetricOptions,
   ): MetricsServiceGauge<TAttributes> {
-    return this.getOrCreateInstrument('gauge', name, () =>
+    return this.getOrCreateInstrument('gauge', name, opts, () =>
       this.meter.createGauge<TAttributes>(name, opts),
     );
   }
@@ -133,7 +173,7 @@ export class DefaultMetricsService implements MetricsService {
     name: string,
     opts?: MetricOptions,
   ): MetricsServiceObservableCounter<TAttributes> {
-    return this.getOrCreateInstrument('observableCounter', name, () =>
+    return this.getOrCreateInstrument('observableCounter', name, opts, () =>
       this.meter.createObservableCounter<TAttributes>(name, opts),
     );
   }
@@ -144,8 +184,11 @@ export class DefaultMetricsService implements MetricsService {
     name: string,
     opts?: MetricOptions,
   ): MetricsServiceObservableUpDownCounter<TAttributes> {
-    return this.getOrCreateInstrument('observableUpDownCounter', name, () =>
-      this.meter.createObservableUpDownCounter<TAttributes>(name, opts),
+    return this.getOrCreateInstrument(
+      'observableUpDownCounter',
+      name,
+      opts,
+      () => this.meter.createObservableUpDownCounter<TAttributes>(name, opts),
     );
   }
 
@@ -155,7 +198,7 @@ export class DefaultMetricsService implements MetricsService {
     name: string,
     opts?: MetricOptions,
   ): MetricsServiceObservableGauge<TAttributes> {
-    return this.getOrCreateInstrument('observableGauge', name, () =>
+    return this.getOrCreateInstrument('observableGauge', name, opts, () =>
       this.meter.createObservableGauge<TAttributes>(name, opts),
     );
   }

--- a/packages/backend-defaults/src/alpha/entrypoints/metrics/metricsServiceFactory.test.ts
+++ b/packages/backend-defaults/src/alpha/entrypoints/metrics/metricsServiceFactory.test.ts
@@ -45,6 +45,7 @@ describe('metricsServiceFactory', () => {
       name: 'backstage-plugin-my-plugin',
       version: undefined,
       schemaUrl: undefined,
+      logger: expect.anything(),
     });
   });
 
@@ -74,6 +75,7 @@ describe('metricsServiceFactory', () => {
       name: 'custom-metrics-name',
       version: undefined,
       schemaUrl: undefined,
+      logger: expect.anything(),
     });
   });
 
@@ -105,6 +107,7 @@ describe('metricsServiceFactory', () => {
       name: 'my-plugin-metrics',
       version: '1.2.3',
       schemaUrl: 'https://example.com/schema',
+      logger: expect.anything(),
     });
   });
 
@@ -117,6 +120,7 @@ describe('metricsServiceFactory', () => {
       name: 'backstage-plugin-test-plugin',
       version: undefined,
       schemaUrl: undefined,
+      logger: expect.anything(),
     });
 
     expect(subject.createCounter).toBeDefined();

--- a/packages/backend-defaults/src/alpha/entrypoints/metrics/metricsServiceFactory.ts
+++ b/packages/backend-defaults/src/alpha/entrypoints/metrics/metricsServiceFactory.ts
@@ -31,8 +31,9 @@ export const metricsServiceFactory = createServiceFactory({
   deps: {
     config: coreServices.rootConfig,
     pluginMetadata: coreServices.pluginMetadata,
+    logger: coreServices.rootLogger,
   },
-  factory: ({ config, pluginMetadata }) => {
+  factory: ({ config, pluginMetadata, logger }) => {
     const pluginId = pluginMetadata.getId();
 
     const meterConfig = config.getOptionalConfig(
@@ -43,6 +44,6 @@ export const metricsServiceFactory = createServiceFactory({
     const version = meterConfig?.getOptionalString('version');
     const schemaUrl = meterConfig?.getOptionalString('schemaUrl');
 
-    return DefaultMetricsService.create({ name, version, schemaUrl });
+    return DefaultMetricsService.create({ name, version, schemaUrl, logger });
   },
 });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes #33741.

`DefaultMetricsService` creates a distinct OpenTelemetry Meter (Instrumentation Scope) per plugin via `metrics.getMeter(opts.name, ...)`. When two plugins register an instrument with the same metric name (e.g. `backend_tasks_task_runs_count_total`), the Prometheus exporter emits one `# HELP`/`# TYPE` block per scope for that name. That produces duplicate HELP lines for a single metric name, which violates the Prometheus text exposition format and causes some Prometheus scrapers to reject the whole `/metrics` payload with `second HELP line for metric name "..."`.

This PR caches instruments in `DefaultMetricsService` by `kind:name`, so a given metric name always resolves to the same underlying instrument regardless of which plugin's meter creates it first. Different instrument kinds (e.g. a `counter` and a `gauge`) sharing a name are still kept separate.

Posted the approach on the issue first (https://github.com/backstage/backstage/issues/33741#issuecomment-5480320654) - opening as a draft in case there's a preferred direction, since a maintainer had mentioned looking into this.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
