### PR TITLE
ci: stop Chromatic from snapshotting every master push

### DIFF
--- a/.github/workflows/verify_chromatic-noop.yml
+++ b/.github/workflows/verify_chromatic-noop.yml
@@ -8,6 +8,7 @@ on:
       - '.github/workflows/verify_chromatic.yml'
       - '.storybook/**'
       - 'packages/ui/src/**'
+      - 'plugins/app/src/**'
       - '**/*.stories.tsx'
 
 permissions:

--- a/.github/workflows/verify_chromatic.yml
+++ b/.github/workflows/verify_chromatic.yml
@@ -1,15 +1,22 @@
 name: Chromatic
 on:
-  # NOTE: If you change these you must update verify_storybook-noop.yml as well
+  # NOTE: If you change these you must update verify_chromatic-noop.yml as well
   workflow_dispatch:
   push:
     branches:
       - master
+    paths:
+      - '.github/workflows/verify_chromatic.yml'
+      - '.storybook/**'
+      - 'packages/ui/src/**'
+      - 'plugins/app/src/**'
+      - '**/*.stories.tsx'
   pull_request:
     paths:
       - '.github/workflows/verify_chromatic.yml'
       - '.storybook/**'
-      - 'packages/ui/**'
+      - 'packages/ui/src/**'
+      - 'plugins/app/src/**'
       - '**/*.stories.tsx'
 
 jobs:
@@ -57,8 +64,10 @@ jobs:
           # https://www.chromatic.com/docs/custom-ci-provider#run-chromatic-on-external-forks-of-open-source-projects
           projectToken: chpt_dab72dc0f97d55b
           storybookBuildDir: dist-storybook
-          autoAcceptChanges: master
           onlyChanged: true
+          # After a PR is merged (including squash merges), accept the master
+          # build as the new baseline. PR builds still require visual review.
+          autoAcceptChanges: master
           externals: |
             packages/ui/**/*.css
             packages/ui/css/**


### PR DESCRIPTION
## Summary
- Chromatic was running on **every** push to `master` (no path filters), which billed snapshots for unrelated merges, docs, plugins, and version bumps.
- Master and PR workflows now share the same path filters (`packages/ui/src/**`, `plugins/app/src/**`, `.storybook/**`, stories) so Chromatic only runs when visual-relevant files change.
- Master still auto-accepts (`autoAcceptChanges: master`) so squash merges update the visual baseline; PRs still require review.

## Hey, I just made a Pull Request!

Chromatic snapshot usage for Backstage UI has grown because the workflow captured a build on every `master` commit. This keeps the intended flow (review on PRs, seal the baseline on master) but stops master from snapshotting the whole monorepo.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets)) — not required (`.github/` only)
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))

## Test plan
- [ ] Confirm this PR itself triggers Chromatic (workflow file is in the path filter)
- [ ] After merge, confirm a non-UI master commit (e.g. docs or a backend plugin) does **not** start the Chromatic workflow
- [ ] Confirm a `packages/ui/src` change still runs Chromatic on the PR and again on master, with the master build auto-accepted
- [ ] Confirm unrelated PRs still get the Chromatic noop required check