### PR TITLE
fix(ui): correct useTable pagination state

### DIFF
--- a/.changeset/tidy-tables-rest.md
+++ b/.changeset/tidy-tables-rest.md
@@ -1,0 +1,7 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed pagination state handling in `useTable`, including initial offsets, shrinking complete datasets, controlled loading transitions, valid zero and empty cursors, cached error recovery, immediately resolving reloads, and unnecessary reloads when controlled callback identities change.
+
+**Affected components:** `useTable`

--- a/packages/ui/report.api.md
+++ b/packages/ui/report.api.md
@@ -2971,7 +2971,6 @@ export interface PaginationOptions
       | 'showPaginationLabel'
     >
   > {
-  // (undocumented)
   initialOffset?: number;
 }
 

--- a/packages/ui/src/components/Table/hooks/types.ts
+++ b/packages/ui/src/components/Table/hooks/types.ts
@@ -133,7 +133,8 @@ export type UseTableCompleteOptions<
     | {
         /**
          * Controlled table data. Set to `undefined` while loading new data;
-         * the previous data remains visible and is reported as stale.
+         * the previous data and pagination metadata remain visible and are
+         * reported as stale.
          */
         data: T[] | undefined;
         getData?: never;

--- a/packages/ui/src/components/Table/hooks/types.ts
+++ b/packages/ui/src/components/Table/hooks/types.ts
@@ -59,6 +59,12 @@ export interface PaginationOptions
       | 'showPaginationLabel'
     >
   > {
+  /**
+   * The zero-based item offset to use for the initial page.
+   *
+   * In complete mode, the offset is adjusted to the last available page if
+   * the data later becomes too short for the current page.
+   */
   initialOffset?: number;
 }
 
@@ -125,6 +131,10 @@ export type UseTableCompleteOptions<
   filterDebounceMs?: number;
 } & (
     | {
+        /**
+         * Controlled table data. Set to `undefined` while loading new data;
+         * the previous data remains visible and is reported as stale.
+         */
         data: T[] | undefined;
         getData?: never;
       }

--- a/packages/ui/src/components/Table/hooks/useCompletePagination.ts
+++ b/packages/ui/src/components/Table/hooks/useCompletePagination.ts
@@ -153,20 +153,27 @@ export function useCompletePagination<T extends TableItem, TFilter>(
     sortFn,
   ]);
 
-  const totalCount = processedData?.length ?? 0;
+  const previousProcessedDataRef = useRef(processedData);
+  if (processedData !== undefined) {
+    previousProcessedDataRef.current = processedData;
+  }
+  const retainedProcessedData =
+    processedData ?? previousProcessedDataRef.current;
+
+  const totalCount = retainedProcessedData?.length ?? 0;
 
   const effectiveOffset = useMemo(() => {
     if (noPagination) {
       return 0;
     }
-    if (processedData === undefined) {
+    if (retainedProcessedData === undefined) {
       return offset;
     }
     if (totalCount === 0) {
       return 0;
     }
     return Math.min(offset, Math.floor((totalCount - 1) / pageSize) * pageSize);
-  }, [noPagination, offset, pageSize, processedData, totalCount]);
+  }, [noPagination, offset, pageSize, retainedProcessedData, totalCount]);
 
   // Persist the corrected offset so later data growth does not restore it.
   useEffect(() => {
@@ -179,9 +186,12 @@ export function useCompletePagination<T extends TableItem, TFilter>(
   const paginatedData = useMemo(
     () =>
       noPagination
-        ? processedData
-        : processedData?.slice(effectiveOffset, effectiveOffset + pageSize),
-    [processedData, effectiveOffset, pageSize, noPagination],
+        ? retainedProcessedData
+        : retainedProcessedData?.slice(
+            effectiveOffset,
+            effectiveOffset + pageSize,
+          ),
+    [retainedProcessedData, effectiveOffset, pageSize, noPagination],
   );
 
   const hasNextPage = !noPagination && effectiveOffset + pageSize < totalCount;

--- a/packages/ui/src/components/Table/hooks/useCompletePagination.ts
+++ b/packages/ui/src/components/Table/hooks/useCompletePagination.ts
@@ -59,9 +59,13 @@ export function useCompletePagination<T extends TableItem, TFilter>(
   const [pageSize, setPageSize] = useState(defaultPageSize);
 
   // Sync pageSize when the caller changes paginationOptions.pageSize
+  const previousDefaultPageSize = useRef(defaultPageSize);
   useEffect(() => {
-    setPageSize(defaultPageSize);
-    setOffset(0);
+    if (previousDefaultPageSize.current !== defaultPageSize) {
+      previousDefaultPageSize.current = defaultPageSize;
+      setPageSize(defaultPageSize);
+      setOffset(0);
+    }
   }, [defaultPageSize]);
 
   // Load data on mount and when loadCount changes (reload trigger)
@@ -72,6 +76,7 @@ export function useCompletePagination<T extends TableItem, TFilter>(
     }
 
     if (!hasGetData) {
+      setIsPending(true);
       return;
     }
 
@@ -150,29 +155,49 @@ export function useCompletePagination<T extends TableItem, TFilter>(
 
   const totalCount = processedData?.length ?? 0;
 
+  const effectiveOffset = useMemo(() => {
+    if (noPagination) {
+      return 0;
+    }
+    if (processedData === undefined) {
+      return offset;
+    }
+    if (totalCount === 0) {
+      return 0;
+    }
+    return Math.min(offset, Math.floor((totalCount - 1) / pageSize) * pageSize);
+  }, [noPagination, offset, pageSize, processedData, totalCount]);
+
+  // Persist the corrected offset so later data growth does not restore it.
+  useEffect(() => {
+    if (offset !== effectiveOffset) {
+      setOffset(effectiveOffset);
+    }
+  }, [effectiveOffset, offset]);
+
   // Paginate the processed data
   const paginatedData = useMemo(
     () =>
       noPagination
         ? processedData
-        : processedData?.slice(offset, offset + pageSize),
-    [processedData, offset, pageSize, noPagination],
+        : processedData?.slice(effectiveOffset, effectiveOffset + pageSize),
+    [processedData, effectiveOffset, pageSize, noPagination],
   );
 
-  const hasNextPage = !noPagination && offset + pageSize < totalCount;
-  const hasPreviousPage = !noPagination && offset > 0;
+  const hasNextPage = !noPagination && effectiveOffset + pageSize < totalCount;
+  const hasPreviousPage = !noPagination && effectiveOffset > 0;
 
   const onNextPage = useCallback(() => {
-    if (offset + pageSize < totalCount) {
-      setOffset(offset + pageSize);
+    if (effectiveOffset + pageSize < totalCount) {
+      setOffset(effectiveOffset + pageSize);
     }
-  }, [offset, pageSize, totalCount]);
+  }, [effectiveOffset, pageSize, totalCount]);
 
   const onPreviousPage = useCallback(() => {
-    if (offset > 0) {
-      setOffset(Math.max(0, offset - pageSize));
+    if (effectiveOffset > 0) {
+      setOffset(Math.max(0, effectiveOffset - pageSize));
     }
-  }, [offset, pageSize]);
+  }, [effectiveOffset, pageSize]);
 
   const onPageSizeChange = useCallback((newSize: number) => {
     setPageSize(newSize);
@@ -189,7 +214,7 @@ export function useCompletePagination<T extends TableItem, TFilter>(
     isPending: isPending,
     error,
     totalCount,
-    offset,
+    offset: effectiveOffset,
     pageSize,
     hasNextPage,
     hasPreviousPage,

--- a/packages/ui/src/components/Table/hooks/useDebouncedReload.ts
+++ b/packages/ui/src/components/Table/hooks/useDebouncedReload.ts
@@ -28,15 +28,21 @@ export function useDebouncedReload<TFilter>(
   reload: () => void,
   delay: number = 200,
 ): void {
-  const prevDepsRef = useRef({ query, pageSize });
+  const { sort, filter, search } = query;
+  const prevDepsRef = useRef({ sort, filter, search, pageSize });
 
   useEffect(() => {
     const prev = prevDepsRef.current;
-    if (prev.query !== query || prev.pageSize !== pageSize) {
-      prevDepsRef.current = { query, pageSize };
+    if (
+      prev.sort !== sort ||
+      prev.filter !== filter ||
+      prev.search !== search ||
+      prev.pageSize !== pageSize
+    ) {
+      prevDepsRef.current = { sort, filter, search, pageSize };
       const timer = setTimeout(reload, delay);
       return () => clearTimeout(timer);
     }
     return undefined;
-  }, [query, pageSize, reload, delay]);
+  }, [sort, filter, search, pageSize, reload, delay]);
 }

--- a/packages/ui/src/components/Table/hooks/usePageCache.ts
+++ b/packages/ui/src/components/Table/hooks/usePageCache.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { useState, useCallback, useRef, useEffect } from 'react';
+import { useState, useCallback, useRef, useEffect, useReducer } from 'react';
 
 const FIRST_PAGE_CURSOR = Symbol('firstPage');
 
@@ -152,6 +152,7 @@ export function usePageCache<T, TCursor extends CursorType = string>(
   const [isPending, setIsPending] = useState(true);
   const [error, setError] = useState<Error | undefined>(undefined);
   const [totalCount, setTotalCount] = useState<number | undefined>(undefined);
+  const [, notifyCacheUpdate] = useReducer(version => version + 1, 0);
 
   const abortControllerRef = useRef<AbortController | null>(null);
 
@@ -168,13 +169,14 @@ export function usePageCache<T, TCursor extends CursorType = string>(
         initialCurrentCursor,
       );
 
-      if (!targetCursor) {
+      if (targetCursor === undefined) {
         return;
       }
 
       const existingEntry = cacheStore.get(targetCursor);
       if (existingEntry?.data !== undefined) {
         setCurrentCursor(targetCursor);
+        setError(undefined);
         return;
       }
 
@@ -215,6 +217,7 @@ export function usePageCache<T, TCursor extends CursorType = string>(
           setTotalCount(result.totalCount);
         }
 
+        notifyCacheUpdate();
         setIsPending(false);
       } catch (err) {
         if (abortController.signal.aborted) {
@@ -241,14 +244,14 @@ export function usePageCache<T, TCursor extends CursorType = string>(
   const onNextPage = useCallback(() => {
     if (isPending) return;
     const page = cacheStore.get(currentCursor);
-    if (!page?.nextCursor) return;
+    if (page?.nextCursor === undefined) return;
     goToPage('next');
   }, [isPending, currentCursor, goToPage, cacheStore]);
 
   const onPreviousPage = useCallback(() => {
     if (isPending) return;
     const page = cacheStore.get(currentCursor);
-    if (!page?.prevCursor) return;
+    if (page?.prevCursor === undefined) return;
     goToPage('prev');
   }, [isPending, currentCursor, goToPage, cacheStore]);
 

--- a/packages/ui/src/components/Table/hooks/useTable.test.tsx
+++ b/packages/ui/src/components/Table/hooks/useTable.test.tsx
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { PagePagination, SortDescriptor } from '../types';
+import type { CursorParams, OffsetParams, UseTableResult } from './types';
+import { useTable } from './useTable';
+
+interface Item {
+  id: number;
+}
+
+const items = Array.from({ length: 25 }, (_, id) => ({ id }));
+
+function getPagination(result: UseTableResult<Item, unknown>): PagePagination {
+  if (result.tableProps.pagination.type !== 'page') {
+    throw new Error('Expected page pagination');
+  }
+  return result.tableProps.pagination;
+}
+
+function createOffsetGetData(source: Item[]) {
+  return jest.fn(async ({ offset, pageSize }: OffsetParams<unknown>) => ({
+    data: source.slice(offset, offset + pageSize),
+    totalCount: source.length,
+  }));
+}
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe('useTable', () => {
+  it('honors the initial offset in complete mode', () => {
+    const { result } = renderHook(() =>
+      useTable<Item>({
+        mode: 'complete',
+        data: items,
+        paginationOptions: { pageSize: 10, initialOffset: 10 },
+      }),
+    );
+
+    expect(result.current.tableProps.data?.map(item => item.id)).toEqual([
+      10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+    ]);
+    expect(result.current.tableProps.pagination).toMatchObject({ offset: 10 });
+  });
+
+  it('reports retained controlled data as pending when data becomes undefined', () => {
+    const { result, rerender } = renderHook(
+      ({ data }: { data: Item[] | undefined }) =>
+        useTable<Item>({
+          mode: 'complete',
+          data,
+          paginationOptions: { pageSize: 10 },
+        }),
+      { initialProps: { data: items as Item[] | undefined } },
+    );
+
+    act(() => getPagination(result.current).onNextPage());
+    rerender({ data: undefined });
+
+    expect(result.current.tableProps.data?.map(item => item.id)).toEqual(
+      Array.from({ length: 10 }, (_, id) => id + 10),
+    );
+    expect(result.current.tableProps.isPending).toBe(true);
+    expect(result.current.tableProps.isStale).toBe(true);
+    expect(getPagination(result.current).offset).toBe(10);
+  });
+
+  it('persists a valid offset when complete data shrinks', () => {
+    const { result, rerender } = renderHook(
+      ({ data }: { data: Item[] }) =>
+        useTable<Item>({
+          mode: 'complete',
+          data,
+          paginationOptions: { pageSize: 10 },
+        }),
+      { initialProps: { data: items } },
+    );
+
+    act(() => getPagination(result.current).onNextPage());
+    act(() => getPagination(result.current).onNextPage());
+
+    rerender({ data: items.slice(0, 15) });
+    expect(result.current.tableProps.pagination).toMatchObject({ offset: 10 });
+    expect(result.current.tableProps.data?.map(item => item.id)).toEqual([
+      10, 11, 12, 13, 14,
+    ]);
+
+    rerender({ data: items });
+    expect(result.current.tableProps.pagination).toMatchObject({ offset: 10 });
+  });
+
+  it('navigates to offset zero from an initial offset', async () => {
+    const getData = createOffsetGetData(items);
+    const { result } = renderHook(() =>
+      useTable<Item>({
+        mode: 'offset',
+        getData,
+        paginationOptions: { pageSize: 10, initialOffset: 10 },
+      }),
+    );
+
+    await waitFor(() =>
+      expect(result.current.tableProps.isPending).toBe(false),
+    );
+    act(() => getPagination(result.current).onPreviousPage());
+
+    await waitFor(() =>
+      expect(result.current.tableProps.data?.[0]?.id).toBe(0),
+    );
+    expect(getPagination(result.current)).toMatchObject({
+      offset: 0,
+      hasPreviousPage: false,
+    });
+  });
+
+  it('navigates with an empty string cursor', async () => {
+    const getData = jest.fn(async ({ cursor }: CursorParams<unknown>) => ({
+      data: cursor === undefined ? items.slice(0, 10) : items.slice(10, 20),
+      nextCursor: cursor === undefined ? '' : undefined,
+      totalCount: items.length,
+    }));
+    const { result } = renderHook(() =>
+      useTable<Item>({ mode: 'cursor', getData }),
+    );
+
+    await waitFor(() =>
+      expect(result.current.tableProps.isPending).toBe(false),
+    );
+    act(() => getPagination(result.current).onNextPage());
+
+    await waitFor(() =>
+      expect(result.current.tableProps.data?.[0]?.id).toBe(10),
+    );
+  });
+
+  it('renders cache updates from immediately resolving reloads', async () => {
+    let source = items;
+    const getData = jest.fn(
+      async ({ offset, pageSize }: OffsetParams<unknown>) => ({
+        data: source.slice(offset, offset + pageSize),
+        totalCount: source.length,
+      }),
+    );
+    const { result } = renderHook(() =>
+      useTable<Item>({ mode: 'offset', getData }),
+    );
+
+    await waitFor(() =>
+      expect(result.current.tableProps.isPending).toBe(false),
+    );
+    source = items.map(item => ({ id: item.id + 100 }));
+    await act(async () => {
+      result.current.reload();
+      await Promise.resolve();
+    });
+
+    expect(result.current.tableProps.data?.[0]?.id).toBe(100);
+  });
+
+  it('recovers from a failed page after returning to cached data', async () => {
+    let failSecondPage = true;
+    const getData = jest.fn(
+      async ({ offset, pageSize }: OffsetParams<unknown>) => {
+        if (offset === 10 && failSecondPage) {
+          throw new Error('page failed');
+        }
+        return {
+          data: items.slice(offset, offset + pageSize),
+          totalCount: items.length,
+        };
+      },
+    );
+    const { result } = renderHook(() =>
+      useTable<Item>({
+        mode: 'offset',
+        getData,
+        paginationOptions: { pageSize: 10 },
+      }),
+    );
+
+    await waitFor(() =>
+      expect(result.current.tableProps.isPending).toBe(false),
+    );
+    act(() => getPagination(result.current).onNextPage());
+    await waitFor(() =>
+      expect(result.current.tableProps.error?.message).toBe('page failed'),
+    );
+
+    act(() => getPagination(result.current).onPreviousPage());
+    expect(result.current.tableProps.error).toBeUndefined();
+    expect(result.current.tableProps.data?.[0]?.id).toBe(0);
+
+    failSecondPage = false;
+    act(() => getPagination(result.current).onNextPage());
+    await waitFor(() =>
+      expect(result.current.tableProps.data?.[0]?.id).toBe(10),
+    );
+  });
+
+  it('does not reload when controlled callback identities change', async () => {
+    const getData = createOffsetGetData(items);
+    const { result, rerender } = renderHook(
+      ({ onSortChange }: { onSortChange: (sort: SortDescriptor) => void }) =>
+        useTable<Item>({ mode: 'offset', getData, onSortChange }),
+      { initialProps: { onSortChange: jest.fn() } },
+    );
+
+    await waitFor(() =>
+      expect(result.current.tableProps.isPending).toBe(false),
+    );
+    jest.useFakeTimers();
+    rerender({ onSortChange: jest.fn() });
+
+    act(() => jest.advanceTimersByTime(250));
+    expect(getData).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/src/components/Table/hooks/useTable.test.tsx
+++ b/packages/ui/src/components/Table/hooks/useTable.test.tsx
@@ -78,7 +78,12 @@ describe('useTable', () => {
     );
     expect(result.current.tableProps.isPending).toBe(true);
     expect(result.current.tableProps.isStale).toBe(true);
-    expect(getPagination(result.current).offset).toBe(10);
+    expect(getPagination(result.current)).toMatchObject({
+      offset: 10,
+      totalCount: 25,
+      hasNextPage: true,
+      hasPreviousPage: true,
+    });
   });
 
   it('persists a valid offset when complete data shrinks', () => {


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes several pagination state edge cases in `useTable`, including initial offsets, shrinking complete datasets, controlled loading transitions, falsey cursors, cached error recovery, immediately resolving reloads, and unnecessary reloads caused by controlled callback identity changes.

This is a focused continuation of the investigation and fixes originally contributed by @XenKloud in #35217. This PR narrows that proposal to `useTable` pagination correctness and adds focused regression coverage.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
