### PR TITLE
fix(ui): synchronize table page size selection

### DIFF
--- a/.changeset/calm-tables-select.md
+++ b/.changeset/calm-tables-select.md
@@ -1,0 +1,7 @@
+---
+'@backstage/ui': patch
+---
+
+Fixed `TablePagination` page-size controls to stay synchronized with controlled values and handle empty option lists without crashing.
+
+**Affected components:** `TablePagination`

--- a/docs-ui/src/app/components/table/props-definition.tsx
+++ b/docs-ui/src/app/components/table/props-definition.tsx
@@ -61,7 +61,8 @@ export const useTableOptionsPropDefs: Record<string, PropDef> = {
         },
         pageSizeOptions: {
           type: 'number[]',
-          description: 'Available page size options for the dropdown.',
+          description:
+            'Available page size options for the dropdown. Pass an empty array to hide the dropdown.',
         },
         initialOffset: {
           type: 'number',
@@ -422,12 +423,14 @@ export const cellProfilePropDefs: Record<string, PropDef> = {
 export const tablePaginationPropDefs: Record<string, PropDef> = {
   pageSize: {
     type: 'number',
-    description: 'Number of items per page.',
+    description:
+      'Controlled number of items per page. Update this value in response to `onPageSizeChange`.',
   },
   pageSizeOptions: {
     type: 'enum',
     values: ['number[]'],
-    description: 'Available page size options for the dropdown.',
+    description:
+      'Available page size options for the dropdown. Pass an empty array to hide the dropdown.',
   },
   offset: {
     type: 'number',

--- a/packages/ui/src/components/Table/hooks/getEffectivePageSize.ts
+++ b/packages/ui/src/components/Table/hooks/getEffectivePageSize.ts
@@ -29,7 +29,7 @@ export function getEffectivePageSize(
 ): number {
   const { pageSize, pageSizeOptions } = paginationOptions;
 
-  if (!pageSizeOptions) {
+  if (!pageSizeOptions?.length) {
     return pageSize ?? DEFAULT_PAGE_SIZE;
   }
 

--- a/packages/ui/src/components/Table/hooks/useTable.test.tsx
+++ b/packages/ui/src/components/Table/hooks/useTable.test.tsx
@@ -44,6 +44,36 @@ afterEach(() => {
 });
 
 describe('useTable', () => {
+  it('uses the supplied or default page size when options are empty', () => {
+    const suppliedPageSize = renderHook(() =>
+      useTable<Item>({
+        mode: 'complete',
+        data: items,
+        paginationOptions: { pageSize: 10, pageSizeOptions: [] },
+      }),
+    );
+
+    expect(getPagination(suppliedPageSize.result.current)).toMatchObject({
+      pageSize: 10,
+      pageSizeOptions: [],
+    });
+    expect(suppliedPageSize.result.current.tableProps.data).toHaveLength(10);
+
+    const defaultPageSize = renderHook(() =>
+      useTable<Item>({
+        mode: 'complete',
+        data: items,
+        paginationOptions: { pageSizeOptions: [] },
+      }),
+    );
+
+    expect(getPagination(defaultPageSize.result.current)).toMatchObject({
+      pageSize: 20,
+      pageSizeOptions: [],
+    });
+    expect(defaultPageSize.result.current.tableProps.data).toHaveLength(20);
+  });
+
   it('honors the initial offset in complete mode', () => {
     const { result } = renderHook(() =>
       useTable<Item>({

--- a/packages/ui/src/components/TablePagination/TablePagination.test.tsx
+++ b/packages/ui/src/components/TablePagination/TablePagination.test.tsx
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { TablePagination } from '.';
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('TablePagination', () => {
+  it('keeps the page size select in sync with the pageSize prop', () => {
+    const onPageSizeChange = jest.fn();
+    const { rerender } = render(
+      <TablePagination
+        pageSize={10}
+        offset={0}
+        totalCount={25}
+        hasNextPage
+        hasPreviousPage={false}
+        onNextPage={jest.fn()}
+        onPreviousPage={jest.fn()}
+        onPageSizeChange={onPageSizeChange}
+      />,
+    );
+
+    const select = screen.getByRole('button', {
+      name: /Select table page size/,
+    });
+    expect(select).toHaveTextContent('Show 10 results');
+
+    rerender(
+      <TablePagination
+        pageSize={20}
+        offset={0}
+        totalCount={25}
+        hasNextPage
+        hasPreviousPage={false}
+        onNextPage={jest.fn()}
+        onPreviousPage={jest.fn()}
+        onPageSizeChange={onPageSizeChange}
+      />,
+    );
+
+    expect(select).toHaveTextContent('Show 20 results');
+
+    fireEvent.click(select);
+    fireEvent.click(screen.getByRole('option', { name: 'Show 5 results' }));
+    expect(onPageSizeChange).toHaveBeenCalledWith(5);
+    expect(select).toHaveTextContent('Show 20 results');
+  });
+
+  it('renders pagination without a page size select when options are empty', () => {
+    render(
+      <TablePagination
+        pageSize={10}
+        pageSizeOptions={[]}
+        offset={0}
+        totalCount={25}
+        hasNextPage
+        hasPreviousPage={false}
+        onNextPage={jest.fn()}
+        onPreviousPage={jest.fn()}
+        onPageSizeChange={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText('1 - 10 of 25')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Next table page' }),
+    ).toBeEnabled();
+    expect(
+      screen.queryByRole('button', { name: /Select table page size/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('falls back to the first option when pageSize is unavailable', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    render(
+      <TablePagination
+        pageSize={7}
+        pageSizeOptions={[10, 25, 50]}
+        offset={0}
+        totalCount={25}
+        hasNextPage
+        hasPreviousPage={false}
+        onNextPage={jest.fn()}
+        onPreviousPage={jest.fn()}
+        onPageSizeChange={jest.fn()}
+      />,
+    );
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('pageSize 7 is not in pageSizeOptions'),
+    );
+    expect(
+      screen.getByRole('button', { name: /Select table page size/ }),
+    ).toHaveTextContent('Show 10 results');
+    expect(screen.getByText('1 - 10 of 25')).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/TablePagination/TablePagination.tsx
+++ b/packages/ui/src/components/TablePagination/TablePagination.tsx
@@ -76,6 +76,9 @@ export function TablePagination(props: TablePaginationProps) {
   );
 
   const effectivePageSize = useMemo(() => {
+    if (pageSizeOptions.length === 0) {
+      return pageSize;
+    }
     const isValid = pageSizeOptions.some(
       opt => getOptionValue(opt) === pageSize,
     );
@@ -105,7 +108,7 @@ export function TablePagination(props: TablePaginationProps) {
   return (
     <div className={classes.root}>
       <div className={classes.left}>
-        {showPageSizeOptions && (
+        {showPageSizeOptions && normalizedOptions.length > 0 && (
           <Select
             name="pageSize"
             size="small"
@@ -114,7 +117,7 @@ export function TablePagination(props: TablePaginationProps) {
               label: opt.label,
               value: String(opt.value),
             }))}
-            defaultValue={effectivePageSize.toString()}
+            value={effectivePageSize.toString()}
             onChange={value => {
               const newPageSize = Number(value);
               onPageSizeChange?.(newPageSize);

--- a/packages/ui/src/components/TablePagination/types.ts
+++ b/packages/ui/src/components/TablePagination/types.ts
@@ -22,7 +22,9 @@ export interface PageSizeOption {
 
 /** @public */
 export type TablePaginationOwnProps = {
+  /** The controlled number of rows displayed per page. */
   pageSize: number;
+  /** Available page sizes. An empty array hides the page-size selector. */
   pageSizeOptions?: number[] | PageSizeOption[];
   offset?: number;
   totalCount?: number;


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes two `TablePagination` page-size behaviors:

- Keeps the visible page-size selection synchronized with the controlled `pageSize` prop after mount.
- Handles an empty `pageSizeOptions` array without crashing by hiding the selector while preserving pagination labels and navigation.

Selecting a page size still calls `onPageSizeChange`; the displayed selection updates when the parent supplies the new `pageSize`. The behavior is documented in both the public types and `docs-ui`.

This is a focused continuation of the investigation and fixes originally contributed by @XenKloud in #35217.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
