### PR TITLE
fix(mcp): always serve the default /v1 server alongside named servers

### DIFF
--- a/.changeset/mcp-actions-default-server-leftovers.md
+++ b/.changeset/mcp-actions-default-server-leftovers.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-mcp-actions-backend': patch
+---
+
+The default MCP server at `/api/mcp-actions/v1` is now always exposed. Previously, configuring `mcpActions.servers` replaced it, so the default endpoint was no longer served once a single named server was added. Named servers are now subsets of the default one, which continues to expose every registered action, so the same action can be exposed both there and on as many named servers as you like.

--- a/docs/ai/mcp-actions.md
+++ b/docs/ai/mcp-actions.md
@@ -111,7 +111,7 @@ This creates two MCP server endpoints:
 
 Each server uses include filter rules with glob patterns on action IDs to control which actions are exposed. For example, `id: 'catalog:*'` matches all actions registered by the catalog plugin.
 
-When `mcpActions.servers` is not configured, the plugin behaves exactly as before with a single server at `/api/mcp-actions/v1`.
+The default server at `/api/mcp-actions/v1` is always available and always exposes every registered action, whether or not `mcpActions.servers` is configured. Named servers are subsets of it, so an action can be exposed on the default server and on any number of named servers at the same time.
 
 ### Filter Rules
 

--- a/plugins/mcp-actions-backend/config.d.ts
+++ b/plugins/mcp-actions-backend/config.d.ts
@@ -59,7 +59,8 @@ export interface Config {
 
     /**
      * Named MCP servers, each exposed at /api/mcp-actions/v1/{key}.
-     * When not configured, the plugin serves a single server at /api/mcp-actions/v1.
+     * These are subsets of the default server at /api/mcp-actions/v1, which is
+     * always exposed and always serves every registered action.
      */
     servers?: {
       [serverKey: string]: {

--- a/plugins/mcp-actions-backend/src/plugin.test.ts
+++ b/plugins/mcp-actions-backend/src/plugin.test.ts
@@ -267,6 +267,67 @@ describe('Mcp Backend', () => {
         'scaffolder-actions.create-app',
       );
     });
+
+    it('should keep serving every action on /v1 when named servers are configured', async () => {
+      const { server } = await startTestBackend({
+        features: [
+          mcpPlugin,
+          mockCatalogPlugin,
+          mockScaffolderPlugin,
+          metricsServiceMock.mock().factory,
+          tracingServiceMock.mock().factory,
+          mockServices.rootConfig.factory({
+            data: {
+              backend: {
+                actions: {
+                  pluginSources: ['catalog-actions', 'scaffolder-actions'],
+                },
+              },
+              mcpActions: {
+                servers: {
+                  catalog: {
+                    name: 'Catalog Server',
+                    filter: {
+                      include: [{ id: 'catalog-actions:*' }],
+                    },
+                  },
+                },
+              },
+            },
+          }),
+        ],
+      });
+
+      const address = server.address();
+      if (typeof address !== 'object' || !('port' in address!)) {
+        throw new Error('server broke');
+      }
+      const serverAddress = `http://localhost:${address.port}`;
+
+      const listTools = async (path: string) => {
+        const client = new Client({ name: 'test', version: '1.0' });
+        await client.connect(
+          new StreamableHTTPClientTransport(new URL(serverAddress + path)),
+        );
+        const result = await client.request(
+          { method: 'tools/list' },
+          ListToolsResultSchema,
+        );
+        return result.tools.map(tool => tool.name);
+      };
+
+      await expect(listTools('/api/mcp-actions/v1')).resolves.toEqual([
+        'catalog-actions.get-entity',
+        'scaffolder-actions.create-app',
+      ]);
+
+      // The named server is a subset of the default one, and since the default
+      // is mounted last and Express matches `use` prefixes, this also guards
+      // against /v1 swallowing /v1/catalog.
+      await expect(listTools('/api/mcp-actions/v1/catalog')).resolves.toEqual([
+        'catalog-actions.get-entity',
+      ]);
+    });
   });
 
   describe('OAuth well-known endpoints', () => {
@@ -379,14 +440,16 @@ describe('Mcp Backend', () => {
     });
 
     const pathTestCases = [
-      { name: 'auth', suffix: '/v1/auth' },
-      { name: 'catalog', suffix: '/v1/catalog' },
-      { name: 'scaffolder', suffix: '/v1/scaffolder' },
+      { name: 'the default server', suffix: '/v1', status: 200 },
+      { name: 'auth', suffix: '/v1/auth', status: 200 },
+      { name: 'catalog', suffix: '/v1/catalog', status: 200 },
+      { name: 'scaffolder', suffix: '/v1/scaffolder', status: 200 },
+      { name: 'an unknown server', suffix: '/v1/unknown', status: 404 },
     ];
 
     it.each(pathTestCases)(
-      'should expose dynamic oauth-protected-resource for $name',
-      async ({ suffix }) => {
+      'should respond to oauth-protected-resource for $name',
+      async ({ suffix, status }) => {
         const mockExternalBaseUrl = 'http://external.local:0/api';
         const mockDiscovery = mockServices.discovery.mock({
           getExternalBaseUrl: async pluginId =>
@@ -425,7 +488,11 @@ describe('Mcp Backend', () => {
         const response = await request(server).get(
           `/.well-known/oauth-protected-resource/api/mcp-actions${suffix}`,
         );
-        expect(response.status).toBe(200);
+        expect(response.status).toBe(status);
+        if (status !== 200) {
+          return;
+        }
+
         const expectedResourceRegex = new RegExp(`/api/mcp-actions${suffix}$`);
         expect(response.body.resource).toMatch(expectedResourceRegex);
         expect(response.body.authorization_servers).toHaveLength(1);

--- a/plugins/mcp-actions-backend/src/plugin.ts
+++ b/plugins/mcp-actions-backend/src/plugin.ts
@@ -99,27 +99,31 @@ export const mcpPlugin = createBackendPlugin({
 
             router.use(`/v1/${key}`, streamableRouter);
           }
-        } else {
-          const serverConfig = {
-            name: config.getOptionalString('mcpActions.name') ?? 'backstage',
-            description: config.getOptionalString('mcpActions.description'),
-            instructions: config.getOptionalString('mcpActions.instructions'),
-            includeRules: [],
-            excludeRules: [],
-          };
+        }
 
-          const streamableRouter = createStreamableRouter({
+        // The default server is always mounted and never filtered, so named
+        // servers are subsets of it rather than partitions of it. Mounted last
+        // so that the more specific named server paths match first.
+        const defaultServerConfig = {
+          name: config.getOptionalString('mcpActions.name') ?? 'backstage',
+          description: config.getOptionalString('mcpActions.description'),
+          instructions: config.getOptionalString('mcpActions.instructions'),
+          includeRules: [],
+          excludeRules: [],
+        };
+
+        router.use(
+          '/v1',
+          createStreamableRouter({
             mcpService,
             httpAuth,
             logger,
             metrics,
             tracing,
             auditor,
-            serverConfig,
-          });
-
-          router.use('/v1', streamableRouter);
-        }
+            serverConfig: defaultServerConfig,
+          }),
+        );
 
         httpRouter.use(router);
 
@@ -153,36 +157,39 @@ export const mcpPlugin = createBackendPlugin({
             'auth.experimentalRefreshToken.enabled',
           );
 
-          const serverSuffixes = serverConfigs?.size
-            ? [...serverConfigs.keys()].map(key => `/v1/${key}`)
-            : ['/v1'];
+          // Registered once for the whole /v1 prefix, since the root router
+          // rejects a named server path as conflicting with the default one.
+          // The server is therefore resolved from the remaining path.
+          rootRouter.use(
+            '/.well-known/oauth-protected-resource/api/mcp-actions/v1',
+            async (req, res) => {
+              const key = req.path.replace(/^\/+|\/+$/g, '');
+              if (key && !serverConfigs?.has(key)) {
+                res.status(404).end();
+                return;
+              }
 
-          for (const suffix of serverSuffixes) {
-            const mcpBasePath = `/api/mcp-actions${suffix}`;
+              const [authBaseUrl, mcpBaseUrl] = await Promise.all([
+                discovery.getExternalBaseUrl('auth'),
+                discovery.getExternalBaseUrl('mcp-actions'),
+              ]);
 
-            rootRouter.use(
-              `/.well-known/oauth-protected-resource${mcpBasePath}`,
-              async (_req, res) => {
-                const [authBaseUrl, mcpBaseUrl] = await Promise.all([
-                  discovery.getExternalBaseUrl('auth'),
-                  discovery.getExternalBaseUrl('mcp-actions'),
-                ]);
+              const suffix = key ? `/v1/${key}` : '/v1';
 
-                res.json({
-                  resource: `${mcpBaseUrl}${suffix}`,
-                  authorization_servers: [authBaseUrl],
-                  // RFC 9728 §2: clients discover which scope to request from
-                  // this field. Without it, RFC-compliant MCP clients request
-                  // no scope and never receive a refresh token (OIDC Core §11
-                  // requires offline_access to signal refresh token issuance).
-                  scopes_supported: [
-                    'openid',
-                    ...(refreshTokenEnabled ? ['offline_access'] : []),
-                  ],
-                });
-              },
-            );
-          }
+              res.json({
+                resource: `${mcpBaseUrl}${suffix}`,
+                authorization_servers: [authBaseUrl],
+                // RFC 9728 §2: clients discover which scope to request from
+                // this field. Without it, RFC-compliant MCP clients request
+                // no scope and never receive a refresh token (OIDC Core §11
+                // requires offline_access to signal refresh token issuance).
+                scopes_supported: [
+                  'openid',
+                  ...(refreshTokenEnabled ? ['offline_access'] : []),
+                ],
+              });
+            },
+          );
         }
       },
     });


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Configuring `mcpActions.servers` replaced the default `/api/mcp-actions/v1` server rather than adding to it, so as soon as a single named server was configured the default endpoint was no longer served and requests to it stopped reaching an MCP server.

- The default server is now always exposed, and always serves every registered action. 
- Named servers are subsets of it rather than a partition of it, so the same action can be served by the default server and by any number of named servers at once. 
- Grouping a few plugins' actions into a focused server no longer removes them from the default one.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x ] Added or updated documentation
- [x ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
