### PR TITLE
fix(scaffolder-backend-module-gitlab): stop persisting secrets in checkpoint state

### DIFF
--- a/.changeset/cyan-tigers-exist.md
+++ b/.changeset/cyan-tigers-exist.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-scaffolder-backend-module-gitlab': patch
+---
+
+The `gitlab:projectVariable:create` action no longer includes the variable value in its checkpoint key, preventing secret values from being persisted in scaffolder task state. The `gitlab:pipeline:trigger` action has been refactored so that the temporary pipeline trigger token is never serialized into checkpoint state.

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabPipelineTrigger.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabPipelineTrigger.test.ts
@@ -64,7 +64,7 @@ describe('gitlab:pipeline:trigger', () => {
 
   const action = createTriggerGitlabPipelineAction({ integrations });
 
-  it('should return a Pipeline Token Id', async () => {
+  it('should return a Pipeline Url and not checkpoint the trigger token', async () => {
     const mockContext = createMockActionContext({
       input: {
         repoUrl: 'gitlab.com?repo=repo&owner=owner',
@@ -74,6 +74,7 @@ describe('gitlab:pipeline:trigger', () => {
       },
       workspacePath: 'seen2much',
     });
+    const checkpointSpy = jest.spyOn(mockContext, 'checkpoint');
 
     mockGitlabClient.PipelineTriggerTokens.create.mockResolvedValue({
       id: 42,
@@ -113,6 +114,15 @@ describe('gitlab:pipeline:trigger', () => {
 
     expect(mockContext.output).toHaveBeenCalledWith(
       'pipelineUrl',
+      'https://gitlab.com/hangar18-/pipelines/99',
+    );
+
+    expect(checkpointSpy).toHaveBeenCalledTimes(1);
+    expect(checkpointSpy).toHaveBeenCalledWith({
+      key: 'trigger.pipeline.123.main.My cool pipeline token',
+      fn: expect.any(Function),
+    });
+    await expect(checkpointSpy.mock.results[0].value).resolves.toBe(
       'https://gitlab.com/hangar18-/pipelines/99',
     );
   });
@@ -250,17 +260,35 @@ describe('gitlab:pipeline:trigger', () => {
       workspacePath: 'seen2much',
     });
 
-    await expect(
-      action.handler({
-        ...mockContext,
-      }),
-    ).rejects.toThrow('Failed to trigger pipeline');
+    mockGitlabClient.PipelineTriggerTokens.create.mockResolvedValue({
+      id: 42,
+      description: 'My cool pipeline token',
+      createdAt: new Date().toISOString(),
+      last_used: null,
+      token: 'glptt-abcdef',
+      updated_at: new Date().toISOString(),
+      owner: null,
+    });
+
+    mockGitlabClient.PipelineTriggerTokens.trigger.mockResolvedValue({
+      id: 99,
+      web_url: 'https://gitlab.com/hangar18-/pipelines/99',
+    });
+
+    await action.handler({
+      ...mockContext,
+    });
 
     expect(mockGitlabClient.PipelineTriggerTokens.trigger).toHaveBeenCalledWith(
       123,
       'main',
       'glptt-abcdef',
       { variables: { var_one: 'val1', var_two: 'val2' } },
+    );
+
+    expect(mockContext.output).toHaveBeenCalledWith(
+      'pipelineUrl',
+      'https://gitlab.com/hangar18-/pipelines/99',
     );
   });
 });

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabPipelineTrigger.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabPipelineTrigger.ts
@@ -80,9 +80,6 @@ export const createTriggerGitlabPipelineAction = (options: {
       },
     },
     async handler(ctx) {
-      let pipelineTriggerToken: string | undefined = undefined;
-      let pipelineTriggerId: number | undefined = undefined;
-
       const { repoUrl, projectId, tokenDescription, token, branch, variables } =
         ctx.input;
 
@@ -94,86 +91,48 @@ export const createTriggerGitlabPipelineAction = (options: {
         requireScmUserCredentials,
       });
 
-      try {
-        ({ pipelineTriggerToken, pipelineTriggerId } = await ctx.checkpoint({
-          key: `create.pipeline.token.${projectId}`,
-          fn: async () => {
-            const res = (await api.PipelineTriggerTokens.create(
-              projectId,
-              tokenDescription,
-            )) as PipelineTriggerTokenSchema;
-            return {
-              pipelineTriggerToken: res.token,
-              pipelineTriggerId: res.id,
-            };
-          },
-        }));
-
-        if (!pipelineTriggerToken) {
-          ctx.logger.error(
-            `Failed to create pipeline token for project ${projectId}.`,
-          );
-          return;
-        }
-        ctx.logger.info(
-          `Pipeline token id ${pipelineTriggerId} created for project ${projectId}.`,
-        );
-
-        // Use the pipeline token to trigger the pipeline in the project
-        const pipelineTriggerResponse =
-          (await api.PipelineTriggerTokens.trigger(
+      const pipelineUrl = await ctx.checkpoint({
+        key: `trigger.pipeline.${projectId}.${branch}.${tokenDescription}`,
+        fn: async () => {
+          const triggerToken = (await api.PipelineTriggerTokens.create(
             projectId,
-            branch,
-            pipelineTriggerToken,
-            { variables },
-          )) as ExpandedPipelineSchema;
+            tokenDescription,
+          )) as PipelineTriggerTokenSchema;
 
-        if (!pipelineTriggerResponse.id) {
-          ctx.logger.error(
-            `Failed to trigger pipeline for project ${projectId}.`,
-          );
-          return;
-        }
-
-        ctx.logger.info(
-          `Pipeline id ${pipelineTriggerResponse.id} for project ${projectId} triggered.`,
-        );
-
-        ctx.output('pipelineUrl', pipelineTriggerResponse.web_url);
-      } catch (error: any) {
-        // Handling other errors
-        throw new InputError(
-          `Failed to trigger Pipeline: ${getErrorMessage(error)}`,
-        );
-      } finally {
-        // Delete the pipeline token if it was created
-        if (pipelineTriggerId) {
           try {
-            await ctx.checkpoint({
-              key: `create.delete.token.${projectId}`,
-              fn: async () => {
-                if (pipelineTriggerId) {
-                  // to make the current version of TypeScript happy
-                  await api.PipelineTriggerTokens.remove(
-                    projectId,
-                    pipelineTriggerId,
-                  );
-                }
-              },
-            });
-            ctx.logger.info(
-              // in version 18.0 of gitlab this was also deleting the pipeline
-              // this is a problem in gitlab which is fixed in version 18.1
-              // https://gitlab.com/gitlab-org/gitlab/-/issues/546669
-              `Deleted pipeline trigger token with token id: ${pipelineTriggerId}.`,
-            );
-          } catch (error: any) {
-            ctx.logger.error(
-              `Failed to delete pipeline trigger token with token id: ${pipelineTriggerId}.`,
-            );
+            const pipeline = (await api.PipelineTriggerTokens.trigger(
+              projectId,
+              branch,
+              triggerToken.token,
+              { variables },
+            )) as ExpandedPipelineSchema;
+
+            if (!pipeline.id) {
+              throw new InputError(
+                `Failed to trigger pipeline for project ${projectId}`,
+              );
+            }
+
+            // Only this non-secret value enters checkpoint state.
+            return pipeline.web_url;
+          } finally {
+            try {
+              await api.PipelineTriggerTokens.remove(
+                projectId,
+                triggerToken.id,
+              );
+            } catch (error) {
+              ctx.logger.error(
+                `Failed to delete pipeline trigger token ${
+                  triggerToken.id
+                }: ${getErrorMessage(error)}`,
+              );
+            }
           }
-        }
-      }
+        },
+      });
+
+      ctx.output('pipelineUrl', pipelineUrl);
     },
   });
 };

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabProjectVariableCreate.test.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabProjectVariableCreate.test.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 The Backstage Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ConfigReader } from '@backstage/config';
+import { ScmIntegrations } from '@backstage/integration';
+import { createMockActionContext } from '@backstage/plugin-scaffolder-node-test-utils';
+import { createGitlabProjectVariableAction } from './gitlabProjectVariableCreate';
+
+const mockGitlabClient = {
+  ProjectVariables: {
+    create: jest.fn(),
+  },
+};
+jest.mock('@gitbeaker/rest', () => ({
+  Gitlab: class {
+    constructor() {
+      return mockGitlabClient;
+    }
+  },
+}));
+
+describe('gitlab:projectVariable:create', () => {
+  const config = new ConfigReader({
+    integrations: {
+      gitlab: [
+        {
+          host: 'gitlab.com',
+          token: 'tokenlols',
+          apiBaseUrl: 'https://api.gitlab.com',
+        },
+      ],
+    },
+  });
+
+  const integrations = ScmIntegrations.fromConfig(config);
+  const action = createGitlabProjectVariableAction({ integrations });
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('creates a project variable and checkpoints without the secret value', async () => {
+    const mockContext = createMockActionContext({
+      input: {
+        repoUrl: 'gitlab.com?repo=repo&owner=owner',
+        projectId: '123',
+        key: 'MY_SECRET',
+        value: 'super-secret-value',
+        variableType: 'env_var',
+        masked: true,
+        environmentScope: 'production',
+      },
+    });
+    const checkpointSpy = jest.spyOn(mockContext, 'checkpoint');
+
+    mockGitlabClient.ProjectVariables.create.mockResolvedValue({});
+
+    await action.handler(mockContext);
+
+    expect(mockGitlabClient.ProjectVariables.create).toHaveBeenCalledWith(
+      '123',
+      'MY_SECRET',
+      'super-secret-value',
+      {
+        variableType: 'env_var',
+        protected: false,
+        masked: true,
+        masked_and_hidden: false,
+        raw: false,
+        environmentScope: 'production',
+      },
+    );
+
+    expect(checkpointSpy).toHaveBeenCalledWith({
+      key: 'create.project.variables.123.MY_SECRET.production',
+      fn: expect.any(Function),
+    });
+    expect(checkpointSpy.mock.calls[0][0].key).not.toContain(
+      'super-secret-value',
+    );
+  });
+
+  it('uses the default environment scope in the checkpoint key', async () => {
+    const mockContext = createMockActionContext({
+      input: {
+        repoUrl: 'gitlab.com?repo=repo&owner=owner',
+        projectId: 456,
+        key: 'API_TOKEN',
+        value: 'another-secret',
+        variableType: 'env_var',
+      },
+    });
+    const checkpointSpy = jest.spyOn(mockContext, 'checkpoint');
+
+    mockGitlabClient.ProjectVariables.create.mockResolvedValue({});
+
+    await action.handler(mockContext);
+
+    expect(checkpointSpy).toHaveBeenCalledWith({
+      key: 'create.project.variables.456.API_TOKEN.*',
+      fn: expect.any(Function),
+    });
+    expect(checkpointSpy.mock.calls[0][0].key).not.toContain('another-secret');
+  });
+});

--- a/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabProjectVariableCreate.ts
+++ b/plugins/scaffolder-backend-module-gitlab/src/actions/gitlabProjectVariableCreate.ts
@@ -127,7 +127,7 @@ export const createGitlabProjectVariableAction = (options: {
       });
 
       await ctx.checkpoint({
-        key: `create.project.variables.${projectId}.${key}.${value}`,
+        key: `create.project.variables.${projectId}.${key}.${environmentScope}`,
         fn: async () => {
           await api.ProjectVariables.create(projectId, key, value, {
             variableType: variableType as VariableType,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fixes secret persistence in scaffolder checkpoint state for two GitLab actions (first part of [#35208](https://github.com/backstage/backstage/issues/35208)).

- `gitlab:projectVariable:create` no longer includes the variable value in its checkpoint key.
- `gitlab:pipeline:trigger` now checkpoints only the pipeline URL; the temporary trigger token is never serialized into task state.

A follow-up PR will add the secure variableKey path for project/deploy token actions and deprecate raw token outputs.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
