### PR TITLE
fix(techdocs-node): get all objects on publish in order to properly delete removed files

### DIFF
--- a/.changeset/quiet-pandas-paginate.md
+++ b/.changeset/quiet-pandas-paginate.md
@@ -1,0 +1,5 @@
+---
+'@backstage/plugin-techdocs-node': patch
+---
+
+Fixed AWS S3 publishing to paginate existing objects in order to properly remove all stale TechDocs files.

--- a/plugins/techdocs-node/src/stages/publish/awsS3.test.ts
+++ b/plugins/techdocs-node/src/stages/publish/awsS3.test.ts
@@ -815,6 +815,46 @@ describe('AwsS3Publish', () => {
       );
     });
 
+    it('should paginate when finding stale files to delete', async () => {
+      let listObjectsCallCount = 0;
+      s3SendMock.mockImplementation(async command => {
+        if (command instanceof ListObjectsV2Command) {
+          listObjectsCallCount++;
+          if (listObjectsCallCount === 1) {
+            return {
+              Contents: [{ Key: 'default/component/backstage/index.html' }],
+              NextContinuationToken: 'next-page',
+            };
+          }
+          return {
+            Contents: [{ Key: 'default/component/backstage/stale-file.png' }],
+          };
+        }
+
+        return defaultS3SendImplementation(command);
+      });
+
+      const publisher = await createPublisherFromConfig();
+      await publisher.publish({ entity, directory });
+
+      const listObjectsCalls = s3SendMock.mock.calls.filter(
+        ([command]) => command instanceof ListObjectsV2Command,
+      );
+      expect(listObjectsCalls).toHaveLength(2);
+      expect(listObjectsCalls[1][0].input).toEqual({
+        Bucket: 'bucketName',
+        ContinuationToken: 'next-page',
+        Prefix: 'default/component/backstage/',
+      });
+      const deleteObjectCalls = s3SendMock.mock.calls.filter(
+        ([command]) => command instanceof DeleteObjectCommand,
+      );
+      expect(deleteObjectCalls[0][0].input).toEqual({
+        Bucket: 'bucketName',
+        Key: 'default/component/backstage/stale-file.png',
+      });
+    });
+
     it('should log error when the stale files deletion fails', async () => {
       const bucketName = 'delete_stale_files_error';
       const publisher = await createPublisherFromConfig({

--- a/plugins/techdocs-node/src/stages/publish/awsS3.ts
+++ b/plugins/techdocs-node/src/stages/publish/awsS3.ts
@@ -476,20 +476,9 @@ export class AwsS3Publish implements PublisherBase {
         useLegacyPathCasing,
         bucketRootPath,
       );
-      const response = await this.retryOperation(
-        async () => {
-          const listCommand = new ListObjectsV2Command({
-            Bucket: this.bucketName,
-            Prefix: remoteFolder,
-          });
-          return this.storageClient.send(listCommand);
-        },
-        'ListObjects',
-        this.maxAttempts,
-      );
-      existingFiles = (response.Contents || [])
-        .map(f => f.Key || '')
-        .filter(f => !!f);
+      existingFiles = await this.getAllObjectsFromBucket({
+        prefix: remoteFolder,
+      });
     } catch (e) {
       this.logger.error(
         `Unable to list files for Entity ${entity.metadata.name}: ${


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Resolves https://github.com/backstage/backstage/issues/35381

Makes use of the existing `getAllObjectsFromBucket` helper to fully paginate the source bucket. This is necessary due to the guard in place that prevents deleting s3 bucket contents for removed files if that file is not present in the bucket. By pulling the entire bucket contents, we can actually confirm that removed files were there and remove them.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation: **N/A**
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes) **N/A**
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
