### PR TITLE
plugins: add SWIRL for Backstage to the plugin directory

### DIFF
--- a/microsite/data/plugins/swirl.yaml
+++ b/microsite/data/plugins/swirl.yaml
@@ -1,0 +1,11 @@
+---
+title: SWIRL for Backstage
+author: SWIRL AI, Inc.
+authorUrl: https://swirlaiconnect.com
+category: Search
+description: Search backend module that answers search from SWIRL, with a Tantivy index for catalog and TechDocs and live GitHub and Confluence results.
+documentation: https://docs.swirlaiconnect.com/backstage-overview
+iconUrl: /img/swirl-for-backstage.svg
+npmPackageName: '@swirl-search/backstage-plugin-search-backend-module-swirl'
+addedDate: '2026-09-03'
+status: active

--- a/microsite/static/img/swirl-for-backstage.svg
+++ b/microsite/static/img/swirl-for-backstage.svg
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SWIRL mark — DS-5588.
+  Icon-only lockup (no wordmark). Designed to read clearly from 16px
+  (favicon) up to 512px (app icon). Same family as swirl-galaxy-logo.svg
+  but simplified for small sizes: three primary spiral arms, nebula core
+  glow, bright nucleus; secondary arms and star field omitted.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128"
+     width="128" height="128"
+     role="img" aria-label="SWIRL">
+  <defs>
+    <radialGradient id="swirl-core" cx="50%" cy="50%" r="50%">
+      <stop offset="0%"  stop-color="#ffffff" stop-opacity="0.95"/>
+      <stop offset="28%" stop-color="#BFE1FF" stop-opacity="0.55"/>
+      <stop offset="70%" stop-color="#0060A8" stop-opacity="0.18"/>
+      <stop offset="100%" stop-color="#0060A8" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="swirl-arm" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%"  stop-color="#0060A8"/>
+      <stop offset="70%" stop-color="#4D9FFF"/>
+      <stop offset="100%" stop-color="#86BDFF"/>
+    </linearGradient>
+  </defs>
+
+  <g transform="translate(64, 64)">
+    <!-- Nebula core -->
+    <circle r="52" fill="url(#swirl-core)"/>
+
+    <!-- Three spiral arms, rotated 120° -->
+    <g stroke="url(#swirl-arm)" stroke-width="9" fill="none"
+       stroke-linecap="round" stroke-linejoin="round">
+      <path d="M 0 -42 C 22 -40, 40 -24, 42 0 C 42 22, 26 32, 12 28"/>
+      <path d="M 0 -42 C 22 -40, 40 -24, 42 0 C 42 22, 26 32, 12 28"
+            transform="rotate(120)"/>
+      <path d="M 0 -42 C 22 -40, 40 -24, 42 0 C 42 22, 26 32, 12 28"
+            transform="rotate(240)"/>
+    </g>
+
+    <!-- Bright nucleus -->
+    <circle r="6" fill="#BFE1FF" opacity="0.75"/>
+    <circle r="3" fill="#ffffff"/>
+    <circle r="1.4" fill="#0060A8"/>
+  </g>
+</svg>


### PR DESCRIPTION
Hey, I just made a Pull Request!

Adds SWIRL for Backstage to the plugin directory: a search backend module that answers Backstage search from SWIRL, with a Tantivy index for the software catalog and TechDocs and live federated results from GitHub and Confluence in the same list. Apache 2.0.

- npm: https://www.npmjs.com/package/@swirl-search/backstage-plugin-search-backend-module-swirl
- Source: https://github.com/swirlai/swirl-backstage
- Docs: https://docs.swirlaiconnect.com/backstage-overview
- Icon: the SWIRL mark, owned by SWIRL AI, Inc.

`node ./scripts/verify-plugin-directory.js` passes.

#### :heavy_check_mark: Checklist

- [x] A changeset describing the change and affected packages. (Not needed: microsite data only)
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes (Not applicable)
- [x] Screenshots attached (for UI changes) (Not applicable)
- [x] All your commits have a `Signed-off-by` line in the message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)